### PR TITLE
Refs #27338 -- Added tests for altering CharField with primary_key=True to AutoField on PostgreSQL.

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -304,6 +304,24 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(AuthorTextFieldWithIndex, old_field, new_field, strict=True)
         self.assertForeignKeyExists(AuthorTextFieldWithIndex, 'text_field_id', 'schema_author')
 
+    @isolate_apps('schema')
+    def test_char_field_pk_to_auto_field(self):
+        class Foo(Model):
+            id = CharField(max_length=255, primary_key=True)
+
+            class Meta:
+                app_label = 'schema'
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Foo)
+        self.isolated_local_models = [Foo]
+        old_field = Foo._meta.get_field('id')
+        new_field = AutoField(primary_key=True)
+        new_field.set_attributes_from_name('id')
+        new_field.model = Foo
+        with connection.schema_editor() as editor:
+            editor.alter_field(Foo, old_field, new_field, strict=True)
+
     @skipUnlessDBFeature('supports_foreign_keys')
     def test_fk_to_proxy(self):
         "Creating a FK to a proxy model creates database constraints."


### PR DESCRIPTION
Fixed in 91b2bc3e70be2632baad86488fb03cf02848b5b6.

https://code.djangoproject.com/ticket/27338
