### PR TITLE
Fixed autocomplete while specified `to_field` in ForeignKey which is not primary

### DIFF
--- a/django/contrib/admin/views/autocomplete.py
+++ b/django/contrib/admin/views/autocomplete.py
@@ -30,7 +30,8 @@ class AutocompleteJsonView(BaseListView):
 
         # specified ForeignKey by `AutocompleteMixin.get_url`
         # ForeignKey may not be a primary_key
-        to_field = request.GET.get('_to_field', 'pk')
+        model = self.model_admin.model
+        to_field = request.GET.get('_to_field', model._meta.pk.name)
 
         if not hasattr(obj, to_field):
             return JsonResponse(

--- a/django/contrib/admin/views/autocomplete.py
+++ b/django/contrib/admin/views/autocomplete.py
@@ -36,7 +36,7 @@ class AutocompleteJsonView(BaseListView):
         for obj in context['object_list']:
             if not hasattr(obj, to_field):
                 return JsonResponse(
-                    {'error': 'to_field `{to_field}` not in model'.format(to_field=to_field)}, 
+                    {'error': 'to_field `{to_field}` not in model'.format(to_field=to_field)},
                     status=400
                 )
 

--- a/django/contrib/admin/views/autocomplete.py
+++ b/django/contrib/admin/views/autocomplete.py
@@ -30,11 +30,11 @@ class AutocompleteJsonView(BaseListView):
 
         # specified ForeignKey by `AutocompleteMixin.get_url`
         # ForeignKey may not be a primary_key
-        fk = request.GET.get('fk', 'pk')
+        to_field = request.GET.get('_to_field', 'pk')
 
         return JsonResponse({
             'results': [
-                {'id': str(getattr(obj, fk)), 'text': str(obj)}
+                {'id': str(getattr(obj, to_field)), 'text': str(obj)}
                 for obj in context['object_list']
             ],
             'pagination': {'more': context['page_obj'].has_next()},

--- a/django/contrib/admin/views/autocomplete.py
+++ b/django/contrib/admin/views/autocomplete.py
@@ -23,12 +23,13 @@ class AutocompleteJsonView(BaseListView):
         if not self.has_perm(request):
             return JsonResponse({'error': '403 Forbidden'}, status=403)
 
+        fk = request.GET.get('fk', 'pk')
         self.term = request.GET.get('term', '')
         self.object_list = self.get_queryset()
         context = self.get_context_data()
         return JsonResponse({
             'results': [
-                {'id': str(obj.pk), 'text': str(obj)}
+                {'id': str(getattr(obj, fk)), 'text': str(obj)}
                 for obj in context['object_list']
             ],
             'pagination': {'more': context['page_obj'].has_next()},

--- a/django/contrib/admin/views/autocomplete.py
+++ b/django/contrib/admin/views/autocomplete.py
@@ -23,10 +23,15 @@ class AutocompleteJsonView(BaseListView):
         if not self.has_perm(request):
             return JsonResponse({'error': '403 Forbidden'}, status=403)
 
-        fk = request.GET.get('fk', 'pk')
         self.term = request.GET.get('term', '')
+        self.paginator_class = self.model_admin.paginator
         self.object_list = self.get_queryset()
         context = self.get_context_data()
+
+        # specified ForeignKey by `AutocompleteMixin.get_url`
+        # ForeignKey may not be a primary_key
+        fk = request.GET.get('fk', 'pk')
+
         return JsonResponse({
             'results': [
                 {'id': str(getattr(obj, fk)), 'text': str(obj)}

--- a/django/contrib/admin/views/autocomplete.py
+++ b/django/contrib/admin/views/autocomplete.py
@@ -32,6 +32,12 @@ class AutocompleteJsonView(BaseListView):
         # ForeignKey may not be a primary_key
         to_field = request.GET.get('_to_field', 'pk')
 
+        if not hasattr(obj, to_field):
+            return JsonResponse(
+                {'error': 'to_field `{to_field}` not in model'.format(to_field=to_field)}, 
+                status=400
+            )
+
         return JsonResponse({
             'results': [
                 {'id': str(getattr(obj, to_field)), 'text': str(obj)}

--- a/django/contrib/admin/views/autocomplete.py
+++ b/django/contrib/admin/views/autocomplete.py
@@ -33,11 +33,12 @@ class AutocompleteJsonView(BaseListView):
         model = self.model_admin.model
         to_field = request.GET.get('_to_field', model._meta.pk.name)
 
-        if not hasattr(obj, to_field):
-            return JsonResponse(
-                {'error': 'to_field `{to_field}` not in model'.format(to_field=to_field)}, 
-                status=400
-            )
+        for obj in context['object_list']:
+            if not hasattr(obj, to_field):
+                return JsonResponse(
+                    {'error': 'to_field `{to_field}` not in model'.format(to_field=to_field)}, 
+                    status=400
+                )
 
         return JsonResponse({
             'results': [

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -392,9 +392,9 @@ class AutocompleteMixin:
 
         `to_field` may not be a primary_key
         """
-        to_field = getattr(self.rel, 'field_name', 'pk')
-        query = '?_to_field={to_field}'.format(to_field=to_field)
         model = self.rel.model
+        to_field = getattr(self.rel, 'field_name', model._meta.pk.name)
+        query = '?_to_field={to_field}'.format(to_field=to_field)
         return reverse(self.url_name % (self.admin_site.name, model._meta.app_label, model._meta.model_name)) + query
 
     def build_attrs(self, base_attrs, extra_attrs=None):
@@ -430,7 +430,8 @@ class AutocompleteMixin:
         if not self.is_required and not self.allow_multiple_selected:
             default[1].append(self.create_option(name, '', '', False, 0))
 
-        fk = getattr(self.rel, 'field_name', 'pk')
+        model = self.rel.model
+        fk = getattr(self.rel, 'field_name', model._meta.pk.name)
         fk_filter = {'{fk}__in'.format(fk=fk): selected_choices}
         choices = [
             (getattr(obj, fk), self.choices.field.label_from_instance(obj))

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -392,8 +392,8 @@ class AutocompleteMixin:
 
         `to_field` may not be a primary_key
         """
-        fk = getattr(self.rel, 'field_name', 'pk')
-        query = '?fk={fk}'.format(fk=fk)
+        to_field = getattr(self.rel, 'field_name', 'pk')
+        query = '?_to_field={to_field}'.format(to_field=to_field)
         model = self.rel.model
         return reverse(self.url_name % (self.admin_site.name, model._meta.app_label, model._meta.model_name)) + query
 

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -397,7 +397,6 @@ class AutocompleteMixin:
         model = self.rel.model
         return reverse(self.url_name % (self.admin_site.name, model._meta.app_label, model._meta.model_name)) + query
 
-
     def build_attrs(self, base_attrs, extra_attrs=None):
         """
         Set select2's AJAX attributes.

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -392,7 +392,7 @@ class AutocompleteMixin:
 
         `to_field` may not be a primary_key
         """
-        fk = self.choices.field.to_field_name or 'pk'
+        fk = self.rel.field_name
         query = '?fk={fk}'.format(fk=fk)
         model = self.rel.model
         return reverse(self.url_name % (self.admin_site.name, model._meta.app_label, model._meta.model_name)) + query
@@ -430,7 +430,7 @@ class AutocompleteMixin:
         if not self.is_required and not self.allow_multiple_selected:
             default[1].append(self.create_option(name, '', '', False, 0))
 
-        fk = self.choices.field.to_field_name or 'pk'
+        fk = self.rel.field_name
         fk_filter = {'{fk}__in'.format(fk=fk): selected_choices}
         choices = [
             (getattr(obj, fk), self.choices.field.label_from_instance(obj))

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -387,10 +387,16 @@ class AutocompleteMixin:
         self.attrs = {} if attrs is None else attrs.copy()
 
     def get_url(self):
-        model = self.rel.model
-        autocomplete_url = reverse(self.url_name % (self.admin_site.name, model._meta.app_label, model._meta.model_name))
+        """
+        specify ForeignKey field in `AutocompleteJsonView`
+
+        `to_field` may not be a primary_key
+        """
         fk = self.choices.field.to_field_name or 'pk'
-        return '{url}?fk={fk}'.format(url=autocomplete_url, fk=fk)
+        query = '?fk={fk}'.format(fk=fk)
+        model = self.rel.model
+        return reverse(self.url_name % (self.admin_site.name, model._meta.app_label, model._meta.model_name)) + query
+
 
     def build_attrs(self, base_attrs, extra_attrs=None):
         """

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -392,7 +392,7 @@ class AutocompleteMixin:
 
         `to_field` may not be a primary_key
         """
-        fk = self.rel.field_name
+        fk = getattr(self.rel, 'field_name', 'pk')
         query = '?fk={fk}'.format(fk=fk)
         model = self.rel.model
         return reverse(self.url_name % (self.admin_site.name, model._meta.app_label, model._meta.model_name)) + query
@@ -430,7 +430,7 @@ class AutocompleteMixin:
         if not self.is_required and not self.allow_multiple_selected:
             default[1].append(self.create_option(name, '', '', False, 0))
 
-        fk = self.rel.field_name
+        fk = getattr(self.rel, 'field_name', 'pk')
         fk_filter = {'{fk}__in'.format(fk=fk): selected_choices}
         choices = [
             (getattr(obj, fk), self.choices.field.label_from_instance(obj))

--- a/tests/admin_widgets/test_autocomplete_widget.py
+++ b/tests/admin_widgets/test_autocomplete_widget.py
@@ -78,7 +78,7 @@ class AutocompleteMixinTests(TestCase):
         rel = Album._meta.get_field('band').remote_field
         w = AutocompleteSelect(rel, admin.site)
         url = w.get_url()
-        self.assertEqual(url, '/admin_widgets/band/autocomplete/')
+        self.assertEqual(url, '/admin_widgets/band/autocomplete/?fk=id')
 
     def test_render_options(self):
         beatles = Band.objects.create(name='The Beatles', style='rock')

--- a/tests/admin_widgets/test_autocomplete_widget.py
+++ b/tests/admin_widgets/test_autocomplete_widget.py
@@ -53,7 +53,7 @@ class AutocompleteMixinTests(TestCase):
             'class': 'my-class admin-autocomplete',
             'data-ajax--cache': 'true',
             'data-ajax--type': 'GET',
-            'data-ajax--url': '/admin_widgets/band/autocomplete/',
+            'data-ajax--url': '/admin_widgets/band/autocomplete/?fk=id',
             'data-theme': 'admin-autocomplete',
             'data-allow-clear': 'false',
             'data-placeholder': ''

--- a/tests/admin_widgets/test_autocomplete_widget.py
+++ b/tests/admin_widgets/test_autocomplete_widget.py
@@ -53,7 +53,7 @@ class AutocompleteMixinTests(TestCase):
             'class': 'my-class admin-autocomplete',
             'data-ajax--cache': 'true',
             'data-ajax--type': 'GET',
-            'data-ajax--url': '/admin_widgets/band/autocomplete/?fk=id',
+            'data-ajax--url': '/admin_widgets/band/autocomplete/?_to_field=id',
             'data-theme': 'admin-autocomplete',
             'data-allow-clear': 'false',
             'data-placeholder': ''
@@ -78,7 +78,7 @@ class AutocompleteMixinTests(TestCase):
         rel = Album._meta.get_field('band').remote_field
         w = AutocompleteSelect(rel, admin.site)
         url = w.get_url()
-        self.assertEqual(url, '/admin_widgets/band/autocomplete/?fk=id')
+        self.assertEqual(url, '/admin_widgets/band/autocomplete/?_to_field=id')
 
     def test_render_options(self):
         beatles = Band.objects.create(name='The Beatles', style='rock')


### PR DESCRIPTION
When use ForeignKey and set `to_field`,
the `autocomplete_view` in admin always used `pk` in queryset result to remark `id`,

obvious, when `to_field` s not a primary_key, `to_field` will not equal to `pk`,

this will make some wrong selected results