### PR TITLE
Fixed #30242 -- Removed extra space before LIMIT/OFFSET SQL.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -325,6 +325,7 @@ answer newbie questions, and generally made Django that much better:
     Guillaume Pannatier <guillaume.pannatier@gmail.com>
     Gustavo Picon
     hambaloney
+    Hang Park <hangpark@kaist.ac.kr>
     Hannes Struß <x@hannesstruss.de>
     Hasan Ramezani <hasan.r67@gmail.com>
     Hawkeye

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -218,10 +218,10 @@ class BaseDatabaseOperations:
     def limit_offset_sql(self, low_mark, high_mark):
         """Return LIMIT/OFFSET SQL clause."""
         limit, offset = self._get_limit_offset_params(low_mark, high_mark)
-        return '%s%s' % (
-            (' LIMIT %d' % limit) if limit else '',
-            (' OFFSET %d' % offset) if offset else '',
-        )
+        return ' '.join(sql for sql in (
+            ('LIMIT %d' % limit) if limit else None,
+            ('OFFSET %d' % offset) if offset else None,
+        ) if sql)
 
     def last_executed_query(self, cursor, sql, params):
         """

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -249,10 +249,10 @@ END;
 
     def limit_offset_sql(self, low_mark, high_mark):
         fetch, offset = self._get_limit_offset_params(low_mark, high_mark)
-        return '%s%s' % (
-            (' OFFSET %d ROWS' % offset) if offset else '',
-            (' FETCH FIRST %d ROWS ONLY' % fetch) if fetch else '',
-        )
+        return ' '.join(sql for sql in (
+            ('OFFSET %d ROWS' % offset) if offset else None,
+            ('FETCH FIRST %d ROWS ONLY' % fetch) if fetch else None,
+        ) if sql)
 
     def last_executed_query(self, cursor, sql, params):
         # https://cx-oracle.readthedocs.io/en/latest/cursor.html#Cursor.statement


### PR DESCRIPTION
`SQLCompiler.as_sql()` joins each SQL clause with `' '` and limit/offset clause string is obtained from `DatabaseOperations.limit_offset_sql()`.

But, current implementation of `limit_offset_sql()` always produces a space at the beginning of its SQL string. This behavior appeared after 03da070f5cfda592a174f8c19349638656a521b2 on PR django/django#9198.

These two facts make double spaces before LIMIT clause when `as_sql()` executes and it can be reproduced easily by checking the result of:

```python
from django.contrib.auth.models import User
User.objects.values('id')[1:2].query.__str__()
```

This commit removes a space produced by `limit_offset_sql()` on both `BaseDatabaseOperations` and `oracle.DatabaseOperations`.

> **Below change was in the original commit, but discarded during a review process.**
> This commit also formats the doc string of `limit_offset_sql()` of `BaseDatabaseOperations` to make it same with other doc strings in the same class.