### PR TITLE
Removed unnecessary string formatting of string values.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -807,7 +807,7 @@ class Ref(Expression):
         return self
 
     def as_sql(self, compiler, connection):
-        return "%s" % connection.ops.quote_name(self.refs), []
+        return connection.ops.quote_name(self.refs), []
 
     def get_group_by_cols(self):
         return [self]

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1410,7 +1410,7 @@ class ManyToManyField(RelatedField):
                 opts = model._meta.auto_created._meta
                 clashing_obj = '%s.%s' % (opts.label, _get_field_name(model))
             else:
-                clashing_obj = '%s' % model._meta.label
+                clashing_obj = model._meta.label
             return [
                 checks.Error(
                     "The field's intermediary table '%s' clashes with the "

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -66,9 +66,9 @@ class DebugSQLTextTestResult(unittest.TextTestResult):
             self.stream.writeln(self.separator1)
             self.stream.writeln("%s: %s" % (flavour, self.getDescription(test)))
             self.stream.writeln(self.separator2)
-            self.stream.writeln("%s" % err)
+            self.stream.writeln(err)
             self.stream.writeln(self.separator2)
-            self.stream.writeln("%s" % sql_debug)
+            self.stream.writeln(sql_debug)
 
 
 class RemoteTestResult:


### PR DESCRIPTION
In all cases, the value was already a string and so didn't require formatting.