### PR TITLE
Fixed #28520 -- Added --start-at/--start-after options to runtests.py.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -213,6 +213,24 @@ Going beyond that, you can specify an individual test method like this:
 
    $ ./runtests.py --settings=path.to.settings i18n.tests.TranslationTests.test_lazy_objects
 
+You can run tests starting at a specified top-level module with ``--start-at``
+option. For example:
+
+.. console::
+
+   $ ./runtests.py --start-at=wsgi
+
+You can also run tests starting after a specified top-level module with
+``--start-after`` option. For example:
+
+.. console::
+
+   $ ./runtests.py --start-after=wsgi
+
+Note that the ``--reverse`` option doesn't impact on ``--start-at`` or
+``--start-after`` options. Moreover these options cannot be used with test
+labels.
+
 Running the Selenium tests
 --------------------------
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -267,6 +267,9 @@ Tests
 * Django test runner now supports headless mode for selenium tests on supported
   browsers. Add the ``--headless`` option to enable this mode.
 
+* Django test runner now supports ``--start-at`` and ``--start-after`` options
+  to run tests starting from a specific top-level module.
+
 URLs
 ~~~~
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -195,6 +195,10 @@ def setup(verbosity, test_labels, parallel):
         print('Aborting: A GIS database backend is required to run gis_tests.')
         sys.exit(1)
 
+    def _module_match_label(module_label, label):
+        # Exact or ancestor match.
+        return module_label == label or module_label.startswith(label + '.')
+
     # Load all the test model apps.
     test_modules = get_test_modules()
 
@@ -208,9 +212,7 @@ def setup(verbosity, test_labels, parallel):
         # no modules were named (i.e., run all), import
         # this module and add it to INSTALLED_APPS.
         module_found_in_labels = not test_labels or any(
-            # exact match or ancestor match
-            module_label == label or module_label.startswith(label + '.')
-            for label in test_labels_set
+            _module_match_label(module_label, label) for label in test_labels_set
         )
 
         if module_name in CONTRIB_TESTS_TO_APPS and module_found_in_labels:


### PR DESCRIPTION
[ticket 28520](https://code.djangoproject.com/ticket/28520)
Continue https://github.com/django/django/pull/8957 work.