### PR TITLE
Fixed #30409 -- Allowed using foreign key's attnames in unique/index_together and Index's fields.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -918,6 +918,7 @@ answer newbie questions, and generally made Django that much better:
     Žan Anderle <zan.anderle@gmail.com>
     Zbigniew Siciarz <zbigniew@siciarz.net>
     zegor
+    Zeynel Özdemir <ozdemir.zynl@gmail.com>
     Zlatko Mašek <zlatko.masek@gmail.com>
     <Please alphabetize new entries>
 

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1569,11 +1569,13 @@ class Model(metaclass=ModelBase):
     def _check_local_fields(cls, fields, option):
         from django.db import models
 
+        forward_fields_map = {}
         # In order to avoid hitting the relation tree prematurely, we use our
         # own fields_map instead of using get_field()
-        forward_fields_map = {
-            field.name: field for field in cls._meta._get_fields(reverse=False)
-        }
+        for field in cls._meta._get_fields(reverse=False):
+            forward_fields_map[field.name] = field
+            if hasattr(field, 'attname'):
+                forward_fields_map[field.attname] = field
 
         errors = []
         for field_name in fields:

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -117,6 +117,19 @@ class IndexTogetherTests(SimpleTestCase):
             ),
         ])
 
+    def test_pointing_to_fk(self):
+        class Foo(models.Model):
+            pass
+
+        class Bar(models.Model):
+            foo_1 = models.ForeignKey(Foo, on_delete=models.CASCADE, related_name='bar_1')
+            foo_2 = models.ForeignKey(Foo, on_delete=models.CASCADE, related_name='bar_2')
+
+            class Meta:
+                index_together = [['foo_1_id', 'foo_2']]
+
+        self.assertEqual(Bar.check(), [])
+
 
 # unique_together tests are very similar to index_together tests.
 @isolate_apps('invalid_models_tests')
@@ -204,6 +217,19 @@ class UniqueTogetherTests(SimpleTestCase):
             ),
         ])
 
+    def test_pointing_to_fk(self):
+        class Foo(models.Model):
+            pass
+
+        class Bar(models.Model):
+            foo_1 = models.ForeignKey(Foo, on_delete=models.CASCADE, related_name='bar_1')
+            foo_2 = models.ForeignKey(Foo, on_delete=models.CASCADE, related_name='bar_2')
+
+            class Meta:
+                unique_together = [['foo_1_id', 'foo_2']]
+
+        self.assertEqual(Bar.check(), [])
+
 
 @isolate_apps('invalid_models_tests')
 class IndexesTests(SimpleTestCase):
@@ -256,6 +282,19 @@ class IndexesTests(SimpleTestCase):
                 id='models.E016',
             ),
         ])
+
+    def test_pointing_to_fk(self):
+        class Foo(models.Model):
+            pass
+
+        class Bar(models.Model):
+            foo_1 = models.ForeignKey(Foo, on_delete=models.CASCADE, related_name='bar_1')
+            foo_2 = models.ForeignKey(Foo, on_delete=models.CASCADE, related_name='bar_2')
+
+            class Meta:
+                indexes = [models.Index(fields=['foo_1_id', 'foo_2'], name='index_name')]
+
+        self.assertEqual(Bar.check(), [])
 
 
 @isolate_apps('invalid_models_tests')


### PR DESCRIPTION
See [#30409](https://code.djangoproject.com/ticket/30409)
Adjusted model checks to allow field attname usage for `indexes`,
`index_together` and `unique_together` in model Meta class.