### PR TITLE
Backport: Fixed #29182 -- Fixed schema table alteration on SQLite 3.26+.

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -24,6 +24,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             c.execute('PRAGMA foreign_keys')
             self._initial_pragma_fk = c.fetchone()[0]
             c.execute('PRAGMA foreign_keys = 0')
+            c.execute('PRAGMA legacy_alter_table = ON')
         return super(DatabaseSchemaEditor, self).__enter__()
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -31,6 +32,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         with self.connection.cursor() as c:
             # Restore initial FK setting - PRAGMA values can't be parametrized
             c.execute('PRAGMA foreign_keys = %s' % int(self._initial_pragma_fk))
+            c.execute('PRAGMA legacy_alter_table = OFF')
 
     def quote_value(self, value):
         # The backend "mostly works" without this function and there are use

--- a/docs/releases/1.11.26.txt
+++ b/docs/releases/1.11.26.txt
@@ -13,3 +13,7 @@ Bugfixes
   ``has_keys``, or ``has_any_keys`` lookup on
   :class:`~django.contrib.postgres.fields.JSONField`, if the right or left hand
   side of an expression is a key transform (:ticket:`30826`).
+
+* Fixed a schema corruption issue on SQLite 3.26+. You might have to drop and
+  rebuild your SQLite database if you applied a migration while using an older
+  version of Django with SQLite 3.26 or later (:ticket:`29182`).


### PR DESCRIPTION
SQLite 3.26 repoints foreign key constraints on table renames even when
foreign_keys pragma is off which breaks every operation that requires
a table rebuild to simulate unsupported ALTER TABLE statements.

The newly introduced legacy_alter_table pragma disables this behavior
and restores the previous schema editor assumptions.

Thanks Florian Apolloner, Christoph Trassl, Chris Lamb for the report and
troubleshooting assistance.

Backport of c8ffdbe514b55ff5c9a2b8cb8bbdf2d3978c188f from master.