### PR TITLE
Fixed #30123 -- Removed tuple support in DatabaseIntrospection.get_field_type().

### DIFF
--- a/django/contrib/gis/db/backends/mysql/introspection.py
+++ b/django/contrib/gis/db/backends/mysql/introspection.py
@@ -10,7 +10,7 @@ class MySQLIntrospection(DatabaseIntrospection):
     data_types_reverse = DatabaseIntrospection.data_types_reverse.copy()
     data_types_reverse[FIELD_TYPE.GEOMETRY] = 'GeometryField'
 
-    def get_geometry_type(self, table_name, geo_col):
+    def get_geometry_type(self, table_name, description):
         with self.connection.cursor() as cursor:
             # In order to get the specific geometry type of the field,
             # we introspect on the table definition using `DESCRIBE`.
@@ -19,7 +19,7 @@ class MySQLIntrospection(DatabaseIntrospection):
             # Increment over description info until we get to the geometry
             # column.
             for column, typ, null, key, default, extra in cursor.fetchall():
-                if column == geo_col:
+                if column == description.name:
                     # Using OGRGeomType to convert from OGC name to Django field.
                     # MySQL does not support 3D or SRIDs, so the field params
                     # are empty.

--- a/django/contrib/gis/db/backends/oracle/introspection.py
+++ b/django/contrib/gis/db/backends/oracle/introspection.py
@@ -10,20 +10,20 @@ class OracleIntrospection(DatabaseIntrospection):
     data_types_reverse = DatabaseIntrospection.data_types_reverse.copy()
     data_types_reverse[cx_Oracle.OBJECT] = 'GeometryField'
 
-    def get_geometry_type(self, table_name, geo_col):
+    def get_geometry_type(self, table_name, description):
         with self.connection.cursor() as cursor:
             # Querying USER_SDO_GEOM_METADATA to get the SRID and dimension information.
             try:
                 cursor.execute(
                     'SELECT "DIMINFO", "SRID" FROM "USER_SDO_GEOM_METADATA" '
                     'WHERE "TABLE_NAME"=%s AND "COLUMN_NAME"=%s',
-                    (table_name.upper(), geo_col.upper())
+                    (table_name.upper(), description.name.upper())
                 )
                 row = cursor.fetchone()
             except Exception as exc:
                 raise Exception(
                     'Could not find entry in USER_SDO_GEOM_METADATA '
-                    'corresponding to "%s"."%s"' % (table_name, geo_col)
+                    'corresponding to "%s"."%s"' % (table_name, description.name)
                 ) from exc
 
             # TODO: Research way to find a more specific geometry field type for

--- a/django/contrib/gis/db/backends/postgis/introspection.py
+++ b/django/contrib/gis/db/backends/postgis/introspection.py
@@ -53,7 +53,7 @@ class PostGISIntrospection(DatabaseIntrospection):
             self.data_types_reverse.update(self.postgis_types_reverse)
         return super().get_field_type(data_type, description)
 
-    def get_geometry_type(self, table_name, geo_col):
+    def get_geometry_type(self, table_name, description):
         """
         The geometry type OID used by PostGIS does not indicate the particular
         type of field that a geometry column is (e.g., whether it's a
@@ -67,11 +67,11 @@ class PostGISIntrospection(DatabaseIntrospection):
                     UNION ALL
                     SELECT * FROM geography_columns
                 ) AS t WHERE t.f_table_name = %s AND t.f_geometry_column = %s
-            """, (table_name, geo_col))
+            """, (table_name, description.name))
             row = cursor.fetchone()
             if not row:
                 raise Exception('Could not find a geometry or geography column for "%s"."%s"' %
-                                (table_name, geo_col))
+                                (table_name, description.name))
             dim, srid, field_type = row
             # OGRGeomType does not require GDAL and makes it easy to convert
             # from OGC geom type name to Django field.

--- a/django/contrib/gis/db/backends/spatialite/introspection.py
+++ b/django/contrib/gis/db/backends/spatialite/introspection.py
@@ -24,17 +24,17 @@ class GeoFlexibleFieldLookupDict(FlexibleFieldLookupDict):
 class SpatiaLiteIntrospection(DatabaseIntrospection):
     data_types_reverse = GeoFlexibleFieldLookupDict()
 
-    def get_geometry_type(self, table_name, geo_col):
+    def get_geometry_type(self, table_name, description):
         with self.connection.cursor() as cursor:
             # Querying the `geometry_columns` table to get additional metadata.
             cursor.execute('SELECT coord_dimension, srid, geometry_type '
                            'FROM geometry_columns '
                            'WHERE f_table_name=%s AND f_geometry_column=%s',
-                           (table_name, geo_col))
+                           (table_name, description.name))
             row = cursor.fetchone()
             if not row:
                 raise Exception('Could not find a geometry column for "%s"."%s"' %
-                                (table_name, geo_col))
+                                (table_name, description.name))
 
             # OGRGeomType does not require GDAL and makes it easy to convert
             # from OGC geom type name to Django field.

--- a/django/contrib/gis/management/commands/inspectdb.py
+++ b/django/contrib/gis/management/commands/inspectdb.py
@@ -9,9 +9,8 @@ class Command(InspectDBCommand):
     def get_field_type(self, connection, table_name, row):
         field_type, field_params, field_notes = super().get_field_type(connection, table_name, row)
         if field_type == 'GeometryField':
-            geo_col = row[0]
             # Getting a more specific field type and any additional parameters
             # from the `get_geometry_type` routine for the spatial backend.
-            field_type, geo_params = connection.introspection.get_geometry_type(table_name, geo_col)
+            field_type, geo_params = connection.introspection.get_geometry_type(table_name, row)
             field_params.update(geo_params)
         return field_type, field_params, field_notes

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -241,12 +241,6 @@ class Command(BaseCommand):
             field_type = 'TextField'
             field_notes.append('This field type is a guess.')
 
-        # This is a hook for data_types_reverse to return a tuple of
-        # (field_type, field_params_dict).
-        if type(field_type) is tuple:
-            field_type, new_params = field_type
-            field_params.update(new_params)
-
         # Add max_length for all CharFields.
         if field_type == 'CharField' and row.internal_size:
             field_params['max_length'] = int(row.internal_size)

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -208,7 +208,8 @@ Database backend API
 This section describes changes that may be needed in third-party database
 backends.
 
-* ...
+* The second argument of ``DatabaseIntrospection.get_geometry_type()`` is now
+  the row description instead of the column name.
 
 Miscellaneous
 -------------

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -211,6 +211,8 @@ backends.
 * The second argument of ``DatabaseIntrospection.get_geometry_type()`` is now
   the row description instead of the column name.
 
+* ``DatabaseIntrospection.get_field_type()`` may no longer return tuples.
+
 Miscellaneous
 -------------
 


### PR DESCRIPTION
Ticket [#30123](https://code.djangoproject.com/ticket/30123).

Split out from #10871, targeting 3.0.

Note that this includes the commits from #10883 upon which this builds.