### PR TITLE
Remove documentation references to deactivate-transaction-management

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -517,8 +517,8 @@ Set this to ``True`` to wrap each view in a transaction on this database. See
 
 Default: ``True``
 
-Set this to ``False`` if you want to :ref:`disable Django's transaction
-management <deactivate-transaction-management>` and implement your own.
+Set this to ``False`` if you want to :ref:`take the resposibility to handle
+commits and rollbacks <setting-autocommit-false>` yourself.
 
 .. setting:: DATABASE-ENGINE
 

--- a/docs/topics/db/transactions.txt
+++ b/docs/topics/db/transactions.txt
@@ -255,18 +255,16 @@ back, depending on whether the query succeeded.
 be initially turned off. Django overrides this default and turns autocommit
 on.
 
-To avoid this, you can :ref:`deactivate the transaction management
-<deactivate-transaction-management>`, but it isn't recommended.
+To avoid this, you can :ref:`set autocommit to False
+<setting-autocommit-false>`, but it isn't recommended.
 
-.. _deactivate-transaction-management:
+.. _setting-autocommit-false:
 
-Deactivating transaction management
------------------------------------
+Setting autocommit to False
+---------------------------
 
-You can totally disable Django's transaction management for a given database
-by setting :setting:`AUTOCOMMIT <DATABASE-AUTOCOMMIT>` to ``False`` in its
-configuration. If you do this, Django won't enable autocommit, and won't
-perform any commits. You'll get the regular behavior of the underlying
+Setting :setting:`AUTOCOMMIT <DATABASE-AUTOCOMMIT>` to ``False`` won't perform
+any *automatic* commits and you'll get the regular behavior of the underlying
 database library.
 
 This requires you to commit explicitly every transaction, even those started


### PR DESCRIPTION
Previous version was misleading because having autocommit = True
shouldn't be considered as 'Django transaction management' because
what really happens is that there is no transaction handling at all
like, for example psycopg2 docs say here
http://initd.org/psycopg/docs/connection.html#connection.autocommit