### PR TITLE
Fixed #30565 -- Closed HttpResponse when wsgi.file_wrapper closes file-like object.

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -858,6 +858,11 @@ Methods
     values you used in ``set_cookie()`` -- otherwise the cookie may not be
     deleted.
 
+.. method:: HttpResponse.close()
+
+    This method is called at the end of the request directly by the WSGI
+    server.
+
 .. method:: HttpResponse.write(content)
 
     This method makes an :class:`HttpResponse` instance a file-like object.

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -861,7 +861,8 @@ Methods
 .. method:: HttpResponse.close()
 
     This method is called at the end of the request directly by the WSGI
-    server.
+    server, or when the WSGI server closes the file-like object, if
+    `wsgi.file_wrapper`_ is used for the request.
 
 .. method:: HttpResponse.write(content)
 

--- a/tests/responses/test_fileresponse.py
+++ b/tests/responses/test_fileresponse.py
@@ -80,3 +80,52 @@ class FileResponseTests(SimpleTestCase):
             response['Content-Disposition'],
             "attachment; filename*=utf-8''%E7%A5%9D%E6%82%A8%E5%B9%B3%E5%AE%89.odt"
         )
+
+    def test_file_to_stream_closes_response(self):
+        # Closing file_to_stream calls FileResponse.close(), even when
+        # file-like object doesn't have a close() method.
+        class FileLike:
+            def read(self):
+                pass
+
+        class FileLikeWithClose(FileLike):
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        for filelike_cls in (FileLike, FileLikeWithClose):
+            with self.subTest(filelike_cls=filelike_cls.__name__):
+                filelike = filelike_cls()
+                response = FileResponse(filelike)
+                self.assertFalse(response.closed)
+                # Object with close() is added to the list of closable.
+                if hasattr(filelike, 'closed'):
+                    self.assertEqual(response._closable_objects, [filelike])
+                else:
+                    self.assertEqual(response._closable_objects, [])
+                file_to_stream = response.file_to_stream
+                file_to_stream.close()
+                if hasattr(filelike, 'closed'):
+                    self.assertTrue(filelike.closed)
+                self.assertTrue(response.closed)
+
+    def test_file_to_stream_closes_response_on_error(self):
+        # Closing file_to_stream calls FileResponse.close(), even when
+        # closing file-like raises exceptions.
+        class FileLikeWithRaisingClose:
+            def read(self):
+                pass
+
+            def close(self):
+                raise RuntimeError()
+
+        filelike = FileLikeWithRaisingClose()
+        response = FileResponse(filelike)
+        self.assertFalse(response.closed)
+        self.assertEqual(response._closable_objects, [filelike])
+        file_to_stream = response.file_to_stream
+        with self.assertRaises(RuntimeError):
+            file_to_stream.close()
+        self.assertTrue(response.closed)


### PR DESCRIPTION
Fixes #30565: https://code.djangoproject.com/ticket/30565