### PR TITLE
Fixed #26813 -- ModelForm RadioSelect widget for foreign keys should not present a blank option if blank=False on the model

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -13,7 +13,7 @@ from django.forms.forms import BaseForm, DeclarativeFieldsMetaclass
 from django.forms.formsets import BaseFormSet, formset_factory
 from django.forms.utils import ErrorList
 from django.forms.widgets import (
-    HiddenInput, MultipleHiddenInput, SelectMultiple,
+    HiddenInput, MultipleHiddenInput, SelectMultiple, RadioSelect
 )
 from django.utils.text import capfirst, get_text_list
 from django.utils.translation import gettext, gettext_lazy as _
@@ -1162,7 +1162,9 @@ class ModelChoiceField(ChoiceField):
                  required=True, widget=None, label=None, initial=None,
                  help_text='', to_field_name=None, limit_choices_to=None,
                  **kwargs):
-        if required and (initial is not None):
+        #  A blank option is not idiomatic for radio buttons, 
+        #  see https://code.djangoproject.com/ticket/26813
+        if required and (initial is not None) or isinstance(widget, RadioSelect):
             self.empty_label = None
         else:
             self.empty_label = empty_label

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -13,7 +13,7 @@ from django.forms.forms import BaseForm, DeclarativeFieldsMetaclass
 from django.forms.formsets import BaseFormSet, formset_factory
 from django.forms.utils import ErrorList
 from django.forms.widgets import (
-    HiddenInput, MultipleHiddenInput, RadioSelect, SelectMultiple
+    HiddenInput, MultipleHiddenInput, RadioSelect, SelectMultiple,
 )
 from django.utils.text import capfirst, get_text_list
 from django.utils.translation import gettext, gettext_lazy as _

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1162,7 +1162,7 @@ class ModelChoiceField(ChoiceField):
                  required=True, widget=None, label=None, initial=None,
                  help_text='', to_field_name=None, limit_choices_to=None,
                  **kwargs):
-        #  A blank option is not idiomatic for radio buttons, 
+        #  A blank option is not idiomatic for radio buttons,
         #  see https://code.djangoproject.com/ticket/26813
         if required and (initial is not None) or isinstance(widget, RadioSelect):
             self.empty_label = None

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -13,7 +13,7 @@ from django.forms.forms import BaseForm, DeclarativeFieldsMetaclass
 from django.forms.formsets import BaseFormSet, formset_factory
 from django.forms.utils import ErrorList
 from django.forms.widgets import (
-    HiddenInput, MultipleHiddenInput, SelectMultiple, RadioSelect
+    HiddenInput, MultipleHiddenInput, RadioSelect, SelectMultiple
 )
 from django.utils.text import capfirst, get_text_list
 from django.utils.translation import gettext, gettext_lazy as _

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -338,6 +338,8 @@ Miscellaneous
   deprecated, ``LocaleMiddleware`` no longer looks for the user's language in
   the session and :func:`django.contrib.auth.logout` no longer preserves the
   session's language after logout.
+  
+* ``ModelChoiceField`` using the ``RadioSelect´´ widget no longer presents an empty label '--------', as it is idiomatically incorrect.
 
 .. _deprecated-features-3.0:
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -339,7 +339,7 @@ Miscellaneous
   the session and :func:`django.contrib.auth.logout` no longer preserves the
   session's language after logout.
   
-* ``ModelChoiceField`` using the ``RadioSelect´´ widget no longer presents an empty label '--------', as it is idiomatically incorrect.
+* ``ModelChoiceField``s using the ``RadioSelect`` widget no longer presents an empty label '--------', as it is idiomatically incorrect.
 
 .. _deprecated-features-3.0:
 

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -585,7 +585,7 @@ class ModelAdminTests(TestCase):
         self.assertEqual(cmafa.base_fields['opening_band'].widget.attrs, {'class': 'radiolist'})
         self.assertEqual(
             list(cmafa.base_fields['opening_band'].widget.choices),
-            [('', 'None'), (self.band.id, 'The Doors')]
+            [(self.band.id, 'The Doors')]
         )
         self.assertEqual(type(cmafa.base_fields['day'].widget), AdminRadioSelect)
         self.assertEqual(cmafa.base_fields['day'].widget.attrs, {'class': 'radiolist'})
@@ -595,7 +595,7 @@ class ModelAdminTests(TestCase):
         self.assertEqual(cmafa.base_fields['transport'].widget.attrs, {'class': 'radiolist inline'})
         self.assertEqual(
             list(cmafa.base_fields['transport'].widget.choices),
-            [('', 'None'), (1, 'Plane'), (2, 'Train'), (3, 'Bus')]
+            [(1, 'Plane'), (2, 'Train'), (3, 'Bus')]
         )
 
         class AdminConcertForm(forms.ModelForm):


### PR DESCRIPTION
Hi, this is an attempt to solve this accepted ticket that's been inactive for a long time. [#26813](https://code.djangoproject.com/ticket/26813)