### PR TITLE
[django 1.11.x] Set content.decode encoding to `response.charset`

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -697,7 +697,7 @@ class Client(RequestFactory):
                     'Content-Type header is "{0}", not "application/json"'
                     .format(response.get('Content-Type'))
                 )
-            response._json = json.loads(response.content.decode(), **extra)
+            response._json = json.loads(response.content.decode(response.charset), **extra)
         return response._json
 
     def _handle_redirects(self, response, **extra):


### PR DESCRIPTION
Otherwise when unicode is passed it will raise `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 168: ordinal not in range(128)`

I've checked master and it's set.