### PR TITLE
Refs #30207: Optimise paginator for tables with massive records by slicing records using pk instead of all columns

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -28,12 +28,15 @@ class EmptyPage(InvalidPage):
 class Paginator:
 
     def __init__(self, object_list, per_page, orphans=0,
-                 allow_empty_first_page=True):
+                 allow_empty_first_page=True, slice_by_pk=False):
         self.object_list = object_list
         self._check_object_list_is_ordered()
         self.per_page = int(per_page)
         self.orphans = int(orphans)
         self.allow_empty_first_page = allow_empty_first_page
+        if slice_by_pk:
+            self.object_list_pks = object_list.values(slice_by_pk)
+        self._slice_by_pk = slice_by_pk
 
     def validate_number(self, number):
         """Validate the given 1-based page number."""
@@ -72,6 +75,8 @@ class Paginator:
         top = bottom + self.per_page
         if top + self.orphans >= self.count:
             top = self.count
+        if self._slice_by_pk:
+            return self._get_page(self.object_list.filter(pk__in=self.object_list_pks[bottom:top]), number, self)
         return self._get_page(self.object_list[bottom:top], number, self)
 
     def _get_page(self, *args, **kwargs):


### PR DESCRIPTION
I had a problem with Paginator class to slice huge dataset. In case of millions of record it can take 30 second to reach the last page. So I cam up with a solution to overcome this problem.

The problem is that for slicing data, current solution needs to compute whole list to render data bottom:top. The reason is that, current script will generate for example SELECT ID, COL_1, ..., COL_N, ... WHERE ... which has huge burden for database to slice the data. To overcome this problem we can instead select primary keys and do the slicing step and then fetch records that their pk are in that sliced list. Very simple but very efficient solution. I improved the performance for our project significantly using this approach. So form 30 seconds to only 2-3 seconds for 8 million records.

Tested DB: Postgres