### PR TITLE
Fixed #29763 -- Added support for column renaming on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -4,6 +4,8 @@ from django.db import utils
 from django.db.backends.base.features import BaseDatabaseFeatures
 from django.utils.functional import cached_property
 
+from .base import Database
+
 
 class DatabaseFeatures(BaseDatabaseFeatures):
     # SQLite can read from a cursor since SQLite 3.6.5, subject to the caveat
@@ -32,6 +34,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_cast_with_precision = False
     time_cast_precision = 3
     can_release_savepoints = True
+    # Is "ALTER TABLE ... RENAME COLUMN" supported?
+    can_alter_table_rename_column = Database.sqlite_version_info >= (3, 25, 0)
 
     @cached_property
     def supports_stddev(self):


### PR DESCRIPTION
It is feasible to use RENAME COLUMN instead of remaking the table and copying the data over for SQLite >= 3.25. Keeping the remake solution for older versions and for when the RENAME COLUMN statement isn't enough. I have implemented one way of doing it.

To test this in the CI I suggest adding a test environment with SQLite 3.25. Then we will be testing both the new and the old way making sure no new changes break it.

https://code.djangoproject.com/ticket/29763