### PR TITLE
Fixed #30880 -- Optimized _tx_resource_for_name() function

### DIFF
--- a/scripts/manage_translations.py
+++ b/scripts/manage_translations.py
@@ -61,10 +61,7 @@ def _get_locale_dirs(resources, include_core=True):
 
 def _tx_resource_for_name(name):
     """ Return the Transifex resource name """
-    if name == 'core':
-        return "django.core"
-    else:
-        return "django.contrib-%s" % name
+    return "django.core" if name == 'core' else "django.contrib-%s" % name
 
 
 def _check_diff(cat_name, base_path):


### PR DESCRIPTION
The function **_tx_resource_for_name()** in the file **manage_translation.py** uses if else statement to return the **Transifex resource name**.
I replaced that if else statement with a ternary operator. It allows us to replace simple if statements with a single line expression and increases code readability by reducing number of lines of code.
