### PR TITLE
Fixed #30988 -- Deprecated the InvalidQuery exception class.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -21,7 +21,7 @@ from django.db.models.deletion import Collector
 from django.db.models.expressions import Case, Expression, F, Value, When
 from django.db.models.fields import AutoField
 from django.db.models.functions import Cast, Trunc
-from django.db.models.query_utils import FilteredRelation, InvalidQuery, Q
+from django.db.models.query_utils import FilteredRelation, Q
 from django.db.models.sql.constants import CURSOR, GET_ITERATOR_CHUNK_SIZE
 from django.db.utils import NotSupportedError
 from django.utils import timezone
@@ -1455,7 +1455,9 @@ class RawQuerySet:
         try:
             model_init_names, model_init_pos, annotation_fields = self.resolve_model_init_order()
             if self.model._meta.pk.attname not in model_init_names:
-                raise InvalidQuery('Raw query must include the primary key')
+                raise exceptions.FieldDoesNotExist(
+                    'Raw query must include the primary key'
+                )
             model_cls = self.model
             fields = [self.model_fields.get(c) for c in self.columns]
             converters = compiler.get_converters([

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -39,6 +39,9 @@ details on these changes.
 * The undocumented usage of the :lookup:`isnull` lookup with non-boolean values
   as the right-hand side will no longer be allowed.
 
+* The ``django.db.models.query_utils.InvalidQuery`` exception class will be
+  removed.
+
 See the :ref:`Django 3.1 release notes <deprecated-features-3.1>` for more
 details on these changes.
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -330,6 +330,11 @@ Miscellaneous
 * The undocumented usage of the :lookup:`isnull` lookup with non-boolean values
   as the right-hand side is deprecated, use ``True`` or ``False`` instead.
 
+* The barely documented ``django.db.models.query_utils.InvalidQuery`` exception
+  class is deprecated in favor of
+  :class:`~django.core.exceptions.FieldDoesNotExist` and
+  :class:`~django.core.exceptions.FieldError`.
+
 .. _removed-features-3.1:
 
 Features removed in 3.1

--- a/docs/topics/db/sql.txt
+++ b/docs/topics/db/sql.txt
@@ -170,8 +170,9 @@ last names were both retrieved on demand when they were printed.
 
 There is only one field that you can't leave out - the primary key
 field. Django uses the primary key to identify model instances, so it
-must always be included in a raw query. An ``InvalidQuery`` exception
-will be raised if you forget to include the primary key.
+must always be included in a raw query. A
+:class:`~django.core.exceptions.FieldDoesNotExist` exception will be raised if
+you forget to include the primary key.
 
 Adding annotations
 ------------------

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -1,4 +1,4 @@
-from django.db.models.query_utils import InvalidQuery
+from django.core.exceptions import FieldError
 from django.test import TestCase
 
 from .models import (
@@ -113,7 +113,7 @@ class DeferTests(AssertionMixin, TestCase):
             'Field Primary.related cannot be both deferred and traversed '
             'using select_related at the same time.'
         )
-        with self.assertRaisesMessage(InvalidQuery, msg):
+        with self.assertRaisesMessage(FieldError, msg):
             Primary.objects.defer("related").select_related("related")[0]
 
     def test_only_select_related_raises_invalid_query(self):
@@ -121,7 +121,7 @@ class DeferTests(AssertionMixin, TestCase):
             'Field Primary.related cannot be both deferred and traversed using '
             'select_related at the same time.'
         )
-        with self.assertRaisesMessage(InvalidQuery, msg):
+        with self.assertRaisesMessage(FieldError, msg):
             Primary.objects.only("name").select_related("related")[0]
 
     def test_defer_foreign_keys_are_deferred_and_not_traversed(self):

--- a/tests/queries/test_deprecation.py
+++ b/tests/queries/test_deprecation.py
@@ -1,0 +1,30 @@
+from contextlib import contextmanager
+
+from django.core.exceptions import FieldDoesNotExist, FieldError
+from django.db.models.query_utils import InvalidQuery
+from django.test import SimpleTestCase
+from django.utils.deprecation import RemovedInDjango40Warning
+
+
+class InvalidQueryTests(SimpleTestCase):
+    @contextmanager
+    def assert_warns(self):
+        msg = (
+            'The InvalidQuery exception class is deprecated. Use '
+            'FieldDoesNotExist or FieldError instead.'
+        )
+        with self.assertWarnsMessage(RemovedInDjango40Warning, msg):
+            yield
+
+    def test_type(self):
+        self.assertIsInstance(InvalidQuery(), InvalidQuery)
+
+    def test_isinstance(self):
+        for exception in (FieldError, FieldDoesNotExist):
+            with self.assert_warns(), self.subTest(exception.__name__):
+                self.assertIsInstance(exception(), InvalidQuery)
+
+    def test_issubclass(self):
+        for exception in (FieldError, FieldDoesNotExist, InvalidQuery):
+            with self.assert_warns(), self.subTest(exception.__name__):
+                self.assertIs(issubclass(exception, InvalidQuery), True)

--- a/tests/raw_query/tests.py
+++ b/tests/raw_query/tests.py
@@ -1,8 +1,8 @@
 from datetime import date
 from decimal import Decimal
 
+from django.core.exceptions import FieldDoesNotExist
 from django.db.models.query import RawQuerySet
-from django.db.models.query_utils import InvalidQuery
 from django.test import TestCase, skipUnlessDBFeature
 
 from .models import (
@@ -235,7 +235,8 @@ class RawQueryTests(TestCase):
 
     def test_missing_fields_without_PK(self):
         query = "SELECT first_name, dob FROM raw_query_author"
-        with self.assertRaisesMessage(InvalidQuery, 'Raw query must include the primary key'):
+        msg = 'Raw query must include the primary key'
+        with self.assertRaisesMessage(FieldDoesNotExist, msg):
             list(Author.objects.raw(query))
 
     def test_annotations(self):


### PR DESCRIPTION
It was barely documented without pointers at its defining location and was abused to prevent misuse of the QuerySet field deferring feature.

---

https://code.djangoproject.com/ticket/30988