### PR TITLE
Let's use a newer string formatting syntax.

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -68,14 +68,14 @@ slightly different, because they take an argument:
     :caption: polls/views.py
 
     def detail(request, question_id):
-        return HttpResponse("You're looking at question %s." % question_id)
+        return HttpResponse("You're looking at question {}.".format(question_id))
 
     def results(request, question_id):
-        response = "You're looking at the results of question %s."
-        return HttpResponse(response % question_id)
+        response = "You're looking at the results of question {}."
+        return HttpResponse(response.format(question_id))
 
     def vote(request, question_id):
-        return HttpResponse("You're voting on question %s." % question_id)
+        return HttpResponse("You're voting on question {}.".format(question_id))
 
 Wire these new views into the ``polls.urls`` module by adding the following
 :func:`~django.urls.path` calls:


### PR DESCRIPTION
I would like to use f-strings here, but tutorial01.txt indicates we're
compatible with Python 3.5. Braces without a number has been
introduced in Python 3.1.