### PR TITLE
Fixed #25624 -- Fixed autoreload crash with jinja2.ModuleLoader.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -9,6 +9,7 @@ import sys
 import threading
 import time
 import traceback
+import weakref
 from collections import defaultdict
 from pathlib import Path
 from types import ModuleType
@@ -98,7 +99,7 @@ def iter_all_python_module_files():
     # This ensures cached results are returned in the usual case that modules
     # aren't loaded on the fly.
     modules_view = sorted(list(sys.modules.items()), key=lambda i: i[0])
-    modules = tuple(m[1] for m in modules_view)
+    modules = tuple(m[1] for m in modules_view if not isinstance(m[1], weakref.ProxyTypes))
     return iter_modules_and_files(modules, frozenset(_error_files))
 
 

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import threading
 import time
+import weakref
 import zipfile
 from importlib import import_module
 from pathlib import Path
@@ -115,6 +116,13 @@ class TestIterModulesAndFiles(SimpleTestCase):
         with extend_sys_path(str(compiled_file.parent)):
             self.import_and_cleanup('test_compiled')
         self.assertFileFound(compiled_file)
+
+    def test_weakref_in_sys_module(self):
+        """iter_all_python_module_file ignores weakref modules."""
+        time_proxy = weakref.proxy(time)
+        sys.modules['time_proxy'] = time_proxy
+        self.addCleanup(lambda: sys.modules.pop('time_proxy', None))
+        list(autoreload.iter_all_python_module_files())  # No crash.
 
 
 class TestCommonRoots(SimpleTestCase):


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/25624

This is really hard to test, so I went with a negative "does not error" case. Regarding the auto-reloader itself, we just skip reloading on dynamically generated weakref modules as there is really nothing sensible we can do with them.