### PR TITLE
Fix for #30178 - allow oracle password to be a string-like object:

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -224,7 +224,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def get_new_connection(self, conn_params):
         return Database.connect(
             user=self.settings_dict['USER'],
-            password=self.settings_dict['PASSWORD'],
+            password=str(self.settings_dict['PASSWORD']),
             dsn=self._dsn(),
             **conn_params,
         )


### PR DESCRIPTION
- Provide a test case in tests/backends/oracle/tests.py
- Provide the most naive fix that could work in django/db/backends/oracle/base.py