### PR TITLE
Fixed #30870 -- Fixed "migrate --plan" outputs "IRREVERSIBLE" on RunPython operations without docstrings.

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -344,15 +344,16 @@ class Command(BaseCommand):
         """Return a string that describes a migration operation for --plan."""
         prefix = ''
         if hasattr(operation, 'code'):
+            _action = None if backwards else ''
             code = operation.reverse_code if backwards else operation.code
-            action = code.__doc__ if code else ''
+            action = (code.__doc__ or _action) if code else _action
         elif hasattr(operation, 'sql'):
             action = operation.reverse_sql if backwards else operation.sql
         else:
             action = ''
             if backwards:
                 prefix = 'Undo '
-        if action is None:
+        if action is None and backwards:
             action = 'IRREVERSIBLE'
             is_error = True
         else:

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -378,6 +378,33 @@ class MigrateTests(MigrationTestBase):
         call_command('migrate', 'migrations', '0003', fake=True, verbosity=0)
         call_command('migrate', 'migrations', 'zero', verbosity=0)
 
+    @override_settings(MIGRATION_MODULES={'migrations': 'migrations.test_migrations_plan_noop'})
+    def test_migrate_plan_noop(self):
+        # Show the plan to initial migration.
+        out = io.StringIO()
+        call_command('migrate', 'migrations', '0001_initial', plan=True, stdout=out, no_color=True)
+        self.assertEqual(
+            'Planned operations:\n'
+            'migrations.0001_initial\n'
+            '    Raw SQL operation -> IRREVERSIBLE\n'
+            '    Raw Python operation -> IRREVERSIBLE\n',
+            out.getvalue()
+        )
+
+        # Migrate to the initial migration.
+        call_command('migrate', 'migrations', '0001', verbosity=0)
+
+        # Show the plan for reverse migration back to zero.
+        out = io.StringIO()
+        call_command('migrate', 'migrations', 'zero', plan=True, stdout=out, no_color=True)
+        self.assertEqual(
+            'Planned operations:\n'
+            'migrations.0001_initial\n'
+            '    Raw SQL operation -> IRREVERSIBLE\n'
+            '    Raw Python operation -> IRREVERSIBLE\n',
+            out.getvalue()
+        )
+
     @override_settings(MIGRATION_MODULES={'migrations': 'migrations.test_migrations_empty'})
     def test_showmigrations_no_migrations(self):
         out = io.StringIO()

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -319,6 +319,7 @@ class MigrateTests(MigrationTestBase):
             'migrations.0001_initial\n'
             '    Create model Salamander\n'
             '    Raw Python operation -> Grow salamander tail.\n'
+            '    Raw Python operation\n'
             'migrations.0002_second\n'
             '    Create model Book\n'
             "    Raw SQL operation -> ['SELECT * FROM migrations_book']\n"
@@ -356,7 +357,8 @@ class MigrateTests(MigrationTestBase):
         self.assertEqual(
             'Planned operations:\n'
             'migrations.0004_fourth\n'
-            '    Raw SQL operation -> SELECT * FROM migrations_author WHE…\n',
+            '    Raw SQL operation -> SELECT * FROM migrations_author WHE…\n'
+            '    Raw Python operation\n',
             out.getvalue()
         )
         # Show the plan when an operation is irreversible.
@@ -367,7 +369,8 @@ class MigrateTests(MigrationTestBase):
         self.assertEqual(
             'Planned operations:\n'
             'migrations.0004_fourth\n'
-            '    Raw SQL operation -> IRREVERSIBLE\n',
+            '    Raw SQL operation -> IRREVERSIBLE\n'
+            '    Raw Python operation -> IRREVERSIBLE\n',
             out.getvalue()
         )
         # Cleanup by unmigrating everything: fake the irreversible, then

--- a/tests/migrations/test_migrations_plan/0001_initial.py
+++ b/tests/migrations/test_migrations_plan/0001_initial.py
@@ -11,6 +11,10 @@ def shrink_tail(x, y):
     pass
 
 
+def forward(apps, schema_editor):
+    pass
+
+
 class Migration(migrations.Migration):
 
     initial = True
@@ -25,4 +29,5 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.RunPython(grow_tail, shrink_tail),
+        migrations.RunPython(forward, shrink_tail),
     ]

--- a/tests/migrations/test_migrations_plan/0004_fourth.py
+++ b/tests/migrations/test_migrations_plan/0004_fourth.py
@@ -1,6 +1,14 @@
 from django.db import migrations
 
 
+def grow_tail(x, y):
+    pass
+
+
+def shrink_tail(x, y):
+    pass
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -8,5 +16,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL('SELECT * FROM migrations_author WHERE id = 1')
+        migrations.RunSQL('SELECT * FROM migrations_author WHERE id = 1'),
+        migrations.RunPython(grow_tail, shrink_tail),
     ]

--- a/tests/migrations/test_migrations_plan_noop/0001_initial.py
+++ b/tests/migrations/test_migrations_plan_noop/0001_initial.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    operations = [
+        migrations.RunSQL(migrations.RunSQL.noop, migrations.RunSQL.noop),
+        migrations.RunPython(migrations.RunPython.noop, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
[ticket 30870](https://code.djangoproject.com/ticket/30870)
Solution Proposed by @felixxm in the ticket.