### PR TITLE
Fixed #30049 -- Fix GIS widget init after "Add another" in admin inlines

### DIFF
--- a/django/contrib/gis/static/gis/js/OLMapWidget.js
+++ b/django/contrib/gis/static/gis/js/OLMapWidget.js
@@ -229,3 +229,23 @@ ol.inherits(GeometryTypeControl, ol.control.Control);
 
     window.MapWidget = MapWidget;
 })();
+
+(function($) {
+    'use strict';
+
+    function initMapWidgetAfterInlineAdd(event, row, prefix) {
+        var el = row[0];
+        var id_regex = new RegExp("(__prefix__)", "g");
+        var replacement = row.attr('id').substring(row.attr('id').lastIndexOf('-')+1);
+        el.innerHTML = el.innerHTML.replace(id_regex, replacement);
+
+        row.find('div.ol-viewport').remove();
+        row.find('script').each(function() {
+            eval(this.innerHTML);
+        });
+    }
+
+    $(document).ready(function() {
+        $(document).on('formset:added', initMapWidgetAfterInlineAdd);
+    });
+})(django.jQuery);

--- a/django/contrib/gis/templates/gis/openlayers.html
+++ b/django/contrib/gis/templates/gis/openlayers.html
@@ -35,6 +35,6 @@
             name: '{{ name }}'
         };
         {% endblock %}
-        var {{ module }} = new MapWidget(options);
+        window.{{ module }} = new MapWidget(options);
     </script>
 </div>


### PR DESCRIPTION
This fixes a initialization of new GIS widget that was added using "Add another" button in admin inlines. The "Add another" button takes a hidden `__prefix__`-ed form, copies it, updates element attributes IDs and NAMEs and put down at right place. The GIS widget template uses inline javascript that initializes widget using IDs and that was a problem!

Proposal solution adds hook for "Add another" action using EventListener for `formset:added` javascript event and fixes inline javascript code and refires it.