### PR TITLE
Fixed #29008 -- Fixed crash of 404 debug page when URL path converter raises Http404.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -5,10 +5,10 @@ import types
 from pathlib import Path
 
 from django.conf import settings
-from django.http import HttpResponse, HttpResponseNotFound
+from django.http import Http404, HttpResponse, HttpResponseNotFound
 from django.template import Context, Engine, TemplateDoesNotExist
 from django.template.defaultfilters import pprint
-from django.urls import Resolver404, resolve
+from django.urls import resolve
 from django.utils import timezone
 from django.utils.datastructures import MultiValueDict
 from django.utils.encoding import force_str
@@ -483,7 +483,7 @@ def technical_404_response(request, exception):
     caller = ''
     try:
         resolver_match = resolve(request.path)
-    except Resolver404:
+    except Http404:
         pass
     else:
         obj = resolver_match.func

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -12,11 +12,13 @@ from unittest import mock
 from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import DatabaseError, connection
+from django.http import Http404
 from django.shortcuts import render
 from django.template import TemplateDoesNotExist
 from django.test import RequestFactory, SimpleTestCase, override_settings
 from django.test.utils import LoggingCaptureMixin
 from django.urls import path, reverse
+from django.urls.converters import IntConverter
 from django.utils.functional import SimpleLazyObject
 from django.utils.safestring import mark_safe
 from django.views.debug import (
@@ -236,6 +238,11 @@ class DebugViewTests(SimpleTestCase):
             m.reset_mock()
             technical_404_response(mock.MagicMock(), mock.Mock())
             m.assert_called_once_with(encoding='utf-8')
+
+    def test_technical_404_converter_raise_404(self):
+        with mock.patch.object(IntConverter, 'to_python', side_effect=Http404):
+            response = self.client.get('/path-post/1/')
+            self.assertContains(response, 'Page not found', status_code=404)
 
 
 class DebugViewQueriesAllowedTests(SimpleTestCase):


### PR DESCRIPTION
Not sure while writing test for this, since `Resolver404` is instance of `Http404` and while raised it only pass.