### PR TITLE
Fixed #20577 -- Deferred filtering of prefetched related querysets.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,6 +40,7 @@ answer newbie questions, and generally made Django that much better:
     Alexander Dutton <dev@alexdutton.co.uk>
     Alexander Myodov <alex@myodov.com>
     Alexandr Tatarinov <tatarinov1997@gmail.com>
+    Alex Aktsipetrov <alex.akts@gmail.com>
     Alex Becker <https://alexcbecker.net/>
     Alex Couper <http://alexcouper.com/>
     Alex Dedul

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -883,6 +883,7 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
             queryset._add_hints(instance=self.instance)
             if self._db:
                 queryset = queryset.using(self._db)
+            queryset._defer_next_filter = True
             return queryset._next_is_sticky().filter(**self.core_filters)
 
         def _remove_prefetched_objects(self):

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -935,7 +935,7 @@ class QuerySet:
             clone.query.add_q(filter_obj)
             return clone
         else:
-            return self._filter_or_exclude(None, **filter_obj)
+            return self._filter_or_exclude(False, **filter_obj)
 
     def _combinator_query(self, combinator, *other_qs, all=False):
         # Clone the query to inherit the select list and everything

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -212,6 +212,12 @@ class PickleabilityTestCase(TestCase):
         qs = Happening.objects.annotate(latest_time=models.Max('when'))
         self.assert_pickles(qs)
 
+    def test_filter_deferred(self):
+        qs = Happening.objects.all()
+        qs._defer_next_filter = True
+        qs = qs.filter(id=0)
+        self.assert_pickles(qs)
+
     def test_missing_django_version_unpickling(self):
         """
         #21430 -- Verifies a warning is raised for querysets that are


### PR DESCRIPTION
Since Queryset._filter_or_exclude machinery is quite heavy, add the
possibility to defer it till actually necessary. Use it in
ManyRelatedManager to avoid O(N) calls to Query.add_q in
prefetch_related.