### PR TITLE
Changed poll_id to poll_ids in examples of custom management commands.

### DIFF
--- a/docs/howto/custom-management-commands.txt
+++ b/docs/howto/custom-management-commands.txt
@@ -49,10 +49,10 @@ look like this::
         help = 'Closes the specified poll for voting'
 
         def add_arguments(self, parser):
-            parser.add_argument('poll_id', nargs='+', type=int)
+            parser.add_argument('poll_ids', nargs='+', type=int)
 
         def handle(self, *args, **options):
-            for poll_id in options['poll_id']:
+            for poll_id in options['poll_ids']:
                 try:
                     poll = Poll.objects.get(pk=poll_id)
                 except Poll.DoesNotExist:
@@ -77,7 +77,7 @@ look like this::
         self.stdout.write("Unterminated line", ending='')
 
 The new custom command can be called using ``python manage.py closepoll
-<poll_id>``.
+<poll_ids>``.
 
 The ``handle()`` method takes one or more ``poll_ids`` and sets ``poll.opened``
 to ``False`` for each one. If the user referenced any nonexistent polls, a
@@ -97,7 +97,7 @@ options can be added in the :meth:`~BaseCommand.add_arguments` method like this:
     class Command(BaseCommand):
         def add_arguments(self, parser):
             # Positional arguments
-            parser.add_argument('poll_id', nargs='+', type=int)
+            parser.add_argument('poll_ids', nargs='+', type=int)
 
             # Named (optional) arguments
             parser.add_argument(


### PR DESCRIPTION
On line 52 in docs/howto/custom-management-commands.txt, the parser adds an argument - 
```python
parser.add_argument('poll_id', nargs='+', type=int)
```
And references it on line 55, to loop through the ids provided via the command
```python
for poll_id in options['poll_id']:
```
Since it's multiple ids that are provided through the command line, it makes more sense to name the argument `poll_ids` signifying plural.