### PR TITLE
Fixed #30171 -- Made DatabaseWrapper thread sharing logic reentrant.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -277,7 +277,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                     return self.__class__(
                         {**self.settings_dict, 'NAME': connection.settings_dict['NAME']},
                         alias=self.alias,
-                        allow_thread_sharing=False,
                     )
         return nodb_connection
 

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1442,7 +1442,7 @@ class LiveServerTestCase(TransactionTestCase):
             # the server thread.
             if conn.vendor == 'sqlite' and conn.is_in_memory_db():
                 # Explicitly enable thread-shareability for this connection
-                conn.allow_thread_sharing = True
+                conn.inc_thread_sharing()
                 connections_override[conn.alias] = conn
 
         cls._live_server_modified_settings = modify_settings(
@@ -1478,10 +1478,9 @@ class LiveServerTestCase(TransactionTestCase):
             # Terminate the live server's thread
             cls.server_thread.terminate()
 
-        # Restore sqlite in-memory database connections' non-shareability
-        for conn in connections.all():
-            if conn.vendor == 'sqlite' and conn.is_in_memory_db():
-                conn.allow_thread_sharing = False
+            # Restore sqlite in-memory database connections' non-shareability.
+            for conn in cls.server_thread.connections_override.values():
+                conn.dec_thread_sharing()
 
     @classmethod
     def tearDownClass(cls):

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -286,6 +286,9 @@ backends.
   * ``_delete_fk_sql()`` (to pair with ``_create_fk_sql()``)
   * ``_create_check_sql()`` and ``_delete_check_sql()``
 
+* The third argument of ``DatabaseWrapper.__init__()``,
+  ``allow_thread_sharing``, is removed.
+
 Admin actions are no longer collected from base ``ModelAdmin`` classes
 ----------------------------------------------------------------------
 

--- a/tests/servers/test_liveserverthread.py
+++ b/tests/servers/test_liveserverthread.py
@@ -18,11 +18,10 @@ class LiveServerThreadTest(TestCase):
         # Pass a connection to the thread to check they are being closed.
         connections_override = {DEFAULT_DB_ALIAS: conn}
 
-        saved_sharing = conn.allow_thread_sharing
+        conn.inc_thread_sharing()
         try:
-            conn.allow_thread_sharing = True
             self.assertTrue(conn.is_usable())
             self.run_live_server_thread(connections_override)
             self.assertFalse(conn.is_usable())
         finally:
-            conn.allow_thread_sharing = saved_sharing
+            conn.dec_thread_sharing()

--- a/tests/staticfiles_tests/test_liveserver.py
+++ b/tests/staticfiles_tests/test_liveserver.py
@@ -64,6 +64,9 @@ class StaticLiveServerChecks(LiveServerBase):
             # app without having set the required STATIC_URL setting.")
             pass
         finally:
+            # Use del to avoid decrementing the database thread sharing count a
+            # second time.
+            del cls.server_thread
             super().tearDownClass()
 
     def test_test_test(self):


### PR DESCRIPTION
Changed to use a reference counting like scheme to allow nested uses. To increment the reference count, use the method `DatabaseWrapper.inc_thread_sharing()`. To decrement it, use the method
`DatabaseWrapper.dec_thread_sharing()`. `DatabaseWrapper.allow_thread_sharing` is `True` if the reference count is greater than zero.

This change obviates the need for passing the value of `allow_thread_sharing to the constructor, so it has been removed.

Fixed the following warning during LiveServerTestCase:

```
    Exception in thread Thread-16:
    Traceback (most recent call last):
      File "/usr/lib64/python3.7/threading.py", line 917, in _bootstrap_inner
        self.run()
      File "django/test/testcases.py", line 1399, in run
        connections.close_all()
      File "django/db/utils.py", line 224, in close_all
        connection.close()
      File "django/db/backends/sqlite3/base.py", line 244, in close
        self.validate_thread_sharing()
      File "django/db/backends/base/base.py", line 531, in validate_thread_sharing
        % (self.alias, self._thread_ident, _thread.get_ident())
    django.db.utils.DatabaseError: DatabaseWrapper objects created in a thread can only be used in that same thread. The object with alias 'default' was created in thread id 140092344866304 and this is thread id 140091929347840.
```

https://code.djangoproject.com/ticket/30171