### PR TITLE
Refs #30426 -- Made security headers active in default project template

### DIFF
--- a/django/conf/project_template/project_name/settings.py-tpl
+++ b/django/conf/project_template/project_name/settings.py-tpl
@@ -114,6 +114,14 @@ USE_L10N = True
 USE_TZ = True
 
 
+# Security settings
+SECURE_CONTENT_TYPE_NOSNIFF = True
+
+SECURE_BROWSER_XSS_FILTER = True
+
+X_FRAME_OPTIONS = 'DENY'
+
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/{{ docs_version }}/howto/static-files/
 


### PR DESCRIPTION
[Ticket 30426](https://code.djangoproject.com/ticket/30426)