### PR TITLE
[2.2.x] Fixed #30380 -- Handled bytes in MySQL backend for PyMySQL support.

### DIFF
--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
 from django.utils import timezone
 from django.utils.duration import duration_microseconds
+from django.utils.encoding import force_str
 
 
 class DatabaseOperations(BaseDatabaseOperations):
@@ -141,10 +142,8 @@ class DatabaseOperations(BaseDatabaseOperations):
         # With MySQLdb, cursor objects have an (undocumented) "_executed"
         # attribute where the exact query sent to the database is saved.
         # See MySQLdb/cursors.py in the source distribution.
-        query = getattr(cursor, '_executed', None)
-        if query is not None:
-            query = query.decode(errors='replace')
-        return query
+        # MySQLdb returns string, PyMySQL bytes.
+        return force_str(getattr(cursor, '_executed', None), errors='replace')
 
     def no_limit_value(self):
         # 2**64 - 1, as recommended by the MySQL documentation

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -28,8 +28,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def quote_value(self, value):
         self.connection.ensure_connection()
+        # MySQLdb returns string, PyMySQL bytes.
         quoted = self.connection.connection.escape(value, self.connection.connection.encoders)
-        if isinstance(value, str):
+        if isinstance(value, str) and isinstance(quoted, bytes):
             quoted = quoted.decode()
         return quoted
 


### PR DESCRIPTION
Backport of a41b09266dcdd01036d59d76fe926fe0386aaade from master.
Backport of 994a00eb70969e4fd8f7a30a95122e2f0411ff48 from master.