### PR TITLE
Fixed #30722 -- Added default rate-limiting requests to admin's Select2 widget.

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -410,6 +410,7 @@ class AutocompleteMixin:
         attrs.setdefault('class', '')
         attrs.update({
             'data-ajax--cache': 'true',
+            'data-ajax--delay': 250,
             'data-ajax--type': 'GET',
             'data-ajax--url': self.get_url(),
             'data-theme': 'admin-autocomplete',

--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 from django.contrib import admin
 from django.contrib.admin.tests import AdminSeleniumTestCase
@@ -189,6 +190,12 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.assertEqual(len(results), PAGINATOR_SIZE + 11)
         # Limit the results with the search field.
         search.send_keys('Who')
+        # Ajax request is delayed.
+        self.assertTrue(result_container.is_displayed())
+        results = result_container.find_elements_by_css_selector('.select2-results__option')
+        self.assertEqual(len(results), PAGINATOR_SIZE + 12)
+        # Wait for ajax delay.
+        time.sleep(0.25)
         self.assertTrue(result_container.is_displayed())
         results = result_container.find_elements_by_css_selector('.select2-results__option')
         self.assertEqual(len(results), 1)
@@ -223,6 +230,12 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.assertEqual(len(results), 31)
         # Limit the results with the search field.
         search.send_keys('Who')
+        # Ajax request is delayed.
+        self.assertTrue(result_container.is_displayed())
+        results = result_container.find_elements_by_css_selector('.select2-results__option')
+        self.assertEqual(len(results), 32)
+        # Wait for ajax delay.
+        time.sleep(0.25)
         self.assertTrue(result_container.is_displayed())
         results = result_container.find_elements_by_css_selector('.select2-results__option')
         self.assertEqual(len(results), 1)

--- a/tests/admin_widgets/test_autocomplete_widget.py
+++ b/tests/admin_widgets/test_autocomplete_widget.py
@@ -52,6 +52,7 @@ class AutocompleteMixinTests(TestCase):
         self.assertEqual(attrs, {
             'class': 'my-class admin-autocomplete',
             'data-ajax--cache': 'true',
+            'data-ajax--delay': 250,
             'data-ajax--type': 'GET',
             'data-ajax--url': '/admin_widgets/band/autocomplete/',
             'data-theme': 'admin-autocomplete',


### PR DESCRIPTION
Avoid unnecessary load on the server by waiting until the user stops typing before Select2 makes a request.