### PR TITLE
Fixed #30588 -- Fixed crash of autoreloader when __main__ module doesn't have __file__ attribute.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -120,7 +120,9 @@ def iter_modules_and_files(modules, extra_files):
             # __main__ (usually manage.py) doesn't always have a __spec__ set.
             # Handle this by falling back to using __file__, resolved below.
             # See https://docs.python.org/reference/import.html#main-spec
-            sys_file_paths.append(module.__file__)
+            # __file__ may not exists, e.g. when running ipdb debugger.
+            if hasattr(module, '__file__'):
+                sys_file_paths.append(module.__file__)
             continue
         if getattr(module, '__spec__', None) is None:
             continue

--- a/docs/releases/2.2.3.txt
+++ b/docs/releases/2.2.3.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Fixed a regression in Django 2.2 where :class:`~django.db.models.Avg`,
   :class:`~django.db.models.StdDev`, and :class:`~django.db.models.Variance`
   crash with ``filter`` argument (:ticket:`30542`).
+
+* Fixed a regression in Django 2.2.2 where auto-reloader crashes with
+  ``AttributeError``, e.g. when using ``ipdb`` (:ticket:`30588`).

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -136,6 +136,10 @@ class TestIterModulesAndFiles(SimpleTestCase):
         main_module = sys.modules['__main__']
         self.assertFileFound(Path(main_module.__file__))
 
+    def test_main_module_without_file_is_not_resolved(self):
+        fake_main = types.ModuleType('__main__')
+        self.assertEqual(autoreload.iter_modules_and_files((fake_main,), frozenset()), frozenset())
+
 
 class TestCommonRoots(SimpleTestCase):
     def test_common_roots(self):


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/30588#ticket