### PR TITLE
Fixed typo in docs/ref/applications.txt.

### DIFF
--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -13,7 +13,7 @@ This registry is simply called :attr:`~django.apps.apps` and it's available in
 
     >>> from django.apps import apps
     >>> apps.get_app_config('admin').verbose_name
-    'Admin'
+    'Administration'
 
 Projects and applications
 =========================


### PR DESCRIPTION
The value of verbose_name is the localized string of "Administration" and none of the translations have the value "Admin".