### PR TITLE
Fixed #30071 -- Fixed error message when no default db is provided.

### DIFF
--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -151,11 +151,10 @@ class ConnectionHandler:
                     'ENGINE': 'django.db.backends.dummy',
                 },
             }
+        if DEFAULT_DB_ALIAS not in self._databases:
+            raise ImproperlyConfigured("You must define a '%s' database." % DEFAULT_DB_ALIAS)
         if self._databases[DEFAULT_DB_ALIAS] == {}:
             self._databases[DEFAULT_DB_ALIAS]['ENGINE'] = 'django.db.backends.dummy'
-
-        if DEFAULT_DB_ALIAS not in self._databases:
-            raise ImproperlyConfigured("You must define a '%s' database" % DEFAULT_DB_ALIAS)
         return self._databases
 
     def ensure_defaults(self, alias):

--- a/tests/db_utils/tests.py
+++ b/tests/db_utils/tests.py
@@ -31,6 +31,13 @@ class ConnectionHandlerTests(SimpleTestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             conns[DEFAULT_DB_ALIAS].ensure_connection()
 
+    def test_no_default_database(self):
+        DATABASES = {'other': {}}
+        conns = ConnectionHandler(DATABASES)
+        msg = "You must define a 'default' database."
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            conns['other'].ensure_connection()
+
 
 class DatabaseErrorWrapperTests(TestCase):
 


### PR DESCRIPTION
In ConnectionHandler, the explicit check for the DEFAULT_DB_ALIAS
key in the databases dict came after an attempt to access that key.

If you have at least one non-default db, but no default db, no dummy
default will be created for you, and the DEFAULT_DB_ALIAS key will
not be present. Under these circumstances, calling the `databases`
property directly would give a KeyError instead of the intended
ImproperlyConfigured error.

Worse, if you tried to access a non-default db, ensure_defaults would
catch that KeyError but misinterpret it as being for the non-default
db name (which does in fact exist in the dict).

(See https://code.djangoproject.com/ticket/30071)

This change moves the explicit check before the attempt to use the key,
so that no KeyError is ever raised for DEFAULT_DB_ALIAS.  It adds
a test for this case, and also adds a test for the case where the
default db is explicitly set to an empty dict.