### PR TITLE
Fixed #29917 — Adjusted MRO collection of ModelAdmin.actions.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -863,7 +863,8 @@ class ModelAdmin(BaseModelAdmin):
         # Then gather them from the model admin and all parent classes,
         # starting with self and working back up.
         for klass in self.__class__.mro()[::-1]:
-            class_actions = getattr(klass, 'actions', []) or []
+            # Access __dict__ directly to avoid walking MRO twice.
+            class_actions = klass.__dict__.get('actions', []) or []
             actions.extend(self.get_action(action) for action in class_actions)
 
         # get_action might have returned None, so filter any of those out.

--- a/tests/modeladmin/test_actions.py
+++ b/tests/modeladmin/test_actions.py
@@ -55,3 +55,27 @@ class AdminActionsTests(TestCase):
                 mock_request.user = user
                 actions = ma.get_actions(mock_request)
                 self.assertEqual(list(actions.keys()), expected)
+
+    def test_actions_mro(self):
+        class AdminBase(admin.ModelAdmin):
+            actions = ['base_action']
+
+            def base_action(modeladmin, request, queryset):
+                pass
+
+        class NoCustomAction(AdminBase):
+            pass
+
+        class WithCustomAction(AdminBase):
+            actions = ['custom_action']
+
+            def custom_action(modeladmin, request, queryset):
+                pass
+
+        ma = NoCustomAction(Band, admin.AdminSite())
+        action_names = [a[1] for a in ma._get_base_actions()]
+        self.assertEqual(action_names, ['delete_selected', 'base_action'])
+
+        ma = WithCustomAction(Band, admin.AdminSite())
+        action_names = [a[1] for a in ma._get_base_actions()]
+        self.assertEqual(action_names, ['delete_selected', 'base_action', 'custom_action'])


### PR DESCRIPTION
BC alternative for #10603. 

Adds test case for failure from https://code.djangoproject.com/ticket/29917 plus prior/existing behaviour. 

This behaviour has been untouched since https://github.com/django/django/commit/bb15cee58a43eeb0d060f8a31f9078b3406f195a, which was some time ago. 