### PR TITLE
Confirmed support for GDAL 2.4.

### DIFF
--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -20,10 +20,10 @@ if lib_path:
     lib_names = None
 elif os.name == 'nt':
     # Windows NT shared libraries
-    lib_names = ['gdal203', 'gdal202', 'gdal201', 'gdal20']
+    lib_names = ['gdal204', 'gdal203', 'gdal202', 'gdal201', 'gdal20']
 elif os.name == 'posix':
     # *NIX library names.
-    lib_names = ['gdal', 'GDAL', 'gdal2.3.0', 'gdal2.2.0', 'gdal2.1.0', 'gdal2.0.0']
+    lib_names = ['gdal', 'GDAL', 'gdal2.4.0', 'gdal2.3.0', 'gdal2.2.0', 'gdal2.1.0', 'gdal2.0.0']
 else:
     raise ImproperlyConfigured('GDAL is unsupported on OS "%s".' % os.name)
 

--- a/docs/ref/contrib/gis/install/geolibs.txt
+++ b/docs/ref/contrib/gis/install/geolibs.txt
@@ -10,7 +10,7 @@ Program                   Description                           Required        
 ========================  ====================================  ================================  ===================================
 :doc:`GEOS <../geos>`     Geometry Engine Open Source           Yes                               3.7, 3.6, 3.5, 3.4
 `PROJ.4`_                 Cartographic Projections library      Yes (PostgreSQL and SQLite only)  5.2, 5.1, 5.0, 4.x
-:doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               2.3, 2.2, 2.1, 2.0
+:doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               2.4, 2.3, 2.2, 2.1, 2.0
 :doc:`GeoIP <../geoip2>`  IP-based geolocation library          No                                2
 `PostGIS`__               Spatial extensions for PostgreSQL     Yes (PostgreSQL only)             2.5, 2.4, 2.3, 2.2
 `SpatiaLite`__            Spatial extensions for SQLite         Yes (SQLite only)                 4.3
@@ -29,6 +29,7 @@ totally fine with GeoDjango. Your mileage may vary.
     GDAL 2.1.0 2016-04
     GDAL 2.2.0 2017-05
     GDAL 2.3.0 2018-05
+    GDAL 2.4.0 2018-12
     PostGIS 2.2.0 2015-10-17
     PostGIS 2.3.0 2016-09-26
     PostGIS 2.4.0 2017-09-30


### PR DESCRIPTION
I don't see any test failures on an Ubuntu 19.10 build which packages GDAL 2.4.