### PR TITLE
Removed redundant os.path.abspath() call.

### DIFF
--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -300,7 +300,7 @@ class Command(BaseCommand):
                 dirs.append(app_dir)
         dirs.extend(fixture_dirs)
         dirs.append('')
-        return [os.path.abspath(os.path.realpath(d)) for d in dirs]
+        return [os.path.realpath(d) for d in dirs]
 
     def parse_name(self, fixture_name):
         """


### PR DESCRIPTION
`os.path.realpath()` calls `os.path.abspath()` before returning:

https://github.com/python/cpython/blob/4f5a3493b534a95fbb01d593b1ffe320db6b395e/Lib/posixpath.py#L392
https://github.com/python/cpython/blob/4f5a3493b534a95fbb01d593b1ffe320db6b395e/Lib/ntpath.py#L523