### PR TITLE
Fixed #30095 -- Fixed system check for RangeField/ArrayField.choices with lists and tuples.

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -46,6 +46,10 @@ class ArrayField(CheckFieldDefaultMixin, Field):
         self.__dict__['model'] = model
         self.base_field.model = model
 
+    @classmethod
+    def _choices_is_value(cls, value):
+        return isinstance(value, (list, tuple)) or super()._choices_is_value(value)
+
     def check(self, **kwargs):
         errors = super().check(**kwargs)
         if self.base_field.remote_field:

--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -60,6 +60,10 @@ class RangeField(models.Field):
         self.__dict__['model'] = model
         self.base_field.model = model
 
+    @classmethod
+    def _choices_is_value(cls, value):
+        return isinstance(value, (list, tuple)) or super()._choices_is_value(value)
+
     def get_prep_value(self, value):
         if value is None:
             return None

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -237,12 +237,13 @@ class Field(RegisterLookupMixin):
         else:
             return []
 
+    @classmethod
+    def _choices_is_value(cls, value):
+        return isinstance(value, (str, Promise)) or not is_iterable(value)
+
     def _check_choices(self):
         if not self.choices:
             return []
-
-        def is_value(value):
-            return isinstance(value, (str, Promise)) or not is_iterable(value)
 
         if not is_iterable(self.choices) or isinstance(self.choices, str):
             return [
@@ -263,7 +264,7 @@ class Field(RegisterLookupMixin):
                 break
             try:
                 if not all(
-                    is_value(value) and is_value(human_name)
+                    self._choices_is_value(value) and self._choices_is_value(human_name)
                     for value, human_name in group_choices
                 ):
                     break
@@ -275,7 +276,7 @@ class Field(RegisterLookupMixin):
             except (TypeError, ValueError):
                 # No groups, choices in the form [value, display]
                 value, human_name = group_name, group_choices
-                if not is_value(value) or not is_value(human_name):
+                if not self._choices_is_value(value) or not self._choices_is_value(human_name):
                     break
                 if self.max_length is not None and isinstance(value, str):
                     choice_max_length = max(choice_max_length, len(value))

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -592,6 +592,20 @@ class TestChecks(PostgreSQLSimpleTestCase):
         self.assertEqual(errors[0].id, 'postgres.E001')
         self.assertIn('max_length', errors[0].msg)
 
+    def test_choices_tuple_list(self):
+        class MyModel(PostgreSQLModel):
+            field = ArrayField(
+                models.CharField(max_length=16),
+                choices=[
+                    [
+                        'Media',
+                        [(['vinyl', 'cd'], 'Audio'), (('vhs', 'dvd'), 'Video')],
+                    ],
+                    (['mp3', 'mp4'], 'Digital'),
+                ],
+            )
+        self.assertEqual(MyModel._meta.get_field('field').check(), [])
+
 
 @unittest.skipUnless(connection.vendor == 'postgresql', "PostgreSQL specific tests")
 class TestMigrations(TransactionTestCase):

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -10,7 +10,7 @@ from django.test import override_settings
 from django.utils import timezone
 
 from . import PostgreSQLSimpleTestCase, PostgreSQLTestCase
-from .models import RangeLookupsModel, RangesModel
+from .models import PostgreSQLModel, RangeLookupsModel, RangesModel
 
 try:
     from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange
@@ -411,6 +411,18 @@ class TestSerialization(PostgreSQLSimpleTestCase):
         data = serializers.serialize('json', [instance])
         new_instance = list(serializers.deserialize('json', data))[0].object
         self.assertEqual(new_instance.ints, NumericRange(10, None))
+
+
+class TestChecks(PostgreSQLSimpleTestCase):
+    def test_choices_tuple_list(self):
+        class Model(PostgreSQLModel):
+            field = pg_fields.IntegerRangeField(
+                choices=[
+                    ['1-50', [((1, 25), '1-25'), ([26, 50], '26-50')]],
+                    ((51, 100), '51-100'),
+                ],
+            )
+        self.assertEqual(Model._meta.get_field('field').check(), [])
 
 
 class TestValidators(PostgreSQLSimpleTestCase):


### PR DESCRIPTION
[ticket 30095](https://code.djangoproject.com/ticket/30095)