### PR TITLE
Removed outdated examples of flatpages on Django.

### DIFF
--- a/docs/ref/contrib/flatpages.txt
+++ b/docs/ref/contrib/flatpages.txt
@@ -20,11 +20,6 @@ template. It can be associated with one, or multiple, sites.
 The content field may optionally be left blank if you prefer to put your
 content in a custom template.
 
-Here are some examples of flatpages on Django-powered sites:
-
-* http://www.lawrence.com/about/contact/
-* http://www2.ljworld.com/site/rules/
-
 Installation
 ============
 


### PR DESCRIPTION
Removing the lawrence journal flat page examples because one is no longer a web page (404) and the other is no longer served by Django: https://www.reddit.com/r/django/comments/8v0fpb/the_lawrence_journalworld_where_django_was/