### PR TITLE
Fixed #28604 -- Prevented ManifestStaticFilesStorage from leaving intermediate files.

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -55,6 +55,7 @@ class HashedFilesMixin:
             (r"""(@import\s*["']\s*(.*?)["'])""", """@import url("%s")"""),
         )),
     )
+    keep_intermediate_files = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -297,8 +298,9 @@ class HashedFilesMixin:
                         self.delete(hashed_name)
                     # then save the processed result
                     content_file = ContentFile(content.encode())
-                    # Save intermediate file for reference
-                    saved_name = self._save(hashed_name, content_file)
+                    if self.keep_intermediate_files:
+                        # Save intermediate file for reference
+                        self._save(hashed_name, content_file)
                     hashed_name = self.hashed_name(name, content_file)
 
                     if self.exists(hashed_name):
@@ -370,6 +372,7 @@ class ManifestFilesMixin(HashedFilesMixin):
     manifest_version = '1.0'  # the manifest format standard
     manifest_name = 'staticfiles.json'
     manifest_strict = True
+    keep_intermediate_files = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -445,6 +445,18 @@ class TestCollectionManifestStorage(TestHashedFiles, CollectionTestCase):
         # File exists on disk
         self.hashed_file_path(missing_file_name)
 
+    def test_intermediate_files(self):
+        cached_files = os.listdir(os.path.join(settings.STATIC_ROOT, 'cached'))
+        # Intermediate files shouldn't be created for reference.
+        self.assertEqual(
+            len([
+                cached_file
+                for cached_file in cached_files
+                if cached_file.startswith('relative.')
+            ]),
+            2,
+        )
+
 
 @override_settings(STATICFILES_STORAGE='staticfiles_tests.storage.SimpleStorage')
 class TestCollectionSimpleStorage(CollectionTestCase):


### PR DESCRIPTION
Added keep_intermediate_files flag in HashedFilesMixin to allow for
different behaviours in CachedStaticFilesStorage and
ManifestStaticFilesStorage.