### PR TITLE
Fixed #30786 -- Used CONVERT_TZ to check if the time zone definitions are installed on MySQL.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -69,10 +69,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     @cached_property
     def has_zoneinfo_database(self):
-        # Test if the time zone definitions are installed.
+        # Test if the time zone definitions are installed. CONVERT_TZ returns
+        # NULL if 'UTC' timezone isn't loaded into the mysql.time_zone.
         with self.connection.cursor() as cursor:
-            cursor.execute("SELECT 1 FROM mysql.time_zone LIMIT 1")
-            return cursor.fetchone() is not None
+            cursor.execute("SELECT CONVERT_TZ('2001-01-01 01:00:00', 'UTC', 'UTC')")
+            return cursor.fetchone()[0] is not None
 
     @cached_property
     def is_sql_auto_is_null_enabled(self):


### PR DESCRIPTION
Replaced a timezone check in the MySQL backend with one that
doesn't require access to the mysql.time_zone database and more
closely aligns with Django's usage of the timezone info.