### PR TITLE
Removed unused default value None to matches_patterns().

### DIFF
--- a/django/contrib/staticfiles/utils.py
+++ b/django/contrib/staticfiles/utils.py
@@ -5,12 +5,12 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 
-def matches_patterns(path, patterns=None):
+def matches_patterns(path, patterns):
     """
     Return True or False depending on whether the ``path`` should be
     ignored (if it matches any pattern in ``ignore_patterns``).
     """
-    return any(fnmatch.fnmatchcase(path, pattern) for pattern in (patterns or []))
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
 
 
 def get_files(storage, ignore_patterns=None, location=''):


### PR DESCRIPTION
An iterable is always passed.