### PR TITLE
Fixed #31056 -- Allowed disabling async-unsafe check with an environment variable.

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -110,7 +110,8 @@ manipulating the data of your Web application. Learn more about it below:
   :doc:`Custom lookups <howto/custom-lookups>` |
   :doc:`Query Expressions <ref/models/expressions>` |
   :doc:`Conditional Expressions <ref/models/conditional-expressions>` |
-  :doc:`Database Functions <ref/models/database-functions>`
+  :doc:`Database Functions <ref/models/database-functions>` |
+  :doc:`Asynchronous Support <topics/async>`
 
 * **Other:**
   :doc:`Supported databases <ref/databases>` |

--- a/docs/releases/3.0.1.txt
+++ b/docs/releases/3.0.1.txt
@@ -9,4 +9,7 @@ Django 3.0.1 fixes several bugs in 3.0.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 3.0 by restoring the ability to use Django
+  inside Jupyter and other environments that force an async context, by adding
+  and option to disable :ref:`async-safety` mechanism with
+  ``DJANGO_ALLOW_ASYNC_UNSAFE`` environment variable (:ticket:`31056`).

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -116,6 +116,7 @@ conf
 config
 contenttypes
 contrib
+coroutine
 coroutines
 covariance
 criticals
@@ -664,6 +665,7 @@ th
 that'll
 Thejaswi
 This'll
+threadpool
 timeframe
 timeline
 timelines

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -309,6 +309,7 @@ ize
 JavaScript
 Jinja
 jQuery
+Jupyter
 jython
 Kaplan
 Kessler

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -1,0 +1,36 @@
+====================
+Asynchronous support
+====================
+
+.. versionadded:: 3.0
+
+Django has developing support for asynchronous ("async") Python, but does not
+yet support asynchronous views or middleware; they will be coming in a future
+release.
+
+There is limited support for other parts of the async ecosystem; namely, Django
+can natively talk :doc:`ASGI </howto/deployment/asgi/index>`, and some async
+safety support.
+
+Async-safety
+------------
+
+Certain key parts of Django are not able to operate safely in an asynchronous
+environment, as they have global state that is not coroutine-aware. These parts
+of Django are classified as "async-unsafe", and are protected from execution in
+an asynchronous environment. The ORM is the main example, but there are other
+parts that are also protected in this way.
+
+If you try to run any of these parts from a thread where there is a *running
+event loop*, you will get a
+:exc:`~django.core.exceptions.SynchronousOnlyOperation` error. Note that you
+don't have to be inside an async function directly to have this error occur. If
+you have called a synchronous function directly from an asynchronous function
+without going through something like ``sync_to_async`` or a threadpool, then it
+can also occur, as your code is still running in an asynchronous context.
+
+If you encounter this error, you should fix your code to not call the offending
+code from an async context; instead, write your code that talks to async-unsafe
+in its own, synchronous function, and call that using
+``asgiref.sync.async_to_sync``, or any other preferred way of running
+synchronous code in its own thread.

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -12,6 +12,8 @@ There is limited support for other parts of the async ecosystem; namely, Django
 can natively talk :doc:`ASGI </howto/deployment/asgi/index>`, and some async
 safety support.
 
+.. _async-safety:
+
 Async-safety
 ------------
 
@@ -34,3 +36,21 @@ code from an async context; instead, write your code that talks to async-unsafe
 in its own, synchronous function, and call that using
 ``asgiref.sync.async_to_sync``, or any other preferred way of running
 synchronous code in its own thread.
+
+If you are *absolutely* in dire need to run this code from an asynchronous
+context - for example, it is being forced on you by an external environment,
+and you are sure there is no chance of it being run concurrently (e.g. you are
+in a Jupyter_ notebook), then you can disable the warning with the
+``DJANGO_ALLOW_ASYNC_UNSAFE`` environment variable.
+
+.. warning::
+
+    If you enable this option and there is concurrent access to the
+    async-unsafe parts of Django, you may suffer data loss or corruption. Be
+    very careful and do not use this in production environments.
+
+If you need to do this from within Python, do that with ``os.environ``::
+
+    os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+
+.. _Jupyter: https://jupyter.org/

--- a/docs/topics/index.txt
+++ b/docs/topics/index.txt
@@ -31,3 +31,4 @@ Introductions to all the key parts of Django you'll need to know:
    signals
    checks
    external-packages
+   async

--- a/tests/async/tests.py
+++ b/tests/async/tests.py
@@ -1,5 +1,6 @@
+import os
 import sys
-from unittest import skipIf
+from unittest import mock, skipIf
 
 from asgiref.sync import async_to_sync
 
@@ -39,3 +40,13 @@ class AsyncUnsafeTest(SimpleTestCase):
         )
         with self.assertRaisesMessage(SynchronousOnlyOperation, msg):
             self.dangerous_method()
+
+    @mock.patch.dict(os.environ, {'DJANGO_ALLOW_ASYNC_UNSAFE': 'true'})
+    @async_to_sync
+    async def test_async_unsafe_suppressed(self):
+        # Decorator doesn't trigger check when the environment variable to
+        # suppress it is set.
+        try:
+            self.dangerous_method()
+        except SynchronousOnlyOperation:
+            self.fail('SynchronousOnlyOperation should not be raised.')


### PR DESCRIPTION
This allows manual disabling of this safety feature, and includes docs about it, plus one test to enforce it.

Fix for https://code.djangoproject.com/ticket/31056