### PR TITLE
Fixed #30335, #29139 -- Fixed crash when ordering or aggregating over a nested JSONField key transforms.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -14,6 +14,7 @@ from django.db.models.sql.query import Query, get_order_dir
 from django.db.transaction import TransactionManagementError
 from django.db.utils import DatabaseError, NotSupportedError
 from django.utils.deprecation import RemovedInDjango31Warning
+from django.utils.hashable import make_hashable
 
 FORCE = object()
 
@@ -126,9 +127,10 @@ class SQLCompiler:
 
         for expr in expressions:
             sql, params = self.compile(expr)
-            if (sql, tuple(params)) not in seen:
+            params_hash = make_hashable(params)
+            if (sql, params_hash) not in seen:
                 result.append((sql, params))
-                seen.add((sql, tuple(params)))
+                seen.add((sql, params_hash))
         return result
 
     def collapse_group_by(self, expressions, having):
@@ -352,9 +354,10 @@ class SQLCompiler:
             # is refactored into expressions, then we can check each part as we
             # generate it.
             without_ordering = self.ordering_parts.search(sql).group(1)
-            if (without_ordering, tuple(params)) in seen:
+            params_hash = make_hashable(params)
+            if (without_ordering, params_hash) in seen:
                 continue
-            seen.add((without_ordering, tuple(params)))
+            seen.add((without_ordering, params_hash))
             result.append((resolved, (sql, params, is_ref)))
         return result
 

--- a/docs/releases/2.2.1.txt
+++ b/docs/releases/2.2.1.txt
@@ -33,3 +33,8 @@ Bugfixes
 * Reverted an optimization in Django 2.2 (:ticket:`29725`) that caused the
   inconsistent behavior of ``count()`` and ``exists()`` on a reverse
   many-to-many relationship with a custom manager (:ticket:`30325`).
+
+* Fixed a regression in Django 2.2 where
+  :class:`~django.core.paginator.Paginator` crashed when ``object_list`` was
+  a queryset ordered or aggregated over a nested ``JSONField`` key transform
+  (:ticket:`30335`).


### PR DESCRIPTION
Ticket: [#30335](https://code.djangoproject.com/ticket/30335)