### PR TITLE
Fixed #28816 -- Prevented silencing data loss when decreasing CharField.max_length on PostgreSQL.

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -21,6 +21,7 @@ from django.db.models.fields.related import (
 )
 from django.db.models.indexes import Index
 from django.db.transaction import TransactionManagementError, atomic
+from django.db.utils import DataError
 from django.test import (
     TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature,
 )
@@ -802,6 +803,21 @@ class SchemaTests(TransactionTestCase):
         new_field.null = True
         with connection.schema_editor() as editor:
             editor.alter_field(Author, old_field, new_field, strict=True)
+
+    @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL specific')
+    def test_alter_char_field_decrease_length(self):
+        # Create the table.
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+        Author.objects.create(name='x' * 255)
+        # Change max_length of CharField.
+        old_field = Author._meta.get_field('name')
+        new_field = CharField(max_length=254)
+        new_field.set_attributes_from_name('name')
+        with connection.schema_editor() as editor:
+            msg = 'value too long for type character varying(254)'
+            with self.assertRaisesMessage(DataError, msg):
+                editor.alter_field(Author, old_field, new_field, strict=True)
 
     def test_alter_textfield_to_null(self):
         """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28816