### PR TITLE
Corrected StreamingHttpResponse.streaming_content description in docs.

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1082,7 +1082,8 @@ Attributes
 
 .. attribute:: StreamingHttpResponse.streaming_content
 
-    An iterator of strings representing the content.
+    An iterator of the response content, bytestring encoded according to
+    :attr:`HttpResponse.charset`.
 
 .. attribute:: StreamingHttpResponse.status_code
 


### PR DESCRIPTION
**StreamingHttpResponse.streaming_content** is an iterator of bytes, not string.