### PR TITLE
Adding note on ordering with nulls using F expressions in order_by (2.1.x branch)

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -371,6 +371,15 @@ query will be ordered by ``pub_date`` and not ``headline``::
 
     Entry.objects.order_by('headline').order_by('pub_date')
 
+.. note::
+
+    When ordering a field (or an annotation) that includes nulls, the database
+    may choose to put nulls at the start or end of the queryset.  To influence
+    this, use an :class:`~django.db.models.F` expression and provide either
+    `nulls_first=True` or `nulls_last=True` in the `asc` or `desc` methods::
+
+        Entry.objects.order_by(models.F('pub_date).asc(nulls_first=True))
+
 .. warning::
 
     Ordering is not a free operation. Each field you add to the ordering


### PR DESCRIPTION
While the `nulls_first` and `nulls_last` are documented in the F expression documentation, this is not included in the documentation on the `order_by` queryset method. It would be useful to include a note, and possibly an example, in the `order_by` method to make it easier to find.

This is the 2.1.x branch version of https://github.com/django/django/pull/11083