### PR TITLE
Fixed #31086 -- Added choices for ForeignKey in admin.E202 error message

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1031,10 +1031,13 @@ def _get_foreign_key(parent_model, model, fk_name=None, can_fail=False):
                 )
             )
         else:
+            fks_name = [fk.name for fk in fks_to_parent]
             raise ValueError(
-                "'%s' has more than one ForeignKey to '%s'." % (
+                "'%s' has more than one ForeignKey to '%s'. "
+                "Choices for ForeignKey are: %s." % (
                     model._meta.label,
                     parent_model._meta.label,
+                    ", ".join(fks_name),
                 )
             )
     return fk

--- a/tests/admin_checks/tests.py
+++ b/tests/admin_checks/tests.py
@@ -636,7 +636,8 @@ class SystemChecksTestCase(SimpleTestCase):
         errors = MyAdmin(Album, AdminSite()).check()
         expected = [
             checks.Error(
-                "'admin_checks.TwoAlbumFKAndAnE' has more than one ForeignKey to 'admin_checks.Album'.",
+                "'admin_checks.TwoAlbumFKAndAnE' has more than one ForeignKey to 'admin_checks.Album'. " \
+                "Choices for ForeignKey are: album1, album2.",
                 obj=TwoAlbumFKAndAnEInline,
                 id='admin.E202',
             )


### PR DESCRIPTION
Added a list of all the valid ForeignKey, to be displayed with the admin
E.202 error message, in the _get_foreign_key() method.