### PR TITLE
Fixed #30386 -- Added pk quoting for admin ForeignKey widgets

### DIFF
--- a/django/contrib/admin/templates/admin/widgets/related_widget_select_option.html
+++ b/django/contrib/admin/templates/admin/widgets/related_widget_select_option.html
@@ -1,0 +1,1 @@
+{% load admin_urls %}<option value="{{ widget.value|admin_urlquote|stringformat:'s' }}"{% include "django/forms/widgets/attrs.html" %}>{{ widget.label }}</option>

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -6,6 +6,7 @@ import json
 
 from django import forms
 from django.conf import settings
+from django.contrib.admin.utils import quote
 from django.core.exceptions import ValidationError
 from django.db.models.deletion import CASCADE
 from django.urls import reverse
@@ -188,7 +189,7 @@ class ForeignKeyRawIdWidget(forms.TextInput):
                     obj._meta.app_label,
                     obj._meta.object_name.lower(),
                 ),
-                args=(obj.pk,)
+                args=(quote(obj.pk),)
             )
         except NoReverseMatch:
             url = ''  # Admin not registered for target model.
@@ -239,6 +240,7 @@ class RelatedFieldWidgetWrapper(forms.Widget):
         self.attrs = widget.attrs
         self.choices = widget.choices
         self.widget = widget
+        self.widget.option_template_name = 'admin/widgets/related_widget_select_option.html'
         self.rel = rel
         # Backwards compatible check for whether a user can add related
         # objects.

--- a/tests/admin_widgets/models.py
+++ b/tests/admin_widgets/models.py
@@ -156,3 +156,19 @@ class Profile(models.Model):
 
     def __str__(self):
         return self.user.username
+
+
+class Topping(models.Model):
+    name = models.CharField(max_length=30, primary_key=True)
+    code = models.CharField(max_length=2, unique=True)
+
+    def __str__(self):
+        return self.name
+
+
+class Pizza(models.Model):
+    name = models.CharField(max_length=40)
+    topping = models.ForeignKey(Topping, on_delete=models.PROTECT, related_name='pizzas')
+
+    def __str__(self):
+        return self.name

--- a/tests/admin_widgets/widgetadmin.py
+++ b/tests/admin_widgets/widgetadmin.py
@@ -1,8 +1,8 @@
 from django.contrib import admin
 
 from .models import (
-    Advisor, Album, Band, Bee, Car, CarTire, Event, Inventory, Member, Profile,
-    School, User,
+    Advisor, Album, Band, Bee, Car, CarTire, Event, Inventory, Member, Pizza,
+    Profile, School, Topping, User,
 )
 
 
@@ -57,3 +57,6 @@ site.register(Advisor)
 site.register(School, SchoolAdmin)
 
 site.register(Profile)
+
+site.register(Topping)
+site.register(Pizza)


### PR DESCRIPTION
[https://code.djangoproject.com/ticket/30386](https://code.djangoproject.com/ticket/30386)

 Refactored  `ForeignKeyRawIdWidget.label_and_url_for_value` method. It was not quoting the `pk` of related object when reversing change action url, which was causing problems if related model uses `CharField` as primary key and pk contains special characters like `_40`, `?a=b`.

Also added client side quoting for `RelatedFieldWidgetWrapper`, since url of change/delete icon should be changed whenever a new option is selected on RelatedField dropdown. 

I am not feeling that comfortable with keeping two functions doing same job both on backend and client side (`django.contrib.admin.utils.quote` and `/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.quotePK()`.)
But it seemed less complex than passing all quoted PK s in context to template, using them for each dropdown option as html data attribute and building the url using this attribute.