### PR TITLE
Changed charset and collation link to MySQL docs.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -711,7 +711,7 @@ backend-specific.
 Supported by the PostgreSQL_ (``postgresql``) and MySQL_ (``mysql``) backends.
 
 .. _PostgreSQL: https://www.postgresql.org/docs/current/multibyte.html
-.. _MySQL: https://dev.mysql.com/doc/refman/en/charset-database.html
+.. _MySQL: https://dev.mysql.com/doc/refman/en/charset-charsets.html
 
 .. setting:: TEST_COLLATION
 


### PR DESCRIPTION
Issue https://github.com/django/djangoproject.com/issues/919
I suggest change links for MySQL at anchors https://docs.djangoproject.com/en/2.2/ref/settings/#charset and https://docs.djangoproject.com/en/2.2/ref/settings/#collation from https://dev.mysql.com/doc/refman/en/charset-database.html to https://dev.mysql.com/doc/refman/en/charset-charsets.html because second one contains "Supported Character Sets and Collations" for MySQL instead of previous.