### PR TITLE
Fixed #30307 -- Fixed passing database user password to dbshell on Oracle.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -213,7 +213,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return settings_dict['NAME']
 
     def _connect_string(self):
-        return '%s/\\"%s\\"@%s' % (self.settings_dict['USER'], self.settings_dict['PASSWORD'], self._dsn())
+        return '%s/"%s"@%s' % (self.settings_dict['USER'], self.settings_dict['PASSWORD'], self._dsn())
 
     def get_connection_params(self):
         conn_params = self.settings_dict['OPTIONS'].copy()

--- a/docs/releases/2.2.1.txt
+++ b/docs/releases/2.2.1.txt
@@ -9,4 +9,6 @@ Django 2.2.1 fixes several bugs in 2.2.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 2.1 that caused the incorrect quoting of
+  database user password when using :djadmin:`dbshell` on Oracle
+  (:ticket:`30307`).

--- a/tests/backends/oracle/tests.py
+++ b/tests/backends/oracle/tests.py
@@ -87,7 +87,7 @@ class TransactionalTests(TransactionTestCase):
         old_password = connection.settings_dict['PASSWORD']
         connection.settings_dict['PASSWORD'] = 'p@ssword'
         try:
-            self.assertIn('/\\"p@ssword\\"@', connection._connect_string())
+            self.assertIn('/"p@ssword"@', connection._connect_string())
             with self.assertRaises(DatabaseError) as context:
                 connection.cursor()
             # Database exception: "ORA-01017: invalid username/password" is


### PR DESCRIPTION
Removed the extra backslash escape in the password componenet of the
login string for Oracle dbshell invocations. Added tests that actually
invoke the client binary for each of the supported core backends.
Updated the runshell interface to support passing additional kwargs to
subprocess.run to help facilitate testing.