### PR TITLE
Clarify runserver is overridden for django.contrib.staticfiles 

### DIFF
--- a/docs/howto/static-files/index.txt
+++ b/docs/howto/static-files/index.txt
@@ -77,16 +77,19 @@ Serving static files during development
 =======================================
 
 If you use :mod:`django.contrib.staticfiles` as explained above,
-:djadmin:`runserver` will do this automatically when :setting:`DEBUG` is set
-to ``True``. If you don't have ``django.contrib.staticfiles`` in
-:setting:`INSTALLED_APPS`, you can still manually serve static files using the
-:func:`django.views.static.serve` view.
+:djadmin:`runserver` will be overriden so that URL patterns are configured
+automatically when :setting:`DEBUG` is set to ``True``. If you don't have
+``django.contrib.staticfiles`` in :setting:`INSTALLED_APPS`, or are using a
+customized :djadmin:`runserver` command, you can still manually serve static
+files using the :func:`django.views.static.serve` view in conjunction with the
+:djadmin:`collectstatic` management command.
 
 This is not suitable for production use! For some common deployment
 strategies, see :doc:`/howto/static-files/deployment`.
 
-For example, if your :setting:`STATIC_URL` is defined as ``/static/``, you can do
-this by adding the following snippet to your urls.py::
+For example, if your :setting:`STATIC_URL` is defined as ``/static/``, and you
+have a :setting:`STATIC_ROOT` path configured, you can do this by adding the
+following snippet to your urls.py::
 
     from django.conf import settings
     from django.conf.urls.static import static
@@ -94,6 +97,13 @@ this by adding the following snippet to your urls.py::
     urlpatterns = [
         # ... the rest of your URLconf goes here ...
     ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+Now, run the :djadmin:`collectstatic` management command to collect the files::
+
+    $ python manage.py collectstatic
+
+Your static files will now be served when running :djadmin:`runserver`.
+
 
 .. note::
 
@@ -152,6 +162,8 @@ of the built-in one that has the ability to transparently serve all the assets
 during execution of these tests in a way very similar to what we get at
 development time with ``DEBUG = True``, i.e. without having to collect them
 using :djadmin:`collectstatic` first.
+
+.. _staticfiles-deployment:
 
 Deployment
 ==========


### PR DESCRIPTION
In the main [static files](https://docs.djangoproject.com/en/dev/howto/static-files/#serving-static-files-during-development) documentation, the serving process is generally explained that `runserver` will automatically serve files if DEBUG is set to true.  This isn't quite the full story because it's not the _original_ `runserver` that is being used, and rather it's the one from `django.contrib.staticfiles`.  This  gets explained if you [dig deeper](https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#runserver), but it isn't clear what's happening before getting this deep.

This PR makes a clarification to the wording of this section in the docs to explain _how_ `runserver` is working its magic, and that if you have a custom `runserver` command (like I did), you need a special strategy.

Trac: https://code.djangoproject.com/ticket/30308