### PR TITLE
Fixed PendingDeprecationWarning in select_for_update test.

### DIFF
--- a/tests/select_for_update/tests.py
+++ b/tests/select_for_update/tests.py
@@ -375,7 +375,7 @@ class SelectForUpdateTests(TransactionTestCase):
 
         # Check the thread has finished. Assuming it has, we should
         # find that it has updated the person's name.
-        self.assertFalse(thread.isAlive())
+        self.assertFalse(thread.is_alive())
 
         # We must commit the transaction to ensure that MySQL gets a fresh read,
         # since by default it runs in REPEATABLE READ mode


### PR DESCRIPTION
When Python warnings are with the -Wa command line argument, appeared
as:

    .../django/tests/select_for_update/tests.py:378: PendingDeprecationWarning: isAlive() is deprecated, use is_alive() instead
      self.assertFalse(thread.isAlive())

Thread.is_alive() has been available since Python 2.6.