### PR TITLE
Changed tuple Mate.unique_together/permissions to lists in docs.

### DIFF
--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -309,7 +309,7 @@ Django quotes column and table names behind the scenes.
     Add, change, delete, and view permissions are automatically created for each
     model. This example specifies an extra permission, ``can_deliver_pizzas``::
 
-        permissions = (("can_deliver_pizzas", "Can deliver pizzas"),)
+        permissions = [('can_deliver_pizzas', 'Can deliver pizzas')]
 
     This is a list or tuple of 2-tuples in the format ``(permission_code,
     human_readable_permission_name)``.
@@ -408,17 +408,17 @@ Django quotes column and table names behind the scenes.
 
     Sets of field names that, taken together, must be unique::
 
-        unique_together = (("driver", "restaurant"),)
+        unique_together = [['driver', 'restaurant']]
 
-    This is a tuple of tuples that must be unique when considered together.
+    This is a list of lists that must be unique when considered together.
     It's used in the Django admin and is enforced at the database level (i.e., the
     appropriate ``UNIQUE`` statements are included in the ``CREATE TABLE``
     statement).
 
-    For convenience, unique_together can be a single tuple when dealing with a single
-    set of fields::
+    For convenience, ``unique_together`` can be a single list when dealing with
+    a single set of fields::
 
-        unique_together = ("driver", "restaurant")
+        unique_together = ['driver', 'restaurant']
 
     A :class:`~django.db.models.ManyToManyField` cannot be included in
     unique_together. (It's not clear what that would even mean!) If you

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -277,10 +277,10 @@ can or cannot do with ``Task`` instances, specific to your application::
     class Task(models.Model):
         ...
         class Meta:
-            permissions = (
+            permissions = [
                 ("change_task_status", "Can change the status of tasks"),
                 ("close_task", "Can remove a task by setting its status as closed"),
-            )
+            ]
 
 The only thing this does is create those extra permissions when you run
 :djadmin:`manage.py migrate <migrate>` (the function that creates permissions

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -328,12 +328,12 @@ inherit the permissions of the concrete model they subclass::
 
     class Person(models.Model):
         class Meta:
-            permissions = (('can_eat_pizzas', 'Can eat pizzas'),)
+            permissions = [('can_eat_pizzas', 'Can eat pizzas')]
 
     class Student(Person):
         class Meta:
             proxy = True
-            permissions = (('can_deliver_pizzas', 'Can deliver pizzas'),)
+            permissions = [('can_deliver_pizzas', 'Can deliver pizzas')]
 
     >>> # Fetch the content type for the proxy model.
     >>> content_type = ContentType.objects.get_for_model(Student, for_concrete_model=False)

--- a/docs/topics/serialization.txt
+++ b/docs/topics/serialization.txt
@@ -367,7 +367,7 @@ Consider the following two models::
         birthdate = models.DateField()
 
         class Meta:
-            unique_together = (('first_name', 'last_name'),)
+            unique_together = [['first_name', 'last_name']]
 
     class Book(models.Model):
         name = models.CharField(max_length=100)
@@ -411,7 +411,7 @@ name::
         objects = PersonManager()
 
         class Meta:
-            unique_together = (('first_name', 'last_name'),)
+            unique_together = [['first_name', 'last_name']]
 
 Now books can use that natural key to refer to ``Person`` objects::
 
@@ -459,7 +459,7 @@ Firstly, you need to add another method -- this time to the model itself::
         objects = PersonManager()
 
         class Meta:
-            unique_together = (('first_name', 'last_name'),)
+            unique_together = [['first_name', 'last_name']]
 
         def natural_key(self):
             return (self.first_name, self.last_name)


### PR DESCRIPTION
Currently docs for [Options.index_together](https://docs.djangoproject.com/en/dev/ref/models/options/#index-together) specifies a list of lists, while [Options.unique_together](https://docs.djangoproject.com/en/dev/ref/models/options/#unique-together) specifies tuple of tuples. It's a bit confusing when these are extremely similar conceptually. Internally, they are normalized using exactly the same routines, and both accept either lists or tuples.

In docs, we should use lists for homogeneous sequences and tuples for "namedtuples without names" i.e. sequences where each item has a different meaning. Because:

1. This is how we already [decided](https://groups.google.com/d/msg/django-developers/h4FSYWzMJhs/_2iVc4qgfsoJ) to do it, and most things have already been cleaned up that way, including most of the other things on the `Options` docs page (e.g. `ordering`, `get_latest_by`, `indexes`).
2. New code/docs are written that way e.g. [Options.constraints](https://docs.djangoproject.com/en/dev/ref/models/options/#django.db.models.Options.constraints).
3. That's the way [Guido intended](https://marc.info/?l=python-dev&m=107666578526990&w=2) :-)

So in example code, `unqiue_together` should be a list of lists. I didn't see the value in specifying it as "list of lists or tuple of tuples" (and list of tuples etc.) because it's an unnecessary complication, and it's probably best to be consistent with `index_together` docs. We've already got the checks framework to validate correct usage.

Similarly, [permissions](https://docs.djangoproject.com/en/dev/ref/models/options/#django.db.models.Options.permissions) should be a list of 2-tuples. 

One remaining item on that page which I haven't addressed is [default_permissions](https://docs.djangoproject.com/en/dev/ref/models/options/#django.db.models.Options.default_permissions). While it is documented as being a list, the default value is specified as a tuple. However, the default value in the code is actually a tuple (though it ought to be a list), and changing that value in the code potentially has backwards compatibility issues. The docs should accurately specify what the default is, so I have left that alone.

