### PR TITLE
Fixed #30725 -- Fixed width of DateTimeField inputs in admin tabular inline.

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -391,11 +391,11 @@ input[type="submit"], button {
     .datetimeshortcuts {
         color: #ccc;
     }
-    
+
     .form-row .datetime input.vDateField, .form-row .datetime input.vTimeField {
         width: 75%;
     }
-    
+
     .inline-group {
         overflow: auto;
     }

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -391,7 +391,11 @@ input[type="submit"], button {
     .datetimeshortcuts {
         color: #ccc;
     }
-
+    
+    .form-row .datetime input.vDateField, .form-row .datetime input.vTimeField {
+        width: 75%;
+    }
+    
     .inline-group {
         overflow: auto;
     }

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -262,7 +262,7 @@ p.datetime {
     color: #ccc;
 }
 
-.datetime input, .form-row .datetime input.vDateField, .form-row .datetime input.vTimeField {    
+.datetime input, .form-row .datetime input.vDateField, .form-row .datetime input.vTimeField {
     margin-left: 5px;
     margin-bottom: 4px;
 }

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -262,8 +262,7 @@ p.datetime {
     color: #ccc;
 }
 
-.datetime input, .form-row .datetime input.vDateField, .form-row .datetime input.vTimeField {
-    width: auto;
+.datetime input, .form-row .datetime input.vDateField, .form-row .datetime input.vTimeField {    
     margin-left: 5px;
     margin-bottom: 4px;
 }

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -263,7 +263,7 @@ p.datetime {
 }
 
 .datetime input, .form-row .datetime input.vDateField, .form-row .datetime input.vTimeField {
-    min-width: 0;
+    width: auto;
     margin-left: 5px;
     margin-bottom: 4px;
 }


### PR DESCRIPTION
This fixed CSS issue of shrunken DateTimeField input box in admin when using user's own local timezone in settings.TIME_ZONE instead of "UTC" or other timezones.

https://code.djangoproject.com/ticket/30725
