### PR TITLE
Fixed #30668 -- Made QuerySet.filter() raise NotSupportedError if any of source expressions is not filterable.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -500,8 +500,6 @@ class TemporalSubtraction(CombinedExpression):
 @deconstructible
 class F(Combinable):
     """An object capable of resolving references to existing query objects."""
-    # Can the expression be used in a WHERE clause?
-    filterable = True
 
     def __init__(self, name):
         """


### PR DESCRIPTION
Fixes [#30668](https://code.djangoproject.com/ticket/30668).
The idea is to propagate `filterable` property through expressions that use other expressions. 
The patch itself is incomplete, at least Case/When is not handled yet.
I wonder if it's worth doing though, because this property probably should be removed altogether when [#28333](https://code.djangoproject.com/ticket/28333) is implemented?