### PR TITLE
Updated WSGI servers ordering according to the more commonly used.

### DIFF
--- a/docs/howto/deployment/wsgi/index.txt
+++ b/docs/howto/deployment/wsgi/index.txt
@@ -16,10 +16,10 @@ Django includes getting-started documentation for the following WSGI servers:
 .. toctree::
    :maxdepth: 1
 
-   modwsgi
-   apache-auth
    gunicorn
    uwsgi
+   modwsgi
+   apache-auth
 
 The ``application`` object
 ==========================


### PR DESCRIPTION
    - Point users toward the more popular WSGI servers first

gunicorn and uwsgi are far more popular these days than mod_wsgi or deploying with Apache in general and the docs should reflect this. 