### PR TITLE
Refs #23748 -- Added AutoField introspection for SQLite.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -143,6 +143,10 @@ class BaseDatabaseFeatures:
     # Can the backend introspect a TimeField, instead of a DateTimeField?
     can_introspect_time_field = True
 
+    # Some backends may not be able to differentiate BigAutoField from other
+    # fields such as AutoField.
+    introspected_big_auto_field_type = 'BigAutoField'
+
     # Some backends may not be able to differentiate BooleanField from other
     # fields such as IntegerField.
     introspected_boolean_field_type = 'BooleanField'

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -16,10 +16,12 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     max_query_params = 999
     supports_mixed_date_datetime_comparisons = False
     autocommits_when_autocommit_is_off = sys.version_info < (3, 6)
+    can_introspect_autofield = True
     can_introspect_decimal_field = False
     can_introspect_duration_field = False
     can_introspect_positive_integer_field = True
     can_introspect_small_integer_field = True
+    introspected_big_auto_field_type = 'AutoField'
     supports_transactions = True
     atomic_transactions = False
     can_rollback_ddl = True

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -192,7 +192,8 @@ Management Commands
   created child tables instead the parent.
 
 * :djadmin:`inspectdb` now introspects :class:`~django.db.models.DurationField`
-  for Oracle and PostgreSQL.
+  for Oracle and PostgreSQL, and :class:`~django.db.models.AutoField` for
+  SQLite.
 
 * On Oracle, :djadmin:`dbshell` is wrapped with ``rlwrap``, if available.
   ``rlwrap`` provides a command history and editing of keyboard input.

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -110,7 +110,7 @@ class IntrospectionTests(TransactionTestCase):
     def test_bigautofield(self):
         with connection.cursor() as cursor:
             desc = connection.introspection.get_table_description(cursor, City._meta.db_table)
-        self.assertIn('BigAutoField', [datatype(r[1], r) for r in desc])
+        self.assertIn(connection.features.introspected_big_auto_field_type, [datatype(r[1], r) for r in desc])
 
     # Regression test for #9991 - 'real' types in postgres
     @skipUnlessDBFeature('has_real_datatype')


### PR DESCRIPTION
Ticket [#23748](https://code.djangoproject.com/ticket/23748).

Rounds out the support for introspection of AutoField by adding support for SQLite.

Please refer to [my comment](https://code.djangoproject.com/ticket/23748#comment:11) on the ticket.