### PR TITLE
Fixed #29983 -- Replaced os.path with pathlib.Path.

### DIFF
--- a/django/conf/project_template/project_name/settings.py-tpl
+++ b/django/conf/project_template/project_name/settings.py-tpl
@@ -10,10 +10,10 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/
 """
 
-import os
+from pathlib import Path
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# Build paths inside the project like this: BASE_DIR / 'subdir'
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 
 # Quick-start development settings - unsuitable for production
@@ -76,7 +76,7 @@ WSGI_APPLICATION = '{{ project_name }}.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': BASE_DIR / 'db.sqlite3',
     }
 }
 

--- a/docs/howto/overriding-templates.txt
+++ b/docs/howto/overriding-templates.txt
@@ -27,9 +27,9 @@ Let's say you're trying to override the templates for a third-party application
 called ``blog``, which provides the templates ``blog/post.html`` and
 ``blog/list.html``. The relevant settings for your project would look like::
 
-    import os
+    from pathlib import Path
 
-    BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    BASE_DIR = Path(__file__).resolve().parent.parent
 
     INSTALLED_APPS = [
         ...,
@@ -40,7 +40,7 @@ called ``blog``, which provides the templates ``blog/post.html`` and
     TEMPLATES = [
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': [os.path.join(BASE_DIR, 'templates')],
+            'DIRS': [BASE_DIR / 'templates'],
             'APP_DIRS': True,
             ...
         },

--- a/docs/howto/static-files/index.txt
+++ b/docs/howto/static-files/index.txt
@@ -52,7 +52,7 @@ you can define a list of directories (:setting:`STATICFILES_DIRS`) in your
 settings file where Django will also look for static files. For example::
 
     STATICFILES_DIRS = [
-        os.path.join(BASE_DIR, "static"),
+        BASE_DIR / "static",
         '/var/www/static/',
     ]
 

--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -191,14 +191,14 @@ this. For a small app like polls, this process isn't too difficult.
    .. code-block:: python
        :caption: django-polls/setup.py
 
-       import os
+       from pathlib import Path
        from setuptools import find_packages, setup
 
-       with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
+       with open(Path(__file__).resolve().parent / 'README.rst') as readme:
            README = readme.read()
 
        # allow setup.py to be run from any path
-       os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
+       os.chdir(Path(__file__).resolve().parent)
 
        setup(
            name='django-polls',

--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -34,7 +34,7 @@ settings:
 * :setting:`NAME` -- The name of your database. If you're using SQLite, the
   database will be a file on your computer; in that case, :setting:`NAME`
   should be the full absolute path, including filename, of that file. The
-  default value, ``os.path.join(BASE_DIR, 'db.sqlite3')``, will store the file
+  default value, ``BASE_DIR / 'db.sqlite3'``, will store the file
   in your project directory.
 
 If you are not using SQLite as your database, additional settings such as

--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -307,7 +307,7 @@ Open your settings file (:file:`mysite/settings.py`, remember) and add a
     TEMPLATES = [
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': [os.path.join(BASE_DIR, 'templates')],
+            'DIRS': [BASE_DIR / 'templates'],
             'APP_DIRS': True,
             'OPTIONS': {
                 'context_processors': [

--- a/docs/ref/contrib/gis/tutorial.txt
+++ b/docs/ref/contrib/gis/tutorial.txt
@@ -324,10 +324,9 @@ If you downloaded the :ref:`worldborders` data earlier in the
 tutorial, then you can determine its path using Python's built-in
 ``os`` module::
 
-    >>> import os
+    >>> from pathlib import Path
     >>> import world
-    >>> world_shp = os.path.abspath(os.path.join(os.path.dirname(world.__file__),
-    ...                             'data', 'TM_WORLD_BORDERS-0.3.shp'))
+    >>> world_shp = Path(world.__file__).resolve().parent / 'data' / 'TM_WORLD_BORDERS-0.3.shp'
 
 Now, open the world borders shapefile using GeoDjango's
 :class:`~django.contrib.gis.gdal.DataSource` interface::
@@ -433,7 +432,7 @@ To import the data, use a LayerMapping in a Python script.
 Create a file called ``load.py`` inside the ``world`` application,
 with the following code::
 
-    import os
+    from pathlib import Path
     from django.contrib.gis.utils import LayerMapping
     from .models import WorldBorder
 
@@ -452,9 +451,7 @@ with the following code::
         'mpoly' : 'MULTIPOLYGON',
     }
 
-    world_shp = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), 'data', 'TM_WORLD_BORDERS-0.3.shp'),
-    )
+    world_shp = Path(__file__).resolve().parent / 'data' / 'TM_WORLD_BORDERS-0.3.shp'
 
     def run(verbose=True):
         lm = LayerMapping(WorldBorder, world_shp, world_mapping, transform=False)

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -832,7 +832,7 @@ loaders that come with Django:
 
         TEMPLATES = [{
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': [os.path.join(BASE_DIR, 'templates')],
+            'DIRS': [BASE_DIR / 'templates')],
         }]
 
     You can also override ``'DIRS'`` and specify specific directories for a
@@ -844,7 +844,7 @@ loaders that come with Django:
                 'loaders': [
                     (
                         'django.template.loaders.filesystem.Loader',
-                        [os.path.join(BASE_DIR, 'templates')],
+                        [BASE_DIR / 'templates')],
                     ),
                 ],
             },
@@ -918,7 +918,7 @@ loaders that come with Django:
 
         TEMPLATES = [{
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': [os.path.join(BASE_DIR, 'templates')],
+            'DIRS': [BASE_DIR / 'templates')],
             'OPTIONS': {
                 'loaders': [
                     ('django.template.loaders.cached.Loader', [


### PR DESCRIPTION
pathlib.Path is more "intuitive" to use, and avoids problems with portability between Windows and not-Windows.

The trouble encountered in #29983 would not have happened if we were using pathlib.