### PR TITLE
Removed unnecessary StatAggregate.resolve_expression().

### DIFF
--- a/django/contrib/postgres/aggregates/statistics.py
+++ b/django/contrib/postgres/aggregates/statistics.py
@@ -15,9 +15,6 @@ class StatAggregate(Aggregate):
             raise ValueError('Both y and x must be provided.')
         super().__init__(y, x, output_field=output_field, filter=filter)
 
-    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
-        return super().resolve_expression(query, allow_joins, reuse, summarize)
-
 
 class Corr(StatAggregate):
     function = 'CORR'


### PR DESCRIPTION
The method only calls the parent method, but without the `for_save` argument The parent class, `Aggregate`, already ignores the `for_save` argument so there is no need for special handling.
`Aggregate.resolve_expression()` contains the comment:

    # Aggregates are not allowed in UPDATE queries, so ignore for_save