### PR TITLE
Fixed #30834 -- Added explicit list of supported databases to the databases docs.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -2,6 +2,17 @@
 Databases
 =========
 
+Django officially supports the following databases:
+
+* :ref:`PostgreSQL <postgresql-notes>`
+* :ref:`MariaDB <mariadb-notes>`
+* :ref:`MySQL <mysql-notes>`
+* :ref:`Oracle <oracle-notes>`
+* :ref:`SQLite <sqlite-notes>`
+
+There are also a number of :ref:`database backends provided by third parties
+<third-party-notes>`.
+
 Django attempts to support as many features as possible on all database
 backends. However, not all database backends are alike, and we've had to make
 design decisions on which features to support and which assumptions we can make


### PR DESCRIPTION
This corrects the assumption from the main docs landing page that this
page is a list of "supported databases", aand prevents readers from
having to read all the top-level section headers to enumerate the
list of supported databases manually.