### PR TITLE
Refs #29926 -- Removed usage of gettext.translation()'s deprecated codeset parameter.

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -120,7 +120,6 @@ class DjangoTranslation(gettext_module.GNUTranslations):
             domain=self.domain,
             localedir=localedir,
             languages=[self.__locale],
-            codeset='utf-8',
             fallback=use_null_fallback,
         )
 


### PR DESCRIPTION
https://bugs.python.org/issue33710