### PR TITLE
Refs #10348 -- Doc'd that ModelAdmin ignores list_select_related when QuerySet.select_related() was already called.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1026,6 +1026,12 @@ subclass::
     If you need to specify a dynamic value based on the request, you can
     implement a :meth:`~ModelAdmin.get_list_select_related` method.
 
+    .. note::
+
+        ``ModelAdmin`` ignores this attribute when
+        :meth:`~django.db.models.query.QuerySet.select_related` was already
+        called on the changelist's ``QuerySet``.
+
 .. attribute:: ModelAdmin.ordering
 
     Set ``ordering`` to specify how lists of objects should be ordered in the


### PR DESCRIPTION
…dy applied

This is the part of code that will ignore the `list_select_related` hence the warning.
https://github.com/django/django/blob/fa8fe09e4e2b538c5d50a559081861d5c0635d55/django/contrib/admin/views/main.py#L449-L450