### PR TITLE
Fixed #29879 -- Added CSRF_COOKIE_HTTPONLY to CSRF AJAX docs.

### DIFF
--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -66,10 +66,13 @@ often easier because many JavaScript frameworks provide hooks that allow
 headers to be set on every request.
 
 First, you must get the CSRF token. How to do that depends on whether or not
-the :setting:`CSRF_USE_SESSIONS` setting is enabled.
+the :setting:`CSRF_USE_SESSIONS` and :setting:`CSRF_COOKIE_HTTPONLY` settings
+are enabled.
 
-Acquiring the token if :setting:`CSRF_USE_SESSIONS` is ``False``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _acquiring-csrf-token-from-cookie:
+
+Acquiring the token if :setting:`CSRF_USE_SESSIONS` and :setting:`CSRF_COOKIE_HTTPONLY` are ``False``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The recommended source for the token is the ``csrftoken`` cookie, which will be
 set if you've enabled CSRF protection for your views as outlined above.
@@ -122,11 +125,14 @@ The above code could be simplified by using the `JavaScript Cookie library
     Django provides a view decorator which forces setting of the cookie:
     :func:`~django.views.decorators.csrf.ensure_csrf_cookie`.
 
-Acquiring the token if :setting:`CSRF_USE_SESSIONS` is ``True``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _acquiring-csrf-token-from-html:
 
-If you activate :setting:`CSRF_USE_SESSIONS`, you must include the CSRF token
-in your HTML and read the token from the DOM with JavaScript:
+Acquiring the token if :setting:`CSRF_USE_SESSIONS` or :setting:`CSRF_COOKIE_HTTPONLY` is ``True``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you activate :setting:`CSRF_USE_SESSIONS` or
+:setting:`CSRF_COOKIE_HTTPONLY`, you must include the CSRF token in your HTML
+and read the token from the DOM with JavaScript:
 
 .. code-block:: html+django
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -335,8 +335,9 @@ Although the setting offers little practical benefit, it's sometimes required
 by security auditors.
 
 If you enable this and need to send the value of the CSRF token with an AJAX
-request, your JavaScript must pull the value from a hidden CSRF token form
-input on the page instead of from the cookie.
+request, your JavaScript must pull the value :ref:`from a hidden CSRF token
+form input <acquiring-csrf-token-from-html>` instead of :ref:`from the cookie
+<acquiring-csrf-token-from-cookie>`.
 
 See :setting:`SESSION_COOKIE_HTTPONLY` for details on ``HttpOnly``.
 


### PR DESCRIPTION
CSRF AJAX section didn't warn the users about CSRF_COOKIE_HTTPONLY setting
and so the csrf token value can't be fetched from the cookie as suggested
in the AJAX section. This commit adds the warning and updates the headings
for steps to follow if CSRF_COOKIE_HTTPONLY is enabled.