### PR TITLE
Removed an outdated comment on DefaultConnectionProxy.

### DIFF
--- a/django/db/__init__.py
+++ b/django/db/__init__.py
@@ -18,11 +18,6 @@ connections = ConnectionHandler()
 router = ConnectionRouter()
 
 
-# DatabaseWrapper.__init__() takes a dictionary, not a settings module, so we
-# manually create the dictionary from the settings, passing only the settings
-# that the database backends care about.
-# We load all these up for backwards compatibility, you should use
-# connections['default'] instead.
 class DefaultConnectionProxy:
     """
     Proxy for accessing the default DatabaseWrapper object's attributes. If you
@@ -42,6 +37,7 @@ class DefaultConnectionProxy:
         return connections[DEFAULT_DB_ALIAS] == other
 
 
+# For backwards compatibility. Prefer connections['default'] instead.
 connection = DefaultConnectionProxy()
 
 


### PR DESCRIPTION
The comments made sense once (see commits 315145f7ca, ff60c5f9d) but no longer. The pertinent information is found in the docstring.