### PR TITLE
Fixed #30470 -- Added assertHTMLEqual() support for all self closing tags.

### DIFF
--- a/django/test/html.py
+++ b/django/test/html.py
@@ -141,10 +141,13 @@ class HTMLParseError(Exception):
 
 
 class Parser(HTMLParser):
-    SELF_CLOSING_TAGS = (
-        'br', 'hr', 'input', 'img', 'meta', 'spacer', 'link', 'frame', 'base',
-        'col',
-    )
+    # https://html.spec.whatwg.org/#void-elements
+    SELF_CLOSING_TAGS = {
+        'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta',
+        'param', 'source', 'track', 'wbr',
+        # Deprecated tags
+        'frame', 'spacer',
+    }
 
     def __init__(self):
         super().__init__()

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -537,10 +537,12 @@ class HTMLEqualTests(SimpleTestCase):
         self.assertEqual(dom.children[0], "<p>foo</p> '</scr'+'ipt>' <span>bar</span>")
 
     def test_self_closing_tags(self):
-        self_closing_tags = (
-            'br', 'hr', 'input', 'img', 'meta', 'spacer', 'link', 'frame',
-            'base', 'col',
-        )
+        self_closing_tags = [
+            'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link',
+            'meta', 'param', 'source', 'track', 'wbr',
+            # Deprecated tags
+            'frame', 'spacer',
+        ]
         for tag in self_closing_tags:
             with self.subTest(tag):
                 dom = parse_html('<p>Hello <%s> world</p>' % tag)


### PR DESCRIPTION
Support for the following tags was added: `area`, `embed`, `param`, `track`, and `wbr`.

The full list of self closing tags is documented at:

https://html.spec.whatwg.org/#void-elements

https://code.djangoproject.com/ticket/30470