### PR TITLE
avoid throwing exceptions on bad input data

### DIFF
--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -240,8 +240,10 @@ def patch_response_headers(response, cache_timeout=None):
         cache_timeout = settings.CACHE_MIDDLEWARE_SECONDS
     if cache_timeout < 0:
         cache_timeout = 0  # Can't have max-age negative
-    if not response.has_header('Expires'):
-        response['Expires'] = http_date(time.time() + cache_timeout)
+    #avoid throwing exceptions on bad input data
+    if response is not None:
+        if not response.has_header('Expires'):
+            response['Expires'] = http_date(time.time() + cache_timeout)
     patch_cache_control(response, max_age=cache_timeout)
 
 


### PR DESCRIPTION
Resolves exceptions being thrown on 'NoneType' object has no attribute 'has_header' when bad input data is passed.

We occasionally have issues with spammers hitting out site throwing the below error, this should resolve the issue


Exception Value: | 'NoneType' object has no attribute 'has_header'
-- | --
/var/www/python-blogs/venv/lib64/python3.7/site-packages/django/utils/cache.py in patch_response_headers, line 243

