### PR TITLE
Refs #28643 -- Used database function compatibility mixins for aggregates.

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -141,9 +141,8 @@ class Min(Aggregate):
     name = 'Min'
 
 
-class StdDev(Aggregate):
+class StdDev(NumericOutputFieldMixin, Aggregate):
     name = 'StdDev'
-    output_field = FloatField()
 
     def __init__(self, expression, sample=False, **extra):
         self.function = 'STDDEV_SAMP' if sample else 'STDDEV_POP'

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -3,7 +3,7 @@ Classes to represent the definitions of aggregate functions.
 """
 from django.core.exceptions import FieldError
 from django.db.models.expressions import Case, Func, Star, When
-from django.db.models.fields import FloatField, IntegerField
+from django.db.models.fields import IntegerField
 from django.db.models.functions.mixins import NumericOutputFieldMixin
 
 __all__ = [
@@ -172,9 +172,8 @@ class Sum(Aggregate):
         return super().as_sql(compiler, connection, **extra_context)
 
 
-class Variance(Aggregate):
+class Variance(NumericOutputFieldMixin, Aggregate):
     name = 'Variance'
-    output_field = FloatField()
 
     def __init__(self, expression, sample=False, **extra):
         self.function = 'VAR_SAMP' if sample else 'VAR_POP'

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -3,7 +3,8 @@ Classes to represent the definitions of aggregate functions.
 """
 from django.core.exceptions import FieldError
 from django.db.models.expressions import Case, Func, Star, When
-from django.db.models.fields import DecimalField, FloatField, IntegerField
+from django.db.models.fields import FloatField, IntegerField
+from django.db.models.functions.mixins import NumericOutputFieldMixin
 
 __all__ = [
     'Aggregate', 'Avg', 'Count', 'Max', 'Min', 'StdDev', 'Sum', 'Variance',
@@ -93,15 +94,9 @@ class Aggregate(Func):
         return options
 
 
-class Avg(Aggregate):
+class Avg(NumericOutputFieldMixin, Aggregate):
     function = 'AVG'
     name = 'Avg'
-
-    def _resolve_output_field(self):
-        source_field = self.get_source_fields()[0]
-        if isinstance(source_field, (IntegerField, DecimalField)):
-            return FloatField()
-        return super()._resolve_output_field()
 
     def as_mysql(self, compiler, connection, **extra_context):
         sql, params = super().as_sql(compiler, connection, **extra_context)

--- a/django/db/models/functions/math.py
+++ b/django/db/models/functions/math.py
@@ -1,33 +1,12 @@
 import math
-import sys
 
 from django.db.models.expressions import Func
-from django.db.models.fields import DecimalField, FloatField, IntegerField
+from django.db.models.fields import FloatField, IntegerField
 from django.db.models.functions import Cast
+from django.db.models.functions.mixins import (
+    FixDecimalInputMixin, NumericOutputFieldMixin,
+)
 from django.db.models.lookups import Transform
-
-
-class DecimalInputMixin:
-
-    def as_postgresql(self, compiler, connection, **extra_context):
-        # Cast FloatField to DecimalField as PostgreSQL doesn't support the
-        # following function signatures:
-        # - LOG(double, double)
-        # - MOD(double, double)
-        output_field = DecimalField(decimal_places=sys.float_info.dig, max_digits=1000)
-        clone = self.copy()
-        clone.set_source_expressions([
-            Cast(expression, output_field) if isinstance(expression.output_field, FloatField)
-            else expression for expression in self.get_source_expressions()
-        ])
-        return clone.as_sql(compiler, connection, **extra_context)
-
-
-class OutputFieldMixin:
-
-    def _resolve_output_field(self):
-        has_decimals = any(isinstance(s.output_field, DecimalField) for s in self.get_source_expressions())
-        return DecimalField() if has_decimals else FloatField()
 
 
 class Abs(Transform):
@@ -35,22 +14,22 @@ class Abs(Transform):
     lookup_name = 'abs'
 
 
-class ACos(OutputFieldMixin, Transform):
+class ACos(NumericOutputFieldMixin, Transform):
     function = 'ACOS'
     lookup_name = 'acos'
 
 
-class ASin(OutputFieldMixin, Transform):
+class ASin(NumericOutputFieldMixin, Transform):
     function = 'ASIN'
     lookup_name = 'asin'
 
 
-class ATan(OutputFieldMixin, Transform):
+class ATan(NumericOutputFieldMixin, Transform):
     function = 'ATAN'
     lookup_name = 'atan'
 
 
-class ATan2(OutputFieldMixin, Func):
+class ATan2(NumericOutputFieldMixin, Func):
     function = 'ATAN2'
     arity = 2
 
@@ -80,12 +59,12 @@ class Ceil(Transform):
         return super().as_sql(compiler, connection, function='CEIL', **extra_context)
 
 
-class Cos(OutputFieldMixin, Transform):
+class Cos(NumericOutputFieldMixin, Transform):
     function = 'COS'
     lookup_name = 'cos'
 
 
-class Cot(OutputFieldMixin, Transform):
+class Cot(NumericOutputFieldMixin, Transform):
     function = 'COT'
     lookup_name = 'cot'
 
@@ -93,7 +72,7 @@ class Cot(OutputFieldMixin, Transform):
         return super().as_sql(compiler, connection, template='(1 / TAN(%(expressions)s))', **extra_context)
 
 
-class Degrees(OutputFieldMixin, Transform):
+class Degrees(NumericOutputFieldMixin, Transform):
     function = 'DEGREES'
     lookup_name = 'degrees'
 
@@ -105,7 +84,7 @@ class Degrees(OutputFieldMixin, Transform):
         )
 
 
-class Exp(OutputFieldMixin, Transform):
+class Exp(NumericOutputFieldMixin, Transform):
     function = 'EXP'
     lookup_name = 'exp'
 
@@ -115,12 +94,12 @@ class Floor(Transform):
     lookup_name = 'floor'
 
 
-class Ln(OutputFieldMixin, Transform):
+class Ln(NumericOutputFieldMixin, Transform):
     function = 'LN'
     lookup_name = 'ln'
 
 
-class Log(DecimalInputMixin, OutputFieldMixin, Func):
+class Log(FixDecimalInputMixin, NumericOutputFieldMixin, Func):
     function = 'LOG'
     arity = 2
 
@@ -134,12 +113,12 @@ class Log(DecimalInputMixin, OutputFieldMixin, Func):
         return clone.as_sql(compiler, connection, **extra_context)
 
 
-class Mod(DecimalInputMixin, OutputFieldMixin, Func):
+class Mod(FixDecimalInputMixin, NumericOutputFieldMixin, Func):
     function = 'MOD'
     arity = 2
 
 
-class Pi(OutputFieldMixin, Func):
+class Pi(NumericOutputFieldMixin, Func):
     function = 'PI'
     arity = 0
 
@@ -147,12 +126,12 @@ class Pi(OutputFieldMixin, Func):
         return super().as_sql(compiler, connection, template=str(math.pi), **extra_context)
 
 
-class Power(OutputFieldMixin, Func):
+class Power(NumericOutputFieldMixin, Func):
     function = 'POWER'
     arity = 2
 
 
-class Radians(OutputFieldMixin, Transform):
+class Radians(NumericOutputFieldMixin, Transform):
     function = 'RADIANS'
     lookup_name = 'radians'
 
@@ -169,16 +148,16 @@ class Round(Transform):
     lookup_name = 'round'
 
 
-class Sin(OutputFieldMixin, Transform):
+class Sin(NumericOutputFieldMixin, Transform):
     function = 'SIN'
     lookup_name = 'sin'
 
 
-class Sqrt(OutputFieldMixin, Transform):
+class Sqrt(NumericOutputFieldMixin, Transform):
     function = 'SQRT'
     lookup_name = 'sqrt'
 
 
-class Tan(OutputFieldMixin, Transform):
+class Tan(NumericOutputFieldMixin, Transform):
     function = 'TAN'
     lookup_name = 'tan'

--- a/django/db/models/functions/mixins.py
+++ b/django/db/models/functions/mixins.py
@@ -1,0 +1,27 @@
+import sys
+
+from django.db.models.fields import DecimalField, FloatField
+from django.db.models.functions import Cast
+
+
+class FixDecimalInputMixin:
+
+    def as_postgresql(self, compiler, connection, **extra_context):
+        # Cast FloatField to DecimalField as PostgreSQL doesn't support the
+        # following function signatures:
+        # - LOG(double, double)
+        # - MOD(double, double)
+        output_field = DecimalField(decimal_places=sys.float_info.dig, max_digits=1000)
+        clone = self.copy()
+        clone.set_source_expressions([
+            Cast(expression, output_field) if isinstance(expression.output_field, FloatField)
+            else expression for expression in self.get_source_expressions()
+        ])
+        return clone.as_sql(compiler, connection, **extra_context)
+
+
+class NumericOutputFieldMixin:
+
+    def _resolve_output_field(self):
+        has_decimals = any(isinstance(s.output_field, DecimalField) for s in self.get_source_expressions())
+        return DecimalField() if has_decimals else FloatField()

--- a/django/db/models/functions/mixins.py
+++ b/django/db/models/functions/mixins.py
@@ -1,6 +1,6 @@
 import sys
 
-from django.db.models.fields import DecimalField, FloatField
+from django.db.models.fields import DecimalField, FloatField, IntegerField
 from django.db.models.functions import Cast
 
 
@@ -23,5 +23,9 @@ class FixDecimalInputMixin:
 class NumericOutputFieldMixin:
 
     def _resolve_output_field(self):
-        has_decimals = any(isinstance(s.output_field, DecimalField) for s in self.get_source_expressions())
-        return DecimalField() if has_decimals else FloatField()
+        source_expressions = self.get_source_expressions()
+        if any(isinstance(s.output_field, DecimalField) for s in source_expressions):
+            return DecimalField()
+        if any(isinstance(s.output_field, IntegerField) for s in source_expressions):
+            return FloatField()
+        return super()._resolve_output_field() if source_expressions else FloatField()

--- a/django/db/models/functions/mixins.py
+++ b/django/db/models/functions/mixins.py
@@ -20,6 +20,25 @@ class FixDecimalInputMixin:
         return clone.as_sql(compiler, connection, **extra_context)
 
 
+class FixDurationInputMixin:
+
+    def as_mysql(self, compiler, connection, **extra_context):
+        sql, params = super().as_sql(compiler, connection, **extra_context)
+        if self.output_field.get_internal_type() == 'DurationField':
+            sql = 'CAST(%s AS SIGNED)' % sql
+        return sql, params
+
+    def as_oracle(self, compiler, connection, **extra_context):
+        if self.output_field.get_internal_type() == 'DurationField':
+            expression = self.get_source_expressions()[0]
+            options = self._get_repr_options()
+            from django.db.backends.oracle.functions import IntervalToSeconds, SecondsToInterval
+            return compiler.compile(
+                SecondsToInterval(self.__class__(IntervalToSeconds(expression), **options))
+            )
+        return super().as_sql(compiler, connection, **extra_context)
+
+
 class NumericOutputFieldMixin:
 
     def _resolve_output_field(self):

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -3387,12 +3387,13 @@ by the aggregate.
 ``StdDev``
 ~~~~~~~~~~
 
-.. class:: StdDev(expression, sample=False, filter=None, **extra)
+.. class:: StdDev(expression, output_field=None, sample=False, filter=None, **extra)
 
     Returns the standard deviation of the data in the provided expression.
 
     * Default alias: ``<field>__stddev``
-    * Return type: ``float``
+    * Return type: ``float`` if input is ``int``, otherwise same as input
+      field, or ``output_field`` if supplied
 
     Has one optional argument:
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -3419,12 +3419,13 @@ by the aggregate.
 ``Variance``
 ~~~~~~~~~~~~
 
-.. class:: Variance(expression, sample=False, filter=None, **extra)
+.. class:: Variance(expression, output_field=None, sample=False, filter=None, **extra)
 
     Returns the variance of the data in the provided expression.
 
     * Default alias: ``<field>__variance``
-    * Return type: ``float``
+    * Return type: ``float`` if input is ``int``, otherwise same as input
+      field, or ``output_field`` if supplied
 
     Has one optional argument:
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -3336,14 +3336,14 @@ by the aggregate.
 ``Avg``
 ~~~~~~~
 
-.. class:: Avg(expression, output_field=FloatField(), filter=None, **extra)
+.. class:: Avg(expression, output_field=None, filter=None, **extra)
 
     Returns the mean value of the given expression, which must be numeric
     unless you specify a different ``output_field``.
 
     * Default alias: ``<field>__avg``
-    * Return type: ``float`` (or the type of whatever ``output_field`` is
-      specified)
+    * Return type: ``float`` if input is ``int``, otherwise same as input
+      field, or ``output_field`` if supplied
 
 ``Count``
 ~~~~~~~~~

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -493,8 +493,9 @@ Miscellaneous
 
 * :djadmin:`runserver` no longer supports `pyinotify` (replaced by Watchman).
 
-* The :class:`~django.db.models.Avg` aggregate function now returns a
-  ``Decimal`` instead of a ``float`` when the input is ``Decimal``.
+* The :class:`~django.db.models.Avg` and :class:`~django.db.models.StdDev`
+  aggregate functions now return a ``Decimal`` instead of a ``float`` when the
+  input is ``Decimal``.
 
 .. _deprecated-features-2.2:
 

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -493,9 +493,9 @@ Miscellaneous
 
 * :djadmin:`runserver` no longer supports `pyinotify` (replaced by Watchman).
 
-* The :class:`~django.db.models.Avg` and :class:`~django.db.models.StdDev`
-  aggregate functions now return a ``Decimal`` instead of a ``float`` when the
-  input is ``Decimal``.
+* The :class:`~django.db.models.Avg`, :class:`~django.db.models.StdDev`, and
+  :class:`~django.db.models.Variance` aggregate functions now return a
+  ``Decimal`` instead of a ``float`` when the input is ``Decimal``.
 
 .. _deprecated-features-2.2:
 

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -493,6 +493,9 @@ Miscellaneous
 
 * :djadmin:`runserver` no longer supports `pyinotify` (replaced by Watchman).
 
+* The :class:`~django.db.models.Avg` aggregate function now returns a
+  ``Decimal`` instead of a ``float`` when the input is ``Decimal``.
+
 .. _deprecated-features-2.2:
 
 Features deprecated in 2.2

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -865,15 +865,15 @@ class AggregateTestCase(TestCase):
 
     def test_avg_decimal_field(self):
         v = Book.objects.filter(rating=4).aggregate(avg_price=(Avg('price')))['avg_price']
-        self.assertIsInstance(v, float)
-        self.assertEqual(v, Approximate(47.39, places=2))
+        self.assertIsInstance(v, Decimal)
+        self.assertEqual(v, Approximate(Decimal('47.39'), places=2))
 
     def test_order_of_precedence(self):
         p1 = Book.objects.filter(rating=4).aggregate(avg_price=(Avg('price') + 2) * 3)
-        self.assertEqual(p1, {'avg_price': Approximate(148.18, places=2)})
+        self.assertEqual(p1, {'avg_price': Approximate(Decimal('148.18'), places=2)})
 
         p2 = Book.objects.filter(rating=4).aggregate(avg_price=Avg('price') + 2 * 3)
-        self.assertEqual(p2, {'avg_price': Approximate(53.39, places=2)})
+        self.assertEqual(p2, {'avg_price': Approximate(Decimal('53.39'), places=2)})
 
     def test_combine_different_types(self):
         msg = 'Expression contains mixed types. You must set output_field.'
@@ -1087,7 +1087,7 @@ class AggregateTestCase(TestCase):
                 return super().as_sql(compiler, connection, function='MAX', **extra_context)
 
         qs = Publisher.objects.annotate(
-            price_or_median=Greatest(Avg('book__rating'), Avg('book__price'))
+            price_or_median=Greatest(Avg('book__rating', output_field=DecimalField()), Avg('book__price'))
         ).filter(price_or_median__gte=F('num_awards')).order_by('num_awards')
         self.assertQuerysetEqual(
             qs, [1, 3, 7, 9], lambda v: v.num_awards)

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -1130,7 +1130,7 @@ class AggregationTests(TestCase):
 
         self.assertEqual(
             Book.objects.aggregate(StdDev('price')),
-            {'price__stddev': Approximate(24.16, 2)}
+            {'price__stddev': Approximate(Decimal('24.16'), 2)}
         )
 
         self.assertEqual(
@@ -1145,7 +1145,7 @@ class AggregationTests(TestCase):
 
         self.assertEqual(
             Book.objects.aggregate(StdDev('price', sample=True)),
-            {'price__stddev': Approximate(26.46, 1)}
+            {'price__stddev': Approximate(Decimal('26.46'), 1)}
         )
 
         self.assertEqual(

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -401,7 +401,7 @@ class AggregationTests(TestCase):
                 When(pages__lt=400, then='discount_price'),
                 output_field=DecimalField()
             )))['test'],
-            22.27, places=2
+            Decimal('22.27'), places=2
         )
 
     def test_distinct_conditional_aggregate(self):
@@ -1041,7 +1041,7 @@ class AggregationTests(TestCase):
         books = Book.objects.values_list("publisher__name").annotate(
             Count("id"), Avg("price"), Avg("authors__age"), avg_pgs=Avg("pages")
         ).order_by("-publisher__name")
-        self.assertEqual(books[0], ('Sams', 1, 23.09, 45.0, 528.0))
+        self.assertEqual(books[0], ('Sams', 1, Decimal('23.09'), 45.0, 528.0))
 
     def test_annotation_disjunction(self):
         qs = Book.objects.annotate(n_authors=Count("authors")).filter(

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -1160,7 +1160,7 @@ class AggregationTests(TestCase):
 
         self.assertEqual(
             Book.objects.aggregate(Variance('price')),
-            {'price__variance': Approximate(583.77, 1)}
+            {'price__variance': Approximate(Decimal('583.77'), 1)}
         )
 
         self.assertEqual(
@@ -1175,7 +1175,7 @@ class AggregationTests(TestCase):
 
         self.assertEqual(
             Book.objects.aggregate(Variance('price', sample=True)),
-            {'price__variance': Approximate(700.53, 2)}
+            {'price__variance': Approximate(Decimal('700.53'), 2)}
         )
 
     def test_filtering_by_annotation_name(self):


### PR DESCRIPTION
Ticket [#28643](https://code.djangoproject.com/ticket/28643).

A few bits of clean up surrounding some of the compatibility tweaks required for different backends.

This moves the two mixins from the newly added math function module into a separate module and changes the names to be clearer to allow for better reuse. I have also made the following changes:

- Moved duplicate code out of the `Avg` and `Sum` aggregates into a mixin.
- Fixed the `Sum` aggregate to handle `self.filter` (although we use `self._get_repr_options()`)
- Made `Avg`, `StdDev` and `Variance` aggregates handle outputs as other math functions, i.e. keep `DecimalField` accuracy.