### PR TITLE
Fixed #27595 -- Made ForeignKey.get_col() follow target chains.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -977,7 +977,13 @@ class ForeignKey(ForeignObject):
         return converters
 
     def get_col(self, alias, output_field=None):
-        return super().get_col(alias, output_field or self.target_field)
+        if output_field is None:
+            output_field = self.target_field
+            while isinstance(output_field, ForeignKey):
+                output_field = output_field.target_field
+                if output_field is self:
+                    raise ValueError('Cannot resolve output_field.')
+        return super().get_col(alias, output_field)
 
 
 class OneToOneField(ForeignKey):

--- a/tests/model_fields/test_uuid.py
+++ b/tests/model_fields/test_uuid.py
@@ -170,8 +170,12 @@ class TestAsPrimaryKey(TestCase):
         self.assertEqual(r.uuid_fk, u2)
 
     def test_two_level_foreign_keys(self):
+        gc = UUIDGrandchild()
         # exercises ForeignKey.get_db_prep_value()
-        UUIDGrandchild().save()
+        gc.save()
+        self.assertIsInstance(gc.uuidchild_ptr_id, uuid.UUID)
+        gc.refresh_from_db()
+        self.assertIsInstance(gc.uuidchild_ptr_id, uuid.UUID)
 
 
 class TestAsPrimaryKeyTransactionTests(TransactionTestCase):


### PR DESCRIPTION
We were previously only following foreign relationships one level deep which
was preventing foreign keys to foreign keys from being resolved appropriately.

This was causing all sorts of weirdness such as improper database value
conversion for UUIDField on SQLite because the resolved expression's output
field's internal type was not correct.

Also added tests to make sure unlikely foreign reference cycles do not cause
recursion errors.

Refs [#24343](https://code.djangoproject.com/ticket/24343) ([PR](https://github.com/django/django/pull/4171))

Thanks oyooyo for the report and Wayne Merry for the investigation.

https://code.djangoproject.com/ticket/27595