### PR TITLE
Protected Watchman autoreloader against busy loops.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -546,6 +546,8 @@ class WatchmanReloader(BaseReloader):
                 for sub in list(self.client.subs.keys()):
                     self._check_subscription(sub)
             yield
+            # Protect against busy loops.
+            time.sleep(0.1)
 
     def stop(self):
         self.client.close()


### PR DESCRIPTION
With an error in the loop above (e.g. using `query` without args), this
would trigger a busy loop.  While this was caused due to changes to the
loop itself, it seems to be just good practice to protect against this.