### PR TITLE
Subquery resolving refactor and bug fixing.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -22,7 +22,7 @@ from django.db import DEFAULT_DB_ALIAS, NotSupportedError, connections
 from django.db.models.aggregates import Count
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import (
-    BaseExpression, Col, F, OuterRef, Ref, SimpleCol,
+    BaseExpression, Col, F, OuterRef, Ref, SimpleCol, Subquery,
 )
 from django.db.models.fields import Field
 from django.db.models.fields.related_lookups import MultiColSource
@@ -382,7 +382,7 @@ class Query(BaseExpression):
                 # before the contains_aggregate/is_summary condition below.
                 new_expr, col_cnt = self.rewrite_cols(expr, col_cnt)
                 new_exprs.append(new_expr)
-            elif isinstance(expr, Col) or (expr.contains_aggregate and not expr.is_summary):
+            elif isinstance(expr, (Col, Subquery)) or (expr.contains_aggregate and not expr.is_summary):
                 # Reference to column. Make sure the referenced column
                 # is selected.
                 col_cnt += 1

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -21,7 +21,9 @@ from django.core.exceptions import (
 from django.db import DEFAULT_DB_ALIAS, NotSupportedError, connections
 from django.db.models.aggregates import Count
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.expressions import BaseExpression, Col, F, Ref, SimpleCol
+from django.db.models.expressions import (
+    BaseExpression, Col, F, OuterRef, Ref, SimpleCol,
+)
 from django.db.models.fields import Field
 from django.db.models.fields.related_lookups import MultiColSource
 from django.db.models.lookups import Lookup
@@ -1639,6 +1641,9 @@ class Query(BaseExpression):
         saner null handling, and is easier for the backend's optimizer to
         handle.
         """
+        filter_lhs, filter_rhs = filter_expr
+        if isinstance(filter_rhs, F):
+            filter_expr = (filter_lhs, OuterRef(filter_rhs.name))
         # Generate the inner query.
         query = Query(self.model)
         query.add_filter(filter_expr)

--- a/tests/aggregation/test_filter_argument.py
+++ b/tests/aggregation/test_filter_argument.py
@@ -87,3 +87,11 @@ class FilteredAggregateTests(TestCase):
             older_friends_count__gte=2,
         )
         self.assertEqual(qs.get(pk__in=qs.values('pk')), self.a1)
+
+    def test_filtered_aggregate_ref_annotation(self):
+        aggs = Author.objects.annotate(
+            double_age=F('age') * 2,
+        ).aggregate(
+            cnt=Count('pk', filter=Q(double_age__gt=100)),
+        )
+        self.assertEqual(aggs['cnt'], 2)

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -551,6 +551,19 @@ class BasicExpressionsTests(TestCase):
         )
         self.assertEqual(qs.get().float, 1.2)
 
+    @skipUnlessDBFeature('supports_subqueries_in_group_by')
+    def test_aggregate_subquery_annotation(self):
+        aggregate = Company.objects.annotate(
+            ceo_salary=Subquery(
+                Employee.objects.filter(
+                    id=OuterRef('ceo_id'),
+                ).values('salary')
+            ),
+        ).aggregate(
+            ceo_salary_gt_20=Count('pk', filter=Q(ceo_salary__gt=20)),
+        )
+        self.assertEqual(aggregate, {'ceo_salary_gt_20': 1})
+
     def test_explicit_output_field(self):
         class FuncA(Func):
             output_field = models.CharField()

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2776,6 +2776,12 @@ class ExcludeTests(TestCase):
             employment__title__in=('Engineer', 'Developer')).distinct().order_by('name')
         self.assertSequenceEqual(alex_nontech_employers, [google, intel, microsoft])
 
+    def test_exclude_reverse_fk_field_ref(self):
+        tag = Tag.objects.create()
+        Note.objects.create(tag=tag, note='note')
+        annotation = Annotation.objects.create(name='annotation', tag=tag)
+        self.assertEqual(Annotation.objects.exclude(tag__note__note=F('name')).get(), annotation)
+
 
 class ExcludeTest17600(TestCase):
     """


### PR DESCRIPTION
This allows the removal of a few hacks and address two tickets

- [#21703](https://code.djangoproject.com/ticket/21703) now that `OuterRef` resolution is moved to `Query` it allows it to use this construct internally when performing a `split_exclude`.
- [#30188](https://code.djangoproject.com/ticket/30188) the resolving logic push downs addresses the `AssertionError` on `set_source_expressions` but another commit was needed to address a broken reference caused by `rewrite_cols`. This method really needs to be refactored to either clear the existing inner queries annotations before performing the rewrite or reused the existing refs to prevent double work. I think this should be handled in a separate PR/ticket though.