### PR TITLE
Fixed trivial source comment typo

### DIFF
--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -274,7 +274,7 @@ class GDALRasterTests(SimpleTestCase):
         result = rast.bands[0].data()
         if numpy:
             result = result.flatten().tolist()
-        # Band data is equal to zero becaues no nodata value has been specified.
+        # Band data is equal to zero because no nodata value has been specified.
         self.assertEqual(result, [0] * 4)
 
     def test_raster_metadata_property(self):


### PR DESCRIPTION
Found via `codespell`