### PR TITLE
Fixed #30066 -- Enabled super user creation without email and password

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -146,7 +146,7 @@ class UserManager(BaseUserManager):
         extra_fields.setdefault('is_superuser', False)
         return self._create_user(username, email, password, **extra_fields)
 
-    def create_superuser(self, username, email, password, **extra_fields):
+    def create_superuser(self, username, email=None, password=None, **extra_fields):
         extra_fields.setdefault('is_staff', True)
         extra_fields.setdefault('is_superuser', True)
 

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -282,10 +282,14 @@ Manager methods
 
         See :ref:`Creating users <topics-auth-creating-users>` for example usage.
 
-    .. method:: create_superuser(username, email, password, **extra_fields)
+    .. method:: create_superuser(username, email=None, password=None, **extra_fields)
 
         Same as :meth:`create_user`, but sets :attr:`~models.User.is_staff` and
         :attr:`~models.User.is_superuser` to ``True``.
+
+        .. versionchanged:: 3.0
+
+            The ``email`` and ``password`` parameters were made optional.
 
 ``AnonymousUser`` object
 ========================

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -735,7 +735,7 @@ providing two additional methods:
 
 .. class:: models.CustomUserManager
 
-    .. method:: models.CustomUserManager.create_user(*username_field*, password=None, **other_fields)
+    .. method:: models.CustomUserManager.create_user(username_field, password=None, **other_fields)
 
         The prototype of ``create_user()`` should accept the username field,
         plus all required fields as arguments. For example, if your user model
@@ -746,7 +746,7 @@ providing two additional methods:
                 # create user here
                 ...
 
-    .. method:: models.CustomUserManager.create_superuser(*username_field*, password=None, **other_fields)
+    .. method:: models.CustomUserManager.create_superuser(username_field, password=None, **other_fields)
 
         The prototype of ``create_superuser()`` should accept the username
         field, plus all required fields as arguments. For example, if your user

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -746,19 +746,16 @@ providing two additional methods:
                 # create user here
                 ...
 
-    .. method:: models.CustomUserManager.create_superuser(*username_field*, password, **other_fields)
+    .. method:: models.CustomUserManager.create_superuser(*username_field*, password=None, **other_fields)
 
         The prototype of ``create_superuser()`` should accept the username
         field, plus all required fields as arguments. For example, if your user
         model uses ``email`` as the username field, and has ``date_of_birth``
         as a required field, then ``create_superuser`` should be defined as::
 
-            def create_superuser(self, email, date_of_birth, password):
+            def create_superuser(self, email, date_of_birth, password=None):
                 # create superuser here
                 ...
-
-        Unlike ``create_user()``, ``create_superuser()`` *must* require the
-        caller to provide a password.
 
 For a :class:`~.ForeignKey` in :attr:`.USERNAME_FIELD` or
 :attr:`.REQUIRED_FIELDS`, these methods receive the value of the
@@ -1044,7 +1041,7 @@ authentication app::
             user.save(using=self._db)
             return user
 
-        def create_superuser(self, email, date_of_birth, password):
+        def create_superuser(self, email, date_of_birth, password=None):
             """
             Creates and saves a superuser with the given email, date of
             birth and password.

--- a/tests/auth_tests/test_basic.py
+++ b/tests/auth_tests/test_basic.py
@@ -73,6 +73,22 @@ class BasicTestCase(TestCase):
         self.assertTrue(super.is_active)
         self.assertTrue(super.is_staff)
 
+    def test_superuser_no_email_or_password(self):
+        cases = [
+            {},
+            {'email': ''},
+            {'email': None},
+            {'password': None},
+        ]
+        for i, kwargs in enumerate(cases):
+            with self.subTest(**kwargs):
+                superuser = User.objects.create_superuser(
+                    'super{}'.format(i),
+                    **kwargs
+                )
+                self.assertEqual(superuser.email, '')
+                self.assertFalse(superuser.has_usable_password())
+
     def test_get_user_model(self):
         "The current user model can be retrieved"
         self.assertEqual(get_user_model(), User)

--- a/tests/auth_tests/test_basic.py
+++ b/tests/auth_tests/test_basic.py
@@ -53,14 +53,18 @@ class BasicTestCase(TestCase):
 
     def test_user_no_email(self):
         "Users can be created without an email"
-        u = User.objects.create_user('testuser1')
-        self.assertEqual(u.email, '')
-
-        u2 = User.objects.create_user('testuser2', email='')
-        self.assertEqual(u2.email, '')
-
-        u3 = User.objects.create_user('testuser3', email=None)
-        self.assertEqual(u3.email, '')
+        cases = [
+            {},
+            {'email': ''},
+            {'email': None},
+        ]
+        for i, kwargs in enumerate(cases):
+            with self.subTest(**kwargs):
+                u = User.objects.create_user(
+                    'testuser{}'.format(i),
+                    **kwargs
+                )
+                self.assertEqual(u.email, '')
 
     def test_superuser(self):
         "Check the creation and properties of a superuser"


### PR DESCRIPTION
Resubmit of existing (unmerged) patch with corresponding corrections in the Documentation.

https://code.djangoproject.com/ticket/30066