### PR TITLE
Fixed #30523 -- Fixed updating file modification times on seen files in auto-reloader when using StatReloader.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -336,9 +336,9 @@ class StatReloader(BaseReloader):
         while True:
             for filepath, mtime in self.snapshot_files():
                 old_time = mtimes.get(filepath)
+                mtimes[filepath] = mtime
                 if old_time is None:
                     logger.debug('File %s first seen with mtime %s', filepath, mtime)
-                    mtimes[filepath] = mtime
                     continue
                 elif mtime > old_time:
                     logger.debug('File %s previous mtime: %s, current mtime: %s', filepath, old_time, mtime)

--- a/docs/releases/2.2.2.txt
+++ b/docs/releases/2.2.2.txt
@@ -28,3 +28,7 @@ Bugfixes
 
 * Fixed a regression in Django 2.2 that caused a crash of auto-reloader when
   an exception with custom signature is raised (:ticket:`30516`).
+
+* Fixed a regression in Django 2.2.1 where auto-reloader unnecessarily reload
+  translation files multiple times when using ``StatReloader``
+  (:ticket:`30523`).

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -659,6 +659,16 @@ class StatReloaderTests(ReloaderTests, IntegrationTests):
         # Shorten the sleep time to speed up tests.
         self.reloader.SLEEP_TIME = 0.01
 
+    @mock.patch('django.utils.autoreload.StatReloader.notify_file_changed')
+    def test_tick_does_not_trigger_twice(self, mock_notify_file_changed):
+        with mock.patch.object(self.reloader, 'watched_files', return_value=[self.existing_file]):
+            ticker = self.reloader.tick()
+            next(ticker)
+            self.increment_mtime(self.existing_file)
+            next(ticker)
+            next(ticker)
+            self.assertEqual(mock_notify_file_changed.call_count, 1)
+
     def test_snapshot_files_ignores_missing_files(self):
         with mock.patch.object(self.reloader, 'watched_files', return_value=[self.nonexistent_file]):
             self.assertEqual(dict(self.reloader.snapshot_files()), {})


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/30523#ticket

Currently we only update the file mtimes if the file has not been 'seen' before - i.e on the first iteration of the loop.

If the mtime has been changed we trigger the `notify_file_changed()` method which in all cases except the translations will result in the process being terminated. However to be strictly correct we need to update the mtime for either branch of the conditional.

I can make a ticket for this, I don't see it as being a serious issue, but in the future if we expand this to watch other non-python files (or have other logic to reset translations) it could well be. 