### PR TITLE
Fixed #30324 -- Technical_500.html Internal Unicode Error Resolving

### DIFF
--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -236,7 +236,7 @@
                 </ol>
               {% endif %}
               <ol start="{{ frame.lineno }}" class="context-line">
-                <li onclick="toggle('pre{{ frame.id }}', 'post{{ frame.id }}')"><pre>{{ frame.context_line }}</pre>{% if not is_email %} <span>…</span>{% endif %}</li>
+                <li onclick="toggle('pre{{ frame.id }}', 'post{{ frame.id }}')"><pre>{{ frame.context_line }}</pre>{% if not is_email %} <span>...</span>{% endif %}</li>
               </ol>
               {% if frame.post_context and not is_email  %}
                 <ol start='{{ frame.lineno|add:"1" }}' class="post-context" id="post{{ frame.id }}">


### PR DESCRIPTION
Ellipsis caused a Unicode error.
So the technical_500.html is generally not rendered.

In versions prior to Django 2.2, elipsis was 3 dots.

Therefore, modify elipsis to 3 dots.
Corrected the technical_500.html to render normally.