### PR TITLE
[1.11.x] Fixed #29182 -- Fixed schema table alteration on SQLite 3.26+.

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -24,11 +24,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             c.execute('PRAGMA foreign_keys')
             self._initial_pragma_fk = c.fetchone()[0]
             c.execute('PRAGMA foreign_keys = 0')
+            c.execute('PRAGMA legacy_alter_table = ON')
         return super(DatabaseSchemaEditor, self).__enter__()
 
     def __exit__(self, exc_type, exc_value, traceback):
         super(DatabaseSchemaEditor, self).__exit__(exc_type, exc_value, traceback)
         with self.connection.cursor() as c:
+            c.execute('PRAGMA legacy_alter_table = OFF')
             # Restore initial FK setting - PRAGMA values can't be parametrized
             c.execute('PRAGMA foreign_keys = %s' % int(self._initial_pragma_fk))
 

--- a/docs/releases/1.11.23.txt
+++ b/docs/releases/1.11.23.txt
@@ -5,3 +5,10 @@ Django 1.11.23 release notes
 *August 1, 2019*
 
 Django 1.11.23 fixes security issues in 1.11.22.
+
+Bugfixes
+========
+
+* Fixed a schema corruption issue on SQLite 3.26+. You might have to drop and
+  rebuild your SQLite database if you applied a migration while using an older
+  version of Django with SQLite 3.26 or later (:ticket:`29182`).


### PR DESCRIPTION
Backport of c8ffdbe514b55ff5c9a2b8cb8bbdf2d3978c188f from master.

This is my take at backporting code from #10733 to the Django 1.11.x LTS series. I am aware of the security fixes only policy, but would highly appreciate if it will still make it in the next release.

The current situation is that once e.g. Heroku updates SQLite, all 1.11.x installations will break, making it effectively impossible to continue using it until the planned decommissioning date. Therefore, I think that this trivial fix warrants an exception to keep it working for everybody, who are in still the process of upgrading to the next LTS, but aren't done with it yet.