### PR TITLE
Refs #30591 -- Fixed introspection of check and unique column constraints on MariaDB.

### DIFF
--- a/tests/introspection/models.py
+++ b/tests/introspection/models.py
@@ -83,6 +83,7 @@ class Comment(models.Model):
 
 class CheckConstraintModel(models.Model):
     up_votes = models.PositiveIntegerField()
+    voting_number = models.PositiveIntegerField(unique=True)
 
     class Meta:
         required_db_features = {

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -268,8 +268,14 @@ class IntrospectionTests(TransactionTestCase):
             elif details['columns'] == ['up_votes'] and details['check']:
                 assertDetails(details, ['up_votes'], check=True)
                 field_constraints.add(name)
+            elif details['columns'] == ['voting_number'] and details['check']:
+                assertDetails(details, ['voting_number'], check=True)
+                field_constraints.add(name)
             elif details['columns'] == ['ref'] and details['unique']:
                 assertDetails(details, ['ref'], unique=True)
+                field_constraints.add(name)
+            elif details['columns'] == ['voting_number'] and details['unique']:
+                assertDetails(details, ['voting_number'], unique=True)
                 field_constraints.add(name)
             elif details['columns'] == ['article_id'] and details['index']:
                 assertDetails(details, ['article_id'], index=True)


### PR DESCRIPTION
Unnamed unique and check columns constraints have the same name as a column. Ensure uniqueness by using custom names.

Thanks Adnan Umer for the report.