### PR TITLE
Changed to exhaust iterator using collections.deque().

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -7,6 +7,7 @@ file upload handlers for processing.
 import base64
 import binascii
 import cgi
+import collections
 from urllib.parse import unquote
 
 from django.conf import settings
@@ -565,9 +566,7 @@ def exhaust(stream_or_iterable):
         iterator = iter(stream_or_iterable)
     except TypeError:
         iterator = ChunkIter(stream_or_iterable, 16384)
-
-    for __ in iterator:
-        pass
+    collections.deque(iterator, maxlen=0)  # consume iterator quickly.
 
 
 def parse_boundary_stream(stream, max_header_size):


### PR DESCRIPTION
Comparison of methods for exhausting an iterator:
```
In [1]: from collections import deque
   ...: from itertools import repeat
   ...: n = 10000
   ...: %timeit -n1000 [__ for __ in repeat(0, n)]
   ...: %timeit -n1000 for __ in repeat(0, n): pass
   ...: %timeit -n1000 list(repeat(0, n))
   ...: %timeit -n1000 deque(repeat(0, n), maxlen=0)
195 µs ± 5.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
74.3 µs ± 204 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
53.2 µs ± 4.66 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
43 µs ± 428 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

Follows from https://github.com/django/django/pull/10676#discussion_r247887259.