### PR TITLE
 Improved error message when index in __getitem__() is invalid.

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -151,7 +151,10 @@ class Page(collections.abc.Sequence):
 
     def __getitem__(self, index):
         if not isinstance(index, (int, slice)):
-            raise TypeError
+            raise TypeError(
+                'Page indices must be integers or slices, not %s.'
+                % type(index).__name__
+            )
         # The object_list is converted to a list so that if it was a QuerySet
         # it won't be a database hit per __getitem__.
         if not isinstance(self.object_list, list):

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -283,7 +283,10 @@ class QuerySet:
     def __getitem__(self, k):
         """Retrieve an item or slice from the set of results."""
         if not isinstance(k, (int, slice)):
-            raise TypeError
+            raise TypeError(
+                'QuerySet indices must be integers or slices, not %s.'
+                % type(k).__name__
+            )
         assert ((not isinstance(k, slice) and (k >= 0)) or
                 (isinstance(k, slice) and (k.start is None or k.start >= 0) and
                  (k.stop is None or k.stop >= 0))), \

--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -63,7 +63,10 @@ class BoundField:
         # Prevent unnecessary reevaluation when accessing BoundField's attrs
         # from templates.
         if not isinstance(idx, (int, slice)):
-            raise TypeError
+            raise TypeError(
+                'BoundField indices must be integers or slices, not %s.'
+                % type(idx).__name__
+            )
         return self.subwidgets[idx]
 
     @property

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -746,6 +746,15 @@ Java</label></li>
             [str(bf[1]), str(bf[2]), str(bf[3])],
         )
 
+    def test_boundfield_invalid_index(self):
+        class TestForm(Form):
+            name = ChoiceField(choices=[])
+
+        field = TestForm()['name']
+        msg = 'BoundField indices must be integers or slices, not str.'
+        with self.assertRaisesMessage(TypeError, msg):
+            field['foo']
+
     def test_boundfield_bool(self):
         """BoundField without any choices (subwidgets) evaluates to True."""
         class TestForm(Form):

--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -366,7 +366,8 @@ class ModelPaginationTests(TestCase):
         # Make sure object_list queryset is not evaluated by an invalid __getitem__ call.
         # (this happens from the template engine when using eg: {% page_obj.has_previous %})
         self.assertIsNone(p.object_list._result_cache)
-        with self.assertRaises(TypeError):
+        msg = 'Page indices must be integers or slices, not str.'
+        with self.assertRaisesMessage(TypeError, msg):
             p['has_previous']
         self.assertIsNone(p.object_list._result_cache)
         self.assertNotIsInstance(p.object_list, list)

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2436,6 +2436,11 @@ class QuerySetSupportsPythonIdioms(TestCase):
         with self.assertRaisesMessage(AssertionError, "Negative indexing is not supported."):
             Article.objects.all()[0:-5]
 
+    def test_invalid_index(self):
+        msg = 'QuerySet indices must be integers or slices, not str.'
+        with self.assertRaisesMessage(TypeError, msg):
+            Article.objects.all()['foo']
+
     def test_can_get_number_of_items_in_queryset_using_standard_len(self):
         self.assertEqual(len(Article.objects.filter(name__exact='Article 1')), 1)
 


### PR DESCRIPTION
Now matches Python's message for an invalid index:

    $ python3 -c 'l = []; l["a"]'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    TypeError: list indices must be integers or slices, not str