### PR TITLE
Fixed #30148 -- Logged COPY ... TO statements in connection.queries on PostgreSQL.

### DIFF
--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -201,6 +201,8 @@ Models
   :class:`~django.db.models.functions.Trunc` database functions determines the
   treatment of nonexistent and ambiguous datetimes.
 
+* ``connection.queries`` now shows ``COPY … TO`` statements on PostgreSQL.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -1,9 +1,10 @@
 import unittest
+from io import StringIO
 from unittest import mock
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DatabaseError, connection, connections
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
 @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL tests')
@@ -176,3 +177,15 @@ class Tests(TestCase):
             self.assertEqual(psycopg2_version(), (4, 2, 1))
         with mock.patch('psycopg2.__version__', '4.2b0.dev1 (dt dec pq3 ext lo64)'):
             self.assertEqual(psycopg2_version(), (4, 2))
+
+    @override_settings(DEBUG=True)
+    def test_copy_cursors(self):
+        out = StringIO()
+        copy_expert_sql = 'COPY django_session TO STDOUT (FORMAT CSV, HEADER)'
+        with connection.cursor() as cursor:
+            cursor.copy_expert(copy_expert_sql, out)
+            cursor.copy_to(out, 'django_session')
+        self.assertEqual(
+            [q['sql'] for q in connection.queries],
+            [copy_expert_sql, 'COPY django_session TO STDOUT'],
+        )


### PR DESCRIPTION
I ran into an issue where I was running postgres commands `copy_expert()` / `copy_to()` and my queries weren't showing up on my `connection.queries` while `DEBUG=True`. I figured no one has needed this before, but I need it for my tests to pass.

https://code.djangoproject.com/ticket/30148#ticket