### PR TITLE
Fixed #30179: Handle Media definitions that cannot be resolved with pairwise merges

### DIFF
--- a/tests/admin_widgets/test_autocomplete_widget.py
+++ b/tests/admin_widgets/test_autocomplete_widget.py
@@ -139,4 +139,4 @@ class AutocompleteMixinTests(TestCase):
                 else:
                     expected_files = base_files
                 with translation.override(lang):
-                    self.assertEqual(AutocompleteSelect(rel, admin.site).media._js, expected_files)
+                    self.assertEqual(AutocompleteSelect(rel, admin.site).media._js, list(expected_files))


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30179

Even if we defer merges until the final asset list is ready to be produced (#30153), there will still be some valid media orderings that cannot be resolved by the strategy of merging lists into the result one by one; this is because the intermediate results are flat lists, which create implicit dependencies between list items that don't exist in the source data. These (bogus) dependencies can then be contradicted by later merges.

To avoid this, we merge all sub-lists in a single operation, building a dependency graph which (in all valid cases) should be acyclic; we follow those dependencies in reverse to establish a valid ordering.