### PR TITLE
Fixed #30453 -- Fixed crash of simple_tag() and inclusion_tag() when function is wrapped.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -107,6 +107,7 @@ answer newbie questions, and generally made Django that much better:
     Bastian Kleineidam <calvin@debian.org>
     Batiste Bieler <batiste.bieler@gmail.com>
     Batman
+    Batuhan Taskaya <batuhanosmantaskaya@gmail.com>
     Baurzhan Ismagulov <ibr@radix50.net>
     Ben Dean Kawamura <ben.dean.kawamura@gmail.com>
     Ben Firshman <ben@firshman.co.uk>

--- a/django/template/library.py
+++ b/django/template/library.py
@@ -1,6 +1,6 @@
 import functools
 from importlib import import_module
-from inspect import getfullargspec
+from inspect import getfullargspec, unwrap
 
 from django.utils.html import conditional_escape
 from django.utils.itercompat import is_iterable
@@ -106,7 +106,7 @@ class Library:
             return 'world'
         """
         def dec(func):
-            params, varargs, varkw, defaults, kwonly, kwonly_defaults, _ = getfullargspec(func)
+            params, varargs, varkw, defaults, kwonly, kwonly_defaults, _ = getfullargspec(unwrap(func))
             function_name = (name or getattr(func, '_decorated_function', func).__name__)
 
             @functools.wraps(func)
@@ -143,7 +143,7 @@ class Library:
             return {'choices': choices}
         """
         def dec(func):
-            params, varargs, varkw, defaults, kwonly, kwonly_defaults, _ = getfullargspec(func)
+            params, varargs, varkw, defaults, kwonly, kwonly_defaults, _ = getfullargspec(unwrap(func))
             function_name = (name or getattr(func, '_decorated_function', func).__name__)
 
             @functools.wraps(func)

--- a/tests/template_tests/test_library.py
+++ b/tests/template_tests/test_library.py
@@ -1,3 +1,5 @@
+import functools
+
 from django.template import Library
 from django.template.base import Node
 from django.test import SimpleTestCase
@@ -61,6 +63,15 @@ class InclusionTagRegistrationTests(SimpleTestCase):
             return ''
         self.assertIn('name', self.library.tags)
 
+    def test_inclusion_tag_wrapped(self):
+        @self.library.inclusion_tag('template.html')
+        @functools.lru_cache(maxsize=32)
+        def func():
+            return ''
+        func_wrapped = self.library.tags['func'].__wrapped__
+        self.assertIs(func_wrapped, func)
+        self.assertTrue(hasattr(func_wrapped, 'cache_info'))
+
 
 class SimpleTagRegistrationTests(SimpleTestCase):
 
@@ -89,6 +100,15 @@ class SimpleTagRegistrationTests(SimpleTestCase):
         msg = "Invalid arguments provided to simple_tag"
         with self.assertRaisesMessage(ValueError, msg):
             self.library.simple_tag('invalid')
+
+    def test_simple_tag_wrapped(self):
+        @self.library.simple_tag
+        @functools.lru_cache(maxsize=32)
+        def func():
+            return ''
+        func_wrapped = self.library.tags['func'].__wrapped__
+        self.assertIs(func_wrapped, func)
+        self.assertTrue(hasattr(func_wrapped, 'cache_info'))
 
 
 class TagRegistrationTests(SimpleTestCase):


### PR DESCRIPTION
Functions unwrapped before the getting fullargspec part.