### PR TITLE
Fixed #30442 -- Added validators to auth/password_validation.py.

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -1,6 +1,27 @@
+__all__ = (
+    # Validator classes
+    "CommonPasswordValidator",
+    "MinimumLengthValidator",
+    "NoAmbiguousCharactersValidator",
+    "NoRepeatSubstringsValidator",
+    "NoSequentialCharsValidator",
+    "NumericPasswordValidator",
+    "ShannonEntropyValidator",
+    "UserAttributeSimilarityValidator",
+    # Top-level functions
+    "get_default_password_validators",
+    "get_password_validators",
+    "password_changed",
+    "password_validators_help_text_html",
+    "password_validators_help_texts",
+    "validate_password"
+)
+
 import functools
 import gzip
+import math
 import re
+from collections import defaultdict
 from difflib import SequenceMatcher
 from pathlib import Path
 
@@ -203,3 +224,238 @@ class NumericPasswordValidator:
 
     def get_help_text(self):
         return _("Your password can't be entirely numeric.")
+
+
+class NoAmbiguousCharactersValidator:
+    """
+    Validate that the password does not contain ambiguous characters.
+
+    The default set of ambiguous characters is:
+
+    - The digit zero, 0
+    - The digit one, 1
+    - Capital letter I as in Isaac
+    - Lowercase letter i as in intrinsic
+    - Lowercase letter l as in leopard
+    - The bar symbol, |
+    - Uppercase letter O as in Onyx
+    - Lowercase letter o as in operation
+
+    This set is partly inspired by the characters included from a random
+    password generated in BaseUserManager.make_random_password() from
+    django/contrib/auth/base_user.py.
+    """
+
+    def __init__(
+        self, ambiguous=frozenset(("0", "1", "I", "i", "|", "l", "O", "o"))
+    ):
+        if not ambiguous:
+            raise ValueError("Must specify at least one ambiguous character.")
+        # Always guarantee O(1) membership testing, no matter what user passes.
+        self.ambiguous = set(ambiguous)
+
+    def validate(self, password, user=None):
+        found = sorted(self.ambiguous.intersection(password))
+        if found:
+            sfound = ", ".join(map(repr, found))
+            msg = ngettext(
+                "This password contains the following ambiguous character: %(sfound)s.",
+                "This password contains the following ambiguous characters: %(sfound)s.",
+                len(found),
+            )
+            raise ValidationError(
+                msg,
+                code="password_has_ambiguous_characters",
+                params={"sfound": sfound},
+            )
+
+    def get_help_text(self):
+        if len(self.ambiguous) == 1:
+            return _(
+                "Your password may not contain the ambiguous character %(char)r."
+            ) % {"char": next(iter(self.ambiguous))}
+        return _(
+            "Your password may not contain ambiguous characters %(chars)s."
+        ) % {"chars": ", ".join(map(repr, sorted(self.ambiguous)))}
+
+
+class NoSequentialCharsValidator:
+    """
+    Validate that the password does not contain sequential repeated chars.
+
+    If the password contains *greater than* `max_sequential_chars` repeats
+    of a character consecutively, a ValidationError is raised.
+    """
+
+    def __init__(self, max_sequential_chars=2):
+        if max_sequential_chars < 1:
+            raise ValueError("`max_sequential_chars` must be >= 1.")
+        self.max_sequential_chars = max_sequential_chars
+
+    def validate(self, password, user=None):
+        if len(password) <= self.max_sequential_chars:
+            return None
+        # Iterate over (i, j) pairs in password, incrementing a `seq`
+        # counter if a repeat occurs or resetting it if one does not.
+        # If at any time `seq` rises above max_sequential_chars,
+        # raise immediately.
+        previous = password[0]
+        seq = 1
+        for char in password[1:]:
+            if char == previous:
+                seq += 1
+                if seq > self.max_sequential_chars:
+                    raise ValidationError(
+                        _(
+                            "This password contains %(seq)d sequential characters."
+                            "  Your password should contain no more than %(max)d"
+                            " sequential characters."
+                        ),
+                        code="password_has_sequential_chars",
+                        params={"seq": seq, "max": self.max_sequential_chars},
+                    )
+            else:
+                seq = 1
+            previous = char
+
+    def get_help_text(self):
+        return ngettext(
+            "Your password must contain no more than %(n)d repeat of the same character in a row.",
+            "Your password must contain no more than %(n)d repeats of the same character in a row.",
+            self.max_sequential_chars,
+        ) % {"n": self.max_sequential_chars}
+
+
+class NoRepeatSubstringsValidator:
+    """
+    Validate that the password does not contain repeated substrings.
+
+    The parameter max_length (int) specifies the *maximum allowed*
+    length of a repeated substring.  `max_length` itself must be
+    greater than 2.
+
+    For example, specifying max_length=2 would raise a ValidationError
+    on the password "abcdefabc", because "abc" is repeated and has a
+    length of 3, which is greater than the maximum allowed of length 2.
+
+    The validator does not concern itself with the *number* of repeats.
+
+    Note that the technical definition here is for *overlapping*
+    strings.  That means that validate("abcabcabc") will tell us that
+    it is actually the substring "abcabc" that is repeated twice,
+    rather than just "abc" as would be the case in the nonoverlappping
+    version.
+
+    The function for substring detection is modified from a recipe from
+    Rajendra Dharmkar:
+
+    https://www.tutorialspoint.com/How-to-find-longest-repetitive-sequence-in-a-string-in-Python
+
+    This is the longest repeated substring problem.
+    It uses what is basically a modified powerset, which is rough on
+    time complexity but fast enough unless the password length gets
+    outrageously long.  The O(N) alternative entails absolutely wicked
+    code complexity in building a suffix tree.
+    """
+
+    def __init__(self, max_length=2):
+        if max_length < 1:
+            raise ValueError("max_length should be greater than 0.")
+        self.max_length = max_length
+
+    def validate(self, password, user=None):
+        def longest_substring(r):
+            def getsubs(loc, s):
+                substr = s[loc:]
+                i = -1
+                while substr:
+                    yield substr
+                    substr = s[loc:i]
+                    i -= 1
+
+            occ = defaultdict(int)
+            for i, __ in enumerate(r):
+                for sub in getsubs(i, r):
+                    if len(sub) >= self.max_length:
+                        occ[sub] += 1
+            try:
+                return max((k for k, v in occ.items() if v >= 2), key=len)
+            except ValueError:
+                return ""
+
+        longest_ss = longest_substring(password)
+        if len(longest_ss) > self.max_length:
+            raise ValidationError(
+                _(
+                    "This password contains a repeated substring longer than %(len)d characters: %(ss)r."
+                )
+                % {"len": self.max_length, "ss": longest_ss},
+                code="password_found_repeat_substring",
+            )
+
+    def get_help_text(self):
+        return ngettext(
+            "Your password should not contain a repeated substring longer than %(mr)d character.",
+            "Your password should not contain a repeated substring longer than %(mr)d characters.",
+            self.max_length,
+        ) % {"mr": self.max_length}
+
+
+class ShannonEntropyValidator:
+    """
+    Validate that the password is sufficiently complex.
+
+    The score is Shannon Entropy, described at:
+    http://bearcave.com/misl/misl_tech/wavelets/compression/shannon.html.
+
+    It is a way to estimate the average minimum number of bits needed
+    to encode a string.
+    """
+
+    # We pick a default number of 3.0 which is, admittedly, not all
+    # that strong, and leave it up to the developer to increase this
+    # threshold.  For some perspective, the Shannon entropy
+    # of the string "({ucdC(Rp7kG" is 3.42.  This string was derived
+    # from Dashlane Password Generator using a combination of
+    # mixed-case letters, digits, and symbols, and scores "Strength: 100"
+    # according to Dashlane.  The string "11123456789" scores a 3.03.
+    DEFAULT_MIN_ENTROPY = 3.0
+
+    def __init__(self, min_entropy=DEFAULT_MIN_ENTROPY):
+        self.min_entropy = min_entropy
+
+    @staticmethod
+    def _shannon_entropy(password):
+        """Number of bits needed *per symbol* if PW optimally encoded.
+
+        Returns: float
+        """
+
+        # Probabilities (values sum to 1.0).  This is a PMF constructed
+        # in linear time, rather than looping over collections.Counter
+        # to first get the counts and then normalize.
+
+        if not password:
+            return 0.
+        freq = defaultdict(float)
+        incr = 1 / len(password)
+        for char in password:
+            freq[char] += incr
+        return -1 * sum(p * math.log2(p) for p in freq.values())
+
+    def validate(self, password, user=None):
+        se = self._shannon_entropy(password)
+        if se < self.min_entropy:
+            raise ValidationError(
+                _("This password does not meet the required complexity "
+                  "score of %(min_entropy).2f; it scores a %(se).2f.  "
+                  "Increase the length of the password and avoid repeating "
+                  "characters."),
+                code="password_not_complex_enough",
+                params={"min_entropy": self.min_entropy, "se": se},
+            )
+
+    def get_help_text(self):
+        return _("Your password should meet an overall complexity score. "
+                 "This score is based on the length of the password and "
+                 "variety of unique characters used.")

--- a/tests/auth_tests/test_validators.py
+++ b/tests/auth_tests/test_validators.py
@@ -3,9 +3,11 @@ import os
 from django.contrib.auth import validators
 from django.contrib.auth.models import User
 from django.contrib.auth.password_validation import (
-    CommonPasswordValidator, MinimumLengthValidator, NumericPasswordValidator,
-    UserAttributeSimilarityValidator, get_default_password_validators,
-    get_password_validators, password_changed,
+    CommonPasswordValidator, MinimumLengthValidator,
+    NoAmbiguousCharactersValidator, NoRepeatSubstringsValidator,
+    NoSequentialCharsValidator, NumericPasswordValidator,
+    ShannonEntropyValidator, UserAttributeSimilarityValidator,
+    get_default_password_validators, get_password_validators, password_changed,
     password_validators_help_text_html, password_validators_help_texts,
     validate_password,
 )
@@ -259,3 +261,198 @@ class UsernameValidatorsTests(SimpleTestCase):
             with self.subTest(invalid=invalid):
                 with self.assertRaises(ValidationError):
                     v(invalid)
+
+
+class NoAmbiguousCharactersValidatorTest(SimpleTestCase):
+    def test_validate_default_ambiguous(self):
+        self.assertIsNone(NoAmbiguousCharactersValidator().validate("abcdef"))
+        self.assertIsNone(NoAmbiguousCharactersValidator().validate("234567"))
+
+        for (ambig_pw, badmsg) in (
+            (
+                "aeiou",
+                "This password contains the following ambiguous characters: 'i', 'o'.",
+            ),
+            (
+                "c0rnhOle",
+                "This password contains the following ambiguous characters: '0', 'O', 'l'.",
+            ),
+            (
+                "carame|",
+                "This password contains the following ambiguous character: '|'.",
+            ),
+        ):
+            with self.subTest(ambig_pw=ambig_pw, badmsg=ambig_pw):
+                with self.assertRaises(ValidationError) as cm:
+                    NoAmbiguousCharactersValidator().validate(ambig_pw)
+                self.assertEqual(cm.exception.messages, [badmsg])
+                self.assertEqual(
+                    cm.exception.error_list[0].code,
+                    "password_has_ambiguous_characters",
+                )
+
+    def test_validate_custom_ambiguous(self):
+        self.assertIsNone(
+            NoAmbiguousCharactersValidator("efg").validate("abcd")
+        )
+        self.assertIsNone(
+            NoAmbiguousCharactersValidator(set("efg")).validate("abcd")
+        )
+
+        for ambig_pw, badmsg in (
+            (
+                "hi_im_007",
+                "This password contains the following ambiguous character: '0'.",
+            ),
+            (
+                "bad_m0Od",
+                "This password contains the following ambiguous characters: '0', 'O'.",
+            ),
+        ):
+            with self.subTest(ambig_pw=ambig_pw, badmsg=ambig_pw):
+                with self.assertRaises(ValidationError) as cm:
+                    NoAmbiguousCharactersValidator(set("0O")).validate(ambig_pw)
+                self.assertEqual(cm.exception.messages, [badmsg])
+                self.assertEqual(
+                    cm.exception.error_list[0].code,
+                    "password_has_ambiguous_characters",
+                )
+
+    def test_get_help_text(self):
+        self.assertEqual(
+            NoAmbiguousCharactersValidator().get_help_text(),
+            "Your password may not contain ambiguous characters '0', '1', 'I', 'O', 'i', 'l', 'o', '|'.",
+        )
+        self.assertEqual(
+            NoAmbiguousCharactersValidator("aaaaa").get_help_text(),
+            "Your password may not contain the ambiguous character 'a'.",
+        )
+
+    def test_requires_atleast_one_ambig(self):
+        with self.assertRaises(ValueError) as cm:
+            NoAmbiguousCharactersValidator(())
+        self.assertEqual(
+            cm.exception.args[0],
+            "Must specify at least one ambiguous character.",
+        )
+
+
+class NoSequentialCharsValidatorTest(SimpleTestCase):
+    def test_get_help_text(self):
+        self.assertEqual(
+            NoSequentialCharsValidator(1).get_help_text(),
+            "Your password must contain no more than 1 repeat of the same "
+            "character in a row.",
+        )
+        self.assertEqual(
+            NoSequentialCharsValidator(99).get_help_text(),
+            "Your password must contain no more than 99 repeats of the same "
+            "character in a row.",
+        )
+
+    def test_max_sequential_chars_param(self):
+        with self.assertRaises(ValueError):
+            NoSequentialCharsValidator(0)
+
+    def test_validate(self):
+        self.assertIsNone(NoSequentialCharsValidator(2).validate("abcda"))
+        self.assertIsNone(NoSequentialCharsValidator(4).validate("abcabc"))
+
+        with self.assertRaises(ValidationError) as cm:
+            NoSequentialCharsValidator(2).validate("rrpeaterrr")
+        self.assertEqual(
+            cm.exception.messages,
+            [
+                "This password contains 3 sequential characters.  "
+                "Your password should contain no more than 2 sequential"
+                " characters."
+            ],
+        )
+        self.assertEqual(
+            cm.exception.error_list[0].code, "password_has_sequential_chars"
+        )
+
+        with self.assertRaises(ValidationError) as cm:
+            NoSequentialCharsValidator(3).validate("paaaassword1!")
+        self.assertEqual(
+            cm.exception.messages,
+            [
+                "This password contains 4 sequential characters.  "
+                "Your password should contain no more than 3 sequential"
+                " characters."
+            ],
+        )
+        self.assertEqual(
+            cm.exception.error_list[0].code, "password_has_sequential_chars"
+        )
+
+
+class ShannonEntropyValidatorTest(SimpleTestCase):
+    def setUp(self):
+        self.entropy = ShannonEntropyValidator._shannon_entropy
+
+    def test_shannon_entropy(self):
+        self.assertGreater(self.entropy("abcd"), self.entropy("abc"))
+        self.assertGreater(self.entropy("abcd"), self.entropy("abca"))
+        self.assertGreater(
+            self.entropy('U*&y=PYZH:*rfuL~h=":|&CmecPK4.'),
+            self.entropy('U*&y=PYZH:*UUUUUUUUU|&CmecPK4.'),
+        )
+        self.assertAlmostEqual(self.entropy("AAAAABBCDE"), 1.9609640474436814)
+        self.assertAlmostEqual(self.entropy("({ucdC(Rp7kG"), 3.418295834054489)
+
+    def test_validate(self):
+        weak = "banana$"  # ~1.84
+        self.assertIsNone(ShannonEntropyValidator(1.8).validate(weak))
+        with self.assertRaises(ValidationError) as cm:
+            ShannonEntropyValidator(2.0).validate(weak)
+
+        self.assertEqual(
+            cm.exception.messages,
+            ['This password does not meet the required complexity score of '
+             '2.00; it scores a 1.84.  Increase the length of the password'
+             ' and avoid repeating characters.']
+        )
+        self.assertEqual(
+            cm.exception.error_list[0].code, "password_not_complex_enough"
+        )
+
+    def test_get_help_text(self):
+        self.assertEqual(
+            ShannonEntropyValidator().get_help_text(),
+            "Your password should meet an overall complexity score. "
+            "This score is based on the length of the password and variety "
+            "of unique characters used.",
+        )
+
+
+class NoRepeatSubstringsValidatorTest(SimpleTestCase):
+    def test_validate(self):
+        with self.assertRaises(ValueError):
+            NoRepeatSubstringsValidator(0)
+        self.assertIsNone(NoRepeatSubstringsValidator(1).validate("aba"))
+        self.assertIsNone(NoRepeatSubstringsValidator(2).validate("abba"))
+        self.assertIsNone(NoRepeatSubstringsValidator(3).validate("abaccc"))
+        for n in (1, 2, 3):
+            with self.subTest(n=n):
+                self.assertIsNone(NoRepeatSubstringsValidator(n).validate("myfirstname"))
+
+        with self.assertRaises(ValidationError) as cm:
+            NoRepeatSubstringsValidator(3).validate("passpassword")
+        self.assertEqual(
+            cm.exception.messages,
+            ["This password contains a repeated substring longer than 3 characters: 'pass'."]
+        )
+        self.assertEqual(
+            cm.exception.error_list[0].code, "password_found_repeat_substring"
+        )
+
+    def test_get_help_text(self):
+        self.assertEqual(
+            NoRepeatSubstringsValidator(1).get_help_text(),
+            "Your password should not contain a repeated substring longer than 1 character."
+        )
+        self.assertEqual(
+            NoRepeatSubstringsValidator(3).get_help_text(),
+            "Your password should not contain a repeated substring longer than 3 characters."
+        )


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/30442

Added the following validator classes:

NoAmbiguousCharactersValidator

    Validate that the password does not contain ambiguous characters.
    The default set of ambiguous characters is:
    { 0, 1, I, i, l, |, O, o }

NoRepeatSubstringsValidator

    Validate that the password does not contain repeated substrings
    longer than a given threshold.

NoSequentialCharsValidator

    Validate that the password does not contain sequential repeated
    characters.

ShannonEntropyValidator

    Validate that the password is sufficiently complex via the
    Shannon Entropy score.

Also added an __all__ dunder to contrib/auth/password_validation.py
that contains both top-level module functions and the full set
of validator classes.

Also added respective test for each of the 4 new classes in
auth_test/test_validators.py.  Each, at a minimum, tests
`.validate()` and `.get_help_text()` in a manner similar to the
existing tests from that module.

--------------------------------------

Why add these classes?

These classes were added in the spirit of _more validation is almost
always better._  These classes `.validate()` are meant to be
straightforward, quick, and lightweight.  They offer checks that are
not captured by the existing validators.

One piece of food for thought is to more thoroughly document that
rules-based password validation can be a fool's errand depending on
how you structure it.  These days, the consensus seems to be moving
towards the conclusion that users should no longer focus on passwords
to passphrases.  The idea here is that *entropy is king*:
a 38-character all-lowercase password could have 170 bits of entropy
but fail a basic "mixed case letters" test.  In other words, all of
the validators are best used in combination, and it should be
advertised everywhere possible that they provide _negative_ checks
in many cases rather than positive ones.