### PR TITLE
Fixed #29714 -- Allowed using ExceptionReporter subclass with AdminEmailHandler.

### DIFF
--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -7,7 +7,6 @@ from django.core import mail
 from django.core.mail import get_connection
 from django.core.management.color import color_style
 from django.utils.module_loading import import_string
-from django.views.debug import ExceptionReporter
 
 request_logger = logging.getLogger('django.request')
 
@@ -83,10 +82,11 @@ class AdminEmailHandler(logging.Handler):
     request data will be provided in the email report.
     """
 
-    def __init__(self, include_html=False, email_backend=None):
+    def __init__(self, include_html=False, email_backend=None, reporter_class=None):
         super().__init__()
         self.include_html = include_html
         self.email_backend = email_backend
+        self.reporter_class = import_string(reporter_class or 'django.views.debug.ExceptionReporter')
 
     def emit(self, record):
         try:
@@ -116,7 +116,7 @@ class AdminEmailHandler(logging.Handler):
         else:
             exc_info = (None, record.getMessage(), None)
 
-        reporter = ExceptionReporter(request, is_email=True, *exc_info)
+        reporter = self.reporter_class(request, is_email=True, *exc_info)
         message = "%s\n\n%s" % (self.format(no_exc_record), reporter.get_traceback_text())
         html_message = reporter.get_traceback_html() if self.include_html else None
         self.send_mail(subject, message, fail_silently=True, html_message=html_message)

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -259,6 +259,14 @@ Internationalization
   language cookies. The default values of these settings preserve the previous
   behavior.
 
+Logging
+~~~~~~~
+
+* The new ``reporter_class`` parameter of
+  :class:`~django.utils.log.AdminEmailHandler` allows providing an
+  ``django.views.debug.ExceptionReporter`` subclass to customize the traceback
+  text sent to site :setting:`ADMINS` when :setting:`DEBUG` is ``False``.
+
 Management Commands
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -595,7 +595,7 @@ Handlers
 Django provides one log handler in addition to those provided by the
 Python logging module.
 
-.. class:: AdminEmailHandler(include_html=False, email_backend=None)
+.. class:: AdminEmailHandler(include_html=False, email_backend=None, reporter_class=None)
 
     This handler sends an email to the site :setting:`ADMINS` for each log
     message it receives.
@@ -651,6 +651,26 @@ Python logging module.
 
     By default, an instance of the email backend specified in
     :setting:`EMAIL_BACKEND` will be used.
+
+    The ``reporter_class`` argument of ``AdminEmailHandler`` allows providing
+    an ``django.views.debug.ExceptionReporter`` subclass to customize the
+    traceback text sent in the email body. You provide a string import path to
+    the class you wish to use, like this:
+
+    .. code-block:: python
+
+        'handlers': {
+            'mail_admins': {
+                'level': 'ERROR',
+                'class': 'django.utils.log.AdminEmailHandler',
+                'include_html': True,
+                'reporter_class': 'somepackage.error_reporter.CustomErrorReporter'
+            }
+        },
+
+    .. versionadded:: 3.0
+
+        The ``reporter_class`` argument was added.
 
     .. method:: send_mail(subject, message, *args, **kwargs)
 

--- a/tests/logging_tests/logconfig.py
+++ b/tests/logging_tests/logconfig.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
+from django.views.debug import ExceptionReporter
 
 
 class MyHandler(logging.Handler):
@@ -13,3 +14,8 @@ class MyHandler(logging.Handler):
 class MyEmailBackend(BaseEmailBackend):
     def send_messages(self, email_messages):
         pass
+
+
+class CustomExceptionReporter(ExceptionReporter):
+    def get_traceback_text(self):
+        return 'custom traceback text'


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29714
As suggested on https://code.djangoproject.com/ticket/25167

Next steps are to move getting cookies here https://github.com/django/django/blob/52e9c753659ffeab67149fcf26b95c10cf137c40/django/views/debug.py#L319 to a wrapper function so that they could be overridden.