### PR TITLE
Fixed #29915 -- Added support for values with hyphens to pattern lookups for UUIDField on backends without UUID datatype.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1304,6 +1304,13 @@ it is recommended to use :attr:`~Field.default`::
 Note that a callable (with the parentheses omitted) is passed to ``default``,
 not an instance of ``UUID``.
 
+.. admonition:: Lookups on PostgreSQL
+
+    Using :lookup:`iexact`, :lookup:`contains`, :lookup:`icontains`,
+    :lookup:`startswith`, :lookup:`istartswith`, :lookup:`endswith`, or
+    :lookup:`iendswith` lookups on PostgreSQL don't work for values without
+    hyphens, because PostgreSQL stores them in a hyphenated uuid datatype type.
+
 Relationship fields
 ===================
 

--- a/tests/model_fields/test_uuid.py
+++ b/tests/model_fields/test_uuid.py
@@ -2,7 +2,9 @@ import json
 import uuid
 
 from django.core import exceptions, serializers
-from django.db import IntegrityError, models
+from django.db import IntegrityError, connection, models
+from django.db.models import CharField, F, Value
+from django.db.models.functions import Concat
 from django.test import (
     SimpleTestCase, TestCase, TransactionTestCase, skipUnlessDBFeature,
 )
@@ -90,16 +92,84 @@ class TestQuerying(TestCase):
             NullableUUIDModel.objects.create(field=None),
         ]
 
+    def assertSequenceEqualWithoutHyphens(self, qs, result):
+        """
+        Backends with a native datatype for UUID don't support fragment lookups
+        without hyphens because they store values with them.
+        """
+        self.assertSequenceEqual(
+            qs,
+            [] if connection.features.has_native_uuid_field else result,
+        )
+
     def test_exact(self):
         self.assertSequenceEqual(
             NullableUUIDModel.objects.filter(field__exact='550e8400e29b41d4a716446655440000'),
             [self.objs[1]]
+        )
+        self.assertSequenceEqual(
+            NullableUUIDModel.objects.filter(
+                field__exact='550e8400-e29b-41d4-a716-446655440000'
+            ),
+            [self.objs[1]],
+        )
+
+    def test_iexact(self):
+        self.assertSequenceEqualWithoutHyphens(
+            NullableUUIDModel.objects.filter(
+                field__iexact='550E8400E29B41D4A716446655440000'
+            ),
+            [self.objs[1]],
         )
 
     def test_isnull(self):
         self.assertSequenceEqual(
             NullableUUIDModel.objects.filter(field__isnull=True),
             [self.objs[2]]
+        )
+
+    def test_contains(self):
+        self.assertSequenceEqualWithoutHyphens(
+            NullableUUIDModel.objects.filter(field__contains='8400e29b'),
+            [self.objs[1]],
+        )
+
+    def test_icontains(self):
+        self.assertSequenceEqualWithoutHyphens(
+            NullableUUIDModel.objects.filter(field__icontains='8400E29B'),
+            [self.objs[1]],
+        )
+
+    def test_startswith(self):
+        self.assertSequenceEqualWithoutHyphens(
+            NullableUUIDModel.objects.filter(field__startswith='550e8400e29b4'),
+            [self.objs[1]],
+        )
+
+    def test_istartswith(self):
+        self.assertSequenceEqualWithoutHyphens(
+            NullableUUIDModel.objects.filter(field__istartswith='550E8400E29B4'),
+            [self.objs[1]],
+        )
+
+    def test_endswith(self):
+        self.assertSequenceEqualWithoutHyphens(
+            NullableUUIDModel.objects.filter(field__endswith='a716446655440000'),
+            [self.objs[1]],
+        )
+
+    def test_iendswith(self):
+        self.assertSequenceEqualWithoutHyphens(
+            NullableUUIDModel.objects.filter(field__iendswith='A716446655440000'),
+            [self.objs[1]],
+        )
+
+    def test_filter_with_expr(self):
+        self.assertSequenceEqualWithoutHyphens(
+            NullableUUIDModel.objects.annotate(
+                value=Concat(Value('8400'), Value('e29b'), output_field=CharField()),
+            ).filter(field__contains=F('value')),
+            [self.objs[1]],
         )
 
 


### PR DESCRIPTION
Support hyphens in `iexact`, `contains`, `icontains`, `startswith`, `istartswith`, `endswith` and `iendswith` `UUIDField` filters.