### PR TITLE
Fixed #30657 -- Allowed customizing Field's descriptors with a descriptor_class attribute.

### DIFF
--- a/django/contrib/gis/db/models/proxy.py
+++ b/django/contrib/gis/db/models/proxy.py
@@ -14,10 +14,9 @@ class SpatialProxy(DeferredAttribute):
         Initialize on the given Geometry or Raster class (not an instance)
         and the corresponding field.
         """
-        self._field = field
         self._klass = klass
         self._load_func = load_func or klass
-        super().__init__(field.attname)
+        super().__init__(field)
 
     def __get__(self, instance, cls=None):
         """
@@ -32,7 +31,7 @@ class SpatialProxy(DeferredAttribute):
 
         # Getting the value of the field.
         try:
-            geo_value = instance.__dict__[self._field.attname]
+            geo_value = instance.__dict__[self.field.attname]
         except KeyError:
             geo_value = super().__get__(instance, cls)
 
@@ -44,7 +43,7 @@ class SpatialProxy(DeferredAttribute):
             # Otherwise, a geometry or raster object is built using the field's
             # contents, and the model's corresponding attribute is set.
             geo_obj = self._load_func(geo_value)
-            setattr(instance, self._field.attname, geo_obj)
+            setattr(instance, self.field.attname, geo_obj)
         return geo_obj
 
     def __set__(self, instance, value):
@@ -56,7 +55,7 @@ class SpatialProxy(DeferredAttribute):
         To set rasters, use JSON or dict values.
         """
         # The geographic type of the field.
-        gtype = self._field.geom_type
+        gtype = self.field.geom_type
 
         if gtype == 'RASTER' and (value is None or isinstance(value, (str, dict, self._klass))):
             # For raster fields, assure input is None or a string, dict, or
@@ -67,7 +66,7 @@ class SpatialProxy(DeferredAttribute):
             # general GeometryField is used.
             if value.srid is None:
                 # Assigning the field SRID if the geometry has no SRID.
-                value.srid = self._field.srid
+                value.srid = self.field.srid
         elif value is None or isinstance(value, (str, memoryview)):
             # Set geometries with None, WKT, HEX, or WKB
             pass
@@ -76,5 +75,5 @@ class SpatialProxy(DeferredAttribute):
                 instance.__class__.__name__, gtype, type(value)))
 
         # Setting the objects dictionary with the value, and returning.
-        instance.__dict__[self._field.attname] = value
+        instance.__dict__[self.field.attname] = value
         return value

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -738,7 +738,7 @@ class Field(RegisterLookupMixin):
             # if you have a classmethod and a field with the same name, then
             # such fields can't be deferred (we don't have a check for this).
             if not getattr(cls, self.attname, None):
-                setattr(cls, self.attname, DeferredAttribute(self.attname))
+                setattr(cls, self.attname, DeferredAttribute(self))
         if self.choices is not None:
             setattr(cls, 'get_%s_display' % self.name,
                     partialmethod(cls._get_FIELD_display, field=self))

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -123,6 +123,8 @@ class Field(RegisterLookupMixin):
     one_to_one = None
     related_model = None
 
+    descriptor_class = DeferredAttribute
+
     # Generic field type description, usually overridden by subclasses
     def _description(self):
         return _('Field of type: %(field_type)s') % {
@@ -738,7 +740,7 @@ class Field(RegisterLookupMixin):
             # if you have a classmethod and a field with the same name, then
             # such fields can't be deferred (we don't have a check for this).
             if not getattr(cls, self.attname, None):
-                setattr(cls, self.attname, DeferredAttribute(self))
+                setattr(cls, self.attname, self.descriptor_class(self))
         if self.choices is not None:
             setattr(cls, 'get_%s_display' % self.name,
                     partialmethod(cls._get_FIELD_display, field=self))

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1793,6 +1793,16 @@ Field API reference
 
         where the arguments are interpolated from the field's ``__dict__``.
 
+    .. attribute:: descriptor_class
+
+        .. versionadded:: 3.0
+
+        A class implementing the :py:ref:`descriptor protocol <descriptors>`
+        that is instantiated and assigned to the model instance attribute. The
+        constructor must accept a single argument, the ``Field`` instance.
+        Overriding this class attribute allows for customizing the get and set
+        behavior.
+
     To map a ``Field`` to a database-specific type, Django exposes several
     methods:
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -283,6 +283,10 @@ Models
   :class:`~django.db.models.Index` now support app label and class
   interpolation using the ``'%(app_label)s'`` and ``'%(class)s'`` placeholders.
 
+* The new :attr:`.Field.descriptor_class` attribute allows model fields to
+  customize the get and set behavior by overriding their
+  :py:ref:`descriptors <descriptors>`.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/field_subclassing/fields.py
+++ b/tests/field_subclassing/fields.py
@@ -1,6 +1,26 @@
 from django.db import models
+from django.db.models.query_utils import DeferredAttribute
 
 
 class CustomTypedField(models.TextField):
     def db_type(self, connection):
         return 'custom_field'
+
+
+class CustomDeferredAttribute(DeferredAttribute):
+    def __get__(self, instance, cls=None):
+        self._count_call(instance, 'get')
+        return super().__get__(instance, cls)
+
+    def __set__(self, instance, value):
+        self._count_call(instance, 'set')
+        instance.__dict__[self.field.attname] = value
+
+    def _count_call(self, instance, get_or_set):
+        count_attr = '_%s_%s_count' % (self.field.attname, get_or_set)
+        count = getattr(instance, count_attr, 0)
+        setattr(instance, count_attr, count + 1)
+
+
+class CustomDescriptorField(models.CharField):
+    descriptor_class = CustomDeferredAttribute

--- a/tests/field_subclassing/tests.py
+++ b/tests/field_subclassing/tests.py
@@ -1,7 +1,7 @@
-from django.db import connection
+from django.db import connection, models
 from django.test import SimpleTestCase
 
-from .fields import CustomTypedField
+from .fields import CustomDescriptorField, CustomTypedField
 
 
 class TestDbType(SimpleTestCase):
@@ -9,3 +9,26 @@ class TestDbType(SimpleTestCase):
     def test_db_parameters_respects_db_type(self):
         f = CustomTypedField()
         self.assertEqual(f.db_parameters(connection)['type'], 'custom_field')
+
+
+class DescriptorClassTest(SimpleTestCase):
+    def test_descriptor_class(self):
+        class CustomDescriptorModel(models.Model):
+            name = CustomDescriptorField(max_length=32)
+
+        m = CustomDescriptorModel()
+        self.assertFalse(hasattr(m, '_name_get_count'))
+        # The field is set to its default in the model constructor.
+        self.assertEqual(m._name_set_count, 1)
+        m.name = 'foo'
+        self.assertFalse(hasattr(m, '_name_get_count'))
+        self.assertEqual(m._name_set_count, 2)
+        self.assertEqual(m.name, 'foo')
+        self.assertEqual(m._name_get_count, 1)
+        self.assertEqual(m._name_set_count, 2)
+        m.name = 'bar'
+        self.assertEqual(m._name_get_count, 1)
+        self.assertEqual(m._name_set_count, 3)
+        self.assertEqual(m.name, 'bar')
+        self.assertEqual(m._name_get_count, 2)
+        self.assertEqual(m._name_set_count, 3)


### PR DESCRIPTION
Allows model Fields to override the descriptor class used on the model
instance attribute.

https://code.djangoproject.com/ticket/30657