### PR TITLE
Fixed #30542 -- Fixed crash of numerical aggregations with filter.

### DIFF
--- a/django/db/models/functions/mixins.py
+++ b/django/db/models/functions/mixins.py
@@ -42,9 +42,9 @@ class FixDurationInputMixin:
 class NumericOutputFieldMixin:
 
     def _resolve_output_field(self):
-        source_expressions = self.get_source_expressions()
-        if any(isinstance(s.output_field, DecimalField) for s in source_expressions):
+        source_fields = self.get_source_fields()
+        if any(isinstance(s, DecimalField) for s in source_fields):
             return DecimalField()
-        if any(isinstance(s.output_field, IntegerField) for s in source_expressions):
+        if any(isinstance(s, IntegerField) for s in source_fields):
             return FloatField()
-        return super()._resolve_output_field() if source_expressions else FloatField()
+        return super()._resolve_output_field() if source_fields else FloatField()

--- a/docs/releases/2.2.3.txt
+++ b/docs/releases/2.2.3.txt
@@ -9,4 +9,6 @@ Django 2.2.3 fixes several bugs in 2.2.2.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 2.2 where :class:`~django.db.models.Avg`,
+  :class:`~django.db.models.StdDev`, and :class:`~django.db.models.Variance`
+  crash with ``filter`` argument (:ticket:`30542`).


### PR DESCRIPTION
Filters in annotations crashed when used with numerical-type aggregations (i.e. `Avg`, `StdDev`, and `Variance`). This was caused as the source expressions no not necessarily have an output_field (such as the filter field), which lead to an AttributeError: 'WhereNode' object has no attribute 'output_field'.

A regression test was also added for this case, and a release page for 2.2.3 was created.

Thanks to Chuan-Zheng Lee for the report.

Regression in c690afb and following two commits (each for different aggregations, e85afa5943695457c85e9bc1c5dc0d985004e303 and 6d4efa8e6a4cc7be4ba957dec71f6f63cd58700d)