### PR TITLE
Fixed #30249 -- Deprecated raising test client requests exceptions in tests.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -869,6 +869,27 @@ class SimpleTestCase(unittest.TestCase):
                 standardMsg = '%s == %s' % (safe_repr(xml1, True), safe_repr(xml2, True))
                 self.fail(self._formatMessage(msg, standardMsg))
 
+    def assertRequestRaises(self, response, expected_exception, expected_message=None, msg=None):
+        """Assert that an exception was raised during a test client request."""
+        try:
+            self.assertIsNotNone(
+                response.exc_info,
+                msg='No exception occurred during the request.'
+            )
+            self.assertEqual(response.status_code, 500)
+            exc_type, exc_value, _ = response.exc_info
+            self.assertTrue(
+                issubclass(exc_type, expected_exception),
+                msg='%r is not a subclass of %r.' % (exc_type, expected_exception)
+            )
+            self.assertIsInstance(exc_value, expected_exception)
+            if expected_message is not None:
+                self.assertIn(expected_message, str(exc_value))
+        except AssertionError as e:
+            if msg is None:
+                raise
+            raise AssertionError(msg) from e
+
 
 class _TransactionTestCaseDatabasesDescriptor:
     """Descriptor for TransactionTestCase.multi_db deprecation."""

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1172,10 +1172,12 @@ If set to ``True``, Django's exception handling of view functions
 is ``True``) and logging of 500 responses (:ref:`django-request-logger`) is
 skipped and exceptions propagate upwards.
 
-This can be useful for some test setups. It shouldn't be used on a live site
-unless you want your web server (instead of Django) to generate "Internal
-Server Error" responses. In that case, make sure your server doesn't show the
-stack trace or other sensitive information in the response.
+This can be useful in tests where you can use the decorator/context manager
+:func:`django.test.override_settings` to raise a request's exception in the
+test function. It shouldn't be used on a live site unless you want your web
+server (instead of Django) to generate "Internal Server Error" responses. In
+that case, make sure your server doesn't show the stack trace or other
+sensitive information in the response.
 
 .. setting:: DECIMAL_SEPARATOR
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -194,13 +194,12 @@ Templates
 Tests
 ~~~~~
 
-* The new test :class:`~django.test.Client` argument
-  ``raise_request_exception`` allows controlling whether or not exceptions
-  raised during the request should also be raised in the test. The value
-  defaults to ``True`` for backwards compatibility. If it is ``False`` and an
-  exception occurs, the test client will return a 500 response with the
-  attribute :attr:`~django.test.Response.exc_info`, a tuple providing
-  information of the exception that occurred.
+* If an exception is raised during a test client request, the attribute
+  :attr:`~django.test.Response.exc_info` is assigned a tuple providing
+  information of the exception.
+
+* The new :meth:`.SimpleTestCase.assertRequestRaises` asserts that an exception
+  was raised during a test client request.
 
 URLs
 ~~~~
@@ -354,6 +353,12 @@ Miscellaneous
   :func:`django.views.i18n.set_language` will stop setting the user's language
   in the session in Django 4.0. Since Django 2.1, the language is always stored
   in the :setting:`LANGUAGE_COOKIE_NAME` cookie.
+
+* Raising exceptions during test client requests is deprecated and will stop in
+  Django 4.0. To continue raising the exception, set
+  :setting:`DEBUG_PROPAGATE_EXCEPTIONS` to ``True``. To use the new behavior
+  and silence the deprecation warning during tests, set the setting to
+  ``None``.
 
 .. _removed-features-3.0:
 

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -128,14 +128,6 @@ Use the ``django.test.Client`` class to make requests.
     The ``json_encoder`` argument allows setting a custom JSON encoder for
     the JSON serialization that's described in :meth:`post`.
 
-    The ``raise_request_exception`` argument allows controlling whether or not
-    exceptions raised during the request should also be raised in the test.
-    Defaults to ``True``.
-
-    .. versionadded:: 3.0
-
-        The ``raise_request_exception`` argument was added.
-
     Once you have a ``Client`` instance, you can call any of the following
     methods:
 
@@ -569,10 +561,16 @@ content type of a response using ``response['Content-Type']``.
 Exceptions
 ----------
 
-If you point the test client at a view that raises an exception and
-``Client.raise_request_exception`` is ``True``, that exception will be visible
-in the test case. You can then use a standard ``try ... except`` block or
-:meth:`~unittest.TestCase.assertRaises` to test for exceptions.
+.. deprecated:: 3.0
+
+This following behavior is deprecated and will be removed in Django 4.0. To
+continue raising exceptions in tests, set :setting:`DEBUG_PROPAGATE_EXCEPTIONS`
+to ``True``.
+
+If you point the test client at a view that raises an exception that exception
+will be visible in the test case. You can then use a standard ``try ...
+except`` block or :meth:`~unittest.TestCase.assertRaises` to test for
+exceptions.
 
 The only exceptions that are not visible to the test client are
 :class:`~django.http.Http404`,
@@ -581,7 +579,7 @@ The only exceptions that are not visible to the test client are
 exceptions internally and converts them into the appropriate HTTP response
 codes. In these cases, you can check ``response.status_code`` in your test.
 
-If ``Client.raise_request_exception`` is ``False``, the test client will return a
+If ``DEBUG_PROPAGATE_EXCEPTIONS`` is ``None``, the test client will return a
 500 response as would be returned to a browser. The response has the attribute
 :attr:`~Response.exc_info` to provide information about the unhandled
 exception.
@@ -1677,6 +1675,17 @@ your test suite.
     See :meth:`~SimpleTestCase.assertJSONEqual` for further details.
 
     Output in case of error can be customized with the ``msg`` argument.
+
+.. method:: SimpleTestCase.assertRequestRaises(response, expected_exception, expected_message=None, msg=None)
+
+   .. versionadded:: 3.0
+
+   Asserts that an exception was raised during a test client request::
+
+        response = self.client.get('/broken-view/')
+        self.assertRequestException(response, NameError, "name 'foo' is not defined")
+
+   Output in case of error can be customized with the ``msg`` argument.
 
 .. method:: TransactionTestCase.assertQuerysetEqual(qs, values, transform=repr, ordered=True, msg=None)
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -890,8 +890,8 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         Refs: #16655, #18593, and #18747
         """
         Simple.objects.create()
-        with self.assertRaises(AttributeError):
-            self.client.get(reverse('admin:admin_views_simple_changelist'))
+        response = self.client.get(reverse('admin:admin_views_simple_changelist'))
+        self.assertRequestRaises(response, AttributeError)
 
     def test_changelist_with_no_change_url(self):
         """

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -857,12 +857,12 @@ class LoginRedirectAuthenticatedUser(AuthViewsTestCase):
             "your LOGIN_REDIRECT_URL doesn't point to a login page."
         )
         with self.settings(LOGIN_REDIRECT_URL=self.do_redirect_url):
-            with self.assertRaisesMessage(ValueError, msg):
-                self.client.get(self.do_redirect_url)
+            response = self.client.get(self.do_redirect_url)
+            self.assertRequestRaises(response, ValueError, msg)
 
             url = self.do_redirect_url + '?bla=2'
-            with self.assertRaisesMessage(ValueError, msg):
-                self.client.get(url)
+            response = self.client.get(url)
+            self.assertRequestRaises(response, ValueError, msg)
 
     def test_permission_required_not_logged_in(self):
         # Not logged in ...

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -386,8 +386,8 @@ class FileUploadTests(TestCase):
             file.seek(0)
 
             msg = 'You cannot alter upload handlers after the upload has been processed.'
-            with self.assertRaisesMessage(AttributeError, msg):
-                self.client.post('/quota/broken/', {'f': file})
+            response = self.client.post('/quota/broken/', {'f': file})
+            self.assertRequestRaises(response, AttributeError, msg)
 
     def test_fileupload_getlist(self):
         file = tempfile.NamedTemporaryFile

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -313,8 +313,8 @@ class TemplateViewTest(SimpleTestCase):
             "TemplateResponseMixin requires either a definition of "
             "'template_name' or an implementation of 'get_template_names()'"
         )
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            self.client.get('/template/no_template/')
+        response = self.client.get('/template/no_template/')
+        self.assertRequestRaises(response, ImproperlyConfigured, msg)
 
     @require_jinja2
     def test_template_engine(self):

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -84,8 +84,8 @@ class ArchiveIndexViewTests(TestDataMixin, TestCase):
             'BookArchive is missing a QuerySet. Define BookArchive.model, '
             'BookArchive.queryset, or override BookArchive.get_queryset().'
         )
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            self.client.get('/dates/books/invalid/')
+        response = self.client.get('/dates/books/invalid/')
+        self.assertRequestRaises(response, ImproperlyConfigured, msg)
 
     def test_archive_view_by_month(self):
         res = self.client.get('/dates/books/by_month/')
@@ -158,8 +158,8 @@ class ArchiveIndexViewTests(TestDataMixin, TestCase):
 
     def test_archive_view_without_date_field(self):
         msg = 'BookArchiveWithoutDateField.date_field is required.'
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            self.client.get('/dates/books/without_date_field/')
+        response = self.client.get('/dates/books/without_date_field/')
+        self.assertRequestRaises(response, ImproperlyConfigured, msg)
 
 
 @override_settings(ROOT_URLCONF='generic_views.urls')
@@ -288,8 +288,9 @@ class YearArchiveViewTests(TestDataMixin, TestCase):
         BaseDateListView.get().
         """
         BookSigning.objects.create(event_date=datetime.datetime(2008, 4, 2, 12, 0))
-        with self.assertRaisesMessage(TypeError, 'context must be a dict rather than MagicMock.'):
-            self.client.get('/dates/booksignings/2008/')
+        msg = 'context must be a dict rather than MagicMock.'
+        response = self.client.get('/dates/booksignings/2008/')
+        self.assertRequestRaises(response, TypeError, msg)
         args, kwargs = mock.call_args
         # These are context values from get_dated_items().
         self.assertEqual(kwargs['year'], datetime.date(2008, 1, 1))
@@ -298,8 +299,8 @@ class YearArchiveViewTests(TestDataMixin, TestCase):
 
     def test_get_dated_items_not_implemented(self):
         msg = 'A DateView must provide an implementation of get_dated_items()'
-        with self.assertRaisesMessage(NotImplementedError, msg):
-            self.client.get('/BaseDateListViewTest/')
+        response = self.client.get('/BaseDateListViewTest/')
+        self.assertRequestRaises(response, NotImplementedError, msg)
 
 
 @override_settings(ROOT_URLCONF='generic_views.urls')
@@ -539,8 +540,9 @@ class WeekArchiveViewTests(TestDataMixin, TestCase):
         self.assertEqual(res.context['week'], datetime.date(2008, 9, 29))
 
     def test_unknown_week_format(self):
-        with self.assertRaisesMessage(ValueError, "Unknown week format '%T'. Choices are: %U, %W"):
-            self.client.get('/dates/books/2008/week/39/unknown_week_format/')
+        msg = "Unknown week format '%T'. Choices are: %U, %W"
+        response = self.client.get('/dates/books/2008/week/39/unknown_week_format/')
+        self.assertRequestRaises(response, ValueError, msg)
 
     def test_datetime_week_view(self):
         BookSigning.objects.create(event_date=datetime.datetime(2008, 4, 2, 12, 0))
@@ -727,8 +729,8 @@ class DateDetailViewTests(TestDataMixin, TestCase):
             'Generic detail view BookDetail must be called with either an '
             'object pk or a slug in the URLconf.'
         )
-        with self.assertRaisesMessage(AttributeError, msg):
-            self.client.get("/dates/books/2008/oct/01/nopk/")
+        response = self.client.get('/dates/books/2008/oct/01/nopk/')
+        self.assertRequestRaises(response, AttributeError, msg)
 
     def test_get_object_custom_queryset(self):
         """

--- a/tests/generic_views/test_detail.py
+++ b/tests/generic_views/test_detail.py
@@ -46,8 +46,8 @@ class DetailViewTest(TestCase):
         self.assertEqual(res.status_code, 404)
 
     def test_detail_object_does_not_exist(self):
-        with self.assertRaises(ObjectDoesNotExist):
-            self.client.get('/detail/doesnotexist/1/')
+        response = self.client.get('/detail/doesnotexist/1/')
+        self.assertRequestRaises(response, ObjectDoesNotExist)
 
     def test_detail_by_custom_pk(self):
         res = self.client.get('/detail/author/bycustompk/%s/' % self.author1.pk)
@@ -171,16 +171,16 @@ class DetailViewTest(TestCase):
         self.assertEqual(form_context_data['author'], self.author1)
 
     def test_invalid_url(self):
-        with self.assertRaises(AttributeError):
-            self.client.get('/detail/author/invalid/url/')
+        response = self.client.get('/detail/author/invalid/url/')
+        self.assertRequestRaises(response, AttributeError)
 
     def test_invalid_queryset(self):
         msg = (
             'AuthorDetail is missing a QuerySet. Define AuthorDetail.model, '
             'AuthorDetail.queryset, or override AuthorDetail.get_queryset().'
         )
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            self.client.get('/detail/author/invalid/qs/')
+        response = self.client.get('/detail/author/invalid/qs/')
+        self.assertRequestRaises(response, ImproperlyConfigured, msg)
 
     def test_non_model_object_with_meta(self):
         res = self.client.get('/detail/nonmodel/1/')

--- a/tests/generic_views/test_edit.py
+++ b/tests/generic_views/test_edit.py
@@ -164,8 +164,11 @@ class CreateViewTests(TestCase):
             'No URL to redirect to.  Either provide a url or define a '
             'get_absolute_url method on the Model.'
         )
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            self.client.post('/edit/authors/create/naive/', {'name': 'Randall Munroe', 'slug': 'randall-munroe'})
+        response = self.client.post(
+            '/edit/authors/create/naive/',
+            {'name': 'Randall Munroe', 'slug': 'randall-munroe'},
+        )
+        self.assertRequestRaises(response, ImproperlyConfigured, msg)
 
     def test_create_restricted(self):
         res = self.client.post(
@@ -308,11 +311,11 @@ class UpdateViewTests(TestCase):
             'No URL to redirect to.  Either provide a url or define a '
             'get_absolute_url method on the Model.'
         )
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            self.client.post(
-                '/edit/author/%d/update/naive/' % self.author.pk,
-                {'name': 'Randall Munroe (author of xkcd)', 'slug': 'randall-munroe'}
-            )
+        response = self.client.post(
+            '/edit/author/%d/update/naive/' % self.author.pk,
+            {'name': 'Randall Munroe (author of xkcd)', 'slug': 'randall-munroe'}
+        )
+        self.assertRequestRaises(response, ImproperlyConfigured, msg)
 
     def test_update_get_object(self):
         res = self.client.get('/edit/author/update/')
@@ -392,5 +395,5 @@ class DeleteViewTests(TestCase):
 
     def test_delete_without_redirect(self):
         msg = 'No URL to redirect to. Provide a success_url.'
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            self.client.post('/edit/author/%d/delete/naive/' % self.author.pk)
+        response = self.client.post('/edit/author/%d/delete/naive/' % self.author.pk)
+        self.assertRequestRaises(response, ImproperlyConfigured, msg)

--- a/tests/generic_views/test_list.py
+++ b/tests/generic_views/test_list.py
@@ -204,16 +204,16 @@ class ListViewTests(TestCase):
             'AuthorList is missing a QuerySet. Define AuthorList.model, '
             'AuthorList.queryset, or override AuthorList.get_queryset().'
         )
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            self.client.get('/list/authors/invalid/')
+        response = self.client.get('/list/authors/invalid/')
+        self.assertRequestRaises(response, ImproperlyConfigured, msg)
 
     def test_invalid_get_queryset(self):
         msg = (
             "AuthorListGetQuerysetReturnsNone requires either a 'template_name' "
             "attribute or a get_queryset() method that returns a QuerySet."
         )
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            self.client.get('/list/authors/get_queryset/')
+        response = self.client.get('/list/authors/get_queryset/')
+        self.assertRequestRaises(response, ImproperlyConfigured, msg)
 
     def test_paginated_list_view_does_not_load_entire_table(self):
         # Regression test for #17535

--- a/tests/gis_tests/geoapp/test_feeds.py
+++ b/tests/gis_tests/geoapp/test_feeds.py
@@ -82,7 +82,7 @@ class GeoFeedTest(TestCase):
             self.assertChildNodes(item, ['title', 'link', 'description', 'guid', 'geo:lat', 'geo:lon'])
 
         # Boxes and Polygons aren't allowed in W3C Geo feeds.
-        with self.assertRaises(ValueError):  # Box in <channel>
-            self.client.get('/feeds/w3cgeo2/')
-        with self.assertRaises(ValueError):  # Polygons in <entry>
-            self.client.get('/feeds/w3cgeo3/')
+        response = self.client.get('/feeds/w3cgeo2/')
+        self.assertRequestRaises(response, ValueError)  # Box in <channel>
+        response = self.client.get('/feeds/w3cgeo3/')
+        self.assertRequestRaises(response, ValueError)  # Polygons in <entry>

--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -200,8 +200,9 @@ class HandlerRequestTests(SimpleTestCase):
             ('/no_response_cbv/', 'handlers.views.NoResponse.__call__'),
         )
         for url, view in tests:
-            with self.subTest(url=url), self.assertRaisesMessage(ValueError, msg % view):
-                self.client.get(url)
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertRequestRaises(response, ValueError, msg % view)
 
 
 class ScriptNameTests(SimpleTestCase):

--- a/tests/messages_tests/base.py
+++ b/tests/messages_tests/base.py
@@ -235,8 +235,8 @@ class BaseTests:
         reverse('show_message')
         for level in ('debug', 'info', 'success', 'warning', 'error'):
             add_url = reverse('add_message', args=(level,))
-            with self.assertRaises(MessageFailure):
-                self.client.post(add_url, data, follow=True)
+            response = self.client.post(add_url, data, follow=True)
+            self.assertRequestRaises(response, MessageFailure)
 
     @modify_settings(
         INSTALLED_APPS={'remove': 'django.contrib.messages'},

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -62,8 +62,8 @@ class MiddlewareTests(SimpleTestCase):
             "NoTemplateResponseMiddleware.process_template_response didn't "
             "return an HttpResponse object. It returned None instead."
         )
-        with self.assertRaisesMessage(ValueError, msg):
-            self.client.get('/middleware_exceptions/template_response/')
+        response = self.client.get('/middleware_exceptions/template_response/')
+        self.assertRequestRaises(response, ValueError, msg)
 
     @override_settings(MIDDLEWARE=['middleware_exceptions.middleware.LogMiddleware'])
     def test_view_exception_converted_before_middleware(self):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -177,6 +177,8 @@ def setup(verbosity, test_labels, parallel):
         'fields.W342',  # ForeignKey(unique=True) -> OneToOneField
     ]
 
+    settings.DEBUG_PROPAGATE_EXCEPTIONS = None  # RemovedInDjango40Warning
+
     # Load all the ALWAYS_INSTALLED_APPS.
     django.setup()
 

--- a/tests/syndication_tests/tests.py
+++ b/tests/syndication_tests/tests.py
@@ -185,12 +185,12 @@ class SyndicationFeedTest(FeedTestCase):
             self.assertEqual(len(enclosures), 1)
 
     def test_rss2_multiple_enclosures(self):
-        with self.assertRaisesMessage(
-            ValueError,
+        msg = (
             "RSS feed items may only have one enclosure, see "
             "http://www.rssboard.org/rss-profile#element-channel-item-enclosure"
-        ):
-            self.client.get('/syndication/rss2/multiple-enclosure/')
+        )
+        response = self.client.get('/syndication/rss2/multiple-enclosure/')
+        self.assertRequestRaises(response, ValueError, msg)
 
     def test_rss091_feed(self):
         """
@@ -456,8 +456,8 @@ class SyndicationFeedTest(FeedTestCase):
             'Give your Article class a get_absolute_url() method, or define '
             'an item_link() method in your Feed class.'
         )
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            self.client.get('/syndication/articles/')
+        response = self.client.get('/syndication/articles/')
+        self.assertRequestRaises(response, ImproperlyConfigured, msg)
 
     def test_template_feed(self):
         """

--- a/tests/test_client/test_deprecated.py
+++ b/tests/test_client/test_deprecated.py
@@ -1,0 +1,19 @@
+from django.test import SimpleTestCase, override_settings
+from django.utils.deprecation import RemovedInDjango40Warning
+
+
+@override_settings(ROOT_URLCONF='test_client.urls')
+class ClientDeprecatedTest(SimpleTestCase):
+    @override_settings(DEBUG_PROPAGATE_EXCEPTIONS=False)
+    def test_exception_warning(self):
+        msg = (
+            'Raising exceptions during test client requests is deprecated. To '
+            'continue raising the exception, set the setting '
+            'DEBUG_PROPAGATE_EXCEPTIONS to True. To silence this warning, set '
+            'it to None. The exception can continue to be tested by inspecting '
+            'response.exc_info or by using '
+            'SimpleTestCase.assertRequestRaises().'
+        )
+        with self.assertWarnsMessage(RemovedInDjango40Warning, msg):
+            with self.assertRaises(KeyError):
+                self.client.get('/broken_view/')

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -854,15 +854,16 @@ class ExceptionTests(TestDataMixin, TestCase):
 
         login = self.client.login(username='testclient', password='password')
         self.assertTrue(login, 'Could not log in')
-        with self.assertRaises(CustomTestException):
-            self.client.get("/staff_only/")
+        response = self.client.get('/staff_only/')
+        self.assertRequestRaises(response, CustomTestException)
 
         # At this point, an exception has been raised, and should be cleared.
 
         # This next operation should be successful; if it isn't we have a problem.
         login = self.client.login(username='staff', password='password')
         self.assertTrue(login, 'Could not log in')
-        self.client.get("/staff_only/")
+        response = self.client.get('/staff_only/')
+        self.assertIsNone(response.exc_info)
 
 
 @override_settings(ROOT_URLCONF='test_client_regress.urls')
@@ -874,8 +875,8 @@ class TemplateExceptionTests(SimpleTestCase):
     }])
     def test_bad_404_template(self):
         "Errors found when rendering 404 error templates are re-raised"
-        with self.assertRaises(TemplateSyntaxError):
-            self.client.get("/no_such_view/")
+        response = self.client.get("/no_such_view/")
+        self.assertRequestRaises(response, TemplateSyntaxError)
 
 
 # We need two different tests to check URLconf substitution -  one to check

--- a/tests/test_utils/urls.py
+++ b/tests/test_utils/urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     path('test_utils/get_person/<int:pk>/', views.get_person),
     path('test_utils/no_template_used/', views.no_template_used, name='no_template_used'),
+    path('test_utils/broken_view/', views.broken_view),
 ]

--- a/tests/test_utils/views.py
+++ b/tests/test_utils/views.py
@@ -17,3 +17,9 @@ def no_template_used(request):
 
 def empty_response(request):
     return HttpResponse()
+
+
+def broken_view(request):
+    d = {}
+    # KeyError: 'foo'
+    d['foo']

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -1001,8 +1001,8 @@ class RequestURLconfTests(SimpleTestCase):
             "Reverse for 'outer' not found. 'outer' is not a valid view "
             "function or pattern name."
         )
-        with self.assertRaisesMessage(NoReverseMatch, msg):
-            self.client.get('/second_test/')
+        response = self.client.get('/second_test/')
+        self.assertRequestRaises(response, NoReverseMatch, msg)
 
     @override_settings(
         MIDDLEWARE=[
@@ -1074,8 +1074,8 @@ class DefaultErrorHandlerTests(SimpleTestCase):
         self.assertEqual(response.status_code, 404)
 
         msg = "I don't think I'm getting good value for this view"
-        with self.assertRaisesMessage(ValueError, msg):
-            self.client.get('/bad_view/')
+        response = self.client.get('/bad_view/')
+        self.assertRequestRaises(response, ValueError, msg)
 
 
 @override_settings(ROOT_URLCONF=None)
@@ -1088,8 +1088,8 @@ class NoRootUrlConfTests(SimpleTestCase):
             "in it. If you see valid patterns in the file then the issue is "
             "probably caused by a circular import."
         )
-        with self.assertRaisesMessage(ImproperlyConfigured, msg):
-            self.client.get('/test/me/')
+        response = self.client.get('/test/me/')
+        self.assertRequestRaises(response, ImproperlyConfigured, msg)
 
 
 @override_settings(ROOT_URLCONF='urlpatterns_reverse.namespace_urls')

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -189,8 +189,8 @@ class DebugViewTests(SimpleTestCase):
         Make sure if you don't specify a template, the debug view doesn't blow up.
         """
         with self.assertLogs('django.request', 'ERROR'):
-            with self.assertRaises(TemplateDoesNotExist):
-                self.client.get('/render_no_template/')
+            response = self.client.get('/render_no_template/')
+            self.assertRequestRaises(response, TemplateDoesNotExist)
 
     @override_settings(ROOT_URLCONF='view_tests.default_urls')
     def test_default_urlconf_template(self):


### PR DESCRIPTION
Added `SimpleTestCase.assertRequestRaises()` to assist in testing a exceptions raised during a test client request.

https://code.djangoproject.com/ticket/30249