### PR TITLE
Refs #26022 -- Used context manager version of assertRaisesMessage in tests.

### DIFF
--- a/tests/dates/tests.py
+++ b/tests/dates/tests.py
@@ -89,14 +89,12 @@ class DatesTests(TestCase):
             Article.objects.dates()
 
     def test_dates_fails_when_given_invalid_field_argument(self):
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             FieldError,
             "Cannot resolve keyword 'invalid_field' into field. Choices are: "
             "categories, comments, id, pub_date, pub_datetime, title",
-            Article.objects.dates,
-            "invalid_field",
-            "year",
-        )
+        ):
+            Article.objects.dates('invalid_field', 'year')
 
     def test_dates_fails_when_given_invalid_kind_argument(self):
         msg = "'kind' must be one of 'year', 'month', 'week', or 'day'."

--- a/tests/m2m_regress/tests.py
+++ b/tests/m2m_regress/tests.py
@@ -34,11 +34,11 @@ class M2MRegressionTests(TestCase):
     def test_internal_related_name_not_in_error_msg(self):
         # The secret internal related names for self-referential many-to-many
         # fields shouldn't appear in the list when an error is made.
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             FieldError,
             "Choices are: id, name, references, related, selfreferchild, selfreferchildsibling",
-            lambda: SelfRefer.objects.filter(porcupine='fred')
-        )
+        ):
+            SelfRefer.objects.filter(porcupine='fred')
 
     def test_m2m_inheritance_symmetry(self):
         # Test to ensure that the relationship between two inherited models

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -32,9 +32,11 @@ class SkippingTestCase(SimpleTestCase):
     def _assert_skipping(self, func, expected_exc, msg=None):
         try:
             if msg is not None:
-                self.assertRaisesMessage(expected_exc, msg, func)
+                with self.assertRaisesMessage(expected_exc, msg):
+                    func()
             else:
-                self.assertRaises(expected_exc, func)
+                with self.assertRaises(expected_exc):
+                    func()
         except unittest.SkipTest:
             self.fail('%s should not result in a skipped test.' % func.__name__)
 


### PR DESCRIPTION
Improves readability and follows a consistent pattern across tests.