### PR TITLE
Allow user-defined related_name customization

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -285,6 +285,19 @@ class RelatedField(FieldCacheMixin, Field):
         # columns from another table.
         return None
 
+    def get_related_name_replacements(self, cls):
+        return {
+            'class': cls.__name__.lower(),
+            'model_name': cls._meta.model_name.lower(),
+            'app_label': cls._meta.app_label.lower()
+        }
+
+    def get_related_query_name_replacements(self, cls):
+        return {
+            'class': cls.__name__.lower(),
+            'app_label': cls._meta.app_label.lower(),
+        }
+
     def contribute_to_class(self, cls, name, private_only=False, **kwargs):
 
         super().contribute_to_class(cls, name, private_only=private_only, **kwargs)
@@ -297,18 +310,11 @@ class RelatedField(FieldCacheMixin, Field):
             else:
                 related_name = self.opts.default_related_name
             if related_name:
-                related_name = related_name % {
-                    'class': cls.__name__.lower(),
-                    'model_name': cls._meta.model_name.lower(),
-                    'app_label': cls._meta.app_label.lower()
-                }
+                related_name = related_name % cls.get_related_name_replacements(cls)
                 self.remote_field.related_name = related_name
 
             if self.remote_field.related_query_name:
-                related_query_name = self.remote_field.related_query_name % {
-                    'class': cls.__name__.lower(),
-                    'app_label': cls._meta.app_label.lower(),
-                }
+                related_query_name = self.remote_field.related_query_name % cls.get_related_query_name_replacements(cls)
                 self.remote_field.related_query_name = related_query_name
 
             def resolve_related_class(model, related, field):


### PR DESCRIPTION
This will allow devs to override the `get_related_name_replacements` or `get_related_query_name_replacements` method(s) on `ForeignKey` to specify custom variables to be used in the generation of the `related_name`/`related_query_name`.

For example...
```python
from django.db import models


class ShortRelatedKey(models.ForeignKey):
    def get_related_name_replacements(self, cls):
        replacements = super().get_related_name_replacements(cls)
        replacements.update({
            'short_name': cls.short_name
        })
        return replacements

"this example is kinda dumb, but this change has good uses"


class CrayonBox(models.Model):
    pass


class CrayonColor(models.Model):
    category = ShortRelatedKey(CrayonBox, related_name="%(short_name)s")

    class Meta:
        abstract = True


class CoolCrayonColors(CrayonColor):
    short_name = 'cools'


class WarmCrayonColors(CrayonColor):
    short_name = 'hots'
```