### PR TITLE
Completed test coverage of views.static.directory_name().

### DIFF
--- a/tests/view_tests/media/subdir/.hidden
+++ b/tests/view_tests/media/subdir/.hidden
@@ -1,0 +1,1 @@
+The directory_name() view ignores files that start with a dot.

--- a/tests/view_tests/tests/test_static.py
+++ b/tests/view_tests/tests/test_static.py
@@ -111,6 +111,14 @@ class StaticTests(SimpleTestCase):
     def test_index(self):
         response = self.client.get('/%s/' % self.prefix)
         self.assertContains(response, 'Index of ./')
+        # Directories have a trailing slash.
+        self.assertIn('subdir/', response.context['file_list'])
+
+    def test_index_subdir(self):
+        response = self.client.get('/%s/subdir/' % self.prefix)
+        self.assertContains(response, 'Index of subdir/')
+        # File with a leading dot (e.g. .hidden) aren't displayed.
+        self.assertEqual(response.context['file_list'], ['visible'])
 
     @override_settings(TEMPLATES=[{
         'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
Improve `test_index_custom_template` and increase test coverage of [directory_index](https://github.com/django/django/blob/c53af5661313079d022553b6c775e6c4f8d34927/django/views/static.py#L83).

The 'test' directory added to `tests/view_tests/media/` for covering [this line](https://github.com/django/django/blob/c53af5661313079d022553b6c775e6c4f8d34927/django/views/static.py#L99).