### PR TITLE
Fixing #30583 -- XML serializer doesn't handle JSONFields

### DIFF
--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -393,6 +393,16 @@ class TestSerialization(PostgreSQLSimpleTestCase):
                 instance = list(serializers.deserialize('json', self.test_data % serialized))[0].object
                 self.assertEqual(instance.field, value)
 
+    def test_xml_serialization(self):
+        test_xml = """type="JSONField">{}</"""
+        for value, serialized in self.test_values:
+            with self.subTest(value=value):
+                instance = JSONModel(field=value)
+                data = serializers.serialize('xml', [instance], fields=["field"])
+                self.assertIn(test_xml.format(serialized), data)
+                new_instance = list(serializers.deserialize("xml", data))[0].object
+                self.assertEqual(new_instance.field, instance.field)
+
 
 class TestValidation(PostgreSQLSimpleTestCase):
 


### PR DESCRIPTION
When using the XML serializer on a JSON field, it was previously trying
to serialize the raw python data object that the JSONField outputs. This
change causes the XML serializer to use json.dumps and json.loads for
serializing and deserializing JSONField data.