### PR TITLE
Refs #18726 -- Added test for excluding circular related fields with F() expression.

### DIFF
--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2782,6 +2782,9 @@ class ExcludeTests(TestCase):
         annotation = Annotation.objects.create(name='annotation', tag=tag)
         self.assertEqual(Annotation.objects.exclude(tag__note__note=F('name')).get(), annotation)
 
+    def test_exclude_with_circular_fk_relation(self):
+        self.assertEqual(ObjectB.objects.exclude(objecta__objectb__name=F('name')).count(), 0)
+
 
 class ExcludeTest17600(TestCase):
     """


### PR DESCRIPTION
Fixed in f19a4945e1191e1696f1ad8e6cdc6f939c702728. (@charettes thanks :star2: ). 

Ticket [18726](https://code.djangoproject.com/ticket/18726).