### PR TITLE
Refs #30033 -- Doc'd change regarding apps without migrations depending on apps with migrations.

### DIFF
--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -446,6 +446,13 @@ Miscellaneous
   :class:`~django.db.models.Variance` aggregate functions now return a
   ``Decimal`` instead of a ``float`` when the input is ``Decimal``.
 
+* Tests will fail on SQLite if apps without migrations have relations to apps
+  with migrations. This has been a documented restriction since migrations were
+  added in Django 1.7, but it fails more reliably now. You'll see tests failing
+  with errors like ``no such table: <app_label>_<model>``. This was observed
+  with several third-party apps that had tests models without migrations. You
+  must add migrations for such models.
+
 .. _deprecated-features-2.2:
 
 Features deprecated in 2.2

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -191,6 +191,10 @@ restrict to a single app. Restricting to a single app (either in
 a guarantee; any other apps that need to be used to get dependencies correct
 will be.
 
+Apps without migrations must not have relations (``ForeignKey``,
+``ManyToManyField``, etc.) to apps with migrations. Sometimes it may work, but
+it's not supported.
+
 .. _migration-files:
 
 Migration files


### PR DESCRIPTION
7289874adceec46b5367ec3157cdd10c711253a0 and the addition of
`self.connection.check_constraints()` in `__exit__()` is the cause.

I described this problem on an unrelated ticket:
https://code.djangoproject.com/ticket/30055#comment:3