### PR TITLE
Stopped setting tzinfo in typecast_timestamp().

### DIFF
--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -6,9 +6,7 @@ import logging
 import time
 from contextlib import contextmanager
 
-from django.conf import settings
 from django.db.utils import NotSupportedError
-from django.utils.timezone import utc
 
 logger = logging.getLogger('django.db.backends')
 
@@ -170,11 +168,10 @@ def typecast_timestamp(s):  # does NOT store time zone information
         seconds, microseconds = seconds.split('.')
     else:
         microseconds = '0'
-    tzinfo = utc if settings.USE_TZ else None
     return datetime.datetime(
         int(dates[0]), int(dates[1]), int(dates[2]),
         int(times[0]), int(times[1]), int(seconds),
-        int((microseconds + '000000')[:6]), tzinfo
+        int((microseconds + '000000')[:6])
     )
 
 


### PR DESCRIPTION
This seems unneeded, although I'm not sure when it became so.