### PR TITLE
Removed deprecated license-file from setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,3 @@ include_trailing_comma = true
 known_first_party = django
 line_length = 79
 multi_line_output = 5
-
-[metadata]
-license-file = LICENSE


### PR DESCRIPTION
Starting with wheel 0.32.0 (2018-09-29), the "license-file" option is deprecated.

https://wheel.readthedocs.io/en/stable/news.html

The wheel will continue to include LICENSE, it is now included automatically:

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file