### PR TITLE
Fixed DatabaseFeatures.update_can_self_select on MariaDB 10.3.2+.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -6,7 +6,6 @@ from django.utils.functional import cached_property
 
 class DatabaseFeatures(BaseDatabaseFeatures):
     empty_fetchmany_value = ()
-    update_can_self_select = False
     allows_group_by_pk = True
     related_fields_match_type = True
     # MySQL doesn't support sliced subqueries with IN/ALL/ANY/SOME.
@@ -61,6 +60,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             cursor.execute("SELECT ENGINE FROM INFORMATION_SCHEMA.ENGINES WHERE SUPPORT = 'DEFAULT'")
             result = cursor.fetchone()
         return result[0]
+
+    @cached_property
+    def update_can_self_select(self):
+        return self.connection.mysql_is_mariadb and self.connection.mysql_version >= (10, 3, 2)
 
     @cached_property
     def can_introspect_foreign_keys(self):


### PR DESCRIPTION
https://mariadb.com/kb/en/library/mariadb-1031-release-notes/#syntax-general-features
https://mariadb.com/kb/en/library/delete/#same-source-and-target-table

https://jira.mariadb.org/browse/MDEV-12874 10.3.2+
https://jira.mariadb.org/browse/MDEV-12137 10.3.1+

Noticed when reviewing #11931