### PR TITLE
Refs #30485 -- Removed non-representative test that emitted a warning.

### DIFF
--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -74,7 +74,6 @@ class URLEncodeTests(SimpleTestCase):
 
     def test_dict_with_bytearray(self):
         self.assertEqual(urlencode({'a': bytearray(range(2))}, doseq=True), 'a=0&a=1')
-        self.assertEqual(urlencode({'a': bytearray(range(2))}, doseq=False), 'a=bytearray%28b%27%5Cx00%5Cx01%27%29')
 
     def test_generator(self):
         self.assertEqual(urlencode({'a': range(2)}, doseq=True), 'a=0&a=1')


### PR DESCRIPTION
Previously, when running the Django test suite with warnings enabled, the following was emitted:

    /usr/lib64/python3.7/urllib/parse.py:915: BytesWarning: str() on a bytearray instance
      v = quote_via(str(v), safe, encoding, errors)

This occurred due to the `bytearray()` being passed to `urllib.parse.urlencode()` which eventually calls `str()` on it. The test does not represent desired real world behavior. Rather than test for and
assert strange unspecified behavior that emits a warning, remove it.

This was also discussed in PR #11374.