### PR TITLE
Fixed #30599 -- Prevented ManifestFilesMixin.read_manifest() from silencing errors other than FileNotFoundError.

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -382,7 +382,7 @@ class ManifestFilesMixin(HashedFilesMixin):
         try:
             with self.open(self.manifest_name) as manifest:
                 return manifest.read().decode()
-        except OSError:
+        except FileNotFoundError:
             return None
 
     def load_manifest(self):

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -385,6 +385,10 @@ class TestCollectionManifestStorage(TestHashedFiles, CollectionTestCase):
         path = storage.staticfiles_storage.path(filename)
         self.assertTrue(os.path.exists(path))
 
+    def test_manifest_does_not_exist(self):
+        storage.staticfiles_storage.manifest_name = 'does.not.exist.json'
+        self.assertIsNone(storage.staticfiles_storage.read_manifest())
+
     def test_loaded_cache(self):
         self.assertNotEqual(storage.staticfiles_storage.hashed_files, {})
         manifest_content = storage.staticfiles_storage.read_manifest()

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import unittest
 from io import StringIO
+from unittest import mock
 
 from django.conf import settings
 from django.contrib.staticfiles import finders, storage
@@ -388,6 +389,11 @@ class TestCollectionManifestStorage(TestHashedFiles, CollectionTestCase):
     def test_manifest_does_not_exist(self):
         storage.staticfiles_storage.manifest_name = 'does.not.exist.json'
         self.assertIsNone(storage.staticfiles_storage.read_manifest())
+
+    def test_manifest_does_not_ignore_permission_error(self):
+        with mock.patch('builtins.open', side_effect=PermissionError):
+            with self.assertRaises(PermissionError):
+                storage.staticfiles_storage.read_manifest()
 
     def test_loaded_cache(self):
         self.assertNotEqual(storage.staticfiles_storage.hashed_files, {})


### PR DESCRIPTION
[ticket 30599](https://code.djangoproject.com/ticket/30599)