### PR TITLE
Fixed #10403 -- Declaraive syntax for FormSet, ModelFormSet & InlineF…

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -463,3 +463,51 @@ def all_valid(formsets):
     for formset in formsets:
         valid &= formset.is_valid()
     return valid
+
+# Declarative FormSet ################################
+
+
+class FormSetMeta(type):
+    """
+    Meta class for creating formsets using Declarative Syntax.
+    """
+
+    def __new__(cls, name, bases, attrs):
+        """
+        Initialize the attributes given to the FormSet class and adds the
+        missing required argument and sets them to default values.
+        """
+        if attrs.get("min_num") is None:
+            attrs["min_num"] = DEFAULT_MIN_NUM
+        if attrs.get("max_num") is None:
+            attrs["max_num"] = DEFAULT_MAX_NUM
+
+        default_attrs = {
+            'form': attrs.get('form') or None,
+            'extra': 1,
+            'can_order': False,
+            'can_delete': False,
+            'min_num': DEFAULT_MIN_NUM,
+            'max_num': DEFAULT_MAX_NUM,
+            'absolute_max': attrs["max_num"] + DEFAULT_MAX_NUM,
+            'validate_min': False,
+            'validate_max': False,
+        }
+
+        for key, value in default_attrs.items():
+            if key not in attrs.keys():
+                attrs.update({key: value})
+
+        new_class = super(FormSetMeta, cls).__new__(cls, name, bases, attrs)
+        return new_class
+
+
+class FormSet(BaseFormSet, metaclass=FormSetMeta):
+    """
+    Base class for which can be used to create formset classes
+    """
+    form = None
+
+    def __init__(self, data=None, files=None, auto_id='id_%s', prefix=None,
+                 initial=None, error_class=ErrorList, form_kwargs=None):
+        super().__init__(data, files, auto_id, prefix, initial, error_class, form_kwargs)

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -10,7 +10,9 @@ from django.core.exceptions import (
 )
 from django.forms.fields import ChoiceField, Field
 from django.forms.forms import BaseForm, DeclarativeFieldsMetaclass
-from django.forms.formsets import BaseFormSet, formset_factory
+from django.forms.formsets import (
+    BaseFormSet, FormSet, FormSetMeta, formset_factory,
+)
 from django.forms.utils import ErrorList
 from django.forms.widgets import (
     HiddenInput, MultipleHiddenInput, SelectMultiple,
@@ -881,7 +883,45 @@ def modelformset_factory(model, form=ModelForm, formfield_callback=None,
     return FormSet
 
 
+class ModelFormSetMeta(FormSetMeta):
+    def __new__(cls, name, bases, attrs):
+
+        default_modelform_factory_attrs = [
+            "fields",
+            "exclude",
+            "formfield_callback",
+            "widgets",
+            "localized_fields",
+            "labels",
+            "help_texts",
+            "error_messages",
+            "field_classes"
+        ]
+
+        kwargs = {}
+        for key in default_modelform_factory_attrs:
+            if key in attrs:
+                kwargs.update({key: attrs.get(key)})
+                attrs.pop(key)
+
+        form = ModelForm
+        if attrs.get("form") is not None:
+            kwargs.update({"form": attrs.get("form")})
+        else:
+            kwargs.update({"form": form})
+
+        if attrs.get("model") is not None:
+            form = modelform_factory(attrs.get("model"), **kwargs)
+            attrs.update({'form': form})
+
+        return super(ModelFormSetMeta, cls).__new__(cls, name, bases, attrs)
+
+
+class ModelFormSet(BaseModelFormSet, FormSet, metaclass=ModelFormSetMeta):
+    pass
+
 # InlineFormSets #############################################################
+
 
 class BaseInlineFormSet(BaseModelFormSet):
     """A formset for child objects related to a parent."""
@@ -1080,7 +1120,47 @@ def inlineformset_factory(parent_model, model, form=ModelForm,
     return FormSet
 
 
+class InlineFormSetMeta(ModelFormSetMeta):
+
+    def __new__(cls, name, bases, attrs):
+        try:
+            parents = [b for b in bases if issubclass(b, InlineFormSet)]
+        except NameError:
+            # we are defining InlineFormSet ourselves
+            parents = None
+
+        new_class = super(InlineFormSetMeta, cls).__new__(cls, name, bases, attrs)
+        if not parents:
+            return new_class
+
+        # Find parent model
+        parent_model = attrs.get('parent_model', None)
+        fk_name = attrs.get('fk_name', None)
+        form = attrs.get('form', None)
+        for base in parents:
+            parent_model = parent_model or getattr(base, 'parent_model', None)
+            fk_name = fk_name or getattr(base, 'fk_name', None)
+            form = form or getattr(base, 'form', None)
+
+        # enforce a max_num=1 when the foreign key
+        # to the parent model is unique.
+        if form and parent_model:
+            new_class.fk = _get_foreign_key(parent_model, form._meta.model, fk_name=fk_name)
+            if new_class.fk.unique:
+                new_class.max_num = 1
+
+        new_class.parent_model = parent_model
+        new_class.fk_name = fk_name
+        new_class.form = form
+
+        return new_class
+
+
+class InlineFormSet(BaseInlineFormSet, ModelFormSet, metaclass=InlineFormSetMeta):
+    pass
+
 # Fields #####################################################################
+
 
 class InlineForeignKeyField(Field):
     """

--- a/docs/ref/forms/formsets.txt
+++ b/docs/ref/forms/formsets.txt
@@ -1,6 +1,6 @@
-=================
-Formset Functions
-=================
+=======
+Formset
+=======
 
 Formset API reference. For introductory material about formsets, see the
 :doc:`/topics/forms/formsets` topic guide.
@@ -8,11 +8,71 @@ Formset API reference. For introductory material about formsets, see the
 .. module:: django.forms.formsets
    :synopsis: Django's functions for building formsets.
 
+``Making a formset``
+====================
+
+.. note::
+    From 3.0 and onwards, a formset can be made using two ways either
+    by using the `formset_factory` or by using the `FormSet` class both are
+    mentioned below.
+
+
+``FormSet class``
+-----------------
+
+.. class:: FormSet.objects
+
+    The :class:`~django.forms.formsets.FormSet` class is used to create the
+    ``Formset`` from the given ``form`` using a declarative syntax.
+    See the following example which shows how to create AuthorFormSet from
+    AuthorForm::
+
+        from django.forms import formsets
+
+        class AuthorFormSet(formsets.FormSet):
+            # adding a form field is must
+            form = AuthorForm
+
 ``formset_factory``
-===================
+-------------------
 
 .. function:: formset_factory(form, formset=BaseFormSet, extra=1, can_order=False, can_delete=False, max_num=None, validate_max=False, min_num=None, validate_min=False)
 
     Returns a ``FormSet`` class for the given ``form`` class.
 
     See :doc:`formsets </topics/forms/formsets>` for example usage.
+
+``Overriding methods in fromset``
+=================================
+
+.. note::
+    Similar to how the formset can be made using two different ways. Overriding the
+    default behavior of the formset methods can also be done in two different ways.
+    Below are the examples of how to override the default `is_valid` method.
+
+``Overiding using BaseFormSet class``
+-------------------------------------
+
+You can inherit a class from the `BaseFormSet` and then pass that as an argument
+to the `formset_factory` to create a formset with the modified method.
+
+    >>> from django.forms import formsets
+    >>> from django.forms import formset_factory
+    >>> class ArticleBaseFormSet(formsets.BaseFormSet):
+    ...     def is_valid(self):
+    ...         #Your custom conditions may go here
+    ...         return super().is_valid
+    >>> ArticleFormSet = formset_factory(form=ArticleForm, formset=ArticleBaseFormSet)
+
+``Overiding using FormSet class``
+---------------------------------
+
+You can directly insert whatever custom methods you want in the class inherited
+form the `FormSet`
+
+    >>> from django.forms import formsets
+    >>> class ArticleFormset(formsets.FormSet):
+    ...     form = ArticleForm
+    ...     def is_valid(self):
+    ...         #Your custom conditions may go here
+    ...         return super().is_valid

--- a/docs/ref/forms/formsets.txt
+++ b/docs/ref/forms/formsets.txt
@@ -6,35 +6,262 @@ Formset API reference. For introductory material about formsets, see the
 :doc:`/topics/forms/formsets` topic guide.
 
 .. module:: django.forms.formsets
-   :synopsis: Django's functions for building formsets.
+   :synopsis: Django's formset layer.
 
 ``Making a formset``
 ====================
 
+Using ``BaseFormSet`` with the ``formset_factory`` method
+---------------------------------------------------------
+
+Hers's how you can create a formset using formset_factory(), for a
+ArticleForm, using the BaseFormSet as the base class.
+
+    >>> from django.forms import formset_factory
+    >>> ArticleFormSet = formset_factory(ArticleForm)
+
+You now have created a formset named ``ArticleFormSet``. The formset gives you
+the ability to iterate over the forms in the formset and display them as you
+would with a regular form::
+
+    >>> formset = ArticleFormSet()
+    >>> for form in formset:
+    ...     print(form.as_table())
+    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" id="id_form-0-title"></td></tr>
+    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" id="id_form-0-pub_date"></td></tr>
+
+Using ``Formset`` class
+-----------------------
+
+.. versionadded:: 3.0
+
+You can use the ``FormSet`` class to declare a formset in same way you declare models.
+This is alternative method to using ``formset_factory`` to make the formset class.
+
+To create a formset out of an ``ArticleForm`` you would do::
+
+    >>> from django.forms import formsets
+    >>> class ArticleFormSet(formsets.FormSet):
+    ...     form = ArticleForm
+
 .. note::
-    From 3.0 and onwards, a formset can be made using two ways either
-    by using the `formset_factory` or by using the `FormSet` class both are
-    mentioned below.
+    It is compulsory to pass the form argument while declaring the Formset class. Similar to
+    how it's compulsory to pass form as first argument to ``formset_factory``.
+
+You now have created a formset named ``ArticleFormSet``, which is similar to how to create
+it using the ``formset_factory``. You can use it in the same way as the previous example::
+
+    >>> formset = ArticleFormSet()
+    >>> for form in formset:
+    ...     print(form.as_table())
+    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" id="id_form-0-title"></td></tr>
+    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" id="id_form-0-pub_date"></td></tr>
+
+``BaseFormSet``
+===============
+
+.. class:: BaseFormSet
+
+    It is the base class from which every FormSet class is derived.
+
+    Following attributes and methods are available in this class
+    see the :doc:`topics</topics/forms/formsets>` page for examples on how to use them
+
+``initial``
+-----------
+
+.. attribute:: initial
+
+    ``initial`` is a dictonary of a initial data which is used as a reference point
+    to detect changes in the formset.
+
+    See :ref:`formsets-initial-data` for example usage.
+
+``max_num``
+-----------
+
+.. attribute:: max_num
+
+    The ``max_num`` parameter gives you the ability to limit the number of forms
+    the formset will display
+
+    See :ref:`formsets-max-num` for example usage.
+
+``extra``
+---------
+
+.. attribute:: extra
+
+    Limits the maximum number of extra blank form to be attached with every formset.
+
+``empty_form``
+--------------
+
+.. attribute:: empty_form
+
+    ``BaseFormSet`` provides an additional attribute ``empty_form`` which returns
+    a form instance with a prefix of ``__prefix__`` for easier use in dynamic
+    forms with JavaScript.
+
+    See :ref:`empty_form` for example usage.
+
+``validate_max``
+----------------
+
+.. attribute:: validate_max
+
+    If ``validate_max=True`` is passed to
+    :func:`~django.forms.formsets.formset_factory`, validation will also check
+    that the number of forms in the data set, minus those marked for
+    deletion, is less than or equal to ``max_num``.
+
+    See :ref:`validate_max` for example usage.
+
+``validate_min``
+----------------
+
+.. attribute:: validate_min
+
+    If ``validate_min=True`` is passed to
+    :func:`~django.forms.formsets.formset_factory`, validation will also check
+    that the number of forms in the data set, minus those marked for
+    deletion, is greater than or equal to ``min_num``.
+
+    See :ref:`validate_min` for example usage.
+
+``can_order``
+-------------
+
+.. attribute:: can_order
+
+    Lets you create a formset with the ability to order.
+
+    See :attr:`~django.forms.formsets.BaseFormSet.can_order` for example usage.
+
+``ordering_widget``
+-------------------
+
+.. attribute:: ordering_widget
+
+.. versionadded:: 3.0
+
+    Set ``ordering_widget`` to specify the widget class to be used with
+    ``can_order``
+
+    See :attr:`~django.forms.formsets.BaseFormSet.ordering_widget` for example usage.
+
+``can_delete``
+--------------
+
+.. attribute:: can_delete
+
+    Default: ``False``
+    Lets you create a formset with the ability to select forms for deletion.
+
+    See :attr:`~django.forms.formsets.BaseFormSet.can_delete` for example usage.
+
+``form_kwargs``
+---------------
+
+.. attribute:: form_kwargs
+
+    You can pass custom parameter to the forms when instantiating the formset
+
+    See :ref:`custom-formset-form-kwargs` for example usage.
+
+``prefix``
+----------
+
+.. attribute:: prefix
+
+    In the rendered HTML, formsets include a prefix on each field's name. By
+    default, the prefix is ``'form'``, but it can be customized using the formset's
+    ``prefix`` argument.
+
+    See :ref:`formset-prefix` for example usage.
+
+``errors``
+----------
+
+.. attribute:: errors
+
+    ``errors`` is a list whose entries correspond to the errors forms in the formset
+
+    See :ref:`formset-validation` for example usage.
+
+``total_error_count``
+---------------------
+
+.. method:: total_error_count
+
+    To check how many errors there are in the formset, we can use the
+    ``total_error_count`` method
+
+    See :ref:`formset-validation` for example usage.
+
+``has_changed``
+---------------
+
+.. method:: has_changed
+
+    Checks if the formset has changed from the initial data provided.
+
+``is_valid``
+------------
+
+.. method:: is_valid
+
+    Calls the ``is_valid`` method on all the forms and return True if
+    all the calls return True, i.e. all the forms are valid.
+
+    See :ref:`formset-validation` for example usage.
+
+``clean``
+---------
+
+.. method:: clean
+
+    Calls the ``clean`` method on all the forms and return True if
+    all the calls return True, i.e. all the forms are clean.
+
+``get_ordering_widget``
+-----------------------
+
+.. method:: get_ordering_widget
+
+.. versionadded:: 3.0
+
+    Override ``get_ordering_widget()`` if you need to provide a widget instance for
+    use with ``can_order``
+
+    See :meth:`~django.forms.formsets.BaseFormSet.get_ordering_widget` for example usage.
+
+``add_fields``
+--------------
+
+.. method:: add_fields
+
+    hook to add custom fields to your forms.
+
+    See :ref:`formset-add-fields` for example usage.
 
 
-``FormSet class``
------------------
+``as_table``
+------------
 
-.. class:: FormSet.objects
+.. method:: as_table
 
-    The :class:`~django.forms.formsets.FormSet` class is used to create the
-    ``Formset`` from the given ``form`` using a declarative syntax.
-    See the following example which shows how to create AuthorFormSet from
-    AuthorForm::
+    prints the formset as HTML table.
 
-        from django.forms import formsets
+``as_p``
+--------
 
-        class AuthorFormSet(formsets.FormSet):
-            # adding a form field is must
-            form = AuthorForm
+.. method:: as_p
+
+    prints the formset as HTML paragraph.
 
 ``formset_factory``
--------------------
+===================
 
 .. function:: formset_factory(form, formset=BaseFormSet, extra=1, can_order=False, can_delete=False, max_num=None, validate_max=False, min_num=None, validate_min=False)
 
@@ -42,37 +269,17 @@ Formset API reference. For introductory material about formsets, see the
 
     See :doc:`formsets </topics/forms/formsets>` for example usage.
 
-``Overriding methods in fromset``
-=================================
+``FormSet class``
+=================
 
-.. note::
-    Similar to how the formset can be made using two different ways. Overriding the
-    default behavior of the formset methods can also be done in two different ways.
-    Below are the examples of how to override the default `is_valid` method.
+.. class:: FormSet.objects
 
-``Overiding using BaseFormSet class``
--------------------------------------
+    The ``FormSet`` class is used to create the ``Formset`` object from
+    the given ``form`` using a declarative syntax.See the following
+    example which shows how to create `AuthorFormSet` from `AuthorForm`::
 
-You can inherit a class from the `BaseFormSet` and then pass that as an argument
-to the `formset_factory` to create a formset with the modified method.
+        from django.forms import formsets
 
-    >>> from django.forms import formsets
-    >>> from django.forms import formset_factory
-    >>> class ArticleBaseFormSet(formsets.BaseFormSet):
-    ...     def is_valid(self):
-    ...         #Your custom conditions may go here
-    ...         return super().is_valid
-    >>> ArticleFormSet = formset_factory(form=ArticleForm, formset=ArticleBaseFormSet)
-
-``Overiding using FormSet class``
----------------------------------
-
-You can directly insert whatever custom methods you want in the class inherited
-form the `FormSet`
-
-    >>> from django.forms import formsets
-    >>> class ArticleFormset(formsets.FormSet):
-    ...     form = ArticleForm
-    ...     def is_valid(self):
-    ...         #Your custom conditions may go here
-    ...         return super().is_valid
+        class AuthorFormSet(formsets.FormSet):
+            # adding a form field is must
+            form = AuthorForm

--- a/docs/ref/forms/models.txt
+++ b/docs/ref/forms/models.txt
@@ -1,6 +1,6 @@
-====================
-Model Form Functions
-====================
+==========
+Model Form
+==========
 
 Model Form API reference. For introductory material about model forms, see the
 :doc:`/topics/forms/modelforms` topic guide.
@@ -68,6 +68,26 @@ Model Form API reference. For introductory material about model forms, see the
 
     See :ref:`model-formsets` for example usage.
 
+``ModelFormSet class reference``
+================================
+
+``objects``
+-----------
+
+.. attribute:: ModelFromSet.objects
+
+    The :class:`~django.forms.models.ModelFormSet` class is used to create the
+    ``Formset`` from the given ``model`` using a declarative syntax.
+    See the following example which shows how to create AuthorFormSet from
+    `Author` model::
+
+        from django.forms import models
+        from myapp.models import Author
+
+        class AuthorFormSet(mdoels.ModelFromSet):
+            model = Author
+            fields = '__all__'
+
 ``inlineformset_factory``
 =========================
 
@@ -81,3 +101,24 @@ Model Form API reference. For introductory material about model forms, see the
     the ``parent_model``, you must specify a ``fk_name``.
 
     See :ref:`inline-formsets` for example usage.
+
+``InlineFormSet class reference``
+=================================
+
+``objects``
+-----------
+
+.. attribute:: InlineFormSet.objects
+
+    The :class:`~django.forms.models.InlineFormSet` class is used to create the
+    ``Formset`` from the given related ``model`` using a declarative syntax.
+    See the following example which shows how to create BookFormSet from
+    `Book` model which is related to the `AUthor` model::
+
+        from django.forms import models
+        from myapp.models import Author, Book
+
+        class AuthorFormSet(mdoels.ModelFromSet):
+            parent_model = Author
+            model = Book
+            fields = '__all__'

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -176,6 +176,18 @@ Forms
   :attr:`~django.forms.formsets.BaseFormSet.ordering_widget` attribute or
   overriding :attr:`~django.forms.formsets.BaseFormSet.get_ordering_widget()`.
 
+* The new :class:`formsets.Formset<django.forms.formsets.FormSet>` enables
+  formsets to be made using the declarative syntax similar to that of the
+  model class.
+
+* The new :class:`forms.models.ModelFormSet<django.forms.models.ModelFormSet>`
+  and :class:`forms.models.InlineFormSet<django.forms.models.InlineFormSet>`
+  classes provides a similar declarative syntax for using the model formsets
+  and replaces the :meth:`forms.models.modelformset_factory()
+  <django.forms.models.modelformset_factory>` and
+  :meth:`forms.models.inlineformset_factory()
+  <django.forms.models.inlineformset_factory>` respectively.
+
 Generic Views
 ~~~~~~~~~~~~~
 

--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -4,7 +4,11 @@ Formsets
 
 .. currentmodule:: django.forms.formsets
 
-.. class:: BaseFormSet
+Making a FormSet
+================
+
+Method 1: Using `formset_factory`
+---------------------------------
 
 A formset is a layer of abstraction to work with multiple forms on the same
 page. It can be best compared to a data grid. Let's say you have the following
@@ -46,10 +50,8 @@ Formsets can also be indexed into, which returns the corresponding form. If you
 override ``__iter__``, you will need to also override ``__getitem__`` to have
 matching behavior.
 
-Using ``FormSet`` class to make the formset
-===========================================
-
-.. class:: FormSet
+Method 2: Using ``FormSet`` class
+---------------------------------
 
 You can use the ``FormSet`` class to declare a formset in same way you declare models.
 This is alternative method to using ``formset_factory`` to make the formset class.
@@ -59,6 +61,10 @@ To create a formset out of an ``ArticleForm`` you would do::
     >>> from django.forms import formsets
     >>> class ArticleFormSet(formsets.FormSet):
     ...     form = ArticleForm
+
+.. note::
+    It is compulsory to pass the form argument while declaring the Formset class. Similar to
+    how it's compulsory to pass form as first argument to ``formset_factory``.
 
 You now have created a formset named ``ArticleFormSet``, which is similar to how to create
 it using the ``formset_factory``. You can use it in the same way as the previous example::
@@ -148,6 +154,8 @@ By default, ``max_num`` only affects how many forms are displayed and does not
 affect validation.  If ``validate_max=True`` is passed to the
 :func:`~django.forms.formsets.formset_factory`, then ``max_num`` will affect
 validation.  See :ref:`validate_max`.
+
+.. _formset-validation:
 
 Formset validation
 ==================
@@ -281,6 +289,9 @@ forms with JavaScript.
 Custom formset validation
 -------------------------
 
+Method 1: using BaseModelFormSet
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 A formset has a ``clean`` method similar to the one on a ``Form`` class. This
 is where you define your own validation that works at the formset level::
 
@@ -324,6 +335,49 @@ is where you define your own validation that works at the formset level::
 The formset ``clean`` method is called after all the ``Form.clean`` methods
 have been called. The errors will be found using the ``non_form_errors()``
 method on the formset.
+
+Method 2: using FormSet Class
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Instead of using ```formset_factory`` you can use the `FormSet` Class to make
+your formset, and then you can directly define a method inside the class this will
+override the default ``clean`` method and will have the similar results as above.::
+
+    >>> from django.forms import formsets
+    >>> from myapp.forms import ArticleForm
+
+    >>> class ArticleFormSet(formsets.FormSet):
+    ...     form = ArticleForm
+    ...     def clean(self):
+    ...         """Checks that no two articles have the same title."""
+    ...         if any(self.errors):
+    ...             # Don't bother validating the formset unless each form is valid on its own
+    ...             return
+    ...         titles = []
+    ...         for form in self.forms:
+    ...             if self.can_delete and self._should_delete_form(form):
+    ...                 continue
+    ...             title = form.cleaned_data.get('title')
+    ...             if title in titles:
+    ...                 raise forms.ValidationError("Articles in a set must have distinct titles.")
+    ...             titles.append(title)
+
+    >>> data = {
+    ...     'form-TOTAL_FORMS': '2',
+    ...     'form-INITIAL_FORMS': '0',
+    ...     'form-MAX_NUM_FORMS': '',
+    ...     'form-0-title': 'Test',
+    ...     'form-0-pub_date': '1904-06-16',
+    ...     'form-1-title': 'Test',
+    ...     'form-1-pub_date': '1912-06-23',
+    ... }
+    >>> formset = ArticleFormSet(data)
+    >>> formset.is_valid()
+    False
+    >>> formset.errors
+    [{}, {}]
+    >>> formset.non_form_errors()
+    ['Articles in a set must have distinct titles.']
 
 Validating the number of forms in a formset
 ===========================================
@@ -375,6 +429,8 @@ excessive.
     forms above ``max_num`` will be validated.  The remainder will be
     truncated entirely.  This is to protect against memory exhaustion attacks
     using forged POST requests.
+
+.. _validate_min:
 
 ``validate_min``
 ----------------
@@ -587,8 +643,13 @@ On the other hand, if you are using a plain ``FormSet``, it's up to you to
 handle ``formset.deleted_forms``, perhaps in your formset's ``save()`` method,
 as there's no general notion of what it means to delete a form.
 
+.. _formset-add-fields:
+
 Adding additional fields to a formset
 =====================================
+
+Method 1: using BaseModelFormSet
+--------------------------------
 
 If you need to add additional fields to the formset this can be easily
 accomplished. The formset base class provides an ``add_fields`` method. You
@@ -610,6 +671,27 @@ default fields/attributes of the order and deletion fields::
     <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" id="id_form-0-title"></td></tr>
     <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" id="id_form-0-pub_date"></td></tr>
     <tr><th><label for="id_form-0-my_field">My field:</label></th><td><input type="text" name="form-0-my_field" id="id_form-0-my_field"></td></tr>
+
+Method 2: using the Formset Class
+---------------------------------
+
+Additional fields can also be easily added while using the `FormSet` class.
+Similar to the above method you just have to override the default ``add_fields`` method::
+
+    >>> from django.forms import formsets
+    >>> from myapp.forms import ArticleForm
+    >>> class ArticleFormSet(formsets.FormSet):
+    ...     def add_fields(self, form, index):
+    ...         super().add_fields(form, index)
+    ...         form.fields["my_field"] = forms.CharField()
+
+    >>> formset = ArticleFormSet()
+    >>> for form in formset:
+    ...     print(form.as_table())
+    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" id="id_form-0-title"></td></tr>
+    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" id="id_form-0-pub_date"></td></tr>
+    <tr><th><label for="id_form-0-my_field">My field:</label></th><td><input type="text" name="form-0-my_field" id="id_form-0-my_field"></td></tr>
+
 
 .. _custom-formset-form-kwargs:
 

--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -46,6 +46,29 @@ Formsets can also be indexed into, which returns the corresponding form. If you
 override ``__iter__``, you will need to also override ``__getitem__`` to have
 matching behavior.
 
+Using ``FormSet`` class to make the formset
+===========================================
+
+.. class:: FormSet
+
+You can use the ``FormSet`` class to declare a formset in same way you declare models.
+This is alternative method to using ``formset_factory`` to make the formset class.
+
+To create a formset out of an ``ArticleForm`` you would do::
+
+    >>> from django.forms import formsets
+    >>> class ArticleFormSet(formsets.FormSet):
+    ...     form = ArticleForm
+
+You now have created a formset named ``ArticleFormSet``, which is similar to how to create
+it using the ``formset_factory``. You can use it in the same way as the previous example::
+
+    >>> formset = ArticleFormSet()
+    >>> for form in formset:
+    ...     print(form.as_table())
+    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" id="id_form-0-title"></td></tr>
+    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" id="id_form-0-pub_date"></td></tr>
+
 .. _formsets-initial-data:
 
 Using initial data with a formset

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -787,6 +787,23 @@ with the ``Author`` model. It works just like a regular formset::
     means that a model formset is just an extension of a basic formset that
     knows how to interact with a particular model.
 
+Alternate method to declare a ModelFormSet
+------------------------------------------
+
+.. class:: models.ModelFormSet
+
+Apart from using ```modelformset_factory`` you can also use the declarative syntax
+to instantiate new `FormSet` objects associated with a model.
+
+    >>> from django.forms import models
+    >>> from myapp.models import Author
+    >>> class AuthorFormSet(models.ModelFormSet):
+    ...     model = Author
+    ...     fields =('name', 'title')
+
+This will create a formset that is capable of working with the data associated
+with the ``Author`` model, which is similar to the previous example.
+
 Changing the queryset
 ---------------------
 
@@ -1164,6 +1181,23 @@ a particular author, you could do this::
 .. seealso::
 
     :ref:`Manually rendered can_delete and can_order <manually-rendered-can-delete-and-can-order>`.
+
+Alternate method to declare a InlineFormSet
+-------------------------------------------
+
+.. class:: models.InlineFormSet
+
+Apart from using ```inlineformset_factory`` you can also use the declarative syntax
+to instantiate new `FormSet` objects associated with a related model.
+
+    >>> from django.forms import models
+    >>> class BookFormSet(models.InlineFormSet):
+    ...     parent_model = Author
+    ...     model = Book
+    ...     fields =('title',)
+
+This will create a formset that is capable of working with the data associated
+with the ``Book`` model, which is similar to the previous example.
 
 Overriding methods on an ``InlineFormSet``
 ------------------------------------------

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -6,7 +6,9 @@ from django.forms import (
     BaseForm, CharField, DateField, FileField, Form, IntegerField,
     SplitDateTimeField, ValidationError, formsets,
 )
-from django.forms.formsets import BaseFormSet, all_valid, formset_factory
+from django.forms.formsets import (
+    BaseFormSet, FormSet, all_valid, formset_factory,
+)
 from django.forms.utils import ErrorList
 from django.forms.widgets import HiddenInput
 from django.test import SimpleTestCase
@@ -18,6 +20,10 @@ class Choice(Form):
 
 
 ChoiceFormSet = formset_factory(Choice)
+
+
+class DeclarativeChoiceFormSet(FormSet):
+    form = Choice
 
 
 class FavoriteDrinkForm(Form):
@@ -1313,3 +1319,38 @@ class AllValidTests(SimpleTestCase):
         expected_errors = [{'votes': ['This field is required.']}, {'votes': ['This field is required.']}]
         self.assertEqual(formset1._errors, expected_errors)
         self.assertEqual(formset2._errors, expected_errors)
+
+
+class DeclarativeFormSetTestCase(FormsFormsetTestCase):
+
+    def make_choiceformset(
+            self, formset_data=None, formset_class=DeclarativeChoiceFormSet,
+            total_forms=None, initial_forms=0, max_num_forms=0, min_num_forms=0, **kwargs):
+        """
+        Make a ChoiceFormset from the given formset_data.
+        The data should be given as a list of (choice, votes) tuples.
+        """
+        kwargs.setdefault('prefix', 'choices')
+        kwargs.setdefault('auto_id', False)
+
+        if formset_data is None:
+            return formset_class(**kwargs)
+
+        if total_forms is None:
+            total_forms = len(formset_data)
+
+        def prefixed(*args):
+            args = (kwargs['prefix'],) + args
+            return '-'.join(args)
+
+        data = {
+            prefixed('TOTAL_FORMS'): str(total_forms),
+            prefixed('INITIAL_FORMS'): str(initial_forms),
+            prefixed('MAX_NUM_FORMS'): str(max_num_forms),
+            prefixed('MIN_NUM_FORMS'): str(min_num_forms),
+        }
+        for i, (choice, votes) in enumerate(formset_data):
+            data[prefixed(str(i), 'choice')] = choice
+            data[prefixed(str(i), 'votes')] = votes
+
+        return formset_class(data, **kwargs)


### PR DESCRIPTION
This patch inlcude the classes FormSet, ModelFormSet and InlineFormSet from
which other class can be directly inherited to create a formset class instead of
using the default factory functions.

https://code.djangoproject.com/ticket/10403