### PR TITLE
Fixed #29985 -- Added ModelAdmin.list_prefetch_related

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -618,6 +618,7 @@ class ModelAdminChecks(BaseModelAdminChecks):
             *self._check_date_hierarchy(admin_obj),
             *self._check_action_permission_methods(admin_obj),
             *self._check_actions_uniqueness(admin_obj),
+            *self._check_list_prefetch_related(admin_obj),
         ]
 
     def _check_save_as(self, obj):
@@ -976,6 +977,14 @@ class ModelAdminChecks(BaseModelAdminChecks):
                 id='admin.E130',
             )]
         return []
+
+    def _check_list_prefetch_related(self, obj):
+        """Check that list_prefetch_related is a list or tuple or None."""
+
+        if not isinstance(obj.list_prefetch_related, (list, tuple)) and obj.list_prefetch_related is not None:
+            return must_be('a list or tuple or None', option='list_prefetch_related', obj=obj, id='admin.E131')
+        else:
+            return []
 
 
 class InlineModelAdminChecks(BaseModelAdminChecks):

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -544,6 +544,7 @@ class ModelAdmin(BaseModelAdmin):
     list_display_links = ()
     list_filter = ()
     list_select_related = False
+    list_prefetch_related = ()
     list_per_page = 100
     list_max_show_all = 200
     list_editable = ()
@@ -737,6 +738,7 @@ class ModelAdmin(BaseModelAdmin):
             self.date_hierarchy,
             self.get_search_fields(request),
             self.get_list_select_related(request),
+            self.get_list_prefetch_related(request),
             self.list_per_page,
             self.list_max_show_all,
             self.list_editable,
@@ -969,6 +971,13 @@ class ModelAdmin(BaseModelAdmin):
         changelist items query.
         """
         return self.list_select_related
+
+    def get_list_prefetch_related(self, request):
+        """
+        Return a list of lookups to add to the prefetch_related() part of the
+        changelist items query.
+        """
+        return self.list_prefetch_related
 
     def get_search_fields(self, request):
         """

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1031,6 +1031,36 @@ subclass::
     If you need to specify a dynamic value based on the request, you can
     implement a :meth:`~ModelAdmin.get_list_select_related` method.
 
+.. attribute:: ModelAdmin.list_prefetch_related
+
+    .. versionadded:: 2.2
+
+    Set ``list_prefetch_related`` to tell Django to use
+    :meth:`~django.db.models.query.QuerySet.prefetch_related` in retrieving
+    the list of objects on the admin change list page.
+
+    The value should be either a list or a tuple, or ``None``. Default is an
+    empty tuple.
+
+    When the value is ``None``, Django will reset any previously set prefetch
+    lookups in the query. When the value is an empty list or tuple,
+    ``prefetch_related`` will not be called.
+
+    If the value is a list or a tuple, it will be passed directly to
+    ``prefetch_related`` as parameters. For example::
+
+        class PizzaAdmin(admin.ModelAdmin):
+            list_prefetch_related = ('toppings',)
+
+    will call ``prefetch_related('toppings')``.
+
+    If you need to specify a dynamic value based on the request, you can
+    implement a :meth:`~ModelAdmin.get_list_prefetch_related` method.
+
+    See
+    :meth:`~django.db.models.query.QuerySet.prefetch_related` for more details
+    of possible lookup values.
+
 .. attribute:: ModelAdmin.ordering
 
     Set ``ordering`` to specify how lists of objects should be ordered in the
@@ -1586,6 +1616,14 @@ templates used by the :class:`ModelAdmin` views:
     The ``get_list_select_related`` method is given the ``HttpRequest`` and
     should return a boolean or list as :attr:`ModelAdmin.list_select_related`
     does.
+
+.. method:: ModelAdmin.get_list_prefetch_related(request)
+
+    .. versionadded:: 2.2
+
+    The ``get_list_prefetch_related`` method is given the ``HttpRequest`` and
+    should return a list, a tuple or None as
+    :attr:`ModelAdmin.list_prefetch_related` does.
 
 .. method:: ModelAdmin.get_search_fields(request)
 

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -46,6 +46,8 @@ Minor features
 
 * Added a CSS class to the column headers of
   :class:`~django.contrib.admin.TabularInline`.
+* Added `list_prefetch_related` option to
+  :class:`~django.contrib.admin.ModelAdmin`.
 
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -31,6 +31,7 @@ site.register(Event, EventAdmin)
 
 class ParentAdmin(admin.ModelAdmin):
     list_filter = ['child__name']
+    list_prefetch_related = ['child_set']
     search_fields = ['child__name']
 
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29985

This PR adds `ModelAdmin.list_prefetch_related` and `ModelAdmin.get_list_prefetch_related()`.