### PR TITLE
Fixed #30339 -- Made Model.delete(keep_parents=True) preserves nested parent reverse relationships.

### DIFF
--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -212,7 +212,8 @@ class Collector:
                                  collect_related=False,
                                  reverse_dependency=True)
         if collect_related:
-            parents = model._meta.parents
+            if keep_parents:
+                parents = set(model._meta.get_parent_list())
             for related in get_candidate_relations_to_delete(model._meta):
                 # Preserve parent reverse relationships if keep_parents=True.
                 if keep_parents and related.model in parents:

--- a/tests/delete/models.py
+++ b/tests/delete/models.py
@@ -28,6 +28,10 @@ class RChild(R):
     pass
 
 
+class RChildChild(RChild):
+    pass
+
+
 class A(models.Model):
     name = models.CharField(max_length=30)
 

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -7,8 +7,8 @@ from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
 from .models import (
     MR, A, Avatar, Base, Child, HiddenUser, HiddenUserProfile, M, M2MFrom,
-    M2MTo, MRNull, Origin, Parent, R, RChild, Referrer, S, T, User, create_a,
-    get_default_r,
+    M2MTo, MRNull, Origin, Parent, R, RChild, RChildChild, Referrer, S, T,
+    User, create_a, get_default_r,
 )
 
 
@@ -368,6 +368,16 @@ class DeletionTests(TestCase):
         parent_referent_id = S.objects.create(r=child.r_ptr).pk
         child.delete(keep_parents=True)
         self.assertFalse(RChild.objects.filter(id=child.id).exists())
+        self.assertTrue(R.objects.filter(id=parent_id).exists())
+        self.assertTrue(S.objects.filter(pk=parent_referent_id).exists())
+
+        childchild = RChildChild.objects.create()
+        parent_id = childchild.rchild_ptr.r_ptr_id
+        child_id = childchild.rchild_ptr_id
+        parent_referent_id = S.objects.create(r=childchild.rchild_ptr.r_ptr).pk
+        childchild.delete(keep_parents=True)
+        self.assertFalse(RChildChild.objects.filter(id=childchild.id).exists())
+        self.assertTrue(RChild.objects.filter(id=child_id).exists())
         self.assertTrue(R.objects.filter(id=parent_id).exists())
         self.assertTrue(S.objects.filter(pk=parent_referent_id).exists())
 


### PR DESCRIPTION
…lationships.

Additional consideration based on this:
https://github.com/django/django/commit/b495d8e334c2487eef6282bac5dd0c1f43da71ef

Without this, info is lost on reverse relations for parents of parents for a model deletion with keep_parents=True.
