### PR TITLE
Fixed #28690:  django.utils.http.parse_http_date two digit year check is incorrect

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -163,7 +163,9 @@ def parse_http_date(date):
     try:
         year = int(m.group('year'))
         if year < 100:
-            if year < 70:
+            current_year = datetime.date.today().year - 2000  # 2018 -> 18
+            # parsing done in reference to current year as in RFC7231
+            if year <= current_year + 50:
                 year += 2000
             else:
                 year += 1900

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -278,6 +278,8 @@ class HttpDateProcessingTests(unittest.TestCase):
         dates = (
             ('Tuesday, 31-Dec-%s 08:49:37 GMT' % (year + 50), datetime(2000 + year + 50, 12, 31, 8, 49, 37)),
             ('Monday, 10-Nov-%s 18:49:37 GMT' % (year + 52), datetime(1900 + year + 52, 11, 10, 18, 49, 37)),
+            # 31-Dec-18 will be interpreted as 2118 around the year 2068.
+            ('Wednesday, 31-Dec-%s 18:49:37 GMT' % (year + 51), datetime(1900 + year + 51, 12, 31, 18, 49, 37)),
         )
         for rfc850str, rfc850date in dates:
             with self.subTest(string=rfc850str):

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -273,6 +273,17 @@ class HttpDateProcessingTests(unittest.TestCase):
         parsed = parse_http_date('Sunday, 06-Nov-94 08:49:37 GMT')
         self.assertEqual(datetime.utcfromtimestamp(parsed), datetime(1994, 11, 6, 8, 49, 37))
 
+    def test_parsing_rfc850_year_50(self):
+        year = datetime.now().year % 100
+        dates = (
+            ('Tuesday, 31-Dec-%s 08:49:37 GMT' % (year + 50), datetime(2000 + year + 50, 12, 31, 8, 49, 37)),
+            ('Monday, 10-Nov-%s 18:49:37 GMT' % (year + 52), datetime(1900 + year + 52, 11, 10, 18, 49, 37)),
+        )
+        for rfc850str, rfc850date in dates:
+            with self.subTest(string=rfc850str):
+                parsed = parse_http_date(rfc850str)
+                self.assertEqual(datetime.utcfromtimestamp(parsed), rfc850date)
+
     def test_parsing_asctime(self):
         parsed = parse_http_date('Sun Nov  6 08:49:37 1994')
         self.assertEqual(datetime.utcfromtimestamp(parsed), datetime(1994, 11, 6, 8, 49, 37))


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28690

This PR picks up from #9214 and adds regression tests in the first commit that pass without applying the fix and adds the fix with another test-case that only passes with the fix applied.
