### PR TITLE
Fixed typo in static files docs

### DIFF
--- a/docs/howto/static-files/index.txt
+++ b/docs/howto/static-files/index.txt
@@ -26,7 +26,7 @@ Configuring static files
    .. code-block:: html+django
 
         {% load static %}
-        <img src="{% static "my_app/example.jpg" %}" alt="My image">
+        <img src="{% static 'my_app/example.jpg' %}" alt="My image">
 
 #. Store your static files in a folder called ``static`` in your app. For
    example ``my_app/static/my_app/example.jpg``.


### PR DESCRIPTION
Removed the use of double quotes inside double quotes in sample code,
see PEP-8: String Quotes
(https://www.python.org/dev/peps/pep-0008/#id25)

[x] Documentation builds without errors (`make html`)