### PR TITLE
Fixed #29852 -- Prevented infinite migrations when using SimpleLazyObject in field arguments.

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -12,6 +12,7 @@ from django.db.migrations.questioner import MigrationQuestioner
 from django.db.migrations.utils import (
     COMPILED_REGEX_TYPE, RegexObject, get_migration_name_timestamp,
 )
+from django.utils.functional import SimpleLazyObject
 
 from .topological_sort import stable_topological_sort
 
@@ -70,6 +71,8 @@ class MigrationAutodetector:
             # If this is a type that implements 'deconstruct' as an instance method,
             # avoid treating this as being deconstructible itself - see #22951
             return obj
+        elif isinstance(obj, SimpleLazyObject):
+            return obj._setupfunc
         elif hasattr(obj, 'deconstruct'):
             deconstructed = obj.deconstruct()
             if isinstance(obj, models.Field):

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -12,7 +12,7 @@ import uuid
 from django.db import models
 from django.db.migrations.operations.base import Operation
 from django.db.migrations.utils import COMPILED_REGEX_TYPE, RegexObject
-from django.utils.functional import LazyObject, Promise
+from django.utils.functional import LazyObject, Promise, SimpleLazyObject
 from django.utils.timezone import utc
 from django.utils.version import get_docs_version
 
@@ -274,6 +274,8 @@ def serializer_factory(value):
     from django.db.migrations.writer import SettingsReference
     if isinstance(value, Promise):
         value = str(value)
+    elif isinstance(value, SimpleLazyObject):
+        value = value._setupfunc
     elif isinstance(value, LazyObject):
         # The unwrapped value is returned as the first item of the arguments
         # tuple.

--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -209,6 +209,8 @@ empty = object()
 
 def new_method_proxy(func):
     def inner(self, *args):
+        if args and isinstance(args[0], type(self)):
+            return func(self._wrapped, args[0]._wrapped)
         if self._wrapped is empty:
             self._setup()
         return func(self._wrapped, *args)

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1,3 +1,4 @@
+import datetime
 import functools
 import re
 from unittest import mock
@@ -5,7 +6,9 @@ from unittest import mock
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser
-from django.core.validators import RegexValidator, validate_slug
+from django.core.validators import (
+    MinValueValidator, RegexValidator, validate_slug,
+)
 from django.db import connection, models
 from django.db.migrations.autodetector import MigrationAutodetector
 from django.db.migrations.graph import MigrationGraph
@@ -14,6 +17,7 @@ from django.db.migrations.questioner import MigrationQuestioner
 from django.db.migrations.state import ModelState, ProjectState
 from django.test import TestCase, override_settings
 from django.test.utils import isolate_lru_cache
+from django.utils.functional import SimpleLazyObject
 
 from .models import FoodManager, FoodQuerySet
 
@@ -1299,6 +1303,37 @@ class AutodetectorTests(TestCase):
         )
         to_state = ModelState(
             "testapp", "model", [("id", models.AutoField(primary_key=True, validators=[validate_slug]))]
+        )
+        changes = self.get_changes([from_state], [to_state])
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+
+    def test_identical_simplelazyobject_doesnt_alter(self):
+        lt_now_validator = MinValueValidator(SimpleLazyObject(datetime.datetime.now))
+        from_state = ModelState(
+            "testapp", "model", [
+                ('dob', models.DateTimeField(validators=[
+                    MinValueValidator(SimpleLazyObject(datetime.datetime.now))
+                ])),
+            ]
+        )
+        to_state = ModelState(
+            "testapp", "model", [('dob', models.DateTimeField(validators=[lt_now_validator]))]
+        )
+        changes = self.get_changes([from_state], [to_state])
+        self.assertNumberMigrations(changes, "testapp", 0)
+
+    def test_different_simplelazyobject_does_alter(self):
+        lt_today_validator = MinValueValidator(SimpleLazyObject(datetime.datetime.today))
+        from_state = ModelState(
+            "testapp", "model", [
+                ('dob', models.DateTimeField(validators=[
+                    MinValueValidator(SimpleLazyObject(datetime.datetime.now))
+                ])),
+            ]
+        )
+        to_state = ModelState(
+            "testapp", "model", [('dob', models.DateTimeField(validators=[lt_today_validator]))]
         )
         changes = self.get_changes([from_state], [to_state])
         self.assertNumberMigrations(changes, "testapp", 1)


### PR DESCRIPTION
Reference: https://code.djangoproject.com/ticket/29852