### PR TITLE
Fixed a problem with the order of the apps in the Template Loader

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -859,6 +859,7 @@ answer newbie questions, and generally made Django that much better:
     Thomas Steinacher <http://www.eggdrop.ch/>
     Thomas Stromberg <tstromberg@google.com>
     Thomas Tanner <tanner@gmx.net>
+    Thomas Turner <tom@twt.me.uk>
     tibimicu@gmx.net
     Tim Allen <tim@pyphilly.org>
     Tim Givois <tim.givois.mendez@gmail.com>

--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -2,7 +2,7 @@ import functools
 import sys
 import threading
 import warnings
-from collections import Counter, defaultdict
+from collections import Counter, defaultdict, OrderedDict
 from functools import partial
 
 from django.core.exceptions import AppRegistryNotReady, ImproperlyConfigured
@@ -34,7 +34,7 @@ class Apps:
         self.all_models = defaultdict(dict)
 
         # Mapping of labels to AppConfig instances for installed apps.
-        self.app_configs = {}
+        self.app_configs = OrderedDict()
 
         # Stack of app_configs. Used to store the current state in
         # set_available_apps and set_installed_apps.

--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -2,7 +2,7 @@ import functools
 import sys
 import threading
 import warnings
-from collections import Counter, defaultdict, OrderedDict
+from collections import Counter, OrderedDict, defaultdict
 from functools import partial
 
 from django.core.exceptions import AppRegistryNotReady, ImproperlyConfigured


### PR DESCRIPTION
Hi I have found a problem when a third party app overrides the Django Admin templates
The problem happens in 'django.template.loaders.app_directories.Loader'
As this apps name are stored in a dictionary the order is not consistent so sometimes you get the template of the Django app and sometimes you get the template of the third party app. This makes it impossible for a third party app to override the admin templates. In the Third Party app I maintain (Django-Tenants) it really important to be able to override the admin templates.
So the fix I have done is very simple it changes the self.app_configs = {} to an ordered dict.