### PR TITLE
Made versionadded/versionchanged annotations without a content end with ".".

### DIFF
--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -153,7 +153,7 @@ class DjangoHTMLTranslator(HTMLTranslator):
         if version_text:
             title = "%s%s" % (
                 version_text % node['version'],
-                ":" if node else "."
+                ":" if len(node) else "."
             )
             self.body.append('<span class="title">%s</span> ' % title)
 


### PR DESCRIPTION
Regression in d2afa5eb2308e672b6313876856e32e2561b90f3.