### PR TITLE
Fixed#30053 -- Added support to only update if condition matches in update_or_create

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -617,6 +617,7 @@ answer newbie questions, and generally made Django that much better:
     Mykola Zamkovoi <nickzam@gmail.com>
     Nagy Károly <charlie@rendszergazda.com>
     Nasimul Haque <nasim.haque@gmail.com>
+    Nasir Hussain <nasirhjafri@gmail.com>
     Natalia Bidart <nataliabidart@gmail.com>
     Nate Bragg <jonathan.bragg@alum.rpi.edu>
     Neal Norwitz <nnorwitz@google.com>

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -3,6 +3,7 @@ The main QuerySet implementation. This provides the public API for the ORM.
 """
 
 import copy
+import inspect
 import operator
 import warnings
 from collections import OrderedDict, namedtuple
@@ -549,6 +550,13 @@ class QuerySet:
         """
         defaults = defaults or {}
         self._for_write = True
+
+        # Check if condition is callable and has one input param
+        # otherwise add it to kwargs and pass to model get
+        if not(callable(condition) and len(inspect.signature(condition).parameters) == 1):
+            kwargs['condition'] = condition
+            condition = None
+
         with transaction.atomic(using=self.db):
             try:
                 obj = self.select_for_update().get(**kwargs)

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -540,10 +540,10 @@ class QuerySet:
             params = self._extract_model_params(defaults, **kwargs)
             return self._create_object_from_params(kwargs, params)
 
-    def update_or_create(self, defaults=None, **kwargs):
+    def update_or_create(self, defaults=None, condition=None, **kwargs):
         """
         Look up an object with the given kwargs, updating one with defaults
-        if it exists, otherwise create a new one.
+        if it exists and matches the condition, otherwise create a new one.
         Return a tuple (object, created), where created is a boolean
         specifying whether an object was created.
         """
@@ -552,6 +552,9 @@ class QuerySet:
         with transaction.atomic(using=self.db):
             try:
                 obj = self.select_for_update().get(**kwargs)
+                if condition and not condition(obj):
+                    return obj, False
+
             except self.model.DoesNotExist:
                 params = self._extract_model_params(defaults, **kwargs)
                 # Lock the row so that a concurrent update is blocked until


### PR DESCRIPTION
**Overview**
Ticket [30053](https://code.djangoproject.com/ticket/30053).

QuerySet.update_or_create() is great since it lifts the burden of thread-safety and repeated code from the client. However, there exists some scenarios where the "update" logic should be hidden behind a condition. (E.g. only update if the value of a DateTimeField is less than some value). There isn't much help for clients in these scenarios, with the best solution being to copy+paste QuerySet.update_or_create() and wrap the setattr-and-save logic in a conditional (worst case being they roll their own code, which likely would lead to thread-safety issues)
The condition would most likely be a callable that accepts one argument, the gotten instance.


**Testing notes**
I've added a new parameter called condition. So if a condition query is given `update_or_create` will chain the query in the existing query set and get the object. If there is no matching object then the function will return the tupple of the object and false otherwise it will move to the next steps and update that object.

Example: 
```python
from django.db import models
from django.db.models import Q


class MyModel(models.Model):
    magic_number = models.IntegerField(default=0)
    should_be_updated = models.BooleanField(default=True)


MyModel.objects.create(magic_number=42, should_be_updated=True)
```
Now the following query will not update anything as the condition doesn't matches.
```python
MyModel.objects.filter(magic_number=42).update_or_create(condition=lambda m: m.should_be_updated),
                                                         defaults={'magic_number': 43})
```

Whereas before, the following query would have created a new object in the database
```python
MyModel.objects.filter(magic_number=42, should_be_updated=False).update_or_create(defaults={'magic_number': 43})
```
