### PR TITLE
Expanded API stability docs to include our policy of continual improvement

### DIFF
--- a/docs/misc/api-stability.txt
+++ b/docs/misc/api-stability.txt
@@ -2,12 +2,21 @@
 API stability
 =============
 
-Django promises API stability and forwards-compatibility since version 1.0. In
-a nutshell, this means that code you develop against a version of Django will
-continue to work with future releases. You may need to make minor changes when
-upgrading the version of Django your project uses: see the "Backwards
-incompatible changes" section of the :doc:`release note </releases/index>` for
-the version or versions to which you are upgrading.
+Django is committed to API stability and forwards-compatibility. In a nutshell,
+this means that code you develop against a version of Django will continue to
+work with future releases. You may need to make minor changes when upgrading
+the version of Django your project uses: see the "Backwards incompatible
+changes" section of the :doc:`release note </releases/index>` for the version
+or versions to which you are upgrading.
+
+At the same time as making API stability a very high priority, Django is also
+committed to continual improvement, along with aiming for "one way to do it"
+(eventually) in the APIs we provide. This means that when we discover clearly
+superior ways to do things, we will deprecate and eventually remove the old
+ways. Our aim is to provide a modern, dependable web framework of the highest
+quality that encourages best practices in all projects that use it. By using
+incremental improvements, we try to avoid both stagnation and large breaking
+upgrades.
 
 What "stable" means
 ===================
@@ -29,8 +38,8 @@ In this context, stable means:
   See :ref:`official-releases` for more details on how Django's version
   numbering scheme works, and how features will be deprecated.
 
-- We'll only break backwards compatibility of these APIs if a bug or
-  security hole makes it completely unavoidable.
+- We'll only break backwards compatibility of these APIs without a deprecation
+  process if a bug or security hole makes it completely unavoidable.
 
 Stable APIs
 ===========


### PR DESCRIPTION
The background to this PR is this thread on https://groups.google.com/forum/#!msg/django-developers/GgqjkYSqfR0/f5zER264EgAJ where I offered to tweak the wording of our API stability docs, and I've finally got round to it!

My aim here is not to change our policy at all, but to make our docs more clearly reflect what I think our actual practice and philosophy is — with some positive spin on why we do it that way — and perhaps avoid the frustrations and disappointment of people like Pakal on the linked thread, for whom its fair to say that the current API stability docs give unrealistic expectations.

I removed reference to version 1.0 since it is no longer relevant, that was a very long time ago...

While I've tried to sum up what I think is our current practice and policy, we may want some discussion on wording etc. obviously that's fine.