### PR TITLE
[2.2.x] Added troubleshooting for testing on OS X High Sierra and later

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -335,6 +335,21 @@ Run the ``locale`` command to confirm the change. Optionally, add those export
 commands to your shell's startup file (e.g. ``~/.bashrc`` for Bash) to avoid
 having to retype them.
 
+Running tests fails on OS X High Sierra and later
+-------------------------------------------------
+
+Due to some changes made in OS X High Sierra which affect how ``fork()`` is
+called, the tests may cause the Python interpreter to crash
+with the following error::
+
+
+    +[__NSPlaceholderDate initialize] may have been in progress in another thread when fork() was called.
+
+
+You can resolve this by configuring the shell to disable this check::
+
+    $ export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+
 Tests that only fail in combination
 -----------------------------------
 


### PR DESCRIPTION
I noticed that running the test suite (`./runtests.py`) was failing with an obscure-looking obj-C error. I did some digging and found that OS X High Sierra introduced some changes to their internal security model which causes `fork()` to misbehave. Adding an environment variable seemed to fix this.