### PR TITLE
Fixed #29861 -- Made TimeField use auto_now/auto_now_add use timezone.now().

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2189,7 +2189,7 @@ class TimeField(DateTimeCheckMixin, Field):
 
     def pre_save(self, model_instance, add):
         if self.auto_now or (self.auto_now_add and add):
-            value = datetime.datetime.now().time()
+            value = timezone.now().time()
             setattr(model_instance, self.attname, value)
             return value
         else:


### PR DESCRIPTION
Ticket https://code.djangoproject.com/ticket/29861