### PR TITLE
Refs #30623 -- Remove duplicate call to `self.update`

### DIFF
--- a/django/template/context.py
+++ b/django/template/context.py
@@ -226,8 +226,6 @@ class RequestContext(Context):
         self._processors_index = len(self.dicts)
 
         # placeholder for context processors output
-        self.update({})
-
         # empty dict for any new modifications
         # (so that context processors don't overwrite them)
         self.update({})


### PR DESCRIPTION
Ticket [#30623](https://code.djangoproject.com/ticket/30623)

`self.update({})` is called twice one after the other on `class RequestContext`.
One of those calls seems unnecesary.