### PR TITLE
Refs #29983 -- Added test for TEMPLATES['DIRS'] pathlib support.

### DIFF
--- a/django/forms/renderers.py
+++ b/django/forms/renderers.py
@@ -39,7 +39,7 @@ class EngineMixin:
     def engine(self):
         return self.backend({
             'APP_DIRS': True,
-            'DIRS': [str(ROOT / self.backend.app_dirname)],
+            'DIRS': [ROOT / self.backend.app_dirname],
             'NAME': 'djangoforms',
             'OPTIONS': {},
         })

--- a/tests/template_backends/test_django.py
+++ b/tests/template_backends/test_django.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from template_tests.test_response import test_processor_name
 
 from django.template import Context, EngineHandler, RequestContext
@@ -164,3 +166,13 @@ class DjangoTemplatesTests(TemplateStringsTests):
     def test_debug_default_template_loaders(self):
         engine = DjangoTemplates({'DIRS': [], 'APP_DIRS': True, 'NAME': 'django', 'OPTIONS': {}})
         self.assertEqual(engine.engine.loaders, self.default_loaders)
+
+    def test_dirs_pathlib(self):
+        engine = DjangoTemplates({
+            'DIRS': [Path(__file__).parent / 'templates' / 'template_backends'],
+            'APP_DIRS': False,
+            'NAME': 'django',
+            'OPTIONS': {},
+        })
+        template = engine.get_template('hello.html')
+        self.assertEqual(template.render({'name': 'Joe'}), 'Hello Joe!\n')

--- a/tests/template_backends/test_jinja2.py
+++ b/tests/template_backends/test_jinja2.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import skipIf
 
 from django.template import TemplateSyntaxError
@@ -85,3 +86,13 @@ class Jinja2Tests(TemplateStringsTests):
         with self.settings(STATIC_URL='/s/'):
             content = template.render(request=request)
         self.assertEqual(content, 'Static URL: /s/')
+
+    def test_dirs_pathlib(self):
+        engine = Jinja2({
+            'DIRS': [Path(__file__).parent / 'templates' / 'template_backends'],
+            'APP_DIRS': False,
+            'NAME': 'jinja2',
+            'OPTIONS': {},
+        })
+        template = engine.get_template('hello.html')
+        self.assertEqual(template.render({'name': 'Joe'}), 'Hello Joe!')


### PR DESCRIPTION
The existing use doesn't need to coerce the Path object to a string.