### PR TITLE
Update code coverage guide: include PYTHONPATH

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -290,7 +290,7 @@ in :ref:`testing code coverage<topics-testing-code-coverage>`.
 Coverage should be run in a single process to obtain accurate statistics. To
 run coverage on the Django test suite using the standard test settings::
 
-   $ coverage run ./runtests.py --settings=test_sqlite --parallel=1
+   $ PYTHONPATH=../ coverage run ./runtests.py --settings=test_sqlite --parallel=1
 
 After running coverage, generate the html report by running::
 


### PR DESCRIPTION
Without this addition, coverage would die with `ImportError: cannot import name RemovedInDjango31Warning`