### PR TITLE
Removed unnecessary import

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1,6 +1,5 @@
 import functools
 import inspect
-from functools import partial
 
 from django import forms
 from django.apps import apps
@@ -77,7 +76,7 @@ def lazy_related_operation(function, model, *related_models, **kwargs):
     models = [model] + [resolve_relation(model, rel) for rel in related_models]
     model_keys = (make_model_tuple(m) for m in models)
     apps = model._meta.apps
-    return apps.lazy_model_operation(partial(function, **kwargs), *model_keys)
+    return apps.lazy_model_operation(functools.partial(function, **kwargs), *model_keys)
 
 
 class RelatedField(FieldCacheMixin, Field):
@@ -1594,7 +1593,7 @@ class ManyToManyField(RelatedField):
         setattr(cls, self.name, ManyToManyDescriptor(self.remote_field, reverse=False))
 
         # Set up the accessor for the m2m table name for the relation.
-        self.m2m_db_table = partial(self._get_m2m_db_table, cls._meta)
+        self.m2m_db_table = functools.partial(self._get_m2m_db_table, cls._meta)
 
     def contribute_to_related_class(self, cls, related):
         # Internal M2Ms (i.e., those with a related name ending with '+')
@@ -1603,15 +1602,15 @@ class ManyToManyField(RelatedField):
             setattr(cls, related.get_accessor_name(), ManyToManyDescriptor(self.remote_field, reverse=True))
 
         # Set up the accessors for the column names on the m2m table.
-        self.m2m_column_name = partial(self._get_m2m_attr, related, 'column')
-        self.m2m_reverse_name = partial(self._get_m2m_reverse_attr, related, 'column')
+        self.m2m_column_name = functools.partial(self._get_m2m_attr, related, 'column')
+        self.m2m_reverse_name = functools.partial(self._get_m2m_reverse_attr, related, 'column')
 
-        self.m2m_field_name = partial(self._get_m2m_attr, related, 'name')
-        self.m2m_reverse_field_name = partial(self._get_m2m_reverse_attr, related, 'name')
+        self.m2m_field_name = functools.partial(self._get_m2m_attr, related, 'name')
+        self.m2m_reverse_field_name = functools.partial(self._get_m2m_reverse_attr, related, 'name')
 
-        get_m2m_rel = partial(self._get_m2m_attr, related, 'remote_field')
+        get_m2m_rel = functools.partial(self._get_m2m_attr, related, 'remote_field')
         self.m2m_target_field_name = lambda: get_m2m_rel().field_name
-        get_m2m_reverse_rel = partial(self._get_m2m_reverse_attr, related, 'remote_field')
+        get_m2m_reverse_rel = functools.partial(self._get_m2m_reverse_attr, related, 'remote_field')
         self.m2m_reverse_target_field_name = lambda: get_m2m_reverse_rel().field_name
 
     def set_attributes_from_rel(self):


### PR DESCRIPTION
Removed unnecessary import.

As `functools` is already imported so instead of importing partial again `from functools import partial` . we can use it from `functools`.

