### PR TITLE
Removed version spec from psycopg2-binary

### DIFF
--- a/tests/requirements/postgres.txt
+++ b/tests/requirements/postgres.txt
@@ -1,1 +1,1 @@
-psycopg2-binary>=2.5.4
+psycopg2-binary


### PR DESCRIPTION
The earliest version of psycopg2-binary is 2.7.3.2 (https://pypi.org/project/psycopg2-binary/#history) so there's no reason to specify a minimal version here.