### PR TITLE
Fixed #30854 -- Fixed QuerySet.select_related() with multiple FilteredRelations.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -890,6 +890,12 @@ class SQLCompiler:
                     select, model._meta, alias, cur_depth + 1,
                     next, restricted)
                 get_related_klass_infos(klass_info, next_klass_infos)
+
+            def local_setter(obj, from_obj):
+                # Set a reverse fk object when relation is non-empty.
+                if from_obj:
+                    f.remote_field.set_cached_value(from_obj, obj)
+
             for name in list(requested):
                 # Filtered relations work only on the topmost level.
                 if cur_depth > 1:
@@ -900,11 +906,6 @@ class SQLCompiler:
                     model = join_opts.model
                     alias = joins[-1]
                     from_parent = issubclass(model, opts.model) and model is not opts.model
-
-                    def local_setter(obj, from_obj):
-                        # Set a reverse fk object when relation is non-empty.
-                        if from_obj:
-                            f.remote_field.set_cached_value(from_obj, obj)
 
                     def remote_setter(obj, from_obj):
                         setattr(from_obj, name, obj)

--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -52,6 +52,18 @@ class FilteredRelationTests(TestCase):
                 (self.author2, self.book3, self.editor_b, self.author2),
             ], lambda x: (x, x.book_join, x.book_join.editor, x.book_join.author))
 
+    def test_select_related_multiple(self):
+        qs = Book.objects.annotate(
+            author_join=FilteredRelation('author'),
+            editor_join=FilteredRelation('editor'),
+        ).select_related('author_join', 'editor_join').order_by('pk')
+        self.assertQuerysetEqual(qs, [
+            (self.book1, self.author1, self.editor_a),
+            (self.book2, self.author2, self.editor_b),
+            (self.book3, self.author2, self.editor_b),
+            (self.book4, self.author1, self.editor_a),
+        ], lambda x: (x, x.author_join, x.editor_join))
+
     def test_select_related_with_empty_relation(self):
         qs = Author.objects.annotate(
             book_join=FilteredRelation('book', condition=Q(pk=-1)),


### PR DESCRIPTION
[ticket 30854](https://code.djangoproject.com/ticket/30854)