### PR TITLE
Fixed #29955 -- Added support for distance expression to the dwithin lookup.

### DIFF
--- a/django/contrib/gis/db/backends/base/features.py
+++ b/django/contrib/gis/db/backends/base/features.py
@@ -36,6 +36,9 @@ class BaseSpatialFeatures:
     # The following properties indicate if the database backend support
     # certain lookups (dwithin, left and right, relate, ...)
     supports_left_right_lookups = False
+    # Does the backend support expressions for specifying distance in the
+    # dwithin lookup?
+    supports_dwithin_distance_expr = True
 
     # Does the database have raster support?
     supports_raster = False

--- a/django/contrib/gis/db/backends/oracle/features.py
+++ b/django/contrib/gis/db/backends/oracle/features.py
@@ -9,3 +9,4 @@ class DatabaseFeatures(BaseSpatialFeatures, OracleDatabaseFeatures):
     supports_geometry_field_introspection = False
     supports_geometry_field_unique_index = False
     supports_perimeter_geodetic = True
+    supports_dwithin_distance_expr = False

--- a/django/contrib/gis/db/models/lookups.py
+++ b/django/contrib/gis/db/models/lookups.py
@@ -1,6 +1,8 @@
 import re
 
 from django.contrib.gis.db.models.fields import BaseSpatialField
+from django.contrib.gis.measure import Distance
+from django.db import NotSupportedError
 from django.db.models.expressions import Expression
 from django.db.models.lookups import Lookup, Transform
 from django.db.models.sql.query import Query
@@ -301,7 +303,20 @@ class DistanceLookupBase(GISLookup):
 @BaseSpatialField.register_lookup
 class DWithinLookup(DistanceLookupBase):
     lookup_name = 'dwithin'
-    sql_template = '%(func)s(%(lhs)s, %(rhs)s, %%s)'
+    sql_template = '%(func)s(%(lhs)s, %(rhs)s, %(value)s)'
+
+    def process_distance(self, compiler, connection):
+        dist_param = self.rhs_params[0]
+        if (
+            not connection.features.supports_dwithin_distance_expr and
+            hasattr(dist_param, 'resolve_expression') and
+            not isinstance(dist_param, Distance)
+        ):
+            raise NotSupportedError(
+                'This backend does not support expressions for specifying '
+                'distance in the dwithin lookup.'
+            )
+        return super().process_distance(compiler, connection)
 
     def process_rhs(self, compiler, connection):
         dist_sql, dist_params = self.process_distance(compiler, connection)

--- a/tests/gis_tests/distapp/models.py
+++ b/tests/gis_tests/distapp/models.py
@@ -28,6 +28,7 @@ class AustraliaCity(NamedModel):
     "City model for Australia, using WGS84."
     point = models.PointField()
     radius = models.IntegerField(default=10000)
+    allowed_distance = models.FloatField(default=0.5)
 
 
 class CensusZipcode(NamedModel):


### PR DESCRIPTION
This was missed when adding support to other distance lookups in refs [#25499](https://code.djangoproject.com/ticket/25499) (37d06cfc46679759c47178a3380b12fbf22a4f25)

Thanks Peter Bex for the report and Mariusz for the testcase.