### PR TITLE
Fixed #30557 -- Fixed crash of ordering by ptr fields when Meta.ordering contains F() expressions.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -722,6 +722,8 @@ class SQLCompiler:
 
             results = []
             for item in opts.ordering:
+                if hasattr(item, 'resolve_expression') and not isinstance(item, OrderBy):
+                    item = item.desc() if descending else item.asc()
                 if isinstance(item, OrderBy):
                     results.append((item, False))
                     continue

--- a/tests/ordering/models.py
+++ b/tests/ordering/models.py
@@ -33,7 +33,7 @@ class Article(models.Model):
     class Meta:
         ordering = (
             '-pub_date',
-            'headline',
+            models.F('headline'),
             models.F('author__name').asc(),
             OrderBy(models.F('second_author__name')),
         )

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -485,7 +485,7 @@ class OrderingTests(TestCase):
     def test_deprecated_values_annotate(self):
         msg = (
             "Article QuerySet won't use Meta.ordering in Django 3.1. Add "
-            ".order_by('-pub_date', 'headline', OrderBy(F(author__name), "
+            ".order_by('-pub_date', F(headline), OrderBy(F(author__name), "
             "descending=False), OrderBy(F(second_author__name), "
             "descending=False)) to retain the current query."
         )


### PR DESCRIPTION
Thanks Can Sarıgöl for the report.

Follow up to 8c5f9906c56ac72fc4f13218dd90bdf9bc8a248b