### PR TITLE
Refs #23919 -- Replaced codecs.open() with open().

### DIFF
--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -3,7 +3,6 @@ A series of tests to establish that the command-line management tools work as
 advertised - especially with regards to the handling of the
 DJANGO_SETTINGS_MODULE and default settings.py files.
 """
-import codecs
 import os
 import re
 import shutil
@@ -2178,7 +2177,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         self.assertNoOutput(err)
         self.assertTrue(os.path.isdir(testproject_dir))
         path = os.path.join(testproject_dir, 'ticket-18091-non-ascii-template.txt')
-        with codecs.open(path, 'r', encoding='utf-8') as f:
+        with open(path, encoding='utf-8') as f:
             self.assertEqual(f.read().splitlines(False), [
                 'Some non-ASCII text for testing ticket #18091:',
                 'üäö €'])

--- a/tests/staticfiles_tests/cases.py
+++ b/tests/staticfiles_tests/cases.py
@@ -1,4 +1,3 @@
-import codecs
 import os
 import shutil
 import tempfile
@@ -86,7 +85,7 @@ class CollectionTestCase(BaseStaticFilesMixin, SimpleTestCase):
     def _get_file(self, filepath):
         assert filepath, 'filepath is empty.'
         filepath = os.path.join(settings.STATIC_ROOT, filepath)
-        with codecs.open(filepath, "r", "utf-8") as f:
+        with open(filepath, encoding='utf-8') as f:
             return f.read()
 
 

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -1,4 +1,3 @@
-import codecs
 import datetime
 import os
 import shutil
@@ -63,7 +62,7 @@ class TestFindStatic(TestDefaults, CollectionTestCase):
     """
     def _get_file(self, filepath):
         path = call_command('findstatic', filepath, all=False, verbosity=0, stdout=StringIO())
-        with codecs.open(path, "r", "utf-8") as f:
+        with open(path, encoding='utf-8') as f:
             return f.read()
 
     def test_all_files(self):


### PR DESCRIPTION
On Python 3, `open()` handles encodings.

https://code.djangoproject.com/ticket/23919