### PR TITLE
Improve the GeoIP test case stability

### DIFF
--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -127,26 +127,12 @@ class GeoIPTest(SimpleTestCase):
             self.assertEqual('Houston', d['city'])
             self.assertEqual('TX', d['region'])
             self.assertEqual('America/Chicago', d['time_zone'])
-
             geom = g.geos(query)
             self.assertIsInstance(geom, GEOSGeometry)
-            lon, lat = (-95.4010, 29.7079)
-            lat_lon = g.lat_lon(query)
-            lat_lon = (lat_lon[1], lat_lon[0])
-            for tup in (geom.tuple, g.coords(query), g.lon_lat(query), lat_lon):
-                self.assertAlmostEqual(lon, tup[0], 4)
-                self.assertAlmostEqual(lat, tup[1], 4)
 
-    @mock.patch('socket.gethostbyname')
-    def test05_unicode_response(self, gethostbyname):
-        "GeoIP strings should be properly encoded (#16553)."
-        gethostbyname.return_value = '194.27.42.76'
-        g = GeoIP2()
-        d = g.city('nigde.edu.tr')
-        self.assertEqual('Niğde', d['city'])
-        d = g.country('200.26.205.1')
-        # Some databases have only unaccented countries
-        self.assertIn(d['country_name'], ('Curaçao', 'Curacao'))
+            for e1, e2 in (geom.tuple, g.coords(query), g.lon_lat(query), g.lat_lon(query)):
+                self.assertIsInstance(e1, float)
+                self.assertIsInstance(e2, float)
 
     def test06_ipv6_query(self):
         "GeoIP can lookup IPv6 addresses."


### PR DESCRIPTION
According to Tim [here](https://github.com/orf/django-docker-box/issues/19) these tests are a pain point and often need fixing when the Maxmind database is updated on Jenkins.

In this PR I've removed the most flakey `test05_unicode_response` test. I believe this is not needed here, it was added 7 years ago and it seems to be testing [this line that no longer exists](https://github.com/django/django/commit/05e29716b4#diff-621f039c3c9707075898dc5614ec546dR61). We do not handle any encoding/decoding ourselves any more as far as I can see, and perhaps its safe to assume that the underlying `geoip2` library will not return bytes? If it does I think it's a bug in their code and not ours. 

Also with Python 3's Unicode changes it perhaps mitigates the need for this test even more.

Secondly I removed the explicit `GEOSGeometry` location check. I'm not sure if there is much point in testing the accuracy accuracy of Maxmind here, as long as it returns a `GEOSGeometry` object with a lat/long that is not 0 we can assume it works?

I left the others because they are testing wider areas and do not seem to fail.

I also renamed the tests to be more in line with the others by removing the numbering in the name, and added some `subTest`'s.

There is no ticket for this, I can create one if needed.