### PR TITLE
Update example Jinja2 static tag

### DIFF
--- a/docs/topics/templates.txt
+++ b/docs/topics/templates.txt
@@ -451,7 +451,7 @@ environment.
 
 For example, you can create ``myproject/jinja2.py`` with this content::
 
-    from django.contrib.staticfiles.storage import staticfiles_storage
+    from django.templatetags.static import static
     from django.urls import reverse
 
     from jinja2 import Environment
@@ -460,7 +460,7 @@ For example, you can create ``myproject/jinja2.py`` with this content::
     def environment(**options):
         env = Environment(**options)
         env.globals.update({
-            'static': staticfiles_storage.url,
+            'static': static,
             'url': reverse,
         })
         return env


### PR DESCRIPTION
This change updates [the example provided](https://docs.djangoproject.com/en/2.1/topics/templates/#django.template.backends.jinja2.Jinja2) to expose `static` to the Jinja2 template engine's context.

As of e.g. [#21221](https://code.djangoproject.com/ticket/21221) the use of `django.templatetags.static.static` now seems to be the canonical way to invoke the static tag. Additionally this change makes it so the example will work when the staticfiles app isn't loaded, by prepending the path with `settings.STATIC_URL` as in https://github.com/django/django/blob/master/django/templatetags/static.py#L119.

Updated docs when rendered locally:

<img width="684" alt="image" src="https://user-images.githubusercontent.com/654645/47123269-778ce200-d248-11e8-92c7-3d8beec57731.png">