### PR TITLE
Fixed #30673 -- Relaxed system check for db_table collision when database routers are installed by turning the error into a warning.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ answer newbie questions, and generally made Django that much better:
     Adam Malinowski <https://adammalinowski.co.uk/>
     Adam Vandenberg
     Adiyat Mubarak <adiyatmubarak@gmail.com>
+    Adnan Umer <u.adnan@outlook.com>
     Adrian Holovaty <adrian@holovaty.com>
     Adrien Lemaire <lemaire.adrien@gmail.com>
     Afonso Fernández Nogueira <fonzzo.django@gmail.com>

--- a/django/core/checks/model_checks.py
+++ b/django/core/checks/model_checks.py
@@ -4,7 +4,8 @@ from collections import defaultdict
 from itertools import chain
 
 from django.apps import apps
-from django.core.checks import Error, Tags, register
+from django.conf import settings
+from django.core.checks import Error, Tags, Warning, register
 
 
 @register(Tags.models)
@@ -35,14 +36,25 @@ def check_all_models(app_configs=None, **kwargs):
             indexes[model_index.name].append(model._meta.label)
         for model_constraint in model._meta.constraints:
             constraints[model_constraint.name].append(model._meta.label)
+    if settings.DATABASE_ROUTERS:
+        error_class, error_id = Warning, 'models.W035'
+        error_hint = (
+            'You have configured settings.DATABASE_ROUTERS. Verify that %s '
+            'are correctly routed to separate databases.'
+        )
+    else:
+        error_class, error_id = Error, 'models.E028'
+        error_hint = None
     for db_table, model_labels in db_table_models.items():
         if len(model_labels) != 1:
+            model_labels_str = ', '.join(model_labels)
             errors.append(
-                Error(
+                error_class(
                     "db_table '%s' is used by multiple models: %s."
-                    % (db_table, ', '.join(db_table_models[db_table])),
+                    % (db_table, model_labels_str),
                     obj=db_table,
-                    id='models.E028',
+                    hint=(error_hint % model_labels_str) if error_hint else None,
+                    id=error_id,
                 )
             )
     for index_name, model_labels in indexes.items():

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -317,6 +317,8 @@ Models
   or a number.
 * **models.E034**: The index name ``<index>`` cannot be longer than
   ``<max_length>`` characters.
+* **models.W035**: ``db_table`` ``<db_table>`` is used by multiple models:
+  ``<model list>``.
 
 Security
 --------

--- a/docs/releases/2.2.5.txt
+++ b/docs/releases/2.2.5.txt
@@ -9,4 +9,6 @@ Django 2.2.5 fixes several bugs in 2.2.4.
 Bugfixes
 ========
 
-* ...
+* Relaxed the system check added in Django 2.2 for models to reallow use of the
+  same ``db_table`` by multiple models when database routers are installed
+  (:ticket:`30673`).


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30673