### PR TITLE
Fixed Admin CSS for .module h2 case consistency

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -524,13 +524,13 @@ input[type=button][disabled].default {
     text-align: left;
     background: #79aec8;
     color: #fff;
+    text-transform: uppercase;
 }
 
 .module caption,
 .inline-group h2 {
     font-size: 12px;
     letter-spacing: 0.5px;
-    text-transform: uppercase;
 }
 
 .module table {


### PR DESCRIPTION
The h2 case is currently inconsistent between a fieldset h2 and an
admin inline h2.

* ModelAdmin.fieldsets h2s not specify case.
* TabularInline h2s use CSS's `text-transform: uppercase`.

This change moves the `text-tranform: uppercase` specificity to ensure
both uses of h2 are uppercase.

Example/Description: https://imgur.com/a/GruVgT4