### PR TITLE
Refs #26608 -- Fixed DatabaseFeatures.supports_frame_range_fixed_distance on SQLite 3.28+, MariaDB 10.2+, and MySQL 8.0.2+.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -88,6 +88,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             return self.connection.mysql_version >= (10, 2)
         return self.connection.mysql_version >= (8, 0, 2)
 
+    supports_frame_range_fixed_distance = property(operator.attrgetter('supports_over_clause'))
+
     @cached_property
     def supports_column_check_constraints(self):
         if self.connection.mysql_is_mariadb:

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -42,3 +42,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_defer_constraint_checks = supports_pragma_foreign_key_check
     supports_functions_in_partial_indexes = Database.sqlite_version_info >= (3, 15, 0)
     supports_over_clause = Database.sqlite_version_info >= (3, 25, 0)
+    supports_frame_range_fixed_distance = Database.sqlite_version_info >= (3, 28, 0)


### PR DESCRIPTION
https://www.sqlite.org/changes.html#version_3_28_0