### PR TITLE
Fixed #30315 -- Fixed crash of ArrayAgg and StringAgg with ordering when used in Subquery.

### DIFF
--- a/django/contrib/postgres/aggregates/mixins.py
+++ b/django/contrib/postgres/aggregates/mixins.py
@@ -33,6 +33,12 @@ class OrderableAggMixin:
             return sql, sql_params + ordering_params
         return super().as_sql(compiler, connection, ordering='')
 
+    def set_source_expressions(self, exprs):
+        # Extract the ordering expressions because ORDER BY clause is handled
+        # in a custom way.
+        self.ordering = exprs[self._get_ordering_expressions_index():]
+        return super().set_source_expressions(exprs[:self._get_ordering_expressions_index()])
+
     def get_source_expressions(self):
         return self.source_expressions + self.ordering
 

--- a/docs/releases/2.2.2.txt
+++ b/docs/releases/2.2.2.txt
@@ -21,3 +21,7 @@ Bugfixes
 
 * Fixed a regression in Django 2.2 where auto-reloader doesn't detect changes
   in ``manage.py`` file when using ``StatReloader`` (:ticket:`30479`).
+
+* Fixed crash of :class:`~django.contrib.postgres.aggregates.ArrayAgg` and
+  :class:`~django.contrib.postgres.aggregates.StringAgg` with ``ordering``
+  argument when used in a ``Subquery`` (:ticket:`30315`).


### PR DESCRIPTION
Trac Ticket: https://code.djangoproject.com/ticket/30315