### PR TITLE
Fixed #15742 -- Fixed an example of collecting selected objects in ModelAdmin.actions docs.

### DIFF
--- a/django/contrib/admin/__init__.py
+++ b/django/contrib/admin/__init__.py
@@ -1,12 +1,9 @@
-# ACTION_CHECKBOX_NAME is unused, but should stay since its import from here
-# has been referenced in documentation.
 from django.contrib.admin.decorators import register
 from django.contrib.admin.filters import (
     AllValuesFieldListFilter, BooleanFieldListFilter, ChoicesFieldListFilter,
     DateFieldListFilter, FieldListFilter, ListFilter, RelatedFieldListFilter,
     RelatedOnlyFieldListFilter, SimpleListFilter,
 )
-from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.contrib.admin.options import (
     HORIZONTAL, VERTICAL, ModelAdmin, StackedInline, TabularInline,
 )
@@ -14,10 +11,10 @@ from django.contrib.admin.sites import AdminSite, site
 from django.utils.module_loading import autodiscover_modules
 
 __all__ = [
-    "register", "ACTION_CHECKBOX_NAME", "ModelAdmin", "HORIZONTAL", "VERTICAL",
-    "StackedInline", "TabularInline", "AdminSite", "site", "ListFilter",
-    "SimpleListFilter", "FieldListFilter", "BooleanFieldListFilter",
-    "RelatedFieldListFilter", "ChoicesFieldListFilter", "DateFieldListFilter",
+    "register", "ModelAdmin", "HORIZONTAL", "VERTICAL", "StackedInline",
+    "TabularInline", "AdminSite", "site", "ListFilter", "SimpleListFilter",
+    "FieldListFilter", "BooleanFieldListFilter", "RelatedFieldListFilter",
+    "ChoicesFieldListFilter", "DateFieldListFilter",
     "AllValuesFieldListFilter", "RelatedOnlyFieldListFilter", "autodiscover",
 ]
 

--- a/docs/ref/contrib/admin/actions.txt
+++ b/docs/ref/contrib/admin/actions.txt
@@ -236,14 +236,16 @@ you'd want to let the user choose a format, and possibly a list of fields to
 include in the export. The best thing to do would be to write a small action
 that redirects to your custom export view::
 
-    from django.contrib import admin
     from django.contrib.contenttypes.models import ContentType
     from django.http import HttpResponseRedirect
 
     def export_selected_objects(modeladmin, request, queryset):
-        selected = request.POST.getlist(admin.ACTION_CHECKBOX_NAME)
+        selected = queryset.values_list('pk', flat=True)
         ct = ContentType.objects.get_for_model(queryset.model)
-        return HttpResponseRedirect("/export/?ct=%s&ids=%s" % (ct.pk, ",".join(selected)))
+        return HttpResponseRedirect('/export/?ct=%s&ids=%s' % (
+            ct.pk,
+            ','.join(str(pk) for pk in selected),
+        ))
 
 As you can see, the action is rather short; all the complex logic would belong
 in your export view. This would need to deal with objects of any type, hence

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -268,6 +268,10 @@ Miscellaneous
 * The compatibility imports of ``Context``, ``ContextPopException``, and
   ``RequestContext`` in ``django.template.base`` are removed.
 
+* The compatibility import of
+  ``django.contrib.admin.helpers.ACTION_CHECKBOX_NAME`` in
+  ``django.contrib.admin`` is removed.
+
 * The :setting:`STATIC_URL` and :setting:`MEDIA_URL` settings set to relative
   paths are now prefixed by the server-provided value of ``SCRIPT_NAME`` (or
   ``/`` if not set). This change should not affect settings set to valid URLs


### PR DESCRIPTION
( https://docs.djangoproject.com/en/2.2/ref/contrib/admin/actions/#actions-that-provide-intermediate-pages )
`/docs/ref/contrib/admin/actions.txt`
in paragraph
`Actions that provide intermediate pages`


recommends directly accessing the form values:

`selected = request.POST.getlist(admin.ACTION_CHECKBOX_NAME)`

to get a list of selected ids.  This fails to take into account if the `select all` box has been selected.

This patch changes one line to suggest using the queryset to get the IDs, which results in the correct behaviour.