### PR TITLE
Update MultiWidget documentation example

### DIFF
--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -416,6 +416,8 @@ foundation for custom widgets.
             def __init__(self, attrs=None):
                 # create choices for days, months, years
                 # example below, the rest snipped for brevity.
+                days = [(day, day) for day in (1, 2, 3)]
+                months = [(month, month) for month in (3, 4, 5)]
                 years = [(year, year) for year in (2011, 2012, 2013)]
                 _widgets = (
                     widgets.Select(attrs=attrs, choices=days),


### PR DESCRIPTION
The previous example of the [MultiWidget](https://docs.djangoproject.com/en/1.11/ref/forms/widgets/#django.forms.MultiWidget) class used two non-defined variables:
- `days`
- `months`

I included those on the docs with some dummy data.