### PR TITLE
Refs #25367 -- Moved Exists.as_oracle SELECT logic to select_format. 

### DIFF
--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -266,13 +266,15 @@ class GeometryField(BaseSpatialField):
             defaults.setdefault('widget', forms.Textarea)
         return super().formfield(**defaults)
 
-    def select_format(self, compiler, sql, params):
+    def select_format(self, compiler, sql, params, subquery):
         """
         Return the selection format string, depending on the requirements
         of the spatial backend. For example, Oracle and MySQL require custom
         selection formats in order to retrieve geometries in OGC WKB.
         """
-        return compiler.connection.ops.select % sql, params
+        if not subquery:
+            return compiler.connection.ops.select % sql, params
+        return sql, params
 
 
 # The OpenGIS Geometry Type Fields
@@ -333,9 +335,9 @@ class ExtentField(Field):
     def get_internal_type(self):
         return "ExtentField"
 
-    def select_format(self, compiler, sql, params):
+    def select_format(self, compiler, sql, params, subquery):
         select = compiler.connection.ops.select_extent
-        return select % sql if select else sql, params
+        return select % sql if not subquery and select else sql, params
 
 
 class RasterField(BaseSpatialField):

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -492,8 +492,8 @@ class TemporalSubtraction(CombinedExpression):
 
     def as_sql(self, compiler, connection):
         connection.ops.check_expression_support(self)
-        lhs = compiler.compile(self.lhs, connection)
-        rhs = compiler.compile(self.rhs, connection)
+        lhs = compiler.compile(self.lhs)
+        rhs = compiler.compile(self.rhs)
         return connection.ops.subtract_temporals(self.lhs.output_field.get_internal_type(), lhs, rhs)
 
 

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1075,12 +1075,11 @@ class Exists(Subquery):
             sql = 'NOT {}'.format(sql)
         return sql, params
 
-    def as_oracle(self, compiler, connection, template=None, **extra_context):
+    def select_format(self, compiler, sql, params, subquery):
         # Oracle doesn't allow EXISTS() in the SELECT list, so wrap it with a
-        # CASE WHEN expression. Change the template since the When expression
-        # requires a left hand side (column) to compare against.
-        sql, params = self.as_sql(compiler, connection, template, **extra_context)
-        sql = 'CASE WHEN {} THEN 1 ELSE 0 END'.format(sql)
+        # CASE WHEN expression.
+        if compiler.connection.vendor == 'oracle':
+            sql = 'CASE WHEN {} THEN 1 ELSE 0 END'.format(sql)
         return sql, params
 
 

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -366,6 +366,13 @@ class BaseExpression:
             if expr:
                 yield from expr.flatten()
 
+    def select_format(self, compiler, sql, params, subquery):
+        """
+        Custom format for select clauses. For example, EXISTS expressions need
+        to be wrapped in CASE WHEN on Oracle to be valid.
+        """
+        return self.output_field.select_format(compiler, sql, params, subquery)
+
     @cached_property
     def identity(self):
         constructor_signature = inspect.signature(self.__init__)

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -389,7 +389,7 @@ class Field(RegisterLookupMixin):
         from django.db.models.expressions import Col
         return Col(self.model._meta.db_table, self)
 
-    def select_format(self, compiler, sql, params):
+    def select_format(self, compiler, sql, params, subquery):
         """
         Custom format for select clauses. For example, GIS columns need to be
         selected as AsText(table.col) on MySQL as the table.col data can't be


### PR DESCRIPTION
An alternative patch which is probably more appropriate given it doesn't leak expression details at the compiler level.