### PR TITLE
Fixed #30646 -- Always close unusable connections

### DIFF
--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -501,14 +501,11 @@ class BaseDatabaseWrapper:
                 self.close()
                 return
 
-            # If an exception other than DataError or IntegrityError occurred
-            # since the last commit / rollback, check if the connection works.
-            if self.errors_occurred:
-                if self.is_usable():
-                    self.errors_occurred = False
-                else:
-                    self.close()
-                    return
+            if self.is_usable():
+                self.errors_occurred = False
+            else:
+                self.close()
+                return
 
             if self.close_at is not None and time.time() >= self.close_at:
                 self.close()


### PR DESCRIPTION
Ensure that unusable connections are always closed whether or not an
error related to the connection has occurred previously.

https://code.djangoproject.com/ticket/30646