### PR TITLE
Removed unneeded ValueError catching in django.utils._replace_entity().

### DIFF
--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -351,7 +351,7 @@ def _replace_entity(match):
     else:
         try:
             return chr(html.entities.name2codepoint[text])
-        except (ValueError, KeyError):
+        except KeyError:
             return match.group(0)
 
 


### PR DESCRIPTION
The `html.entities.name2codepoint` dict contains only valid Unicode codepoints. Either the key exists and `chr()` will succeed or the key does not exist.

https://docs.python.org/3/library/html.entities.html#html.entities.name2codepoint