### PR TITLE
Fixed #30733 -- Doc'd that datetime lookups require time zone definitions in the database.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2969,7 +2969,8 @@ Example::
 implementation of the relevant query varies among different database engines.)
 
 When :setting:`USE_TZ` is ``True``, fields are converted to the current time
-zone before filtering.
+zone before filtering. This requires :ref:`time zone definitions in the
+database <database-time-zone-definitions>`.
 
 .. fieldlookup:: year
 
@@ -2994,7 +2995,8 @@ SQL equivalent:
 (The exact SQL syntax varies for each database engine.)
 
 When :setting:`USE_TZ` is ``True``, datetime fields are converted to the
-current time zone before filtering.
+current time zone before filtering. This requires :ref:`time zone definitions
+in the database <database-time-zone-definitions>`.
 
 .. fieldlookup:: iso_year
 
@@ -3014,7 +3016,8 @@ Example::
 (The exact SQL syntax varies for each database engine.)
 
 When :setting:`USE_TZ` is ``True``, datetime fields are converted to the
-current time zone before filtering.
+current time zone before filtering. This requires :ref:`time zone definitions
+in the database <database-time-zone-definitions>`.
 
 .. fieldlookup:: month
 
@@ -3088,8 +3091,9 @@ Example::
 (No equivalent SQL code fragment is included for this lookup because
 implementation of the relevant query varies among different database engines.)
 
-When :setting:`USE_TZ` is ``True``, fields are converted to the current time
-zone before filtering.
+When :setting:`USE_TZ` is ``True``, datetime fields are converted to the
+current time zone before filtering. This requires :ref:`time zone definitions
+in the database <database-time-zone-definitions>`.
 
 .. fieldlookup:: week_day
 
@@ -3155,7 +3159,8 @@ Example::
 implementation of the relevant query varies among different database engines.)
 
 When :setting:`USE_TZ` is ``True``, fields are converted to the current time
-zone before filtering.
+zone before filtering. This requires :ref:`time zone definitions in the
+database <database-time-zone-definitions>`.
 
 .. fieldlookup:: hour
 
@@ -3181,8 +3186,9 @@ SQL equivalent:
 
 (The exact SQL syntax varies for each database engine.)
 
-For datetime fields, when :setting:`USE_TZ` is ``True``, values are converted
-to the current time zone before filtering.
+When :setting:`USE_TZ` is ``True``, datetime fields are converted to the
+current time zone before filtering. This requires :ref:`time zone definitions
+in the database <database-time-zone-definitions>`.
 
 .. fieldlookup:: minute
 
@@ -3208,8 +3214,9 @@ SQL equivalent:
 
 (The exact SQL syntax varies for each database engine.)
 
-For datetime fields, When :setting:`USE_TZ` is ``True``, values are converted
-to the current time zone before filtering.
+When :setting:`USE_TZ` is ``True``, datetime fields are converted to the
+current time zone before filtering. This requires :ref:`time zone definitions
+in the database <database-time-zone-definitions>`.
 
 .. fieldlookup:: second
 
@@ -3235,8 +3242,9 @@ SQL equivalent:
 
 (The exact SQL syntax varies for each database engine.)
 
-For datetime fields, when :setting:`USE_TZ` is ``True``, values are converted
-to the current time zone before filtering.
+When :setting:`USE_TZ` is ``True``, datetime fields are converted to the
+current time zone before filtering. This requires :ref:`time zone definitions
+in the database <database-time-zone-definitions>`.
 
 .. fieldlookup:: isnull
 


### PR DESCRIPTION
In the QuerySet documentation, many of the APIs that work on
datetime fields have a variation of the same notice indicating
that when the USE_TZ setting is set to True, the database is
used to do timezone conversions.  This commit replaces the
variations with, IMO, the most helpful of these variations.