### PR TITLE
Fixed #26743 -- Fixed UnboundLocalError crash when deserializing m2m fields and value isn't iterable.

### DIFF
--- a/django/core/serializers/base.py
+++ b/django/core/serializers/base.py
@@ -283,8 +283,12 @@ def deserialize_m2m_values(field, field_value, using, handle_forward_references)
             return model._meta.pk.to_python(v)
 
     try:
+        pks_iter = iter(field_value)
+    except TypeError as e:
+        raise M2MDeserializationError(e, field_value)
+    try:
         values = []
-        for pk in field_value:
+        for pk in pks_iter:
             values.append(m2m_convert(pk))
         return values
     except Exception as e:

--- a/tests/serializers/test_json.py
+++ b/tests/serializers/test_json.py
@@ -252,6 +252,20 @@ class JsonSerializerTestCase(SerializersTestBase, TestCase):
             for obj in serializers.deserialize('json', test_string, ignore=False):
                 obj.save()
 
+    def test_helpful_error_message_for_many2many_not_iterable(self):
+        """
+        Not iterable many-to-many field value throws a helpful error message.
+        """
+        test_string = """[{
+            "pk": 1,
+            "model": "serializers.m2mdata",
+            "fields": {"data": null}
+        }]"""
+
+        expected = "(serializers.m2mdata:pk=1) field_value was 'None'"
+        with self.assertRaisesMessage(DeserializationError, expected):
+            next(serializers.deserialize('json', test_string, ignore=False))
+
 
 class JsonSerializerTransactionTestCase(SerializersTransactionTestBase, TransactionTestCase):
     serializer_name = "json"


### PR DESCRIPTION
Even though this change affect all serializers, I only added a test for the `json` one. This seems like a somewhat consistent practice: `tests_json.py` has a lot more test methods than `tests_xml.py` for example and not all of them are json-specific.

Adding the test to the base class (the one in `tests.py` that gets executed for all available serialization formats) is complicated because it's not straightforward to generate the broken serialized data that correspond to the active format (`self.serializer_name`).


ticket-26743