### PR TITLE
Fixed #29830 -- Fixed loss of custom utf-8 body encoding in mails.

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -170,7 +170,7 @@ class SafeMIMEText(MIMEMixin, MIMEText):
         MIMEText.__setitem__(self, name, val)
 
     def set_payload(self, payload, charset=None):
-        if charset == 'utf-8':
+        if charset == 'utf-8' and not isinstance(charset, Charset.Charset):
             has_long_lines = any(
                 len(l.encode()) > RFC5322_EMAIL_LINE_LENGTH_LIMIT
                 for l in payload.splitlines()


### PR DESCRIPTION
When setting the encoding of a EmailMessage to Python’s email.charset.Charset the body encoding (e.g. quoted printable or base64) in the final mail was overwritten in some cases.

See the [trac ticket](https://code.djangoproject.com/ticket/29830).

Can I add documentation for this, where would this be? Or is there? This is my first contribution.