### PR TITLE
Fixed #28699 - Deferred CSRF token rotation on login to middleware process response phase.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -766,6 +766,7 @@ answer newbie questions, and generally made Django that much better:
     Rob Hudson <https://rob.cogit8.org/>
     Rob Nguyen <tienrobertnguyenn@gmail.com>
     Robin Munn <http://www.geekforgod.com/>
+    Rodrigo Gadea <matematica.a3k@gmail.com>
     Rodrigo Pinheiro Marques de Araújo <fenrrir@gmail.com>
     Romain Garrigues <romain.garrigues.cs@gmail.com>
     Ronny Haryanto <https://ronny.haryan.to/>

--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -4,7 +4,6 @@ import re
 from django.apps import apps as django_apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
-from django.middleware.csrf import rotate_token
 from django.utils.crypto import constant_time_compare
 from django.utils.module_loading import import_string
 
@@ -128,7 +127,8 @@ def login(request, user, backend=None):
     request.session[HASH_SESSION_KEY] = session_auth_hash
     if hasattr(request, 'user'):
         request.user = user
-    rotate_token(request)
+    # Persist the action in the request for further processing, i.e. (CSRF) middleware
+    request.new_user_login = True
     user_logged_in.send(sender=user.__class__, request=request, user=user)
 
 

--- a/docs/howto/auth-remote-user.txt
+++ b/docs/howto/auth-remote-user.txt
@@ -104,6 +104,13 @@ If you need more control, you can create your own authentication backend
 that inherits from :class:`~django.contrib.auth.backends.RemoteUserBackend` and
 override one or more of its attributes and methods.
 
+.. note::
+
+    The ``RemoteUserBackend`` will login the user after the first request with
+    the correct header - even with a GET request - and the CSFR middleware will
+    rotate the token after a login, returning the new one in the response's
+    cookies.
+
 .. _persistent-remote-user-middleware-howto:
 
 Using ``REMOTE_USER`` on login pages only

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -10,7 +10,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.admin.models import LogEntry
 from django.contrib.auth import (
-    BACKEND_SESSION_KEY, REDIRECT_FIELD_NAME, SESSION_KEY,
+    BACKEND_SESSION_KEY, REDIRECT_FIELD_NAME, SESSION_KEY, login as auth_login,
 )
 from django.contrib.auth.forms import (
     AuthenticationForm, PasswordChangeForm, SetPasswordForm,
@@ -25,7 +25,7 @@ from django.contrib.sessions.middleware import SessionMiddleware
 from django.contrib.sites.requests import RequestSite
 from django.core import mail
 from django.db import connection
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponseRedirect
 from django.middleware.csrf import CsrfViewMiddleware, get_token
 from django.test import Client, TestCase, override_settings
 from django.test.client import RedirectCycleError
@@ -679,6 +679,65 @@ class LoginTest(AuthViewsTestCase):
 
         # Check the CSRF token switched
         self.assertNotEqual(token1, token2)
+
+    def test_login_csrf_mw_token_rotation(self):
+        """
+        Makes sure that token rotation on login is done by the middleware.
+        Tests that django.contrib.auth.login does not rotates the CSRF token
+        and delegates it to the CSRF Middleware's process_response.
+        """
+        # The first part is analogous to test_login_csrf_rotate():
+        # Do a GET to establish a CSRF token
+        # The test client isn't used here as it's a test for middleware.
+        req = HttpRequest()
+        CsrfViewMiddleware().process_view(req, LoginView.as_view(), (), {})
+        # get_token() triggers CSRF token inclusion in the response
+        get_token(req)
+        resp = LoginView.as_view()(req)
+        resp2 = CsrfViewMiddleware().process_response(req, resp)
+        csrf_cookie = resp2.cookies.get(settings.CSRF_COOKIE_NAME, None)
+        token1 = csrf_cookie.coded_value
+
+        # Prepare the POST request
+        req = HttpRequest()
+        req.COOKIES[settings.CSRF_COOKIE_NAME] = token1
+        req.method = "POST"
+        req.POST = {
+            'username': 'testclient',
+            'password': 'password',
+            'csrfmiddlewaretoken': token1
+        }
+
+        # Here comes the difference:
+        # LoginView is decorated inside with 'csrf_protect', which calls
+        # MW.process_response, rotating the token indeed, but what the goal of
+        # the test is to check that the login function
+        # (which is not a view but the test ended up here :) does
+        # not rotate it and delegates it to the middleware. For this, the
+        # behaviour of LoginView will be reproduced to be tested.
+
+        # Apply the middleware before the view execution
+        SessionMiddleware().process_request(req)
+        CsrfViewMiddleware().process_request(req)
+        CsrfViewMiddleware().process_view(req, LoginView.as_view(), (), {})
+        # If it gets up to here, then the MW has accepted the request
+        # (and its token), and instead of calling
+        # `resp = LoginView.as_view()(req)`
+        # its logic will be reproduced (wrapping with csrf_exempt at this point
+        # doesn't prevent the execution of process_response)
+        form = AuthenticationForm(data=req.POST)
+        form.is_valid()
+        auth_login(req, form.get_user())
+        # Check the token hasn't been rotated
+        self.assertEqual(req.META["CSRF_COOKIE"], token1)
+        resp = HttpResponseRedirect(settings.LOGIN_REDIRECT_URL)
+        # Here (process_response) is where the rotation occurs
+        resp2 = CsrfViewMiddleware().process_response(req, resp)
+        csrf_cookie2 = resp2.cookies.get(settings.CSRF_COOKIE_NAME, None)
+        token2 = csrf_cookie2.coded_value
+
+        # Check the CSRF token switched
+        self.assertNotEqual(token2, token1)
 
     def test_session_key_flushed_on_login(self):
         """

--- a/tests/auth_tests/urls.py
+++ b/tests/auth_tests/urls.py
@@ -9,6 +9,7 @@ from django.shortcuts import render
 from django.template import RequestContext, Template
 from django.urls import path, re_path, reverse_lazy
 from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_protect, ensure_csrf_cookie
 from django.views.i18n import set_language
 
 
@@ -19,6 +20,8 @@ class CustomRequestAuthenticationForm(AuthenticationForm):
 
 
 @never_cache
+@ensure_csrf_cookie
+@csrf_protect
 def remote_user_auth_view(request):
     "Dummy view for remote user tests"
     t = Template("Username is {{ user }}.")


### PR DESCRIPTION
Delegate CSRF token rotation on login to middleware instead of
django.auth.login and clarify documentation.