### PR TITLE
Updated a test to reflect the fact that "import *" isn't used in URLconfs anymore (refs #14675).

### DIFF
--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -1064,7 +1064,7 @@ class ErrorHandlerResolutionTests(SimpleTestCase):
                 self.assertEqual(self.callable_resolver.resolve_error_handler(code), handler)
 
 
-@override_settings(ROOT_URLCONF='urlpatterns_reverse.urls_without_full_import')
+@override_settings(ROOT_URLCONF='urlpatterns_reverse.urls_without_handlers')
 class DefaultErrorHandlerTests(SimpleTestCase):
 
     def test_default_handler(self):

--- a/tests/urlpatterns_reverse/urls_without_handlers.py
+++ b/tests/urlpatterns_reverse/urls_without_handlers.py
@@ -1,6 +1,4 @@
-# A URLs file that doesn't use the default
-# from django.conf.urls import *
-# import pattern.
+# A URLconf that doesn't define any handlerXXX.
 from django.conf.urls import url
 
 from .views import bad_view, empty_view


### PR DESCRIPTION
Test was added in 859fc020a7c5ce30784d6388858ffbc613ef6612.