### PR TITLE
[2.2.x] Fixed #30216 -- Doc'd that BooleanField is no longer blank=True in Django 2.1.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -462,6 +462,10 @@ isn't defined.
     use :class:`NullBooleanField` instead. Using the latter is now discouraged
     as it's likely to be deprecated in a future version of Django.
 
+    In older versions, this field has :attr:`blank=True <Field.blank>`
+    implicitly. You can restore the previous behavior by setting
+    ``blank=True``.
+
 ``CharField``
 -------------
 


### PR DESCRIPTION
Changed de documentation to alert for this implicit behavior change.

Following the /pull/11831 comments