### PR TITLE
Fixed #29961 -- Made RelatedFieldWidgetWrapper hide related item links if wrapping a hidden widget.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -329,6 +329,7 @@ answer newbie questions, and generally made Django that much better:
     Helen Sherwood-Taylor <helen@rrdlabs.co.uk>
     Henrique Romano <onaiort@gmail.com>
     Henry Dang <henrydangprg@gmail.com>
+    Hidde Bultsma
     Himanshu Chauhan <hchauhan1404@outlook.com>
     hipertracker@gmail.com
     Hiroki Kiyohara <hirokiky@gmail.com>

--- a/django/contrib/admin/templates/admin/widgets/related_widget_wrapper.html
+++ b/django/contrib/admin/templates/admin/widgets/related_widget_wrapper.html
@@ -3,6 +3,7 @@
     {{ rendered_widget }}
     {% block links %}
         {% spaceless %}
+        {% if not is_hidden %}
         {% if can_change_related %}
         <a class="related-widget-wrapper-link change-related" id="change_id_{{ name }}"
             data-href-template="{{ change_related_template_url }}?{{ url_params }}"
@@ -23,6 +24,7 @@
             title="{% blocktrans %}Delete selected {{ model }}{% endblocktrans %}">
             <img src="{% static 'admin/img/icon-deletelink.svg' %}" alt="{% trans 'Delete' %}">
         </a>
+        {% endif %}
         {% endif %}
         {% endspaceless %}
     {% endblock %}

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -285,6 +285,7 @@ class RelatedFieldWidgetWrapper(forms.Widget):
         ])
         context = {
             'rendered_widget': self.widget.render(name, value, attrs),
+            'is_hidden': self.is_hidden,
             'name': name,
             'url_params': url_params,
             'model': rel_opts.verbose_name,

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -687,6 +687,29 @@ class RelatedFieldWidgetWrapperTests(SimpleTestCase):
         wrapper = widgets.RelatedFieldWidgetWrapper(widget, rel, widget_admin_site)
         self.assertIs(wrapper.value_omitted_from_data({}, {}, 'band'), False)
 
+    def test_widget_is_hidden(self):
+        rel = Album._meta.get_field('band').remote_field
+        widget = forms.HiddenInput()
+        widget.choices = ()
+        wrapper = widgets.RelatedFieldWidgetWrapper(widget, rel, widget_admin_site)
+        self.assertIs(wrapper.is_hidden, True)
+        context = wrapper.get_context('band', None, {})
+        self.assertIs(context['is_hidden'], True)
+        output = wrapper.render('name', 'value')
+        # Related item links are hidden.
+        self.assertNotIn('<a ', output)
+
+    def test_widget_is_not_hidden(self):
+        rel = Album._meta.get_field('band').remote_field
+        widget = forms.Select()
+        wrapper = widgets.RelatedFieldWidgetWrapper(widget, rel, widget_admin_site)
+        self.assertIs(wrapper.is_hidden, False)
+        context = wrapper.get_context('band', None, {})
+        self.assertIs(context['is_hidden'], False)
+        output = wrapper.render('name', 'value')
+        # Related item links are present.
+        self.assertIn('<a ', output)
+
 
 @override_settings(ROOT_URLCONF='admin_widgets.urls')
 class AdminWidgetSeleniumTestCase(AdminSeleniumTestCase):


### PR DESCRIPTION
This PR makes the change-add-delete links of the `RelatedFieldWidgetWrapper` not render when it's wrapping a hidden widget.
https://code.djangoproject.com/ticket/29961