### PR TITLE
Fixed outdated import in django/utils/safestring.py.

### DIFF
--- a/django/utils/safestring.py
+++ b/django/utils/safestring.py
@@ -5,7 +5,7 @@ that the producer of the string has already turned characters that should not
 be interpreted by the HTML engine (e.g. '<') into the appropriate entities.
 """
 
-from django.utils.functional import wraps
+from functools import wraps
 
 
 class SafeData:


### PR DESCRIPTION
The backported version of `functools.wraps` was removed a while ago in 13864703bc1d5dd4dac63c96c6a4b42a392bc57f so we can import directly from `functools` now.