### PR TITLE
Updated docs for fast column creation with defaults in PostgreSQL 11.

### DIFF
--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -67,9 +67,10 @@ PostgreSQL
 ----------
 
 PostgreSQL is the most capable of all the databases here in terms of schema
-support; the only caveat is that adding columns with default values will
-cause a full rewrite of the table, for a time proportional to its size.
+support.
 
+The only caveat is that prior to PostgreSQL 11, adding columns with default
+values causes a full rewrite of the table, for a time proportional to its size.
 For this reason, it's recommended you always create new columns with
 ``null=True``, as this way they will be added immediately.
 


### PR DESCRIPTION
Update documentation to reflect a change in functionality of postgres as the advice does not apply to posgres 11 and up.