### PR TITLE
Bumped minimum Pillow version to 6.2.0 in test requirements.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -277,7 +277,7 @@ dependencies:
 *  geoip2_
 *  jinja2_ 2.7+
 *  numpy_
-*  Pillow_
+*  Pillow_ 6.2.0+
 *  PyYAML_
 *  pytz_ (required)
 *  pywatchman_

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -5,7 +5,7 @@ docutils
 geoip2
 jinja2 >= 2.9.2
 numpy
-Pillow != 5.4.0
+Pillow >= 6.2.0
 # pylibmc/libmemcached can't be built on Windows.
 pylibmc; sys.platform != 'win32'
 python-memcached >= 1.59


### PR DESCRIPTION
`Pillow` < 6.2.0 is vulnerable to [CVE-2019-16865](https://nvd.nist.gov/vuln/detail/CVE-2019-16865).