### PR TITLE
Honor LANG environment variable during testing

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -402,6 +402,7 @@ class RequestFactory:
         parsed = urlparse(str(path))  # path can be lazy
         data = force_bytes(data, settings.DEFAULT_CHARSET)
         r = {
+            'HTTP_ACCEPT_LANGUAGE': os.environ.get('LANG', '*'),
             'PATH_INFO': self._get_path(parsed),
             'REQUEST_METHOD': method,
             'SERVER_PORT': '443' if secure else '80',


### PR DESCRIPTION
Sets HTTP_ACCEPT_LANGUAGE header for the client request during testing. This will allow you to do:

```
$ export LANG=fr-FR
$ firefox http://127.0.0.1:8000/ - for manual testing
$ ./manage.py test  - for automated testing
```

From what I can tell it is not possible to configure the language used during testing, for all tests at once! 

Background:
In Kiwi TCMS we are using django-vinaigrette which allows some model fields to be translated in .po files and depending on how we use the values (e.g. dictionary lookup) there could be failures. My intention was to re-run the existing test suite by activating some of our most popular languages and discover all the places where the app fails. It is possible with the change in this PR.

Note: I realize that when matching strings (e.g. `self.assertContains()`) we'll have to match against the translated version. This is exactly what we need!