### PR TITLE
Fixed #26678 -- Doc'd that RelatedManager.add()/remove()/set() accepts the field the relation points to.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -1148,7 +1148,8 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
         def _remove_items(self, source_field_name, target_field_name, *objs):
             # source_field_name: the PK colname in join table for the source object
             # target_field_name: the PK colname in join table for the target object
-            # *objs - objects to remove
+            # *objs - objects to remove. Either object instances, or primary
+            # keys of object instances.
             if not objs:
                 return
 

--- a/docs/ref/models/relations.txt
+++ b/docs/ref/models/relations.txt
@@ -66,6 +66,9 @@ Related objects reference
         Using ``add()`` on a relation that already exists won't duplicate the
         relation, but it will still trigger signals.
 
+        ``add()`` also accepts the field the relation points to as an argument.
+        The above example can be rewritten as ``b.entry_set.add(234)``.
+
         Use the ``through_defaults`` argument to specify values for the new
         :ref:`intermediate model <intermediary-manytomany>` instance(s), if
         needed.
@@ -128,6 +131,10 @@ Related objects reference
         :data:`~django.db.models.signals.m2m_changed` signal if you wish to
         execute custom code when a relationship is deleted.
 
+        Similarly to :meth:`add()`, ``remove()`` also accepts the field the
+        relation points to as an argument. The above example can be rewritten
+        as ``b.entry_set.remove(234)``.
+
         For :class:`~django.db.models.ForeignKey` objects, this method only
         exists if ``null=True``. If the related field can't be set to ``None``
         (``NULL``), then an object can't be removed from a relation without
@@ -187,6 +194,10 @@ Related objects reference
         Note that since ``set()`` is a compound operation, it is subject to
         race conditions. For instance, new objects may be added to the database
         in between the call to ``clear()`` and the call to ``add()``.
+
+        Similarly to :meth:`add()`, ``set()`` also accepts the field the
+        relation points to as an argument. The above example can be rewritten
+        as ``e.related_set.set([obj1.pk, obj2.pk, obj3.pk])``.
 
         Use the ``through_defaults`` argument to specify values for the new
         :ref:`intermediate model <intermediary-manytomany>` instance(s), if

--- a/tests/many_to_many/models.py
+++ b/tests/many_to_many/models.py
@@ -38,6 +38,7 @@ class Article(models.Model):
     # correctly created. Refs #20207
     publications = models.ManyToManyField(Publication, name='publications')
     tags = models.ManyToManyField(Tag, related_name='tags')
+    authors = models.ManyToManyField('User', through='UserArticle')
 
     objects = NoDeletedArticleManager()
 
@@ -46,6 +47,18 @@ class Article(models.Model):
 
     def __str__(self):
         return self.headline
+
+
+class User(models.Model):
+    username = models.CharField(max_length=20, unique=True)
+
+    def __str__(self):
+        return self.username
+
+
+class UserArticle(models.Model):
+    user = models.ForeignKey(User, models.CASCADE, to_field='username')
+    article = models.ForeignKey(Article, models.CASCADE)
 
 
 # Models to test correct related_name inheritance

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -3,7 +3,9 @@ from unittest import mock
 from django.db import transaction
 from django.test import TestCase, skipUnlessDBFeature
 
-from .models import Article, InheritedArticleA, InheritedArticleB, Publication
+from .models import (
+    Article, InheritedArticleA, InheritedArticleB, Publication, User,
+)
 
 
 class ManyToManyTests(TestCase):
@@ -75,6 +77,32 @@ class ManyToManyTests(TestCase):
                 '<Publication: The Python Journal>',
             ]
         )
+
+    def test_add_remove_set_by_pk(self):
+        a5 = Article.objects.create(headline='Django lets you create Web apps easily')
+        a5.publications.add(self.p1.pk)
+        self.assertQuerysetEqual(
+            a5.publications.all(),
+            ['<Publication: The Python Journal>'],
+        )
+        a5.publications.set([self.p2.pk])
+        self.assertQuerysetEqual(
+            a5.publications.all(),
+            ['<Publication: Science News>'],
+        )
+        a5.publications.remove(self.p2.pk)
+        self.assertQuerysetEqual(a5.publications.all(), [])
+
+    def test_add_remove_set_by_to_field(self):
+        user_1 = User.objects.create(username='Jean')
+        user_2 = User.objects.create(username='Joe')
+        a5 = Article.objects.create(headline='Django lets you create Web apps easily')
+        a5.authors.add(user_1.username)
+        self.assertQuerysetEqual(a5.authors.all(), ['<User: Jean>'])
+        a5.authors.set([user_2.username])
+        self.assertQuerysetEqual(a5.authors.all(), ['<User: Joe>'])
+        a5.authors.remove(user_2.username)
+        self.assertQuerysetEqual(a5.authors.all(), [])
 
     def test_reverse_add(self):
         # Adding via the 'other' end of an m2m


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26678