### PR TITLE
Do not escape unicode in jsonfield display

### DIFF
--- a/django/contrib/postgres/forms/jsonb.py
+++ b/django/contrib/postgres/forms/jsonb.py
@@ -51,7 +51,7 @@ class JSONField(forms.CharField):
     def prepare_value(self, value):
         if isinstance(value, InvalidJSONInput):
             return value
-        return json.dumps(value)
+        return json.dumps(value, ensure_ascii=False)
 
     def has_changed(self, initial, data):
         if super().has_changed(initial, data):


### PR DESCRIPTION
without this unicode characters are show like \u00f6