### PR TITLE
Fixed #23051 -- Raise exception on only() calls with reverse fields

### DIFF
--- a/tests/defer_regress/tests.py
+++ b/tests/defer_regress/tests.py
@@ -160,9 +160,6 @@ class DeferRegressionTest(TestCase):
         self.assertEqual(len(Item.objects.select_related(
             'one_to_one_item').defer('one_to_one_item__name')), 1)
         self.assertEqual(len(Item.objects.select_related('one_to_one_item').defer('value')), 1)
-        # Make sure that `only()` doesn't break when we pass in a unique relation,
-        # rather than a field on the relation.
-        self.assertEqual(len(Item.objects.only('one_to_one_item')), 1)
         with self.assertNumQueries(1):
             i = Item.objects.select_related('one_to_one_item')[0]
             self.assertEqual(i.one_to_one_item.pk, o2o.pk)

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -3081,10 +3081,9 @@ class WhereNodeTest(SimpleTestCase):
 
 class QuerySetExceptionTests(SimpleTestCase):
     def test_iter_exceptions(self):
-        qs = ExtraInfo.objects.only('author')
-        msg = "'ManyToOneRel' object has no attribute 'attname'"
-        with self.assertRaisesMessage(AttributeError, msg):
-            list(qs)
+        msg = "only() does not support reverse relation fields. Use select_related instead."
+        with self.assertRaisesMessage(ValueError, msg):
+            ExtraInfo.objects.only('author')
 
     def test_invalid_qs_list(self):
         # Test for #19895 - second iteration over invalid queryset


### PR DESCRIPTION
Fixed https://code.djangoproject.com/ticket/23051