### PR TITLE
Fixed #20122 -- Made pluralize template filter return '' on invalid input.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -851,8 +851,8 @@ def filesizeformat(bytes_):
 @register.filter(is_safe=False)
 def pluralize(value, arg='s'):
     """
-    Return a plural suffix if the value is not 1. By default, use 's' as the
-    suffix:
+    Return a plural suffix if the value is not 1, '1', or an object of
+    length 1. By default, use 's' as the suffix:
 
     * If value is 0, vote{{ value|pluralize }} display "votes".
     * If value is 1, vote{{ value|pluralize }} display "vote".

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -879,17 +879,15 @@ def pluralize(value, arg='s'):
     singular_suffix, plural_suffix = bits[:2]
 
     try:
-        if float(value) != 1:
-            return plural_suffix
+        return singular_suffix if float(value) == 1 else plural_suffix
     except ValueError:  # Invalid string that's not a number.
         pass
     except TypeError:  # Value isn't a string or a number; maybe it's a list?
         try:
-            if len(value) != 1:
-                return plural_suffix
+            return singular_suffix if len(value) == 1 else plural_suffix
         except TypeError:  # len() of unsized object.
             pass
-    return singular_suffix
+    return ''
 
 
 @register.filter("phone2numeric", is_safe=True)

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1990,8 +1990,8 @@ If ``value`` is ``800-COLLECT``, the output will be ``800-2655328``.
 ``pluralize``
 -------------
 
-Returns a plural suffix if the value is not 1. By default, this suffix is
-``'s'``.
+Returns a plural suffix if the value is not ``1``, ``'1'``, or an object of
+length 1. By default, this suffix is ``'s'``.
 
 Example::
 

--- a/tests/template_tests/filter_tests/test_pluralize.py
+++ b/tests/template_tests/filter_tests/test_pluralize.py
@@ -58,8 +58,9 @@ class FunctionTests(SimpleTestCase):
         self.assertEqual(pluralize(0, 'y,ies,error'), '')
 
     def test_no_len_type(self):
-        self.assertEqual(pluralize(object(), 'y,es'), 'y')
+        self.assertEqual(pluralize(object(), 'y,es'), '')
         self.assertEqual(pluralize(object(), 'es'), '')
 
     def test_value_error(self):
-        self.assertEqual(pluralize('', 'y,es'), 'y')
+        self.assertEqual(pluralize('', 'y,es'), '')
+        self.assertEqual(pluralize('', 'es'), '')


### PR DESCRIPTION
``pluralize`` wasn't correctly documented up until now, so I fixed that first.

https://code.djangoproject.com/ticket/20122