### PR TITLE
Fixed #30897 -- Improved QuerySet.explain() for newer versions of MariaDB, MySQL and PostgreSQL.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -48,8 +48,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         END;
     """
     db_functions_convert_bytes_to_str = True
-    # Alias MySQL's TRADITIONAL to TEXT for consistency with other backends.
-    supported_explain_formats = {'JSON', 'TEXT', 'TRADITIONAL'}
     # Neither MySQL nor MariaDB support partial indexes.
     supports_partial_indexes = False
 
@@ -118,6 +116,15 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     def needs_explain_extended(self):
         # EXTENDED is deprecated (and not required) in MySQL 5.7.
         return not self.connection.mysql_is_mariadb and self.connection.mysql_version < (5, 7)
+
+    @cached_property
+    def supported_explain_formats(self):
+        # Alias MySQL's TRADITIONAL to TEXT for consistency with other
+        # backends.
+        formats = {'JSON', 'TEXT', 'TRADITIONAL'}
+        if not self.connection.mysql_is_mariadb and self.connection.mysql_version >= (8, 0, 16):
+            formats.add('TREE')
+        return formats
 
     @cached_property
     def supports_transactions(self):

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -118,6 +118,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         return not self.connection.mysql_is_mariadb and self.connection.mysql_version < (5, 7)
 
     @cached_property
+    def supports_explain_analyze(self):
+        return self.connection.mysql_is_mariadb or self.connection.mysql_version >= (8, 0, 18)
+
+    @cached_property
     def supported_explain_formats(self):
         # Alias MySQL's TRADITIONAL to TEXT for consistency with other
         # backends.

--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -296,6 +296,9 @@ class DatabaseOperations(BaseDatabaseOperations):
         # Alias MySQL's TRADITIONAL to TEXT for consistency with other backends.
         if format and format.upper() == 'TEXT':
             format = 'TRADITIONAL'
+        elif not format and 'TREE' in self.connection.features.supported_explain_formats:
+            # Use TREE by default (if supported) as it's more informative.
+            format = 'TREE'
         prefix = super().explain_query_prefix(format, **options)
         if format:
             prefix += ' FORMAT=%s' % format

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2569,12 +2569,12 @@ The output differs significantly between databases.
 ``explain()`` is supported by all built-in database backends except Oracle
 because an implementation there isn't straightforward.
 
-The ``format`` parameter changes the output format from the databases's default,
-usually text-based. PostgreSQL supports ``'TEXT'``, ``'JSON'``, ``'YAML'``, and
-``'XML'`` formats. MariaDB and MySQL support ``'TEXT'`` (also called
-``'TRADITIONAL'``) and ``'JSON'`` formats. MySQL 8.0.16+ also supports an
-improved ``'TREE'`` format, which is similar to PostgreSQL's ``'TEXT'`` output
-and is used by default, if supported.
+The ``format`` parameter changes the output format from the databases's
+default, which is usually text-based. PostgreSQL supports ``'TEXT'``,
+``'JSON'``, ``'YAML'``, and ``'XML'`` formats. MariaDB and MySQL support
+``'TEXT'`` (also called ``'TRADITIONAL'``) and ``'JSON'`` formats. MySQL
+8.0.16+ also supports an improved ``'TREE'`` format, which is similar to
+PostgreSQL's ``'TEXT'`` output and is used by default, if supported.
 
 Some databases accept flags that can return more information about the query.
 Pass these flags as keyword arguments. For example, when using PostgreSQL::

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2571,8 +2571,10 @@ because an implementation there isn't straightforward.
 
 The ``format`` parameter changes the output format from the databases's default,
 usually text-based. PostgreSQL supports ``'TEXT'``, ``'JSON'``, ``'YAML'``, and
-``'XML'``. MySQL supports ``'TEXT'`` (also called ``'TRADITIONAL'``) and
-``'JSON'``.
+``'XML'`` formats. MariaDB and MySQL support ``'TEXT'`` (also called
+``'TRADITIONAL'``) and ``'JSON'`` formats. MySQL 8.0.16+ also supports an
+improved ``'TREE'`` format, which is similar to PostgreSQL's ``'TEXT'`` output
+and is used by default, if supported.
 
 Some databases accept flags that can return more information about the query.
 Pass these flags as keyword arguments. For example, when using PostgreSQL::
@@ -2588,6 +2590,10 @@ On some databases, flags may cause the query to be executed which could have
 adverse effects on your database. For example, PostgreSQL's ``ANALYZE`` flag
 could result in changes to data if there are triggers or if a function is
 called, even for a ``SELECT`` query.
+
+.. versionchanged:: 3.1
+
+    Support for the ``'TREE'`` format on MySQL 8.0.16+ was added.
 
 .. _field-lookups:
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2587,13 +2587,14 @@ Pass these flags as keyword arguments. For example, when using PostgreSQL::
     Execution time: 0.058 ms
 
 On some databases, flags may cause the query to be executed which could have
-adverse effects on your database. For example, PostgreSQL's ``ANALYZE`` flag
-could result in changes to data if there are triggers or if a function is
-called, even for a ``SELECT`` query.
+adverse effects on your database. For example, the ``ANALYZE`` flag supported
+by MariaDB, MySQL 8.0.18+, and PostgreSQL could result in changes to data if
+there are triggers or if a function is called, even for a ``SELECT`` query.
 
 .. versionchanged:: 3.1
 
-    Support for the ``'TREE'`` format on MySQL 8.0.16+ was added.
+    Support for the ``'TREE'`` format on MySQL 8.0.16+ and ``analyze`` option
+    on MariaDB and MySQL 8.0.18+ were added.
 
 .. _field-lookups:
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -169,7 +169,10 @@ Models
   :class:`~django.db.models.DateTimeField`, and the new :lookup:`iso_week_day`
   lookup allows querying by an ISO-8601 day of week.
 
-* :meth:`.QuerySet.explain` now supports ``TREE`` format on MySQL 8.0.16+.
+* :meth:`.QuerySet.explain` now supports:
+
+  * ``TREE`` format on MySQL 8.0.16+,
+  * ``analyze`` option on MySQL 8.0.18+ and MariaDB.
 
 Pagination
 ~~~~~~~~~~

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -169,6 +169,8 @@ Models
   :class:`~django.db.models.DateTimeField`, and the new :lookup:`iso_week_day`
   lookup allows querying by an ISO-8601 day of week.
 
+* :meth:`.QuerySet.explain` now supports ``TREE`` format on MySQL 8.0.16+.
+
 Pagination
 ~~~~~~~~~~
 

--- a/tests/queries/test_explain.py
+++ b/tests/queries/test_explain.py
@@ -71,9 +71,10 @@ class ExplainTests(TestCase):
 
     @unittest.skipUnless(connection.vendor == 'mysql', 'MySQL specific')
     def test_mysql_text_to_traditional(self):
-        # Initialize the cached property, if needed, to prevent a query for
-        # the MySQL version during the QuerySet evaluation.
+        # Ensure these cached properties are initialized to prevent queries for
+        # the MariaDB or MySQL version during the QuerySet evaluation.
         connection.features.needs_explain_extended
+        connection.features.supported_explain_formats
         with CaptureQueriesContext(connection) as captured_queries:
             Tag.objects.filter(name='test').explain(format='text')
         self.assertEqual(len(captured_queries), 1)


### PR DESCRIPTION
Ticket [#30897](https://code.djangoproject.com/ticket/30897).

Would you mind looking at this @orf as you originally added `QuerySet.explain()` IIRC?