### PR TITLE
Fixed #25762 -- Refactored numberformat.format for speed

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -896,6 +896,7 @@ answer newbie questions, and generally made Django that much better:
     Tim Givois <tim.givois.mendez@gmail.com>
     Tim Graham <timograham@gmail.com>
     Tim Heap <tim@timheap.me>
+    Tim McCurrach <tim.mccurrach@gmail.com>
     Tim Saylor <tim.saylor@gmail.com>
     Tobias Kunze <rixx@cutebit.de>
     Tobias McNulty <https://www.caktusgroup.com/blog/>

--- a/django/utils/numberformat.py
+++ b/django/utils/numberformat.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 from django.conf import settings
-from django.utils.safestring import mark_safe
+from django.utils.safestring import SafeString
 
 
 def format(number, decimal_sep, decimal_pos=None, grouping=0, thousand_sep='',
@@ -18,46 +18,99 @@ def format(number, decimal_sep, decimal_pos=None, grouping=0, thousand_sep='',
         module in locale.localeconv() LC_NUMERIC grouping (e.g. (3, 2, 0)).
     * thousand_sep: Thousand separator symbol (for example ",")
     """
-    use_grouping = (use_l10n or (use_l10n is None and settings.USE_L10N)) and settings.USE_THOUSAND_SEPARATOR
-    use_grouping = use_grouping or force_grouping
-    use_grouping = use_grouping and grouping != 0
+    if force_grouping:
+        pass
+    elif not settings.USE_THOUSAND_SEPARATOR:
+        grouping = 0
+    elif use_l10n is False:
+        grouping = 0
+    elif use_l10n is None and not settings.USE_L10N:
+        grouping = 0
+
     # Make the common case fast
-    if isinstance(number, int) and not use_grouping and not decimal_pos:
-        return mark_safe(number)
-    # sign
-    sign = ''
-    # Treat potentially very large/small floats as Decimals.
-    if isinstance(number, float) and 'e' in str(number).lower():
-        number = Decimal(str(number))
+    if isinstance(number, int) and (grouping == 0 or grouping == 3):
+        return _format_int(number, decimal_sep, decimal_pos, thousand_sep, grouping)
+
+    # Handle Decimals
     if isinstance(number, Decimal):
+        return _format_dec(number, decimal_sep, decimal_pos, thousand_sep, grouping)
 
-        if decimal_pos is not None:
-            # If the provided number is too small to affect any of the visible
-            # decimal places, consider it equal to '0'.
-            cutoff = Decimal('0.' + '1'.rjust(decimal_pos, '0'))
-            if abs(number) < cutoff:
-                number = Decimal('0')
+    # Don't unnecessarily convert number to string for speed
+    if isinstance(number, str):
+        return _format_string(number, decimal_sep, decimal_pos, thousand_sep, grouping)
 
-        # Format values with more than 200 digits (an arbitrary cutoff) using
-        # scientific notation to avoid high memory usage in {:f}'.format().
-        _, digits, exponent = number.as_tuple()
-        if abs(exponent) + len(digits) > 200:
-            number = '{:e}'.format(number)
-            coefficient, exponent = number.split('e')
-            # Format the coefficient.
-            coefficient = format(
-                coefficient, decimal_sep, decimal_pos, grouping,
-                thousand_sep, force_grouping, use_l10n,
-            )
-            return '{}e{}'.format(coefficient, exponent)
-        else:
-            str_number = '{:f}'.format(number)
+    str_number = str(number)
+    # Treat potentially very large/small floats as Decimals.
+    if isinstance(number, float) and 'e' in str_number.lower():
+        return _format_dec(Decimal(str_number), decimal_sep, decimal_pos, thousand_sep, grouping)
+
+    # Format all other cases as a string
+    return _format_string(str_number, decimal_sep, decimal_pos, thousand_sep, grouping)
+
+
+def _format_int(number, decimal_sep, decimal_pos, thousand_sep, grouping):
+    """
+    Formats an integer, returning it as a string.
+
+    This function should only be used when grouping is 0 or 3. See
+    numberformat.format docstring for details about arguments.
+    """
+    if grouping and (number > 999 or number < -999):
+        # f'{number:,}' returns a string with a ',' as a thousand separator
+        number = f'{number:,}'.replace(',', thousand_sep)
     else:
-        str_number = str(number)
+        # It is unclear as to why this case should be marked safe, but
+        # we return SafeString here to avoid a change in functionality
+        # from the previous implementation of format.
+        number = SafeString(number)
+    if decimal_pos:
+        return number + decimal_sep + '0' * decimal_pos
+    return number
+
+
+def _format_dec(number, decimal_sep, decimal_pos, thousand_sep, grouping):
+    """
+    Gets a number as a Decimal instance, and formats it as a string.
+
+    See numberformat.format docstring for details about arguments.
+    """
+    if decimal_pos is not None:
+        # If the provided number is too small to affect any of the visible
+        # decimal places, consider it equal to '0'.
+        cutoff = Decimal('0.' + '1'.rjust(decimal_pos, '0'))
+        if abs(number) < cutoff:
+            if decimal_pos:
+                return '0' + decimal_sep + '0' * decimal_pos
+            return '0'
+    # Format values with more than 200 digits (an arbitrary cutoff) using
+    # scientific notation to avoid high memory usage in {:f}'.format().
+    _, digits, exponent = number.as_tuple()
+    if abs(exponent) + len(digits) > 200:
+        number = f'{number:e}'
+        coefficient, exponent = number.split('e')
+        # Format the coefficient.
+        coefficient = _format_string(
+            coefficient, decimal_sep, decimal_pos,
+            thousand_sep, grouping,
+        )
+        return f'{coefficient}e{exponent}'
+
+    number = f'{number:f}'
+    return _format_string(number, decimal_sep, decimal_pos, thousand_sep, grouping)
+
+
+def _format_string(str_number, decimal_sep, decimal_pos, thousand_sep, grouping):
+    """
+    Gets a number as a string, and formats it as a string.
+
+    See numberformat.format docstring for details about arguments.
+    """
+    sign = ''
     if str_number[0] == '-':
         sign = '-'
         str_number = str_number[1:]
-    # decimal part
+
+    # Get int_part, and dec_part
     if '.' in str_number:
         int_part, dec_part = str_number.split('.')
         if decimal_pos is not None:
@@ -67,8 +120,14 @@ def format(number, decimal_sep, decimal_pos=None, grouping=0, thousand_sep='',
     if decimal_pos is not None:
         dec_part = dec_part + ('0' * (decimal_pos - len(dec_part)))
     dec_part = dec_part and decimal_sep + dec_part
+
     # grouping
-    if use_grouping:
+    if grouping == 3:
+        # Use builtins.format where we can for speed.
+        int_part = f'{int(int_part):,}'
+        if thousand_sep != ',':
+            int_part = int_part.replace(',', thousand_sep)
+    elif grouping:
         try:
             # if grouping is a sequence
             intervals = list(grouping)

--- a/tests/utils_tests/test_numberformat.py
+++ b/tests/utils_tests/test_numberformat.py
@@ -1,35 +1,147 @@
 from decimal import Decimal
 from sys import float_info
+from unittest import mock
 
 from django.test import SimpleTestCase
-from django.utils.numberformat import format as nformat
+from django.utils.numberformat import (
+    _format_dec, _format_int, _format_string, format as nformat,
+)
 
 
+class EuroDecimal(Decimal):
+    """
+    Wrapper for Decimal which prefixes each amount with the € symbol.
+    """
+    def __format__(self, specifier, **kwargs):
+        amount = super().__format__(specifier, **kwargs)
+        return '€ {}'.format(amount)
+
+
+@mock.patch("django.utils.numberformat._format_string")
+@mock.patch("django.utils.numberformat._format_dec")
+@mock.patch("django.utils.numberformat._format_int")
 class TestNumberFormat(SimpleTestCase):
+    def test_grouping_behaviour(self, mock_f_int, mock_f_dec, mock_f_string):
+        tests = [
+            (   # use_l10n should over-write settings.USE_L10N(True)
+                {"use_l10n": False},
+                {"USE_THOUSAND_SEPARATOR": True, "USE_L10N": True},
+                0
+            ),
+            (   # When use_l10n is None, settings.USE_L10N(True) should be used
+                {},
+                {"USE_THOUSAND_SEPARATOR": True, "USE_L10N": True},
+                3
+            ),
+            (   # force_grouping takes precedence over use_l10n
+                {"use_l10n": False, "force_grouping": True},
+                {"USE_THOUSAND_SEPARATOR": True, "USE_L10N": True},
+                3
+            ),
+            (   # use_l10n should over-write settings.USE_L10N(False)
+                {"use_l10n": True},
+                {"USE_THOUSAND_SEPARATOR": True, "USE_L10N": False},
+                3
+            ),
+            (   # When use_l10n == None, settings.USE_L10N(False) should be used
+                {},
+                {"USE_THOUSAND_SEPARATOR": True, "USE_L10N": False},
+                0
+            ),
+            (   # settings.USE_THOUSAND_SEPARATOR takes precedence over use_l10n
+                {"use_l10n": True},
+                {"USE_THOUSAND_SEPARATOR": False, "USE_L10N": True},
+                0
+            ),
+            (   # settings.USE_THOUSAND_SEPARATOR takes precedence over settings.USE_L10N
+                {},
+                {"USE_THOUSAND_SEPARATOR": False, "USE_L10N": True},
+                0
+            ),
+            (   # force_grouping takes precedence over settings.USE_THOUSAND_SEPARATOR
+                {"force_grouping": True},
+                {"USE_THOUSAND_SEPARATOR": False, "USE_L10N": True},
+                3
+            ),
+        ]
 
-    def test_format_number(self):
-        self.assertEqual(nformat(1234, '.'), '1234')
-        self.assertEqual(nformat(1234.2, '.'), '1234.2')
-        self.assertEqual(nformat(1234, '.', decimal_pos=2), '1234.00')
-        self.assertEqual(nformat(1234, '.', grouping=2, thousand_sep=','), '1234')
-        self.assertEqual(nformat(1234, '.', grouping=2, thousand_sep=',', force_grouping=True), '12,34')
-        self.assertEqual(nformat(-1234.33, '.', decimal_pos=1), '-1234.3')
-        # The use_l10n parameter can force thousand grouping behavior.
-        with self.settings(USE_THOUSAND_SEPARATOR=True, USE_L10N=True):
-            self.assertEqual(nformat(1234, '.', grouping=3, thousand_sep=',', use_l10n=False), '1234')
-        with self.settings(USE_THOUSAND_SEPARATOR=True, USE_L10N=False):
-            self.assertEqual(nformat(1234, '.', grouping=3, thousand_sep=',', use_l10n=True), '1,234')
+        for [args, settings, expected] in tests:
+            with self.settings(**settings):
+                with self.subTest(settings=settings):
+                    nformat(1234, ".", grouping=3, **args)
+                    mock_f_int.assert_called_once_with(1234, ".", None, "", expected)
+                    mock_f_int.reset_mock()
 
-    def test_format_string(self):
-        self.assertEqual(nformat('1234', '.'), '1234')
-        self.assertEqual(nformat('1234.2', '.'), '1234.2')
-        self.assertEqual(nformat('1234', '.', decimal_pos=2), '1234.00')
-        self.assertEqual(nformat('1234', '.', grouping=2, thousand_sep=','), '1234')
-        self.assertEqual(nformat('1234', '.', grouping=2, thousand_sep=',', force_grouping=True), '12,34')
-        self.assertEqual(nformat('-1234.33', '.', decimal_pos=1), '-1234.3')
-        self.assertEqual(nformat('10000', '.', grouping=3, thousand_sep='comma', force_grouping=True), '10comma000')
+                    nformat('1234', ".", grouping=3, **args)
+                    mock_f_string.assert_called_once_with('1234', ".", None, "", expected)
+                    mock_f_string.reset_mock()
 
-    def test_large_number(self):
+                    nformat(Decimal(1234), ".", grouping=3, **args)
+                    mock_f_dec.assert_called_once_with(Decimal(1234), ".", None, "", expected)
+                    mock_f_dec.reset_mock()
+
+    def test_types_are_handled_correctly(self, mock_f_int, mock_f_dec, mock_f_string):
+        """
+        Test that the correct sub-function is called for different types.
+        """
+        tests = [
+            (123, mock_f_int, 123),
+            ("123", mock_f_string, "123"),
+            (Decimal(123), mock_f_dec, Decimal(123)),
+            (123.45, mock_f_string, "123.45"),
+            (EuroDecimal(123.45), mock_f_dec, EuroDecimal(123.45)),
+            (9e-19, mock_f_dec, Decimal('9e-19')),                # Very Small Floats
+            (0.000001, mock_f_dec, Decimal("1e-6")),
+            (1E16, mock_f_dec, Decimal("1E16")),                  # Very Large Floats
+            (100000000000000000000.0, mock_f_dec, Decimal('1e+20')),
+            # A float without a fractional part (3.) results in a ".0" when no
+            # decimal_pos is given. Contrast that with the Decimal('3.') case
+            # in test_decimal_numbers which doesn't return a fractional part.
+            (3., mock_f_string, "3.0"),
+
+
+        ]
+        for [number, expected_func, expected_arg] in tests:
+            with self.subTest(number=number):
+                nformat(number, ".")
+                expected_func.assert_called_once_with(expected_arg, ".", None, "", 0)
+                expected_func.reset_mock()
+
+        # When grouping is not 0 or 3, integers should be converted to strings
+        nformat(123, ".", grouping=3, force_grouping=True)
+        mock_f_int.assert_called_once_with(123, ".", None, "", 3)
+        mock_f_int.reset_mock()
+        nformat(123, ".", grouping=2, force_grouping=True)
+        mock_f_string.assert_called_once_with('123', ".", None, "", 2)
+        mock_f_string.reset_mock()
+        nformat(123, ".", grouping=(1, 2), force_grouping=True)
+        mock_f_string.assert_called_once_with('123', ".", None, "", (1, 2))
+        mock_f_string.reset_mock()
+
+
+class TestNumberFormatInt(SimpleTestCase):
+    def test_integers(self):
+        tests = [
+            (123, ".", None, "", 0, '123'),                    # Default
+            (123456789, ".", None, ", ", 3, '123, 456, 789'),  # With Grouping (3s)
+            (123456789, ".", None, "*", 3, '123*456*789'),     # With '*' as thousand_sep
+            (123456789, ".", None, "", 3, '123456789'),        # With empty string thousand_sep
+            (123456, ".", 0, "", 0, '123456'),                 # With 0 decimal places
+            (123456, ".", 2, "", 0, '123456.00'),              # With 2 decimal places
+            (123456, ", ", 2, "", 0, '123456, 00'),            # With ', ' as decimal_sep
+            (123456, ".", 2, ", ", 3, '123, 456.00'),          # With 2 decimal places and grouping
+            (-123, ".", None, "", 0, '-123'),                  # Negative number
+            (-123456, ".", None, ", ", 3, '-123, 456'),        # Negative number with grouping
+            (0, ".", 5, ", ", 3, '0.00000')                    # 0 with decimals and grouping
+        ]
+        for [number, *other_args, expected_value] in tests:
+            with self.subTest(value=number):
+                self.assertEqual(
+                    _format_int(number, *other_args),
+                    expected_value
+                )
+
+    def test_large_integers(self):
         most_max = (
             '{}179769313486231570814527423731704356798070567525844996'
             '598917476803157260780028538760589558632766878171540458953'
@@ -39,68 +151,56 @@ class TestNumberFormat(SimpleTestCase):
             '29988125040402618412485836{}'
         )
         most_max2 = (
-            '{}35953862697246314162905484746340871359614113505168999'
-            '31978349536063145215600570775211791172655337563430809179'
-            '07028764928468642653778928365536935093407075033972099821'
-            '15310256415249098018077865788815173701691026788460916647'
-            '38064458963316171186642466965495956524082894463374763543'
-            '61838599762500808052368249716736'
+            '{}359, 538, 626, 972, 463, 141, 629, 054, 847, 463, 408, 713, 596, 141, '
+            '135, 051, 689, 993, 197, 834, 953, 606, 314, 521, 560, 057, 077, 521, 179, '
+            '117, 265, 533, 756, 343, 080, 917, 907, 028, 764, 928, 468, 642, 653, 778, '
+            '928, 365, 536, 935, 093, 407, 075, 033, 972, 099, 821, 153, 102, 564, 152, '
+            '490, 980, 180, 778, 657, 888, 151, 737, 016, 910, 267, 884, 609, 166, 473, '
+            '806, 445, 896, 331, 617, 118, 664, 246, 696, 549, 595, 652, 408, 289, 446, '
+            '337, 476, 354, 361, 838, 599, 762, 500, 808, 052, 368, 249, 716, 736{}'
         )
+
         int_max = int(float_info.max)
-        self.assertEqual(nformat(int_max, '.'), most_max.format('', '8'))
-        self.assertEqual(nformat(int_max + 1, '.'), most_max.format('', '9'))
-        self.assertEqual(nformat(int_max * 2, '.'), most_max2.format(''))
-        self.assertEqual(nformat(0 - int_max, '.'), most_max.format('-', '8'))
-        self.assertEqual(nformat(-1 - int_max, '.'), most_max.format('-', '9'))
-        self.assertEqual(nformat(-2 * int_max, '.'), most_max2.format('-'))
 
-    def test_float_numbers(self):
         tests = [
-            (9e-10, 10, '0.0000000009'),
-            (9e-19, 2, '0.00'),
-            (.00000000000099, 0, '0'),
-            (.00000000000099, 13, '0.0000000000009'),
-            (1e16, None, '10000000000000000'),
-            (1e16, 2, '10000000000000000.00'),
-            # A float without a fractional part (3.) results in a ".0" when no
-            # decimal_pos is given. Contrast that with the Decimal('3.') case
-            # in test_decimal_numbers which doesn't return a fractional part.
-            (3., None, '3.0'),
+            (int_max, '.', None, ', ', 0, most_max.format('', '8')),        # Default
+            (int_max + 1, '.', 2, ', ', 0, most_max.format('', '9.00')),    # 2 decimal places
+            (int_max * 2, '.', None, ', ', 3, most_max2.format('', '')),    # Grouping (3s)
+            (-1 * int_max, '.', None, ', ', 0, most_max.format('-', '8')),  # Negative number
+            (-1 - int_max, '.', 2, ', ', 0, most_max.format('-', '9.00')),  # Negative number with 2 decimal places
+            (-2 * int_max, '.', 2, ', ', 3, most_max2.format('-', '.00'))   # Negative, grouping with decimals
         ]
-        for value, decimal_pos, expected_value in tests:
-            with self.subTest(value=value, decimal_pos=decimal_pos):
-                self.assertEqual(nformat(value, '.', decimal_pos), expected_value)
-        # Thousand grouping behavior.
-        self.assertEqual(
-            nformat(1e16, '.', thousand_sep=',', grouping=3, force_grouping=True),
-            '10,000,000,000,000,000',
-        )
-        self.assertEqual(
-            nformat(1e16, '.', decimal_pos=2, thousand_sep=',', grouping=3, force_grouping=True),
-            '10,000,000,000,000,000.00',
-        )
+        for [number, *other_args, expected_value] in tests:
+            with self.subTest(value=number):
+                self.assertEqual(
+                    _format_int(number, *other_args),
+                    expected_value
+                )
 
-    def test_decimal_numbers(self):
-        self.assertEqual(nformat(Decimal('1234'), '.'), '1234')
-        self.assertEqual(nformat(Decimal('1234.2'), '.'), '1234.2')
-        self.assertEqual(nformat(Decimal('1234'), '.', decimal_pos=2), '1234.00')
-        self.assertEqual(nformat(Decimal('1234'), '.', grouping=2, thousand_sep=','), '1234')
-        self.assertEqual(nformat(Decimal('1234'), '.', grouping=2, thousand_sep=',', force_grouping=True), '12,34')
-        self.assertEqual(nformat(Decimal('-1234.33'), '.', decimal_pos=1), '-1234.3')
-        self.assertEqual(nformat(Decimal('0.00000001'), '.', decimal_pos=8), '0.00000001')
-        self.assertEqual(nformat(Decimal('9e-19'), '.', decimal_pos=2), '0.00')
-        self.assertEqual(nformat(Decimal('.00000000000099'), '.', decimal_pos=0), '0')
-        self.assertEqual(
-            nformat(Decimal('1e16'), '.', thousand_sep=',', grouping=3, force_grouping=True),
-            '10,000,000,000,000,000'
-        )
-        self.assertEqual(
-            nformat(Decimal('1e16'), '.', decimal_pos=2, thousand_sep=',', grouping=3, force_grouping=True),
-            '10,000,000,000,000,000.00'
-        )
-        self.assertEqual(nformat(Decimal('3.'), '.'), '3')
-        self.assertEqual(nformat(Decimal('3.0'), '.'), '3.0')
-        # Very large & small numbers.
+
+class TestNumberFormatDec(SimpleTestCase):
+    def test_decimals(self):
+        tests = [
+            ('1234', '.', None, "", 0, '1234'),                           # Integer
+            ('1234.2', '.', None, " ", 0, '1234.2'),                      # With decimal
+            ('1234', '.', 2, ", ", 0, '1234.00'),                         # dec_pos specified
+            ('12345', ".", 2, ", ", 2, "1, 23, 45.00"),                   # dec_pos specified, and grouping
+            ('-1234.56', ', ', 1, 0, "", "-1234, 5"),                     # Negative
+            ('9e-19', ".", 2, "", 3, "0.00"),                             # Small number with dec_pos
+            ('0.0000099', ".", 0, "", 3, "0"),                            # Small number with dec_pos == 0
+            ('1e16', ".", None, ", ", 3, '10, 000, 000, 000, 000, 000'),  # Grouping with large number
+            ('1e13', ".", 2, ", ", 3, '10, 000, 000, 000, 000.00'),       # Grouping and decimals with large number
+            ('3.', '.', None, "", 0, "3"),                                # With trailing decimal
+            ('3.0', '.', None, "", 0, "3.0"),                             # With trailing 0
+        ]
+        for [number, *other_args, expected_value] in tests:
+            with self.subTest(value=number):
+                self.assertEqual(
+                    _format_dec(Decimal(number), *other_args),
+                    expected_value
+                )
+
+    def test_very_large_and_small_decimals(self):
         tests = [
             ('9e9999', None, '9e+9999'),
             ('9e9999', 3, '9.000e+9999'),
@@ -118,16 +218,47 @@ class TestNumberFormat(SimpleTestCase):
         ]
         for value, decimal_pos, expected_value in tests:
             with self.subTest(value=value):
-                self.assertEqual(nformat(Decimal(value), '.', decimal_pos), expected_value)
+                self.assertEqual(
+                    _format_dec(Decimal(value), '.', decimal_pos, "", 0),
+                    expected_value
+                )
 
     def test_decimal_subclass(self):
-        class EuroDecimal(Decimal):
-            """
-            Wrapper for Decimal which prefixes each amount with the € symbol.
-            """
-            def __format__(self, specifier, **kwargs):
-                amount = super().__format__(specifier, **kwargs)
-                return '€ {}'.format(amount)
-
         price = EuroDecimal('1.23')
-        self.assertEqual(nformat(price, ','), '€ 1,23')
+        self.assertEqual(_format_dec(price, ', ', None, "", 0), '€ 1, 23')
+
+
+class TestNumberFormatString(SimpleTestCase):
+    def test_strings(self):
+        tests = [
+            ('123.23', ".", None, "", 0, '123.23'),               # Default
+            ('123456789', ".", None, ", ", 3, '123, 456, 789'),   # With Grouping (3s)
+            ('123456789.0', ".", None, "*", 3, '123*456*789.0'),  # With '*' as thousand_sep
+            ('123456789', ".", None, "", 3, '123456789'),         # With empty string thousand_sep
+            ('123456.99', ".", 0, "", 0, '123456'),               # With 0 decimal places
+            ('123456.009', ".", 2, "", 0, '123456.00'),           # With 2 decimal places
+            ('123456', ", ", 2, "", 0, '123456, 00'),             # With ', ' as decimal_sep
+            ('123456.2', ".", 4, ", ", 3, '123, 456.2000'),       # With 4 decimal places and grouping
+            ('-123.0', ".", None, "", 0, '-123.0'),               # Negative number
+            ('-123456', ".", None, ", ", 2, '-12, 34, 56'),       # Negative number with grouping (2s)
+            ('0', ".", 5, ", ", 3, '0.00000')                     # 0 with decimals and grouping
+        ]
+        for [number, *other_args, expected_value] in tests:
+            with self.subTest(value=number):
+                self.assertEqual(
+                    _format_string(number, *other_args),
+                    expected_value
+                )
+
+    def test_string_tuple_groupings(self):
+        tests = [
+            ("123456789", ".", None, ", ", (3, ), '123, 456, 789'),
+            ("123456789", ".", None, ", ", (3, 2), '12, 34, 56, 789'),
+            ("56789123456789", ".", None, ", ", (3, 5, 1), '5, 6, 7, 8, 9, 1, 23456, 789')
+        ]
+        for [number, *other_args, expected_value] in tests:
+            with self.subTest(value=number):
+                self.assertEqual(
+                    _format_string(number, *other_args),
+                    expected_value
+                )


### PR DESCRIPTION
Optimises `numberformat.format` by utilising the bult-in `format` function where applicable. This is based off the work by Jaap Roes in [#5668](https://github.com/django/django/pull/5668).

See [https://code.djangoproject.com/ticket/25762](https://code.djangoproject.com/ticket/25762) for further details.