### PR TITLE
Fixed #30665 -- Added support for distinct argument to Avg() and Sum().

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -99,6 +99,7 @@ class Aggregate(Func):
 class Avg(FixDurationInputMixin, NumericOutputFieldMixin, Aggregate):
     function = 'AVG'
     name = 'Avg'
+    allow_distinct = True
 
 
 class Count(Aggregate):
@@ -142,6 +143,7 @@ class StdDev(NumericOutputFieldMixin, Aggregate):
 class Sum(FixDurationInputMixin, Aggregate):
     function = 'SUM'
     name = 'Sum'
+    allow_distinct = True
 
 
 class Variance(NumericOutputFieldMixin, Aggregate):

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -3378,7 +3378,7 @@ by the aggregate.
 ``Avg``
 ~~~~~~~
 
-.. class:: Avg(expression, output_field=None, filter=None, **extra)
+.. class:: Avg(expression, output_field=None, distinct=False, filter=None, **extra)
 
     Returns the mean value of the given expression, which must be numeric
     unless you specify a different ``output_field``.
@@ -3386,6 +3386,18 @@ by the aggregate.
     * Default alias: ``<field>__avg``
     * Return type: ``float`` if input is ``int``, otherwise same as input
       field, or ``output_field`` if supplied
+
+    Has one optional argument:
+
+    .. attribute:: distinct
+
+        If ``distinct=True``, ``Avg`` returns the mean value of unique values.
+        This is the SQL equivalent of ``AVG(DISTINCT <field>)``. The default
+        value is ``False``.
+
+    .. versionchanged:: 3.0
+
+        Support for ``distinct=True`` was added.
 
 ``Count``
 ~~~~~~~~~
@@ -3451,12 +3463,24 @@ by the aggregate.
 ``Sum``
 ~~~~~~~
 
-.. class:: Sum(expression, output_field=None, filter=None, **extra)
+.. class:: Sum(expression, output_field=None, distinct=False, filter=None, **extra)
 
     Computes the sum of all values of the given expression.
 
     * Default alias: ``<field>__sum``
     * Return type: same as input field, or ``output_field`` if supplied
+
+    Has one optional argument:
+
+    .. attribute:: distinct
+
+        If ``distinct=True``, ``Sum`` returns the sum of unique values. This is
+        the SQL equivalent of ``SUM(DISTINCT <field>)``. The default value is
+        ``False``.
+
+    .. versionchanged:: 3.0
+
+        Support for ``distinct=True`` was added.
 
 ``Variance``
 ~~~~~~~~~~~~

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -291,6 +291,9 @@ Models
   customize the get and set behavior by overriding their
   :py:ref:`descriptors <descriptors>`.
 
+* :class:`~django.db.models.Avg` and :class:`~django.db.models.Sum` now support
+  the ``distinct`` argument.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -388,9 +388,6 @@ class AggregateTestCase(TestCase):
         vals = Book.objects.aggregate(Count("rating"))
         self.assertEqual(vals, {"rating__count": 6})
 
-        vals = Book.objects.aggregate(Count("rating", distinct=True))
-        self.assertEqual(vals, {"rating__count": 4})
-
     def test_count_star(self):
         with self.assertNumQueries(1) as ctx:
             Book.objects.aggregate(n=Count("*"))
@@ -402,6 +399,10 @@ class AggregateTestCase(TestCase):
             distinct_ratings=Count(Case(When(pages__gt=300, then='rating')), distinct=True),
         )
         self.assertEqual(aggs['distinct_ratings'], 4)
+
+    def test_distinct_on_aggregate(self):
+        books = Book.objects.aggregate(ratings=Count('rating', distinct=True))
+        self.assertEqual(books['ratings'], 4)
 
     def test_non_grouped_annotation_not_in_group_by(self):
         """

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -401,8 +401,14 @@ class AggregateTestCase(TestCase):
         self.assertEqual(aggs['distinct_ratings'], 4)
 
     def test_distinct_on_aggregate(self):
-        books = Book.objects.aggregate(ratings=Count('rating', distinct=True))
-        self.assertEqual(books['ratings'], 4)
+        for aggregate, expected_result in (
+            (Avg, 4.125),
+            (Count, 4),
+            (Sum, 16.5),
+        ):
+            with self.subTest(aggregate=aggregate.__name__):
+                books = Book.objects.aggregate(ratings=aggregate('rating', distinct=True))
+                self.assertEqual(books['ratings'], expected_result)
 
     def test_non_grouped_annotation_not_in_group_by(self):
         """


### PR DESCRIPTION
These aggregations (Avg, Min, Max, and Sum) can have the DISTINCT keyword applied in most (if not all) database backends, and so using the distinct parameter should also work. These aggregations were left behind when adding the restriction on DISTINCT (#9174).

Tests for these aggregations were also added, as well as release notes.