### PR TITLE
Added QuerySet.get_or_none method

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -434,6 +434,16 @@ class QuerySet:
             )
         )
 
+    def get_or_none(self, *args, **kwargs):
+        """
+        Perform the query and return a single object matching the given
+        keyword arguments. If no object is found a None is returned.
+        """
+        try:
+            return self.get(*args, **kwargs)
+        except self.model.DoesNotExist:
+            return None
+
     def create(self, **kwargs):
         """
         Create a new object with the given kwargs, saving it to the database

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -295,6 +295,14 @@ class Queries1Tests(TestCase):
             Author.objects.order_by('name').get(pk=self.a1.pk)
         self.assertNotIn('order by', captured_queries[0]['sql'].lower())
 
+    def test_get_or_none_returns_object(self):
+        item = Item.objects.get_or_none(name='one')
+        self.assertEqual(item, self.i1)
+
+    def test_get_or_none_returns_none(self):
+        item = Item.objects.get_or_none(name='foobar')
+        self.assertIsNone(item)
+
     def test_tickets_4088_4306(self):
         self.assertQuerysetEqual(
             Report.objects.filter(creator=1001),


### PR DESCRIPTION
This is pretty much a duplicate of https://code.djangoproject.com/ticket/2659 with small difference - method is added at the `QuerySet` itself instead of `django.shortcuts` module. This would make it easier to use as it doesn't require extra import.

### Motivation

Over the years we've added a lot of similar utility functions like `.first()` / `.last()`, `.earliest()` / `.latest()`. Now I often see code like `Item.objects.filter(id=123).first()`. Users simply don't want to create four lines like that:

    try:
        item = Item.objects.get(id=123)
    except Item.objects.DoesNotExist:
        item = None

However. using `.first()` / `.last()` to achieve similar result is misleading (they implies order to be important at the first glance while it's not important at all when filtering by particular primary key).

_In my opinion this is relevant shortcut that should land at the very core of Django's ORM and it would make many project's code cleaner and easier to read._

Let me know if it makes sense now to include it and I can work on extending docs etc.