### PR TITLE
Fixed #31086 -- Improved error message for admin model inlines with more than one foreign key to the same parent.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1032,7 +1032,8 @@ def _get_foreign_key(parent_model, model, fk_name=None, can_fail=False):
             )
         else:
             raise ValueError(
-                "'%s' has more than one ForeignKey to '%s'." % (
+                "'%s' has more than one ForeignKey to '%s'. You must specify "
+                "a 'fk_name' attribute." % (
                     model._meta.label,
                     parent_model._meta.label,
                 )

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -645,7 +645,8 @@ inline on a :class:`~django.contrib.admin.ModelAdmin`.
 * **admin.E201**: Cannot exclude the field ``<field name>``, because it is the
   foreign key to the parent model ``<app_label>.<model>``.
 * **admin.E202**: ``<model>`` has no ``ForeignKey`` to ``<parent model>``./
-  ``<model>`` has more than one ``ForeignKey`` to ``<parent model>``.
+  ``<model>`` has more than one ``ForeignKey`` to ``<parent model>``. You must
+  specify a ``fk_name`` attribute.
 * **admin.E203**: The value of ``extra`` must be an integer.
 * **admin.E204**: The value of ``max_num`` must be an integer.
 * **admin.E205**: The value of ``min_num`` must be an integer.

--- a/tests/admin_checks/tests.py
+++ b/tests/admin_checks/tests.py
@@ -636,7 +636,9 @@ class SystemChecksTestCase(SimpleTestCase):
         errors = MyAdmin(Album, AdminSite()).check()
         expected = [
             checks.Error(
-                "'admin_checks.TwoAlbumFKAndAnE' has more than one ForeignKey to 'admin_checks.Album'.",
+                "'admin_checks.TwoAlbumFKAndAnE' has more than one ForeignKey "
+                "to 'admin_checks.Album'. You must specify a 'fk_name' "
+                "attribute.",
                 obj=TwoAlbumFKAndAnEInline,
                 id='admin.E202',
             )


### PR DESCRIPTION
Added a list of foreign keys available for a model, in the error message
raised by the ```__get_foreign_key``` method. Also updated the error message
for the admin_checks test's , ```test_inline_self_check``` method.