### PR TITLE
Fix typos in signals and custom management commands docs.

### DIFF
--- a/docs/howto/custom-management-commands.txt
+++ b/docs/howto/custom-management-commands.txt
@@ -82,7 +82,7 @@ The new custom command can be called using ``python manage.py closepoll
 The ``handle()`` method takes one or more ``poll_ids`` and sets ``poll.opened``
 to ``False`` for each one. If the user referenced any nonexistent polls, a
 :exc:`CommandError` is raised. The ``poll.opened`` attribute does not exist in
-the :doc:`tutorial</intro/tutorial01>` and was added to
+the :doc:`tutorial</intro/tutorial02>` and was added to
 ``polls.models.Question`` for this example.
 
 .. _custom-commands-options:

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -39,8 +39,8 @@ model system.
 
     Model signals ``sender`` model can be lazily referenced when connecting a
     receiver by specifying its full application label. For example, an
-    ``Answer`` model defined in the ``polls`` application could be referenced
-    as ``'polls.Answer'``. This sort of reference can be quite handy when
+    ``Question`` model defined in the ``polls`` application could be referenced
+    as ``'polls.Question'``. This sort of reference can be quite handy when
     dealing with circular import dependencies and swappable models.
 
 ``pre_init``


### PR DESCRIPTION
Continue to [PR 11483](https://github.com/django/django/pull/11483).