### PR TITLE
Ignored pywatchman.SocketTimeout in Watchman autoreloader.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -506,6 +506,8 @@ class WatchmanReloader(BaseReloader):
                 self.processed_request.clear()
             try:
                 self.client.receive()
+            except pywatchman.SocketTimeout:
+                pass
             except pywatchman.WatchmanError as ex:
                 self.check_server_status(ex)
             else:

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -888,7 +888,8 @@ If you're using Linux or MacOS and install both `pywatchman`_ and the
 `Watchman`_ service, kernel signals will be used to autoreload the server
 (rather than polling file modification timestamps each second). This offers
 better performance on large projects, reduced response time after code changes,
-more robust change detection, and a reduction in power usage.
+more robust change detection, and a reduction in power usage. Django supports
+``pywatchman`` 1.2.0 and higher.
 
 .. admonition:: Large directories with many files may cause performance issues
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -368,6 +368,8 @@ Miscellaneous
 * The ``django-admin test -k`` option now works as the :option:`unittest
   -k<unittest.-k>` option rather than as a shortcut for ``--keepdb``.
 
+* Support for ``pywatchman`` < 1.2.0 is removed.
+
 .. _deprecated-features-3.0:
 
 Features deprecated in 3.0


### PR DESCRIPTION
These are expected with the non-blocking loop.

Only with other errors, e.g. `WatchmanError('empty watchman response')`
after killing `watchman` need to check the server status.