### PR TITLE
Migrations do not ignore unmanaged models (unlike syncdb)

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -227,8 +227,9 @@ class ProjectState(object):
         "Takes in an Apps and returns a ProjectState matching it"
         app_models = {}
         for model in apps.get_models(include_swapped=True):
-            model_state = ModelState.from_model(model)
-            app_models[(model_state.app_label, model_state.name_lower)] = model_state
+            if model._meta.managed:
+                model_state = ModelState.from_model(model)
+                app_models[(model_state.app_label, model_state.name_lower)] = model_state
         return cls(app_models)
 
     def __eq__(self, other):

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -108,6 +108,14 @@ class StateTests(SimpleTestCase):
                 app_label = "migrations"
                 apps = new_apps
 
+        class Unmanaged(models.Model):
+            title = models.CharField(max_length=1000)
+
+            class Meta:
+                app_label = "migrations"
+                apps = new_apps
+                managed = False
+
         project_state = ProjectState.from_apps(new_apps)
         author_state = project_state.models['migrations', 'author']
         author_proxy_state = project_state.models['migrations', 'authorproxy']
@@ -119,6 +127,10 @@ class StateTests(SimpleTestCase):
         food_order_manager_state = project_state.models['migrations', 'foodorderedmanagers']
         book_index = models.Index(fields=['title'])
         book_index.set_name_with_model(Book)
+
+        # unmanaged models should not appear in migrations
+        with self.assertRaises(KeyError):
+            project_state.models['migrations', 'unmanaged']
 
         self.assertEqual(author_state.app_label, "migrations")
         self.assertEqual(author_state.name, "Author")


### PR DESCRIPTION
Migrations do not ignore unmanaged models (unlike syncdb); Ticket #22331; Adding this fix to 1.11.x

This has already been fixed in version 2. Related ticket is 22331. Can we please get this into the latest stable version 1 release