### PR TITLE
Allow explicit None setting in SAMESITE cookie setting

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -196,8 +196,8 @@ class HttpResponseBase:
         if httponly:
             self.cookies[key]['httponly'] = True
         if samesite:
-            if samesite.lower() not in ('lax', 'strict'):
-                raise ValueError('samesite must be "lax" or "strict".')
+            if samesite.lower() not in ('lax', 'strict', 'none'):
+                raise ValueError('samesite must be "lax", "strict" or "none".')
             self.cookies[key]['samesite'] = samesite
 
     def setdefault(self, key, value):


### PR DESCRIPTION
Because of changes starting with Chrome 76, for Django apps to work within an iframe, they need to explicitly set the SAMESITE attribute to "None" for the cookie. Otherwise the default is "Lax" as described here: https://www.netsparker.com/blog/web-security/same-site-cookies-by-default/ . Please let me know if there are some documentation/test changes that need to go with this. Note that this is different than using the value `None` - instead, to set SAMESITE explicitly, the user would have to pass in the string `"None"` - so the behavior is still backwards compatible.