### PR TITLE
Removed unused **kwargs from GEOSFuncFactory.__call__().

### DIFF
--- a/django/contrib/gis/geos/libgeos.py
+++ b/django/contrib/gis/geos/libgeos.py
@@ -150,8 +150,8 @@ class GEOSFuncFactory:
         self.args = args
         self.kwargs = kwargs
 
-    def __call__(self, *args, **kwargs):
-        return self.func(*args, **kwargs)
+    def __call__(self, *args):
+        return self.func(*args)
 
     @cached_property
     def func(self):


### PR DESCRIPTION
This slightly improves performance:

Before:
```
$ python -m pyperf timeit -s 'from django.contrib.gis.geos import Point; p = Point()' "p.empty"  --duplicate=100
.....................
Mean +- std dev: 2.00 us +- 0.04 us
```

After:
```
$ python -m pyperf timeit -s 'from django.contrib.gis.geos import Point; p = Point()' "p.empty"  --duplicate=100
.....................
Mean +- std dev: 1.94 us +- 0.03 us
```