### PR TITLE
Fixed optimize" __eq__(self, other)" method of  CaseInsensitiveMapping in django/utils/datastructures.py

### DIFF
--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -336,4 +336,4 @@ class CaseInsensitiveMapping(Mapping):
         return repr({key: value for key, value in self._store.values()})
 
     def copy(self):
-        return self
+        return self.__class__(self._store.values())

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -323,7 +323,7 @@ class CaseInsensitiveMapping(Mapping):
         return len(self._store)
 
     def __eq__(self, other):
-        return isinstance(other, Mapping) and {
+        return isinstance(other, Mapping) and len(self) == len(other) and {
             k.lower(): v for k, v in self.items()
         } == {
             k.lower(): v for k, v in other.items()


### PR DESCRIPTION
if they don't have same length, then there is no need to create two dict