### PR TITLE
Followed style guide for model attribute ordering.

### DIFF
--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -59,21 +59,21 @@ class AbstractBaseUser(models.Model):
     class Meta:
         abstract = True
 
-    def get_username(self):
-        "Return the identifying username for this User"
-        return getattr(self, self.USERNAME_FIELD)
-
     def __str__(self):
         return self.get_username()
-
-    def clean(self):
-        setattr(self, self.USERNAME_FIELD, self.normalize_username(self.get_username()))
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         if self._password is not None:
             password_validation.password_changed(self._password, self)
             self._password = None
+
+    def get_username(self):
+        """Return the username for this User."""
+        return getattr(self, self.USERNAME_FIELD)
+
+    def clean(self):
+        setattr(self, self.USERNAME_FIELD, self.normalize_username(self.get_username()))
 
     def natural_key(self):
         return (self.get_username(),)

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -60,6 +60,7 @@ class Permission(models.Model):
         verbose_name=_('content type'),
     )
     codename = models.CharField(_('codename'), max_length=100)
+
     objects = PermissionManager()
 
     class Meta:

--- a/django/contrib/gis/db/backends/oracle/models.py
+++ b/django/contrib/gis/db/backends/oracle/models.py
@@ -23,6 +23,9 @@ class OracleGeometryColumns(models.Model):
         db_table = 'USER_SDO_GEOM_METADATA'
         managed = False
 
+    def __str__(self):
+        return '%s - %s (SRID: %s)' % (self.table_name, self.column_name, self.srid)
+
     @classmethod
     def table_name_col(cls):
         """
@@ -38,9 +41,6 @@ class OracleGeometryColumns(models.Model):
         geometry column.
         """
         return 'column_name'
-
-    def __str__(self):
-        return '%s - %s (SRID: %s)' % (self.table_name, self.column_name, self.srid)
 
 
 class OracleSpatialRefSys(models.Model, SpatialRefSysMixin):

--- a/django/contrib/gis/db/backends/postgis/models.py
+++ b/django/contrib/gis/db/backends/postgis/models.py
@@ -23,6 +23,15 @@ class PostGISGeometryColumns(models.Model):
         db_table = 'geometry_columns'
         managed = False
 
+    def __str__(self):
+        return '%s.%s - %dD %s field (SRID: %d)' % (
+            self.f_table_name,
+            self.f_geometry_column,
+            self.coord_dimension,
+            self.type,
+            self.srid,
+        )
+
     @classmethod
     def table_name_col(cls):
         """
@@ -38,11 +47,6 @@ class PostGISGeometryColumns(models.Model):
         geometry column.
         """
         return 'f_geometry_column'
-
-    def __str__(self):
-        return "%s.%s - %dD %s field (SRID: %d)" % \
-               (self.f_table_name, self.f_geometry_column,
-                self.coord_dimension, self.type, self.srid)
 
 
 class PostGISSpatialRefSys(models.Model, SpatialRefSysMixin):

--- a/django/contrib/gis/db/backends/spatialite/models.py
+++ b/django/contrib/gis/db/backends/spatialite/models.py
@@ -21,6 +21,15 @@ class SpatialiteGeometryColumns(models.Model):
         db_table = 'geometry_columns'
         managed = False
 
+    def __str__(self):
+        return '%s.%s - %dD %s field (SRID: %d)' % (
+            self.f_table_name,
+            self.f_geometry_column,
+            self.coord_dimension,
+            self.type,
+            self.srid,
+        )
+
     @classmethod
     def table_name_col(cls):
         """
@@ -37,11 +46,6 @@ class SpatialiteGeometryColumns(models.Model):
         """
         return 'f_geometry_column'
 
-    def __str__(self):
-        return "%s.%s - %dD %s field (SRID: %d)" % \
-               (self.f_table_name, self.f_geometry_column,
-                self.coord_dimension, self.type, self.srid)
-
 
 class SpatialiteSpatialRefSys(models.Model, SpatialRefSysMixin):
     """
@@ -54,11 +58,11 @@ class SpatialiteSpatialRefSys(models.Model, SpatialRefSysMixin):
     proj4text = models.CharField(max_length=2048)
     srtext = models.CharField(max_length=2048)
 
-    @property
-    def wkt(self):
-        return self.srtext
-
     class Meta:
         app_label = 'gis'
         db_table = 'spatial_ref_sys'
         managed = False
+
+    @property
+    def wkt(self):
+        return self.srtext

--- a/django/contrib/sites/models.py
+++ b/django/contrib/sites/models.py
@@ -84,6 +84,7 @@ class Site(models.Model):
         unique=True,
     )
     name = models.CharField(_('display name'), max_length=50)
+
     objects = SiteManager()
 
     class Meta:

--- a/docs/topics/db/examples/many_to_many.txt
+++ b/docs/topics/db/examples/many_to_many.txt
@@ -17,21 +17,21 @@ objects, and a ``Publication`` has multiple ``Article`` objects:
     class Publication(models.Model):
         title = models.CharField(max_length=30)
 
-        def __str__(self):
-            return self.title
-
         class Meta:
             ordering = ('title',)
+
+        def __str__(self):
+            return self.title
 
     class Article(models.Model):
         headline = models.CharField(max_length=100)
         publications = models.ManyToManyField(Publication)
 
-        def __str__(self):
-            return self.headline
-
         class Meta:
             ordering = ('headline',)
+
+        def __str__(self):
+            return self.headline
 
 What follows are examples of operations that can be performed using the Python
 API facilities. Note that if you are using :ref:`an intermediate model

--- a/docs/topics/serialization.txt
+++ b/docs/topics/serialization.txt
@@ -404,12 +404,11 @@ name::
             return self.get(first_name=first_name, last_name=last_name)
 
     class Person(models.Model):
-        objects = PersonManager()
-
         first_name = models.CharField(max_length=100)
         last_name = models.CharField(max_length=100)
-
         birthdate = models.DateField()
+
+        objects = PersonManager()
 
         class Meta:
             unique_together = (('first_name', 'last_name'),)
@@ -453,18 +452,17 @@ So how do you get Django to emit a natural key when serializing an object?
 Firstly, you need to add another method -- this time to the model itself::
 
     class Person(models.Model):
-        objects = PersonManager()
-
         first_name = models.CharField(max_length=100)
         last_name = models.CharField(max_length=100)
-
         birthdate = models.DateField()
 
-        def natural_key(self):
-            return (self.first_name, self.last_name)
+        objects = PersonManager()
 
         class Meta:
             unique_together = (('first_name', 'last_name'),)
+
+        def natural_key(self):
+            return (self.first_name, self.last_name)
 
 That method should always return a natural key tuple -- in this
 example, ``(first name, last name)``. Then, when you call

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -80,12 +80,12 @@ class Chapter(models.Model):
     content = models.TextField()
     book = models.ForeignKey(Book, models.CASCADE)
 
-    def __str__(self):
-        return self.title
-
     class Meta:
         # Use a utf-8 bytestring to ensure it works (see #11710)
         verbose_name = '¿Chapter?'
+
+    def __str__(self):
+        return self.title
 
 
 class ChapterXtra1(models.Model):

--- a/tests/admin_widgets/models.py
+++ b/tests/admin_widgets/models.py
@@ -135,11 +135,11 @@ class Advisor(models.Model):
 class Student(models.Model):
     name = models.CharField(max_length=255)
 
-    def __str__(self):
-        return self.name
-
     class Meta:
         ordering = ('name',)
+
+    def __str__(self):
+        return self.name
 
 
 class School(models.Model):

--- a/tests/custom_columns/models.py
+++ b/tests/custom_columns/models.py
@@ -23,12 +23,12 @@ class Author(models.Model):
     first_name = models.CharField(max_length=30, db_column='firstname')
     last_name = models.CharField(max_length=30, db_column='last')
 
-    def __str__(self):
-        return '%s %s' % (self.first_name, self.last_name)
-
     class Meta:
         db_table = 'my_author_table'
         ordering = ('last_name', 'first_name')
+
+    def __str__(self):
+        return '%s %s' % (self.first_name, self.last_name)
 
 
 class Article(models.Model):
@@ -43,8 +43,8 @@ class Article(models.Model):
         null=True,
     )
 
-    def __str__(self):
-        return self.headline
-
     class Meta:
         ordering = ('headline',)
+
+    def __str__(self):
+        return self.headline

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -20,22 +20,22 @@ class Category(models.Model):
     title = models.CharField(max_length=100)
     description = models.TextField()
 
-    def __str__(self):
-        return self.title
-
     class Meta:
         ordering = ('title',)
+
+    def __str__(self):
+        return self.title
 
 
 class Article(models.Model):
     headline = models.CharField(max_length=100, default='Default headline')
     pub_date = models.DateTimeField()
 
-    def __str__(self):
-        return self.headline
-
     class Meta:
         ordering = ('-pub_date', 'headline')
+
+    def __str__(self):
+        return self.headline
 
 
 class Blog(models.Model):
@@ -68,11 +68,11 @@ class Person(models.Model):
     objects = PersonManager()
     name = models.CharField(max_length=100)
 
-    def __str__(self):
-        return self.name
-
     class Meta:
         ordering = ('name',)
+
+    def __str__(self):
+        return self.name
 
     def natural_key(self):
         return (self.name,)
@@ -106,12 +106,12 @@ class Book(models.Model):
     name = models.CharField(max_length=100)
     authors = models.ManyToManyField(Person)
 
+    class Meta:
+        ordering = ('name',)
+
     def __str__(self):
         authors = ' and '.join(a.name for a in self.authors.all())
         return '%s by %s' % (self.name, authors) if authors else self.name
-
-    class Meta:
-        ordering = ('name',)
 
 
 class PrimaryKeyUUIDModel(models.Model):

--- a/tests/fixtures_model_package/models/__init__.py
+++ b/tests/fixtures_model_package/models/__init__.py
@@ -5,9 +5,9 @@ class Article(models.Model):
     headline = models.CharField(max_length=100, default='Default headline')
     pub_date = models.DateTimeField()
 
-    def __str__(self):
-        return self.headline
-
     class Meta:
         app_label = 'fixtures_model_package'
         ordering = ('-pub_date', 'headline')
+
+    def __str__(self):
+        return self.headline

--- a/tests/fixtures_regress/models.py
+++ b/tests/fixtures_regress/models.py
@@ -98,9 +98,10 @@ class TestManager(models.Manager):
 
 
 class Store(models.Model):
-    objects = TestManager()
     name = models.CharField(max_length=255)
     main = models.ForeignKey('self', models.SET_NULL, null=True)
+
+    objects = TestManager()
 
     class Meta:
         ordering = ('name',)
@@ -113,8 +114,9 @@ class Store(models.Model):
 
 
 class Person(models.Model):
-    objects = TestManager()
     name = models.CharField(max_length=255)
+
+    objects = TestManager()
 
     class Meta:
         ordering = ('name',)
@@ -245,6 +247,7 @@ class BaseNKModel(models.Model):
     Base model with a natural_key and a manager with `get_by_natural_key`
     """
     data = models.CharField(max_length=20, unique=True)
+
     objects = NKManager()
 
     class Meta:

--- a/tests/introspection/models.py
+++ b/tests/introspection/models.py
@@ -41,15 +41,15 @@ class Article(models.Model):
     response_to = models.ForeignKey('self', models.SET_NULL, null=True)
     unmanaged_reporters = models.ManyToManyField(Reporter, through='ArticleReporter', related_name='+')
 
-    def __str__(self):
-        return self.headline
-
     class Meta:
         ordering = ('headline',)
         index_together = [
             ["headline", "pub_date"],
             ['headline', 'response_to', 'pub_date', 'reporter'],
         ]
+
+    def __str__(self):
+        return self.headline
 
 
 class ArticleReporter(models.Model):

--- a/tests/m2m_and_m2o/models.py
+++ b/tests/m2m_and_m2o/models.py
@@ -15,11 +15,11 @@ class Issue(models.Model):
     cc = models.ManyToManyField(User, blank=True, related_name='test_issue_cc')
     client = models.ForeignKey(User, models.CASCADE, related_name='test_issue_client')
 
-    def __str__(self):
-        return str(self.num)
-
     class Meta:
         ordering = ('num',)
+
+    def __str__(self):
+        return str(self.num)
 
 
 class StringReferenceModel(models.Model):

--- a/tests/m2m_regress/models.py
+++ b/tests/m2m_regress/models.py
@@ -73,11 +73,11 @@ class User(models.Model):
 class BadModelWithSplit(models.Model):
     name = models.CharField(max_length=1)
 
-    def split(self):
-        raise RuntimeError('split should not be called')
-
     class Meta:
         abstract = True
+
+    def split(self):
+        raise RuntimeError('split should not be called')
 
 
 class RegressionModelSplit(BadModelWithSplit):

--- a/tests/m2m_through/models.py
+++ b/tests/m2m_through/models.py
@@ -55,12 +55,12 @@ class CustomMembership(models.Model):
     weird_fk = models.ForeignKey(Membership, models.SET_NULL, null=True)
     date_joined = models.DateTimeField(default=datetime.now)
 
-    def __str__(self):
-        return "%s is a member of %s" % (self.person.name, self.group.name)
-
     class Meta:
         db_table = "test_table"
         ordering = ["date_joined"]
+
+    def __str__(self):
+        return "%s is a member of %s" % (self.person.name, self.group.name)
 
 
 class TestNoDefaultsOrNulls(models.Model):

--- a/tests/m2m_through_regress/models.py
+++ b/tests/m2m_through_regress/models.py
@@ -52,11 +52,11 @@ class Car(models.Model):
 class Driver(models.Model):
     name = models.CharField(max_length=20, unique=True, null=True)
 
-    def __str__(self):
-        return "%s" % self.name
-
     class Meta:
         ordering = ('name',)
+
+    def __str__(self):
+        return "%s" % self.name
 
 
 class CarDriver(models.Model):

--- a/tests/many_to_many/models.py
+++ b/tests/many_to_many/models.py
@@ -12,11 +12,11 @@ from django.db import models
 class Publication(models.Model):
     title = models.CharField(max_length=30)
 
-    def __str__(self):
-        return self.title
-
     class Meta:
         ordering = ('title',)
+
+    def __str__(self):
+        return self.title
 
 
 class Tag(models.Model):
@@ -34,11 +34,11 @@ class Article(models.Model):
     publications = models.ManyToManyField(Publication, name='publications')
     tags = models.ManyToManyField(Tag, related_name='tags')
 
-    def __str__(self):
-        return self.headline
-
     class Meta:
         ordering = ('headline',)
+
+    def __str__(self):
+        return self.headline
 
 
 # Models to test correct related_name inheritance

--- a/tests/many_to_one/models.py
+++ b/tests/many_to_one/models.py
@@ -20,11 +20,11 @@ class Article(models.Model):
     pub_date = models.DateField()
     reporter = models.ForeignKey(Reporter, models.CASCADE)
 
-    def __str__(self):
-        return self.headline
-
     class Meta:
         ordering = ('headline',)
+
+    def __str__(self):
+        return self.headline
 
 
 class City(models.Model):

--- a/tests/model_forms/models.py
+++ b/tests/model_forms/models.py
@@ -215,11 +215,11 @@ class Price(models.Model):
     price = models.DecimalField(max_digits=10, decimal_places=2)
     quantity = models.PositiveIntegerField()
 
-    def __str__(self):
-        return "%s for %s" % (self.quantity, self.price)
-
     class Meta:
         unique_together = (('price', 'quantity'),)
+
+    def __str__(self):
+        return "%s for %s" % (self.quantity, self.price)
 
 
 class Triple(models.Model):

--- a/tests/model_formsets/models.py
+++ b/tests/model_formsets/models.py
@@ -135,11 +135,11 @@ class Price(models.Model):
     price = models.DecimalField(max_digits=10, decimal_places=2)
     quantity = models.PositiveIntegerField()
 
-    def __str__(self):
-        return "%s for %s" % (self.quantity, self.price)
-
     class Meta:
         unique_together = (('price', 'quantity'),)
+
+    def __str__(self):
+        return "%s for %s" % (self.quantity, self.price)
 
 
 class MexicanRestaurant(Restaurant):

--- a/tests/multiple_database/models.py
+++ b/tests/multiple_database/models.py
@@ -12,11 +12,11 @@ class Review(models.Model):
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey()
 
-    def __str__(self):
-        return self.source
-
     class Meta:
         ordering = ('source',)
+
+    def __str__(self):
+        return self.source
 
 
 class PersonManager(models.Manager):
@@ -25,14 +25,15 @@ class PersonManager(models.Manager):
 
 
 class Person(models.Model):
-    objects = PersonManager()
     name = models.CharField(max_length=100)
 
-    def __str__(self):
-        return self.name
+    objects = PersonManager()
 
     class Meta:
         ordering = ('name',)
+
+    def __str__(self):
+        return self.name
 
 
 # This book manager doesn't do anything interesting; it just
@@ -48,7 +49,6 @@ class BookManager(models.Manager):
 
 
 class Book(models.Model):
-    objects = BookManager()
     title = models.CharField(max_length=100)
     published = models.DateField()
     authors = models.ManyToManyField(Person)
@@ -56,22 +56,24 @@ class Book(models.Model):
     reviews = GenericRelation(Review)
     pages = models.IntegerField(default=100)
 
-    def __str__(self):
-        return self.title
+    objects = BookManager()
 
     class Meta:
         ordering = ('title',)
+
+    def __str__(self):
+        return self.title
 
 
 class Pet(models.Model):
     name = models.CharField(max_length=100)
     owner = models.ForeignKey(Person, models.CASCADE)
 
-    def __str__(self):
-        return self.name
-
     class Meta:
         ordering = ('name',)
+
+    def __str__(self):
+        return self.name
 
 
 class UserProfile(models.Model):

--- a/tests/null_fk_ordering/models.py
+++ b/tests/null_fk_ordering/models.py
@@ -17,11 +17,11 @@ class Article(models.Model):
     title = models.CharField(max_length=150)
     author = models.ForeignKey(Author, models.SET_NULL, null=True)
 
-    def __str__(self):
-        return 'Article titled: %s' % self.title
-
     class Meta:
         ordering = ['author__name']
+
+    def __str__(self):
+        return 'Article titled: %s' % self.title
 
 
 # These following 4 models represent a far more complex ordering case.

--- a/tests/prefetch_related/models.py
+++ b/tests/prefetch_related/models.py
@@ -15,11 +15,11 @@ class Author(models.Model):
     favorite_authors = models.ManyToManyField(
         'self', through='FavoriteAuthors', symmetrical=False, related_name='favors_me')
 
-    def __str__(self):
-        return self.name
-
     class Meta:
         ordering = ['id']
+
+    def __str__(self):
+        return self.name
 
 
 class AuthorWithAge(Author):
@@ -50,11 +50,11 @@ class Book(models.Model):
     title = models.CharField(max_length=255)
     authors = models.ManyToManyField(Author, related_name='books')
 
-    def __str__(self):
-        return self.title
-
     class Meta:
         ordering = ['id']
+
+    def __str__(self):
+        return self.title
 
 
 class BookWithYear(Book):
@@ -78,11 +78,11 @@ class Reader(models.Model):
     name = models.CharField(max_length=50)
     books_read = models.ManyToManyField(Book, related_name='read_by')
 
-    def __str__(self):
-        return self.name
-
     class Meta:
         ordering = ['id']
+
+    def __str__(self):
+        return self.name
 
 
 class BookReview(models.Model):
@@ -122,11 +122,11 @@ class Teacher(models.Model):
     objects = TeacherManager()
     objects_custom = TeacherQuerySet.as_manager()
 
-    def __str__(self):
-        return "%s (%s)" % (self.name, ", ".join(q.name for q in self.qualifications.all()))
-
     class Meta:
         ordering = ['id']
+
+    def __str__(self):
+        return "%s (%s)" % (self.name, ", ".join(q.name for q in self.qualifications.all()))
 
 
 class Department(models.Model):
@@ -165,11 +165,11 @@ class TaggedItem(models.Model):
     favorite_fkey = models.CharField(max_length=64, null=True)
     favorite = GenericForeignKey('favorite_ct', 'favorite_fkey')
 
-    def __str__(self):
-        return self.tag
-
     class Meta:
         ordering = ['id']
+
+    def __str__(self):
+        return self.tag
 
 
 class Bookmark(models.Model):
@@ -243,11 +243,11 @@ class Employee(models.Model):
     name = models.CharField(max_length=50)
     boss = models.ForeignKey('self', models.SET_NULL, null=True, related_name='serfs')
 
-    def __str__(self):
-        return self.name
-
     class Meta:
         ordering = ['id']
+
+    def __str__(self):
+        return self.name
 
 
 # Ticket #19607
@@ -275,11 +275,11 @@ class Author2(models.Model):
     first_book = models.ForeignKey('Book', models.CASCADE, related_name='first_time_authors+')
     favorite_books = models.ManyToManyField('Book', related_name='+')
 
-    def __str__(self):
-        return self.name
-
     class Meta:
         ordering = ['id']
+
+    def __str__(self):
+        return self.name
 
 
 # Models for many-to-many with UUID pk test:

--- a/tests/serializers/models/natural.py
+++ b/tests/serializers/models/natural.py
@@ -10,10 +10,10 @@ class NaturalKeyAnchorManager(models.Manager):
 
 
 class NaturalKeyAnchor(models.Model):
-    objects = NaturalKeyAnchorManager()
-
     data = models.CharField(max_length=100, unique=True)
     title = models.CharField(max_length=100, null=True)
+
+    objects = NaturalKeyAnchorManager()
 
     def natural_key(self):
         return (self.data,)


### PR DESCRIPTION
Django's coding style guide specifies

> The order of model inner classes and standard methods should be as
> follows (noting that these are not all required):
> 
> + All database fields
> + Custom manager attributes
> + class Meta
> + def __str__()
> + def save()
> + def get_absolute_url()
> + Any custom methods

(see here:
https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#model-style)

However this isn't actually followed consistently throughout the
docs—specifically the position of the Meta class. This changeset
enforces the correct Meta class position.

Occasionally throughout the docs there were methods with `@classmethod`
and `@property` decorators positioned above the Meta class. I left them
as they were, as I wasn't 100% if they fell into "any custom methods" or
if they were special cases.