### PR TITLE
Update tutorials03 to use newer format() function

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -68,14 +68,13 @@ slightly different, because they take an argument:
     :caption: polls/views.py
 
     def detail(request, question_id):
-        return HttpResponse("You're looking at question %s." % question_id)
+        return HttpResponse("You're looking at question {}.".format(question_id))
 
     def results(request, question_id):
-        response = "You're looking at the results of question %s."
-        return HttpResponse(response % question_id)
+        return HttpResponse("You're looking at the results of question {}.".format(question_id))
 
     def vote(request, question_id):
-        return HttpResponse("You're voting on question %s." % question_id)
+        return HttpResponse("You're voting on question {}.".format(question_id))
 
 Wire these new views into the ``polls.urls`` module by adding the following
 :func:`~django.urls.path` calls:


### PR DESCRIPTION
Just noticed while going through the tutorial the use of the older "%"-style string replacement which isn't really needed anymore in newer versions of Python.