### PR TITLE
Refs #30236 -- Added release note for autocapitalize attributes on UsernameField.

### DIFF
--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -108,6 +108,10 @@ Minor features
   to mirror the existing
   :meth:`~django.contrib.auth.models.User.get_group_permissions()` method.
 
+* Added HTML ``autocapitalize`` attribute to widgets of username fields in
+  :mod:`django.contrib.auth.forms` using a value of ``none`` to disable
+  undesirable auto-capitalization in browsers.
+
 * Added HTML ``autocomplete`` attribute to widgets of username, email, and
   password fields in :mod:`django.contrib.auth.forms` for better interaction
   with browser password managers.


### PR DESCRIPTION
It was initially decided that no release note should be added for the `autocapitalize` attribute, but one was added for the `autocomplete` attribute that was added in a more recent commit. It makes sense to also mention the `autocapitalize` attribute as it highlights that this common source of irritation has been addressed.