### PR TITLE
Fixed #30460: make ManyToManyField respect custom through ordering

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -489,6 +489,11 @@ There are a few restrictions on the intermediate model:
   :attr:`symmetrical=False <ManyToManyField.symmetrical>` (see
   :ref:`the model field reference <manytomany-arguments>`).
 
+* Many-to-many relationships with intermediary model which specify a custom
+  ``Meta.ordering`` will sort on that column by default (this is useful for
+  situations where you might define an intermediary model which contains
+  a column for tracking list position or order).
+
 Now that you have set up your :class:`~django.db.models.ManyToManyField` to use
 your intermediary model (``Membership``, in this case), you're ready to start
 creating some many-to-many relationships. You do this by creating instances of

--- a/tests/m2m_through/tests.py
+++ b/tests/m2m_through/tests.py
@@ -24,7 +24,7 @@ class M2mThroughTests(TestCase):
         Membership.objects.create(person=self.jim, group=self.rock)
         Membership.objects.create(person=self.jane, group=self.rock)
 
-        expected = ['Jane', 'Jim']
+        expected = ['Jim', 'Jane']
         self.assertQuerysetEqual(
             self.rock.members.all(),
             expected,

--- a/tests/m2m_through_regress/models.py
+++ b/tests/m2m_through_regress/models.py
@@ -94,3 +94,31 @@ class CompetingTeam(Competitor):
 class ProxiedIndividualCompetitor(IndividualCompetitor):
     class Meta:
         proxy = True
+
+
+# Through model with default ordering defined
+# i.e., first place, second place, third place
+class Dog(models.Model):
+    class Meta:
+        ordering = ('name',)
+
+    name = models.CharField(max_length=128)
+
+    def __str__(self):
+        return self.name
+
+
+class OrderedMembership(models.Model):
+
+    class Meta:
+        ordering = ('position',)
+
+    dog = models.ForeignKey('Dog', models.CASCADE)
+    winner = models.ForeignKey('Winner', models.CASCADE)
+    position = models.PositiveIntegerField()
+
+
+class Winner(models.Model):
+    name = models.CharField(max_length=128)
+    # OrderedMembership object defined as a class
+    members = models.ManyToManyField(Dog, through=OrderedMembership)


### PR DESCRIPTION
`ManyToManyField`s that implement a custom through intermediary table
might _also_ define a `Meta.ordering`; in this scenario, Django should
respect the order of the intermediary table when constructing the query
for the M2M relation