### PR TITLE
Refs #25705 -- Fixed invalid SQL generated by SQLFuncMixin.as_sql() in custom_lookups tests.

### DIFF
--- a/tests/custom_lookups/tests.py
+++ b/tests/custom_lookups/tests.py
@@ -133,7 +133,7 @@ class Exactly(models.lookups.Exact):
 
 class SQLFuncMixin:
     def as_sql(self, compiler, connection):
-        return '%s()', [self.name]
+        return '%s()' % self.name, []
 
     @property
     def output_field(self):


### PR DESCRIPTION
See comments https://github.com/django/django/pull/10568#pullrequestreview-296832467 and https://github.com/django/django/pull/12156#discussion_r352130061.