### PR TITLE
Fixed #30704 -- Fixed crash of JSONField nested key and index transforms on expressions with params.

### DIFF
--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -107,7 +107,7 @@ class KeyTransform(Transform):
             previous = previous.lhs
         lhs, params = compiler.compile(previous)
         if len(key_transforms) > 1:
-            return "(%s %s %%s)" % (lhs, self.nested_operator), [key_transforms] + params
+            return '(%s %s %%s)' % (lhs, self.nested_operator), params + [key_transforms]
         try:
             lookup = int(self.key_name)
         except ValueError:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30704