### PR TITLE
Fixed #29774 -- Fixed django-admin shell hang on startup.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ answer newbie questions, and generally made Django that much better:
     Abeer Upadhyay <ab.esquarer@gmail.com>
     Abhinav Patil <https://github.com/ubadub/>
     Abhishek Gautam <abhishekg1128@yahoo.com>
+    Adam Allred <adam.w.allred@gmail.com>
     Adam Bogdał <adam@bogdal.pl>
     Adam Donaghy
     Adam Johnson <https://github.com/adamchainz>

--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -88,7 +88,7 @@ class Command(BaseCommand):
 
         # Execute stdin if it has anything to read and exit.
         # Not supported on Windows due to select.select() limitations.
-        if sys.platform != 'win32' and select.select([sys.stdin], [], [], 0)[0]:
+        if sys.platform != 'win32' and not sys.stdin.isatty() and select.select([sys.stdin], [], [], 0)[0]:
             exec(sys.stdin.read())
             return
 

--- a/docs/releases/2.1.3.txt
+++ b/docs/releases/2.1.3.txt
@@ -11,3 +11,6 @@ Bugfixes
 
 * Fixed a regression in Django 2.0 where combining ``Q`` objects with ``__in``
   lookups and lists crashed (:ticket:`29838`).
+
+* Fixed a regression in Django 1.11 where ``django-admin shell`` may hang
+  on startup (:ticket:`29774`).


### PR DESCRIPTION
sys.stdin.read() blocks waiting for EOF in shell.py, which will
likely never come if the user provides input on stdin via
keyboard before the shell starts. Added check for a tty, and
skip reading stdin if it's not present.

This still allows piping of code into the shell (which should
have no TTY and should have an EOF), but also doesn't cause it
to hang if multi-line input is provided.