### PR TITLE
Fixed broken tests and comments for the security middleware.

### DIFF
--- a/tests/middleware/test_security.py
+++ b/tests/middleware/test_security.py
@@ -43,7 +43,7 @@ class SecurityMiddlewareTest(SimpleTestCase):
     @override_settings(SECURE_HSTS_SECONDS=3600)
     def test_sts_on(self):
         """
-        With HSTS_SECONDS=3600, the middleware adds
+        With SECURE_HSTS_SECONDS=3600, the middleware adds
         "Strict-Transport-Security: max-age=3600" to the response.
         """
         self.assertEqual(
@@ -62,7 +62,7 @@ class SecurityMiddlewareTest(SimpleTestCase):
             headers={"Strict-Transport-Security": "max-age=7200"})
         self.assertEqual(response["Strict-Transport-Security"], "max-age=7200")
 
-    @override_settings(HSTS_SECONDS=3600)
+    @override_settings(SECURE_HSTS_SECONDS=3600)
     def test_sts_only_if_secure(self):
         """
         The "Strict-Transport-Security" header is not added to responses going
@@ -70,30 +70,28 @@ class SecurityMiddlewareTest(SimpleTestCase):
         """
         self.assertNotIn("Strict-Transport-Security", self.process_response(secure=False))
 
-    @override_settings(HSTS_SECONDS=0)
+    @override_settings(SECURE_HSTS_SECONDS=0)
     def test_sts_off(self):
         """
-        With HSTS_SECONDS of 0, the middleware does not add a
+        With SECURE_HSTS_SECONDS=0, the middleware does not add a
         "Strict-Transport-Security" header to the response.
         """
         self.assertNotIn("Strict-Transport-Security", self.process_response(secure=True))
 
-    @override_settings(
-        SECURE_HSTS_SECONDS=600, SECURE_HSTS_INCLUDE_SUBDOMAINS=True)
+    @override_settings(SECURE_HSTS_SECONDS=600, SECURE_HSTS_INCLUDE_SUBDOMAINS=True)
     def test_sts_include_subdomains(self):
         """
-        With HSTS_SECONDS non-zero and HSTS_INCLUDE_SUBDOMAINS
+        With SECURE_HSTS_SECONDS non-zero and SECURE_HSTS_INCLUDE_SUBDOMAINS
         True, the middleware adds a "Strict-Transport-Security" header with the
         "includeSubDomains" directive to the response.
         """
         response = self.process_response(secure=True)
         self.assertEqual(response["Strict-Transport-Security"], "max-age=600; includeSubDomains")
 
-    @override_settings(
-        SECURE_HSTS_SECONDS=600, SECURE_HSTS_INCLUDE_SUBDOMAINS=False)
+    @override_settings(SECURE_HSTS_SECONDS=600, SECURE_HSTS_INCLUDE_SUBDOMAINS=False)
     def test_sts_no_include_subdomains(self):
         """
-        With HSTS_SECONDS non-zero and HSTS_INCLUDE_SUBDOMAINS
+        With SECURE_HSTS_SECONDS non-zero and SECURE_HSTS_INCLUDE_SUBDOMAINS
         False, the middleware adds a "Strict-Transport-Security" header without
         the "includeSubDomains" directive to the response.
         """
@@ -103,9 +101,9 @@ class SecurityMiddlewareTest(SimpleTestCase):
     @override_settings(SECURE_HSTS_SECONDS=10886400, SECURE_HSTS_PRELOAD=True)
     def test_sts_preload(self):
         """
-        With HSTS_SECONDS non-zero and SECURE_HSTS_PRELOAD True, the middleware
-        adds a "Strict-Transport-Security" header with the "preload" directive
-        to the response.
+        With SECURE_HSTS_SECONDS non-zero and SECURE_HSTS_PRELOAD True, the
+        middleware adds a "Strict-Transport-Security" header with the "preload"
+        directive to the response.
         """
         response = self.process_response(secure=True)
         self.assertEqual(response["Strict-Transport-Security"], "max-age=10886400; preload")
@@ -113,7 +111,7 @@ class SecurityMiddlewareTest(SimpleTestCase):
     @override_settings(SECURE_HSTS_SECONDS=10886400, SECURE_HSTS_INCLUDE_SUBDOMAINS=True, SECURE_HSTS_PRELOAD=True)
     def test_sts_subdomains_and_preload(self):
         """
-        With HSTS_SECONDS non-zero, SECURE_HSTS_INCLUDE_SUBDOMAINS and
+        With SECURE_HSTS_SECONDS non-zero, SECURE_HSTS_INCLUDE_SUBDOMAINS and
         SECURE_HSTS_PRELOAD True, the middleware adds a "Strict-Transport-Security"
         header containing both the "includeSubDomains" and "preload" directives
         to the response.
@@ -124,7 +122,7 @@ class SecurityMiddlewareTest(SimpleTestCase):
     @override_settings(SECURE_HSTS_SECONDS=10886400, SECURE_HSTS_PRELOAD=False)
     def test_sts_no_preload(self):
         """
-        With HSTS_SECONDS non-zero and SECURE_HSTS_PRELOAD
+        With SECURE_HSTS_SECONDS non-zero and SECURE_HSTS_PRELOAD
         False, the middleware adds a "Strict-Transport-Security" header without
         the "preload" directive to the response.
         """
@@ -134,7 +132,7 @@ class SecurityMiddlewareTest(SimpleTestCase):
     @override_settings(SECURE_CONTENT_TYPE_NOSNIFF=True)
     def test_content_type_on(self):
         """
-        With CONTENT_TYPE_NOSNIFF set to True, the middleware adds
+        With SECURE_CONTENT_TYPE_NOSNIFF set to True, the middleware adds
         "X-Content-Type-Options: nosniff" header to the response.
         """
         self.assertEqual(self.process_response()["X-Content-Type-Options"], "nosniff")
@@ -151,7 +149,7 @@ class SecurityMiddlewareTest(SimpleTestCase):
     @override_settings(SECURE_CONTENT_TYPE_NOSNIFF=False)
     def test_content_type_off(self):
         """
-        With CONTENT_TYPE_NOSNIFF False, the middleware does not add an
+        With SECURE_CONTENT_TYPE_NOSNIFF False, the middleware does not add an
         "X-Content-Type-Options" header to the response.
         """
         self.assertNotIn("X-Content-Type-Options", self.process_response())
@@ -159,12 +157,10 @@ class SecurityMiddlewareTest(SimpleTestCase):
     @override_settings(SECURE_BROWSER_XSS_FILTER=True)
     def test_xss_filter_on(self):
         """
-        With BROWSER_XSS_FILTER set to True, the middleware adds
+        With SECURE_BROWSER_XSS_FILTER set to True, the middleware adds
         "s-xss-protection: 1; mode=block" header to the response.
         """
-        self.assertEqual(
-            self.process_response()["X-XSS-Protection"],
-            "1; mode=block")
+        self.assertEqual(self.process_response()["X-XSS-Protection"], "1; mode=block")
 
     @override_settings(SECURE_BROWSER_XSS_FILTER=True)
     def test_xss_filter_already_present(self):
@@ -175,24 +171,23 @@ class SecurityMiddlewareTest(SimpleTestCase):
         response = self.process_response(secure=True, headers={"X-XSS-Protection": "foo"})
         self.assertEqual(response["X-XSS-Protection"], "foo")
 
-    @override_settings(BROWSER_XSS_FILTER=False)
+    @override_settings(SECURE_BROWSER_XSS_FILTER=False)
     def test_xss_filter_off(self):
         """
-        With BROWSER_XSS_FILTER set to False, the middleware does not add an
-        "X-XSS-Protection" header to the response.
+        With SECURE_BROWSER_XSS_FILTER set to False, the middleware does not
+        add an "X-XSS-Protection" header to the response.
         """
         self.assertNotIn("X-XSS-Protection", self.process_response())
 
     @override_settings(SECURE_SSL_REDIRECT=True)
     def test_ssl_redirect_on(self):
         """
-        With SSL_REDIRECT True, the middleware redirects any non-secure
+        With SECURE_SSL_REDIRECT True, the middleware redirects any non-secure
         requests to the https:// version of the same URL.
         """
         ret = self.process_request("get", "/some/url?query=string")
         self.assertEqual(ret.status_code, 301)
-        self.assertEqual(
-            ret["Location"], "https://testserver/some/url?query=string")
+        self.assertEqual(ret["Location"], "https://testserver/some/url?query=string")
 
     @override_settings(SECURE_SSL_REDIRECT=True)
     def test_no_redirect_ssl(self):
@@ -202,8 +197,7 @@ class SecurityMiddlewareTest(SimpleTestCase):
         ret = self.process_request("get", "/some/url", secure=True)
         self.assertIsNone(ret)
 
-    @override_settings(
-        SECURE_SSL_REDIRECT=True, SECURE_REDIRECT_EXEMPT=["^insecure/"])
+    @override_settings(SECURE_SSL_REDIRECT=True, SECURE_REDIRECT_EXEMPT=["^insecure/"])
     def test_redirect_exempt(self):
         """
         The middleware does not redirect requests with URL path matching an
@@ -212,11 +206,10 @@ class SecurityMiddlewareTest(SimpleTestCase):
         ret = self.process_request("get", "/insecure/page")
         self.assertIsNone(ret)
 
-    @override_settings(
-        SECURE_SSL_REDIRECT=True, SECURE_SSL_HOST="secure.example.com")
+    @override_settings(SECURE_SSL_REDIRECT=True, SECURE_SSL_HOST="secure.example.com")
     def test_redirect_ssl_host(self):
         """
-        The middleware redirects to SSL_HOST if given.
+        The middleware redirects to SECURE_SSL_HOST if given.
         """
         ret = self.process_request("get", "/some/url")
         self.assertEqual(ret.status_code, 301)
@@ -225,7 +218,7 @@ class SecurityMiddlewareTest(SimpleTestCase):
     @override_settings(SECURE_SSL_REDIRECT=False)
     def test_ssl_redirect_off(self):
         """
-        With SSL_REDIRECT False, the middleware does no redirect.
+        With SECURE_SSL_REDIRECT False, the middleware does not redirect.
         """
         ret = self.process_request("get", "/some/url")
         self.assertIsNone(ret)


### PR DESCRIPTION
A number of comments and some of the calls to `@override_settings()` didn't correctly prefix some of the setting names with `SECURE_`.