### PR TITLE
Fixed #30841 -- Fixed join promotion for non-boolean isnull.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1310,7 +1310,7 @@ class Query(BaseExpression):
         lookup_type = condition.lookup_name
         clause.add(condition, AND)
 
-        require_outer = lookup_type == 'isnull' and condition.rhs is True and not current_negated
+        require_outer = lookup_type == 'isnull' and condition.rhs and not current_negated
         if current_negated and (lookup_type != 'isnull' or condition.rhs is False) and condition.rhs is not None:
             require_outer = True
             if (lookup_type != 'isnull' and (

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -3160,6 +3160,15 @@ class NullJoinPromotionOrTest(TestCase):
         self.assertEqual(str(qs.query).count('INNER JOIN'), 1)
         self.assertEqual(list(qs), [self.a2])
 
+    def test_isnull_filter_promotion_non_bool(self):
+        qs = ModelA.objects.filter(Q(b__name__isnull=1))
+        self.assertEqual(str(qs.query).count('LEFT OUTER'), 1)
+        self.assertEqual(list(qs), [self.a1])
+
+        qs = ModelA.objects.filter(Q(b__name__isnull=0))
+        self.assertEqual(str(qs.query).count('INNER JOIN'), 1)
+        self.assertEqual(list(qs), [self.a2])
+
     def test_null_join_demotion(self):
         qs = ModelA.objects.filter(Q(b__name__isnull=False) & Q(b__name__isnull=True))
         self.assertIn(' INNER JOIN ', str(qs.query))


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/30841
Briefly discussed here: https://groups.google.com/forum/#!topic/django-developers/AhY2b3rxkfA

When setting `isnull` on a `filter()` with a value that is not a boolean will cause problems when deciding to promote the `INNER JOIN ` to a `LEFT OUTER`.

One realistic case where this would happen is when one defines it's own `__bool__()` method and pass that object to `isnull`.