### PR TITLE
Update libgeos.py to fix version_regex to match bad CAPI version strings

### DIFF
--- a/django/contrib/gis/geos/libgeos.py
+++ b/django/contrib/gis/geos/libgeos.py
@@ -179,7 +179,7 @@ geos_version = GEOSFuncFactory('GEOSversion', restype=c_char_p)
 # '3.0.0rc4-CAPI-1.3.3', '3.0.0-CAPI-1.4.1', '3.4.0dev-CAPI-1.8.0' or '3.4.0dev-CAPI-1.8.0 r0'
 version_regex = re.compile(
     r'^(?P<version>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<subminor>\d+))'
-    r'((rc(?P<release_candidate>\d+))|dev)?-CAPI-(?P<capi_version>\d+\.\d+\.\d+)( r\d+)?( \w+)?$'
+    r'((rc(?P<release_candidate>\d+))|dev)?-CAPI-(?P<capi_version>\d+\.\d+\.\d+)( r\d+)?( \w+)?\s+?$'
 )
 
 


### PR DESCRIPTION
The latest 3.0.x-CAPI version strings has a space char suffixed appended, and won't match the `version_regex` regular expression, breaking migration commands.