### PR TITLE
Refs #25367 -- Moved Oracle SELECT EXISTS wrapping logic to the compiler.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -288,6 +288,8 @@ class BaseDatabaseFeatures:
     # field(s)?
     allows_multiple_constraints_on_same_fields = True
 
+    supports_boolean_predicates = True
+
     def __init__(self, connection):
         self.connection = connection
 

--- a/django/db/backends/oracle/compiler.py
+++ b/django/db/backends/oracle/compiler.py
@@ -1,0 +1,28 @@
+from django.db.models.expressions import Exists
+from django.db.models.sql import compiler
+
+
+class SQLCompiler(compiler.SQLCompiler):
+    @staticmethod
+    def _wrap_exists(expr, sql, params):
+        # Oracle doesn't allow EXISTS() in the SELECT clauses unless it's
+        # wrapped with a CASE WHEN expression. This is done here and not in
+        # Exists.as_oracle because the latter is not aware of which part of
+        # the query it's compiled for.
+        if isinstance(expr, Exists):
+            sql = 'CASE WHEN %s THEN 1 ELSE 0 END' % sql
+        return sql, params
+
+    def get_select(self):
+        select, klass_info, annotation_col_map = super().get_select()
+        select = [
+            (expr, self._wrap_exists(expr, sql, params), alias)
+            for expr, (sql, params), alias in select
+        ]
+        return select, klass_info, annotation_col_map
+
+
+SQLInsertCompiler = compiler.SQLInsertCompiler
+SQLDeleteCompiler = compiler.SQLDeleteCompiler
+SQLUpdateCompiler = compiler.SQLUpdateCompiler
+SQLAggregateCompiler = compiler.SQLAggregateCompiler

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -58,3 +58,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_partial_indexes = False
     supports_slicing_ordering_in_compound = True
     allows_multiple_constraints_on_same_fields = False
+    supports_boolean_predicates = False

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -16,6 +16,8 @@ from .utils import BulkInsertMapper, InsertVar, Oracle_datetime
 
 
 class DatabaseOperations(BaseDatabaseOperations):
+    compiler_module = "django.db.backends.oracle.compiler"
+
     # Oracle uses NUMBER(11) and NUMBER(19) for integer fields.
     integer_field_ranges = {
         'SmallIntegerField': (-99999999999, 99999999999),

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1068,14 +1068,6 @@ class Exists(Subquery):
             sql = 'NOT {}'.format(sql)
         return sql, params
 
-    def as_oracle(self, compiler, connection, template=None, **extra_context):
-        # Oracle doesn't allow EXISTS() in the SELECT list, so wrap it with a
-        # CASE WHEN expression. Change the template since the When expression
-        # requires a left hand side (column) to compare against.
-        sql, params = self.as_sql(compiler, connection, template, **extra_context)
-        sql = 'CASE WHEN {} THEN 1 ELSE 0 END'.format(sql)
-        return sql, params
-
 
 class OrderBy(BaseExpression):
     template = '%(expression)s %(ordering)s'
@@ -1132,6 +1124,17 @@ class OrderBy(BaseExpression):
         elif self.nulls_first:
             template = 'IF(ISNULL(%(expression)s),0,1), %(expression)s %(ordering)s '
         return self.as_sql(compiler, connection, template=template)
+
+    def as_oracle(self, compiler, connection):
+        if isinstance(self.expression, Exists):
+            copy = self.copy()
+            # XXX: Use copy.expression = Case(When(self.expression)) when
+            # When accepts boolean expressions.
+            exists_sql, params = compiler.compile(self.expression)
+            case_sql = 'CASE WHEN %s THEN 1 ELSE 0 END' % exists_sql
+            copy.expression = RawSQL(case_sql, params)
+            return copy.as_sql(compiler, connection)
+        return self.as_sql(compiler, connection)
 
     def get_group_by_cols(self, alias=None):
         cols = []


### PR DESCRIPTION
This might need to be adjusted to support `Q` object annotations in the future but this should avoid passing around a contextual boolean during expression resolution for the sole purpose of working around this Oracle quirk.