### PR TITLE
Removed unused *args and **kwargs from GEOSFuncFactory.__init__().

### DIFF
--- a/django/contrib/gis/geos/libgeos.py
+++ b/django/contrib/gis/geos/libgeos.py
@@ -139,7 +139,7 @@ class GEOSFuncFactory:
     restype = None
     errcheck = None
 
-    def __init__(self, func_name, *args, restype=None, errcheck=None, argtypes=None, **kwargs):
+    def __init__(self, func_name, *, restype=None, errcheck=None, argtypes=None):
         self.func_name = func_name
         if restype is not None:
             self.restype = restype
@@ -147,8 +147,6 @@ class GEOSFuncFactory:
             self.errcheck = errcheck
         if argtypes is not None:
             self.argtypes = argtypes
-        self.args = args
-        self.kwargs = kwargs
 
     def __call__(self, *args, **kwargs):
         return self.func(*args, **kwargs)


### PR DESCRIPTION
Follow-up to ff17ef1adab864d2c165d50501fa0b0684808d07.