### PR TITLE
Fixed 30138 -- Allow QuerySet.bulk_create() to set pk of created objects when ignore_conflicts=True

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -179,7 +179,8 @@ class BaseDatabaseOperations:
         statement into a table that has an auto-incrementing ID, return the
         newly created ID.
         """
-        return cursor.fetchone()[0]
+        results = cursor.fetchone()
+        return results[0] if isinstance(results, tuple) else None
 
     def field_cast_sql(self, db_type, internal_type):
         """

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1187,7 +1187,7 @@ class QuerySet:
         inserted_ids = []
         bulk_return = connections[self.db].features.can_return_rows_from_bulk_insert
         for item in [objs[i:i + batch_size] for i in range(0, len(objs), batch_size)]:
-            if bulk_return and not ignore_conflicts:
+            if bulk_return:
                 inserted_id = self._insert(
                     item, fields=fields, using=self.db, return_id=True,
                     ignore_conflicts=ignore_conflicts,

--- a/tests/postgres_tests/test_bulk_create.py
+++ b/tests/postgres_tests/test_bulk_create.py
@@ -1,0 +1,33 @@
+from datetime import date
+
+from . import PostgreSQLTestCase
+from .models import (
+    HStoreModel, IntegerArrayModel, JSONModel, NestedIntegerArrayModel,
+    NullableIntegerArrayModel, OtherTypesArrayModel, RangesModel,
+)
+
+try:
+    from psycopg2.extras import NumericRange, DateRange
+except ImportError:
+    pass  # psycopg2 isn't installed.
+
+
+class BulkCreateTests(PostgreSQLTestCase):
+    def test_bulk_create_to_set_pk_when_ignore_conflicts(self):
+        test_data = [
+            (IntegerArrayModel, 'field', [], [1, 2, 3]),
+            (NullableIntegerArrayModel, 'field', [1, 2, 3], None),
+            (JSONModel, 'field', {'a': 'b'}, {'c': 'd'}),
+            (NestedIntegerArrayModel, 'field', [], [[1, 2, 3]]),
+            (HStoreModel, 'field', {}, {1: 2}),
+            (RangesModel, 'ints', None, NumericRange(lower=1, upper=10)),
+            (RangesModel, 'dates', None, DateRange(lower=date.today(), upper=date.today())),
+            (OtherTypesArrayModel, 'ips', [], ['1.2.3.4']),
+            (OtherTypesArrayModel, 'json', [], [{'a': 'b'}])
+        ]
+        for Model, field, initial, new in test_data:
+            with self.subTest(model=Model, field=field):
+                objs = (Model(**{field: initial}) for _ in range(20))
+                instances = Model.objects.bulk_create(objs, ignore_conflicts=True)
+                for instance in instances:
+                    self.assertIsNotNone(instance.pk)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30138