### PR TITLE
Fixed #29058 -- return geom type for GeoDjango fields when using Spatialite backend so that migrations don't fail.

### DIFF
--- a/django/contrib/gis/db/backends/spatialite/operations.py
+++ b/django/contrib/gis/db/backends/spatialite/operations.py
@@ -116,7 +116,7 @@ class SpatiaLiteOperations(BaseSpatialOperations, DatabaseOperations):
         Return None because geometry columns are added via the
         `AddGeometryColumn` stored procedure on SpatiaLite.
         """
-        return None
+        return f.geom_type
 
     def get_distance(self, f, value, lookup_type):
         """

--- a/tests/gis_tests/gis_migrations/migrations/0001_initial.py
+++ b/tests/gis_tests/gis_migrations/migrations/0001_initial.py
@@ -46,7 +46,12 @@ ops = [
         name='family',
         field=models.ForeignKey('gis_migrations.Family', models.SET_NULL, blank=True, null=True),
         preserve_default=True,
-    )
+    ),
+    migrations.AlterField(
+        model_name='household',
+        name='geom',
+        field=models.PointField(srid=4326, geography=True, verbose_name='Geoms'),
+    ),
 ]
 
 if connection.features.supports_raster:


### PR DESCRIPTION
[Ticket 29058](https://code.djangoproject.com/ticket/29058)