### PR TITLE
Adjusted multi-db example to avoid confusion with DATABASES keys.

### DIFF
--- a/docs/topics/db/multi-db.txt
+++ b/docs/topics/db/multi-db.txt
@@ -275,25 +275,25 @@ databases::
     DATABASES = {
         'default': {},
         'auth_db': {
-            'NAME': 'auth_db',
+            'NAME': 'auth_db_name',
             'ENGINE': 'django.db.backends.mysql',
             'USER': 'mysql_user',
             'PASSWORD': 'swordfish',
         },
         'primary': {
-            'NAME': 'primary',
+            'NAME': 'primary_name',
             'ENGINE': 'django.db.backends.mysql',
             'USER': 'mysql_user',
             'PASSWORD': 'spam',
         },
         'replica1': {
-            'NAME': 'replica1',
+            'NAME': 'replica1_name',
             'ENGINE': 'django.db.backends.mysql',
             'USER': 'mysql_user',
             'PASSWORD': 'eggs',
         },
         'replica2': {
-            'NAME': 'replica2',
+            'NAME': 'replica2_name',
             'ENGINE': 'django.db.backends.mysql',
             'USER': 'mysql_user',
             'PASSWORD': 'bacon',


### PR DESCRIPTION
In the routers, it was not clear that auth_db is which auth_db between the lines 306-343. Was it the key of the dictionary or name field? I added _name suffix to name fields of databases. Now it's clear that reader should use dictionary key of a database in routers to access it. Not the name.