### PR TITLE
Fixed #30283 -- Fixed shellcheck warnings in django_bash_completion.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,7 +31,7 @@ answer newbie questions, and generally made Django that much better:
     Akshesh Doshi <aksheshdoshi+django@gmail.com>
     alang@bright-green.com
     Alasdair Nicol <https://al.sdair.co.uk/>
-    Albert Wang <aywang31@gmail.com>
+    Albert Wang <https://github.com/albertyw/>
     Alcides Fonseca
     Aleksandra Sendecka <asendecka@hauru.eu>
     Aleksi Häkli <aleksi.hakli@iki.fi>

--- a/extras/django_bash_completion
+++ b/extras/django_bash_completion
@@ -43,13 +43,11 @@ _python_django_completion()
 {
     if [[ ${COMP_CWORD} -ge 2 ]]; then
         local PYTHON_EXE=${COMP_WORDS[0]##*/}
-        echo $PYTHON_EXE | egrep "python([3-9]\.[0-9])?" >/dev/null 2>&1
-        if [[ $? == 0 ]]; then
+        if echo "$PYTHON_EXE" | grep -qE "python([3-9]\.[0-9])?"; then
             local PYTHON_SCRIPT=${COMP_WORDS[1]##*/}
-            echo $PYTHON_SCRIPT | egrep "manage\.py|django-admin(\.py)?" >/dev/null 2>&1
-            if [[ $? == 0 ]]; then
-                COMPREPLY=( $( COMP_WORDS="${COMP_WORDS[*]:1}" \
-                               COMP_CWORD=$(( COMP_CWORD-1 )) \
+            if echo "$PYTHON_SCRIPT" | grep -qE "manage\.py|django-admin(\.py)?"; then
+                COMPREPLY=( $( COMP_WORDS=( "${COMP_WORDS[*]:1}" )
+                               COMP_CWORD=$(( COMP_CWORD-1 ))
                                DJANGO_AUTO_COMPLETE=1 ${COMP_WORDS[*]} ) )
             fi
         fi
@@ -64,7 +62,7 @@ if command -v whereis &>/dev/null; then
         [[ $python != *-config ]] && pythons="${pythons} ${python##*/}"
     done
     unset python_interpreters
-    pythons=$(echo $pythons | tr " " "\n" | sort -u | tr "\n" " ")
+    pythons=$(echo "$pythons" | tr " " "\n" | sort -u | tr "\n" " ")
 else
     pythons=python
 fi


### PR DESCRIPTION
Fixes https://code.djangoproject.com/ticket/30283

This fixes all shellcheck errors except for `^-- SC2148: Tips depend on target shell and yours is unknown. Add a shebang.` because the script is meant to be sourced instead of directly run.