### PR TITLE
Fixed #30947 -- Changed tuples to lists in model Meta options in django.contrib modules.

### DIFF
--- a/django/contrib/admin/migrations/0001_initial.py
+++ b/django/contrib/admin/migrations/0001_initial.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
                 )),
             ],
             options={
-                'ordering': ('-action_time',),
+                'ordering': ['-action_time'],
                 'db_table': 'django_admin_log',
                 'verbose_name': 'log entry',
                 'verbose_name_plural': 'log entries',

--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -66,7 +66,7 @@ class LogEntry(models.Model):
         verbose_name = _('log entry')
         verbose_name_plural = _('log entries')
         db_table = 'django_admin_log'
-        ordering = ('-action_time',)
+        ordering = ['-action_time']
 
     def __repr__(self):
         return str(self.action_time)

--- a/django/contrib/auth/migrations/0001_initial.py
+++ b/django/contrib/auth/migrations/0001_initial.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
                 ('codename', models.CharField(max_length=100, verbose_name='codename')),
             ],
             options={
-                'ordering': ('content_type__app_label', 'content_type__model', 'codename'),
+                'ordering': ['content_type__app_label', 'content_type__model', 'codename'],
                 'unique_together': {('content_type', 'codename')},
                 'verbose_name': 'permission',
                 'verbose_name_plural': 'permissions',

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -66,9 +66,8 @@ class Permission(models.Model):
     class Meta:
         verbose_name = _('permission')
         verbose_name_plural = _('permissions')
-        unique_together = (('content_type', 'codename'),)
-        ordering = ('content_type__app_label', 'content_type__model',
-                    'codename')
+        unique_together = [['content_type', 'codename']]
+        ordering = ['content_type__app_label', 'content_type__model', 'codename']
 
     def __str__(self):
         return '%s | %s' % (self.content_type, self.name)

--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -139,7 +139,7 @@ class ContentType(models.Model):
         verbose_name = _('content type')
         verbose_name_plural = _('content types')
         db_table = 'django_content_type'
-        unique_together = (('app_label', 'model'),)
+        unique_together = [['app_label', 'model']]
 
     def __str__(self):
         return self.app_labeled_name

--- a/django/contrib/flatpages/migrations/0001_initial.py
+++ b/django/contrib/flatpages/migrations/0001_initial.py
@@ -29,7 +29,7 @@ class Migration(migrations.Migration):
                 ('sites', models.ManyToManyField(to='sites.Site', verbose_name='sites')),
             ],
             options={
-                'ordering': ('url',),
+                'ordering': ['url'],
                 'db_table': 'django_flatpage',
                 'verbose_name': 'flat page',
                 'verbose_name_plural': 'flat pages',

--- a/django/contrib/flatpages/models.py
+++ b/django/contrib/flatpages/models.py
@@ -30,7 +30,7 @@ class FlatPage(models.Model):
         db_table = 'django_flatpage'
         verbose_name = _('flat page')
         verbose_name_plural = _('flat pages')
-        ordering = ('url',)
+        ordering = ['url']
 
     def __str__(self):
         return "%s -- %s" % (self.url, self.title)

--- a/django/contrib/redirects/migrations/0001_initial.py
+++ b/django/contrib/redirects/migrations/0001_initial.py
@@ -29,7 +29,7 @@ class Migration(migrations.Migration):
                 )),
             ],
             options={
-                'ordering': ('old_path',),
+                'ordering': ['old_path'],
                 'unique_together': {('site', 'old_path')},
                 'db_table': 'django_redirect',
                 'verbose_name': 'redirect',

--- a/django/contrib/redirects/models.py
+++ b/django/contrib/redirects/models.py
@@ -22,8 +22,8 @@ class Redirect(models.Model):
         verbose_name = _('redirect')
         verbose_name_plural = _('redirects')
         db_table = 'django_redirect'
-        unique_together = (('site', 'old_path'),)
-        ordering = ('old_path',)
+        unique_together = [['site', 'old_path']]
+        ordering = ['old_path']
 
     def __str__(self):
         return "%s ---> %s" % (self.old_path, self.new_path)

--- a/django/contrib/sites/migrations/0001_initial.py
+++ b/django/contrib/sites/migrations/0001_initial.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=50, verbose_name='display name')),
             ],
             options={
-                'ordering': ('domain',),
+                'ordering': ['domain'],
                 'db_table': 'django_site',
                 'verbose_name': 'site',
                 'verbose_name_plural': 'sites',

--- a/django/contrib/sites/models.py
+++ b/django/contrib/sites/models.py
@@ -91,7 +91,7 @@ class Site(models.Model):
         db_table = 'django_site'
         verbose_name = _('site')
         verbose_name_plural = _('sites')
-        ordering = ('domain',)
+        ordering = ['domain']
 
     def __str__(self):
         return self.domain

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -282,6 +282,11 @@ Miscellaneous
 * :tfilter:`floatformat` template filter now outputs (positive) ``0`` for
   negative numbers which round to zero.
 
+* :attr:`Meta.ordering <django.db.models.Options.ordering>` and
+  :attr:`Meta.unique_together <django.db.models.Options.unique_together>`
+  options on models in ``django.contrib`` modules that were formerly tuples are
+  now lists.
+
 .. _deprecated-features-3.1:
 
 Features deprecated in 3.1

--- a/docs/topics/db/examples/many_to_many.txt
+++ b/docs/topics/db/examples/many_to_many.txt
@@ -18,7 +18,7 @@ objects, and a ``Publication`` has multiple ``Article`` objects:
         title = models.CharField(max_length=30)
 
         class Meta:
-            ordering = ('title',)
+            ordering = ['title']
 
         def __str__(self):
             return self.title
@@ -28,7 +28,7 @@ objects, and a ``Publication`` has multiple ``Article`` objects:
         publications = models.ManyToManyField(Publication)
 
         class Meta:
-            ordering = ('headline',)
+            ordering = ['headline']
 
         def __str__(self):
             return self.headline

--- a/docs/topics/db/examples/many_to_one.txt
+++ b/docs/topics/db/examples/many_to_one.txt
@@ -23,7 +23,7 @@ To define a many-to-one relationship, use :class:`~django.db.models.ForeignKey`:
             return self.headline
 
         class Meta:
-            ordering = ('headline',)
+            ordering = ['headline']
 
 What follows are examples of operations that can be performed using the Python
 API facilities.


### PR DESCRIPTION
The Django "Model Meta options" docs provide examples and generally point the reader to use lists for the `unique_together` and `ordering` options. Follow our own advice for contrib models.

More generally, lists should be used for homogeneous sequences of arbitrary lengths of which both `unique_together` and `ordering` are.

https://code.djangoproject.com/ticket/30947