### PR TITLE
Removed docs of unused libgeoip1/python-gdal packages.

### DIFF
--- a/docs/ref/contrib/gis/install/geolibs.txt
+++ b/docs/ref/contrib/gis/install/geolibs.txt
@@ -53,11 +53,6 @@ install, directly or by dependency, the required geospatial libraries:
 
     $ sudo apt-get install binutils libproj-dev gdal-bin
 
-Optional packages to consider:
-
-* ``libgeoip1``: for :doc:`GeoIP <../geoip2>` support
-* ``python-gdal`` for GDAL's own Python bindings -- includes interfaces for raster manipulation
-
 Please also consult platform-specific instructions if you are on :ref:`macos`
 or :ref:`windows`.
 


### PR DESCRIPTION
Maybe libgeoip1 did something for the old version of geoip, but geoip2 tests are passing without it.
I believe python-gdal is https://pypi.org/project/GDAL/ which Django doesn't seem to use (no "osgeo" imports). 

(Now maybe this mention is merely to suggest other convenient libraries for use in GIS projects, but I think that's not really the place for Django's docs.)

Hopefully a GIS user can correct me if I missed something \cc @claudep @sir-sigurd 

I think `libproj-dev` may also be more than is needed. It installs a `libprojXY` as a side effect which it seems is what's required.