### PR TITLE
Refs #30512, #15042 -- Added local-only address to sanitize_email() tests cases.

### DIFF
--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -716,6 +716,7 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
                 'utf-8',
                 '=?utf-8?q?A_name?= <to@example.com>',
             ),
+            ('localpartonly', 'ascii', 'localpartonly'),
             # ASCII addresses with display names.
             ('A name <to@example.com>', 'ascii', 'A name <to@example.com>'),
             ('A name <to@example.com>', 'utf-8', '=?utf-8?q?A_name?= <to@example.com>'),


### PR DESCRIPTION
`email.headerregistry.parser.get_mailbox()` returns a token with a `token_type` attribute.

If `token_type` is `'invalid-mailbox'` then RFC violations have been detected. Emails with only the local part, and no domain,  are correctly parsed but are marked as `'invalid-mailbox'`.

As per #15042, local-only are supported, to enable sending to addresses on localhost.

`sanitize_email()` does not currently check `token_type`. This test is added to avoid a regression in case this is revisited in the future.