### PR TITLE
Refs #15372 -- Removed obsolete docs about manage.py setting sys.path.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -5,14 +5,10 @@
 ``django-admin`` is Django's command-line utility for administrative tasks.
 This document outlines all it can do.
 
-In addition, ``manage.py`` is automatically created in each Django project.
-``manage.py`` does the same thing as ``django-admin`` but takes care of a few
-things for you:
-
-* It puts your project's package on ``sys.path``.
-
-* It sets the :envvar:`DJANGO_SETTINGS_MODULE` environment variable so that
-  it points to your project's ``settings.py`` file.
+In addition, ``manage.py`` is automatically created in each Django project. It
+does the same thing as ``django-admin`` but also sets the
+:envvar:`DJANGO_SETTINGS_MODULE` environment variable so that it points to your
+project's ``settings.py`` file.
 
 The ``django-admin`` script should be on your system path if you installed
 Django via its ``setup.py`` utility. If it's not on your path, you can find it


### PR DESCRIPTION
The current django-admin documentation page contains an outdated and incorrect description of what manage.py does.

[The docs say](https://docs.djangoproject.com/en/2.1/ref/django-admin/#django-admin-and-manage-py) that manage.py adds the project package to `sys.path`, but this is not true as of Django 1.4.

In versions of Django before 1.4, the manage.py script invoked logic that would add your project to `sys.path`. This code lived in [`django.core.management.setup_environ`](https://github.com/django/django/blob/1.3.7/django/core/management/__init__.py#L381).

The [changes to manage.py](https://docs.djangoproject.com/en/2.1/releases/1.4/#updated-default-project-layout-and-manage-py) and the [deprecation of this sys.path behavior]( https://docs.djangoproject.com/en/2.1/releases/1.4/#django-core-management-setup-environ) were documented in the 1.4 release notes. It looks like the logic was removed in 1.6.