### PR TITLE
Remove outdated bad URL references

### DIFF
--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -6,9 +6,6 @@ A clean, elegant URL scheme is an important detail in a high-quality Web
 application. Django lets you design URLs however you want, with no framework
 limitations.
 
-There's no ``.php`` or ``.cgi`` required, and certainly none of that
-``0,2097,1-1-1928,00`` nonsense.
-
 See `Cool URIs don't change`_, by World Wide Web creator Tim Berners-Lee, for
 excellent arguments on why URLs should be clean and usable.
 


### PR DESCRIPTION
Pretty much all web frameworks do this now, and comparing Django to old-fashioned alternatives is confusing to new developers - see https://www.reddit.com/r/django/comments/9oyntn/a_question_about_something_trivial_in_the_django/