### PR TITLE
Fixed #27995 -- Added error messages on unsupported operations following union(), intersection(), and difference().

### DIFF
--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -1,3 +1,4 @@
+from django.db import connection
 from django.db.models import Exists, F, IntegerField, OuterRef, Value
 from django.db.utils import DatabaseError, NotSupportedError
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
@@ -258,3 +259,29 @@ class QuerySetSetOperationTests(TestCase):
         numbers = list(range(10))
         self.assertNumbersEqual(union.order_by('num'), numbers)
         self.assertNumbersEqual(union.order_by('other_num'), reversed(numbers))
+
+    def test_unsupported_operations_on_combined_qs(self):
+        qs = Number.objects.all()
+        msg = 'Calling QuerySet.%s() after %s() is not supported.'
+        combinators = ['union']
+        if connection.features.supports_select_difference:
+            combinators.append('difference')
+        if connection.features.supports_select_intersection:
+            combinators.append('intersection')
+        for combinator in combinators:
+            for operation in (
+                'annotate',
+                'defer',
+                'exclude',
+                'extra',
+                'filter',
+                'only',
+                'prefetch_related',
+                'select_related',
+            ):
+                with self.subTest(combinator=combinator, operation=operation):
+                    with self.assertRaisesMessage(
+                        NotSupportedError,
+                        msg % (operation, combinator),
+                    ):
+                        getattr(getattr(qs, combinator)(qs), operation)()


### PR DESCRIPTION
[Ticket 27995](https://code.djangoproject.com/ticket/27995)