### PR TITLE
Fixed #27910: Added a ChoiceEnum class for use in field choices

### DIFF
--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -7,6 +7,7 @@ from django.db.models.constraints import __all__ as constraints_all
 from django.db.models.deletion import (
     CASCADE, DO_NOTHING, PROTECT, SET, SET_DEFAULT, SET_NULL, ProtectedError,
 )
+from django.db.models.enums import ChoiceEnum, ChoiceIntEnum, ChoiceStrEnum
 from django.db.models.expressions import (
     Case, Exists, Expression, ExpressionList, ExpressionWrapper, F, Func,
     OuterRef, RowRange, Subquery, Value, ValueRange, When, Window, WindowFrame,
@@ -36,6 +37,7 @@ __all__ = aggregates_all + constraints_all + fields_all + indexes_all
 __all__ += [
     'ObjectDoesNotExist', 'signals',
     'CASCADE', 'DO_NOTHING', 'PROTECT', 'SET', 'SET_DEFAULT', 'SET_NULL',
+    'ChoiceEnum', 'ChoiceIntEnum', 'ChoiceStrEnum',
     'ProtectedError',
     'Case', 'Exists', 'Expression', 'ExpressionList', 'ExpressionWrapper', 'F',
     'Func', 'OuterRef', 'RowRange', 'Subquery', 'Value', 'ValueRange', 'When',

--- a/django/db/models/enums.py
+++ b/django/db/models/enums.py
@@ -1,0 +1,87 @@
+from enum import Enum, EnumMeta
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+__all__ = ['ChoiceEnum', 'ChoiceIntEnum', 'ChoiceStrEnum']
+
+
+class ChoiceEnumMeta(EnumMeta):
+    def __new__(metacls, classname, bases, classdict):
+        choices = {}
+        for key in classdict._member_names:
+            value = classdict[key]
+            if isinstance(value, (list, tuple)):
+                try:
+                    value, display = value
+                except ValueError as e:
+                    raise ValueError('Invalid ChoiceEnum member %r' % key) from e
+            else:
+                display = key.replace('_', ' ').title()
+            choices[value] = display
+            # Use dict.__setitem__() to suppress defenses against double
+            # assignment in enum's classdict.
+            dict.__setitem__(classdict, key, value)
+        cls = super().__new__(metacls, classname, bases, classdict)
+        cls._choices = choices
+        cls.choices = tuple(choices.items())
+        return cls
+
+
+class ChoiceEnum(Enum, metaclass=ChoiceEnumMeta):
+    """
+    A class suitable for using as an enum with translatable choices.
+
+    The typical use is similar to the stdlib's enums, with three
+    modifications:
+    * Instead of values in the enum, we use "(value, display)" tuples.
+      The "display" can be a lazy translatable string.
+    * We add a class method "choices()" which returns a value suitable
+      for use as "choices" in a Django field definition.
+    * We add a property "display" on enum values, to return the display
+      specified.
+
+    Thus, the definition of the Enum class can look like:
+
+    class YearInSchool(ChoiceStrEnum):
+        FRESHMAN = 'FR', _('Freshman')
+        SOPHOMORE = 'SO', _('Sophomore')
+        JUNIOR = 'JR', _('Junior')
+        SENIOR = 'SR', _('Senior')
+
+    or even
+
+    class Suit(ChoiceIntEnum):
+        DIAMOND = 1, _('Diamond')
+        SPADE   = 2, _('Spade')
+        HEART   = 3, _('Heart')
+        CLUB    = 4, _('Club')
+
+    A field could be defined as
+
+    class Card(models.Model):
+        suit = models.IntegerField(choices=Suit.choices)
+
+    Suit.HEART, Suit['HEART'] and Suit(3) work as expected, while
+    Suit.HEART.display is a pretty, translatable string.
+    """
+    @property
+    def display(self):
+        return self._choices[self]
+
+    @classmethod
+    def validate(cls, value, message=_('Invalid choice')):
+        try:
+            cls(value)
+        except ValueError:
+            raise ValidationError(message)
+
+
+class ChoiceIntEnum(int, ChoiceEnum):
+    """Class for creating an enum int choices."""
+    pass
+
+
+class ChoiceStrEnum(str, ChoiceEnum):
+    """Class for creating an enum string choices."""
+    pass

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -6,8 +6,6 @@ import operator
 import uuid
 import warnings
 from base64 import b64decode, b64encode
-from collections import OrderedDict
-from enum import Enum, EnumMeta
 from functools import partialmethod, total_ordering
 
 from django import forms
@@ -35,14 +33,13 @@ from django.utils.translation import gettext_lazy as _
 
 __all__ = [
     'AutoField', 'BLANK_CHOICE_DASH', 'BigAutoField', 'BigIntegerField',
-    'BinaryField', 'BooleanField', 'CharField', 'ChoiceEnum', 'ChoiceIntEnum',
-    'ChoiceStrEnum', 'CommaSeparatedIntegerField', 'DateField',
-    'DateTimeField', 'DecimalField', 'DurationField', 'EmailField', 'Empty',
-    'Field', 'FieldDoesNotExist', 'FilePathField', 'FloatField',
-    'GenericIPAddressField', 'IPAddressField', 'IntegerField', 'NOT_PROVIDED',
-    'NullBooleanField', 'PositiveIntegerField', 'PositiveSmallIntegerField',
-    'SlugField', 'SmallIntegerField', 'TextField', 'TimeField', 'URLField',
-    'UUIDField',
+    'BinaryField', 'BooleanField', 'CharField', 'CommaSeparatedIntegerField',
+    'DateField', 'DateTimeField', 'DecimalField', 'DurationField',
+    'EmailField', 'Empty', 'Field', 'FieldDoesNotExist', 'FilePathField',
+    'FloatField', 'GenericIPAddressField', 'IPAddressField', 'IntegerField',
+    'NOT_PROVIDED', 'NullBooleanField', 'PositiveIntegerField',
+    'PositiveSmallIntegerField', 'SlugField', 'SmallIntegerField', 'TextField',
+    'TimeField', 'URLField', 'UUIDField',
 ]
 
 
@@ -57,87 +54,6 @@ class NOT_PROVIDED:
 # The values to use for "blank" in SelectFields. Will be appended to the start
 # of most "choices" lists.
 BLANK_CHOICE_DASH = [("", "---------")]
-
-
-class ChoiceEnumMeta(EnumMeta):
-    def __new__(metacls, classname, bases, classdict):
-        choices = {}
-        for key in classdict._member_names:
-            value = classdict[key]
-            if isinstance(value, (list, tuple)):
-                try:
-                    value, display = value
-                except ValueError as e:
-                    raise ValueError('Invalid ChoiceEnum member %r' % key) from e
-            else:
-                display = key.replace('_', ' ').title()
-            choices[value] = display
-            # Use dict.__setitem__() to suppress defenses against double
-            # assignment in enum's classdict.
-            dict.__setitem__(classdict, key, value)
-        cls = super().__new__(metacls, classname, bases, classdict)
-        cls._choices = choices
-        cls.choices = tuple(choices.items())
-        return cls
-
-
-class ChoiceEnum(Enum, metaclass=ChoiceEnumMeta):
-    """
-    A class suitable for using as an enum with translatable choices.
-
-    The typical use is similar to the stdlib's enums, with three
-    modifications:
-    * Instead of values in the enum, we use "(value, display)" tuples.
-      The "display" can be a lazy translatable string.
-    * We add a class method "choices()" which returns a value suitable
-      for use as "choices" in a Django field definition.
-    * We add a property "display" on enum values, to return the display
-      specified.
-
-    Thus, the definition of the Enum class can look like:
-
-    class YearInSchool(ChoiceStrEnum):
-        FRESHMAN = 'FR', _('Freshman')
-        SOPHOMORE = 'SO', _('Sophomore')
-        JUNIOR = 'JR', _('Junior')
-        SENIOR = 'SR', _('Senior')
-
-    or even
-
-    class Suit(ChoiceIntEnum):
-        DIAMOND = 1, _('Diamond')
-        SPADE   = 2, _('Spade')
-        HEART   = 3, _('Heart')
-        CLUB    = 4, _('Club')
-
-    A field could be defined as
-
-    class Card(models.Model):
-        suit = models.IntegerField(choices=Suit.choices)
-
-    Suit.HEART, Suit['HEART'] and Suit(3) work as expected, while
-    Suit.HEART.display is a pretty, translatable string.
-    """
-    @property
-    def display(self):
-        return self._choices[self]
-
-    @classmethod
-    def validate(cls, value, message=_('Invalid choice')):
-        try:
-            cls(value)
-        except ValueError:
-            raise exceptions.ValidationError(message)
-
-
-class ChoiceIntEnum(int, ChoiceEnum):
-    """Class for creating an enum int choices."""
-    pass
-
-
-class ChoiceStrEnum(str, ChoiceEnum):
-    """Class for creating an enum string choices."""
-    pass
 
 
 def _load_field(app_label, model_name, field_name):

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -6,6 +6,8 @@ import operator
 import uuid
 import warnings
 from base64 import b64decode, b64encode
+from collections import OrderedDict
+from enum import Enum, EnumMeta
 from functools import partialmethod, total_ordering
 
 from django import forms
@@ -33,11 +35,11 @@ from django.utils.translation import gettext_lazy as _
 
 __all__ = [
     'AutoField', 'BLANK_CHOICE_DASH', 'BigAutoField', 'BigIntegerField',
-    'BinaryField', 'BooleanField', 'CharField', 'CommaSeparatedIntegerField',
-    'DateField', 'DateTimeField', 'DecimalField', 'DurationField',
-    'EmailField', 'Empty', 'Field', 'FieldDoesNotExist', 'FilePathField',
-    'FloatField', 'GenericIPAddressField', 'IPAddressField', 'IntegerField',
-    'NOT_PROVIDED', 'NullBooleanField', 'PositiveIntegerField',
+    'BinaryField', 'BooleanField', 'CharField', 'ChoiceEnum', 'ChoiceIntEnum',
+    'CommaSeparatedIntegerField', 'DateField', 'DateTimeField', 'DecimalField',
+    'DurationField', 'EmailField', 'Empty', 'Field', 'FieldDoesNotExist',
+    'FilePathField', 'FloatField', 'GenericIPAddressField', 'IPAddressField',
+    'IntegerField', 'NOT_PROVIDED', 'NullBooleanField', 'PositiveIntegerField',
     'PositiveSmallIntegerField', 'SlugField', 'SmallIntegerField', 'TextField',
     'TimeField', 'URLField', 'UUIDField',
 ]
@@ -54,6 +56,86 @@ class NOT_PROVIDED:
 # The values to use for "blank" in SelectFields. Will be appended to the start
 # of most "choices" lists.
 BLANK_CHOICE_DASH = [("", "---------")]
+
+
+class ChoiceEnumMeta(EnumMeta):
+    """A metaclass to support ChoiceEnum"""
+    def __new__(metacls, classname, bases, classdict):
+        choices = OrderedDict()
+        for key in classdict._member_names:
+
+            source_value = classdict[key]
+            if isinstance(source_value, (list, tuple)):
+                try:
+                    val, display = source_value
+                except ValueError:
+                    raise ValueError(f"Invalid ChoiceEnum member '{key}'")
+            else:
+                val = source_value
+                display = key.replace("_", " ").title()
+
+            choices[val] = display
+            # Use dict.__setitem__() to suppress defenses against
+            # double assignment in enum's classdict
+            dict.__setitem__(classdict, key, val)
+        cls = super().__new__(metacls, classname, bases, classdict)
+        cls._choices = choices
+        cls.choices = tuple(choices.items())
+        return cls
+
+
+class ChoiceEnum(Enum, metaclass=ChoiceEnumMeta):
+    """
+    A class suitable for using as an enum with translatable choices
+
+    The typical use is similar to the stdlib's enums, with three
+    modifications:
+    * Instead of values in the enum, we use "(value, display)" tuples.
+      The "display" can be a lazy translatable string.
+    * We add a class method "choices()" which returns a value suitable
+      for use as "choices" in a Django field definition.
+    * We add a property "display" on enum values, to return the display
+      specified.
+
+    Thus, the definition of the Enum class can look like:
+
+    class YearInSchool(ChoiceEnum):
+        FRESHMAN = 'FR', _('Freshman')
+        SOPHOMORE = 'SO', _('Sophomore')
+        JUNIOR = 'JR', _('Junior')
+        SENIOR = 'SR', _('Senior')
+
+    or even
+
+    class Suit(ChoiceIntEnum):
+        DIAMOND = 1, _('Diamond')
+        SPADE   = 2, _('Spade')
+        HEART   = 3, _('Heart')
+        CLUB    = 4, _('Club')
+
+    A field could be defined as
+
+    class Card(models.Model):
+        suit = models.IntegerField(choices=Suit.choices)
+
+    Suit.HEART, Suit['HEART'] and Suit(3) work as expected, while
+    Suit.HEART.display is a pretty, translatable string.
+    """
+    @property
+    def display(self):
+        return self._choices[self]
+
+    @classmethod
+    def validate(cls, value, message=_("Invalid choice")):
+        try:
+            cls(value)
+        except ValueError:
+            raise exceptions.ValidationError(message)
+
+
+class ChoiceIntEnum(int, ChoiceEnum):
+    """Included for symmetry with IntEnum"""
+    pass
 
 
 def _load_field(app_label, model_name, field_name):

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -100,9 +100,9 @@ Django provides a special Enum type you can subclass to define this iterable
 in a concise way::
 
     from django.db import models
-    from django.utils.translation import ugettext as _
+    from django.utils.translation import gettext_lazy as _
 
-    class YearInSchool(str, models.ChoiceEnum):
+    class YearInSchool(models.ChoiceStrEnum):
         FRESHMAN = 'FR', _('Freshman')
         SOPHOMORE = 'SO', _('Sophomore')
         JUNIOR = 'JR', _('Junior')

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -96,36 +96,42 @@ and the second element is the human-readable name. For example::
         ('SR', 'Senior'),
     ]
 
-Generally, it's best to define choices inside a model class, and to
-define a suitably-named constant for each value::
+Django provides a special Enum type you can subclass to define this iterable
+in a concise way::
 
     from django.db import models
+    from django.utils.translation import ugettext as _
+
+    class YearInSchool(str, models.ChoiceEnum):
+        FRESHMAN = 'FR', _('Freshman')
+        SOPHOMORE = 'SO', _('Sophomore')
+        JUNIOR = 'JR', _('Junior')
+        SENIOR = 'SR', _('Senior')
+
 
     class Student(models.Model):
+        year_in_school = models.CharField(
+            max_length=2,
+            choices=YearInSchool.choices,
+            default=YearInSchool.FRESHMAN,
+        )
+
+        def is_upperclass(self):
+            return self.year_in_school in (YearInSchool.JUNIOR, YearInSchool.SENIOR)
+
+If you do not need to have the human-readable names translated, you
+can have them inferred from the enum member name (replacing
+underscores to spaces and using title-case)::
+
+    class YearInSchool(str, models.ChoiceEnum):
         FRESHMAN = 'FR'
         SOPHOMORE = 'SO'
         JUNIOR = 'JR'
         SENIOR = 'SR'
-        YEAR_IN_SCHOOL_CHOICES = [
-            (FRESHMAN, 'Freshman'),
-            (SOPHOMORE, 'Sophomore'),
-            (JUNIOR, 'Junior'),
-            (SENIOR, 'Senior'),
-        ]
-        year_in_school = models.CharField(
-            max_length=2,
-            choices=YEAR_IN_SCHOOL_CHOICES,
-            default=FRESHMAN,
-        )
 
-        def is_upperclass(self):
-            return self.year_in_school in (self.JUNIOR, self.SENIOR)
-
-Though you can define a choices list outside of a model class and then
-refer to it, defining the choices and names for each choice inside the
-model class keeps all of that information with the class that uses it,
-and makes the choices easy to reference (e.g, ``Student.SOPHOMORE``
-will work anywhere that the ``Student`` model has been imported).
+Since the case where the enum values need to be integers is extremely
+common, Django provides a ``ChoiceIntEnum`` class (inheriting int and
+``ChoiceEnum``).
 
 You can also collect your available choices into named groups that can
 be used for organizational purposes::
@@ -170,6 +176,11 @@ with the select box. To override this behavior, add a tuple to ``choices``
 containing ``None``; e.g. ``(None, 'Your String For Display')``.
 Alternatively, you can use an empty string instead of ``None`` where this makes
 sense - such as on a :class:`~django.db.models.CharField`.
+
+.. versionadded: 3.0
+
+   The ``ChoiceEnum`` and ``ChoiceIntEnum`` classes were added in Django 3.0.
+
 
 ``db_column``
 -------------

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -263,6 +263,9 @@ Models
 * Allowed symmetrical intermediate table for self-referential
   :class:`~django.db.models.ManyToManyField`.
 
+* Added the ``ChoiceEnum`` and ``ChoiceIntEnum`` helpers for defining field
+  :attr:`~django.db.models.Field.choices`.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -193,6 +193,7 @@ elidable
 encodings
 Endian
 Enero
+Enum
 environ
 esque
 Ess

--- a/tests/model_fields/test_charfield.py
+++ b/tests/model_fields/test_charfield.py
@@ -29,7 +29,7 @@ class TestCharField(TestCase):
         self.assertEqual(p.title, 'Smile 😀')
 
     def test_assignment_from_choice_enum(self):
-        class Choices(str, models.ChoiceEnum):
+        class Choices(models.ChoiceStrEnum):
             C = 'Carnival!'
             F = 'Festival!'
         p = Post.objects.create(title=Choices.C, body=Choices.F)
@@ -39,7 +39,7 @@ class TestCharField(TestCase):
 
 class ValidationTests(SimpleTestCase):
 
-    class CharChoices(str, models.ChoiceEnum):
+    class CharChoices(models.ChoiceStrEnum):
         C = 'c', 'C'
         D = 'd'
 

--- a/tests/model_fields/test_choiceenum.py
+++ b/tests/model_fields/test_choiceenum.py
@@ -29,7 +29,7 @@ class TestChoiceEnumDefinition(SimpleTestCase):
 
     def test_simple_definition_str(self):
 
-        class MyEnum(str, models.ChoiceEnum):
+        class MyEnum(models.ChoiceStrEnum):
             ONE = '1', 'One'
             TWO = '2', 'Two'
 
@@ -38,7 +38,7 @@ class TestChoiceEnumDefinition(SimpleTestCase):
         self.assertSequenceEqual(MyEnum.choices, [('1', 'One'), ('2', 'Two')])
 
     def test_simple_definition_str_default_display(self):
-        class MyEnum(str, models.ChoiceEnum):
+        class MyEnum(models.ChoiceStrEnum):
             ONE = '1', 'One'
             ONE_PLUS_ONE = '2'
             THREE = '3'
@@ -59,7 +59,7 @@ class TestChoiceEnumValidation(SimpleTestCase):
         ONE = 1, 'One'
         TWO = 2, 'Two'
 
-    class StrEnum(str, models.ChoiceEnum):
+    class StrEnum(models.ChoiceStrEnum):
         ONE = '1', 'One'
         ONE_PLUS_ONE = '2'
         THREE = '3'
@@ -83,7 +83,7 @@ class TestChoiceEnumValidation(SimpleTestCase):
 
 class TestStrChoiceEnumInDatabase(TestCase):
 
-    class StrEnum(str, models.ChoiceEnum):
+    class StrEnum(models.ChoiceStrEnum):
         ONE = '1', 'One'
         ONE_PLUS_ONE = '2'
         THREE = '3'

--- a/tests/model_fields/test_choiceenum.py
+++ b/tests/model_fields/test_choiceenum.py
@@ -1,0 +1,79 @@
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.test import SimpleTestCase
+
+
+class TestChoiceEnumDefinition(SimpleTestCase):
+
+    def test_simple_definition_int(self):
+
+        class MyEnum(models.ChoiceIntEnum):
+            ONE = 1, 'One'
+            TWO = 2, 'Two'
+
+        self.assertEqual(MyEnum.ONE, 1)
+        self.assertEqual(MyEnum.TWO.display, 'Two')
+        self.assertSequenceEqual(MyEnum.choices, [(1, 'One'), (2, 'Two')])
+
+    def test_simple_definition_int_default_display(self):
+        class MyEnum(models.ChoiceIntEnum):
+            ONE = 1, 'One'
+            ONE_PLUS_ONE = 2
+            THREE = 3
+
+        self.assertEqual(MyEnum.ONE.display, 'One')
+        self.assertEqual(MyEnum.ONE_PLUS_ONE.display, 'One Plus One')
+        self.assertSequenceEqual(MyEnum.choices, [(1, 'One'), (2, 'One Plus One'), (3, 'Three')])
+
+    def test_simple_definition_str(self):
+
+        class MyEnum(str, models.ChoiceEnum):
+            ONE = '1', 'One'
+            TWO = '2', 'Two'
+
+        self.assertEqual(MyEnum.ONE, '1')
+        self.assertEqual(MyEnum.TWO.display, 'Two')
+        self.assertSequenceEqual(MyEnum.choices, [('1', 'One'), ('2', 'Two')])
+
+    def test_simple_definition_str_default_display(self):
+        class MyEnum(str, models.ChoiceEnum):
+            ONE = '1', 'One'
+            ONE_PLUS_ONE = '2'
+            THREE = '3'
+
+        self.assertEqual(MyEnum.ONE.display, 'One')
+        self.assertEqual(MyEnum.ONE_PLUS_ONE.display, 'One Plus One')
+        self.assertSequenceEqual(MyEnum.choices, [('1', 'One'), ('2', 'One Plus One'), ('3', 'Three')])
+
+    def test_invalid_definition(self):
+        with self.assertRaisesRegex(ValueError, '.*[Ii]nvalid.*ONE.*'):
+            class MyEnum(models.ChoiceIntEnum):
+                ONE = 1, 'One', 'One too many'
+
+
+class TestChoiceEnumValidation(SimpleTestCase):
+
+    class IntEnum(models.ChoiceIntEnum):
+        ONE = 1, 'One'
+        TWO = 2, 'Two'
+
+    class StrEnum(str, models.ChoiceEnum):
+        ONE = '1', 'One'
+        ONE_PLUS_ONE = '2'
+        THREE = '3'
+
+    def test_validates_valid_value(self):
+        self.IntEnum.validate(1)
+        self.StrEnum.validate('2')
+
+    def test_invalidates_correctly_typed_value(self):
+        with self.assertRaises(ValidationError):
+            self.IntEnum.validate(7)
+        with self.assertRaises(ValidationError):
+            self.StrEnum.validate('monster')
+
+    def test_invalidates_incorrectly_typed_value(self):
+        with self.assertRaises(ValidationError):
+            self.IntEnum.validate('not int')
+        with self.assertRaises(ValidationError):
+            self.StrEnum.validate(b'2')

--- a/tests/model_fields/test_choiceenum.py
+++ b/tests/model_fields/test_choiceenum.py
@@ -95,7 +95,7 @@ class TestStrChoiceEnumInDatabase(TestCase):
         self.assertEquals(foo.a, '1')
 
     def test_value_query(self):
-        foo = Foo.objects.create(a=self.StrEnum.ONE_PLUS_ONE, d=2.0)
+        Foo.objects.create(a=self.StrEnum.ONE_PLUS_ONE, d=2.0)
         bar = Foo.objects.get(a=self.StrEnum.ONE_PLUS_ONE)
         self.assertEquals(bar.a, self.StrEnum.ONE_PLUS_ONE)
         self.assertEquals(bar.a, '2')

--- a/tests/model_fields/test_integerfield.py
+++ b/tests/model_fields/test_integerfield.py
@@ -167,6 +167,9 @@ class PositiveIntegerFieldTests(IntegerFieldTests):
 
 class ValidationTests(SimpleTestCase):
 
+    class Choices(models.ChoiceIntEnum):
+        A = 1
+
     def test_integerfield_cleans_valid_string(self):
         f = models.IntegerField()
         self.assertEqual(f.clean('2', None), 2)
@@ -200,3 +203,14 @@ class ValidationTests(SimpleTestCase):
         f = models.IntegerField(choices=((1, 1),))
         with self.assertRaises(ValidationError):
             f.clean('0', None)
+
+    def test_integerfield_with_choices_cleans_valid_choice_from_enum(self):
+        f = models.IntegerField(choices=self.Choices.choices)
+        self.assertEqual(1, f.clean('1', None))
+
+    def test_charfield_with_choices_raises_error_on_invalid_choice_from_enum(self):
+        f = models.IntegerField(choices=self.Choices.choices)
+        with self.assertRaises(ValidationError):
+            f.clean('A', None)
+        with self.assertRaises(ValidationError):
+            f.clean('3', None)


### PR DESCRIPTION
The class can serve as a base class for user enums, supporting
translatable human-readable names, or names automatically inferred
from the enum member name.

A ChoiceIntEnum is also probided.