### PR TITLE
Fixed #30366 -- Skipped StatReloaderTests on HFS+ filesystems.

### DIFF
--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -11,13 +11,15 @@ import weakref
 import zipfile
 from importlib import import_module
 from pathlib import Path
-from unittest import mock, skip
+from unittest import mock, skip, skipIf
 
 from django.apps.registry import Apps
 from django.test import SimpleTestCase
 from django.test.utils import extend_sys_path
 from django.utils import autoreload
 from django.utils.autoreload import WatchmanUnavailable
+
+from .utils import on_macos_with_hfs
 
 
 class TestIterModulesAndFiles(SimpleTestCase):
@@ -637,6 +639,7 @@ class WatchmanReloaderTests(ReloaderTests, IntegrationTests):
                 self.assertIsInstance(mocked_server_status.call_args[0][0], TestException)
 
 
+@skipIf(on_macos_with_hfs(), "These tests do not work with HFS+ as a filesystem")
 class StatReloaderTests(ReloaderTests, IntegrationTests):
     RELOADER_CLS = autoreload.StatReloader
 

--- a/tests/utils_tests/utils.py
+++ b/tests/utils_tests/utils.py
@@ -1,0 +1,14 @@
+import platform
+
+
+def on_macos_with_hfs():
+    """
+    MacOS 10.13 (High Sierra) and lower can use HFS+ as a filesystem.
+    HFS+ has a time resolution of only one second which can be too low for
+    some of the tests.
+    """
+    macos_version = platform.mac_ver()[0]
+    if macos_version != '':
+        parsed_macos_version = tuple(int(x) for x in macos_version.split('.'))
+        return parsed_macos_version < (10, 14)
+    return False


### PR DESCRIPTION
When on OSX Sierra or below (<=10.12 which uses HFS+) we should not adjust the reloader.SLEEP_TIME to less than 1 second.

This fixes issue https://code.djangoproject.com/ticket/30366