### PR TITLE
Fixes #27080 -- QuerySet.use_in_migrations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -641,6 +641,7 @@ answer newbie questions, and generally made Django that much better:
     oggie rob <oz.robharvey@gmail.com>
     oggy <ognjen.maric@gmail.com>
     Oliver Beattie <oliver@obeattie.com>
+    Oliver Newman <https://www.onewman.com>
     Oliver Rutherfurd <http://rutherfurd.net/>
     Olivier Sels <olivier.sels@gmail.com>
     Olivier Tabone <olivier.tabone@ripplemotion.fr>

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -204,6 +204,8 @@ class QuerySet:
         # Address the circular dependency between `Queryset` and `Manager`.
         from django.db.models.manager import Manager
         manager = Manager.from_queryset(cls)()
+        if hasattr(cls, 'use_in_migrations'):
+            manager.use_in_migrations = cls.use_in_migrations
         manager._built_with_as_manager = True
         return manager
     as_manager.queryset_only = True

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -262,6 +262,15 @@ by defining a ``use_in_migrations`` attribute on the manager class::
     class MyModel(models.Model):
         objects = MyManager()
 
+A manager derived from a queryset also inherits the queryset's
+``use_in_migrations`` attribute:
+
+    class MyQuerySet(models.QuerySet):
+        use_in_migrations = True
+
+    class MyModel(models.Model):
+        objects = MyQuerySet.as_manager()
+
 If you are using the :meth:`~django.db.models.from_queryset` function to
 dynamically generate a manager class, you need to inherit from the generated
 class to make it importable::

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -254,6 +254,23 @@ class StateTests(SimpleTestCase):
         boss_state = project_state.models['migrations', 'boss']
         self.assertEqual(boss_state.managers, [('objects', Boss.objects)])
 
+    def test_manager_inherits_queryset_migration_flag(self):
+        new_apps = Apps(['migrations'])
+
+        class AuthorQuerySet(models.QuerySet):
+            use_in_migrations = True
+
+        class Author(models.Model):
+            objects = AuthorQuerySet.as_manager()
+
+            class Meta:
+                app_label = 'migrations'
+                apps = new_apps
+
+        project_state = ProjectState.from_apps(new_apps)
+        author_state = project_state.models['migrations', 'author']
+        self.assertEqual(author_state.managers, [('objects', Author.objects)])
+
     def test_custom_default_manager(self):
         new_apps = Apps(['migrations'])
 


### PR DESCRIPTION
Addresses #27080 by letting model managers created using `QuerySet.as_manager()` inherit the `use_in_migrations` attribute of the queryset. This was formerly addressed by PR #7110, but it was closed due to lack of tests.