### PR TITLE
Mistake in the documentation

### DIFF
--- a/docs/howto/deployment/wsgi/modwsgi.txt
+++ b/docs/howto/deployment/wsgi/modwsgi.txt
@@ -156,8 +156,8 @@ a static file. All other URLs will be served using mod_wsgi:
     Alias /robots.txt /path/to/mysite.com/static/robots.txt
     Alias /favicon.ico /path/to/mysite.com/static/favicon.ico
 
-    Alias /media/ /path/to/mysite.com/media/
-    Alias /static/ /path/to/mysite.com/static/
+    Alias /media /path/to/mysite.com/media/
+    Alias /static /path/to/mysite.com/static/
 
     <Directory /path/to/mysite.com/static>
     Require all granted


### PR DESCRIPTION
The example given in the documentation does not work.
Link for more information:
https://stackoverflow.com/questions/5682809/django-static-file-hosting-an-apache