### PR TITLE
Refs #30111 -- Fixed test cleanup in tests/postgres_tests/test_integration.py.

### DIFF
--- a/tests/postgres_tests/test_integration.py
+++ b/tests/postgres_tests/test_integration.py
@@ -2,11 +2,13 @@ import os
 import subprocess
 import sys
 
-from tests.postgres_tests import PostgreSQLSimpleTestCase
+from . import PostgreSQLSimpleTestCase
 
 
 class PostgresIntegrationTests(PostgreSQLSimpleTestCase):
     def test_check(self):
+        old_cwd = os.getcwd()
+        self.addCleanup(lambda: os.chdir(old_cwd))
         os.chdir(os.path.dirname(__file__))
         result = subprocess.run(
             [sys.executable, '-m', 'django', 'check', '--settings', 'integration_settings'],


### PR DESCRIPTION
Fixed "ERROR: Step ‘Publish JUnit test result report’ failed: No test
report files were found. Configuration error?" on Jenkins because report
files were put in tests/postgres_tests.