### PR TITLE
add get_or_none

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -419,6 +419,16 @@ class QuerySet:
                 num if not limit or num < limit else 'more than %s' % (limit - 1),
             )
         )
+        
+    def get_or_none(self, *args, **kwargs):
+        """
+        Perform the query and return a single object matching the given
+        keyword arguments or None.
+        """
+        try:
+            return self.get(*args, **kwargs)
+        except self.model.DoesNotExist:
+            return None
 
     def create(self, **kwargs):
         """


### PR DESCRIPTION
```def get_or_none```  can be used usefully in python3.8. 
example.
```
try:
    post = Post.objects.get(name='hoge'):
except Post.DoesNotExist:
    pass
```
or
```
if Post.objects.filter(name='hoge').exists():
    post = Post.objects.get(name='hoge'):
```
to
```
if post := Post.objects.get_or_none(name='hoge'):
```
