### PR TITLE
Fixed #30013 -- Fixed DatabaseOperations.last_executed_query() with mysqlclient 1.3.14+.

### DIFF
--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -138,10 +138,10 @@ class DatabaseOperations(BaseDatabaseOperations):
         return [(None, ("NULL", [], False))]
 
     def last_executed_query(self, cursor, sql, params):
-        # With MySQLdb, cursor objects have an (undocumented) "_last_executed"
+        # With MySQLdb, cursor objects have an (undocumented) "_executed"
         # attribute where the exact query sent to the database is saved.
         # See MySQLdb/cursors.py in the source distribution.
-        query = getattr(cursor, '_last_executed', None)
+        query = getattr(cursor, '_executed', None)
         if query is not None:
             query = query.decode(errors='replace')
         return query

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -258,7 +258,7 @@ END;
         # https://cx-oracle.readthedocs.io/en/latest/cursor.html#Cursor.statement
         # The DB API definition does not define this attribute.
         statement = cursor.statement
-        # Unlike Psycopg's `query` and MySQLdb`'s `_last_executed`, CxOracle's
+        # Unlike Psycopg's `query` and MySQLdb`'s `_executed`, CxOracle's
         # `statement` doesn't contain the query parameters. refs #20010.
         return super().last_executed_query(cursor, statement, params)
 

--- a/docs/releases/2.1.5.txt
+++ b/docs/releases/2.1.5.txt
@@ -10,4 +10,4 @@ Django 2.1.5 fixes several bugs in 2.1.4.
 Bugfixes
 ========
 
-* ...
+* Fixed compatibility with mysqlclient 1.3.14 (:ticket:`30013`).

--- a/tests/backends/mysql/test_schema.py
+++ b/tests/backends/mysql/test_schema.py
@@ -7,11 +7,12 @@ from django.test import TestCase
 @unittest.skipUnless(connection.vendor == 'mysql', 'MySQL tests')
 class SchemaEditorTests(TestCase):
     def test_quote_value(self):
+        import MySQLdb
         editor = connection.schema_editor()
         tested_values = [
             ('string', "'string'"),
             (42, '42'),
-            (1.754, '1.754'),
+            (1.754, '1.754e0' if MySQLdb.version_info >= (1, 3, 14) else '1.754'),
             (False, '0'),
         ]
         for value, expected in tested_values:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30013