### PR TITLE
Refs #28428 -- Made FileSystemStorage.save() to support pathlib.Path.

### DIFF
--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -284,7 +284,7 @@ class FileSystemStorage(Storage):
             os.chmod(full_path, self.file_permissions_mode)
 
         # Store filenames with forward slashes, even on Windows.
-        return name.replace('\\', '/')
+        return str(name).replace('\\', '/')
 
     def delete(self, name):
         assert name, "The name argument is not allowed to be empty."


### PR DESCRIPTION
`name` can be a `pathlib.Path` object and then `.replace` is different operation, which results in error:
`replace() takes 2 positional arguments but 3 were given`

Fixed by casting `pathlib.Path` to `str` before `.replace`.