### PR TITLE
Fix commas every three digits.

### DIFF
--- a/django/contrib/humanize/templatetags/humanize.py
+++ b/django/contrib/humanize/templatetags/humanize.py
@@ -72,7 +72,8 @@ def intcomma(value, use_l10n=True):
         else:
             return number_format(value, force_grouping=True)
     orig = str(value)
-    new = re.sub(r"^(-?\d+)(\d{3})", r'\g<1>,\g<2>', orig)
+    sep = (',','.')[settings.USE_L10N]
+    new = re.sub(r"^(-?\d+)(\d{3})", r'\g<1>' + sep + r'\g<2>', orig)
     if orig == new:
         return new
     else:


### PR DESCRIPTION
This change replaces the decimal separator according to the "settings.USE_L10N" variable.
For exemple, 2000 becomes 2,000 or 2.000