### PR TITLE
Simplified FileBasedCache.clear().

### DIFF
--- a/django/core/cache/backends/filebased.py
+++ b/django/core/cache/backends/filebased.py
@@ -129,8 +129,6 @@ class FileBasedCache(BaseCache):
         """
         Remove all the cache files.
         """
-        if not os.path.exists(self._dir):
-            return
         for fname in self._list_cache_files():
             self._delete(fname)
 
@@ -153,8 +151,7 @@ class FileBasedCache(BaseCache):
         Get a list of paths to all the cache files. These are all the files
         in the root cache dir that end on the cache_suffix.
         """
-        if not os.path.exists(self._dir):
-            return []
-        filelist = [os.path.join(self._dir, fname) for fname
-                    in glob.glob1(self._dir, '*%s' % self.cache_suffix)]
-        return filelist
+        return [
+            os.path.join(self._dir, fname)
+            for fname in glob.glob1(self._dir, '*%s' % self.cache_suffix)
+        ]


### PR DESCRIPTION
In `FileBasedCache.clear()`, remove the unnecessary exists guard and instead iterate over an empty list returned by `FileBasedCache._list_cache_files()`.

In `FileBasedCache._list_cache_files()`, remove the unnecessary exists guard as `glob.glob1()` already ignores missing paths. For example:

    >>> import glob
    >>> glob.glob1('missing', '*')
    []