### PR TITLE
Fixed #30769 -- Fixed a crash when filtering against a subquery JSON/HStoreField annotation.

### DIFF
--- a/django/contrib/postgres/fields/hstore.py
+++ b/django/contrib/postgres/fields/hstore.py
@@ -86,7 +86,7 @@ class KeyTransform(Transform):
 
     def as_sql(self, compiler, connection):
         lhs, params = compiler.compile(self.lhs)
-        return '(%s -> %%s)' % lhs, params + [self.key_name]
+        return '(%s -> %%s)' % lhs, tuple(params) + (self.key_name,)
 
 
 class KeyTransformFactory:

--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -112,7 +112,7 @@ class KeyTransform(Transform):
             lookup = int(self.key_name)
         except ValueError:
             lookup = self.key_name
-        return '(%s %s %%s)' % (lhs, self.operator), params + [lookup]
+        return '(%s %s %%s)' % (lhs, self.operator), tuple(params) + (lookup,)
 
 
 class KeyTextTransform(KeyTransform):

--- a/docs/releases/1.11.25.txt
+++ b/docs/releases/1.11.25.txt
@@ -9,4 +9,6 @@ Django 1.11.25 fixes a regression in 1.11.23.
 Bugfixes
 ========
 
-* ...
+* Fixed a crash when filtering with a ``Subquery()`` annotation of a queryset
+  containing :class:`~django.contrib.postgres.fields.JSONField` or
+  :class:`~django.contrib.postgres.fields.HStoreField` (:ticket:`30769`).

--- a/docs/releases/2.1.13.txt
+++ b/docs/releases/2.1.13.txt
@@ -9,4 +9,6 @@ Django 2.1.13 fixes a regression in 2.1.11.
 Bugfixes
 ========
 
-* ...
+* Fixed a crash when filtering with a ``Subquery()`` annotation of a queryset
+  containing :class:`~django.contrib.postgres.fields.JSONField` or
+  :class:`~django.contrib.postgres.fields.HStoreField` (:ticket:`30769`).

--- a/docs/releases/2.2.6.txt
+++ b/docs/releases/2.2.6.txt
@@ -11,3 +11,8 @@ Bugfixes
 
 * Fixed migrations crash on SQLite when altering a model containing partial
   indexes (:ticket:`30754`).
+
+* Fixed a regression in Django 2.2.4 that caused a crash when filtering with a
+  ``Subquery()`` annotation of a queryset containing
+  :class:`~django.contrib.postgres.fields.JSONField` or
+  :class:`~django.contrib.postgres.fields.HStoreField` (:ticket:`30769`).


### PR DESCRIPTION
This was a regression introduced by 7deeabc7c7526786df6894429ce89a9c4b614086 to address CVE-2019-14234.

Thanks Tim Kleinschmidt for the report and Mariusz for the tests.

---

@felixxm I guess we should backport down to 1.11.x?