### PR TITLE
[WIP] Refs #28935 -- Corrected template error message

### DIFF
--- a/django/template/context.py
+++ b/django/template/context.py
@@ -4,6 +4,7 @@ from copy import copy
 # Hard-coded processor for easier use of CSRF protection.
 _builtin_context_processors = ('django.template.context_processors.csrf',)
 
+template_stack = []
 
 class ContextPopException(Exception):
     "pop() has been called more times than push()"
@@ -200,6 +201,7 @@ class RenderContext(BaseContext):
 
     @contextmanager
     def push_state(self, template, isolated_context=True):
+        template_stack.append(template)
         initial = self.template
         self.template = template
         if isolated_context:


### PR DESCRIPTION
### Work in progress.

[#28935](https://code.djangoproject.com/ticket/28935)
Issue is:
When "extends" and "include" template tags are used together in same html page, and "include" tries to include nonexistent html file, error page gives incorrect information (filename and line number) under the heading "Error during template rendering".

### Example: 
base.html
```
{% block content %}
{% endblock %}
```

home.html
```
{% extends 'base.html' %}
{% block content %}
{% include "./nonexistent.html" %}    <== TemplateNotFound
{% endblock %}
```

This gives 
```
Error during template rendering
In template /.../base.html, error at line 0 
```

But the expected error reporting should be
```
In template /.../home.html, error at line 3
```

### What I've done:
Django template engine is saving only most recently rendered/visited template informations.
In this case, `home.html -> base.html -> `then error occurs here, without going back to home.html.
This makes "base.html" the most recent one, and error information is pulled from the base.html.

Therefore, I made a global variable, "template_stack", to save and pull out previously rendered page information, i.e. home.html.
Please have a look and see if this approach is Okay.

There is one test failure, but if I mimic the test with actual files and browser it seems to be working fine.
```
======================================================================
FAIL: test_compile_tag_error_27956 (template_tests.tests.TemplateTests)
Errors in a child of {% extends %} are displayed correctly.
----------------------------------------------------------------------
AssertionError: 'nt.html&quot; %}\n' != '{% badtag %}'
```