### PR TITLE
Fixed #30178 -- Allowed DATABASES password to be a lazy string.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -224,7 +224,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def get_new_connection(self, conn_params):
         return Database.connect(
             user=self.settings_dict['USER'],
-            password=self.settings_dict['PASSWORD'],
+            password=str(self.settings_dict['PASSWORD']),
             dsn=self._dsn(),
             **conn_params,
         )


### PR DESCRIPTION
Please review and provide feedback.