### PR TITLE
Fixed #31055 -- Handled database errors on check constraint support check.

### DIFF
--- a/django/contrib/postgres/constraints.py
+++ b/django/contrib/postgres/constraints.py
@@ -102,3 +102,6 @@ class ExclusionConstraint(BaseConstraint):
             self.expressions,
             '' if self.condition is None else ', condition=%s' % self.condition,
         )
+
+    def supported(self, connection):
+        return connection.vendor == 'postgresql'

--- a/django/core/checks/database.py
+++ b/django/core/checks/database.py
@@ -7,16 +7,20 @@ from . import Tags, register
 
 
 @register(Tags.database)
-def check_database_backends(app_configs=None, **kwargs):
+def check_database_backends(app_configs=None, database=None, **kwargs):
     if app_configs is None:
         models = apps.get_models()
     else:
         models = chain.from_iterable(app_config.get_models() for app_config in app_configs)
     issues = []
     for conn in connections.all():
+        if database and conn.alias != database:
+            continue
         issues.extend(conn.validation.check(**kwargs))
     for model in models:
         for conn in connections.all():
+            if database and conn.alias != database:
+                continue
             if not router.allow_migrate_model(conn.alias, model):
                 continue
             issues.extend(conn.validation.check_model(model, **kwargs))

--- a/django/core/checks/database.py
+++ b/django/core/checks/database.py
@@ -7,20 +7,20 @@ from . import Tags, register
 
 
 @register(Tags.database)
-def check_database_backends(app_configs=None, database=None, **kwargs):
+def check_database_backends(app_configs=None, databases=None, **kwargs):
+    if databases is None:
+        return []
     if app_configs is None:
         models = apps.get_models()
     else:
         models = chain.from_iterable(app_config.get_models() for app_config in app_configs)
     issues = []
-    for conn in connections.all():
-        if database and conn.alias != database:
-            continue
+    for alias in databases:
+        conn = connections[alias]
         issues.extend(conn.validation.check(**kwargs))
     for model in models:
-        for conn in connections.all():
-            if database and conn.alias != database:
-                continue
+        for alias in databases:
+            conn = connections[alias]
             if not router.allow_migrate_model(conn.alias, model):
                 continue
             issues.extend(conn.validation.check_model(model, **kwargs))

--- a/django/core/checks/database.py
+++ b/django/core/checks/database.py
@@ -1,11 +1,23 @@
-from django.db import connections
+from itertools import chain
+
+from django.apps import apps
+from django.db import connections, router
 
 from . import Tags, register
 
 
 @register(Tags.database)
-def check_database_backends(*args, **kwargs):
+def check_database_backends(app_configs=None, **kwargs):
+    if app_configs is None:
+        models = apps.get_models()
+    else:
+        models = chain.from_iterable(app_config.get_models() for app_config in app_configs)
     issues = []
     for conn in connections.all():
         issues.extend(conn.validation.check(**kwargs))
+    for model in models:
+        for conn in connections.all():
+            if not router.allow_migrate_model(conn.alias, model):
+                continue
+            issues.extend(conn.validation.check_model(model, **kwargs))
     return issues

--- a/django/core/checks/registry.py
+++ b/django/core/checks/registry.py
@@ -54,7 +54,7 @@ class CheckRegistry:
                 tags += (check,)
             return inner
 
-    def run_checks(self, app_configs=None, tags=None, include_deployment_checks=False):
+    def run_checks(self, app_configs=None, tags=None, include_deployment_checks=False, databases=None):
         """
         Run all registered checks and return list of Errors and Warnings.
         """
@@ -63,13 +63,9 @@ class CheckRegistry:
 
         if tags is not None:
             checks = [check for check in checks if not set(check.tags).isdisjoint(tags)]
-        else:
-            # By default, 'database'-tagged checks are not run as they do more
-            # than mere static code analysis.
-            checks = [check for check in checks if Tags.database not in check.tags]
 
         for check in checks:
-            new_errors = check(app_configs=app_configs)
+            new_errors = check(app_configs=app_configs, databases=databases)
             assert is_iterable(new_errors), (
                 "The function %r did not return a list. All functions registered "
                 "with the checks registry must return a list." % check)

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -382,7 +382,8 @@ class BaseCommand:
         return checks.run_checks(**kwargs)
 
     def check(self, app_configs=None, tags=None, display_num_errors=False,
-              include_deployment_checks=False, fail_level=checks.ERROR):
+              include_deployment_checks=False, fail_level=checks.ERROR,
+              databases=None):
         """
         Use the system check framework to validate entire Django project.
         Raise CommandError for any serious message (error or critical errors).
@@ -393,6 +394,7 @@ class BaseCommand:
             app_configs=app_configs,
             tags=tags,
             include_deployment_checks=include_deployment_checks,
+            databases=databases,
         )
 
         header, body, footer = "", "", ""

--- a/django/core/management/commands/check.py
+++ b/django/core/management/commands/check.py
@@ -32,6 +32,10 @@ class Command(BaseCommand):
                 'non-zero status. Default is ERROR.'
             ),
         )
+        parser.add_argument(
+            '--database', action='append', dest='databases',
+            help='Run database related checks against these aliases.',
+        )
 
     def handle(self, *app_labels, **options):
         include_deployment_checks = options['deploy']

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -2,7 +2,6 @@ import time
 from importlib import import_module
 
 from django.apps import apps
-from django.core.checks import Tags, run_checks
 from django.core.management.base import (
     BaseCommand, CommandError, no_translations,
 )
@@ -20,6 +19,7 @@ from django.utils.text import Truncator
 
 class Command(BaseCommand):
     help = "Updates database schema. Manages both apps with migrations and those without."
+    requires_system_checks = False
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -58,18 +58,20 @@ class Command(BaseCommand):
             '--run-syncdb', action='store_true',
             help='Creates tables for apps without migrations.',
         )
-
-    def _run_checks(self, **kwargs):
-        issues = run_checks(tags=[Tags.database])
-        issues.extend(super()._run_checks(database=self.database, **kwargs))
-        return issues
+        parser.add_argument(
+            '--skip-checks', action='store_true',
+            help='Skip system checks.',
+        )
 
     @no_translations
     def handle(self, *args, **options):
+        self.database = options['database']
+
+        if not options['skip_checks']:
+            self.check(databases=[self.database])
 
         self.verbosity = options['verbosity']
         self.interactive = options['interactive']
-        self.database = options['database']
 
         # Import the 'management' module within each installed app, to register
         # dispatcher events.

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
 
     def _run_checks(self, **kwargs):
         issues = run_checks(tags=[Tags.database])
-        issues.extend(super()._run_checks(**kwargs))
+        issues.extend(super()._run_checks(database=self.database, **kwargs))
         return issues
 
     @no_translations
@@ -69,6 +69,7 @@ class Command(BaseCommand):
 
         self.verbosity = options['verbosity']
         self.interactive = options['interactive']
+        self.database = options['database']
 
         # Import the 'management' module within each installed app, to register
         # dispatcher events.
@@ -77,8 +78,7 @@ class Command(BaseCommand):
                 import_module('.management', app_config.name)
 
         # Get the database we're operating from
-        db = options['database']
-        connection = connections[db]
+        connection = connections[self.database]
 
         # Hook for backends needing any database preparation
         connection.prepare_database()

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -26,6 +26,9 @@ class BaseConstraint:
         _, args, kwargs = self.deconstruct()
         return self.__class__(*args, **kwargs)
 
+    def supported(self, connection):
+        return True
+
 
 class CheckConstraint(BaseConstraint):
     def __init__(self, *, check, name):
@@ -67,6 +70,9 @@ class CheckConstraint(BaseConstraint):
         path, args, kwargs = super().deconstruct()
         kwargs['check'] = self.check
         return path, args, kwargs
+
+    def supported(self, connection):
+        return connection.features.supports_table_check_constraints
 
 
 class UniqueConstraint(BaseConstraint):

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -12,7 +12,7 @@ from django import forms
 from django.apps import apps
 from django.conf import settings
 from django.core import checks, exceptions, validators
-from django.db import connection, connections, router
+from django.db import connection
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query_utils import DeferredAttribute, RegisterLookupMixin
 from django.utils import timezone

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -200,7 +200,6 @@ class Field(RegisterLookupMixin):
             *self._check_choices(),
             *self._check_db_index(),
             *self._check_null_allowed_for_primary_keys(),
-            *self._check_backend_specific_checks(**kwargs),
             *self._check_validators(),
             *self._check_deprecation_details(),
         ]
@@ -334,13 +333,6 @@ class Field(RegisterLookupMixin):
             ]
         else:
             return []
-
-    def _check_backend_specific_checks(self, **kwargs):
-        app_label = self.model._meta.app_label
-        for db in connections:
-            if router.allow_migrate(db, app_label, model_name=self.model._meta.model_name):
-                return connections[db].validation.check_field(self, **kwargs)
-        return []
 
     def _check_validators(self):
         errors = []

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -630,10 +630,10 @@ class DiscoverRunner:
             'buffer': self.buffer,
         }
 
-    def run_checks(self):
+    def run_checks(self, databases):
         # Checks are run after database creation since some checks require
         # database access.
-        call_command('check', verbosity=self.verbosity)
+        call_command('check', databases=databases, verbosity=self.verbosity)
 
     def run_suite(self, suite, **kwargs):
         kwargs = self.get_test_runner_kwargs()
@@ -695,7 +695,7 @@ class DiscoverRunner:
         old_config = self.setup_databases(aliases=databases)
         run_failed = False
         try:
-            self.run_checks()
+            self.run_checks(databases)
             result = self.run_suite(suite)
         except Exception:
             run_failed = True

--- a/tests/check_framework/test_multi_db.py
+++ b/tests/check_framework/test_multi_db.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from django.core.checks.database import check_database_backends
 from django.db import connections, models
-from django.test import SimpleTestCase
+from django.test import TestCase
 from django.test.utils import isolate_apps, override_settings
 
 
@@ -14,13 +14,14 @@ class TestRouter:
         return db == ('other' if model_name.startswith('other') else 'default')
 
 
+@override_settings(DATABASE_ROUTERS=[TestRouter()])
 @isolate_apps('check_framework', attr_name='apps')
-class TestMultiDBChecks(SimpleTestCase):
+class TestMultiDBChecks(TestCase):
+    databases = {'default', 'other'}
 
     def _patch_check_field_on(self, db):
         return mock.patch.object(connections[db].validation, 'check_field')
 
-    @override_settings(DATABASE_ROUTERS=[TestRouter()])
     def test_checks_called_on_the_default_database(self):
         class Model(models.Model):
             field = models.CharField(max_length=100)
@@ -31,7 +32,6 @@ class TestMultiDBChecks(SimpleTestCase):
                 self.assertTrue(mock_check_field_default.called)
                 self.assertFalse(mock_check_field_other.called)
 
-    @override_settings(DATABASE_ROUTERS=[TestRouter()])
     def test_checks_called_on_the_other_database(self):
         class OtherModel(models.Model):
             field = models.CharField(max_length=100)
@@ -39,17 +39,5 @@ class TestMultiDBChecks(SimpleTestCase):
         with self._patch_check_field_on('other') as mock_check_field_other:
             with self._patch_check_field_on('default') as mock_check_field_default:
                 check_database_backends(app_configs=self.apps.get_app_configs())
-                self.assertTrue(mock_check_field_other.called)
-                self.assertFalse(mock_check_field_default.called)
-
-    def test_database_kwarg(self):
-        class Model(models.Model):
-            field = models.CharField(max_length=100)
-
-        with self._patch_check_field_on('other') as mock_check_field_other:
-            with self._patch_check_field_on('default') as mock_check_field_default:
-                check_database_backends(
-                    app_configs=self.apps.get_app_configs(), database='other',
-                )
                 self.assertTrue(mock_check_field_other.called)
                 self.assertFalse(mock_check_field_default.called)

--- a/tests/check_framework/test_multi_db.py
+++ b/tests/check_framework/test_multi_db.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from django.core.checks.database import check_database_backends
 from django.db import connections, models
 from django.test import SimpleTestCase
 from django.test.utils import isolate_apps, override_settings
@@ -13,31 +14,42 @@ class TestRouter:
         return db == ('other' if model_name.startswith('other') else 'default')
 
 
-@override_settings(DATABASE_ROUTERS=[TestRouter()])
-@isolate_apps('check_framework')
+@isolate_apps('check_framework', attr_name='apps')
 class TestMultiDBChecks(SimpleTestCase):
 
     def _patch_check_field_on(self, db):
         return mock.patch.object(connections[db].validation, 'check_field')
 
+    @override_settings(DATABASE_ROUTERS=[TestRouter()])
     def test_checks_called_on_the_default_database(self):
         class Model(models.Model):
             field = models.CharField(max_length=100)
 
-        model = Model()
         with self._patch_check_field_on('default') as mock_check_field_default:
             with self._patch_check_field_on('other') as mock_check_field_other:
-                model.check()
+                check_database_backends(app_configs=self.apps.get_app_configs())
                 self.assertTrue(mock_check_field_default.called)
                 self.assertFalse(mock_check_field_other.called)
 
+    @override_settings(DATABASE_ROUTERS=[TestRouter()])
     def test_checks_called_on_the_other_database(self):
         class OtherModel(models.Model):
             field = models.CharField(max_length=100)
 
-        model = OtherModel()
         with self._patch_check_field_on('other') as mock_check_field_other:
             with self._patch_check_field_on('default') as mock_check_field_default:
-                model.check()
+                check_database_backends(app_configs=self.apps.get_app_configs())
+                self.assertTrue(mock_check_field_other.called)
+                self.assertFalse(mock_check_field_default.called)
+
+    def test_database_kwarg(self):
+        class Model(models.Model):
+            field = models.CharField(max_length=100)
+
+        with self._patch_check_field_on('other') as mock_check_field_other:
+            with self._patch_check_field_on('default') as mock_check_field_default:
+                check_database_backends(
+                    app_configs=self.apps.get_app_configs(), database='other',
+                )
                 self.assertTrue(mock_check_field_other.called)
                 self.assertFalse(mock_check_field_default.called)

--- a/tests/check_framework/test_multi_db.py
+++ b/tests/check_framework/test_multi_db.py
@@ -14,7 +14,6 @@ class TestRouter:
         return db == ('other' if model_name.startswith('other') else 'default')
 
 
-@override_settings(DATABASE_ROUTERS=[TestRouter()])
 @isolate_apps('check_framework', attr_name='apps')
 class TestMultiDBChecks(TestCase):
     databases = {'default', 'other'}
@@ -22,6 +21,7 @@ class TestMultiDBChecks(TestCase):
     def _patch_check_field_on(self, db):
         return mock.patch.object(connections[db].validation, 'check_field')
 
+    @override_settings(DATABASE_ROUTERS=[TestRouter()])
     def test_checks_called_on_the_default_database(self):
         class Model(models.Model):
             field = models.CharField(max_length=100)
@@ -32,6 +32,7 @@ class TestMultiDBChecks(TestCase):
                 self.assertTrue(mock_check_field_default.called)
                 self.assertFalse(mock_check_field_other.called)
 
+    @override_settings(DATABASE_ROUTERS=[TestRouter()])
     def test_checks_called_on_the_other_database(self):
         class OtherModel(models.Model):
             field = models.CharField(max_length=100)
@@ -39,5 +40,17 @@ class TestMultiDBChecks(TestCase):
         with self._patch_check_field_on('other') as mock_check_field_other:
             with self._patch_check_field_on('default') as mock_check_field_default:
                 check_database_backends(app_configs=self.apps.get_app_configs())
+                self.assertTrue(mock_check_field_other.called)
+                self.assertFalse(mock_check_field_default.called)
+
+    def test_database_kwarg(self):
+        class Model(models.Model):
+            field = models.CharField(max_length=100)
+
+        with self._patch_check_field_on('other') as mock_check_field_other:
+            with self._patch_check_field_on('default') as mock_check_field_default:
+                check_database_backends(
+                    app_configs=self.apps.get_app_configs(), database='other',
+                )
                 self.assertTrue(mock_check_field_other.called)
                 self.assertFalse(mock_check_field_default.called)

--- a/tests/check_framework/test_multi_db.py
+++ b/tests/check_framework/test_multi_db.py
@@ -28,7 +28,9 @@ class TestMultiDBChecks(TestCase):
 
         with self._patch_check_field_on('default') as mock_check_field_default:
             with self._patch_check_field_on('other') as mock_check_field_other:
-                check_database_backends(app_configs=self.apps.get_app_configs())
+                check_database_backends(
+                    app_configs=self.apps.get_app_configs(), databases=self.databases,
+                )
                 self.assertTrue(mock_check_field_default.called)
                 self.assertFalse(mock_check_field_other.called)
 
@@ -39,18 +41,20 @@ class TestMultiDBChecks(TestCase):
 
         with self._patch_check_field_on('other') as mock_check_field_other:
             with self._patch_check_field_on('default') as mock_check_field_default:
-                check_database_backends(app_configs=self.apps.get_app_configs())
+                check_database_backends(
+                    app_configs=self.apps.get_app_configs(), databases=self.databases,
+                )
                 self.assertTrue(mock_check_field_other.called)
                 self.assertFalse(mock_check_field_default.called)
 
-    def test_database_kwarg(self):
+    def test_databases_kwarg(self):
         class Model(models.Model):
             field = models.CharField(max_length=100)
 
         with self._patch_check_field_on('other') as mock_check_field_other:
             with self._patch_check_field_on('default') as mock_check_field_default:
                 check_database_backends(
-                    app_configs=self.apps.get_app_configs(), database='other',
+                    app_configs=self.apps.get_app_configs(), databases=['other'],
                 )
                 self.assertTrue(mock_check_field_other.called)
                 self.assertFalse(mock_check_field_default.called)

--- a/tests/check_framework/tests.py
+++ b/tests/check_framework/tests.py
@@ -160,22 +160,28 @@ class CheckCommandTests(SimpleTestCase):
     @override_system_checks([simple_system_check, tagged_system_check])
     def test_simple_call(self):
         call_command('check')
-        self.assertEqual(simple_system_check.kwargs, {'app_configs': None})
-        self.assertEqual(tagged_system_check.kwargs, {'app_configs': None})
+        self.assertEqual(simple_system_check.kwargs, {'app_configs': None, 'databases': None})
+        self.assertEqual(tagged_system_check.kwargs, {'app_configs': None, 'databases': None})
 
     @override_system_checks([simple_system_check, tagged_system_check])
     def test_given_app(self):
         call_command('check', 'auth', 'admin')
         auth_config = apps.get_app_config('auth')
         admin_config = apps.get_app_config('admin')
-        self.assertEqual(simple_system_check.kwargs, {'app_configs': [auth_config, admin_config]})
-        self.assertEqual(tagged_system_check.kwargs, {'app_configs': [auth_config, admin_config]})
+        self.assertEqual(simple_system_check.kwargs, {
+            'app_configs': [auth_config, admin_config],
+            'databases': None,
+        })
+        self.assertEqual(tagged_system_check.kwargs, {
+            'app_configs': [auth_config, admin_config],
+            'databases': None,
+        })
 
     @override_system_checks([simple_system_check, tagged_system_check])
     def test_given_tag(self):
         call_command('check', tags=['simpletag'])
         self.assertIsNone(simple_system_check.kwargs)
-        self.assertEqual(tagged_system_check.kwargs, {'app_configs': None})
+        self.assertEqual(tagged_system_check.kwargs, {'app_configs': None, 'databases': None})
 
     @override_system_checks([simple_system_check, tagged_system_check])
     def test_invalid_tag(self):

--- a/tests/invalid_models_tests/test_backend_specific.py
+++ b/tests/invalid_models_tests/test_backend_specific.py
@@ -17,16 +17,17 @@ def dummy_allow_migrate(db, app_label, **hints):
 class BackendSpecificChecksTests(SimpleTestCase):
 
     @mock.patch('django.db.router.allow_migrate', new=dummy_allow_migrate)
-    def test_check_field(self):
+    def test_validation_check(self):
         """ Test if backend specific checks are performed. """
         error = Error('an error')
 
         class Model(models.Model):
             pass
 
-        with mock.patch.object(connections['default'].validation, 'check_field', return_value=[error]):
+        with mock.patch.object(connections['default'].validation, 'check', return_value=[error]):
             self.assertEqual(
                 check_database_backends(
                     app_configs=self.apps.get_app_configs(),
+                    databases=['default'],
                 ), [error]
             )

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -1215,7 +1215,7 @@ class ConstraintsTests(TestCase):
                 constraints = [constraint]
 
         errors = check_database_backends(
-            app_configs=self.apps.get_app_configs(), database='default',
+            app_configs=self.apps.get_app_configs(), databases=['default'],
         )
         warn = Warning(
             '%s does not support %r.' % (connection.display_name, constraint),
@@ -1238,6 +1238,6 @@ class ConstraintsTests(TestCase):
                 constraints = [models.CheckConstraint(check=models.Q(age__gte=18), name='is_adult')]
 
         errors = check_database_backends(
-            app_configs=self.apps.get_app_configs(), database='default',
+            app_configs=self.apps.get_app_configs(), databases=['default'],
         )
         self.assertEqual(errors, [])

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -1205,8 +1205,6 @@ class OtherModelTests(SimpleTestCase):
 
 @isolate_apps('invalid_models_tests', attr_name='apps')
 class ConstraintsTests(TestCase):
-    databases = {'default', 'other'}
-
     def test_check_constraints(self):
         constraint = models.CheckConstraint(check=models.Q(age__gte=18), name='is_adult')
 
@@ -1216,7 +1214,9 @@ class ConstraintsTests(TestCase):
             class Meta:
                 constraints = [constraint]
 
-        errors = check_database_backends(app_configs=self.apps.get_app_configs())
+        errors = check_database_backends(
+            app_configs=self.apps.get_app_configs(), database='default',
+        )
         warn = Warning(
             '%s does not support %r.' % (connection.display_name, constraint),
             hint=(
@@ -1237,5 +1237,7 @@ class ConstraintsTests(TestCase):
                 required_db_features = {'supports_table_check_constraints'}
                 constraints = [models.CheckConstraint(check=models.Q(age__gte=18), name='is_adult')]
 
-        errors = check_database_backends(app_configs=self.apps.get_app_configs())
+        errors = check_database_backends(
+            app_configs=self.apps.get_app_configs(), database='default',
+        )
         self.assertEqual(errors, [])


### PR DESCRIPTION
Since #28478 test databases are only created if necessary for the subset of
tests targeted.

Under such circumstances its possible for some databases defined in
settings.DATABASES not to exist which prevents the retrieval of the
supports_table_check_constraints feature flag on MySQL since it requires a
usable connection.

Skipping the check when this happens should not be harmful given it will run
under normal circumstances when the full set of tests are targeted or when
checks are run from a different management command.

---

https://code.djangoproject.com/ticket/31055