### PR TITLE
Fixed #30826 -- Fixed crash of many JSONField lookups when one hand side is key transform.

### DIFF
--- a/django/contrib/postgres/lookups.py
+++ b/django/contrib/postgres/lookups.py
@@ -8,7 +8,7 @@ class PostgresSimpleLookup(FieldGetDbPrepValueMixin, Lookup):
     def as_sql(self, qn, connection):
         lhs, lhs_params = self.process_lhs(qn, connection)
         rhs, rhs_params = self.process_rhs(qn, connection)
-        params = lhs_params + rhs_params
+        params = tuple(lhs_params) + tuple(rhs_params)
         return '%s %s %s' % (lhs, self.operator, rhs), params
 
 

--- a/docs/releases/1.11.26.txt
+++ b/docs/releases/1.11.26.txt
@@ -9,4 +9,7 @@ Django 1.11.26 fixes a regression in 1.11.25.
 Bugfixes
 ========
 
-* ...
+* Fixed a crash when using a ``contains``, ``contained_by``, ``has_key``,
+  ``has_keys``, or ``has_any_keys`` lookup on
+  :class:`~django.contrib.postgres.fields.JSONField`, if the right or left hand
+  side of an expression is a key transform (:ticket:`30826`).

--- a/docs/releases/2.1.14.txt
+++ b/docs/releases/2.1.14.txt
@@ -9,4 +9,7 @@ Django 2.1.14 fixes a regression in 2.1.13.
 Bugfixes
 ========
 
-* ...
+* Fixed a crash when using a ``contains``, ``contained_by``, ``has_key``,
+  ``has_keys``, or ``has_any_keys`` lookup on
+  :class:`~django.contrib.postgres.fields.JSONField`, if the right or left hand
+  side of an expression is a key transform (:ticket:`30826`).

--- a/docs/releases/2.2.7.txt
+++ b/docs/releases/2.2.7.txt
@@ -9,4 +9,7 @@ Django 2.2.7 fixes several bugs in 2.2.6.
 Bugfixes
 ========
 
-* ...
+* Fixed a crash when using a ``contains``, ``contained_by``, ``has_key``,
+  ``has_keys``, or ``has_any_keys`` lookup on
+  :class:`~django.contrib.postgres.fields.JSONField`, if the right or left hand
+  side of an expression is a key transform (:ticket:`30826`).

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -135,7 +135,12 @@ class TestQuerying(PostgreSQLTestCase):
                 'k': True,
                 'l': False,
             }),
-            JSONModel(field={'foo': 'bar'}),
+            JSONModel(field={
+                'foo': 'bar',
+                'baz': {'a': 'b', 'c': 'd'},
+                'bar': ['foo', 'bar'],
+                'bax': {'foo': 'bar'},
+            }),
         ])
 
     def test_exact(self):
@@ -385,6 +390,26 @@ class TestQuerying(PostgreSQLTestCase):
             """."field" -> 'test'' = ''"a"'') OR 1 = 1 OR (''d') = '"x"' """,
             queries[0]['sql'],
         )
+
+    def test_lookups_with_key_transform(self):
+        tests = (
+            ('field__d__contains', 'e'),
+            ('field__baz__contained_by', {'a': 'b', 'c': 'd', 'e': 'f'}),
+            ('field__baz__has_key', 'c'),
+            ('field__baz__has_keys', ['a', 'c']),
+            ('field__baz__has_any_keys', ['a', 'x']),
+            ('field__contains', KeyTransform('bax', 'field')),
+            (
+                'field__contained_by',
+                KeyTransform('x', RawSQL('%s::jsonb', ['{"x": {"a": "b", "c": 1, "d": "e"}}'])),
+            ),
+            ('field__has_key', KeyTextTransform('foo', 'field')),
+        )
+        for lookup, value in tests:
+            with self.subTest(lookup=lookup):
+                self.assertTrue(JSONModel.objects.filter(
+                    **{lookup: value},
+                ).exists())
 
 
 @isolate_apps('postgres_tests')


### PR DESCRIPTION
When doing `as_sql` the `compiler.compile` executes this to get the sql and params.
https://github.com/django/django/blob/master/django/db/models/sql/compiler.py#L412

In the jsonb `KeyTransform` code, we return a tuple https://github.com/django/django/blob/master/django/contrib/postgres/fields/jsonb.py#L115

Which makes `PostgresSimpleLookup.as_sql` fail: https://github.com/django/django/blob/master/django/contrib/postgres/lookups.py#L11 because `lhs_params` is a tuple and `rhs_params` is a list.

```
lhs_params ('d',)
rhs_params [<django.contrib.postgres.fields.jsonb.JsonAdapter object at 0x104e7f090>]
```

The fact that it's a tuple was introduced here: https://github.com/django/django/commit/6c3dfba89215fc56fc27ef61829a6fff88be4abb to fix a subquery bug.

I have doubts on wether we should use `tuple` or `list` for params.




