### PR TITLE
Moved django.db.migrations.writer.SettingsReference to django.conf.

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -30,6 +30,18 @@ FILE_CHARSET_DEPRECATED_MSG = (
 )
 
 
+class SettingsReference(str):
+    """
+    String subclass which references a current settings value. It's treated as
+    the value in memory but serializes to a settings.NAME attribute reference.
+    """
+    def __new__(self, value, setting_name):
+        return str.__new__(self, value)
+
+    def __init__(self, value, setting_name):
+        self.setting_name = setting_name
+
+
 class LazySettings(LazyObject):
     """
     A lazy proxy for either global Django settings or a custom settings object.

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -9,6 +9,7 @@ import re
 import types
 import uuid
 
+from django.conf import SettingsReference
 from django.db import models
 from django.db.migrations.operations.base import Operation
 from django.db.migrations.utils import COMPILED_REGEX_TYPE, RegexObject
@@ -271,7 +272,6 @@ class UUIDSerializer(BaseSerializer):
 
 
 def serializer_factory(value):
-    from django.db.migrations.writer import SettingsReference
     if isinstance(value, Promise):
         value = str(value)
     elif isinstance(value, LazyObject):

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -4,26 +4,14 @@ from importlib import import_module
 
 from django import get_version
 from django.apps import apps
+# SettingsReference imported for backwards compatibility in Django 2.2.
+from django.conf import SettingsReference  # NOQA
 from django.db import migrations
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.serializer import serializer_factory
 from django.utils.inspect import get_func_args
 from django.utils.module_loading import module_dir
 from django.utils.timezone import now
-
-
-class SettingsReference(str):
-    """
-    Special subclass of string which actually references a current settings
-    value. It's treated as the value in memory, but serializes out to a
-    settings.NAME attribute reference.
-    """
-
-    def __new__(self, value, setting_name):
-        return str.__new__(self, value)
-
-    def __init__(self, value, setting_name):
-        self.setting_name = setting_name
 
 
 class OperationWriter:

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -4,6 +4,7 @@ from functools import partial
 
 from django import forms
 from django.apps import apps
+from django.conf import SettingsReference
 from django.core import checks, exceptions
 from django.db import connection, router
 from django.db.backends import utils
@@ -590,7 +591,6 @@ class ForeignObject(RelatedField):
                         % (kwargs['to'].setting_name, swappable_setting)
                     )
             # Set it
-            from django.db.migrations.writer import SettingsReference
             kwargs['to'] = SettingsReference(
                 kwargs['to'],
                 swappable_setting,
@@ -1457,7 +1457,6 @@ class ManyToManyField(RelatedField):
                         "(%s and %s)" % (kwargs['to'].setting_name, swappable_setting)
                     )
 
-            from django.db.migrations.writer import SettingsReference
             kwargs['to'] = SettingsReference(
                 kwargs['to'],
                 swappable_setting,

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -12,12 +12,10 @@ import custom_migration_operations.more_operations
 import custom_migration_operations.operations
 
 from django import get_version
-from django.conf import settings
+from django.conf import SettingsReference, settings
 from django.core.validators import EmailValidator, RegexValidator
 from django.db import migrations, models
-from django.db.migrations.writer import (
-    MigrationWriter, OperationWriter, SettingsReference,
-)
+from django.db.migrations.writer import MigrationWriter, OperationWriter
 from django.test import SimpleTestCase
 from django.utils.deconstruct import deconstructible
 from django.utils.functional import SimpleLazyObject


### PR DESCRIPTION
Reduced the possibility of circular imports.
(from https://github.com/django/django/pull/10673)