### PR TITLE
Fixed #30413 -- Fixed test database signature on SQLite when test database name is provided.

### DIFF
--- a/django/db/backends/sqlite3/creation.py
+++ b/django/db/backends/sqlite3/creation.py
@@ -98,4 +98,6 @@ class DatabaseCreation(BaseDatabaseCreation):
         sig = [self.connection.settings_dict['NAME']]
         if self.is_in_memory_db(test_database_name):
             sig.append(self.connection.alias)
+        else:
+            sig.append(test_database_name)
         return tuple(sig)

--- a/tests/backends/sqlite/test_creation.py
+++ b/tests/backends/sqlite/test_creation.py
@@ -1,0 +1,18 @@
+import copy
+import unittest
+
+from django.db import connection
+from django.test import SimpleTestCase
+
+
+@unittest.skipUnless(connection.vendor == 'sqlite', 'SQLite tests')
+class TestDbSignatureTests(SimpleTestCase):
+    def test_custom_test_name(self):
+        saved_settings = copy.deepcopy(connection.settings_dict)
+        try:
+            connection.settings_dict['NAME'] = None
+            connection.settings_dict['TEST']['NAME'] = 'custom.sqlite.db'
+            signature = connection.creation.test_db_signature()
+            self.assertEqual(signature, (None, 'custom.sqlite.db'))
+        finally:
+            connection.settings_dict = saved_settings


### PR DESCRIPTION
Added regression test for test_db_signature, test db name is
added to the database name list in order to prepare signatures list
for the database.

Signed-off-by: Farhaan Bukhsh <farhaan.bukhsh@gmail.com>