### PR TITLE
Fixed #30427, Fixed #16176 -- Corrected setting descriptor in Field.contribute_to_class().

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -763,11 +763,7 @@ class Field(RegisterLookupMixin):
         self.model = cls
         cls._meta.add_field(self, private=private_only)
         if self.column:
-            # Don't override classmethods with the descriptor. This means that
-            # if you have a classmethod and a field with the same name, then
-            # such fields can't be deferred (we don't have a check for this).
-            if not getattr(cls, self.attname, None):
-                setattr(cls, self.attname, self.descriptor_class(self))
+            setattr(cls, self.attname, self.descriptor_class(self))
         if self.choices is not None:
             # Don't override a get_FOO_display() method defined explicitly on
             # this class, but don't check methods derived from inheritance, to

--- a/tests/check_framework/tests.py
+++ b/tests/check_framework/tests.py
@@ -287,6 +287,12 @@ class CheckFrameworkReservedNamesTests(SimpleTestCase):
                 id='models.E020'
             ),
             Error(
+                "The 'ModelWithFieldCalledCheck.check()' class method is "
+                "currently overridden by %r." % ModelWithFieldCalledCheck.check,
+                obj=ModelWithFieldCalledCheck,
+                id='models.E020'
+            ),
+            Error(
                 "The 'ModelWithRelatedManagerCalledCheck.check()' class method is "
                 "currently overridden by %r." % ModelWithRelatedManagerCalledCheck.check,
                 obj=ModelWithRelatedManagerCalledCheck,

--- a/tests/defer/models.py
+++ b/tests/defer/models.py
@@ -23,6 +23,14 @@ class Child(Primary):
     pass
 
 
+class ShadowParent(models.Model):
+    name = 'aphrodite'
+
+
+class ShadowChild(ShadowParent):
+    name = models.CharField(default='adonis', max_length=6)
+
+
 class BigChild(Primary):
     other = models.CharField(max_length=50)
 

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 
 from .models import (
     BigChild, Child, ChildProxy, Primary, RefreshPrimaryProxy, Secondary,
+    ShadowChild,
 )
 
 
@@ -209,6 +210,16 @@ class BigChildDeferTests(AssertionMixin, TestCase):
         self.assertEqual(obj.name, "b1")
         self.assertEqual(obj.value, "foo")
         self.assertEqual(obj.other, "bar")
+
+
+class ShadowDeferTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.s1 = ShadowChild.objects.create()
+
+    def test_defer(self):
+        obj = ShadowChild.objects.defer('name').get()
+        self.assertEqual(obj.name, 'adonis')
 
 
 class TestDefer2(AssertionMixin, TestCase):

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -1089,10 +1089,8 @@ class OtherModelTests(SimpleTestCase):
         class Model(models.Model):
             fk = models.ForeignKey('self', models.CASCADE)
 
-            @property
-            def fk_id(self):
-                pass
-
+        # Override related field accessor.
+        Model.fk_id = property(lambda self: 'ERROR')
         self.assertEqual(Model.check(), [
             Error(
                 "The property 'fk_id' clashes with a related field accessor.",

--- a/tests/model_inheritance/test_abstract_inheritance.py
+++ b/tests/model_inheritance/test_abstract_inheritance.py
@@ -35,6 +35,30 @@ class AbstractInheritanceTests(SimpleTestCase):
         self.assertEqual(DerivedChild._meta.get_field('name').max_length, 50)
         self.assertEqual(DerivedGrandChild._meta.get_field('name').max_length, 50)
 
+    def test_diamond_inheritance_mro(self):
+        class AbstractBase(models.Model):
+            name = models.CharField(max_length=30)
+
+            class Meta:
+                abstract = True
+
+        class DescendantOne(AbstractBase):
+            class Meta:
+                abstract = True
+
+        class DescendantTwo(AbstractBase):
+            name = models.CharField(max_length=50)
+
+            class Meta:
+                abstract = True
+
+        class Derived(DescendantOne, DescendantTwo):
+            pass
+
+        self.assertEqual(DescendantOne._meta.get_field('name').max_length, 30)
+        self.assertEqual(DescendantTwo._meta.get_field('name').max_length, 50)
+        self.assertEqual(Derived._meta.get_field('name').max_length, 50)
+
     def test_multiple_inheritance_cannot_shadow_inherited_field(self):
         class ParentA(models.Model):
             name = models.CharField(max_length=255)

--- a/tests/model_inheritance/test_abstract_inheritance.py
+++ b/tests/model_inheritance/test_abstract_inheritance.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.checks import Error
 from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import models
+from django.db.models.query_utils import DeferredAttribute
 from django.test import SimpleTestCase
 from django.test.utils import isolate_apps
 
@@ -348,3 +349,33 @@ class AbstractInheritanceTests(SimpleTestCase):
                 ('name', models.CharField),
             ]
         )
+
+    def test_shadow_parent_attribute_with_field(self):
+        class Base(models.Model):
+            foo = 1
+
+        class Inherited(Base):
+            foo = models.IntegerField()
+
+        self.assertEqual(type(Inherited.foo), DeferredAttribute)
+
+    def test_shadow_parent_property_with_field(self):
+        class Base(models.Model):
+            @property
+            def foo(self):
+                pass
+
+        class Inherited(Base):
+            foo = models.IntegerField()
+
+        self.assertEqual(type(Inherited.foo), DeferredAttribute)
+
+    def test_shadow_parent_method_with_field(self):
+        class Base(models.Model):
+            def foo(self):
+                pass
+
+        class Inherited(Base):
+            foo = models.IntegerField()
+
+        self.assertEqual(type(Inherited.foo), DeferredAttribute)


### PR DESCRIPTION
[Ticket #30427](https://code.djangoproject.com/ticket/30427)

Previously: DeferredAttributes would not get stapled onto models where the model (or an ancestor) already had an existing *truthy* attribute (despite comment only mentioning protecting against overriding *classmethods*).
With this change: DeferredAttributes will ~not get stapled onto models where the model (or an ancestor) already has a *callable* attribute~ always get stapled on, regardless of other attributes on the models or their ancestors.

This means we have the following changes:
- If a model field is declared twice (once on the class and once on the ancestor), mro order is respected when deciding which should take precedence.
- If a model field is declared over a class attribute on the ancestor, the model field will override.

Aside from the change, this PR includes:
- Failing tests. ~A failing test that this change fixes.~
- ~An update to an existing test, covering the new overriding order of DeferredAttributes. Arguably, what was previously being tested for didn't make sense.~

Problems:
- Albeit obscure, this introduces a slight change in behaviour, so we might have to somehow communicate that..
- ~`@property` decorators throw a fly in the ointment. They look like methods, but the decorator makes `callable` return `False` for them. It's why the testsuite is failing presently. We can add an additional check for the existence of `__isabstractmethod__` on the attribute, but it starts to feel rabbitholey. Perhaps we should think about a more aggressive change here, such as always overriding everything. Why do we protect classmethods anyway?~

Happy to discuss ideas on how to solve this here or on the ticket.

[2020-03-04] edit: updated to reflect most recent decisions/discussion.