### PR TITLE
Refs #27149 -- Based recursive nested subquery detection of sys.getrecursionlimit().

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -894,7 +894,7 @@ class Query(BaseExpression):
                 self.alias_prefix = prefix
                 break
             if pos > local_recursion_limit:
-                raise RuntimeError(
+                raise RecursionError(
                     'Maximum recursion depth exceeded: too many subqueries.'
                 )
         self.subq_aliases = self.subq_aliases.union([self.alias_prefix])

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -9,6 +9,7 @@ all about the internals of models in order to get the information it needs.
 import difflib
 import functools
 import inspect
+import sys
 import warnings
 from collections import Counter, namedtuple
 from collections.abc import Iterator, Mapping
@@ -883,7 +884,11 @@ class Query(BaseExpression):
             # No clashes between self and outer query should be possible.
             return
 
-        local_recursion_limit = 67  # explicitly avoid infinite loop
+        # Explicitly avoid infinite loop. The constant divider is based on how
+        # much depth recursive subquery references add to the stack. This value
+        # might need to be adjusted when adding or removing function calls from
+        # the code path in charge of performing these operations.
+        local_recursion_limit = sys.getrecursionlimit() // 16
         for pos, prefix in enumerate(prefix_gen()):
             if prefix not in self.subq_aliases:
                 self.alias_prefix = prefix

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -405,7 +405,7 @@ class Queries1Tests(TestCase):
         x = Tag.objects.filter(pk=1)
         local_recursion_limit = sys.getrecursionlimit() // 16
         msg = 'Maximum recursion depth exceeded: too many subqueries.'
-        with self.assertRaisesMessage(RuntimeError, msg):
+        with self.assertRaisesMessage(RecursionError, msg):
             for i in range(local_recursion_limit + 2):
                 x = Tag.objects.filter(pk__in=x)
 

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -1,5 +1,6 @@
 import datetime
 import pickle
+import sys
 import unittest
 from operator import attrgetter
 
@@ -402,10 +403,10 @@ class Queries1Tests(TestCase):
 
     def test_avoid_infinite_loop_on_too_many_subqueries(self):
         x = Tag.objects.filter(pk=1)
-        local_recursion_limit = 67
+        local_recursion_limit = sys.getrecursionlimit() // 16
         msg = 'Maximum recursion depth exceeded: too many subqueries.'
         with self.assertRaisesMessage(RuntimeError, msg):
-            for i in range(local_recursion_limit * 2):
+            for i in range(local_recursion_limit + 2):
                 x = Tag.objects.filter(pk__in=x)
 
     def test_reasonable_number_of_subq_aliases(self):


### PR DESCRIPTION
@felixxm I made sure this fixed the failures you encountered on `django-docker-box` which were caused by a smaller `sys.getrecursionlimit()` value (1000).

I found out about [`RecursionError` while reading about `getrecursionlimit`](https://docs.python.org/3/library/exceptions.html#RecursionError).