### PR TITLE
Fixed #30177 -- Fixed format_number() crash with over 200 digits.

### DIFF
--- a/django/utils/numberformat.py
+++ b/django/utils/numberformat.py
@@ -36,7 +36,7 @@ def format(number, decimal_sep, decimal_pos=None, grouping=0, thousand_sep='',
             # Format the coefficient.
             coefficient = format(
                 coefficient, decimal_sep, decimal_pos, grouping,
-                thousand_sep, force_grouping, use_l10n,
+                thousand_sep, force_grouping,
             )
             return '{}e{}'.format(coefficient, exponent)
         else:

--- a/docs/releases/2.0.13.txt
+++ b/docs/releases/2.0.13.txt
@@ -1,0 +1,13 @@
+===========================
+Django 2.0.13 release notes
+===========================
+
+*February 12, 2019*
+
+Django 2.0.13 fixes a regression in 2.0.12/2.0.11.
+
+Bugfixes
+========
+
+* Fixed crash in ``django.utils.numberformat.format_number()`` when the number
+  has over 200 digits (:ticket:`30177`).

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -25,6 +25,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   2.0.13
    2.0.12
    2.0.11
    2.0.10


### PR DESCRIPTION
There are existing test failures. The incorrect patch was applied
in 1f42f82566c9d2d73aff1c42790d6b1b243f7676.

https://code.djangoproject.com/ticket/30177