### PR TITLE
Extended watchman timeout for slower computers

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -370,7 +370,7 @@ class WatchmanReloader(BaseReloader):
 
     @cached_property
     def client(self):
-        return pywatchman.client()
+        return pywatchman.client(timeout=5.0)
 
     def _watch_root(self, root):
         # In practice this shouldn't occur, however, it's possible that a


### PR DESCRIPTION
The watchman timeout was currently the default 1 second, causing it to timeout on slower computers.

Since the development server is not time-critical, I extended it to 5 seconds, which allows it to not fail on slower computers.