### PR TITLE
Adjusted expected exception message for Windows.

### DIFF
--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -569,7 +569,10 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
                 filebased.EmailBackend
             )
 
-        msg = 'expected str, bytes or os.PathLike object, not object'
+        if sys.platform == 'win32':
+            msg = '_getfullpathname: path should be string, bytes or os.PathLike, not object'
+        else:
+            msg = 'expected str, bytes or os.PathLike object, not object'
         with self.assertRaisesMessage(TypeError, msg):
             mail.get_connection('django.core.mail.backends.filebased.EmailBackend', file_path=object())
         self.assertIsInstance(mail.get_connection(), locmem.EmailBackend)


### PR DESCRIPTION
Test failure introduced in fbbff7f80870bc3e98de4a2fc9cd853949842fd0.

Windows uses a different error message when a non-path is passed to
os.path functions.