### PR TITLE
#30609 - Add reference to FileWrapper class being removed inDjango 1.9

### DIFF
--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -1403,6 +1403,8 @@ These features have reached the end of their deprecation cycle and are removed
 in Django 1.9. See :ref:`deprecated-features-1.7` for details, including how to
 remove usage of these features.
 
+* ``django.core.servers.FileWrapper`` is removed.
+
 * ``django.utils.dictconfig`` is removed.
 
 * ``django.utils.importlib`` is removed.


### PR DESCRIPTION
Ticket: [#30609](https://code.djangoproject.com/ticket/30609)

The class FileWrapper that was made available in django.core.servers for
backward compatibility was removed in Django 1.9 release.

To make it more visible here are the references:
Django 1.8.x

https://github.com/django/django/blob/stable/1.8.x/django/core/servers/basehttp.py#L15

Django 1.9.x
https://github.com/django/django/blob/stable/1.9.x/django/core/servers/basehttp.py#L15

This is being added to ensure if anyone still upgrading from Django 1.8 to
Django 1.9 is aware of this.