### PR TITLE
Fixed #30413 - Update test setup_databases for multidb sqlite

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -164,24 +164,20 @@ def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, paral
             old_names.append((connection, db_name, first_alias is None))
 
             # Actually create the database for the first connection
-            if first_alias is None:
-                first_alias = alias
-                connection.creation.create_test_db(
-                    verbosity=verbosity,
-                    autoclobber=not interactive,
-                    keepdb=keepdb,
-                    serialize=connection.settings_dict.get('TEST', {}).get('SERIALIZE', True),
-                )
-                if parallel > 1:
-                    for index in range(parallel):
-                        connection.creation.clone_test_db(
-                            suffix=str(index + 1),
-                            verbosity=verbosity,
-                            keepdb=keepdb,
-                        )
-            # Configure all other connections as mirrors of the first one
-            else:
-                connections[alias].creation.set_as_test_mirror(connections[first_alias].settings_dict)
+            first_alias = alias
+            connection.creation.create_test_db(
+                verbosity=verbosity,
+                autoclobber=not interactive,
+                keepdb=keepdb,
+                serialize=connection.settings_dict.get('TEST', {}).get('SERIALIZE', True),
+            )
+            if parallel > 1:
+                for index in range(parallel):
+                    connection.creation.clone_test_db(
+                        suffix=str(index + 1),
+                        verbosity=verbosity,
+                        keepdb=keepdb,
+                    )
 
     # Configure the test mirrors.
     for alias, mirror_alias in mirrored_aliases.items():

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -15,9 +15,15 @@
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
+        'TEST': {
+            'NAME': 'django_test_default.sqlite3'
+        },
     },
     'other': {
         'ENGINE': 'django.db.backends.sqlite3',
+        'TEST': {
+            'NAME': 'django_test_other.sqlite3'
+        },
     }
 }
 


### PR DESCRIPTION
During `setup_databases`, all other connection configured as mirror of the first one which raises `django.db.utils.OperationalError`: database is locked