### PR TITLE
Fixed #30928 -- Clarified MySQL/MariaDB support of QuerySet.select_for_update() options.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -625,10 +625,17 @@ both MySQL and Django will attempt to convert the values from UTC to local time.
 Row locking with ``QuerySet.select_for_update()``
 -------------------------------------------------
 
-MySQL does not support the ``NOWAIT``, ``SKIP LOCKED``, and ``OF`` options to
-the ``SELECT ... FOR UPDATE`` statement. If ``select_for_update()`` is used
-with ``nowait=True``, ``skip_locked=True``, or ``of`` then a
-:exc:`~django.db.NotSupportedError` is raised.
+MySQL and MariaDB do not support some options to the ``SELECT ... FOR UPDATE``
+statement. If ``select_for_update()`` is used with an unsupported option, then
+a :exc:`~django.db.NotSupportedError` is raised.
+
+=============== ========= ==========
+Option          MariaDB   MySQL
+=============== ========= ==========
+``SKIP LOCKED``           X (≥8.0.1)
+``NOWAIT``      X (≥10.3) X (≥8.0.1)
+``OF``
+=============== ========= ==========
 
 When using ``select_for_update()`` on MySQL, make sure you filter a queryset
 against at least set of fields contained in unique constraints or only against

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1706,8 +1706,9 @@ them::
     <QuerySet [<Person: ...)>, ...]>
 
 Currently, the ``postgresql``, ``oracle``, and ``mysql`` database
-backends support ``select_for_update()``. However, MySQL doesn't support the
-``nowait``, ``skip_locked``, and ``of`` arguments.
+backends support ``select_for_update()``. However, MariaDB 10.3+ supports only
+the ``nowait`` argument and MySQL 8.0.1+ supports the ``nowait`` and
+``skip_locked`` arguments. MySQL and MariaDB don't support the ``of`` argument.
 
 Passing ``nowait=True``, ``skip_locked=True``, or ``of`` to
 ``select_for_update()`` using database backends that do not support these


### PR DESCRIPTION
MySQL added support for `NOWAIT` and `SKIP LOCKED` options in version [8.0.1](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html#mysqld-8-0-1-feature) with documentation done [here](https://dev.mysql.com/doc/refman/8.0/en/innodb-locking-reads.html#innodb-locking-reads-nowait-skip-locked). MariaDB added support for only the `NOWAIT` option in version [10.3.0](https://mariadb.com/kb/en/library/wait-and-nowait/) with the Jira issue on adding support for the `SKIP LOCKED` still open [here](https://jira.mariadb.org/browse/MDEV-13115).

This change updates the documentation to reflect the support for both options for MySQL and just the `NOWAIT` for MariaDB.

Issue ticket - https://code.djangoproject.com/ticket/30928