### PR TITLE
Use pymysql as a drop-in replacement for MySQLdb.

### DIFF
--- a/django/contrib/gis/db/backends/mysql/introspection.py
+++ b/django/contrib/gis/db/backends/mysql/introspection.py
@@ -6,6 +6,7 @@ from django.db.backends.mysql.introspection import DatabaseIntrospection
 
 pymysql.install_as_MySQLdb()
 
+
 class MySQLIntrospection(DatabaseIntrospection):
     # Updating the data_types_reverse dictionary with the appropriate
     # type for Geometry fields.

--- a/django/contrib/gis/db/backends/mysql/introspection.py
+++ b/django/contrib/gis/db/backends/mysql/introspection.py
@@ -1,8 +1,10 @@
+import pymysql
 from MySQLdb.constants import FIELD_TYPE
 
 from django.contrib.gis.gdal import OGRGeomType
 from django.db.backends.mysql.introspection import DatabaseIntrospection
 
+pymysql.install_as_MySQLdb()
 
 class MySQLIntrospection(DatabaseIntrospection):
     # Updating the data_types_reverse dictionary with the appropriate

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -5,12 +5,15 @@ Requires mysqlclient: https://pypi.org/project/mysqlclient/
 """
 import re
 
+import pymysql
+
 from django.core.exceptions import ImproperlyConfigured
 from django.db import utils
 from django.db.backends import utils as backend_utils
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.utils.functional import cached_property
 
+pymysql.install_as_MySQLdb()
 try:
     import MySQLdb as Database
 except ImportError as err:

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -5,6 +5,7 @@ from django.db.models import NOT_PROVIDED
 
 pymysql.install_as_MySQLdb()
 
+
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     sql_rename_table = "RENAME TABLE %(old_table)s TO %(new_table)s"

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -1,6 +1,9 @@
+import pymysql
+
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.models import NOT_PROVIDED
 
+pymysql.install_as_MySQLdb()
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 

--- a/tests/backends/mysql/test_schema.py
+++ b/tests/backends/mysql/test_schema.py
@@ -1,4 +1,5 @@
 import unittest
+import pymysql
 
 from django.db import connection
 from django.test import TestCase
@@ -8,6 +9,7 @@ from django.test import TestCase
 class SchemaEditorTests(TestCase):
     def test_quote_value(self):
         import MySQLdb
+        pymysql.install_as_MySQLdb()
         editor = connection.schema_editor()
         tested_values = [
             ('string', "'string'"),

--- a/tests/backends/mysql/test_schema.py
+++ b/tests/backends/mysql/test_schema.py
@@ -1,4 +1,5 @@
 import unittest
+
 import pymysql
 
 from django.db import connection

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -5,6 +5,7 @@ geoip2
 jinja2 >= 2.9.2
 numpy
 Pillow != 5.4.0
+pymysql
 # pylibmc/libmemcached can't be built on Windows.
 pylibmc; sys.platform != 'win32'
 python-memcached >= 1.59

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import warnings
+
 import pymysql
 
 import django

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import warnings
+import pymysql
 
 import django
 from django.apps import apps
@@ -23,6 +24,7 @@ from django.utils.deprecation import (
 )
 from django.utils.log import DEFAULT_LOGGING
 
+pymysql.install_as_MySQLdb()
 try:
     import MySQLdb
 except ImportError:


### PR DESCRIPTION
Looks like pymysql is currently the best maintained MySQLdb python wrapper... I think switching to it is the best option for now :)