### PR TITLE
[wip] Fixed #29871 -- Allowed setting pk=None on a child model to create a copy.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -553,6 +553,8 @@ class Model(metaclass=ModelBase):
         return getattr(self, meta.pk.attname)
 
     def _set_pk_val(self, value):
+        for parent_link in self._meta.parents.values():
+            setattr(self, parent_link.target_field.attname, value)
         return setattr(self, self._meta.pk.attname, value)
 
     pk = property(_get_pk_val, _set_pk_val)

--- a/tests/model_inheritance_regress/tests.py
+++ b/tests/model_inheritance_regress/tests.py
@@ -10,10 +10,11 @@ from django.test import TestCase
 
 from .models import (
     ArticleWithAuthor, BachelorParty, BirthdayParty, BusStation, Child,
-    DerivedM, InternalCertificationAudit, ItalianRestaurant, M2MChild,
-    MessyBachelorParty, ParkingLot, ParkingLot3, ParkingLot4A, ParkingLot4B,
-    Person, Place, Profile, QualityControl, Restaurant, SelfRefChild,
-    SelfRefParent, Senator, Supplier, TrainStation, User, Wholesaler,
+    Congressman, DerivedM, InternalCertificationAudit, ItalianRestaurant,
+    M2MChild, MessyBachelorParty, ParkingLot, ParkingLot3, ParkingLot4A,
+    ParkingLot4B, Person, Place, Politician, Profile, QualityControl,
+    Restaurant, SelfRefChild, SelfRefParent, Senator, Supplier, TrainStation,
+    User, Wholesaler,
 )
 
 
@@ -558,3 +559,15 @@ class ModelInheritanceTest(TestCase):
         italian_restaurant.restaurant_ptr = None
         self.assertIsNone(italian_restaurant.pk)
         self.assertIsNone(italian_restaurant.id)
+
+    def test_create_new_instance_with_pk_equals_none(self):
+        c1 = Congressman.objects.create(state='PA', title='senator 1')
+        c2 = Politician.objects.get(pk=c1.pk).congressman
+        # Create a new congressman by setting pk = None.
+        c2.pk = None
+        c2.title = 'senator 2'
+        c2.save()
+        self.assertEqual(Congressman.objects.count(), 2)
+        # p1 remains unaffected.
+        p1 = Politician.objects.get(pk=c1.pk)
+        self.assertEqual(p1.title, 'senator 1')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29871