### PR TITLE
Fixed #23829 -- Added support for https scheme and site_domain in ping_google

### DIFF
--- a/django/contrib/sitemaps/management/commands/ping_google.py
+++ b/django/contrib/sitemaps/management/commands/ping_google.py
@@ -7,6 +7,12 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('sitemap_url', nargs='?')
+        parser.add_argument('-d', '--site-domain')
+        parser.add_argument('--use-http', default=False, action='store_false')
 
     def handle(self, *args, **options):
-        ping_google(sitemap_url=options['sitemap_url'])
+        ping_google(
+            sitemap_url=options['sitemap_url'],
+            site_domain=options['site_domain'],
+            use_http=options['use_http'],
+        )

--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -548,12 +548,16 @@ ping Google using the ``ping_google`` management command::
 
 The management command accepts the following optional arguments:
 
-    * ``-d --site-domain``, If you are not using ``django.contrib.sites``, use this
-        to pass your site's domain (e.g., ``example.com``)
+.. django-admin-option:: --site-domain SITE_DOMAIN
 
-    * ``--use-http``, A boolean to indicate to use ``http://`` scheme instead of
-        ``https://``. Defaults to ``False``.
+.. versionadded:: 2.2
 
-    .. versionadded:: 2.2
+Specifies the site domain to be used if ``django.contrib.sites`` is not used.
+Defaults to current site's domain.
 
-    Arguments ``--site-domain`` and ``--use-http`` were added.
+.. django-admin-option:: --use-http
+
+.. versionadded:: 2.2
+
+Specifies the usage of ``http://`` scheme instead of ``https://``. Defaults to
+``False``.

--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -483,15 +483,30 @@ that: :func:`django.contrib.sitemaps.ping_google()`.
 
 .. function:: ping_google
 
-    :func:`ping_google` takes an optional argument, ``sitemap_url``,
-    which should be the absolute path to your site's sitemap (e.g.,
-    :file:`'/sitemap.xml'`). If this argument isn't provided,
-    :func:`ping_google` will attempt to figure out your
-    sitemap by performing a reverse looking in your URLconf.
+    :func:`ping_google` takes the following optional arguments:
+
+    * ``sitemap_url`` which should be the absolute path to your site's sitemap
+        (e.g., :file:`'/sitemap.xml'`). If this argument isn't provided,
+        :func:`ping_google` will attempt to figure out your
+        sitemap by performing a reverse looking in your URLconf.
+
+    * ``ping_url`` defaults to `Google Webmaster Ping Tool`_.
+
+    .. _`Google Webmaster Ping Tool`: https://www.google.com/webmasters/tools/ping
+
+    * ``site-domain``, If you are not using ``django.contrib.sites``, use this
+        to pass your site's domain (e.g., ``example.com``)
+
+    * ``use-http``, A boolean to indicate to use ``http://`` scheme instead of
+        ``https://``. Defaults to ``False``.
 
     :func:`ping_google` raises the exception
     ``django.contrib.sitemaps.SitemapNotFound`` if it cannot determine your
     sitemap URL.
+
+    .. versionadded:: 2.2
+
+    Arguments ``site-domain`` and ``use-http`` were added.
 
 .. admonition:: Register with Google first!
 
@@ -530,3 +545,15 @@ Once the sitemaps application is added to your project, you may also
 ping Google using the ``ping_google`` management command::
 
     python manage.py ping_google [/sitemap.xml]
+
+The management command accepts the following optional arguments:
+
+    * ``-d --site-domain``, If you are not using ``django.contrib.sites``, use this
+        to pass your site's domain (e.g., ``example.com``)
+
+    * ``--use-http``, A boolean to indicate to use ``http://`` scheme instead of
+        ``https://``. Defaults to ``False``.
+
+    .. versionadded:: 2.2
+
+    Arguments ``--site-domain`` and ``--use-http`` were added.

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1599,14 +1599,6 @@ Can be run as a cron job or directly to clean out expired sessions.
 This command is only available if the :doc:`Sitemaps framework
 </ref/contrib/sitemaps>` (``django.contrib.sitemaps``) is installed.
 
-.. django-admin-option:: --site-domain SITE_DOMAIN
-
-Specifies the site domain to be used if ``django.contrib.sites`` is not used. Defaults to current site's domain.
-
-.. django-admin-option:: --use-http
-
-Specifies the usage of ``http://`` scheme instead of ``https://``. Defaults to ``False``.
-
 Please refer to its :djadmin:`description <ping_google>` in the Sitemaps
 documentation.
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1599,6 +1599,14 @@ Can be run as a cron job or directly to clean out expired sessions.
 This command is only available if the :doc:`Sitemaps framework
 </ref/contrib/sitemaps>` (``django.contrib.sitemaps``) is installed.
 
+.. django-admin-option:: --site-domain SITE_DOMAIN
+
+Specifies the site domain to be used if ``django.contrib.sites`` is not used. Defaults to current site's domain.
+
+.. django-admin-option:: --use-http
+
+Specifies the usage of ``http://`` scheme instead of ``https://``. Defaults to ``False``.
+
 Please refer to its :djadmin:`description <ping_google>` in the Sitemaps
 documentation.
 

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -110,7 +110,11 @@ Minor features
 :mod:`django.contrib.sitemaps`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The ``ping_google`` management command now accepts the --site-domain and
+  --use-http options. ``-d --site-domain`` indicates the site domain to be used
+  if ``django.contrib.sites`` is not used.  ``--use-http`` indicates the
+  use of ``http`` instead of ``https`` scheme.  All URLs were ``http``
+  in previous versions.
 
 :mod:`django.contrib.sites`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -426,6 +430,9 @@ Miscellaneous
 * To improve readability, the ``UUIDField`` form field now displays values with
   dashes, e.g. ``550e8400-e29b-41d4-a716-446655440000`` instead of
   ``550e8400e29b41d4a716446655440000``.
+
+* The ``ping_google`` management command now uses ``https`` scheme by default.
+  All URLs were ``http`` in previous versions.
 
 * On SQLite, ``PositiveIntegerField`` and ``PositiveSmallIntegerField`` now
   include a check constraint to prevent negative values in the database. If you

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -110,11 +110,10 @@ Minor features
 :mod:`django.contrib.sitemaps`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* The ``ping_google`` management command now accepts the --site-domain and
-  --use-http options. ``-d --site-domain`` indicates the site domain to be used
-  if ``django.contrib.sites`` is not used.  ``--use-http`` indicates the
-  use of ``http`` instead of ``https`` scheme.  All URLs were ``http``
-  in previous versions.
+* The :option:`ping_google --site-domain` and
+  :option:`ping_google --use-http` options are added.  The first option allows
+  passing the site domain to be used if ``django.contrib.sites`` is not used.
+  The second option allows using ``http`` instead of ``https`` scheme.
 
 :mod:`django.contrib.sites`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/sitemaps_tests/test_management.py
+++ b/tests/sitemaps_tests/test_management.py
@@ -10,8 +10,14 @@ class PingGoogleTests(SitemapTestsBase):
 
     def test_default(self, ping_google_func):
         call_command('ping_google')
-        ping_google_func.assert_called_with(sitemap_url=None)
+        ping_google_func.assert_called_with(sitemap_url=None, use_http=False, site_domain=None)
 
-    def test_arg(self, ping_google_func):
+    def test_args(self, ping_google_func):
         call_command('ping_google', 'foo.xml')
-        ping_google_func.assert_called_with(sitemap_url='foo.xml')
+        ping_google_func.assert_called_with(sitemap_url='foo.xml', use_http=False, site_domain=None)
+        call_command('ping_google', 'foo.xml', '--use-http')
+        ping_google_func.assert_called_with(sitemap_url='foo.xml', use_http=False, site_domain=None)
+        call_command('ping_google', 'foo.xml', '-d', 'google.com')
+        ping_google_func.assert_called_with(sitemap_url='foo.xml', use_http=False, site_domain='google.com')
+        call_command('ping_google', 'foo.xml', '--site-domain', 'google.com')
+        ping_google_func.assert_called_with(sitemap_url='foo.xml', use_http=False, site_domain='google.com')


### PR DESCRIPTION
This PR adds optional arguments to `ping_google` to support changing to `https` scheme using `secure` option and overriding the domain of sitemaps using `site_domain`.

https://code.djangoproject.com/ticket/23829