### PR TITLE
Fixed #30491 -- Clarified when save() on object with pk executes INSERT.

### DIFF
--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -472,7 +472,8 @@ follows this algorithm:
   ``True`` (i.e., a value other than ``None`` or the empty string), Django
   executes an ``UPDATE``.
 * If the object's primary key attribute is *not* set or if the ``UPDATE``
-  didn't update anything, Django executes an ``INSERT``.
+  didn't update anything (e.g. if primary key is set to a value that doesn't
+  exist in the database), Django executes an ``INSERT``.
 
 The one gotcha here is that you should be careful not to specify a primary-key
 value explicitly when saving new objects, if you cannot guarantee the


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/30491

The docs for 'How Django knows to UPDATE vs. INSERT'
do not make any mention of a potentially confusing condition,
which is that updating a PK followed by a call to `.save()`
will always result in an INSERT rather than an UPDATE.

While this note is present in the primary key docstring
itself, it would be worthwhile to duplicate it to this section
as a gotcha.

See also: https://stackoverflow.com/q/56212145/7954504