### PR TITLE
[1.11.x] Refs #30375 -- Add NO KEY option for Postgres select_for_update

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -182,7 +182,7 @@ class BaseDatabaseOperations(object):
         """
         return []
 
-    def for_update_sql(self, nowait=False, skip_locked=False):
+    def for_update_sql(self, nowait=False, skip_locked=False, no_key=False):
         """
         Returns the FOR UPDATE SQL clause to lock rows for an update operation.
         """

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -270,3 +270,13 @@ class DatabaseOperations(BaseDatabaseOperations):
             "Add 'django.contrib.postgres' to settings.INSTALLED_APPS to use "
             "the search operator."
         )
+
+    def for_update_sql(self, nowait=False, skip_locked=False, no_key=False):
+        """
+        Return the FOR UPDATE SQL clause to lock rows for an update operation.
+        """
+        return 'FOR%s UPDATE%s%s' % (
+            ' NO KEY' if no_key else '',
+            ' NOWAIT' if nowait else '',
+            ' SKIP LOCKED' if skip_locked else '',
+        )

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -862,7 +862,7 @@ class QuerySet(object):
             return self
         return self._combinator_query('difference', *other_qs)
 
-    def select_for_update(self, nowait=False, skip_locked=False):
+    def select_for_update(self, nowait=False, skip_locked=False, no_key=False):
         """
         Returns a new QuerySet instance that will select objects with a
         FOR UPDATE lock.
@@ -874,6 +874,7 @@ class QuerySet(object):
         obj.query.select_for_update = True
         obj.query.select_for_update_nowait = nowait
         obj.query.select_for_update_skip_locked = skip_locked
+        obj.query.select_for_no_key_update = no_key
         return obj
 
     def select_related(self, *fields):

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -469,6 +469,7 @@ class SQLCompiler(object):
 
                     nowait = self.query.select_for_update_nowait
                     skip_locked = self.query.select_for_update_skip_locked
+                    no_key = self.query.select_for_no_key_update
                     # If it's a NOWAIT/SKIP LOCKED query but the backend
                     # doesn't support it, raise a DatabaseError to prevent a
                     # possible deadlock.
@@ -476,7 +477,7 @@ class SQLCompiler(object):
                         raise DatabaseError('NOWAIT is not supported on this database backend.')
                     elif skip_locked and not self.connection.features.has_select_for_update_skip_locked:
                         raise DatabaseError('SKIP LOCKED is not supported on this database backend.')
-                    for_update_part = self.connection.ops.for_update_sql(nowait=nowait, skip_locked=skip_locked)
+                    for_update_part = self.connection.ops.for_update_sql(nowait=nowait, skip_locked=skip_locked, no_key=no_key)
 
                 if for_update_part and self.connection.features.for_update_after_from:
                     result.append(for_update_part)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -170,6 +170,7 @@ class Query(object):
         self.select_for_update = False
         self.select_for_update_nowait = False
         self.select_for_update_skip_locked = False
+        self.select_for_no_key_update = False
 
         self.select_related = False
         # Arbitrary limit for select_related to prevents infinite recursion.
@@ -295,6 +296,7 @@ class Query(object):
         obj.select_for_update = self.select_for_update
         obj.select_for_update_nowait = self.select_for_update_nowait
         obj.select_for_update_skip_locked = self.select_for_update_skip_locked
+        obj.select_for_no_key_update = self.select_for_no_key_update
         obj.select_related = self.select_related
         obj.values_select = self.values_select[:]
         obj._annotations = self._annotations.copy() if self._annotations is not None else None


### PR DESCRIPTION
Added a no_key paremeter to select_for_update which makes SQL to compile as "[...] FOR NO KEY UPDATE". This reduces lock contention in Postgres when applying DML in rows referencing (via foreign key) a FOR UPDATE locked row.