### PR TITLE
Fixed #30521 -- Fixed invalid HTML in default error pages. 

### DIFF
--- a/django/views/defaults.py
+++ b/django/views/defaults.py
@@ -11,6 +11,17 @@ ERROR_404_TEMPLATE_NAME = '404.html'
 ERROR_403_TEMPLATE_NAME = '403.html'
 ERROR_400_TEMPLATE_NAME = '400.html'
 ERROR_500_TEMPLATE_NAME = '500.html'
+ERROR_PAGE_TEMPLATE = """
+<!doctype html>
+<html lang="en">
+<head>
+  <title>%(title)s</title>
+</head>
+<body>
+  <h1>%(title)s</h1><p>%(details)s</p>
+</body>
+</html>
+"""
 
 
 # This can be called when CsrfViewMiddleware.process_view has not run,
@@ -55,8 +66,11 @@ def page_not_found(request, exception, template_name=ERROR_404_TEMPLATE_NAME):
         # Render template (even though there are no substitutions) to allow
         # inspecting the context in tests.
         template = Engine().from_string(
-            '<h1>Not Found</h1>'
-            '<p>The requested resource was not found on this server.</p>')
+            ERROR_PAGE_TEMPLATE % {
+                'title': 'Not Found',
+                'details': 'The requested resource was not found on this server.',
+            },
+        )
         body = template.render(Context(context))
         content_type = 'text/html'
     return HttpResponseNotFound(body, content_type=content_type)
@@ -76,7 +90,10 @@ def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
         if template_name != ERROR_500_TEMPLATE_NAME:
             # Reraise if it's a missing custom template.
             raise
-        return HttpResponseServerError('<h1>Server Error (500)</h1>', content_type='text/html')
+        return HttpResponseServerError(
+            ERROR_PAGE_TEMPLATE % {'title': 'Server Error (500)', 'details': ''},
+            content_type='text/html',
+        )
     return HttpResponseServerError(template.render())
 
 
@@ -94,7 +111,10 @@ def bad_request(request, exception, template_name=ERROR_400_TEMPLATE_NAME):
         if template_name != ERROR_400_TEMPLATE_NAME:
             # Reraise if it's a missing custom template.
             raise
-        return HttpResponseBadRequest('<h1>Bad Request (400)</h1>', content_type='text/html')
+        return HttpResponseBadRequest(
+            ERROR_PAGE_TEMPLATE % {'title': 'Bad Request (400)', 'details': ''},
+            content_type='text/html',
+        )
     # No exception content is passed to the template, to not disclose any sensitive information.
     return HttpResponseBadRequest(template.render())
 
@@ -119,7 +139,10 @@ def permission_denied(request, exception, template_name=ERROR_403_TEMPLATE_NAME)
         if template_name != ERROR_403_TEMPLATE_NAME:
             # Reraise if it's a missing custom template.
             raise
-        return HttpResponseForbidden('<h1>403 Forbidden</h1>', content_type='text/html')
+        return HttpResponseForbidden(
+            ERROR_PAGE_TEMPLATE % {'title': '403 Forbidden', 'details': ''},
+            content_type='text/html',
+        )
     return HttpResponseForbidden(
         template.render(request=request, context={'exception': str(exception)})
     )

--- a/tests/view_tests/tests/test_defaults.py
+++ b/tests/view_tests/tests/test_defaults.py
@@ -47,6 +47,11 @@ class DefaultsTests(TestCase):
         for url in self.nonexistent_urls:
             response = self.client.get(url)
             self.assertEqual(response.status_code, 404)
+        self.assertIn(b'<h1>Not Found</h1>', response.content)
+        self.assertIn(
+            b'<p>The requested resource was not found on this server.</p>',
+            response.content,
+        )
 
     @override_settings(TEMPLATES=[{
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -71,7 +76,7 @@ class DefaultsTests(TestCase):
     def test_server_error(self):
         "The server_error view raises a 500 status"
         response = self.client.get('/server_error/')
-        self.assertEqual(response.status_code, 500)
+        self.assertContains(response, b'<h1>Server Error (500)</h1>', status_code=500)
 
     def test_bad_request(self):
         request = self.request_factory.get('/')


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/30521
Simple solution to have better html responses form default error pages