### PR TITLE
Refs #26192 -- Changed test_order_raises_on_non_selected_column() to order by function instead of static value.

### DIFF
--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -1,4 +1,5 @@
 from django.db.models import Exists, F, IntegerField, OuterRef, Value
+from django.db.models.functions import Power
 from django.db.utils import DatabaseError, NotSupportedError
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
@@ -204,7 +205,7 @@ class QuerySetSetOperationTests(TestCase):
 
     def test_order_raises_on_non_selected_column(self):
         qs1 = Number.objects.filter().annotate(
-            annotation=Value(1, IntegerField()),
+            annotation=Power('num', Value(2, IntegerField())),
         ).values('annotation', num2=F('num'))
         qs2 = Number.objects.filter().values('id', 'num')
         # Should not raise


### PR DESCRIPTION
Order by static value doesn't have much sense and can be problematic on PostgreSQL (see ticket [26192](https://code.djangoproject.com/ticket/26192)).

IMO we can remove static values from `ORDER BY` clause as a part of query optimization (see #11384).