### PR TITLE
Clarified that SECURE_REDIRECT_EXEMPT patterns should not include leading slashes.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2306,8 +2306,11 @@ available in ``request.META``.)
 Default: ``[]`` (Empty list)
 
 If a URL path matches a regular expression in this list, the request will not be
-redirected to HTTPS. If :setting:`SECURE_SSL_REDIRECT` is ``False``, this
-setting has no effect.
+redirected to HTTPS. The
+:class:`~django.middleware.security.SecurityMiddleware` strips leading slashes
+from URL paths, so patterns shouldn't include them, e.g.
+``SECURE_REDIRECT_EXEMPT = [r'^no-ssl/$', …]``. If
+:setting:`SECURE_SSL_REDIRECT` is ``False``, this setting has no effect.
 
 .. setting:: SECURE_REFERRER_POLICY
 


### PR DESCRIPTION
If someone sets `SECURE_REDIRECT_EXEMPT` to something like `r'^/no-ssl/$'`, the pattern will not match, because `SecurityMiddleware` strips leading slashes. This PR contains a small change to the docs that clarifies this behaviour.