### PR TITLE
Fixed #30266 -- Kept a sequence owner when altering an AutoField/BigAutoField on PostgreSQL.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -243,6 +243,7 @@ answer newbie questions, and generally made Django that much better:
     Dmitri Fedortchenko <zeraien@gmail.com>
     Dmitry Jemerov <intelliyole@gmail.com>
     dne@mayonnaise.net
+    Dolan Antenucci <antenucci.d@gmail.com>
     Donald Harvey <donald@donaldharvey.co.uk>
     Donald Stufft <donald@stufft.io>
     Don Spaulding <donspauldingii@gmail.com>

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -11,6 +11,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_create_sequence = "CREATE SEQUENCE %(sequence)s"
     sql_delete_sequence = "DROP SEQUENCE IF EXISTS %(sequence)s CASCADE"
     sql_set_sequence_max = "SELECT setval('%(sequence)s', MAX(%(column)s)) FROM %(table)s"
+    sql_set_sequence_owner = 'ALTER SEQUENCE %(sequence)s OWNED BY %(table)s.%(column)s'
 
     sql_create_index = "CREATE INDEX %(name)s ON %(table)s%(using)s (%(columns)s)%(extra)s%(condition)s"
     sql_delete_index = "DROP INDEX IF EXISTS %(name)s"
@@ -98,6 +99,14 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                             "table": self.quote_name(table),
                             "column": self.quote_name(column),
                             "sequence": self.quote_name(sequence_name),
+                        },
+                        [],
+                    ),
+                    (
+                        self.sql_set_sequence_owner % {
+                            'table': self.quote_name(table),
+                            'column': self.quote_name(column),
+                            'sequence': self.quote_name(sequence_name),
                         },
                         [],
                     ),


### PR DESCRIPTION
This fixes ticket [30266](https://code.djangoproject.com/ticket/30266). 

