### PR TITLE
Fixed #29260 -- Skipped an UPDATE when adding a model instance with primary key that has a default.

### DIFF
--- a/tests/basic/models.py
+++ b/tests/basic/models.py
@@ -3,6 +3,8 @@ Bare-bones model
 
 This is a basic model with only two non-primary-key fields.
 """
+import uuid
+
 from django.db import models
 
 
@@ -40,3 +42,7 @@ class SelfRef(models.Model):
         # This method intentionally doesn't work for all cases - part
         # of the test for ticket #20278
         return SelfRef.objects.get(selfref=self).pk
+
+
+class PrimaryKeyWithDefault(models.Model):
+    uuid = models.UUIDField(primary_key=True, default=uuid.uuid4)

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -10,7 +10,10 @@ from django.test import (
 )
 from django.utils.translation import gettext_lazy
 
-from .models import Article, ArticleSelectOnSave, FeaturedArticle, SelfRef
+from .models import (
+    Article, ArticleSelectOnSave, FeaturedArticle, PrimaryKeyWithDefault,
+    SelfRef,
+)
 
 
 class ModelInstanceCreationTests(TestCase):
@@ -129,6 +132,11 @@ class ModelInstanceCreationTests(TestCase):
         self.assertIn(a, Article.objects.all())
         # ... but there will often be more efficient ways if that is all you need:
         self.assertTrue(Article.objects.filter(id=a.id).exists())
+
+    def test_save_primary_with_default(self):
+        # An UPDATE attempt is skipped when a primary key has default.
+        with self.assertNumQueries(1):
+            PrimaryKeyWithDefault().save()
 
 
 class ModelTest(TestCase):


### PR DESCRIPTION
[ticket 29260](https://code.djangoproject.com/ticket/29260)