### PR TITLE
Added test case for related manager on FK to subclass model

### DIFF
--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -375,3 +375,18 @@ class UUIDChild(PrimaryKeyUUIDModel):
 
 class UUIDGrandchild(UUIDChild):
     pass
+
+
+class BaseModel(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    subx = models.ForeignKey('SubModel', models.CASCADE, blank=True, null=True)
+    # setting a related_name explicitly to the default will make the test pass
+    # subx = models.ForeignKey('SubModel', models.CASCADE, blank=True, null=True, related_name='submodel_set')
+    suby = models.ForeignKey('SubModel', models.CASCADE, blank=True, null=True, related_name='i_work')
+
+    def __str__(self):
+        return str(self.id)
+
+
+class SubModel(BaseModel):
+    pass


### PR DESCRIPTION
A test case for a problem with foreign keys on base concrete models that relate to subclass models. In this case the foreignkey is treated as a OneToOneField. 

The PR does not currently correct the problem.

If a related_name is set on the FK, it appears to correct the problem, even if the related_name is set to the same name as the default.