### PR TITLE
Added code example for generic editing with AJAX

### DIFF
--- a/docs/topics/class-based-views/generic-editing.txt
+++ b/docs/topics/class-based-views/generic-editing.txt
@@ -238,6 +238,12 @@ works for AJAX requests as well as 'normal' form POSTs::
         Mixin to add AJAX support to a form.
         Must be used with an object-based FormView (e.g. CreateView)
         """
+        def get_success_url(self):
+            if self.request.is_ajax():
+                return None
+            else:
+                return super().get_success_url()
+
         def form_invalid(self, form):
             response = super().form_invalid(form)
             if self.request.is_ajax():


### PR DESCRIPTION
An object-based FormView required redirect URL even if some models don't need them. (e. g. Comment)
If the method `get_absolute_url` or `get_success_url` doesn't exist, an `ImproperlyConfigured` error occurred, and the AJAX request fails to get a response from the server.
So define method `get_success_url` in Mixin, if the request is AJAX, return None to avoid error and if not return parent's `get_success_url`.