### PR TITLE
Removed unnecessary assignments immediately before a return.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -610,7 +610,7 @@ class ModelAdmin(BaseModelAdmin):
 
         info = self.model._meta.app_label, self.model._meta.model_name
 
-        urlpatterns = [
+        return [
             path('', wrap(self.changelist_view), name='%s_%s_changelist' % info),
             path('add/', wrap(self.add_view), name='%s_%s_add' % info),
             path('autocomplete/', wrap(self.autocomplete_view), name='%s_%s_autocomplete' % info),
@@ -622,7 +622,6 @@ class ModelAdmin(BaseModelAdmin):
                 pattern_name='%s:%s_%s_change' % ((self.admin_site.name,) + info)
             ))),
         ]
-        return urlpatterns
 
     @property
     def urls(self):

--- a/django/contrib/flatpages/views.py
+++ b/django/contrib/flatpages/views.py
@@ -66,5 +66,4 @@ def render_flatpage(request, f):
     f.title = mark_safe(f.title)
     f.content = mark_safe(f.content)
 
-    response = HttpResponse(template.render({'flatpage': f}, request))
-    return response
+    return HttpResponse(template.render({'flatpage': f}, request))

--- a/django/contrib/gis/gdal/prototypes/errcheck.py
+++ b/django/contrib/gis/gdal/prototypes/errcheck.py
@@ -69,8 +69,7 @@ def check_string(result, func, cargs, offset=-1, str_result=False):
 # ### Envelope checking ###
 def check_envelope(result, func, cargs, offset=-1):
     "Check a function that returns an OGR Envelope by reference."
-    env = ptr_byref(cargs, offset)
-    return env
+    return ptr_byref(cargs, offset)
 
 
 # ### Geometry error-checking routines ###

--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -97,8 +97,7 @@ class BaseCache:
         if version is None:
             version = self.version
 
-        new_key = self.key_func(key, self.key_prefix, version)
-        return new_key
+        return self.key_func(key, self.key_prefix, version)
 
     def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
         """

--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -300,8 +300,7 @@ class Command(BaseCommand):
                 dirs.append(app_dir)
         dirs.extend(fixture_dirs)
         dirs.append('')
-        dirs = [os.path.abspath(os.path.realpath(d)) for d in dirs]
-        return dirs
+        return [os.path.abspath(os.path.realpath(d)) for d in dirs]
 
     def parse_name(self, fixture_name):
         """

--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -14,8 +14,7 @@ def sql_flush(style, connection, only_django=False, reset_sequences=True, allow_
     else:
         tables = connection.introspection.table_names(include_views=False)
     seqs = connection.introspection.sequence_list() if reset_sequences else ()
-    statements = connection.ops.sql_flush(style, tables, seqs, allow_cascade)
-    return statements
+    return connection.ops.sql_flush(style, tables, seqs, allow_cascade)
 
 
 def emit_pre_migrate_signal(verbosity, interactive, db, **kwargs):

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -198,14 +198,13 @@ class DatabaseOperations(BaseDatabaseOperations):
             # Simulate TRUNCATE CASCADE by recursively collecting the tables
             # referencing the tables to be flushed.
             tables = set(chain.from_iterable(self._references_graph(table) for table in tables))
-        sql = ['%s %s %s;' % (
+        # Note: No requirement for reset of auto-incremented indices (cf. other
+        # sql_flush() implementations). Just return SQL at this point
+        return ['%s %s %s;' % (
             style.SQL_KEYWORD('DELETE'),
             style.SQL_KEYWORD('FROM'),
             style.SQL_FIELD(self.quote_name(table))
         ) for table in tables]
-        # Note: No requirement for reset of auto-incremented indices (cf. other
-        # sql_flush() implementations). Just return SQL at this point
-        return sql
 
     def adapt_datetimefield_value(self, value):
         if value is None:

--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -134,9 +134,10 @@ class BaseFormSet:
     def forms(self):
         """Instantiate forms at first property access."""
         # DoS protection is included in total_form_count()
-        forms = [self._construct_form(i, **self.get_form_kwargs(i))
-                 for i in range(self.total_form_count())]
-        return forms
+        return [
+            self._construct_form(i, **self.get_form_kwargs(i))
+            for i in range(self.total_form_count())
+        ]
 
     def get_form_kwargs(self, index):
         """

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -360,8 +360,7 @@ class LazyStream:
                     remaining -= len(emitting)
                     yield emitting
 
-        out = b''.join(parts())
-        return out
+        return b''.join(parts())
 
     def __next__(self):
         """

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -64,8 +64,7 @@ def _unsalt_cipher_token(token):
     token = token[CSRF_SECRET_LENGTH:]
     chars = CSRF_ALLOWED_CHARS
     pairs = zip((chars.index(x) for x in token), (chars.index(x) for x in salt))
-    secret = ''.join(chars[x - y] for x, y in pairs)  # Note negative values are ok
-    return secret
+    return ''.join(chars[x - y] for x, y in pairs)  # Note negative values are ok
 
 
 def _get_new_csrf_token():

--- a/django/template/response.py
+++ b/django/template/response.py
@@ -80,8 +80,7 @@ class SimpleTemplateResponse(HttpResponse):
         """
         template = self.resolve_template(self.template_name)
         context = self.resolve_context(self.context_data)
-        content = template.render(context, self._request)
-        return content
+        return template.render(context, self._request)
 
     def add_post_render_callback(self, callback):
         """Add a new post-rendering callback.

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -306,8 +306,7 @@ def get_runner(settings, test_runner_class=None):
     else:
         test_module_name = '.'
     test_module = __import__(test_module_name, {}, {}, test_path[-1])
-    test_runner = getattr(test_module, test_path[-1])
-    return test_runner
+    return getattr(test_module, test_path[-1])
 
 
 class TestContextDecorator:
@@ -757,7 +756,7 @@ def require_jinja2(test_func):
     Django template engine for a test or skip it if Jinja2 isn't available.
     """
     test_func = skipIf(jinja2 is None, "this test requires jinja2")(test_func)
-    test_func = override_settings(TEMPLATES=[{
+    return override_settings(TEMPLATES=[{
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'APP_DIRS': True,
     }, {
@@ -765,7 +764,6 @@ def require_jinja2(test_func):
         'APP_DIRS': True,
         'OPTIONS': {'keep_trailing_newline': True},
     }])(test_func)
-    return test_func
 
 
 class override_script_prefix(TestContextDecorator):

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -251,11 +251,10 @@ class AdminEmailHandlerTest(SimpleTestCase):
     def get_admin_email_handler(self, logger):
         # AdminEmailHandler does not get filtered out
         # even with DEBUG=True.
-        admin_email_handler = [
+        return [
             h for h in logger.handlers
             if h.__class__.__name__ == "AdminEmailHandler"
         ][0]
-        return admin_email_handler
 
     def test_fail_silently(self):
         admin_email_handler = self.get_admin_email_handler(self.logger)

--- a/tests/test_client_regress/views.py
+++ b/tests/test_client_regress/views.py
@@ -117,8 +117,7 @@ def return_text_file(request):
     else:
         charset = settings.DEFAULT_CHARSET
 
-    response = HttpResponse(request.body, status=200, content_type='text/plain; charset=%s' % charset)
-    return response
+    return HttpResponse(request.body, status=200, content_type='text/plain; charset=%s' % charset)
 
 
 def check_headers(request):


### PR DESCRIPTION
Simplifies the pattern:

```
var = <expression>
return var
```

To:

```
return <expression>
```