### PR TITLE
Fixed #30216 -- Document BooleanField no longer blank=True in Django …

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -583,6 +583,12 @@ or :class:`~django.forms.NullBooleanSelect` if :attr:`null=True <Field.null>`.
 The default value of ``BooleanField`` is ``None`` when :attr:`Field.default`
 isn't defined.
 
+.. versionchanged:: 2.1
+
+    In older versions (pre 2.1), this field was ``blank=True`` implicitly.
+    Now it is ``blank=False`` as default. If you need the old behavior please
+    add ``blank=True``.
+
 ``CharField``
 -------------
 


### PR DESCRIPTION
Changed de documentation to alert for this implicit behavior change.

reverted some lines from: 9b15ff08ba638a7070fb51c1ab4c01e245556ae8

Removing .. versionchanged:: 2.1, while there are people still migration from 1.11 to 2.2, can be dangerous. There should be a more cautious methodology. Or eventually, create a way to capture all the changes between two consecutive LTS.