### PR TITLE
Fixed #30447 - Added 'is_in_european_union' in GeoIP2.city() dict.

### DIFF
--- a/django/contrib/gis/geoip2/resources.py
+++ b/django/contrib/gis/geoip2/resources.py
@@ -6,6 +6,7 @@ def City(response):
         'country_code': response.country.iso_code,
         'country_name': response.country.name,
         'dma_code': response.location.metro_code,
+        'is_in_european_union': response.country.is_in_european_union,
         'latitude': response.location.latitude,
         'longitude': response.location.longitude,
         'postal_code': response.postal.code,

--- a/docs/ref/contrib/gis/geoip2.txt
+++ b/docs/ref/contrib/gis/geoip2.txt
@@ -38,6 +38,7 @@ Here is an example of its usage::
     'country_code': 'US',
     'country_name': 'United States',
     'dma_code': 807,
+    'is_in_european_union': False,
     'latitude': 37.419200897216797,
     'longitude': -122.05740356445312,
     'postal_code': '94043',

--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -127,6 +127,7 @@ class GeoIPTest(SimpleTestCase):
             self.assertEqual('Houston', d['city'])
             self.assertEqual('TX', d['region'])
             self.assertEqual('America/Chicago', d['time_zone'])
+            self.assertFalse(d['is_in_european_union'])
             geom = g.geos(query)
             self.assertIsInstance(geom, GEOSGeometry)
 


### PR DESCRIPTION
Maxmind data supplies european union information as part of both the free and paid database sets.
This isn't accessible from the GeoIP2 city dict, despite it being available.