### PR TITLE
Fixed #30030 -- Fixed misleading error raised when a view inheriting …

### DIFF
--- a/django/views/generic/detail.py
+++ b/django/views/generic/detail.py
@@ -43,8 +43,8 @@ class SingleObjectMixin(ContextMixin):
         # If none of those are defined, it's an error.
         if pk is None and slug is None:
             raise AttributeError(
-                "Generic detail view %s must be called with either an object "
-                "pk or a slug in the URLconf." % self.__class__.__name__
+                "%s that inherits from SingleObjectMixin must be called with either "
+                "an object pk or a slug in the URLconf." % self.__class__.__name__
             )
 
         try:

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -724,8 +724,8 @@ class DateDetailViewTests(TestDataMixin, TestCase):
 
     def test_invalid_url(self):
         msg = (
-            'Generic detail view BookDetail must be called with either an '
-            'object pk or a slug in the URLconf.'
+            'BookDetail that inherits from SingleObjectMixin must be called '
+            'with either an object pk or a slug in the URLconf.'
         )
         with self.assertRaisesMessage(AttributeError, msg):
             self.client.get("/dates/books/2008/oct/01/nopk/")


### PR DESCRIPTION
…from SingleObjectMixin is called without pk or slug

`https://code.djangoproject.com/ticket/30030#ticket`