### PR TITLE
Fixed #27590 -- Allowed customizing a manifest file storage in ManifestFilesMixin.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -423,6 +423,7 @@ answer newbie questions, and generally made Django that much better:
     Jan Rademaker
     Jarek Głowacki <jarekwg@gmail.com>
     Jarek Zgoda <jarek.zgoda@gmail.com>
+    Jarosław Wygoda <jaroslaw@wygoda.me>
     Jason Davies (Esaj) <https://www.jasondavies.com/>
     Jason Huggins <http://www.jrandolph.com/blog/>
     Jason McBrayer <http://www.carcosa.net/jason/>

--- a/docs/ref/contrib/staticfiles.txt
+++ b/docs/ref/contrib/staticfiles.txt
@@ -313,12 +313,28 @@ For example, the ``'css/styles.css'`` file with this content:
 
     @import url("../admin/css/base.27e20196a850.css");
 
+You can change the location of the manifest file by using a custom
+``ManifestStaticFilesStorage`` subclass that sets the ``manifest_storage``
+argument. For example::
+
+    from django.conf import settings
+    from django.contrib.staticfiles.storage import (
+        ManifestStaticFilesStorage, StaticFilesStorage,
+    )
+
+    class MyManifestStaticFilesStorage(ManifestStaticFilesStorage):
+        def __init__(self, *args, **kwargs):
+            manifest_storage = StaticFilesStorage(location=settings.BASE_DIR)
+            super().__init__(*args, manifest_storage=manifest_storage, **kwargs)
+
 .. versionchanged:: 4.0
 
     Support for finding paths in the source map comments was added.
 
     Support for finding paths to JavaScript modules in ``import`` and
     ``export`` statements was added.
+
+    The ``manifest_storage`` argument was added.
 
 .. attribute:: storage.ManifestStaticFilesStorage.max_post_process_passes
 
@@ -383,6 +399,10 @@ hashing algorithm.
 
 Use this mixin with a custom storage to append the MD5 hash of the file's
 content to the filename as :class:`~storage.ManifestStaticFilesStorage` does.
+
+.. versionchanged:: 4.0
+
+    The ``manifest_storage`` argument was added.
 
 Finders Module
 ==============

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -174,6 +174,11 @@ Minor features
   replaces paths to JavaScript modules in ``import`` and ``export`` statements
   with their hashed counterparts.
 
+* The new ``manifest_storage`` argument of
+  :class:`~django.contrib.staticfiles.storage.ManifestFilesMixin` and
+  :class:`~django.contrib.staticfiles.storage.ManifestStaticFilesStorage`
+  allows customizing the manifest file storage.
+
 :mod:`django.contrib.syndication`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import sys
@@ -13,7 +14,7 @@ from django.contrib.staticfiles.management.commands.collectstatic import (
     Command as CollectstaticCommand,
 )
 from django.core.management import call_command
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 
 from .cases import CollectionTestCase
 from .settings import TEST_ROOT
@@ -497,6 +498,55 @@ class TestCollectionSimpleStorage(CollectionTestCase):
             content = relfile.read()
             self.assertNotIn(b"cached/other.css", content)
             self.assertIn(b"other.deploy12345.css", content)
+
+
+class CustomManifestStorage(storage.ManifestStaticFilesStorage):
+    def __init__(self, *args, manifest_storage=None, **kwargs):
+        manifest_storage = storage.StaticFilesStorage(
+            location=kwargs.pop('manifest_location'),
+        )
+        super().__init__(*args, manifest_storage=manifest_storage, **kwargs)
+
+
+class TestCustomManifestStorage(SimpleTestCase):
+    def setUp(self):
+        self.manifest_path = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.manifest_path)
+
+        self.staticfiles_storage = CustomManifestStorage(
+            manifest_location=self.manifest_path,
+        )
+        self.manifest_file = self.manifest_path / self.staticfiles_storage.manifest_name
+        # Manifest without paths.
+        self.manifest = {'version': self.staticfiles_storage.manifest_version}
+        with self.manifest_file.open('w') as manifest_file:
+            json.dump(self.manifest, manifest_file)
+
+    def test_read_manifest(self):
+        self.assertEqual(
+            self.staticfiles_storage.read_manifest(),
+            json.dumps(self.manifest),
+        )
+
+    def test_read_manifest_nonexistent(self):
+        os.remove(self.manifest_file)
+        self.assertIsNone(self.staticfiles_storage.read_manifest())
+
+    def test_save_manifest_override(self):
+        self.assertIs(self.manifest_file.exists(), True)
+        self.staticfiles_storage.save_manifest()
+        self.assertIs(self.manifest_file.exists(), True)
+        new_manifest = json.loads(self.staticfiles_storage.read_manifest())
+        self.assertIn('paths', new_manifest)
+        self.assertNotEqual(new_manifest, self.manifest)
+
+    def test_save_manifest_create(self):
+        os.remove(self.manifest_file)
+        self.staticfiles_storage.save_manifest()
+        self.assertIs(self.manifest_file.exists(), True)
+        new_manifest = json.loads(self.staticfiles_storage.read_manifest())
+        self.assertIn('paths', new_manifest)
+        self.assertNotEqual(new_manifest, self.manifest)
 
 
 class CustomStaticFilesStorage(storage.StaticFilesStorage):


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/27590)