### PR TITLE
Refs #15362 -- Removed obsolete workaround in file_uploads test view.

### DIFF
--- a/tests/file_uploads/views.py
+++ b/tests/file_uploads/views.py
@@ -54,32 +54,15 @@ def file_upload_view_verify(request):
 
 
 def file_upload_unicode_name(request):
-
     # Check to see if unicode name came through properly.
     if not request.FILES['file_unicode'].name.endswith(UNICODE_FILENAME):
         return HttpResponseServerError()
-
-    response = None
-
     # Check to make sure the exotic characters are preserved even
     # through file save.
     uni_named_file = request.FILES['file_unicode']
-    obj = FileModel.objects.create(testfile=uni_named_file)
+    FileModel.objects.create(testfile=uni_named_file)
     full_name = '%s/%s' % (UPLOAD_TO, uni_named_file.name)
-    if not os.path.exists(full_name):
-        response = HttpResponseServerError()
-
-    # Cleanup the object with its exotic file name immediately.
-    # (shutil.rmtree used elsewhere in the tests to clean up the
-    # upload directory has been seen to choke on unicode
-    # filenames on Windows.)
-    obj.delete()
-    os.unlink(full_name)
-
-    if response:
-        return response
-    else:
-        return HttpResponse()
+    return HttpResponse() if os.path.exists(full_name) else HttpResponseServerError()
 
 
 def file_upload_echo(request):


### PR DESCRIPTION
The file path must exist otherwise the call to `os.unlink()` would raise `FileNotFoundError`.