### PR TITLE
Removed "Pocket PC" from terminal color support function.

### DIFF
--- a/django/core/management/color.py
+++ b/django/core/management/color.py
@@ -14,8 +14,7 @@ def supports_color():
     Return True if the running system's terminal supports color,
     and False otherwise.
     """
-    plat = sys.platform
-    supported_platform = plat != 'Pocket PC' and (plat != 'win32' or 'ANSICON' in os.environ)
+    supported_platform = sys.platform != 'win32' or 'ANSICON' in os.environ
 
     # isatty is not always implemented, #6223.
     is_a_tty = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()


### PR DESCRIPTION
Introduced over 13 years ago in 9bea530c33e, Pocket PC was surpassed by Windows Mobile, then Windows Phone, which has since been retired. The value "Pocket PC" isn't documented as a value for ``sys.platform`` and it isn't clear whether it ever worked. There are no tests for this.

Found while reviewing #12034.