### PR TITLE
 Fixed #29981 -- Fixed inline formsets with a OnetoOneField primary key that uses to_field.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -958,8 +958,12 @@ class BaseInlineFormSet(BaseModelFormSet):
             kwargs = {
                 'label': getattr(form.fields.get(name), 'label', capfirst(self.fk.verbose_name))
             }
-            if self.fk.remote_field.field_name != self.fk.remote_field.model._meta.pk.name:
-                kwargs['to_field'] = self.fk.remote_field.field_name
+
+        # The InlineForeignKeyField assumes that the foreign key relation is
+        # based on the parent model's pk. If this isn't the case, set to_field
+        # to correctly resolve the initial form value.
+        if self.fk.remote_field.field_name != self.fk.remote_field.model._meta.pk.name:
+            kwargs['to_field'] = self.fk.remote_field.field_name
 
         # If we're adding a new object, ignore a parent's auto-generated key
         # as it will be regenerated on the save request.

--- a/tests/model_formsets_regress/models.py
+++ b/tests/model_formsets_regress/models.py
@@ -16,6 +16,15 @@ class UserProfile(models.Model):
     about = models.TextField()
 
 
+class UserPreferences(models.Model):
+    user = models.OneToOneField(
+        User, models.CASCADE,
+        to_field='username',
+        primary_key=True,
+    )
+    favorite_number = models.IntegerField()
+
+
 class ProfileNetwork(models.Model):
     profile = models.ForeignKey(UserProfile, models.CASCADE, to_field="user")
     network = models.IntegerField()

--- a/tests/model_formsets_regress/tests.py
+++ b/tests/model_formsets_regress/tests.py
@@ -8,8 +8,8 @@ from django.forms.utils import ErrorDict, ErrorList
 from django.test import TestCase
 
 from .models import (
-    Host, Manager, Network, ProfileNetwork, Restaurant, User, UserProfile,
-    UserSite,
+    Host, Manager, Network, ProfileNetwork, Restaurant, User, UserPreferences,
+    UserProfile, UserSite,
 )
 
 
@@ -170,6 +170,14 @@ class InlineFormsetTests(TestCase):
 
         # Testing the inline model's relation
         self.assertEqual(formset[0].instance.user_id, "guido")
+
+    def test_inline_model_with_primary_to_field(self):
+        """An inline model with a OneToOneField with to_field & primary key."""
+        FormSet = inlineformset_factory(User, UserPreferences, exclude=('is_superuser',))
+        user = User.objects.create(username='guido', serial=1337)
+        UserPreferences.objects.create(user=user, favorite_number=10)
+        formset = FormSet(instance=user)
+        self.assertEqual(formset[0].fields['user'].initial, 'guido')
 
     def test_inline_model_with_to_field_to_rel(self):
         """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29981

When using contrib.admin to edit an inline model that fulfills the below
criterias, the model would fail to save. This would give the error
message "Please correct the error below." with no errors displayed.
  1. The inline model has a one-to-one relation with the parent
  2. The inline model is tied to another field than the parent pk
  3. The inline model uses the one-to-one field as its pk

This appears to have been caused by an incorrect deduction of the inline
model's pk. This deduction previously worked correctly for all cases
except for when critera 3 is met, as tested by an old regression test
from issue #11120. The code in this patch makes sure that the expected
behaviour is replicated for the above sets of criteras as well.