### PR TITLE
Fixed #30265 -- Fixed a tutorial number in Reusable App tutorial.

### DIFF
--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -26,7 +26,7 @@ need to write the parts that make your project unique.
 
 Let's say you were starting a new project that needed a polls app like the one
 we've been working on. How do you make this app reusable? Luckily, you're well
-on the way already. In :doc:`Tutorial 3 </intro/tutorial03>`, we saw how we
+on the way already. In :doc:`Tutorial 1 </intro/tutorial01>`, we saw how we
 could decouple polls from the project-level URLconf using an ``include``.
 In this tutorial, we'll take further steps to make the app easy to use in new
 projects and ready to publish for others to install and use.


### PR DESCRIPTION
In the Advanced Tutorial Docs in the Reusable Apps section, decoupling by using include is referred to tutorial 03 whereas it is mentioned in Tutorial 01.