### PR TITLE
Improved performance of loading common passwords in CommonPasswordValidator.

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -171,13 +171,11 @@ class CommonPasswordValidator:
 
     def __init__(self, password_list_path=DEFAULT_PASSWORD_LIST_PATH):
         try:
-            with gzip.open(str(password_list_path)) as f:
-                common_passwords_lines = f.read().decode().splitlines()
+            with gzip.open(str(password_list_path), 'rt') as f:
+                self.passwords = {x.strip() for x in f}
         except OSError:
             with open(str(password_list_path)) as f:
-                common_passwords_lines = f.readlines()
-
-        self.passwords = {p.strip() for p in common_passwords_lines}
+                self.passwords = {x.strip() for x in f}
 
     def validate(self, password, user=None):
         if password.lower().strip() in self.passwords:


### PR DESCRIPTION
`CommonPasswordValidator.__init__` previously called either
splitlines or readlines, creating an unneeded intermediate list
in memory.  For large custom password files, this could be
burdensome.

This change takes advantage of the fact that the file object
is iterable and maps a lambda over its lines, then takes the
set of the results.