### PR TITLE
Removed unnecessary app_template directory from flake8 exclude.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ doc_files = docs extras AUTHORS INSTALL LICENSE README.rst
 install-script = scripts/rpm-install.sh
 
 [flake8]
-exclude = build,.git,.tox,./django/conf/app_template/*,./tests/.env
+exclude = build,.git,.tox,./tests/.env
 ignore = W504,W601
 max-line-length = 119
 


### PR DESCRIPTION
Unnecessary since abc0777b63057e2ff97eee2ff184356051e14c47 where the `.py` suffix was change for template files.