### PR TITLE
Fixed #30181 -- Made cache.get() with default work correctly on PyLibMCCache if None is cached.

### DIFF
--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -68,10 +68,7 @@ class BaseMemcachedCache(BaseCache):
 
     def get(self, key, default=None, version=None):
         key = self.make_key(key, version=version)
-        val = self._cache.get(key)
-        if val is None:
-            return default
-        return val
+        return self._cache.get(key, default)
 
     def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
         key = self.make_key(key, version=version)
@@ -162,6 +159,16 @@ class MemcachedCache(BaseMemcachedCache):
     def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None):
         key = self.make_key(key, version=version)
         return self._cache.touch(key, self.get_backend_timeout(timeout)) != 0
+
+    def get(self, key, default=None, version=None):
+        key = self.make_key(key, version=version)
+        val = self._cache.get(key)
+        # python-memcached doesn't support default values in get().
+        # https://github.com/linsomniac/python-memcached/issues/159
+        # Remove this method if that issue is fixed.
+        if val is None:
+            return default
+        return val
 
 
 class PyLibMCCache(BaseMemcachedCache):

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -274,6 +274,11 @@ class BaseCacheTests:
         cache.set("key", "value")
         self.assertEqual(cache.get("key"), "value")
 
+    def test_default_used_when_none_is_set(self):
+        """If None is cached, get() returns it instead of the default."""
+        cache.set('key_default_none', None)
+        self.assertIsNone(cache.get('key_default_none', default='default'))
+
     def test_add(self):
         # A key can be added to a cache
         cache.add("addkey1", "value")
@@ -1364,6 +1369,14 @@ class MemcachedCacheTests(BaseMemcachedTests, TestCase):
     ))
     def test_memcached_options(self):
         self.assertEqual(cache._cache.server_max_value_length, 9999)
+
+    def test_default_used_when_none_is_set(self):
+        """
+        python-memcached doesn't support default in get() so this test
+        overrides the one in BaseCacheTests.
+        """
+        cache.set('key_default_none', None)
+        self.assertEqual(cache.get('key_default_none', default='default'), 'default')
 
 
 @unittest.skipUnless(PyLibMCCache_params, "PyLibMCCache backend not configured")


### PR DESCRIPTION
This PR fixes https://code.djangoproject.com/ticket/30181