### PR TITLE
Fixed #30463 -- Fixed crash of deprecation message when Meta.ordering contains expressions.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -553,9 +553,9 @@ class SQLCompiler:
                         # order_by = None
                         warnings.warn(
                             "%s QuerySet won't use Meta.ordering in Django 3.1. "
-                            "Add .order_by('%s') to retain the current query." % (
+                            "Add .order_by(%s) to retain the current query." % (
                                 self.query.model.__name__,
-                                "', '".join(self._meta_ordering)
+                                ', '.join(repr(f) for f in self._meta_ordering),
                             ),
                             RemovedInDjango31Warning,
                             stacklevel=4,

--- a/docs/releases/2.2.2.txt
+++ b/docs/releases/2.2.2.txt
@@ -11,3 +11,6 @@ Bugfixes
 
 * Fixed a regression in Django 2.2 that stopped Show/Hide toggles working on
   dynamically added admin inlines (:ticket:`30459`).
+
+* Fixed a regression in Django 2.2 where deprecation message crashes if
+  ``Meta.ordering`` contains an expression (:ticket:`30463`).

--- a/tests/ordering/models.py
+++ b/tests/ordering/models.py
@@ -14,6 +14,7 @@ undefined -- not random, just undefined.
 """
 
 from django.db import models
+from django.db.models.expressions import OrderBy
 
 
 class Author(models.Model):
@@ -30,7 +31,12 @@ class Article(models.Model):
     pub_date = models.DateTimeField()
 
     class Meta:
-        ordering = ('-pub_date', 'headline')
+        ordering = (
+            '-pub_date',
+            'headline',
+            models.F('author__name').asc(),
+            OrderBy(models.F('second_author__name')),
+        )
 
     def __str__(self):
         return self.headline

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -408,7 +408,9 @@ class OrderingTests(TestCase):
     def test_deprecated_values_annotate(self):
         msg = (
             "Article QuerySet won't use Meta.ordering in Django 3.1. Add "
-            ".order_by('-pub_date', 'headline') to retain the current query."
+            ".order_by('-pub_date', 'headline', OrderBy(F(author__name), "
+            "descending=False), OrderBy(F(second_author__name), "
+            "descending=False)) to retain the current query."
         )
         with self.assertRaisesMessage(RemovedInDjango31Warning, msg):
             list(Article.objects.values('author').annotate(Count('headline')))


### PR DESCRIPTION
This solves the error raised when `self._meta_ordering` encountered OrderBy instances in `.join()` function. I've used regex function and python replace method to convert the string such that quotation marks are at the desired place and, the string remains in the form of real source code compatible with `order_by()`.

I'd appreciate any cleaner solution than this one and would be happy to improve the code.  