### PR TITLE
Fixed #31024 -- Clarified {% firstof %} tag's handling of arguments.

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -261,8 +261,9 @@ Sample usage::
 ``firstof``
 -----------
 
-Outputs the first argument variable that is not ``False``. Outputs nothing if
-all the passed variables are ``False``.
+Outputs the first argument variable that is not "false" (i.e. exists, is not
+empty, is not a false boolean value, and is not a zero numeric value). Outputs
+nothing if all the passed variables are "false".
 
 Sample usage::
 


### PR DESCRIPTION
Changed the documentation to say that firstof returns
the first argument that is not "Falsy" (instead of "False").

Ticket: https://code.djangoproject.com/ticket/31024