### PR TITLE
Refs #28670 -- Fixed DatabaseFeatures.supports_slicing_ordering_in_compound on Oracle.

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -64,3 +64,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def allow_sliced_subqueries_with_in(self):
         return self.has_fetch_offset_support
+
+    @cached_property
+    def supports_slicing_ordering_in_compound(self):
+        return self.has_fetch_offset_support


### PR DESCRIPTION
Oracle supports slicing ordering in compound from version 12.2, because it supports `FETCH/OFFSET` syntax (see 0899d583bdb140910698d00d17f5f1abc8774b07 and 024abe5b82d95ee60cb18a77ebf841ad715467fa).