### PR TITLE
Fixed #23829 -- Made ping_google command/function use https for the sitemap URL.

### DIFF
--- a/django/contrib/sitemaps/__init__.py
+++ b/django/contrib/sitemaps/__init__.py
@@ -15,19 +15,19 @@ class SitemapNotFound(Exception):
     pass
 
 
-def ping_google(sitemap_url=None, ping_url=PING_URL):
+def ping_google(sitemap_url=None, ping_url=PING_URL, sitemap_uses_https=True):
     """
     Alert Google that the sitemap for the current site has been updated.
     If sitemap_url is provided, it should be an absolute path to the sitemap
     for this site -- e.g., '/sitemap.xml'. If sitemap_url is not provided, this
     function will attempt to deduce it by using urls.reverse().
     """
-    sitemap_full_url = _get_sitemap_full_url(sitemap_url)
+    sitemap_full_url = _get_sitemap_full_url(sitemap_url, sitemap_uses_https)
     params = urlencode({'sitemap': sitemap_full_url})
     urlopen('%s?%s' % (ping_url, params))
 
 
-def _get_sitemap_full_url(sitemap_url):
+def _get_sitemap_full_url(sitemap_url, sitemap_uses_https=True):
     if not django_apps.is_installed('django.contrib.sites'):
         raise ImproperlyConfigured("ping_google requires django.contrib.sites, which isn't installed.")
 
@@ -47,7 +47,8 @@ def _get_sitemap_full_url(sitemap_url):
 
     Site = django_apps.get_model('sites.Site')
     current_site = Site.objects.get_current()
-    return 'http://%s%s' % (current_site.domain, sitemap_url)
+    scheme = 'https' if sitemap_uses_https else 'http'
+    return '%s://%s%s' % (scheme, current_site.domain, sitemap_url)
 
 
 class Sitemap:

--- a/django/contrib/sitemaps/management/commands/ping_google.py
+++ b/django/contrib/sitemaps/management/commands/ping_google.py
@@ -7,6 +7,10 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('sitemap_url', nargs='?')
+        parser.add_argument('--sitemap-uses-http', action='store_true')
 
     def handle(self, *args, **options):
-        ping_google(sitemap_url=options['sitemap_url'])
+        ping_google(
+            sitemap_url=options['sitemap_url'],
+            sitemap_uses_https=not options['sitemap_uses_http'],
+        )

--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -481,7 +481,7 @@ You may want to "ping" Google when your sitemap changes, to let it know to
 reindex your site. The sitemaps framework provides a function to do just
 that: :func:`django.contrib.sitemaps.ping_google()`.
 
-.. function:: ping_google(sitemap_url=None, ping_url=PING_URL)
+.. function:: ping_google(sitemap_url=None, ping_url=PING_URL, sitemap_uses_https=True)
 
     ``ping_google`` takes these optional arguments:
 
@@ -493,9 +493,17 @@ that: :func:`django.contrib.sitemaps.ping_google()`.
     * ``ping_url`` - Defaults to Google's Ping Tool:
       https://www.google.com/webmasters/tools/ping.
 
+    * ``sitemap_uses_https`` - Set to ``False`` if your site uses ``http``
+      rather than ``https``.
+
     :func:`ping_google` raises the exception
     ``django.contrib.sitemaps.SitemapNotFound`` if it cannot determine your
     sitemap URL.
+
+    .. versionadded:: 2.2
+
+        The ``sitemap_uses_https`` argument was added. Older versions of
+        Django always use ``http`` for a sitemap's URL.
 
 .. admonition:: Register with Google first!
 
@@ -534,3 +542,9 @@ Once the sitemaps application is added to your project, you may also
 ping Google using the ``ping_google`` management command::
 
     python manage.py ping_google [/sitemap.xml]
+
+.. django-admin-option:: --sitemap-uses-http
+
+.. versionadded:: 2.2
+
+Use this option if your sitemap uses ``http`` rather than ``https``.

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -479,6 +479,12 @@ Miscellaneous
   passed as a value to encode because ``None`` can't be encoded in GET and POST
   data. Either pass an empty string or omit the value.
 
+* The :djadmin:`ping_google` management command now defaults to ``https``
+  instead of ``http`` for the sitemap's URL. If your site uses http, use the
+  new :option:`ping_google --sitemap-uses-http` option. If you use the
+  :func:`~django.contrib.sitemaps.ping_google` function, set the new
+  ``sitemap_uses_https`` argument to ``False``.
+
 .. _deprecated-features-2.2:
 
 Features deprecated in 2.2

--- a/tests/sitemaps_tests/test_management.py
+++ b/tests/sitemaps_tests/test_management.py
@@ -10,8 +10,8 @@ class PingGoogleTests(SitemapTestsBase):
 
     def test_default(self, ping_google_func):
         call_command('ping_google')
-        ping_google_func.assert_called_with(sitemap_url=None)
+        ping_google_func.assert_called_with(sitemap_url=None, sitemap_uses_https=True)
 
-    def test_arg(self, ping_google_func):
-        call_command('ping_google', 'foo.xml')
-        ping_google_func.assert_called_with(sitemap_url='foo.xml')
+    def test_args(self, ping_google_func):
+        call_command('ping_google', 'foo.xml', '--sitemap-uses-http')
+        ping_google_func.assert_called_with(sitemap_url='foo.xml', sitemap_uses_https=False)

--- a/tests/sitemaps_tests/test_utils.py
+++ b/tests/sitemaps_tests/test_utils.py
@@ -15,16 +15,16 @@ class PingGoogleTests(SitemapTestsBase):
     @mock.patch('django.contrib.sitemaps.urlopen')
     def test_something(self, urlopen):
         ping_google()
-        params = urlencode({'sitemap': 'http://example.com/sitemap-without-entries/sitemap.xml'})
+        params = urlencode({'sitemap': 'https://example.com/sitemap-without-entries/sitemap.xml'})
         full_url = 'https://www.google.com/webmasters/tools/ping?%s' % params
         urlopen.assert_called_with(full_url)
 
     def test_get_sitemap_full_url_global(self):
-        self.assertEqual(_get_sitemap_full_url(None), 'http://example.com/sitemap-without-entries/sitemap.xml')
+        self.assertEqual(_get_sitemap_full_url(None), 'https://example.com/sitemap-without-entries/sitemap.xml')
 
     @override_settings(ROOT_URLCONF='sitemaps_tests.urls.index_only')
     def test_get_sitemap_full_url_index(self):
-        self.assertEqual(_get_sitemap_full_url(None), 'http://example.com/simple/index.xml')
+        self.assertEqual(_get_sitemap_full_url(None), 'https://example.com/simple/index.xml')
 
     @override_settings(ROOT_URLCONF='sitemaps_tests.urls.empty')
     def test_get_sitemap_full_url_not_detected(self):
@@ -33,7 +33,13 @@ class PingGoogleTests(SitemapTestsBase):
             _get_sitemap_full_url(None)
 
     def test_get_sitemap_full_url_exact_url(self):
-        self.assertEqual(_get_sitemap_full_url('/foo.xml'), 'http://example.com/foo.xml')
+        self.assertEqual(_get_sitemap_full_url('/foo.xml'), 'https://example.com/foo.xml')
+
+    def test_get_sitemap_full_url_insecure(self):
+        self.assertEqual(
+            _get_sitemap_full_url('/foo.xml', sitemap_uses_https=False),
+            'http://example.com/foo.xml'
+        )
 
     @modify_settings(INSTALLED_APPS={'remove': 'django.contrib.sites'})
     def test_get_sitemap_full_url_no_sites(self):


### PR DESCRIPTION
(extracted from https://github.com/django/django/pull/10651)
https://code.djangoproject.com/ticket/23829