### PR TITLE
Doc'd that migrate commmand accepts a unique migration name prefix.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -802,8 +802,10 @@ The behavior of this command changes depending on the arguments provided:
 * ``<app_label> <migrationname>``: Brings the database schema to a state where
   the named migration is applied, but no later migrations in the same app are
   applied. This may involve unapplying migrations if you have previously
-  migrated past the named migration. Use the name ``zero`` to migrate all the
-  way back i.e. to revert all applied migrations for an app.
+  migrated past the named migration. You can use a prefix of the migration
+  name, e.g. ``0001``, as long as it's unique for the given app name. Use the
+  name ``zero`` to migrate all the way back i.e. to revert all applied
+  migrations for an app.
 
 .. warning::
 


### PR DESCRIPTION
Documented: You can use the <migration_name> prefix when django-admin <app_label> <migrate>