### PR TITLE
Fixed #23521 -- Support changing model bases in migrations

### DIFF
--- a/django/db/migrations/operations/__init__.py
+++ b/django/db/migrations/operations/__init__.py
@@ -1,9 +1,9 @@
 from .fields import AddField, AlterField, RemoveField, RenameField
 from .models import (
-    AddConstraint, AddIndex, AlterIndexTogether, AlterModelManagers,
-    AlterModelOptions, AlterModelTable, AlterOrderWithRespectTo,
-    AlterUniqueTogether, CreateModel, DeleteModel, RemoveConstraint,
-    RemoveIndex, RenameModel,
+    AddConstraint, AddIndex, AlterIndexTogether, AlterModelBases,
+    AlterModelManagers, AlterModelOptions, AlterModelTable,
+    AlterOrderWithRespectTo, AlterUniqueTogether, CreateModel, DeleteModel,
+    RemoveConstraint, RemoveIndex, RenameModel,
 )
 from .special import RunPython, RunSQL, SeparateDatabaseAndState
 
@@ -11,7 +11,7 @@ __all__ = [
     'CreateModel', 'DeleteModel', 'AlterModelTable', 'AlterUniqueTogether',
     'RenameModel', 'AlterIndexTogether', 'AlterModelOptions', 'AddIndex',
     'RemoveIndex', 'AddField', 'RemoveField', 'AlterField', 'RenameField',
-    'AddConstraint', 'RemoveConstraint',
+    'AlterModelBases', 'AddConstraint', 'RemoveConstraint',
     'SeparateDatabaseAndState', 'RunSQL', 'RunPython',
     'AlterOrderWithRespectTo', 'AlterModelManagers',
 ]

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -483,6 +483,28 @@ class AlterModelTable(ModelOperation):
         return super().reduce(operation, app_label=app_label)
 
 
+class AlterModelBases(ModelOperation):
+    reduce_to_sql = False
+    reversible = True
+
+    def __init__(self, model_name, bases):
+        self.model_name = model_name
+        self.bases = bases
+
+    def state_forwards(self, app_label, state):
+        state.models[app_label, self.model_name].bases = self.bases
+        state.reload_model(app_label, self.model_name)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        pass
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        pass
+
+    def describe(self):
+        return "Update %s bases to %s" % (self.model_name, self.bases)
+
+
 class ModelOptionOperation(ModelOperation):
     def reduce(self, operation, app_label=None):
         if isinstance(operation, (self.__class__, DeleteModel)) and self.name_lower == operation.name_lower:

--- a/docs/howto/writing-migrations.txt
+++ b/docs/howto/writing-migrations.txt
@@ -326,3 +326,35 @@ If you want to change an unmanaged model (:attr:`managed=False
 ``managed=False`` and generate a migration before making other schema-related
 changes to the model, since schema changes that appear in the migration that
 contains the operation to change ``Meta.managed`` may not be applied.
+
+Disconnecting a subclass from a concrete parent model
+=====================================================
+
+If you have a model ``Parent`` and a subclass ``Child`` and you want to make
+the ``Child`` model independent you need to write a custom migration. The key
+parts are ``AlterModelBases`` to tell django what the new model hierarchy is
+and ``AlterField`` to convert the implicit ``OneToOneField`` into an implicit
+``AutoField`` primary key. The ``RenameField` is useful to avoid needing to add
+the ``parent_ptr`` field explicitly to the updated ``Child`` model.
+
+.. code-block:: python
+    :caption: myapp/migrations/0002_disconnect_parent.py
+
+    from django.db import migrations, models
+
+    class Migration(migrations.Migration):
+        dependencies = [('myapp', '0001_initial')]
+        operations = [
+            migrations.AlterModelBases('child', (models.Model,)),
+            migrations.AlterField(
+                model_name='child',
+                name='parent_ptr',
+                field=models.AutoField(
+                    auto_created=True,
+                    primary_key=True,
+                    serialize=False,
+                    verbose_name='ID',
+                ),
+            ),
+            migrations.RenameField('child', 'parent_ptr', 'id'),
+        ]

--- a/docs/ref/migration-operations.txt
+++ b/docs/ref/migration-operations.txt
@@ -132,6 +132,18 @@ should be a dictionary mapping option names to values.
 
 Alters the managers that are available during migrations.
 
+``AlterModelBases``
+-------------------
+
+.. class:: AlterModelBases(model_name, bases)
+
+.. versionadded:: 3.0
+
+Updates the list of concrete base models in the model's inheritance hierarchy.
+Abstract parent models should not be included.
+
+    AlterModelBases('child', (models.Model, Parent))
+
 ``AddField``
 ------------
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -171,7 +171,7 @@ Management Commands
 Migrations
 ~~~~~~~~~~
 
-* ...
+* Added migration operation :class:`~django.db.migrations.operations.AlterModelBases`.
 
 Models
 ~~~~~~

--- a/tests/migrations/subclass_migrations/0001_initial.py
+++ b/tests/migrations/subclass_migrations/0001_initial.py
@@ -1,0 +1,45 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='Parent',
+            fields=[
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                ('name', models.CharField(max_length=255)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Child',
+            fields=[
+                (
+                    'parent_ptr',
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to='migrations.Parent',
+                    ),
+                ),
+                ('age', models.IntegerField()),
+            ],
+            bases=('migrations.parent',),
+        ),
+    ]

--- a/tests/migrations/subclass_migrations/0002_data.py
+++ b/tests/migrations/subclass_migrations/0002_data.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+def insert_data(apps, schema_editor):
+    Child = apps.get_model('migrations', 'Child')
+    Child.objects.create(name='alpha', age=10)
+    Child.objects.create(name='bravo', age=20)
+    Child.objects.create(name='charlie', age=30)
+    Child.objects.create(name='delta', age=40)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('migrations', '0001_initial')]
+
+    operations = [migrations.RunPython(insert_data, migrations.RunPython.noop)]

--- a/tests/migrations/subclass_migrations/0003_base.py
+++ b/tests/migrations/subclass_migrations/0003_base.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('migrations', '0002_data')]
+
+    operations = [
+        migrations.AlterModelBases('child', (models.Model,)),
+        migrations.AlterField(
+            model_name='child',
+            name='parent_ptr',
+            field=models.AutoField(
+                auto_created=True,
+                primary_key=True,
+                serialize=False,
+                verbose_name='ID',
+            ),
+        ),
+        migrations.RenameField('child', 'parent_ptr', 'id'),
+    ]

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1375,6 +1375,25 @@ class OperationTests(OperationTestBase):
         self.assertTableExists(original_m2m_table)
         self.assertTableNotExists(new_m2m_table)
 
+    def test_alter_model_bases(self):
+        """
+        Tests the AlterModelBases operation.
+        """
+        project_state = self.set_up_test_model("test_almotb", mti_model=True)
+        # Test the state alteration
+        operation = migrations.AlterModelBases("shetlandpony", bases=(models.Model,))
+        self.assertEqual(operation.describe(), "Update shetlandpony bases to {}".format((models.Model,)))
+        new_state = project_state.clone()
+        operation.state_forwards("test_almotb", new_state)
+        self.assertEqual(new_state.models["test_almotb", "shetlandpony"].bases, (models.Model,))
+        # Test the database alteration
+        # And test reversal
+        # And deconstruction
+        definition = operation.deconstruct()
+        self.assertEqual(definition[0], "AlterModelBases")
+        self.assertEqual(definition[1], ('shetlandpony',))
+        self.assertEqual(definition[2], {'bases': (models.Model,)})
+
     def test_alter_field(self):
         """
         Tests the AlterField operation.

--- a/tests/migrations/test_subclassing.py
+++ b/tests/migrations/test_subclassing.py
@@ -1,0 +1,38 @@
+from django.core.management import call_command
+from django.db import connection
+from django.test import override_settings
+
+from .test_base import MigrationTestBase
+
+
+class TestDisconnectSubclass(MigrationTestBase):
+    @override_settings(MIGRATION_MODULES={'migrations': 'migrations.subclass_migrations'})
+    def test_migrate(self):
+        expected_data = ((1, 10), (2, 20), (3, 30), (4, 40))
+
+        # Test base state
+        call_command('migrate', 'migrations', '0002', verbosity=0)
+        self.assertFKExists('migrations_child', ['parent_ptr_id'], ('migrations_parent', 'id'))
+
+        with connection.cursor() as cursor:
+            cursor.execute('select parent_ptr_id, age from migrations_child')
+            data = cursor.fetchall()
+        self.assertSequenceEqual(data, expected_data)
+
+        # Test migrate forwards
+        call_command('migrate', 'migrations', '0003', verbosity=0)
+        self.assertFKNotExists('migrations_child', ['parent_ptr_id'], ('migrations_parent', 'id'))
+
+        with connection.cursor() as cursor:
+            cursor.execute('select id, age from migrations_child')
+            data = cursor.fetchall()
+        self.assertSequenceEqual(data, expected_data)
+
+        # Test migrate backwards
+        call_command('migrate', 'migrations', '0002', verbosity=0)
+        self.assertFKExists('migrations_child', ['parent_ptr_id'], ('migrations_parent', 'id'))
+
+        with connection.cursor() as cursor:
+            cursor.execute('select parent_ptr_id, age from migrations_child')
+            data = cursor.fetchall()
+        self.assertSequenceEqual(data, expected_data)


### PR DESCRIPTION
Also document how to use the new `AlterModelBases` operation to refactor a concrete model inheritance into a stand-alone model.

https://code.djangoproject.com/ticket/23521