### PR TITLE
Fixed #30664 -- Fixed migrations crash when altering table on SQLite or altering AutoField/BigAutoField on PostgreSQL for models with quoted db_table.

### DIFF
--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -2,6 +2,7 @@ import psycopg2
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.backends.ddl_references import IndexColumns
+from django.db.backends.utils import strip_quotes
 
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
@@ -67,7 +68,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         if self._field_data_type(old_field) != self._field_data_type(new_field):
             self.sql_alter_column_type += ' USING %(column)s::%(type)s'
         # Make ALTER TYPE with SERIAL make sense.
-        table = model._meta.db_table
+        table = strip_quotes(model._meta.db_table)
         if new_type.lower() in ("serial", "bigserial"):
             column = new_field.column
             sequence_name = "%s_%s_seq" % (table, column)

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -70,7 +70,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # Make ALTER TYPE with SERIAL make sense.
         table = strip_quotes(model._meta.db_table)
         if new_type.lower() in ("serial", "bigserial"):
-            column = new_field.column
+            column = strip_quotes(new_field.column)
             sequence_name = "%s_%s_seq" % (table, column)
             col_type = "integer" if new_type.lower() == "serial" else "bigint"
             return (

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from django.apps.registry import Apps
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.backends.ddl_references import Statement
+from django.db.backends.utils import strip_quotes
 from django.db.models import UniqueConstraint
 from django.db.transaction import atomic
 from django.db.utils import NotSupportedError
@@ -263,7 +264,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         body_copy = copy.deepcopy(body)
         meta_contents = {
             'app_label': model._meta.app_label,
-            'db_table': 'new__%s' % model._meta.db_table,
+            'db_table': 'new__%s' % strip_quotes(model._meta.db_table),
             'unique_together': unique_together,
             'index_together': index_together,
             'indexes': indexes,

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -636,6 +636,26 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.alter_field(Author, old_field, new_field, strict=True)
 
+    @isolate_apps('schema')
+    def test_alter_auto_field_quoted_db_column(self):
+        class Foo(Model):
+            id = AutoField(primary_key=True, db_column='"quoted_id"')
+
+            class Meta:
+                app_label = 'schema'
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Foo)
+        self.isolated_local_models = [Foo]
+        old_field = Foo._meta.get_field('id')
+        new_field = BigAutoField(primary_key=True)
+        new_field.model = Foo
+        new_field.db_column = '"quoted_id"'
+        new_field.set_attributes_from_name('id')
+        with connection.schema_editor() as editor:
+            editor.alter_field(Foo, old_field, new_field, strict=True)
+        Foo.objects.create()
+
     def test_alter_not_unique_field_to_primary_key(self):
         # Create the table.
         with connection.schema_editor() as editor:

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -649,6 +649,24 @@ class SchemaTests(TransactionTestCase):
             editor.remove_field(Author, Author._meta.get_field('id'))
             editor.alter_field(Author, old_field, new_field, strict=True)
 
+    @isolate_apps('schema')
+    def test_alter_primary_key_quoted_db_table(self):
+        class Foo(Model):
+            class Meta:
+                app_label = 'schema'
+                db_table = '"foo"'
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Foo)
+        self.isolated_local_models = [Foo]
+        old_field = Foo._meta.get_field('id')
+        new_field = BigAutoField(primary_key=True)
+        new_field.model = Foo
+        new_field.set_attributes_from_name('id')
+        with connection.schema_editor() as editor:
+            editor.alter_field(Foo, old_field, new_field, strict=True)
+        Foo.objects.create()
+
     def test_alter_text_field(self):
         # Regression for "BLOB/TEXT column 'info' can't have a default value")
         # on MySQL.


### PR DESCRIPTION
Fixed migration fail in SQLite when using quoted db_table