### PR TITLE
Refs #26207 -- Removed obsolete note about slow constructing a model with deferred fields.

### DIFF
--- a/docs/topics/db/optimization.txt
+++ b/docs/topics/db/optimization.txt
@@ -233,14 +233,12 @@ you know that you won't need (or won't need in most cases) to avoid loading
 them. Note that if you *do* use them, the ORM will have to go and get them in
 a separate query, making this a pessimization if you use it inappropriately.
 
-Also, be aware that there is some (small extra) overhead incurred inside
-Django when constructing a model with deferred fields. Don't be too aggressive
-in deferring fields without profiling as the database has to read most of the
-non-text, non-VARCHAR data from the disk for a single row in the results, even
-if it ends up only using a few columns. The ``defer()`` and ``only()`` methods
-are most useful when you can avoid loading a lot of text data or for fields
-that might take a lot of processing to convert back to Python. As always,
-profile first, then optimize.
+Don't be too aggressive in deferring fields without profiling as the database
+has to read most of the non-text, non-VARCHAR data from the disk for a single
+row in the results, even if it ends up only using a few columns. The
+``defer()`` and ``only()`` methods are most useful when you can avoid loading a
+lot of text data or for fields that might take a lot of processing to convert
+back to Python. As always, profile first, then optimize.
 
 Use ``QuerySet.count()``
 ------------------------


### PR DESCRIPTION
This is not true since 7f51876f998 removed the necessity of creating proxy model classes at runtime for each deferred field sets.

For the record it was `deferred_class_factory` that motivated the addition of this note

https://github.com/django/django/commit/7f51876f99851fdc3fef63aecdfbcffa199c26b9#diff-1e7fc0d7d1b36358e371fab97bd1ddb1L233-L274