### PR TITLE
Pinned Pillow != 5.4.0 in test requirements.

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -4,7 +4,7 @@ docutils
 geoip2
 jinja2 >= 2.9.2
 numpy
-Pillow
+Pillow != 5.4.0
 # pylibmc/libmemcached can't be built on Windows.
 pylibmc; sys.platform != 'win32'
 python-memcached >= 1.59


### PR DESCRIPTION
There's a bug that causes a test failure in forms_tests:
https://github.com/python-pillow/Pillow/pull/3501/files#r244651761.