### PR TITLE
Fixed #29843 -- Manage contenttypes and permissions using migration operations

### DIFF
--- a/django/contrib/contenttypes/apps.py
+++ b/django/contrib/contenttypes/apps.py
@@ -3,7 +3,8 @@ from django.contrib.contenttypes.checks import (
     check_generic_foreign_keys, check_model_name_lengths,
 )
 from django.core import checks
-from django.db.models.signals import post_migrate, pre_migrate
+from django.db import migrations
+from django.db.models.signals import post_migrate, post_operation
 from django.utils.translation import gettext_lazy as _
 
 from .management import (
@@ -16,7 +17,7 @@ class ContentTypesConfig(AppConfig):
     verbose_name = _("Content Types")
 
     def ready(self):
-        pre_migrate.connect(inject_rename_contenttypes_operations, sender=self)
+        post_operation.connect(inject_rename_contenttypes_operations, sender=migrations.RenameModel)
         post_migrate.connect(create_contenttypes)
         checks.register(check_generic_foreign_keys, checks.Tags.models)
         checks.register(check_model_name_lengths, checks.Tags.models)

--- a/django/contrib/contenttypes/management/__init__.py
+++ b/django/contrib/contenttypes/management/__init__.py
@@ -42,10 +42,12 @@ class RenameContentType(migrations.RunPython):
         self._rename(apps, schema_editor, self.new_model, self.old_model)
 
 
-def inject_rename_contenttypes_operations(migration, operation, from_state, to_state, **kwargs):
+def inject_rename_contenttypes_operations(migration, operation, from_state, to_state, injected_operations, **kwargs):
     if isinstance(operation, migrations.RenameModel):
-        return RenameContentType(
-            migration.app_label, operation.old_name_lower, operation.new_name_lower
+        injected_operations.append(
+            RenameContentType(
+                migration.app_label, operation.old_name_lower, operation.new_name_lower
+            )
         )
 
 

--- a/django/contrib/contenttypes/management/__init__.py
+++ b/django/contrib/contenttypes/management/__init__.py
@@ -42,46 +42,11 @@ class RenameContentType(migrations.RunPython):
         self._rename(apps, schema_editor, self.new_model, self.old_model)
 
 
-def inject_rename_contenttypes_operations(plan=None, apps=global_apps, using=DEFAULT_DB_ALIAS, **kwargs):
-    """
-    Insert a `RenameContentType` operation after every planned `RenameModel`
-    operation.
-    """
-    if plan is None:
-        return
-
-    # Determine whether or not the ContentType model is available.
-    try:
-        ContentType = apps.get_model('contenttypes', 'ContentType')
-    except LookupError:
-        available = False
-    else:
-        if not router.allow_migrate_model(using, ContentType):
-            return
-        available = True
-
-    for migration, backward in plan:
-        if (migration.app_label, migration.name) == ('contenttypes', '0001_initial'):
-            # There's no point in going forward if the initial contenttypes
-            # migration is unapplied as the ContentType model will be
-            # unavailable from this point.
-            if backward:
-                break
-            else:
-                available = True
-                continue
-        # The ContentType model is not available yet.
-        if not available:
-            continue
-        inserts = []
-        for index, operation in enumerate(migration.operations):
-            if isinstance(operation, migrations.RenameModel):
-                operation = RenameContentType(
-                    migration.app_label, operation.old_name_lower, operation.new_name_lower
-                )
-                inserts.append((index + 1, operation))
-        for inserted, (index, operation) in enumerate(inserts):
-            migration.operations.insert(inserted + index, operation)
+def inject_rename_contenttypes_operations(migration, operation, from_state, to_state, **kwargs):
+    if isinstance(operation, migrations.RenameModel):
+        return RenameContentType(
+            migration.app_label, operation.old_name_lower, operation.new_name_lower
+        )
 
 
 def get_contenttypes_and_models(app_config, using, ContentType):

--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -52,12 +52,13 @@ def emit_post_migrate_signal(verbosity, interactive, db, **kwargs):
         )
 
 
-def emit_post_operation_signal(migration, operation, from_state, to_state, **kwargs):
-    results = models.signals.post_operation.send(
+def emit_post_operation_signal(migration, operation, from_state, to_state, injected_operations, **kwargs):
+    """The receivers will append operations to the injected_operations list."""
+    models.signals.post_operation.send(
         sender=operation.__class__,
         migration=migration,
         operation=operation,
         from_state=from_state,
         to_state=to_state,
+        injected_operations=injected_operations,
     )
-    return [operation for __, operation in results if operation]

--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -50,3 +50,14 @@ def emit_post_migrate_signal(verbosity, interactive, db, **kwargs):
             using=db,
             **kwargs
         )
+
+
+def emit_post_operation_signal(migration, operation, from_state, to_state, **kwargs):
+    results = models.signals.post_operation.send(
+        sender=operation.__class__,
+        migration=migration,
+        operation=operation,
+        from_state=from_state,
+        to_state=to_state,
+    )
+    return [operation for __, operation in results if operation]

--- a/django/db/migrations/migration.py
+++ b/django/db/migrations/migration.py
@@ -125,8 +125,8 @@ class Migration:
                 operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
             return (old_state, project_state)
 
-        def _apply_operations(operations, depth=50):
-            if not operations or depth <= 0:
+        def _apply_operations(operations):
+            if not operations:
                 return
 
             injected_operations = []
@@ -140,9 +140,14 @@ class Migration:
                     injected_operations=injected_operations,
                 )
 
-            _apply_operations(injected_operations, depth - 1)
+            _apply_operations(injected_operations)
 
-        _apply_operations(self.operations)
+        try:
+            _apply_operations(self.operations)
+        except RecursionError:
+            raise RecursionError(
+                "A cycle in the post_operation signal's chain has caused infinite recursion."
+            )
 
         return project_state
 

--- a/django/db/migrations/migration.py
+++ b/django/db/migrations/migration.py
@@ -132,11 +132,12 @@ class Migration:
             injected_operations = []
             for operation in operations:
                 from_state, to_state = _apply_operation(operation)
-                injected_operations += emit_post_operation_signal(
+                emit_post_operation_signal(
                     migration=self,
                     operation=operation,
                     from_state=from_state,
                     to_state=to_state,
+                    injected_operations=injected_operations,
                 )
 
             _apply_operations(injected_operations, depth - 1)

--- a/django/db/models/signals.py
+++ b/django/db/models/signals.py
@@ -51,4 +51,4 @@ m2m_changed = ModelSignal(
 
 pre_migrate = Signal(providing_args=["app_config", "verbosity", "interactive", "using", "apps", "plan"])
 post_migrate = Signal(providing_args=["app_config", "verbosity", "interactive", "using", "apps", "plan"])
-post_operation = Signal(providing_args=["migration", "operation", "from_state", "to_state"])
+post_operation = Signal(providing_args=["migration", "operation", "from_state", "to_state", "injected_operations"])

--- a/django/db/models/signals.py
+++ b/django/db/models/signals.py
@@ -51,3 +51,4 @@ m2m_changed = ModelSignal(
 
 pre_migrate = Signal(providing_args=["app_config", "verbosity", "interactive", "using", "apps", "plan"])
 post_migrate = Signal(providing_args=["app_config", "verbosity", "interactive", "using", "apps", "plan"])
+post_operation = Signal(providing_args=["migration", "operation", "from_state", "to_state"])


### PR DESCRIPTION
# Context

ticket: [#29843](https://code.djangoproject.com/ticket/29843)
mailing list: [Content types shouldn't be created on post_migrate signal](https://groups.google.com/forum/#!topic/django-developers/HDKVHrmSMdE/discussion)

related ticket for permissions: [#27489](https://code.djangoproject.com/ticket/27489)
and pull request: https://github.com/django/django/pull/7673

# TODO

- [x] Trigger `emit_post_operation_signal` in `django.db.migrations.migration.apply_migration`
- [ ] Trigger `emit_post_operation_signal` in `django.db.migrations.migration.unapply_migration`
- [x] Update `RenameContentType` to register to the `post_operation` signal instead of `pre_migrate`
- [ ] Add `CreateContentType` operation
- [ ] Add `CreatePermission` operation
- [ ] Add `RenamePermission` operation
- [ ] Add tests
- [ ] Add docs on `post_operation` signal