### PR TITLE
Fixed #30775 -- Added admonition about missing imports to "Running tests" section in tutorial 5.

### DIFF
--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -443,8 +443,9 @@ models, not only for your own convenience when dealing with the interactive
 prompt, but also because objects' representations are used throughout Django's
 automatically-generated admin.
 
-Note these are normal Python methods. Let's add a custom method, just for
-demonstration:
+.. _tutorial02-import-timezone:
+
+Let's also add a custom method to this model:
 
 .. code-block:: python
     :caption: polls/models.py

--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -220,6 +220,13 @@ and you'll see something like::
     FAILED (failures=1)
     Destroying test database for alias 'default'...
 
+.. admonition:: Different error?
+
+    If instead you're getting a ``NameError`` here, you may have missed a step
+    in :ref:`Part 2 <tutorial02-import-timezone>` where we added imports of
+    ``datetime`` and ``timezone`` to ``polls/models.py``. Copy the imports from
+    that section, and try running your tests again.
+
 What happened is this:
 
 * ``manage.py test polls`` looked for tests in the ``polls`` application


### PR DESCRIPTION
Ensures that users go back and check for their `models.py` imports if they get an error different to the expected bug