### PR TITLE
Fixed #30358 -- Removed redundant assertion in FormsUtilsTestCase.test_error_dict_copy().

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -485,6 +485,7 @@ answer newbie questions, and generally made Django that much better:
     knox <christobzr@gmail.com>
     konrad@gwu.edu
     Kowito Charoenratchatabhan <kowito@felspar.com>
+    Krišjānis Vaiders <krisjanisvaiders@gmail.com>
     krzysiek.pawlik@silvermedia.pl
     Krzysztof Jurewicz <krzysztof.jurewicz@gmail.com>
     Krzysztof Kulewski <kulewski@gmail.com>

--- a/tests/forms_tests/tests/test_utils.py
+++ b/tests/forms_tests/tests/test_utils.py
@@ -151,7 +151,6 @@ class FormsUtilsTestCase(SimpleTestCase):
 
         e_deepcopy = copy.deepcopy(e)
         self.assertEqual(e, e_deepcopy)
-        self.assertEqual(e.as_data(), e_copy.as_data())
 
     def test_error_dict_html_safe(self):
         e = ErrorDict()


### PR DESCRIPTION
Ticket [30358](https://code.djangoproject.com/ticket/30358)