### PR TITLE
Documentation updates: Sites reference and assertNumQueries().

### DIFF
--- a/docs/ref/contrib/sites.txt
+++ b/docs/ref/contrib/sites.txt
@@ -47,11 +47,10 @@ Why would you use sites? It's best explained through examples.
 Associating content with multiple sites
 ---------------------------------------
 
-The Django-powered sites LJWorld.com_ and Lawrence.com_ are operated by the
-same news organization -- the Lawrence Journal-World newspaper in Lawrence,
-Kansas. LJWorld.com focuses on news, while Lawrence.com focuses on local
-entertainment. But sometimes editors want to publish an article on *both*
-sites.
+The LJWorld.com_ and Lawrence.com_ sites are operated by the same news
+organization -- the Lawrence Journal-World newspaper in Lawrence, Kansas.
+LJWorld.com focused on news, while Lawrence.com focused on local entertainment.
+But sometimes editors wanted to publish an article on *both* sites.
 
 The naive way of solving the problem would be to require site producers to
 publish the same story twice: once for LJWorld.com and again for Lawrence.com.

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1675,9 +1675,12 @@ your test suite.
     ``num`` database queries are executed.
 
     If a ``"using"`` key is present in ``kwargs`` it is used as the database
-    alias for which to check the number of queries.  If you wish to call a
-    function with a ``using`` parameter you can do it by wrapping the call with
-    a ``lambda`` to add an extra parameter::
+    alias for which to check the number of queries::
+
+        self.assertNumQueries(7, using='non_default_db')
+
+    If you wish to call a function with a ``using`` parameter you can do it by
+    wrapping the call with a ``lambda`` to add an extra parameter::
 
         self.assertNumQueries(7, lambda: my_function(using=7))
 


### PR DESCRIPTION
This PR contains two documentation updates. 

1. To address the request here: https://github.com/django/django/pull/11667 -- my goal is minimal changes while still keep the good example in place. 
2. Hopefully make the `assertNumQueries` be more obvious that you can pass `using` as a kwarg. I got confused when I read the docs and the example talked about the `lambda` for the `call`.