### PR TITLE
Fixed #30385 -- Restored SearchVector(config) immutability.

### DIFF
--- a/docs/releases/2.2.1.txt
+++ b/docs/releases/2.2.1.txt
@@ -42,3 +42,7 @@ Bugfixes
 * Fixed a regression in Django 2.2 where ``IntegerField`` validation of
   database limits crashes if ``limit_value`` attribute in a custom validator is
   callable (:ticket:`30328`).
+
+* Fixed a regression in Django 2.2 where
+  :class:`~django.contrib.postgres.search.SearchVector` generates SQL that is
+  not indexable (:ticket:`30385`).


### PR DESCRIPTION
The usage of `CONCAT` introduced in 1a28dc to allow `SearchVector` to deal with non-text fields made the generated expression non-`IMMUTABLE` which prevents a functional index to be created for it.

Using a combination of `COALESCE` and `::text` makes sure the expression preserves its immutability.

Refs #29582.