### PR TITLE
Fixed datetime string format examples in docs/howto/custom-template-tags.txt.

### DIFF
--- a/docs/howto/custom-template-tags.txt
+++ b/docs/howto/custom-template-tags.txt
@@ -1014,7 +1014,7 @@ Here's how you'd use this new version of the tag:
 
 .. code-block:: html+django
 
-    {% current_time "%Y-%M-%d %I:%M %p" %}<p>The time is {{ current_time }}.</p>
+    {% current_time "%Y-%m-%d %I:%M %p" %}<p>The time is {{ current_time }}.</p>
 
 .. admonition:: Variable scope in context
 
@@ -1032,7 +1032,7 @@ like so:
 
 .. code-block:: html+django
 
-    {% current_time "%Y-%M-%d %I:%M %p" as my_current_time %}
+    {% current_time "%Y-%m-%d %I:%M %p" as my_current_time %}
     <p>The current time is {{ my_current_time }}.</p>
 
 To do that, you'll need to refactor both the compilation function and ``Node``


### PR DESCRIPTION
%M is minutes, and the example is clearly trying to output months