### PR TITLE
Fixed relative paths imports per isort 4.3.5.

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -8,9 +8,9 @@ from django.db.models import Field, IntegerField, Transform
 from django.db.models.lookups import Exact, In
 from django.utils.translation import gettext_lazy as _
 
-from ..utils import prefix_validation_error
 from .mixins import CheckFieldDefaultMixin
 from .utils import AttributeSetter
+from ..utils import prefix_validation_error
 
 __all__ = ['ArrayField']
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ include_trailing_comma = true
 known_first_party = django
 line_length = 79
 multi_line_output = 5
-not_skip = __init__.py
 
 [metadata]
 license-file = LICENSE

--- a/tests/gis_tests/distapp/tests.py
+++ b/tests/gis_tests/distapp/tests.py
@@ -9,12 +9,12 @@ from django.db import NotSupportedError, connection
 from django.db.models import F, Q
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
-from ..utils import (
-    FuncTestMixin, mysql, no_oracle, oracle, postgis, spatialite,
-)
 from .models import (
     AustraliaCity, CensusZipcode, Interstate, SouthTexasCity, SouthTexasCityFt,
     SouthTexasInterstate, SouthTexasZipcode,
+)
+from ..utils import (
+    FuncTestMixin, mysql, no_oracle, oracle, postgis, spatialite,
 )
 
 

--- a/tests/gis_tests/geo3d/tests.py
+++ b/tests/gis_tests/geo3d/tests.py
@@ -8,11 +8,11 @@ from django.contrib.gis.db.models.functions import (
 from django.contrib.gis.geos import GEOSGeometry, LineString, Point, Polygon
 from django.test import TestCase, skipUnlessDBFeature
 
-from ..utils import FuncTestMixin
 from .models import (
     City3D, Interstate2D, Interstate3D, InterstateProj2D, InterstateProj3D,
     MultiPoint3D, Point2D, Point3D, Polygon2D, Polygon3D,
 )
+from ..utils import FuncTestMixin
 
 data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), '..', 'data'))
 city_file = os.path.join(data_path, 'cities', 'cities.shp')

--- a/tests/gis_tests/geoapp/test_expressions.py
+++ b/tests/gis_tests/geoapp/test_expressions.py
@@ -6,8 +6,8 @@ from django.db import connection
 from django.db.models import Count, Min
 from django.test import TestCase, skipUnlessDBFeature
 
-from ..utils import postgis
 from .models import City, ManyPointModel, MultiFields
+from ..utils import postgis
 
 
 class GeoExpressionsTests(TestCase):

--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -12,8 +12,8 @@ from django.db import NotSupportedError, connection
 from django.db.models import Sum
 from django.test import TestCase, skipUnlessDBFeature
 
-from ..utils import FuncTestMixin, mysql, oracle, postgis, spatialite
 from .models import City, Country, CountryWebMercator, State, Track
+from ..utils import FuncTestMixin, mysql, oracle, postgis, spatialite
 
 
 class GISFunctionsTests(FuncTestMixin, TestCase):

--- a/tests/gis_tests/geoapp/test_regress.py
+++ b/tests/gis_tests/geoapp/test_regress.py
@@ -5,8 +5,8 @@ from django.contrib.gis.shortcuts import render_to_kmz
 from django.db.models import Count, Min
 from django.test import TestCase, skipUnlessDBFeature
 
-from ..utils import no_oracle
 from .models import City, PennsylvaniaCity, State, Truth
+from ..utils import no_oracle
 
 
 class GeoRegressionTests(TestCase):

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -12,12 +12,12 @@ from django.core.management import call_command
 from django.db import NotSupportedError, connection
 from django.test import TestCase, skipUnlessDBFeature
 
-from ..utils import (
-    mysql, no_oracle, oracle, postgis, skipUnlessGISLookup, spatialite,
-)
 from .models import (
     City, Country, Feature, MinusOneSRID, NonConcreteModel, PennsylvaniaCity,
     State, Track,
+)
+from ..utils import (
+    mysql, no_oracle, oracle, postgis, skipUnlessGISLookup, spatialite,
 )
 
 

--- a/tests/gis_tests/geogapp/tests.py
+++ b/tests/gis_tests/geogapp/tests.py
@@ -11,8 +11,8 @@ from django.db import NotSupportedError, connection
 from django.db.models.functions import Cast
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
-from ..utils import FuncTestMixin, oracle, postgis, spatialite
 from .models import City, County, Zipcode
+from ..utils import FuncTestMixin, oracle, postgis, spatialite
 
 
 class GeographyTest(TestCase):

--- a/tests/gis_tests/inspectapp/tests.py
+++ b/tests/gis_tests/inspectapp/tests.py
@@ -9,9 +9,9 @@ from django.db import connection, connections
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
 from django.test.utils import modify_settings
 
+from .models import AllOGRFields
 from ..test_data import TEST_DATA
 from ..utils import postgis
-from .models import AllOGRFields
 
 
 class InspectDbTests(TestCase):

--- a/tests/gis_tests/rasterapp/test_rasterfield.py
+++ b/tests/gis_tests/rasterapp/test_rasterfield.py
@@ -12,8 +12,8 @@ from django.db.models import Q
 from django.test import TransactionTestCase, skipUnlessDBFeature
 from django.test.utils import CaptureQueriesContext
 
-from ..data.rasters.textrasters import JSON_RASTER
 from .models import RasterModel, RasterRelatedModel
+from ..data.rasters.textrasters import JSON_RASTER
 
 
 @skipUnlessDBFeature('supports_raster')

--- a/tests/gis_tests/relatedapp/tests.py
+++ b/tests/gis_tests/relatedapp/tests.py
@@ -5,10 +5,10 @@ from django.test import TestCase, skipUnlessDBFeature
 from django.test.utils import override_settings
 from django.utils import timezone
 
-from ..utils import no_oracle
 from .models import (
     Article, Author, Book, City, DirectoryEntry, Event, Location, Parcel,
 )
+from ..utils import no_oracle
 
 
 class RelatedGeoModelTest(TestCase):

--- a/tests/template_tests/filter_tests/test_date.py
+++ b/tests/template_tests/filter_tests/test_date.py
@@ -4,8 +4,8 @@ from django.template.defaultfilters import date
 from django.test import SimpleTestCase, override_settings
 from django.utils import timezone, translation
 
-from ..utils import setup
 from .timezone_utils import TimezoneTestCase
+from ..utils import setup
 
 
 class DateTests(TimezoneTestCase):

--- a/tests/template_tests/filter_tests/test_time.py
+++ b/tests/template_tests/filter_tests/test_time.py
@@ -4,8 +4,8 @@ from django.template.defaultfilters import time as time_filter
 from django.test import SimpleTestCase, override_settings
 from django.utils import timezone, translation
 
-from ..utils import setup
 from .timezone_utils import TimezoneTestCase
+from ..utils import setup
 
 
 class TimeTests(TimezoneTestCase):

--- a/tests/template_tests/filter_tests/test_timesince.py
+++ b/tests/template_tests/filter_tests/test_timesince.py
@@ -4,8 +4,8 @@ from django.template.defaultfilters import timesince_filter
 from django.test import SimpleTestCase
 from django.test.utils import requires_tz_support
 
-from ..utils import setup
 from .timezone_utils import TimezoneTestCase
+from ..utils import setup
 
 
 class TimesinceTests(TimezoneTestCase):

--- a/tests/template_tests/filter_tests/test_timeuntil.py
+++ b/tests/template_tests/filter_tests/test_timeuntil.py
@@ -4,8 +4,8 @@ from django.template.defaultfilters import timeuntil_filter
 from django.test import SimpleTestCase
 from django.test.utils import requires_tz_support
 
-from ..utils import setup
 from .timezone_utils import TimezoneTestCase
+from ..utils import setup
 
 
 class TimeuntilTests(TimezoneTestCase):

--- a/tests/template_tests/syntax_tests/i18n/test_blocktrans.py
+++ b/tests/template_tests/syntax_tests/i18n/test_blocktrans.py
@@ -7,8 +7,8 @@ from django.utils import translation
 from django.utils.safestring import mark_safe
 from django.utils.translation import trans_real
 
-from ...utils import setup
 from .base import MultipleLocaleActivationTestCase, extended_locale_paths, here
+from ...utils import setup
 
 
 class I18nBlockTransTagTests(SimpleTestCase):

--- a/tests/template_tests/syntax_tests/i18n/test_trans.py
+++ b/tests/template_tests/syntax_tests/i18n/test_trans.py
@@ -7,8 +7,8 @@ from django.utils import translation
 from django.utils.safestring import mark_safe
 from django.utils.translation import trans_real
 
-from ...utils import setup
 from .base import MultipleLocaleActivationTestCase, extended_locale_paths
+from ...utils import setup
 
 
 class I18nTransTagTests(SimpleTestCase):

--- a/tests/template_tests/syntax_tests/i18n/test_underscore_syntax.py
+++ b/tests/template_tests/syntax_tests/i18n/test_underscore_syntax.py
@@ -2,8 +2,8 @@ from django.template import Context, Template
 from django.test import SimpleTestCase
 from django.utils import translation
 
-from ...utils import setup
 from .base import MultipleLocaleActivationTestCase
+from ...utils import setup
 
 
 class MultipleLocaleActivationTests(MultipleLocaleActivationTestCase):

--- a/tests/template_tests/syntax_tests/test_exceptions.py
+++ b/tests/template_tests/syntax_tests/test_exceptions.py
@@ -1,8 +1,8 @@
 from django.template import TemplateDoesNotExist, TemplateSyntaxError
 from django.test import SimpleTestCase
 
-from ..utils import setup
 from .test_extends import inheritance_templates
+from ..utils import setup
 
 
 class ExceptionsTests(SimpleTestCase):

--- a/tests/template_tests/syntax_tests/test_include.py
+++ b/tests/template_tests/syntax_tests/test_include.py
@@ -3,8 +3,8 @@ from django.template import (
 )
 from django.test import SimpleTestCase
 
-from ..utils import setup
 from .test_basic import basic_templates
+from ..utils import setup
 
 include_fail_templates = {
     'include-fail1': '{% load bad_tag %}{% badtag %}',


### PR DESCRIPTION
See [`isort` 4.3.5](https://github.com/timothycrosley/isort/blob/master/CHANGELOG.md#435---february-24-2019---last-python-27-maintenance-release)