### PR TITLE
Fixed #30625 -- Doc'd cache.get()/delete() behavior change in Django 2.2.

### DIFF
--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -471,6 +471,9 @@ Miscellaneous
   with several third-party apps that had models in tests without migrations.
   You must add migrations for such models.
 
+* Providing an integer in the ``key`` argument of the :meth:`.cache.delete` or
+  :meth:`.cache.get` now raises :exc:`ValueError`.
+
 .. _deprecated-features-2.2:
 
 Features deprecated in 2.2


### PR DESCRIPTION
Documentation part for [ticket 30625](https://code.djangoproject.com/ticket/30625).