### PR TITLE
Used time.monotonic() instead of time.time() where applicable.

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -261,33 +261,33 @@ class Command(BaseCommand):
             compute_time = self.verbosity > 1
             if action == "apply_start":
                 if compute_time:
-                    self.start = time.time()
+                    self.start = time.monotonic()
                 self.stdout.write("  Applying %s..." % migration, ending="")
                 self.stdout.flush()
             elif action == "apply_success":
-                elapsed = " (%.3fs)" % (time.time() - self.start) if compute_time else ""
+                elapsed = " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
                 if fake:
                     self.stdout.write(self.style.SUCCESS(" FAKED" + elapsed))
                 else:
                     self.stdout.write(self.style.SUCCESS(" OK" + elapsed))
             elif action == "unapply_start":
                 if compute_time:
-                    self.start = time.time()
+                    self.start = time.monotonic()
                 self.stdout.write("  Unapplying %s..." % migration, ending="")
                 self.stdout.flush()
             elif action == "unapply_success":
-                elapsed = " (%.3fs)" % (time.time() - self.start) if compute_time else ""
+                elapsed = " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
                 if fake:
                     self.stdout.write(self.style.SUCCESS(" FAKED" + elapsed))
                 else:
                     self.stdout.write(self.style.SUCCESS(" OK" + elapsed))
             elif action == "render_start":
                 if compute_time:
-                    self.start = time.time()
+                    self.start = time.monotonic()
                 self.stdout.write("  Rendering model states...", ending="")
                 self.stdout.flush()
             elif action == "render_success":
-                elapsed = " (%.3fs)" % (time.time() - self.start) if compute_time else ""
+                elapsed = " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
                 self.stdout.write(self.style.SUCCESS(" DONE" + elapsed))
 
     def sync_apps(self, connection, app_labels):

--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -187,7 +187,7 @@ class BaseDatabaseWrapper:
         self.needs_rollback = False
         # Reset parameters defining when to close the connection
         max_age = self.settings_dict['CONN_MAX_AGE']
-        self.close_at = None if max_age is None else time.time() + max_age
+        self.close_at = None if max_age is None else time.monotonic() + max_age
         self.closed_in_transaction = False
         self.errors_occurred = False
         # Establish the connection
@@ -510,7 +510,7 @@ class BaseDatabaseWrapper:
                     self.close()
                     return
 
-            if self.close_at is not None and time.time() >= self.close_at:
+            if self.close_at is not None and time.monotonic() >= self.close_at:
                 self.close()
                 return
 

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -3,8 +3,8 @@ import decimal
 import functools
 import hashlib
 import logging
+import time
 from contextlib import contextmanager
-from time import time
 
 from django.conf import settings
 from django.db.utils import NotSupportedError
@@ -105,11 +105,11 @@ class CursorDebugWrapper(CursorWrapper):
 
     @contextmanager
     def debug_sql(self, sql=None, params=None, use_last_executed_query=False, many=False):
-        start = time()
+        start = time.monotonic()
         try:
             yield
         finally:
-            stop = time()
+            stop = time.monotonic()
             duration = stop - start
             if use_last_executed_query:
                 sql = self.db.ops.last_executed_query(self.cursor, sql, params)

--- a/docs/topics/db/instrumentation.txt
+++ b/docs/topics/db/instrumentation.txt
@@ -69,7 +69,7 @@ For a more complete example, a query logger could look like this::
 
         def __call__(self, execute, sql, params, many, context):
             current_query = {'sql': sql, 'params': params, 'many': many}
-            start = time.time()
+            start = time.monotonic()
             try:
                 result = execute(sql, params, many, context)
             except Exception as e:
@@ -80,7 +80,7 @@ For a more complete example, a query logger could look like this::
                 current_query['status'] = 'ok'
                 return result
             finally:
-                duration = time.time() - start
+                duration = time.monotonic() - start
                 current_query['duration'] = duration
                 self.queries.append(current_query)
 


### PR DESCRIPTION
`time.monotonic()` [1] available from Python 3.3:

- Nicely communicates a narrow intent of "get a local system monotonic
  clock time" instead of possible "get a not necessarily accurate Unix
  time stamp because it needs to be communicated to outside of this
  process/machine" when `time.time()` is used.

- Its result isn't affected by the system clock updates.

There are three classes of `time.time()` uses changed to
`time.monotonic()` by this change:

1. Most common is measuring time taken to run some code.

2. In case of django/db/backends/base/base.py -- setting and checking a
   "close_at" threshold for for persistent db connections.

[1] https://docs.python.org/3/library/time.html#time.monotonic