### PR TITLE
Fixed #30819 -- Fixed year determination in admin calendar widget for two-digit years.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -285,6 +285,7 @@ answer newbie questions, and generally made Django that much better:
     Eugene Lazutkin <http://lazutkin.com/blog/>
     Evan Grim <https://github.com/egrim>
     Fabrice Aneche <akh@nobugware.com>
+    Farhaan Bukhsh <farhaan.bukhsh@gmail.com>
     favo@exoweb.net
     fdr <drfarina@gmail.com>
     Federico Capoano <nemesis@ninux.org>

--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ answer newbie questions, and generally made Django that much better:
     Alasdair Nicol <https://al.sdair.co.uk/>
     Albert Wang <https://github.com/albertyw/>
     Alcides Fonseca
+    Aldian Fazrihady <mobile@aldian.net>
     Aleksandra Sendecka <asendecka@hauru.eu>
     Aleksi Häkli <aleksi.hakli@iki.fi>
     Alexander Dutton <dev@alexdutton.co.uk>

--- a/django/conf/locale/id/formats.py
+++ b/django/conf/locale/id/formats.py
@@ -14,8 +14,8 @@ FIRST_DAY_OF_WEEK = 1  # Monday
 # The *_INPUT_FORMATS strings use the Python strftime format syntax,
 # see https://docs.python.org/library/datetime.html#strftime-strptime-behavior
 DATE_INPUT_FORMATS = [
-    '%d-%m-%y', '%d/%m/%y',             # '25-10-09', 25/10/09'
     '%d-%m-%Y', '%d/%m/%Y',             # '25-10-2009', 25/10/2009'
+    '%d-%m-%y', '%d/%m/%y',             # '25-10-09', 25/10/09'
     '%d %b %Y',                         # '25 Oct 2006',
     '%d %B %Y',                         # '25 October 2006'
 ]

--- a/django/contrib/admin/static/admin/js/core.js
+++ b/django/contrib/admin/static/admin/js/core.js
@@ -159,7 +159,14 @@ function findPosY(obj) {
                 year = date[i];
                 break;
             case "%y":
-                year = date[i];
+                // A %y value in the range of [00, 68] is in the current
+                // century, while [69, 99] is in the previous century,
+                // according to the Open Group Specification.
+                if (parseInt(date[i], 10) >= 69) {
+                    year = date[i];
+                } else {
+                    year = (new Date(Date.UTC(date[i], 0))).getUTCFullYear() + 100;
+                }
                 break;
             }
             ++i;

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -391,6 +391,10 @@ Miscellaneous
   options on models in ``django.contrib`` modules that were formerly tuples are
   now lists.
 
+* The admin calendar widget now handles two-digit years according to the Open
+  Group Specification, i.e. values between 69 and 99 are mapped to the previous
+  century, and values between 0 and 68 are mapped to the current century.
+
 .. _deprecated-features-3.1:
 
 Features deprecated in 3.1

--- a/js_tests/admin/core.test.js
+++ b/js_tests/admin/core.test.js
@@ -55,6 +55,7 @@ QUnit.test('String.strptime', function(assert) {
     assert.equal(firstParsedDate.getUTCMonth(), 1);
     assert.equal(firstParsedDate.getUTCFullYear(), 1988);
 
+    // A %y value in the range of [69, 99] is in the previous century.
     var secondParsedDate = '26/02/88'.strptime('%d/%m/%y');
     assert.equal(secondParsedDate.getUTCDate(), 26);
     assert.equal(secondParsedDate.getUTCMonth(), 1);
@@ -66,6 +67,12 @@ QUnit.test('String.strptime', function(assert) {
     assert.equal(thirdParsedDate.getUTCDate(), 20);
     assert.equal(thirdParsedDate.getUTCMonth(), 10);
     assert.equal(thirdParsedDate.getUTCFullYear(), 1983);
+
+    // A %y value in the range of [00, 68] is in the current century.
+    var fourthParsedDate = '27/09/68'.strptime('%d/%m/%y');
+    assert.equal(fourthParsedDate.getUTCDate(), 27);
+    assert.equal(fourthParsedDate.getUTCMonth(), 8);
+    assert.equal(fourthParsedDate.getUTCFullYear(), 2068);
 
     // Extracting from a Date object with local time must give the correct
     // result. Without proper conversion, timezones from GMT+0100 to GMT+1200


### PR DESCRIPTION
Completing this PR: https://github.com/django/django/pull/11904