### PR TITLE
Remove "encoding" from gis tutorial.

### DIFF
--- a/docs/ref/contrib/gis/tutorial.txt
+++ b/docs/ref/contrib/gis/tutorial.txt
@@ -474,9 +474,6 @@ A few notes about what's going on:
   the script will still work.
 * The ``transform`` keyword is set to ``False`` because the data in the
   shapefile does not need to be converted -- it's already in WGS84 (SRID=4326).
-* The ``encoding`` keyword is set to the character encoding of the string
-  values in the shapefile. This ensures that string values are read and saved
-  correctly from their original encoding system.
 
 Afterwards, invoke the Django shell from the ``geodjango`` project directory:
 


### PR DESCRIPTION
It seems 388165ade4219aeefac1e231c1d44c51a7b62829 removed the "encoding" keyword from a code snippet, but the explanation of that keyword remained in the explanation below the snippet, which was confusing.