### PR TITLE
Fixed #30688 -- Added examples for base manager usage

### DIFF
--- a/docs/topics/db/managers.txt
+++ b/docs/topics/db/managers.txt
@@ -214,6 +214,15 @@ appropriate for your circumstances, you can tell Django which class to use by
 setting :attr:`Meta.base_manager_name
 <django.db.models.Options.base_manager_name>`.
 
+For example::
+
+    class Person(models.Model):
+        #...
+        people = PersonManager()
+
+        class Meta:
+            base_manager_name = 'people'
+
 Base managers aren't used when querying on related models. For example, if the
 ``Question`` model :ref:`from the tutorial <creating-models>` had a ``deleted``
 field and a base manager that filters out instances with ``deleted=True``, a


### PR DESCRIPTION
Previously, there was no example base manager usage in the docs, here
in topics or in the reference. It was unclear what specifically
Meta.base_manager_name should be set to and this caused some confusion
and mistakes. The example and description clarify the usage.

Per [my ticket](https://code.djangoproject.com/ticket/30688), this originated from [experiencing confusion](https://github.com/agilgur5/django-serializable-model/issues/4#issuecomment-519338032) in a `django` library I maintain and mistakenly using the wrong name by reading `base_manager_name` very literally.