### PR TITLE
Switched TestCase to SimpleTestCase where possible in Django's tests.

### DIFF
--- a/tests/admin_docs/test_utils.py
+++ b/tests/admin_docs/test_utils.py
@@ -4,11 +4,11 @@ from django.contrib.admindocs.utils import (
     docutils_is_available, parse_docstring, parse_rst, trim_docstring,
 )
 
-from .tests import AdminDocsTestCase
+from .tests import AdminDocsSimpleTestCase
 
 
 @unittest.skipUnless(docutils_is_available, "no docutils installed.")
-class TestUtils(AdminDocsTestCase):
+class TestUtils(AdminDocsSimpleTestCase):
     """
     This __doc__ output is required for testing. I copied this example from
     `admindocs` documentation. (TITLE)

--- a/tests/admin_docs/tests.py
+++ b/tests/admin_docs/tests.py
@@ -1,5 +1,7 @@
 from django.contrib.auth.models import User
-from django.test import TestCase, modify_settings, override_settings
+from django.test import (
+    SimpleTestCase, TestCase, modify_settings, override_settings,
+)
 
 
 class TestDataMixin:
@@ -7,6 +9,12 @@ class TestDataMixin:
     @classmethod
     def setUpTestData(cls):
         cls.superuser = User.objects.create_superuser(username='super', password='secret', email='super@example.com')
+
+
+@override_settings(ROOT_URLCONF='admin_docs.urls')
+@modify_settings(INSTALLED_APPS={'append': 'django.contrib.admindocs'})
+class AdminDocsSimpleTestCase(SimpleTestCase):
+    pass
 
 
 @override_settings(ROOT_URLCONF='admin_docs.urls')

--- a/tests/auth_tests/test_mixins.py
+++ b/tests/auth_tests/test_mixins.py
@@ -7,7 +7,7 @@ from django.contrib.auth.mixins import (
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.views.generic import View
 
 
@@ -111,7 +111,7 @@ class AccessMixinTests(TestCase):
             view(request)
 
 
-class UserPassesTestTests(TestCase):
+class UserPassesTestTests(SimpleTestCase):
 
     factory = RequestFactory()
 

--- a/tests/auth_tests/test_models.py
+++ b/tests/auth_tests/test_models.py
@@ -156,7 +156,7 @@ class UserManagerTestCase(TestCase):
             self.assertIn(char, allowed_chars)
 
 
-class AbstractBaseUserTests(TestCase):
+class AbstractBaseUserTests(SimpleTestCase):
 
     def test_has_usable_password(self):
         """

--- a/tests/auth_tests/test_validators.py
+++ b/tests/auth_tests/test_validators.py
@@ -11,7 +11,7 @@ from django.contrib.auth.password_validation import (
 )
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.test.utils import isolate_apps
 from django.utils.html import conditional_escape
 
@@ -22,7 +22,7 @@ from django.utils.html import conditional_escape
         'min_length': 12,
     }},
 ])
-class PasswordValidationTest(TestCase):
+class PasswordValidationTest(SimpleTestCase):
     def test_get_default_password_validators(self):
         validators = get_default_password_validators()
         self.assertEqual(len(validators), 2)
@@ -95,7 +95,7 @@ class PasswordValidationTest(TestCase):
         self.assertEqual(password_validators_help_text_html(), '')
 
 
-class MinimumLengthValidatorTest(TestCase):
+class MinimumLengthValidatorTest(SimpleTestCase):
     def test_validate(self):
         expected_error = "This password is too short. It must contain at least %d characters."
         self.assertIsNone(MinimumLengthValidator().validate('12345678'))
@@ -182,7 +182,7 @@ class UserAttributeSimilarityValidatorTest(TestCase):
         )
 
 
-class CommonPasswordValidatorTest(TestCase):
+class CommonPasswordValidatorTest(SimpleTestCase):
     def test_validate(self):
         expected_error = "This password is too common."
         self.assertIsNone(CommonPasswordValidator().validate('a-safe-password'))
@@ -214,7 +214,7 @@ class CommonPasswordValidatorTest(TestCase):
         )
 
 
-class NumericPasswordValidatorTest(TestCase):
+class NumericPasswordValidatorTest(SimpleTestCase):
     def test_validate(self):
         expected_error = "This password is entirely numeric."
         self.assertIsNone(NumericPasswordValidator().validate('a-safe-password'))
@@ -231,7 +231,7 @@ class NumericPasswordValidatorTest(TestCase):
         )
 
 
-class UsernameValidatorsTests(TestCase):
+class UsernameValidatorsTests(SimpleTestCase):
     def test_unicode_validator(self):
         valid_usernames = ['joe', 'René', 'ᴮᴵᴳᴮᴵᴿᴰ', 'أحمد']
         invalid_usernames = [

--- a/tests/backends/base/test_features.py
+++ b/tests/backends/base/test_features.py
@@ -1,8 +1,8 @@
 from django.db import connection
-from django.test import TestCase
+from django.test import SimpleTestCase
 
 
-class TestDatabaseFeatures(TestCase):
+class TestDatabaseFeatures(SimpleTestCase):
 
     def test_nonexistent_feature(self):
         self.assertFalse(hasattr(connection.features, 'nonexistent'))

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1785,7 +1785,7 @@ class CacheHEADTest(SimpleTestCase):
         ('es', 'Spanish'),
     ],
 )
-class CacheI18nTest(TestCase):
+class CacheI18nTest(SimpleTestCase):
 
     def setUp(self):
         self.path = '/cache/test/'

--- a/tests/check_framework/test_multi_db.py
+++ b/tests/check_framework/test_multi_db.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from django.db import connections, models
-from django.test import TestCase
+from django.test import SimpleTestCase
 from django.test.utils import isolate_apps, override_settings
 
 
@@ -15,8 +15,7 @@ class TestRouter:
 
 @override_settings(DATABASE_ROUTERS=[TestRouter()])
 @isolate_apps('check_framework')
-class TestMultiDBChecks(TestCase):
-    multi_db = True
+class TestMultiDBChecks(SimpleTestCase):
 
     def _patch_check_field_on(self, db):
         return mock.patch.object(connections[db].validation, 'check_field')

--- a/tests/custom_lookups/tests.py
+++ b/tests/custom_lookups/tests.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 
 from django.core.exceptions import FieldError
 from django.db import connection, models
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.test.utils import register_lookup
 from django.utils import timezone
 
@@ -513,7 +513,7 @@ class TrackCallsYearTransform(YearTransform):
         return super().get_transform(lookup_name)
 
 
-class LookupTransformCallOrderTests(TestCase):
+class LookupTransformCallOrderTests(SimpleTestCase):
     def test_call_order(self):
         with register_lookup(models.DateField, TrackCallsYearTransform):
             # junk lookup - tries lookup, then transform, then fails
@@ -540,7 +540,7 @@ class LookupTransformCallOrderTests(TestCase):
                              ['lookup'])
 
 
-class CustomisedMethodsTests(TestCase):
+class CustomisedMethodsTests(SimpleTestCase):
 
     def test_overridden_get_lookup(self):
         q = CustomModel.objects.filter(field__lookupfunc_monkeys=3)

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1437,7 +1437,7 @@ class FieldTransformTests(TestCase):
         )
 
 
-class ReprTests(TestCase):
+class ReprTests(SimpleTestCase):
 
     def test_expressions(self):
         self.assertEqual(

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -2,7 +2,7 @@ import unittest
 
 from django.core.checks import Error, Warning as DjangoWarning
 from django.db import connection, models
-from django.test import SimpleTestCase, TestCase, skipIfDBFeature
+from django.test import SimpleTestCase, skipIfDBFeature
 from django.test.utils import isolate_apps, override_settings
 from django.utils.functional import lazy
 from django.utils.timezone import now
@@ -40,7 +40,7 @@ class AutoFieldTests(SimpleTestCase):
 
 
 @isolate_apps('invalid_models_tests')
-class CharFieldTests(TestCase):
+class CharFieldTests(SimpleTestCase):
 
     def test_valid_field(self):
         class Model(models.Model):
@@ -312,7 +312,7 @@ class CharFieldTests(TestCase):
 
 
 @isolate_apps('invalid_models_tests')
-class DateFieldTests(TestCase):
+class DateFieldTests(SimpleTestCase):
     maxDiff = None
 
     def test_auto_now_and_auto_now_add_raise_error(self):
@@ -375,7 +375,7 @@ class DateFieldTests(TestCase):
 
 
 @isolate_apps('invalid_models_tests')
-class DateTimeFieldTests(TestCase):
+class DateTimeFieldTests(SimpleTestCase):
     maxDiff = None
 
     def test_fix_default_value(self):
@@ -638,7 +638,7 @@ class IntegerFieldTests(SimpleTestCase):
 
 
 @isolate_apps('invalid_models_tests')
-class TimeFieldTests(TestCase):
+class TimeFieldTests(SimpleTestCase):
     maxDiff = None
 
     def test_fix_default_value(self):
@@ -680,7 +680,7 @@ class TimeFieldTests(TestCase):
 
 
 @isolate_apps('invalid_models_tests')
-class TextFieldTests(TestCase):
+class TextFieldTests(SimpleTestCase):
 
     @skipIfDBFeature('supports_index_on_text_field')
     def test_max_length_warning(self):

--- a/tests/managers_regress/tests.py
+++ b/tests/managers_regress/tests.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.template import Context, Template
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.test.utils import isolate_apps
 
 from .models import (
@@ -160,7 +160,7 @@ class ManagersRegressionTests(TestCase):
 
 
 @isolate_apps('managers_regress')
-class TestManagerInheritance(TestCase):
+class TestManagerInheritance(SimpleTestCase):
     def test_implicit_inheritance(self):
         class CustomManager(models.Manager):
             pass

--- a/tests/migrations/test_executor.py
+++ b/tests/migrations/test_executor.py
@@ -8,7 +8,7 @@ from django.db.migrations.graph import MigrationGraph
 from django.db.migrations.recorder import MigrationRecorder
 from django.db.utils import DatabaseError
 from django.test import (
-    TestCase, modify_settings, override_settings, skipUnlessDBFeature,
+    SimpleTestCase, modify_settings, override_settings, skipUnlessDBFeature,
 )
 
 from .test_base import MigrationTestBase
@@ -685,7 +685,7 @@ class FakeMigration:
         return 'M<%s>' % self.name
 
 
-class ExecutorUnitTests(TestCase):
+class ExecutorUnitTests(SimpleTestCase):
     """(More) isolated unit tests for executor methods."""
     def test_minimize_rollbacks(self):
         """

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -15,7 +15,7 @@ class Nested:
         pass
 
 
-class BasicFieldTests(TestCase):
+class BasicFieldTests(SimpleTestCase):
 
     def test_show_hidden_initial(self):
         """

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -2849,7 +2849,7 @@ class CustomMetaclassTestCase(SimpleTestCase):
         self.assertEqual(new_cls.base_fields, {})
 
 
-class StrictAssignmentTests(TestCase):
+class StrictAssignmentTests(SimpleTestCase):
     """
     Should a model do anything special with __setattr__() or descriptors which
     raise a ValidationError, a model form should catch the error (#24706).

--- a/tests/model_inheritance/test_abstract_inheritance.py
+++ b/tests/model_inheritance/test_abstract_inheritance.py
@@ -5,12 +5,12 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.checks import Error
 from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import models
-from django.test import TestCase
+from django.test import SimpleTestCase
 from django.test.utils import isolate_apps
 
 
 @isolate_apps('model_inheritance')
-class AbstractInheritanceTests(TestCase):
+class AbstractInheritanceTests(SimpleTestCase):
     def test_single_parent(self):
         class AbstractBase(models.Model):
             name = models.CharField(max_length=30)

--- a/tests/model_regress/test_pickle.py
+++ b/tests/model_regress/test_pickle.py
@@ -1,11 +1,11 @@
 import pickle
 
 from django.db import DJANGO_VERSION_PICKLE_KEY, models
-from django.test import TestCase
+from django.test import SimpleTestCase
 from django.utils.version import get_version
 
 
-class ModelPickleTestCase(TestCase):
+class ModelPickleTests(SimpleTestCase):
     def test_missing_django_version_unpickling(self):
         """
         #21430 -- Verifies a warning is raised for models that are

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -2091,7 +2091,7 @@ class NoRelationRouter:
 
 
 @override_settings(DATABASE_ROUTERS=[NoRelationRouter()])
-class RelationAssignmentTests(TestCase):
+class RelationAssignmentTests(SimpleTestCase):
     """allow_relation() is called with unsaved model instances."""
     multi_db = True
     router_prevents_msg = 'the current database router prevents this relation'

--- a/tests/order_with_respect_to/tests.py
+++ b/tests/order_with_respect_to/tests.py
@@ -1,7 +1,7 @@
 from operator import attrgetter
 
 from django.db import models
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.test.utils import isolate_apps
 
 from .base_tests import BaseOrderWithRespectToTests
@@ -14,7 +14,7 @@ class OrderWithRespectToBaseTests(BaseOrderWithRespectToTests, TestCase):
     Question = Question
 
 
-class OrderWithRespectToTests(TestCase):
+class OrderWithRespectToTests(SimpleTestCase):
 
     @isolate_apps('order_with_respect_to')
     def test_duplicate_order_field(self):

--- a/tests/postgres_tests/__init__.py
+++ b/tests/postgres_tests/__init__.py
@@ -3,7 +3,12 @@ import unittest
 from forms_tests.widget_tests.base import WidgetTest
 
 from django.db import connection
-from django.test import TestCase, modify_settings
+from django.test import SimpleTestCase, TestCase, modify_settings
+
+
+@unittest.skipUnless(connection.vendor == 'postgresql', "PostgreSQL specific tests")
+class PostgreSQLSimpleTestCase(SimpleTestCase):
+    pass
 
 
 @unittest.skipUnless(connection.vendor == 'postgresql', "PostgreSQL specific tests")
@@ -14,5 +19,5 @@ class PostgreSQLTestCase(TestCase):
 @unittest.skipUnless(connection.vendor == 'postgresql', "PostgreSQL specific tests")
 # To locate the widget's template.
 @modify_settings(INSTALLED_APPS={'append': 'django.contrib.postgres'})
-class PostgreSQLWidgetTestCase(WidgetTest, PostgreSQLTestCase):
+class PostgreSQLWidgetTestCase(WidgetTest, PostgreSQLSimpleTestCase):
     pass

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -12,7 +12,9 @@ from django.test import TransactionTestCase, modify_settings, override_settings
 from django.test.utils import isolate_apps
 from django.utils import timezone
 
-from . import PostgreSQLTestCase, PostgreSQLWidgetTestCase
+from . import (
+    PostgreSQLSimpleTestCase, PostgreSQLTestCase, PostgreSQLWidgetTestCase,
+)
 from .models import (
     ArrayFieldSubclass, CharArrayModel, DateTimeArrayModel, IntegerArrayModel,
     NestedIntegerArrayModel, NullableIntegerArrayModel, OtherTypesArrayModel,
@@ -440,7 +442,7 @@ class TestOtherTypesExactQuerying(PostgreSQLTestCase):
 
 
 @isolate_apps('postgres_tests')
-class TestChecks(PostgreSQLTestCase):
+class TestChecks(PostgreSQLSimpleTestCase):
 
     def test_field_checks(self):
         class MyModel(PostgreSQLModel):
@@ -589,7 +591,7 @@ class TestMigrations(TransactionTestCase):
             self.assertNotIn(table_name, connection.introspection.table_names(cursor))
 
 
-class TestSerialization(PostgreSQLTestCase):
+class TestSerialization(PostgreSQLSimpleTestCase):
     test_data = (
         '[{"fields": {"field": "[\\"1\\", \\"2\\", null]"}, "model": "postgres_tests.integerarraymodel", "pk": null}]'
     )
@@ -604,7 +606,7 @@ class TestSerialization(PostgreSQLTestCase):
         self.assertEqual(instance.field, [1, 2, None])
 
 
-class TestValidation(PostgreSQLTestCase):
+class TestValidation(PostgreSQLSimpleTestCase):
 
     def test_unbounded(self):
         field = ArrayField(models.IntegerField())
@@ -664,7 +666,7 @@ class TestValidation(PostgreSQLTestCase):
         self.assertEqual(exception.params, {'nth': 1, 'value': 0, 'limit_value': 1, 'show_value': 0})
 
 
-class TestSimpleFormField(PostgreSQLTestCase):
+class TestSimpleFormField(PostgreSQLSimpleTestCase):
 
     def test_valid(self):
         field = SimpleArrayField(forms.CharField())
@@ -782,7 +784,7 @@ class TestSimpleFormField(PostgreSQLTestCase):
         self.assertIs(field.has_changed([], ''), False)
 
 
-class TestSplitFormField(PostgreSQLTestCase):
+class TestSplitFormField(PostgreSQLSimpleTestCase):
 
     def test_valid(self):
         class SplitForm(forms.Form):

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -2,9 +2,9 @@ import json
 
 from django.core import checks, exceptions, serializers
 from django.forms import Form
-from django.test.utils import isolate_apps, modify_settings
+from django.test.utils import isolate_apps
 
-from . import PostgreSQLTestCase
+from . import PostgreSQLSimpleTestCase, PostgreSQLTestCase
 from .models import HStoreModel, PostgreSQLModel
 
 try:
@@ -15,12 +15,7 @@ except ImportError:
     pass
 
 
-@modify_settings(INSTALLED_APPS={'append': 'django.contrib.postgres'})
-class HStoreTestCase(PostgreSQLTestCase):
-    pass
-
-
-class SimpleTests(HStoreTestCase):
+class SimpleTests(PostgreSQLTestCase):
     def test_save_load_success(self):
         value = {'a': 'b'}
         instance = HStoreModel(field=value)
@@ -69,7 +64,7 @@ class SimpleTests(HStoreTestCase):
         self.assertEqual(instance.array_field, expected_value)
 
 
-class TestQuerying(HStoreTestCase):
+class TestQuerying(PostgreSQLTestCase):
 
     def setUp(self):
         self.objs = [
@@ -191,7 +186,7 @@ class TestQuerying(HStoreTestCase):
 
 
 @isolate_apps('postgres_tests')
-class TestChecks(PostgreSQLTestCase):
+class TestChecks(PostgreSQLSimpleTestCase):
 
     def test_invalid_default(self):
         class MyModel(PostgreSQLModel):
@@ -218,7 +213,7 @@ class TestChecks(PostgreSQLTestCase):
         self.assertEqual(MyModel().check(), [])
 
 
-class TestSerialization(HStoreTestCase):
+class TestSerialization(PostgreSQLSimpleTestCase):
     test_data = json.dumps([{
         'model': 'postgres_tests.hstoremodel',
         'pk': None,
@@ -248,7 +243,7 @@ class TestSerialization(HStoreTestCase):
         self.assertEqual(instance.field, new_instance.field)
 
 
-class TestValidation(HStoreTestCase):
+class TestValidation(PostgreSQLSimpleTestCase):
 
     def test_not_a_string(self):
         field = HStoreField()
@@ -262,7 +257,7 @@ class TestValidation(HStoreTestCase):
         self.assertEqual(field.clean({'a': None}, None), {'a': None})
 
 
-class TestFormField(HStoreTestCase):
+class TestFormField(PostgreSQLSimpleTestCase):
 
     def test_valid(self):
         field = forms.HStoreField()
@@ -325,7 +320,7 @@ class TestFormField(HStoreTestCase):
         self.assertTrue(form_w_hstore.has_changed())
 
 
-class TestValidator(HStoreTestCase):
+class TestValidator(PostgreSQLSimpleTestCase):
 
     def test_simple_valid(self):
         validator = KeysValidator(keys=['a', 'b'])

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -11,7 +11,7 @@ from django.db.utils import NotSupportedError
 from django.test import skipUnlessDBFeature
 from django.test.utils import register_lookup
 
-from . import PostgreSQLTestCase
+from . import PostgreSQLSimpleTestCase, PostgreSQLTestCase
 from .models import CharFieldModel, IntegerArrayModel
 
 
@@ -31,7 +31,7 @@ class IndexTestMixin:
 
 
 @skipUnlessDBFeature('has_brin_index_support')
-class BrinIndexTests(IndexTestMixin, PostgreSQLTestCase):
+class BrinIndexTests(IndexTestMixin, PostgreSQLSimpleTestCase):
     index_class = BrinIndex
 
     def test_suffix(self):
@@ -54,7 +54,7 @@ class BrinIndexTests(IndexTestMixin, PostgreSQLTestCase):
             BrinIndex(fields=['title'], name='test_title_brin', pages_per_range=0)
 
 
-class BTreeIndexTests(IndexTestMixin, PostgreSQLTestCase):
+class BTreeIndexTests(IndexTestMixin, PostgreSQLSimpleTestCase):
     index_class = BTreeIndex
 
     def test_suffix(self):
@@ -68,7 +68,7 @@ class BTreeIndexTests(IndexTestMixin, PostgreSQLTestCase):
         self.assertEqual(kwargs, {'fields': ['title'], 'name': 'test_title_btree', 'fillfactor': 80})
 
 
-class GinIndexTests(IndexTestMixin, PostgreSQLTestCase):
+class GinIndexTests(IndexTestMixin, PostgreSQLSimpleTestCase):
     index_class = GinIndex
 
     def test_suffix(self):
@@ -92,7 +92,7 @@ class GinIndexTests(IndexTestMixin, PostgreSQLTestCase):
         })
 
 
-class GistIndexTests(IndexTestMixin, PostgreSQLTestCase):
+class GistIndexTests(IndexTestMixin, PostgreSQLSimpleTestCase):
     index_class = GistIndex
 
     def test_suffix(self):
@@ -111,7 +111,7 @@ class GistIndexTests(IndexTestMixin, PostgreSQLTestCase):
         })
 
 
-class HashIndexTests(IndexTestMixin, PostgreSQLTestCase):
+class HashIndexTests(IndexTestMixin, PostgreSQLSimpleTestCase):
     index_class = HashIndex
 
     def test_suffix(self):
@@ -125,7 +125,7 @@ class HashIndexTests(IndexTestMixin, PostgreSQLTestCase):
         self.assertEqual(kwargs, {'fields': ['title'], 'name': 'test_title_hash', 'fillfactor': 80})
 
 
-class SpGistIndexTests(IndexTestMixin, PostgreSQLTestCase):
+class SpGistIndexTests(IndexTestMixin, PostgreSQLSimpleTestCase):
     index_class = SpGistIndex
 
     def test_suffix(self):

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -9,7 +9,7 @@ from django.forms import CharField, Form, widgets
 from django.test.utils import isolate_apps
 from django.utils.html import escape
 
-from . import PostgreSQLTestCase
+from . import PostgreSQLSimpleTestCase, PostgreSQLTestCase
 from .models import JSONModel, PostgreSQLModel
 
 try:
@@ -301,7 +301,7 @@ class TestQuerying(PostgreSQLTestCase):
 
 
 @isolate_apps('postgres_tests')
-class TestChecks(PostgreSQLTestCase):
+class TestChecks(PostgreSQLSimpleTestCase):
 
     def test_invalid_default(self):
         class MyModel(PostgreSQLModel):
@@ -336,7 +336,7 @@ class TestChecks(PostgreSQLTestCase):
         self.assertEqual(model.check(), [])
 
 
-class TestSerialization(PostgreSQLTestCase):
+class TestSerialization(PostgreSQLSimpleTestCase):
     test_data = (
         '[{"fields": {"field": %s, "field_custom": null}, '
         '"model": "postgres_tests.jsonmodel", "pk": null}]'
@@ -362,7 +362,7 @@ class TestSerialization(PostgreSQLTestCase):
                 self.assertEqual(instance.field, value)
 
 
-class TestValidation(PostgreSQLTestCase):
+class TestValidation(PostgreSQLSimpleTestCase):
 
     def test_not_serializable(self):
         field = JSONField()
@@ -378,7 +378,7 @@ class TestValidation(PostgreSQLTestCase):
         self.assertEqual(field.clean(datetime.timedelta(days=1), None), datetime.timedelta(days=1))
 
 
-class TestFormField(PostgreSQLTestCase):
+class TestFormField(PostgreSQLSimpleTestCase):
 
     def test_valid(self):
         field = forms.JSONField()

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -9,7 +9,7 @@ from django.test import ignore_warnings, override_settings
 from django.utils import timezone
 from django.utils.deprecation import RemovedInDjango31Warning
 
-from . import PostgreSQLTestCase
+from . import PostgreSQLSimpleTestCase, PostgreSQLTestCase
 from .models import RangeLookupsModel, RangesModel
 
 try:
@@ -355,7 +355,7 @@ class TestQueryingWithRanges(PostgreSQLTestCase):
         )
 
 
-class TestSerialization(PostgreSQLTestCase):
+class TestSerialization(PostgreSQLSimpleTestCase):
     test_data = (
         '[{"fields": {"ints": "{\\"upper\\": \\"10\\", \\"lower\\": \\"0\\", '
         '\\"bounds\\": \\"[)\\"}", "decimals": "{\\"empty\\": true}", '
@@ -405,7 +405,7 @@ class TestSerialization(PostgreSQLTestCase):
         self.assertEqual(new_instance.ints, NumericRange(10, None))
 
 
-class TestValidators(PostgreSQLTestCase):
+class TestValidators(PostgreSQLSimpleTestCase):
 
     def test_max(self):
         validator = RangeMaxValueValidator(5)
@@ -430,7 +430,7 @@ class TestValidators(PostgreSQLTestCase):
             validator(NumericRange(None, 10))  # an unbound range
 
 
-class TestFormField(PostgreSQLTestCase):
+class TestFormField(PostgreSQLSimpleTestCase):
 
     def test_valid_integer(self):
         field = pg_forms.IntegerRangeField()
@@ -708,7 +708,7 @@ class TestFormField(PostgreSQLTestCase):
         self.assertIsInstance(form_field, pg_forms.DateTimeRangeField)
 
 
-class TestWidget(PostgreSQLTestCase):
+class TestWidget(PostgreSQLSimpleTestCase):
     def test_range_widget(self):
         f = pg_forms.ranges.DateTimeRangeField()
         self.assertHTMLEqual(

--- a/tests/project_template/test_settings.py
+++ b/tests/project_template/test_settings.py
@@ -3,11 +3,11 @@ import shutil
 import tempfile
 
 from django import conf
-from django.test import TestCase
+from django.test import SimpleTestCase
 from django.test.utils import extend_sys_path
 
 
-class TestStartProjectSettings(TestCase):
+class TestStartProjectSettings(SimpleTestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp_dir.cleanup)

--- a/tests/queries/test_query.py
+++ b/tests/queries/test_query.py
@@ -8,13 +8,13 @@ from django.db.models.functions import Lower
 from django.db.models.lookups import Exact, GreaterThan, IsNull, LessThan
 from django.db.models.sql.query import Query
 from django.db.models.sql.where import OR
-from django.test import TestCase
+from django.test import SimpleTestCase
 from django.test.utils import register_lookup
 
 from .models import Author, Item, ObjectC, Ranking
 
 
-class TestQuery(TestCase):
+class TestQuery(SimpleTestCase):
     def test_simple_query(self):
         query = Query(Author)
         where = query.build_where(Q(num__gt=2))

--- a/tests/signals/tests.py
+++ b/tests/signals/tests.py
@@ -4,13 +4,13 @@ from django.apps.registry import Apps
 from django.db import models
 from django.db.models import signals
 from django.dispatch import receiver
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.test.utils import isolate_apps
 
 from .models import Author, Book, Car, Person
 
 
-class BaseSignalTest(TestCase):
+class BaseSignalSetup:
     def setUp(self):
         # Save up the number of connected signals so that we can check at the
         # end that all the signals we register get properly unregistered (#9989)
@@ -32,7 +32,7 @@ class BaseSignalTest(TestCase):
         self.assertEqual(self.pre_signals, post_signals)
 
 
-class SignalTests(BaseSignalTest):
+class SignalTests(BaseSignalSetup, TestCase):
     def test_model_pre_init_and_post_init(self):
         data = []
 
@@ -281,7 +281,7 @@ class SignalTests(BaseSignalTest):
         ref.assert_not_called()
 
 
-class LazyModelRefTest(BaseSignalTest):
+class LazyModelRefTests(BaseSignalSetup, SimpleTestCase):
     def setUp(self):
         super().setUp()
         self.received = []

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 from contextlib import contextmanager
 from unittest import TestSuite, TextTestRunner, defaultTestLoader
 
-from django.test import TestCase
+from django.test import SimpleTestCase
 from django.test.runner import DiscoverRunner
 from django.test.utils import captured_stdout
 
@@ -20,7 +20,7 @@ def change_cwd(directory):
         os.chdir(old_cwd)
 
 
-class DiscoverRunnerTest(TestCase):
+class DiscoverRunnerTests(SimpleTestCase):
 
     def test_init_debug_mode(self):
         runner = DiscoverRunner()

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -581,7 +581,7 @@ class ForcedTimeZoneDatabaseTests(TransactionTestCase):
 
 @skipUnlessDBFeature('supports_timezones')
 @override_settings(TIME_ZONE='Africa/Nairobi', USE_TZ=True)
-class UnsupportedTimeZoneDatabaseTests(TestCase):
+class UnsupportedTimeZoneDatabaseTests(SimpleTestCase):
 
     def test_time_zone_parameter_not_supported_if_database_supports_timezone(self):
         connections.databases['tz'] = connections.databases['default'].copy()

--- a/tests/utils_tests/test_feedgenerator.py
+++ b/tests/utils_tests/test_feedgenerator.py
@@ -1,12 +1,11 @@
 import datetime
-import unittest
 
-from django.test import TestCase
+from django.test import SimpleTestCase
 from django.utils import feedgenerator
 from django.utils.timezone import get_fixed_timezone, utc
 
 
-class FeedgeneratorTest(unittest.TestCase):
+class FeedgeneratorTests(SimpleTestCase):
     """
     Tests for the low-level syndication feed framework.
     """
@@ -131,10 +130,6 @@ class FeedgeneratorTest(unittest.TestCase):
         feed_content = feed.writeString('utf-8')
         self.assertIn('href="/link/" rel="alternate"', feed_content)
 
-
-class FeedgeneratorDBTest(TestCase):
-
-    # setting the timezone requires a database query on PostgreSQL.
     def test_latest_post_date_returns_utc_time(self):
         for use_tz in (True, False):
             with self.settings(USE_TZ=use_tz):

--- a/tests/utils_tests/test_module_loading.py
+++ b/tests/utils_tests/test_module_loading.py
@@ -4,7 +4,7 @@ import unittest
 from importlib import import_module
 from zipimport import zipimporter
 
-from django.test import SimpleTestCase, TestCase, modify_settings
+from django.test import SimpleTestCase, modify_settings
 from django.test.utils import extend_sys_path
 from django.utils.module_loading import (
     autodiscover_modules, import_string, module_has_submodule,
@@ -119,7 +119,7 @@ class EggLoader(unittest.TestCase):
                 import_module('egg_module.sub1.sub2.no_such_module')
 
 
-class ModuleImportTestCase(TestCase):
+class ModuleImportTests(SimpleTestCase):
     def test_import_string(self):
         cls = import_string('django.utils.module_loading.import_string')
         self.assertEqual(cls, import_string)

--- a/tests/validation/__init__.py
+++ b/tests/validation/__init__.py
@@ -1,8 +1,7 @@
 from django.core.exceptions import ValidationError
-from django.test import TestCase
 
 
-class ValidationTestCase(TestCase):
+class ValidationAssertions:
     def assertFailsValidation(self, clean, failed_fields, **kwargs):
         with self.assertRaises(ValidationError) as cm:
             clean(**kwargs)

--- a/tests/validation/test_custom_messages.py
+++ b/tests/validation/test_custom_messages.py
@@ -1,8 +1,10 @@
-from . import ValidationTestCase
+from django.test import SimpleTestCase
+
+from . import ValidationAssertions
 from .models import CustomMessagesModel
 
 
-class CustomMessagesTest(ValidationTestCase):
+class CustomMessagesTests(ValidationAssertions, SimpleTestCase):
     def test_custom_simple_validator_message(self):
         cmm = CustomMessagesModel(number=12)
         self.assertFieldFailsValidationWithMessage(cmm.full_clean, 'number', ['AAARGH'])

--- a/tests/validation/test_validators.py
+++ b/tests/validation/test_validators.py
@@ -1,8 +1,10 @@
-from . import ValidationTestCase
+from django.test import SimpleTestCase
+
+from . import ValidationAssertions
 from .models import ModelToValidate
 
 
-class TestModelsWithValidators(ValidationTestCase):
+class TestModelsWithValidators(ValidationAssertions, SimpleTestCase):
     def test_custom_validator_passes_for_correct_value(self):
         mtv = ModelToValidate(number=10, name='Some Name', f_with_custom_validator=42,
                               f_with_iterable_of_validators=42)

--- a/tests/validation/tests.py
+++ b/tests/validation/tests.py
@@ -3,14 +3,14 @@ from django.core.exceptions import NON_FIELD_ERRORS
 from django.test import TestCase
 from django.utils.functional import lazy
 
-from . import ValidationTestCase
+from . import ValidationAssertions
 from .models import (
     Article, Author, GenericIPAddressTestModel, GenericIPAddrUnpackUniqueTest,
     ModelToValidate,
 )
 
 
-class BaseModelValidationTests(ValidationTestCase):
+class BaseModelValidationTests(ValidationAssertions, TestCase):
 
     def test_missing_required_field_raises_error(self):
         mtv = ModelToValidate(f_with_custom_validator=42)
@@ -126,7 +126,7 @@ class ModelFormsTests(TestCase):
         self.assertEqual(list(form.errors), ['pub_date'])
 
 
-class GenericIPAddressFieldTests(ValidationTestCase):
+class GenericIPAddressFieldTests(ValidationAssertions, TestCase):
 
     def test_correct_generic_ip_passes(self):
         giptm = GenericIPAddressTestModel(generic_ip="1.2.3.4")


### PR DESCRIPTION
Crude identification methodology:
```diff
diff --git a/django/test/testcases.py b/django/test/testcases.py
index 9f549f626f..6352310991 100644
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -874,8 +874,8 @@ class TransactionTestCase(SimpleTestCase):
         # Clear the queries_log so that it's less likely to overflow (a single
         # test probably won't execute 9K queries). If queries_log overflows,
         # then assertNumQueries() doesn't work.
-        for db_name in self._databases_names(include_mirrors=False):
-            connections[db_name].queries_log.clear()
+        # for db_name in self._databases_names(include_mirrors=False):
+        #     connections[db_name].queries_log.clear()
 
     @classmethod
     def _databases_names(cls, include_mirrors=True):
@@ -997,6 +997,9 @@ def connections_support_transactions():
     return all(conn.features.supports_transactions for conn in connections.all())
 
 
+_queries = False
+
+
 class TestCase(TransactionTestCase):
     """
     Similar to TransactionTestCase, but use `transaction.atomic()` to achieve
@@ -1040,14 +1043,22 @@ class TestCase(TransactionTestCase):
                 except Exception:
                     cls._rollback_atomics(cls.cls_atomics)
                     raise
+        global _queries
+        _queries = False
         try:
+            cls._has_test_data = True
             cls.setUpTestData()
+            if cls._has_test_data:
+                _queries = True
         except Exception:
             cls._rollback_atomics(cls.cls_atomics)
             raise
 
     @classmethod
     def tearDownClass(cls):
+        global _queries
+        if not _queries:
+            print(cls)
         if connections_support_transactions():
             cls._rollback_atomics(cls.cls_atomics)
             for conn in connections.all():
@@ -1057,6 +1068,7 @@ class TestCase(TransactionTestCase):
     @classmethod
     def setUpTestData(cls):
         """Load initial data for the TestCase."""
+        cls._has_test_data = False
         pass
 
     def _should_reload_connections(self):
@@ -1073,8 +1085,14 @@ class TestCase(TransactionTestCase):
 
         assert not self.reset_sequences, 'reset_sequences cannot be used on TestCase instances'
         self.atomics = self._enter_atomics()
+        for db_name in self._databases_names(include_mirrors=False):
+            connections[db_name].queries_log.clear()
 
     def _fixture_teardown(self):
+        global _queries
+        for db_name in self._databases_names(include_mirrors=False):
+            _queries |= bool(connections[db_name].queries_log)
+
         if not connections_support_transactions():
             return super()._fixture_teardown()
         try:
```