### PR TITLE
Fixed #30324 -- Forced utf-8 encoding when loading debug templates.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -328,14 +328,14 @@ class ExceptionReporter:
 
     def get_traceback_html(self):
         """Return HTML version of debug 500 HTTP error page."""
-        with Path(CURRENT_DIR, 'templates', 'technical_500.html').open() as fh:
+        with Path(CURRENT_DIR, 'templates', 'technical_500.html').open(encoding='utf-8') as fh:
             t = DEBUG_ENGINE.from_string(fh.read())
         c = Context(self.get_traceback_data(), use_l10n=False)
         return t.render(c)
 
     def get_traceback_text(self):
         """Return plain text version of debug 500 HTTP error page."""
-        with Path(CURRENT_DIR, 'templates', 'technical_500.txt').open() as fh:
+        with Path(CURRENT_DIR, 'templates', 'technical_500.txt').open(encoding='utf-8') as fh:
             t = DEBUG_ENGINE.from_string(fh.read())
         c = Context(self.get_traceback_data(), autoescape=False, use_l10n=False)
         return t.render(c)

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -497,7 +497,7 @@ def technical_404_response(request, exception):
             module = obj.__module__
             caller = '%s.%s' % (module, caller)
 
-    with Path(CURRENT_DIR, 'templates', 'technical_404.html').open() as fh:
+    with Path(CURRENT_DIR, 'templates', 'technical_404.html').open(encoding='utf-8') as fh:
         t = DEBUG_ENGINE.from_string(fh.read())
     c = Context({
         'urlconf': urlconf,
@@ -514,7 +514,7 @@ def technical_404_response(request, exception):
 
 def default_urlconf(request):
     """Create an empty URLconf 404 error response."""
-    with Path(CURRENT_DIR, 'templates', 'default_urlconf.html').open() as fh:
+    with Path(CURRENT_DIR, 'templates', 'default_urlconf.html').open(encoding='utf-8') as fh:
         t = DEBUG_ENGINE.from_string(fh.read())
     c = Context({
         'version': get_docs_version(),

--- a/docs/releases/2.2.1.txt
+++ b/docs/releases/2.2.1.txt
@@ -14,3 +14,6 @@ Bugfixes
   (:ticket:`30307`).
 
 * Added compatibility for ``psycopg2`` 2.8 (:ticket:`30331`).
+
+* Fixed a regression in Django 2.2 that caused a crash when loading the
+  template for the technical 500 debug page (:ticket:`30324`).

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -224,6 +224,19 @@ class DebugViewTests(SimpleTestCase):
             status_code=404
         )
 
+    def test_template_encoding(self):
+        """
+        The templates are loaded directly, not via a template loader, and
+        should be opened as utf-8 charset as is the default specified on
+        template engines.
+        """
+        with mock.patch.object(DebugPath, 'open') as m:
+            default_urlconf(None)
+            m.assert_called_once_with(encoding='utf-8')
+            m.reset_mock()
+            technical_404_response(mock.MagicMock(), mock.Mock())
+            m.assert_called_once_with(encoding='utf-8')
+
 
 class DebugViewQueriesAllowedTests(SimpleTestCase):
     # May need a query to initialize MySQL connection


### PR DESCRIPTION
Refs #28007 and #29654.

Regression in ea542a9c7239b5b665797b7c809f1aceb0b412cf and 50b8493581fea3d7137dd8db33bac7008868d23a.