### PR TITLE
Ignored flake8 newly added W504 warning.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ install-script = scripts/rpm-install.sh
 
 [flake8]
 exclude = build,.git,.tox,./django/utils/six.py,./django/conf/app_template/*,./tests/.env
-ignore = W601
+ignore = W504,W601
 max-line-length = 119
 
 [isort]


### PR DESCRIPTION
Ignored `flake8` newly added `W504` warning.
Fixed F841 flake8 warnings in django/db/backends/postgresql/creation.py. 

`W504` is mutually exclusive with `W503` that we follow (see https://github.com/django/django/commit/2cd2d188516475ddf256e6267cd82c495fb5c430).