### PR TITLE
Add new test case for GEOS

### DIFF
--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -1356,6 +1356,7 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         versions = (
             (b'3.0.0rc4-CAPI-1.3.3', (3, 0, 0)),
             (b'3.0.0-CAPI-1.4.1', (3, 0, 0)),
+            (b'3.8.0-CAPI-1.13.0 ', (3, 8, 0)),
             (b'3.4.0dev-CAPI-1.8.0', (3, 4, 0)),
             (b'3.4.0dev-CAPI-1.8.0 r0', (3, 4, 0)),
             (b'3.6.2-CAPI-1.10.2 4d2925d6', (3, 6, 2)),


### PR DESCRIPTION
I'm seeing this error on Django 1.11.25:

    raise GEOSException('Could not parse version info string "%s"' %
    ver)
    django.contrib.gis.geos.error.GEOSException: Could not parse version
    info string "3.8.0-CAPI-1.13.1 "

So, I'm adding this as a test case.

Related:
  https://code.djangoproject.com/ticket/28441#comment:13