### PR TITLE
Fixed #29966 -- Add test coverage for BaseHandler's "The view didn't return an HttpResponse object." error

### DIFF
--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -189,6 +189,16 @@ class HandlerRequestTests(SimpleTestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             self.client.get('/')
 
+    def test_no_response(self):
+        msg = "The view %s didn't return an HttpResponse object. It returned None instead."
+        tests = (
+            ('/no_response_fbv/', 'handlers.views.no_response'),
+            ('/no_response_cbv/', 'handlers.views.NoResponse.__call__'),
+        )
+        for url, view in tests:
+            with self.subTest(url=url), self.assertRaisesMessage(ValueError, msg % view):
+                self.client.get(url)
+
 
 class ScriptNameTests(SimpleTestCase):
     def test_get_script_name(self):

--- a/tests/handlers/urls.py
+++ b/tests/handlers/urls.py
@@ -1,9 +1,12 @@
 from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
     url(r'^regular/$', views.regular),
+    path('no_response_fbv/', views.no_response),
+    path('no_response_cbv/', views.NoResponse()),
     url(r'^streaming/$', views.streaming),
     url(r'^in_transaction/$', views.in_transaction),
     url(r'^not_in_transaction/$', views.not_in_transaction),

--- a/tests/handlers/views.py
+++ b/tests/handlers/views.py
@@ -10,6 +10,15 @@ def regular(request):
     return HttpResponse(b"regular content")
 
 
+def no_response(request):
+    pass
+
+
+class NoResponse:
+    def __call__(self, request):
+        pass
+
+
 def streaming(request):
     return StreamingHttpResponse([b"streaming", b" ", b"content"])
 


### PR DESCRIPTION
[ticket_29966](https://code.djangoproject.com/ticket/29966)

It covers `FBV`:
https://github.com/django/django/blob/d5f4ce9849b062cc788988f2600359dc3c2890cb/django/core/handlers/base.py#L119

But I don't know how to test the `CBV`. I test some class-based view like this:
```
class WithoutReponse(ListView):

    def get(self, request):
        pass
```

But, when I call this view, the `callback` type is `FunctionType` and the `else` block doesn't execute.