### PR TITLE
Fixed #29444 -- Allowed returning multiple fields from INSERT statements on Oracle.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -23,7 +23,6 @@ class BaseDatabaseFeatures:
 
     can_use_chunked_reads = True
     can_return_columns_from_insert = False
-    can_return_multiple_columns_from_insert = False
     can_return_rows_from_bulk_insert = False
     has_bulk_insert = True
     uses_savepoints = True

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -176,7 +176,7 @@ class BaseDatabaseOperations:
         else:
             return ['DISTINCT'], []
 
-    def fetch_returned_insert_columns(self, cursor):
+    def fetch_returned_insert_columns(self, cursor, returning_params):
         """
         Given a cursor object that has just performed an INSERT...RETURNING
         statement into a table, return the newly created data.

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -10,6 +10,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_select_for_update_of = True
     select_for_update_of_column = True
     can_return_columns_from_insert = True
+    can_return_multiple_columns_from_insert = True
     can_introspect_autofield = True
     supports_subqueries_in_group_by = False
     supports_transactions = True

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -10,7 +10,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_select_for_update_of = True
     select_for_update_of_column = True
     can_return_columns_from_insert = True
-    can_return_multiple_columns_from_insert = True
     can_introspect_autofield = True
     supports_subqueries_in_group_by = False
     supports_transactions = True

--- a/django/db/backends/oracle/utils.py
+++ b/django/db/backends/oracle/utils.py
@@ -27,11 +27,14 @@ class InsertVar:
     def __init__(self, field):
         internal_type = getattr(field, 'target_field', field).get_internal_type()
         self.db_type = self.types.get(internal_type, str)
+        self.bound_param = None
 
     def bind_parameter(self, cursor):
-        param = cursor.cursor.var(self.db_type)
-        cursor._insert_id_var = param
-        return param
+        self.bound_param = cursor.cursor.var(self.db_type)
+        return self.bound_param
+
+    def get_value(self):
+        return self.bound_param.getvalue()
 
 
 class Oracle_datetime(datetime.datetime):

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -8,7 +8,6 @@ from django.utils.functional import cached_property
 class DatabaseFeatures(BaseDatabaseFeatures):
     allows_group_by_selected_pks = True
     can_return_columns_from_insert = True
-    can_return_multiple_columns_from_insert = True
     can_return_rows_from_bulk_insert = True
     has_real_datatype = True
     has_native_uuid_field = True

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1334,14 +1334,6 @@ class SQLInsertCompiler(SQLCompiler):
             if self.connection.features.can_return_rows_from_bulk_insert and len(self.query.objs) > 1:
                 return self.connection.ops.fetch_returned_insert_rows(cursor)
             if self.connection.features.can_return_columns_from_insert:
-                if (
-                    len(self.returning_fields) > 1 and
-                    not self.connection.features.can_return_multiple_columns_from_insert
-                ):
-                    raise NotSupportedError(
-                        'Returning multiple columns from INSERT statements is '
-                        'not supported on this database backend.'
-                    )
                 assert len(self.query.objs) == 1
                 return self.connection.ops.fetch_returned_insert_columns(cursor, self.returning_params)
             return [self.connection.ops.last_insert_id(

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -208,7 +208,8 @@ Database backend API
 This section describes changes that may be needed in third-party database
 backends.
 
-* ...
+* ``DatabaseOperations.fetch_returned_insert_columns()`` now requires an
+  additional ``returning_params`` argument.
 
 Miscellaneous
 -------------

--- a/tests/queries/test_db_returning.py
+++ b/tests/queries/test_db_returning.py
@@ -1,7 +1,7 @@
 import datetime
 
-from django.db import NotSupportedError, connection
-from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
+from django.db import connection
+from django.test import TestCase, skipUnlessDBFeature
 from django.test.utils import CaptureQueriesContext
 
 from .models import DumbCategory, NonIntegerPKReturningModel, ReturningModel
@@ -25,7 +25,6 @@ class ReturningValuesTests(TestCase):
         self.assertTrue(obj.created)
         self.assertIsInstance(obj.created, datetime.datetime)
 
-    @skipUnlessDBFeature('can_return_multiple_columns_from_insert')
     def test_insert_returning_multiple(self):
         with CaptureQueriesContext(connection) as captured_queries:
             obj = ReturningModel.objects.create()
@@ -42,19 +41,7 @@ class ReturningValuesTests(TestCase):
         self.assertTrue(obj.pk)
         self.assertIsInstance(obj.created, datetime.datetime)
 
-    @skipIfDBFeature('can_return_multiple_columns_from_insert')
-    def test_insert_returning_multiple_not_supported(self):
-        msg = (
-            'Returning multiple columns from INSERT statements is '
-            'not supported on this database backend.'
-        )
-        with self.assertRaisesMessage(NotSupportedError, msg):
-            ReturningModel.objects.create()
-
-    @skipUnlessDBFeature(
-        'can_return_rows_from_bulk_insert',
-        'can_return_multiple_columns_from_insert',
-    )
+    @skipUnlessDBFeature('can_return_rows_from_bulk_insert')
     def test_bulk_insert(self):
         objs = [ReturningModel(), ReturningModel(pk=2 ** 11), ReturningModel()]
         ReturningModel.objects.bulk_create(objs)


### PR DESCRIPTION
@felixxm this is that bit fixed `can_return_multiple_columns_from_insert` for Oracle.