### PR TITLE
Refs #30536 - Make django.setup() idempotent and tweakable

### DIFF
--- a/django/__init__.py
+++ b/django/__init__.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.version import get_version
 
 VERSION = (3, 0, 0, 'alpha', 0)
@@ -5,7 +6,11 @@ VERSION = (3, 0, 0, 'alpha', 0)
 __version__ = get_version(VERSION)
 
 
-def setup(set_prefix=True):
+# Flag also used to prevent multiple setup() calls
+is_ready = False
+
+
+def _setup(set_prefix=True):
     """
     Configure the settings (this happens as a side effect of accessing the
     first setting), configure logging and populate the app registry.
@@ -22,3 +27,38 @@ def setup(set_prefix=True):
             '/' if settings.FORCE_SCRIPT_NAME is None else settings.FORCE_SCRIPT_NAME
         )
     apps.populate(settings.INSTALLED_APPS)
+
+
+def setup(set_prefix=True):
+    """
+    This function is idempotent (calling it several times changes nothing), but
+    not reentrant (recursively calling it would have an unexpected result).
+
+    It delegates actual setup of Django to settings.DJANGO_SETUP_CALLABLE  (if set),
+    else to ``django._setup``
+
+    Returns True iff actual setup occurred.
+    """
+    global is_ready
+    if is_ready:
+        return False
+
+    from django.conf import settings
+    from importlib import import_module
+
+    if settings.DJANGO_SETUP_CALLABLE:
+        try:
+            mod_path, _, callable_name = settings.DJANGO_SETUP_CALLABLE.rpartition('.')
+            mod = import_module(mod_path)
+            setup_callable = getattr(mod, callable_name)
+            setup_callable()  # No arguments expected for this callable
+        except (ImportError, AttributeError) as exc:
+            raise ImproperlyConfigured("Could not load '%s' callable (%r)." %
+                                       (settings.DJANGO_SETUP_CALLABLE, exc))
+    else:
+        # Default case: do standard apps/logging setup
+        _setup(set_prefix=set_prefix)
+
+    # Only now that setup was successful, we prevent later recalls
+    is_ready = True
+    return True

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -232,6 +232,10 @@ PREPEND_WWW = False
 # Override the server-derived value of SCRIPT_NAME
 FORCE_SCRIPT_NAME = None
 
+# Dotted-string callable taken as a replacement for the django._setup() initialization
+# routine, which is called by django.setup().
+DJANGO_SETUP_CALLABLE = None
+
 # List of compiled regular expression objects representing User-Agent strings
 # that are not allowed to visit any page, systemwide. Use this for bad
 # robots/crawlers. Here are a few examples:

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1572,6 +1572,26 @@ of the preferred value or not supplied at all. It is also used by
 request/response cycle (e.g. in management commands and standalone scripts) to
 generate correct URLs when ``SCRIPT_NAME`` is not ``/``.
 
+
+.. setting:: DJANGO_SETUP_CALLABLE
+
+``DJANGO_SETUP_CALLABLE``
+---------------------------
+
+Default: ``None``
+
+If not ``None``, this must be a dotted string representing the callable of
+your choice, e.g. "myapp.my_function". This callable will be used (without
+arguments) as a replacement for the ``django._setup()`` initialization routine,
+when ``django.setup()`` gets called.
+
+You can use this setting to run pre/post operations against the environment, at
+the moment django is setup. Don't forget to call ``django._setup()`` from your
+custom setup callable, else logging, apps registry and other features won't be
+properly configured.
+
+
+
 .. setting:: FORM_RENDERER
 
 ``FORM_RENDERER``

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1586,7 +1586,7 @@ arguments) as a replacement for the ``django._setup()`` initialization routine,
 when ``django.setup()`` gets called.
 
 You can use this setting to run pre/post operations against the environment, at
-the moment django is setup. Don't forget to call ``django._setup()`` from your
+the moment Django is setup. Don't forget to call ``django._setup()`` from your
 custom setup callable, else logging, apps registry and other features won't be
 properly configured.
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -131,6 +131,13 @@ Minor features
   The default value is :func:`~django.utils.translation.get_language()` instead
   of :setting:`LANGUAGE_CODE`.
 
+App-loading changes
+~~~~~~~~~~~~~~~~~~~~
+
+* ``django.setup()`` is now idempotent, and its actual operations can be
+  overridden using :setting:`DJANGO_SETUP_CALLABLE`, e.g. to setup test mockups
+  before App registry is populated.
+
 Cache
 ~~~~~
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -368,6 +368,7 @@ misconfiguration
 mitre
 mixin
 mixins
+mockups
 modelforms
 modelformset
 modwsgi

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -308,7 +308,7 @@ main application::
 
 
 Customizing ``django.setup()`` behavior
-------------------------------------------
+---------------------------------------
 
 By default, ``django.setup()`` delegates actual configuration (settings, logging,
 app registry...) to ``django._setup()``.
@@ -319,7 +319,7 @@ for testing purposes, you can provide an alternative callable setup, in settings
     DJANGO_SETUP_CALLABLE = "myapp.my_function"
 
 This alternative callable will be called without arguments.
-Don't forget, in its implementation, to call ``django._setup()`` at some point,
+Don't forget to call ``django._setup()`` in its implementation at some point,
 to perform actual configuration of the framework.
 
 

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -291,16 +291,37 @@ Note that calling ``django.setup()`` is only necessary if your code is truly
 standalone. When invoked by your Web server, or through :doc:`django-admin
 </ref/django-admin>`, Django will handle this for you.
 
-.. admonition:: ``django.setup()`` may only be called once.
+Note that ``django.setup()`` is idempotent - all calls after the first one will
+be ignored (along with their potential arguments). This function returns True
+if and only if actual setup operations occurred. You can also check this
+beforehand, with the ``django.is_ready`` boolean.
 
-    Therefore, avoid putting reusable application logic in standalone scripts
-    so that you have to import from the script elsewhere in your application.
-    If you can't avoid that, put the call to ``django.setup()`` inside an
-    ``if`` block::
+It is good practice to avoid putting reusable application logic in standalone
+scripts, so that you don't have to import from the script elsewhere in your
+application. However if you can't avoid that, put the call to ``django.setup()``
+inside an ``if`` block, so that you don't interfere with the setup logic of the
+main application::
 
-        if __name__ == '__main__':
-            import django
-            django.setup()
+    if __name__ == '__main__':
+        import django
+        django.setup()
+
+
+Customizing ``django.setup()`` behavior
+------------------------------------------
+
+By default, ``django.setup()`` delegates actual configuration (settings, logging,
+app registry...) to ``django._setup()``.
+
+If you need to modify the environment before these operations occur, e.g.
+for testing purposes, you can provide an alternative callable setup, in settings::
+
+    DJANGO_SETUP_CALLABLE = "myapp.my_function"
+
+This alternative callable will be called without arguments.
+Don't forget, in its implementation, to call ``django._setup()`` at some point,
+to perform actual configuration of the framework.
+
 
 .. seealso::
 

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -250,7 +250,7 @@ class ViewTest(SimpleTestCase):
     def test_not_calling_parent_setup_error(self):
         class TestView(View):
             def setup(self, request, *args, **kwargs):
-                pass  # Not calling supre().setup()
+                pass  # Not calling super().setup()
 
         msg = (
             "TestView instance has no 'request' attribute. Did you override "

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -473,8 +473,9 @@ class SetupConfigureLogging(SimpleTestCase):
         LOGGING=OLD_LOGGING,
     )
     def test_configure_initializes_logging(self):
-        from django import setup
-        setup()
+        import django
+        django.is_ready = False  # hack to break idempotence of django.setup()
+        django.setup()
         self.assertTrue(dictConfig.called)
 
 


### PR DESCRIPTION
The new DJANGO_SETUP_CALLABLE setting allows users to tweak django setup, especially when using external test runners and mockups.

See https://code.djangoproject.com/ticket/30536