### PR TITLE
Fixed #30421 -- Allowed symmetrical intermediate table for self-referential ManyToManyField.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -632,6 +632,7 @@ answer newbie questions, and generally made Django that much better:
     msundstr
     Mushtaq Ali <mushtaak@gmail.com>
     Mykola Zamkovoi <nickzam@gmail.com>
+    Nadège Michel <michel.nadege@gmail.com>
     Nagy Károly <charlie@rendszergazda.com>
     Nasimul Haque <nasim.haque@gmail.com>
     Nasir Hussain <nasirhjafri@gmail.com>

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1234,18 +1234,6 @@ class ManyToManyField(RelatedField):
                 to_model_name = to_model._meta.object_name
             relationship_model_name = self.remote_field.through._meta.object_name
             self_referential = from_model == to_model
-
-            # Check symmetrical attribute.
-            if (self_referential and self.remote_field.symmetrical and
-                    not self.remote_field.through._meta.auto_created):
-                errors.append(
-                    checks.Error(
-                        'Many-to-many fields with intermediate tables must not be symmetrical.',
-                        obj=self,
-                        id='fields.E332',
-                    )
-                )
-
             # Count foreign keys in intermediate model
             if self_referential:
                 seen_self = sum(

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -938,11 +938,14 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
                     through_defaults=through_defaults,
                 )
                 # If this is a symmetrical m2m relation to self, add the mirror
-                # entry in the m2m table. `through_defaults` aren't used here
-                # because of the system check error fields.E332: Many-to-many
-                # fields with intermediate tables must not be symmetrical.
+                # entry in the m2m table.
                 if self.symmetrical:
-                    self._add_items(self.target_field_name, self.source_field_name, *objs)
+                    self._add_items(
+                        self.target_field_name,
+                        self.source_field_name,
+                        *objs,
+                        through_defaults=through_defaults,
+                    )
         add.alters_data = True
 
         def remove(self, *objs):

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -222,7 +222,7 @@ Related fields
 * **fields.E331**: Field specifies a many-to-many relation through model
   ``<model>``, which has not been installed.
 * **fields.E332**: Many-to-many fields with intermediate tables must not be
-  symmetrical.
+  symmetrical. *This check appeared before Django 3.0.*
 * **fields.E333**: The model is used as an intermediate model by ``<model>``,
   but it has more than two foreign keys to ``<model>``, which is ambiguous.
   You must specify which two foreign keys Django should use via the

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1537,6 +1537,11 @@ that control how the relationship functions.
     add the descriptor for the reverse relationship, allowing
     :class:`ManyToManyField` relationships to be non-symmetrical.
 
+    .. versionchanged:: 3.0
+
+        Specifying ``symmetrical=True`` for recursive many-to-many
+        relationships using an intermediary model was allowed.
+
 .. attribute:: ManyToManyField.through
 
     Django will automatically generate a table to manage many-to-many
@@ -1548,6 +1553,16 @@ that control how the relationship functions.
     The most common use for this option is when you want to associate
     :ref:`extra data with a many-to-many relationship
     <intermediary-manytomany>`.
+
+    .. note::
+
+        Recursive relationships using an intermediary model and defined as
+        symmetrical (that is, with :attr:`symmetrical=True
+        <ManyToManyField.symmetrical>`, which is the default) can't determine
+        the reverse accessors names, as they would be the same. You need to set
+        a :attr:`~ForeignKey.related_name` to at least one of them. If you'd
+        prefer Django not to create a backwards relation, set ``related_name``
+        to ``'+'``.
 
     If you don't specify an explicit ``through`` model, there is still an
     implicit ``through`` model class you can use to directly access the table
@@ -1623,12 +1638,6 @@ that control how the relationship functions.
     when an intermediary model is used and there are more than two
     foreign keys to the model, or you want to explicitly specify which two
     Django should use.
-
-    Recursive relationships using an intermediary model are always defined as
-    non-symmetrical -- that is, with :attr:`symmetrical=False <ManyToManyField.symmetrical>`
-    -- therefore, there is the concept of a "source" and a "target". In that
-    case ``'field1'`` will be treated as the "source" of the relationship and
-    ``'field2'`` as the "target".
 
 .. attribute:: ManyToManyField.db_table
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -254,6 +254,9 @@ Models
 
 * :class:`~django.db.models.FilePathField` now accepts a callable ``path``.
 
+* Allowed symmetrical intermediate table for self-referential
+  :class:`~django.db.models.ManyToManyField`.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -260,24 +260,6 @@ class RelativeFieldTests(SimpleTestCase):
         field = Group._meta.get_field('members')
         self.assertEqual(field.check(from_model=Group), [])
 
-    def test_symmetrical_self_referential_field(self):
-        class Person(models.Model):
-            # Implicit symmetrical=False.
-            friends = models.ManyToManyField('self', through="Relationship")
-
-        class Relationship(models.Model):
-            first = models.ForeignKey(Person, models.CASCADE, related_name="rel_from_set")
-            second = models.ForeignKey(Person, models.CASCADE, related_name="rel_to_set")
-
-        field = Person._meta.get_field('friends')
-        self.assertEqual(field.check(from_model=Person), [
-            Error(
-                'Many-to-many fields with intermediate tables must not be symmetrical.',
-                obj=field,
-                id='fields.E332',
-            ),
-        ])
-
     def test_too_many_foreign_keys_in_self_referential_model(self):
         class Person(models.Model):
             friends = models.ManyToManyField('self', through="InvalidRelationship", symmetrical=False)
@@ -298,52 +280,6 @@ class RelativeFieldTests(SimpleTestCase):
                 hint='Use through_fields to specify which two foreign keys Django should use.',
                 obj=InvalidRelationship,
                 id='fields.E333',
-            ),
-        ])
-
-    def test_symmetric_self_reference_with_intermediate_table(self):
-        class Person(models.Model):
-            # Explicit symmetrical=True.
-            friends = models.ManyToManyField('self', through="Relationship", symmetrical=True)
-
-        class Relationship(models.Model):
-            first = models.ForeignKey(Person, models.CASCADE, related_name="rel_from_set")
-            second = models.ForeignKey(Person, models.CASCADE, related_name="rel_to_set")
-
-        field = Person._meta.get_field('friends')
-        self.assertEqual(field.check(from_model=Person), [
-            Error(
-                'Many-to-many fields with intermediate tables must not be symmetrical.',
-                obj=field,
-                id='fields.E332',
-            ),
-        ])
-
-    def test_symmetric_self_reference_with_intermediate_table_and_through_fields(self):
-        """
-        Using through_fields in a m2m with an intermediate model shouldn't
-        mask its incompatibility with symmetry.
-        """
-        class Person(models.Model):
-            # Explicit symmetrical=True.
-            friends = models.ManyToManyField(
-                'self',
-                symmetrical=True,
-                through="Relationship",
-                through_fields=('first', 'second'),
-            )
-
-        class Relationship(models.Model):
-            first = models.ForeignKey(Person, models.CASCADE, related_name="rel_from_set")
-            second = models.ForeignKey(Person, models.CASCADE, related_name="rel_to_set")
-            referee = models.ForeignKey(Person, models.CASCADE, related_name="referred")
-
-        field = Person._meta.get_field('friends')
-        self.assertEqual(field.check(from_model=Person), [
-            Error(
-                'Many-to-many fields with intermediate tables must not be symmetrical.',
-                obj=field,
-                id='fields.E332',
             ),
         ])
 

--- a/tests/m2m_recursive/models.py
+++ b/tests/m2m_recursive/models.py
@@ -22,7 +22,14 @@ from django.db import models
 class Person(models.Model):
     name = models.CharField(max_length=20)
     friends = models.ManyToManyField('self')
+    colleagues = models.ManyToManyField('self', symmetrical=True, through='Colleague')
     idols = models.ManyToManyField('self', symmetrical=False, related_name='stalkers')
 
     def __str__(self):
         return self.name
+
+
+class Colleague(models.Model):
+    first = models.ForeignKey(Person, models.CASCADE)
+    second = models.ForeignKey(Person, models.CASCADE, related_name='+')
+    first_meet = models.DateField()

--- a/tests/m2m_through/models.py
+++ b/tests/m2m_through/models.py
@@ -72,6 +72,7 @@ class TestNoDefaultsOrNulls(models.Model):
 class PersonSelfRefM2M(models.Model):
     name = models.CharField(max_length=5)
     friends = models.ManyToManyField('self', through="Friendship", symmetrical=False)
+    sym_friends = models.ManyToManyField('self', through='SymmetricalFriendship', symmetrical=True)
 
     def __str__(self):
         return self.name
@@ -81,6 +82,12 @@ class Friendship(models.Model):
     first = models.ForeignKey(PersonSelfRefM2M, models.CASCADE, related_name="rel_from_set")
     second = models.ForeignKey(PersonSelfRefM2M, models.CASCADE, related_name="rel_to_set")
     date_friended = models.DateTimeField()
+
+
+class SymmetricalFriendship(models.Model):
+    first = models.ForeignKey(PersonSelfRefM2M, models.CASCADE)
+    second = models.ForeignKey(PersonSelfRefM2M, models.CASCADE, related_name='+')
+    date_friended = models.DateField()
 
 
 # Custom through link fields


### PR DESCRIPTION
Ticket https://code.djangoproject.com/ticket/30421