### PR TITLE
Refs #9982 -- Added test for saving OneToOneField field after saving related object.

### DIFF
--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -280,6 +280,14 @@ class OneToOneTests(TestCase):
         self.assertEqual(num_deleted, 1)
         self.assertEqual(objs, {'one_to_one.Pointer': 1})
 
+    def test_save_nullable_o2o_after_parent(self):
+        place = Place(name='Rose tattoo')
+        bar = UndergroundBar(place=place)
+        place.save()
+        bar.save()
+        bar.refresh_from_db()
+        self.assertEqual(bar.place, place)
+
     def test_reverse_object_does_not_exist_cache(self):
         """
         Regression for #13839 and #17439.


### PR DESCRIPTION
Fixed in 519016e5f25d7c0a040015724f9920581551cab0.