### PR TITLE
Documented arguments for custom 500 error view.

### DIFF
--- a/docs/ref/urls.txt
+++ b/docs/ref/urls.txt
@@ -192,5 +192,5 @@ that should be called in case of server errors. Server errors happen when you
 have runtime errors in view code.
 
 By default, this is :func:`django.views.defaults.server_error`. If you
-implement a custom view, be sure it returns an
-:class:`~django.http.HttpResponseServerError`.
+implement a custom view, be sure it accepts a ``request`` argument and returns
+an :class:`~django.http.HttpResponseServerError`.


### PR DESCRIPTION
Matches note in django.urls.resolvers.py at def _check_custom_error_handlers(self):