### PR TITLE
Fixed #30259 -- Fixed crash of admin views when properties don't have admin_order_field attribute.

### DIFF
--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -130,7 +130,7 @@ def result_headers(cl):
             admin_order_field = getattr(attr, "admin_order_field", None)
             # Set ordering for attr that is a property, if defined.
             if isinstance(attr, property) and hasattr(attr, 'fget'):
-                admin_order_field = getattr(attr.fget, 'admin_order_field')
+                admin_order_field = getattr(attr.fget, 'admin_order_field', None)
             if not admin_order_field:
                 is_field_sortable = False
 

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -104,7 +104,7 @@ class ArticleAdmin(admin.ModelAdmin):
     list_display = (
         'content', 'date', callable_year, 'model_year', 'modeladmin_year',
         'model_year_reversed', 'section', lambda obj: obj.title,
-        'order_by_expression', 'model_property_year',
+        'order_by_expression', 'model_property_year', 'model_month',
     )
     list_editable = ('section',)
     list_filter = ('date', 'section')

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -60,6 +60,10 @@ class Article(models.Model):
     property_year.admin_order_field = 'date'
     model_property_year = property(property_year)
 
+    @property
+    def model_month(self):
+        return self.date.month
+
 
 class Book(models.Model):
     """


### PR DESCRIPTION
Ticket [30259](https://code.djangoproject.com/ticket/30259).

I didn't add a separate test because the original test `test_change_list_sorting_property()` is falling after adding a property to the list of fields.