### PR TITLE
Fixed #31010 -- Allowed subdomains of localhost in the Host header by default when DEBUG=True.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -108,7 +108,7 @@ class HttpRequest:
         # Allow variants of localhost if ALLOWED_HOSTS is empty and DEBUG=True.
         allowed_hosts = settings.ALLOWED_HOSTS
         if settings.DEBUG and not allowed_hosts:
-            allowed_hosts = ['localhost', '127.0.0.1', '[::1]']
+            allowed_hosts = ['.localhost', '127.0.0.1', '[::1]']
 
         domain, port = split_domain_port(host)
         if domain and validate_host(domain, allowed_hosts):

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -90,7 +90,7 @@ list, the :meth:`django.http.HttpRequest.get_host()` method will raise
 :exc:`~django.core.exceptions.SuspiciousOperation`.
 
 When :setting:`DEBUG` is ``True`` and ``ALLOWED_HOSTS`` is empty, the host
-is validated against ``['localhost', '127.0.0.1', '[::1]']``.
+is validated against ``['.localhost', '127.0.0.1', '[::1]']``.
 
 ``ALLOWED_HOSTS`` is also :ref:`checked when running tests
 <topics-testing-advanced-multiple-hosts>`.
@@ -98,6 +98,11 @@ is validated against ``['localhost', '127.0.0.1', '[::1]']``.
 This validation only applies via :meth:`~django.http.HttpRequest.get_host()`;
 if your code accesses the ``Host`` header directly from ``request.META`` you
 are bypassing this security protection.
+
+.. versionchanged:: 3.1
+
+    If ``ALLOWED_HOSTS`` is empty and ``DEBUG=True``, subdomains of localhost
+    were allowed.
 
 .. setting:: APPEND_SLASH
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -222,7 +222,8 @@ Pagination
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* If :setting:`ALLOWED_HOSTS` is empty and ``DEBUG=True``, subdomains of
+  localhost are now allowed in the ``Host`` header, e.g. ``static.localhost``.
 
 Serialization
 ~~~~~~~~~~~~~

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -758,7 +758,7 @@ class HostValidationTests(SimpleTestCase):
         If ALLOWED_HOSTS is empty and DEBUG is True, variants of localhost are
         allowed.
         """
-        valid_hosts = ['localhost', '127.0.0.1', '[::1]']
+        valid_hosts = ['localhost', 'subdomain.localhost', '127.0.0.1', '[::1]']
         for host in valid_hosts:
             request = HttpRequest()
             request.META = {'HTTP_HOST': host}


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31010