### PR TITLE
Fixed #30436 -- Added check that on_delete is callable in ForeignKey and OneToOneField.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -797,6 +797,8 @@ class ForeignKey(ForeignObject):
             # the to_field during FK construction. It won't be guaranteed to
             # be correct until contribute_to_class is called. Refs #12190.
             to_field = to_field or (to._meta.pk and to._meta.pk.name)
+        if not callable(on_delete):
+            raise TypeError('on_delete must be callable.')
 
         kwargs['rel'] = self.rel_class(
             self, to, to_field,

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -21,6 +21,13 @@ class OnDeleteTests(TestCase):
         a.auto.delete()
         self.assertFalse(A.objects.filter(name='auto').exists())
 
+    def test_non_callable(self):
+        msg = 'on_delete must be callable.'
+        with self.assertRaisesMessage(TypeError, msg):
+            models.ForeignKey('self', on_delete=None)
+        with self.assertRaisesMessage(TypeError, msg):
+            models.OneToOneField('self', on_delete=None)
+
     def test_auto_nullable(self):
         a = create_a('auto_nullable')
         a.auto_nullable.delete()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30436