### PR TITLE
Added .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/coverage_html/
 tests/.coverage
 build/
 tests/report/
+.vscode


### PR DESCRIPTION
Just opening to discuss initially. 

Lots of people use VS Code now. If we ignore `.vscode` files we avoid accidental inclusion in commits, and subsequent discussion, and correction, and so on. 

We could equally add other editor and OS specific files too (this latter e.g. `.DS_Store` on macOS and so on.) 

An alternative might be to script a CI lint step checking such files aren't included. There will be other options. I'm not sure the best strategy. 

Goal: help people avoid these kind of things and/or catch them automatically.