### PR TITLE
Added stub release notes for 2.1.5 release.

### DIFF
--- a/docs/releases/2.1.5.txt
+++ b/docs/releases/2.1.5.txt
@@ -1,0 +1,13 @@
+==========================
+Django 2.1.5 release notes
+==========================
+
+*Expected January 7, 2019*
+
+
+Django 2.1.5 fixes several bugs in 2.1.4.
+
+Bugfixes
+========
+
+* ...

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -32,6 +32,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   2.1.5
    2.1.4
    2.1.3
    2.1.2


### PR DESCRIPTION
Scheduling 2.1.5. 

I've opted for 7th January, which just allows time around _New Year_ in case any Release Blockers come up over the holidays. 

We _could_ do it the week before, but I don't see any benefit. 

Just checking there's no problem with that. 