### PR TITLE
Removed shell=True from subprocess.run() where unnecessary.

### DIFF
--- a/django/contrib/admin/bin/compress.py
+++ b/django/contrib/admin/bin/compress.py
@@ -49,12 +49,16 @@ Compiler library and Java version 6 or later."""
         to_compress = file_path.expanduser()
         if to_compress.exists():
             to_compress_min = to_compress.with_suffix('.min.js')
-            cmd = "java -jar %s --rewrite_polyfills=false --js %s --js_output_file %s" % (
-                compiler, to_compress, to_compress_min,
-            )
+            cmd = [
+                'java',
+                '-jar', str(compiler),
+                '--rewrite_polyfills=false',
+                '--js', str(to_compress),
+                '--js_output_file', str(to_compress_min),
+            ]
             if options.verbose:
-                sys.stdout.write("Running: %s\n" % cmd)
-            subprocess.run(cmd.split())
+                sys.stdout.write("Running: %s\n" % ' '.join(cmd))
+            subprocess.run(cmd)
         else:
             sys.stdout.write("File %s not found. Sure it exists?\n" % to_compress)
 

--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -78,7 +78,7 @@ def get_git_changeset():
     """
     repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     git_log = subprocess.run(
-        'git log --pretty=format:%ct --quiet -1 HEAD',
+        ['git', 'log', '--pretty=format:%ct', '--quiet', '-1', 'HEAD'],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
         shell=True, cwd=repo_dir, universal_newlines=True,
     )

--- a/scripts/manage_translations.py
+++ b/scripts/manage_translations.py
@@ -144,12 +144,11 @@ def fetch(resources=None, languages=None):
     for name, dir_ in locale_dirs:
         # Transifex pull
         if languages is None:
-            run('tx pull -r %(res)s -a -f  --minimum-perc=5' % {'res': _tx_resource_for_name(name)}, shell=True)
+            run(['tx', 'pull', '-r', _tx_resource_for_name(name), '-a', '-f', '--minimum-perc=5'])
             target_langs = sorted(d for d in os.listdir(dir_) if not d.startswith('_') and d != 'en')
         else:
             for lang in languages:
-                run('tx pull -r %(res)s -f -l %(lang)s' % {
-                    'res': _tx_resource_for_name(name), 'lang': lang}, shell=True)
+                run(['tx', 'pull', '-r', _tx_resource_for_name(name), '-f', '-l', lang])
             target_langs = languages
 
         # msgcat to wrap lines and msgfmt for compilation of .mo file
@@ -160,8 +159,8 @@ def fetch(resources=None, languages=None):
                 print("No %(lang)s translation for resource %(name)s" % {
                     'lang': lang, 'name': name})
                 continue
-            run('msgcat --no-location -o %s %s' % (po_path, po_path), shell=True)
-            msgfmt = run('msgfmt -c -o %s.mo %s' % (po_path[:-3], po_path), shell=True)
+            run(['msgcat', '--no-location', '-o', po_path, po_path])
+            msgfmt = run(['msgfmt', '-c', '-o', '%s.mo' % po_path[:-3], po_path])
             if msgfmt.returncode != 0:
                 errors.append((name, lang))
     if errors:


### PR DESCRIPTION
The Python docs recommend passing a sequence to subprocess.run() when
possible. Doing so allows for automatic escaping and quoting of
arguments.

https://docs.python.org/3/library/subprocess.html#frequently-used-arguments

> args is required for all calls and should be a string, or a sequence
> of program arguments. Providing a sequence of arguments is generally
> preferred, as it allows the module to take care of any required
> escaping and quoting of arguments (e.g. to permit spaces in file
> names).