### PR TITLE
Updated reverse generic relation examples

### DIFF
--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -394,21 +394,21 @@ be used to retrieve their associated ``TaggedItems``::
 Defining :class:`~django.contrib.contenttypes.fields.GenericRelation` with
 ``related_query_name`` set allows querying from the related object::
 
-    tags = GenericRelation(TaggedItem, related_query_name='bookmarks')
+    tags = GenericRelation(TaggedItem, related_query_name='bookmark')
 
 This enables filtering, ordering, and other query operations on ``Bookmark``
 from ``TaggedItem``::
 
     >>> # Get all tags belonging to bookmarks containing `django` in the url
-    >>> TaggedItem.objects.filter(bookmarks__url__contains='django')
+    >>> TaggedItem.objects.filter(bookmark__url__contains='django')
     <QuerySet [<TaggedItem: django>, <TaggedItem: python>]>
 
-Of course, if you don't add the reverse relationship, you can do the
+Of course, if you don't add the ``related_query_name``, you can do the
 same types of lookups manually::
 
-    >>> b = Bookmark.objects.get(url='https://www.djangoproject.com/')
-    >>> bookmark_type = ContentType.objects.get_for_model(b)
-    >>> TaggedItem.objects.filter(content_type__pk=bookmark_type.id, object_id=b.id)
+    >>> bookmarks = Bookmark.objects.filter(url__contains='django')
+    >>> bookmark_type = ContentType.objects.get_for_model(Bookmark)
+    >>> TaggedItem.objects.filter(content_type__pk=bookmark_type.id, object_id__in=bookmarks)
     <QuerySet [<TaggedItem: django>, <TaggedItem: python>]>
 
 Just as :class:`~django.contrib.contenttypes.fields.GenericForeignKey`


### PR DESCRIPTION
I found the current example in the content types documentation slightly confusing as:

- it sets `related_query_name='bookmarks'` in the example, when it actually refers to a many to one relationship
- the example to "do the same types of lookups manually" differs from the one above it, which uses `related_query_name`:

  The first example is to "get all tags belonging to bookmarks containing `django` in the url", while the second gets 1 bookmark (matching the django project url exactly) and finds the tags that relate to that bookmark only.