### PR TITLE
Removed uneeded if-condition in BaseExpression.flatten.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -371,8 +371,7 @@ class BaseExpression:
         """
         yield self
         for expr in self.get_source_expressions():
-            if expr:
-                yield from expr.flatten()
+            yield from expr.flatten()
 
     def select_format(self, compiler, sql, params):
         """


### PR DESCRIPTION
I believe that due to `Value(arg)` in https://github.com/django/django/blob/master/django/db/models/expressions.py#L184 the `if`-condition is unnecessary. I found it by going through the coverage report.