### PR TITLE
Fixed #27676 -- Allowed BLOB/TEXT defaults on MariaDB 10.2.1+.

### DIFF
--- a/django/contrib/gis/db/backends/mysql/schema.py
+++ b/django/contrib/gis/db/backends/mysql/schema.py
@@ -16,11 +16,11 @@ class MySQLGISSchemaEditor(DatabaseSchemaEditor):
         self.geometry_sql = []
 
     def skip_default(self, field):
-        return (
-            super().skip_default(field) or
-            # Geometry fields are stored as BLOB/TEXT and can't have defaults.
-            isinstance(field, GeometryField)
-        )
+        # Geometry fields are stored as BLOB/TEXT, for which MySQL and MariaDB
+        # < 10.2.1 don't support defaults.
+        if isinstance(field, GeometryField) and not self._supports_limited_data_type_defaults:
+            return True
+        return super().skip_default(field)
 
     def column_sql(self, model, field, include_default=False):
         column_sql = super().column_sql(model, field, include_default)

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -130,9 +130,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'UUIDField': 'char(32)',
     }
 
-    # For these columns, MySQL doesn't:
-    # - accept default values and implicitly treats these columns as nullable
-    # - support a database index
+    # For these data types:
+    # - MySQL and MariaDB < 10.2.1 don't accept default values and implicitly
+    #   treat them as nullable
+    # - all versions of MySQL and MariaDB don't support full width database
+    #   indexes
     _limited_data_types = (
         'tinyblob', 'blob', 'mediumblob', 'longblob', 'tinytext', 'text',
         'mediumtext', 'longtext', 'json',

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -48,7 +48,16 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         return db_type is not None and db_type.lower() in self.connection._limited_data_types
 
     def skip_default(self, field):
-        return self._is_limited_data_type(field)
+        if not self._supports_limited_data_type_defaults:
+            return self._is_limited_data_type(field)
+        return False
+
+    @property
+    def _supports_limited_data_type_defaults(self):
+        # Only MariaDB >= 10.2.1 supports defaults for BLOB and TEXT.
+        if self.connection.mysql_is_mariadb:
+            return self.connection.mysql_version >= (10, 2, 1)
+        return False
 
     def add_field(self, model, field):
         super().add_field(model, field)


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/27676)