### PR TITLE
Fixed #30907 -- Fixed SplitArrayField.has_changed() with removal of empty trailing values.

### DIFF
--- a/django/contrib/postgres/forms/array.py
+++ b/django/contrib/postgres/forms/array.py
@@ -221,3 +221,14 @@ class SplitArrayField(forms.Field):
         if errors:
             raise ValidationError(list(chain.from_iterable(errors)))
         return cleaned_data
+
+    def has_changed(self, initial, data):
+        try:
+            data = self.to_python(data)
+        except ValidationError:
+            pass
+        else:
+            data, _ = self._remove_trailing_nulls(data)
+            if initial in self.empty_values and data in self.empty_values:
+                return False
+        return super().has_changed(initial, data)

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -975,6 +975,26 @@ class TestSplitFormField(PostgreSQLSimpleTestCase):
                 form = Form(data, instance=obj)
                 self.assertIs(form.has_changed(), expected_result)
 
+    def test_splitarrayfield_remove_trailing_nulls_has_changed(self):
+        class Form(forms.ModelForm):
+            field = SplitArrayField(forms.IntegerField(), required=False, size=2, remove_trailing_nulls=True)
+
+            class Meta:
+                model = IntegerArrayModel
+                fields = ('field',)
+
+        tests = [
+            ({}, {'field_0': '', 'field_1': ''}, False),
+            ({'field': None}, {'field_0': '', 'field_1': ''}, False),
+            ({'field': []}, {'field_0': '', 'field_1': ''}, False),
+            ({'field': [1]}, {'field_0': '1', 'field_1': ''}, False),
+        ]
+        for initial, data, expected_result in tests:
+            with self.subTest(initial=initial, data=data):
+                obj = IntegerArrayModel(**initial)
+                form = Form(data, instance=obj)
+                self.assertIs(form.has_changed(), expected_result)
+
 
 class TestSplitFormWidget(PostgreSQLWidgetTestCase):
 

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -961,9 +961,19 @@ class TestSplitFormField(PostgreSQLSimpleTestCase):
                 model = IntegerArrayModel
                 fields = ('field',)
 
-        obj = IntegerArrayModel(field=[1, 2])
-        form = Form({'field_0': '1', 'field_1': '2'}, instance=obj)
-        self.assertFalse(form.has_changed())
+        tests = [
+            ({}, {'field_0': '', 'field_1': ''}, True),
+            ({'field': None}, {'field_0': '', 'field_1': ''}, True),
+            ({'field': [1]}, {'field_0': '', 'field_1': ''}, True),
+            ({'field': [1]}, {'field_0': '1', 'field_1': '0'}, True),
+            ({'field': [1, 2]}, {'field_0': '1', 'field_1': '2'}, False),
+            ({'field': [1, 2]}, {'field_0': 'a', 'field_1': 'b'}, True),
+        ]
+        for initial, data, expected_result in tests:
+            with self.subTest(initial=initial, data=data):
+                obj = IntegerArrayModel(**initial)
+                form = Form(data, instance=obj)
+                self.assertIs(form.has_changed(), expected_result)
 
 
 class TestSplitFormWidget(PostgreSQLWidgetTestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30907

`django.contrib.postgres.forms.SplitArrayField.has_changed()` returns `True` when `initial` is empty list and `data` is list of empty strings. This is a problem when a form is submitted with input fields left blank - resulting in e.g. `["", "",]` (passed to `has_changed()` and evaluated as `True` instead of `False`). I believe the issue I'm describing should be more clear from the written tests.

Note that this bug in `has_changed()` method causes issues with FormSets which fail to correctly validate empty forms (in cases where `SplitArrayField` is used).

The issue is similar to https://github.com/django/django/pull/9520