### PR TITLE
#30042 (Use of kwargs in the tutorial.)

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -357,8 +357,8 @@ of this in a bit.
 :func:`~django.urls.path` argument: ``kwargs``
 ----------------------------------------------
 
-Arbitrary keyword arguments can be passed in a dictionary to the target view. We
-aren't going to use this feature of Django in the tutorial.
+Arbitrary keyword arguments can be passed in a dictionary to the target view. Keyword
+arguments can be seen in the 'polls' directory: name='index'.
 
 :func:`~django.urls.path` argument: ``name``
 --------------------------------------------


### PR DESCRIPTION
Lines 360 and 361 above states:
"We aren't going to use this feature of Django in the tutorial."
However, as the tutorial makes use of it, would it not be better to say: 
"kwargs are used in the URLconf in the 'polls' directory: name='index' "

Apologies if incorrect, I am just learning Django and going through the tutorial for the first time.