### PR TITLE
Remove 'naturaltime' context for '(delta) ago' for Swedish.

### DIFF
--- a/django/contrib/humanize/locale/sv/LC_MESSAGES/django.po
+++ b/django/contrib/humanize/locale/sv/LC_MESSAGES/django.po
@@ -204,7 +204,6 @@ msgid "yesterday"
 msgstr "igår"
 
 #, python-format
-msgctxt "naturaltime"
 msgid "%(delta)s ago"
 msgstr "%(delta)s sedan"
 


### PR DESCRIPTION
The Swedish version of "1 week ago" currently is "1 vecka ago", but should be "1 vecka sedan".

Hopefully, this is not trivial enough to be fixed without a ticket.