### PR TITLE
Fixed #30216 -- Document BooleanField no longer blank=True in Django 2.1+

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -459,6 +459,10 @@ isn't defined.
     use :class:`NullBooleanField` instead. Using the latter is now discouraged
     as it's likely to be deprecated in a future version of Django.
 
+    In older versions, this field was ``blank=True`` implicitly. Now it is
+    ``blank=False`` as default. If you need the old behavior please add
+    ``blank=True``.
+
 ``CharField``
 -------------
 


### PR DESCRIPTION
The documentation for 2.1 already mentioned the null change, I just added the implicit blank=True there, to be explicit about it.