### PR TITLE
Fixed #30115 -- Fixed SQLite introspection crash with a varchar primary key.

### DIFF
--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -40,6 +40,7 @@ class FlexibleFieldLookupDict:
         'real': 'FloatField',
         'text': 'TextField',
         'char': 'CharField',
+        'varchar': 'CharField',
         'blob': 'BinaryField',
         'date': 'DateField',
         'datetime': 'DateTimeField',
@@ -47,14 +48,8 @@ class FlexibleFieldLookupDict:
     }
 
     def __getitem__(self, key):
-        key = key.lower()
-        try:
-            return self.base_data_types_reverse[key]
-        except KeyError:
-            size = get_field_size(key)
-            if size is not None:
-                return ('CharField', {'max_length': size})
-            raise KeyError
+        key = key.lower().split('(', 1)[0].strip()
+        return self.base_data_types_reverse[key]
 
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):


### PR DESCRIPTION
Ticket [#30115](https://code.djangoproject.com/ticket/30115).

Supersedes #10863.

**Edit:** Other simplifications and clean up moved to #10883 & #10885; and ticket [#30123](https://code.djangoproject.com/ticket/30123).