### PR TITLE
Fixed #30953 -- of args of select_for_update only includes parent model

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ answer newbie questions, and generally made Django that much better:
     Aaron Swartz <http://www.aaronsw.com/>
     Aaron T. Myers <atmyers@gmail.com>
     Abeer Upadhyay <ab.esquarer@gmail.com>
+    Abhijeet Viswa <abhijeetviswa@gmail.com>
     Abhinav Patil <https://github.com/ubadub/>
     Abhishek Gautam <abhishekg1128@yahoo.com>
     Adam Allred <adam.w.allred@gmail.com>

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -981,10 +981,11 @@ class SQLCompiler:
             Return a list of OneToOneField relations that are pointers to
             ancestors of the base 'model'
             """
-            from django.db.models import OneToOneField
-            ancestors = self.query.get_meta().get_parent_list()
-            cols = [c[0] for c in self.select if isinstance(c[0].target, OneToOneField) and
-                    c[0].target.related_model in ancestors and c[0].target.remote_field.parent_link]
+            parents = set(self.query.get_meta().get_parent_list())
+            cols = [
+                c[0] for c in self.select
+                if c[0].target.related_model in parents and c[0].target.remote_field.parent_link
+            ]
             return cols
 
         ancestor_pointers = _get_model_ancestor_pointers()

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1690,7 +1690,14 @@ query. For example, rows of related objects specified in :meth:`select_related`
 are locked in addition to rows of the queryset's model. If this isn't desired,
 specify the related objects you want to lock in ``select_for_update(of=(...))``
 using the same fields syntax as :meth:`select_related`. Use the value ``'self'``
-to refer to the queryset's model.
+to refer to the queryset's model. To lock the parent models of the queryset's
+model, specify the child models link to the parent. Consider the example models
+specified under :ref:`multi-table-inheritance`. The following queryset locks
+the rows for both the ``Place`` as well as ``Restaurant`` models::
+
+
+    Restaurant.objects.all().select_for_update(of=('self', 'place_ptr'))
+
 
 You can't use ``select_for_update()`` on nullable relations::
 

--- a/docs/releases/2.2.8.txt
+++ b/docs/releases/2.2.8.txt
@@ -10,4 +10,5 @@ Django 2.2.8 fixes several bugs in 2.2.7 and adds compatibility with Python
 Bugfixes
 ========
 
-* ...
+* Fixed only parent models of specified models being locked when ``of``
+  argument is specified in ``select_for_update``` (:ticket:`30953`)


### PR DESCRIPTION
When using `select_for_update` with the `of` args specified, only the
parent model (for multi-table inheritance) would be included in the
query. To specify the parent models, the field representing the link
between the models have to be specified.

The docs have been updated to specify this change with proper
examples.