### PR TITLE
Moved release note for refs #30158 from deprecated to backwards incompatible changes.

### DIFF
--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -584,6 +584,9 @@ Miscellaneous
 * On MySQL 8.0.16+, ``PositiveIntegerField`` and ``PositiveSmallIntegerField``
   now include a check constraint to prevent negative values in the database.
 
+* ``alias=None`` is added to the signature of
+  :meth:`.Expression.get_group_by_cols`.
+
 .. _deprecated-features-3.0:
 
 Features deprecated in 3.0
@@ -618,9 +621,6 @@ Miscellaneous
   :func:`django.views.i18n.set_language` will stop setting the user's language
   in the session in Django 4.0. Since Django 2.1, the language is always stored
   in the :setting:`LANGUAGE_COOKIE_NAME` cookie.
-
-* ``alias=None`` is added to the signature of
-  :meth:`.Expression.get_group_by_cols`.
 
 * ``django.utils.text.unescape_entities()`` is deprecated in favor of
   :func:`html.unescape`. Note that unlike ``unescape_entities()``,


### PR DESCRIPTION
Follow up to 9dc367dc10594ad024c83d398a8e3c3f8f221446.