### PR TITLE
Refs #30241 -- Fixed BytesWarning emitted in test_translation tests.

### DIFF
--- a/django/core/checks/translation.py
+++ b/django/core/checks/translation.py
@@ -4,17 +4,17 @@ from django.utils.translation.trans_real import language_code_re
 from . import Error, Tags, register
 
 E001 = Error(
-    'You have provided an invalid value for the LANGUAGE_CODE setting: {}.',
+    'You have provided an invalid value for the LANGUAGE_CODE setting: {!r}.',
     id='translation.E001',
 )
 
 E002 = Error(
-    'You have provided an invalid language code in the LANGUAGES setting: {}.',
+    'You have provided an invalid language code in the LANGUAGES setting: {!r}.',
     id='translation.E002',
 )
 
 E003 = Error(
-    'You have provided an invalid language code in the LANGUAGES_BIDI setting: {}.',
+    'You have provided an invalid language code in the LANGUAGES_BIDI setting: {!r}.',
     id='translation.E003',
 )
 

--- a/tests/check_framework/test_translation.py
+++ b/tests/check_framework/test_translation.py
@@ -42,7 +42,7 @@ class TranslationCheckTests(SimpleTestCase):
                 self.assertEqual(check_setting_language_code(None), [])
 
     def test_invalid_language_code(self):
-        msg = 'You have provided an invalid value for the LANGUAGE_CODE setting: %s.'
+        msg = 'You have provided an invalid value for the LANGUAGE_CODE setting: %r.'
         for tag in self.invalid_tags:
             with self.subTest(tag), self.settings(LANGUAGE_CODE=tag):
                 self.assertEqual(check_setting_language_code(None), [
@@ -55,7 +55,7 @@ class TranslationCheckTests(SimpleTestCase):
                 self.assertEqual(check_setting_languages(None), [])
 
     def test_invalid_languages(self):
-        msg = 'You have provided an invalid language code in the LANGUAGES setting: %s.'
+        msg = 'You have provided an invalid language code in the LANGUAGES setting: %r.'
         for tag in self.invalid_tags:
             with self.subTest(tag), self.settings(LANGUAGES=[(tag, tag)]):
                 self.assertEqual(check_setting_languages(None), [
@@ -68,7 +68,7 @@ class TranslationCheckTests(SimpleTestCase):
                 self.assertEqual(check_setting_languages_bidi(None), [])
 
     def test_invalid_languages_bidi(self):
-        msg = 'You have provided an invalid language code in the LANGUAGES_BIDI setting: %s.'
+        msg = 'You have provided an invalid language code in the LANGUAGES_BIDI setting: %r.'
         for tag in self.invalid_tags:
             with self.subTest(tag), self.settings(LANGUAGES_BIDI=[tag]):
                 self.assertEqual(check_setting_languages_bidi(None), [


### PR DESCRIPTION
When running the Django test suite with the Python command line option `-b`, the following warnings are emitted:

    .../django/core/checks/translation.py:33: BytesWarning: str() on a bytes instance
      return [Error(E001.msg.format(tag), id=E001.id)]
    .../tests/check_framework/test_translation.py:49: BytesWarning: str() on a bytes instance
      Error(msg % tag, id='translation.E001'),
    .../django/core/checks/translation.py:42: BytesWarning: str() on a bytes instance
      for tag, _ in settings.LANGUAGES if not isinstance(tag, str) or not language_code_re.match(tag)
    .../tests/check_framework/test_translation.py:62: BytesWarning: str() on a bytes instance
      Error(msg % tag, id='translation.E002'),
    .../django/core/checks/translation.py:51: BytesWarning: str() on a bytes instance
      for tag in settings.LANGUAGES_BIDI if not isinstance(tag, str) or not language_code_re.match(tag)
    .../tests/check_framework/test_translation.py:75: BytesWarning: str() on a bytes instance
      Error(msg % tag, id='translation.E003'),

This occurs because a `bytes` object is formatted as string. Instead, format the invalid value to its repr, which is guaranteed to be a `str`.

Python docs on the `-b` command line option: https://docs.python.org/3/using/cmdline.html#cmdoption-b