### PR TITLE
Updated links to the PostgreSQL documentation.

### DIFF
--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -18,7 +18,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         if internal_type in ("GenericIPAddressField", "IPAddressField", "TimeField", "UUIDField"):
             # PostgreSQL will resolve a union as type 'text' if input types are
             # 'unknown'.
-            # https://www.postgresql.org/docs/current/static/typeconv-union-case.html
+            # https://www.postgresql.org/docs/current/typeconv-union-case.html
             # These fields cannot be implicitly cast back in the default
             # PostgreSQL configuration so we need to explicitly cast them.
             # We must also remove components of the type within brackets:
@@ -27,7 +27,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         return '%s'
 
     def date_extract_sql(self, lookup_type, field_name):
-        # https://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
+        # https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
         if lookup_type == 'week_day':
             # For consistency across backends, we return Sunday=1, Saturday=7.
             return "EXTRACT('dow' FROM %s) + 1" % field_name
@@ -37,7 +37,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             return "EXTRACT('%s' FROM %s)" % (lookup_type, field_name)
 
     def date_trunc_sql(self, lookup_type, field_name):
-        # https://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
+        # https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
         return "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
 
     def _convert_field_to_tz(self, field_name, tzname):
@@ -59,7 +59,7 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def datetime_trunc_sql(self, lookup_type, field_name, tzname):
         field_name = self._convert_field_to_tz(field_name, tzname)
-        # https://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
+        # https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
         return "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
 
     def time_trunc_sql(self, lookup_type, field_name):

--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -19,7 +19,7 @@ only the common types, such as ``VARCHAR`` and ``INTEGER``. For more obscure
 column types, such as geographic polygons or even user-created types such as
 `PostgreSQL custom types`_, you can define your own Django ``Field`` subclasses.
 
-.. _PostgreSQL custom types: https://www.postgresql.org/docs/current/static/sql-createtype.html
+.. _PostgreSQL custom types: https://www.postgresql.org/docs/current/sql-createtype.html
 
 Alternatively, you may have a complex Python object that can somehow be
 serialized to fit into a standard database column type. This is another case

--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -7,7 +7,7 @@ PostgreSQL specific aggregation functions
 
 These functions are available from the ``django.contrib.postgres.aggregates``
 module. They are described in more detail in the `PostgreSQL docs
-<https://www.postgresql.org/docs/current/static/functions-aggregate.html>`_.
+<https://www.postgresql.org/docs/current/functions-aggregate.html>`_.
 
 .. note::
 

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -283,8 +283,8 @@ transform do not change. For example::
     ``max_length`` won't be enforced in the database since ``citext`` behaves
     similar to PostgreSQL's ``text`` type.
 
-    .. _citext: https://www.postgresql.org/docs/current/static/citext.html
-    .. _the performance considerations: https://www.postgresql.org/docs/current/static/citext.html#AEN178177
+    .. _citext: https://www.postgresql.org/docs/current/citext.html
+    .. _the performance considerations: https://www.postgresql.org/docs/current/citext.html#AEN178177
 
 ``HStoreField``
 ===============

--- a/docs/ref/contrib/postgres/functions.txt
+++ b/docs/ref/contrib/postgres/functions.txt
@@ -18,7 +18,7 @@ The `pgcrypto extension`_ must be installed. You can use the
 :class:`~django.contrib.postgres.operations.CryptoExtension` migration
 operation to install it.
 
-.. _pgcrypto extension: https://www.postgresql.org/docs/current/static/pgcrypto.html
+.. _pgcrypto extension: https://www.postgresql.org/docs/current/pgcrypto.html
 
 Usage example::
 

--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -13,14 +13,14 @@ available from the ``django.contrib.postgres.indexes`` module.
 .. class:: BrinIndex(autosummarize=None, pages_per_range=None, **options)
 
     Creates a `BRIN index
-    <https://www.postgresql.org/docs/current/static/brin-intro.html>`_.
+    <https://www.postgresql.org/docs/current/brin-intro.html>`_.
 
     Set the ``autosummarize`` parameter to ``True`` to enable `automatic
     summarization`_ to be performed by autovacuum.
 
     The ``pages_per_range`` argument takes a positive integer.
 
-    .. _automatic summarization: https://www.postgresql.org/docs/current/static/brin-intro.html#BRIN-OPERATION
+    .. _automatic summarization: https://www.postgresql.org/docs/current/brin-intro.html#BRIN-OPERATION
 
     .. versionchanged:: 2.2
 
@@ -38,20 +38,19 @@ available from the ``django.contrib.postgres.indexes`` module.
     Provide an integer value from 10 to 100 to the fillfactor_ parameter to
     tune how packed the index pages will be. PostgreSQL's default is 90.
 
-    .. _fillfactor: https://www.postgresql.org/docs/current/static/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
+    .. _fillfactor: https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
 
 ``GinIndex``
 ============
 
 .. class:: GinIndex(fastupdate=None, gin_pending_list_limit=None, **options)
 
-    Creates a `gin index
-    <https://www.postgresql.org/docs/current/static/gin.html>`_.
+    Creates a `gin index <https://www.postgresql.org/docs/current/gin.html>`_.
 
     To use this index on data types not in the `built-in operator classes
-    <https://www.postgresql.org/docs/current/static/gin-builtin-opclasses.html>`_,
+    <https://www.postgresql.org/docs/current/gin-builtin-opclasses.html>`_,
     you need to activate the `btree_gin extension
-    <https://www.postgresql.org/docs/current/static/btree-gin.html>`_ on
+    <https://www.postgresql.org/docs/current/btree-gin.html>`_ on
     PostgreSQL. You can install it using the
     :class:`~django.contrib.postgres.operations.BtreeGinExtension` migration
     operation.
@@ -63,8 +62,8 @@ available from the ``django.contrib.postgres.indexes`` module.
     to tune the maximum size of the GIN pending list which is used when
     ``fastupdate`` is enabled.
 
-    .. _GIN Fast Update Technique: https://www.postgresql.org/docs/current/static/gin-implementation.html#GIN-FAST-UPDATE
-    .. _gin_pending_list_limit: https://www.postgresql.org/docs/current/static/runtime-config-client.html#GUC-GIN-PENDING-LIST-LIMIT
+    .. _GIN Fast Update Technique: https://www.postgresql.org/docs/current/gin-implementation.html#GIN-FAST-UPDATE
+    .. _gin_pending_list_limit: https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-GIN-PENDING-LIST-LIMIT
 
 ``GistIndex``
 =============
@@ -72,18 +71,18 @@ available from the ``django.contrib.postgres.indexes`` module.
 .. class:: GistIndex(buffering=None, fillfactor=None, **options)
 
     Creates a `GiST index
-    <https://www.postgresql.org/docs/current/static/gist.html>`_. These indexes
-    are automatically created on spatial fields with :attr:`spatial_index=True
+    <https://www.postgresql.org/docs/current/gist.html>`_. These indexes are
+    automatically created on spatial fields with :attr:`spatial_index=True
     <django.contrib.gis.db.models.BaseSpatialField.spatial_index>`. They're
     also useful on other types, such as
     :class:`~django.contrib.postgres.fields.HStoreField` or the :ref:`range
     fields <range-fields>`.
 
     To use this index on data types not in the built-in `gist operator classes
-    <https://www.postgresql.org/docs/current/static/gist-builtin-opclasses.html>`_,
+    <https://www.postgresql.org/docs/current/gist-builtin-opclasses.html>`_,
     you need to activate the `btree_gist extension
-    <https://www.postgresql.org/docs/current/static/btree-gist.html>`_ on
-    PostgreSQL. You can install it using the
+    <https://www.postgresql.org/docs/current/btree-gist.html>`_ on PostgreSQL.
+    You can install it using the
     :class:`~django.contrib.postgres.operations.BtreeGistExtension` migration
     operation.
 
@@ -93,8 +92,8 @@ available from the ``django.contrib.postgres.indexes`` module.
     Provide an integer value from 10 to 100 to the fillfactor_ parameter to
     tune how packed the index pages will be. PostgreSQL's default is 90.
 
-    .. _buffering build: https://www.postgresql.org/docs/current/static/gist-implementation.html#GIST-BUFFERING-BUILD
-    .. _fillfactor: https://www.postgresql.org/docs/current/static/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
+    .. _buffering build: https://www.postgresql.org/docs/current/gist-implementation.html#GIST-BUFFERING-BUILD
+    .. _fillfactor: https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
 
 ``HashIndex``
 =============
@@ -113,7 +112,7 @@ available from the ``django.contrib.postgres.indexes`` module.
         Hash indexes have been available in PostgreSQL for a long time, but
         they suffer from a number of data integrity issues in older versions.
 
-    .. _fillfactor: https://www.postgresql.org/docs/current/static/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
+    .. _fillfactor: https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
 
 ``SpGistIndex``
 ===============
@@ -123,9 +122,9 @@ available from the ``django.contrib.postgres.indexes`` module.
     .. versionadded:: 2.2
 
     Creates an `SP-GiST index
-    <https://www.postgresql.org/docs/current/static/spgist.html>`_.
+    <https://www.postgresql.org/docs/current/spgist.html>`_.
 
     Provide an integer value from 10 to 100 to the fillfactor_ parameter to
     tune how packed the index pages will be. PostgreSQL's default is 90.
 
-    .. _fillfactor: https://www.postgresql.org/docs/current/static/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
+    .. _fillfactor: https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS

--- a/docs/ref/contrib/postgres/lookups.txt
+++ b/docs/ref/contrib/postgres/lookups.txt
@@ -15,8 +15,8 @@ similarity threshold.
 
 To use it, add ``'django.contrib.postgres'`` in your :setting:`INSTALLED_APPS`
 and activate the `pg_trgm extension
-<https://www.postgresql.org/docs/current/static/pgtrgm.html>`_ on
-PostgreSQL. You can install the extension using the
+<https://www.postgresql.org/docs/current/pgtrgm.html>`_ on PostgreSQL. You can
+install the extension using the
 :class:`~django.contrib.postgres.operations.TrigramExtension` migration
 operation.
 
@@ -41,7 +41,7 @@ the `unaccent extension on PostgreSQL`_. The
 :class:`~django.contrib.postgres.operations.UnaccentExtension` migration
 operation is available if you want to perform this activation using migrations).
 
-.. _unaccent extension on PostgreSQL: https://www.postgresql.org/docs/current/static/unaccent.html
+.. _unaccent extension on PostgreSQL: https://www.postgresql.org/docs/current/unaccent.html
 
 The ``unaccent`` lookup can be used on
 :class:`~django.db.models.CharField` and :class:`~django.db.models.TextField`::

--- a/docs/ref/contrib/postgres/search.txt
+++ b/docs/ref/contrib/postgres/search.txt
@@ -4,7 +4,7 @@ Full text search
 
 The database functions in the ``django.contrib.postgres.search`` module ease
 the use of PostgreSQL's `full text search engine
-<https://www.postgresql.org/docs/current/static/textsearch.html>`_.
+<https://www.postgresql.org/docs/current/textsearch.html>`_.
 
 For the examples in this document, we'll use the models defined in
 :doc:`/topics/db/queries`.
@@ -83,7 +83,7 @@ as a single phrase. If ``search_type`` is ``'raw'``, then you can provide a
 formatted search query with terms and operators. Read PostgreSQL's `Full Text
 Search docs`_ to learn about differences and syntax. Examples:
 
-.. _Full Text Search docs: https://www.postgresql.org/docs/current/static/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
+.. _Full Text Search docs: https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
 
     >>> from django.contrib.postgres.search import SearchQuery
     >>> SearchQuery('red tomato')  # two keywords
@@ -184,7 +184,7 @@ In the event that all the fields you're querying on are contained within one
 particular model, you can create a functional index which matches the search
 vector you wish to use. The PostgreSQL documentation has details on
 `creating indexes for full text search
-<https://www.postgresql.org/docs/current/static/textsearch-tables.html#TEXTSEARCH-TABLES-INDEX>`_.
+<https://www.postgresql.org/docs/current/textsearch-tables.html#TEXTSEARCH-TABLES-INDEX>`_.
 
 ``SearchVectorField``
 ---------------------
@@ -200,7 +200,7 @@ if it were an annotated ``SearchVector``::
     >>> Entry.objects.filter(search_vector='cheese')
     [<Entry: Cheese on Toast recipes>, <Entry: Pizza recipes>]
 
-.. _PostgreSQL documentation: https://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-UPDATE-TRIGGERS
+.. _PostgreSQL documentation: https://www.postgresql.org/docs/current/textsearch-features.html#TEXTSEARCH-UPDATE-TRIGGERS
 
 Trigram similarity
 ==================
@@ -210,8 +210,8 @@ three consecutive characters. In addition to the :lookup:`trigram_similar`
 lookup, you can use a couple of other expressions.
 
 To use them, you need to activate the `pg_trgm extension
-<https://www.postgresql.org/docs/current/static/pgtrgm.html>`_ on
-PostgreSQL. You can install it using the
+<https://www.postgresql.org/docs/current/pgtrgm.html>`_ on PostgreSQL. You can
+install it using the
 :class:`~django.contrib.postgres.operations.TrigramExtension` migration
 operation.
 

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -121,7 +121,7 @@ user with `ALTER ROLE`_.
 Django will work just fine without this optimization, but each new connection
 will do some additional queries to set these parameters.
 
-.. _ALTER ROLE: https://www.postgresql.org/docs/current/static/sql-alterrole.html
+.. _ALTER ROLE: https://www.postgresql.org/docs/current/sql-alterrole.html
 
 .. _database-isolation-level:
 
@@ -148,7 +148,7 @@ configuration in :setting:`DATABASES`::
     handle exceptions raised on serialization failures. This option is
     designed for advanced uses.
 
-.. _isolation level: https://www.postgresql.org/docs/current/static/transaction-iso.html
+.. _isolation level: https://www.postgresql.org/docs/current/transaction-iso.html
 
 Indexes for ``varchar`` and ``text`` columns
 --------------------------------------------
@@ -162,7 +162,7 @@ for the column.  The extra index is necessary to correctly perform
 lookups that use the ``LIKE`` operator in their SQL, as is done with the
 ``contains`` and ``startswith`` lookup types.
 
-.. _PostgreSQL operator class: https://www.postgresql.org/docs/current/static/indexes-opclass.html
+.. _PostgreSQL operator class: https://www.postgresql.org/docs/current/indexes-opclass.html
 
 Migration operation for adding extensions
 -----------------------------------------
@@ -185,7 +185,7 @@ faster, but this could diminish performance if more than 10% of the results are
 retrieved. PostgreSQL's assumptions on the number of rows retrieved for a
 cursor query is controlled with the `cursor_tuple_fraction`_ option.
 
-.. _cursor_tuple_fraction: https://www.postgresql.org/docs/current/static/runtime-config-query.html#GUC-CURSOR-TUPLE-FRACTION
+.. _cursor_tuple_fraction: https://www.postgresql.org/docs/current/runtime-config-query.html#GUC-CURSOR-TUPLE-FRACTION
 
 .. _transaction-pooling-server-side-cursors:
 
@@ -244,8 +244,8 @@ If you need to specify such values, reset the sequence afterwards to avoid
 reusing a value that's already in the table. The :djadmin:`sqlsequencereset`
 management command generates the SQL statements to do that.
 
-.. _SERIAL data type: https://www.postgresql.org/docs/current/static/datatype-numeric.html#DATATYPE-SERIAL
-.. _sequence: https://www.postgresql.org/docs/current/static/sql-createsequence.html
+.. _SERIAL data type: https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL
+.. _sequence: https://www.postgresql.org/docs/current/sql-createsequence.html
 
 Test database templates
 -----------------------
@@ -253,13 +253,13 @@ Test database templates
 You can use the :setting:`TEST['TEMPLATE'] <TEST_TEMPLATE>` setting to specify
 a `template`_ (e.g. ``'template0'``) from which to create a test database.
 
-.. _template: https://www.postgresql.org/docs/current/static/sql-createdatabase.html
+.. _template: https://www.postgresql.org/docs/current/sql-createdatabase.html
 
 Speeding up test execution with non-durable settings
 ----------------------------------------------------
 
 You can speed up test execution times by `configuring PostgreSQL to be
-non-durable <https://www.postgresql.org/docs/current/static/non-durability.html>`_.
+non-durable <https://www.postgresql.org/docs/current/non-durability.html>`_.
 
 .. warning::
 

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -1492,7 +1492,7 @@ Usage example::
 
 .. admonition:: PostgreSQL
 
-    The `pgcrypto extension <https://www.postgresql.org/docs/current/static/
+    The `pgcrypto extension <https://www.postgresql.org/docs/current/
     pgcrypto.html>`_ must be installed. You can use the
     :class:`~django.contrib.postgres.operations.CryptoExtension` migration
     operation to install it.

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -77,7 +77,7 @@ in the same tablespace as the table.
 .. versionadded:: 2.2
 
 The names of the `PostgreSQL operator classes
-<https://www.postgresql.org/docs/current/static/indexes-opclass.html>`_ to use for
+<https://www.postgresql.org/docs/current/indexes-opclass.html>`_ to use for
 this index. If you require a custom operator class, you must provide one for
 each field in the index.
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -792,7 +792,7 @@ object. If it's ``None``, Django uses the :ref:`current time zone
     - MySQL: load the time zone tables with `mysql_tzinfo_to_sql`_.
 
     .. _pytz: http://pytz.sourceforge.net/
-    .. _Time Zones: https://www.postgresql.org/docs/current/static/datatype-datetime.html#DATATYPE-TIMEZONES
+    .. _Time Zones: https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-TIMEZONES
     .. _Choosing a Time Zone File: https://docs.oracle.com/en/database/oracle/
        oracle-database/18/nlspg/datetime-data-types-and-time-zone-support.html
        #GUID-805AB986-DE12-4FEA-AF56-5AABCD2132DF

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -710,7 +710,7 @@ backend-specific.
 
 Supported by the PostgreSQL_ (``postgresql``) and MySQL_ (``mysql``) backends.
 
-.. _PostgreSQL: https://www.postgresql.org/docs/current/static/multibyte.html
+.. _PostgreSQL: https://www.postgresql.org/docs/current/multibyte.html
 .. _MySQL: https://dev.mysql.com/doc/refman/en/charset-database.html
 
 .. setting:: TEST_COLLATION
@@ -791,7 +791,7 @@ This is a PostgreSQL-specific setting.
 The name of a `template`_ (e.g. ``'template0'``) from which to create the test
 database.
 
-.. _template: https://www.postgresql.org/docs/current/static/sql-createdatabase.html
+.. _template: https://www.postgresql.org/docs/current/sql-createdatabase.html
 
 .. setting:: TEST_CREATE
 

--- a/docs/ref/unicode.txt
+++ b/docs/ref/unicode.txt
@@ -28,7 +28,7 @@ able to store certain characters in the database, and information will be lost.
   for internal encoding.
 
 .. _MySQL manual: https://dev.mysql.com/doc/refman/en/charset-database.html
-.. _PostgreSQL manual: https://www.postgresql.org/docs/current/static/multibyte.html
+.. _PostgreSQL manual: https://www.postgresql.org/docs/current/multibyte.html
 .. _Oracle manual: https://docs.oracle.com/en/database/oracle/oracle-database/18/nlspg/index.html
 .. _section 2: https://docs.oracle.com/en/database/oracle/oracle-database/18/nlspg/choosing-character-set.html
 .. _section 11: https://docs.oracle.com/en/database/oracle/oracle-database/18/nlspg/character-set-migration.html

--- a/docs/topics/db/sql.txt
+++ b/docs/topics/db/sql.txt
@@ -190,7 +190,7 @@ of people with their ages calculated by the database::
 You can often avoid using raw SQL to compute annotations by instead using a
 :ref:`Func() expression <func-expressions>`.
 
-__ https://www.postgresql.org/docs/current/static/functions-datetime.html
+__ https://www.postgresql.org/docs/current/functions-datetime.html
 
 Passing parameters into ``raw()``
 ---------------------------------


### PR DESCRIPTION
The canonical links have changed and `/static` is no longer required.