### PR TITLE
Increase test coverage for `django.utils.text.Truncator.chars()`

### DIFF
--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -58,6 +58,7 @@ class TestUtilsText(SimpleTestCase):
         self.assertEqual('The quick brown fox jumped over the lazy dog.', truncator.chars(100)),
         self.assertEqual('The quick brown fox …', truncator.chars(21)),
         self.assertEqual('The quick brown fo.....', truncator.chars(23, '.....')),
+        self.assertEqual('.....', truncator.chars(4, '.....')),
 
         nfc = text.Truncator('o\xfco\xfco\xfco\xfc')
         nfd = text.Truncator('ou\u0308ou\u0308ou\u0308ou\u0308')


### PR DESCRIPTION
try to cover https://github.com/django/django/blob/709a8b861de14204f0e13c9a0fbfd61c11b3565d/django/utils/text.py#L96