### PR TITLE
Fixed keep-alive support in manage.py runserver.

### DIFF
--- a/tests/servers/urls.py
+++ b/tests/servers/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     url(r'^example_view/$', views.example_view),
+    url(r'^streaming_example_view/$', views.streaming_example_view),
     url(r'^model_view/$', views.model_view),
     url(r'^create_model_instance/$', views.create_model_instance),
     url(r'^environ_view/$', views.environ_view),

--- a/tests/servers/views.py
+++ b/tests/servers/views.py
@@ -1,12 +1,16 @@
 from urllib.request import urlopen
 
-from django.http import HttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 
 from .models import Person
 
 
 def example_view(request):
     return HttpResponse('example view')
+
+
+def streaming_example_view(request):
+    return StreamingHttpResponse((b'I', b'am', b'a', b'stream'))
 
 
 def model_view(request):


### PR DESCRIPTION
Ticket #25619 changed the default protocol to HTTP/1.1 but did not
properly implement keep-alive. As a "fix" keep-alive was disabled in
ticket #28440 to prevent clients from hanging (they expect the server to
send more data if the connection is not closed and there is no content
length set).

The combination of those two fixes resulted in yet another problem:
HTTP/1.1 by default allows a client to assume that keep-alive is
supported unless the server disables it via 'Connection: close' -- see
RFC2616 8.1.2.1 for details on persistent connection negotiation. Now if
the client receives a response from Django without 'Connection: close'
and immediately sends a new request (on the same tcp connection) before
our server closes the tcp connection, it will error out at some point
because the connection does get closed a few milli seconds later.

This patch fixes the mentioned issues by always sending 'Connection:
close' if we cannot determine a content length. The code is inefficient
in the sense that it does not allow for persistent connections when
chunked responses are used, but that should not really cause any
problems (Django does not generate those) and it only affects the
development server anyways.