### PR TITLE
Fixed #29882 - add --routines when cloning mysql

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -194,6 +194,7 @@ answer newbie questions, and generally made Django that much better:
     dackze+django@gmail.com
     Dagur Páll Ammendrup <dagurp@gmail.com>
     Dane Springmeyer
+    Dan Davis <dan@danizen.net>
     Dan Fairs <dan@fezconsulting.com>
     Daniel Alves Barbosa de Oliveira Vaz <danielvaz@gmail.com>
     Daniel Duan <DaNmarner@gmail.com>

--- a/django/db/backends/mysql/creation.py
+++ b/django/db/backends/mysql/creation.py
@@ -57,6 +57,7 @@ class DatabaseCreation(BaseDatabaseCreation):
     def _clone_db(self, source_database_name, target_database_name):
         dump_cmd = DatabaseClient.settings_to_cmd_args(self.connection.settings_dict)
         dump_cmd[0] = 'mysqldump'
+        dump_cmd[-2] = '--routines'
         dump_cmd[-1] = source_database_name
         load_cmd = DatabaseClient.settings_to_cmd_args(self.connection.settings_dict)
         load_cmd[-1] = target_database_name


### PR DESCRIPTION
- Added '--routines' to mysqldump when cloning for parallel test run.
- No tests provided as mysqldump is external.
- Ticket #29882 has a reference to a repository that reproduced issue and shows it is fixed.