### PR TITLE
Fixed #30312 -- Relaxed admin check from django.contrib.sessions to SessionMiddleware subclasses.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -65,7 +65,6 @@ def check_dependencies(**kwargs):
         ('django.contrib.contenttypes', 401),
         ('django.contrib.auth', 405),
         ('django.contrib.messages', 406),
-        ('django.contrib.sessions', 407),
     )
     for app_name, error_code in app_dependencies:
         if not apps.is_installed(app_name):
@@ -117,6 +116,12 @@ def check_dependencies(**kwargs):
             "'django.contrib.messages.middleware.MessageMiddleware' must "
             "be in MIDDLEWARE in order to use the admin application.",
             id='admin.E409',
+        ))
+    if not _contains_subclass('django.contrib.sessions.middleware.SessionMiddleware', settings.MIDDLEWARE):
+        errors.append(checks.Error(
+            "'django.contrib.sessions.middleware.SessionMiddleware' must "
+            "be in MIDDLEWARE in order to use the admin application.",
+            id='admin.E410',
         ))
     return errors
 

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -666,12 +666,12 @@ The following checks are performed on the default
   :setting:`INSTALLED_APPS` in order to use the admin application.
 * **admin.E406**: :mod:`django.contrib.messages` must be in
   :setting:`INSTALLED_APPS` in order to use the admin application.
-* **admin.E407**: :mod:`django.contrib.sessions` must be in
-  :setting:`INSTALLED_APPS` in order to use the admin application.
 * **admin.E408**:
   :class:`django.contrib.auth.middleware.AuthenticationMiddleware` must be in
   :setting:`MIDDLEWARE` in order to use the admin application.
 * **admin.E409**: :class:`django.contrib.messages.middleware.MessageMiddleware`
+  must be in :setting:`MIDDLEWARE` in order to use the admin application.
+* **admin.E410**: :class:`django.contrib.sessions.middleware.SessionMiddleware`
   must be in :setting:`MIDDLEWARE` in order to use the admin application.
 
 ``auth``

--- a/docs/releases/2.2.1.txt
+++ b/docs/releases/2.2.1.txt
@@ -49,3 +49,9 @@ Bugfixes
 
 * Fixed a regression in Django 2.2 that caused an exception to be raised when
   a custom error handler could not be imported (:ticket:`30318`).
+
+* Relaxed the system check added in Django 2.2 for the admin app's dependencies
+  to reallow use of
+  :class:`~django.contrib.sessions.middleware.SessionMiddleware` subclasses,
+  rather than requiring :mod:`django.contrib.sessions` to be in
+  :setting:`INSTALLED_APPS` (:ticket:`30312`).

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1103,13 +1103,13 @@ class ManageCheck(AdminScriptTestCase):
                 'django.contrib.auth',
                 'django.contrib.contenttypes',
                 'django.contrib.messages',
-                'django.contrib.sessions',
             ],
             sdict={
                 'DEBUG': True,
                 'MIDDLEWARE': [
                     'django.contrib.messages.middleware.MessageMiddleware',
                     'django.contrib.auth.middleware.AuthenticationMiddleware',
+                    'django.contrib.sessions.middleware.SessionMiddleware',
                 ],
                 'TEMPLATES': [
                     {


### PR DESCRIPTION
Instead of enforcing that `django.contrib.sessions` is an installed app, only check for the existence of a middleware deriving from `django.contrib.sessions.middleware.SessionMiddleware`.

https://code.djangoproject.com/ticket/30312