### PR TITLE
Fixed #30342 -- Removed a system check for LANGUAGES_BIDI setting.

### DIFF
--- a/django/core/checks/translation.py
+++ b/django/core/checks/translation.py
@@ -24,12 +24,6 @@ E004 = Error(
     id='translation.E004',
 )
 
-E005 = Error(
-    'You have provided values in the LANGUAGES_BIDI setting that are not in '
-    'the LANGUAGES setting.',
-    id='translation.E005',
-)
-
 
 @register(Tags.translation)
 def check_setting_language_code(app_configs, **kwargs):
@@ -62,9 +56,6 @@ def check_setting_languages_bidi(app_configs, **kwargs):
 def check_language_settings_consistent(app_configs, **kwargs):
     """Error if language settings are not consistent with each other."""
     available_tags = {i for i, _ in settings.LANGUAGES} | {'en-us'}
-    messages = []
     if settings.LANGUAGE_CODE not in available_tags:
-        messages.append(E004)
-    if not available_tags.issuperset(settings.LANGUAGES_BIDI):
-        messages.append(E005)
-    return messages
+        return [E004]
+    return []

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -448,9 +448,6 @@ The following checks are performed on your translation configuration:
 * **translation.E004**: You have provided a value for the
   :setting:`LANGUAGE_CODE` setting that is not in the :setting:`LANGUAGES`
   setting.
-* **translation.E005**: You have provided values in the
-  :setting:`LANGUAGES_BIDI` setting that are not in the :setting:`LANGUAGES`
-  setting.
 
 URLs
 ----

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1879,15 +1879,17 @@ Here's a sample settings file::
 ``LANGUAGES_BIDI``
 ------------------
 
-Default: A list of all language codes from the :setting:`LANGUAGES` setting
-that are written right-to-left. You can see the current list of these languages
-by looking in :source:`django/conf/global_settings.py`.
+Default: A list of all language codes that are written right-to-left. You can
+see the current list of these languages by looking in
+:source:`django/conf/global_settings.py`.
 
 The list contains :term:`language codes<language code>` for languages that are
 written right-to-left.
 
 Generally, the default value should suffice. Only set this setting if you want
 to restrict language selection to a subset of the Django-provided languages.
+If you define a custom :setting:`LANGUAGES` setting, the list of bidirectional
+languages may contain language codes which are not enabled on a given site.
 
 .. setting:: LOCALE_PATHS
 

--- a/tests/check_framework/test_translation.py
+++ b/tests/check_framework/test_translation.py
@@ -80,15 +80,7 @@ class TranslationCheckTests(SimpleTestCase):
             'You have provided a value for the LANGUAGE_CODE setting that is '
             'not in the LANGUAGES setting.'
         )
-        with self.settings(LANGUAGE_CODE='fr', LANGUAGES=[('en', 'English')], LANGUAGES_BIDI=[]):
+        with self.settings(LANGUAGE_CODE='fr', LANGUAGES=[('en', 'English')]):
             self.assertEqual(check_language_settings_consistent(None), [
                 Error(msg, id='translation.E004'),
-            ])
-        msg = (
-            'You have provided values in the LANGUAGES_BIDI setting that are '
-            'not in the LANGUAGES setting.'
-        )
-        with self.settings(LANGUAGE_CODE='en', LANGUAGES=[('en', 'English')], LANGUAGES_BIDI=['he']):
-            self.assertEqual(check_language_settings_consistent(None), [
-                Error(msg, id='translation.E005'),
             ])


### PR DESCRIPTION
Alternative proposal to #11190 

For reviewers: This check was never part of a released version of Django. It only exists on current master and is part of what will become Django 3.0, so removing this only reinstates the behavior as it was for the last >10 years.