### PR TITLE
Fixed #30023 -- Prevented SQLite schema alterations while foreign key checks are enabled.

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -19,8 +19,15 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def __enter__(self):
         # Some SQLite schema alterations need foreign key constraints to be
-        # disabled. Enforce it here for the duration of the transaction.
-        self.connection.disable_constraint_checking()
+        # disabled. Enforce it here for the duration of the schema edition.
+        if not self.connection.disable_constraint_checking():
+            raise NotSupportedError(
+                'SQLite schema editor cannot be used while foreign key '
+                'constraint checks are enabled. Make sure to disable them '
+                'before entering a transaction.atomic() context because '
+                'SQLite3 does not support disabling them in the middle of '
+                'a multi-statement transaction.'
+            )
         self.connection.cursor().execute('PRAGMA legacy_alter_table = ON')
         return super().__enter__()
 

--- a/docs/releases/2.0.10.txt
+++ b/docs/releases/2.0.10.txt
@@ -16,3 +16,6 @@ Bugfixes
 * Fixed a schema corruption issue on SQLite 3.26+. You might have to drop and
   rebuild your SQLite database if you applied a migration while using an older
   version of Django with SQLite 3.26 or later (:ticket:`29182`).
+
+* Prevented SQLite schema alterations while foreign key checks are enabled to
+  avoid the possibility of schema corruption (:ticket:`30023`).

--- a/docs/releases/2.1.5.txt
+++ b/docs/releases/2.1.5.txt
@@ -15,3 +15,6 @@ Bugfixes
 * Fixed a schema corruption issue on SQLite 3.26+. You might have to drop and
   rebuild your SQLite database if you applied a migration while using an older
   version of Django with SQLite 3.26 or later (:ticket:`29182`).
+
+* Prevented SQLite schema alterations while foreign key checks are enabled to
+  avoid the possibility of schema corruption (:ticket:`30023`).

--- a/tests/indexes/tests.py
+++ b/tests/indexes/tests.py
@@ -25,12 +25,12 @@ class SchemaIndexesTests(TestCase):
         """
         Index names should be deterministic.
         """
-        with connection.schema_editor() as editor:
-            index_name = editor._create_index_name(
-                table_name=Article._meta.db_table,
-                column_names=("c1",),
-                suffix="123",
-            )
+        editor = connection.schema_editor()
+        index_name = editor._create_index_name(
+            table_name=Article._meta.db_table,
+            column_names=("c1",),
+            suffix="123",
+        )
         self.assertEqual(index_name, "indexes_article_c1_a52bd80b123")
 
     def test_index_name(self):
@@ -41,12 +41,12 @@ class SchemaIndexesTests(TestCase):
             * Include a deterministic hash.
         """
         long_name = 'l%sng' % ('o' * 100)
-        with connection.schema_editor() as editor:
-            index_name = editor._create_index_name(
-                table_name=Article._meta.db_table,
-                column_names=('c1', 'c2', long_name),
-                suffix='ix',
-            )
+        editor = connection.schema_editor()
+        index_name = editor._create_index_name(
+            table_name=Article._meta.db_table,
+            column_names=('c1', 'c2', long_name),
+            suffix='ix',
+        )
         expected = {
             'mysql': 'indexes_article_c1_c2_looooooooooooooooooo_255179b2ix',
             'oracle': 'indexes_a_c1_c2_loo_255179b2ix',

--- a/tests/model_options/test_tablespaces.py
+++ b/tests/model_options/test_tablespaces.py
@@ -1,7 +1,9 @@
 from django.apps import apps
 from django.conf import settings
 from django.db import connection
-from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
+from django.test import (
+    TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature,
+)
 
 from .models.tablespaces import (
     Article, ArticleRef, Authors, Reviewers, Scientist, ScientistRef,
@@ -21,7 +23,8 @@ def sql_for_index(model):
 # We can't test the DEFAULT_TABLESPACE and DEFAULT_INDEX_TABLESPACE settings
 # because they're evaluated when the model class is defined. As a consequence,
 # @override_settings doesn't work, and the tests depend
-class TablespacesTests(TestCase):
+class TablespacesTests(TransactionTestCase):
+    available_apps = ['model_options']
 
     def setUp(self):
         # The unmanaged models need to be removed after the test in order to

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -11,9 +11,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
-from django.test import (
-    TestCase, TransactionTestCase, skipUnlessDBFeature, testcases,
-)
+from django.test import TransactionTestCase, skipUnlessDBFeature, testcases
 from django.test.runner import DiscoverRunner
 from django.test.testcases import connections_support_transactions
 from django.test.utils import dependency_ordered
@@ -242,8 +240,9 @@ class Ticket17477RegressionTests(AdminScriptTestCase):
         self.assertNoOutput(err)
 
 
-class Sqlite3InMemoryTestDbs(TestCase):
+class Sqlite3InMemoryTestDbs(TransactionTestCase):
     multi_db = True
+    available_apps = ['test_runner']
 
     @unittest.skipUnless(all(db.connections[conn].vendor == 'sqlite' for conn in db.connections),
                          "This is an sqlite-specific issue")


### PR DESCRIPTION
Prior to this change foreign key constraint references could be left pointing at tables dropped during operations simulating unsupported table alterations  because of an unexpected failure to disable foreign key constraint checks.
    
SQLite3 does not allow disabling such checks while in a transaction so they must be disabled beforehand.
