### PR TITLE
Made a requests test that will fail in 2028 fail 10 years later.

### DIFF
--- a/tests/responses/test_cookie.py
+++ b/tests/responses/test_cookie.py
@@ -47,12 +47,12 @@ class SetCookieTests(SimpleTestCase):
     def test_far_expiration(self):
         """Cookie will expire when a distant expiration time is provided."""
         response = HttpResponse()
-        response.set_cookie('datetime', expires=datetime(2028, 1, 1, 4, 5, 6))
+        response.set_cookie('datetime', expires=datetime(2038, 1, 1, 4, 5, 6))
         datetime_cookie = response.cookies['datetime']
         self.assertIn(
             datetime_cookie['expires'],
             # assertIn accounts for slight time dependency (#23450)
-            ('Sat, 01 Jan 2028 04:05:06 GMT', 'Sat, 01 Jan 2028 04:05:07 GMT')
+            ('Fri, 01 Jan 2038 04:05:06 GMT', 'Fri, 01 Jan 2038 04:05:07 GMT')
         )
 
     def test_max_age_expiration(self):


### PR DESCRIPTION
Forward-port of #10993 

Fix tests in 2028, but staying in 2038 to not fail on 32-bit systems

Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +15 years, because that is how long I expect some software will be used in some places.

See https://reproducible-builds.org/ on this topic.