### PR TITLE
Fixed #30301 -- Removed OutputWrapper.__init__()'s unused style_func arg.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -126,7 +126,7 @@ class OutputWrapper(TextIOBase):
         else:
             self._style_func = lambda x: x
 
-    def __init__(self, out, style_func=None, ending='\n'):
+    def __init__(self, out, ending='\n'):
         self._out = out
         self.style_func = None
         self.ending = ending
@@ -355,7 +355,7 @@ class BaseCommand:
         if options.get('stdout'):
             self.stdout = OutputWrapper(options['stdout'])
         if options.get('stderr'):
-            self.stderr = OutputWrapper(options['stderr'], self.stderr.style_func)
+            self.stderr = OutputWrapper(options['stderr'])
 
         if self.requires_system_checks and not options.get('skip_checks'):
             self.check()


### PR DESCRIPTION
Unused since 533532302ae842c95cf7294ef6cd7f3e2bfaca65.
https://code.djangoproject.com/ticket/30301