### PR TITLE
Update executor.py

### DIFF
--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -271,7 +271,7 @@ class MigrationExecutor:
         if migration.replaces:
             for app_label, name in migration.replaces:
                 self.recorder.record_unapplied(app_label, name)
-            # Now this squash migration himself can reocord_unapplied, 
+            # Now this squash migration himself can reocord_unapplied,
             # therefore migrations will be in consistent state
             self.recorder.record_unapplied(migration.app_label, migration.name)
         else:

--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -271,7 +271,8 @@ class MigrationExecutor:
         if migration.replaces:
             for app_label, name in migration.replaces:
                 self.recorder.record_unapplied(app_label, name)
-            self.recorder.record_unapplied(migration.app_label, migration.name) # Now this guy himself can reocord_unapplied, therefore migrations will be in consistent state. 
+            # Now this guy himself can reocord_unapplied, therefore migrations will be in consistent state
+            self.recorder.record_unapplied(migration.app_label, migration.name)
         else:
             self.recorder.record_unapplied(migration.app_label, migration.name)
         # Report progress

--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -271,7 +271,8 @@ class MigrationExecutor:
         if migration.replaces:
             for app_label, name in migration.replaces:
                 self.recorder.record_unapplied(app_label, name)
-            # Now this guy himself can reocord_unapplied, therefore migrations will be in consistent state
+            # Now this squash migration himself can reocord_unapplied, 
+            # therefore migrations will be in consistent state
             self.recorder.record_unapplied(migration.app_label, migration.name)
         else:
             self.recorder.record_unapplied(migration.app_label, migration.name)

--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -271,6 +271,7 @@ class MigrationExecutor:
         if migration.replaces:
             for app_label, name in migration.replaces:
                 self.recorder.record_unapplied(app_label, name)
+            self.recorder.record_unapplied(migration.app_label, migration.name) # Now this guy himself can reocord_unapplied, therefore migrations will be in consistent state. 
         else:
             self.recorder.record_unapplied(migration.app_label, migration.name)
         # Report progress


### PR DESCRIPTION
While recording unapplied migrations in case of squash migrations, all of its replaces migrations are recorded to be unapplied but squash migrations itself does not record unapplied. Therefore it causes inconsistency in case, if squash migration has a parent migration. e.g below
django.db.migrations.exceptions.InconsistentMigrationHistory: Migration compliance.0007_auto_20180329_1238_squashed_0026_auto_20180815_0741 is applied before its dependency survey.0092_prospectfarmerviewlinkcompliancelink on database 'default' .

So, i simply solved it by adding one line of recording unapplied.