### PR TITLE
Fixed #30908 -- Fixed FilePathField raises FileNotFoundError for nonexistent path.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1105,15 +1105,20 @@ class FilePathField(ChoiceField):
                             self.choices.append((f, f.replace(path, "", 1)))
         else:
             choices = []
-            for f in os.scandir(self.path):
-                if f.name == '__pycache__':
-                    continue
-                if (((self.allow_files and f.is_file()) or
-                        (self.allow_folders and f.is_dir())) and
-                        (self.match is None or self.match_re.search(f.name))):
-                    choices.append((f.path, f.name))
-            choices.sort(key=operator.itemgetter(1))
-            self.choices.extend(choices)
+            try:
+                entries = os.scandir(self.path)
+            except FileNotFoundError:
+                pass
+            else:
+                for f in entries:
+                    if f.name == '__pycache__':
+                        continue
+                    if (((self.allow_files and f.is_file()) or
+                            (self.allow_folders and f.is_dir())) and
+                            (self.match is None or self.match_re.search(f.name))):
+                        choices.append((f.path, f.name))
+                choices.sort(key=operator.itemgetter(1))
+                self.choices.extend(choices)
 
         self.widget.choices = self.choices
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -209,6 +209,8 @@ Forms
   :attr:`~django.forms.formsets.BaseFormSet.can_order` by setting the
   :attr:`~django.forms.formsets.BaseFormSet.ordering_widget` attribute or
   overriding :attr:`~django.forms.formsets.BaseFormSet.get_ordering_widget()`.
+* Fixed :class:`~django.forms.FilePathField` raises `FileNotFoundError` for
+  nonexistent path.
 
 Internationalization
 ~~~~~~~~~~~~~~~~~~~~

--- a/tests/forms_tests/field_tests/test_filepathfield.py
+++ b/tests/forms_tests/field_tests/test_filepathfield.py
@@ -38,6 +38,10 @@ class FilePathFieldTest(SimpleTestCase):
     def assertChoices(self, field, expected_choices):
         self.assertEqual(fix_os_paths(field.choices), expected_choices)
 
+    def test_nonexistent_path(self):
+        f = FilePathField(path='nonexistent')
+        self.assertChoices(f, [])
+
     def test_fix_os_paths(self):
         self.assertEqual(fix_os_paths(self.path), ('/filepathfield_test_dir/'))
 


### PR DESCRIPTION
[Ticket 30908](https://code.djangoproject.com/ticket/30908).
Thanks, @felixxm for the test case.