### PR TITLE
Fixed #30111 -- Fixed AppRegistryNotReady error with django.contrib.postgres in INSTALLED_APPS.

### DIFF
--- a/django/db/migrations/recorder.py
+++ b/django/db/migrations/recorder.py
@@ -1,6 +1,7 @@
 from django.apps.registry import Apps
 from django.db import models
 from django.db.utils import DatabaseError
+from django.utils.decorators import classproperty
 from django.utils.timezone import now
 
 from .exceptions import MigrationSchemaMissing
@@ -18,19 +19,30 @@ class MigrationRecorder:
     If a migration is unapplied its row is removed from the table. Having
     a row in the table always means a migration is applied.
     """
+    _migration_class = None
 
-    class Migration(models.Model):
-        app = models.CharField(max_length=255)
-        name = models.CharField(max_length=255)
-        applied = models.DateTimeField(default=now)
+    @classproperty
+    def Migration(cls):
+        """
+        Lazy load to avoid AppRegistryNotReady if installed apps import
+        MigrationRecorder.
+        """
+        if cls._migration_class is None:
+            class Migration(models.Model):
+                app = models.CharField(max_length=255)
+                name = models.CharField(max_length=255)
+                applied = models.DateTimeField(default=now)
 
-        class Meta:
-            apps = Apps()
-            app_label = "migrations"
-            db_table = "django_migrations"
+                class Meta:
+                    apps = Apps()
+                    app_label = 'migrations'
+                    db_table = 'django_migrations'
 
-        def __str__(self):
-            return "Migration %s for %s" % (self.name, self.app)
+                def __str__(self):
+                    return 'Migration %s for %s' % (self.name, self.app)
+
+            cls._migration_class = Migration
+        return cls._migration_class
 
     def __init__(self, connection):
         self.connection = connection

--- a/tests/postgres_tests/integration_settings.py
+++ b/tests/postgres_tests/integration_settings.py
@@ -1,0 +1,5 @@
+SECRET_KEY = 'abcdefg'
+
+INSTALLED_APPS = [
+    'django.contrib.postgres',
+]

--- a/tests/postgres_tests/test_integration.py
+++ b/tests/postgres_tests/test_integration.py
@@ -1,0 +1,17 @@
+import os
+import subprocess
+import sys
+
+from tests.postgres_tests import PostgreSQLSimpleTestCase
+
+
+class PostgresIntegrationTests(PostgreSQLSimpleTestCase):
+    def test_check(self):
+        os.chdir(os.path.dirname(__file__))
+        result = subprocess.run(
+            [sys.executable, '-m', 'django', 'check', '--settings', 'integration_settings'],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        stderr = '\n'.join([e.decode() for e in result.stderr.splitlines()])
+        self.assertEqual(result.returncode, 0, msg=stderr)


### PR DESCRIPTION
When contrib.postgres is in INSTALLED_APPS it triggers `from django.db.migrations.writer import MigrationWriter` import in https://github.com/django/django/blob/7185ea6902532eb195d0575d1bf1492ca9d45dea/django/contrib/postgres/apps.py#L8 which further triggered https://github.com/django/django/blob/7185ea6902532eb195d0575d1bf1492ca9d45dea/django/db/models/base.py#L99 in ModelBase Meta class.
ModelBase checks for `self.check_apps_ready()` while apps have not loaded completely yet. So an exception is raised `raise AppRegistryNotReady("Apps aren't loaded yet.")`

Fix: I've changed `django/django/contrib/postgres/apps.py` to import MigrationWriter only when needed to avoid `check for apps ready` cycle.

https://code.djangoproject.com/ticket/30111