### PR TITLE
Fixed #27635 -- Used secrets module in django.utils.crypto.

### DIFF
--- a/django/utils/crypto.py
+++ b/django/utils/crypto.py
@@ -4,20 +4,9 @@ Django's standard crypto functions and utilities.
 import hashlib
 import hmac
 import random
-import time
 
 from django.conf import settings
 from django.utils.encoding import force_bytes
-
-# Use the system PRNG if possible
-try:
-    random = random.SystemRandom()
-    using_sysrandom = True
-except NotImplementedError:
-    import warnings
-    warnings.warn('A secure pseudo-random number generator is not available '
-                  'on your system. Falling back to Mersenne Twister.')
-    using_sysrandom = False
 
 
 def salted_hmac(key_salt, value, secret=None):
@@ -54,18 +43,6 @@ def get_random_string(length=12,
     The default length of 12 with the a-z, A-Z, 0-9 character set returns
     a 71-bit value. log_2((26+26+10)^12) =~ 71 bits
     """
-    if not using_sysrandom:
-        # This is ugly, and a hack, but it makes things better than
-        # the alternative of predictability. This re-seeds the PRNG
-        # using a value that is hard for an attacker to predict, every
-        # time a random string is required. This may change the
-        # properties of the chosen random sequence slightly, but this
-        # is better than absolute predictability.
-        random.seed(
-            hashlib.sha256(
-                ('%s%s%s' % (random.getstate(), time.time(), settings.SECRET_KEY)).encode()
-            ).digest()
-        )
     return ''.join(random.choice(allowed_chars) for i in range(length))
 
 

--- a/django/utils/crypto.py
+++ b/django/utils/crypto.py
@@ -3,7 +3,7 @@ Django's standard crypto functions and utilities.
 """
 import hashlib
 import hmac
-import random
+import secrets
 
 from django.conf import settings
 from django.utils.encoding import force_bytes
@@ -43,12 +43,12 @@ def get_random_string(length=12,
     The default length of 12 with the a-z, A-Z, 0-9 character set returns
     a 71-bit value. log_2((26+26+10)^12) =~ 71 bits
     """
-    return ''.join(random.choice(allowed_chars) for i in range(length))
+    return ''.join(secrets.choice(allowed_chars) for i in range(length))
 
 
 def constant_time_compare(val1, val2):
     """Return True if the two strings are equal, False otherwise."""
-    return hmac.compare_digest(force_bytes(val1), force_bytes(val2))
+    return secrets.compare_digest(force_bytes(val1), force_bytes(val2))
 
 
 def pbkdf2(password, salt, iterations, dklen=0, digest=None):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27635

This is an alternate pull request following on from https://github.com/django/django/pull/11357#issuecomment-492839409.

The first commit fixes the fallback in the absence of a secure pseudo-random number generator and adds a test. The second commit switches over to using the `secrets` module. And the (optional) third commit drops support for the fallback given that it didn't work before the first commit fixed it anyway. We could remove it as I'm not aware of any complaints that this never worked.