### PR TITLE
Fixed #29186 -- Add SocketHandler replacing logic and PicklableRequestSocketHandler class

### DIFF
--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -98,7 +98,7 @@ class PicklableRequestSocketHandler(logging.handlers.SocketHandler):
             for k, v in request.META.items() if isinstance(v, (int, str, bool))
         }
         for k in self.picklable_keys:
-            picklable_request_dict[k] =getattr(request, k, None)
+            picklable_request_dict[k] = getattr(request, k, None)
         return picklable_request_dict
 
     def emit(self, record):


### PR DESCRIPTION
Since the logging.handlers.SocketHandler allows pickle-able data,

1. Add `PicklableRequestSocketHandler` class
    - if the request is passed as the instance variable of the log record, only pickle-able data will be extracted and be pickled
2. If `SocketHandler` selected, replacing it into `PicklableRequestSocketHandler`