### PR TITLE
Fixed #30423 -- Made PasswordResetTokenGenerator's timeout extendable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ answer newbie questions, and generally made Django that much better:
     Anssi Kääriäinen <akaariai@gmail.com>
     ant9000@netwise.it
     Anthony Briggs <anthony.briggs@gmail.com>
+    Antoine Humeau <humeau.antoine@gmail.com>
     Anton Samarchyan <desecho@gmail.com>
     Antoni Aloy
     Antonio Cavedoni <http://cavedoni.com/>

--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -12,6 +12,7 @@ class PasswordResetTokenGenerator:
     """
     key_salt = "django.contrib.auth.tokens.PasswordResetTokenGenerator"
     secret = settings.SECRET_KEY
+    timeout_days = settings.PASSWORD_RESET_TIMEOUT_DAYS
 
     def make_token(self, user):
         """
@@ -46,7 +47,7 @@ class PasswordResetTokenGenerator:
         # link is generated 5 minutes before midnight and used 6 minutes later,
         # that counts as 1 day. Therefore, PASSWORD_RESET_TIMEOUT_DAYS = 1 means
         # "at least 1 day, could be up to 2."
-        if (self._num_days(self._today()) - ts) > settings.PASSWORD_RESET_TIMEOUT_DAYS:
+        if (self._num_days(self._today()) - ts) > self.timeout_days:
             return False
 
         return True

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -59,7 +59,7 @@ Minor features
 :mod:`django.contrib.auth`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* Made PasswordResetTokenGenerator's timeout extendable
 
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
[Ticket 30423](https://code.djangoproject.com/ticket/30423)

Added a `timeout_days` class attribute to `PasswordResetTokenGenerator` which is used in place of `settings.PASSWORD_RESET_TIMEOUT_DAYS` . This enables subclasses to easily override the value.

Note: I moved and renamed the mocked version of `PasswordResetTokenGenerator` used in `auth_tests.test_tokens.TokenGeneratorTest.test_timeout` so it can be reused.