### PR TITLE
Fixed #30862 -- Allowed setting SameSite cookies flags to 'None'.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -197,8 +197,8 @@ class HttpResponseBase:
         if httponly:
             self.cookies[key]['httponly'] = True
         if samesite:
-            if samesite.lower() not in ('lax', 'strict'):
-                raise ValueError('samesite must be "lax" or "strict".')
+            if samesite.lower() not in ('lax', 'none', 'strict'):
+                raise ValueError('samesite must be "lax", "none", or "strict".')
             self.cookies[key]['samesite'] = samesite
 
     def setdefault(self, key, value):

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -819,6 +819,8 @@ Methods
       ``domain="example.com"`` will set a cookie that is readable by the
       domains www.example.com, blog.example.com, etc. Otherwise, a cookie will
       only be readable by the domain that set it.
+    * Use ``secure=True`` if you want the cookie to be only sent to the server
+      when a request is made with the ``https`` scheme.
     * Use ``httponly=True`` if you want to prevent client-side
       JavaScript from having access to the cookie.
 

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -803,7 +803,7 @@ Methods
 
     Sets a header unless it has already been set.
 
-.. method:: HttpResponse.set_cookie(key, value='', max_age=None, expires=None, path='/', domain=None, secure=None, httponly=False, samesite=None)
+.. method:: HttpResponse.set_cookie(key, value='', max_age=None, expires=None, path='/', domain=None, secure=False, httponly=False, samesite=None)
 
     Sets a cookie. The parameters are the same as in the
     :class:`~http.cookies.Morsel` cookie object in the Python standard library.
@@ -842,7 +842,7 @@ Methods
         attempt to store a cookie of more than 4096 bytes, but many browsers
         will not set the cookie correctly.
 
-.. method:: HttpResponse.set_signed_cookie(key, value, salt='', max_age=None, expires=None, path='/', domain=None, secure=None, httponly=False, samesite=None)
+.. method:: HttpResponse.set_signed_cookie(key, value, salt='', max_age=None, expires=None, path='/', domain=None, secure=False, httponly=False, samesite=None)
 
     Like :meth:`~HttpResponse.set_cookie()`, but
     :doc:`cryptographic signing </topics/signing>` the cookie before setting

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -833,8 +833,15 @@ Methods
       isn't supported by all browsers, so it's not a replacement for Django's
       CSRF protection, but rather a defense in depth measure.
 
+      Use ``samesite='None'`` (string) to explicitly state that this cookie is
+      sent with all same-site and cross-site requests.
+
     .. _HttpOnly: https://www.owasp.org/index.php/HttpOnly
     .. _SameSite: https://www.owasp.org/index.php/SameSite
+
+    .. versionchanged:: 3.1
+
+        Using ``samesite='None'`` (string) was allowed.
 
     .. warning::
 
@@ -852,6 +859,10 @@ Methods
     You can use the optional ``salt`` argument for added key strength, but
     you will need to remember to pass it to the corresponding
     :meth:`HttpRequest.get_signed_cookie` call.
+
+    .. versionchanged:: 3.1
+
+        Using ``samesite='None'`` (string) was allowed.
 
 .. method:: HttpResponse.delete_cookie(key, path='/', domain=None)
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -383,6 +383,10 @@ cookie from being sent in cross-site requests.
 
 See :setting:`SESSION_COOKIE_SAMESITE` for details about ``SameSite``.
 
+.. versionchanged:: 3.1
+
+    Setting ``CSRF_COOKIE_SAMESITE = 'None'`` was allowed.
+
 .. setting:: CSRF_COOKIE_SECURE
 
 ``CSRF_COOKIE_SECURE``
@@ -1862,6 +1866,10 @@ cookie from being sent in cross-site requests.
 
 See :setting:`SESSION_COOKIE_SAMESITE` for details about ``SameSite``.
 
+.. versionchanged:: 3.1
+
+    Setting ``LANGUAGE_COOKIE_SAMESITE = 'None'`` was allowed.
+
 .. setting:: LANGUAGE_COOKIE_SECURE
 
 ``LANGUAGE_COOKIE_SECURE``
@@ -3208,7 +3216,14 @@ Possible values for the setting are:
   regular link from an external website and be blocked in CSRF-prone request
   methods (e.g. ``POST``).
 
-* ``None``: disables the flag.
+* ``'None'`` (string): the session cookie will be sent with all same-site and
+  cross-site requests.
+
+* ``False``: disables the flag.
+
+.. versionchanged:: 3.1
+
+    Setting ``SESSION_COOKIE_SAMESITE = 'None'`` was allowed.
 
 .. _SameSite: https://www.owasp.org/index.php/SameSite
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -105,7 +105,9 @@ Minor features
 :mod:`django.contrib.sessions`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The :setting:`SESSION_COOKIE_SAMESITE` setting now allows ``'None'`` (string)
+  value to explicitly state that the cookie is sent with all same-site and
+  cross-site requests.
 
 :mod:`django.contrib.sitemaps`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -141,7 +143,9 @@ Cache
 CSRF
 ~~~~
 
-* ...
+* The :setting:`CSRF_COOKIE_SAMESITE` setting now allows ``'None'`` (string)
+  value to explicitly state that the cookie is sent with all same-site and
+  cross-site requests.
 
 Email
 ~~~~~
@@ -173,7 +177,9 @@ Generic Views
 Internationalization
 ~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The :setting:`LANGUAGE_COOKIE_SAMESITE` setting now allows ``'None'``
+  (string) value to explicitly state that the cookie is sent with all same-site
+  and cross-site requests.
 
 Logging
 ~~~~~~~
@@ -231,6 +237,10 @@ Requests and Responses
 
 * If :setting:`ALLOWED_HOSTS` is empty and ``DEBUG=True``, subdomains of
   localhost are now allowed in the ``Host`` header, e.g. ``static.localhost``.
+
+* :meth:`.HttpResponse.set_cookie` and :meth:`.HttpResponse.set_signed_cookie`
+  now allow using ``samesite='None'`` (string) to explicitly state that the
+  cookie is sent with all same-site and cross-site requests.
 
 Serialization
 ~~~~~~~~~~~~~

--- a/tests/responses/test_cookie.py
+++ b/tests/responses/test_cookie.py
@@ -81,13 +81,16 @@ class SetCookieTests(SimpleTestCase):
 
     def test_samesite(self):
         response = HttpResponse()
+        response.set_cookie('example', samesite='None')
+        self.assertEqual(response.cookies['example']['samesite'], 'None')
         response.set_cookie('example', samesite='Lax')
         self.assertEqual(response.cookies['example']['samesite'], 'Lax')
         response.set_cookie('example', samesite='strict')
         self.assertEqual(response.cookies['example']['samesite'], 'strict')
 
     def test_invalid_samesite(self):
-        with self.assertRaisesMessage(ValueError, 'samesite must be "lax" or "strict".'):
+        msg = 'samesite must be "lax", "none", or "strict".'
+        with self.assertRaisesMessage(ValueError, msg):
             HttpResponse().set_cookie('example', samesite='invalid')
 
 


### PR DESCRIPTION
Other changes:
- Improve documentation for 'secure' flag
- Fix method signatures for 'samesite' in `.set_cookie` and
`.set_signed_cookie`

Ticket: https://code.djangoproject.com/ticket/30862#ticket