### PR TITLE
Refs #25251 -- Filtered out skipped tests when processing the test suite to set _next_serialized_rollback.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -646,7 +646,12 @@ def reorder_postprocess(reordered_suite):
     If the next test has no serialized_rollback attribute, it means there
     aren't any more TransactionTestCases.
     """
-    for previous_test, next_test in zip(reordered_suite._tests[:-1], reordered_suite._tests[1:]):
+    # Filter out skipped tests.
+    active_tests = [
+        test for test in reordered_suite._tests
+        if not getattr(test, '__unittest_skip__', False)
+    ]
+    for previous_test, next_test in zip(active_tests[:-1], active_tests[1:]):
         next_serialized_rollback = getattr(next_test, 'serialized_rollback', None)
         if next_serialized_rollback is not None:
             previous_test._next_serialized_rollback = next_serialized_rollback

--- a/tests/test_discovery_sample3/tests_transaction_test_case_mixed.py
+++ b/tests/test_discovery_sample3/tests_transaction_test_case_mixed.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 
-from django.test import TestCase as DjangoTestCase, TransactionTestCase
+from django.test import (
+    TestCase as DjangoTestCase, TransactionTestCase, skipUnlessDBFeature,
+)
 
 
 class TestVanillaUnittest(TestCase):
@@ -29,7 +31,18 @@ class TestTransactionTestCase2(TransactionTestCase):
         self.assertEqual(1, 1)
 
 
+# django.test.runner.reorder_postprocess() ignores this skipped test when
+# assigning _next_serialized_rollback.
+@skipUnlessDBFeature('nonexistent')
 class TestTransactionTestCase3(TransactionTestCase):
+    available_apps = ['test_discovery_sample3']
+    serialized_rollback = True
+
+    def test_sample(self):
+        self.assertEqual(1, 1)
+
+
+class TestTransactionTestCase4(TransactionTestCase):
     available_apps = ['test_discovery_sample3']
     serialized_rollback = False
 

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -234,20 +234,21 @@ class DiscoverRunnerTests(SimpleTestCase):
     def test_transaction_test_case_next_serialized_rollback_option(self):
         runner = DiscoverRunner()
         suite = runner.build_suite(['test_discovery_sample3.tests_transaction_test_case_mixed'])
-        django_test_case, first_transaction_test_case, middle_transaction_test_case, \
-            last_transaction_test_case, vanilla_test_case = suite
+        django_test_case, first_transaction_test_case, second_transaction_test_case, \
+            third_transaction_test_case, fourth_transaction_test_case, vanilla_test_case = suite
         # TransactionTestCase1._next_serialized_rollback is
         # TransactionTestCase2.serialize_rollback.
         self.assertEqual(
             first_transaction_test_case._next_serialized_rollback,
-            middle_transaction_test_case.serialized_rollback
+            second_transaction_test_case.serialized_rollback
         )
         # TransactionTestCase2._next_serialized_rollback is
-        # TransactionTestCase3.serialize_rollback.
+        # TransactionTestCase4.serialize_rollback because TransactionTestCase3
+        # is skipped.
         self.assertEqual(
-            middle_transaction_test_case._next_serialized_rollback,
-            last_transaction_test_case.serialized_rollback
+            second_transaction_test_case._next_serialized_rollback,
+            fourth_transaction_test_case.serialized_rollback
         )
         # The last TransactionTestCase of the suite has
-        # _next_serialized_rollback to = True.
-        self.assertIs(last_transaction_test_case._next_serialized_rollback, True)
+        # _next_serialized_rollback = True.
+        self.assertIs(fourth_transaction_test_case._next_serialized_rollback, True)


### PR DESCRIPTION
Reported at https://github.com/django/django/pull/7528#issuecomment-437196837.