### PR TITLE
Fixed #30449 -- Made RelatedFieldListFilter respect Model._meta.ordering.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -825,9 +825,12 @@ class Field(RegisterLookupMixin):
             if hasattr(self.remote_field, 'get_related_field')
             else 'pk'
         )
+        choices_qs = rel_model._default_manager.complex_filter(limit_choices_to)
+        if ordering:
+            choices_qs = choices_qs.order_by(*ordering)
         return (blank_choice if include_blank else []) + [
             (choice_func(x), str(x))
-            for x in rel_model._default_manager.complex_filter(limit_choices_to).order_by(*ordering)
+            for x in choices_qs
         ]
 
     def value_to_string(self, obj):

--- a/django/db/models/fields/reverse_related.py
+++ b/django/db/models/fields/reverse_related.py
@@ -122,8 +122,11 @@ class ForeignObjectRel(FieldCacheMixin):
         Analog of django.db.models.fields.Field.get_choices(), provided
         initially for utilization by RelatedFieldListFilter.
         """
+        choices_qs = self.related_model._default_manager.all()
+        if ordering:
+            choices_qs = choices_qs.order_by(*ordering)
         return (blank_choice if include_blank else []) + [
-            (x.pk, str(x)) for x in self.related_model._default_manager.order_by(*ordering)
+            (x.pk, str(x)) for x in choices_qs
         ]
 
     def is_hidden(self):


### PR DESCRIPTION
Fix for [ticket 30703](https://code.djangoproject.com/ticket/30703).