### PR TITLE
Completed test coverage of views.defaults.bad_request().

### DIFF
--- a/tests/view_tests/tests/test_defaults.py
+++ b/tests/view_tests/tests/test_defaults.py
@@ -72,6 +72,13 @@ class DefaultsTests(TestCase):
         response = self.client.get('/server_error/')
         self.assertEqual(response.status_code, 500)
 
+    def test_bad_request(self):
+        rf = RequestFactory()
+        request = rf.get('/')
+        response = bad_request(request, Exception())
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content, b'<h1>Bad Request (400)</h1>')
+
     @override_settings(TEMPLATES=[{
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'OPTIONS': {


### PR DESCRIPTION
cover line [94 of view/defaults.py](https://github.com/django/django/blob/76b3367035889d87ffef7a52cd44d70e30537f6f/django/views/defaults.py#L94). 