### PR TITLE
Changed docs to link to Python's description of iterable.

### DIFF
--- a/docs/howto/outputting-csv.txt
+++ b/docs/howto/outputting-csv.txt
@@ -47,7 +47,7 @@ mention:
   bill.
 
 * For each row in your CSV file, call ``writer.writerow``, passing it an
-  iterable object such as a list or tuple.
+  :term:`iterable`.
 
 * The CSV module takes care of quoting for you, so you don't have to worry
   about escaping strings with quotes or commas in them. Just pass

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -407,13 +407,13 @@ For each field, we describe the default widget used if you don't specify
 
     .. attribute:: choices
 
-        Either an iterable (e.g., a list or tuple) of 2-tuples to use as
-        choices for this field, or a callable that returns such an iterable.
-        This argument accepts the same formats as the ``choices`` argument to a
-        model field. See the :ref:`model field reference documentation on
-        choices <field-choices>` for more details. If the argument is a
-        callable, it is evaluated each time the field's form is initialized.
-        Defaults to an empty list.
+        Either an :term:`iterable` of 2-tuples to use as choices for this
+        field, or a callable that returns such an iterable. This argument
+        accepts the same formats as the ``choices`` argument to a model field.
+        See the :ref:`model field reference documentation on choices
+        <field-choices>` for more details. If the argument is a callable, it is
+        evaluated each time the field's form is initialized. Defaults to an
+        empty list.
 
 ``TypedChoiceField``
 --------------------

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -80,11 +80,11 @@ If a field has ``blank=False``, the field will be required.
 
 .. attribute:: Field.choices
 
-An iterable (e.g., a list or tuple) consisting itself of iterables of exactly
-two items (e.g. ``[(A, B), (A, B) ...]``) to use as choices for this field. If
-choices are given, they're enforced by :ref:`model validation
-<validating-objects>` and the default form widget will be a select box with
-these choices instead of the standard text field.
+An :term:`iterable` consisting itself of iterables of exactly two items (e.g.
+``[(A, B), (A, B) ...]``) to use as choices for this field. If choices are
+given, they're enforced by :ref:`model validation <validating-objects>` and the
+default form widget will be a select box with these choices instead of the
+standard text field.
 
 The first element in each tuple is the actual value to be set on the model,
 and the second element is the human-readable name. For example::

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -154,10 +154,9 @@ ones:
     <Field.blank>`, the field will be required.
 
 :attr:`~Field.choices`
-    An iterable (e.g., a list or tuple) of 2-tuples to use as choices for
-    this field. If this is given, the default form widget will be a select box
-    instead of the standard text field and will limit choices to the choices
-    given.
+    An :term:`iterable` of 2-tuples to use as choices for this field. If this
+    is given, the default form widget will be a select box instead of the
+    standard text field and will limit choices to the choices given.
 
     A choices list looks like this::
 


### PR DESCRIPTION
Inspired by the discussion in PR #11330. Rather than describing the Python term "iterable" link to Python's description.