### PR TITLE
Refs #30102 -- Added comment on use of Template without placeholders in page_not_found() view.

### DIFF
--- a/django/views/defaults.py
+++ b/django/views/defaults.py
@@ -52,6 +52,8 @@ def page_not_found(request, exception, template_name=ERROR_404_TEMPLATE_NAME):
         if template_name != ERROR_404_TEMPLATE_NAME:
             # Reraise if it's a missing custom template.
             raise
+        # Render template (even though there are no substitutions) to allow
+        # inspecting the context in tests.
         template = Engine().from_string(
             '<h1>Not Found</h1>'
             '<p>The requested resource was not found on this server.</p>')


### PR DESCRIPTION
Closes #10841. 

>  I guess we might have to "wontfix" the ticket and instead add a comment about this.
