### PR TITLE
Fixed #30816 -- Doc'd how to create projects with a local copy of Django.

### DIFF
--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -177,15 +177,27 @@ command line to help you keep track of which one you are using. Anything you
 install through ``pip`` while this name is displayed will be installed in that
 virtual environment, isolated from other environments and system-wide packages.
 
+.. _intro-contributing-install-local-copy:
+
 Go ahead and install the previously cloned copy of Django:
 
 .. console::
 
     $ python -m pip install -e /path/to/your/local/clone/django/
 
-The installed version of Django is now pointing at your local copy. You will
-immediately see any changes you make to it, which is of great help when writing
-your first patch.
+The installed version of Django is now pointing at your local copy by installing
+in editable mode. You will immediately see any changes you make to it, which is
+of great help when writing your first patch.
+
+Creating projects with a local copy of Django
+---------------------------------------------
+
+It may be helpful to test your local changes with a Django project. First you
+have to create a new virtual environment, :ref:`install the previously cloned
+local copy of Django in editable mode <intro-contributing-install-local-copy>`,
+and create a new Django project outside of your local copy of Django. You will
+immediately see any changes you make to Django in your new project, which is
+of great help when writing your first patch.
 
 Running Django's test suite for the first time
 ==============================================


### PR DESCRIPTION
Added notes to clarify how a new contributor can try out newly made
changes in a local project by creating a new virtual env also pointing
to local Django clone from where to start a new project with
django-admin startproject.

This alleviates confusion for people who end up trying to run
django-admin startproject within the directory in which they have
cloned Django to run tests.

Added link to pip "editable install" documentation for reference.