### PR TITLE
Refs #25361 -- Added test for pickling queryset of abstract-inherited models with Meta.ordering.

### DIFF
--- a/tests/queryset_pickle/models.py
+++ b/tests/queryset_pickle/models.py
@@ -58,3 +58,17 @@ class Container:
 
 class M2MModel(models.Model):
     groups = models.ManyToManyField(Group)
+
+
+class AbstractEvent(Event):
+    class Meta:
+        abstract = True
+        ordering = ['title']
+
+
+class MyEvent(AbstractEvent):
+    pass
+
+
+class Edition(models.Model):
+    event = models.ForeignKey('MyEvent', on_delete=models.CASCADE)

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.test import TestCase
 from django.utils.version import get_version
 
-from .models import Container, Event, Group, Happening, M2MModel
+from .models import Container, Event, Group, Happening, M2MModel, MyEvent
 
 
 class PickleabilityTestCase(TestCase):
@@ -237,6 +237,12 @@ class PickleabilityTestCase(TestCase):
         msg = "Pickled queryset instance's Django version 1.0 does not match the current version %s." % get_version()
         with self.assertRaisesMessage(RuntimeWarning, msg):
             pickle.loads(pickle.dumps(qs))
+
+    def test_order_by_model_with_abstract_inheritance_and_meta_ordering(self):
+        group = Group.objects.create(name='test')
+        event = MyEvent.objects.create(title='test event', group=group)
+        event.edition_set.create()
+        self.assert_pickles(event.edition_set.order_by('event'))
 
 
 class InLookupTests(TestCase):


### PR DESCRIPTION
While triaging some old tickets, I found that ticket-25361 appears to have been fixed as a side-effect of another issue.

I propose adding this test based on the report and closing the ticket.