### PR TITLE
Fixed #30516 -- Fixed crash of autoreloader when re-raising exceptions with custom signature.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -74,7 +74,7 @@ def check_errors(fn):
 def raise_last_exception():
     global _exception
     if _exception is not None:
-        raise _exception[0](_exception[1]).with_traceback(_exception[2])
+        raise _exception[1]
 
 
 def ensure_echo_on():

--- a/docs/releases/2.2.2.txt
+++ b/docs/releases/2.2.2.txt
@@ -25,3 +25,6 @@ Bugfixes
 * Fixed crash of :class:`~django.contrib.postgres.aggregates.ArrayAgg` and
   :class:`~django.contrib.postgres.aggregates.StringAgg` with ``ordering``
   argument when used in a ``Subquery`` (:ticket:`30315`).
+
+* Fixed a regression in Django 2.2 that caused a crash of auto-reloader when
+  an exception with custom signature is raised (:ticket:`30516`).


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/30516