### PR TITLE
Forced utf-8 encoding when loading common passwords in CommonPasswordValidator.

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -171,7 +171,7 @@ class CommonPasswordValidator:
 
     def __init__(self, password_list_path=DEFAULT_PASSWORD_LIST_PATH):
         try:
-            with gzip.open(password_list_path, 'rt') as f:
+            with gzip.open(password_list_path, 'rt', encoding='utf-8') as f:
                 self.passwords = {x.strip() for x in f}
         except OSError:
             with open(password_list_path) as f:


### PR DESCRIPTION
Follow up to 28eac41510eb9de728bdfbc22a36f33ac75394f2 (see #11391)