### PR TITLE
Fixed #30066 -- Enabled super user creation without email and password

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -150,7 +150,7 @@ class UserManager(BaseUserManager):
         extra_fields.setdefault('is_superuser', False)
         return self._create_user(username, email, password, **extra_fields)
 
-    def create_superuser(self, username, email, password, **extra_fields):
+    def create_superuser(self, username, email=None, password=None, **extra_fields):
         extra_fields.setdefault('is_staff', True)
         extra_fields.setdefault('is_superuser', True)
 

--- a/tests/auth_tests/test_models.py
+++ b/tests/auth_tests/test_models.py
@@ -155,6 +155,18 @@ class UserManagerTestCase(TestCase):
         for char in password:
             self.assertIn(char, allowed_chars)
 
+    def test_create_user_no_email(self):
+        user = User.objects.create_user('user')
+        self.assertEqual(user.email, "")
+        self.assertEqual(user.username, 'user')
+        self.assertFalse(user.has_usable_password())
+
+    def test_create_super_user_no_email(self):
+        user = User.objects.create_superuser('user')
+        self.assertEqual(user.email, "")
+        self.assertEqual(user.username, 'user')
+        self.assertFalse(user.has_usable_password())
+
 
 class AbstractBaseUserTests(SimpleTestCase):
 


### PR DESCRIPTION
I added a test case with no email and password for the super user which failed. later i changed the code in the models to email = None and password = None in the contrib/auth/models createsuperuser params and now the test case is passing