### PR TITLE
Fixed #28790 -- Doc'd how to avoid running certain test classes in parallel.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1402,6 +1402,13 @@ Each process gets its own database. You must ensure that different test cases
 don't access the same resources. For instance, test cases that touch the
 filesystem should create a temporary directory for their own use.
 
+.. note::
+
+    If you have test cases that needs to access the same resources, one
+    solution is to make these test cases not run in parallel, see
+    :doc:`Enforce serialization of TestCases that share a common resource </topics/testing/advanced>`
+    for details.
+
 This option requires the third-party ``tblib`` package to display tracebacks
 correctly:
 

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -301,6 +301,37 @@ Advanced features of ``TransactionTestCase``
 
 .. _testing-reusable-applications:
 
+Enforce serialization of TestCases that share a common resource
+===============================================================
+
+If you have test cases that needs to access the same resources, one solution is
+to make these test cases not run in parallel using
+``django.test.testcases.SerializeMixin``. This mixin requires a ``lockfile``
+that must point to a file that exist on the filesystem.
+
+For example, you could use ``__file__`` to determine that all test cases
+extending ``SerializeMixin`` in the same file will run serially::
+
+    from django.test.testcases import SerializeMixin
+
+    class ImageTestCaseMixin(SerializeMixin):
+        lockfile = __file__
+
+        def setUp(self):
+            self.filename = os.path.join(temp_storage_dir, 'my_file.png')
+            self.file = create_file(self.filename)
+
+    class RemoveImageTestCase(ImageTestCaseMixin, TestCase):
+        def test_remove_image(self):
+            remove_image(self.file)
+            self.assertFalse(file_exists(self.file))
+
+    class ResizeImageTestCase(ImageTestCaseMixin, TestCase):
+        def test_resize_image(self):
+            resize_image(self.file, (48, 48))
+            self.assertEqual((48, 48), get_image_size(self.file))
+
+
 Using the Django test runner to test reusable applications
 ==========================================================
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/28790

<img width="672" alt="Screen Shot 2019-06-05 at 11 37 22 AM" src="https://user-images.githubusercontent.com/55533/58965055-4dac0f80-8786-11e9-9b42-ec85f1f91fbc.png">

---

<img width="669" alt="Screen Shot 2019-06-05 at 11 37 13 AM" src="https://user-images.githubusercontent.com/55533/58965056-4e44a600-8786-11e9-8c80-079462be42ff.png">