### PR TITLE
Fixed #30004 -- Set default FILE_UPLOAD_PERMISSION to 0o644

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -304,7 +304,7 @@ FILE_UPLOAD_TEMP_DIR = None
 
 # The numeric mode to set newly-uploaded files to. The value should be a mode
 # you'd pass directly to os.chmod; see https://docs.python.org/library/os.html#files-and-directories.
-FILE_UPLOAD_PERMISSIONS = None
+FILE_UPLOAD_PERMISSIONS = 0o644
 
 # The numeric mode to assign to newly-created directories, when uploading files.
 # The value should be a mode as you'd pass to os.chmod;

--- a/docs/howto/deployment/checklist.txt
+++ b/docs/howto/deployment/checklist.txt
@@ -154,16 +154,6 @@ server never attempts to interpret them. For instance, if a user uploads a
 
 Now is a good time to check your backup strategy for these files.
 
-:setting:`FILE_UPLOAD_PERMISSIONS`
-----------------------------------
-
-With the default file upload settings, files smaller than
-:setting:`FILE_UPLOAD_MAX_MEMORY_SIZE` may be stored with a different mode
-than larger files as described in :setting:`FILE_UPLOAD_PERMISSIONS`.
-
-Setting :setting:`FILE_UPLOAD_PERMISSIONS` ensures all files are uploaded with
-the same permissions.
-
 HTTPS
 =====
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1484,7 +1484,7 @@ This value mirrors the functionality and caveats of the
 ``FILE_UPLOAD_PERMISSIONS``
 ---------------------------
 
-Default: ``None``
+Default: ``0o644``
 
 The numeric mode (i.e. ``0o644``) to set newly uploaded files to. For
 more information about what these modes mean, see the documentation for
@@ -1510,6 +1510,10 @@ when using the :djadmin:`collectstatic` management command. See
     ``0`` is very important: it indicates an octal number, which is the
     way that modes must be specified. If you try to use ``644``, you'll
     get totally incorrect behavior.
+
+.. versionchanged:: 3.0
+
+    In older versions, the default value is ``None``.
 
 .. setting:: FILE_UPLOAD_TEMP_DIR
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -284,6 +284,17 @@ Django 3.0, we're removing these APIs at this time.
 
 * ``django.utils.safestring.SafeBytes`` - Unused since Django 2.0.
 
+New default value for the ``FILE_UPLOAD_PERMISSIONS`` setting
+-------------------------------------------------------------
+
+In older versions, the :setting:`FILE_UPLOAD_PERMISSIONS` setting defaults to
+``None``. With the default :setting:`FILE_UPLOAD_HANDLERS`, this results in
+uploaded files having different permissions depending on their size and which
+upload handler is used.
+
+``FILE_UPLOAD_PERMISSION`` now defaults to ``0o644`` to avoid this
+inconsistency.
+
 Miscellaneous
 -------------
 

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -1099,7 +1099,7 @@ class OverrideSettingsTests(SimpleTestCase):
         the file_permissions_mode attribute of
         django.core.files.storage.default_storage.
         """
-        self.assertIsNone(default_storage.file_permissions_mode)
+        self.assertEqual(default_storage.file_permissions_mode, 0o644)
         with self.settings(FILE_UPLOAD_PERMISSIONS=0o777):
             self.assertEqual(default_storage.file_permissions_mode, 0o777)
 


### PR DESCRIPTION
Updated FILE_UPLOAD_PERMISSION settings default value
to 0o644 to avoid inconsitency in file permissions.
Updated test case to test against new default value and
added documentation regarding this breaking change.