### PR TITLE
Fixed #29396, #30494 -- Added indirect values support to __year lookups.

### DIFF
--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -135,6 +135,11 @@ class DateFunctionTests(TestCase):
                 qs = DTModel.objects.filter(**{'start_datetime__%s__gte' % lookup: 2015})
                 self.assertEqual(qs.count(), 2)
                 self.assertEqual(str(qs.query).lower().count('extract'), 0)
+                qs = DTModel.objects.annotate(
+                    start_year=ExtractYear('start_datetime'),
+                ).filter(**{'end_datetime__%s__gte' % lookup: F('start_year')})
+                self.assertEqual(qs.count(), 1)
+                self.assertGreaterEqual(str(qs.query).lower().count('extract'), 2)
 
     def test_extract_year_lessthan_lookup(self):
         start_datetime = datetime(2015, 6, 15, 14, 10)
@@ -153,6 +158,11 @@ class DateFunctionTests(TestCase):
                 qs = DTModel.objects.filter(**{'start_datetime__%s__lte' % lookup: 2016})
                 self.assertEqual(qs.count(), 2)
                 self.assertEqual(str(qs.query).count('extract'), 0)
+                qs = DTModel.objects.annotate(
+                    end_year=ExtractYear('end_datetime'),
+                ).filter(**{'start_datetime__%s__lte' % lookup: F('end_year')})
+                self.assertEqual(qs.count(), 1)
+                self.assertGreaterEqual(str(qs.query).lower().count('extract'), 2)
 
     def test_extract_func(self):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)

--- a/tests/lookup/test_lookups.py
+++ b/tests/lookup/test_lookups.py
@@ -2,16 +2,16 @@ from datetime import datetime
 
 from django.db.models import Value
 from django.db.models.fields import DateTimeField
-from django.db.models.lookups import YearComparisonLookup
+from django.db.models.lookups import YearLookup
 from django.test import SimpleTestCase
 
 
-class YearComparisonLookupTests(SimpleTestCase):
-    def test_get_bound(self):
-        look_up = YearComparisonLookup(
+class YearLookupTests(SimpleTestCase):
+    def test_get_bound_params(self):
+        look_up = YearLookup(
             lhs=Value(datetime(2010, 1, 1, 0, 0, 0), output_field=DateTimeField()),
             rhs=Value(datetime(2010, 1, 1, 23, 59, 59), output_field=DateTimeField()),
         )
-        msg = 'subclasses of YearComparisonLookup must provide a get_bound() method'
+        msg = 'subclasses of YearLookup must provide a get_bound_params() method'
         with self.assertRaisesMessage(NotImplementedError, msg):
-            look_up.get_bound(datetime(2010, 1, 1, 0, 0, 0), datetime(2010, 1, 1, 23, 59, 59))
+            look_up.get_bound_params(datetime(2010, 1, 1, 0, 0, 0), datetime(2010, 1, 1, 23, 59, 59))


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30494

The previous heuristics were naively enabling the `BETWEEN` optimization on successful cast of the first rhs SQL params to an integer while it was not appropriate for a lot of database resolved expressions.

Thanks Alexey Chernov for the report.