### PR TITLE
Fix old-style super call

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -295,7 +295,7 @@ class FloatField(IntegerField):
         Validate that float() can be called on the input. Return the result
         of float() or None for empty values.
         """
-        value = super(IntegerField, self).to_python(value)
+        value = super().to_python(value)
         if value in self.empty_values:
             return None
         if self.localize:


### PR DESCRIPTION
Looks like this was missed  by #7905 when switching code to `super()`.