### PR TITLE
Fixed #30060 -- Moved indexes and constraints SQL generation to SchemaEditor.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1059,10 +1059,11 @@ class BaseDatabaseSchemaEditor:
         return self._delete_constraint_sql(self.sql_delete_check, model, name)
 
     def _delete_constraint_sql(self, template, model, name):
-        return template % {
-            "table": self.quote_name(model._meta.db_table),
-            "name": self.quote_name(name),
-        }
+        return Statement(
+            template,
+            table=Table(model._meta.db_table, self.quote_name),
+            name=self.quote_name(name),
+        )
 
     def _constraint_names(self, model, column_names=None, unique=None,
                           primary_key=None, index=None, foreign_key=None,

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -422,7 +422,7 @@ class BaseDatabaseSchemaEditor:
         # Check constraints can go on the column SQL here
         db_params = field.db_parameters(connection=self.connection)
         if db_params['check']:
-            definition += " CHECK (%s)" % db_params['check']
+            definition += " " + self.sql_check_constraint % db_params['check']
         # Build the SQL and run it
         sql = self.sql_create_column % {
             "table": self.quote_name(model._meta.db_table),

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -931,7 +931,14 @@ class BaseDatabaseSchemaEditor:
             using=using,
             columns=self._index_columns(table, columns, col_suffixes, opclasses),
             extra=tablespace_sql,
-            condition=condition,
+            condition=(' WHERE ' + condition) if condition else '',
+        )
+
+    def _delete_index_sql(self, model, name):
+        return Statement(
+            self.sql_delete_index,
+            table=Table(model._meta.db_table, self.quote_name),
+            name=self.quote_name(name),
         )
 
     def _index_columns(self, table, columns, col_suffixes, opclasses):

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -114,7 +114,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             (old_type.startswith('citext') and not new_type.startswith('citext'))
         ):
             index_name = self._create_index_name(model._meta.db_table, [old_field.column], suffix='_like')
-            self.execute(self._delete_constraint_sql(self.sql_delete_index, model, index_name))
+            self.execute(self._delete_index_sql(model, index_name))
 
         super()._alter_field(
             model, old_field, new_field, old_type, new_type, old_db_params,
@@ -130,7 +130,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # Removed an index? Drop any PostgreSQL-specific indexes.
         if old_field.unique and not (new_field.db_index or new_field.unique):
             index_to_remove = self._create_index_name(model._meta.db_table, [old_field.column], suffix='_like')
-            self.execute(self._delete_constraint_sql(self.sql_delete_index, model, index_to_remove))
+            self.execute(self._delete_index_sql(model, index_to_remove))
 
     def _index_columns(self, table, columns, col_suffixes, opclasses):
         if opclasses:

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -11,10 +11,10 @@ from django.db.utils import NotSupportedError
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     sql_delete_table = "DROP TABLE %(table)s"
+    sql_create_fk = None
     sql_create_inline_fk = "REFERENCES %(to_table)s (%(to_column)s) DEFERRABLE INITIALLY DEFERRED"
     sql_create_unique = "CREATE UNIQUE INDEX %(name)s ON %(table)s (%(columns)s)"
     sql_delete_unique = "DROP INDEX %(name)s"
-    sql_foreign_key_constraint = None
 
     def __enter__(self):
         # Some SQLite schema alterations need foreign key constraints to be

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -65,7 +65,7 @@ class Index:
         sql, params = query.where.as_sql(compiler=compiler, connection=schema_editor.connection)
         # BaseDatabaseSchemaEditor does the same map on the params, but since
         # it's handled outside of that class, the work is done here.
-        return ' WHERE ' + (sql % tuple(map(schema_editor.quote_value, params)))
+        return sql % tuple(map(schema_editor.quote_value, params))
 
     def create_sql(self, model, schema_editor, using=''):
         fields = [model._meta.get_field(field_name) for field_name, _ in self.fields_orders]
@@ -77,11 +77,7 @@ class Index:
         )
 
     def remove_sql(self, model, schema_editor):
-        quote_name = schema_editor.quote_name
-        return schema_editor.sql_delete_index % {
-            'table': quote_name(model._meta.db_table),
-            'name': quote_name(self.name),
-        }
+        return schema_editor._delete_index_sql(model, self.name)
 
     def deconstruct(self):
         path = '%s.%s' % (self.__class__.__module__, self.__class__.__name__)

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -322,13 +322,6 @@ backends.
 * Third party database backends must implement support for partial indexes or
   set ``DatabaseFeatures.supports_partial_indexes`` to ``False``.
 
-* Several ``SchemaEditor`` attributes are changed:
-
-  * ``sql_create_check`` is replaced with ``sql_create_constraint``.
-  * ``sql_delete_check`` is replaced with ``sql_delete_constraint``.
-  * ``sql_create_fk`` is replaced with ``sql_foreign_key_constraint``,
-    ``sql_constraint``, and ``sql_create_constraint``.
-
 * ``DatabaseIntrospection.table_name_converter()`` and
   ``column_name_converter()`` are removed. Third party database backends may
   need to instead implement ``DatabaseIntrospection.identifier_converter()``.
@@ -336,13 +329,14 @@ backends.
   ``DatabaseIntrospection.get_constraints()`` returns must be normalized by
   ``identifier_converter()``.
 
-* Several ``SchemaEditor`` methods added:
+* SQL generation for indexes is moved from :class:`~django.db.models.Index` to
+  ``SchemaEditor`` and these ``SchemaEditor`` methods are added:
 
-  * added ``_create_primary_key_sql`` and ``_delete_primary_key_sql``
-  * added ``_delete_index_sql`` (as pair to ``_create_index_sql``)
-  * added ``_delete_unique_sql`` (as pair to ``_create_unique_sql``)
-  * added ``_delete_fk_sql`` (as pair to ``_create_fk_sql``)
-  * added ``_create_check_sql`` and ``_delete_check_sql``
+  * ``_create_primary_key_sql()`` and ``_delete_primary_key_sql()``
+  * ``_delete_index_sql()`` (to pair with ``_create_index_sql()``)
+  * ``_delete_unique_sql`` (to pair with ``_create_unique_sql()``)
+  * ``_delete_fk_sql()`` (to pair with ``_create_fk_sql()``)
+  * ``_create_check_sql()`` and ``_delete_check_sql()``
 
 Admin actions are no longer collected from base ``ModelAdmin`` classes
 ----------------------------------------------------------------------

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -336,6 +336,14 @@ backends.
   ``DatabaseIntrospection.get_constraints()`` returns must be normalized by
   ``identifier_converter()``.
 
+* Several ``SchemaEditor`` methods added:
+
+  * added ``_create_primary_key_sql`` and ``_delete_primary_key_sql``
+  * added ``_delete_index_sql`` (as pair to ``_create_index_sql``)
+  * added ``_delete_unique_sql`` (as pair to ``_create_unique_sql``)
+  * added ``_delete_fk_sql`` (as pair to ``_create_fk_sql``)
+  * added ``_create_check_sql`` and ``_delete_check_sql``
+
 Admin actions are no longer collected from base ``ModelAdmin`` classes
 ----------------------------------------------------------------------
 

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -18,6 +18,18 @@ class BaseConstraintTests(SimpleTestCase):
         with self.assertRaisesMessage(NotImplementedError, msg):
             c.constraint_sql(None, None)
 
+    def test_create_sql(self):
+        c = BaseConstraint('name')
+        msg = 'This method must be implemented by a subclass.'
+        with self.assertRaisesMessage(NotImplementedError, msg):
+            c.create_sql(None, None)
+
+    def test_remove_sql(self):
+        c = BaseConstraint('name')
+        msg = 'This method must be implemented by a subclass.'
+        with self.assertRaisesMessage(NotImplementedError, msg):
+            c.remove_sql(None, None)
+
 
 class CheckConstraintTests(TestCase):
     def test_repr(self):

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -2147,23 +2147,17 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(model, get_field(unique=True), field, strict=True)
             self.assertNotIn(expected_constraint_name, self.get_constraints(model._meta.db_table))
 
-            if editor.sql_foreign_key_constraint:
+            if editor.sql_create_fk:
                 constraint_name = 'CamelCaseFKConstraint'
                 expected_constraint_name = identifier_converter(constraint_name)
-                fk_sql = editor.sql_foreign_key_constraint % {
-                    "column": editor.quote_name(column),
-                    "to_table": editor.quote_name(table),
-                    "to_column": editor.quote_name(model._meta.auto_field.column),
-                    "deferrable": connection.ops.deferrable_sql(),
-                }
-                constraint_sql = editor.sql_constraint % {
-                    "name": editor.quote_name(constraint_name),
-                    "constraint": fk_sql,
-                }
                 editor.execute(
-                    editor.sql_create_constraint % {
+                    editor.sql_create_fk % {
                         "table": editor.quote_name(table),
-                        "constraint": constraint_sql,
+                        "name": editor.quote_name(constraint_name),
+                        "column": editor.quote_name(column),
+                        "to_table": editor.quote_name(table),
+                        "to_column": editor.quote_name(model._meta.auto_field.column),
+                        "deferrable": connection.ops.deferrable_sql(),
                     }
                 )
                 self.assertIn(expected_constraint_name, self.get_constraints(model._meta.db_table))


### PR DESCRIPTION
This MR contains:

- small schema refactorings
- move sql generation for condition from model.indexes to schema
- move sql generation from model.constraints to schema
- provide special methods for index/unique/primary key/foreign key/check constraints sql generation

And one contradiction (last) commit where I propose back to FK/check/unique constraint generation from template instead parts composition:
Just template a bit easier for reading than previous constraint parts generation.
Old constraints also have issues in next cases:
 1. sqlite use UNIQUE INDEX for constraint in django
 2. postgresql partial unique constraint can be created only as UNIQUE INDEX
- so this examples require using of special conditions or methods for sql generation, but it a bit easier extend schema backend just with template overriding.