### PR TITLE
auth/base_user.py: Used staticmethod appropriately

### DIFF
--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -15,8 +15,8 @@ from django.utils.translation import gettext_lazy as _
 
 class BaseUserManager(models.Manager):
 
-    @classmethod
-    def normalize_email(cls, email):
+    @staticmethod
+    def normalize_email(email):
         """
         Normalize the email address by lowercasing the domain part of it.
         """
@@ -29,7 +29,8 @@ class BaseUserManager(models.Manager):
             email = email_name + '@' + domain_part.lower()
         return email
 
-    def make_random_password(self, length=10,
+    @staticmethod
+    def make_random_password(length=10,
                              allowed_chars='abcdefghjkmnpqrstuvwxyz'
                                            'ABCDEFGHJKLMNPQRSTUVWXYZ'
                                            '23456789'):
@@ -134,6 +135,6 @@ class AbstractBaseUser(models.Model):
         except AttributeError:
             return 'email'
 
-    @classmethod
-    def normalize_username(cls, username):
+    @staticmethod
+    def normalize_username(username):
         return unicodedata.normalize('NFKC', username) if isinstance(username, str) else username


### PR DESCRIPTION
- Converted `BaseUserManager.normalize_email`, `BaseUserManager.make_random_password`, and `AbstractBaseUser.normalize_username` to staticmethods
- All three make more sense as staticmethods given that they don't reference either the instance or class (conventionally `self/cls`, respectively; one of them had a `cls` param but then didn't actually use it.