### PR TITLE
Fixed #30860 -- Disabled unneeded NULLS FIRST/LAST workaround on SQLite 3.30+.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1146,10 +1146,11 @@ class OrderBy(BaseExpression):
 
     def as_sqlite(self, compiler, connection):
         template = None
-        if self.nulls_last:
-            template = '%(expression)s IS NULL, %(expression)s %(ordering)s'
-        elif self.nulls_first:
-            template = '%(expression)s IS NOT NULL, %(expression)s %(ordering)s'
+        if connection.Database.sqlite_version_info < (3, 30, 0):
+            if self.nulls_last:
+                template = '%(expression)s IS NULL, %(expression)s %(ordering)s'
+            elif self.nulls_first:
+                template = '%(expression)s IS NOT NULL, %(expression)s %(ordering)s'
         return self.as_sql(compiler, connection, template=template)
 
     def as_mysql(self, compiler, connection):


### PR DESCRIPTION
Confirmed that ordering related tests pass against SQLite 3.30 locally.