### PR TITLE
Fixed typo in internals/contributing/writing-documentation.txt.

### DIFF
--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -235,9 +235,9 @@ documentation:
     Five
     ^^^^
 
-* Use :rst:role:`:rfc:<rfc>` to reference RFC and and try to link to the
-  relevant section if possible. For example, use ``:rfc:`2324#section-2.3.2```
-  or ``:rfc:`Custom link text <2324#section-2.3.2>```.
+* Use :rst:role:`:rfc:<rfc>` to reference RFC and try to link to the relevant
+  section if possible. For example, use ``:rfc:`2324#section-2.3.2``` or
+  ``:rfc:`Custom link text <2324#section-2.3.2>```.
 
 Django-specific markup
 ======================


### PR DESCRIPTION
An extra `and` has been removed.