### PR TITLE
Fixed DatabaseFeatures.can_introspect_check_constraints on MariaDB < 10.2.22, 10.3.0 - 10.3.9.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -99,8 +99,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     def can_introspect_check_constraints(self):
         if self.connection.mysql_is_mariadb:
             version = self.connection.mysql_version
-            if (version >= (10, 2, 22) and version < (10, 3)) or version >= (10, 3, 10):
-                return True
+            return (version >= (10, 2, 22) and version < (10, 3)) or version >= (10, 3, 10)
         return self.connection.mysql_version >= (8, 0, 16)
 
     @cached_property


### PR DESCRIPTION
Regression in e2c6a0858d7d9ad85eda353076a5b46608b704a9.