### PR TITLE
Fixed #30411 -- Improved formatting of text tracebacks in technical 500 templates.

### DIFF
--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -313,14 +313,13 @@ In template {{ template_info.name }}, error at line {{ template_info.line }}
    {{ template_info.message }}
 {% for source_line in template_info.source_lines %}{% if source_line.0 == template_info.line %}   {{ source_line.0 }} : {{ template_info.before }} {{ template_info.during }} {{ template_info.after }}{% else %}   {{ source_line.0 }} : {{ source_line.1 }}{% endif %}{% endfor %}{% endif %}
 
-Traceback:{% for frame in frames %}
+Traceback (most recent call last):{% for frame in frames %}
 {% ifchanged frame.exc_cause %}{% if frame.exc_cause %}{% if frame.exc_cause_explicit %}
 The above exception ({{ frame.exc_cause|force_escape }}) was the direct cause of the following exception:
 {% else %}
 During handling of the above exception ({{ frame.exc_cause|force_escape }}), another exception occurred:
-{% endif %}{% endif %}{% endifchanged %}
-File "{{ frame.filename }}" in {{ frame.function }}
-{% if frame.context_line %}  {{ frame.lineno }}. {{ frame.context_line }}{% endif %}{% endfor %}
+{% endif %}{% endif %}{% endifchanged %}  File "{{ frame.filename }}"{% if frame.context_line %}, line {{ frame.lineno }}{% endif %}, in {{ frame.function }}
+{% if frame.context_line %}    {% spaceless %}{{ frame.context_line }}{% endspaceless %}{% endif %}{% endfor %}
 
 Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
 Exception Value: {{ exception_value|force_escape }}

--- a/django/views/templates/technical_500.txt
+++ b/django/views/templates/technical_500.txt
@@ -27,12 +27,11 @@ In template {{ template_info.name }}, error at line {{ template_info.line }}
    {{ template_info.message }}
 {% for source_line in template_info.source_lines %}{% if source_line.0 == template_info.line %}   {{ source_line.0 }} : {{ template_info.before }} {{ template_info.during }} {{ template_info.after }}{% else %}   {{ source_line.0 }} : {{ source_line.1 }}{% endif %}{% endfor %}{% endif %}{% if frames %}
 
-Traceback:
+Traceback (most recent call last):
 {% for frame in frames %}{% ifchanged frame.exc_cause %}{% if frame.exc_cause %}
 {% if frame.exc_cause_explicit %}The above exception ({{ frame.exc_cause }}) was the direct cause of the following exception:{% else %}During handling of the above exception ({{ frame.exc_cause }}), another exception occurred:{% endif %}
-{% endif %}{% endifchanged %}
-File "{{ frame.filename }}" in {{ frame.function }}
-{% if frame.context_line %}  {{ frame.lineno }}. {{ frame.context_line }}{% endif %}
+{% endif %}{% endifchanged %}  File "{{ frame.filename }}"{% if frame.context_line %}, line {{ frame.lineno }}{% endif %}, in {{ frame.function }}
+{% if frame.context_line %}    {% spaceless %}{{ frame.context_line }}{% endspaceless %}{% endif %}
 {% endfor %}
 {% if exception_type %}Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
 {% if exception_value %}Exception Value: {{ exception_value }}{% endif %}{% endif %}{% endif %}

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -415,9 +415,18 @@ class ExceptionReporterTests(SimpleTestCase):
         self.assertEqual(last_frame['function'], 'funcName')
         self.assertEqual(last_frame['lineno'], 2)
         html = reporter.get_traceback_html()
-        self.assertIn('generated in funcName', html)
+        self.assertIn('generated in funcName, line 2', html)
+        self.assertIn(
+            '"generated", line 2, in funcName\n'
+            '    &lt;source code not available&gt;',
+            html,
+        )
         text = reporter.get_traceback_text()
-        self.assertIn('"generated" in funcName', text)
+        self.assertIn(
+            '"generated", line 2, in funcName\n'
+            '    <source code not available>',
+            text,
+        )
 
     def test_reporting_frames_for_cyclic_reference(self):
         try:
@@ -698,7 +707,7 @@ class PlainTextReportTests(SimpleTestCase):
         self.assertIn('USER: jacob', text)
         self.assertIn('Exception Type:', text)
         self.assertIn('Exception Value:', text)
-        self.assertIn('Traceback:', text)
+        self.assertIn('Traceback (most recent call last):', text)
         self.assertIn('Request information:', text)
         self.assertNotIn('Request data not supplied', text)
 
@@ -717,7 +726,7 @@ class PlainTextReportTests(SimpleTestCase):
         self.assertNotIn('USER:', text)
         self.assertIn('Exception Type:', text)
         self.assertIn('Exception Value:', text)
-        self.assertIn('Traceback:', text)
+        self.assertIn('Traceback (most recent call last):', text)
         self.assertIn('Request data not supplied', text)
 
     def test_no_exception(self):


### PR DESCRIPTION
Fixes [30411](https://code.djangoproject.com/ticket/30411).