### PR TITLE
WIP/RFC: Cache model state renders in migrations

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -572,7 +572,7 @@ class ModelState:
         # If the properties for creating the render haven't changed, let's return the previously rendered type
         if self._can_use_cached_render():
             # we just need to register the model again (since below we rely on this step in the class construction)
-            apps.register_model(self.app_label, self._cached_render)
+            apps.register_model(self._cached_render._meta.app_label, self._cached_render)
             return self._cached_render
         # clear out the cache properties
         self._cached_render = None


### PR DESCRIPTION
(This PR is the result of some fruitful work during the DjangoCongress JP 2019 sprint day)

 Model state rendering happens a lot in larger migrations, but for the most part the resulting models are the same. this tries to reduce the amount of work that needs to happen for larger migration work (notably happens during testing)

For the stats on this: on my 2017 Macbook Pro, on what I would call a "decently large" project (241 models over 89 apps, 492 migrations), the total run time of migrating went from 230 seconds to 42 seconds (averaged over a lot of runs). The cache hit rate on this is roughly 90% (for a full run I found:
```
CACHE HITS  63867
CACHE MISSES  5985
```
)

So this makes the migration step during a test in CI _much_ faster for us. But it obviously won't be a huge deal for migrating in production, since one rarely runs that many migrations in production.

I'm torn between performance and potentially missing an issue about correctness here, but I think this change would make sense at least behind some "useful for testing" flag.

(I am going to post something in the developers mailing list in a bit with some more context/other improvements I think are possible in this space in a bit)