### PR TITLE
Fixes #30806 by configuring OBJC_DISABLE_INITIALIZE_FORK_SAFETY

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ usedevelop = true
 passenv = DJANGO_SETTINGS_MODULE PYTHONPATH HOME DISPLAY
 setenv =
     PYTHONDONTWRITEBYTECODE=1
+    OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 deps =
     py{3,36,37}: -rtests/requirements/py3.txt
     postgres: -rtests/requirements/postgres.txt


### PR DESCRIPTION
MacOS OBJC default forking configuration causes tests to hang. This sets the env var under tox.