### PR TITLE
FIX django jet integration

### DIFF
--- a/django/contrib/gis/templates/gis/admin/openlayers.html
+++ b/django/contrib/gis/templates/gis/admin/openlayers.html
@@ -36,5 +36,5 @@
 {% endif %}
 {% if display_wkt %}<p>{% trans "WKT debugging window:" %} </p>{% endif %}
 <textarea id="{{ id }}" class="vWKTField required" cols="150" rows="10" name="{{ name }}">{{ wkt }}</textarea>
-<script type="text/javascript">{% block init_function %}{{ module }}.init();{% endblock %}</script>
+<script type="text/javascript">{% block init_function %}jQuery(document).ready(function ($){{{ module }}.init();});{% endblock %}</script>
 </span>


### PR DESCRIPTION
Jet expects for jquery to be loaded and fails (from years)
https://github.com/geex-arts/django-jet/issues/148
This fixes the problem