### PR TITLE
[WIP] Fixed #30398 -- Added CONN_HEALTH_CHECK_DELAY db setting

### DIFF
--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -173,6 +173,7 @@ class ConnectionHandler:
         if conn['ENGINE'] == 'django.db.backends.' or not conn['ENGINE']:
             conn['ENGINE'] = 'django.db.backends.dummy'
         conn.setdefault('CONN_MAX_AGE', 0)
+        conn.setdefault('CONN_HEALTH_CHECK_DELAY', None)
         conn.setdefault('OPTIONS', {})
         conn.setdefault('TIME_ZONE', None)
         for setting in ['NAME', 'USER', 'PASSWORD', 'HOST', 'PORT']:


### PR DESCRIPTION
This is a proof of concept solution for [ticket 30398](https://code.djangoproject.com/ticket/30398), with no docs or tests yet.

Introduce a `CONN_HEALTH_CHECK_DELAY` DB setting to Django which can be used to configure database connection health checks for Django's [persistent DB connections](https://docs.djangoproject.com/en/2.2/ref/databases/#persistent-connections).

- If it's set to `None` (default), the behavior is the same as without this change.

- Otherwise, it expects an integer with a number of seconds after which the connection should be health checked before it's reused (`0` for "before every reuse").

When checks are enabled, it works as follows (assuming an already existing "persistent" DB connection):

- Before each connection reuse, perform a connection test (eg. `SELECT 1` query in case of PostgreSQL).

- This only happens if last check was performed more than `CONN_HEALTH_CHECK_DELAY` seconds ago.

- This only happens once per request, regardless of how many DB transactions will be performed during the handling of the request.

- This only happens for "requests" that do use the database.

- If the check fails, close the connection and create a new one.

More info about the rationale and motivation in the [ticket 30398](https://code.djangoproject.com/ticket/30398).