### PR TITLE
Fixed #30218 -- Fixed size of admin changelist's search button.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -98,7 +98,8 @@
 
 #changelist #toolbar form input[type="submit"] {
     border: 1px solid #ccc;
-    padding: 2px 10px;
+    font-size: 13px;
+    padding: 4px 8px;
     margin: 0;
     vertical-align: middle;
     background: #fff;


### PR DESCRIPTION
The search input has a font size of 13px, the button however was
set to 14px. On certain resolutions the button would appear to small.
Furthermore the button was inconsistent with the changelist action
from button.

Before:
<img width="63" alt="screen shot 2019-02-27 at 11 11 38" src="https://user-images.githubusercontent.com/1772890/53489070-6d99ac00-3a90-11e9-98b4-d0edd84f30b9.png">

After:
<img width="126" alt="screen shot 2019-02-27 at 13 07 19" src="https://user-images.githubusercontent.com/1772890/53489137-a5a0ef00-3a90-11e9-86d8-dd8d3f4ab689.png">

