### PR TITLE
Raise CommandError for ./manage.py migrate

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -215,15 +215,13 @@ class Command(BaseCommand):
                 )
                 changes = autodetector.changes(graph=executor.loader.graph)
                 if changes:
-                    self.stdout.write(self.style.NOTICE(
+                    raise CommandError(
                         "  Your models have changes that are not yet reflected "
                         "in a migration, and so won't be applied."
-                    ))
-                    self.stdout.write(self.style.NOTICE(
                         "  Run 'manage.py makemigrations' to make new "
                         "migrations, and then re-run 'manage.py migrate' to "
                         "apply them."
-                    ))
+                    )
             fake = False
             fake_initial = False
         else:


### PR DESCRIPTION
if models have changes that are not yet reflected in a migration.

This will cause a non-zero exit code and allow to use the command to detect forgotten migrations.

The background here is that in our application we had the django-simple-history recently upgraded and that caused some changes and we need to create a migration for the historical record. We want to use `./manage.py migrate` inside CI to make sure this doesn't happen again.