### PR TITLE
Fixed #29667 -- Prohibited whitespaces in URL path converters.

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -8,6 +8,7 @@ attributes of the resolved URL match.
 import functools
 import inspect
 import re
+import string
 from importlib import import_module
 from urllib.parse import quote
 
@@ -206,6 +207,8 @@ def _route_to_regex(route, is_endpoint=False):
     For example, 'foo/<int:pk>' returns '^foo\\/(?P<pk>[0-9]+)'
     and {'pk': <django.urls.converters.IntConverter>}.
     """
+    if not set(route).isdisjoint(string.whitespace):
+        raise ImproperlyConfigured("URL route '%s' cannot contain whitespace." % route)
     original_route = route
     parts = ['^']
     converters = {}

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -130,6 +130,11 @@ class SimplifiedURLTests(SimpleTestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             path('foo/<nonexistent:var>/', empty_view)
 
+    def test_space_in_route(self):
+        msg = "URL route 'space/<int: num>' cannot contain whitespace."
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            path('space/<int: num>', empty_view)
+
 
 @override_settings(ROOT_URLCONF='urlpatterns.converter_urls')
 class ConverterTests(SimpleTestCase):


### PR DESCRIPTION
[ticket 29667](https://code.djangoproject.com/ticket/29667)