### PR TITLE
Fixed #30754 -- Prevented inclusion of aliases in partial index conditions.

### DIFF
--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -41,13 +41,10 @@ class Index:
         if self.condition is None:
             return None
         query = Query(model=model)
-        query.add_q(self.condition)
+        where = query.build_where(self.condition)
         compiler = query.get_compiler(connection=schema_editor.connection)
-        # Only the WhereNode is of interest for the partial index.
-        sql, params = query.where.as_sql(compiler=compiler, connection=schema_editor.connection)
-        # BaseDatabaseSchemaEditor does the same map on the params, but since
-        # it's handled outside of that class, the work is done here.
-        return sql % tuple(map(schema_editor.quote_value, params))
+        sql, params = where.as_sql(compiler, schema_editor.connection)
+        return sql % tuple(schema_editor.quote_value(p) for p in params)
 
     def create_sql(self, model, schema_editor, using='', **kwargs):
         fields = [model._meta.get_field(field_name) for field_name, _ in self.fields_orders]

--- a/docs/releases/2.2.6.txt
+++ b/docs/releases/2.2.6.txt
@@ -9,4 +9,5 @@ Django 2.2.6 fixes several bugs in 2.2.5.
 Bugfixes
 ========
 
-* ...
+* Fixed migrations crash on SQLite when altering a model containing partial
+  indexes (:ticket:`30754`).

--- a/tests/indexes/tests.py
+++ b/tests/indexes/tests.py
@@ -108,7 +108,7 @@ class PartialIndexConditionIgnoredTests(TransactionTestCase):
             editor.add_index(Article, index)
 
         self.assertNotIn(
-            'WHERE %s.%s' % (editor.quote_name(Article._meta.db_table), 'published'),
+            'WHERE %s' % editor.quote_name('published'),
             str(index.create_sql(Article, editor))
         )
 
@@ -258,7 +258,7 @@ class PartialIndexTests(TransactionTestCase):
                 )
             )
             self.assertIn(
-                'WHERE %s.%s' % (editor.quote_name(Article._meta.db_table), editor.quote_name("pub_date")),
+                'WHERE %s' % editor.quote_name('pub_date'),
                 str(index.create_sql(Article, schema_editor=editor))
             )
             editor.add_index(index=index, model=Article)
@@ -275,7 +275,7 @@ class PartialIndexTests(TransactionTestCase):
                 condition=Q(pk__gt=1),
             )
             self.assertIn(
-                'WHERE %s.%s' % (editor.quote_name(Article._meta.db_table), editor.quote_name('id')),
+                'WHERE %s' % editor.quote_name('id'),
                 str(index.create_sql(Article, schema_editor=editor))
             )
             editor.add_index(index=index, model=Article)
@@ -292,7 +292,7 @@ class PartialIndexTests(TransactionTestCase):
                 condition=Q(published=True),
             )
             self.assertIn(
-                'WHERE %s.%s' % (editor.quote_name(Article._meta.db_table), editor.quote_name('published')),
+                'WHERE %s' % editor.quote_name('published'),
                 str(index.create_sql(Article, schema_editor=editor))
             )
             editor.add_index(index=index, model=Article)
@@ -319,7 +319,7 @@ class PartialIndexTests(TransactionTestCase):
             sql = str(index.create_sql(Article, schema_editor=editor))
             where = sql.find('WHERE')
             self.assertIn(
-                'WHERE (%s.%s' % (editor.quote_name(Article._meta.db_table), editor.quote_name("pub_date")),
+                'WHERE (%s' % editor.quote_name('pub_date'),
                 sql
             )
             # Because each backend has different syntax for the operators,
@@ -339,7 +339,7 @@ class PartialIndexTests(TransactionTestCase):
                 condition=Q(pub_date__isnull=False),
             )
             self.assertIn(
-                'WHERE %s.%s IS NOT NULL' % (editor.quote_name(Article._meta.db_table), editor.quote_name("pub_date")),
+                'WHERE %s IS NOT NULL' % editor.quote_name('pub_date'),
                 str(index.create_sql(Article, schema_editor=editor))
             )
             editor.add_index(index=index, model=Article)


### PR DESCRIPTION
SQLite doesn't repoint table aliases in partial index conditions on table rename which breaks the documented table alteration procedure.

Thanks Pēteris Caune for the report.