### PR TITLE
Simplified AlterModelTable by making it subclass ModelOptionOperation.

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -428,7 +428,14 @@ class RenameModel(ModelOperation):
         )
 
 
-class AlterModelTable(ModelOperation):
+class ModelOptionOperation(ModelOperation):
+    def reduce(self, operation, app_label=None):
+        if isinstance(operation, (self.__class__, DeleteModel)) and self.name_lower == operation.name_lower:
+            return [operation]
+        return super().reduce(operation, app_label=app_label)
+
+
+class AlterModelTable(ModelOptionOperation):
     """Rename a model's table."""
 
     def __init__(self, name, table):
@@ -476,18 +483,6 @@ class AlterModelTable(ModelOperation):
             self.name,
             self.table if self.table is not None else "(default)"
         )
-
-    def reduce(self, operation, app_label=None):
-        if isinstance(operation, (AlterModelTable, DeleteModel)) and self.name_lower == operation.name_lower:
-            return [operation]
-        return super().reduce(operation, app_label=app_label)
-
-
-class ModelOptionOperation(ModelOperation):
-    def reduce(self, operation, app_label=None):
-        if isinstance(operation, (self.__class__, DeleteModel)) and self.name_lower == operation.name_lower:
-            return [operation]
-        return super().reduce(operation, app_label=app_label)
 
 
 class AlterTogetherOptionOperation(ModelOptionOperation):


### PR DESCRIPTION
It seems like it was an oversight in 49f4c9f4c61. I looked through the original PR (#5957) and couldn't find a reason that this shouldn't have been done. Can you cast an eye over this @charettes as the original author? Thanks.