### PR TITLE
WIP #30149 -- Empty value selected check in Admin Filter prevents subclassing

### DIFF
--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -214,7 +214,7 @@ class RelatedFieldListFilter(FieldListFilter):
             }
         if self.include_empty_choice:
             yield {
-                'selected': self.lookup_val_isnull == 'True',
+                'selected': bool(self.lookup_val_isnull),
                 'query_string': changelist.get_query_string({self.lookup_kwarg_isnull: 'True'}, [self.lookup_kwarg]),
                 'display': self.empty_value_display,
             }
@@ -287,7 +287,7 @@ class ChoicesFieldListFilter(FieldListFilter):
             }
         if none_title:
             yield {
-                'selected': self.lookup_val_isnull == 'True',
+                'selected': bool(self.lookup_val_isnull),
                 'query_string': changelist.get_query_string({self.lookup_kwarg_isnull: 'True'}, [self.lookup_kwarg]),
                 'display': none_title,
             }
@@ -407,7 +407,7 @@ class AllValuesFieldListFilter(FieldListFilter):
             }
         if include_none:
             yield {
-                'selected': self.lookup_val_isnull == 'True',
+                'selected': bool(self.lookup_val_isnull),
                 'query_string': changelist.get_query_string({self.lookup_kwarg_isnull: 'True'}, [self.lookup_kwarg]),
                 'display': self.empty_value_display,
             }

--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -214,7 +214,7 @@ class RelatedFieldListFilter(FieldListFilter):
             }
         if self.include_empty_choice:
             yield {
-                'selected': bool(self.lookup_val_isnull),
+                'selected': self.lookup_val_isnull == 'True',
                 'query_string': changelist.get_query_string({self.lookup_kwarg_isnull: 'True'}, [self.lookup_kwarg]),
                 'display': self.empty_value_display,
             }
@@ -287,7 +287,7 @@ class ChoicesFieldListFilter(FieldListFilter):
             }
         if none_title:
             yield {
-                'selected': bool(self.lookup_val_isnull),
+                'selected': self.lookup_val_isnull == 'True',
                 'query_string': changelist.get_query_string({self.lookup_kwarg_isnull: 'True'}, [self.lookup_kwarg]),
                 'display': none_title,
             }
@@ -407,7 +407,7 @@ class AllValuesFieldListFilter(FieldListFilter):
             }
         if include_none:
             yield {
-                'selected': bool(self.lookup_val_isnull),
+                'selected': self.lookup_val_isnull == 'True',
                 'query_string': changelist.get_query_string({self.lookup_kwarg_isnull: 'True'}, [self.lookup_kwarg]),
                 'display': self.empty_value_display,
             }

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -197,7 +197,7 @@ class RelatedFieldListNotIsNullFilter(RelatedFieldListFilter):
     def choices(self, changelist):
         yield from super().choices(changelist)
         yield {
-            'selected': self.lookup_val_isnull == 'False',
+            'selected': self.lookup_val_isnull is False,
             'query_string': changelist.get_query_string(
                 {self.lookup_kwarg_isnull: 'False'}, [self.lookup_kwarg]
             ),


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30149

Created PR to see if any tests fail if I change check for `lookup_val_isnull` from `bool` to string comparison. Will do more thorough research on this later. As @carltongibson suggests in the ticket this probably should be addressed on design level first, like using `form` to convert `request.GET` values