### PR TITLE
Fixed #30819 -- Fix admin datepicker year display when the input is two digits year.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ answer newbie questions, and generally made Django that much better:
     Alasdair Nicol <https://al.sdair.co.uk/>
     Albert Wang <https://github.com/albertyw/>
     Alcides Fonseca
+    Aldian Fazrihady <mobile@aldian.net>
     Aleksandra Sendecka <asendecka@hauru.eu>
     Aleksi Häkli <aleksi.hakli@iki.fi>
     Alexander Dutton <dev@alexdutton.co.uk>

--- a/django/conf/locale/id/formats.py
+++ b/django/conf/locale/id/formats.py
@@ -14,8 +14,8 @@ FIRST_DAY_OF_WEEK = 1  # Monday
 # The *_INPUT_FORMATS strings use the Python strftime format syntax,
 # see https://docs.python.org/library/datetime.html#strftime-strptime-behavior
 DATE_INPUT_FORMATS = [
-    '%d-%m-%y', '%d/%m/%y',             # '25-10-09', 25/10/09'
     '%d-%m-%Y', '%d/%m/%Y',             # '25-10-2009', 25/10/2009'
+    '%d-%m-%y', '%d/%m/%y',             # '25-10-09', 25/10/09'
     '%d %b %Y',                         # '25 Oct 2006',
     '%d %B %Y',                         # '25 October 2006'
 ]

--- a/django/contrib/admin/static/admin/js/core.js
+++ b/django/contrib/admin/static/admin/js/core.js
@@ -159,7 +159,12 @@ function findPosY(obj) {
                 year = date[i];
                 break;
             case "%y":
-                year = date[i];
+                // 50 is cut off year. 50 to 99 means year 19xx.  00 to 49 means year 20xx.
+                if (parseInt(date[i], 10) >= 50) {
+                    year = date[i];
+                } else {
+                    year = (new Date(Date.UTC(date[i], 0))).getUTCFullYear() + 100;
+                }
                 break;
             }
             ++i;

--- a/js_tests/admin/core.test.js
+++ b/js_tests/admin/core.test.js
@@ -67,6 +67,11 @@ QUnit.test('String.strptime', function(assert) {
     assert.equal(thirdParsedDate.getUTCMonth(), 10);
     assert.equal(thirdParsedDate.getUTCFullYear(), 1983);
 
+    var fourthParsedDate = '27/09/19'.strptime('%d/%m/%y');
+    assert.equal(fourthParsedDate.getUTCDate(), 27);
+    assert.equal(fourthParsedDate.getUTCMonth(), 8);
+    assert.equal(fourthParsedDate.getUTCFullYear(), 2019);
+
     // Extracting from a Date object with local time must give the correct
     // result. Without proper conversion, timezones from GMT+0100 to GMT+1200
     // gives a date one day earlier than necessary, e.g. converting local time


### PR DESCRIPTION
There is a bug in JS code causing datepicker to to display the wrong year.
When date input field is using two digits year, the datepicker showing 4 digits year will miss the year by 100 years.
For example, if the input field has `19` as the year part, the calendar will show year `1919` instead of `2019`.
A screenshot: 
https://drive.google.com/file/d/17KEkY89TqimwJIJ0kz-b2IJpYETpd46g/view.
Ticket: https://code.djangoproject.com/ticket/30819

Thanks @felixxm  for triaging.

