### PR TITLE
Fixed #29791 -- Honor engine's autoescape attribute in render_to_string

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -627,6 +627,7 @@ answer newbie questions, and generally made Django that much better:
     Nasir Hussain <nasirhjafri@gmail.com>
     Natalia Bidart <nataliabidart@gmail.com>
     Nate Bragg <jonathan.bragg@alum.rpi.edu>
+    Nathan Gaberel <nathan@gnab.fr>
     Neal Norwitz <nnorwitz@google.com>
     Nebojša Dorđević
     Ned Batchelder <https://nedbatchelder.com/>

--- a/django/template/engine.py
+++ b/django/template/engine.py
@@ -160,7 +160,7 @@ class Engine:
         if isinstance(context, Context):
             return t.render(context)
         else:
-            return t.render(Context(context))
+            return t.render(Context(context, autoescape=self.autoescape))
 
     def select_template(self, template_name_list):
         """

--- a/tests/template_tests/test_engine.py
+++ b/tests/template_tests/test_engine.py
@@ -21,6 +21,13 @@ class RenderToStringTest(SimpleTestCase):
             'obj:test\n',
         )
 
+    def test_autoescape_off(self):
+        engine = Engine(dirs=[TEMPLATE_DIR], autoescape=False)
+        self.assertEqual(
+            engine.render_to_string('test_context.html', {'obj': '<script>'}),
+            'obj:<script>\n',
+        )
+
 
 class GetDefaultTests(SimpleTestCase):
 


### PR DESCRIPTION
Passed down autoescape value from Engine to Context in Engine.render_to_string.