### PR TITLE
Fixed #30771 -- Fixed Exact lookup so GROUP BY works in subquery.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -384,6 +384,7 @@ answer newbie questions, and generally made Django that much better:
     James Bennett <james@b-list.org>
     James Murty
     James Tauber <jtauber@jtauber.com>
+    James Timmins <jameshtimmins@gmail.com>
     James Wheare <django@sparemint.com>
     Jannis Leidel <jannis@leidel.info>
     Janos Guljas

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -262,9 +262,9 @@ class Exact(FieldGetDbPrepValueMixin, BuiltinLookup):
         from django.db.models.sql.query import Query
         if isinstance(self.rhs, Query):
             if self.rhs.has_limit_one():
-                # The subquery must select only the pk.
-                self.rhs.clear_select_clause()
-                self.rhs.add_fields(['pk'])
+                if not getattr(self.rhs, 'has_select_fields', True):
+                    self.rhs.clear_select_clause()
+                    self.rhs.add_fields(['pk'])
             else:
                 raise ValueError(
                     'The QuerySet value for an exact lookup must be limited to '


### PR DESCRIPTION
Added check in Exact class to use pre-existing select fields (and thereby GROUP BY fields) from subquery if they were specified, instead of always defaulting to pk

Thanks Aur Saraf for the report and Simon Charette for guidance.