### PR TITLE
Fixed #30043 -- AdminURLFieldWidget incorrectly unquotes URLs e.g. containing %2F

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -8,7 +8,7 @@ from urllib.parse import (
     parse_qsl, quote, unquote, urlencode, urlsplit, urlunsplit,
 )
 
-from django.utils.encoding import punycode
+from django.utils.encoding import punycode, iri_to_uri
 from django.utils.functional import Promise, keep_lazy, keep_lazy_text
 from django.utils.http import RFC3986_GENDELIMS, RFC3986_SUBDELIMS
 from django.utils.safestring import SafeData, SafeString, mark_safe
@@ -197,6 +197,10 @@ def strip_spaces_between_tags(value):
 def smart_urlquote(url):
     """Quote a URL if it isn't already quoted."""
     def unquote_quote(segment):
+        # Special case where segment is already quoted on non-quotable character '/'
+        if '%2F' in segment:
+            return iri_to_uri(segment)
+
         segment = unquote(segment)
         # Tilde is part of RFC3986 Unreserved Characters
         # https://tools.ietf.org/html/rfc3986#section-2.3

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -188,6 +188,7 @@ class TestUtilsHtml(SimpleTestCase):
             ('http://example.com/?q=http%3A%2F%2Fexample.com%2F%3Fx%3D1%26q%3Ddjango',
              'http://example.com/?q=http%3A%2F%2Fexample.com%2F%3Fx%3D1%26q%3Ddjango'),
             ('http://.www.f oo.bar/', 'http://.www.f%20oo.bar/'),
+            ('%2F', '%2F')
         )
         # IDNs are properly quoted
         for value, output in items:


### PR DESCRIPTION
# What this does
Attempts to solve this by adding a check for this special case, and if this special case exists within the segment being quoted, the segment instead gets passed through the iri_to_uri function to properly ignore the `%2F` due to `iri_to_uri` adding the `%` to the "safe" characters. 

This issue arrises due to `/` being a safe character when encoded on the path, however when this has already been encoded on the path, the unquote would turn `%2F` into `/` which was undesirable according to this ticket:
https://code.djangoproject.com/ticket/30043