### PR TITLE
Refs #25367 -- Moved Oracle Exists() handling to contextual methods. 

### DIFF
--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -272,7 +272,9 @@ class GeometryField(BaseSpatialField):
         of the spatial backend. For example, Oracle and MySQL require custom
         selection formats in order to retrieve geometries in OGC WKB.
         """
-        return compiler.connection.ops.select % sql, params
+        if not compiler.query.subquery:
+            return compiler.connection.ops.select % sql, params
+        return sql, params
 
 
 # The OpenGIS Geometry Type Fields

--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -288,6 +288,9 @@ class BaseDatabaseFeatures:
     # field(s)?
     allows_multiple_constraints_on_same_fields = True
 
+    # Does the backend support boolean expressions in the SELECT clause?
+    supports_boolean_expr_in_select_clause = True
+
     def __init__(self, connection):
         self.connection = connection
 

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -58,3 +58,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_partial_indexes = False
     supports_slicing_ordering_in_compound = True
     allows_multiple_constraints_on_same_fields = False
+    supports_boolean_expr_in_select_clause = False

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -366,6 +366,13 @@ class BaseExpression:
             if expr:
                 yield from expr.flatten()
 
+    def select_format(self, compiler, sql, params):
+        """
+        Custom format for select clauses. For example, EXISTS expressions need
+        to be wrapped in CASE WHEN on Oracle.
+        """
+        return self.output_field.select_format(compiler, sql, params)
+
     @cached_property
     def identity(self):
         constructor_signature = inspect.signature(self.__init__)

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -17,8 +17,6 @@ from django.db.utils import DatabaseError, NotSupportedError
 from django.utils.deprecation import RemovedInDjango31Warning
 from django.utils.hashable import make_hashable
 
-FORCE = object()
-
 
 class SQLCompiler:
     def __init__(self, query, connection, using):
@@ -244,10 +242,12 @@ class SQLCompiler:
         ret = []
         for col, alias in select:
             try:
-                sql, params = self.compile(col, select_format=True)
+                sql, params = self.compile(col)
             except EmptyResultSet:
                 # Select a predicate that's always False.
                 sql, params = '0', ()
+            else:
+                sql, params = col.select_format(self, sql, params)
             ret.append((col, (sql, params), alias))
         return ret, klass_info, annotations
 
@@ -402,14 +402,12 @@ class SQLCompiler:
         self.quote_cache[name] = r
         return r
 
-    def compile(self, node, select_format=False):
+    def compile(self, node):
         vendor_impl = getattr(node, 'as_' + self.connection.vendor, None)
         if vendor_impl:
             sql, params = vendor_impl(self, self.connection)
         else:
             sql, params = node.as_sql(self, self.connection)
-        if select_format is FORCE or (select_format and not self.query.subquery):
-            return node.output_field.select_format(self, sql, params)
         return sql, params
 
     def get_combinator_sql(self, combinator, all):
@@ -1503,7 +1501,8 @@ class SQLAggregateCompiler(SQLCompiler):
         """
         sql, params = [], []
         for annotation in self.query.annotation_select.values():
-            ann_sql, ann_params = self.compile(annotation, select_format=FORCE)
+            ann_sql, ann_params = self.compile(annotation)
+            ann_sql, ann_params = annotation.select_format(self, ann_sql, ann_params)
             sql.append(ann_sql)
             params.extend(ann_params)
         self.col_count = len(self.query.annotation_select)


### PR DESCRIPTION
Oracle requires the `EXISTS` expression to be wrapped in a `CASE WHEN` in the following cases.

1. When part of a `SELECT` clause.
2. When part of a `ORDER BY` clause.
3. When compared against another expression in the `WHERE` clause.

This commit moves the systematic `CASE WHEN` wrapping from `Exists.as_oracle` to
contextual `.select_format`, `Lookup.as_oracle`, and `OrderBy.as_oracle` methods in order to avoid the unnecessary wrapping.

Closes #11641, #11642 as it supersedes them.