### PR TITLE
formset.errors can be out of sync with formset.forms

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -335,6 +335,7 @@ class BaseFormSet:
             # _should_delete_form() requires cleaned_data.
             form_errors = form.errors
             if self.can_delete and self._should_delete_form(form):
+                self._errors.append({})
                 continue
             self._errors.append(form_errors)
         try:


### PR DESCRIPTION
If you delete a form in a formset you now a situation where len(formset.forms) != len(formset.errors). But the documentation for formset.errors says "Return a list of form.errors for every form in self.forms.". To keep them in sync, insert an empty dict for deleted entries. 

The workaround is to never use formset.errors but instead get the form from formset.forms and then use the errors property from that form.