### PR TITLE
Fixed #31069, Refs #26431 -- Doc'd RegexPattern behavior change in passing optional named groups in Django 3.0.

### DIFF
--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -548,6 +548,10 @@ Miscellaneous
 
 * Support for ``sqlparse`` < 0.2.2 is removed.
 
+* ``RegexPattern``, used by :func:`~django.urls.re_path`, no longer returns
+  keyword arguments with ``None`` values to be passed to the view for the
+  optional named groups that are missing.
+
 .. _deprecated-features-3.0:
 
 Features deprecated in 3.0

--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -56,9 +56,14 @@ algorithm the system follows to determine which Python code to execute:
    * If the matched URL pattern contained no named groups, then the
      matches from the regular expression are provided as positional arguments.
    * The keyword arguments are made up of any named parts matched by the
-     path expression, overridden by any arguments specified in the optional
-     ``kwargs`` argument to :func:`django.urls.path` or
+     path expression that are provided, overridden by any arguments specified
+     in the optional ``kwargs`` argument to :func:`django.urls.path` or
      :func:`django.urls.re_path`.
+
+     .. versionchanged:: 3.0
+
+          In older versions, the keyword arguments with ``None`` values are
+          made up also for not provided named parts.
 
 #. If no URL pattern matches, or if an exception is raised during any
    point in this process, Django invokes an appropriate


### PR DESCRIPTION
[Ticket 31069](https://code.djangoproject.com/ticket/31069)