### PR TITLE
Fixed #23559 - Prevent non-superusers from granting superuser rights

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -150,6 +150,11 @@ class UserChangeForm(forms.ModelForm):
         user_permissions = self.fields.get('user_permissions')
         if user_permissions:
             user_permissions.queryset = user_permissions.queryset.select_related('content_type')
+        # Prevent non-superusers from granting superusers rights.
+        is_superuser = self.fields.get('is_superuser')
+        if is_superuser:
+            if not getattr(self.instance, 'is_superuser', False):
+                is_superuser.disabled = True
 
     def clean_password(self):
         # Regardless of what the user provides, return the initial value.

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -740,6 +740,19 @@ class UserChangeFormTest(TestDataMixin, TestCase):
         form = UserChangeForm()
         self.assertEqual(form.fields['username'].widget.attrs.get('autocapitalize'), 'none')
 
+    def test_only_superuser_should_be_able_to_grant_superuser(self):
+        not_superuser = User.objects.get(username='staff')
+        form = UserChangeForm(instance=not_superuser)
+        self.assertTrue(form.fields['is_superuser'].disabled)
+
+        superuser = User.objects.create_superuser(
+            username='superfoo',
+            email='foo@bar.baz',
+            password='secret',
+        )
+        form = UserChangeForm(instance=superuser)
+        self.assertFalse(form.fields['is_superuser'].disabled)
+
 
 @override_settings(TEMPLATES=AUTH_TEMPLATES)
 class PasswordResetFormTest(TestDataMixin, TestCase):


### PR DESCRIPTION
I recently found that non-superuser staff users with `auth.change_user` permission can turn themselves into superusers. A [similar issue](https://code.djangoproject.com/ticket/23559) was brought up a few years ago, and was eventually resolved by adding a small comment in the documentation. Having used Django for years, this was a big surprise for me.

I think it's important for Django to provide a better default and prevent this case. I personally can't think of any reason why anyone would want non-superusers to be able to turn themselves, or any user, to superusers.