### PR TITLE
Fixed #30117 -- Fixed SchemaEditor.quote_value() test for mysqlclient 1.4.0+.

### DIFF
--- a/tests/backends/mysql/test_schema.py
+++ b/tests/backends/mysql/test_schema.py
@@ -13,7 +13,7 @@ class SchemaEditorTests(TestCase):
             ('string', "'string'"),
             (42, '42'),
             (1.754, '1.754e0' if MySQLdb.version_info >= (1, 3, 14) else '1.754'),
-            (False, '0'),
+            (False, b'0' if MySQLdb.version_info >= (1, 4, 0) else '0'),
         ]
         for value, expected in tested_values:
             with self.subTest(value=value):


### PR DESCRIPTION
Behavior has been changed in https://github.com/PyMySQL/mysqlclient-python/commit/819688b630be850ee485d265b60cd9fa4040c07e.