### PR TITLE
Readded comment about the default params of cursor.execute().

### DIFF
--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -80,6 +80,7 @@ class CursorWrapper:
         self.db.validate_no_broken_transaction()
         with self.db.wrap_database_errors:
             if params is None:
+                # params default might be backend specific.
                 return self.cursor.execute(sql)
             else:
                 return self.cursor.execute(sql, params)


### PR DESCRIPTION
It was removed in 728548e483, but is worth keeping - given that it still
applies, which I have not checked.

/cc @aaugustin 