### PR TITLE
Remove unused 'template_cache' dictionary from cached template loader

### DIFF
--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -14,7 +14,6 @@ from .base import Loader as BaseLoader
 class Loader(BaseLoader):
 
     def __init__(self, engine, loaders):
-        self.template_cache = {}
         self.get_template_cache = {}
         self.loaders = engine.get_template_loaders(loaders)
         super().__init__(engine)
@@ -90,5 +89,4 @@ class Loader(BaseLoader):
 
     def reset(self):
         "Empty the template cache."
-        self.template_cache.clear()
         self.get_template_cache.clear()


### PR DESCRIPTION
Unused since 5d8da093a974f41e08573bbe0d32d5ffeaadd0ad.