### PR TITLE
Fixed #30865 -- Doc'd that not all DATABASES['OPTIONS'] are passed to command-line client.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -222,6 +222,12 @@ program manually.
 
 Specifies the database onto which to open a shell. Defaults to ``default``.
 
+.. note::
+
+    Be aware that not all options set it in the :setting:`OPTIONS` part of your
+    database configuration in :setting:`DATABASES` are passed to the
+    command-line client, e.g. ``'isolation_level'``.
+
 ``diffsettings``
 ----------------
 


### PR DESCRIPTION
Some of the DATABASES['OPTIONS'] were not passed to the dbshell, added the documentation pointing
the same.

Signed-off-by: Farhaan Bukhsh <farhaan.bukhsh@gmail.com>