### PR TITLE
Changed missing template variables to log only on silenced exceptions

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -864,14 +864,13 @@ class Variable:
                                 raise
         except Exception as e:
             template_name = getattr(context, 'template_name', None) or 'unknown'
-            logger.debug(
-                "Exception while resolving variable '%s' in template '%s'.",
-                bit,
-                template_name,
-                exc_info=True,
-            )
-
             if getattr(e, 'silent_variable_failure', False):
+                logger.debug(
+                    "Exception while resolving variable '%s' in template '%s'.",
+                    bit,
+                    template_name,
+                    exc_info=True,
+                )
                 current = context.template.engine.string_if_invalid
             else:
                 raise

--- a/tests/template_tests/test_logging.py
+++ b/tests/template_tests/test_logging.py
@@ -43,21 +43,14 @@ class VariableResolveLoggingTests(SimpleTestCase):
         raised_exception = log_record.exc_info[1]
         self.assertEqual(str(raised_exception), 'Attribute does not exist.')
 
-    def test_log_on_variable_does_not_exist_not_silent(self):
-        with self.assertLogs('django.template', self.loglevel) as cm:
-            with self.assertRaises(VariableDoesNotExist):
-                Variable('article.author').resolve({'article': {'section': 'News'}})
+    def test_do_not_log_on_variable_does_not_exist_not_silent(self):
+        with self.assertRaisesMessage(AssertionError, 'no logs'):
+            with self.assertLogs('django.template', self.loglevel):
+                with self.assertRaises(VariableDoesNotExist) as cm:
+                    Variable('article.author').resolve({'article': {'section': 'News'}})
 
-        self.assertEqual(len(cm.records), 1)
-        log_record = cm.records[0]
         self.assertEqual(
-            log_record.getMessage(),
-            "Exception while resolving variable 'author' in template 'unknown'."
-        )
-        self.assertIsNotNone(log_record.exc_info)
-        raised_exception = log_record.exc_info[1]
-        self.assertEqual(
-            str(raised_exception),
+            str(cm.exception),
             "Failed lookup for key [author] in {'section': 'News'}"
         )
 


### PR DESCRIPTION
If the exception is raised then it will either be caught and logged elsewhere (eg in middleware) or be explicitly ignored
so the debug message will be noise