### PR TITLE
Fixed #30368 -- Fixed prefetch_related() for GenericForeignKey when i…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -880,6 +880,7 @@ answer newbie questions, and generally made Django that much better:
     Vinay Karanam <https://github.com/vinayinvicible>
     Vinay Sajip <vinay_sajip@yahoo.co.uk>
     Vincent Foley <vfoleybourgon@yahoo.ca>
+    Vinny Do <vdo.code@gmail.com>
     Vitaly Babiy <vbabiy86@gmail.com>
     Vladimir Kuzma <vladimirkuzma.ch@gmail.com>
     Vlado <vlado@labath.org>

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -939,6 +939,9 @@ class ForeignKey(ForeignObject):
     def get_db_prep_value(self, value, connection, prepared=False):
         return self.target_field.get_db_prep_value(value, connection, prepared)
 
+    def get_prep_value(self, value):
+        return self.target_field.get_prep_value(value)
+
     def contribute_to_related_class(self, cls, related):
         super().contribute_to_related_class(cls, related)
         if self.remote_field.field_name is None:

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -964,6 +964,16 @@ class GenericRelationTests(TestCase):
         # instance returned by the manager.
         self.assertEqual(list(bookmark.tags.all()), list(bookmark.tags.all().all()))
 
+    def test_foreign_key_GFK(self):
+        book = Book.objects.create(title="Poems")
+        book_with_year = BookWithYear.objects.create(book=book, published_year=2019)
+        Comment.objects.create(comment="awesome", content_object=book_with_year)
+
+        with self.assertNumQueries(2):
+            qs = Comment.objects.prefetch_related("content_object")
+            for c in qs:
+                self.assertIsNotNone(c.content_object)
+
 
 class MultiTableInheritanceTest(TestCase):
 


### PR DESCRIPTION
…ts PK is also a foreign key.