### PR TITLE
 Fixed #30097 -- Made 'obj' arg of InlineModelAdmin.has_add_permission() optional.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2126,7 +2126,8 @@ class InlineModelAdmin(BaseModelAdmin):
             queryset = queryset.none()
         return queryset
 
-    def has_add_permission(self, request, obj):
+    def has_add_permission(self, request, obj=None):
+        # RemovedInDjango31Warning: obj becomes a mandatory argument.
         if self.opts.auto_created:
             # We're checking the rights to an auto-created intermediate model,
             # which doesn't have its own individual permissions. The user needs

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2413,7 +2413,9 @@ The ``InlineModelAdmin`` class adds or customizes:
 
     .. versionchanged:: 2.1
 
-        The ``obj`` argument was added.
+        The ``obj`` argument was added. During the deprecation period, it may
+        also be ``None`` if third-party calls to ``has_add_permission()`` don't
+        provide it.
 
 .. method:: InlineModelAdmin.has_change_permission(request, obj=None)
 

--- a/docs/releases/2.1.6.txt
+++ b/docs/releases/2.1.6.txt
@@ -9,4 +9,6 @@ Django 2.1.6 several bugs in 2.1.5.
 Bugfixes
 ========
 
-* ...
+* Made the ``obj`` argument of ``InlineModelAdmin.has_add_permission()``
+  optional to restore backwards compatibility with third-party code that
+  doesn't provide it (:ticket:`30097`).


### PR DESCRIPTION
Ticket [#30097](https://code.djangoproject.com/ticket/30097).