### PR TITLE
Fixed #30506 -- Fixed crash of autoreloader when path contains null characters.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -143,6 +143,10 @@ def iter_modules_and_files(modules, extra_files):
             # The module could have been removed, don't fail loudly if this
             # is the case.
             continue
+        except ValueError as e:
+            # Network filesystems may return null bytes in file paths.
+            logger.debug('"%s" raised when resolving path: "%s"' % (str(e), path))
+            continue
         results.add(resolved_path)
     return frozenset(results)
 

--- a/docs/releases/2.2.4.txt
+++ b/docs/releases/2.2.4.txt
@@ -18,3 +18,6 @@ Bugfixes
   :class:`~django.contrib.postgres.fields.DateRangeField` or
   :class:`~django.contrib.postgres.fields.DateTimeRangeField`, if the right
   hand side of an expression is the same type (:ticket:`30621`).
+
+* Fixed a regression in Django 2.2 where auto-reloader crashes if a file path
+  contains nulls characters (``'\x00'``) (:ticket:`30506`).

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -140,6 +140,17 @@ class TestIterModulesAndFiles(SimpleTestCase):
         fake_main = types.ModuleType('__main__')
         self.assertEqual(autoreload.iter_modules_and_files((fake_main,), frozenset()), frozenset())
 
+    def test_path_with_embedded_null_bytes(self):
+        for path in (
+            'embedded_null_byte\x00.py',
+            'di\x00rectory/embedded_null_byte.py',
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(
+                    autoreload.iter_modules_and_files((), frozenset([path])),
+                    frozenset(),
+                )
+
 
 class TestCommonRoots(SimpleTestCase):
     def test_common_roots(self):


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/30506