### PR TITLE
Refs #27685 -- Removed the watchman unavailable message.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -578,10 +578,6 @@ def run_with_reloader(main_func, *args, **kwargs):
             logger.info('Watching for file changes with %s', reloader.__class__.__name__)
             start_django(reloader, main_func, *args, **kwargs)
         else:
-            try:
-                WatchmanReloader.check_availability()
-            except WatchmanUnavailable as e:
-                logger.info('Watchman unavailable: %s', e)
             exit_code = restart_with_reloader()
             sys.exit(exit_code)
     except KeyboardInterrupt:


### PR DESCRIPTION
As per [the recent discussion on the mailing list](https://groups.google.com/d/msgid/django-developers/23ecaa54-a148-4439-a16b-16937da9e934%40googlegroups.com?utm_medium=email&utm_source=footer), I strongly agree with @claudep. 

I think including this 'watchman unavailable' message was an oversight on my part and really not great UX.

This PR just removes this message. I can make a ticket if required.