### PR TITLE
FieldFile - wrong data if custom __str__ used

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -275,11 +275,10 @@ class FileField(Field):
         return "FileField"
 
     def get_prep_value(self, value):
-        value = super().get_prep_value(value)
         # Need to convert File objects provided via a form to string for database insertion
         if value is None:
             return None
-        return str(value)
+        return value.name
 
     def pre_save(self, model_instance, add):
         file = super().pre_save(model_instance, add)


### PR DESCRIPTION
Original get_prep_value relies on FieldFile.__str__ function. If some overrides it database data will be corrupt (invalid). Should use file.name for get_prep_value instead of str(file)