### PR TITLE
Changed 'using either one of' to 'using one of'

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1921,7 +1921,7 @@ Examples::
 Note that command options that take no arguments are passed as keywords
 with ``True`` or ``False``, as you can see with the ``interactive`` option above.
 
-Named arguments can be passed by using either one of the following syntaxes::
+Named arguments can be passed by using one of the following syntaxes::
 
       # Similar to the command line
       management.call_command('dumpdata', '--natural-foreign')


### PR DESCRIPTION
Changed "Named arguments can be passed by using either one of the following syntaxes::
" to "Named arguments can be passed by using one of the following syntaxes::
"