### PR TITLE
Fixed #30440 -- Prevented any_selected() in SelectFilter2.js from leaving temporary required attribute.

### DIFF
--- a/django/contrib/admin/static/admin/js/SelectFilter2.js
+++ b/django/contrib/admin/static/admin/js/SelectFilter2.js
@@ -179,11 +179,11 @@ Requires jQuery, core.js, and SelectBox.js.
                 // This is much faster in WebKit browsers than the fallback.
                 field.attr('required', 'required');
                 any_selected = field.is(':valid');
-                field.removeAttr('required');
             } catch (e) {
                 // Browsers that don't support :valid (IE < 10)
                 any_selected = field.find('option:selected').length > 0;
             }
+            field.removeAttr('required');
             return any_selected;
         },
         refresh_icons: function(field_id) {


### PR DESCRIPTION
Fixes bug on browsers which do support the required attribute but not the `:valid` pseudo-selector

Fixes https://code.djangoproject.com/ticket/30440#ticket