### PR TITLE
Fixed #30810 -- Fixed WatchmanReloaderTests.test_setting_timeout_from_environment_variable test.

### DIFF
--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -651,7 +651,7 @@ class WatchmanReloaderTests(ReloaderTests, IntegrationTests):
 
     @mock.patch.dict(os.environ, {'DJANGO_WATCHMAN_TIMEOUT': '10'})
     def test_setting_timeout_from_environment_variable(self):
-        self.assertEqual(self.RELOADER_CLS.client_timeout, 10)
+        self.assertEqual(self.RELOADER_CLS().client_timeout, 10)
 
 
 @skipIf(on_macos_with_hfs(), "These tests do not work with HFS+ as a filesystem")


### PR DESCRIPTION
Please review https://code.djangoproject.com/ticket/30810

`client_timeout` is an instance attribute of the watchman reloader implementation.

The reason of creating a new instance instead of using the `self.reloader` one is the `setUp` tampering the `client_timeout` value.