### PR TITLE
Fixed #30966 -- Fixed Migration crashes due to foreign key issue, depending on otherwise irrelevant order.

### DIFF
--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -889,6 +889,16 @@ class MigrateTests(MigrationTestBase):
         applied_migrations = recorder.applied_migrations()
         self.assertNotIn(("migrations", "0001_initial"), applied_migrations)
 
+    @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrate_change_foreing_key"})
+    def test_migrate_change_foreing_key(self):
+        out = io.StringIO()
+        with mock.patch('django.core.management.color.supports_color', lambda *args: False):
+            call_command('migrate', 'migrations', '0002', stdout=out, verbosity=1)
+        value = out.getvalue().lower()
+        self.assertIn('target specific migration: 0002_alter_user_id, from migrations', value)
+        self.assertIn('applying migrations.0001_initial... ok', value)
+        self.assertIn('applying migrations.0002_alter_user_id... ok', value)
+
 
 class MakeMigrationsTests(MigrationTestBase):
     """

--- a/tests/migrations/test_migrate_change_foreing_key/0001_initial.py
+++ b/tests/migrations/test_migrate_change_foreing_key/0001_initial.py
@@ -1,0 +1,46 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="User",
+            fields=[
+                ("id", models.AutoField(primary_key=True)),
+                ("email", models.EmailField(max_length=191, unique=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name="Domain",
+            fields=[
+                ("id", models.AutoField(primary_key=True)),
+                ("owner", models.ForeignKey("migrations.User", models.SET_NULL)),
+            ],
+        ),
+        migrations.CreateModel(
+            name="RRset",
+            fields=[
+                ("id", models.AutoField(primary_key=True)),
+                ("subname", models.CharField(blank=True, max_length=178)),
+                ("domain", models.ForeignKey("migrations.Domain", models.SET_NULL)),
+            ],
+        ),
+        migrations.CreateModel(
+            name="Token",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True)),
+                ("user", models.ForeignKey("migrations.User", models.SET_NULL)),
+            ],
+        ),
+        migrations.AlterField(
+            model_name="RRset",
+            name="subname",
+            field=models.CharField(blank=False, max_length=178),
+        ),
+    ]

--- a/tests/migrations/test_migrate_change_foreing_key/0002_alter_user_id.py
+++ b/tests/migrations/test_migrate_change_foreing_key/0002_alter_user_id.py
@@ -1,0 +1,16 @@
+import uuid
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("migrations", "0001_initial")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="user",
+            name="id",
+            field=models.CharField(default=uuid.uuid4, max_length=32, primary_key=True),
+        ),
+    ]


### PR DESCRIPTION
Description on [ticke comment](https://code.djangoproject.com/ticket/30966#comment:4).