### PR TITLE
Remove sender from update_last_login

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from .validators import UnicodeUsernameValidator
 
 
-def update_last_login(sender, user, **kwargs):
+def update_last_login(user, **kwargs):
     """
     A signal receiver which updates the last_login date for
     the user logging in.


### PR DESCRIPTION
I can't see the attribute "sender" in update_last_login being used anywhere in this file nor is it returned so another object could use it.