### PR TITLE
Fixed #27086 - Doc'd multithreading error while testing on MacOS.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -401,6 +401,20 @@ test failures. You can adjust this behavior with the ``--parallel`` option::
 You can also use the ``DJANGO_TEST_PROCESSES`` environment variable for this
 purpose.
 
+Tests hang with "in progress in another thread" message
+-------------------------------------------------------
+
+On macOS (High Sierra and newer versions), you might see this message while
+tests are running, after which the testing freezes::
+
+    objc[42074]: +[__NSPlaceholderDate initialize] may have been in progress in another thread when fork() was called.
+
+This happens because multithreading was restricted.
+One workaround is to run tests with the environment variable
+``OBJC_DISABLE_INITIALIZE_FORK_SAFETY`` enabled, for example by running::
+
+    OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ./runtests.py
+
 Tips for writing tests
 ----------------------
 


### PR DESCRIPTION
I ran into this in february, but only now did it occur to me to document it. 

Some clever googling (which i was unable to do, someone on IRC helped me out) will yield results like https://stackoverflow.com/questions/50168647/multiprocessing-causes-python-to-crash-and-gives-an-error-may-have-been-in-progr, but if this is an error many users will run in to, it might make sense to have it in Django's documentation. 

I'm not sure if this occurs for all users of said OSX versions, so maybe the text needs more detail in that respect.