### PR TITLE
manage.py migrate: raise error on missing migrations

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -214,15 +214,13 @@ class Command(BaseCommand):
                 )
                 changes = autodetector.changes(graph=executor.loader.graph)
                 if changes:
-                    self.stdout.write(self.style.NOTICE(
-                        "  Your models have changes that are not yet reflected "
-                        "in a migration, and so won't be applied."
-                    ))
-                    self.stdout.write(self.style.NOTICE(
-                        "  Run 'manage.py makemigrations' to make new "
+                    raise CommandError(
+                        "Your models have changes that are not yet reflected "
+                        "in a migration, and so won't be applied. "
+                        "Run 'manage.py makemigrations' to make new "
                         "migrations, and then re-run 'manage.py migrate' to "
                         "apply them."
-                    ))
+                    )
             fake = False
             fake_initial = False
         else:


### PR DESCRIPTION
It would be very useful for authomatic deploy scripts to understand if the `./manage.py migrate` command actually migrated the changes, or encountered issues.
If there are any unreflected changes in a migration, it should be considered a hard error and exit with a non-zero code.