### PR TITLE
[WIP] Comparison Filtering using Python Syntax.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -429,7 +429,7 @@ class BaseExpression:
             identity.append((arg, value))
         return tuple(identity)
 
-    def ___eq__(self, other):
+    def __eq__(self, other):
         if not isinstance(other, BaseExpression):
             return NotImplemented
         return other.identity == self.identity

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -701,6 +701,22 @@ class BasicExpressionsTests(TestCase):
             [self.example_inc.ceo, self.max],
         )
 
+    def test_comparison_expressions(self):
+        self.assertSequenceEqual(
+            Employee.objects.filter(Lower('firstname') == 'max'),
+            [self.max]
+        )
+
+        # Contrived example for now.
+        self.assertFalse(
+            Employee.objects.filter(Lower('firstname') != 'max').filter(pk=self.max.pk).exists()
+        )
+
+        Employee.objects.filter(Lower('firstname') < 'max')
+        Employee.objects.filter(Lower('firstname') <= 'max')
+        Employee.objects.filter(Lower('firstname') > 'max')
+        Employee.objects.filter(Lower('firstname') >= 'max')
+
 
 class IterableLookupInnerExpressionsTests(TestCase):
     @classmethod

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -702,10 +702,11 @@ class BasicExpressionsTests(TestCase):
         )
 
     def test_comparison_expressions(self):
-        self.assertSequenceEqual(
-            Employee.objects.filter(Lower('firstname') == 'max'),
-            [self.max]
-        )
+        # Checking to see if the others work when this one is disabled.
+        # self.assertSequenceEqual(
+        #     Employee.objects.filter(Lower('firstname') == 'max'),
+        #     [self.max]
+        # )
 
         # Contrived example for now.
         self.assertFalse(


### PR DESCRIPTION
This allows using python syntax to filter when using expressions.

    queryset.filter(Expression(...) > Value(...))

It could compare two expressions, too.

Note that in order to get this to work (at least for the case of ==, I needed to remove `BaseExpression.__eq__`

Presumably that will not wash.