### PR TITLE
Refs #28767 -- Added test for annotating Value() with empty list as an ArrayField.

### DIFF
--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -149,6 +149,14 @@ class TestQuerying(PostgreSQLTestCase):
             NullableIntegerArrayModel(field=None),
         ])
 
+    def test_empty_list(self):
+        NullableIntegerArrayModel.objects.create(field=[])
+        obj = NullableIntegerArrayModel.objects.annotate(
+            empty_array=models.Value([], output_field=ArrayField(models.IntegerField())),
+        ).filter(field=models.F('empty_array')).get()
+        self.assertEqual(obj.field, [])
+        self.assertEqual(obj.empty_array, [])
+
     def test_exact(self):
         self.assertSequenceEqual(
             NullableIntegerArrayModel.objects.filter(field__exact=[1]),


### PR DESCRIPTION
Fixed in 3af695eda24b874486ee8be7e0d729761b3bdc71.

Ticket [28767](https://code.djangoproject.com/ticket/28767).