### PR TITLE
Fixes #30807 -- Fix permissions when extracting archives

### DIFF
--- a/django/utils/archive.py
+++ b/django/utils/archive.py
@@ -100,12 +100,10 @@ class BaseArchive:
     @staticmethod
     def _copy_permissions(mode, filename):
         """
-        If the file in the archive has some permissions (this assumes a file
-        won't be writable/executable without being readable), apply those
-        permissions to the unarchived file.
+        Carry over permissions from the archive, ensuring extracted files are 
+        always owner readable.
         """
-        if mode & stat.S_IROTH:
-            os.chmod(filename, mode)
+        os.chmod(filename, mode | stat.S_IROTH)
 
     def split_leading_dir(self, path):
         path = str(path)

--- a/tests/utils_tests/test_archive.py
+++ b/tests/utils_tests/test_archive.py
@@ -32,8 +32,6 @@ class TestArchive(unittest.TestCase):
     def test_extract_file_permissions(self):
         """archive.extract() preserves file permissions."""
         mask = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
-        umask = os.umask(0)
-        os.umask(umask)  # Restore the original umask.
         for entry in os.scandir(self.testdir):
             if entry.name.startswith('leadpath_'):
                 continue
@@ -44,4 +42,4 @@ class TestArchive(unittest.TestCase):
                 self.assertEqual(os.stat(filepath).st_mode & mask, 0o775)
                 # A file is readable even if permission data is missing.
                 filepath = os.path.join(tmpdir, 'no_permissions')
-                self.assertEqual(os.stat(filepath).st_mode & mask, 0o664 & ~umask)
+                self.assertEqual(os.stat(filepath).st_mode & mask, 0o4)


### PR DESCRIPTION
When extracting archives, files that do not have “owner read”
permissions in the archive metadata are now extracted with
“owner read”, as opposed to leaving the permissions up to OS default.

Test has been updated to now expect “owner read” only when extracting 
a file with zero permissions in the archive.

This fixes a regression introduced after #27628 fixed a prior 
regression in #27494, but that became only apparent after more 
tests were introduced in #30160.