### PR TITLE
Fixed #30750 -- Added support for check constraints on MySQL 8.0.16+.

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -61,6 +61,7 @@ class CursorWrapper:
     codes_for_integrityerror = (
         1048,  # Column cannot be null
         1690,  # BIGINT UNSIGNED value is out of range
+        3819,  # CHECK constraint is violated
         4025,  # CHECK constraint failed
     )
 

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -89,7 +89,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     @cached_property
     def supports_column_check_constraints(self):
-        return self.connection.mysql_is_mariadb and self.connection.mysql_version >= (10, 2, 1)
+        if self.connection.mysql_is_mariadb:
+            return self.connection.mysql_version >= (10, 2, 1)
+        return self.connection.mysql_version >= (8, 0, 16)
 
     supports_table_check_constraints = property(operator.attrgetter('supports_column_check_constraints'))
 
@@ -99,7 +101,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             version = self.connection.mysql_version
             if (version >= (10, 2, 22) and version < (10, 3)) or version >= (10, 3, 10):
                 return True
-        return False
+        return self.connection.mysql_version >= (8, 0, 16)
 
     @cached_property
     def has_select_for_update_skip_locked(self):

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -28,10 +28,15 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_delete_pk = "ALTER TABLE %(table)s DROP PRIMARY KEY"
 
     sql_create_index = 'CREATE INDEX %(name)s ON %(table)s (%(columns)s)%(extra)s'
-    # The name of the column check constraint is the same as the field name on
-    # MariaDB. Adding IF EXISTS clause prevents migrations crash. Constraint is
-    # removed during a "MODIFY" column statement.
-    sql_delete_check = 'ALTER TABLE %(table)s DROP CONSTRAINT IF EXISTS %(name)s'
+
+    @property
+    def sql_delete_check(self):
+        if self.connection.mysql_is_mariadb:
+            # The name of the column check constraint is the same as the field
+            # name on MariaDB. Adding IF EXISTS clause prevents migrations
+            # crash. Constraint is removed during a "MODIFY" column statement.
+            return 'ALTER TABLE %(table)s DROP CONSTRAINT IF EXISTS %(name)s'
+        return 'ALTER TABLE %(table)s DROP CHECK %(name)s'
 
     def quote_value(self, value):
         self.connection.ensure_connection()

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -353,6 +353,8 @@ Models
 
 * :attr:`.FileField.upload_to` now supports :class:`pathlib.Path`.
 
+* :class:`~django.db.models.CheckConstraint` is now supported on MySQL 8.0.16+.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -578,6 +580,9 @@ Miscellaneous
   :class:`~django.middleware.security.SecurityMiddleware` sets the
   :ref:`x-content-type-options` header on all responses that do not already
   have it.
+
+* On MySQL 8.0.16+, ``PositiveIntegerField`` and ``PositiveSmallIntegerField``
+  now include a check constraint to prevent negative values in the database.
 
 .. _deprecated-features-3.0:
 

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1130,6 +1130,7 @@ class SchemaTests(TransactionTestCase):
         # The unique constraint remains.
         self.assertEqual(counts, {'fks': expected_fks, 'uniques': 1, 'indexes': 0})
 
+    @skipUnlessDBFeature('ignores_table_name_case')
     def test_alter_db_table_case(self):
         # Create the table
         with connection.schema_editor() as editor:


### PR DESCRIPTION
[ticket 30750](https://code.djangoproject.com/ticket/30750).
The original patch was from @felixxm. I just fixed a small test.