### PR TITLE
Fixed #30604 -- Made mail_admins()/mail_managers() raise ValueError if ADMINS/MANAGERS is set incorrectly.

### DIFF
--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -91,6 +91,8 @@ def mail_admins(subject, message, fail_silently=False, connection=None,
     """Send a message to the admins, as defined by the ADMINS setting."""
     if not settings.ADMINS:
         return
+    if not all(isinstance(a, (list, tuple)) and len(a) == 2 for a in settings.ADMINS):
+        raise ValueError('The ADMINS setting must be a list of 2-tuples.')
     mail = EmailMultiAlternatives(
         '%s%s' % (settings.EMAIL_SUBJECT_PREFIX, subject), message,
         settings.SERVER_EMAIL, [a[1] for a in settings.ADMINS],
@@ -106,6 +108,8 @@ def mail_managers(subject, message, fail_silently=False, connection=None,
     """Send a message to the managers, as defined by the MANAGERS setting."""
     if not settings.MANAGERS:
         return
+    if not all(isinstance(a, (list, tuple)) and len(a) == 2 for a in settings.MANAGERS):
+        raise ValueError('The MANAGERS setting must be a list of 2-tuples.')
     mail = EmailMultiAlternatives(
         '%s%s' % (settings.EMAIL_SUBJECT_PREFIX, subject), message,
         settings.SERVER_EMAIL, [a[1] for a in settings.MANAGERS],

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -991,6 +991,23 @@ class BaseEmailBackendTests(HeadersCheckMixin):
         mail_managers('hi', 'there')
         self.assertEqual(self.get_mailbox_content(), [])
 
+    def test_wrong_admins_managers(self):
+        tests = (
+            'test@example.com',
+            ('test@example.com',),
+            ['test@example.com', 'other@example.com'],
+            ('test@example.com', 'other@example.com'),
+        )
+        for setting, mail_func in (
+            ('ADMINS', mail_admins),
+            ('MANAGERS', mail_managers),
+        ):
+            msg = 'The %s setting must be a list of 2-tuples.' % setting
+            for value in tests:
+                with self.subTest(setting=setting, value=value), self.settings(**{setting: value}):
+                    with self.assertRaisesMessage(ValueError, msg):
+                        mail_func('subject', 'content')
+
     def test_message_cc_header(self):
         """
         Regression test for #7722

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -340,7 +340,7 @@ class CommonMiddlewareTest(SimpleTestCase):
 
 @override_settings(
     IGNORABLE_404_URLS=[re.compile(r'foo')],
-    MANAGERS=['PHB@dilbert.com'],
+    MANAGERS=[('PHD', 'PHB@dilbert.com')],
 )
 class BrokenLinkEmailsMiddlewareTest(SimpleTestCase):
 


### PR DESCRIPTION
[ticket 30604](https://code.djangoproject.com/ticket/30604)