### PR TITLE
Fixed #30295 -- Fixed max_lengths.tests.MaxLengthORMTests when run in isolation.

### DIFF
--- a/tests/max_lengths/tests.py
+++ b/tests/max_lengths/tests.py
@@ -1,5 +1,7 @@
 import unittest
 
+from django.test import TestCase
+
 from .models import PersonWithCustomMaxLengths, PersonWithDefaultMaxLengths
 
 
@@ -21,7 +23,7 @@ class MaxLengthArgumentsTests(unittest.TestCase):
         self.verify_max_length(PersonWithCustomMaxLengths, 'avatar', 250)
 
 
-class MaxLengthORMTests(unittest.TestCase):
+class MaxLengthORMTests(TestCase):
 
     def test_custom_max_lengths(self):
         args = {


### PR DESCRIPTION
Ticket [#30295](https://code.djangoproject.com/ticket/30295).