### PR TITLE
Fixed #30050 -- Fixed InlineModelAdmin.has_change_permission() being called with non-None obj during add.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1956,7 +1956,7 @@ class ModelAdmin(BaseModelAdmin):
 
             # Bypass validation of each view-only inline form (since the form's
             # data won't be in request.POST), unless the form was deleted.
-            if not inline.has_change_permission(request, obj):
+            if not inline.has_change_permission(request, obj if change else None):
                 for index, form in enumerate(formset.initial_forms):
                     if user_deleted_form(request, obj, formset, index):
                         continue

--- a/docs/releases/2.1.5.txt
+++ b/docs/releases/2.1.5.txt
@@ -22,3 +22,7 @@ Bugfixes
 * Fixed a regression in Django 2.1.4 (which enabled keep-alive connections)
   where request body data isn't properly consumed for such connections
   (:ticket:`30015`).
+
+* Fixed a regression in Django 2.1.4 where
+  ``InlineModelAdmin.has_change_permission()`` is incorrectly called with a
+  non-``None`` ``obj`` argument during an object add (:ticket:`30050`).


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30050