### PR TITLE
Fixed #29529 -- Allowed models.fields.FilePathField to accept a callable path.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1709,7 +1709,7 @@ class FilePathField(Field):
 
     def formfield(self, **kwargs):
         return super().formfield(**{
-            'path': self.path,
+            'path': self.path() if callable(self.path) else self.path,
             'match': self.match,
             'recursive': self.recursive,
             'form_class': forms.FilePathField,

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -868,6 +868,23 @@ directory on the filesystem. Has three special arguments, of which the first is
     Required. The absolute filesystem path to a directory from which this
     :class:`FilePathField` should get its choices. Example: ``"/home/images"``.
 
+    ``path`` may also be a callable, such as a function to dynamically set the
+    path at runtime. Example::
+
+        import os
+        from django.conf import settings
+        from django.db import models
+
+        def images_path():
+            return os.path.join(settings.LOCAL_FILE_DIR, 'images')
+
+        class MyModel(models.Model):
+            file = models.FilePathField(path=images_path)
+
+    .. versionchanged:: 3.0
+
+        ``path`` can now be a callable.
+
 .. attribute:: FilePathField.match
 
     Optional. A regular expression, as a string, that :class:`FilePathField`

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -206,6 +206,8 @@ Models
 
 * ``connection.queries`` now shows ``COPY … TO`` statements on PostgreSQL.
 
+* :class:`~django.db.models.FilePathField` now accepts a callable ``path``.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/model_fields/test_filepathfield.py
+++ b/tests/model_fields/test_filepathfield.py
@@ -1,0 +1,12 @@
+import os
+
+from django.db.models import FilePathField
+from django.test import SimpleTestCase
+
+
+class FilePathFieldTests(SimpleTestCase):
+    def test_path(self):
+        path = os.path.dirname(__file__)
+        field = FilePathField(path=path)
+        self.assertEqual(field.path, path)
+        self.assertEqual(field.formfield().path, path)

--- a/tests/model_fields/test_filepathfield.py
+++ b/tests/model_fields/test_filepathfield.py
@@ -10,3 +10,13 @@ class FilePathFieldTests(SimpleTestCase):
         field = FilePathField(path=path)
         self.assertEqual(field.path, path)
         self.assertEqual(field.formfield().path, path)
+
+    def test_callable_path(self):
+        path = os.path.dirname(__file__)
+
+        def generate_path():
+            return path
+
+        field = FilePathField(path=generate_path)
+        self.assertEqual(field.path(), path)
+        self.assertEqual(field.formfield().path, path)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29529