### PR TITLE
Fix Mistake in Plural Translation in Persian

### DIFF
--- a/django/contrib/admin/locale/fa/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/fa/LC_MESSAGES/django.po
@@ -37,7 +37,7 @@ msgstr "آیا مطمئن هستید؟"
 
 #, python-format
 msgid "Delete selected %(verbose_name_plural)s"
-msgstr "حذف  %(verbose_name_plural)s های انتخاب شده"
+msgstr "حذف  %(verbose_name_plural)s انتخاب شده"
 
 msgid "Administration"
 msgstr "مدیریت"


### PR DESCRIPTION
In Persian language, "ها" is the equivalent of "s" in English. It's how most plural forms are made.
It should be removed when we use `verbose_name_plural`.