### PR TITLE
Fixed typos in test comments.

### DIFF
--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -40,7 +40,7 @@ class DeferTests(AssertionMixin, TestCase):
         # of them except the model's primary key see #15494
         self.assert_delayed(qs.only("pk")[0], 3)
         # You can use 'pk' with reverse foreign key lookups.
-        # The related_id is alawys set even if it's not fetched from the DB,
+        # The related_id is always set even if it's not fetched from the DB,
         # so pk and related_id are not deferred.
         self.assert_delayed(self.s1.primary_set.all().only('pk')[0], 2)
 

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -628,7 +628,7 @@ class ExceptionReporterTests(SimpleTestCase):
             'items (application/octet-stream)&gt;</pre></td>',
             html
         )
-        # COOKES
+        # COOKIES
         rf = RequestFactory()
         rf.cookies['items'] = 'Oops'
         request = rf.get('/test_view/')
@@ -773,7 +773,7 @@ class PlainTextReportTests(SimpleTestCase):
         reporter = ExceptionReporter(request, None, None, None)
         text = reporter.get_traceback_text()
         self.assertIn('items = <InMemoryUploadedFile:', text)
-        # COOKES
+        # COOKIES
         rf = RequestFactory()
         rf.cookies['items'] = 'Oops'
         request = rf.get('/test_view/')


### PR DESCRIPTION
* Replace `alawys` with `always`.
* Replace `COOKES` with `COOKIES` to match test section.