### PR TITLE
Fixed #30253 -- Doc'd how to order nulls in QuerySet.order_by().

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -312,9 +312,13 @@ identical to::
     Entry.objects.order_by('blog__name')
 
 You can also order by :doc:`query expressions </ref/models/expressions>` by
-calling ``asc()`` or ``desc()`` on the expression::
+calling :meth:`~.Expression.asc` or :meth:`~.Expression.desc` on the
+expression::
 
     Entry.objects.order_by(Coalesce('summary', 'headline').desc())
+
+:meth:`~.Expression.asc` and :meth:`~.Expression.desc` have arguments
+(``nulls_first`` and ``nulls_last``) that control how null values are sorted.
 
 Be cautious when ordering by fields in related models if you are also using
 :meth:`distinct()`. See the note in :meth:`distinct` for an explanation of how


### PR DESCRIPTION
While the `nulls_first` and `nulls_last` are documented in the `F` expression documentation, this is not included in the documentation on the `order_by` queryset method. It would be useful to include a note, and possibly and example, in the `order_by` method to make it easier to find.