### PR TITLE
Fixed #30468 -- Fixed assertHTMLEqual() to handle all ASCII whitespace in a class attribute.

### DIFF
--- a/django/test/html.py
+++ b/django/test/html.py
@@ -180,7 +180,7 @@ class Parser(HTMLParser):
         # Special case handling of 'class' attribute, so that comparisons of DOM
         # instances are not sensitive to ordering of classes.
         attrs = [
-            (name, " ".join(sorted(value.split(" "))))
+            (name, ' '.join(sorted(value for value in ASCII_WHITESPACE.split(value) if value)))
             if name == "class"
             else (name, value)
             for name, value in attrs

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -612,6 +612,20 @@ class HTMLEqualTests(SimpleTestCase):
             '<input type="text" id="id_name" />',
             '<input type="password" id="id_name" />')
 
+    def test_class_attribute(self):
+        pairs = [
+            ('<p class="foo bar"></p>', '<p class="bar foo"></p>'),
+            ('<p class=" foo bar "></p>', '<p class="bar foo"></p>'),
+            ('<p class="   foo    bar    "></p>', '<p class="bar foo"></p>'),
+            ('<p class="foo\tbar"></p>', '<p class="bar foo"></p>'),
+            ('<p class="\tfoo\tbar\t"></p>', '<p class="bar foo"></p>'),
+            ('<p class="\t\t\tfoo\t\t\tbar\t\t\t"></p>', '<p class="bar foo"></p>'),
+            ('<p class="\t \nfoo \t\nbar\n\t "></p>', '<p class="bar foo"></p>'),
+        ]
+        for html1, html2 in pairs:
+            with self.subTest(html1):
+                self.assertHTMLEqual(html1, html2)
+
     def test_normalize_refs(self):
         pairs = [
             ('&#39;', '&#x27;'),


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30468