### PR TITLE
Fixed #29928 -- Enabled deferred constraint checks on SQLite 3.20+.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -38,6 +38,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     # Is "ALTER TABLE ... RENAME COLUMN" supported?
     can_alter_table_rename_column = Database.sqlite_version_info >= (3, 25, 0)
     supports_parentheses_in_compound = False
+    # Deferred constraint checks can be emulated on SQLite < 3.20 but not in a
+    # reasonably performant way.
+    can_defer_constraint_checks = Database.version_info >= (3, 20, 0)
 
     @cached_property
     def supports_stddev(self):

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -265,6 +265,11 @@ Tests
 * The new :setting:`ORACLE_MANAGED_FILES <TEST_ORACLE_MANAGED_FILES>` test
   database setting allows using Oracle Managed Files (OMF) tablespaces.
 
+* Deferrable database constraints are now checked at the end of each
+  :class:`~django.test.TestCase` test on SQLite 3.20+ as well. These checks
+  were previously skipped on SQLite because they required expensive table
+  introspection before version 3.20 introduced native support.
+
 URLs
 ~~~~
 


### PR DESCRIPTION
Contains eb5dd93 which is also part of #10744.