### PR TITLE
Refs #13312 -- Removed unnecessary IF wrapping in MySQL nulls_last handling.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1156,7 +1156,7 @@ class OrderBy(BaseExpression):
     def as_mysql(self, compiler, connection):
         template = None
         if self.nulls_last:
-            template = 'IF(ISNULL(%(expression)s),1,0), %(expression)s %(ordering)s '
+            template = 'ISNULL(%(expression)s), %(expression)s %(ordering)s '
         elif self.nulls_first:
             template = 'IF(ISNULL(%(expression)s),0,1), %(expression)s %(ordering)s '
         return self.as_sql(compiler, connection, template=template)


### PR DESCRIPTION
[The MySQL `ISNULL` function already returns 0 and 1 booleans](https://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_isnull)