### PR TITLE
Simplified temporary directory handling in AdminScriptTestCase.

### DIFF
--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -39,23 +39,13 @@ SYSTEM_CHECK_MSG = 'System check identified no issues'
 
 
 class AdminScriptTestCase(SimpleTestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.test_dir = os.path.realpath(os.path.join(
-            tempfile.gettempdir(),
-            cls.__name__,
-            'test_project',
-        ))
-        os.makedirs(cls.test_dir)
-        with open(os.path.join(cls.test_dir, '__init__.py'), 'w'):
+    def setUp(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        self.test_dir = os.path.join(tmpdir.name, 'test_project')
+        os.mkdir(self.test_dir)
+        with open(os.path.join(self.test_dir, '__init__.py'), 'w'):
             pass
-
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.test_dir)
-        super().tearDownClass()
 
     def write_settings(self, filename, apps=None, is_dir=False, sdict=None, extra=None):
         if is_dir:
@@ -89,19 +79,6 @@ class AdminScriptTestCase(SimpleTestCase):
             if sdict:
                 for k, v in sdict.items():
                     settings_file.write("%s = %s\n" % (k, v))
-
-    def remove_settings(self, filename, is_dir=False):
-        full_name = os.path.join(self.test_dir, filename)
-        if is_dir:
-            shutil.rmtree(full_name)
-        else:
-            os.remove(full_name)
-
-        # Also remove a __pycache__ directory, if it exists; it could
-        # mess up later tests that depend upon the .py file not existing
-        cache_name = os.path.join(self.test_dir, '__pycache__')
-        if os.path.isdir(cache_name):
-            shutil.rmtree(cache_name)
 
     def _ext_backend_paths(self):
         """
@@ -157,12 +134,6 @@ class AdminScriptTestCase(SimpleTestCase):
         return self.run_test(os.path.join(script_dir, 'django-admin.py'), args, settings_file)
 
     def run_manage(self, args, settings_file=None, configured_settings=False):
-        def safe_remove(path):
-            try:
-                os.remove(path)
-            except OSError:
-                pass
-
         template_manage_py = (
             os.path.join(os.path.dirname(__file__), 'configured_settings_manage.py')
             if configured_settings else
@@ -177,7 +148,6 @@ class AdminScriptTestCase(SimpleTestCase):
             "{{ project_name }}", "test_project")
         with open(test_manage_py, 'w') as fp:
             fp.write(manage_py_contents)
-        self.addCleanup(safe_remove, test_manage_py)
 
         return self.run_test('./manage.py', args, settings_file)
 
@@ -246,10 +216,8 @@ class DjangoAdminDefaultSettings(AdminScriptTestCase):
     contains the test application.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py')
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_builtin_command(self):
         "default: django-admin builtin commands fail with an error when no settings provided"
@@ -314,11 +282,9 @@ class DjangoAdminFullPathDefaultSettings(AdminScriptTestCase):
     contains the test application specified using a full path.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py', ['django.contrib.auth', 'django.contrib.contenttypes',
                                             'admin_scripts', 'admin_scripts.complex_app'])
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_builtin_command(self):
         "fulldefault: django-admin builtin commands fail with an error when no settings provided"
@@ -383,10 +349,8 @@ class DjangoAdminMinimalSettings(AdminScriptTestCase):
     doesn't contain the test application.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py', apps=['django.contrib.auth', 'django.contrib.contenttypes'])
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_builtin_command(self):
         "minimal: django-admin builtin commands fail with an error when no settings provided"
@@ -451,10 +415,8 @@ class DjangoAdminAlternateSettings(AdminScriptTestCase):
     with a name other than 'settings.py'.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings('alternate_settings.py')
-
-    def tearDown(self):
-        self.remove_settings('alternate_settings.py')
 
     def test_builtin_command(self):
         "alternate: django-admin builtin commands fail with an error when no settings provided"
@@ -521,12 +483,9 @@ class DjangoAdminMultipleSettings(AdminScriptTestCase):
     alternate settings must be used by the running script.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py', apps=['django.contrib.auth', 'django.contrib.contenttypes'])
         self.write_settings('alternate_settings.py')
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
-        self.remove_settings('alternate_settings.py')
 
     def test_builtin_command(self):
         "alternate: django-admin builtin commands fail with an error when no settings provided"
@@ -592,17 +551,14 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
     """
 
     def setUp(self):
+        super().setUp()
         self.write_settings('settings', is_dir=True)
-
-    def tearDown(self):
-        self.remove_settings('settings', is_dir=True)
 
     def test_setup_environ(self):
         "directory: startapp creates the correct directory"
         args = ['startapp', 'settings_test']
         app_path = os.path.join(self.test_dir, 'settings_test')
         out, err = self.run_django_admin(args, 'test_project.settings')
-        self.addCleanup(shutil.rmtree, app_path)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(app_path))
         with open(os.path.join(app_path, 'apps.py')) as f:
@@ -616,7 +572,6 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         args = ['startapp', '--template', template_path, 'custom_settings_test']
         app_path = os.path.join(self.test_dir, 'custom_settings_test')
         out, err = self.run_django_admin(args, 'test_project.settings')
-        self.addCleanup(shutil.rmtree, app_path)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(app_path))
         self.assertTrue(os.path.exists(os.path.join(app_path, 'api.py')))
@@ -626,7 +581,6 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         args = ['startapp', 'こんにちは']
         app_path = os.path.join(self.test_dir, 'こんにちは')
         out, err = self.run_django_admin(args, 'test_project.settings')
-        self.addCleanup(shutil.rmtree, app_path)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(app_path))
         with open(os.path.join(app_path, 'apps.py'), encoding='utf8') as f:
@@ -713,10 +667,8 @@ class ManageDefaultSettings(AdminScriptTestCase):
     contains the test application.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py')
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_builtin_command(self):
         "default: manage.py builtin commands succeed when default settings are appropriate"
@@ -780,10 +732,8 @@ class ManageFullPathDefaultSettings(AdminScriptTestCase):
     contains the test application specified using a full path.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py', ['django.contrib.auth', 'django.contrib.contenttypes', 'admin_scripts'])
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_builtin_command(self):
         "fulldefault: manage.py builtin commands succeed when default settings are appropriate"
@@ -847,10 +797,8 @@ class ManageMinimalSettings(AdminScriptTestCase):
     doesn't contain the test application.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py', apps=['django.contrib.auth', 'django.contrib.contenttypes'])
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_builtin_command(self):
         "minimal: manage.py builtin commands fail with an error when no settings provided"
@@ -914,10 +862,8 @@ class ManageAlternateSettings(AdminScriptTestCase):
     with a name other than 'settings.py'.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings('alternate_settings.py')
-
-    def tearDown(self):
-        self.remove_settings('alternate_settings.py')
 
     def test_builtin_command(self):
         "alternate: manage.py builtin commands fail with an error when no default settings provided"
@@ -1005,12 +951,9 @@ class ManageMultipleSettings(AdminScriptTestCase):
     alternate settings must be used by the running script.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py', apps=['django.contrib.auth', 'django.contrib.contenttypes'])
         self.write_settings('alternate_settings.py')
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
-        self.remove_settings('alternate_settings.py')
 
     def test_builtin_command(self):
         "multiple: manage.py builtin commands fail with an error when no settings provided"
@@ -1074,9 +1017,6 @@ class ManageSettingsWithSettingsErrors(AdminScriptTestCase):
     Tests for manage.py when using the default settings.py file containing
     runtime errors.
     """
-    def tearDown(self):
-        self.remove_settings('settings.py')
-
     def write_settings_with_import_error(self, filename):
         settings_file_path = os.path.join(self.test_dir, filename)
         with open(settings_file_path, 'w') as settings_file:
@@ -1130,9 +1070,6 @@ class ManageSettingsWithSettingsErrors(AdminScriptTestCase):
 
 
 class ManageCheck(AdminScriptTestCase):
-    def tearDown(self):
-        self.remove_settings('settings.py')
-
     def test_nonexistent_app(self):
         """check reports an error on a nonexistent app in INSTALLED_APPS."""
         self.write_settings(
@@ -1280,7 +1217,7 @@ class ManageCheck(AdminScriptTestCase):
         self.assertNoOutput(out)
 
 
-class ManageRunserver(AdminScriptTestCase):
+class ManageRunserver(SimpleTestCase):
     def setUp(self):
         def monkey_run(*args, **options):
             return
@@ -1398,13 +1335,11 @@ class ManageRunserverMigrationWarning(TestCase):
 
 class ManageRunserverEmptyAllowedHosts(AdminScriptTestCase):
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py', sdict={
             'ALLOWED_HOSTS': [],
             'DEBUG': False,
         })
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_empty_allowed_hosts_error(self):
         out, err = self.run_manage(['runserver'])
@@ -1412,7 +1347,7 @@ class ManageRunserverEmptyAllowedHosts(AdminScriptTestCase):
         self.assertOutput(err, 'CommandError: You must set settings.ALLOWED_HOSTS if DEBUG is False.')
 
 
-class ManageTestserver(AdminScriptTestCase):
+class ManageTestserver(SimpleTestCase):
 
     @mock.patch.object(TestserverCommand, 'handle', return_value='')
     def test_testserver_handle_params(self, mock_handle):
@@ -1468,10 +1403,8 @@ class ColorCommand(BaseCommand):
 class CommandTypes(AdminScriptTestCase):
     "Tests for the various types of base command types that can be defined."
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py')
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_version(self):
         "version is handled as a special case"
@@ -1889,12 +1822,9 @@ class ArgumentOrder(AdminScriptTestCase):
     individual command.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py', apps=['django.contrib.auth', 'django.contrib.contenttypes'])
         self.write_settings('alternate_settings.py')
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
-        self.remove_settings('alternate_settings.py')
 
     def test_setting_then_option(self):
         """ Options passed after settings are correctly handled. """
@@ -1956,7 +1886,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         "Make sure the startproject management command creates a project"
         args = ['startproject', 'testproject']
         testproject_dir = os.path.join(self.test_dir, 'testproject')
-        self.addCleanup(shutil.rmtree, testproject_dir, True)
 
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
@@ -1972,7 +1901,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         for bad_name in ('7testproject', '../testproject'):
             args = ['startproject', bad_name]
             testproject_dir = os.path.join(self.test_dir, bad_name)
-            self.addCleanup(shutil.rmtree, testproject_dir, True)
 
             out, err = self.run_django_admin(args)
             self.assertOutput(
@@ -1990,7 +1918,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         bad_name = 'os'
         args = ['startproject', bad_name]
         testproject_dir = os.path.join(self.test_dir, bad_name)
-        self.addCleanup(shutil.rmtree, testproject_dir, True)
 
         out, err = self.run_django_admin(args)
         self.assertOutput(
@@ -2006,7 +1933,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         args = ['startproject', 'testproject', 'othertestproject']
         testproject_dir = os.path.join(self.test_dir, 'othertestproject')
         os.mkdir(testproject_dir)
-        self.addCleanup(shutil.rmtree, testproject_dir)
 
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
@@ -2022,7 +1948,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         template_path = os.path.join(custom_templates_dir, 'project_template')
         args = ['startproject', '--template', template_path, 'customtestproject']
         testproject_dir = os.path.join(self.test_dir, 'customtestproject')
-        self.addCleanup(shutil.rmtree, testproject_dir, True)
 
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
@@ -2034,7 +1959,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         template_path = os.path.join(custom_templates_dir, 'project_template' + os.sep)
         args = ['startproject', '--template', template_path, 'customtestproject']
         testproject_dir = os.path.join(self.test_dir, 'customtestproject')
-        self.addCleanup(shutil.rmtree, testproject_dir, True)
 
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
@@ -2046,7 +1970,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         template_path = os.path.join(custom_templates_dir, 'project_template.tgz')
         args = ['startproject', '--template', template_path, 'tarballtestproject']
         testproject_dir = os.path.join(self.test_dir, 'tarballtestproject')
-        self.addCleanup(shutil.rmtree, testproject_dir, True)
 
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
@@ -2059,7 +1982,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         args = ['startproject', '--template', template_path, 'tarballtestproject', 'altlocation']
         testproject_dir = os.path.join(self.test_dir, 'altlocation')
         os.mkdir(testproject_dir)
-        self.addCleanup(shutil.rmtree, testproject_dir)
 
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
@@ -2075,7 +1997,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
 
         args = ['startproject', '--template', template_url, 'urltestproject']
         testproject_dir = os.path.join(self.test_dir, 'urltestproject')
-        self.addCleanup(shutil.rmtree, testproject_dir, True)
 
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
@@ -2088,7 +2009,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
 
         args = ['startproject', '--template', template_url, 'urltestproject']
         testproject_dir = os.path.join(self.test_dir, 'urltestproject')
-        self.addCleanup(shutil.rmtree, testproject_dir, True)
 
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
@@ -2100,7 +2020,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         template_path = os.path.join(custom_templates_dir, 'project_template')
         args = ['startproject', '--template', template_path, 'customtestproject', '-e', 'txt', '-n', 'Procfile']
         testproject_dir = os.path.join(self.test_dir, 'customtestproject')
-        self.addCleanup(shutil.rmtree, testproject_dir, True)
 
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
@@ -2118,7 +2037,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         args = ['startproject', '--template', template_path, 'another_project', 'project_dir']
         testproject_dir = os.path.join(self.test_dir, 'project_dir')
         os.mkdir(testproject_dir)
-        self.addCleanup(shutil.rmtree, testproject_dir)
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
         test_manage_py = os.path.join(testproject_dir, 'manage.py')
@@ -2131,7 +2049,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         "Make sure template context variables are not html escaped"
         # We're using a custom command so we need the alternate settings
         self.write_settings('alternate_settings.py')
-        self.addCleanup(self.remove_settings, 'alternate_settings.py')
         template_path = os.path.join(custom_templates_dir, 'project_template')
         args = [
             'custom_startproject', '--template', template_path,
@@ -2140,7 +2057,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         ]
         testproject_dir = os.path.join(self.test_dir, 'project_dir')
         os.mkdir(testproject_dir)
-        self.addCleanup(shutil.rmtree, testproject_dir)
         out, err = self.run_manage(args)
         self.assertNoOutput(err)
         test_manage_py = os.path.join(testproject_dir, 'additional_dir', 'extra.py')
@@ -2169,7 +2085,6 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         template_path = os.path.join(custom_templates_dir, 'project_template')
         args = ['startproject', '--template', template_path, '--extension=txt', 'customtestproject']
         testproject_dir = os.path.join(self.test_dir, 'customtestproject')
-        self.addCleanup(shutil.rmtree, testproject_dir, True)
 
         out, err = self.run_django_admin(args)
         self.assertNoOutput(err)
@@ -2188,7 +2103,6 @@ class StartApp(AdminScriptTestCase):
         for bad_name in ('7testproject', '../testproject'):
             args = ['startapp', bad_name]
             testproject_dir = os.path.join(self.test_dir, bad_name)
-            self.addCleanup(shutil.rmtree, testproject_dir, True)
 
             out, err = self.run_django_admin(args)
             self.assertOutput(
@@ -2206,7 +2120,6 @@ class StartApp(AdminScriptTestCase):
         bad_name = 'os'
         args = ['startapp', bad_name]
         testproject_dir = os.path.join(self.test_dir, bad_name)
-        self.addCleanup(shutil.rmtree, testproject_dir, True)
 
         out, err = self.run_django_admin(args)
         self.assertOutput(
@@ -2224,7 +2137,6 @@ class DiffSettings(AdminScriptTestCase):
     def test_basic(self):
         """Runs without error and emits settings diff."""
         self.write_settings('settings_to_diff.py', sdict={'FOO': '"bar"'})
-        self.addCleanup(self.remove_settings, 'settings_to_diff.py')
         args = ['diffsettings', '--settings=settings_to_diff']
         out, err = self.run_manage(args)
         self.assertNoOutput(err)
@@ -2238,7 +2150,6 @@ class DiffSettings(AdminScriptTestCase):
     def test_all(self):
         """The all option also shows settings with the default value."""
         self.write_settings('settings_to_diff.py', sdict={'STATIC_URL': 'None'})
-        self.addCleanup(self.remove_settings, 'settings_to_diff.py')
         args = ['diffsettings', '--settings=settings_to_diff', '--all']
         out, err = self.run_manage(args)
         self.assertNoOutput(err)
@@ -2250,9 +2161,7 @@ class DiffSettings(AdminScriptTestCase):
         comparison.
         """
         self.write_settings('settings_default.py', sdict={'FOO': '"foo"', 'BAR': '"bar1"'})
-        self.addCleanup(self.remove_settings, 'settings_default.py')
         self.write_settings('settings_to_diff.py', sdict={'FOO': '"foo"', 'BAR': '"bar2"'})
-        self.addCleanup(self.remove_settings, 'settings_to_diff.py')
         out, err = self.run_manage(['diffsettings', '--settings=settings_to_diff', '--default=settings_default'])
         self.assertNoOutput(err)
         self.assertNotInOutput(out, "FOO")
@@ -2261,7 +2170,6 @@ class DiffSettings(AdminScriptTestCase):
     def test_unified(self):
         """--output=unified emits settings diff in unified mode."""
         self.write_settings('settings_to_diff.py', sdict={'FOO': '"bar"'})
-        self.addCleanup(self.remove_settings, 'settings_to_diff.py')
         args = ['diffsettings', '--settings=settings_to_diff', '--output=unified']
         out, err = self.run_manage(args)
         self.assertNoOutput(err)
@@ -2276,7 +2184,6 @@ class DiffSettings(AdminScriptTestCase):
         settings with the default value.
         """
         self.write_settings('settings_to_diff.py', sdict={'FOO': '"bar"'})
-        self.addCleanup(self.remove_settings, 'settings_to_diff.py')
         args = ['diffsettings', '--settings=settings_to_diff', '--output=unified', '--all']
         out, err = self.run_manage(args)
         self.assertNoOutput(err)
@@ -2289,10 +2196,8 @@ class Dumpdata(AdminScriptTestCase):
     """Tests for dumpdata management command."""
 
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py')
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_pks_parsing(self):
         """Regression for #20509
@@ -2320,10 +2225,8 @@ class MainModule(AdminScriptTestCase):
 
 class DjangoAdminSuggestions(AdminScriptTestCase):
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py')
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_suggestions(self):
         args = ['rnserver', '--settings=test_project.settings']

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -439,6 +439,7 @@ class SettingsConfigTest(AdminScriptTestCase):
     a circular import error.
     """
     def setUp(self):
+        super().setUp()
         log_config = """{
     'version': 1,
     'handlers': {
@@ -449,9 +450,6 @@ class SettingsConfigTest(AdminScriptTestCase):
     }
 }"""
         self.write_settings('settings.py', sdict={'LOGGING': log_config})
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_circular_dependency(self):
         # validate is just an example command to trigger settings configuration
@@ -518,6 +516,7 @@ class SettingsCustomLoggingTest(AdminScriptTestCase):
     callable in LOGGING_CONFIG (i.e., logging.config.fileConfig).
     """
     def setUp(self):
+        super().setUp()
         logging_conf = """
 [loggers]
 keys=root
@@ -544,7 +543,6 @@ format=%(message)s
 
     def tearDown(self):
         self.temp_file.close()
-        self.remove_settings('settings.py')
 
     def test_custom_logging(self):
         out, err = self.run_manage(['check'])

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -155,13 +155,11 @@ class CustomTestRunnerOptionsSettingsTests(AdminScriptTestCase):
     through a settings file.
     """
     def setUp(self):
+        super().setUp()
         settings = {
             'TEST_RUNNER': '\'test_runner.runner.CustomOptionsTestRunner\'',
         }
         self.write_settings('settings.py', sdict=settings)
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_default_options(self):
         args = ['test', '--settings=test_project.settings']
@@ -195,10 +193,8 @@ class CustomTestRunnerOptionsCmdlineTests(AdminScriptTestCase):
     using --testrunner.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py')
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_testrunner_option(self):
         args = [
@@ -228,10 +224,8 @@ class CustomTestRunnerOptionsCmdlineTests(AdminScriptTestCase):
 
 class Ticket17477RegressionTests(AdminScriptTestCase):
     def setUp(self):
+        super().setUp()
         self.write_settings('settings.py')
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_ticket_17477(self):
         """'manage.py help test' works after r16352."""

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -534,13 +534,11 @@ class ReverseLazySettingsTest(AdminScriptTestCase):
     import error.
     """
     def setUp(self):
+        super().setUp()
         self.write_settings(
             'settings.py',
             extra="from django.urls import reverse_lazy\nLOGIN_URL = reverse_lazy('login')",
         )
-
-    def tearDown(self):
-        self.remove_settings('settings.py')
 
     def test_lazy_in_settings(self):
         out, err = self.run_manage(['check'])

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -234,9 +234,6 @@ class CommandRunTests(AdminScriptTestCase):
     """
     Tests that need to run by simulating the command line, not by call_command.
     """
-    def tearDown(self):
-        self.remove_settings('settings.py')
-
     def test_script_prefix_set_in_commands(self):
         self.write_settings('settings.py', apps=['user_commands'], sdict={
             'ROOT_URLCONF': '"user_commands.urls"',


### PR DESCRIPTION
In `AdminScriptTestCase.setUp()`, use Python's `tempfile.TemporaryDirectory()` to create and destroy a temporary directory per run. This removes the need for individual tests to delete files as the entire directory will be destroyed and rebuilt between runs. The result is less state and boilerplate to manage.

For test classes that don't use the temporary directory, inherit from `SimpleTestCase` instead.