### PR TITLE
Refs #30597 -- Added a warning about dependent apps when unapplying migrations.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -805,6 +805,12 @@ The behavior of this command changes depending on the arguments provided:
   migrated past the named migration. Use the name ``zero`` to unapply all
   migrations for an app.
 
+.. warning::
+
+    When unapplying migrations, all dependent migrations will also be
+    unapplied, regardless of ``<app_label>``. You can use ``--plan`` to check
+    which migrations will be unapplied.
+
 .. django-admin-option:: --database DATABASE
 
 Specifies the database to migrate. Defaults to ``default``.


### PR DESCRIPTION
When unapplying a migration it could spread out to other dependent apps

following the comment in /pull/11821/