### PR TITLE
Refs #20456 -- Moved initialization of HEAD method based on GET to the View.setup() for generic views.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -286,6 +286,7 @@ answer newbie questions, and generally made Django that much better:
     favo@exoweb.net
     fdr <drfarina@gmail.com>
     Federico Capoano <nemesis@ninux.org>
+    Felipe Lee <felipe.lee.garcia@gmail.com>
     Filip Noetzel <http://filip.noetzel.co.uk/>
     Filip Wasilewski <filip.wasilewski@gmail.com>
     Finn Gruwier Larsen <finn@gruwier.dk>

--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -60,8 +60,6 @@ class View:
 
         def view(request, *args, **kwargs):
             self = cls(**initkwargs)
-            if hasattr(self, 'get') and not hasattr(self, 'head'):
-                self.head = self.get
             self.setup(request, *args, **kwargs)
             if not hasattr(self, 'request'):
                 raise AttributeError(
@@ -82,6 +80,8 @@ class View:
 
     def setup(self, request, *args, **kwargs):
         """Initialize attributes shared by all view methods."""
+        if hasattr(self, 'get') and not hasattr(self, 'head'):
+            self.head = self.get
         self.request = request
         self.args = args
         self.kwargs = kwargs

--- a/docs/ref/class-based-views/base.txt
+++ b/docs/ref/class-based-views/base.txt
@@ -79,12 +79,9 @@ MRO is an acronym for Method Resolution Order.
 
     .. method:: setup(request, *args, **kwargs)
 
-        Initializes view instance attributes: ``self.request``, ``self.args``,
-        and ``self.kwargs`` prior to :meth:`dispatch`.
+        Performs key view initialization prior to :meth:`dispatch`.
 
-        Overriding this method allows mixins to setup instance attributes for
-        reuse in child classes. When overriding this method, you must call
-        ``super()``.
+        If overriding this method, you must call ``super()``.
 
     .. method:: dispatch(request, *args, **kwargs)
 

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -113,6 +113,13 @@ class ViewTest(SimpleTestCase):
         response = SimpleView.as_view()(self.rf.head('/'))
         self.assertEqual(response.status_code, 200)
 
+    def test_setup_get_and_head(self):
+        view_instance = SimpleView()
+        self.assertFalse(hasattr(view_instance, 'head'))
+        view_instance.setup(self.rf.get('/'))
+        self.assertTrue(hasattr(view_instance, 'head'))
+        self.assertEqual(view_instance.head, view_instance.get)
+
     def test_head_no_get(self):
         """
         Test a view which supplies no GET method responds to HEAD with HTTP 405.

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -259,6 +259,17 @@ class ViewTest(SimpleTestCase):
         with self.assertRaisesMessage(AttributeError, msg):
             TestView.as_view()(self.rf.get('/'))
 
+    def test_setup_adds_args_kwargs_request(self):
+        request = self.rf.get('/')
+        args = ('arg 1', 'arg 2')
+        kwargs = {'kwarg_1': 1, 'kwarg_2': 'year'}
+
+        view = View()
+        view.setup(request, *args, **kwargs)
+        self.assertEqual(request, view.request)
+        self.assertEqual(args, view.args)
+        self.assertEqual(kwargs, view.kwargs)
+
     def test_direct_instantiation(self):
         """
         It should be possible to use the view by directly instantiating it


### PR DESCRIPTION
I've added documentation, but it got a bit long. Not sure if I should cut it down a bit, move it elsewhere, add more, or if it's fine as is.

I ran the doc build, spelling check, flake8, and django tests (sqlite and postgres).

