### PR TITLE
Fixed #30902 -- Added __str__() for model choice enums.

### DIFF
--- a/django/db/models/enums.py
+++ b/django/db/models/enums.py
@@ -60,7 +60,13 @@ class ChoicesMeta(enum.EnumMeta):
 
 class Choices(enum.Enum, metaclass=ChoicesMeta):
     """Class for creating enumerated choices."""
-    pass
+
+    def __str__(self):
+        """
+        Use value when cast to str, so that Choices set as model instance
+        attributes are rendered as expected in templates and similar contexts.
+        """
+        return str(self.value)
 
 
 class IntegerChoices(int, Choices):

--- a/tests/model_enums/tests.py
+++ b/tests/model_enums/tests.py
@@ -143,6 +143,12 @@ class ChoicesTests(SimpleTestCase):
                 APPLE = 1, 'Apple'
                 PINEAPPLE = 1, 'Pineapple'
 
+    def test_str(self):
+        for test in [Gender, Suit, YearInSchool, Vehicle]:
+            for member in test:
+                with self.subTest(member=member):
+                    self.assertEqual(str(test[member.name]), str(member.value))
+
 
 class Separator(bytes, models.Choices):
     FS = b'\x1c', 'File Separator'


### PR DESCRIPTION
Allows expected comparison against strings, matching behaviour of created
instances with those fetched from the DB.


@shaib @pope1ni — This looks right to me, especially given the example on the ticket of the difference between created and retrieved instances but, what do you think? Thanks! 