### PR TITLE
Fix #25598 -- Prefix SCRIPT_NAME to STATIC_URL and MEDIA_URL

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -44,15 +44,18 @@ def add_script_prefix(value):
         return value
     except (ValidationError, AttributeError):
         pass
+    try:
+        value = value.strip()
+    except AttributeError:
+        return value
+    if value.startswith('/'):
+        return value
     from django.urls import get_script_prefix  # circular dependency if top-level import
     prefix = get_script_prefix()
     if not prefix or prefix == '/':
         return value
     # try to detect if the prefix is already prefixed appropriately.
-    try:
-        if value.startswith(prefix) and value != prefix:
-            return value
-    except AttributeError:
+    if value.startswith(prefix) and value != prefix:
         return value
     return os.path.join(prefix, value.lstrip('/'))
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1962,6 +1962,14 @@ Example: ``"http://media.example.com/"``
     :setting:`MEDIA_URL` and :setting:`STATIC_URL` must have different
     values. See :setting:`MEDIA_ROOT` for more details.
 
+.. note::
+
+    If :setting:`MEDIA_URL` is a path (i.e., not a URL) and the ``SCRIPT_NAME``
+    header is present, then the ``SCRIPT_NAME`` value will be prefixed to this
+    setting's value, unless that prefix is already present as a prefix in the
+    value. This makes it easier to serve a Django application at a subpath
+    without adding extra configuration to the settings.
+
 .. setting:: MIDDLEWARE
 
 ``MIDDLEWARE``
@@ -3239,6 +3247,15 @@ It must end in a slash if set to a non-empty value.
 You may need to :ref:`configure these files to be served in development
 <serving-static-files-in-development>` and will definitely need to do so
 :doc:`in production </howto/static-files/deployment>`.
+
+.. note::
+
+    If :setting:`STATIC_URL` is a path (i.e., not a URL) and the ``SCRIPT_NAME``
+    header is present, then the ``SCRIPT_NAME`` value will be prefixed to this
+    setting's value, unless that prefix is already present as a prefix in the
+    value. This makes it easier to serve a Django application at a subpath
+    without adding extra configuration to the settings.
+
 
 .. setting:: STATICFILES_DIRS
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1964,11 +1964,12 @@ Example: ``"http://media.example.com/"``
 
 .. note::
 
-    If :setting:`MEDIA_URL` is a path (i.e., not a URL) and the ``SCRIPT_NAME``
-    header is present, then the ``SCRIPT_NAME`` value will be prefixed to this
-    setting's value, unless that prefix is already present as a prefix in the
-    value. This makes it easier to serve a Django application at a subpath
-    without adding extra configuration to the settings.
+    If :setting:`MEDIA_URL` is a path (i.e., not a URL) that does *not* begin
+    with a forward slash and if the ``SCRIPT_NAME`` header is present, then the
+    ``SCRIPT_NAME`` value will be prefixed to this setting's value, unless that
+    prefix is already present as a prefix in the value. This makes it easier to
+    serve a Django application at a subpath without adding extra configuration
+    to the settings.
 
 .. setting:: MIDDLEWARE
 
@@ -3250,11 +3251,12 @@ You may need to :ref:`configure these files to be served in development
 
 .. note::
 
-    If :setting:`STATIC_URL` is a path (i.e., not a URL) and the ``SCRIPT_NAME``
-    header is present, then the ``SCRIPT_NAME`` value will be prefixed to this
-    setting's value, unless that prefix is already present as a prefix in the
-    value. This makes it easier to serve a Django application at a subpath
-    without adding extra configuration to the settings.
+    If :setting:`STATIC_URL` is a path (i.e., not a URL) that does *not* begin
+    with a forward slash and if the ``SCRIPT_NAME`` header is present, then the
+    ``SCRIPT_NAME`` value will be prefixed to this setting's value, unless that
+    prefix is already present as a prefix in the value. This makes it easier to
+    serve a Django application at a subpath without adding extra configuration
+    to the settings.
 
 
 .. setting:: STATICFILES_DIRS

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -438,8 +438,9 @@ Miscellaneous
 
 * The ``STATIC_URL`` and ``MEDIA_URL`` settings will now automatically have the
   ``SCRIPT_NAME`` header prefixed to their values when the settings attribute
-  is requested. This auto-prefixation occurs only if the initial values are
-  not valid URLs and if those initial values do not already contain
+  is requested. This auto-prefixation occurs only if *all* of the following are
+  true of the initial values: a) they are *not* valid URLs, b) they do *not*
+  begin with a forward slash, and c) they do *not* already contain
   ``SCRIPT_NAME`` as a prefix. This may cause backwards incompatibility in
   certain rare corner cases, i.e., where one of these settings is intentionally
   configured to be identical to the header-supplied ``SCRIPT_NAME``. In these

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -436,6 +436,15 @@ Miscellaneous
 * :attr:`Group.name <django.contrib.auth.models.Group.name>` ``max_length``
   is increased from 80 to 150 characters.
 
+* The ``STATIC_URL`` and ``MEDIA_URL`` settings will now automatically have the
+  ``SCRIPT_NAME`` header prefixed to their values when the settings attribute
+  is requested. This auto-prefixation occurs only if the initial values are
+  not valid URLs and if those initial values do not already contain
+  ``SCRIPT_NAME`` as a prefix. This may cause backwards incompatibility in
+  certain rare corner cases, i.e., where one of these settings is intentionally
+  configured to be identical to the header-supplied ``SCRIPT_NAME``. In these
+  cases, the ``*_URL`` setting should be set to an empty string.
+
 .. _deprecated-features-2.2:
 
 Features deprecated in 2.2

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -476,6 +476,7 @@ prefetch
 prefetched
 prefetches
 prefetching
+prefixation
 preload
 prepend
 prepended

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -559,15 +559,15 @@ ScriptNameTestCase = namedtuple(
 
 script_name_test_cases = (
 
-    # SCRIPT_NAME ends with no slash, settings start with slashes; will prefix
+    # SCRIPT_NAME ends with no slash, settings start with slashes; will NOT prefix
     ScriptNameTestCase(
         script_name='/somesubpath',
         initial_static_url='/static/',
-        final_static_url='/somesubpath/static/',
+        final_static_url='/static/',
         initial_media_url='/media/',
-        final_media_url='/somesubpath/media/',),
+        final_media_url='/media/',),
 
-    # SCRIPT_NAME ends with no slash, settings start with no slashes; will prefix
+    # SCRIPT_NAME ends with no slash, settings start with no slashes; WILL prefix
     ScriptNameTestCase(
         script_name='/somesubpath',
         initial_static_url='static/',
@@ -575,15 +575,15 @@ script_name_test_cases = (
         initial_media_url='media/',
         final_media_url='/somesubpath/media/',),
 
-    # SCRIPT_NAME ends with slash, settings start with slashes; will prefix
+    # SCRIPT_NAME ends with slash, settings start with slashes; will NOT prefix
     ScriptNameTestCase(
         script_name='/somesubpath/',
         initial_static_url='/static/',
-        final_static_url='/somesubpath/static/',
+        final_static_url='/static/',
         initial_media_url='/media/',
-        final_media_url='/somesubpath/media/',),
+        final_media_url='/media/',),
 
-    # SCRIPT_NAME ends with slash, settings start with no slashes; will prefix
+    # SCRIPT_NAME ends with slash, settings start with no slashes; WILL prefix
     ScriptNameTestCase(
         script_name='/somesubpath/',
         initial_static_url='static/',
@@ -615,13 +615,21 @@ script_name_test_cases = (
         initial_media_url='/somesubpath/media/',
         final_media_url='/somesubpath/media/',),
 
+    # Settings lacking slash prefix and already having prefix---no change expected
+    ScriptNameTestCase(
+        script_name='somesubpath/',
+        initial_static_url='somesubpath/static/',
+        final_static_url='somesubpath/static/',
+        initial_media_url='somesubpath/media/',
+        final_media_url='somesubpath/media/',),
+
     # Settings identical to SCRIPT_NAME so prefixation occurs; strange but
     # consistent.
     ScriptNameTestCase(
         script_name='/somesubpath/',
-        initial_static_url='/somesubpath/',
+        initial_static_url='somesubpath/',
         final_static_url='/somesubpath/somesubpath/',
-        initial_media_url='/somesubpath/',
+        initial_media_url='somesubpath/',
         final_media_url='/somesubpath/somesubpath/',),
 
     # Empty string settings should be used if we want to ensure that
@@ -644,26 +652,26 @@ script_name_test_cases = (
     # SCRIPT_NAME not set so no prefixation occurs
     ScriptNameTestCase(
         script_name=None,
-        initial_static_url='/static/',
-        final_static_url='/static/',
-        initial_media_url='/media/',
-        final_media_url='/media/',),
+        initial_static_url='static/',
+        final_static_url='static/',
+        initial_media_url='media/',
+        final_media_url='media/',),
 
     # SCRIPT_NAME is empty string: no prefixation
     ScriptNameTestCase(
         script_name='',
-        initial_static_url='/static/',
-        final_static_url='/static/',
-        initial_media_url='/media/',
-        final_media_url='/media/',),
+        initial_static_url='static/',
+        final_static_url='static/',
+        initial_media_url='media/',
+        final_media_url='media/',),
 
     # SCRIPT_NAME is forward slash: no prefixation
     ScriptNameTestCase(
         script_name='/',
-        initial_static_url='/static/',
-        final_static_url='/static/',
-        initial_media_url='/media/',
-        final_media_url='/media/',),
+        initial_static_url='static/',
+        final_static_url='static/',
+        initial_media_url='media/',
+        final_media_url='media/',),
 
 )
 


### PR DESCRIPTION
This is a new attempt to bring in the same type of changes that [closed PR 7000](https://github.com/django/django/pull/7000) was trying to bring in. It aims to resolve [ticket 25598](https://code.djangoproject.com/ticket/25598#trac-add-comment).