### PR TITLE
Fixed #30323 -- Fixed spurious autoreload failures.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -78,19 +78,22 @@ def raise_last_exception():
 
 
 def ensure_echo_on():
-    if termios:
-        fd = sys.stdin
-        if fd.isatty():
-            attr_list = termios.tcgetattr(fd)
-            if not attr_list[3] & termios.ECHO:
-                attr_list[3] |= termios.ECHO
-                if hasattr(signal, 'SIGTTOU'):
-                    old_handler = signal.signal(signal.SIGTTOU, signal.SIG_IGN)
-                else:
-                    old_handler = None
-                termios.tcsetattr(fd, termios.TCSANOW, attr_list)
-                if old_handler is not None:
-                    signal.signal(signal.SIGTTOU, old_handler)
+    """
+    Ensure that echo mode is enabled. Some tools such as PDB disable
+    it which causes usability issues after reload.
+    """
+    if not termios or not sys.stdin.isatty():
+        return
+    attr_list = termios.tcgetattr(sys.stdin)
+    if not attr_list[3] & termios.ECHO:
+        attr_list[3] |= termios.ECHO
+        if hasattr(signal, 'SIGTTOU'):
+            old_handler = signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+        else:
+            old_handler = None
+        termios.tcsetattr(sys.stdin, termios.TCSANOW, attr_list)
+        if old_handler is not None:
+            signal.signal(signal.SIGTTOU, old_handler)
 
 
 def iter_all_python_module_files():

--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -272,7 +272,12 @@ class BaseReloader:
         from django.urls import get_resolver
         # Prevent a race condition where URL modules aren't loaded when the
         # reloader starts by accessing the urlconf_module property.
-        get_resolver().urlconf_module
+        try:
+            get_resolver().urlconf_module
+        except Exception:
+            # Loading the urlconf can result in errors during development.
+            # If this occurs then swallow the error and continue.
+            pass
         logger.debug('Apps ready_event triggered. Sending autoreload_started signal.')
         autoreload_started.send(sender=self)
         self.run_loop()

--- a/docs/releases/2.2.1.txt
+++ b/docs/releases/2.2.1.txt
@@ -67,3 +67,6 @@ Bugfixes
 
 * Fixed a regression in Django 2.2 that caused a crash of :djadmin:`runserver`
   when URLConf modules raised exceptions (:ticket:`30323`).
+
+* Fixed a regression in Django 2.2 where changes were not reliably detected by
+  auto-reloader when using ``StatReloader`` (:ticket:`30323`).

--- a/docs/releases/2.2.1.txt
+++ b/docs/releases/2.2.1.txt
@@ -64,3 +64,6 @@ Bugfixes
   permissions for proxy models if the target permissions already existed. For
   example, when a permission had been created manually or a model had been
   migrated from concrete to proxy (:ticket:`30351`).
+
+* Fixed a regression in Django 2.2 that caused a crash of :djadmin:`runserver`
+  when URLConf modules raised exceptions (:ticket:`30323`).


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/30323

A few fixes and changes here:

1.  Loading the urlconf module can result in SyntaxErrors. We now swallow them to prevent the reloader from quitting.

2. Simplified the ensure_echo_on method

3. Simplified the stat autoreloader. The implementation is now pretty much exactly the same as the one in Flask/Werkzeug

4. The thread running Django itself is now named `django-main-thread` to help with tracebacks.