### PR TITLE
Fixed #30159 -- Removed obsolete use of OrderedDict with Python 3.6+.

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -2,7 +2,7 @@ import functools
 import sys
 import threading
 import warnings
-from collections import Counter, OrderedDict, defaultdict
+from collections import Counter, defaultdict
 from functools import partial
 
 from django.core.exceptions import AppRegistryNotReady, ImproperlyConfigured
@@ -31,10 +31,10 @@ class Apps:
         # and whether the registry has been populated. Since it isn't possible
         # to reimport a module safely (it could reexecute initialization code)
         # all_models is never overridden or reset.
-        self.all_models = defaultdict(OrderedDict)
+        self.all_models = defaultdict(dict)
 
         # Mapping of labels to AppConfig instances for installed apps.
-        self.app_configs = OrderedDict()
+        self.app_configs = {}
 
         # Stack of app_configs. Used to store the current state in
         # set_available_apps and set_installed_apps.
@@ -316,10 +316,11 @@ class Apps:
             )
 
         self.stored_app_configs.append(self.app_configs)
-        self.app_configs = OrderedDict(
-            (label, app_config)
+        self.app_configs = {
+            label: app_config
             for label, app_config in self.app_configs.items()
-            if app_config.name in available)
+            if app_config.name in available
+        }
         self.clear_cache()
 
     def unset_available_apps(self):
@@ -347,7 +348,7 @@ class Apps:
         if not self.ready:
             raise AppRegistryNotReady("App registry isn't ready yet.")
         self.stored_app_configs.append(self.app_configs)
-        self.app_configs = OrderedDict()
+        self.app_configs = {}
         self.apps_ready = self.models_ready = self.loading = self.ready = False
         self.clear_cache()
         self.populate(installed)

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2,7 +2,6 @@ import copy
 import json
 import operator
 import re
-from collections import OrderedDict
 from functools import partial, reduce, update_wrapper
 from urllib.parse import quote as urlquote
 
@@ -682,10 +681,7 @@ class ModelAdmin(BaseModelAdmin):
         exclude = exclude or None
 
         # Remove declared form fields which are in readonly_fields.
-        new_attrs = OrderedDict.fromkeys(
-            f for f in readonly_fields
-            if f in self.form.declared_fields
-        )
+        new_attrs = dict.fromkeys(f for f in readonly_fields if f in self.form.declared_fields)
         form = type(self.form.__name__, (self.form,), new_attrs)
 
         defaults = {
@@ -886,13 +882,9 @@ class ModelAdmin(BaseModelAdmin):
         # If self.actions is set to None that means actions are disabled on
         # this page.
         if self.actions is None or IS_POPUP_VAR in request.GET:
-            return OrderedDict()
+            return {}
         actions = self._filter_actions_by_permissions(request, self._get_base_actions())
-        # Convert the actions into an OrderedDict keyed by name.
-        return OrderedDict(
-            (name, (func, name, desc))
-            for func, name, desc in actions
-        )
+        return {name: (func, name, desc) for func, name, desc in actions}
 
     def get_action_choices(self, request, default_choices=BLANK_CHOICE_DASH):
         """

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from datetime import datetime, timedelta
 
 from django.conf import settings
@@ -361,12 +360,12 @@ class ChangeList:
 
     def get_ordering_field_columns(self):
         """
-        Return an OrderedDict of ordering field column numbers and asc/desc.
+        Return a dictionary of ordering field column numbers and asc/desc.
         """
         # We must cope with more than one column having the same underlying sort
         # field, so we base things on column numbers.
         ordering = self._get_default_ordering()
-        ordering_fields = OrderedDict()
+        ordering_fields = {}
         if ORDER_VAR not in self.params:
             # for ordering specified on ModelAdmin or model Meta, we don't know
             # the right column numbers absolutely, because there might be more

--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -4,7 +4,6 @@ import functools
 import hashlib
 import importlib
 import warnings
-from collections import OrderedDict
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -256,12 +255,12 @@ class PBKDF2PasswordHasher(BasePasswordHasher):
     def safe_summary(self, encoded):
         algorithm, iterations, salt, hash = encoded.split('$', 3)
         assert algorithm == self.algorithm
-        return OrderedDict([
-            (_('algorithm'), algorithm),
-            (_('iterations'), iterations),
-            (_('salt'), mask_hash(salt)),
-            (_('hash'), mask_hash(hash)),
-        ])
+        return {
+            _('algorithm'): algorithm,
+            _('iterations'): iterations,
+            _('salt'): mask_hash(salt),
+            _('hash'): mask_hash(hash),
+        }
 
     def must_update(self, encoded):
         algorithm, iterations, salt, hash = encoded.split('$', 3)
@@ -330,16 +329,16 @@ class Argon2PasswordHasher(BasePasswordHasher):
         (algorithm, variety, version, time_cost, memory_cost, parallelism,
             salt, data) = self._decode(encoded)
         assert algorithm == self.algorithm
-        return OrderedDict([
-            (_('algorithm'), algorithm),
-            (_('variety'), variety),
-            (_('version'), version),
-            (_('memory cost'), memory_cost),
-            (_('time cost'), time_cost),
-            (_('parallelism'), parallelism),
-            (_('salt'), mask_hash(salt)),
-            (_('hash'), mask_hash(data)),
-        ])
+        return {
+            _('algorithm'): algorithm,
+            _('variety'): variety,
+            _('version'): version,
+            _('memory cost'): memory_cost,
+            _('time cost'): time_cost,
+            _('parallelism'): parallelism,
+            _('salt'): mask_hash(salt),
+            _('hash'): mask_hash(data),
+        }
 
     def must_update(self, encoded):
         (algorithm, variety, version, time_cost, memory_cost, parallelism,
@@ -426,12 +425,12 @@ class BCryptSHA256PasswordHasher(BasePasswordHasher):
         algorithm, empty, algostr, work_factor, data = encoded.split('$', 4)
         assert algorithm == self.algorithm
         salt, checksum = data[:22], data[22:]
-        return OrderedDict([
-            (_('algorithm'), algorithm),
-            (_('work factor'), work_factor),
-            (_('salt'), mask_hash(salt)),
-            (_('checksum'), mask_hash(checksum)),
-        ])
+        return {
+            _('algorithm'): algorithm,
+            _('work factor'): work_factor,
+            _('salt'): mask_hash(salt),
+            _('checksum'): mask_hash(checksum),
+        }
 
     def must_update(self, encoded):
         algorithm, empty, algostr, rounds, data = encoded.split('$', 4)
@@ -486,11 +485,11 @@ class SHA1PasswordHasher(BasePasswordHasher):
     def safe_summary(self, encoded):
         algorithm, salt, hash = encoded.split('$', 2)
         assert algorithm == self.algorithm
-        return OrderedDict([
-            (_('algorithm'), algorithm),
-            (_('salt'), mask_hash(salt, show=2)),
-            (_('hash'), mask_hash(hash)),
-        ])
+        return {
+            _('algorithm'): algorithm,
+            _('salt'): mask_hash(salt, show=2),
+            _('hash'): mask_hash(hash),
+        }
 
     def harden_runtime(self, password, encoded):
         pass
@@ -517,11 +516,11 @@ class MD5PasswordHasher(BasePasswordHasher):
     def safe_summary(self, encoded):
         algorithm, salt, hash = encoded.split('$', 2)
         assert algorithm == self.algorithm
-        return OrderedDict([
-            (_('algorithm'), algorithm),
-            (_('salt'), mask_hash(salt, show=2)),
-            (_('hash'), mask_hash(hash)),
-        ])
+        return {
+            _('algorithm'): algorithm,
+            _('salt'): mask_hash(salt, show=2),
+            _('hash'): mask_hash(hash),
+        }
 
     def harden_runtime(self, password, encoded):
         pass
@@ -553,10 +552,10 @@ class UnsaltedSHA1PasswordHasher(BasePasswordHasher):
     def safe_summary(self, encoded):
         assert encoded.startswith('sha1$$')
         hash = encoded[6:]
-        return OrderedDict([
-            (_('algorithm'), self.algorithm),
-            (_('hash'), mask_hash(hash)),
-        ])
+        return {
+            _('algorithm'): self.algorithm,
+            _('hash'): mask_hash(hash),
+        }
 
     def harden_runtime(self, password, encoded):
         pass
@@ -589,10 +588,10 @@ class UnsaltedMD5PasswordHasher(BasePasswordHasher):
         return constant_time_compare(encoded, encoded_2)
 
     def safe_summary(self, encoded):
-        return OrderedDict([
-            (_('algorithm'), self.algorithm),
-            (_('hash'), mask_hash(encoded, show=3)),
-        ])
+        return {
+            _('algorithm'): self.algorithm,
+            _('hash'): mask_hash(encoded, show=3),
+        }
 
     def harden_runtime(self, password, encoded):
         pass
@@ -627,11 +626,11 @@ class CryptPasswordHasher(BasePasswordHasher):
     def safe_summary(self, encoded):
         algorithm, salt, data = encoded.split('$', 2)
         assert algorithm == self.algorithm
-        return OrderedDict([
-            (_('algorithm'), algorithm),
-            (_('salt'), salt),
-            (_('hash'), mask_hash(data, show=3)),
-        ])
+        return {
+            _('algorithm'): algorithm,
+            _('salt'): salt,
+            _('hash'): mask_hash(data, show=3),
+        }
 
     def harden_runtime(self, password, encoded):
         pass

--- a/django/contrib/staticfiles/finders.py
+++ b/django/contrib/staticfiles/finders.py
@@ -1,6 +1,5 @@
 import functools
 import os
-from collections import OrderedDict
 
 from django.apps import apps
 from django.conf import settings
@@ -54,7 +53,7 @@ class FileSystemFinder(BaseFinder):
         # List of locations with static files
         self.locations = []
         # Maps dir paths to an appropriate storage instance
-        self.storages = OrderedDict()
+        self.storages = {}
         for root in settings.STATICFILES_DIRS:
             if isinstance(root, (list, tuple)):
                 prefix, root = root
@@ -144,7 +143,7 @@ class AppDirectoriesFinder(BaseFinder):
         # The list of apps that are handled
         self.apps = []
         # Mapping of app names to storage instances
-        self.storages = OrderedDict()
+        self.storages = {}
         app_configs = apps.get_app_configs()
         if app_names:
             app_names = set(app_names)

--- a/django/contrib/staticfiles/management/commands/collectstatic.py
+++ b/django/contrib/staticfiles/management/commands/collectstatic.py
@@ -1,5 +1,4 @@
 import os
-from collections import OrderedDict
 
 from django.apps import apps
 from django.contrib.staticfiles.finders import get_finders
@@ -100,7 +99,7 @@ class Command(BaseCommand):
         else:
             handler = self.copy_file
 
-        found_files = OrderedDict()
+        found_files = {}
         for finder in get_finders():
             for path, storage in finder.list(self.ignore_patterns):
                 # Prefix the relative path if the source storage contains it

--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -4,7 +4,6 @@ import os
 import posixpath
 import re
 import warnings
-from collections import OrderedDict
 from urllib.parse import unquote, urldefrag, urlsplit, urlunsplit
 
 from django.conf import settings
@@ -59,7 +58,7 @@ class HashedFilesMixin:
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._patterns = OrderedDict()
+        self._patterns = {}
         self.hashed_files = {}
         for extension, patterns in self.patterns:
             for pattern in patterns:
@@ -208,7 +207,7 @@ class HashedFilesMixin:
 
     def post_process(self, paths, dry_run=False, **options):
         """
-        Post process the given OrderedDict of files (called from collectstatic).
+        Post process the given dictionary of files (called from collectstatic).
 
         Processing is actually two separate operations:
 
@@ -225,7 +224,7 @@ class HashedFilesMixin:
             return
 
         # where to store the new paths
-        hashed_files = OrderedDict()
+        hashed_files = {}
 
         # build a list of adjustable files
         adjustable_paths = [
@@ -386,20 +385,20 @@ class ManifestFilesMixin(HashedFilesMixin):
     def load_manifest(self):
         content = self.read_manifest()
         if content is None:
-            return OrderedDict()
+            return {}
         try:
-            stored = json.loads(content, object_pairs_hook=OrderedDict)
+            stored = json.loads(content)
         except json.JSONDecodeError:
             pass
         else:
             version = stored.get('version')
             if version == '1.0':
-                return stored.get('paths', OrderedDict())
+                return stored.get('paths', {})
         raise ValueError("Couldn't load manifest '%s' (version %s)" %
                          (self.manifest_name, self.manifest_version))
 
     def post_process(self, *args, **kwargs):
-        self.hashed_files = OrderedDict()
+        self.hashed_files = {}
         yield from super().post_process(*args, **kwargs)
         self.save_manifest()
 

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -2,7 +2,7 @@ import functools
 import os
 import pkgutil
 import sys
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from difflib import get_close_matches
 from importlib import import_module
 
@@ -339,8 +339,8 @@ class ManagementUtility:
                     # The exception will be raised later in the child process
                     # started by the autoreloader. Pretend it didn't happen by
                     # loading an empty list of applications.
-                    apps.all_models = defaultdict(OrderedDict)
-                    apps.app_configs = OrderedDict()
+                    apps.all_models = defaultdict(dict)
+                    apps.app_configs = {}
                     apps.apps_ready = apps.models_ready = apps.ready = True
 
                     # Remove options not compatible with the built-in runserver

--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -1,5 +1,4 @@
 import warnings
-from collections import OrderedDict
 
 from django.apps import apps
 from django.core import serializers
@@ -87,14 +86,14 @@ class Command(BaseCommand):
         if not app_labels:
             if primary_keys:
                 raise CommandError("You can only use --pks option with one model")
-            app_list = OrderedDict.fromkeys(
+            app_list = dict.fromkeys(
                 app_config for app_config in apps.get_app_configs()
                 if app_config.models_module is not None and app_config not in excluded_apps
             )
         else:
             if len(app_labels) > 1 and primary_keys:
                 raise CommandError("You can only use --pks option with one model")
-            app_list = OrderedDict()
+            app_list = {}
             for label in app_labels:
                 try:
                     app_label, model_label = label.split('.')

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -1,6 +1,5 @@
 import keyword
 import re
-from collections import OrderedDict
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
@@ -98,7 +97,7 @@ class Command(BaseCommand):
                 column_to_field_name = {}  # Maps column names to names of model fields
                 for row in table_description:
                     comment_notes = []  # Holds Field notes, to be displayed in a Python comment.
-                    extra_params = OrderedDict()  # Holds Field parameters such as 'db_column'.
+                    extra_params = {}  # Holds Field parameters such as 'db_column'.
                     column_name = row.name
                     is_relation = column_name in relations
 
@@ -232,7 +231,7 @@ class Command(BaseCommand):
         description, this routine will return the given field type name, as
         well as any additional keyword parameters and notes for the field.
         """
-        field_params = OrderedDict()
+        field_params = {}
         field_notes = []
 
         try:

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -1,5 +1,4 @@
 import time
-from collections import OrderedDict
 from importlib import import_module
 
 from django.apps import apps
@@ -314,10 +313,10 @@ class Command(BaseCommand):
                 (opts.auto_created and converter(opts.auto_created._meta.db_table) in tables)
             )
 
-        manifest = OrderedDict(
-            (app_name, list(filter(model_installed, model_list)))
+        manifest = {
+            app_name: list(filter(model_installed, model_list))
             for app_name, model_list in all_models
-        )
+        }
 
         # Create the tables for each model
         if self.verbosity >= 1:

--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -3,7 +3,6 @@ A Python "serializer". Doesn't do much serializing per se -- just converts to
 and from basic Python data types (lists, dicts, strings, etc.). Useful as a basis for
 other serializers.
 """
-from collections import OrderedDict
 
 from django.apps import apps
 from django.core.serializers import base
@@ -26,14 +25,14 @@ class Serializer(base.Serializer):
         pass
 
     def start_object(self, obj):
-        self._current = OrderedDict()
+        self._current = {}
 
     def end_object(self, obj):
         self.objects.append(self.get_dump_object(obj))
         self._current = None
 
     def get_dump_object(self, obj):
-        data = OrderedDict([('model', str(obj._meta))])
+        data = {'model': str(obj._meta)}
         if not self.use_natural_primary_keys or not hasattr(obj, 'natural_key'):
             data["pk"] = self._value_from_field(obj, obj._meta.pk)
         data['fields'] = self._current

--- a/django/core/serializers/pyyaml.py
+++ b/django/core/serializers/pyyaml.py
@@ -34,6 +34,9 @@ class DjangoSafeDumper(SafeDumper):
 
 DjangoSafeDumper.add_representer(decimal.Decimal, DjangoSafeDumper.represent_decimal)
 DjangoSafeDumper.add_representer(collections.OrderedDict, DjangoSafeDumper.represent_ordered_dict)
+# Workaround to represent dictionaries in insertion order.
+# See https://github.com/yaml/pyyaml/pull/143.
+DjangoSafeDumper.add_representer(dict, DjangoSafeDumper.represent_ordered_dict)
 
 
 class Serializer(PythonSerializer):

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -8,7 +8,6 @@ import math
 import re
 import types
 import uuid
-from collections import OrderedDict
 
 from django.conf import SettingsReference
 from django.db import models
@@ -273,25 +272,26 @@ class UUIDSerializer(BaseSerializer):
 
 
 class Serializer:
-    _registry = OrderedDict([
-        (frozenset, FrozensetSerializer),
-        (list, SequenceSerializer),
-        (set, SetSerializer),
-        (tuple, TupleSerializer),
-        (dict, DictionarySerializer),
-        (enum.Enum, EnumSerializer),
-        (datetime.datetime, DatetimeDatetimeSerializer),
-        ((datetime.date, datetime.timedelta, datetime.time), DateTimeSerializer),
-        (SettingsReference, SettingsReferenceSerializer),
-        (float, FloatSerializer),
-        ((bool, int, type(None), bytes, str), BaseSimpleSerializer),
-        (decimal.Decimal, DecimalSerializer),
-        ((functools.partial, functools.partialmethod), FunctoolsPartialSerializer),
-        ((types.FunctionType, types.BuiltinFunctionType, types.MethodType), FunctionTypeSerializer),
-        (collections.abc.Iterable, IterableSerializer),
-        ((COMPILED_REGEX_TYPE, RegexObject), RegexSerializer),
-        (uuid.UUID, UUIDSerializer),
-    ])
+    _registry = {
+        # Some of these are order-dependent.
+        frozenset: FrozensetSerializer,
+        list: SequenceSerializer,
+        set: SetSerializer,
+        tuple: TupleSerializer,
+        dict: DictionarySerializer,
+        enum.Enum: EnumSerializer,
+        datetime.datetime: DatetimeDatetimeSerializer,
+        (datetime.date, datetime.timedelta, datetime.time): DateTimeSerializer,
+        SettingsReference: SettingsReferenceSerializer,
+        float: FloatSerializer,
+        (bool, int, type(None), bytes, str): BaseSimpleSerializer,
+        decimal.Decimal: DecimalSerializer,
+        (functools.partial, functools.partialmethod): FunctoolsPartialSerializer,
+        (types.FunctionType, types.BuiltinFunctionType, types.MethodType): FunctionTypeSerializer,
+        collections.abc.Iterable: IterableSerializer,
+        (COMPILED_REGEX_TYPE, RegexObject): RegexSerializer,
+        uuid.UUID: UUIDSerializer,
+    }
 
     @classmethod
     def register(cls, type_, serializer):

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -1,5 +1,4 @@
 import copy
-from collections import OrderedDict
 from contextlib import contextmanager
 
 from django.apps import AppConfig
@@ -334,7 +333,7 @@ class StateApps(Apps):
         if app_label not in self.app_configs:
             self.app_configs[app_label] = AppConfigStub(app_label)
             self.app_configs[app_label].apps = self
-            self.app_configs[app_label].models = OrderedDict()
+            self.app_configs[app_label].models = {}
         self.app_configs[app_label].models[model._meta.model_name] = model
         self.do_pending_operations(model)
         self.clear_cache()

--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -1,4 +1,4 @@
-from collections import Counter, OrderedDict
+from collections import Counter
 from operator import attrgetter
 
 from django.db import IntegrityError, connections, transaction
@@ -64,7 +64,7 @@ class Collector:
     def __init__(self, using):
         self.using = using
         # Initially, {model: {instances}}, later values become lists.
-        self.data = OrderedDict()
+        self.data = {}
         self.field_updates = {}  # {model: {(field, value): {instances}}}
         # fast_deletes is a list of queryset-likes that can be deleted without
         # fetching the objects into memory.
@@ -257,8 +257,7 @@ class Collector:
                     found = True
             if not found:
                 return
-        self.data = OrderedDict((model, self.data[model])
-                                for model in sorted_models)
+        self.data = {model: self.data[model] for model in sorted_models}
 
     def delete(self):
         # sort instance collections

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -1,7 +1,7 @@
 import copy
 import inspect
 from bisect import bisect
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 
 from django.apps import apps
 from django.conf import settings
@@ -117,7 +117,7 @@ class Options:
         # concrete models, the concrete_model is always the class itself.
         self.concrete_model = None
         self.swappable = None
-        self.parents = OrderedDict()
+        self.parents = {}
         self.auto_created = False
 
         # List of all lookups defined in ForeignKey 'limit_choices_to' options

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -5,7 +5,7 @@ The main QuerySet implementation. This provides the public API for the ORM.
 import copy
 import operator
 import warnings
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from functools import lru_cache
 from itertools import chain
 
@@ -725,7 +725,7 @@ class QuerySet:
         query = self.query.chain(sql.UpdateQuery)
         query.add_update_values(kwargs)
         # Clear any annotations so that they won't be present in subqueries.
-        query._annotations = None
+        query.annotations = {}
         with transaction.mark_for_rollback_on_error(using=self.db):
             rows = query.get_compiler(self.db).execute_sql(CURSOR)
         self._result_cache = None
@@ -744,7 +744,7 @@ class QuerySet:
         query = self.query.chain(sql.UpdateQuery)
         query.add_update_fields(values)
         # Clear any annotations so that they won't be present in subqueries.
-        query._annotations = None
+        query.annotations = {}
         self._result_cache = None
         return query.get_compiler(self.db).execute_sql(CURSOR)
     _update.alters_data = True
@@ -1014,7 +1014,7 @@ class QuerySet:
         with extra data or aggregations.
         """
         self._validate_values_are_expressions(args + tuple(kwargs.values()), method_name='annotate')
-        annotations = OrderedDict()  # To preserve ordering of args
+        annotations = {}
         for arg in args:
             # The default_alias property may raise a TypeError.
             try:

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -317,7 +317,7 @@ class SQLCompiler:
                     ), False))
                 continue
 
-            if not self.query._extra or col not in self.query._extra:
+            if not self.query.extra or col not in self.query.extra:
                 # 'col' is of the form 'field' or 'field1__field2' or
                 # '-field1__field2__field', etc.
                 order_by.extend(self.find_ordering_name(
@@ -1438,7 +1438,7 @@ class SQLUpdateCompiler(SQLCompiler):
         query = self.query.chain(klass=Query)
         query.select_related = False
         query.clear_ordering(True)
-        query._extra = {}
+        query.extra = {}
         query.select = []
         query.add_fields([query.get_meta().pk.name])
         super().pre_sql_setup()

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -3,7 +3,6 @@ Form classes
 """
 
 import copy
-from collections import OrderedDict
 
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 # BoundField is imported for backwards compatibility in Django 1.9
@@ -31,12 +30,12 @@ class DeclarativeFieldsMetaclass(MediaDefiningClass):
             if isinstance(value, Field):
                 current_fields.append((key, value))
                 attrs.pop(key)
-        attrs['declared_fields'] = OrderedDict(current_fields)
+        attrs['declared_fields'] = dict(current_fields)
 
         new_class = super(DeclarativeFieldsMetaclass, mcs).__new__(mcs, name, bases, attrs)
 
         # Walk through the MRO.
-        declared_fields = OrderedDict()
+        declared_fields = {}
         for base in reversed(new_class.__mro__):
             # Collect fields from base class.
             if hasattr(base, 'declared_fields'):
@@ -51,11 +50,6 @@ class DeclarativeFieldsMetaclass(MediaDefiningClass):
         new_class.declared_fields = declared_fields
 
         return new_class
-
-    @classmethod
-    def __prepare__(metacls, name, bases, **kwds):
-        # Remember the order in which form fields are defined.
-        return OrderedDict()
 
 
 @html_safe
@@ -129,7 +123,7 @@ class BaseForm:
         """
         if field_order is None:
             return
-        fields = OrderedDict()
+        fields = {}
         for key in field_order:
             try:
                 fields[key] = self.fields.pop(key)

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -3,7 +3,6 @@ Helper functions for creating Form classes from Django models
 and database field objects.
 """
 
-from collections import OrderedDict
 from itertools import chain
 
 from django.core.exceptions import (
@@ -105,7 +104,7 @@ def fields_for_model(model, fields=None, exclude=None, widgets=None,
                      labels=None, help_texts=None, error_messages=None,
                      field_classes=None, *, apply_limit_choices_to=True):
     """
-    Return an ``OrderedDict`` containing form fields for the given model.
+    Return a dictionary containing form fields for the given model.
 
     ``fields`` is an optional list of field names. If provided, return only the
     named fields.
@@ -134,7 +133,7 @@ def fields_for_model(model, fields=None, exclude=None, widgets=None,
     ``apply_limit_choices_to`` is a boolean indicating if limit_choices_to
     should be applied to a field's queryset.
     """
-    field_list = []
+    field_dict = {}
     ignored = []
     opts = model._meta
     # Avoid circular import
@@ -178,15 +177,14 @@ def fields_for_model(model, fields=None, exclude=None, widgets=None,
         if formfield:
             if apply_limit_choices_to:
                 apply_limit_choices_to_to_formfield(formfield)
-            field_list.append((f.name, formfield))
+            field_dict[f.name] = formfield
         else:
             ignored.append(f.name)
-    field_dict = OrderedDict(field_list)
     if fields:
-        field_dict = OrderedDict(
-            [(f, field_dict.get(f)) for f in fields
-                if ((not exclude) or (exclude and f not in exclude)) and (f not in ignored)]
-        )
+        field_dict = {
+            f: field_dict.get(f) for f in fields
+            if (not exclude or f not in exclude) and f not in ignored
+        }
     return field_dict
 
 

--- a/django/template/utils.py
+++ b/django/template/utils.py
@@ -1,5 +1,5 @@
 import functools
-from collections import Counter, OrderedDict
+from collections import Counter
 from pathlib import Path
 
 from django.apps import apps
@@ -27,7 +27,7 @@ class EngineHandler:
         if self._templates is None:
             self._templates = settings.TEMPLATES
 
-        templates = OrderedDict()
+        templates = {}
         backend_names = []
         for tpl in self._templates:
             try:

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -1,4 +1,3 @@
-import collections
 import logging
 import re
 import sys
@@ -280,8 +279,7 @@ def get_unique_databases_and_mirrors(aliases=None):
                 if alias != DEFAULT_DB_ALIAS and connection.creation.test_db_signature() != default_sig:
                     dependencies[alias] = test_settings.get('DEPENDENCIES', [DEFAULT_DB_ALIAS])
 
-    test_databases = dependency_ordered(test_databases.items(), dependencies)
-    test_databases = collections.OrderedDict(test_databases)
+    test_databases = dict(dependency_ordered(test_databases.items(), dependencies))
     return test_databases, mirrored_aliases
 
 

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -1,16 +1,14 @@
 import copy
-from collections import OrderedDict
 from collections.abc import Mapping
 
 
 class OrderedSet:
     """
     A set which keeps the ordering of the inserted items.
-    Currently backs onto OrderedDict.
     """
 
     def __init__(self, iterable=None):
-        self.dict = OrderedDict.fromkeys(iterable or ())
+        self.dict = dict.fromkeys(iterable or ())
 
     def add(self, item):
         self.dict[item] = None

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -5,7 +5,6 @@ import os
 import re
 import sys
 import warnings
-from collections import OrderedDict
 from threading import local
 
 from django.apps import apps
@@ -385,9 +384,9 @@ def check_for_language(lang_code):
 @functools.lru_cache()
 def get_languages():
     """
-    Cache of settings.LANGUAGES in an OrderedDict for easy lookups by key.
+    Cache of settings.LANGUAGES in a dictionary for easy lookups by key.
     """
-    return OrderedDict(settings.LANGUAGES)
+    return dict(settings.LANGUAGES)
 
 
 @functools.lru_cache(maxsize=1000)

--- a/django/utils/xmlutils.py
+++ b/django/utils/xmlutils.py
@@ -3,7 +3,6 @@ Utilities for XML generation/parsing.
 """
 
 import re
-from collections import OrderedDict
 from xml.sax.saxutils import XMLGenerator
 
 
@@ -30,5 +29,5 @@ class SimplerXMLGenerator(XMLGenerator):
 
     def startElement(self, name, attrs):
         # Sort attrs for a deterministic output.
-        sorted_attrs = OrderedDict(sorted(attrs.items())) if attrs else attrs
+        sorted_attrs = dict(sorted(attrs.items())) if attrs else attrs
         super().startElement(name, sorted_attrs)

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1363,17 +1363,14 @@ of the arguments is required, but you should use at least one of them.
 
   In some rare cases, you might wish to pass parameters to the SQL
   fragments in ``extra(select=...)``. For this purpose, use the
-  ``select_params`` parameter. Since ``select_params`` is a sequence and
-  the ``select`` attribute is a dictionary, some care is required so that
-  the parameters are matched up correctly with the extra select pieces.
-  In this situation, you should use a :class:`collections.OrderedDict` for
-  the ``select`` value, not just a normal Python dictionary.
+  ``select_params`` parameter.
 
   This will work, for example::
 
       Blog.objects.extra(
-          select=OrderedDict([('a', '%s'), ('b', '%s')]),
-          select_params=('one', 'two'))
+          select={'a': '%s', 'b': '%s'},
+          select_params=('one', 'two'),
+      )
 
   If you need to use a literal ``%s`` inside your select string, use
   the sequence ``%%s``.

--- a/tests/extra_regress/tests.py
+++ b/tests/extra_regress/tests.py
@@ -1,5 +1,4 @@
 import datetime
-from collections import OrderedDict
 
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -73,10 +72,7 @@ class ExtraRegressTests(TestCase):
         # Extra select parameters should stay tied to their corresponding
         # select portions. Applies when portions are updated or otherwise
         # moved around.
-        qs = User.objects.extra(
-            select=OrderedDict((("alpha", "%s"), ("beta", "2"), ("gamma", "%s"))),
-            select_params=(1, 3)
-        )
+        qs = User.objects.extra(select={'alpha': '%s', 'beta': "2", 'gamma': '%s'}, select_params=(1, 3))
         qs = qs.extra(select={"beta": 4})
         qs = qs.extra(select={"alpha": "%s"}, select_params=[5])
         self.assertEqual(
@@ -184,7 +180,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values()
             ),
             [{
@@ -198,7 +194,7 @@ class ExtraRegressTests(TestCase):
             list(
                 TestObject.objects
                 .values()
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
             ),
             [{
                 'bar': 'second', 'third': 'third', 'second': 'second', 'whiz': 'third', 'foo': 'first',
@@ -210,7 +206,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values('first', 'second')
             ),
             [{'second': 'second', 'first': 'first'}]
@@ -221,7 +217,7 @@ class ExtraRegressTests(TestCase):
             list(
                 TestObject.objects
                 .values('first', 'second')
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
             ),
             [{'second': 'second', 'first': 'first'}]
         )
@@ -230,7 +226,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values('first', 'second', 'foo')
             ),
             [{'second': 'second', 'foo': 'first', 'first': 'first'}]
@@ -240,7 +236,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values('foo', 'whiz')
             ),
             [{'foo': 'first', 'whiz': 'third'}]
@@ -251,7 +247,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values_list()
             ),
             [('first', 'second', 'third', obj.pk, 'first', 'second', 'third')]
@@ -262,7 +258,7 @@ class ExtraRegressTests(TestCase):
             list(
                 TestObject.objects
                 .values_list()
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
             ),
             [('first', 'second', 'third', obj.pk, 'first', 'second', 'third')]
         )
@@ -271,7 +267,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values_list('first', 'second')
             ),
             [('first', 'second')]
@@ -282,7 +278,7 @@ class ExtraRegressTests(TestCase):
             list(
                 TestObject.objects
                 .values_list('first', 'second')
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
             ),
             [('first', 'second')]
         )
@@ -290,7 +286,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values_list('second', flat=True)
             ),
             ['second']
@@ -300,7 +296,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values_list('first', 'second', 'whiz')
             ),
             [('first', 'second', 'third')]
@@ -310,7 +306,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values_list('foo', 'whiz')
             ),
             [('first', 'third')]
@@ -319,7 +315,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values_list('whiz', flat=True)
             ),
             ['third']
@@ -329,7 +325,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values_list('whiz', 'foo')
             ),
             [('third', 'first')]
@@ -338,7 +334,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values_list('first', 'id')
             ),
             [('first', obj.pk)]
@@ -347,7 +343,7 @@ class ExtraRegressTests(TestCase):
         self.assertEqual(
             list(
                 TestObject.objects
-                .extra(select=OrderedDict((('foo', 'first'), ('bar', 'second'), ('whiz', 'third'))))
+                .extra(select={'foo': 'first', 'bar': 'second', 'whiz': 'third'})
                 .values_list('whiz', 'first', 'bar', 'id')
             ),
             [('third', 'first', 'second', obj.pk)]

--- a/tests/sitemaps_tests/urls/http.py
+++ b/tests/sitemaps_tests/urls/http.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from datetime import date, datetime
 
 from django.conf.urls.i18n import i18n_patterns
@@ -102,27 +101,27 @@ fixed_lastmod__mixed_sitemaps = {
     'fixed-lastmod-mixed': FixedLastmodMixedSitemap,
 }
 
-sitemaps_lastmod_mixed_ascending = OrderedDict([
-    ('no-lastmod', EmptySitemap),
-    ('lastmod', FixedLastmodSitemap),
-])
+sitemaps_lastmod_mixed_ascending = {
+    'no-lastmod': EmptySitemap,
+    'lastmod': FixedLastmodSitemap,
+}
 
-sitemaps_lastmod_mixed_descending = OrderedDict([
-    ('lastmod', FixedLastmodSitemap),
-    ('no-lastmod', EmptySitemap),
-])
+sitemaps_lastmod_mixed_descending = {
+    'lastmod': FixedLastmodSitemap,
+    'no-lastmod': EmptySitemap,
+}
 
-sitemaps_lastmod_ascending = OrderedDict([
-    ('date', DateSiteMap),
-    ('datetime', FixedLastmodSitemap),
-    ('datetime-newer', FixedNewerLastmodSitemap),
-])
+sitemaps_lastmod_ascending = {
+    'date': DateSiteMap,
+    'datetime': FixedLastmodSitemap,
+    'datetime-newer': FixedNewerLastmodSitemap,
+}
 
-sitemaps_lastmod_descending = OrderedDict([
-    ('datetime-newer', FixedNewerLastmodSitemap),
-    ('datetime', FixedLastmodSitemap),
-    ('date', DateSiteMap),
-])
+sitemaps_lastmod_descending = {
+    'datetime-newer': FixedNewerLastmodSitemap,
+    'datetime': FixedLastmodSitemap,
+    'date': DateSiteMap,
+}
 
 generic_sitemaps = {
     'generic': GenericSitemap({'queryset': TestModel.objects.order_by('pk').all()}),


### PR DESCRIPTION
Ticket [#30159](https://code.djangoproject.com/ticket/30159).

Follows on from https://github.com/django/django/pull/10894#issuecomment-458984351.

Use of `OrderedDict` remains in two places:

- `django.core.cache.backends.locmem` -- uses [`OrderedDict.move_to_end()`](https://docs.python.org/3/library/collections.html#collections.OrderedDict.move_to_end).
- `django.core.serializers.pyyaml` -- retain ability to serialize `OrderedDict`.

Some observations:

- We no longer need `DeclarativeFieldsMetaclass.__prepare__()` as the [class namespace is initialised as an empty ordered mapping](https://docs.python.org/3.6/reference/datamodel.html#preparing-the-class-namespace).
- We no longer need the `object_pairs_hook` parameter to [`json.loads()`](https://docs.python.org/3/library/json.html#json.loads) in `ManifestFilesMixin.load_manifest()` as `dict` is the default.
- A workaround is currently required in `django.core.serializers.pyyaml` because dictionary items are sorted by key, see yaml/pyyaml#143.
- `Query.annotations` and `Query.extra` are simplified because it is no longer necessary to instantiate an `OrderedDict` lazily.
- The unit test `queries.tests.Queries1Tests.test_ticket2902` is obsolete and is removed.