### PR TITLE
Fixed #6785 -- Made QuerySet.get() fetch a limited number of rows.

### DIFF
--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import DEFAULT_DB_ALIAS, DatabaseError, connections, models
 from django.db.models.manager import BaseManager
-from django.db.models.query import EmptyQuerySet, QuerySet
+from django.db.models.query import MAX_GET_RESULTS, EmptyQuerySet, QuerySet
 from django.test import (
     SimpleTestCase, TestCase, TransactionTestCase, skipUnlessDBFeature,
 )
@@ -386,6 +386,26 @@ class ModelTest(TestCase):
             self.assertEqual(article.headline, 'foo')
         # Fields that weren't deleted aren't reloaded.
         self.assertEqual(article.pub_date, new_pub_date)
+
+    def test_multiple_objects_max_num_fetched(self):
+        max_results = MAX_GET_RESULTS - 1
+        Article.objects.bulk_create(
+            Article(headline='Area %s' % i, pub_date=datetime(2005, 7, 28))
+            for i in range(max_results)
+        )
+        self.assertRaisesMessage(
+            MultipleObjectsReturned,
+            'get() returned more than one Article -- it returned %d!' % max_results,
+            Article.objects.get,
+            headline__startswith='Area',
+        )
+        Article.objects.create(headline='Area %s' % max_results, pub_date=datetime(2005, 7, 28))
+        self.assertRaisesMessage(
+            MultipleObjectsReturned,
+            'get() returned more than one Article -- it returned more than %d!' % max_results,
+            Article.objects.get,
+            headline__startswith='Area',
+        )
 
 
 class ModelLookupTest(TestCase):


### PR DESCRIPTION
Fixes https://code.djangoproject.com/ticket/6785 by using the hints from Shai Berger and Anssi. Needs tests with an Oracle DB please.