### PR TITLE
Fixed #30999 -- Fixed typo in docs/howto/custom-template-tags.txt.

### DIFF
--- a/docs/howto/custom-template-tags.txt
+++ b/docs/howto/custom-template-tags.txt
@@ -892,7 +892,7 @@ Registering the tag
 -------------------
 
 Finally, register the tag with your module's ``Library`` instance, as explained
-in :ref:`writing custom template filters<howto-writing-custom-template-tags>`
+in :ref:`writing custom template tags<howto-writing-custom-template-tags>`
 above. Example::
 
     register.tag('current_time', do_current_time)


### PR DESCRIPTION
[Ticket 30999](https://code.djangoproject.com/ticket/30999)