### PR TITLE
Fixed #30803 -- Allowed comma separators for miliseconds in parse_datetime(), parse_time() and parse_duration().

### DIFF
--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -16,13 +16,13 @@ date_re = re.compile(
 
 time_re = re.compile(
     r'(?P<hour>\d{1,2}):(?P<minute>\d{1,2})'
-    r'(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?'
+    r'(?::(?P<second>\d{1,2})(?:[\.,](?P<microsecond>\d{1,6})\d{0,6})?)?'
 )
 
 datetime_re = re.compile(
     r'(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})'
     r'[T ](?P<hour>\d{1,2}):(?P<minute>\d{1,2})'
-    r'(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?'
+    r'(?::(?P<second>\d{1,2})(?:[\.,](?P<microsecond>\d{1,6})\d{0,6})?)?'
     r'(?P<tzinfo>Z|[+-]\d{2}(?::?\d{2})?)?$'
 )
 
@@ -33,7 +33,7 @@ standard_duration_re = re.compile(
     r'((?:(?P<hours>\d+):)(?=\d+:\d+))?'
     r'(?:(?P<minutes>\d+):)?'
     r'(?P<seconds>\d+)'
-    r'(?:\.(?P<microseconds>\d{1,6})\d{0,6})?'
+    r'(?:[\.,](?P<microseconds>\d{1,6})\d{0,6})?'
     r'$'
 )
 

--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -23,6 +23,7 @@ class DateParseTests(unittest.TestCase):
         self.assertEqual(parse_time('09:15:00'), time(9, 15))
         self.assertEqual(parse_time('10:10'), time(10, 10))
         self.assertEqual(parse_time('10:20:30.400'), time(10, 20, 30, 400000))
+        self.assertEqual(parse_time('10:20:30,400'), time(10, 20, 30, 400000))
         self.assertEqual(parse_time('4:8:16'), time(4, 8, 16))
         # Invalid inputs
         self.assertIsNone(parse_time('091500'))
@@ -38,6 +39,7 @@ class DateParseTests(unittest.TestCase):
             ('2012-04-23T10:20:30.400+02:30', datetime(2012, 4, 23, 10, 20, 30, 400000, get_fixed_timezone(150))),
             ('2012-04-23T10:20:30.400+02', datetime(2012, 4, 23, 10, 20, 30, 400000, get_fixed_timezone(120))),
             ('2012-04-23T10:20:30.400-02', datetime(2012, 4, 23, 10, 20, 30, 400000, get_fixed_timezone(-120))),
+            ('2012-04-23T10:20:30,400-02', datetime(2012, 4, 23, 10, 20, 30, 400000, get_fixed_timezone(-120))),
         )
         for source, expected in valid_inputs:
             with self.subTest(source=source):


### PR DESCRIPTION
ISO 8601:2004 states that parsers should support both delineators, with a preference for commas.

https://www.iso.org/standard/40874.html

A decimal mark, either a comma or a dot (without any preference as stated in resolution 10 of the 22nd General Conference CGPM in 2003,[16] but with a preference for a comma according to ISO 8601:2004)


Trac issue https://code.djangoproject.com/ticket/30803#ticket