### PR TITLE
Fixed #11929 -- Make sure YAML output order is helpful

### DIFF
--- a/tests/serializers/test_yaml.py
+++ b/tests/serializers/test_yaml.py
@@ -85,29 +85,29 @@ class NoYamlSerializerTestCase(SimpleTestCase):
 @unittest.skipUnless(HAS_YAML, "No yaml library detected")
 class YamlSerializerTestCase(SerializersTestBase, TestCase):
     serializer_name = "yaml"
-    fwd_ref_str = """- fields:
+    fwd_ref_str = """- model: serializers.article
+  pk: 1
+  fields:
     headline: Forward references pose no problem
     pub_date: 2006-06-16 15:00:00
     categories: [1]
     author: 1
+- model: serializers.category
   pk: 1
-  model: serializers.article
-- fields:
+  fields:
     name: Reference
+- model: serializers.author
   pk: 1
-  model: serializers.category
-- fields:
-    name: Agnes
-  pk: 1
-  model: serializers.author"""
+  fields:
+    name: Agnes"""
 
-    pkless_str = """- fields:
-    name: Reference
+    pkless_str = """- model: serializers.category
   pk: null
-  model: serializers.category
-- fields:
-    name: Non-fiction
-  model: serializers.category"""
+  fields:
+    name: Reference
+- model: serializers.category
+  fields:
+    name: Non-fiction"""
 
     mapping_ordering_str = """- model: serializers.article
   pk: %(article_pk)s
@@ -159,22 +159,31 @@ class YamlSerializerTestCase(SerializersTestBase, TestCase):
             for obj in serializers.deserialize("yaml", "{"):
                 pass
 
+    def test_yaml_output_ordering(self):
+        """Output is in the expected order of model, pk, fields."""
+        from .models import Article
+        serial_str = serializers.serialize(self.serializer_name, Article.objects.all())
+        expected_start = """- model: serializers.article
+  pk: {a1.pk}
+  fields:""".format(a1=Article.objects.first())
+        self.assertEqual(serial_str[:len(expected_start)], expected_start)
+
 
 @unittest.skipUnless(HAS_YAML, "No yaml library detected")
 class YamlSerializerTransactionTestCase(SerializersTransactionTestBase, TransactionTestCase):
     serializer_name = "yaml"
-    fwd_ref_str = """- fields:
+    fwd_ref_str = """- model: serializers.article
+  pk: 1
+  fields:
     headline: Forward references pose no problem
     pub_date: 2006-06-16 15:00:00
     categories: [1]
     author: 1
+- model: serializers.category
   pk: 1
-  model: serializers.article
-- fields:
+  fields:
     name: Reference
+- model: serializers.author
   pk: 1
-  model: serializers.category
-- fields:
-    name: Agnes
-  pk: 1
-  model: serializers.author"""
+  fields:
+    name: Agnes"""


### PR DESCRIPTION
By adopting Python 3.6+, this was already happening, but this test makes
sure we'll have no regression.

https://code.djangoproject.com/ticket/11929