### PR TITLE
Updated the default cache key transformation in documentation.

### DIFF
--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -949,7 +949,7 @@ key version to provide a final cache key. By default, the three parts
 are joined using colons to produce a final string::
 
     def make_key(key, key_prefix, version):
-        return ':'.join([key_prefix, str(version), key])
+        return '%s:%s:%s' % (key_prefix, version, key)
 
 If you want to combine the parts in different ways, or apply other
 processing to the final key (e.g., taking a hash digest of the key


### PR DESCRIPTION
The documention has been updated to reflect the current default_key_func.
It seems the documentation wasn't updated [when the code was](https://github.com/django/django/commit/6c69de80bdcd2744bc64cb933c2d863dd5e74a33).