### PR TITLE
Form field label i18n performances fixes

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -137,6 +137,7 @@ class BoundField:
         label_suffix overrides the form's label_suffix.
         """
         contents = contents or self.label
+        contents = str(contents)  # Evaluate lazy strings (just once)
         if label_suffix is None:
             label_suffix = (self.field.label_suffix if self.field.label_suffix is not None
                             else self.form.label_suffix)

--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -11,7 +11,11 @@ from django.utils.translation import gettext as _, gettext_lazy, pgettext
 @keep_lazy_text
 def capfirst(x):
     """Capitalize the first letter of a string."""
-    return x and str(x)[0].upper() + str(x)[1:]
+    if x is None:
+        return None
+    else:
+        x = str(x)  # evaluate lazy strings (just once)
+        return x and x[0].upper() + x[1:]
 
 
 # Set up regular expressions

--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -3,7 +3,7 @@ import sys
 
 from django.test import SimpleTestCase
 from django.utils import text
-from django.utils.functional import lazystr
+from django.utils.functional import lazy, lazystr
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy, override
 
@@ -242,3 +242,24 @@ class TestUtilsText(SimpleTestCase):
         )
         with override('fr'):
             self.assertEqual('Ajout de article «\xa0My first try\xa0».', s)
+
+    def test_capfirst(self):
+        self.assertEqual(text.capfirst('hello there'), 'Hello there')
+
+    def test_capfirst_falsy(self):
+        self.assertIs(text.capfirst(None), None)
+        self.assertEqual(text.capfirst(''), '')
+
+    def test_capfirst_lazy(self):
+        counter = 0
+
+        def a_callable():
+            nonlocal counter
+            counter += 1
+            return 'some text'
+
+        lazy_callable = lazy(a_callable, str)
+        lazy_value = lazy_callable()
+        self.assertEqual(counter, 0)
+        self.assertEqual(text.capfirst(lazy_value), 'Some text')
+        self.assertEqual(counter, 1)


### PR DESCRIPTION
The combined effect of these 2 fixes is to reduce the number of calls to the gettext functions from 9 to 1 for each form field label that is rendered, in the common case of form field labels that are generated via ModelForm from models that use i18n to create the `verbose_name` property of fields (as all builtin models do). 

It will similarly improve performance in other situations involving lazy strings.
