### PR TITLE
Fixed #29471 -- Added 'Vary: Cookie' to the response on invalid cookie

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,6 +45,7 @@ answer newbie questions, and generally made Django that much better:
     Alex Ogier <alex.ogier@gmail.com>
     Alex Robbins <alexander.j.robbins@gmail.com>
     Alexey Boriskin <alex@boriskin.me>
+    Alexey Tsivunin <most-208@yandex.ru>
     Aljosa Mohorovic <aljosa.mohorovic@gmail.com>
     Amit Chakradeo <https://amit.chakradeo.net/>
     Amit Ramon <amit.ramon@gmail.com>

--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -40,6 +40,7 @@ class SessionMiddleware(MiddlewareMixin):
                     path=settings.SESSION_COOKIE_PATH,
                     domain=settings.SESSION_COOKIE_DOMAIN,
                 )
+                patch_vary_headers(response, ('Cookie',))
             else:
                 if accessed:
                     patch_vary_headers(response, ('Cookie',))


### PR DESCRIPTION
Previously, when an invalid session was passed via cookie,
SessionMiddleware responded by deleting cookie, but this response
was cached without 'Vary: Cookie' header.