### PR TITLE
Optimise paginator for tables with massive records

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -34,6 +34,7 @@ class Paginator:
         self.per_page = int(per_page)
         self.orphans = int(orphans)
         self.allow_empty_first_page = allow_empty_first_page
+        self.object_list_ids = object_list.values('id')
 
     def validate_number(self, number):
         """Validate the given 1-based page number."""
@@ -72,7 +73,7 @@ class Paginator:
         top = bottom + self.per_page
         if top + self.orphans >= self.count:
             top = self.count
-        return self._get_page(self.object_list[bottom:top], number, self)
+        return self._get_page(self.object_list.filter(pk__in=self.object_list_ids[bottom:top]), number, self)
 
     def _get_page(self, *args, **kwargs):
         """

--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -34,7 +34,7 @@ class Paginator:
         self.per_page = int(per_page)
         self.orphans = int(orphans)
         self.allow_empty_first_page = allow_empty_first_page
-        self.object_list_ids = object_list.values('id')
+        self.object_list_ids = object_list.values('uuid')
 
     def validate_number(self, number):
         """Validate the given 1-based page number."""


### PR DESCRIPTION
I had a problem with Paginator class to slice huge dataset. In case of millions of record it can take 30 second to reach the last page. So I cam up with a solution to overcome this problem.

The problem is that for slicing data, current solution needs to compute whole list to render data `bottom:top`. The reason is that, current script will generate for example `SELECT ID, COL_1, ..., COL_N, ... WHERE ...` which has huge burden for database to slice the data. To overcome this problem we can instead select primary keys and do the slicing step and then fetch records that their pk are in that sliced list. Very simple but very efficient solution. I improved the performance for our project significantly using this approach. So form 30 seconds to only 2-3 seconds for 8 million records.