### PR TITLE
Fixed #27360 -- Make it easier to track down the offending models for AlreadyRegistered exceptions.

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -1,3 +1,4 @@
+import re
 from functools import update_wrapper
 from weakref import WeakSet
 
@@ -106,7 +107,14 @@ class AdminSite:
                 )
 
             if model in self._registry:
-                raise AlreadyRegistered('The model %s is already registered' % model.__name__)
+                registered_admin = str(self._registry[model])
+                msg = 'The model %s is already registered ' % model.__name__
+                if registered_admin.endswith('.ModelAdmin'):
+                    # Most likely registered without a ModelAdmin subclass.
+                    msg += 'in app %r.' % re.sub(r'\.ModelAdmin$', '', registered_admin)
+                else:
+                    msg += 'with %r.' % registered_admin
+                raise AlreadyRegistered(msg)
 
             # Ignore the registration if the model has been
             # swapped out.

--- a/tests/admin_registration/tests.py
+++ b/tests/admin_registration/tests.py
@@ -30,9 +30,18 @@ class TestRegistration(SimpleTestCase):
 
     def test_prevent_double_registration(self):
         self.site.register(Person)
-        msg = 'The model Person is already registered'
+        msg = "The model Person is already registered in app 'admin_registration'."
         with self.assertRaisesMessage(admin.sites.AlreadyRegistered, msg):
             self.site.register(Person)
+
+    def test_prevent_double_registration_for_custom_admin(self):
+        class PersonAdmin(admin.ModelAdmin):
+            pass
+
+        self.site.register(Person, PersonAdmin)
+        msg = "The model Person is already registered with 'admin_registration.PersonAdmin'."
+        with self.assertRaisesMessage(admin.sites.AlreadyRegistered, msg):
+            self.site.register(Person, PersonAdmin)
 
     def test_registration_with_star_star_options(self):
         self.site.register(Person, search_fields=['name'])


### PR DESCRIPTION
[ticket_27360](https://code.djangoproject.com/ticket/27360)
Continue [https://github.com/django/django/pull/7423](https://github.com/django/django/pull/7423)