### PR TITLE
Fixed #26431 -- Prevented django.urls.resolve() from returning missing optional parameters.

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -153,7 +153,7 @@ class RegexPattern(CheckURLMixin):
             # If there are any named groups, use those as kwargs, ignoring
             # non-named groups. Otherwise, pass all non-named arguments as
             # positional arguments.
-            kwargs = match.groupdict()
+            kwargs = {k: v for k, v in match.groupdict().items() if v is not None}
             args = () if kwargs else match.groups()
             return path[match.end():], args, kwargs
         return None

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -160,6 +160,10 @@ class URLTranslationTests(URLTestCaseBase):
             self.assertEqual(translation.get_language(), 'en')
             # URL with parameters.
             self.assertEqual(
+                translate_url('/en/with-arguments/regular-argument/', 'nl'),
+                '/nl/with-arguments/regular-argument/',
+            )
+            self.assertEqual(
                 translate_url('/en/with-arguments/regular-argument/optional.html', 'nl'),
                 '/nl/with-arguments/regular-argument/optional.html',
             )

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -158,6 +158,11 @@ class URLTranslationTests(URLTestCaseBase):
             # path() URL pattern
             self.assertEqual(translate_url('/en/account/register-as-path/', 'nl'), '/nl/profiel/registreren-als-pad/')
             self.assertEqual(translation.get_language(), 'en')
+            # URL with parameters.
+            self.assertEqual(
+                translate_url('/en/with-arguments/regular-argument/optional.html', 'nl'),
+                '/nl/with-arguments/regular-argument/optional.html',
+            )
 
         with translation.override('nl'):
             self.assertEqual(translate_url('/nl/gebruikers/', 'en'), '/en/users/')

--- a/tests/i18n/patterns/urls/default.py
+++ b/tests/i18n/patterns/urls/default.py
@@ -15,6 +15,11 @@ urlpatterns = [
 urlpatterns += i18n_patterns(
     path('prefixed/', view, name='prefixed'),
     path('prefixed.xml', view, name='prefixed_xml'),
+    re_path(
+        _(r'^with-arguments/(?P<argument>[\w-]+)/(?:(?P<optional>[\w-]+).html)?$'),
+        view,
+        name='with-arguments',
+    ),
     re_path(_(r'^users/$'), view, name='users'),
     re_path(_(r'^account/'), include('i18n.patterns.urls.namespace', namespace='account')),
 )

--- a/tests/urlpatterns/path_urls.py
+++ b/tests/urlpatterns/path_urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('users/<id>/', views.empty_view, name='user-with-id'),
     path('included_urls/', include('urlpatterns.included_urls')),
     re_path(r'^regex/(?P<pk>[0-9]+)/$', views.empty_view, name='regex'),
+    re_path(r'^regex_optional/(?P<arg1>\d+)/(?:(?P<arg2>\d+)/)?', views.empty_view, name='regex_optional'),
     path('', include('urlpatterns.more_urls')),
     path('<lang>/<path:url>/', views.empty_view, name='lang-and-path'),
 ]

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -54,6 +54,12 @@ class SimplifiedURLTests(SimpleTestCase):
         self.assertEqual(match.kwargs, {'pk': '1'})
         self.assertEqual(match.route, '^regex/(?P<pk>[0-9]+)/$')
 
+    def test_re_path_with_optional_parameter(self):
+        match = resolve('/regex_optional/1/2/')
+        self.assertEqual(match.url_name, 'regex_optional')
+        self.assertEqual(match.kwargs, {'arg1': '1', 'arg2': '2'})
+        self.assertEqual(match.route, r'^regex_optional/(?P<arg1>\d+)/(?:(?P<arg2>\d+)/)?')
+
     def test_path_lookup_with_inclusion(self):
         match = resolve('/included_urls/extra/something/')
         self.assertEqual(match.url_name, 'inner-extra')

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -55,10 +55,18 @@ class SimplifiedURLTests(SimpleTestCase):
         self.assertEqual(match.route, '^regex/(?P<pk>[0-9]+)/$')
 
     def test_re_path_with_optional_parameter(self):
-        match = resolve('/regex_optional/1/2/')
-        self.assertEqual(match.url_name, 'regex_optional')
-        self.assertEqual(match.kwargs, {'arg1': '1', 'arg2': '2'})
-        self.assertEqual(match.route, r'^regex_optional/(?P<arg1>\d+)/(?:(?P<arg2>\d+)/)?')
+        for url, kwargs in (
+            ('/regex_optional/1/2/', {'arg1': '1', 'arg2': '2'}),
+            ('/regex_optional/1/', {'arg1': '1'}),
+        ):
+            with self.subTest(url=url):
+                match = resolve(url)
+                self.assertEqual(match.url_name, 'regex_optional')
+                self.assertEqual(match.kwargs, kwargs)
+                self.assertEqual(
+                    match.route,
+                    r'^regex_optional/(?P<arg1>\d+)/(?:(?P<arg2>\d+)/)?',
+                )
 
     def test_path_lookup_with_inclusion(self):
         match = resolve('/included_urls/extra/something/')

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -180,6 +180,8 @@ test_data = (
     ('named_optional', '/optional/1/', [], {'arg1': 1}),
     ('named_optional', '/optional/1/2/', [1, 2], {}),
     ('named_optional', '/optional/1/2/', [], {'arg1': 1, 'arg2': 2}),
+    ('named_optional_terminated', '/optional/1/', [1], {}),
+    ('named_optional_terminated', '/optional/1/', [], {'arg1': 1}),
     ('named_optional_terminated', '/optional/1/2/', [1, 2], {}),
     ('named_optional_terminated', '/optional/1/2/', [], {'arg1': 1, 'arg2': 2}),
     ('hardcoded', '/hardcoded/', [], {}),


### PR DESCRIPTION
…amed groups are missing in the URL pattern

Commit Message too long?

I had patched with the original patch provided by the reporter, but then dug a bit deeper. I then patched at
`_reverse_with_prefix` which is where most of my previous work was situated. (Delete kwargs with `None` values that are valid parameters- using set magic). But the tests for `named_optional` and `named_optional_terminated` with just one parameter still went through, so I dug deeper.

Usually these None-value parameters never make it to `_reverse_with_prefix`. The culprit, in the end, was django.urls.resolvers.RegexPattern.match. It user groupdict() which returns a `None` as a default value instead of nixing the parameter: https://docs.python.org/3.6/library/re.html#re.match.groupdict

https://code.djangoproject.com/ticket/26431