### PR TITLE
Refs #23576 -- Disabled MySQL multi-alias deletion path on MariaDB >= 10.3.2.

### DIFF
--- a/django/db/backends/mysql/compiler.py
+++ b/django/db/backends/mysql/compiler.py
@@ -15,7 +15,7 @@ class SQLInsertCompiler(compiler.SQLInsertCompiler, SQLCompiler):
 
 class SQLDeleteCompiler(compiler.SQLDeleteCompiler, SQLCompiler):
     def as_sql(self):
-        if self.single_alias:
+        if self.connection.features.update_can_self_select or self.single_alias:
             return super().as_sql()
         # MySQL and MariaDB < 10.3.2 doesn't support deletion with a subquery
         # which is what the default implementation of SQLDeleteCompiler uses


### PR DESCRIPTION
It looks like MariaDB dropped support for the `DELETE $table FROM $table` MySQL'ism during the 10.3.X lifecycle after adding support for `DELETE FROM $table WHERE id IN (SELECT .. FROM $table)` in 10.3.1 https://mariadb.com/kb/en/library/mariadb-1031-release-notes/

This commit disables this workaround when not necessary.

I tested against MariaDB 10.2 and 10.3 using django-docker-box.