### PR TITLE
Refs #30767 -- Improved deployment documentation.

### DIFF
--- a/docs/howto/deployment/index.txt
+++ b/docs/howto/deployment/index.txt
@@ -6,13 +6,33 @@ Django is full of shortcuts to make Web developers' lives easier, but all
 those tools are of no use if you can't easily deploy your sites. Since Django's
 inception, ease of deployment has been a major goal.
 
-This section contains guides to the two main ways to deploy Django. WSGI is the
-main Python standard for communicating between Web servers and applications,
-but it only supports synchronous code.
+There are many options for deploying your Django application, based on your
+architecture or your particular business needs, but that discussion is outside
+the scope of what Django can give you as guidance.
 
-ASGI is the new, asynchronous-friendly standard that will allow your Django
-site to use asynchronous Python features, and asynchronous Django features as
-they are developed.
+Django, being a web framework, needs a web server in order to operate. And
+since most web servers don't natively speak Python, we need an interface to
+make that communication happen.
+
+Django currently supports two interfaces: WSGI and ASGI.
+
+* `WSGI`_ is the main Python standard for communicating between Web servers and
+  applications, but it only supports synchronous code.
+
+* `ASGI`_ is the new, asynchronous-friendly standard that will allow your
+  Django site to use asynchronous Python features, and asynchronous Django
+  features as they are developed.
+
+You should also consider how you will handle :doc:`static files
+</howto/static-files/deployment>` for your application, and how to handle
+:doc:`error reporting</howto/error-reporting>`.
+
+Finally, before you deploy your application to production, you should run
+through our :doc:`deployment checklist<checklist>` to ensure that your
+configurations are suitable.
+
+.. _WSGI: https://wsgi.readthedocs.io/en/latest/
+.. _ASGI: https://asgi.readthedocs.io/en/latest/
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Continuation of https://code.djangoproject.com/ticket/30767

(unsure if I should open a seperate ticket)

In essence: I found that there is, hiding in the middle of the [`django-admin` reference docs](https://docs.djangoproject.com/en/2.2/ref/django-admin/#runserver), a very important statement: 

> We’re in the business of making Web frameworks, not Web servers

Exposing that up in the top level of the howto documentation I think is important. Especially around explaining *why* we don't and aren't giving recommendations. 

I also did not link to any other resources on purpose as not to pick favourites (even the djangogirls section on deployment makes a [choice](https://tutorial.djangogirls.org/en/deploy/) out of necessity. 