### PR TITLE
Refs #13312 -- Simplified handling of nulls ordering on MySQL.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -88,6 +88,9 @@ class BaseDatabaseFeatures:
     # Does the backend order NULL values as largest or smallest?
     nulls_order_largest = False
 
+    # Does the backend support NULLS FIRST and NULLS LAST in ORDER BY?
+    supports_order_by_nulls_modifier = True
+
     # The database's limit on the number of query parameters.
     max_query_params = None
 

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -50,6 +50,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     db_functions_convert_bytes_to_str = True
     # Neither MySQL nor MariaDB support partial indexes.
     supports_partial_indexes = False
+    supports_order_by_nulls_modifier = False
 
     @cached_property
     def _mysql_storage_engine(self):

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -44,3 +44,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_over_clause = Database.sqlite_version_info >= (3, 25, 0)
     supports_frame_range_fixed_distance = Database.sqlite_version_info >= (3, 28, 0)
     supports_aggregate_filter_clause = Database.sqlite_version_info >= (3, 30, 1)
+    supports_order_by_nulls_modifier = Database.sqlite_version_info >= (3, 30, 0)


### PR DESCRIPTION
MySQL & MariaDB support the standard ``IS NULL`` and ``IS NOT NULL`` so the same workaround used for ``NULLS FIRST`` and ``NULLS LAST`` that is used for SQLite < 3.30.0 can be used. Let's combine them and simplify ``OrderBy()``.

Following on from a [discussion](https://github.com/django/django/pull/12001#pullrequestreview-310125225) with @charettes.