### PR TITLE
Refs #28816 -- Prevented silencing data loss when decreasing CharField.max_length for ArrayField.base_field on PostgreSQL.

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -895,6 +895,54 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.alter_field(Foo, old_field, new_field, strict=True)
 
+    @isolate_apps('schema')
+    @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL specific')
+    def test_alter_array_field_decrease_base_field_length(self):
+        from django.contrib.postgres.fields import ArrayField
+
+        class ArrayModel(Model):
+            field = ArrayField(CharField(max_length=16))
+
+            class Meta:
+                app_label = 'schema'
+
+        with connection.schema_editor() as editor:
+            editor.create_model(ArrayModel)
+        self.isolated_local_models = [ArrayModel]
+        ArrayModel.objects.create(field=['x' * 16])
+        old_field = ArrayModel._meta.get_field('field')
+        new_field = ArrayField(CharField(max_length=15))
+        new_field.set_attributes_from_name('field')
+        new_field.model = ArrayModel
+        with connection.schema_editor() as editor:
+            msg = 'value too long for type character varying(15)'
+            with self.assertRaisesMessage(DataError, msg):
+                editor.alter_field(ArrayModel, old_field, new_field, strict=True)
+
+    @isolate_apps('schema')
+    @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL specific')
+    def test_alter_array_field_decrease_nested_base_field_length(self):
+        from django.contrib.postgres.fields import ArrayField
+
+        class ArrayModel(Model):
+            field = ArrayField(ArrayField(CharField(max_length=16)))
+
+            class Meta:
+                app_label = 'schema'
+
+        with connection.schema_editor() as editor:
+            editor.create_model(ArrayModel)
+        self.isolated_local_models = [ArrayModel]
+        ArrayModel.objects.create(field=[['x' * 16]])
+        old_field = ArrayModel._meta.get_field('field')
+        new_field = ArrayField(ArrayField(CharField(max_length=15)))
+        new_field.set_attributes_from_name('field')
+        new_field.model = ArrayModel
+        with connection.schema_editor() as editor:
+            msg = 'value too long for type character varying(15)'
+            with self.assertRaisesMessage(DataError, msg):
+                editor.alter_field(ArrayModel, old_field, new_field, strict=True)
+
     def test_alter_textfield_to_null(self):
         """
         #24307 - Should skip an alter statement on databases with


### PR DESCRIPTION
Fix for [ticket 28816 comment](https://code.djangoproject.com/ticket/28816#comment:7).