### PR TITLE
Fixed #11385 -- Made forms.DateTimeField accept ISO 8601 date inputs.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -25,7 +25,7 @@ from django.forms.widgets import (
     URLInput,
 )
 from django.utils import formats
-from django.utils.dateparse import parse_duration
+from django.utils.dateparse import parse_datetime, parse_duration
 from django.utils.duration import duration_string
 from django.utils.ipv6 import clean_ipv6_address
 from django.utils.regex_helper import _lazy_re_compile
@@ -459,7 +459,12 @@ class DateTimeField(BaseTemporalField):
         if isinstance(value, datetime.date):
             result = datetime.datetime(value.year, value.month, value.day)
             return from_current_timezone(result)
-        result = super().to_python(value)
+        try:
+            result = parse_datetime(value.strip())
+        except ValueError:
+            raise ValidationError(self.error_messages['invalid'], code='invalid')
+        if not result:
+            result = super().to_python(value)
         return from_current_timezone(result)
 
     def strptime(self, value, format):

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -490,13 +490,30 @@ For each field, we describe the default widget used if you don't specify
     .. attribute:: input_formats
 
         A list of formats used to attempt to convert a string to a valid
-        ``datetime.datetime`` object.
+        ``datetime.datetime`` object, in addition to ISO 8601 formats.
+
+    The field always accepts strings in ISO 8601 formatted dates or similar
+    recognized by :func:`~django.utils.dateparse.parse_datetime`. Some examples
+    are::
+
+        * '2006-10-25 14:30:59'
+        * '2006-10-25T14:30:59'
+        * '2006-10-25 14:30'
+        * '2006-10-25T14:30'
+        * '2006-10-25T14:30Z'
+        * '2006-10-25T14:30+02:00'
+        * '2006-10-25'
 
     If no ``input_formats`` argument is provided, the default input formats are
     taken from :setting:`DATETIME_INPUT_FORMATS` if :setting:`USE_L10N` is
     ``False``, or from the active locale format ``DATETIME_INPUT_FORMATS`` key
     if localization is enabled. See also :doc:`format localization
     </topics/i18n/formatting>`.
+
+    .. versionchanged:: 3.1
+
+        Support for ISO 8601 date string parsing (including optional timezone)
+        was added.
 
 ``DecimalField``
 ----------------

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -467,25 +467,11 @@ For each field, we describe the default widget used if you don't specify
         A list of formats used to attempt to convert a string to a valid
         ``datetime.date`` object.
 
-    If no ``input_formats`` argument is provided, the default input formats are::
-
-        ['%Y-%m-%d',      # '2006-10-25'
-         '%m/%d/%Y',      # '10/25/2006'
-         '%m/%d/%y']      # '10/25/06'
-
-    Additionally, if you specify :setting:`USE_L10N=False<USE_L10N>` in your settings, the
-    following will also be included in the default input formats::
-
-        ['%b %d %Y',      # 'Oct 25 2006'
-         '%b %d, %Y',     # 'Oct 25, 2006'
-         '%d %b %Y',      # '25 Oct 2006'
-         '%d %b, %Y',     # '25 Oct, 2006'
-         '%B %d %Y',      # 'October 25 2006'
-         '%B %d, %Y',     # 'October 25, 2006'
-         '%d %B %Y',      # '25 October 2006'
-         '%d %B, %Y']     # '25 October, 2006'
-
-    See also :doc:`format localization </topics/i18n/formatting>`.
+    If no ``input_formats`` argument is provided, the default input formats are
+    taken from :setting:`DATE_INPUT_FORMATS` if :setting:`USE_L10N` is
+    ``False``, or from the active locale format ``DATE_INPUT_FORMATS`` key if
+    localization is enabled. See also :doc:`format localization
+    </topics/i18n/formatting>`.
 
 ``DateTimeField``
 -----------------
@@ -506,19 +492,11 @@ For each field, we describe the default widget used if you don't specify
         A list of formats used to attempt to convert a string to a valid
         ``datetime.datetime`` object.
 
-    If no ``input_formats`` argument is provided, the default input formats are::
-
-        ['%Y-%m-%d %H:%M:%S',    # '2006-10-25 14:30:59'
-         '%Y-%m-%d %H:%M',       # '2006-10-25 14:30'
-         '%Y-%m-%d',             # '2006-10-25'
-         '%m/%d/%Y %H:%M:%S',    # '10/25/2006 14:30:59'
-         '%m/%d/%Y %H:%M',       # '10/25/2006 14:30'
-         '%m/%d/%Y',             # '10/25/2006'
-         '%m/%d/%y %H:%M:%S',    # '10/25/06 14:30:59'
-         '%m/%d/%y %H:%M',       # '10/25/06 14:30'
-         '%m/%d/%y']             # '10/25/06'
-
-    See also :doc:`format localization </topics/i18n/formatting>`.
+    If no ``input_formats`` argument is provided, the default input formats are
+    taken from :setting:`DATETIME_INPUT_FORMATS` if :setting:`USE_L10N` is
+    ``False``, or from the active locale format ``DATETIME_INPUT_FORMATS`` key
+    if localization is enabled. See also :doc:`format localization
+    </topics/i18n/formatting>`.
 
 ``DecimalField``
 ----------------
@@ -928,10 +906,11 @@ For each field, we describe the default widget used if you don't specify
         A list of formats used to attempt to convert a string to a valid
         ``datetime.time`` object.
 
-    If no ``input_formats`` argument is provided, the default input formats are::
-
-        '%H:%M:%S',     # '14:30:59'
-        '%H:%M',        # '14:30'
+    If no ``input_formats`` argument is provided, the default input formats are
+    taken from :setting:`TIME_INPUT_FORMATS` if :setting:`USE_L10N` is
+    ``False``, or from the active locale format ``TIME_INPUT_FORMATS`` key if
+    localization is enabled. See also :doc:`format localization
+    </topics/i18n/formatting>`.
 
 ``URLField``
 ------------

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -179,6 +179,10 @@ Forms
   to access model instances. See :ref:`iterating-relationship-choices` for
   details.
 
+* :class:`django.forms.DateTimeField` now accepts dates in a subset of ISO 8601
+  datetime formats, including optional timezone (e.g. ``2019-10-10T06:47``,
+  ``2019-10-10T06:47:23+04:00``, or ``2019-10-10T06:47:23Z``).
+
 Generic Views
 ~~~~~~~~~~~~~
 

--- a/tests/forms_tests/tests/test_input_formats.py
+++ b/tests/forms_tests/tests/test_input_formats.py
@@ -703,7 +703,7 @@ class LocalizedDateTimeTests(SimpleTestCase):
         f = forms.DateTimeField(input_formats=["%H.%M.%S %m.%d.%Y", "%H.%M %m-%d-%Y"], localize=True)
         # Parse a date in an unaccepted format; get an error
         with self.assertRaises(forms.ValidationError):
-            f.clean('2010-12-21 13:30:05')
+            f.clean('2010/12/21 13:30:05')
         with self.assertRaises(forms.ValidationError):
             f.clean('1:30:05 PM 21/12/2010')
         with self.assertRaises(forms.ValidationError):
@@ -711,8 +711,12 @@ class LocalizedDateTimeTests(SimpleTestCase):
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('13.30.05 12.21.2010')
-        self.assertEqual(result, datetime(2010, 12, 21, 13, 30, 5))
-
+        self.assertEqual(datetime(2010, 12, 21, 13, 30, 5), result)
+        # ISO format is always valid.
+        self.assertEqual(
+            f.clean('2010-12-21 13:30:05'),
+            datetime(2010, 12, 21, 13, 30, 5),
+        )
         # The parsed result does a round trip to the same format
         text = f.widget.format_value(result)
         self.assertEqual(text, "21.12.2010 13:30:05")
@@ -733,7 +737,7 @@ class CustomDateTimeInputFormatsTests(SimpleTestCase):
         f = forms.DateTimeField()
         # Parse a date in an unaccepted format; get an error
         with self.assertRaises(forms.ValidationError):
-            f.clean('2010-12-21 13:30:05')
+            f.clean('2010/12/21 13:30:05')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('1:30:05 PM 21/12/2010')
@@ -756,7 +760,7 @@ class CustomDateTimeInputFormatsTests(SimpleTestCase):
         f = forms.DateTimeField(localize=True)
         # Parse a date in an unaccepted format; get an error
         with self.assertRaises(forms.ValidationError):
-            f.clean('2010-12-21 13:30:05')
+            f.clean('2010/12/21 13:30:05')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('1:30:05 PM 21/12/2010')
@@ -781,7 +785,7 @@ class CustomDateTimeInputFormatsTests(SimpleTestCase):
         with self.assertRaises(forms.ValidationError):
             f.clean('13:30:05 21.12.2010')
         with self.assertRaises(forms.ValidationError):
-            f.clean('2010-12-21 13:30:05')
+            f.clean('2010/12/21 13:30:05')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('12.21.2010 13:30:05')
@@ -806,7 +810,7 @@ class CustomDateTimeInputFormatsTests(SimpleTestCase):
         with self.assertRaises(forms.ValidationError):
             f.clean('13:30:05 21.12.2010')
         with self.assertRaises(forms.ValidationError):
-            f.clean('2010-12-21 13:30:05')
+            f.clean('2010/12/21 13:30:05')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('12.21.2010 13:30:05')
@@ -877,7 +881,7 @@ class SimpleDateTimeFormatTests(SimpleTestCase):
         f = forms.DateTimeField(input_formats=["%I:%M:%S %p %d.%m.%Y", "%I:%M %p %d-%m-%Y"])
         # Parse a date in an unaccepted format; get an error
         with self.assertRaises(forms.ValidationError):
-            f.clean('2010-12-21 13:30:05')
+            f.clean('2010/12/21 13:30:05')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('1:30:05 PM 21.12.2010')
@@ -900,7 +904,7 @@ class SimpleDateTimeFormatTests(SimpleTestCase):
         f = forms.DateTimeField(input_formats=["%I:%M:%S %p %d.%m.%Y", "%I:%M %p %d-%m-%Y"], localize=True)
         # Parse a date in an unaccepted format; get an error
         with self.assertRaises(forms.ValidationError):
-            f.clean('2010-12-21 13:30:05')
+            f.clean('2010/12/21 13:30:05')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('1:30:05 PM 21.12.2010')

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -1081,11 +1081,6 @@ class NewFormsTests(TestCase):
             self.assertTrue(form.is_valid())
             self.assertEqual(form.cleaned_data['dt'], datetime.datetime(2011, 9, 1, 10, 20, 30, tzinfo=UTC))
 
-    def test_form_with_explicit_timezone(self):
-        form = EventForm({'dt': '2011-09-01 17:20:30+07:00'})
-        # Datetime inputs formats don't allow providing a time zone.
-        self.assertFalse(form.is_valid())
-
     def test_form_with_non_existent_time(self):
         with timezone.override(pytz.timezone('Europe/Paris')):
             form = EventForm({'dt': '2011-03-27 02:30:00'})


### PR DESCRIPTION
Thanks José Padilla for the initial patch.