### PR TITLE
fix ModelChoiceField.to_python

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1240,6 +1240,8 @@ class ModelChoiceField(ChoiceField):
             return None
         try:
             key = self.to_field_name or 'pk'
+            if isinstance(value, self.queryset.model):
+                return value
             value = self.queryset.get(**{key: value})
         except (ValueError, TypeError, self.queryset.model.DoesNotExist):
             raise ValidationError(self.error_messages['invalid_choice'], code='invalid_choice')


### PR DESCRIPTION
if `field.disabled` set to `True`, and you try to submit form initial value would be used.
In this case method to_python fails, because it tries to make a `qs.filter(pk=obj)`.
In same time `ModelChoiceField` doesn't accept pk as initial value, only object.

