### PR TITLE
Fixed #20601 - intcomma internationalization error

### DIFF
--- a/tests/humanize_tests/tests.py
+++ b/tests/humanize_tests/tests.py
@@ -115,9 +115,9 @@ class HumanizeTests(SimpleTestCase):
 
     def test_i18n_intcomma(self):
         test_list = (100, 1000, 10123, 10311, 1000000, 1234567.25,
-                     '100', '1000', '10123', '10311', '1000000', None)
+                     '100', '1000', '10123', '10311', '1000000', '1234567.25', None)
         result_list = ('100', '1.000', '10.123', '10.311', '1.000.000', '1.234.567,25',
-                       '100', '1.000', '10.123', '10.311', '1.000.000', None)
+                       '100', '1.000', '10.123', '10.311', '1.000.000', '1.234.567,25', None)
         with self.settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True):
             with translation.override('de'):
                 self.humanize_tester(test_list, result_list, 'intcomma')


### PR DESCRIPTION
Fixed regex transform to set appropriate THOUSAND_SEPARATOR and
DECIMAL_SEPARATOR for the given locale/language.
Added test case in 'test_i18n_intcomma'