### PR TITLE
[2.2.x] Fixed #30481 -- document force_text() can return non-text str

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ answer newbie questions, and generally made Django that much better:
     Adam Allred <adam.w.allred@gmail.com>
     Adam Bogdał <adam@bogdal.pl>
     Adam Donaghy
+    Adam Hooper <adam@adamhooper.com>
     Adam Johnson <https://github.com/adamchainz>
     Adam Malinowski <https://adammalinowski.co.uk/>
     Adam Vandenberg

--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -54,6 +54,13 @@ def force_text(s, encoding='utf-8', strings_only=False, errors='strict'):
     strings, rather than kept as lazy objects.
 
     If strings_only is True, don't convert (some) non-string-like objects.
+
+    Note: force_text() returns a str object; but not all str
+    objects are valid text. For instance, "\ud800" is valid JSON; but
+    once parsed, you cannot print() it or render it in a template.
+    force_text() will not modify such strings. (To remove Unicode
+    surrogates in raw_str that are valid in JSON but invalid text, use
+    safe_str = re.sub('[\ud800-\udfff]', '\ufffd', raw_str))
     """
     # Handle the common case first for performance reasons.
     if issubclass(type(s), str):

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -223,6 +223,13 @@ The functions defined in this module share the following properties:
     If ``strings_only`` is ``True``, don't convert (some) non-string-like
     objects.
 
+    Note: ``force_text()`` returns a ``str`` object; but not all ``str``
+    objects are valid text. For instance, ``"\ud800"`` is valid JSON; but
+    once parsed, you cannot ``print()`` it or render it in a template.
+    ``force_text()`` will not modify such strings. (To remove Unicode
+    surrogates in ``raw_str`` that are valid in JSON but invalid text, use
+    ``safe_str = re.sub('[\ud800-\udfff]', '\ufffd', raw_str)``)
+
 .. function:: smart_bytes(s, encoding='utf-8', strings_only=False, errors='strict')
 
     Returns a bytestring version of arbitrary object ``s``, encoded as


### PR DESCRIPTION
Not needed in Django 3.x because "force_text()" is deprecated there
in favor of "force_str()". This documentation clarifies "yes, we said
text but really we mean str"; that's not needed when the function says
"str" in the first place.