### PR TITLE
Fixed typo in QuerySet.bulk_update documentation

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2129,7 +2129,7 @@ them, but it has a few caveats:
 * If ``objs`` contains duplicates, only the first one is updated.
 
 The ``batch_size`` parameter controls how many objects are saved in a single
-query. The default is to create all objects in one batch, except for SQLite
+query. The default is to update all objects in one batch, except for SQLite
 and Oracle which have restrictions on the number of variables used in a query.
 
 ``count()``


### PR DESCRIPTION
Looks like an accidental carry over from the pre-existing `QuerySet.bulk_create` documentation.

Introduced in #9606 which added `QuerySet.bulk_update` and this documentation for it.