### PR TITLE
Avoid calling complex_filters when limit_choices_to is empty

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -96,7 +96,7 @@ def apply_limit_choices_to_to_formfield(formfield):
     """Apply limit_choices_to to the formfield's queryset if needed."""
     if hasattr(formfield, 'queryset') and hasattr(formfield, 'get_limit_choices_to'):
         limit_choices_to = formfield.get_limit_choices_to()
-        if limit_choices_to is not None:
+        if limit_choices_to:
             formfield.queryset = formfield.queryset.complex_filter(limit_choices_to)
 
 


### PR DESCRIPTION
The if condition always evaluated to True by default, when no limit_choices_to option has been passed at all, because it is an empty dict `{}` by default.

Fixes the following traceback when using a lookupy QuerySet instead of a django QuerySet:

```


File "/home/jpic/.local/lib/python3.7/site-packages/django/core/handlers/exception.py" in inner
  34.             response = get_response(request)

File "/home/jpic/.local/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
  126.                 response = self.process_exception_by_middleware(e, request)

File "/home/jpic/.local/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
  124.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/home/jpic/.local/lib/python3.7/site-packages/django/views/generic/base.py" in view
  68.             return self.dispatch(request, *args, **kwargs)

File "/home/jpic/src/crudlfap/src/crudlfap/route.py" in dispatch
  185.         return super().dispatch(request, *args, **kwargs)

File "/home/jpic/.local/lib/python3.7/site-packages/django/views/generic/base.py" in dispatch
  88.         return handler(request, *args, **kwargs)

File "/home/jpic/src/crudlfap/src/crudlfap/mixins/template.py" in get
  18.         return self.render_to_response()

File "/home/jpic/src/crudlfap/src/crudlfap/mixins/template.py" in render_to_response
  30.             context=self.context,

File "/home/jpic/src/crudlfap/src/crudlfap/factory.py" in __getattr__
  28.             methresult = getter()

File "/home/jpic/src/crudlfap/src/crudlfap/mixins/object.py" in get_context
  19.         return super().get_context(**context)

File "/home/jpic/src/crudlfap/src/crudlfap/mixins/form.py" in get_context
  13.         context['form'] = self.form

File "/home/jpic/src/crudlfap/src/crudlfap/factory.py" in __getattr__
  28.             methresult = getter()

File "/home/jpic/src/crudlfap/src/crudlfap/mixins/modelform.py" in get_form
  23.         self.form = self.form_class(**self.form_kwargs)

File "/home/jpic/.local/lib/python3.7/site-packages/django/forms/models.py" in __init__
  306.             apply_limit_choices_to_to_formfield(formfield)

File "/home/jpic/.local/lib/python3.7/site-packages/django/forms/models.py" in apply_limit_choices_to_to_formfield
  100.             formfield.queryset = formfield.queryset.complex_filter(limit_choices_to)

Exception Type: AttributeError at /url/UserUpdateView/permission
Exception Value: 'QuerySet' object has no attribute 'complex_filter'
```

Request for comments