### PR TITLE
Fixed #30408 -- Fixed crash when adding check constraints with LIKE operator on Oracle and PostgreSQL.

### DIFF
--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -23,7 +23,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         if isinstance(value, (datetime.date, datetime.time, datetime.datetime)):
             return "'%s'" % value
         elif isinstance(value, str):
-            return "'%s'" % value.replace("\'", "\'\'")
+            return "'%s'" % value.replace("\'", "\'\'").replace('%', '%%')
         elif isinstance(value, (bytes, bytearray, memoryview)):
             return "'%s'" % value.hex()
         elif isinstance(value, bool):

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -24,6 +24,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_delete_procedure = 'DROP FUNCTION %(procedure)s(%(param_types)s)'
 
     def quote_value(self, value):
+        if isinstance(value, str):
+            value = value.replace('%', '%%')
         # getquoted() returns a quoted bytestring of the adapted value.
         return psycopg2.extensions.adapt(value).getquoted().decode()
 

--- a/docs/releases/2.2.1.txt
+++ b/docs/releases/2.2.1.txt
@@ -70,3 +70,7 @@ Bugfixes
 
 * Fixed a regression in Django 2.2 where changes were not reliably detected by
   auto-reloader when using ``StatReloader`` (:ticket:`30323`).
+
+* Fixed a migration crash on Oracle and PostgreSQL when adding a check
+  constraint with a ``contains``, ``startswith``, or ``endswith`` lookup (or
+  their case-insensitive variant) (:ticket:`30408`).


### PR DESCRIPTION
The LIKE operator wildcard generated for contains, startswith, endswith and
their case-insensitive variant lookups was conflicting with parameter
interpolation on CREATE constraint statement execution.

Ideally we'd delegate parameters interpolation in DDL statements on backends
that support it but that would require backward incompatible changes to the
Index and Constraint SQL generating methods.

Thanks David Sanders for the report.