### PR TITLE
Fixing change password path on es_MX translations

### DIFF
--- a/django/contrib/auth/locale/es_MX/LC_MESSAGES/django.po
+++ b/django/contrib/auth/locale/es_MX/LC_MESSAGES/django.po
@@ -73,7 +73,7 @@ msgid ""
 msgstr ""
 "Las contraseñas no se almacenan en texto plano, así que no hay manera de ver "
 "la contraseña del usuario, pero se puede cambiar la contraseña mediante <a "
-"href=\"password/\">este formulario</a>."
+"href=\"{}\">este formulario</a>."
 
 #, python-format
 msgid ""


### PR DESCRIPTION
Currently, when changing locale to es_MX, the change password link on the admin is broken. This patch fix it