### PR TITLE
Clarified license is BSD 3-Clause in package metadata.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     description=('A high-level Python Web framework that encourages '
                  'rapid development and clean, pragmatic design.'),
     long_description=read('README.rst'),
-    license='BSD',
+    license='BSD-3-Clause',
     packages=find_packages(),
     include_package_data=True,
     scripts=['django/bin/django-admin.py'],


### PR DESCRIPTION
Use the SPDX identifier in the license metadata field to clarify that the primary license for Django is the BSD 3-Clause "New" or "Revised" License. The 'License :: OSI Approved :: BSD License' trove classifier is not clear enough to indicate which if the variants of the BSD license Django uses.

See https://github.com/django/django/pull/12013#discussion_r342001037