### PR TITLE
Fixed typo in ModelChoiceFieldTests.

### DIFF
--- a/tests/model_forms/test_modelchoicefield.py
+++ b/tests/model_forms/test_modelchoicefield.py
@@ -275,7 +275,7 @@ class ModelChoiceFieldTests(TestCase):
 
         class CustomCheckboxSelectMultiple(CheckboxSelectMultiple):
             def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
-                option = super().create_option(name, value, label, selected, index, subindex=None, attrs=None)
+                option = super().create_option(name, value, label, selected, index, subindex, attrs)
                 # Modify the HTML based on the object being rendered.
                 c = value.obj
                 option['attrs']['data-slug'] = c.slug


### PR DESCRIPTION
The `subindex` and `attrs` arguments should be passed through to the parent, not overridden as `None`.