### PR TITLE
Fixed #30596 -- Fixed SplitArrayField.has_changed() for non-string base fields.

### DIFF
--- a/django/contrib/postgres/forms/array.py
+++ b/django/contrib/postgres/forms/array.py
@@ -178,6 +178,10 @@ class SplitArrayField(forms.Field):
         kwargs.setdefault('widget', widget)
         super().__init__(**kwargs)
 
+    def to_python(self, value):
+        value = super().to_python(value)
+        return [self.base_field.to_python(item) for item in value]
+
     def clean(self, value):
         cleaned_data = []
         errors = []

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -909,6 +909,18 @@ class TestSplitFormField(PostgreSQLSimpleTestCase):
         obj = form.save(commit=False)
         self.assertEqual(obj.field, [1, 2])
 
+    def test_splitarrayfield_has_changed(self):
+        class Form(forms.ModelForm):
+            field = SplitArrayField(forms.IntegerField(), required=False, size=2)
+
+            class Meta:
+                model = IntegerArrayModel
+                fields = ('field',)
+
+        obj = IntegerArrayModel(field=[1, 2])
+        form = Form({'field_0': '1', 'field_1': '2'}, instance=obj)
+        self.assertFalse(form.has_changed())
+
 
 class TestSplitFormWidget(PostgreSQLWidgetTestCase):
 


### PR DESCRIPTION
SplitArrayField.has_changed() is always returning True when it is an
array of numeric fields. This fix cleans the data when to_python method
is called, coercing data to be numeric type instead of strings.

Thanks to Evgeniy Krysanov for the report and the idea to use to_python
Thanks to felixxm for the test case