### PR TITLE
Refs #27795 -- Removed unnecessary force_bytes() calls in uri_to_iri().

### DIFF
--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -236,7 +236,7 @@ def repercent_broken_unicode(path):
             # CVE-2019-14235: A recursion shouldn't be used since the exception
             # handling uses massive amounts of memory
             repercent = quote(path[e.start:e.end], safe=b"/#%[]=:;$&()+,!?*@'~")
-            path = path[:e.start] + force_bytes(repercent) + path[e.end:]
+            path = path[:e.start] + repercent.encode() + path[e.end:]
         else:
             return path
 


### PR DESCRIPTION
The argument to `uri_to_iri()` is always a string, so can safely call `.encode()`.

The value returned from `urllib.parse.quote()` is always a string, so can safely call `.encode()`.

https://code.djangoproject.com/ticket/27795