### PR TITLE
Fixed #30005 -- Corrected transaction.atomic example.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -671,6 +671,7 @@ answer newbie questions, and generally made Django that much better:
     permonik@mesias.brnonet.cz
     Petar Marić <http://www.petarmaric.com/>
     Pete Crosier <pete.crosier@gmail.com>
+    Peter Hull <design.services@oikoi.com>
     peter@mymart.com
     Peter Sheats <sheats@gmail.com>
     Peter van Kampen

--- a/docs/topics/db/transactions.txt
+++ b/docs/topics/db/transactions.txt
@@ -131,7 +131,6 @@ Django provides a single API to control database transactions.
 
         from django.db import IntegrityError, transaction
 
-        @transaction.atomic
         def viewfunc(request):
             create_parent()
 


### PR DESCRIPTION
The documentation of transaction.atomic includes a
misleading example which uses both the decorator and
the context-manager forms of atomic, and contradicts
the warning immediately below it about not catching
exceptions inside an atomic() block.  This commit
removes the decorator, which resolves the conflict.