### PR TITLE
#25633: Updated Spatialite installation instructions for MacOS

### DIFF
--- a/docs/ref/contrib/gis/install/spatialite.txt
+++ b/docs/ref/contrib/gis/install/spatialite.txt
@@ -97,12 +97,12 @@ First, follow the instructions in the :ref:`kyngchaos` section.
 
 When creating a SpatiaLite database, the ``spatialite`` program is required.
 However, instead of attempting to compile the SpatiaLite tools from source,
-download the `SpatiaLite Binaries`__ for macOS, and install ``spatialite`` in a
-location available in your ``PATH``.  For example::
+download the `SpatiaLite Tools`__ package for macOS, and install ``spatialite``
+in a location available in your ``PATH``.  For example::
 
-    $ curl -O https://www.gaia-gis.it/spatialite/spatialite-tools-osx-x86-2.3.1.tar.gz
-    $ tar xzf spatialite-tools-osx-x86-2.3.1.tar.gz
-    $ cd spatialite-tools-osx-x86-2.3.1/bin
+    $ curl -O https://www.kyngchaos.com/files/software/frameworks/Spatialite_Tools-4.3.zip
+    $ unzip Spatialite_Tools-4.3.zip
+    $ cd Spatialite\ Tools/tools
     $ sudo cp spatialite /Library/Frameworks/SQLite3.framework/Programs
 
 Finally, for GeoDjango to be able to find the KyngChaos SpatiaLite library,
@@ -110,7 +110,7 @@ add the following to your ``settings.py``::
 
     SPATIALITE_LIBRARY_PATH='/Library/Frameworks/SQLite3.framework/SQLite3'
 
-__ https://www.gaia-gis.it/spatialite-2.3.1/binaries.html
+__ https://www.kyngchaos.com/software/frameworks/
 
 Homebrew
 --------


### PR DESCRIPTION
Using the latest available version from KyngChaos, as Gaia-SINS does not provide MacOS binaries anymore.