### PR TITLE
[WIP] Fixed #28236 - Adapt dj-database-url into Django

### DIFF
--- a/django/conf/service_urls/__init__.py
+++ b/django/conf/service_urls/__init__.py
@@ -1,0 +1,2 @@
+from .base import Service  # noqa: F401
+from .services import cache, db, email  # noqa: F401

--- a/django/conf/service_urls/base.py
+++ b/django/conf/service_urls/base.py
@@ -1,0 +1,90 @@
+import re
+from urllib import parse
+
+
+class Service:
+    validation = re.compile(r'^(?P<scheme>\S+)://\S*')
+
+    def config_from_url(self, engine, scheme, url):
+        raise NotImplementedError('')
+
+    def __init__(self):
+        self._schemes = {}
+
+    def validate(self, data):
+        match = self.validation.match(data)
+        return match.groups()[0] if match else None
+
+    def _parse(self, data):
+        if not isinstance(data, str):
+            return data
+
+        scheme = self.validate(data)
+        if scheme is None:
+            raise ValueError('{dsn} is invalid, only full dsn urls (scheme://host...) allowed'.format(dsn=data))
+        try:
+            _scheme = self._schemes[scheme]
+        except KeyError:
+            raise ValueError('{scheme}:// scheme not registered'.format(scheme=scheme))
+        callback, engine = _scheme['callback'], _scheme['engine']
+        return callback(self, engine, scheme, data)
+
+    def parse(self, data):
+        if isinstance(data, dict):
+            return {k: self._parse(v) for k, v in data.items()}
+        return self._parse(data)
+
+    @staticmethod
+    def parse_url(url, *, multiple_netloc=False):
+        """
+        A method to parse URLs into components that handles quirks
+        with the stdlib urlparse, such as lower-cased hostnames.
+        Also parses querystrings into typed components.
+        """
+        # This method may be called with an already parsed URL
+        if isinstance(url, dict):
+            return url
+
+        # scheme://netloc/path;parameters?query#fragment
+        parsed = parse.urlparse(url)
+        # 1) cannot have multiple files, so assume that they are always hostnames
+        # 2) parsed.hostname always returns a lower-cased hostname
+        #    this isn't correct if hostname is a file path, so use '_hostinfo'
+        #    to get the actual host
+        netlocs = parsed.netloc.split(',') if multiple_netloc else []
+        hostname, port = (None, None) if len(netlocs) > 1 else parsed._hostinfo
+        if port:
+            port = int(port)
+
+        query = parse.parse_qs(parsed.query)
+        options = {}
+        for key, values in query.items():
+            value = values[-1]
+            if value.isdigit():
+                value = int(value)
+            elif value.lower() == 'true':
+                value = True
+            elif value.lower() == 'false':
+                value = False
+            options[key] = value
+        path = parsed.path[1:]
+
+        config = {
+            'scheme': parsed.scheme,
+            'username': parsed.username,
+            'password': parsed.password,
+            'hostname': hostname,
+            'port': port,
+            'path': path,
+            'fullpath': parsed.path,
+            'options': options,
+            'location': netlocs if len(netlocs) > 1 else parsed.netloc,
+        }
+        return config
+
+    def register(self, *args):
+        def wrapper(func):
+            for (scheme, engine) in args:
+                self._schemes[scheme] = {'callback': func, 'engine': engine}
+            return func
+        return wrapper

--- a/django/conf/service_urls/services.py
+++ b/django/conf/service_urls/services.py
@@ -1,0 +1,211 @@
+from urllib import parse
+
+from .base import Service
+
+
+class DbService(Service):
+    def config_from_url(self, engine, scheme, url):
+        parsed = self.parse_url(url)
+        return {
+            'ENGINE': engine,
+            'NAME': parse.unquote(parsed['path'] or ''),
+            'USER': parse.unquote(parsed['username'] or ''),
+            'PASSWORD': parse.unquote(parsed['password'] or ''),
+            'HOST': parsed['hostname'],
+            'PORT': parsed['port'] or '',
+            'OPTIONS': parsed['options'],
+        }
+
+
+db = DbService()
+
+
+@db.register(('sqlite', 'django.db.backends.sqlite3'), ('spatialite', 'django.contrib.gis.db.backends.spatialite'))
+def sqlite_config_from_url(backend, engine, scheme, url):
+    # These special URLs cannot be parsed correctly.
+    if url in ('sqlite://:memory:', 'sqlite://'):
+        return {
+            'ENGINE': engine,
+            'NAME': ':memory:',
+        }
+
+    parsed = backend.parse_url(url)
+    path = '/' + parsed['path']
+    # On windows a path like C:/a/b is parsed with C as the hostname
+    # and a/b/ as the path. Reconstruct the windows path here.
+    if parsed['hostname']:
+        path = '{0}:{1}'.format(parsed['hostname'], path)
+        parsed['location'] = parsed['hostname'] = ''
+    parsed['path'] = path
+    return backend.config_from_url(engine, scheme, parsed)
+
+
+@db.register(
+    ('postgres', 'django.db.backends.postgresql'), ('postgis', 'django.contrib.gis.db.backends.postgis'),
+    # dj_database_url compat aliases
+    ('postgresql', 'django.db.backends.postgresql'), ('pgsql', 'django.db.backends.postgresql'),
+)
+def postgresql_config_from_url(backend, engine, scheme, url):
+    parsed = backend.parse_url(url)
+    host = parsed['hostname'].lower()
+    # Handle postgres percent-encoded paths.
+    if '%2f' in host or '%3a' in host:
+        parsed['hostname'] = parse.unquote(parsed['hostname'])
+    config = backend.config_from_url(engine, scheme, parsed)
+    if 'currentSchema' in config['OPTIONS']:
+        value = config['OPTIONS'].pop('currentSchema')
+        config['OPTIONS']['options'] = '-c search_path={0}'.format(value)
+    return config
+
+
+@db.register(('mysql', 'django.db.backends.mysql'), ('mysql+gis', 'django.contrib.gis.db.backends.mysql'))
+def mysql_config_from_url(backend, engine, scheme, url):
+    config = backend.config_from_url(engine, scheme, url)
+    if 'ssl-ca' in config['OPTIONS']:
+        value = config['OPTIONS'].pop('ssl-ca')
+        config['OPTIONS']['ssl'] = {'ca': value}
+    return config
+
+
+@db.register(('oracle', 'django.db.backends.oracle'), ('oracle+gis', 'django.contrib.gis.db.backends.oracle'))
+def oracle_config_from_url(backend, engine, scheme, url):
+    config = backend.config_from_url(engine, scheme, url)
+    # Oracle requires string ports
+    config['PORT'] = str(config['PORT'])
+    return config
+
+
+class CacheService(Service):
+    def config_from_url(self, engine, scheme, url, *, multiple_netloc=True):
+        parsed = self.parse_url(url, multiple_netloc=multiple_netloc)
+        config = {
+            'BACKEND': engine,
+        }
+        if multiple_netloc and parsed['location']:
+            config['LOCATION'] = parsed['location']
+        else:
+            if parsed['hostname']:
+                config['LOCATION'] = parsed['hostname']
+                if parsed['port']:
+                    config['LOCATION'] += ':%s' % parsed['port']
+        for key in ('timeout', 'key_prefix', 'version'):
+            if key in parsed['options']:
+                option = parsed['options'].pop(key)
+                config[key.upper()] = option
+        config['OPTIONS'] = parsed['options']
+        return config
+
+
+cache = CacheService()
+
+
+@cache.register(('memory', 'django.core.cache.backends.locmem.LocMemCache'))
+def memory_config_from_url(backend, engine, scheme, url):
+    return backend.config_from_url(engine, scheme, url)
+
+
+@cache.register(('db', 'django.core.cache.backends.db.DatabaseCache'))
+def db_config_from_url(backend, engine, scheme, url):
+    return backend.config_from_url(engine, scheme, url)
+
+
+@cache.register(('dummy', 'django.core.cache.backends.dummy.DummyCache'))
+def dummy_config_from_url(backend, engine, scheme, url):
+    return backend.config_from_url(engine, scheme, url)
+
+
+@cache.register(('memcached', 'django.core.cache.backends.memcached.MemcachedCache'))
+def memcached_config_from_url(backend, engine, scheme, url):
+    parsed = backend.parse_url(url, multiple_netloc=True)
+    config = backend.config_from_url(engine, scheme, parsed, multiple_netloc=True)
+    if parsed['path']:
+        # We are dealing with a URI like memcached:///socket/path
+        config['LOCATION'] = 'unix:/{0}'.format(parsed['path'])
+    return config
+
+
+@cache.register(('memcached+pylibmccache', 'django.core.cache.backends.memcached.PyLibMCCache'))
+def pylibmccache_config_from_url(backend, engine, scheme, url):
+    parsed = backend.parse_url(url, multiple_netloc=True)
+    # We are dealing with a URI like memcached://unix:/abc
+    # Set the hostname to be the unix path
+    parsed['hostname'] = '/{}'.format(parsed['path'])
+    parsed['path'] = None
+    return backend.config_from_url(engine, scheme, parsed)
+
+
+@cache.register(('file', 'django.core.cache.backends.filebased.FileBasedCache'))
+def file_config_from_url(backend, engine, scheme, url):
+    parsed = backend.parse_url(url)
+    config = backend.config_from_url(engine, scheme, parsed)
+    path = '/' + parsed['path']
+    # On windows a path like C:/a/b is parsed with C as the hostname
+    # and a/b/ as the path. Reconstruct the windows path here.
+    if parsed['hostname']:
+        path = '{0}:{1}'.format(parsed['hostname'], path)
+    config['LOCATION'] = path
+    return config
+
+
+class EmailService(Service):
+    def config_from_url(self, engine, scheme, url):
+        return {
+            'ENGINE': engine,
+        }
+
+
+email = EmailService()
+
+
+@email.register(
+    ('smtp', 'django.core.mail.backends.smtp.EmailBackend'),
+    ('smtps', 'django.core.mail.backends.smtp.EmailBackend'),  # smtp+tls alias
+    ('smtp+tls', 'django.core.mail.backends.smtp.EmailBackend'),
+    ('smtp+ssl', 'django.core.mail.backends.smtp.EmailBackend'),
+)
+def email_smtp_config_url(backend, engine, scheme, url):
+    config = backend.config_from_url(engine, scheme, url)
+    parsed = backend.parse_url(url)
+    return {
+        'HOST': parsed['hostname'] or 'localhost',
+        'PORT': parsed['port'] or 25,
+        'HOST_USER': parsed['username'] or '',
+        'HOST_PASSWORD': parsed['password'] or '',
+        'USE_TLS': parsed['options'].get('use_tls', scheme in ('smtps', 'smtp+tls')),
+        'USE_SSL': parsed['options'].get('use_ssl', scheme == 'smtp+ssl'),
+        'SSL_CERTFILE': parsed['options'].get('ssl_certfile', None),
+        'SSL_KEYFILE': parsed['options'].get('ssl_keyfile', None),
+        'TIMEOUT': parsed['options'].get('timeout', None),
+        'USE_LOCALTIME': parsed['options'].get('use_localtime', False),
+        **config,
+    }
+
+
+@email.register(('console', 'django.core.mail.backends.console.EmailBackend'))
+def email_console_config_url(backend, engine, scheme, url):
+    return backend.config_from_url(engine, scheme, url)
+
+
+@email.register(('file', 'django.core.mail.backends.filebased.EmailBackend'))
+def email_file_config_url(backend, engine, scheme, url):
+    config = backend.config_from_url(engine, scheme, url)
+    parsed = backend.parse_url(url)
+    path = '/' + parsed['path']
+    # On windows a path like C:/a/b is parsed with C as the hostname
+    # and a/b/ as the path. Reconstruct the windows path here.
+    if parsed['hostname']:
+        path = '{0}:{1}'.format(parsed['hostname'], path)
+    return {
+        'FILE_PATH': path,
+        **config,
+    }
+
+
+@email.register(('memory', 'django.core.mail.backends.locmem.EmailBackend'))
+def email_memory_config_url(backend, engine, scheme, url):
+    return backend.config_from_url(engine, scheme, url)
+
+
+@email.register(('dummy', 'django.core.mail.backends.dummy.EmailBackend'))
+def email_dummy_config_url(backend, engine, scheme, url):
+    return backend.config_from_url(engine, scheme, url)

--- a/tests/service_urls/settings.py
+++ b/tests/service_urls/settings.py
@@ -1,0 +1,24 @@
+SECRET_KEY = 'secret'
+
+DATABASES = {
+    'default': 'sqlite://:memory:',
+    'postgresql': 'postgres://uf07k1i6d8ia0v:@:5435/d8r82722r2kuvn',
+    'mysql': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'd8r82722r2kuvn',
+        'HOST': 'ec2-107-21-253-135.compute-1.amazonaws.com',
+        'USER': 'uf07k1i6d8ia0v',
+        'PASSWORD': 'wegauwhgeuioweg',
+        'PORT': 3306,
+    },
+}
+
+CACHES = {
+    'default': 'memory://',
+    'dummy': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    },
+    'memcached': 'memcached://1.2.3.4:1567,1.2.3.5:1568',
+}
+
+EMAIL_BACKEND = 'smtps://user:passwd@localhost:465'

--- a/tests/service_urls/test_services.py
+++ b/tests/service_urls/test_services.py
@@ -1,0 +1,405 @@
+import unittest
+
+from django.conf.service_urls import Service, cache, db, email
+
+GENERIC_TESTS = [
+    (
+        'username:password@domain/database',
+        ('username', 'password', 'domain', '', 'database', {})
+    ),
+    (
+        'username:password@domain:123/database',
+        ('username', 'password', 'domain', 123, 'database', {})
+    ),
+    (
+        'domain:123/database',
+        ('', '', 'domain', 123, 'database', {})
+    ),
+    (
+        'user@domain:123/database',
+        ('user', '', 'domain', 123, 'database', {})
+    ),
+    (
+        'username:password@[2001:db8:1234::1234:5678:90af]:123/database',
+        ('username', 'password', '2001:db8:1234::1234:5678:90af', 123, 'database', {})
+    ),
+    (
+        'username:password@host:123/database?reconnect=true',
+        ('username', 'password', 'host', 123, 'database', {'reconnect': True})
+    ),
+    (
+        'username:password@/database',
+        ('username', 'password', '', '', 'database', {})
+    ),
+]
+
+
+class DatabaseTestCase(unittest.TestCase):
+    SCHEME = None
+    STRING_PORTS = False  # Workaround for Oracle
+
+    def test_parsing(self):
+        if self.SCHEME is None:
+            return
+        for value, (user, passw, host, port, database, options) in GENERIC_TESTS:
+            value = '{scheme}://{value}'.format(scheme=self.SCHEME, value=value)
+            with self.subTest(value=value):
+                result = db.parse(value)
+                self.assertEqual(result['NAME'], database)
+                self.assertEqual(result['HOST'], host)
+                self.assertEqual(result['USER'], user)
+                self.assertEqual(result['PASSWORD'], passw)
+                self.assertEqual(result['PORT'], port if not self.STRING_PORTS else str(port))
+                self.assertDictEqual(result['OPTIONS'], options)
+
+
+class SqliteTests(unittest.TestCase):
+    SCHEME = 'sqlite'
+
+    def test_empty_url(self):
+        url = db.parse('sqlite://')
+        self.assertEqual(url['ENGINE'], 'django.db.backends.sqlite3')
+        self.assertEqual(url['NAME'], ':memory:')
+
+    def test_memory_url(self):
+        url = db.parse('sqlite://:memory:')
+        self.assertEqual(url['ENGINE'], 'django.db.backends.sqlite3')
+        self.assertEqual(url['NAME'], ':memory:')
+
+    def test_memory_url(self):
+        url = db.parse('sqlite://:memory:')
+        self.assertEqual(url['ENGINE'], 'django.db.backends.sqlite3')
+        self.assertEqual(url['NAME'], ':memory:')
+
+    def _test_file(self, dbname):
+        url = db.parse('sqlite://{}'.format(dbname))
+        self.assertEqual(url['ENGINE'], 'django.db.backends.sqlite3')
+        self.assertEqual(url['NAME'], dbname)
+        self.assertEqual(url['HOST'], '')
+        self.assertEqual(url['USER'], '')
+        self.assertEqual(url['PASSWORD'], '')
+        self.assertEqual(url['PORT'], '')
+        self.assertDictEqual(url['OPTIONS'], {})
+
+    def test_file(self):
+        self._test_file('/home/user/projects/project/app.sqlite3')
+        self._test_file('C:/home/user/projects/project/app.sqlite3')
+
+
+class PostgresTests(DatabaseTestCase):
+    SCHEME = 'postgres'
+
+    def test_network_parsing(self):
+        url = db.parse('postgres://uf07k1i6d8ia0v:@:5435/d8r82722r2kuvn')
+        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(url['HOST'], '')
+        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(url['PASSWORD'], '')
+        self.assertEqual(url['PORT'], 5435)
+
+    def test_unix_socket_parsing(self):
+        url = db.parse('postgres://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn')
+        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(url['HOST'], '/var/run/postgresql')
+        self.assertEqual(url['USER'], '')
+        self.assertEqual(url['PASSWORD'], '')
+        self.assertEqual(url['PORT'], '')
+
+        url = db.parse('postgres://C%3A%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn')
+        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(url['HOST'], 'C:/var/run/postgresql')
+        self.assertEqual(url['USER'], '')
+        self.assertEqual(url['PASSWORD'], '')
+        self.assertEqual(url['PORT'], '')
+
+    def test_search_path_schema_parsing(self):
+        url = db.parse(
+            'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431'
+            '/d8r82722r2kuvn?currentSchema=otherschema'
+        )
+        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
+        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(url['PASSWORD'], 'wegauwhgeuioweg')
+        self.assertEqual(url['PORT'], 5431)
+        self.assertEqual(url['OPTIONS']['options'], '-c search_path=otherschema')
+        self.assertNotIn('currentSchema', url['OPTIONS'])
+
+    def test_parsing_with_special_characters(self):
+        url = db.parse('postgres://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database')
+        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(url['NAME'], '#database')
+        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
+        self.assertEqual(url['USER'], '#user')
+        self.assertEqual(url['PASSWORD'], '#password')
+        self.assertEqual(url['PORT'], 5431)
+
+    def test_database_url_with_options(self):
+        # Test full options
+        url = db.parse(
+            'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg'
+            '@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn'
+            '?sslrootcert=rds-combined-ca-bundle.pem&sslmode=verify-full'
+        )
+        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
+        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(url['PASSWORD'], 'wegauwhgeuioweg')
+        self.assertEqual(url['PORT'], 5431)
+        self.assertEqual(url['OPTIONS'], {
+            'sslrootcert': 'rds-combined-ca-bundle.pem',
+            'sslmode': 'verify-full'
+        })
+
+    def test_gis_search_path_parsing(self):
+        url = db.parse(
+            'postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431'
+            '/d8r82722r2kuvn?currentSchema=otherschema'
+        )
+        self.assertEqual(url['ENGINE'], 'django.contrib.gis.db.backends.postgis')
+        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
+        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(url['PASSWORD'], 'wegauwhgeuioweg')
+        self.assertEqual(url['PORT'], 5431)
+        self.assertEqual(url['OPTIONS']['options'], '-c search_path=otherschema')
+        self.assertNotIn('currentSchema', url['OPTIONS'])
+
+
+class MysqlTests(DatabaseTestCase):
+    SCHEME = 'mysql'
+
+    def test_with_sslca_options(self):
+        url = db.parse(
+            'mysql://uf07k1i6d8ia0v:wegauwhgeuioweg'
+            '@ec2-107-21-253-135.compute-1.amazonaws.com:3306/d8r82722r2kuvn'
+            '?ssl-ca=rds-combined-ca-bundle.pem'
+        )
+        self.assertEqual(url['ENGINE'], 'django.db.backends.mysql')
+        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
+        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(url['PASSWORD'], 'wegauwhgeuioweg')
+        self.assertEqual(url['PORT'], 3306)
+        self.assertEqual(url['OPTIONS'], {
+            'ssl': {
+                'ca': 'rds-combined-ca-bundle.pem'
+            }
+        })
+
+
+class OracleTests(DatabaseTestCase):
+    SCHEME = 'oracle'
+    STRING_PORTS = True
+
+    def test_dsn_parsing(self):
+        dsn = (
+            '(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)'
+            '(HOST=oraclehost)(PORT=1521)))'
+            '(CONNECT_DATA=(SID=hr)))'
+        )
+        url = db.parse('oracle://scott:tiger@/' + dsn)
+        self.assertEqual(url['ENGINE'], 'django.db.backends.oracle')
+        self.assertEqual(url['USER'], 'scott')
+        self.assertEqual(url['PASSWORD'], 'tiger')
+        self.assertEqual(url['HOST'], '')
+        self.assertEqual(url['PORT'], '')
+
+    def test_empty_dsn_parsing(self):
+        dsn = (
+            '(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)'
+            '(HOST=oraclehost)(PORT=1521)))'
+            '(CONNECT_DATA=(SID=hr)))'
+        )
+        self.assertRaises(ValueError, db.parse, dsn)
+
+
+class TestCaches(unittest.TestCase):
+    def test_local_caching_no_params(self):
+        result = cache.parse('memory://')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.locmem.LocMemCache')
+        self.assertNotIn('LOCATION', result)
+
+    def test_local_caching_with_location(self):
+        result = cache.parse('memory://abc')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.locmem.LocMemCache')
+        self.assertEqual(result['LOCATION'], 'abc')
+
+    def test_database_caching(self):
+        result = cache.parse('db://table-name')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.db.DatabaseCache')
+        self.assertEqual(result['LOCATION'], 'table-name')
+
+    def test_dummy_caching_no_params(self):
+        result = cache.parse('dummy://')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.dummy.DummyCache')
+        self.assertNotIn('LOCATION', result)
+
+    def test_dummy_caching_with_location(self):
+        result = cache.parse('dummy://abc')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.dummy.DummyCache')
+        self.assertEqual(result['LOCATION'], 'abc')
+
+    def test_memcached_with_single_ip(self):
+        result = cache.parse('memcached://1.2.3.4:1567')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.MemcachedCache')
+        self.assertEqual(result['LOCATION'], '1.2.3.4:1567')
+
+    def test_memcached_with_multiple_ips(self):
+        result = cache.parse('memcached://1.2.3.4:1567,1.2.3.5:1568')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.MemcachedCache')
+        self.assertEqual(result['LOCATION'], ['1.2.3.4:1567', '1.2.3.5:1568'])
+
+    def test_memcached_without_port(self):
+        result = cache.parse('memcached://1.2.3.4')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.MemcachedCache')
+        self.assertEqual(result['LOCATION'], '1.2.3.4')
+
+    def test_memcached_with_unix_socket(self):
+        result = cache.parse('memcached:///tmp/memcached.sock')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.MemcachedCache')
+        self.assertEqual(result['LOCATION'], 'unix:/tmp/memcached.sock')
+
+    def test_pylibmccache_memcached_with_single_ip(self):
+        result = cache.parse('memcached+pylibmccache://1.2.3.4:1567')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.PyLibMCCache')
+        self.assertEqual(result['LOCATION'], '1.2.3.4:1567')
+
+    def test_pylibmccache_memcached_with_multiple_ips(self):
+        result = cache.parse('memcached+pylibmccache://1.2.3.4:1567,1.2.3.5:1568')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.PyLibMCCache')
+        self.assertEqual(result['LOCATION'], ['1.2.3.4:1567', '1.2.3.5:1568'])
+
+    def test_pylibmccache_memcached_without_port(self):
+        result = cache.parse('memcached+pylibmccache://1.2.3.4')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.PyLibMCCache')
+        self.assertEqual(result['LOCATION'], '1.2.3.4')
+
+    def test_pylibmccache_memcached_with_unix_socket(self):
+        result = cache.parse('memcached+pylibmccache:///tmp/memcached.sock')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.PyLibMCCache')
+        self.assertEqual(result['LOCATION'], '/tmp/memcached.sock')
+
+    def test_file_cache_windows_path(self):
+        result = cache.parse('file://C:/abc/def/xyz')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.filebased.FileBasedCache')
+        self.assertEqual(result['LOCATION'], 'C:/abc/def/xyz')
+
+    def test_file_cache_unix_path(self):
+        result = cache.parse('file:///abc/def/xyz')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.filebased.FileBasedCache')
+        self.assertEqual(result['LOCATION'], '/abc/def/xyz')
+
+
+EMAIL_SMTP_TESTS = [
+    ('smtp://:@:', {'HOST': 'localhost', 'PORT': 25, 'HOST_USER': '', 'HOST_PASSWORD': '', 'USE_TLS': False, 'USE_SSL': False, 'SSL_CERTFILE': None, 'SSL_KEYFILE': None, 'TIMEOUT': None}),  # noqa
+    ('smtps://:@:', {'HOST': 'localhost', 'PORT': 25, 'HOST_USER': '', 'HOST_PASSWORD': '', 'USE_TLS': True, 'USE_SSL': False, 'SSL_CERTFILE': None, 'SSL_KEYFILE': None, 'TIMEOUT': None}),  # noqa
+    ('smtp+tls://:@:', {'HOST': 'localhost', 'PORT': 25, 'HOST_USER': '', 'HOST_PASSWORD': '', 'USE_TLS': True, 'USE_SSL': False, 'SSL_CERTFILE': None, 'SSL_KEYFILE': None, 'TIMEOUT': None}),  # noqa
+    ('smtp+ssl://:@:', {'HOST': 'localhost', 'PORT': 25, 'HOST_USER': '', 'HOST_PASSWORD': '', 'USE_TLS': False, 'USE_SSL': True, 'SSL_CERTFILE': None, 'SSL_KEYFILE': None, 'TIMEOUT': None}),  # noqa
+]
+
+
+class EmailsTests(unittest.TestCase):
+    def test_smtp(self):
+        for test in EMAIL_SMTP_TESTS:
+            url = email.parse(test[0])
+            self.assertEqual(url['ENGINE'], 'django.core.mail.backends.smtp.EmailBackend')
+            for k, v in test[1].items():
+                self.assertEqual(url[k], v)
+
+    def test_console(self):
+        url = email.parse('console://')
+        self.assertEqual(url['ENGINE'], 'django.core.mail.backends.console.EmailBackend')
+
+    def test_file(self):
+        url = email.parse('file://')
+        self.assertEqual(url['ENGINE'], 'django.core.mail.backends.filebased.EmailBackend')
+        self.assertEqual(url['FILE_PATH'], '/')
+
+    def test_memory(self):
+        url = email.parse('memory://')
+        self.assertEqual(url['ENGINE'], 'django.core.mail.backends.locmem.EmailBackend')
+
+    def test_dummy(self):
+        url = email.parse('dummy://')
+        self.assertEqual(url['ENGINE'], 'django.core.mail.backends.dummy.EmailBackend')
+
+
+class TestParseURL(unittest.TestCase):
+    def setUp(self):
+        self.backend = Service()
+
+    def test_hostname_sensitivity(self):
+        parsed = self.backend.parse_url('http://CaseSensitive')
+        self.assertEqual(parsed['hostname'], 'CaseSensitive')
+
+    def test_port_is_an_integer(self):
+        parsed = self.backend.parse_url('http://CaseSensitive:123')
+        self.assertIsInstance(parsed['port'], int)
+
+    def test_path_strips_leading_slash(self):
+        parsed = self.backend.parse_url('http://test/abc')
+        self.assertEqual(parsed['path'], 'abc')
+
+    def test_query_parameters_integer(self):
+        parsed = self.backend.parse_url('http://test/?a=1')
+        self.assertDictEqual(parsed['options'], {'a': 1})
+
+    def test_query_parameters_boolean(self):
+        parsed = self.backend.parse_url('http://test/?a=true&b=false')
+        self.assertDictEqual(parsed['options'], {'a': True, 'b': False})
+
+    def test_query_last_parameter(self):
+        parsed = self.backend.parse_url('http://test/?a=one&a=two')
+        self.assertDictEqual(parsed['options'], {'a': 'two'})
+
+    def test_does_not_reparse(self):
+        parsed = self.backend.parse_url('http://test/abc')
+        self.assertIs(self.backend.parse_url(parsed), parsed)
+
+
+class DictionaryTests(unittest.TestCase):
+    def test_databases(self):
+        result = db.parse({
+            'default': 'sqlite://:memory:',
+            'postgresql': 'postgres://uf07k1i6d8ia0v:@:5435/d8r82722r2kuvn',
+            'mysql': {
+                'ENGINE': 'django.db.backends.mysql',
+                'NAME': 'd8r82722r2kuvn',
+                'HOST': 'ec2-107-21-253-135.compute-1.amazonaws.com',
+                'USER': 'uf07k1i6d8ia0v',
+                'PASSWORD': 'wegauwhgeuioweg',
+                'PORT': 3306,
+            },
+        })
+        self.assertEqual(result['default']['ENGINE'], 'django.db.backends.sqlite3')
+        self.assertEqual(result['default']['NAME'], ':memory:')
+        self.assertEqual(result['postgresql']['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(result['postgresql']['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(result['postgresql']['HOST'], '')
+        self.assertEqual(result['postgresql']['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(result['postgresql']['PASSWORD'], '')
+        self.assertEqual(result['postgresql']['PORT'], 5435)
+        self.assertEqual(result['mysql']['ENGINE'], 'django.db.backends.mysql')
+        self.assertEqual(result['mysql']['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(result['mysql']['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
+        self.assertEqual(result['mysql']['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(result['mysql']['PASSWORD'], 'wegauwhgeuioweg')
+        self.assertEqual(result['mysql']['PORT'], 3306)
+
+    def test_caches(self):
+        result = cache.parse({
+            'default': 'memory://',
+            'dummy': {
+                'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+            },
+            'memcached': 'memcached://1.2.3.4:1567,1.2.3.5:1568',
+        })
+        self.assertEqual(result['default']['BACKEND'], 'django.core.cache.backends.locmem.LocMemCache')
+        self.assertEqual(result['dummy']['BACKEND'], 'django.core.cache.backends.dummy.DummyCache')
+        self.assertEqual(result['memcached']['BACKEND'], 'django.core.cache.backends.memcached.MemcachedCache')
+        self.assertEqual(result['memcached']['LOCATION'], ['1.2.3.4:1567', '1.2.3.5:1568'])

--- a/tests/service_urls/test_settings.py
+++ b/tests/service_urls/test_settings.py
@@ -1,0 +1,43 @@
+from django.conf import LazySettings, Settings
+from django.test import TestCase
+
+settings = LazySettings()
+settings.configure(Settings('tests.service_urls.settings'))
+
+
+class SettingsTest(TestCase):
+    def test_databases(self):
+        result = settings.DATABASES
+        self.assertEqual(result['default']['ENGINE'], 'django.db.backends.sqlite3')
+        self.assertEqual(result['default']['NAME'], ':memory:')
+        self.assertEqual(result['postgresql']['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(result['postgresql']['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(result['postgresql']['HOST'], '')
+        self.assertEqual(result['postgresql']['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(result['postgresql']['PASSWORD'], '')
+        self.assertEqual(result['postgresql']['PORT'], 5435)
+        self.assertEqual(result['mysql']['ENGINE'], 'django.db.backends.mysql')
+        self.assertEqual(result['mysql']['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(result['mysql']['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
+        self.assertEqual(result['mysql']['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(result['mysql']['PASSWORD'], 'wegauwhgeuioweg')
+        self.assertEqual(result['mysql']['PORT'], 3306)
+
+    def test_caches(self):
+        result = settings.CACHES
+        self.assertEqual(result['default']['BACKEND'], 'django.core.cache.backends.locmem.LocMemCache')
+        self.assertEqual(result['dummy']['BACKEND'], 'django.core.cache.backends.dummy.DummyCache')
+        self.assertEqual(result['memcached']['BACKEND'], 'django.core.cache.backends.memcached.MemcachedCache')
+        self.assertEqual(result['memcached']['LOCATION'], ['1.2.3.4:1567', '1.2.3.5:1568'])
+
+    def test_email_backend(self):
+        self.assertEqual(settings.EMAIL_BACKEND, 'django.core.mail.backends.smtp.EmailBackend')
+        self.assertEqual(settings.EMAIL_HOST, 'localhost')
+        self.assertEqual(settings.EMAIL_PORT, 465)
+        self.assertEqual(settings.EMAIL_HOST_USER, 'user')
+        self.assertEqual(settings.EMAIL_HOST_PASSWORD, 'passwd')
+        self.assertEqual(settings.EMAIL_USE_TLS, True)
+        self.assertEqual(settings.EMAIL_USE_SSL, False)
+        self.assertEqual(settings.EMAIL_SSL_CERTFILE, None)
+        self.assertEqual(settings.EMAIL_SSL_KEYFILE, None)
+        self.assertEqual(settings.EMAIL_TIMEOUT, None)


### PR DESCRIPTION
Ticket https://code.djangoproject.com/ticket/28236

This is my implementation of https://github.com/django/django/pull/8562 version (which where I started from).
I think it is less intrusive than the other implementation, and I've implemented a totally independent package https://pypi.org/project/django-service-urls/ ([main repo](https://bitbucket.org/rsalmaso/django-service-urls/) - [github mirror](https://github.com/rsalmaso/django-service-urls)) which I currenty use in my projects from some time.

One improvement from https://github.com/django/django/pull/8562 is the EMAIL_BACKEND adapter.

Currently this wip lacks all docs, which are present in my package.