### PR TITLE
Fixed #30858 -- Clarified that AdminEmailHandler processes all 5xx responses.

### DIFF
--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -20,10 +20,11 @@ Server errors
 
 When :setting:`DEBUG` is ``False``, Django will email the users listed in the
 :setting:`ADMINS` setting whenever your code raises an unhandled exception and
-results in an internal server error (HTTP status code 500). This gives the
-administrators immediate notification of any errors. The :setting:`ADMINS` will
-get a description of the error, a complete Python traceback, and details about
-the HTTP request that caused the error.
+results in an internal server error (strictly speaking, for any response with
+an HTTP status code of 500 or greater). This gives the administrators immediate
+notification of any errors. The :setting:`ADMINS` will get a description of the
+error, a complete Python traceback, and details about the HTTP request that
+caused the error.
 
 .. note::
 


### PR DESCRIPTION
Not quite sure this is worth the change but... 


