### PR TITLE
[2.2.x] Fixed #30928 -- Updated docs for MySQL support of nowait and skip_locked options

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -612,10 +612,12 @@ both MySQL and Django will attempt to convert the values from UTC to local time.
 Row locking with ``QuerySet.select_for_update()``
 -------------------------------------------------
 
-MySQL does not support the ``NOWAIT``, ``SKIP LOCKED``, and ``OF`` options to
+For MySQL versions lower than 8.0.1, MySQL does not support the
+``NOWAIT``, ``SKIP LOCKED``, and ``OF`` options to
 the ``SELECT ... FOR UPDATE`` statement. If ``select_for_update()`` is used
 with ``nowait=True``, ``skip_locked=True``, or ``of`` then a
-:exc:`~django.db.NotSupportedError` is raised.
+:exc:`~django.db.NotSupportedError` is raised. However, MySQL supports only
+``NOWAIT`` and ``SKIP LOCKED`` options in version 8.0.1 upwards.
 
 When using ``select_for_update()`` on MySQL, make sure you filter a queryset
 against at least set of fields contained in unique constraints or only against

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1710,12 +1710,13 @@ them::
     <QuerySet [<Person: ...)>, ...]>
 
 Currently, the ``postgresql``, ``oracle``, and ``mysql`` database
-backends support ``select_for_update()``. However, MySQL doesn't support the
-``nowait``, ``skip_locked``, and ``of`` arguments.
+backends support ``select_for_update()``. However, MySQL supports only the
+``nowait`` and ``skip_locked`` arguments starting from MYSQL version 8.0.1.
+Note that lower versions of MySQL do not support any of the three arguments.
 
 Passing ``nowait=True``, ``skip_locked=True``, or ``of`` to
 ``select_for_update()`` using database backends that do not support these
-options, such as MySQL, raises a :exc:`~django.db.NotSupportedError`. This
+options raises a :exc:`~django.db.NotSupportedError`. This
 prevents code from unexpectedly blocking.
 
 Evaluating a queryset with ``select_for_update()`` in autocommit mode on


### PR DESCRIPTION
MySQL added support for `NOWAIT` and `SKIP LOCKED` options in version [8.0](https://dev.mysql.com/doc/refman/8.0/en/innodb-locking-reads.html) and was added to the Django codebase in this commit https://github.com/django/django/commit/a7bc1aea03508f544c9dfac0f34b01996653cef4.

This change updates the documentation to reflect the support for both options for MySQL database backend.

Issue ticket - https://code.djangoproject.com/ticket/30928