### PR TITLE
Fixed #30512 -- Used email.headerregistry.parser for parsing emails in sanitize_address().

### DIFF
--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -259,7 +259,7 @@ All parameters are optional and can be set at any time prior to calling the
 * ``body``: The body text. This should be a plain text message.
 
 * ``from_email``: The sender's address. Both ``fred@example.com`` and
-  ``Fred <fred@example.com>`` forms are legal. If omitted, the
+  ``"Fred" <fred@example.com>`` forms are legal. If omitted, the
   :setting:`DEFAULT_FROM_EMAIL` setting is used.
 
 * ``to``: A list or tuple of recipient addresses.

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -748,9 +748,29 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
                 'utf-8',
                 '=?utf-8?q?to=40other=2Ecom?= <to@example.com>',
             ),
+            (
+                ('To Example', 'to@other.com@example.com'),
+                'utf-8',
+                '=?utf-8?q?To_Example?= <"to@other.com"@example.com>',
+            ),
         ):
             with self.subTest(email_address=email_address, encoding=encoding):
                 self.assertEqual(sanitize_address(email_address, encoding), expected_result)
+
+    def test_sanitize_address_invalid(self):
+        for email_address in (
+            # Invalid address with two @ signs.
+            'to@other.com@example.com',
+            # Invalid address without the quotes.
+            'to@other.com <to@example.com>',
+            # Other invalid addresses.
+            '@',
+            'to@',
+            '@example.com',
+        ):
+            with self.subTest(email_address=email_address):
+                with self.assertRaises(ValueError):
+                    sanitize_address(email_address, encoding='utf-8')
 
 
 @requires_tz_support


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30512#ticket

> `django.core.mail.message.sanitize_address` uses email.utils.parseaddr from the standard lib. On Python 3, email.headerregistry.parser.get_mailbox() does the same, and is less error-prone.

This PR does that, adds some test cases and fixes doc where it advertizes using things that go against the RFC.

Not sure if I should be adding something to the changelog or what ?