### PR TITLE
Remove deprecated render attribute in widget

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -93,7 +93,6 @@ class BoundField:
             name=self.html_initial_name if only_initial else self.html_name,
             value=self.value(),
             attrs=attrs,
-            renderer=self.form.renderer,
         )
 
     def as_text(self, attrs=None, **kwargs):


### PR DESCRIPTION
Hi, in file forms/boundfield.py there is a deprecated option used according this documentation https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1 .
I deleted "renderer=self.form.renderer" because it returned an error 500 when the function was called.
Thanks !
