### PR TITLE
Fixed #30948 -- Changed packaging to use setuptools declarative config in setup.cfg.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -3,8 +3,6 @@ Thanks for downloading Django.
 To install it, make sure you have Python 3.6 or greater installed. Then run
 this command from the command prompt:
 
-    python setup.py install
-
-If you're upgrading from a previous version, you need to remove it first.
+    python -m pip install .
 
 For more detailed instructions, see docs/intro/install.txt.

--- a/docs/faq/troubleshooting.txt
+++ b/docs/faq/troubleshooting.txt
@@ -14,9 +14,9 @@ Problems running ``django-admin``
 -----------------------------------
 
 :doc:`django-admin </ref/django-admin>` should be on your system path if you
-installed Django via ``python setup.py``. If it's not on your path, you can
-find it in ``site-packages/django/bin``, where ``site-packages`` is a directory
-within your Python installation. Consider symlinking to :doc:`django-admin
+installed Django via ``pip``. If it's not on your path, you can find it in
+``site-packages/django/bin``, where ``site-packages`` is a directory within
+your Python installation. Consider symlinking to :doc:`django-admin
 </ref/django-admin>` from some place on your path, such as
 :file:`/usr/local/bin`.
 

--- a/docs/internals/howto-release-django.txt
+++ b/docs/internals/howto-release-django.txt
@@ -206,7 +206,7 @@ OK, this is the fun part, where we actually push out a release!
    on ``VERSION``.
 
 #. If this is a pre-release package, update the "Development Status" trove
-   classifier in ``setup.py`` to reflect this. Otherwise, make sure the
+   classifier in ``setup.cfg`` to reflect this. Otherwise, make sure the
    classifier is set to ``Development Status :: 5 - Production/Stable``.
 
 #. Tag the release using ``git tag``. For example::

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -11,8 +11,8 @@ does the same thing as ``django-admin`` but also sets the
 project's ``settings.py`` file.
 
 The ``django-admin`` script should be on your system path if you installed
-Django via its ``setup.py`` utility. If it's not on your path, you can find it
-in ``site-packages/django/bin`` within your Python installation. Consider
+Django via ``pip``. If it's not on your path, you can find it in
+``site-packages/django/bin`` within your Python installation. Consider
 symlinking it from some place on your path, such as ``/usr/local/bin``.
 
 For Windows users, who do not have symlinking functionality available, you can

--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -89,7 +89,7 @@ To use Argon2 as your default storage algorithm, do the following:
 #. Install the `argon2-cffi library`_.  This can be done by running
    ``python -m pip install django[argon2]``, which is equivalent to
    ``python -m pip install argon2-cffi`` (along with any version requirement
-   from Django's ``setup.py``).
+   from Django's ``setup.cfg``).
 
 #. Modify :setting:`PASSWORD_HASHERS` to list ``Argon2PasswordHasher`` first.
    That is, in your settings file, you'd put::
@@ -119,7 +119,7 @@ To use Bcrypt as your default storage algorithm, do the following:
 #. Install the `bcrypt library`_. This can be done by running
    ``python -m pip install django[bcrypt]``, which is equivalent to
    ``python -m pip install bcrypt`` (along with any version requirement from
-   Django's ``setup.py``).
+   Django's ``setup.cfg``).
 
 #. Modify :setting:`PASSWORD_HASHERS` to list ``BCryptSHA256PasswordHasher``
    first. That is, in your settings file, you'd put::

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,55 @@
+[metadata]
+name = Django
+version = attr: django.__version__
+url = https://www.djangoproject.com/
+author = Django Software Foundation
+author_email = foundation@djangoproject.com
+description = A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
+long_description = file: README.rst
+license = BSD-3-Clause
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Environment :: Web Environment
+    Framework :: Django
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Internet :: WWW/HTTP
+    Topic :: Internet :: WWW/HTTP :: Dynamic Content
+    Topic :: Internet :: WWW/HTTP :: WSGI
+    Topic :: Software Development :: Libraries :: Application Frameworks
+    Topic :: Software Development :: Libraries :: Python Modules
+project_urls =
+    Documentation = https://docs.djangoproject.com/
+    Funding = https://www.djangoproject.com/fundraising/
+    Source = https://github.com/django/django
+    Tracker = https://code.djangoproject.com/
+
+[options]
+python_requires = >=3.6
+packages = find:
+scripts = django/bin/django-admin.py
+include_package_data = true
+zip_safe = false
+install_requires =
+    asgiref
+    pytz
+    sqlparse >= 0.2.2
+
+[options.entry_points]
+console_scripts =
+    django-admin = django.core.management:execute_from_command_line
+
+[options.extras_require]
+argon2 = argon2-cffi >= 16.1.0
+bcrypt = bcrypt
+
 [bdist_rpm]
 doc_files = docs extras AUTHORS INSTALL LICENSE README.rst
 install-script = scripts/rpm-install.sh

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import sys
 from distutils.sysconfig import get_python_lib
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 CURRENT_PYTHON = sys.version_info[:2]
 REQUIRED_PYTHON = (3, 6)
@@ -52,64 +52,7 @@ if "install" in sys.argv:
             break
 
 
-# Dynamically calculate the version based on django.VERSION.
-version = __import__('django').get_version()
-
-
-def read(fname):
-    with open(os.path.join(os.path.dirname(__file__), fname)) as f:
-        return f.read()
-
-
-setup(
-    name='Django',
-    version=version,
-    python_requires='>={}.{}'.format(*REQUIRED_PYTHON),
-    url='https://www.djangoproject.com/',
-    author='Django Software Foundation',
-    author_email='foundation@djangoproject.com',
-    description=('A high-level Python Web framework that encourages '
-                 'rapid development and clean, pragmatic design.'),
-    long_description=read('README.rst'),
-    license='BSD-3-Clause',
-    packages=find_packages(),
-    include_package_data=True,
-    scripts=['django/bin/django-admin.py'],
-    entry_points={'console_scripts': [
-        'django-admin = django.core.management:execute_from_command_line',
-    ]},
-    install_requires=['pytz', 'sqlparse >= 0.2.2', 'asgiref'],
-    extras_require={
-        "bcrypt": ["bcrypt"],
-        "argon2": ["argon2-cffi >= 16.1.0"],
-    },
-    zip_safe=False,
-    classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Environment :: Web Environment',
-        'Framework :: Django',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3 :: Only',
-        'Topic :: Internet :: WWW/HTTP',
-        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-        'Topic :: Internet :: WWW/HTTP :: WSGI',
-        'Topic :: Software Development :: Libraries :: Application Frameworks',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
-    project_urls={
-        'Documentation': 'https://docs.djangoproject.com/',
-        'Funding': 'https://www.djangoproject.com/fundraising/',
-        'Source': 'https://github.com/django/django',
-        'Tracker': 'https://code.djangoproject.com/',
-    },
-)
+setup()
 
 
 if overlay_warning:


### PR DESCRIPTION
setuptools allows using `setup.cfg` to define a package’s metadata and other options that are normally supplied to the `setup()`. This declarative approach avoids the need for some logic in `setup.py` which can help reduce boilerplate and support automation with external tools.

Available since setuptools 30.3.0 (8 Dec 2016).

https://code.djangoproject.com/ticket/30948