### PR TITLE
Allow different response classes via `klass` param

### DIFF
--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -6,18 +6,25 @@ for convenience's sake.
 from django.http import (
     Http404, HttpResponse, HttpResponsePermanentRedirect, HttpResponseRedirect,
 )
+from django.http.response import HttpResponseBase
 from django.template import loader
 from django.urls import NoReverseMatch, reverse
 from django.utils.functional import Promise
 
 
-def render(request, template_name, context=None, content_type=None, status=None, using=None):
+def render(request, template_name, context=None, content_type=None,
+           status=None, using=None, klass=HttpResponse):
     """
     Return a HttpResponse whose content is filled with the result of calling
     django.template.loader.render_to_string() with the passed arguments.
+
+    klass may be any subclass of http.response.HttpResponseBase, and
+    defaults to http.HttpResponse.
     """
+    if not issubclass(klass, HttpResponseBase):
+        raise TypeError("`klass` must be HttpResponseBase subclass")
     content = loader.render_to_string(template_name, context, request, using=using)
-    return HttpResponse(content, content_type, status)
+    return klass(content, content_type, status)
 
 
 def redirect(to, *args, permanent=False, **kwargs):


### PR DESCRIPTION
Adds a `klass` parameter to `render()` that lets user specify a response class other than `HttpResponse`.

- Allow any subclass of `http.HttpResponseBase`
- Default to `http.HttpResponse`
- Do a quick `issubclass()` check on the argument

Ticket: https://code.djangoproject.com/ticket/30429#ticket