### PR TITLE
"default User model" instead of "default user"

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -29,7 +29,7 @@ exists in Django's authentication framework, i.e., :attr:`'superusers'
 <django.contrib.auth.models.User.is_staff>` users are just user objects with
 special attributes set, not different classes of user objects.
 
-The primary attributes of the default user are:
+The primary attributes of the default :class:`~models.User` model are:
 
 * :attr:`~django.contrib.auth.models.User.username`
 * :attr:`~django.contrib.auth.models.User.password`


### PR DESCRIPTION
"default user" can be misunderstood as a default user _instance_.