### PR TITLE
Added custom remote user backend 

### DIFF
--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -231,3 +231,16 @@ class RemoteUserBackend(ModelBackend):
 class AllowAllUsersRemoteUserBackend(RemoteUserBackend):
     def user_can_authenticate(self, user):
         return True
+    
+    
+class LowerCaseRemoteUserBackend(RemoteUserBackend):
+    """
+    This backend makes sure all users created using an external authentication
+    service are created with an all lower-case username to avoid case-sensitivty 
+    problems. 
+    """
+    def clean_username(self, username):
+        """
+        Returns an all lower-case username
+        """
+        return username.lower()

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -279,3 +279,25 @@ class PersistentRemoteUserTest(RemoteUserTest):
         response = self.client.get('/remote_user/')
         self.assertFalse(response.context['user'].is_anonymous)
         self.assertEqual(response.context['user'].username, 'knownuser')
+
+
+class LowerCaseRemoteUserTest(RemoteUserTest):
+    """
+    LowerCaseRemoteUserBackend converts the username of the logged-in 
+    user to all lower case username.
+    """
+
+    backend = 'django.contrib.auth.backends.LowerCaseRemoteUserBackend'
+    # REMOTE_USER strings with all upper case letters for the to
+    # the lower case backend to clean.
+    known_user = 'KNOWNUSER'
+
+    def test_known_user(self):
+        """
+        Tests the case where the username passed in the header is a valid User.
+        """
+        User.objects.create(username='knownuser')
+
+        response = self.client.get('/remote_user/',
+                                   **{self.header: self.known_user})
+        self.assertEqual(response.context['user'].username, 'knowuser')


### PR DESCRIPTION
Added ``LowerCaseRemoteUserBackend`` that converts the logged-in user username to all lower case username. This is important because some external authentication services return a case-sensitive username upon login. This is problematic with Django as the built-in user model is case-sensitive. This means a single remote user may have two different records in that database (e.g. 'Username' is different than 'username').