### PR TITLE
Refs #30116 -- Simplified stdout/stderr decoding with subprocess.run()'s encoding argument.

### DIFF
--- a/scripts/manage_translations.py
+++ b/scripts/manage_translations.py
@@ -124,14 +124,17 @@ def lang_stats(resources=None, languages=None):
             p = run(
                 ['msgfmt', '-vc', '-o', '/dev/null', po_path],
                 stdout=PIPE, stderr=PIPE,
-                env={'LANG': 'C'}
+                env={'LANG': 'C'},
+                encoding='utf-8',
             )
             if p.returncode == 0:
                 # msgfmt output stats on stderr
-                print("%s: %s" % (lang, p.stderr.decode().strip()))
+                print('%s: %s' % (lang, p.stderr.strip()))
             else:
-                print("Errors happened when checking %s translation for %s:\n%s" % (
-                    lang, name, p.stderr.decode()))
+                print(
+                    'Errors happened when checking %s translation for %s:\n%s'
+                    % (lang, name, p.stderr)
+                )
 
 
 def fetch(resources=None, languages=None):

--- a/tests/postgres_tests/test_integration.py
+++ b/tests/postgres_tests/test_integration.py
@@ -16,7 +16,7 @@ class PostgresIntegrationTests(PostgreSQLSimpleTestCase):
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
             cwd=os.path.dirname(__file__),
-            env=test_environ
+            env=test_environ,
+            encoding='utf-8',
         )
-        stderr = '\n'.join([e.decode() for e in result.stderr.splitlines()])
-        self.assertEqual(result.returncode, 0, msg=stderr)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)


### PR DESCRIPTION
The encoding argument has been available since Python 3.6.

https://docs.python.org/3/library/subprocess.html#subprocess.run