### PR TITLE
Fixed false positive tests of Paginator.count property.

### DIFF
--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -156,7 +156,7 @@ class PaginationTests(SimpleTestCase):
                 raise AttributeError('abc')
 
         with self.assertRaisesMessage(AttributeError, 'abc'):
-            Paginator(AttributeErrorContainer(), 10).count()
+            Paginator(AttributeErrorContainer(), 10).count
 
     def test_count_does_not_silence_type_error(self):
         class TypeErrorContainer:
@@ -164,7 +164,7 @@ class PaginationTests(SimpleTestCase):
                 raise TypeError('abc')
 
         with self.assertRaisesMessage(TypeError, 'abc'):
-            Paginator(TypeErrorContainer(), 10).count()
+            Paginator(TypeErrorContainer(), 10).count
 
     def check_indexes(self, params, page_num, indexes):
         """


### PR DESCRIPTION
Those two invocations generate false-positives on django-stubs test suite. They make no difference for Django itself, as exception is raised before attempting to call an integer. But technically, they are incorrect. 