### PR TITLE
Fixed #30138 -- Changed QuerySet.bulk_create() to set pk of created objects when ignore_conflicts=True.

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -182,7 +182,8 @@ class BaseDatabaseOperations:
         Given a cursor object that has just performed an INSERT...RETURNING
         statement into a table, return the newly created data.
         """
-        return cursor.fetchone()
+        results = cursor.fetchone()
+        return (None, ) if results is None else results
 
     def field_cast_sql(self, db_type, internal_type):
         """

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1239,7 +1239,7 @@ class QuerySet:
         inserted_rows = []
         bulk_return = connections[self.db].features.can_return_rows_from_bulk_insert
         for item in [objs[i:i + batch_size] for i in range(0, len(objs), batch_size)]:
-            if bulk_return and not ignore_conflicts:
+            if bulk_return:
                 inserted_columns = self._insert(
                     item, fields=fields, using=self.db,
                     returning_fields=self.model._meta.db_returning_fields,

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2096,9 +2096,13 @@ where the default is such that at most 999 variables per query are used.
 
 On databases that support it (all but Oracle), setting the ``ignore_conflicts``
 parameter to ``True`` tells the database to ignore failure to insert any rows
-that fail constraints such as duplicate unique values. Enabling this parameter
-disables setting the primary key on each model instance (if the database
-normally supports it).
+that fail constraints such as duplicate unique values.
+
+.. versionchanged:: 3.1
+
+    In older version, Enabling the ``ignore_conflicts`` parameter would disable
+    setting the primary key on each model instance (if the database normally
+    supports it).
 
 ``bulk_update()``
 ~~~~~~~~~~~~~~~~~

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -314,3 +314,17 @@ class BulkCreateTests(TestCase):
         # Without ignore_conflicts=True, there's a problem.
         with self.assertRaises(IntegrityError):
             TwoFields.objects.bulk_create(conflicting_objects)
+
+    @skipUnlessDBFeature('can_return_rows_from_bulk_insert')
+    def test_set_pk_ignore_conflicts_ignore(self):
+        data = [
+            TwoFields(f1=1, f2=1),
+            TwoFields(f1=2, f2=2),
+            TwoFields(f1=3, f2=3),
+        ]
+        TwoFields.objects.bulk_create(data)
+        new_object = TwoFields(f1=4, f2=4)
+        new_instances = TwoFields.objects.bulk_create([new_object], ignore_conflicts=True)
+        self.assertEqual(TwoFields.objects.count(), 4)
+        self.assertIsNotNone(new_object.pk)
+        self.assertIsNotNone(new_instances[0].pk)


### PR DESCRIPTION
[Ticket 30138](https://code.djangoproject.com/ticket/30138)
Continue to The [PR](https://github.com/django/django/pull/10998)