### PR TITLE
Fixed #28699 - REMOTE_USER issues with CSRF

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -756,6 +756,7 @@ answer newbie questions, and generally made Django that much better:
     Rob Hudson <https://rob.cogit8.org/>
     Rob Nguyen <tienrobertnguyenn@gmail.com>
     Robin Munn <http://www.geekforgod.com/>
+    Rodrigo Gadea <matematica.a3k@gmail.com>
     Rodrigo Pinheiro Marques de Araújo <fenrrir@gmail.com>
     Romain Garrigues <romain.garrigues.cs@gmail.com>
     Ronny Haryanto <https://ronny.haryan.to/>

--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -37,6 +37,10 @@ def get_backends():
     return _get_backends(return_tuples=False)
 
 
+def csrf_is_enabled():
+    return 'django.middleware.csrf.CsrfViewMiddleware' in settings.MIDDLEWARE
+
+
 def _clean_credentials(credentials):
     """
     Clean a dictionary of credentials of potentially sensitive info before
@@ -127,7 +131,10 @@ def login(request, user, backend=None):
     request.session[HASH_SESSION_KEY] = session_auth_hash
     if hasattr(request, 'user'):
         request.user = user
-    rotate_token(request)
+    if csrf_is_enabled():
+        request.META['CSRF_COOKIE_USED'] = True
+        request.csrf_cookie_needs_reset = True
+        request.csrf_token_rotation = True
     user_logged_in.send(sender=user.__class__, request=request, user=user)
 
 

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -319,6 +319,12 @@ class CsrfViewMiddleware(MiddlewareMixin):
         if not request.META.get("CSRF_COOKIE_USED", False):
             return response
 
+        # Handle token rotation
+        if getattr(request, 'csrf_token_rotation', False):
+            request.META.update({
+                "CSRF_COOKIE": _get_new_csrf_token(),
+            })
+
         # Set the CSRF cookie even if it's already set, so we renew
         # the expiry timer.
         self._set_token(request, response)

--- a/docs/howto/auth-remote-user.txt
+++ b/docs/howto/auth-remote-user.txt
@@ -104,6 +104,14 @@ If you need more control, you can create your own authentication backend
 that inherits from :class:`~django.contrib.auth.backends.RemoteUserBackend` and
 override one or more of its attributes and methods.
 
+.. note::
+
+    Note that for POSTing to CSRF-protected views, you must acquire the CSRF
+    token that will rotate after login. The ``RemoteUserBackend`` will login 
+    the user after the first request with the correct header - even with a GET
+    request - and the CSFR middleware will rotate the token, returning the new
+    one in the response's cookies.
+
 .. _persistent-remote-user-middleware-howto:
 
 Using ``REMOTE_USER`` on login pages only

--- a/tests/auth_tests/urls.py
+++ b/tests/auth_tests/urls.py
@@ -9,6 +9,7 @@ from django.shortcuts import render
 from django.template import RequestContext, Template
 from django.urls import path, re_path, reverse_lazy
 from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import ensure_csrf_cookie, csrf_protect
 from django.views.i18n import set_language
 
 
@@ -19,6 +20,8 @@ class CustomRequestAuthenticationForm(AuthenticationForm):
 
 
 @never_cache
+@ensure_csrf_cookie
+@csrf_protect
 def remote_user_auth_view(request):
     "Dummy view for remote user tests"
     t = Template("Username is {{ user }}.")


### PR DESCRIPTION
Delegate CSRF token rotation on login to middleware instead of
django.auth.login and clarify documentation.