### PR TITLE
Fixed #30158 -- Stopped grouping by annotated subqueries.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1080,6 +1080,9 @@ class Subquery(Expression):
             clone.template = '%(subquery)s'
             return clone
         return self
+    
+    def get_group_by_cols(self):
+        return []
 
 
 class Exists(Subquery):


### PR DESCRIPTION
Fixed for https://code.djangoproject.com/ticket/30158#ticket

I think I need help coming up with a testcase. Not sure how to check if the unnecessary subqueries are rendered by the qs.query, but I confirmed it works for my use case and in the ticket Simon states the fix does not break existing tests. @charettes can you think of a good way to validate in the existing Django unittests?