### PR TITLE
Allow configuring session cache prefix

### DIFF
--- a/django/contrib/sessions/backends/cache.py
+++ b/django/contrib/sessions/backends/cache.py
@@ -4,7 +4,7 @@ from django.contrib.sessions.backends.base import (
 )
 from django.core.cache import caches
 
-KEY_PREFIX = "django.contrib.sessions.cache"
+KEY_PREFIX = settings.SESSION_CACHE_KEY_PREFIX if settings.SESSION_CACHE_KEY_PREFIX else "django.contrib.sessions.cache"
 
 
 class SessionStore(SessionBase):


### PR DESCRIPTION
By default this creates a key without a separator

`django_cache:1:django.contrib.sessions.cachecte1pz8c5vlu0ta601a8xqqbge5hh2fz`