### PR TITLE
Fixed #29182 -- Fixed schema table alteration on SQLite 3.26+.

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -21,10 +21,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # Some SQLite schema alterations need foreign key constraints to be
         # disabled. Enforce it here for the duration of the transaction.
         self.connection.disable_constraint_checking()
+        self.connection.cursor().execute('PRAGMA legacy_alter_table = ON')
         return super().__enter__()
 
     def __exit__(self, exc_type, exc_value, traceback):
         super().__exit__(exc_type, exc_value, traceback)
+        self.connection.cursor().execute('PRAGMA legacy_alter_table = OFF')
         self.connection.enable_constraint_checking()
 
     def quote_value(self, value):

--- a/docs/releases/2.0.10.txt
+++ b/docs/releases/2.0.10.txt
@@ -12,3 +12,7 @@ Bugfixes
 * Prevented repetitive calls to ``geos_version_tuple()`` in the ``WKBWriter``
   class in an attempt to fix a random crash involving ``LooseVersion`` since
   Django 2.0.6 (:ticket:`29959`).
+
+* Fixed a schema corruption issue on SQLite 3.26+. You might have to drop and
+  rebuild your SQLite database if you applied a migration while using an older
+  version of Django with SQLite 3.26 or later (:ticket:`29182`).

--- a/docs/releases/2.1.5.txt
+++ b/docs/releases/2.1.5.txt
@@ -11,3 +11,7 @@ Bugfixes
 ========
 
 * Fixed compatibility with mysqlclient 1.3.14 (:ticket:`30013`).
+
+* Fixed a schema corruption issue on SQLite 3.26+. You might have to drop and
+  rebuild your SQLite database if you applied a migration while using an older
+  version of Django with SQLite 3.26 or later (:ticket:`29182`).


### PR DESCRIPTION
SQLite 3.26 repoints foreign key constraints on table renames even when foreign_keys pragma is off which breaks every operation that requires a table rebuild to simulate unsupported ALTER TABLE statements.

Fortunately the newly introduced legacy_alter_table pragma allows one to disable this behavior and restore the previous schema editor assumptions.

Thanks to Florian Apolloner, Christoph Trassl, Chris Lamb for the report and troubleshooting assistance.