### PR TITLE
 Fixed #30316 -- Added source code link to the default logging configuration in logging docs.

### DIFF
--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -752,4 +752,5 @@ handlers are attached to the root logger to provide the behavior described
 above.
 
 See also :ref:`Configuring logging <configuring-logging>` to learn how you can
-complement or replace this default logging configuration.
+complement or replace this default logging configuration defined in
+:source:`django/utils/log.py`.


### PR DESCRIPTION
Full description in https://code.djangoproject.com/ticket/30316

Since the link corresponds to the default logging I decided to put it there, since the link to configure the logger is reachable trough the default logger.