### PR TITLE
Removed unnecessary EXCLUDE_FROM_PACKAGES from setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,11 +52,6 @@ if "install" in sys.argv:
             break
 
 
-EXCLUDE_FROM_PACKAGES = ['django.conf.project_template',
-                         'django.conf.app_template',
-                         'django.bin']
-
-
 # Dynamically calculate the version based on django.VERSION.
 version = __import__('django').get_version()
 
@@ -77,7 +72,7 @@ setup(
                  'rapid development and clean, pragmatic design.'),
     long_description=read('README.rst'),
     license='BSD',
-    packages=find_packages(exclude=EXCLUDE_FROM_PACKAGES),
+    packages=find_packages(),
     include_package_data=True,
     scripts=['django/bin/django-admin.py'],
     entry_points={'console_scripts': [


### PR DESCRIPTION
Excluding the directories containing templates has been unnecessary
since abc0777b63057e2ff97eee2ff184356051e14c47 where the extension was
changed to not be .py.

As django.bin does not have a __init__.py, it is not a package and
therefore is not excluded by this argument.