### PR TITLE
Fixed #29949 -- Refactored db introspection identifiers converters.

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -295,7 +295,7 @@ class Command(BaseCommand):
 
         def model_installed(model):
             opts = model._meta
-            converter = connection.introspection.table_name_converter
+            converter = connection.introspection.identifier_converter
             return not (
                 (converter(opts.db_table) in tables) or
                 (opts.auto_created and converter(opts.auto_created._meta.db_table) in tables)

--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -200,8 +200,6 @@ class BaseDatabaseFeatures:
     # If NULL is implied on columns without needing to be explicitly specified
     implied_column_null = False
 
-    uppercases_column_names = False
-
     # Does the backend support "select for update" queries with limit (and offset)?
     supports_select_for_update_with_limit = True
 

--- a/django/db/backends/base/introspection.py
+++ b/django/db/backends/base/introspection.py
@@ -24,21 +24,13 @@ class BaseDatabaseIntrospection:
         """
         return self.data_types_reverse[data_type]
 
-    def table_name_converter(self, name):
+    def identifier_converter(self, name):
         """
-        Apply a conversion to the name for the purposes of comparison.
+        Apply a conversion to the identifier for the purposes of comparison.
 
-        The default table name converter is for case sensitive comparison.
+        The default identifier converter is for case sensitive comparison.
         """
         return name
-
-    def column_name_converter(self, name):
-        """
-        Apply a conversion to the column name for the purposes of comparison.
-
-        Use table_name_converter() by default.
-        """
-        return self.table_name_converter(name)
 
     def table_names(self, cursor=None, include_views=False):
         """
@@ -83,11 +75,11 @@ class BaseDatabaseIntrospection:
                 )
         tables = list(tables)
         if only_existing:
-            existing_tables = self.table_names(include_views=include_views)
+            existing_tables = set(self.table_names(include_views=include_views))
             tables = [
                 t
                 for t in tables
-                if self.table_name_converter(t) in existing_tables
+                if self.identifier_converter(t) in existing_tables
             ]
         return tables
 
@@ -101,10 +93,10 @@ class BaseDatabaseIntrospection:
         all_models = []
         for app_config in apps.get_app_configs():
             all_models.extend(router.get_migratable_models(app_config, self.connection.alias))
-        tables = list(map(self.table_name_converter, tables))
+        tables = set(map(self.identifier_converter, tables))
         return {
             m for m in all_models
-            if self.table_name_converter(m._meta.db_table) in tables
+            if self.identifier_converter(m._meta.db_table) in tables
         }
 
     def sequence_list(self):

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1047,7 +1047,7 @@ class BaseDatabaseSchemaEditor:
         """Return all constraint names matching the columns and conditions."""
         if column_names is not None:
             column_names = [
-                self.connection.introspection.column_name_converter(name)
+                self.connection.introspection.identifier_converter(name)
                 for name in column_names
             ]
         with self.connection.cursor() as cursor:

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -28,7 +28,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     requires_literal_defaults = True
     closed_cursor_error_class = InterfaceError
     bare_select_suffix = " FROM DUAL"
-    uppercases_column_names = True
     # select for update with limit can be achieved on Oracle, but not with the current backend.
     supports_select_for_update_with_limit = False
     supports_temporal_subtraction = True

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1346,7 +1346,7 @@ class RawQuerySet:
 
     def resolve_model_init_order(self):
         """Resolve the init field names and value positions."""
-        converter = connections[self.db].introspection.column_name_converter
+        converter = connections[self.db].introspection.identifier_converter
         model_init_fields = [f for f in self.model._meta.fields if converter(f.column) in self.columns]
         annotation_fields = [(column, pos) for pos, column in enumerate(self.columns)
                              if column not in self.model_fields]
@@ -1468,7 +1468,7 @@ class RawQuerySet:
     @cached_property
     def model_fields(self):
         """A dict mapping column names to model field names."""
-        converter = connections[self.db].introspection.table_name_converter
+        converter = connections[self.db].introspection.identifier_converter
         model_fields = {}
         for field in self.model._meta.fields:
             name, column = field.get_attname_column()

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -92,7 +92,7 @@ class RawQuery:
     def get_columns(self):
         if self.cursor is None:
             self._execute_query()
-        converter = connections[self.using].introspection.column_name_converter
+        converter = connections[self.using].introspection.identifier_converter
         return [converter(column_meta[0])
                 for column_meta in self.cursor.description]
 

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -304,6 +304,13 @@ Database backend API
   * ``sql_create_fk`` is replaced with ``sql_foreign_key_constraint``,
     ``sql_constraint``, and ``sql_create_constraint``.
 
+* ``DatabaseIntrospection.table_name_converter()`` and
+  ``column_name_converter()`` are removed. Third party database backends may
+  need to instead implement ``DatabaseIntrospection.identifier_converter()``.
+  In that case, the constraint names that
+  ``DatabaseIntrospection.get_constraints()`` returns must be normalized by
+  ``identifier_converter()``.
+
 Admin actions are no longer collected from base ``ModelAdmin`` classes
 ----------------------------------------------------------------------
 

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -80,7 +80,7 @@ class ParameterHandlingTest(TestCase):
         "An executemany call with too many/not enough parameters will raise an exception (Refs #12612)"
         with connection.cursor() as cursor:
             query = ('INSERT INTO %s (%s, %s) VALUES (%%s, %%s)' % (
-                connection.introspection.table_name_converter('backends_square'),
+                connection.introspection.identifier_converter('backends_square'),
                 connection.ops.quote_name('root'),
                 connection.ops.quote_name('square')
             ))
@@ -217,7 +217,7 @@ class BackendTestCase(TransactionTestCase):
 
     def create_squares(self, args, paramstyle, multiple):
         opts = Square._meta
-        tbl = connection.introspection.table_name_converter(opts.db_table)
+        tbl = connection.introspection.identifier_converter(opts.db_table)
         f1 = connection.ops.quote_name(opts.get_field('root').column)
         f2 = connection.ops.quote_name(opts.get_field('square').column)
         if paramstyle == 'format':
@@ -303,7 +303,7 @@ class BackendTestCase(TransactionTestCase):
                 'SELECT %s, %s FROM %s ORDER BY %s' % (
                     qn(f3.column),
                     qn(f4.column),
-                    connection.introspection.table_name_converter(opts2.db_table),
+                    connection.introspection.identifier_converter(opts2.db_table),
                     qn(f3.column),
                 )
             )

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -48,8 +48,6 @@ class CheckConstraintTests(TestCase):
     def test_name(self):
         constraints = get_constraints(Product._meta.db_table)
         expected_name = 'price_gt_discounted_price'
-        if connection.features.uppercases_column_names:
-            expected_name = expected_name.upper()
         self.assertIn(expected_name, constraints)
 
 
@@ -87,6 +85,4 @@ class UniqueConstraintTests(TestCase):
     def test_name(self):
         constraints = get_constraints(Product._meta.db_table)
         expected_name = 'unique_name'
-        if connection.features.uppercases_column_names:
-            expected_name = expected_name.upper()
         self.assertIn(expected_name, constraints)

--- a/tests/gis_tests/gis_migrations/test_operations.py
+++ b/tests/gis_tests/gis_migrations/test_operations.py
@@ -63,12 +63,9 @@ class OperationTestCase(TransactionTestCase):
         self.current_state = self.apply_operations('gis', ProjectState(), operations)
 
     def assertGeometryColumnsCount(self, expected_count):
-        table_name = 'gis_neighborhood'
-        if connection.features.uppercases_column_names:
-            table_name = table_name.upper()
         self.assertEqual(
             GeometryColumns.objects.filter(**{
-                GeometryColumns.table_name_col(): table_name,
+                '%s__iexact' % GeometryColumns.table_name_col(): 'gis_neighborhood',
             }).count(),
             expected_count
         )

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -184,7 +184,7 @@ class InspectDBTestCase(TestCase):
         out = StringIO()
         call_command('inspectdb', table_name_filter=special_table_only, stdout=out)
         output = out.getvalue()
-        base_name = 'field' if connection.features.uppercases_column_names else 'Field'
+        base_name = connection.introspection.identifier_converter('Field')
         self.assertIn("field = models.IntegerField()", output)
         self.assertIn("field_field = models.IntegerField(db_column='%s_')" % base_name, output)
         self.assertIn("field_field_0 = models.IntegerField(db_column='%s__')" % base_name, output)

--- a/tests/select_for_update/tests.py
+++ b/tests/select_for_update/tests.py
@@ -113,11 +113,10 @@ class SelectForUpdateTests(TransactionTestCase):
             ))
         features = connections['default'].features
         if features.select_for_update_of_column:
-            expected = ['"select_for_update_person"."id"', '"select_for_update_country"."id"']
+            expected = ['select_for_update_person"."id', 'select_for_update_country"."id']
         else:
-            expected = ['"select_for_update_person"', '"select_for_update_country"']
-        if features.uppercases_column_names:
-            expected = [value.upper() for value in expected]
+            expected = ['select_for_update_person', 'select_for_update_country']
+        expected = [connection.ops.quote_name(value) for value in expected]
         self.assertTrue(self.has_for_update_sql(ctx.captured_queries, of=expected))
 
     @skipUnlessDBFeature('has_select_for_update_of')


### PR DESCRIPTION
Removed `DatabaseIntrospection.table_name_converter()/column_name_converter()` and
use instead `DatabaseIntrospection.identifier_converter().`

Removed `DatabaseFeatures.uppercases_column_names`.

From the list of [3rd-party database backends](https://docs.djangoproject.com/en/2.1/ref/databases/#using-a-3rd-party-database-backend) only [django-firebird](https://github.com/maxirobaina/django-firebird/blob/master/firebird/introspection.py#L53-L54) uses `table_name_converter()` and `uppercases_column_names`.

- [x] Release notes.

Ticket [29949](https://code.djangoproject.com/ticket/29949#ticket).