### PR TITLE
Fixed #30922 -- Fixed ModelAdmin.date_hierarchy queries with DST changes.

### DIFF
--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -173,8 +173,6 @@ class ChangeList:
                     )
                 except ValueError as e:
                     raise IncorrectLookupParameters(e) from e
-                if settings.USE_TZ:
-                    from_date = make_aware(from_date)
                 if day:
                     to_date = from_date + timedelta(days=1)
                 elif month:
@@ -183,6 +181,9 @@ class ChangeList:
                     to_date = (from_date + timedelta(days=32)).replace(day=1)
                 else:
                     to_date = from_date.replace(year=from_date.year + 1)
+                if settings.USE_TZ:
+                    from_date = make_aware(from_date)
+                    to_date = make_aware(to_date)
                 lookup_params.update({
                     '%s__gte' % self.date_hierarchy: from_date,
                     '%s__lt' % self.date_hierarchy: to_date,

--- a/tests/admin_changelist/test_date_hierarchy.py
+++ b/tests/admin_changelist/test_date_hierarchy.py
@@ -46,6 +46,24 @@ class DateHierarchyTests(TestCase):
                 make_aware(datetime(2017, 3, 1)),
             )
 
+    def test_bounded_params_with_dst_time_zone(self):
+        tests = [
+            # Northern hemisphere.
+            ('Asia/Jerusalem', 3),
+            ('Asia/Jerusalem', 10),
+            # Southern hemisphere.
+            ('Pacific/Chatham', 4),
+            ('Pacific/Chatham', 9),
+        ]
+        for time_zone, month in tests:
+            with self.subTest(time_zone=time_zone, month=month):
+                with self.settings(USE_TZ=True, TIME_ZONE=time_zone):
+                    self.assertDateParams(
+                        {'year': 2019, 'month': month},
+                        make_aware(datetime(2019, month, 1)),
+                        make_aware(datetime(2019, month + 1, 1)),
+                    )
+
     def test_invalid_params(self):
         tests = (
             {'year': 'x'},


### PR DESCRIPTION
[ticket](https://code.djangoproject.com/ticket/30922)

There was an issue where admin date_hierarchy didn't render last day of month in
dst-switch month (usually october in northern hemispere), due to applying
start-of-month timezone to end-of-month date. This fixes it by making from_date and to_date timezone aware seperately, to make sure they get the correct timezone for their own date.