### PR TITLE
Fixed #29138 -- Add ModelAdmin.autocomplete_fields support for ForeignKeys that use to_field

### DIFF
--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -37,7 +37,7 @@ from .models import (
     Person, Persona, Picture, Pizza, Plot, PlotDetails, PlotProxy,
     PluggableSearchPerson, Podcast, Post, PrePopulatedPost,
     PrePopulatedPostLargeSlug, PrePopulatedSubPost, Promo, Question,
-    ReadablePizza, ReadOnlyPizza, Recipe, Recommendation, Recommender,
+    ReadablePizza, ReadOnlyPizza, Recipe, Recommendation, Recommender, ParentWithFK,
     ReferencedByGenRel, ReferencedByInline, ReferencedByParent,
     RelatedPrepopulated, RelatedWithUUIDPKModel, Report, Reservation,
     Restaurant, RowLevelChangePermissionModel, Section, ShortMessage, Simple,
@@ -644,12 +644,17 @@ class PluggableSearchPersonAdmin(admin.ModelAdmin):
 class AlbumAdmin(admin.ModelAdmin):
     list_filter = ['title']
 
-
 class QuestionAdmin(admin.ModelAdmin):
     ordering = ['-posted']
     search_fields = ['question']
     autocomplete_fields = ['related_questions']
 
+class ReferencedByParentAdmin(admin.ModelAdmin):
+    search_fields = ['name']
+
+class ParentWithFKAdmin(admin.ModelAdmin):
+    search_fields = ['fk__name']
+    autocomplete_fields = ['fk']
 
 class AnswerAdmin(admin.ModelAdmin):
     autocomplete_fields = ['question']
@@ -1012,7 +1017,6 @@ site.register(City, CityAdmin)
 site.register(Restaurant, RestaurantAdmin)
 site.register(Worker, WorkerAdmin)
 site.register(FunkyTag, FunkyTagAdmin)
-site.register(ReferencedByParent)
 site.register(ChildOfReferer)
 site.register(ReferencedByInline)
 site.register(InlineReferer, InlineRefererAdmin)
@@ -1039,6 +1043,8 @@ site.register(ReadablePizza)
 site.register(Topping, ToppingAdmin)
 site.register(Album, AlbumAdmin)
 site.register(Question, QuestionAdmin)
+site.register(ReferencedByParent, ReferencedByParentAdmin)
+site.register(ParentWithFK, ParentWithFKAdmin)
 site.register(Answer, AnswerAdmin, date_hierarchy='question__posted')
 site.register(Answer2, date_hierarchy='question__expires')
 site.register(PrePopulatedPost, PrePopulatedPostAdmin)

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -887,6 +887,9 @@ class Worker(models.Model):
 class ReferencedByParent(models.Model):
     name = models.CharField(max_length=20, unique=True)
 
+    def __str__(self):
+        return self.name
+
 
 class ParentWithFK(models.Model):
     fk = models.ForeignKey(
@@ -895,6 +898,9 @@ class ParentWithFK(models.Model):
         to_field='name',
         related_name='hidden+',
     )
+
+    def __str__(self):
+        return str(self.fk)
 
 
 class ChildOfReferer(ParentWithFK):

--- a/tests/admin_widgets/test_autocomplete_widget.py
+++ b/tests/admin_widgets/test_autocomplete_widget.py
@@ -5,7 +5,7 @@ from django.forms import ModelChoiceField
 from django.test import TestCase, override_settings
 from django.utils import translation
 
-from .models import Album, Band
+from .models import Album, Band, Profile
 
 
 class AlbumForm(forms.ModelForm):
@@ -53,7 +53,7 @@ class AutocompleteMixinTests(TestCase):
             'class': 'my-class admin-autocomplete',
             'data-ajax--cache': 'true',
             'data-ajax--type': 'GET',
-            'data-ajax--url': '/admin_widgets/band/autocomplete/',
+            'data-ajax--url': '/admin_widgets/band/autocomplete/?to_field=id',
             'data-theme': 'admin-autocomplete',
             'data-allow-clear': 'false',
             'data-placeholder': ''
@@ -78,7 +78,13 @@ class AutocompleteMixinTests(TestCase):
         rel = Album._meta.get_field('band').remote_field
         w = AutocompleteSelect(rel, admin.site)
         url = w.get_url()
-        self.assertEqual(url, '/admin_widgets/band/autocomplete/')
+        self.assertEqual(url, '/admin_widgets/band/autocomplete/?to_field=id')
+
+    def test_get_url_to_field(self):
+        rel = Profile._meta.get_field('user').remote_field
+        w = AutocompleteSelect(rel, admin.site)
+        url = w.get_url()
+        self.assertEqual(url, '/auth/user/autocomplete/?to_field=username')
 
     def test_render_options(self):
         beatles = Band.objects.create(name='The Beatles', style='rock')


### PR DESCRIPTION
Bug fix for [29138](https://code.djangoproject.com/ticket/29138); creating [PR as requested](https://code.djangoproject.com/ticket/29138#comment:10).

NOTE: one of the unit tests doesn't pass due to a DisallowedModelAdminToField error being raised; I'm not sure how to resolve this issue as I'm not familiar with `to_field_allowed`

For reference, I originally submitted this fix based on `stable/2.1.x` (see [10494](https://github.com/django/django/pull/10494)); changing the base to `master` caused too many conflicts so I'm resubmitting a new one.