### PR TITLE
Optimize the check for DISALLOWED_USER_AGENTS

### DIFF
--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -38,9 +38,10 @@ class CommonMiddleware(MiddlewareMixin):
         """
 
         # Check for denied User-Agents
-        if 'HTTP_USER_AGENT' in request.META:
+        user_agent = request.META.get('HTTP_USER_AGENT')
+        if user_agent is not None:
             for user_agent_regex in settings.DISALLOWED_USER_AGENTS:
-                if user_agent_regex.search(request.META['HTTP_USER_AGENT']):
+                if user_agent_regex.search(user_agent):
                     raise PermissionDenied('Forbidden user agent')
 
         # Check for a redirect based on settings.PREPEND_WWW


### PR DESCRIPTION
Previously, this required a getattribute + getitem for each entry in `DISALLOWED_USER_AGENTS`.