### PR TITLE
Simplified test_transform()s in db_functions.math.

### DIFF
--- a/tests/db_functions/math/test_abs.py
+++ b/tests/db_functions/math/test_abs.py
@@ -49,5 +49,5 @@ class AbsTests(TestCase):
         with register_lookup(DecimalField, Abs):
             DecimalModel.objects.create(n1=Decimal('-1.5'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('-0.5'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__abs__gt=1)
-            self.assertQuerysetEqual(objs, [Decimal('-1.5')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__abs__gt=1).get()
+            self.assertEqual(obj.n1, Decimal('-1.5'))

--- a/tests/db_functions/math/test_acos.py
+++ b/tests/db_functions/math/test_acos.py
@@ -50,5 +50,5 @@ class ACosTests(TestCase):
         with register_lookup(DecimalField, ACos):
             DecimalModel.objects.create(n1=Decimal('0.5'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('-0.9'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__acos__lt=2)
-            self.assertQuerysetEqual(objs, [Decimal('0.5')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__acos__lt=2).get()
+            self.assertEqual(obj.n1, Decimal('0.5'))

--- a/tests/db_functions/math/test_asin.py
+++ b/tests/db_functions/math/test_asin.py
@@ -50,5 +50,5 @@ class ASinTests(TestCase):
         with register_lookup(DecimalField, ASin):
             DecimalModel.objects.create(n1=Decimal('0.1'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('1.0'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__asin__gt=1)
-            self.assertQuerysetEqual(objs, [Decimal('1.0')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__asin__gt=1).get()
+            self.assertEqual(obj.n1, Decimal('1.0'))

--- a/tests/db_functions/math/test_atan.py
+++ b/tests/db_functions/math/test_atan.py
@@ -50,5 +50,5 @@ class ATanTests(TestCase):
         with register_lookup(DecimalField, ATan):
             DecimalModel.objects.create(n1=Decimal('3.12'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('-5'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__atan__gt=0)
-            self.assertQuerysetEqual(objs, [Decimal('3.12')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__atan__gt=0).get()
+            self.assertEqual(obj.n1, Decimal('3.12'))

--- a/tests/db_functions/math/test_ceil.py
+++ b/tests/db_functions/math/test_ceil.py
@@ -50,5 +50,5 @@ class CeilTests(TestCase):
         with register_lookup(DecimalField, Ceil):
             DecimalModel.objects.create(n1=Decimal('3.12'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('1.25'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__ceil__gt=3)
-            self.assertQuerysetEqual(objs, [Decimal('3.12')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__ceil__gt=3).get()
+            self.assertEqual(obj.n1, Decimal('3.12'))

--- a/tests/db_functions/math/test_cos.py
+++ b/tests/db_functions/math/test_cos.py
@@ -50,5 +50,5 @@ class CosTests(TestCase):
         with register_lookup(DecimalField, Cos):
             DecimalModel.objects.create(n1=Decimal('-8.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('3.14'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__cos__gt=-0.2)
-            self.assertQuerysetEqual(objs, [Decimal('-8.0')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__cos__gt=-0.2).get()
+            self.assertEqual(obj.n1, Decimal('-8.0'))

--- a/tests/db_functions/math/test_cot.py
+++ b/tests/db_functions/math/test_cot.py
@@ -50,5 +50,5 @@ class CotTests(TestCase):
         with register_lookup(DecimalField, Cot):
             DecimalModel.objects.create(n1=Decimal('12.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('1.0'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__cot__gt=0)
-            self.assertQuerysetEqual(objs, [Decimal('1.0')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__cot__gt=0).get()
+            self.assertEqual(obj.n1, Decimal('1.0'))

--- a/tests/db_functions/math/test_degrees.py
+++ b/tests/db_functions/math/test_degrees.py
@@ -50,5 +50,5 @@ class DegreesTests(TestCase):
         with register_lookup(DecimalField, Degrees):
             DecimalModel.objects.create(n1=Decimal('5.4'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('-30'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__degrees__gt=0)
-            self.assertQuerysetEqual(objs, [Decimal('5.4')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__degrees__gt=0).get()
+            self.assertEqual(obj.n1, Decimal('5.4'))

--- a/tests/db_functions/math/test_exp.py
+++ b/tests/db_functions/math/test_exp.py
@@ -50,5 +50,5 @@ class ExpTests(TestCase):
         with register_lookup(DecimalField, Exp):
             DecimalModel.objects.create(n1=Decimal('12.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('-1.0'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__exp__gt=10)
-            self.assertQuerysetEqual(objs, [Decimal('12.0')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__exp__gt=10).get()
+            self.assertEqual(obj.n1, Decimal('12.0'))

--- a/tests/db_functions/math/test_floor.py
+++ b/tests/db_functions/math/test_floor.py
@@ -50,5 +50,5 @@ class FloorTests(TestCase):
         with register_lookup(DecimalField, Floor):
             DecimalModel.objects.create(n1=Decimal('5.4'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('3.4'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__floor__gt=4)
-            self.assertQuerysetEqual(objs, [Decimal('5.4')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__floor__gt=4).get()
+            self.assertEqual(obj.n1, Decimal('5.4'))

--- a/tests/db_functions/math/test_ln.py
+++ b/tests/db_functions/math/test_ln.py
@@ -50,5 +50,5 @@ class LnTests(TestCase):
         with register_lookup(DecimalField, Ln):
             DecimalModel.objects.create(n1=Decimal('12.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('1.0'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__ln__gt=0)
-            self.assertQuerysetEqual(objs, [Decimal('12.0')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__ln__gt=0).get()
+            self.assertEqual(obj.n1, Decimal('12.0'))

--- a/tests/db_functions/math/test_radians.py
+++ b/tests/db_functions/math/test_radians.py
@@ -50,5 +50,5 @@ class RadiansTests(TestCase):
         with register_lookup(DecimalField, Radians):
             DecimalModel.objects.create(n1=Decimal('2.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('-1.0'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__radians__gt=0)
-            self.assertQuerysetEqual(objs, [Decimal('2.0')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__radians__gt=0).get()
+            self.assertEqual(obj.n1, Decimal('2.0'))

--- a/tests/db_functions/math/test_round.py
+++ b/tests/db_functions/math/test_round.py
@@ -49,5 +49,5 @@ class RoundTests(TestCase):
         with register_lookup(DecimalField, Round):
             DecimalModel.objects.create(n1=Decimal('2.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('-1.0'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__round__gt=0)
-            self.assertQuerysetEqual(objs, [Decimal('2.0')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__round__gt=0).get()
+            self.assertEqual(obj.n1, Decimal('2.0'))

--- a/tests/db_functions/math/test_sin.py
+++ b/tests/db_functions/math/test_sin.py
@@ -50,5 +50,5 @@ class SinTests(TestCase):
         with register_lookup(DecimalField, Sin):
             DecimalModel.objects.create(n1=Decimal('5.4'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('0.1'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__sin__lt=0)
-            self.assertQuerysetEqual(objs, [Decimal('5.4')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__sin__lt=0).get()
+            self.assertEqual(obj.n1, Decimal('5.4'))

--- a/tests/db_functions/math/test_sqrt.py
+++ b/tests/db_functions/math/test_sqrt.py
@@ -50,5 +50,5 @@ class SqrtTests(TestCase):
         with register_lookup(DecimalField, Sqrt):
             DecimalModel.objects.create(n1=Decimal('6.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('1.0'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__sqrt__gt=2)
-            self.assertQuerysetEqual(objs, [Decimal('6.0')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__sqrt__gt=2).get()
+            self.assertEqual(obj.n1, Decimal('6.0'))

--- a/tests/db_functions/math/test_tan.py
+++ b/tests/db_functions/math/test_tan.py
@@ -50,5 +50,5 @@ class TanTests(TestCase):
         with register_lookup(DecimalField, Tan):
             DecimalModel.objects.create(n1=Decimal('0.0'), n2=Decimal('0'))
             DecimalModel.objects.create(n1=Decimal('12.0'), n2=Decimal('0'))
-            objs = DecimalModel.objects.filter(n1__tan__lt=0)
-            self.assertQuerysetEqual(objs, [Decimal('12.0')], lambda a: a.n1)
+            obj = DecimalModel.objects.filter(n1__tan__lt=0).get()
+            self.assertEqual(obj.n1, Decimal('12.0'))


### PR DESCRIPTION
IMO `assertQuerysetEqual()` and lambda expressions are unnecessary.