### PR TITLE
Fix Discrepency in Max and Min Value Validators

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -338,8 +338,26 @@ class BaseValidator:
 
 
 @deconstructible
-class MaxValueValidator(BaseValidator):
+class InclusiveMaxValueValidator(BaseValidator):
     message = _('Ensure this value is less than or equal to %(limit_value)s.')
+    code = 'max_value'
+
+    def compare(self, a, b):
+        return a >= b
+
+
+@deconstructible
+class InclusiveMinValueValidator(BaseValidator):
+    message = _('Ensure this value is greater than or equal to %(limit_value)s.')
+    code = 'min_value'
+
+    def compare(self, a, b):
+        return a <= b
+
+    
+@deconstructible
+class ExclusiveMaxValueValidator(BaseValidator):
+    message = _('Ensure this value is less than %(limit_value)s.')
     code = 'max_value'
 
     def compare(self, a, b):
@@ -347,13 +365,16 @@ class MaxValueValidator(BaseValidator):
 
 
 @deconstructible
-class MinValueValidator(BaseValidator):
-    message = _('Ensure this value is greater than or equal to %(limit_value)s.')
+class ExclusiveMinValueValidator(BaseValidator):
+    message = _('Ensure this value is greater than %(limit_value)s.')
     code = 'min_value'
 
     def compare(self, a, b):
         return a < b
 
+    
+MaxValueValidator = ExclusiveMaxValueValidator
+MinValueValidator = ExclusiveMinValueValidator
 
 @deconstructible
 class MinLengthValidator(BaseValidator):


### PR DESCRIPTION
Classes MinValueValidator and MaxValueValidator had a discrepancy between their error message and their actual behavior.
Both classes returned false if the comparison values were equal - even though the error message said that equal values should return true.
I created 4 new classes that are explicit about which behavior the user should expect: InclusiveMaxValueValidator, InclusiveMinValueValidator, ExclusiveMaxValueValidator, ExclusiveMinValueValidator. The "Inclusive" validators return true if the comparison values are equal; the "Exclusive" validators return false if the values are equal. The error messages of these classes are consistent with their behavior.

The original MaxValueValidator and MinValueValidator classes are now shortcuts to the "Exclusive" validators, because that matches the behavior of these classes before this patch. It preserves backwards-compatibility, but I think this also sacrifices the intuitive understanding of how these classes should work (as "Inclusive" comparisons), so this could be looked at at a later date.