### PR TITLE
Fixed #30505 -- Prevented migrations detecting changes on field choices order

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -463,7 +463,7 @@ class Field(RegisterLookupMixin):
             value = getattr(self, attr_overrides.get(name, name))
             # Unroll anything iterable for choices into a concrete list
             if name == "choices" and isinstance(value, collections.abc.Iterable):
-                value = list(value)
+                value = list(sorted(value))
             # Do correct kind of comparison
             if name in equals_comparison:
                 if value != default:

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -463,7 +463,7 @@ class Field(RegisterLookupMixin):
             value = getattr(self, attr_overrides.get(name, name))
             # Unroll anything iterable for choices into a concrete list
             if name == "choices" and isinstance(value, collections.abc.Iterable):
-                value = list(sorted(value))
+                value = sorted(list(value))
             # Do correct kind of comparison
             if name in equals_comparison:
                 if value != default:

--- a/docs/releases/2.2.2.txt
+++ b/docs/releases/2.2.2.txt
@@ -18,3 +18,6 @@ Bugfixes
 * Fixed a regression in Django 2.2.1 where
   :class:`~django.contrib.postgres.search.SearchVector` generates SQL with a
   redundant ``Coalesce`` call (:ticket:`30488`).
+
+* Prevented migrations from detecting changes on field choices when only the
+  ordering has changed (:ticket:`30505`).

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -193,6 +193,20 @@ class AutodetectorTests(TestCase):
             c=None,
         ))),
     ])
+    author_with_choices = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("choices", models.CharField(max_length=3, choices=[
+            ("foo", "Foo"),
+            ("bar", "Bar"),
+        ])),
+    ])
+    author_with_choices_ordered = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("choices", models.CharField(max_length=3, choices=[
+            ("bar", "Bar"),
+            ("foo", "Foo"),
+        ])),
+    ])
     author_custom_pk = ModelState("testapp", "Author", [("pk_field", models.IntegerField(primary_key=True))])
     author_with_biography_non_blank = ModelState("testapp", "Author", [
         ("id", models.AutoField(primary_key=True)),
@@ -775,6 +789,14 @@ class AutodetectorTests(TestCase):
             (_content_file_name, ('file',), {'spam': 'eggs'}),
             (value.func, value.args, value.keywords)
         )
+
+    def test_alter_field_choices(self):
+        """
+        #30505 - Different order of choices should not trigger a migration
+        """
+        changes = self.get_changes(
+            [self.author_with_choices], [self.author_with_choices_ordered])
+        self.assertNumberMigrations(changes, 'testapp', 0)
 
     @mock.patch('django.db.migrations.questioner.MigrationQuestioner.ask_not_null_alteration',
                 side_effect=AssertionError("Should not have prompted for not null addition"))


### PR DESCRIPTION
Trac ticket: https://code.djangoproject.com/ticket/30505