### PR TITLE
Refs #30183 -- Doc'd dropping support for sqlparse < 0.2.2.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -285,7 +285,7 @@ dependencies:
 *  memcached_, plus a :ref:`supported Python binding <memcached>`
 *  gettext_ (:ref:`gettext_on_windows`)
 *  selenium_
-*  sqlparse_ (required)
+*  sqlparse_ 0.2.2+ (required)
 *  tblib_ 1.5.0+
 
 You can find these dependencies in `pip requirements files`_ inside the

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -550,6 +550,8 @@ Miscellaneous
 * ``alias=None`` is added to the signature of
   :meth:`.Expression.get_group_by_cols`.
 
+* Support for ``sqlparse`` < 0.2.2 is removed.
+
 .. _deprecated-features-3.0:
 
 Features deprecated in 3.0

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     entry_points={'console_scripts': [
         'django-admin = django.core.management:execute_from_command_line',
     ]},
-    install_requires=['pytz', 'sqlparse', 'asgiref'],
+    install_requires=['pytz', 'sqlparse >= 0.2.2', 'asgiref'],
     extras_require={
         "bcrypt": ["bcrypt"],
         "argon2": ["argon2-cffi >= 16.1.0"],

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -13,5 +13,5 @@ pytz
 pywatchman; sys.platform != 'win32'
 PyYAML
 selenium
-sqlparse
+sqlparse >= 0.2.2
 tblib >= 1.5.0


### PR DESCRIPTION
From sqlparse [change log](https://github.com/andialbrecht/sqlparse/blob/master/CHANGELOG):

Release 0.2.2 (Oct 22, 2016)
----------------------------

Internal Changes

* `is_whitespace` and `is_group` changed into properties

  [1]: https://github.com/andialbrecht/sqlparse/blob/master/CHANGELOG