### PR TITLE
Fixed #29939 -- Increased Group.name max_length to 150 characters.

### DIFF
--- a/django/contrib/auth/migrations/0010_alter_group_name_max_length.py
+++ b/django/contrib/auth/migrations/0010_alter_group_name_max_length.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0009_alter_user_last_name_max_length'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='group',
+            name='name',
+            field=models.CharField(max_length=150, unique=True, verbose_name='name'),
+        ),
+    ]

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -108,7 +108,7 @@ class Group(models.Model):
     members-only portion of your site, or sending them members-only email
     messages.
     """
-    name = models.CharField(_('name'), max_length=80, unique=True)
+    name = models.CharField(_('name'), max_length=150, unique=True)
     permissions = models.ManyToManyField(
         Permission,
         verbose_name=_('permissions'),

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -382,8 +382,12 @@ Fields
 
     .. attribute:: name
 
-        Required. 80 characters or fewer. Any characters are permitted. Example:
-        ``'Awesome Users'``.
+        Required. 150 characters or fewer. Any characters are permitted.
+        Example: ``'Awesome Users'``.
+
+        .. versionchanged:: 2.2
+
+             The ``max_length`` increased from 80 to 150 characters.
 
     .. attribute:: permissions
 

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -384,6 +384,8 @@ Miscellaneous
   renders ``<option>`` values of ``unknown``, ``true``, and ``false`` instead
   of ``1``, ``2``, and ``3``. For backwards compatibility, the old values are
   still accepted as data.
+* :attr:`Group.name <django.contrib.auth.models.Group.name>` ``max_length``
+  is increased from 80 to 150 characters.
 
 .. _deprecated-features-2.2:
 


### PR DESCRIPTION
This PR increases the max_length of `django.contrib.auth` model `Group` field `name` to 191, to match recent changes to `username`, `first_name`, and `last_name` in the `User` model. ([Ticket](https://code.djangoproject.com/ticket/29939))