### PR TITLE
Fixed #30510 - Adjust Oracle bulk insert column types to match

### DIFF
--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -657,3 +657,9 @@ class BaseDatabaseWrapper:
         if alias is None:
             alias = self.alias
         return type(self)(settings_dict, alias)
+
+    def adjust_param_rows(self, param_rows, cursor):
+        """
+        Only the Oracle backend needs to adjust parameters of the query.
+        """
+        return param_rows

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -49,6 +49,19 @@ class BulkCreateTests(TestCase):
         Country.objects.bulk_create([Country(description='Ж' * 3000)])
         self.assertEqual(Country.objects.count(), 1)
 
+    @skipUnlessDBFeature('has_bulk_insert')
+    def test_long_and_short(self):
+        """
+        A bulk insert with long and short values for the same field should
+        ensure that if one field requires a CLOB type they all get the CLOB
+        type.
+        """
+        Country.objects.bulk_create([
+            Country(description='aaa'),
+            Country(description='a' * 6000),
+        ])
+        self.assertEqual(Country.objects.count(), 2)
+
     def test_multi_table_inheritance_unsupported(self):
         expected_message = "Can't bulk create a multi-table inherited model"
         with self.assertRaisesMessage(ValueError, expected_message):


### PR DESCRIPTION
Patch to address the issue described in https://code.djangoproject.com/ticket/30510

This adds an extra `adjust_param_rows` hook at the connection backend level that allows the query parameters to an insert to be adjusted with a view of the inserted matrix.