### PR TITLE
Fixed #26803 -- Added --stats-only argument to makemessages

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -733,6 +733,12 @@ Prevents deleting the temporary ``.pot`` files generated before creating the
 ``.po`` file. This is useful for debugging errors which may prevent the final
 language files from being created.
 
+.. django-admin-option:: --stats-only
+
+Writes ``.po`` files to a temporary directory, so that ``.po`` files in default
+directories are not overwritten, and outputs translation statistics as returned
+by GNU gettext ``msgfmt`` command. The output is localized as per system locale.
+
 .. seealso::
 
     See :ref:`customizing-makemessages` for instructions on how to customize


### PR DESCRIPTION
Implemented a statistics option for `makemessages`, as per suggestion from @claudep:
https://code.djangoproject.com/ticket/26803#comment:3

It's a DRAFT pull-request, the progress is as follows:

- [x] implementation;
- [ ] exit code requirement implementation (https://code.djangoproject.com/ticket/26803#comment:4);
- [ ] tests;
- [x] docs;
- [ ] changelog.

The exit code thingie seems to be somewhat complex to implement properly, given that `msgfmt` output is localised as per system locale, and it seems there's not much that can be done but hackishly parsing the string (see http://git.savannah.gnu.org/cgit/gettext.git/tree/gettext-tools/src/msgfmt.c#n875).

This possibly can be worked around by explicitly invoking `msgfmt` with a known locale, and parsing the output, but this still makes this all too fragile, prone to break each time GNU gettext is updated.