### PR TITLE
Fixed #21238 -- Fixed restoring attributes when pickling FileField and ImageField.

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -123,11 +123,21 @@ class FieldFile(File):
             file.close()
 
     def __getstate__(self):
-        # FieldFile needs access to its associated model field and an instance
-        # it's attached to in order to work properly, but the only necessary
-        # data to be pickled is the file's name itself. Everything else will
-        # be restored later, by FileDescriptor below.
-        return {'name': self.name, 'closed': False, '_committed': True, '_file': None}
+        # FieldFile needs access to its associated model field, an instance and
+        # the file's name. Everything else will be restored later, by
+        # FileDescriptor below.
+        return {
+            'name': self.name,
+            'closed': False,
+            '_committed': True,
+            '_file': None,
+            'instance': self.instance,
+            'field': self.field,
+        }
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.storage = self.field.storage
 
 
 class FileDescriptor:

--- a/tests/model_fields/test_filefield.py
+++ b/tests/model_fields/test_filefield.py
@@ -122,3 +122,7 @@ class FileFieldTests(TestCase):
             myfile_dump = pickle.dumps(document.myfile)
             loaded_myfile = pickle.loads(myfile_dump)
             self.assertEqual(document.myfile, loaded_myfile)
+            self.assertEqual(document.myfile.url, loaded_myfile.url)
+            self.assertEqual(document.myfile.storage, loaded_myfile.storage)
+            self.assertEqual(document.myfile.instance, loaded_myfile.instance)
+            self.assertEqual(document.myfile.field, loaded_myfile.field)

--- a/tests/model_fields/test_filefield.py
+++ b/tests/model_fields/test_filefield.py
@@ -1,10 +1,11 @@
 import os
+import pickle
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-from django.core.files import temp
+from django.core.files import File, temp
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.db.utils import IntegrityError
@@ -103,3 +104,21 @@ class FileFieldTests(TestCase):
                 with TemporaryUploadedFile('foo.txt', 'text/plain', 1, 'utf-8') as tmp_file:
                     Document.objects.create(myfile=tmp_file)
                     self.assertTrue(os.path.exists(os.path.join(tmp_dir, 'unused', 'foo.txt')))
+
+    def test_pickle(self):
+        with open(__file__, 'rb') as fp:
+            file1 = File(fp, name='test_file.py')
+            document = Document(myfile='test_file.py')
+            document.myfile.save('test_file.py', file1)
+
+            dump = pickle.dumps(document)
+            loaded_document = pickle.loads(dump)
+            self.assertEqual(document.myfile, loaded_document.myfile)
+            self.assertEqual(document.myfile.url, loaded_document.myfile.url)
+            self.assertEqual(document.myfile.storage, loaded_document.myfile.storage)
+            self.assertEqual(document.myfile.instance, loaded_document.myfile.instance)
+            self.assertEqual(document.myfile.field, loaded_document.myfile.field)
+
+            myfile_dump = pickle.dumps(document.myfile)
+            loaded_myfile = pickle.loads(myfile_dump)
+            self.assertEqual(document.myfile, loaded_myfile)

--- a/tests/model_fields/test_imagefield.py
+++ b/tests/model_fields/test_imagefield.py
@@ -180,6 +180,14 @@ class ImageFieldTests(ImageFieldTestMixin, TestCase):
 
         loaded_p = pickle.loads(dump)
         self.assertEqual(p.mugshot, loaded_p.mugshot)
+        self.assertEqual(p.mugshot.url, loaded_p.mugshot.url)
+        self.assertEqual(p.mugshot.storage, loaded_p.mugshot.storage)
+        self.assertEqual(p.mugshot.instance, loaded_p.mugshot.instance)
+        self.assertEqual(p.mugshot.field, loaded_p.mugshot.field)
+
+        mugshot_dump = pickle.dumps(p.mugshot)
+        loaded_mugshot = pickle.loads(mugshot_dump)
+        self.assertEqual(p.mugshot, loaded_mugshot)
 
     def test_defer(self):
         self.PersonModel.objects.create(name='Joe', mugshot=self.file1)

--- a/tests/model_fields/test_imagefield.py
+++ b/tests/model_fields/test_imagefield.py
@@ -178,9 +178,6 @@ class ImageFieldTests(ImageFieldTestMixin, TestCase):
         p.mugshot.save("mug", self.file1)
         dump = pickle.dumps(p)
 
-        p2 = Person(name="Bob")
-        p2.mugshot = self.file1
-
         loaded_p = pickle.loads(dump)
         self.assertEqual(p.mugshot, loaded_p.mugshot)
 

--- a/tests/model_fields/test_imagefield.py
+++ b/tests/model_fields/test_imagefield.py
@@ -188,6 +188,10 @@ class ImageFieldTests(ImageFieldTestMixin, TestCase):
         mugshot_dump = pickle.dumps(p.mugshot)
         loaded_mugshot = pickle.loads(mugshot_dump)
         self.assertEqual(p.mugshot, loaded_mugshot)
+        self.assertEqual(p.mugshot.url, loaded_mugshot.url)
+        self.assertEqual(p.mugshot.storage, loaded_mugshot.storage)
+        self.assertEqual(p.mugshot.instance, loaded_mugshot.instance)
+        self.assertEqual(p.mugshot.field, loaded_mugshot.field)
 
     def test_defer(self):
         self.PersonModel.objects.create(name='Joe', mugshot=self.file1)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/21238