### PR TITLE
Fixed #30578 - Made SelectDateWidget respect a custom date format when USE_L10N is disabled.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -1070,18 +1070,15 @@ class SelectDateWidget(Widget):
         if y == m == d == '':
             return None
         if y is not None and m is not None and d is not None:
-            if settings.USE_L10N:
-                input_format = get_format('DATE_INPUT_FORMATS')[0]
-                try:
-                    date_value = datetime.date(int(y), int(m), int(d))
-                except ValueError:
-                    pass
-                else:
-                    date_value = datetime_safe.new_date(date_value)
-                    return date_value.strftime(input_format)
-            # Return pseudo-ISO dates with zeros for any unselected values,
-            # e.g. '2017-0-23'.
-            return '%s-%s-%s' % (y or 0, m or 0, d or 0)
+            input_format = get_format('DATE_INPUT_FORMATS')[0]
+            try:
+                date_value = datetime.date(int(y), int(m), int(d))
+            except ValueError:
+                # Return pseudo-ISO dates with zeros for any unselected values,
+                # e.g. '2017-0-23'.
+                return '%s-%s-%s' % (y or 0, m or 0, d or 0)
+            date_value = datetime_safe.new_date(date_value)
+            return date_value.strftime(input_format)
         return data.get(name)
 
     def value_omitted_from_data(self, data, files, name):

--- a/tests/forms_tests/field_tests/test_datefield.py
+++ b/tests/forms_tests/field_tests/test_datefield.py
@@ -22,7 +22,7 @@ class DateFieldTest(SimpleTestCase):
         # accept the input from the "as_hidden" rendering as well.
         self.assertHTMLEqual(
             a['mydate'].as_hidden(),
-            '<input type="hidden" name="mydate" value="2008-4-1" id="id_mydate">',
+            '<input type="hidden" name="mydate" value="2008-04-01" id="id_mydate">',
         )
 
         b = GetDate({'mydate': '2008-4-1'})

--- a/tests/forms_tests/widget_tests/test_selectdatewidget.py
+++ b/tests/forms_tests/widget_tests/test_selectdatewidget.py
@@ -524,6 +524,21 @@ class SelectDateWidgetTest(WidgetTest):
             '13-08-0001',
         )
 
+    @override_settings(USE_L10N=False, DATE_INPUT_FORMATS=['%d.%m.%Y'])
+    def test_custom_input_format(self):
+        w = SelectDateWidget(years=('0001', '1899', '2009', '2010'))
+        for values, expected in (
+            (('0001', '8', '13'), '13.08.0001'),
+            (('1899', '7', '11'), '11.07.1899'),
+            (('2009', '3', '7'), '07.03.2009'),
+        ):
+            with self.subTest(values=values):
+                data = {
+                    'field_%s' % field: value
+                    for field, value in zip(('year', 'month', 'day'), values)
+                }
+                self.assertEqual(w.value_from_datadict(data, {}, 'field'), expected)
+
     def test_format_value(self):
         valid_formats = [
             '2000-1-1', '2000-10-15', '2000-01-01',
@@ -545,7 +560,7 @@ class SelectDateWidgetTest(WidgetTest):
 
     def test_value_from_datadict(self):
         tests = [
-            (('2000', '12', '1'), '2000-12-1'),
+            (('2000', '12', '01'), '2000-12-01'),
             (('', '12', '1'), '0-12-1'),
             (('2000', '', '1'), '2000-0-1'),
             (('2000', '12', ''), '2000-12-0'),


### PR DESCRIPTION
Had reproduced and yielded invalid dates. Now fixed and updated tests.