### PR TITLE
Fixed #31046 -- Allowed RelatedManager.add()/create()/set() to accept callable values in through_defaults.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -1113,49 +1113,48 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
             # source_field_name: the PK fieldname in join table for the source object
             # target_field_name: the PK fieldname in join table for the target object
             # *objs - objects to add. Either object instances, or primary keys of object instances.
+            if not objs:
+                return
+
             through_defaults = through_defaults or {}
+            target_ids = self._get_target_ids(target_field_name, objs)
+            db = router.db_for_write(self.through, instance=self.instance)
+            can_ignore_conflicts, must_send_signals, can_fast_add = self._get_add_plan(db, source_field_name)
+            if can_fast_add:
+                self.through._default_manager.using(db).bulk_create([
+                    self.through(**{
+                        '%s_id' % source_field_name: self.related_val[0],
+                        '%s_id' % target_field_name: target_id,
+                    })
+                    for target_id in target_ids
+                ], ignore_conflicts=True)
+                return
 
-            # If there aren't any objects, there is nothing to do.
-            if objs:
-                target_ids = self._get_target_ids(target_field_name, objs)
-                db = router.db_for_write(self.through, instance=self.instance)
-                can_ignore_conflicts, must_send_signals, can_fast_add = self._get_add_plan(db, source_field_name)
-                if can_fast_add:
-                    self.through._default_manager.using(db).bulk_create([
-                        self.through(**{
-                            '%s_id' % source_field_name: self.related_val[0],
-                            '%s_id' % target_field_name: target_id,
-                        })
-                        for target_id in target_ids
-                    ], ignore_conflicts=True)
-                    return
+            missing_target_ids = self._get_missing_target_ids(
+                source_field_name, target_field_name, db, target_ids
+            )
+            with transaction.atomic(using=db, savepoint=False):
+                if must_send_signals:
+                    signals.m2m_changed.send(
+                        sender=self.through, action='pre_add',
+                        instance=self.instance, reverse=self.reverse,
+                        model=self.model, pk_set=missing_target_ids, using=db,
+                    )
+                # Add the ones that aren't there already.
+                self.through._default_manager.using(db).bulk_create([
+                    self.through(**through_defaults, **{
+                        '%s_id' % source_field_name: self.related_val[0],
+                        '%s_id' % target_field_name: target_id,
+                    })
+                    for target_id in missing_target_ids
+                ], ignore_conflicts=can_ignore_conflicts)
 
-                missing_target_ids = self._get_missing_target_ids(
-                    source_field_name, target_field_name, db, target_ids
-                )
-                with transaction.atomic(using=db, savepoint=False):
-                    if must_send_signals:
-                        signals.m2m_changed.send(
-                            sender=self.through, action='pre_add',
-                            instance=self.instance, reverse=self.reverse,
-                            model=self.model, pk_set=missing_target_ids, using=db,
-                        )
-
-                    # Add the ones that aren't there already.
-                    self.through._default_manager.using(db).bulk_create([
-                        self.through(**through_defaults, **{
-                            '%s_id' % source_field_name: self.related_val[0],
-                            '%s_id' % target_field_name: target_id,
-                        })
-                        for target_id in missing_target_ids
-                    ], ignore_conflicts=can_ignore_conflicts)
-
-                    if must_send_signals:
-                        signals.m2m_changed.send(
-                            sender=self.through, action='post_add',
-                            instance=self.instance, reverse=self.reverse,
-                            model=self.model, pk_set=missing_target_ids, using=db,
-                        )
+                if must_send_signals:
+                    signals.m2m_changed.send(
+                        sender=self.through, action='post_add',
+                        instance=self.instance, reverse=self.reverse,
+                        model=self.model, pk_set=missing_target_ids, using=db,
+                    )
 
         def _remove_items(self, source_field_name, target_field_name, *objs):
             # source_field_name: the PK colname in join table for the source object

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -68,6 +68,7 @@ from django.db import connections, router, transaction
 from django.db.models import Q, signals
 from django.db.models.query import QuerySet
 from django.db.models.query_utils import DeferredAttribute
+from django.db.models.utils import resolve_callables
 from django.utils.functional import cached_property
 
 
@@ -1116,7 +1117,7 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
             if not objs:
                 return
 
-            through_defaults = through_defaults or {}
+            through_defaults = dict(resolve_callables(through_defaults or {}))
             target_ids = self._get_target_ids(target_field_name, objs)
             db = router.db_for_write(self.through, instance=self.instance)
             can_ignore_conflicts, must_send_signals, can_fast_add = self._get_add_plan(db, source_field_name)

--- a/django/db/models/utils.py
+++ b/django/db/models/utils.py
@@ -19,3 +19,12 @@ def make_model_tuple(model):
             "Invalid model reference '%s'. String model references "
             "must be of the form 'app_label.ModelName'." % model
         )
+
+
+def resolve_callables(mapping):
+    """
+    Generate key/value pairs for the given mapping where the values are
+    evaluated if they're callable.
+    """
+    for k, v in mapping.items():
+        yield k, v() if callable(v) else v

--- a/docs/ref/models/relations.txt
+++ b/docs/ref/models/relations.txt
@@ -71,7 +71,13 @@ Related objects reference
 
         Use the ``through_defaults`` argument to specify values for the new
         :ref:`intermediate model <intermediary-manytomany>` instance(s), if
-        needed.
+        needed. You can use callables as values in the ``through_defaults``
+        dictionary and they will be evaluated once before creating any
+        intermediate instance(s).
+
+        .. versionchanged:: 3.1
+
+            ``through_defaults`` values can now be callables.
 
     .. method:: create(through_defaults=None, **kwargs)
 
@@ -105,7 +111,12 @@ Related objects reference
 
         Use the ``through_defaults`` argument to specify values for the new
         :ref:`intermediate model <intermediary-manytomany>` instance, if
-        needed.
+        needed. You can use callables as values in the ``through_defaults``
+        dictionary.
+
+        .. versionchanged:: 3.1
+
+            ``through_defaults`` values can now be callables.
 
     .. method:: remove(*objs, bulk=True)
 
@@ -193,7 +204,13 @@ Related objects reference
 
         Use the ``through_defaults`` argument to specify values for the new
         :ref:`intermediate model <intermediary-manytomany>` instance(s), if
-        needed.
+        needed. You can use callables as values in the ``through_defaults``
+        dictionary and they will be evaluated once before creating any
+        intermediate instance(s).
+
+        .. versionchanged:: 3.1
+
+            ``through_defaults`` values can now be callables.
 
     .. note::
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -209,6 +209,10 @@ Models
 
 * :attr:`.CheckConstraint.check` now supports boolean expressions.
 
+* The :meth:`.RelatedManager.add`, :meth:`~.RelatedManager.create`, and
+  :meth:`~.RelatedManager.set` methods now accept callables as values in the
+  ``through_defaults`` argument.
+
 Pagination
 ~~~~~~~~~~
 


### PR DESCRIPTION
ticket-31046