### PR TITLE
Fixed #30165 -- Deprecated ugettext, ugettext_lazy, ugettext_noop, ungettext, and ungettext_lazy.

### DIFF
--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -2,9 +2,11 @@
 Internationalization support.
 """
 import re
+import warnings
 from contextlib import ContextDecorator
 
 from django.utils.autoreload import autoreload_started, file_changed
+from django.utils.deprecation import RemovedInDjango40Warning
 from django.utils.functional import lazy
 
 __all__ = [
@@ -72,23 +74,51 @@ def gettext_noop(message):
     return _trans.gettext_noop(message)
 
 
-ugettext_noop = gettext_noop
+def ugettext_noop(message):
+    """
+    A legacy compatibility wrapper for Unicode handling on Python 2.
+    Alias of gettext_noop() since Django 2.0.
+    """
+    warnings.warn(
+        'django.utils.translation.ugettext_noop() is deprecated in favor of '
+        'django.utils.translation.gettext_noop().',
+        RemovedInDjango40Warning, stacklevel=2,
+    )
+    return gettext_noop(message)
 
 
 def gettext(message):
     return _trans.gettext(message)
 
 
-# An alias since Django 2.0
-ugettext = gettext
+def ugettext(message):
+    """
+    A legacy compatibility wrapper for Unicode handling on Python 2.
+    Alias of gettext() since Django 2.0.
+    """
+    warnings.warn(
+        'django.utils.translation.ugettext() is deprecated in favor of '
+        'django.utils.translation.gettext().',
+        RemovedInDjango40Warning, stacklevel=2,
+    )
+    return gettext(message)
 
 
 def ngettext(singular, plural, number):
     return _trans.ngettext(singular, plural, number)
 
 
-# An alias since Django 2.0
-ungettext = ngettext
+def ungettext(singular, plural, number):
+    """
+    A legacy compatibility wrapper for Unicode handling on Python 2.
+    Alias of ngettext() since Django 2.0.
+    """
+    warnings.warn(
+        'django.utils.translation.ungettext() is deprecated in favor of '
+        'django.utils.translation.ngettext().',
+        RemovedInDjango40Warning, stacklevel=2,
+    )
+    return ngettext(singular, plural, number)
 
 
 def pgettext(context, message):
@@ -99,8 +129,21 @@ def npgettext(context, singular, plural, number):
     return _trans.npgettext(context, singular, plural, number)
 
 
-gettext_lazy = ugettext_lazy = lazy(gettext, str)
+gettext_lazy = lazy(gettext, str)
 pgettext_lazy = lazy(pgettext, str)
+
+
+def ugettext_lazy(message):
+    """
+    A legacy compatibility wrapper for Unicode handling on Python 2. Has been
+    Alias of gettext_lazy since Django 2.0.
+    """
+    warnings.warn(
+        'django.utils.translation.ugettext_lazy() is deprecated in favor of '
+        'django.utils.translation.gettext_lazy().',
+        RemovedInDjango40Warning, stacklevel=2,
+    )
+    return gettext_lazy(message)
 
 
 def lazy_number(func, resultclass, number=None, **kwargs):
@@ -158,8 +201,17 @@ def ngettext_lazy(singular, plural, number=None):
     return lazy_number(ngettext, str, singular=singular, plural=plural, number=number)
 
 
-# An alias since Django 2.0
-ungettext_lazy = ngettext_lazy
+def ungettext_lazy(singular, plural, number=None):
+    """
+    A legacy compatibility wrapper for Unicode handling on Python 2.
+    An alias of ungettext_lazy() since Django 2.0.
+    """
+    warnings.warn(
+        'django.utils.translation.ungettext_lazy() is deprecated in favor of '
+        'django.utils.translation.ngettext_lazy().',
+        RemovedInDjango40Warning, stacklevel=2,
+    )
+    return ngettext_lazy(singular, plural, number)
 
 
 def npgettext_lazy(context, singular, plural, number=None):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -20,6 +20,10 @@ details on these changes.
 
 * ``django.utils.encoding.force_text()`` and ``smart_text()`` will be removed.
 
+* ``django.utils.translation.ugettext()``, ``ugettext_lazy()``,
+  ``ugettext_noop()``, ``ungettext()``, and ``ungettext_lazy()`` will be
+  removed.
+
 .. _deprecation-removed-in-3.1:
 
 3.1

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -978,7 +978,6 @@ between unicode and bytestrings. If your code doesn't support Python 2, use the
 functions without the ``u``.
 
 .. function:: gettext(message)
-.. function:: ugettext(message)
 
     Translates ``message`` and returns it as a string.
 
@@ -989,7 +988,6 @@ functions without the ``u``.
     For more information, see :ref:`contextual-markers`.
 
 .. function:: gettext_lazy(message)
-.. function:: ugettext_lazy(message)
 .. function:: pgettext_lazy(context, message)
 
     Same as the non-lazy versions above, but using lazy execution.
@@ -997,7 +995,6 @@ functions without the ``u``.
     See :ref:`lazy translations documentation <lazy-translations>`.
 
 .. function:: gettext_noop(message)
-.. function:: ugettext_noop(message)
 
     Marks strings for translation but doesn't translate them now. This can be
     used to store strings in global variables that should stay in the base
@@ -1005,7 +1002,6 @@ functions without the ``u``.
     later.
 
 .. function:: ngettext(singular, plural, number)
-.. function:: ungettext(singular, plural, number)
 
     Translates ``singular`` and ``plural`` and returns the appropriate string
     based on ``number``.
@@ -1016,7 +1012,6 @@ functions without the ``u``.
     based on ``number`` and the ``context``.
 
 .. function:: ngettext_lazy(singular, plural, number)
-.. function:: ungettext_lazy(singular, plural, number)
 .. function:: npgettext_lazy(context, singular, plural, number)
 
     Same as the non-lazy versions above, but using lazy execution.

--- a/docs/releases/1.4.txt
+++ b/docs/releases/1.4.txt
@@ -378,7 +378,7 @@ Translating URL patterns
 Django can now look for a language prefix in the URLpattern when using the new
 :func:`~django.conf.urls.i18n.i18n_patterns` helper function.
 It's also now possible to define translatable URL patterns using
-:func:`~django.utils.translation.ugettext_lazy`. See
+``django.utils.translation.ugettext_lazy()``. See
 :ref:`url-internationalization` for more information about the language prefix
 and how to internationalize URL patterns.
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -309,6 +309,14 @@ Miscellaneous
   aliases for: :func:`urllib.parse.quote`, :func:`~urllib.parse.quote_plus`,
   :func:`~urllib.parse.unquote`, and :func:`~urllib.parse.unquote_plus`.
 
+* ``django.utils.translation.ugettext()``, ``ugettext_lazy()``,
+  ``ugettext_noop()``, ``ungettext()``, and ``ungettext_lazy()`` are deprecated
+  in favor of the functions that they're aliases for:
+  :func:`django.utils.translation.gettext`,
+  :func:`~django.utils.translation.gettext_lazy`,
+  :func:`~django.utils.translation.gettext_noop`,
+  :func:`~django.utils.translation.ngettext`, and
+  :func:`~django.utils.translation.ngettext_lazy`.
 
 .. _removed-features-3.0:
 

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -23,6 +23,7 @@ from django.test import (
     RequestFactory, SimpleTestCase, TestCase, override_settings,
 )
 from django.utils import translation
+from django.utils.deprecation import RemovedInDjango40Warning
 from django.utils.formats import (
     date_format, get_format, get_format_modules, iter_format_modules, localize,
     localize_input, reset_format_cache, sanitize_separators, time_format,
@@ -34,7 +35,8 @@ from django.utils.translation import (
     get_language, get_language_bidi, get_language_from_request,
     get_language_info, gettext, gettext_lazy, ngettext, ngettext_lazy,
     npgettext, npgettext_lazy, pgettext, to_language, to_locale, trans_null,
-    trans_real, ugettext, ugettext_lazy, ungettext, ungettext_lazy,
+    trans_real, ugettext, ugettext_lazy, ugettext_noop, ungettext,
+    ungettext_lazy,
 )
 from django.utils.translation.reloader import (
     translation_file_changed, watch_for_translation_changes,
@@ -74,13 +76,39 @@ class TranslationTests(SimpleTestCase):
         """
         Pre-Django 2.0 aliases with u prefix are still available.
         """
-        self.assertEqual(ugettext("Image"), "Bild")
-        self.assertEqual(ugettext_lazy("Image"), gettext_lazy("Image"))
-        self.assertEqual(ungettext("%d year", "%d years", 0) % 0, "0 Jahre")
-        self.assertEqual(
-            ungettext_lazy("%d year", "%d years", 0) % 0,
-            ngettext_lazy("%d year", "%d years", 0) % 0,
+        msg = (
+            'django.utils.translation.ugettext_noop() is deprecated in favor '
+            'of django.utils.translation.gettext_noop().'
         )
+        with self.assertWarnsMessage(RemovedInDjango40Warning, msg):
+            self.assertEqual(ugettext_noop("Image"), "Image")
+        msg = (
+            'django.utils.translation.ugettext() is deprecated in favor of '
+            'django.utils.translation.gettext().'
+        )
+        with self.assertWarnsMessage(RemovedInDjango40Warning, msg):
+            self.assertEqual(ugettext("Image"), "Bild")
+        msg = (
+            'django.utils.translation.ugettext_lazy() is deprecated in favor '
+            'of django.utils.translation.gettext_lazy().'
+        )
+        with self.assertWarnsMessage(RemovedInDjango40Warning, msg):
+            self.assertEqual(ugettext_lazy("Image"), gettext_lazy("Image"))
+        msg = (
+            'django.utils.translation.ungettext() is deprecated in favor of '
+            'django.utils.translation.ngettext().'
+        )
+        with self.assertWarnsMessage(RemovedInDjango40Warning, msg):
+            self.assertEqual(ungettext("%d year", "%d years", 0) % 0, "0 Jahre")
+        msg = (
+            'django.utils.translation.ungettext_lazy() is deprecated in favor '
+            'of django.utils.translation.ngettext_lazy().'
+        )
+        with self.assertWarnsMessage(RemovedInDjango40Warning, msg):
+            self.assertEqual(
+                ungettext_lazy("%d year", "%d years", 0) % 0,
+                ngettext_lazy("%d year", "%d years", 0) % 0,
+            )
 
     @translation.override('fr')
     def test_plural(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30165