### PR TITLE
Fixed #28944 - allow select_for_update(of) in values() queries

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2028,7 +2028,6 @@ class Query(BaseExpression):
         self._extra_select_cache = None
 
     def set_values(self, fields):
-        self.select_related = False
         self.clear_deferred_loading()
         self.clear_select_fields()
 


### PR DESCRIPTION
Ticket: [#28944](https://code.djangoproject.com/ticket/28944)
Hi, I was trying to understand this ticket and I've noticed that when we use `values` or `values_list` after `select_related`, `set_values` set `self.select_related` as False. I removed this line and I have not encountered a problem except all column return in result. `get_related_selections` uses `get_default_columns` to append the columns into `select_fields`. To fix this, I added a case.
Is this appropriate? Does remove `self.select_related = False` line cause a problem?