### PR TITLE
Fixed #30732 -- Doc'd that SameSite cookies flags can affect xframe_options_exempt.

### DIFF
--- a/docs/ref/clickjacking.txt
+++ b/docs/ref/clickjacking.txt
@@ -88,6 +88,11 @@ that tells the middleware not to set the header::
     def ok_to_load_in_a_frame(request):
         return HttpResponse("This page is safe to load in a frame on any site.")
 
+.. note::
+
+    If you want to submit a form or access a session cookie within a frame or
+    iframe, you may need to modify the :setting:`CSRF_COOKIE_SAMESITE` or
+    :setting:`SESSION_COOKIE_SAMESITE` settings.
 
 Setting ``X-Frame-Options`` per view
 ------------------------------------


### PR DESCRIPTION
Added note for CSRF_COOKIE_SAMESITE and SESSION_COOKIE_SAMESITE
below the xframe_options_exempt of the clickjacking guide.