### PR TITLE
Refs #26840 -- Adjusted SQLite connection mocking in a setup_database() test.

### DIFF
--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -285,7 +285,7 @@ class InspectDBTestCase(TestCase):
 
 
 class InspectDBTransactionalTests(TransactionTestCase):
-    available_apps = None
+    available_apps = ['inspectdb']
 
     def test_include_views(self):
         """inspectdb --include-views creates models for database views."""

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -247,6 +247,17 @@ class SQLiteInMemoryTestDbs(TransactionTestCase):
     @unittest.skipUnless(all(db.connections[conn].vendor == 'sqlite' for conn in db.connections),
                          "This is an sqlite-specific issue")
     def test_transaction_support(self):
+        # Assert connections mocking is appropriately applied by preventing
+        # any attempts at calling create_test_db on the global connection
+        # objects.
+        for connection in db.connections.all():
+            create_test_db = mock.patch.object(
+                connection.creation,
+                'create_test_db',
+                side_effect=AssertionError("Global connection object shouldn't be manipulated.")
+            )
+            create_test_db.start()
+            self.addCleanup(create_test_db.stop)
         for option_key, option_value in (
                 ('NAME', ':memory:'), ('TEST', {'NAME': ':memory:'})):
             tested_connections = db.ConnectionHandler({
@@ -259,16 +270,17 @@ class SQLiteInMemoryTestDbs(TransactionTestCase):
                     option_key: option_value,
                 },
             })
-            with mock.patch('django.db.connections', new=tested_connections):
-                with mock.patch('django.test.testcases.connections', new=tested_connections):
-                    other = tested_connections['other']
-                    DiscoverRunner(verbosity=0).setup_databases()
-                    msg = ("DATABASES setting '%s' option set to sqlite3's ':memory:' value "
-                           "shouldn't interfere with transaction support detection." % option_key)
-                    # Transaction support should be properly initialized for the 'other' DB
-                    self.assertTrue(other.features.supports_transactions, msg)
-                    # And all the DBs should report that they support transactions
-                    self.assertTrue(connections_support_transactions(), msg)
+            with mock.patch('django.test.utils.connections', new=tested_connections):
+                other = tested_connections['other']
+                DiscoverRunner(verbosity=0).setup_databases()
+                msg = (
+                    "DATABASES setting '%s' option set to sqlite3's ':memory:' value "
+                    "shouldn't interfere with transaction support detection." % option_key
+                )
+                # Transaction support is properly initialized for the 'other' DB.
+                self.assertTrue(other.features.supports_transactions, msg)
+                # And all the DBs report that they support transactions.
+                self.assertTrue(connections_support_transactions(), msg)
 
 
 class DummyBackendTest(unittest.TestCase):


### PR DESCRIPTION
The second commit is not necessary to get tests passing but should give a significant speedup of these tests.

Before on Oracle

https://djangoci.com/job/django-oracle/database=oracle12,python=python3.5/lastCompletedBuild/testReport/inspectdb.tests/InspectDBTransactionalTests/

After on Oracle

https://djangoci.com/job/pull-requests-oracle/database=oracle12,label=bionic-pr,python=python3.7/272/testReport/inspectdb.tests/InspectDBTransactionalTests/