### PR TITLE
Removed order by from get_group_by in SQLCompiler

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -54,10 +54,10 @@ class SQLCompiler:
         self.where, self.having = self.query.where.split_having()
         extra_select = self.get_extra_select(order_by, self.select)
         self.has_extra_select = bool(extra_select)
-        group_by = self.get_group_by(self.select + extra_select, order_by)
+        group_by = self.get_group_by(self.select + extra_select)
         return extra_select, order_by, group_by
 
-    def get_group_by(self, select, order_by):
+    def get_group_by(self, select):
         """
         Return a list of 2-tuples of form (sql, params).
 
@@ -115,11 +115,6 @@ class SQLCompiler:
             cols = expr.get_group_by_cols()
             for col in cols:
                 expressions.append(col)
-        for expr, (sql, params, is_ref) in order_by:
-            # Skip References to the select clause, as all expressions in the
-            # select clause are already part of the group by.
-            if not expr.contains_aggregate and not is_ref:
-                expressions.extend(expr.get_source_expressions())
         having_group_by = self.having.get_group_by_cols() if self.having else ()
         for expr in having_group_by:
             expressions.append(expr)


### PR DESCRIPTION
Ticket: [#26434](https://code.djangoproject.com/ticket/26434)

I opened this pull request to discuss when collecting group by columns why are order by columns added into extensions. 

For example: 
Model.objects.values("col_a").annotate(max=Max("col_b")).order_by('col_c')
current query:
```
select col_a, MAX(col_b) as max 
from Model 
group by col_a, col_c
order by col_c
```
I think the expected behavior has should be like that:
`django.db.utils.ProgrammingError: column "Model.col_c" must appear in the GROUP BY clause or be used in an aggregate function`

Because this behavior changes my group by and result. if I'm lucky, my result doesn't change.

If we check `test_annotation_with_value`, 'name' column is being added into `group_by` because Book model has `Meta.ordering`.