### PR TITLE
Fixed #30918 -- Made timesince()/timeuntil() respect custom time strings for future and the same datetimes.

### DIFF
--- a/django/utils/timesince.py
+++ b/django/utils/timesince.py
@@ -69,7 +69,7 @@ def timesince(d, now=None, reversed=False, time_strings=None):
     since = delta.days * 24 * 60 * 60 + delta.seconds
     if since <= 0:
         # d is in the future compared to now, stop processing.
-        return avoid_wrapping(gettext('0 minutes'))
+        return avoid_wrapping(time_strings['minute'] % 0)
     for i, (seconds, name) in enumerate(TIMESINCE_CHUNKS):
         count = since // seconds
         if count != 0:

--- a/tests/utils_tests/test_timesince.py
+++ b/tests/utils_tests/test_timesince.py
@@ -2,8 +2,9 @@ import datetime
 import unittest
 
 from django.test.utils import requires_tz_support
-from django.utils import timezone
+from django.utils import timezone, translation
 from django.utils.timesince import timesince, timeuntil
+from django.utils.translation import npgettext_lazy
 
 
 class TimesinceTests(unittest.TestCase):
@@ -73,6 +74,18 @@ class TimesinceTests(unittest.TestCase):
             timesince(self.t, self.t - 2 * self.oneweek - 3 * self.onehour - 4 * self.oneminute), '0\xa0minutes'
         )
         self.assertEqual(timesince(self.t, self.t - 4 * self.oneday - 5 * self.oneminute), '0\xa0minutes')
+
+    def test_second_before_equal_first_humanize_time_strings(self):
+        time_strings = {
+            'minute': npgettext_lazy('naturaltime-future', '%d minute', '%d minutes'),
+        }
+        with translation.override('cs'):
+            for now in [self.t, self.t - self.onemicrosecond, self.t - self.oneday]:
+                with self.subTest(now):
+                    self.assertEqual(
+                        timesince(self.t, now, time_strings=time_strings),
+                        '0\xa0minut',
+                    )
 
     @requires_tz_support
     def test_different_timezones(self):


### PR DESCRIPTION
[Ticket 30918](https://code.djangoproject.com/ticket/30918)