### PR TITLE
Fixed #26552 -- Fixed a serialized_rollback crash due to constraints ordering.

### DIFF
--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -5,7 +5,7 @@ from io import StringIO
 from django.apps import apps
 from django.conf import settings
 from django.core import serializers
-from django.db import router
+from django.db import router, transaction
 
 # The prefix to put on the default database name when creating
 # the test database.
@@ -129,8 +129,9 @@ class BaseDatabaseCreation:
         the serialize_db_to_string() method.
         """
         data = StringIO(data)
-        for obj in serializers.deserialize("json", data, using=self.connection.alias):
-            obj.save()
+        with transaction.atomic(using=self.connection.alias):
+            for obj in serializers.deserialize("json", data, using=self.connection.alias):
+                obj.save()
 
     def _get_database_display_str(self, verbosity, database_name):
         """


### PR DESCRIPTION
This ended up biting me for a couple of hours. General gist is that `serialized_rollback` on testcases does not respect ordering of foreign key constraints, which causes integrity failures when running more than a single test in a test case. Wrapping in an atomic block fixes the issue.

Not sure if this really needs testing, but if so I can figure out where to add them. FWIW this ended up fixing the issue on my end.

Also reviewed the contributing guidelines and it appears a ticket for this issue has already been created so not creating another one: https://code.djangoproject.com/ticket/26552