### PR TITLE
Give the Django main thread a distinct name while autoreloading

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -555,7 +555,7 @@ def start_django(reloader, main_func, *args, **kwargs):
     ensure_echo_on()
 
     main_func = check_errors(main_func)
-    django_main_thread = threading.Thread(target=main_func, args=args, kwargs=kwargs)
+    django_main_thread = threading.Thread(target=main_func, args=args, kwargs=kwargs, name='django-main-thread')
     django_main_thread.setDaemon(True)
     django_main_thread.start()
 

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -253,7 +253,7 @@ class StartDjangoTests(SimpleTestCase):
         self.assertEqual(mocked_thread.call_count, 1)
         self.assertEqual(
             mocked_thread.call_args[1],
-            {'target': fake_main_func, 'args': (123,), 'kwargs': {'abc': 123}}
+            {'target': fake_main_func, 'args': (123,), 'kwargs': {'abc': 123}, 'name': 'django-main-thread'}
         )
         self.assertSequenceEqual(fake_thread.setDaemon.call_args[0], [True])
         self.assertTrue(fake_thread.start.called)


### PR DESCRIPTION
No ticket for this,  but while debugging an autoreloading issue it was somewhat hard to differentiate which thread is causing which issue. Right now they are called `thread-1` and `thread-2`, can we make the thread that loads the Django app have a distinct name, i.e `django-main-thread`?