### PR TITLE
Fixed #30058 -- Made SMTP EmailBackend.send_messages() return 0 for empty/error cases.

### DIFF
--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -98,13 +98,13 @@ class EmailBackend(BaseEmailBackend):
         messages sent.
         """
         if not email_messages:
-            return
+            return 0
         with self._lock:
             new_conn_created = self.open()
             if not self.connection or new_conn_created is None:
                 # We failed silently on open().
                 # Trying to send would be pointless.
-                return
+                return 0
             num_sent = 0
             for message in email_messages:
                 sent = self._send(message)

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -1527,7 +1527,12 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
         backend.connection = True
         backend.open = lambda: None
         email = EmailMessage('Subject', 'Content', 'from@example.com', ['to@example.com'])
-        self.assertEqual(backend.send_messages([email]), None)
+        self.assertEqual(backend.send_messages([email]), 0)
+
+    def test_send_messages_empty_list(self):
+        backend = smtp.EmailBackend()
+        backend.connection = True
+        self.assertEqual(backend.send_messages([]), 0)
 
     def test_send_messages_zero_sent(self):
         """A message isn't sent if it doesn't have any recipients."""


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30058

This PR ensures that SMTP EmailBackend.send_messages() always returns an integer