### PR TITLE
Fixed #30934 - Include database alias in `django.db.backends` debug output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -248,6 +248,7 @@ answer newbie questions, and generally made Django that much better:
     David Sanders <dsanders11@ucsbalum.com>
     David Schein
     David Tulig <david.tulig@gmail.com>
+    David Winterbottom <david.winterbottom@gmail.com>
     David Wobrock <david.wobrock@gmail.com>
     Davide Ceretti <dav.ceretti@gmail.com>
     Deep L. Sukhwani <deepsukhwani@gmail.com>

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -121,11 +121,12 @@ class CursorDebugWrapper(CursorWrapper):
                 'time': '%.3f' % duration,
             })
             logger.debug(
-                '(%.3f) %s; args=%s',
+                '(%.3f) %s; args=%s; alias=%s',
                 duration,
                 sql,
                 params,
-                extra={'duration': duration, 'sql': sql, 'params': params},
+                self.db.alias,
+                extra={'duration': duration, 'sql': sql, 'params': params, 'alias': self.db.alias},
             )
 
 

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -568,6 +568,9 @@ Messages to this logger have the following extra context:
 * ``duration``: The time taken to execute the SQL statement.
 * ``sql``: The SQL statement that was executed.
 * ``params``: The parameters that were used in the SQL call.
+* ``alias``: The alias of the database used in the SQL call.
+  
+  .. versionchanged:: 3.2
 
 For performance reasons, SQL logging is only enabled when
 ``settings.DEBUG`` is set to ``True``, regardless of the logging

--- a/tests/backends/test_utils.py
+++ b/tests/backends/test_utils.py
@@ -3,7 +3,7 @@ from decimal import Decimal, Rounded
 
 from django.db import NotSupportedError, connection
 from django.db.backends.utils import (
-    format_number, split_identifier, truncate_name,
+    DebugWrapper, format_number, split_identifier, truncate_name,
 )
 from django.test import (
     SimpleTestCase, TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature,


### PR DESCRIPTION
This is useful if you're working with database routers and want to inspect 
where SQL statements are being routed to.