### PR TITLE
Optimization: only look up HTTP_USER_AGENT once

### DIFF
--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -38,10 +38,13 @@ class CommonMiddleware(MiddlewareMixin):
         """
 
         # Check for denied User-Agents
-        if 'HTTP_USER_AGENT' in request.META:
+        try:
+            uagent = request.META['HTTP_USER_AGENT']
             for user_agent_regex in settings.DISALLOWED_USER_AGENTS:
-                if user_agent_regex.search(request.META['HTTP_USER_AGENT']):
+                if user_agent_regex.search(uagent):
                     raise PermissionDenied('Forbidden user agent')
+        except KeyError:
+            pass
 
         # Check for a redirect based on settings.PREPEND_WWW
         host = request.get_host()


### PR DESCRIPTION
Optimizes the check for each `DISALLOWED_USER_AGENTS`.

Previously, this required a getattribute + getitem for each entry in `DISALLOWED_USER_AGENTS`.