### PR TITLE
Refs #27086 -- Corrections to unit testing contributor docs. 

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -373,6 +373,13 @@ in ``tests/auth_tests``.
 Troubleshooting
 ===============
 
+Test suite hangs or shows failures on ``master`` branch
+-------------------------------------------------------
+
+Ensure you have the latest point release of a :ref:`supported Python version
+<faq-python-version-support>`, since there are often bugs in earlier versions
+that may cause the test suite to fail or hang.
+
 Many test failures with ``UnicodeEncodeError``
 ----------------------------------------------
 

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -476,12 +476,12 @@ You can also use the ``DJANGO_TEST_PROCESSES`` environment variable for this
 purpose.
 
 Tips for writing tests
-----------------------
+======================
 
 .. highlight:: python
 
 Isolating model registration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 
 To avoid polluting the global :attr:`~django.apps.apps` registry and prevent
 unnecessary table creation, models defined in a test method should be bound to

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -380,6 +380,20 @@ Ensure you have the latest point release of a :ref:`supported Python version
 <faq-python-version-support>`, since there are often bugs in earlier versions
 that may cause the test suite to fail or hang.
 
+On **macOS** (High Sierra and newer versions), you might see this message
+logged, after which the tests hang::
+
+    objc[42074]: +[__NSPlaceholderDate initialize] may have been in progress in
+    another thread when fork() was called.
+
+To avoid this set a ``OBJC_DISABLE_INITIALIZE_FORK_SAFETY`` environment
+variable, for example::
+
+    $ OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ./runtests.py
+
+Or add ``export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`` to your shell's
+startup file (e.g. ``~/.profile``).
+
 Many test failures with ``UnicodeEncodeError``
 ----------------------------------------------
 


### PR DESCRIPTION
In the [unit tests contributor docs](https://docs.djangoproject.com/en/2.2/internals/contributing/writing-code/unit-tests/), the _Tips_ section is over-indented under the _Troubleshooting_ section. It should be a sibling. (I think.) 

This just outdents it a notch. 

#### Before:

<img width="265" alt="before" src="https://user-images.githubusercontent.com/64686/66469493-38bef000-ea88-11e9-8a56-56eac5cd3ef4.png">

#### After:

<img width="284" alt="after" src="https://user-images.githubusercontent.com/64686/66469509-3f4d6780-ea88-11e9-8771-be3bc3555d75.png">
