### PR TITLE
Fixed 29918: Added support for object permissions in PermissionRequiredMixin

### DIFF
--- a/django/contrib/auth/mixins.py
+++ b/django/contrib/auth/mixins.py
@@ -72,12 +72,16 @@ class PermissionRequiredMixin(AccessMixin):
             perms = self.permission_required
         return perms
 
+    def get_permission_object(self):
+        return None
+
     def has_permission(self):
         """
         Override this method to customize the way permissions are checked.
         """
         perms = self.get_permission_required()
-        return self.request.user.has_perms(perms)
+        permission_object = self.get_permission_object()
+        return self.request.user.has_perms(perms, obj=permission_object)
 
     def dispatch(self, request, *args, **kwargs):
         if not self.has_permission():

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -53,7 +53,9 @@ Minor features
 :mod:`django.contrib.auth`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The new ``get_permission_object()`` method on
+  :class:`~django.contrib.auth.mixins.PermissionRequiredMixin` allows
+  checking object permissions.
 
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -255,6 +255,8 @@ authenticated users do not.
 Do not forget to test for the ``is_active`` attribute of the user in your own
 backend permission methods.
 
+.. _object_permissions:
+
 Handling object permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -754,12 +754,20 @@ To apply permission checks to :doc:`class-based views
         the ``permission_required`` attribute, converted to a tuple if
         necessary.
 
+    .. method:: get_permission_object()
+
+        .. versionadded:: 2.2
+
+        Returns the object that is used for checking :ref:`object permissions
+        <object_permissions>`. Defaults to ``None``.
+
     .. method:: has_permission()
 
         Returns a boolean denoting whether the current user has permission to
         execute the decorated view. By default, this returns the result of
         calling :meth:`~django.contrib.auth.models.User.has_perms()` with the
-        list of permissions returned by :meth:`get_permission_required()`.
+        list of permissions returned by :meth:`get_permission_required()` and
+        the object returned by :meth:`get_permission_object()`.
 
 Redirecting unauthorized requests in class-based views
 ------------------------------------------------------


### PR DESCRIPTION
Currently, external apps have to ship their own mixin because the default one does not support object permissions. This PR adds a method `get_permission_object()`. This is what django-guardian
does. However, here it returns None by default for backwards compatibility (In django-guardian it falls back to `get_object()`).