### PR TITLE
Improved performance of BoundField.label_tag with lazy labels.

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.forms.utils import flatatt, pretty_name
 from django.forms.widgets import Textarea, TextInput
+from django.utils.encoding import force_text
 from django.utils.functional import cached_property
 from django.utils.html import conditional_escape, format_html, html_safe
 from django.utils.safestring import mark_safe
@@ -143,6 +144,7 @@ class BoundField:
         # Only add the suffix if the label does not end in punctuation.
         # Translators: If found as last label character, these punctuation
         # characters will prevent the default label_suffix to be appended to the label
+        contents = force_text(contents)
         if label_suffix and contents and contents[-1] not in _(':?.!'):
             contents = format_html('{}{}', contents, label_suffix)
         widget = self.field.widget

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -20,6 +20,8 @@ from django.http import QueryDict
 from django.template import Context, Template
 from django.test import SimpleTestCase
 from django.utils.datastructures import MultiValueDict
+from django.utils.encoding import force_text
+from django.utils.functional import lazy
 from django.utils.safestring import mark_safe
 
 
@@ -3065,6 +3067,36 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         form = SomeForm()
         self.assertHTMLEqual(form['custom'].label_tag(), '<label for="custom_id_custom">Custom:</label>')
         self.assertHTMLEqual(form['empty'].label_tag(), '<label>Empty:</label>')
+
+    def test_boundfield_label_tag_performance(self):
+        counter = 0
+
+        def my_field_label():
+            nonlocal counter
+            counter += 1
+            return 'a field label'
+
+        lazy_field_label_callable = lazy(my_field_label, str)
+
+        class SomeForm(Form):
+            field = CharField(label=lazy_field_label_callable())
+
+        # Sanity check:
+        self.assertEqual(counter, 0)
+
+        # First measure how many times 'force_text' calls 'my_field_label'
+        self.assertEqual(force_text(lazy_field_label_callable()), 'a field label')
+        str_evaluation_count = counter
+
+        # Clear counter
+        counter = 0
+
+        # Now check that label_tag() doesn't do more than the necessary work
+        form = SomeForm({})
+        field = form.visible_fields()[0]
+        self.assertEqual(counter, 0)
+        self.assertIn('a field label', field.label_tag())
+        self.assertEqual(counter, str_evaluation_count)
 
     def test_boundfield_empty_label(self):
         class SomeForm(Form):


### PR DESCRIPTION
For the common case of 'label' being a lazy string (created via lazy i18n
functions), the wrapped callable was being evaluated 3 times without this
patch, but just once with it.