### PR TITLE
Refs #30669 -- Removed unused branch in ASGIHander.read_body().

### DIFF
--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -3,7 +3,6 @@ import logging
 import sys
 import tempfile
 import traceback
-from io import BytesIO
 
 from asgiref.sync import sync_to_async
 
@@ -175,12 +174,8 @@ class ASGIHandler(base.BaseHandler):
 
     async def read_body(self, receive):
         """Reads a HTTP body from an ASGI connection."""
-        # Use the tempfile that auto rolls-over to a disk file as it fills up,
-        # if a maximum in-memory size is set. Otherwise use a BytesIO object.
-        if settings.FILE_UPLOAD_MAX_MEMORY_SIZE is None:
-            body_file = BytesIO()
-        else:
-            body_file = tempfile.SpooledTemporaryFile(max_size=settings.FILE_UPLOAD_MAX_MEMORY_SIZE, mode='w+b')
+        # Use the tempfile that auto rolls-over to a disk file as it fills up.
+        body_file = tempfile.SpooledTemporaryFile(max_size=settings.FILE_UPLOAD_MAX_MEMORY_SIZE, mode='w+b')
         while True:
             message = await receive()
             if message['type'] == 'http.disconnect':


### PR DESCRIPTION
`None` is not valid for `settings.FILE_UPLOAD_MAX_MEMORY_SIZE`.
Always use `SpooledTemporaryFile`.