### PR TITLE
Refs #30033 -- Fixed contenttypes_tests failure on SQLite when run in isolation.

### DIFF
--- a/tests/contenttypes_tests/test_operations.py
+++ b/tests/contenttypes_tests/test_operations.py
@@ -16,6 +16,7 @@ from django.test import TransactionTestCase, override_settings
 class ContentTypeOperationsTests(TransactionTestCase):
     available_apps = [
         'contenttypes_tests',
+        'django.contrib.auth',
         'django.contrib.contenttypes',
     ]
 


### PR DESCRIPTION
Regression in 7289874adceec46b5367ec3157cdd10c711253a0.
Reported at https://github.com/django/django/pull/10744#issuecomment-448864664.