### PR TITLE
Fixed #30931 -- Restored ability to override Model.get_FIELD_display().

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -763,8 +763,12 @@ class Field(RegisterLookupMixin):
             if not getattr(cls, self.attname, None):
                 setattr(cls, self.attname, self.descriptor_class(self))
         if self.choices is not None:
-            setattr(cls, 'get_%s_display' % self.name,
-                    partialmethod(cls._get_FIELD_display, field=self))
+            if not hasattr(cls, 'get_%s_display' % self.name):
+                setattr(
+                    cls,
+                    'get_%s_display' % self.name,
+                    partialmethod(cls._get_FIELD_display, field=self),
+                )
 
     def get_filter_kwargs_for_object(self, obj):
         """

--- a/docs/releases/2.2.7.txt
+++ b/docs/releases/2.2.7.txt
@@ -21,3 +21,6 @@ Bugfixes
 * Fixed migrations crash on PostgreSQL when adding an
   :class:`~django.db.models.Index` with fields ordering and
   :attr:`~.Index.opclasses` (:ticket:`30903`).
+
+* Restored the ability to override
+  :meth:`~django.db.models.Model.get_FOO_display` (:ticket:`30931`).

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -168,6 +168,16 @@ class GetFieldDisplayTests(SimpleTestCase):
         self.assertIsInstance(val, str)
         self.assertEqual(val, 'translated')
 
+    def test_overriding_FIELD_display(self):
+        class FooBar(models.Model):
+            foo_bar = models.IntegerField(choices=[(1, 'foo'), (2, 'bar')])
+
+            def get_foo_bar_display(self):
+                return 'something'
+
+        f = FooBar(foo_bar=1)
+        self.assertEqual(f.get_foo_bar_display(), 'something')
+
     def test_iterator_choices(self):
         """
         get_choices() works with Iterators.


### PR DESCRIPTION
~~* Test case, plus...~~
~~* Docs example (for 2.2+)~~

Test and fix. 