### PR TITLE
Fixed #31094 -- Included columns referenced by subqueries in GROUP BY on aggregations.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1040,7 +1040,7 @@ class Subquery(Expression):
     def get_group_by_cols(self, alias=None):
         if alias:
             return [Ref(alias, self)]
-        return []
+        return self.query.get_external_cols()
 
 
 class Exists(Subquery):

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -109,7 +109,14 @@ class SQLCompiler:
         # Note that even if the group_by is set, it is only the minimal
         # set to group by. So, we need to add cols in select, order_by, and
         # having into the select in any case.
+        ref_sources = {
+            expr.source for expr in expressions if isinstance(expr, Ref)
+        }
         for expr, _, _ in select:
+            # Skip members of the select clause that are already included
+            # by reference.
+            if expr in ref_sources:
+                continue
             cols = expr.get_group_by_cols()
             for col in cols:
                 expressions.append(col)
@@ -399,7 +406,7 @@ class SQLCompiler:
             return self.quote_cache[name]
         if ((name in self.query.alias_map and name not in self.query.table_map) or
                 name in self.query.extra_select or (
-                    name in self.query.external_aliases and name not in self.query.table_map)):
+                    self.query.external_aliases.get(name) and name not in self.query.table_map)):
             self.quote_cache[name] = name
             return name
         r = self.connection.ops.quote_name(name)

--- a/docs/releases/3.0.2.txt
+++ b/docs/releases/3.0.2.txt
@@ -9,4 +9,5 @@ Django 3.0.2 fixes several bugs in 3.0.1.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 3.0 that didn't include columns referenced by a
+  ``Subquery()`` in the ``GROUP BY`` clause (:ticket:`31094`).

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -1172,3 +1172,23 @@ class AggregateTestCase(TestCase):
             Exists(long_books_qs),
         ).annotate(total=Count('*'))
         self.assertEqual(dict(has_long_books_breakdown), {True: 2, False: 3})
+
+    def test_aggregation_subquery_annotation_related_field(self):
+        publisher = Publisher.objects.create(name=self.a9.name, num_awards=2)
+        book = Book.objects.create(
+            isbn='159059999', name='Test book.', pages=819, rating=2.5,
+            price=Decimal('14.44'), contact=self.a9, publisher=publisher,
+            pubdate=datetime.date(2019, 12, 6),
+        )
+        book.authors.add(self.a5, self.a6, self.a7)
+        books_qs = Book.objects.annotate(
+            contact_publisher=Subquery(
+                Publisher.objects.filter(
+                    pk=OuterRef('publisher'),
+                    name=OuterRef('contact__name'),
+                ).values('name')[:1],
+            )
+        ).filter(
+            contact_publisher__isnull=False,
+        ).annotate(count=Count('authors'))
+        self.assertSequenceEqual(books_qs, [book])

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -1138,6 +1138,8 @@ class AggregateTestCase(TestCase):
         with self.assertNumQueries(1) as ctx:
             list(publisher_qs)
         self.assertEqual(ctx[0]['sql'].count('SELECT'), 2)
+        # The GROUP BY should not be by alias either.
+        self.assertEqual(ctx[0]['sql'].lower().count('latest_book_pubdate'), 1)
 
     @skipUnlessDBFeature('supports_subqueries_in_group_by')
     def test_group_by_subquery_annotation(self):


### PR DESCRIPTION
Failing to include such columns resulted in a crash on PostgreSQL where only
selected table primary keys are included unless an explicit grouping set is
specified.

Thanks Johannes Hoppe for the report.

Refs #30158.

Co-authored-by: Mariusz Felisiak <felisiak.mariusz@gmail.com>

--- 

https://code.djangoproject.com/ticket/31094

---

I didn't have the chance to get a full suite run so there will likely be failures and the patch could likely be broken into separate commits.

The idea here is to piggy back on `external_aliases` to include *all* external aliases and not only the ones that are aliased (aliased external aliases) with a flag denoting whether or not they are aliases.

Now that a query knows which aliases are external to itself it can walk through it's collection of expressions and determine which ones are referring to external aliases. These are the ones that need to be included in the `GROUP BY` clause on PostgreSQL.