### PR TITLE
Removed some outdated backwards compatibility imports and misleading comments.

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -155,7 +155,3 @@ class Command(BaseCommand):
             if shutdown_message:
                 self.stdout.write(shutdown_message)
             sys.exit(0)
-
-
-# Kept for backward compatibility
-BaseRunserverCommand = Command

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -12,10 +12,6 @@ from django import forms
 from django.apps import apps
 from django.conf import settings
 from django.core import checks, exceptions, validators
-# When the _meta object was formalized, this exception was moved to
-# django.core.exceptions. It is retained here for backwards compatibility
-# purposes.
-from django.core.exceptions import FieldDoesNotExist  # NOQA
 from django.db import connection, connections, router
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query_utils import DeferredAttribute, RegisterLookupMixin
@@ -35,11 +31,11 @@ __all__ = [
     'AutoField', 'BLANK_CHOICE_DASH', 'BigAutoField', 'BigIntegerField',
     'BinaryField', 'BooleanField', 'CharField', 'CommaSeparatedIntegerField',
     'DateField', 'DateTimeField', 'DecimalField', 'DurationField',
-    'EmailField', 'Empty', 'Field', 'FieldDoesNotExist', 'FilePathField',
-    'FloatField', 'GenericIPAddressField', 'IPAddressField', 'IntegerField',
-    'NOT_PROVIDED', 'NullBooleanField', 'PositiveIntegerField',
-    'PositiveSmallIntegerField', 'SlugField', 'SmallAutoField',
-    'SmallIntegerField', 'TextField', 'TimeField', 'URLField', 'UUIDField',
+    'EmailField', 'Empty', 'Field', 'FilePathField', 'FloatField',
+    'GenericIPAddressField', 'IPAddressField', 'IntegerField', 'NOT_PROVIDED',
+    'NullBooleanField', 'PositiveIntegerField', 'PositiveSmallIntegerField',
+    'SlugField', 'SmallAutoField', 'SmallIntegerField', 'TextField',
+    'TimeField', 'URLField', 'UUIDField',
 ]
 
 

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -34,9 +34,6 @@ MAX_GET_RESULTS = 21
 # The maximum number of items to display in a QuerySet.__repr__
 REPR_OUTPUT_SIZE = 20
 
-# Pull into this namespace for backwards compatibility.
-EmptyResultSet = sql.EmptyResultSet
-
 
 class BaseIterable:
     def __init__(self, queryset, chunked_fetch=False, chunk_size=GET_ITERATOR_CHUNK_SIZE):

--- a/django/db/models/sql/__init__.py
+++ b/django/db/models/sql/__init__.py
@@ -1,7 +1,6 @@
-from django.core.exceptions import EmptyResultSet
 from django.db.models.sql.query import *  # NOQA
 from django.db.models.sql.query import Query
 from django.db.models.sql.subqueries import *  # NOQA
 from django.db.models.sql.where import AND, OR
 
-__all__ = ['Query', 'AND', 'OR', 'EmptyResultSet']
+__all__ = ['Query', 'AND', 'OR']

--- a/django/db/models/sql/datastructures.py
+++ b/django/db/models/sql/datastructures.py
@@ -2,8 +2,6 @@
 Useful auxiliary data structures for query construction. Not useful outside
 the SQL domain.
 """
-# for backwards-compatibility in Django 1.11
-from django.core.exceptions import EmptyResultSet  # NOQA: F401
 from django.db.models.sql.constants import INNER, LOUTER
 
 

--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -15,8 +15,6 @@ from urllib.parse import urlsplit, urlunsplit
 
 from django.core import validators
 from django.core.exceptions import ValidationError
-# Provide this import for backwards compatibility.
-from django.core.validators import EMPTY_VALUES  # NOQA
 from django.forms.boundfield import BoundField
 from django.forms.utils import from_current_timezone, to_current_timezone
 from django.forms.widgets import (

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -5,11 +5,8 @@ Form classes
 import copy
 
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
-# BoundField is imported for backwards compatibility in Django 1.9
-from django.forms.boundfield import BoundField  # NOQA
 from django.forms.fields import Field, FileField
-# pretty_name is imported for backwards compatibility in Django 1.9
-from django.forms.utils import ErrorDict, ErrorList, pretty_name  # NOQA
+from django.forms.utils import ErrorDict, ErrorList
 from django.forms.widgets import Media, MediaDefiningClass
 from django.utils.datastructures import MultiValueDict
 from django.utils.functional import cached_property

--- a/django/forms/utils.py
+++ b/django/forms/utils.py
@@ -2,7 +2,7 @@ import json
 from collections import UserList
 
 from django.conf import settings
-from django.core.exceptions import ValidationError  # backwards compatibility
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.html import escape, format_html, format_html_join, html_safe
 from django.utils.translation import gettext_lazy as _

--- a/django/template/__init__.py
+++ b/django/template/__init__.py
@@ -53,12 +53,12 @@ __all__ = ('Engine', 'engines')
 
 # Public exceptions
 from .base import VariableDoesNotExist                                  # NOQA isort:skip
-from .context import ContextPopException                                # NOQA isort:skip
+from .context import Context, ContextPopException, RequestContext       # NOQA isort:skip
 from .exceptions import TemplateDoesNotExist, TemplateSyntaxError       # NOQA isort:skip
 
 # Template parts
 from .base import (                                                     # NOQA isort:skip
-    Context, Node, NodeList, Origin, RequestContext, Template, Variable,
+    Node, NodeList, Origin, Template, Variable,
 )
 
 # Library management

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -55,9 +55,7 @@ import re
 from enum import Enum
 from inspect import getcallargs, getfullargspec, unwrap
 
-from django.template.context import (  # NOQA: imported for backwards compatibility
-    BaseContext, Context, ContextPopException, RequestContext,
-)
+from django.template.context import BaseContext
 from django.utils.formats import localize
 from django.utils.html import conditional_escape, escape
 from django.utils.safestring import SafeData, mark_safe

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -15,10 +15,11 @@ from django.utils.safestring import mark_safe
 from .base import (
     BLOCK_TAG_END, BLOCK_TAG_START, COMMENT_TAG_END, COMMENT_TAG_START,
     FILTER_SEPARATOR, SINGLE_BRACE_END, SINGLE_BRACE_START,
-    VARIABLE_ATTRIBUTE_SEPARATOR, VARIABLE_TAG_END, VARIABLE_TAG_START,
-    Context, Node, NodeList, TemplateSyntaxError, VariableDoesNotExist,
-    kwarg_re, render_value_in_context, token_kwargs,
+    VARIABLE_ATTRIBUTE_SEPARATOR, VARIABLE_TAG_END, VARIABLE_TAG_START, Node,
+    NodeList, TemplateSyntaxError, VariableDoesNotExist, kwarg_re,
+    render_value_in_context, token_kwargs,
 )
+from .context import Context
 from .defaultfilters import date
 from .library import Library
 from .smartif import IfParser, Literal

--- a/django/template/engine.py
+++ b/django/template/engine.py
@@ -4,8 +4,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 
-from .base import Context, Template
-from .context import _builtin_context_processors
+from .base import Template
+from .context import Context, _builtin_context_processors
 from .exceptions import TemplateDoesNotExist
 from .library import import_library
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -220,6 +220,19 @@ Miscellaneous
   Django 3.1, the first request to any previously cached template fragment will
   be a cache miss.
 
+* The compatibility imports of ``django.core.exceptions.EmptyResultSet`` in
+  ``django.db.models.query``, ``django.db.models.sql``, and
+  ``django.db.models.sql.datastructures`` are removed.
+
+* The compatibility import of ``django.core.exceptions.FieldDoesNotExist`` in
+  ``django.db.models.fields`` is removed.
+
+* The compatibility imports of ``django.forms.utils.pretty_name()`` and
+  ``django.forms.boundfield.BoundField`` in ``django.forms.forms`` are removed.
+
+* The compatibility imports of ``Context``, ``ContextPopException``, and
+  ``RequestContext`` in ``django.template.base`` are removed.
+
 .. _deprecated-features-3.1:
 
 Features deprecated in 3.1

--- a/tests/template_tests/syntax_tests/test_basic.py
+++ b/tests/template_tests/syntax_tests/test_basic.py
@@ -1,4 +1,5 @@
-from django.template.base import Context, TemplateSyntaxError
+from django.template.base import TemplateSyntaxError
+from django.template.context import Context
 from django.test import SimpleTestCase
 
 from ..utils import SilentAttrClass, SilentGetItemClass, SomeClass, setup


### PR DESCRIPTION
I found some comments with "Backwards compatibility" in them, importing different things into other modules. `EmptyResultSet` is not documented as available from `django.db.models.query` and the two lines were last changed in 2008. Django 1.9 is no longer maintained, so I guess `BoundField` and `pretty_name` are not relevant either.

There are also two lines in `django.db.models.sql.datastructures`:
    
    # for backwards-compatibility in Django 1.11
    from django.core.exceptions import EmptyResultSet  # NOQA: F401

I'm not sure if they can be removed as well.

There are other things added for backwards compatibility, but no version numbers are in the comments.
