### PR TITLE
Fixed broken links to Dive Into Python 3 book.

### DIFF
--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -43,7 +43,7 @@ so that it can be of use to the widest audience.
     to |django-developers| or drop by `#django-dev on irc.freenode.net`__ to
     chat with other Django users who might be able to help.
 
-__ https://www.diveinto.org/python3/
+__ https://diveinto.org/python3/table-of-contents.html
 __ irc://irc.freenode.net/django-dev
 
 What does this tutorial cover?

--- a/docs/intro/index.txt
+++ b/docs/intro/index.txt
@@ -36,5 +36,5 @@ place: read this material to quickly get up and running.
 
     .. _python: https://python.org/
     .. _list of Python resources for non-programmers: https://wiki.python.org/moin/BeginnersGuide/NonProgrammers
-    .. _Dive Into Python: https://www.diveinto.org/python3/
+    .. _Dive Into Python: https://diveinto.org/python3/table-of-contents.html
     .. _books about Python: https://wiki.python.org/moin/PythonBooks


### PR DESCRIPTION
I was reading through the contributing documentation to start contributing, and found that the dive into python link was broken.