### PR TITLE
Removed unnecessary code in Model.__init__().

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -457,11 +457,6 @@ class Model(metaclass=ModelBase):
                             val = kwargs.pop(field.attname)
                         except KeyError:
                             val = field.get_default()
-                    else:
-                        # Object instance was passed in. Special case: You can
-                        # pass in "None" for related objects if it's allowed.
-                        if rel_obj is None and field.null:
-                            val = None
                 else:
                     try:
                         val = kwargs.pop(field.attname)


### PR DESCRIPTION
As `is_related_object` is `True`, the `val` variable is unused for the remainder of the method.

Dead code since 53da1e47942f22a56e761d786ba89d05ca55a224.