### PR TITLE
Fixed admin_scripts test failures on macOS.

### DIFF
--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -42,7 +42,9 @@ class AdminScriptTestCase(SimpleTestCase):
     def setUp(self):
         tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(tmpdir.cleanup)
-        self.test_dir = os.path.join(tmpdir.name, 'test_project')
+        # os.path.realpath() is required for temporary directories on macOS,
+        # where `/var` is a symlink to `/private/var`.
+        self.test_dir = os.path.realpath(os.path.join(tmpdir.name, 'test_project'))
         os.mkdir(self.test_dir)
         with open(os.path.join(self.test_dir, '__init__.py'), 'w'):
             pass


### PR DESCRIPTION
os.path.realpath() is required for temporary directories on macOS, where `/var` is a symlink to `/private/var`[*].

Regression in 487d904bf253de2f5633f181a168f94086bcd6cb. (See https://github.com/django/django/commit/487d904bf253de2f5633f181a168f94086bcd6cb#commitcomment-32304839)


[*]: 
```
~ $ ls -ld /var
lrwxr-xr-x@ 1 root  wheel  11 Dec 11 14:41 /var -> private/var
```