### PR TITLE
Fixed #29919 -- Fixed RelatedOnlyFieldListFilter crash with reverse relationships.

### DIFF
--- a/django/db/models/fields/reverse_related.py
+++ b/django/db/models/fields/reverse_related.py
@@ -114,7 +114,10 @@ class ForeignObjectRel(FieldCacheMixin):
             self.related_model._meta.model_name,
         )
 
-    def get_choices(self, include_blank=True, blank_choice=BLANK_CHOICE_DASH, ordering=()):
+    def get_choices(
+        self, include_blank=True, blank_choice=BLANK_CHOICE_DASH,
+        limit_choices_to=None, ordering=(),
+    ):
         """
         Return choices with a default blank choices included, for use
         as <select> choices for this field.
@@ -122,7 +125,8 @@ class ForeignObjectRel(FieldCacheMixin):
         Analog of django.db.models.fields.Field.get_choices(), provided
         initially for utilization by RelatedFieldListFilter.
         """
-        qs = self.related_model._default_manager.all()
+        limit_choices_to = limit_choices_to or self.limit_choices_to
+        qs = self.related_model._default_manager.complex_filter(limit_choices_to)
         if ordering:
             qs = qs.order_by(*ordering)
         return (blank_choice if include_blank else []) + [

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -266,3 +266,26 @@ class GetChoicesOrderingTests(TestCase):
             self.field.remote_field.get_choices(include_blank=False),
             [self.bar2, self.bar1]
         )
+
+
+class GetChoicesLimitChoicesToTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.foo1 = Foo.objects.create(a='a', d='12.34')
+        cls.foo2 = Foo.objects.create(a='b', d='12.34')
+        cls.bar1 = Bar.objects.create(a=cls.foo1, b='b')
+        cls.bar2 = Bar.objects.create(a=cls.foo2, b='a')
+        cls.field = Bar._meta.get_field('a')
+
+    def assertChoicesEqual(self, choices, objs):
+        self.assertEqual(choices, [(obj.pk, str(obj)) for obj in objs])
+
+    def test_get_choices(self):
+        self.assertChoicesEqual(
+            self.field.get_choices(include_blank=False, limit_choices_to={'a': 'a'}),
+            [self.foo1],
+        )
+        self.assertChoicesEqual(
+            self.field.get_choices(include_blank=False, limit_choices_to={}),
+            [self.foo1, self.foo2],
+        )

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -289,3 +289,14 @@ class GetChoicesLimitChoicesToTests(TestCase):
             self.field.get_choices(include_blank=False, limit_choices_to={}),
             [self.foo1, self.foo2],
         )
+
+    def test_get_choices_reverse_related_field(self):
+        field = self.field.remote_field
+        self.assertChoicesEqual(
+            field.get_choices(include_blank=False, limit_choices_to={'b': 'b'}),
+            [self.bar1],
+        )
+        self.assertChoicesEqual(
+            field.get_choices(include_blank=False, limit_choices_to={}),
+            [self.bar1, self.bar2],
+        )


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29919