### PR TITLE
Fixed typos in comments and docs

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -174,7 +174,7 @@ class Template:
         """
         Parse and compile the template source into a nodelist. If debug
         is True and an exception occurs during parsing, the exception is
-        is annotated with contextual line information where it occurred in the
+        annotated with contextual line information where it occurred in the
         template source.
         """
         if self.engine.debug:

--- a/docs/howto/deployment/asgi/uvicorn.txt
+++ b/docs/howto/deployment/asgi/uvicorn.txt
@@ -19,7 +19,7 @@ Running Django in Uvicorn
 
 When Uvicorn is installed, a ``uvicorn`` command is available which runs ASGI
 applications. Uvicorn needs to be called with the location of a module
-containing a ASGI application object, followed by what the application is
+containing an ASGI application object, followed by what the application is
 called (separated by a colon).
 
 For a typical Django project, invoking Uvicorn would look like::

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -194,7 +194,7 @@ When contributing to Django it's very important that your code changes don't
 introduce bugs into other areas of Django. One way to check that Django still
 works after you make your changes is by running Django's test suite. If all
 the tests still pass, then you can be reasonably sure that your changes
-work and haven't broken other parts Django. If you've never run Django's test
+work and haven't broken other parts of Django. If you've never run Django's test
 suite before, it's a good idea to run it once beforehand to get familiar with
 its output.
 

--- a/docs/ref/middleware.txt
+++ b/docs/ref/middleware.txt
@@ -294,8 +294,8 @@ for:
     keeping CSRF protection, consider enabling only same-origin referrers.
 
 ``SecurityMiddleware`` can set the ``Referrer-Policy`` header for you, based on
-the the :setting:`SECURE_REFERRER_POLICY` setting (note spelling: browsers send
-a ``Referer`` header when a user clicks a link, but the header instructing a
+the :setting:`SECURE_REFERRER_POLICY` setting (note spelling: browsers send a
+``Referer`` header when a user clicks a link, but the header instructing a
 browser whether to do so is spelled ``Referrer-Policy``). The valid values for
 this setting are:
 
@@ -522,7 +522,7 @@ Here are some hints about the ordering of various Django middleware classes:
 
 #. :class:`~django.contrib.sessions.middleware.SessionMiddleware`
 
-   Before any middleware that may raise an an exception to trigger an error
+   Before any middleware that may raise an exception to trigger an error
    view (such as :exc:`~django.core.exceptions.PermissionDenied`) if you're
    using :setting:`CSRF_USE_SESSIONS`.
 

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1129,7 +1129,7 @@ class ExpressionOperatorTests(TestCase):
         self.assertEqual(Number.objects.get(pk=self.n.pk).float, Approximate(15.500, places=3))
 
     def test_lefthand_power(self):
-        # LH Powert arithmetic operation on floats and integers
+        # LH Power arithmetic operation on floats and integers
         Number.objects.filter(pk=self.n.pk).update(integer=F('integer') ** 2, float=F('float') ** 1.5)
         self.assertEqual(Number.objects.get(pk=self.n.pk).integer, 1764)
         self.assertEqual(Number.objects.get(pk=self.n.pk).float, Approximate(61.02, places=2))
@@ -1171,7 +1171,7 @@ class ExpressionOperatorTests(TestCase):
         self.assertEqual(Number.objects.get(pk=self.n.pk).float, Approximate(15.500, places=3))
 
     def test_righthand_power(self):
-        # RH Powert arithmetic operation on floats and integers
+        # RH Power arithmetic operation on floats and integers
         Number.objects.filter(pk=self.n.pk).update(integer=2 ** F('integer'), float=1.5 ** F('float'))
         self.assertEqual(Number.objects.get(pk=self.n.pk).integer, 4398046511104)
         self.assertEqual(Number.objects.get(pk=self.n.pk).float, Approximate(536.308, places=3))

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -235,7 +235,7 @@ class SpecializedFieldTest(SimpleTestCase):
         ogr.transform(3857)
         self.assertIn(escape(ogr.json), rendered)
 
-    # map_srid in operlayers.html template must not be localized.
+    # map_srid in openlayers.html template must not be localized.
     @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
     def test_pointfield(self):
         class PointForm(forms.Form):


### PR DESCRIPTION
Some of them were found by reading, and the others were by script.
