### PR TITLE
Fixed #30108 -- Allowed adding foreign key constraints in the same statement that adds a field.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -179,6 +179,9 @@ class BaseDatabaseFeatures:
     # Does it support foreign keys?
     supports_foreign_keys = True
 
+    # Can it create foreign key constraints inline when adding columns?
+    can_create_inline_fk = True
+
     # Does it support CHECK constraints?
     supports_column_check_constraints = True
     supports_table_check_constraints = True

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -16,7 +16,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_rename_column = "ALTER TABLE %(table)s CHANGE %(old_column)s %(new_column)s %(type)s"
 
     sql_delete_unique = "ALTER TABLE %(table)s DROP INDEX %(name)s"
-
+    sql_create_column_inline_fk = (
+        ', ADD CONSTRAINT %(name)s FOREIGN KEY (%(column)s) '
+        'REFERENCES %(to_table)s(%(to_column)s)'
+    )
     sql_delete_fk = "ALTER TABLE %(table)s DROP FOREIGN KEY %(name)s"
 
     sql_delete_index = "DROP INDEX %(name)s ON %(table)s"

--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -15,6 +15,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_alter_column_default = "MODIFY %(column)s DEFAULT %(default)s"
     sql_alter_column_no_default = "MODIFY %(column)s DEFAULT NULL"
     sql_delete_column = "ALTER TABLE %(table)s DROP COLUMN %(column)s"
+    sql_create_column_inline_fk = 'CONSTRAINT %(name)s REFERENCES %(to_table)s(%(to_column)s)%(deferrable)s'
     sql_delete_table = "DROP TABLE %(table)s CASCADE CONSTRAINTS"
     sql_create_index = "CREATE INDEX %(name)s ON %(table)s (%(columns)s)%(extra)s"
 

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -15,6 +15,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_create_index = "CREATE INDEX %(name)s ON %(table)s%(using)s (%(columns)s)%(extra)s%(condition)s"
     sql_delete_index = "DROP INDEX IF EXISTS %(name)s"
 
+    sql_create_column_inline_fk = 'REFERENCES %(to_table)s(%(to_column)s)%(deferrable)s'
     # Setting the constraint to IMMEDIATE runs any deferred checks to allow
     # dropping it in the same transaction.
     sql_delete_fk = "SET CONSTRAINTS %(name)s IMMEDIATE; ALTER TABLE %(table)s DROP CONSTRAINT %(name)s"

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -26,6 +26,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     atomic_transactions = False
     can_rollback_ddl = True
     supports_atomic_references_rename = Database.sqlite_version_info >= (3, 26, 0)
+    can_create_inline_fk = False
     supports_paramstyle_pyformat = False
     supports_sequence_reset = False
     can_clone_databases = True

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -214,6 +214,10 @@ backends.
 
 * ``DatabaseIntrospection.get_field_type()`` may no longer return tuples.
 
+* If the database can create foreign keys in the same SQL statement that adds a
+  field, add ``SchemaEditor.sql_create_column_inline_fk`` with the appropriate
+  SQL; otherwise, set ``DatabaseFeatures.can_create_inline_fk = False``.
+
 Miscellaneous
 -------------
 

--- a/tests/indexes/tests.py
+++ b/tests/indexes/tests.py
@@ -226,11 +226,9 @@ class SchemaIndexesMySQLTests(TransactionTestCase):
                 new_field.set_attributes_from_name('new_foreign_key')
                 editor.add_field(ArticleTranslation, new_field)
                 field_created = True
-                self.assertEqual([str(statement) for statement in editor.deferred_sql], [
-                    'ALTER TABLE `indexes_articletranslation` '
-                    'ADD CONSTRAINT `indexes_articletrans_new_foreign_key_id_d27a9146_fk_indexes_a` '
-                    'FOREIGN KEY (`new_foreign_key_id`) REFERENCES `indexes_article` (`id`)'
-                ])
+                # No deferred SQL. The FK constraint is included in the
+                # statement to add the field.
+                self.assertFalse(editor.deferred_sql)
         finally:
             if field_created:
                 with connection.schema_editor() as editor:

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -241,6 +241,27 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(Book, old_field, new_field, strict=True)
         self.assertForeignKeyExists(Book, 'author_id', 'schema_tag')
 
+    @skipUnlessDBFeature('can_create_inline_fk')
+    def test_inline_fk(self):
+        # Create some tables.
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+            editor.create_model(Book)
+            editor.create_model(Note)
+        self.assertForeignKeyNotExists(Note, 'book_id', 'schema_book')
+        # Add a foreign key from one to the other.
+        with connection.schema_editor() as editor:
+            new_field = ForeignKey(Book, CASCADE)
+            new_field.set_attributes_from_name('book')
+            editor.add_field(Note, new_field)
+        self.assertForeignKeyExists(Note, 'book_id', 'schema_book')
+        # Creating a FK field with a constraint uses a single statement without
+        # a deferred ALTER TABLE.
+        self.assertFalse([
+            sql for sql in (str(statement) for statement in editor.deferred_sql)
+            if sql.startswith('ALTER TABLE') and 'ADD CONSTRAINT' in sql
+        ])
+
     @skipUnlessDBFeature('supports_foreign_keys')
     def test_char_field_with_db_index_to_fk(self):
         # Create the table


### PR DESCRIPTION
Curiously, the `BaseDatabaseSchemaEditor` class already supported the attribute `sql_create_inline_fk`, but the only implementation that supported it was sqlite3. Moreover, this attribute was only used to create FK constraints inline during table creation, not when adding a new field to an existing table.

This introduces another attribute, `sql_add_field_inline_fk`, for creating FK constraints inline when adding fields. The sqlite3 engine supports this, and so does PostgreSQL.

It was not trivially easy to enable this functionality for table creation in PostgreSQL, as explained in a [comment on #30108](https://code.djangoproject.com/ticket/30108#comment:1):

> Unfortunately this ended up causing test failures because there are ​test models defined with a cyclic dependency. It seems that SQLite doesn't mind if you create a table with a foreign key to another table that doesn't exist yet, but PostgreSQL does.

Fortunately, creating FK constraints inline on table _creation_ is hardly critical, as the default behavior of doing so in a deferred query, thereby triggering a table scan, is effectively benign for an empty table.