### PR TITLE
Fixed #30693 -- Removed separate import of os.path in django.core.management.templates.

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -6,7 +6,6 @@ import shutil
 import stat
 import tempfile
 from importlib import import_module
-from os import path
 from urllib.request import urlretrieve
 
 import django
@@ -66,7 +65,7 @@ class TemplateCommand(BaseCommand):
 
         # if some directory is given, make sure it's nicely expanded
         if target is None:
-            top_dir = path.join(os.getcwd(), name)
+            top_dir = os.path.join(os.getcwd(), name)
             try:
                 os.makedirs(top_dir)
             except FileExistsError:
@@ -76,7 +75,7 @@ class TemplateCommand(BaseCommand):
         else:
             if app_or_project == 'app':
                 self.validate_name(os.path.basename(target), 'directory')
-            top_dir = os.path.abspath(path.expanduser(target))
+            top_dir = os.path.abspath(os.path.expanduser(target))
             if not os.path.exists(top_dir):
                 raise CommandError("Destination directory '%s' does not "
                                    "exist, please create it first." % top_dir)
@@ -122,7 +121,7 @@ class TemplateCommand(BaseCommand):
             path_rest = root[prefix_length:]
             relative_dir = path_rest.replace(base_name, name)
             if relative_dir:
-                target_dir = path.join(top_dir, relative_dir)
+                target_dir = os.path.join(top_dir, relative_dir)
                 os.makedirs(target_dir, exist_ok=True)
 
             for dirname in dirs[:]:
@@ -133,15 +132,16 @@ class TemplateCommand(BaseCommand):
                 if filename.endswith(('.pyo', '.pyc', '.py.class')):
                     # Ignore some files as they cause various breakages.
                     continue
-                old_path = path.join(root, filename)
-                new_path = path.join(top_dir, relative_dir,
-                                     filename.replace(base_name, name))
+                old_path = os.path.join(root, filename)
+                new_path = os.path.join(
+                    top_dir, relative_dir, filename.replace(base_name, name)
+                )
                 for old_suffix, new_suffix in self.rewrite_template_suffixes:
                     if new_path.endswith(old_suffix):
                         new_path = new_path[:-len(old_suffix)] + new_suffix
                         break  # Only rewrite once
 
-                if path.exists(new_path):
+                if os.path.exists(new_path):
                     raise CommandError(
                         "%s already exists. Overlaying %s %s into an existing "
                         "directory won't replace conflicting files." % (
@@ -176,7 +176,7 @@ class TemplateCommand(BaseCommand):
             if self.verbosity >= 2:
                 self.stdout.write("Cleaning up temporary files.\n")
             for path_to_remove in self.paths_to_remove:
-                if path.isfile(path_to_remove):
+                if os.path.isfile(path_to_remove):
                     os.remove(path_to_remove)
                 else:
                     shutil.rmtree(path_to_remove)
@@ -188,20 +188,20 @@ class TemplateCommand(BaseCommand):
         directory isn't known.
         """
         if template is None:
-            return path.join(django.__path__[0], 'conf', subdir)
+            return os.path.join(django.__path__[0], 'conf', subdir)
         else:
             if template.startswith('file://'):
                 template = template[7:]
-            expanded_template = path.expanduser(template)
-            expanded_template = path.normpath(expanded_template)
-            if path.isdir(expanded_template):
+            expanded_template = os.path.expanduser(template)
+            expanded_template = os.path.normpath(expanded_template)
+            if os.path.isdir(expanded_template):
                 return expanded_template
             if self.is_url(template):
                 # downloads the file and returns the path
                 absolute_path = self.download(template)
             else:
-                absolute_path = path.abspath(expanded_template)
-            if path.exists(absolute_path):
+                absolute_path = os.path.abspath(expanded_template)
+            if os.path.exists(absolute_path):
                 return self.extract(absolute_path)
 
         raise CommandError("couldn't handle %s template %s." %
@@ -261,7 +261,7 @@ class TemplateCommand(BaseCommand):
         if self.verbosity >= 2:
             self.stdout.write("Downloading %s\n" % display_url)
         try:
-            the_path, info = urlretrieve(url, path.join(tempdir, filename))
+            the_path, info = urlretrieve(url, os.path.join(tempdir, filename))
         except OSError as e:
             raise CommandError("couldn't download URL %s to %s: %s" %
                                (url, filename, e))
@@ -287,7 +287,7 @@ class TemplateCommand(BaseCommand):
         # Move the temporary file to a filename that has better
         # chances of being recognized by the archive utils
         if used_name != guessed_filename:
-            guessed_path = path.join(tempdir, guessed_filename)
+            guessed_path = os.path.join(tempdir, guessed_filename)
             shutil.move(the_path, guessed_path)
             return guessed_path
 


### PR DESCRIPTION
Removed relative import for 'path' module. Refactored all
relative import usage of 'path' module to absolute import.
e.g from 'path.join(some_path)' to 'os.path.join(some_path)'

Ticket [here](https://code.djangoproject.com/ticket/30693).