### PR TITLE
Removed unused RunInTmpDirMixin.rmfile().

### DIFF
--- a/tests/i18n/utils.py
+++ b/tests/i18n/utils.py
@@ -59,7 +59,3 @@ class RunInTmpDirMixin:
         if os.path.commonprefix([self.test_dir, os.path.abspath(dname)]) != self.test_dir:
             return
         shutil.rmtree(dname)
-
-    def rmfile(self, filepath):
-        if os.path.exists(filepath):
-            os.remove(filepath)


### PR DESCRIPTION
Unused since bb7bb379e8cd91a91336946829519d64e919a1d2.