### PR TITLE
Changed git cloning from SSH to HTTPS URL

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -28,7 +28,7 @@ Next, clone your fork, install some requirements, and run the tests:
 
 .. console::
 
-   $ git clone git@github.com:YourGitHubName/django.git django-repo
+   $ git clone https://github.com/YourGitHubName/django.git django-repo
    $ cd django-repo/tests
    $ python -m pip install -e ..
    $ python -m pip install -r requirements/py3.txt

--- a/docs/internals/contributing/writing-code/working-with-git.txt
+++ b/docs/internals/contributing/writing-code/working-with-git.txt
@@ -45,7 +45,7 @@ When you have created your GitHub account, with the nick "GitHub_nick", and
 `forked Django's repository <https://github.com/django/django/fork>`__,
 create a local copy of your fork::
 
-    git clone git@github.com:GitHub_nick/django.git
+    git clone https://github.com/GitHub_nick/django.git
 
 This will create a new directory "django", containing a clone of your GitHub
 repository. The rest of the git commands on this page need to be run within the

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -113,7 +113,7 @@ Download the Django source code repository using the following command:
 
 .. console::
 
-    $ git clone git@github.com:YourGitHubName/django.git
+    $ git clone https://github.com/YourGitHubName/django.git
 
 .. admonition:: Low bandwidth connection?
 


### PR DESCRIPTION
Cloning with HTTPS is recommended compared to SSH as per github.
https://help.github.com/en/articles/which-remote-url-should-i-use

Cloning with SSH URL requires generating an SSH key and adding it to the GitHub account.

I believe using HTTPS URL consistently across the docs is much easier for beginners to follow along.
