### PR TITLE
Fixed #30986 -- Fixed queryset crash when filtering against boolean RawSQL expressions on Oracle.

### DIFF
--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
 from django.db.backends.utils import strip_quotes, truncate_name
-from django.db.models.expressions import Exists, ExpressionWrapper
+from django.db.models.expressions import Exists, ExpressionWrapper, RawSQL
 from django.db.models.query_utils import Q
 from django.db.utils import DatabaseError
 from django.utils import timezone
@@ -635,5 +635,7 @@ END;
         if isinstance(expression, Exists):
             return True
         if isinstance(expression, ExpressionWrapper) and isinstance(expression.expression, Q):
+            return True
+        if isinstance(expression, RawSQL) and expression.conditional:
             return True
         return False

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -92,6 +92,14 @@ class BasicExpressionsTests(TestCase):
             2,
         )
 
+    def test_filtering_on_rawsql_that_is_boolean(self):
+        self.assertEqual(
+            Company.objects.filter(
+                RawSQL('num_employees > %s', (3,), output_field=models.BooleanField()),
+            ).count(),
+            2,
+        )
+
     def test_filter_inter_attribute(self):
         # We can filter on attribute relationships on same model obj, e.g.
         # find companies where the number of employees is greater


### PR DESCRIPTION
Ticket [30986](https://code.djangoproject.com/ticket/30986), see [discussion on PR#12067](https://github.com/django/django/pull/12067/files#r346680973).