### PR TITLE
Fixed typo in docs/releases/2.2.txt.

### DIFF
--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -484,7 +484,7 @@ Miscellaneous
   read from disk must be UTF-8 encoded.
 
 * ``django.contrib.staticfiles.storage.CachedStaticFilesStorage`` is
-  deprecated due to the intractable problems that is has. Use
+  deprecated due to the intractable problems that it has. Use
   :class:`.ManifestStaticFilesStorage` or a third-party cloud storage instead.
 
 * :meth:`.RemoteUserBackend.configure_user` is now passed ``request`` as the


### PR DESCRIPTION
Just noticed this typo while reading the notes on the website... I'm not sure if this is the right branch to be committing the change to though, but I didn't see the release notes in the `master` branch.