### PR TITLE
Added Feature -- Pagination for FormSets

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ValidationError
+from django.core.paginator import Paginator
 from django.forms import Form
 from django.forms.fields import BooleanField, IntegerField
 from django.forms.utils import ErrorList
@@ -429,6 +430,9 @@ class BaseFormSet:
         "Return this formset rendered as HTML <li>s."
         forms = ' '.join(form.as_ul() for form in self)
         return mark_safe(str(self.management_form) + '\n' + forms)
+
+    def paginator(self, per_page, orphans=0, allow_empty_first_page=True):
+        return Paginator(self, per_page, orphans=0, allow_empty_first_page=True)
 
 
 def formset_factory(form, formset=BaseFormSet, extra=1, can_order=False,

--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -564,6 +564,36 @@ On the other hand, if you are using a plain ``FormSet``, it's up to you to
 handle ``formset.deleted_forms``, perhaps in your formset's ``save()`` method,
 as there's no general notion of what it means to delete a form.
 
+Pagination for formsets
+=======================
+
+You can paginate formsets by simply calling the ``paginator`` function of the
+formset. This function returns a :class:`~django.core.paginator.Paginator`
+object. One can easily manipulate formset using this paginator object.
+
+    >>> from django.forms import formset_factory
+    >>> from myapp.forms import ArticleForm
+    >>> ArticleFormSet = formset_factory(ArticleForm, can_delete=True)
+    >>> formset = ArticleFormSet(initial=[
+    ...     {'title': 'Article #1', 'pub_date': datetime.date(2008, 5, 10)},
+    ...     {'title': 'Article #2', 'pub_date': datetime.date(2008, 5, 11)},
+    ...     {'title': 'Article #3', 'pub_date': datetime.date(2008, 5, 12)},
+    ...     {'title': 'Article #4', 'pub_date': datetime.date(2008, 5, 13)},
+    ...     {'title': 'Article #5', 'pub_date': datetime.date(2008, 5, 14)},
+    ...     {'title': 'Article #6', 'pub_date': datetime.date(2008, 5, 15)},
+    ...     {'title': 'Article #7', 'pub_date': datetime.date(2008, 5, 16)},
+    ...     {'title': 'Article #8', 'pub_date': datetime.date(2008, 5, 17)},
+    ...     {'title': 'Article #9', 'pub_date': datetime.date(2008, 5, 18)},
+    ... ])
+    >>> p = formset.paginator(per_page=5)
+    >>> p.count
+    9
+    >>> p.num_pages
+    2
+
+To know more about how to use this objects, read more on
+:class:`~django.core.paginator.Paginator`.
+
 Adding additional fields to a formset
 =====================================
 


### PR DESCRIPTION
Formset includes a ``paginator`` method which returns a django.core.utlis.Paginator object.
This will be a handy and useful shortcut to create paginator directly from the formset instance.
Added tests and documentation as well for formsets.paginator