### PR TITLE
Moved "Sign the CLA" to the bottom of New Contributor First Steps.

### DIFF
--- a/docs/internals/contributing/new-contributors.txt
+++ b/docs/internals/contributing/new-contributors.txt
@@ -15,13 +15,6 @@ First steps
 
 Start with these steps to discover Django's development process.
 
-* **Sign the Contributor License Agreement**
-
-  The code that you write belongs to you or your employer. If your
-  contribution is more than one or two lines of code, you need to sign the
-  `CLA`_. See the `Contributor License Agreement FAQ`_ for a more thorough
-  explanation.
-
 * **Triage tickets**
 
   If an `unreviewed ticket`_ reports a bug, try and reproduce it. If you
@@ -62,6 +55,13 @@ Start with these steps to discover Django's development process.
       suggested above.
 
       .. _reports page: https://code.djangoproject.com/wiki/Reports
+
+* **Sign the Contributor License Agreement**
+
+  The code that you write belongs to you or your employer. If your
+  contribution is more than one or two lines of code, you need to sign the
+  `CLA`_. See the `Contributor License Agreement FAQ`_ for a more thorough
+  explanation.
 
 .. _CLA: https://www.djangoproject.com/foundation/cla/
 .. _Contributor License Agreement FAQ: https://www.djangoproject.com/foundation/cla/faq/


### PR DESCRIPTION
[As discussed on the mailing list][0]:

> Step 1 of First Steps shouldn't be "Find a printer".

[0]: https://groups.google.com/d/topic/django-developers/owOqFmxufgs/discussion