### PR TITLE
Refs #28161 -- Doc'd INSTALLED_APPS requirement for ArrayField(CIText).

### DIFF
--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -265,6 +265,11 @@ transform do not change. For example::
     :ref:`setup the citext extension <create-postgresql-extensions>` in
     PostgreSQL before the first ``CreateModel`` migration operation.
 
+    If you're using an :class:`~django.contrib.postgres.fields.ArrayField`
+    of ``CIText`` fields, you must add ``'django.contrib.postgres'`` in your
+    :setting:`INSTALLED_APPS`, otherwise field values will appear as strings
+    like ``'{thoughts,django}'``.
+
     Several fields that use the mixin are provided:
 
 .. class:: CICharField(**options)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28161 (PR #8453) fixed type handling for ArrayFields of CIText types. The psycopg2 array type registration requires `django.contrib.postgres` to be in `INSTALLED_APPS`, similarly to [`HStoreField`](https://docs.djangoproject.com/en/2.2/ref/contrib/postgres/fields/#django.contrib.postgres.fields.HStoreField).

Without:
```
>>> MyModel.objects.create(id=1, tags=['alpacas', 'Sheep'])
>>> m = MyModel.objects.get(pk=1)
>>> m.tags
'{alpacas,Sheep}'
```
With:
```
>>> m = MyModel.objects.get(pk=1)
>>> m.tags
['alpacas', 'Sheep']
```