### PR TITLE
Fixed "Getting Started" docs typo - changed "outer" to "inner"

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -120,7 +120,7 @@ These files are:
 The development server
 ======================
 
-Let's verify your Django project works. Change into the outer :file:`mysite` directory, if
+Let's verify your Django project works. Change into the inner :file:`mysite` directory, if
 you haven't already, and run the following commands:
 
 .. console::


### PR DESCRIPTION
I'm a django-newbie going through the tutorial, and I noticed a small typo. Under [The development server](https://docs.djangoproject.com/en/2.2/intro/tutorial01/#the-development-server), the docs say to "_Change into the outer mysite directory_", when it should be saying "_Change into the **inner** mysite directory_". Figured I'd go ahead and make a PR.