### PR TITLE
Fixed #30443 -- Format negative durations more intuitively.

### DIFF
--- a/django/utils/duration.py
+++ b/django/utils/duration.py
@@ -2,6 +2,12 @@ import datetime
 
 
 def _get_duration_components(duration):
+    if duration < datetime.timedelta(0):
+        sign = '-'
+        duration *= -1
+    else:
+        sign = ''
+
     days = duration.days
     seconds = duration.seconds
     microseconds = duration.microseconds
@@ -12,14 +18,14 @@ def _get_duration_components(duration):
     hours = minutes // 60
     minutes = minutes % 60
 
-    return days, hours, minutes, seconds, microseconds
+    return sign, days, hours, minutes, seconds, microseconds
 
 
 def duration_string(duration):
     """Version of str(timedelta) which is not English specific."""
-    days, hours, minutes, seconds, microseconds = _get_duration_components(duration)
+    sign, days, hours, minutes, seconds, microseconds = _get_duration_components(duration)
 
-    string = '{:02d}:{:02d}:{:02d}'.format(hours, minutes, seconds)
+    string = '{}{:02d}:{:02d}:{:02d}'.format(sign, hours, minutes, seconds)
     if days:
         string = '{} '.format(days) + string
     if microseconds:
@@ -29,13 +35,7 @@ def duration_string(duration):
 
 
 def duration_iso_string(duration):
-    if duration < datetime.timedelta(0):
-        sign = '-'
-        duration *= -1
-    else:
-        sign = ''
-
-    days, hours, minutes, seconds, microseconds = _get_duration_components(duration)
+    sign, days, hours, minutes, seconds, microseconds = _get_duration_components(duration)
     ms = '.{:06d}'.format(microseconds) if microseconds else ""
     return '{}P{}DT{:02d}H{:02d}M{:02d}{}S'.format(sign, days, hours, minutes, seconds, ms)
 

--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -111,7 +111,8 @@ class DurationParseTests(unittest.TestCase):
 
     def test_negative(self):
         test_values = (
-            ('-4 15:30', timedelta(days=-4, minutes=15, seconds=30)),
+            ('-4 15:30', timedelta(days=-4, minutes=-15, seconds=-30)),
+            ('-4 -15:30', None),
             ('-172800', timedelta(days=-2)),
             ('-15:30', timedelta(minutes=-15, seconds=-30)),
             ('-1:15:30', timedelta(hours=-1, minutes=-15, seconds=-30)),

--- a/tests/utils_tests/test_duration.py
+++ b/tests/utils_tests/test_duration.py
@@ -23,7 +23,7 @@ class TestDurationString(unittest.TestCase):
 
     def test_negative(self):
         duration = datetime.timedelta(days=-1, hours=1, minutes=3, seconds=5)
-        self.assertEqual(duration_string(duration), '-1 01:03:05')
+        self.assertEqual(duration_string(duration), '-22:56:55')
 
 
 class TestParseDurationRoundtrip(unittest.TestCase):


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/30443 for rationale.

Basically, `duration_string(parse_duration("-00:00:05"))` should not be `-1 23:59:55`.