### PR TITLE
Fixed #30040 -- Documentation on permissions on templates is wrong

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -676,13 +676,13 @@ The ``permission_required`` decorator
 
         from django.contrib.auth.decorators import permission_required
 
-        @permission_required('polls.can_vote')
+        @permission_required('polls.add_vote')
         def my_view(request):
             ...
 
     Just like the :meth:`~django.contrib.auth.models.User.has_perm` method,
     permission names take the form ``"<app label>.<permission codename>"``
-    (i.e. ``polls.can_vote`` for a permission on a model in the ``polls``
+    (i.e. ``polls.add_vote`` for a permission on a model in the ``polls``
     application).
 
     The decorator may also take an iterable of permissions, in which case the
@@ -693,7 +693,7 @@ The ``permission_required`` decorator
 
         from django.contrib.auth.decorators import permission_required
 
-        @permission_required('polls.can_vote', login_url='/loginpage/')
+        @permission_required('polls.add_vote', login_url='/loginpage/')
         def my_view(request):
             ...
 
@@ -712,7 +712,7 @@ The ``permission_required`` decorator
         from django.contrib.auth.decorators import login_required, permission_required
 
         @login_required
-        @permission_required('polls.can_vote', raise_exception=True)
+        @permission_required('polls.add_vote', raise_exception=True)
         def my_view(request):
             ...
 
@@ -738,9 +738,9 @@ To apply permission checks to :doc:`class-based views
         from django.contrib.auth.mixins import PermissionRequiredMixin
 
         class MyView(PermissionRequiredMixin, View):
-            permission_required = 'polls.can_vote'
+            permission_required = 'polls.add_vote'
             # Or multiple of permissions:
-            permission_required = ('polls.can_open', 'polls.can_edit')
+            permission_required = ('polls.view_open', 'polls.change_edit')
 
     You can set any of the parameters of
     :class:`~django.contrib.auth.mixins.AccessMixin` to customize the handling
@@ -1568,9 +1568,9 @@ the logged-in user has any permissions in the ``foo`` app::
 
 Evaluating a two-level-attribute lookup as a boolean is a proxy to
 :meth:`User.has_perm() <django.contrib.auth.models.User.has_perm>`. For example,
-to check if the logged-in user has the permission ``foo.can_vote``::
+to check if the logged-in user has the permission ``foo.add_vote``::
 
-    {% if perms.foo.can_vote %}
+    {% if perms.foo.add_vote %}
 
 Here's a more complete example of checking permissions in a template:
 
@@ -1578,11 +1578,11 @@ Here's a more complete example of checking permissions in a template:
 
     {% if perms.foo %}
         <p>You have permission to do something in the foo app.</p>
-        {% if perms.foo.can_vote %}
-            <p>You can vote!</p>
+        {% if perms.foo.add_vote %}
+            <p>You add vote!</p>
         {% endif %}
-        {% if perms.foo.can_drive %}
-            <p>You can drive!</p>
+        {% if perms.foo.add_driving %}
+            <p>You add drivng!</p>
         {% endif %}
     {% else %}
         <p>You don't have permission to do anything in the foo app.</p>
@@ -1594,7 +1594,7 @@ For example:
 .. code-block:: html+django
 
     {% if 'foo' in perms %}
-        {% if 'foo.can_vote' in perms %}
+        {% if 'foo.add_vote' in perms %}
             <p>In lookup works, too.</p>
         {% endif %}
     {% endif %}


### PR DESCRIPTION
`can_vote` is not django standard permission expression.
so, fixed to `can_vote` to `add_vote` in permission detail expression.

related django bug report url:
https://code.djangoproject.com/ticket/30040

Thank you for my commit message reading.