### PR TITLE
Refs #29892 -- Replaced Selenium .submit() shim with .click() on the submit button.

### DIFF
--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -941,7 +941,7 @@ class DateTimePickerShortcutsSeleniumTests(AdminWidgetSeleniumTestCase):
 
         # Submit the form.
         with self.wait_page_loaded():
-            self.selenium.find_element_by_tag_name('form').submit()
+            self.selenium.find_element_by_name('_save').click()
 
         # Make sure that "now" in javascript is within 10 seconds
         # from "now" on the server side.


### PR DESCRIPTION
There is no WebDriver submit primitive. The Selenium project implements
it as a convenience only. The geckodriver developers recommend against
using it. Replace it with a real primitive, click on the submit button.

Fixes failing Seleninum test test_date_time_picker_shortcuts when using
the Firefox Selenium driver.

https://code.djangoproject.com/ticket/29892