### PR TITLE
Fixed #29936 -- Improved font customization in the admin

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -2,8 +2,6 @@
     DJANGO Admin styles
 */
 
-@import url(fonts.css);
-
 body {
     margin: 0;
     padding: 0;

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -3,6 +3,7 @@
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>
 <title>{% block title %}{% endblock %}</title>
+{% block adminfonts %}<link rel="stylesheet" type="text/css" href="{% static "admin/css/fonts.css" %}">{% endblock %}
 <link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
 {% block extrastyle %}{% endblock %}
 {% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}">{% endif %}


### PR DESCRIPTION
Removed the hardcoded `@import 'fonts.css';` rule in the admin’s `base.css` and substituted with a `<link>` element within a new, extendable block named `adminfonts` inside the admin’s `base.html` builtin template. The result is that custom admin templates can skip the loading of the built-in admin fonts altogether and keep overriding / extending the base CSS via the `extrastyle` block.