### PR TITLE
Fixed #30193 -- Avoided PostgreSQL connection health checks on initialization.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -195,7 +195,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return connection
 
     def ensure_timezone(self):
-        if not self.is_usable():
+        if self.connection is None:
             return False
         conn_timezone_name = self.connection.get_parameter_status('TimeZone')
         timezone_name = self.timezone_name
@@ -208,7 +208,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def init_connection_state(self):
         self.connection.set_client_encoding('UTF8')
 
-        self.ensure_connection()
         timezone_changed = self.ensure_timezone()
         if timezone_changed:
             # Commit after setting the time zone (see #17062)
@@ -248,8 +247,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self.cursor().execute('SET CONSTRAINTS ALL DEFERRED')
 
     def is_usable(self):
-        if self.connection is None:
-            return False
         try:
             # Use a psycopg cursor directly, bypassing Django's utilities.
             self.connection.cursor().execute("SELECT 1")

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -134,6 +134,12 @@ class Tests(TestCase):
         finally:
             new_connection.close()
 
+    def test_connect_no_is_usable_checks(self):
+        new_connection = connection.copy()
+        with mock.patch.object(new_connection, 'is_usable') as is_usable:
+            new_connection.connect()
+        is_usable.assert_not_called()
+
     def _select(self, val):
         with connection.cursor() as cursor:
             cursor.execute('SELECT %s', (val,))


### PR DESCRIPTION
This addressed a regression introduced by a96b901 as identified by @bluetech.

Refs [#28478](https://code.djangoproject.com/ticket/28478).