### PR TITLE
Fixed #30557 -- Fixed crash of ordering when parent model's Meta.ordering contains expressions.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -23,7 +23,7 @@ from django.db import DEFAULT_DB_ALIAS, NotSupportedError, connections
 from django.db.models.aggregates import Count
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import (
-    BaseExpression, Col, F, OuterRef, Ref, SimpleCol,
+    BaseExpression, Col, F, OrderBy, OuterRef, Ref, SimpleCol,
 )
 from django.db.models.fields import Field
 from django.db.models.fields.related_lookups import MultiColSource
@@ -2198,6 +2198,9 @@ def get_order_dir(field, default='ASC'):
     prefix) should sort. The '-' prefix always sorts the opposite way.
     """
     dirn = ORDER_DIR[default]
+    if isinstance(field, OrderBy):
+        return field.expression.name, 'DESC' if field.descending else 'ASC'
+
     if field[0] == '-':
         return field[1:], dirn[1]
     return field, dirn[0]

--- a/tests/model_inheritance/models.py
+++ b/tests/model_inheritance/models.py
@@ -91,6 +91,9 @@ class Place(models.Model):
     def __str__(self):
         return "%s the place" % self.name
 
+    class Meta:
+        ordering = [models.F('name').desc(nulls_last=True)]
+
 
 class Rating(models.Model):
     rating = models.IntegerField(null=True, blank=True)

--- a/tests/ordering/models.py
+++ b/tests/ordering/models.py
@@ -59,3 +59,7 @@ class Reference(models.Model):
 
     class Meta:
         ordering = ('article',)
+
+
+class SubArticle(Article):
+    pass

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -9,7 +9,7 @@ from django.db.models.functions import Upper
 from django.test import TestCase
 from django.utils.deprecation import RemovedInDjango31Warning
 
-from .models import Article, Author, OrderedByFArticle, Reference
+from .models import Article, Author, OrderedByFArticle, Reference, SubArticle
 
 
 class OrderingTests(TestCase):
@@ -461,6 +461,12 @@ class OrderingTests(TestCase):
             articles, ['Article 1', 'Article 4', 'Article 3', 'Article 2'],
             attrgetter('headline')
         )
+
+    def test_default_parent_ordering_by_expression(self):
+        sub1 = SubArticle.objects.create(headline='Sub 1', pub_date=datetime(2005, 7, 26))
+        sub2 = SubArticle.objects.create(headline='Sub 2', pub_date=datetime(2005, 7, 27))
+        articles = SubArticle.objects.order_by('article_ptr')
+        self.assertSequenceEqual(articles, [sub2, sub1])
 
     def test_deprecated_values_annotate(self):
         msg = (


### PR DESCRIPTION
Add check for instance of OrderBy inside got_order_dir. Not sure if this is full solution, but it solves the bugs in the ticket test cases.
