### PR TITLE
Fixed #29545 -- Fixed using filter lookups againts nested subquery expressions.

### DIFF
--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -184,18 +184,20 @@ class WhereNode(tree.Node):
         return any(child.is_summary for child in self.children)
 
     @staticmethod
-    def _resolve_rhs(rhs, query, *args, **kwargs):
-        if hasattr(rhs, 'resolve_expression'):
-            rhs = rhs.resolve_expression(query, *args, **kwargs)
-        return rhs
+    def _resolve_leaf(expr, query, *args, **kwargs):
+        if hasattr(expr, 'resolve_expression'):
+            expr = expr.resolve_expression(query, *args, **kwargs)
+        return expr
 
     @classmethod
     def _resolve_node(cls, node, query, *args, **kwargs):
         if hasattr(node, 'children'):
             for child in node.children:
                 cls._resolve_node(child, query, *args, **kwargs)
+        if hasattr(node, 'lhs'):
+            node.lhs = cls._resolve_leaf(node.lhs, query, *args, **kwargs)
         if hasattr(node, 'rhs'):
-            node.rhs = cls._resolve_rhs(node.rhs, query, *args, **kwargs)
+            node.rhs = cls._resolve_leaf(node.rhs, query, *args, **kwargs)
 
     def resolve_expression(self, *args, **kwargs):
         clone = self.clone()

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -942,3 +942,17 @@ class LookupTests(TestCase):
             pk_exists=Exists(qs),
         )
         self.assertCountEqual(seasons, Season.objects.all())
+
+    def test_nested_outerref_lhs(self):
+        tag = Tag.objects.create(name=self.au1.alias)
+        tag.articles.add(self.a1)
+        qs = Tag.objects.annotate(
+            has_author_alias_match=Exists(
+                Article.objects.annotate(
+                    author_exists=Exists(
+                        Author.objects.filter(alias=OuterRef(OuterRef('name')))
+                    ),
+                ).filter(author_exists=True)
+            ),
+        )
+        self.assertEqual(qs.get(has_author_alias_match=True), tag)


### PR DESCRIPTION
This is necessary to allow filter lookups against nested subquery expressions to properly resolve their `OuterRef`s to `Col`s.

Thanks Oskar Persson for the simplified test case.