### PR TITLE
Fixed #25941 -- Improved error message for runtests.py when django is not on path.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -10,18 +10,24 @@ import sys
 import tempfile
 import warnings
 
-import django
-from django.apps import apps
-from django.conf import settings
-from django.db import connection, connections
-from django.test import TestCase, TransactionTestCase
-from django.test.runner import default_test_processes
-from django.test.selenium import SeleniumTestCaseBase
-from django.test.utils import get_runner
-from django.utils.deprecation import (
-    RemovedInDjango31Warning, RemovedInDjango40Warning,
-)
-from django.utils.log import DEFAULT_LOGGING
+try:
+    import django
+except ImportError as e:
+    raise RuntimeError(
+        'Django module not found, reference tests/README.rst for instructions.'
+    ) from e
+else:
+    from django.apps import apps
+    from django.conf import settings
+    from django.db import connection, connections
+    from django.test import TestCase, TransactionTestCase
+    from django.test.runner import default_test_processes
+    from django.test.selenium import SeleniumTestCaseBase
+    from django.test.utils import get_runner
+    from django.utils.deprecation import (
+        RemovedInDjango31Warning, RemovedInDjango40Warning,
+    )
+    from django.utils.log import DEFAULT_LOGGING
 
 try:
     import MySQLdb


### PR DESCRIPTION
Catches the ImportError in the runtest.py and outputs an
improved message. The message directs the user to the documentation.
The steps in the tests/README.rst solve the ImportError.

Ticket: https://code.djangoproject.com/ticket/25941