### PR TITLE
Refs #29808 -- Fixed MigrateTests.test_migrate_fake_initial_case_insensitive() crash on Oracle.

### DIFF
--- a/tests/migrations/test_fake_initial_case_insensitive/fake_initial/0001_initial.py
+++ b/tests/migrations/test_fake_initial_case_insensitive/fake_initial/0001_initial.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
                 ('field', models.CharField(max_length=20)),
             ],
             options={
-                'db_table': 'migrations_mIxEd_cAsE_iNiTiAl_mOdEl',
+                'db_table': 'migrations_mIxEd_cAsE_mOdEl',
             },
         ),
         migrations.AddField(

--- a/tests/migrations/test_fake_initial_case_insensitive/initial/0001_initial.py
+++ b/tests/migrations/test_fake_initial_case_insensitive/initial/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={
-                'db_table': 'migrations_MiXeD_CaSe_InItIaL_MoDel',
+                'db_table': 'migrations_MiXeD_CaSe_MoDel',
             },
         ),
     ]


### PR DESCRIPTION
Previous `db_table` name was too long, an identifier cannot be longer than 30 chars on Oracle.


