### PR TITLE
Fixed #25791 -- Made cached template loader do nothing when DEBUG is on.

### DIFF
--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -5,6 +5,7 @@ to load templates from them in order, caching the result.
 
 import hashlib
 
+from django.conf import settings
 from django.template import TemplateDoesNotExist
 from django.template.backends.django import copy_exception
 
@@ -40,6 +41,9 @@ class Loader(BaseLoader):
         memory leak. Thus, unraised copies of the exceptions are cached and
         copies of those copies are raised after they're fetched from the cache.
         """
+        if settings.DEBUG:
+            return super().get_template(template_name, skip)
+
         key = self.cache_key(template_name, skip)
         cached = self.get_template_cache.get(key)
         if cached:

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -180,7 +180,8 @@ Signals
 Templates
 ~~~~~~~~~
 
-* ...
+* The :ref:`cached template loader<template-loaders>` no longer caches
+  templates when ``DEBUG=True``.
 
 Tests
 ~~~~~

--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -93,6 +93,11 @@ class CachedLoaderTests(SimpleTestCase):
         """
         self.assertEqual(self.engine.template_loaders[0].cache_key(lazystr('template.html'), []), 'template.html')
 
+    @override_settings(DEBUG=True)
+    def test_debug_does_not_cache(self):
+        self.engine.get_template('index.html')
+        self.assertEqual(self.engine.template_loaders[0].get_template_cache, {})
+
 
 class FileSystemLoaderTests(SimpleTestCase):
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/25791

I originally implemented an autoreloader hook that attempted to clear the template cache, and while this is possible to do I feel it might be missing the point: Templates are cached in development. We can get around this by simply not caching them when `DEBUG` is `True`, which I feel is a lot cleaner and a lot simpler to implement.

~~I need to add tests, and I'm not happy with the way the autoreloader is set up. It's actually a case I did not consider when designing it: the `django.template.loaders.*` are lazy-loaded and so are not imported until a template is rendered. Which is tricky for us as we need to register a signal at *import time*, before the auto-reloader is started.~~

~~So I've put the auto-reload code inside `django.template.autoreload` even though I really feel it should belong inside `django.template.loaders.cached`, and I've triggered an import of this module from `django.template`. Which is also not nice, as this module is a kind of public API and I don't want to pollute it with `autoreload` stuff (or signal handing, if we where to use `.connect()` instead of `receiver()`).~~