### PR TITLE
Fixed #30309 - Removed hasattr() reference in One-to-One example.

### DIFF
--- a/docs/topics/db/examples/one_to_one.txt
+++ b/docs/topics/db/examples/one_to_one.txt
@@ -71,11 +71,6 @@ p2 doesn't have an associated restaurant::
     >>>     print("There is no restaurant here.")
     There is no restaurant here.
 
-You can also use ``hasattr`` to avoid the need for exception catching::
-
-    >>> hasattr(p2, 'restaurant')
-    False
-
 Set the place using assignment notation. Because place is the primary key on
 Restaurant, the save will create a new restaurant::
 


### PR DESCRIPTION
The One-to-One example of using `hasattr` to avoid exception handling is based on the side effect of `hasattr` swallowing all exceptions.  This was pre-Python 3.2 behaviour and has been changed to only suppress AttributeErrors as explained at https://bugs.python.org/issue9666.

This PR removes the outdated reference.

Trac: https://code.djangoproject.com/ticket/30309