### PR TITLE
Refs #28859 -- Simplified fetch_returned_insert_id() by using int data type for binding variable on Oracle.

### DIFF
--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -227,17 +227,16 @@ END;
         return " DEFERRABLE INITIALLY DEFERRED"
 
     def fetch_returned_insert_id(self, cursor):
-        try:
-            value = cursor._insert_id_var.getvalue()
-            # cx_Oracle < 7 returns value, >= 7 returns list with single value.
-            return int(value[0] if isinstance(value, list) else value)
-        except (IndexError, TypeError):
-            # cx_Oracle < 6.3 returns None, >= 6.3 raises IndexError.
+        value = cursor._insert_id_var.getvalue()
+        if value is None or value == []:
+            # cx_Oracle < 6.3 returns None, >= 6.3 returns empty list.
             raise DatabaseError(
                 'The database did not return a new row id. Probably "ORA-1403: '
                 'no data found" was raised internally but was hidden by the '
                 'Oracle OCI library (see https://code.djangoproject.com/ticket/28859).'
             )
+        # cx_Oracle < 7 returns value, >= 7 returns list with single value.
+        return value[0] if isinstance(value, list) else value
 
     def field_cast_sql(self, db_type, internal_type):
         if db_type and db_type.endswith('LOB'):

--- a/django/db/backends/oracle/utils.py
+++ b/django/db/backends/oracle/utils.py
@@ -9,9 +9,8 @@ class InsertIdVar:
     as a parameter, in order to receive the id of the row created by an
     insert statement.
     """
-
     def bind_parameter(self, cursor):
-        param = cursor.cursor.var(Database.NUMBER)
+        param = cursor.cursor.var(int)
         cursor._insert_id_var = param
         return param
 


### PR DESCRIPTION
`cx_Oracle` accepts some Python data types for variables (see [Cursor.var](https://cx-oracle.readthedocs.io/en/latest/cursor.html?highlight=cursor.var#Cursor.var)). IMO `fetch_returned_insert_id()` is clearer with using `int` data type for binding variable. This can also be helpful for #9983.