### PR TITLE
Fixed #29929 -- Fixed admin view-only change form crash when using ModelAdmin.prepopulated_fields.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1585,7 +1585,8 @@ class ModelAdmin(BaseModelAdmin):
         adminForm = helpers.AdminForm(
             form,
             list(self.get_fieldsets(request, obj)),
-            self.get_prepopulated_fields(request, obj),
+            # Clear prepopulated fields on a view-only form to avoid a crash.
+            self.get_prepopulated_fields(request, obj) if add or self.has_change_permission(request, obj) else {},
             readonly_fields,
             model_admin=self)
         media = self.media + adminForm.media

--- a/docs/releases/2.1.4.txt
+++ b/docs/releases/2.1.4.txt
@@ -19,3 +19,6 @@ Bugfixes
 
 * Fixed keep-alive support in ``runserver`` after it was disabled to fix
   another issue in Django 2.0 (:ticket:`29849`).
+
+* Fixed admin view-only change form crash when using
+  ``ModelAdmin.prepopulated_fields`` (:ticket:`29929`).

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -459,6 +459,13 @@ class PrePopulatedPostAdmin(admin.ModelAdmin):
         return self.prepopulated_fields
 
 
+class PrePopulatedPostReadOnlyAdmin(admin.ModelAdmin):
+    prepopulated_fields = {'slug': ('title',)}
+
+    def has_change_permission(self, *args, **kwargs):
+        return False
+
+
 class PostAdmin(admin.ModelAdmin):
     list_display = ['title', 'public']
     readonly_fields = (
@@ -1085,6 +1092,7 @@ site2.register(Person, save_as_continue=False)
 site7 = admin.AdminSite(name="admin7")
 site7.register(Article, ArticleAdmin2)
 site7.register(Section)
+site7.register(PrePopulatedPost, PrePopulatedPostReadOnlyAdmin)
 
 
 # Used to test ModelAdmin.sortable_by and get_sortable_by().

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4211,6 +4211,25 @@ class PrePopulatedTest(TestCase):
         response = self.client.get(reverse('admin:admin_views_prepopulatedpostlargeslug_add'))
         self.assertContains(response, "&quot;maxLength&quot;: 1000")  # instead of 1,000
 
+    def test_view_only_add_form(self):
+        """
+        PrePopulatedPostReadOnlyAdmin.prepopulated_fields includes 'slug'
+        which is present in the add view, even if the
+        ModelAdmin.has_change_permission() returns False.
+        """
+        response = self.client.get(reverse('admin7:admin_views_prepopulatedpost_add'))
+        self.assertContains(response, 'data-prepopulated-fields=')
+        self.assertContains(response, '&quot;id&quot;: &quot;#id_slug&quot;')
+
+    def test_view_only_change_form(self):
+        """
+        PrePopulatedPostReadOnlyAdmin.prepopulated_fields includes 'slug'. That
+        doesn't break a view-only change view.
+        """
+        response = self.client.get(reverse('admin7:admin_views_prepopulatedpost_change', args=(self.p1.pk,)))
+        self.assertContains(response, 'data-prepopulated-fields="[]"')
+        self.assertContains(response, '<div class="readonly">%s</div>' % self.p1.slug)
+
 
 @override_settings(ROOT_URLCONF='admin_views.urls')
 class SeleniumTests(AdminSeleniumTestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29929