### PR TITLE
Do not require npm installed for JavaScript tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,9 +58,9 @@ commands = isort --recursive --check-only --diff django tests scripts
 
 [testenv:javascript]
 usedevelop = false
-deps =
+deps = nodeenv
 changedir = {toxinidir}
-whitelist_externals = npm
 commands =
+    nodeenv -p
     npm install
     npm test


### PR DESCRIPTION
Now we use nodeenv for JavaScript test running via `tox -e javascript`
to not force developers to install Node.js for tests execution.

Closes-Bug: #30478