### PR TITLE
Fixed #29908 -- Fixed setting of foreign key after related set access if ForeignKey uses to_field.

### DIFF
--- a/tests/many_to_one/models.py
+++ b/tests/many_to_one/models.py
@@ -71,7 +71,7 @@ class Child(models.Model):
 
 
 class ToFieldChild(models.Model):
-    parent = models.ForeignKey(Parent, models.CASCADE, to_field='name')
+    parent = models.ForeignKey(Parent, models.CASCADE, to_field='name', related_name='to_field_children')
 
 
 # Multiple paths to the same model (#7110, #7125)

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -672,3 +672,10 @@ class ManyToOneTests(TestCase):
         child = ToFieldChild.objects.create(parent=parent)
         with self.assertNumQueries(0):
             self.assertIs(child.parent, parent)
+
+    def test_reverse_foreign_key_instance_to_field_caching(self):
+        parent = Parent.objects.create(name='a')
+        ToFieldChild.objects.create(parent=parent)
+        child = parent.to_field_children.get()
+        with self.assertNumQueries(0):
+            self.assertIs(child.parent, parent)


### PR DESCRIPTION
Thanks Carsten Fuchs for the report.

https://code.djangoproject.com/ticket/29908

This unveiled an issue with `ForeignObject` as well where related managers were causing extra queries.