### PR TITLE
Fixed #29376 -- Allowed hiding "Save and Add Another" button in admin.

### DIFF
--- a/django/contrib/admin/templatetags/admin_modify.py
+++ b/django/contrib/admin/templatetags/admin_modify.py
@@ -54,12 +54,20 @@ def submit_row(context):
     is_popup = context['is_popup']
     save_as = context['save_as']
     show_save = context.get('show_save', True)
+    show_save_and_add_another = context.get('show_save_and_add_another', True)
     show_save_and_continue = context.get('show_save_and_continue', True)
     has_add_permission = context['has_add_permission']
     has_change_permission = context['has_change_permission']
     has_view_permission = context['has_view_permission']
     has_editable_inline_admin_formsets = context['has_editable_inline_admin_formsets']
     can_save = (has_change_permission and change) or (has_add_permission and add) or has_editable_inline_admin_formsets
+    can_save_and_add_another = (
+        has_add_permission and
+        not is_popup and
+        (not save_as or add) and
+        can_save and
+        show_save_and_add_another
+    )
     can_save_and_continue = not is_popup and can_save and has_view_permission and show_save_and_continue
     can_change = has_change_permission or has_editable_inline_admin_formsets
     ctx = Context(context)
@@ -70,10 +78,7 @@ def submit_row(context):
             change and context.get('show_delete', True)
         ),
         'show_save_as_new': not is_popup and has_change_permission and change and save_as,
-        'show_save_and_add_another': (
-            has_add_permission and not is_popup and
-            (not save_as or add) and can_save
-        ),
+        'show_save_and_add_another': can_save_and_add_another,
         'show_save_and_continue': can_save_and_continue,
         'show_save': show_save and can_save,
         'show_close': not(show_save and can_save)

--- a/tests/admin_views/test_templatetags.py
+++ b/tests/admin_views/test_templatetags.py
@@ -29,6 +29,25 @@ class AdminTemplateTagsTest(AdminViewBasicTestCase):
         self.assertIs(template_context['extra'], True)
         self.assertIs(template_context['show_save'], True)
 
+    def test_override_show_save_and_add_another(self):
+        request = self.request_factory.get(
+            reverse('admin:auth_user_change', args=[self.superuser.pk]),
+        )
+        request.user = self.superuser
+        admin = UserAdmin(User, site)
+        for extra_context, expected_flag in (
+            ({}, True),  # Default.
+            ({'show_save_and_add_another': False}, False),
+        ):
+            with self.subTest(show_save_and_add_another=expected_flag):
+                response = admin.change_view(
+                    request,
+                    str(self.superuser.pk),
+                    extra_context=extra_context,
+                )
+                template_context = submit_row(response.context_data)
+                self.assertIs(template_context['show_save_and_add_another'], expected_flag)
+
     def test_override_change_form_template_tags(self):
         """
         admin_modify template tags follow the standard search pattern


### PR DESCRIPTION
[ticket 29376](https://code.djangoproject.com/ticket/29376)