### PR TITLE
inspectdb should generate related names for FK fields

### DIFF
--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -125,9 +125,10 @@ class Command(BaseCommand):
                             else table2model(relations[column_name][1])
                         )
                         if rel_to in known_models:
-                            field_type = '%s(%s' % (rel_type, rel_to)
+                            field_type = 'ForeignKey(%s' % rel_to
                         else:
-                            field_type = "%s('%s'" % (rel_type, rel_to)
+                            field_type = "ForeignKey('%s'" % rel_to
+                        extra_params['related_name'] = '%s_%s' % (table2model(table_name), column_to_field_name[column_name])
                     else:
                         # Calling `get_field_type` to get the field type string and any
                         # additional parameters and notes.


### PR DESCRIPTION
Currently the `inspectdb` command leaves the developer to the painful task of manually adding a proper `related_name` to each ForeingKey field for each Model that's imported from a DB if a collission occurs, this however could be avoided if the script were to automatically generate a related_name for each FK field by default. 

Code is not my own but comes from this SO answer: https://stackoverflow.com/a/52872876/1605873 I've yet to find any scenario where it fails, and though I reckon it can probably be improved for readabilty and ease of maintenance, it works so I'm submitting it on behalf of the poster.