### PR TITLE
Fixed #30107 -- Removed unused dirs variable from cache template loader keys.

### DIFF
--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -66,7 +66,7 @@ class Loader(BaseLoader):
 
     def cache_key(self, template_name, skip=None):
         """
-        Generate a cache key for the template name, dirs, and skip.
+        Generate a cache key for the template name and skip.
 
         If skip is provided, only origins that match template_name are included
         in the cache key. This ensures each template is only parsed and cached
@@ -76,7 +76,6 @@ class Loader(BaseLoader):
             y -> a -> a
             z -> a -> a
         """
-        dirs_prefix = ''
         skip_prefix = ''
 
         if skip:
@@ -84,7 +83,7 @@ class Loader(BaseLoader):
             if matching:
                 skip_prefix = self.generate_hash(matching)
 
-        return '-'.join(s for s in (str(template_name), skip_prefix, dirs_prefix) if s)
+        return '-'.join(s for s in (str(template_name), skip_prefix) if s)
 
     def generate_hash(self, values):
         return hashlib.sha1('|'.join(values).encode()).hexdigest()


### PR DESCRIPTION
Unused since 5d8da093a974f41e08573bbe0d32d5ffeaadd0ad.
https://code.djangoproject.com/ticket/30107