### PR TITLE
Fixed #31026 -- Switch form rendering to template engine

### DIFF
--- a/django/contrib/admin/static/admin/js/vendor/select2/select2.full.js
+++ b/django/contrib/admin/static/admin/js/vendor/select2/select2.full.js
@@ -1,4 +1,4 @@
-/*!
+translate_url/*!
  * Select2 4.0.13
  * https://select2.github.io
  *

--- a/django/contrib/admin/static/admin/js/vendor/select2/select2.full.js
+++ b/django/contrib/admin/static/admin/js/vendor/select2/select2.full.js
@@ -1,4 +1,4 @@
-translate_url/*!
+/*!
  * Select2 4.0.13
  * https://select2.github.io
  *

--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -1,10 +1,10 @@
 import datetime
 import re
 
-from django.forms.utils import flatatt, pretty_name
+from django.forms.utils import pretty_name
 from django.forms.widgets import Textarea, TextInput
 from django.utils.functional import cached_property
-from django.utils.html import conditional_escape, format_html, html_safe
+from django.utils.html import format_html, html_safe
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
@@ -161,11 +161,14 @@ class BoundField:
                     attrs['class'] += ' ' + self.form.required_css_class
                 else:
                     attrs['class'] = self.form.required_css_class
-            attrs = flatatt(attrs) if attrs else ''
-            contents = format_html('<label{}>{}</label>', attrs, contents)
-        else:
-            contents = conditional_escape(contents)
-        return mark_safe(contents)
+
+        return mark_safe(self.form.renderer.render(self.form.template_name_label, {
+            'form': self.form,
+            'field': self,
+            'label': contents,
+            'attrs': attrs,
+            'use_tag': bool(id_),
+        }))
 
     def css_classes(self, extra_classes=None):
         """

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -291,9 +291,9 @@ class BaseForm:
         hidden_fields = []
         top_errors = self.non_field_errors()
         for name, field in self.fields.items():
-            bf = self[name]
-            bf_errors = self.error_class(bf.errors)
-            if bf.is_hidden:
+            bound_field = self[name]
+            bf_errors = self.error_class(bound_field.errors)
+            if bound_field.is_hidden:
                 if bf_errors:
                     top_errors.extend(
                         [
@@ -301,9 +301,9 @@ class BaseForm:
                             for e in bf_errors
                         ]
                     )
-                hidden_fields.append(bf)
+                hidden_fields.append(bound_field)
             else:
-                bound_fields.append((bf, mark_safe(str(bf_errors))))
+                bound_fields.append((bound_field, mark_safe(str(bf_errors))))
         return {
             'form': self,
             'fields': bound_fields,

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -289,7 +289,7 @@ class BaseForm:
         """
         bound_fields = []
         hidden_fields = []
-        top_errors = self.non_field_errors()
+        top_errors = self.non_field_errors().copy()
         for name, field in self.fields.items():
             bound_field = self[name]
             bf_errors = self.error_class(bound_field.errors)

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -10,7 +10,7 @@ from django.forms.fields import Field, FileField
 from django.forms.utils import ErrorDict, ErrorList
 from django.forms.widgets import Media, MediaDefiningClass
 from django.utils.datastructures import MultiValueDict
-from django.utils.deprecation import RemovedInNextVersionWarning
+from django.utils.deprecation import RemovedInDjango50Warning
 from django.utils.functional import cached_property
 from django.utils.html import conditional_escape, html_safe
 from django.utils.safestring import mark_safe
@@ -67,7 +67,6 @@ class BaseForm:
     template_name_p = 'django/forms/p.html'
     template_name_table = 'django/forms/table.html'
     template_name_ul = 'django/forms/ul.html'
-
     template_name_label = 'django/forms/label.html'
 
     def __init__(self, data=None, files=None, auto_id='id_%s', prefix=None,
@@ -200,7 +199,7 @@ class BaseForm:
         "Output HTML. Used by as_table(), as_ul(), as_p()."
         warnings.warn(
             '`django.forms.BaseForm._html_output` is deprecated.'
-            ' Please use the `render` and `get_context` methods.', RemovedInNextVersionWarning)
+            ' Please use the `render` and `get_context` methods.', RemovedInDjango50Warning)
         # Errors that should be displayed above all fields.
         top_errors = self.non_field_errors().copy()
         output, hidden_fields = [], []
@@ -279,7 +278,7 @@ class BaseForm:
 
     def get_context(self):
         """
-        Return context text for form rendering.
+        Return context for form rendering.
 
         The available context is:
 
@@ -287,7 +286,6 @@ class BaseForm:
             `fields`: All bound fields, except the hidden fields.
             `hidden_fields`: All hidden bound fields.
             `errors`: All non field related or hidden field related form errors.
-
         """
         bound_fields = []
         hidden_fields = []

--- a/django/forms/jinja2/django/forms/attrs.html
+++ b/django/forms/jinja2/django/forms/attrs.html
@@ -1,0 +1,1 @@
+{% for name, value in attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}

--- a/django/forms/jinja2/django/forms/default.html
+++ b/django/forms/jinja2/django/forms/default.html
@@ -1,0 +1,1 @@
+{% include "django/forms/table.html" %}

--- a/django/forms/jinja2/django/forms/errors/default.html
+++ b/django/forms/jinja2/django/forms/errors/default.html
@@ -1,0 +1,1 @@
+{% include "django/forms/errors/ul.html" %}

--- a/django/forms/jinja2/django/forms/errors/ul.html
+++ b/django/forms/jinja2/django/forms/errors/ul.html
@@ -1,0 +1,7 @@
+{% if errors %}
+  <ul class="{{ error_class }}">
+    {% for error in errors %}
+      <li>{{ error }}</li>
+    {% endfor %}
+  </ul>
+{% endif %}

--- a/django/forms/jinja2/django/forms/label.html
+++ b/django/forms/jinja2/django/forms/label.html
@@ -1,0 +1,1 @@
+{% if use_tag %}<label{% include 'django/forms/attrs.html' %}>{{ label }}</label>{% else %}{{ label }}{% endif %}

--- a/django/forms/jinja2/django/forms/p.html
+++ b/django/forms/jinja2/django/forms/p.html
@@ -1,0 +1,20 @@
+{{ errors }}
+{% if errors and not fields %}
+  <p>{% for field in hidden_fields %}{{ field }}{% endfor %}</p>
+{% endif %}
+{% for field, errors in fields %}
+  {{ errors }}
+  <p{% if field.css_classes %} class="{{ field.css_classes }}"{% endif %}>
+    {% if field.label %}{{ field.label_tag }}{% endif %}
+    {{ field }}
+    {% if field.help_text %}
+      <span class="helptext">{{ field.help_text }}</span>
+    {% endif %}
+    {% if forloop.last %}
+      {% for field in hidden_fields %}{{ field }}{% endfor %}
+    {% endif %}
+  </p>
+{% endfor %}
+{% if not fields and not errors %}
+  {% for field in hidden_fields %}{{ field }}{% endfor %}
+{% endif %}

--- a/django/forms/jinja2/django/forms/table.html
+++ b/django/forms/jinja2/django/forms/table.html
@@ -1,0 +1,29 @@
+{% for  error in  errors %}
+  <tr>
+    <td colspan="2">
+      {{ errors }}
+      {% if not fields %}
+        {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% endif %}
+    </td>
+  </tr>
+{% endfor %}
+{% for field, errors in fields %}
+  <tr{% if field.css_classes %} class="{{ field.css_classes }}"{% endif %}>
+    <th>{% if field.label %}{{ field.label_tag }}{% endif %}</th>
+    <td>
+      {{ errors }}
+      {{ field }}
+      {% if field.help_text %}
+        <br>
+        <span class="helptext">{{ field.help_text }}</span>
+      {% endif %}
+      {% if forloop.last %}
+        {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% endif %}
+    </td>
+  </tr>
+{% endfor %}
+{% if not fields and not errors %}
+  {% for field in hidden_fields %}{{ field }}{% endfor %}
+{% endif %}

--- a/django/forms/jinja2/django/forms/ul.html
+++ b/django/forms/jinja2/django/forms/ul.html
@@ -1,0 +1,24 @@
+{% for  error in  errors %}
+  <li>
+    {{ errors }}
+  {% if not fields %}
+    {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% endif %}
+  </li>
+{% endfor %}
+{% for field, errors in fields %}
+  <li{% if field.css_classes %} class="{{ field.css_classes }}"{% endif %}>
+    {{ errors }}
+    {% if field.label %}{{ field.label_tag }}{% endif %}
+    {{ field }}
+    {% if field.help_text %}
+      <span class="helptext">{{ field.help_text }}</span>
+    {% endif %}
+  {% if forloop.last %}
+    {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% endif %}
+  </li>
+{% endfor %}
+{% if not fields and not errors %}
+ {% for field in hidden_fields %}{{ field }}{% endfor %}
+{% endif %}

--- a/django/forms/templates/django/forms/attrs.html
+++ b/django/forms/templates/django/forms/attrs.html
@@ -1,0 +1,1 @@
+{% for name, value in attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}

--- a/django/forms/templates/django/forms/default.html
+++ b/django/forms/templates/django/forms/default.html
@@ -1,0 +1,1 @@
+{% include "django/forms/table.html" %}

--- a/django/forms/templates/django/forms/errors/default.html
+++ b/django/forms/templates/django/forms/errors/default.html
@@ -1,0 +1,1 @@
+{% include "django/forms/errors/ul.html" %}

--- a/django/forms/templates/django/forms/errors/ul.html
+++ b/django/forms/templates/django/forms/errors/ul.html
@@ -1,0 +1,7 @@
+{% if errors %}
+  <ul class="{{ error_class }}">
+    {% for error in errors %}
+      <li>{{ error }}</li>
+    {% endfor %}
+  </ul>
+{% endif %}

--- a/django/forms/templates/django/forms/formsets/default.html
+++ b/django/forms/templates/django/forms/formsets/default.html
@@ -1,0 +1,2 @@
+{{ formset.management_form }}
+{% for form in formset %}{{ form }}{% endfor %}

--- a/django/forms/templates/django/forms/formsets/p.html
+++ b/django/forms/templates/django/forms/formsets/p.html
@@ -1,0 +1,2 @@
+{{ formset.management_form }}
+{% for form in formset %}{{ form.as_p }}{% endfor %}

--- a/django/forms/templates/django/forms/formsets/table.html
+++ b/django/forms/templates/django/forms/formsets/table.html
@@ -1,0 +1,2 @@
+{{ formset.management_form }}
+{% for form in formset %}{{ form.as_table }}{% endfor %}

--- a/django/forms/templates/django/forms/formsets/ul.html
+++ b/django/forms/templates/django/forms/formsets/ul.html
@@ -1,0 +1,2 @@
+{{ formset.management_form }}
+{% for form in formset %}{{ form.as_ul }}{% endfor %}

--- a/django/forms/templates/django/forms/label.html
+++ b/django/forms/templates/django/forms/label.html
@@ -1,0 +1,1 @@
+{% if use_tag %}<label{% include 'django/forms/attrs.html' %}>{{ label }}</label>{% else %}{{ label }}{% endif %}

--- a/django/forms/templates/django/forms/p.html
+++ b/django/forms/templates/django/forms/p.html
@@ -1,0 +1,20 @@
+{{ errors }}
+{% if errors and not fields %}
+  <p>{% for field in hidden_fields %}{{ field }}{% endfor %}</p>
+{% endif %}
+{% for field, errors in fields %}
+  {{ errors }}
+  <p{% if field.css_classes %} class="{{ field.css_classes }}"{% endif %}>
+    {% if field.label %}{{ field.label_tag }}{% endif %}
+    {{ field }}
+    {% if field.help_text %}
+      <span class="helptext">{{ field.help_text }}</span>
+    {% endif %}
+    {% if forloop.last %}
+      {% for field in hidden_fields %}{{ field }}{% endfor %}
+    {% endif %}
+  </p>
+{% endfor %}
+{% if not fields and not errors %}
+  {% for field in hidden_fields %}{{ field }}{% endfor %}
+{% endif %}

--- a/django/forms/templates/django/forms/table.html
+++ b/django/forms/templates/django/forms/table.html
@@ -1,0 +1,29 @@
+{% for  error in  errors %}
+  <tr>
+    <td colspan="2">
+      {{ errors }}
+      {% if not fields %}
+        {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% endif %}
+    </td>
+  </tr>
+{% endfor %}
+{% for field, errors in fields %}
+  <tr{% if field.css_classes %} class="{{ field.css_classes }}"{% endif %}>
+    <th>{% if field.label %}{{ field.label_tag }}{% endif %}</th>
+    <td>
+      {{ errors }}
+      {{ field }}
+      {% if field.help_text %}
+        <br>
+        <span class="helptext">{{ field.help_text }}</span>
+      {% endif %}
+      {% if forloop.last %}
+        {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% endif %}
+    </td>
+  </tr>
+{% endfor %}
+{% if not fields and not errors %}
+  {% for field in hidden_fields %}{{ field }}{% endfor %}
+{% endif %}

--- a/django/forms/templates/django/forms/table.html
+++ b/django/forms/templates/django/forms/table.html
@@ -1,4 +1,4 @@
-{% for  error in  errors %}
+{% if errors %}
   <tr>
     <td colspan="2">
       {{ errors }}
@@ -7,7 +7,7 @@
       {% endif %}
     </td>
   </tr>
-{% endfor %}
+{% endif %}
 {% for field, errors in fields %}
   <tr{% if field.css_classes %} class="{{ field.css_classes }}"{% endif %}>
     <th>{% if field.label %}{{ field.label_tag }}{% endif %}</th>

--- a/django/forms/templates/django/forms/ul.html
+++ b/django/forms/templates/django/forms/ul.html
@@ -1,0 +1,24 @@
+{% for  error in  errors %}
+  <li>
+    {{ errors }}
+  {% if not fields %}
+    {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% endif %}
+  </li>
+{% endfor %}
+{% for field, errors in fields %}
+  <li{% if field.css_classes %} class="{{ field.css_classes }}"{% endif %}>
+    {{ errors }}
+    {% if field.label %}{{ field.label_tag }}{% endif %}
+    {{ field }}
+    {% if field.help_text %}
+      <span class="helptext">{{ field.help_text }}</span>
+    {% endif %}
+  {% if forloop.last %}
+    {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% endif %}
+  </li>
+{% endfor %}
+{% if not fields and not errors %}
+ {% for field in hidden_fields %}{{ field }}{% endfor %}
+{% endif %}

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -27,6 +27,8 @@ details on these changes.
 * The default sitemap protocol for sitemaps built outside the context of a
   request will change from ``'http'`` to ``'https'``.
 
+* ``BaseForm._html_output()`` will be removed.
+
 .. _deprecation-removed-in-4.1:
 
 4.1

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -504,11 +504,11 @@ a form object, and each rendering method returns a string.
 
 .. versionadded:: 4.0
 
-Template that is going to going to be rendered if the form is case into a
-string, e.g. via ``print(form)`` or in a template via ``{{ form }}``.
-The template can be changed per form by overwriting the ``template_name``
-attribute or by overriding the default template, see also
-:ref:`Overriding built-in form templates <overriding-built-in-form-templates>`.
+Template that is going to be rendered if the form is case into a string, e.g.
+via ``print(form)`` or in a template via ``{{ form }}``. The template can be
+changed per form by overwriting the ``template_name`` attribute or by
+overriding the default template, see also :ref:`Overriding built-in form
+templates <overriding-built-in-form-templates>`.
 
 ``as_p()``
 ----------
@@ -588,9 +588,9 @@ The available context is:
 
 .. versionadded:: 4.0
 
-The render method is is called by the ``__str__`` as well as the
-:meth:`.Form.as_table`, :meth:`.Form.as_p` and :meth:`.Form.as_ul` methods.
-All arguments are optional and will default to:
+The render method is called by the ``__str__`` as well as the
+:meth:`.Form.as_table`, :meth:`.Form.as_p` and :meth:`.Form.as_ul` methods. All
+arguments are optional and will default to:
 
 * ``template_name``: :attr:`.Form.template_name`
 * ``context``: :meth:`.Form.get_context`

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -504,7 +504,7 @@ a form object, and each rendering method returns a string.
 
 .. versionadded:: 4.0
 
-Template that is going to be rendered if the form is case into a string, e.g.
+Template that is going to be rendered if the form is cast into a string, e.g.
 via ``print(form)`` or in a template via ``{{ form }}``. The template can be
 changed per form by overwriting the ``template_name`` attribute or by
 overriding the default template, see also :ref:`Overriding built-in form

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -497,6 +497,19 @@ Although ``<table>`` output is the default output style when you ``print`` a
 form, other output styles are available. Each style is available as a method on
 a form object, and each rendering method returns a string.
 
+``template_name``
+-----------------
+
+.. attribute:: Form.template_name
+
+.. versionadded:: 4.0
+
+Template that is going to going to be rendered if the form is case into a
+string, e.g. via ``print(form)`` or in a template via ``{{ form }}``.
+The template can be changed per form by overwriting the ``template_name``
+attribute or by overriding the default template, see also
+:ref:`Overriding built-in form templates <overriding-built-in-form-templates>`.
+
 ``as_p()``
 ----------
 
@@ -550,6 +563,38 @@ it calls its ``as_table()`` method behind the scenes::
     <tr><th><label for="id_message">Message:</label></th><td><input type="text" name="message" id="id_message" required></td></tr>
     <tr><th><label for="id_sender">Sender:</label></th><td><input type="email" name="sender" id="id_sender" required></td></tr>
     <tr><th><label for="id_cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="id_cc_myself"></td></tr>
+
+
+``get_context()``
+-----------------
+
+.. method:: Form.get_context()
+
+.. versionadded:: 4.0
+
+Return context text for form rendering.
+
+The available context is:
+
+* ``form``: The bound form.
+* ``fields``: All bound fields, except the hidden fields.
+* ``hidden_fields``: All hidden bound fields.
+* ``errors``: All non field related or hidden field related form errors.
+
+``render(template_name=None, context=None, renderer=None)``
+-----------------------------------------------------------
+
+.. method:: Form.render()
+
+.. versionadded:: 4.0
+
+The render method is is called by the ``__str__`` as well as the
+:meth:`.Form.as_table`, :meth:`.Form.as_p` and :meth:`.Form.as_ul` methods.
+All arguments are optional and will default to:
+
+* ``template_name``: :attr:`.Form.template_name`
+* ``context``: :meth:`.Form.get_context`
+* ``renderer``: :attr:`.Form.default_renderer`
 
 .. _ref-forms-api-styling-form-rows:
 

--- a/docs/ref/forms/renderers.txt
+++ b/docs/ref/forms/renderers.txt
@@ -97,6 +97,19 @@ Using this renderer along with the built-in widget templates requires either:
 Using this renderer requires you to make sure the form templates your project
 needs can be located.
 
+Context available in form templates
+===================================
+
+.. versionadded:: 4.0
+
+Form templates receive a context from :meth:`.Form.get_context`. Be default,
+forms receive dictionary with the following values:
+
+* ``form``: The bound form.
+* ``fields``: All bound fields, except the hidden fields.
+* ``hidden_fields``: All hidden bound fields.
+* ``errors``: All non field related or hidden field related form errors.
+
 Context available in widget templates
 =====================================
 
@@ -113,6 +126,19 @@ dictionary that contains values like:
 Some widgets add further information to the context. For instance, all widgets
 that subclass ``Input`` defines ``widget['type']`` and :class:`.MultiWidget`
 defines ``widget['subwidgets']`` for looping purposes.
+
+Overriding built-in form templates
+==================================
+
+.. versionadded:: 4.0
+
+.. _overriding-built-in-form-templates:
+
+:attr:`.Form.template_name`
+
+To override form templates, you must use the :class:`TemplatesSetting`
+renderer. Then overriding widget templates works :doc:`the same as
+</howto/overriding-templates>` overriding any other template in your project.
 
 .. _overriding-built-in-widget-templates:
 

--- a/docs/ref/forms/renderers.txt
+++ b/docs/ref/forms/renderers.txt
@@ -102,8 +102,8 @@ Context available in form templates
 
 .. versionadded:: 4.0
 
-Form templates receive a context from :meth:`.Form.get_context`. Be default,
-forms receive dictionary with the following values:
+Form templates receive a context from :meth:`.Form.get_context`. By default,
+forms receive a dictionary with the following values:
 
 * ``form``: The bound form.
 * ``fields``: All bound fields, except the hidden fields.

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -465,6 +465,9 @@ Miscellaneous
 * The default sitemap protocol for sitemaps built outside the context of a
   request will change from ``'http'`` to ``'https'`` in Django 5.0.
 
+* Since form rendering now uses the template engine, the undocumented
+  ``BaseForm._html_output()` helper method is deprecated.
+
 Features removed in 4.0
 =======================
 

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -466,7 +466,7 @@ Miscellaneous
   request will change from ``'http'`` to ``'https'`` in Django 5.0.
 
 * Since form rendering now uses the template engine, the undocumented
-  ``BaseForm._html_output()` helper method is deprecated.
+  ``BaseForm._html_output()`` helper method is deprecated.
 
 Features removed in 4.0
 =======================

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -143,10 +143,10 @@ class TestInline(TestDataMixin, TestCase):
         }
         response = self.client.post(reverse('admin:admin_inlines_titlecollection_add'), data)
         # Here colspan is "4": two fields (title1 and title2), one hidden field and the delete checkbox.
-        self.assertContains(
-            response,
+        self.assertInHTML(
             '<tr class="row-form-errors"><td colspan="4"><ul class="errorlist nonfield">'
-            '<li>The two titles must be the same</li></ul></td></tr>'
+            '<li>The two titles must be the same</li></ul></td></tr>',
+            response.content.decode(),
         )
 
     def test_no_parent_callable_lookup(self):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -6365,7 +6365,7 @@ class AdminViewOnSiteTests(TestCase):
             response, 'inline_admin_formset', 0, None,
             ['Children must share a family name with their parents in this contrived test case']
         )
-        msg = "The formset 'inline_admin_formset' in context 12 does not contain any non-form errors."
+        msg = "The formset 'inline_admin_formset' in context 22 does not contain any non-form errors."
         with self.assertRaisesMessage(AssertionError, msg):
             self.assertFormsetError(response, 'inline_admin_formset', None, None, ['Error'])
 

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -1036,7 +1036,7 @@ class ReadOnlyPasswordHashTest(SimpleTestCase):
 
         bound_field = TestForm()['hash_field']
         self.assertEqual(bound_field.field.widget.id_for_label('id'), None)
-        self.assertEqual(bound_field.label_tag(), '<label>Hash field:</label>')
+        self.assertHTMLEqual(bound_field.label_tag(), '<label>Hash field:</label>')
 
 
 class AdminPasswordChangeFormTest(TestDataMixin, TestCase):

--- a/tests/forms_tests/field_tests/test_datefield.py
+++ b/tests/forms_tests/field_tests/test_datefield.py
@@ -35,7 +35,7 @@ class DateFieldTest(SimpleTestCase):
 
         # label tag is correctly associated with month dropdown
         d = GetDate({'mydate_month': '1', 'mydate_day': '1', 'mydate_year': '2010'})
-        self.assertIn('<label for="id_mydate_month">', d.as_p())
+        self.assertIn('<label for="id_mydate_month"', d.as_p())
 
     @override_settings(USE_L10N=True)
     @translation.override('nl')
@@ -109,7 +109,7 @@ class DateFieldTest(SimpleTestCase):
     def test_form_label_association(self):
         # label tag is correctly associated with first rendered dropdown
         a = GetDate({'mydate_month': '1', 'mydate_day': '1', 'mydate_year': '2010'})
-        self.assertIn('<label for="id_mydate_day">', a.as_p())
+        self.assertIn('<label for="id_mydate_day"', a.as_p())
 
     def test_datefield_1(self):
         f = DateField()

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -18,8 +18,9 @@ from django.forms.renderers import DjangoTemplates, get_default_renderer
 from django.forms.utils import ErrorList
 from django.http import QueryDict
 from django.template import Context, Template
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, ignore_warnings
 from django.utils.datastructures import MultiValueDict
+from django.utils.deprecation import RemovedInDjango50Warning
 from django.utils.safestring import mark_safe
 
 
@@ -3169,6 +3170,7 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
 
         self.assertHTMLEqual(boundfield.label_tag(label_suffix='$'), '<label for="id_field">Field$</label>')
 
+    @ignore_warnings(category=RemovedInDjango50Warning)
     def test_field_name(self):
         """#5749 - `field_name` may be used as a key in _html_output()."""
         class SomeForm(Form):
@@ -3186,6 +3188,7 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
         form = SomeForm()
         self.assertHTMLEqual(form.as_p(), '<p id="p_some_field"></p>')
 
+    @ignore_warnings(category=RemovedInDjango50Warning)
     def test_field_without_css_classes(self):
         """
         `css_classes` may be used as a key in _html_output() (empty classes).
@@ -3205,6 +3208,7 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
         form = SomeForm()
         self.assertHTMLEqual(form.as_p(), '<p class=""></p>')
 
+    @ignore_warnings(category=RemovedInDjango50Warning)
     def test_field_with_css_class(self):
         """
         `css_classes` may be used as a key in _html_output() (class comes
@@ -3226,6 +3230,7 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
         form = SomeForm()
         self.assertHTMLEqual(form.as_p(), '<p class="foo"></p>')
 
+    @ignore_warnings(category=RemovedInDjango50Warning)
     def test_field_name_with_hidden_input(self):
         """
         BaseForm._html_output() should merge all the hidden input fields and
@@ -3253,6 +3258,7 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
             '<input id="id_hidden2" name="hidden2" type="hidden"></p>'
         )
 
+    @ignore_warnings(category=RemovedInDjango50Warning)
     def test_field_name_with_hidden_input_and_non_matching_row_ender(self):
         """
         BaseForm._html_output() should merge all the hidden input fields and

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -3366,7 +3366,7 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
             '* Foo\n* Foobar'
         )
 
-        self.assertEqual(
+        self.assertHTMLEqual(
             e.as_ul(),
             '<ul class="errorlist"><li>Foo</li><li>Foobar</li></ul>'
         )
@@ -3382,7 +3382,7 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
         e = ErrorList()
         e.append('Foo')
         e.append(ValidationError('Foo%(bar)s', code='foobar', params={'bar': 'bar'}))
-        self.assertEqual(
+        self.assertHTMLEqual(
             e.as_ul(),
             '<ul class="errorlist"><li>Foo</li><li>Foobar</li></ul>'
         )
@@ -3391,7 +3391,7 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
         e = ErrorList(error_class='foobar-error-class')
         e.append('Foo')
         e.append(ValidationError('Foo%(bar)s', code='foobar', params={'bar': 'bar'}))
-        self.assertEqual(
+        self.assertHTMLEqual(
             e.as_ul(),
             '<ul class="errorlist foobar-error-class"><li>Foo</li><li>Foobar</li></ul>'
         )

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1313,7 +1313,7 @@ class TestIsBoundBehavior(SimpleTestCase):
         )
         self.assertEqual(formset.errors, [])
         # Can still render the formset.
-        self.assertEqual(
+        self.assertHTMLEqual(
             str(formset),
             '<tr><td colspan="2">'
             '<ul class="errorlist nonfield">'
@@ -1344,7 +1344,7 @@ class TestIsBoundBehavior(SimpleTestCase):
         )
         self.assertEqual(formset.errors, [])
         # Can still render the formset.
-        self.assertEqual(
+        self.assertHTMLEqual(
             str(formset),
             '<tr><td colspan="2">'
             '<ul class="errorlist nonfield">'

--- a/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
+++ b/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
@@ -205,4 +205,4 @@ class CheckboxSelectMultipleTest(WidgetTest):
 
         bound_field = TestForm()['f']
         self.assertEqual(bound_field.field.widget.id_for_label('id'), '')
-        self.assertEqual(bound_field.label_tag(), '<label>F:</label>')
+        self.assertHTMLEqual(bound_field.label_tag(), '<label>F:</label>')


### PR DESCRIPTION
ticket-31026

**TL;DR**
You can now change Django's form rendering by overwriting templates like:
`django/forms/default.html` or `./table.html` as well as `./label.html` and `./errors/default.html` and others.
You can still overwrite the methods on a form, but use a new `render` method to render custom templates for individual forms.


