### PR TITLE
[WIP] Fixed #30398 -- Added CONN_HEALTH_CHECKS db setting

### DIFF
--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -173,6 +173,7 @@ class ConnectionHandler:
         if conn['ENGINE'] == 'django.db.backends.' or not conn['ENGINE']:
             conn['ENGINE'] = 'django.db.backends.dummy'
         conn.setdefault('CONN_MAX_AGE', 0)
+        conn.setdefault('CONN_HEALTH_CHECKS', False)
         conn.setdefault('OPTIONS', {})
         conn.setdefault('TIME_ZONE', None)
         for setting in ['NAME', 'USER', 'PASSWORD', 'HOST', 'PORT']:


### PR DESCRIPTION
This is a proof of concept solution for [ticket 30398](https://code.djangoproject.com/ticket/30398), with no docs or tests yet.

Introduce a `CONN_HEALTH_CHECKS` DB setting to Django which can be used to enable database connection health checks for Django's [persistent DB connections](https://docs.djangoproject.com/en/2.2/ref/databases/#persistent-connections).

If it's set to `False` (default), the behavior is the same as without this change.

If it's set to `True`, then health checks are enabled. They work as
follows (assuming an already existing "persistent" DB connection):

- Before each connection reuse, perform a connection test
  (eg. `SELECT 1` query in case of PostgreSQL).

- This only happens once per request, regardless of how many DB
  transactions will be performed during the handling of the request.

- This only happens for "requests" that do use the database.

- If the check fails, close the connection and create a new one.

More info about the rationale and motivation in the [ticket 30398](https://code.djangoproject.com/ticket/30398).

----
This is a simpler alternative to #11311 (thanks @apollo13 for the suggestion to drop the checks based on the timer), with the general approach being the same.