### PR TITLE
Fixed typo in contrib.gis variable name.

### DIFF
--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -278,12 +278,12 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
         not in the SRID of the field. Specifically, this routine will
         substitute in the ST_Transform() function call.
         """
-        tranform_func = self.spatial_function_name('Transform')
+        transform_func = self.spatial_function_name('Transform')
         if hasattr(value, 'as_sql'):
             if value.field.srid == f.srid:
                 placeholder = '%s'
             else:
-                placeholder = '%s(%%s, %s)' % (tranform_func, f.srid)
+                placeholder = '%s(%%s, %s)' % (transform_func, f.srid)
             return placeholder
 
         # Get the srid for this object
@@ -297,7 +297,7 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
         if value_srid is None or value_srid == f.srid:
             placeholder = '%s'
         else:
-            placeholder = '%s(%%s, %s)' % (tranform_func, f.srid)
+            placeholder = '%s(%%s, %s)' % (transform_func, f.srid)
 
         return placeholder
 

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -49,7 +49,7 @@ class RedirectCycleError(Exception):
 class FakePayload:
     """
     A wrapper around BytesIO that restricts what can be read since data from
-    the network can't be sought and cannot be read outside of its content
+    the network can't be seeked and cannot be read outside of its content
     length. This makes sure that views can't do anything under the test client
     that wouldn't work in real life.
     """

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -49,7 +49,7 @@ class RedirectCycleError(Exception):
 class FakePayload:
     """
     A wrapper around BytesIO that restricts what can be read since data from
-    the network can't be seeked and cannot be read outside of its content
+    the network can't be sought and cannot be read outside of its content
     length. This makes sure that views can't do anything under the test client
     that wouldn't work in real life.
     """


### PR DESCRIPTION

- ~~`django/test/client.py`~~
    - ~~Replace *"seeked"* with *"sought"* in class docstring~~
- `django/contrib/gis/db/backends/postgis/operations.py`
    - Replace the variable name *"tranform_func"* with *"transform_func"*