### PR TITLE
Refs #27753 -- Deprecated django.utils.http urllib aliases.

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -3,6 +3,7 @@ import calendar
 import datetime
 import re
 import unicodedata
+import warnings
 from binascii import Error as BinasciiError
 from email.utils import formatdate
 from urllib.parse import (
@@ -13,6 +14,7 @@ from urllib.parse import (
 
 from django.core.exceptions import TooManyFieldsSent
 from django.utils.datastructures import MultiValueDict
+from django.utils.deprecation import RemovedInDjango40Warning
 from django.utils.functional import keep_lazy_text
 
 # based on RFC 7232, Appendix C
@@ -48,6 +50,11 @@ def urlquote(url, safe='/'):
     A legacy compatibility wrapper to Python's urllib.parse.quote() function.
     (was used for unicode handling on Python 2)
     """
+    warnings.warn(
+        'django.utils.http.urlquote() is deprecated in favor of '
+        'urllib.parse.quote().',
+        RemovedInDjango40Warning, stacklevel=2,
+    )
     return quote(url, safe)
 
 
@@ -57,6 +64,11 @@ def urlquote_plus(url, safe=''):
     A legacy compatibility wrapper to Python's urllib.parse.quote_plus()
     function. (was used for unicode handling on Python 2)
     """
+    warnings.warn(
+        'django.utils.http.urlquote_plus() is deprecated in favor of '
+        'urllib.parse.quote_plus(),',
+        RemovedInDjango40Warning, stacklevel=2,
+    )
     return quote_plus(url, safe)
 
 
@@ -66,6 +78,11 @@ def urlunquote(quoted_url):
     A legacy compatibility wrapper to Python's urllib.parse.unquote() function.
     (was used for unicode handling on Python 2)
     """
+    warnings.warn(
+        'django.utils.http.urlunquote() is deprecated in favor of '
+        'urllib.parse.unquote().',
+        RemovedInDjango40Warning, stacklevel=2,
+    )
     return unquote(quoted_url)
 
 
@@ -75,6 +92,11 @@ def urlunquote_plus(quoted_url):
     A legacy compatibility wrapper to Python's urllib.parse.unquote_plus()
     function. (was used for unicode handling on Python 2)
     """
+    warnings.warn(
+        'django.utils.http.urlunquote_plus() is deprecated in favor of '
+        'urllib.parse.unquote_plus().',
+        RemovedInDjango40Warning, stacklevel=2,
+    )
     return unquote_plus(quoted_url)
 
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -15,6 +15,9 @@ about each item can often be found in the release notes of two versions prior.
 See the :ref:`Django 3.0 release notes <deprecated-features-3.0>` for more
 details on these changes.
 
+* ``django.utils.http.urlquote()``, ``urlquote_plus()``, ``urlunquote()``, and
+  ``urlunquote_plus()`` will be removed.
+
 .. _deprecation-removed-in-3.1:
 
 3.1

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -235,7 +235,11 @@ Features deprecated in 3.0
 Miscellaneous
 -------------
 
-* ...
+* ``django.utils.http.urlquote()``, ``urlquote_plus()``, ``urlunquote()``, and
+  ``urlunquote_plus()`` are deprecated in favor of the functions that they're
+  aliases for: :func:`urllib.parse.quote`, :func:`~urllib.parse.quote_plus`,
+  :func:`~urllib.parse.unquote`, and :func:`~urllib.parse.unquote_plus`.
+
 
 .. _removed-features-3.0:
 

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -1,8 +1,9 @@
 import unittest
 from datetime import datetime
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, ignore_warnings
 from django.utils.datastructures import MultiValueDict
+from django.utils.deprecation import RemovedInDjango40Warning
 from django.utils.http import (
     base36_to_int, escape_leading_slashes, http_date, int_to_base36,
     is_safe_url, is_same_domain, parse_etags, parse_http_date, quote_etag,
@@ -216,6 +217,7 @@ class URLSafeBase64Tests(unittest.TestCase):
         self.assertEqual(bytestring, decoded)
 
 
+@ignore_warnings(category=RemovedInDjango40Warning)
 class URLQuoteTests(unittest.TestCase):
     def test_quote(self):
         self.assertEqual(urlquote('Paris & Orl\xe9ans'), 'Paris%20%26%20Orl%C3%A9ans')


### PR DESCRIPTION
Updated from https://github.com/django/django/pull/7906.