### PR TITLE
Removed redundant check from StaticFilesHandler.

### DIFF
--- a/django/contrib/staticfiles/handlers.py
+++ b/django/contrib/staticfiles/handlers.py
@@ -6,6 +6,7 @@ from django.contrib.staticfiles import utils
 from django.contrib.staticfiles.views import serve
 from django.core.handlers.exception import response_for_exception
 from django.core.handlers.wsgi import WSGIHandler, get_path_info
+from django.http import Http404
 
 
 class StaticFilesHandler(WSGIHandler):
@@ -51,8 +52,6 @@ class StaticFilesHandler(WSGIHandler):
         return serve(request, self.file_path(request.path), insecure=True)
 
     def get_response(self, request):
-        from django.http import Http404
-
         try:
             return self.serve(request)
         except Http404 as e:

--- a/django/contrib/staticfiles/handlers.py
+++ b/django/contrib/staticfiles/handlers.py
@@ -53,12 +53,10 @@ class StaticFilesHandler(WSGIHandler):
     def get_response(self, request):
         from django.http import Http404
 
-        if self._should_handle(request.path):
-            try:
-                return self.serve(request)
-            except Http404 as e:
-                return response_for_exception(request, e)
-        return super().get_response(request)
+        try:
+            return self.serve(request)
+        except Http404 as e:
+            return response_for_exception(request, e)
 
     def __call__(self, environ, start_response):
         if not self._should_handle(get_path_info(environ)):


### PR DESCRIPTION
As per https://github.com/django/django/pull/11209#discussion_r280065461 the `_should_handle()` check is already performed in `__call__()`. 

Both calls were added without tests in 8e96584f6363cba7cbbac41771a4318dde9f46dd 9 years ago. 
Looks like overkill. Nothing fails removing the 2nd call from `get_response()`, which is only called via `__call__()`.