### PR TITLE
Refs #30233 Add support for InlineModelAdmin to access parent_model's…

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1927,7 +1927,7 @@ class ModelAdmin(BaseModelAdmin):
             formset_params = {
                 'instance': obj,
                 'prefix': prefix,
-                'queryset': inline.get_queryset(request),
+                'queryset': inline.get_queryset_with_parent_obj(request, obj),
             }
             if request.method == 'POST':
                 formset_params.update({
@@ -2110,6 +2110,9 @@ class InlineModelAdmin(BaseModelAdmin):
         if not self.has_view_or_change_permission(request):
             queryset = queryset.none()
         return queryset
+
+    def get_queryset_with_parent_obj(self, request, obj):
+        return self.get_queryset(request)
 
     def has_add_permission(self, request, obj):
         if self.opts.auto_created:


### PR DESCRIPTION
Refs [Ticket 30233](https://code.djangoproject.com/ticket/30233)
maybe we can add a optional `obj=None` parameter to `get_queryset` method like `has_change_permission` and It's still  backward campability.