### PR TITLE
Fixed #26480 -- Fixed crash of contrib.auth.authenticate() on decorated authenticate() methods of authentication backends.

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -63,8 +63,9 @@ def authenticate(request=None, **credentials):
     If the given credentials are valid, return a User object.
     """
     for backend, backend_path in _get_backends(return_tuples=True):
+        backend_signature = inspect.signature(backend.authenticate)
         try:
-            inspect.getcallargs(backend.authenticate, request, **credentials)
+            backend_signature.bind(request, **credentials)
         except TypeError:
             # This backend doesn't accept these credentials as arguments. Try the next one.
             continue

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1916,9 +1916,8 @@ class Query(BaseExpression):
         group_by = list(self.select)
         if self.annotation_select:
             for alias, annotation in self.annotation_select.items():
-                try:
-                    inspect.getcallargs(annotation.get_group_by_cols, alias=alias)
-                except TypeError:
+                signature = inspect.signature(annotation.get_group_by_cols)
+                if 'alias' not in signature.parameters:
                     annotation_class = annotation.__class__
                     msg = (
                         '`alias=None` must be added to the signature of '

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -50,10 +50,10 @@ times with multiple contexts)
 '<html></html>'
 """
 
+import inspect
 import logging
 import re
 from enum import Enum
-from inspect import getcallargs, getfullargspec, unwrap
 
 from django.template.context import BaseContext
 from django.utils.formats import localize
@@ -707,9 +707,9 @@ class FilterExpression:
         # First argument, filter input, is implied.
         plen = len(provided) + 1
         # Check to see if a decorator is providing the real function.
-        func = unwrap(func)
+        func = inspect.unwrap(func)
 
-        args, _, _, defaults, _, _, _ = getfullargspec(func)
+        args, _, _, defaults, _, _, _ = inspect.getfullargspec(func)
         alen = len(args)
         dlen = len(defaults or [])
         # Not enough OR Too many
@@ -858,7 +858,7 @@ class Variable:
                             current = current()
                         except TypeError:
                             try:
-                                getcallargs(current)
+                                inspect.getcallargs(current)
                             except TypeError:  # arguments *were* required
                                 current = context.template.engine.string_if_invalid  # invalid method call
                             else:

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -857,8 +857,9 @@ class Variable:
                         try:  # method call (assuming no args required)
                             current = current()
                         except TypeError:
+                            signature = inspect.signature(current)
                             try:
-                                inspect.getcallargs(current)
+                                signature.bind()
                             except TypeError:  # arguments *were* required
                                 current = context.template.engine.string_if_invalid  # invalid method call
                             else:

--- a/tests/auth_tests/test_auth_backends.py
+++ b/tests/auth_tests/test_auth_backends.py
@@ -13,6 +13,7 @@ from django.http import HttpRequest
 from django.test import (
     SimpleTestCase, TestCase, modify_settings, override_settings,
 )
+from django.views.decorators.debug import sensitive_variables
 
 from .models import (
     CustomPermissionsUser, CustomUser, CustomUserWithoutIsActiveField,
@@ -642,6 +643,12 @@ class SkippedBackend:
         pass
 
 
+class SkippedBackendWithDecoratedMethod:
+    @sensitive_variables()
+    def authenticate(self):
+        pass
+
+
 class AuthenticateTests(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -662,6 +669,13 @@ class AuthenticateTests(TestCase):
         A backend (SkippedBackend) is ignored if it doesn't accept the
         credentials as arguments.
         """
+        self.assertEqual(authenticate(username='test', password='test'), self.user1)
+
+    @override_settings(AUTHENTICATION_BACKENDS=(
+        'auth_tests.test_auth_backends.SkippedBackendWithDecoratedMethod',
+        'django.contrib.auth.backends.ModelBackend',
+    ))
+    def test_skips_backends_with_decorated_method(self):
         self.assertEqual(authenticate(username='test', password='test'), self.user1)
 
 


### PR DESCRIPTION
`inspect.getcallargs()` doesn't follow potential `__wrapped__` functions (set by `functools.wraps()` for example) and is deprecated since Python 3.5.

Fixes ticket-26480 as a side-effect.

I've split the pull request into 3 commits for easier review:
1) Rewrote imports to make the actual fix less noisy (should be a noop)
2) Added test for ticket-26480 (failing)
3) Replaced all usages of `inspect.getcallargs()` (there were only 3).