### PR TITLE
Use same validator method for fields choices:

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -600,15 +600,16 @@ class Field(RegisterLookupMixin):
             # Skip validation for non-editable fields.
             return
 
+        text_value = str(value)
         if self.choices is not None and value not in self.empty_values:
             for option_key, option_value in self.choices:
                 if isinstance(option_value, (list, tuple)):
                     # This is an optgroup, so look inside the group for
                     # options.
                     for optgroup_key, optgroup_value in option_value:
-                        if value == optgroup_key:
+                        if value == optgroup_key or text_value == str(optgroup_key):
                             return
-                elif value == option_key:
+                elif value == option_key or text_value == str(option_key):
                     return
             raise exceptions.ValidationError(
                 self.error_messages['invalid_choice'],

--- a/tests/model_fields/test_charfield.py
+++ b/tests/model_fields/test_charfield.py
@@ -44,6 +44,10 @@ class ValidationTests(SimpleTestCase):
         f = models.CharField(max_length=1, choices=[('a', 'A'), ('b', 'B')])
         self.assertEqual('a', f.clean('a', None))
 
+    def test_charfield_with_choices_cleans_valid_int_choice(self):
+        f = models.CharField(max_length=1, choices=[(1, 'One'), (2, 'Two')])
+        self.assertEqual('1', f.clean('1', None))
+
     def test_charfield_with_choices_raises_error_on_invalid_choice(self):
         f = models.CharField(choices=[('a', 'A'), ('b', 'B')])
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
In commit 9883551d50e105b324d8071232bf420935844e43 introduce choice
validate in fields choices as str. If set integer indices for choices in
field the validation pass the forms/fields but not db/models/fields

This change use the same method in db/models/fields to validate choices as
forms/fields.py