### PR TITLE
Fixed #30589 -- Clarified that urlize should be applied only to email addresses without single quotes.

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -2432,8 +2432,9 @@ Django's built-in :tfilter:`escape` filter. The default value for
 
 .. note::
 
-    If ``urlize`` is applied to text that already contains HTML markup,
-    things won't work as expected. Apply this filter only to plain text.
+    If ``urlize`` is applied to text that already contains HTML markup, or to
+    email addresses that contain single quotes (``'``), things won't work as
+    expected. Apply this filter only to plain text.
 
 .. templatefilter:: urlizetrunc
 


### PR DESCRIPTION
This PR adds a notice in the templates documentation that 'urlize' doesnt not work as intended with email addresses containing single quotes.