### PR TITLE
Fixed #31090: Log when DB transactions are committed and rolled back

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -727,6 +727,7 @@ answer newbie questions, and generally made Django that much better:
     Peter Zsoldos <http://zsoldosp.eu>
     Pete Shinners <pete@shinners.org>
     Petr Marhoun <petr.marhoun@gmail.com>
+    Petter Strandmark
     pgross@thoughtworks.com
     phaedo <http://phaedo.cx/>
     phil.h.smith@gmail.com

--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -1,5 +1,6 @@
 import _thread
 import copy
+import logging
 import threading
 import time
 import warnings
@@ -21,6 +22,8 @@ from django.utils.asyncio import async_unsafe
 from django.utils.functional import cached_property
 
 NO_DB_ALIAS = '__no_db__'
+
+logger = logging.getLogger('django.db.backends')
 
 
 class BaseDatabaseWrapper:
@@ -238,11 +241,15 @@ class BaseDatabaseWrapper:
 
     def _commit(self):
         if self.connection is not None:
+            if self.queries_logged:
+                logger.debug("COMMIT")
             with self.wrap_database_errors:
                 return self.connection.commit()
 
     def _rollback(self):
         if self.connection is not None:
+            if self.queries_logged:
+                logger.debug("ROLLBACK")
             with self.wrap_database_errors:
                 return self.connection.rollback()
 

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -451,6 +451,9 @@ Miscellaneous
 
 * Instantiating an abstract model now raises ``TypeError``.
 
+* The database debug log now also logs when transactions are committed and 
+  rolled back.
+
 .. _deprecated-features-3.2:
 
 Features deprecated in 3.2


### PR DESCRIPTION
Background: I was debugging database calls today with the `django.db.backends` log.

Problem: The `BEGIN` SQL calls show up in the logs, but there is no way to see when the transaction is commited or if it is rolled back. 

This PR adds a debug log statement with the same logger and level as here: https://github.com/django/django/blob/4161e35048d91fa84abf4dd2ebf64e04e0c37ca4/django/db/backends/utils.py#L123 Since these statements are guarded behind `self.queries_logged` as well, this PR does the same.