### PR TITLE
add app_label identifier to ContentTypes name method

### DIFF
--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -149,7 +149,7 @@ class ContentType(models.Model):
         model = self.model_class()
         if not model:
             return self.model
-        return str(model._meta.verbose_name)
+        return "{0} :: {1}".format(model._meta.app_label, model._meta.verbose_name)
 
     def model_class(self):
         """Return the model class for this type of content."""


### PR DESCRIPTION
Hi all, this is my first attempted contribution to Django. I noticed a dissimilarity in how Django handles models from different apps. In Permissions, for example, they are rendered like this:

    admin | admin :: log entry | Can add log entry

Which is great since I can distinguish between models of different apps that might have the same name. However, when looking at a ContentType it just shows the `verbose_name` of the model, like:

    log entry

So if I have two apps that have models that have the same name, then they would be indistinguishable.

A simple way to fix this behavior is to fix the `__str__()` method on the `ContentType` model. I noticed that it uses a helper `name()` method, so I decided to make the change there:

    class ContentType(models.Model):
             model = self.model_class()
             if not model:
                 return self.model
    -        return str(model._meta.verbose_name)
    +        return "{0} :: {1}".format(model._meta.app_label, model._meta.verbose_name)

I used the `::` separator to keep convention with the Permissions style.

Would the developers/community consider this change please?

Thanks!