### PR TITLE
Fixed #29669 -- Allow admin method in the 'ordering' tuple of a ModelAdmin.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -558,6 +558,21 @@ class BaseModelAdminChecks:
             try:
                 obj.model._meta.get_field(field_name)
             except FieldDoesNotExist:
+                attr = getattr(obj, field_name, None)
+                if attr is not None and callable(attr):  # Check field name in admin methods
+                    if hasattr(attr, 'admin_order_field'):
+                        return []
+                    else:
+                        return [
+                            checks.Error(
+                                "The value of 'ordering' refers to '%s', which is an 'admin method' "
+                                "and the method doesn't have 'admin_order_field' attribute" % field_name,
+                                hint="Add 'admin_order_field' attribute to 'admin method'",
+                                obj=obj.__class__,
+                                id='admin.E041',
+                            )
+                        ]
+
                 return refer_to_missing_field(field=field_name, option=label, obj=obj, id='admin.E033')
             else:
                 return []

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -540,6 +540,10 @@ with the admin site:
   referenced by ``<modeladmin>.autocomplete_fields``.
 * **admin.E040**: ``<modeladmin>`` must define ``search_fields``, because
   it's referenced by ``<other_modeladmin>.autocomplete_fields``.
+* **admin.E041**: The value of ``ordering`` refers to ``<field name>``, which
+  is an ``admin method`` and the method doesn't have ``admin_order_field``
+  attribute.
+
 
 ``ModelAdmin``
 ~~~~~~~~~~~~~~

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -15,6 +15,7 @@ from django.core.exceptions import ValidationError
 from django.core.files.storage import FileSystemStorage
 from django.core.mail import EmailMessage
 from django.db import models
+from django.db.models import Count
 from django.forms.models import BaseModelFormSet
 from django.http import HttpResponse, StreamingHttpResponse
 from django.utils.html import format_html
@@ -1128,11 +1129,25 @@ class ColorAdmin6(admin.ModelAdmin):
         return ()
 
 
+class BookAdmin6(admin.ModelAdmin):
+    list_display = ('name', 'chapter_count')
+    ordering = ('chapter_count', )
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.annotate(_chapter_count=Count('chapter'))
+
+    def chapter_count(self, obj):
+        return obj._chapter_count
+    chapter_count.admin_order_field = '_chapter_count'
+
+
 site6 = admin.AdminSite(name='admin6')
 site6.register(Article, ArticleAdmin6)
 site6.register(Actor, ActorAdmin6)
 site6.register(Chapter, ChapterAdmin6)
 site6.register(Color, ColorAdmin6)
+site6.register(Book, BookAdmin6)
 
 
 class ArticleAdmin9(admin.ModelAdmin):
@@ -1141,8 +1156,22 @@ class ArticleAdmin9(admin.ModelAdmin):
         return obj is None
 
 
+class BookAdmin9(admin.ModelAdmin):
+    list_display = ('name', 'chapter_count')
+    ordering = ('-chapter_count', )
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.annotate(_chapter_count=Count('chapter'))
+
+    def chapter_count(self, obj):
+        return obj._chapter_count
+    chapter_count.admin_order_field = '_chapter_count'
+
+
 site9 = admin.AdminSite(name='admin9')
 site9.register(Article, ArticleAdmin9)
+site9.register(Book, BookAdmin9)
 
 
 class ArticleAdmin10(admin.ModelAdmin):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -122,6 +122,7 @@ class AdminViewBasicTestCase(TestCase):
         cls.chap2 = Chapter.objects.create(title='Chapter 2', content='[ insert contents here ]', book=cls.b1)
         cls.chap3 = Chapter.objects.create(title='Chapter 1', content='[ insert contents here ]', book=cls.b2)
         cls.chap4 = Chapter.objects.create(title='Chapter 2', content='[ insert contents here ]', book=cls.b2)
+        cls.chap5 = Chapter.objects.create(title='Chapter 3', content='[ insert contents here ]', book=cls.b2)
         cls.cx1 = ChapterXtra1.objects.create(chap=cls.chap1, xtra='ChapterXtra1 1')
         cls.cx2 = ChapterXtra1.objects.create(chap=cls.chap3, xtra='ChapterXtra1 2')
         Actor.objects.create(name='Palin', age=27)
@@ -486,6 +487,18 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
 
         response = self.client.get(reverse('admin:admin_views_podcast_changelist'), {})
         self.assertContentBefore(response, link1, link2)
+
+    def test_change_list_sorting_based_on_admin_method(self):
+        # Test ordering by admin method
+        link1 = reverse('admin6:admin_views_book_change', args=(self.b1.pk,))
+        link2 = reverse('admin6:admin_views_book_change', args=(self.b2.pk,))
+        response = self.client.get(reverse('admin6:admin_views_book_changelist'), {})
+        self.assertContentBefore(response, link1, link2)
+
+        link1 = reverse('admin9:admin_views_book_change', args=(self.b1.pk,))
+        link2 = reverse('admin9:admin_views_book_change', args=(self.b2.pk,))
+        response = self.client.get(reverse('admin9:admin_views_book_changelist'), {})
+        self.assertContentBefore(response, link2, link1)
 
     def test_multiple_sort_same_field(self):
         # The changelist displays the correct columns if two columns correspond

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -900,6 +900,51 @@ class OrderingCheckTests(CheckTestCase):
 
         self.assertIsValid(TestModelAdmin, ValidationTestModel)
 
+    def test_admin_method(self):
+        class TestModelAdmin(ModelAdmin):
+            ordering = ('test_method', )
+
+            def test_method(self, obj):
+                return 'test'
+
+            test_method.admin_order_field = 'name'
+        self.assertIsValid(TestModelAdmin, ValidationTestModel)
+
+        # Descending
+        class TestModelAdmin(ModelAdmin):
+            ordering = ('-test_method', )
+
+            def test_method(self, obj):
+                return 'test'
+            test_method.admin_order_field = 'name'
+        self.assertIsValid(TestModelAdmin, ValidationTestModel)
+
+        # Without method
+        class TestModelAdmin(ModelAdmin):
+            ordering = ('test_method', )
+
+        self.assertIsInvalid(
+            TestModelAdmin, ValidationTestModel,
+            "The value of 'ordering[0]' refers to 'test_method', which is not "
+            "an attribute of 'modeladmin.ValidationTestModel'.",
+            'admin.E033'
+        )
+
+        # Without admin_order_field
+        class TestModelAdmin(ModelAdmin):
+            ordering = ('test_method', )
+
+            def test_method(self, obj):
+                return 'test'
+
+        self.assertIsInvalid(
+            TestModelAdmin, ValidationTestModel,
+            "The value of 'ordering' refers to 'test_method', which is an "
+            "'admin method' and the method doesn't have 'admin_order_field' attribute",
+            'admin.E041',
+            hint="Add 'admin_order_field' attribute to 'admin method'",
+        )
+
 
 class ListSelectRelatedCheckTests(CheckTestCase):
 


### PR DESCRIPTION
[ticket_29669](https://code.djangoproject.com/ticket/29669)