### PR TITLE
Fixed #30331 -- Added support for psycopg2 2.8.

### DIFF
--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -77,7 +77,18 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         """, [table_name])
         field_map = {line[0]: line[1:] for line in cursor.fetchall()}
         cursor.execute("SELECT * FROM %s LIMIT 1" % self.connection.ops.quote_name(table_name))
-        return [FieldInfo(*line[0:6], *field_map[line.name]) for line in cursor.description]
+        return [
+            FieldInfo(
+                line.name,
+                line.type_code,
+                line.display_size,
+                line.internal_size,
+                line.precision,
+                line.scale,
+                *field_map[line.name],
+            )
+            for line in cursor.description
+        ]
 
     def get_sequences(self, cursor, table_name, table_fields=()):
         cursor.execute("""

--- a/docs/releases/2.2.1.txt
+++ b/docs/releases/2.2.1.txt
@@ -12,3 +12,5 @@ Bugfixes
 * Fixed a regression in Django 2.1 that caused the incorrect quoting of
   database user password when using :djadmin:`dbshell` on Oracle
   (:ticket:`30307`).
+
+* Added compatibility for ``psycopg2`` 2.8 (:ticket:`30331`).


### PR DESCRIPTION
See `cursor.description` changes in [Psycopg 2.8](http://initd.org/psycopg/docs/cursor.html#cursor.description).