### PR TITLE
Made DatabaseFeatures.uses_savepoints default to True. 

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -26,7 +26,7 @@ class BaseDatabaseFeatures:
     can_return_id_from_insert = False
     can_return_ids_from_bulk_insert = False
     has_bulk_insert = True
-    uses_savepoints = False
+    uses_savepoints = True
     can_release_savepoints = False
 
     # If True, don't use integer foreign keys referring to, e.g., positive

--- a/django/db/backends/dummy/features.py
+++ b/django/db/backends/dummy/features.py
@@ -3,3 +3,4 @@ from django.db.backends.base.features import BaseDatabaseFeatures
 
 class DummyDatabaseFeatures(BaseDatabaseFeatures):
     supports_transactions = False
+    uses_savepoints = False

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -23,7 +23,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_timezones = False
     requires_explicit_null_ordering_when_grouping = True
     allows_auto_pk_0 = False
-    uses_savepoints = True
     can_release_savepoints = True
     atomic_transactions = False
     supports_column_check_constraints = False

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -5,7 +5,6 @@ from django.utils.functional import cached_property
 
 class DatabaseFeatures(BaseDatabaseFeatures):
     interprets_empty_strings_as_nulls = True
-    uses_savepoints = True
     has_select_for_update = True
     has_select_for_update_nowait = True
     has_select_for_update_skip_locked = True

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -14,7 +14,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_select_for_update = True
     has_select_for_update_nowait = True
     has_select_for_update_of = True
-    uses_savepoints = True
     can_release_savepoints = True
     supports_tablespaces = True
     supports_transactions = True

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -227,16 +227,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             BaseDatabaseWrapper.close(self)
 
     def _savepoint_allowed(self):
-        # Two conditions are required here:
-        # - A sufficiently recent version of SQLite to support savepoints,
-        # - Being in a transaction, which can only happen inside 'atomic'.
-
         # When 'isolation_level' is not None, sqlite3 commits before each
         # savepoint; it's a bug. When it is None, savepoints don't make sense
         # because autocommit is enabled. The only exception is inside 'atomic'
         # blocks. To work around that bug, on SQLite, 'atomic' starts a
         # transaction explicitly rather than simply disable autocommit.
-        return self.features.uses_savepoints and self.in_atomic_block
+        return self.in_atomic_block
 
     def _set_autocommit(self, autocommit):
         if autocommit:

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -29,7 +29,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     ignores_table_name_case = True
     supports_cast_with_precision = False
     time_cast_precision = 3
-    uses_savepoints = True
     can_release_savepoints = True
 
     @cached_property

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -283,6 +283,8 @@ Database backend API
   ``DurationField`` or set ``DatabaseFeatures.can_introspect_duration_field``
   to ``False``.
 
+* ``DatabaseFeatures.uses_savepoints`` now defaults to ``True``.
+
 :mod:`django.contrib.gis`
 -------------------------
 


### PR DESCRIPTION
Removed useless check in sqlite's DatabaseWrapper._savepoint_allowed().
Obsolete since 27193ae.