### PR TITLE
Fixed #30880 -- Optimized _tx_resource_for_name()

### DIFF
--- a/scripts/manage_translations.py
+++ b/scripts/manage_translations.py
@@ -61,11 +61,8 @@ def _get_locale_dirs(resources, include_core=True):
 
 def _tx_resource_for_name(name):
     """ Return the Transifex resource name """
-    if name == 'core':
-        return "django.core"
-    else:
-        return "django.contrib-%s" % name
-
+    return "django.core" if name == 'core' else "django.contrib-%s" % name
+    
 
 def _check_diff(cat_name, base_path):
     """


### PR DESCRIPTION
The _tx_resource_for_name() function in django/scripts/manage_translations.py uses simple if else statement to return the Transifex resource name.
I replaced the simple if else statement with a ternary operator. It reduced the number of lines of codes and make the code more readable.
