### PR TITLE
Refs #24462 -- Added BaseSubquery datastructure.

### DIFF
--- a/django/db/backends/mysql/compiler.py
+++ b/django/db/backends/mysql/compiler.py
@@ -19,7 +19,3 @@ class SQLDeleteCompiler(compiler.SQLDeleteCompiler, SQLCompiler):
 
 class SQLUpdateCompiler(compiler.SQLUpdateCompiler, SQLCompiler):
     pass
-
-
-class SQLAggregateCompiler(compiler.SQLAggregateCompiler, SQLCompiler):
-    pass

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1493,27 +1493,6 @@ class SQLUpdateCompiler(SQLCompiler):
         self.query.reset_refcounts(refcounts_before)
 
 
-class SQLAggregateCompiler(SQLCompiler):
-    def as_sql(self):
-        """
-        Create the SQL for this query. Return the SQL string and list of
-        parameters.
-        """
-        sql, params = [], []
-        for annotation in self.query.annotation_select.values():
-            ann_sql, ann_params = self.compile(annotation)
-            ann_sql, ann_params = annotation.select_format(self, ann_sql, ann_params)
-            sql.append(ann_sql)
-            params.extend(ann_params)
-        self.col_count = len(self.query.annotation_select)
-        sql = ', '.join(sql)
-        params = tuple(params)
-
-        sql = 'SELECT %s FROM (%s) subquery' % (sql, self.query.subquery)
-        params = params + self.query.sub_params
-        return sql, params
-
-
 def cursor_iter(cursor, sentinel, col_count, itersize):
     """
     Yield blocks of rows from a cursor and ensure the cursor is closed when

--- a/django/db/models/sql/datastructures.py
+++ b/django/db/models/sql/datastructures.py
@@ -168,3 +168,25 @@ class BaseTable:
             self.table_name == other.table_name and
             self.table_alias == other.table_alias
         )
+
+
+class BaseSubquery:
+    join_type = None
+    parent_alias = None
+    filtered_relation = None
+
+    def __init__(self, query, alias):
+        self.query = query
+        self.query.subquery = True
+        self.table_name = self.table_alias = alias
+
+    def as_sql(self, compiler, connection):
+        subquery_sql, subquery_params = self.query.as_sql(
+            compiler, connection, with_col_aliases=True
+        )
+        return '%s %s' % (subquery_sql, self.table_alias), subquery_params
+
+    def relabeled_clone(self, change_map):
+        return self.__class__(
+            self.query, change_map.get(self.table_alias, self.table_alias)
+        )

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -10,7 +10,7 @@ from django.db.models.sql.constants import (
 )
 from django.db.models.sql.query import Query
 
-__all__ = ['DeleteQuery', 'UpdateQuery', 'InsertQuery', 'AggregateQuery']
+__all__ = ['DeleteQuery', 'UpdateQuery', 'InsertQuery']
 
 
 class DeleteQuery(Query):
@@ -179,16 +179,3 @@ class InsertQuery(Query):
         self.fields = fields
         self.objs = objs
         self.raw = raw
-
-
-class AggregateQuery(Query):
-    """
-    Take another query as a parameter to the FROM clause and only select the
-    elements in the provided list.
-    """
-
-    compiler = 'SQLAggregateCompiler'
-
-    def add_subquery(self, query, using):
-        query.subquery = True
-        self.subquery, self.sub_params = query.get_compiler(using).as_sql(with_col_aliases=True)

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -983,7 +983,7 @@ class AggregationTests(TestCase):
     def test_empty_filter_aggregate(self):
         self.assertEqual(
             Author.objects.filter(id__in=[]).annotate(Count("friends")).aggregate(Count("pk")),
-            {"pk__count": None}
+            {"pk__count": 0}
         )
 
     def test_none_call_before_aggregate(self):


### PR DESCRIPTION
This is a sketch on how to eventually introduce QuerySet.subquery(), see [#24462](https://code.djangoproject.com/ticket/24462). 

Added new `Join`-like class `BaseSubquery` which is meant to be used in
FROM clauses. Rewrote `Query.get_aggregation` with it. Got rid of
`AggregateQuery` and `SQLAggregateCompiler` as redundant.

The only change in tests is related to [#26430](https://code.djangoproject.com/ticket/26430). Currently there is an early return from `get_aggregation` in case of provably empty query, and it doesn't run through converters. This looks like a bug to me, so changed outright. Is deprecation cycle needed here?

@charettes, could you please take a look?