### PR TITLE
Ref #30790 -- fixes a bug with `autocomplete_fields`

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -186,7 +186,7 @@ class BaseModelAdminChecks:
                         id='admin.E039',
                     )
                 ]
-            elif not related_admin.search_fields:
+            elif not related_admin.search_fields and not related_admin.get_search_fields(None):
                 return [
                     checks.Error(
                         '%s must define "search_fields", because it\'s '


### PR DESCRIPTION
When `search_fields` is not defined but `get_search_fields` is the `autocomplete_fields` feature fails this check. This commit should fix that.

https://code.djangoproject.com/ticket/30790#ticket