### PR TITLE
Fixed #26167 -- Added support for functional indexes.

### DIFF
--- a/django/contrib/postgres/apps.py
+++ b/django/contrib/postgres/apps.py
@@ -6,10 +6,13 @@ from django.apps import AppConfig
 from django.db import connections
 from django.db.backends.signals import connection_created
 from django.db.migrations.writer import MigrationWriter
-from django.db.models import CharField, TextField
+from django.db.models import CharField, OrderBy, TextField
+from django.db.models.functions import Collate
+from django.db.models.indexes import IndexExpression
 from django.test.signals import setting_changed
 from django.utils.translation import gettext_lazy as _
 
+from .indexes import OpClass
 from .lookups import SearchLookup, TrigramSimilar, Unaccent
 from .serializers import RangeSerializer
 from .signals import register_type_handlers
@@ -63,3 +66,4 @@ class PostgresConfig(AppConfig):
         CharField.register_lookup(TrigramSimilar)
         TextField.register_lookup(TrigramSimilar)
         MigrationWriter.register_serializer(RANGE_TYPES, RangeSerializer)
+        IndexExpression.register_wrappers(OrderBy, OpClass, Collate)

--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -281,6 +281,10 @@ class BaseDatabaseFeatures:
     supports_functions_in_partial_indexes = True
     # Does the backend support covering indexes (CREATE INDEX ... INCLUDE ...)?
     supports_covering_indexes = False
+    # Does the backend support indexes on expressions?
+    supports_expression_indexes = False
+    # Does the backend treat COLLATE as an indexed expression?
+    collate_as_index_expression = False
 
     # Does the database allow more than one constraint or index on the same
     # field(s)?

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -2,10 +2,11 @@ import logging
 from datetime import datetime
 
 from django.db.backends.ddl_references import (
-    Columns, ForeignKeyName, IndexName, Statement, Table,
+    Columns, Expressions, ForeignKeyName, IndexName, Statement, Table,
 )
 from django.db.backends.utils import names_digest, split_identifier
 from django.db.models import Deferrable, Index
+from django.db.models.sql import Query
 from django.db.transaction import TransactionManagementError, atomic
 from django.utils import timezone
 
@@ -354,10 +355,20 @@ class BaseDatabaseSchemaEditor:
 
     def add_index(self, model, index):
         """Add an index on a model."""
+        if (
+            index.contains_expressions and
+            not self.connection.features.supports_expression_indexes
+        ):
+            return None
         self.execute(index.create_sql(model, self), params=None)
 
     def remove_index(self, model, index):
         """Remove an index from a model."""
+        if (
+            index.contains_expressions and
+            not self.connection.features.supports_expression_indexes
+        ):
+            return None
         self.execute(index.remove_sql(model, self))
 
     def add_constraint(self, model, constraint):
@@ -992,12 +1003,17 @@ class BaseDatabaseSchemaEditor:
 
     def _create_index_sql(self, model, *, fields=None, name=None, suffix='', using='',
                           db_tablespace=None, col_suffixes=(), sql=None, opclasses=(),
-                          condition=None, include=None):
+                          condition=None, include=None, expressions=None):
         """
-        Return the SQL statement to create the index for one or several fields.
-        `sql` can be specified if the syntax differs from the standard (GIS
-        indexes, ...).
+        Return the SQL statement to create the index for one or several fields
+        or expressions. `sql` can be specified if the syntax differs from the
+        standard (GIS indexes, ...).
         """
+        fields = fields or []
+        expressions = expressions or []
+        compiler = Query(model, alias_cols=False).get_compiler(
+            connection=self.connection,
+        )
         tablespace_sql = self._get_index_tablespace_sql(model, fields, db_tablespace=db_tablespace)
         columns = [field.column for field in fields]
         sql_create_index = sql or self.sql_create_index
@@ -1014,7 +1030,11 @@ class BaseDatabaseSchemaEditor:
             table=Table(table, self.quote_name),
             name=IndexName(table, columns, suffix, create_index_name),
             using=using,
-            columns=self._index_columns(table, columns, col_suffixes, opclasses),
+            columns=(
+                self._index_columns(table, columns, col_suffixes, opclasses)
+                if columns
+                else Expressions(table, expressions, compiler, self.quote_value)
+            ),
             extra=tablespace_sql,
             condition=self._index_condition_sql(condition),
             include=self._index_include_sql(model, include),
@@ -1046,7 +1066,11 @@ class BaseDatabaseSchemaEditor:
             output.append(self._create_index_sql(model, fields=fields, suffix='_idx'))
 
         for index in model._meta.indexes:
-            output.append(index.create_sql(model, self))
+            if (
+                not index.contains_expressions or
+                self.connection.features.supports_expression_indexes
+            ):
+                output.append(index.create_sql(model, self))
         return output
 
     def _field_indexes_sql(self, model, field):

--- a/django/db/backends/ddl_references.py
+++ b/django/db/backends/ddl_references.py
@@ -2,6 +2,7 @@
 Helpers to manipulate deferred DDL statements that might need to be adjusted or
 discarded within when executing a migration.
 """
+from copy import deepcopy
 
 
 class Reference:
@@ -198,3 +199,38 @@ class Statement(Reference):
 
     def __str__(self):
         return self.template % self.parts
+
+
+class Expressions(TableColumns):
+    def __init__(self, table, expressions, compiler, quote_value):
+        self.compiler = compiler
+        self.expressions = expressions
+        self.quote_value = quote_value
+        columns = [col.target.column for col in self.compiler.query._gen_cols([self.expressions])]
+        super().__init__(table, columns)
+
+    def rename_table_references(self, old_table, new_table):
+        if self.table != old_table:
+            return
+        expressions = deepcopy(self.expressions)
+        self.columns = []
+        for col in self.compiler.query._gen_cols([expressions]):
+            col.alias = new_table
+        self.expressions = expressions
+        super().rename_table_references(old_table, new_table)
+
+    def rename_column_references(self, table, old_column, new_column):
+        if self.table != table:
+            return
+        expressions = deepcopy(self.expressions)
+        self.columns = []
+        for col in self.compiler.query._gen_cols([expressions]):
+            if col.target.column == old_column:
+                col.target.column = new_column
+            self.columns.append(col.target.column)
+        self.expressions = expressions
+
+    def __str__(self):
+        sql, params = self.compiler.compile(self.expressions)
+        params = map(self.quote_value, params)
+        return sql % tuple(params)

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -59,6 +59,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_ignore_conflicts = False
     max_query_params = 2**16 - 1
     supports_partial_indexes = False
+    supports_expression_indexes = True
     supports_slicing_ordering_in_compound = True
     allows_multiple_constraints_on_same_fields = False
     supports_boolean_expr_in_select_clause = False

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -58,6 +58,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_deferrable_unique_constraints = True
     has_json_operators = True
     json_key_contains_list_matching_requires_list = True
+    supports_expression_indexes = True
 
     django_test_skips = {
         'opclasses are PostgreSQL only.': {

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -227,11 +227,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     def _create_index_sql(
         self, model, *, fields=None, name=None, suffix='', using='',
         db_tablespace=None, col_suffixes=(), sql=None, opclasses=(),
-        condition=None, concurrently=False, include=None,
+        condition=None, concurrently=False, include=None, expressions=None,
     ):
         sql = self.sql_create_index if not concurrently else self.sql_create_index_concurrently
         return super()._create_index_sql(
             model, fields=fields, name=name, suffix=suffix, using=using,
             db_tablespace=db_tablespace, col_suffixes=col_suffixes, sql=sql,
             opclasses=opclasses, condition=condition, include=include,
+            expressions=expressions,
         )

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -38,6 +38,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_pragma_foreign_key_check = Database.sqlite_version_info >= (3, 20, 0)
     can_defer_constraint_checks = supports_pragma_foreign_key_check
     supports_functions_in_partial_indexes = Database.sqlite_version_info >= (3, 15, 0)
+    supports_expression_indexes = True
     supports_over_clause = Database.sqlite_version_info >= (3, 25, 0)
     supports_frame_range_fixed_distance = Database.sqlite_version_info >= (3, 28, 0)
     supports_aggregate_filter_clause = Database.sqlite_version_info >= (3, 30, 1)

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -777,6 +777,12 @@ class AddIndex(IndexOperation):
         )
 
     def describe(self):
+        if self.index.expressions:
+            return 'Create index %s on %s on model %s' % (
+                self.index.name,
+                ', '.join([str(expression) for expression in self.index.expressions]),
+                self.model_name,
+            )
         return 'Create index %s on field(s) %s of model %s' % (
             self.index.name,
             ', '.join(self.index.fields),

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1681,6 +1681,22 @@ class Model(metaclass=ModelBase):
                         id='models.W040',
                     )
                 )
+            if not (
+                connection.features.supports_expression_indexes or
+                'supports_expression_indexes' in cls._meta.required_db_features
+            ) and any(index.contains_expressions for index in cls._meta.indexes):
+                errors.append(
+                    checks.Warning(
+                        '%s does not support indexes on expressions.'
+                        % connection.display_name,
+                        hint=(
+                            "An index won't be created. Silence this warning "
+                            "if you don't care about it."
+                        ),
+                        obj=cls,
+                        id='models.W043',
+                    )
+                )
         fields = [field for index in cls._meta.indexes for field, _ in index.fields_orders]
         fields += [include for index in cls._meta.indexes for include in index.include]
         errors.extend(cls._check_local_fields(fields, 'indexes'))

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -375,7 +375,10 @@ class BaseExpression:
         yield self
         for expr in self.get_source_expressions():
             if expr:
-                yield from expr.flatten()
+                if hasattr(expr, 'flatten'):
+                    yield from expr.flatten()
+                else:
+                    yield expr
 
     def select_format(self, compiler, sql, params):
         """
@@ -896,6 +899,10 @@ class ExpressionList(Func):
 
     def __str__(self):
         return self.arg_joiner.join(str(arg) for arg in self.source_expressions)
+
+    def as_sqlite(self, compiler, connection, **extra_context):
+        # Casting to numeric is unnecessary.
+        return self.as_sql(compiler, connection, **extra_context)
 
 
 class ExpressionWrapper(Expression):

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -1,6 +1,9 @@
 from django.db.backends.utils import names_digest, split_identifier
+from django.db.models.expressions import Col, ExpressionList, F, Func, OrderBy
+from django.db.models.functions import Collate
 from django.db.models.query_utils import Q
 from django.db.models.sql import Query
+from django.utils.functional import partition
 
 __all__ = ['Index']
 
@@ -13,7 +16,7 @@ class Index:
 
     def __init__(
         self,
-        *,
+        *expressions,
         fields=(),
         name=None,
         db_tablespace=None,
@@ -31,11 +34,25 @@ class Index:
             raise ValueError('Index.fields must be a list or tuple.')
         if not isinstance(opclasses, (list, tuple)):
             raise ValueError('Index.opclasses must be a list or tuple.')
+        if not expressions and not fields:
+            raise ValueError(
+                'At least one field or expression is required to define an '
+                'index.'
+            )
+        if expressions and fields:
+            raise ValueError(
+                'Index.fields and expressions are mutually exclusive.',
+            )
+        if expressions and not name:
+            raise ValueError('An index must be named to use expressions.')
+        if expressions and opclasses:
+            raise ValueError(
+                'Index.opclasses cannot be used with expressions. Use '
+                'django.contrib.postgres.indexes.OpClass() instead.'
+            )
         if opclasses and len(fields) != len(opclasses):
             raise ValueError('Index.fields and Index.opclasses must have the same number of elements.')
-        if not fields:
-            raise ValueError('At least one field is required to define an index.')
-        if not all(isinstance(field, str) for field in fields):
+        if fields and not all(isinstance(field, str) for field in fields):
             raise ValueError('Index.fields must contain only strings with field names.')
         if include and not name:
             raise ValueError('A covering index must be named.')
@@ -52,6 +69,14 @@ class Index:
         self.opclasses = opclasses
         self.condition = condition
         self.include = tuple(include) if include else ()
+        self.expressions = tuple(
+            F(expression) if isinstance(expression, str) else expression
+            for expression in expressions
+        )
+
+    @property
+    def contains_expressions(self):
+        return bool(self.expressions)
 
     def _get_condition_sql(self, model, schema_editor):
         if self.condition is None:
@@ -63,15 +88,31 @@ class Index:
         return sql % tuple(schema_editor.quote_value(p) for p in params)
 
     def create_sql(self, model, schema_editor, using='', **kwargs):
-        fields = [model._meta.get_field(field_name) for field_name, _ in self.fields_orders]
         include = [model._meta.get_field(field_name).column for field_name in self.include]
-        col_suffixes = [order[1] for order in self.fields_orders]
         condition = self._get_condition_sql(model, schema_editor)
+        if self.expressions:
+            index_expressions = []
+            for expression in self.expressions:
+                index_expression = IndexExpression(expression)
+                index_expression.set_wrapper_classes(schema_editor.connection)
+                index_expressions.append(index_expression)
+            expressions = ExpressionList(*index_expressions).resolve_expression(
+                Query(model, alias_cols=False),
+            )
+            fields = None
+            col_suffixes = None
+        else:
+            fields = [
+                model._meta.get_field(field_name)
+                for field_name, _ in self.fields_orders
+            ]
+            col_suffixes = [order[1] for order in self.fields_orders]
+            expressions = None
         return schema_editor._create_index_sql(
             model, fields=fields, name=self.name, using=using,
             db_tablespace=self.db_tablespace, col_suffixes=col_suffixes,
             opclasses=self.opclasses, condition=condition, include=include,
-            **kwargs,
+            expressions=expressions, **kwargs,
         )
 
     def remove_sql(self, model, schema_editor, **kwargs):
@@ -80,7 +121,9 @@ class Index:
     def deconstruct(self):
         path = '%s.%s' % (self.__class__.__module__, self.__class__.__name__)
         path = path.replace('django.db.models.indexes', 'django.db.models')
-        kwargs = {'fields': self.fields, 'name': self.name}
+        kwargs = {'name': self.name}
+        if self.fields:
+            kwargs['fields'] = self.fields
         if self.db_tablespace is not None:
             kwargs['db_tablespace'] = self.db_tablespace
         if self.opclasses:
@@ -89,12 +132,12 @@ class Index:
             kwargs['condition'] = self.condition
         if self.include:
             kwargs['include'] = self.include
-        return (path, (), kwargs)
+        return (path, self.expressions, kwargs)
 
     def clone(self):
         """Create a copy of this Index."""
-        _, _, kwargs = self.deconstruct()
-        return self.__class__(**kwargs)
+        _, args, kwargs = self.deconstruct()
+        return self.__class__(*args, **kwargs)
 
     def set_name_with_model(self, model):
         """
@@ -126,8 +169,12 @@ class Index:
             self.name = 'D%s' % self.name[1:]
 
     def __repr__(self):
-        return "<%s: fields='%s'%s%s%s>" % (
-            self.__class__.__name__, ', '.join(self.fields),
+        return '<%s:%s%s%s%s%s>' % (
+            self.__class__.__name__,
+            '' if not self.fields else " fields='%s'" % ', '.join(self.fields),
+            '' if not self.expressions else " expressions='%s'" % ', '.join([
+                str(expression) for expression in self.expressions
+            ]),
             '' if self.condition is None else ' condition=%s' % self.condition,
             '' if not self.include else " include='%s'" % ', '.join(self.include),
             '' if not self.opclasses else " opclasses='%s'" % ', '.join(self.opclasses),
@@ -137,3 +184,84 @@ class Index:
         if self.__class__ == other.__class__:
             return self.deconstruct() == other.deconstruct()
         return NotImplemented
+
+
+class IndexExpression(Func):
+    """Order and wrap expressions for CREATE INDEX statements."""
+    template = '%(expressions)s'
+    wrapper_classes = (OrderBy, Collate)
+
+    def set_wrapper_classes(self, connection=None):
+        # Some databases (e.g. MySQL) treats COLLATE as an indexed expression.
+        if connection and connection.features.collate_as_index_expression:
+            self.wrapper_classes = tuple([
+                wrapper_cls
+                for wrapper_cls in self.wrapper_classes
+                if wrapper_cls is not Collate
+            ])
+
+    @classmethod
+    def register_wrappers(cls, *wrapper_classes):
+        cls.wrapper_classes = wrapper_classes
+
+    def resolve_expression(
+        self,
+        query=None,
+        allow_joins=True,
+        reuse=None,
+        summarize=False,
+        for_save=False,
+    ):
+        expressions = list(self.flatten())
+        # Split expressions and wrappers.
+        index_expressions, wrappers = partition(
+            lambda e: isinstance(e, self.wrapper_classes),
+            expressions,
+        )
+        wrapper_types = [type(wrapper) for wrapper in wrappers]
+        if len(wrapper_types) != len(set(wrapper_types)):
+            raise ValueError(
+                "Multiple references to %s can't be used in an indexed "
+                "expression." % ', '.join([
+                    wrapper_cls.__qualname__ for wrapper_cls in self.wrapper_classes
+                ])
+            )
+        if expressions[1:len(wrappers) + 1] != wrappers:
+            raise ValueError(
+                '%s must be topmost expressions in an indexed expression.'
+                % ', '.join([
+                    wrapper_cls.__qualname__ for wrapper_cls in self.wrapper_classes
+                ])
+            )
+        # Wrap expressions in parentheses if they are not column references.
+        root_expression = index_expressions[1]
+        resolve_root_expression = root_expression.resolve_expression(
+            query,
+            allow_joins,
+            reuse,
+            summarize,
+            for_save,
+        )
+        if not isinstance(resolve_root_expression, Col):
+            root_expression = Func(root_expression, template='(%(expressions)s)')
+
+        if wrappers:
+            # Order wrappers and set their expressions.
+            wrappers = sorted(
+                wrappers,
+                key=lambda w: self.wrapper_classes.index(type(w)),
+            )
+            wrappers = [wrapper.copy() for wrapper in wrappers]
+            for i, wrapper in enumerate(wrappers[:-1]):
+                wrapper.set_source_expressions([wrappers[i + 1]])
+            # Set the root expression on the deepest wrapper.
+            wrappers[-1].set_source_expressions([root_expression])
+            self.set_source_expressions([wrappers[0]])
+        else:
+            # Use the root expression, if there are no wrappers.
+            self.set_source_expressions([root_expression])
+        return super().resolve_expression(query, allow_joins, reuse, summarize, for_save)
+
+    def as_sqlite(self, compiler, connection, **extra_context):
+        # Casting to numeric is unnecessary.
+        return self.as_sql(compiler, connection, **extra_context)

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -381,6 +381,7 @@ Models
 * **models.E041**: ``constraints`` refers to the joined field ``<field name>``.
 * **models.W042**: Auto-created primary key used when not defining a primary
   key type, by default ``django.db.models.AutoField``.
+* **models.W043**: ``<database>`` does not support indexes on expressions.
 
 Security
 --------

--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -10,7 +10,7 @@ available from the ``django.contrib.postgres.indexes`` module.
 ``BloomIndex``
 ==============
 
-.. class:: BloomIndex(length=None, columns=(), **options)
+.. class:: BloomIndex(*expressions, length=None, columns=(), **options)
 
     .. versionadded:: 3.1
 
@@ -30,10 +30,15 @@ available from the ``django.contrib.postgres.indexes`` module.
 
     .. _bloom: https://www.postgresql.org/docs/current/bloom.html
 
+    .. versionchanged:: 3.2
+
+        Positional argument ``*expressions`` was added in order to support
+        functional indexes.
+
 ``BrinIndex``
 =============
 
-.. class:: BrinIndex(autosummarize=None, pages_per_range=None, **options)
+.. class:: BrinIndex(*expressions, autosummarize=None, pages_per_range=None, **options)
 
     Creates a `BRIN index
     <https://www.postgresql.org/docs/current/brin-intro.html>`_.
@@ -43,24 +48,34 @@ available from the ``django.contrib.postgres.indexes`` module.
 
     The ``pages_per_range`` argument takes a positive integer.
 
+    .. versionchanged:: 3.2
+
+        Positional argument ``*expressions`` was added in order to support
+        functional indexes.
+
     .. _automatic summarization: https://www.postgresql.org/docs/current/brin-intro.html#BRIN-OPERATION
 
 ``BTreeIndex``
 ==============
 
-.. class:: BTreeIndex(fillfactor=None, **options)
+.. class:: BTreeIndex(*expressions, fillfactor=None, **options)
 
     Creates a B-Tree index.
 
     Provide an integer value from 10 to 100 to the fillfactor_ parameter to
     tune how packed the index pages will be. PostgreSQL's default is 90.
 
+    .. versionchanged:: 3.2
+
+        Positional argument ``*expressions`` was added in order to support
+        functional indexes.
+
     .. _fillfactor: https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
 
 ``GinIndex``
 ============
 
-.. class:: GinIndex(fastupdate=None, gin_pending_list_limit=None, **options)
+.. class:: GinIndex(*expressions, fastupdate=None, gin_pending_list_limit=None, **options)
 
     Creates a `gin index <https://www.postgresql.org/docs/current/gin.html>`_.
 
@@ -79,13 +94,18 @@ available from the ``django.contrib.postgres.indexes`` module.
     to tune the maximum size of the GIN pending list which is used when
     ``fastupdate`` is enabled.
 
+    .. versionchanged:: 3.2
+
+        Positional argument ``*expressions`` was added in order to support
+        functional indexes.
+
     .. _GIN Fast Update Technique: https://www.postgresql.org/docs/current/gin-implementation.html#GIN-FAST-UPDATE
     .. _gin_pending_list_limit: https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-GIN-PENDING-LIST-LIMIT
 
 ``GistIndex``
 =============
 
-.. class:: GistIndex(buffering=None, fillfactor=None, **options)
+.. class:: GistIndex(*expressions, buffering=None, fillfactor=None, **options)
 
     Creates a `GiST index
     <https://www.postgresql.org/docs/current/gist.html>`_. These indexes are
@@ -109,13 +129,18 @@ available from the ``django.contrib.postgres.indexes`` module.
     Provide an integer value from 10 to 100 to the fillfactor_ parameter to
     tune how packed the index pages will be. PostgreSQL's default is 90.
 
+    .. versionchanged:: 3.2
+
+        Positional argument ``*expressions`` was added in order to support
+        functional indexes.
+
     .. _buffering build: https://www.postgresql.org/docs/current/gist-implementation.html#GIST-BUFFERING-BUILD
     .. _fillfactor: https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
 
 ``HashIndex``
 =============
 
-.. class:: HashIndex(fillfactor=None, **options)
+.. class:: HashIndex(*expressions, fillfactor=None, **options)
 
     Creates a hash index.
 
@@ -127,12 +152,17 @@ available from the ``django.contrib.postgres.indexes`` module.
         Hash indexes have been available in PostgreSQL for a long time, but
         they suffer from a number of data integrity issues in older versions.
 
+    .. versionchanged:: 3.2
+
+        Positional argument ``*expressions`` was added in order to support
+        functional indexes.
+
     .. _fillfactor: https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
 
 ``SpGistIndex``
 ===============
 
-.. class:: SpGistIndex(fillfactor=None, **options)
+.. class:: SpGistIndex(*expressions, fillfactor=None, **options)
 
     Creates an `SP-GiST index
     <https://www.postgresql.org/docs/current/spgist.html>`_.
@@ -140,4 +170,30 @@ available from the ``django.contrib.postgres.indexes`` module.
     Provide an integer value from 10 to 100 to the fillfactor_ parameter to
     tune how packed the index pages will be. PostgreSQL's default is 90.
 
+    .. versionchanged:: 3.2
+
+        Positional argument ``*expressions`` was added in order to support
+        functional indexes.
+
     .. _fillfactor: https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
+
+``OpClass()`` expressions
+=========================
+
+.. versionadded:: 3.2
+
+.. class:: OpClass(expression, name)
+
+    An ``OpClass()`` expression represents the ``expression`` with a custom
+    `operator class`_ that can be used to define functional indexes. To use it,
+    you need to add ``'django.contrib.postgres'`` in your
+    :setting:`INSTALLED_APPS`. Set the ``name`` parameter to the name of the
+    `operator class`_.
+
+    For example::
+
+        Index(OpClass(Lower('username'), name='varchar_pattern_ops'))
+
+    creates an index on ``Lower('username')`` using ``varchar_pattern_ops``.
+
+    .. _operator class: https://www.postgresql.org/docs/current/indexes-opclass.html

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -21,9 +21,54 @@ options`_.
 ``Index`` options
 =================
 
-.. class:: Index(fields=(), name=None, db_tablespace=None, opclasses=(), condition=None, include=None)
+.. class:: Index(*expressions, fields=(), name=None, db_tablespace=None, opclasses=(), condition=None, include=None)
 
     Creates an index (B-Tree) in the database.
+
+``expressions``
+---------------
+
+.. attribute:: Index.expressions
+
+.. versionadded:: 3.2
+
+Positional argument ``*expressions`` allows creating functional indexes on
+expressions and database functions.
+
+For example::
+
+    Index(Lower('title').desc(), 'pub_date', name='lower_title_date_idx')
+
+creates an index on the lowercased value of the ``title`` field in descending
+order and the ``pub_date`` field in the default ascending order.
+
+Another example::
+
+    Index(F('height') * F('weight'), Round('weight'), name='calc_idx')
+
+creates an index on the result of multiplying fields ``height`` and ``weight``
+and the ``weight`` rounded to the nearest integer.
+
+:attr:`Index.name` is required when using ``*expressions``.
+
+.. admonition:: Restrictions on Oracle
+
+    Oracle requires functions referenced in an index to be marked as
+    ``DETERMINISTIC``. Django doesn't validate this but Oracle will error. This
+    means that functions such as
+    :class:`Random() <django.db.models.functions.Random>` aren't accepted.
+
+.. admonition:: Restrictions on PostgreSQL
+
+    PostgreSQL requires functions and operators referenced in an index to be
+    marked as ``IMMUTABLE``. Django doesn't validate this but PostgreSQL will
+    error. This means that functions such as
+    :class:`Concat() <django.db.models.functions.Concat>` aren't accepted.
+
+.. admonition:: MySQL and MariaDB
+
+    Functional indexes are ignored with MySQL < 8.0.13 and MariaDB as neither
+    supports them.
 
 ``fields``
 ----------
@@ -130,8 +175,8 @@ indexes records with more than 400 pages.
 .. admonition:: Oracle
 
     Oracle does not support partial indexes. Instead, partial indexes can be
-    emulated using functional indexes. Use a :doc:`migration
-    </topics/migrations>` to add the index using :class:`.RunSQL`.
+    emulated by using functional indexes together with
+    :class:`~django.db.models.expressions.Case` expressions.
 
 .. admonition:: MySQL and MariaDB
 

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -95,6 +95,42 @@ or on a per-model basis::
 In anticipation of the changing default, a system check will provide a warning
 if you do not have an explicit setting for :setting:`DEFAULT_AUTO_FIELD`.
 
+.. _new_functional_indexes:
+
+Functional indexes
+------------------
+
+The new :attr:`*expressions <django.db.models.Index.expressions>` positional
+argument of :class:`Index() <django.db.models.Index>` enables creating
+functional indexes on expressions and database functions. For example::
+
+    from django.db import models
+    from django.db.models import F, Index, Value
+    from django.db.models.functions import Lower, Upper
+
+
+    class MyModel(models.Model):
+        first_name = models.CharField(max_length=255)
+        last_name = models.CharField(max_length=255)
+        height = models.IntegerField()
+        weight = models.IntegerField()
+
+        class Meta:
+            indexes = [
+                Index(
+                    Lower('first_name'),
+                    Upper('last_name').desc(),
+                    name='first_last_name_idx',
+                ),
+                Index(
+                    F('height') / (F('weight') + Value(5)),
+                    name='calc_idx',
+                ),
+            ]
+
+Functional indexes are added to models using the
+:attr:`Meta.indexes <django.db.models.Options.indexes>` option.
+
 ``pymemcache`` support
 ----------------------
 
@@ -209,6 +245,10 @@ Minor features
 
 * Lookups for :class:`~django.contrib.postgres.fields.ArrayField` now allow
   (non-nested) arrays containing expressions as right-hand sides.
+
+* The new :class:`OpClass() <django.contrib.postgres.indexes.OpClass>`
+  expression allows creating functional indexes on expressions with a custom
+  operator class. See :ref:`new_functional_indexes` for more details.
 
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -495,6 +495,36 @@ class IndexesTests(TestCase):
 
         self.assertEqual(Model.check(databases=self.databases), [])
 
+    def test_func_index(self):
+        class Model(models.Model):
+            name = models.CharField(max_length=10)
+
+            class Meta:
+                indexes = [models.Index(Lower('name'), name='index_lower_name')]
+
+        warn = Warning(
+            '%s does not support indexes on expressions.'
+            % connection.display_name,
+            hint=(
+                "An index won't be created. Silence this warning if you don't "
+                "care about it."
+            ),
+            obj=Model,
+            id='models.W043',
+        )
+        expected = [] if connection.features.supports_expression_indexes else [warn]
+        self.assertEqual(Model.check(databases=self.databases), expected)
+
+    def test_func_index_required_db_features(self):
+        class Model(models.Model):
+            name = models.CharField(max_length=10)
+
+            class Meta:
+                indexes = [models.Index(Lower('name'), name='index_lower_name')]
+                required_db_features = {'supports_expression_indexes'}
+
+        self.assertEqual(Model.check(databases=self.databases), [])
+
 
 @isolate_apps('invalid_models_tests')
 class FieldNamesTests(TestCase):

--- a/tests/migrations/test_base.py
+++ b/tests/migrations/test_base.py
@@ -73,6 +73,20 @@ class MigrationTestBase(TransactionTestCase):
     def assertIndexNotExists(self, table, columns):
         return self.assertIndexExists(table, columns, False)
 
+    def assertIndexNameExists(self, table, index, using='default'):
+        with connections[using].cursor() as cursor:
+            self.assertIn(
+                index,
+                connection.introspection.get_constraints(cursor, table),
+            )
+
+    def assertIndexNameNotExists(self, table, index, using='default'):
+        with connections[using].cursor() as cursor:
+            self.assertNotIn(
+                index,
+                connection.introspection.get_constraints(cursor, table),
+            )
+
     def assertConstraintExists(self, table, name, value=True, using='default'):
         with connections[using].cursor() as cursor:
             constraints = connections[using].introspection.get_constraints(cursor, table).items()
@@ -194,6 +208,7 @@ class OperationTestBase(MigrationTestBase):
         multicol_index=False, related_model=False, mti_model=False,
         proxy_model=False, manager_model=False, unique_together=False,
         options=False, db_table=None, index_together=False, constraints=None,
+        indexes=None,
     ):
         """Creates a test model state and database table."""
         # Make the "current" state.
@@ -225,6 +240,9 @@ class OperationTestBase(MigrationTestBase):
                 'Pony',
                 models.Index(fields=['pink', 'weight'], name='pony_test_idx'),
             ))
+        if indexes:
+            for index in indexes:
+                operations.append(migrations.AddIndex('Pony', index))
         if constraints:
             for constraint in constraints:
                 operations.append(migrations.AddConstraint('Pony', constraint))

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -5,6 +5,7 @@ from django.db import (
 from django.db.migrations.migration import Migration
 from django.db.migrations.operations.fields import FieldOperation
 from django.db.migrations.state import ModelState, ProjectState
+from django.db.models.functions import Abs
 from django.db.transaction import atomic
 from django.test import SimpleTestCase, override_settings, skipUnlessDBFeature
 
@@ -1938,6 +1939,76 @@ class OperationTests(OperationTestBase):
         operation.state_forwards('test_rminsf', new_state)
         new_model = new_state.apps.get_model('test_rminsf', 'Pony')
         self.assertIsNot(old_model, new_model)
+
+    @skipUnlessDBFeature('supports_expression_indexes')
+    def test_add_func_index(self):
+        app_label = 'test_addfuncin'
+        index_name = f'{app_label}_pony_abs_idx'
+        table_name = f'{app_label}_pony'
+        project_state = self.set_up_test_model(app_label)
+        index = models.Index(Abs('weight'), name=index_name)
+        operation = migrations.AddIndex('Pony', index)
+        self.assertEqual(
+            operation.describe(),
+            'Create index test_addfuncin_pony_abs_idx on Abs(F(weight)) on model Pony',
+        )
+        self.assertEqual(
+            operation.migration_name_fragment,
+            'pony_test_addfuncin_pony_abs_idx',
+        )
+        new_state = project_state.clone()
+        operation.state_forwards(app_label, new_state)
+        self.assertEqual(len(new_state.models[app_label, 'pony'].options['indexes']), 1)
+        self.assertIndexNameNotExists(table_name, index_name)
+        # Add index.
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
+        self.assertIndexNameExists(table_name, index_name)
+        # Reversal.
+        with connection.schema_editor() as editor:
+            operation.database_backwards(app_label, editor, new_state, project_state)
+        self.assertIndexNameNotExists(table_name, index_name)
+        # Deconstruction.
+        definition = operation.deconstruct()
+        self.assertEqual(definition[0], 'AddIndex')
+        self.assertEqual(definition[1], [])
+        self.assertEqual(definition[2], {'model_name': 'Pony', 'index': index})
+
+    @skipUnlessDBFeature('supports_expression_indexes')
+    def test_remove_func_index(self):
+        app_label = 'test_rmfuncin'
+        index_name = f'{app_label}_pony_abs_idx'
+        table_name = f'{app_label}_pony'
+        project_state = self.set_up_test_model(app_label, indexes=[
+            models.Index(Abs('weight'), name=index_name),
+        ])
+        self.assertTableExists(table_name)
+        self.assertIndexNameExists(table_name, index_name)
+        operation = migrations.RemoveIndex('Pony', index_name)
+        self.assertEqual(
+            operation.describe(),
+            'Remove index test_rmfuncin_pony_abs_idx from Pony',
+        )
+        self.assertEqual(
+            operation.migration_name_fragment,
+            'remove_pony_test_rmfuncin_pony_abs_idx',
+        )
+        new_state = project_state.clone()
+        operation.state_forwards(app_label, new_state)
+        self.assertEqual(len(new_state.models[app_label, 'pony'].options['indexes']), 0)
+        # Remove index.
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
+        self.assertIndexNameNotExists(table_name, index_name)
+        # Reversal.
+        with connection.schema_editor() as editor:
+            operation.database_backwards(app_label, editor, new_state, project_state)
+        self.assertIndexNameExists(table_name, index_name)
+        # Deconstruction.
+        definition = operation.deconstruct()
+        self.assertEqual(definition[0], 'RemoveIndex')
+        self.assertEqual(definition[1], [])
+        self.assertEqual(definition[2], {'model_name': 'Pony', 'name': index_name})
 
     def test_alter_field_with_index(self):
         """

--- a/tests/model_indexes/tests.py
+++ b/tests/model_indexes/tests.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from django.conf import settings
 from django.db import connection, models
+from django.db.models.functions import Lower, Upper
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
 from django.test.utils import isolate_apps
 
@@ -27,6 +28,7 @@ class SimpleIndexesTests(SimpleTestCase):
             name='opclasses_idx',
             opclasses=['varchar_pattern_ops', 'text_pattern_ops'],
         )
+        func_index = models.Index(Lower('title'), name='book_func_idx')
         self.assertEqual(repr(index), "<Index: fields='title'>")
         self.assertEqual(repr(multi_col_index), "<Index: fields='title, author'>")
         self.assertEqual(repr(partial_index), "<Index: fields='title' condition=(AND: ('pages__gt', 400))>")
@@ -39,6 +41,7 @@ class SimpleIndexesTests(SimpleTestCase):
             "<Index: fields='headline, body' "
             "opclasses='varchar_pattern_ops, text_pattern_ops'>",
         )
+        self.assertEqual(repr(func_index), "<Index: expressions='Lower(F(title))'>")
 
     def test_eq(self):
         index = models.Index(fields=['title'])
@@ -47,6 +50,14 @@ class SimpleIndexesTests(SimpleTestCase):
         index.model = Book
         same_index.model = Book
         another_index.model = Book
+        self.assertEqual(index, same_index)
+        self.assertEqual(index, mock.ANY)
+        self.assertNotEqual(index, another_index)
+
+    def test_eq_func(self):
+        index = models.Index(Lower('title'), models.F('author'), name='book_func_idx')
+        same_index = models.Index(Lower('title'), 'author', name='book_func_idx')
+        another_index = models.Index(Lower('title'), name='book_func_idx')
         self.assertEqual(index, same_index)
         self.assertEqual(index, mock.ANY)
         self.assertNotEqual(index, another_index)
@@ -63,10 +74,15 @@ class SimpleIndexesTests(SimpleTestCase):
     def test_fields_tuple(self):
         self.assertEqual(models.Index(fields=('title',)).fields, ['title'])
 
-    def test_raises_error_without_field(self):
-        msg = 'At least one field is required to define an index.'
+    def test_requires_field_or_expression(self):
+        msg = 'At least one field or expression is required to define an index.'
         with self.assertRaisesMessage(ValueError, msg):
             models.Index()
+
+    def test_expressions_and_fields_mutually_exclusive(self):
+        msg = "Index.fields and expressions are mutually exclusive."
+        with self.assertRaisesMessage(ValueError, msg):
+            models.Index(Upper('foo'), fields=['field'])
 
     def test_opclasses_requires_index_name(self):
         with self.assertRaisesMessage(ValueError, 'An index must be named to use opclasses.'):
@@ -84,6 +100,23 @@ class SimpleIndexesTests(SimpleTestCase):
     def test_condition_requires_index_name(self):
         with self.assertRaisesMessage(ValueError, 'An index must be named to use condition.'):
             models.Index(condition=models.Q(pages__gt=400))
+
+    def test_expressions_requires_index_name(self):
+        msg = 'An index must be named to use expressions.'
+        with self.assertRaisesMessage(ValueError, msg):
+            models.Index(Lower('field'))
+
+    def test_expressions_with_opclasses(self):
+        msg = (
+            'Index.opclasses cannot be used with expressions. Use '
+            'django.contrib.postgres.indexes.OpClass() instead.'
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            models.Index(
+                Lower('field'),
+                name='test_func_opclass',
+                opclasses=['jsonb_path_ops'],
+            )
 
     def test_condition_must_be_q(self):
         with self.assertRaisesMessage(ValueError, 'Index.condition must be a Q instance.'):
@@ -181,11 +214,24 @@ class SimpleIndexesTests(SimpleTestCase):
             },
         )
 
+    def test_deconstruct_with_expressions(self):
+        index = models.Index(Upper('title'), name='book_func_idx')
+        path, args, kwargs = index.deconstruct()
+        self.assertEqual(path, 'django.db.models.Index')
+        self.assertEqual(args, (Upper('title'),))
+        self.assertEqual(kwargs, {'name': 'book_func_idx'})
+
     def test_clone(self):
         index = models.Index(fields=['title'])
         new_index = index.clone()
         self.assertIsNot(index, new_index)
         self.assertEqual(index.fields, new_index.fields)
+
+    def test_clone_with_expressions(self):
+        index = models.Index(Upper('title'), name='book_func_idx')
+        new_index = index.clone()
+        self.assertIsNot(index, new_index)
+        self.assertEqual(index.expressions, new_index.expressions)
 
     def test_name_set(self):
         index_names = [index.name for index in Book._meta.indexes]
@@ -248,3 +294,29 @@ class IndexesTests(TestCase):
         # db_tablespace.
         index = models.Index(fields=['shortcut'])
         self.assertIn('"idx_tbls"', str(index.create_sql(Book, editor)).lower())
+
+    @skipUnlessDBFeature('supports_tablespaces')
+    def test_func_with_tablespace(self):
+        # Functional index with db_tablespace attribute.
+        index = models.Index(
+            Lower('shortcut').desc(),
+            name='functional_tbls',
+            db_tablespace='idx_tbls2',
+        )
+        with connection.schema_editor() as editor:
+            sql = str(index.create_sql(Book, editor))
+            self.assertIn(editor.quote_name('idx_tbls2'), sql)
+        # Functional index without db_tablespace attribute.
+        index = models.Index(Lower('shortcut').desc(), name='functional_no_tbls')
+        with connection.schema_editor() as editor:
+            sql = str(index.create_sql(Book, editor))
+            # The DEFAULT_INDEX_TABLESPACE setting can't be tested because it's
+            # evaluated when the model class is defined. As a consequence,
+            # @override_settings doesn't work.
+            if settings.DEFAULT_INDEX_TABLESPACE:
+                self.assertIn(
+                    editor.quote_name(settings.DEFAULT_INDEX_TABLESPACE),
+                    sql,
+                )
+            else:
+                self.assertNotIn('TABLESPACE', sql)

--- a/tests/postgres_tests/fields.py
+++ b/tests/postgres_tests/fields.py
@@ -12,7 +12,7 @@ try:
         CITextField, DateRangeField, DateTimeRangeField, DecimalRangeField,
         HStoreField, IntegerRangeField,
     )
-    from django.contrib.postgres.search import SearchVectorField
+    from django.contrib.postgres.search import SearchVector, SearchVectorField
 except ImportError:
     class DummyArrayField(models.Field):
         def __init__(self, base_field, size=None, **kwargs):
@@ -36,6 +36,7 @@ except ImportError:
     DecimalRangeField = models.Field
     HStoreField = models.Field
     IntegerRangeField = models.Field
+    SearchVector = models.Expression
     SearchVectorField = models.Field
 
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/26167

This PR continues the work started in https://github.com/django/django/pull/8056. Since a lot of stuff have happened in regards to index creation rebasing on that fork was not really an option.

~~One important change is made in https://github.com/django/django/pull/11929/commits/3d64e9c919fc8c91ba2de2354fdad209fa3d796f where an adjustment of wrapping parentheses had to be made to support casted indexes on postgres.~~ This is enables pretty powerful expressions like having `tsvector` GIN-indexes on regular columns:

```python
GinIndex(
    fields=[Cast('field', SearchVectorField())], name=index_name
)
```

or B-Tree indexes on keys in `jsonb` columns which values are not text:

```python
Index(
    fields=[Cast(KeyTextTransform('some_key', 'field'), IntegerField())], name=index_name
)
```

One other change from the work in https://github.com/django/django/pull/8056 is that when using expressions in class based indexes it is required to define a name. Since it's hard to resolve a column name from an expression `django.db.backends.base.schema.BaseDatabaseSchemaEditor._create_index_name` could not be used. [ExclusionConstraint](https://docs.djangoproject.com/en/dev/ref/contrib/postgres/constraints/#exclusionconstraint) also requires setting a `name` so I figured it might be OK.

A space was also added in https://github.com/django/django/pull/11929/commits/5fff6c3f04d483589b1ba7a2fc10f0220b4df657 between the column name and the suffix on index creation. This makes the generated SQL easier to read. I could not find a purpose for not having a space here 

This is my first PR to Django so bear with me if I've missed anything.