### PR TITLE
Changed tuple choices to list in docs.

### DIFF
--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -258,17 +258,17 @@ Model style
   * ``def get_absolute_url()``
   * Any custom methods
 
-* If ``choices`` is defined for a given model field, define each choice as
-  a tuple of tuples, with an all-uppercase name as a class attribute on the
-  model. Example::
+* If ``choices`` is defined for a given model field, define each choice as a
+  list of tuples, with an all-uppercase name as a class attribute on the model.
+  Example::
 
     class MyModel(models.Model):
         DIRECTION_UP = 'U'
         DIRECTION_DOWN = 'D'
-        DIRECTION_CHOICES = (
+        DIRECTION_CHOICES = [
             (DIRECTION_UP, 'Up'),
             (DIRECTION_DOWN, 'Down'),
-        )
+        ]
 
 Use of ``django.conf.settings``
 ===============================

--- a/docs/ref/contrib/admin/actions.txt
+++ b/docs/ref/contrib/admin/actions.txt
@@ -47,11 +47,11 @@ simple news application with an ``Article`` model::
 
     from django.db import models
 
-    STATUS_CHOICES = (
+    STATUS_CHOICES = [
         ('d', 'Draft'),
         ('p', 'Published'),
         ('w', 'Withdrawn'),
-    )
+    ]
 
     class Article(models.Model):
         title = models.CharField(max_length=100)

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -57,12 +57,12 @@ widget on the field. In the following example, the
 
     from django import forms
 
-    BIRTH_YEAR_CHOICES = ('1980', '1981', '1982')
-    FAVORITE_COLORS_CHOICES = (
+    BIRTH_YEAR_CHOICES = ['1980', '1981', '1982']
+    FAVORITE_COLORS_CHOICES = [
         ('blue', 'Blue'),
         ('green', 'Green'),
         ('black', 'Black'),
-    )
+    ]
 
     class SimpleForm(forms.Form):
         birth_year = forms.DateField(widget=forms.SelectDateWidget(years=BIRTH_YEAR_CHOICES))
@@ -90,14 +90,14 @@ changing :attr:`ChoiceField.choices` will update :attr:`Select.choices`. For
 example::
 
     >>> from django import forms
-    >>> CHOICES = (('1', 'First',), ('2', 'Second',))
+    >>> CHOICES = [('1', 'First'), ('2', 'Second')]
     >>> choice_field = forms.ChoiceField(widget=forms.RadioSelect, choices=CHOICES)
     >>> choice_field.choices
     [('1', 'First'), ('2', 'Second')]
     >>> choice_field.widget.choices
     [('1', 'First'), ('2', 'Second')]
-    >>> choice_field.widget.choices = ()
-    >>> choice_field.choices = (('1', 'First and only',),)
+    >>> choice_field.widget.choices = []
+    >>> choice_field.choices = [('1', 'First and only')]
     >>> choice_field.widget.choices
     [('1', 'First and only')]
 

--- a/docs/ref/models/conditional-expressions.txt
+++ b/docs/ref/models/conditional-expressions.txt
@@ -21,11 +21,11 @@ We'll be using the following model in the subsequent examples::
         REGULAR = 'R'
         GOLD = 'G'
         PLATINUM = 'P'
-        ACCOUNT_TYPE_CHOICES = (
+        ACCOUNT_TYPE_CHOICES = [
             (REGULAR, 'Regular'),
             (GOLD, 'Gold'),
             (PLATINUM, 'Platinum'),
-        )
+        ]
         name = models.CharField(max_length=50)
         registered_on = models.DateField()
         account_type = models.CharField(

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -89,12 +89,12 @@ these choices instead of the standard text field.
 The first element in each tuple is the actual value to be set on the model,
 and the second element is the human-readable name. For example::
 
-    YEAR_IN_SCHOOL_CHOICES = (
+    YEAR_IN_SCHOOL_CHOICES = [
         ('FR', 'Freshman'),
         ('SO', 'Sophomore'),
         ('JR', 'Junior'),
         ('SR', 'Senior'),
-    )
+    ]
 
 Generally, it's best to define choices inside a model class, and to
 define a suitably-named constant for each value::
@@ -106,12 +106,12 @@ define a suitably-named constant for each value::
         SOPHOMORE = 'SO'
         JUNIOR = 'JR'
         SENIOR = 'SR'
-        YEAR_IN_SCHOOL_CHOICES = (
+        YEAR_IN_SCHOOL_CHOICES = [
             (FRESHMAN, 'Freshman'),
             (SOPHOMORE, 'Sophomore'),
             (JUNIOR, 'Junior'),
             (SENIOR, 'Senior'),
-        )
+        ]
         year_in_school = models.CharField(
             max_length=2,
             choices=YEAR_IN_SCHOOL_CHOICES,
@@ -130,7 +130,7 @@ will work anywhere that the ``Student`` model has been imported).
 You can also collect your available choices into named groups that can
 be used for organizational purposes::
 
-    MEDIA_CHOICES = (
+    MEDIA_CHOICES = [
         ('Audio', (
                 ('vinyl', 'Vinyl'),
                 ('cd', 'CD'),
@@ -142,7 +142,7 @@ be used for organizational purposes::
             )
         ),
         ('unknown', 'Unknown'),
-    )
+    ]
 
 The first element in each tuple is the name to apply to the group. The
 second element is an iterable of 2-tuples, with each 2-tuple containing

--- a/docs/topics/db/managers.txt
+++ b/docs/topics/db/managers.txt
@@ -161,7 +161,7 @@ For example::
     class Person(models.Model):
         first_name = models.CharField(max_length=50)
         last_name = models.CharField(max_length=50)
-        role = models.CharField(max_length=1, choices=(('A', _('Author')), ('E', _('Editor'))))
+        role = models.CharField(max_length=1, choices=[('A', _('Author')), ('E', _('Editor'))])
         people = models.Manager()
         authors = AuthorManager()
         editors = EditorManager()
@@ -261,7 +261,7 @@ custom ``QuerySet`` if you also implement them on the ``Manager``::
     class Person(models.Model):
         first_name = models.CharField(max_length=50)
         last_name = models.CharField(max_length=50)
-        role = models.CharField(max_length=1, choices=(('A', _('Author')), ('E', _('Editor'))))
+        role = models.CharField(max_length=1, choices=[('A', _('Author')), ('E', _('Editor'))])
         people = PersonManager()
 
 This example allows you to call both ``authors()`` and ``editors()`` directly from

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -161,13 +161,13 @@ ones:
 
     A choices list looks like this::
 
-        YEAR_IN_SCHOOL_CHOICES = (
+        YEAR_IN_SCHOOL_CHOICES = [
             ('FR', 'Freshman'),
             ('SO', 'Sophomore'),
             ('JR', 'Junior'),
             ('SR', 'Senior'),
             ('GR', 'Graduate'),
-        )
+        ]
 
     The first element in each tuple is the value that will be stored in the
     database. The second element is displayed by the field's form widget.

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -165,11 +165,11 @@ Consider this set of models::
     from django.db import models
     from django.forms import ModelForm
 
-    TITLE_CHOICES = (
+    TITLE_CHOICES = [
         ('MR', 'Mr.'),
         ('MRS', 'Mrs.'),
         ('MS', 'Ms.'),
-    )
+    ]
 
     class Author(models.Model):
         name = models.CharField(max_length=100)


### PR DESCRIPTION
I'll copy @spookylukey great reasoning from PR  #11267 with minor adaptations. Credit to Luke for the write up.

---

Choices are documented as accepting any iterable.

In docs, we should use lists for homogeneous sequences and tuples for "namedtuples without names" i.e. sequences where each item has a different meaning. Because:

1. This is how we already [decided](https://groups.google.com/d/msg/django-developers/h4FSYWzMJhs/_2iVc4qgfsoJ) to do it, and most things have already been cleaned up that way, …
2. New code/docs are written that way e.g. [Options.constraints](https://docs.djangoproject.com/en/dev/ref/models/options/#django.db.models.Options.constraints).
3. That's the way [Guido intended](https://marc.info/?l=python-dev&m=107666578526990&w=2) :-)

So in example code, choices should be a list of tuples.
