### PR TITLE
Refs #30137 -- Fixed template test on Windows.

### DIFF
--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -195,7 +195,8 @@ class FileSystemLoaderTests(SimpleTestCase):
                     self.engine.get_template(tmpfile.name)
 
     def test_notafile_error(self):
-        with self.assertRaises(IsADirectoryError):
+        # Windows raises PermissionError when trying to open a directory.
+        with self.assertRaises(PermissionError if sys.platform.startswith('win') else IsADirectoryError):
             self.engine.get_template('first')
 
 


### PR DESCRIPTION
Broken in 7785e03ba89aafbd949191f126361fb9103cb980.