### PR TITLE
Fixed #31076 -- Fixed dbshell crash on Windows with Python < 3.8.

### DIFF
--- a/django/db/backends/sqlite3/client.py
+++ b/django/db/backends/sqlite3/client.py
@@ -7,6 +7,8 @@ class DatabaseClient(BaseDatabaseClient):
     executable_name = 'sqlite3'
 
     def runshell(self):
+        # TODO: Remove str() when dropping support for PY37.
+        # args parameter accepts path-like objects since Python 3.8.
         args = [self.executable_name,
-                self.connection.settings_dict['NAME']]
+                str(self.connection.settings_dict['NAME'])]
         subprocess.run(args, check=True)

--- a/tests/dbshell/test_sqlite.py
+++ b/tests/dbshell/test_sqlite.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest import mock, skipUnless
+
+from django.db import connection
+from django.db.backends.sqlite3.client import DatabaseClient
+from django.test import SimpleTestCase
+
+
+@skipUnless(connection.vendor == 'sqlite', 'SQLite tests.')
+class SqliteDbshellCommandTestCase(SimpleTestCase):
+    def _run_dbshell(self):
+        """Run runshell command and capture its arguments."""
+        def _mock_subprocess_run(*args, **kwargs):
+            self.subprocess_args = list(*args)
+            return CompletedProcess(self.subprocess_args, 0)
+
+        client = DatabaseClient(connection)
+        with mock.patch('subprocess.run', new=_mock_subprocess_run):
+            client.runshell()
+        return self.subprocess_args
+
+    def test_path_name(self):
+        with mock.patch.dict(
+            connection.settings_dict,
+            {'NAME': Path('test.db.sqlite3')},
+        ):
+            self.assertEqual(
+                self._run_dbshell(),
+                ['sqlite3', 'test.db.sqlite3'],
+            )


### PR DESCRIPTION
`dbshell` command fails for sqllite on Windows for python 
versions older than 3.8. see [ticket 31076](https://code.djangoproject.com/ticket/31076)

I am not sure if I should add any tests for this fix.