### PR TITLE
Fixed #24858 -- Added support for get_FOO_display() to ArrayField and RangeFields.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -33,6 +33,7 @@ from django.db.models.signals import (
 )
 from django.db.models.utils import make_model_tuple
 from django.utils.encoding import force_str
+from django.utils.hashable import make_hashable
 from django.utils.text import capfirst, get_text_list
 from django.utils.translation import gettext_lazy as _
 from django.utils.version import get_version
@@ -940,8 +941,9 @@ class Model(metaclass=ModelBase):
 
     def _get_FIELD_display(self, field):
         value = getattr(self, field.attname)
+        choices_dict = dict(make_hashable(field.flatchoices))
         # force_str() to coerce lazy strings.
-        return force_str(dict(field.flatchoices).get(value, value), strings_only=True)
+        return force_str(choices_dict.get(make_hashable(value), value), strings_only=True)
 
     def _get_next_or_previous_by_FIELD(self, field, is_next, **kwargs):
         if not self.pk:

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -797,6 +797,11 @@ For example::
     >>> p.get_shirt_size_display()
     'Large'
 
+.. versionchanged:: 3.1
+
+    Support for :class:`~django.contrib.postgres.fields.ArrayField` and
+    :class:`~django.contrib.postgres.fields.RangeField` was added.
+
 .. method:: Model.get_next_by_FOO(**kwargs)
 .. method:: Model.get_previous_by_FOO(**kwargs)
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -76,6 +76,10 @@ Minor features
   :class:`~django.contrib.postgres.operations.BloomExtension` migration
   operation installs the ``bloom`` extension to add support for this index.
 
+* :meth:`~django.db.models.Model.get_FOO_display` now supports
+  :class:`~django.contrib.postgres.fields.ArrayField` and
+  :class:`~django.contrib.postgres.fields.RangeField`.
+
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -37,6 +37,53 @@ except ImportError:
     pass
 
 
+@isolate_apps('postgres_tests')
+class BasicTests(PostgreSQLSimpleTestCase):
+    def test_get_field_display(self):
+        class MyModel(PostgreSQLModel):
+            field = ArrayField(
+                models.CharField(max_length=16),
+                choices=[
+                    ['Media', [(['vinyl', 'cd'], 'Audio')]],
+                    (('mp3', 'mp4'), 'Digital'),
+                ],
+            )
+
+        tests = (
+            (['vinyl', 'cd'], 'Audio'),
+            (('mp3', 'mp4'), 'Digital'),
+            (('a', 'b'), "('a', 'b')"),
+            (['c', 'd'], "['c', 'd']"),
+        )
+        for value, display in tests:
+            with self.subTest(value=value, display=display):
+                instance = MyModel(field=value)
+                self.assertEqual(instance.get_field_display(), display)
+
+    def test_get_field_display_nested_array(self):
+        class MyModel(PostgreSQLModel):
+            field = ArrayField(
+                ArrayField(models.CharField(max_length=16)),
+                choices=[
+                    [
+                        'Media',
+                        [([['vinyl', 'cd'], ('x',)], 'Audio')],
+                    ],
+                    ((['mp3'], ('mp4',)), 'Digital'),
+                ],
+            )
+        tests = (
+            ([['vinyl', 'cd'], ('x',)], 'Audio'),
+            ((['mp3'], ('mp4',)), 'Digital'),
+            ((('a', 'b'), ('c',)), "(('a', 'b'), ('c',))"),
+            ([['a', 'b'], ['c']], "[['a', 'b'], ['c']]"),
+        )
+        for value, display in tests:
+            with self.subTest(value=value, display=display):
+                instance = MyModel(field=value)
+                self.assertEqual(instance.get_field_display(), display)
+
+
 class TestSaveLoad(PostgreSQLTestCase):
 
     def test_integer(self):


### PR DESCRIPTION
[Ticket 24858](https://code.djangoproject.com/ticket/24858).
It is possible to do this change in the model base like this:
```
diff --git a/django/db/models/base.py b/django/db/models/base.py
index 0a5e5ff673..0847427248 100644
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -939,9 +939,15 @@ class Model(metaclass=ModelBase):
     delete.alters_data = True
 
     def _get_FIELD_display(self, field):
-        value = getattr(self, field.attname)
+        original_value = getattr(self, field.attname)
+        d = {
+            (tuple(k) if isinstance(k, list) else k): v
+            for k, v in field.flatchoices
+        }
+        value = tuple(original_value) if isinstance(original_value, list) else original_value
+
         # force_str() to coerce lazy strings.
-        return force_str(dict(field.flatchoices).get(value, value), strings_only=True)
+        return force_str(d.get(value, original_value), strings_only=True)
```
and don't add these changes both `ArrayField` and `RangeField`.