### PR TITLE
Refs #29738 -- Removed module level import of django.db.migrations.writer.

### DIFF
--- a/django/contrib/postgres/apps.py
+++ b/django/contrib/postgres/apps.py
@@ -5,7 +5,6 @@ from psycopg2.extras import (
 from django.apps import AppConfig
 from django.db import connections
 from django.db.backends.signals import connection_created
-from django.db.migrations.writer import MigrationWriter
 from django.db.models import CharField, TextField
 from django.test.signals import setting_changed
 from django.utils.translation import gettext_lazy as _
@@ -22,6 +21,7 @@ def uninstall_if_needed(setting, value, enter, **kwargs):
     Undo the effects of PostgresConfig.ready() when django.contrib.postgres
     is "uninstalled" by override_settings().
     """
+    from django.db.migrations.writer import MigrationWriter
     if not enter and setting == 'INSTALLED_APPS' and 'django.contrib.postgres' not in set(value):
         connection_created.disconnect(register_type_handlers)
         CharField._unregister_lookup(Unaccent)
@@ -42,6 +42,7 @@ class PostgresConfig(AppConfig):
     verbose_name = _('PostgreSQL extensions')
 
     def ready(self):
+        from django.db.migrations.writer import MigrationWriter
         setting_changed.connect(uninstall_if_needed)
         # Connections may already exist before we are called.
         for conn in connections.all():

--- a/tests/postgres_tests/integration/manage.py
+++ b/tests/postgres_tests/integration/manage.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+if __name__ == '__main__':
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)

--- a/tests/postgres_tests/integration/settings.py
+++ b/tests/postgres_tests/integration/settings.py
@@ -1,0 +1,5 @@
+SECRET_KEY = 'abcdefg'
+
+INSTALLED_APPS = [
+    'django.contrib.postgres',
+]

--- a/tests/postgres_tests/test_integration.py
+++ b/tests/postgres_tests/test_integration.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+import sys
+import unittest
+
+from django.test import SimpleTestCase
+
+try:
+    import psycopg2
+except ImportError:
+    psycopg2 = None
+
+
+@unittest.skipIf(psycopg2 is None, 'psycopg2 is required')
+class PostgresIntegrationTest(SimpleTestCase):
+    def test_management_command(self):
+        manage_py = os.path.join(os.path.dirname(__file__), 'integration', 'manage.py')
+        result = subprocess.run(
+            [sys.executable, manage_py, 'check'],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        self.assertEqual(result.returncode, 0)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29738#comment:14

---

I wonder if this is exposing a deeper issue with `MigrationWriter.register_serializer()`. I believe this means a similar workaround is required for all `apps.py` files.