### PR TITLE
Refs #23433 -- Fixed test_django_admin_py.DeprecationTest tests failures on Windows and Python < 3.8.

### DIFF
--- a/tests/admin_scripts/test_django_admin_py.py
+++ b/tests/admin_scripts/test_django_admin_py.py
@@ -1,6 +1,6 @@
+import os
 import subprocess
 import sys
-from pathlib import Path
 
 import django
 from django.test import SimpleTestCase
@@ -12,6 +12,10 @@ class DeprecationTests(SimpleTestCase):
         b'django-admin.'
     )
 
+    def setUp(self):
+        script_dir = os.path.abspath(os.path.join(os.path.dirname(django.__file__), 'bin'))
+        self.django_admin_py = os.path.join(script_dir, 'django-admin.py')
+
     def _run_test(self, args):
         p = subprocess.run(
             [sys.executable, *args],
@@ -22,8 +26,7 @@ class DeprecationTests(SimpleTestCase):
         return p.stdout, p.stderr
 
     def test_django_admin_py_deprecated(self):
-        django_admin_py = Path(django.__file__).parent / 'bin' / 'django-admin.py'
-        _, err = self._run_test(['-Wd', django_admin_py, '--version'])
+        _, err = self._run_test(['-Wd', self.django_admin_py, '--version'])
         self.assertIn(self.DEPRECATION_MESSAGE, err)
 
     def test_main_not_deprecated(self):
@@ -31,7 +34,6 @@ class DeprecationTests(SimpleTestCase):
         self.assertNotIn(self.DEPRECATION_MESSAGE, err)
 
     def test_django_admin_py_equivalent_main(self):
-        django_admin_py = Path(django.__file__).parent / 'bin' / 'django-admin.py'
-        django_admin_py_out, _ = self._run_test([django_admin_py, '--version'])
+        django_admin_py_out, _ = self._run_test([self.django_admin_py, '--version'])
         django_out, _ = self._run_test(['-m', 'django', '--version'])
         self.assertEqual(django_admin_py_out, django_out)


### PR DESCRIPTION
`subprocess.run()`'s `args` parameter accepts a path-like object on Windows since Python 3.8 (see [documentation](https://docs.python.org/3/library/subprocess.html).