### PR TITLE
TestCase: call _post_teardown always when _pre_setup worked

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -265,18 +265,25 @@ class SimpleTestCase(unittest.TestCase):
                     raise
                 result.addError(self, sys.exc_info())
                 return
-        if debug:
-            super().debug()
-        else:
-            super().__call__(result)
-        if not skipped:
-            try:
-                self._post_teardown()
-            except Exception:
-                if debug:
-                    raise
-                result.addError(self, sys.exc_info())
-                return
+
+        call_teardown = not skipped
+        try:
+            if debug:
+                super().debug()
+            else:
+                super().__call__(result)
+        except BaseException:
+            if debug:
+                call_teardown = False
+                raise
+        finally:
+            if call_teardown:
+                try:
+                    self._post_teardown()
+                except Exception:
+                    if debug:
+                        raise
+                    result.addError(self, sys.exc_info())
 
     def _pre_setup(self):
         """

--- a/tests/test_utils/test_simpletestcase.py
+++ b/tests/test_utils/test_simpletestcase.py
@@ -87,7 +87,9 @@ class DebugInvocationTests(SimpleTestCase):
     def test_run_skipped_via_SkipTest_cleanup(self, _pre_setup, _post_teardown):
         test_suite = unittest.TestSuite()
         test_suite.addTest(ErrorTestCase('skipped_test_via_SkipTest'))
-        test_suite.run(self.get_runner()._makeResult())
+        result = _DebugResult()
+        with self.assertRaisesMessage(unittest.SkipTest, 'skipped via SkipTest'):
+            test_suite.run(result, debug=True)
         self.assertTrue(_post_teardown.called)
         self.assertTrue(_pre_setup.called)
 

--- a/tests/test_utils/test_simpletestcase.py
+++ b/tests/test_utils/test_simpletestcase.py
@@ -18,6 +18,9 @@ class ErrorTestCase(SimpleTestCase):
     def skipped_test(self):
         pass
 
+    def skipped_test_via_SkipTest(self):
+        raise unittest.SkipTest('skipped via SkipTest')
+
 
 @mock.patch.object(ErrorTestCase, '_post_teardown')
 @mock.patch.object(ErrorTestCase, '_pre_setup')
@@ -80,6 +83,13 @@ class DebugInvocationTests(SimpleTestCase):
             self.fail('SkipTest should not be raised at this stage.')
         self.assertFalse(_post_teardown.called)
         self.assertFalse(_pre_setup.called)
+
+    def test_run_skipped_via_SkipTest_cleanup(self, _pre_setup, _post_teardown):
+        test_suite = unittest.TestSuite()
+        test_suite.addTest(ErrorTestCase('skipped_test_via_SkipTest'))
+        test_suite.run(self.get_runner()._makeResult())
+        self.assertTrue(_post_teardown.called)
+        self.assertTrue(_pre_setup.called)
 
     def test_debug_cleanup(self, _pre_setup, _post_teardown):
         """Simple debug run without errors."""


### PR DESCRIPTION
This is in line with unittest itself calling `TearDown` when `SetUp`
succeeded.

Ref/via: https://github.com/pytest-dev/pytest-django/issues/772