### PR TITLE
Add SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+Please see our [full security policies](https://docs.djangoproject.com/en/dev/internals/security/) for more details.
+
+## Reporting a Vulnerability
+
+**Please report security issues by emailing security@djangoproject.com**.
+
+Once you’ve submitted an issue via email, you should receive an acknowledgment from a member of the security team within 48 hours, and depending on the action to be taken, you may receive further followup emails.
+
+If you want to send an encrypted email (optional), the public key ID for security@djangoproject.com is 0xfcb84b8d1d17f80b, and this public key is available from most commonly-used keyservers.
+
+## Supported Versions
+
+At any given time, the Django team provides official security support for several versions of Django:
+
+* The master development branch, hosted on GitHub, which will become the next major release of Django, receives security support. Security issues that only affect the master development branch and not any stable released versions are fixed in public without going through the disclosure process.
+* The two most recent Django release series receive security support. For example, during the development cycle leading to the release of Django 1.5, support will be provided for Django 1.4 and Django 1.3. Upon the release of Django 1.5, Django 1.3’s security support will end.
+* Long-term support releases will receive security updates for a specified period.
+
+When new releases are issued for security reasons, the accompanying notice will include a list of affected versions. This list is comprised solely of supported versions of Django: older versions may also be affected, but we do not investigate to determine that, and will not issue patches or new releases for those versions.


### PR DESCRIPTION
### Summary

Adds a `SECURITY.md` file that GitHub will pick up and link to from a tooltip when users are creating their first issue. [See an example on nodejs/nodejs](https://github.com/nodejs/node/issues/new).

Fixes https://code.djangoproject.com/ticket/30793.

### Other Information

I've duplicated the content here from https://docs.djangoproject.com/en/dev/internals/security/.