### PR TITLE
Fixed non int values in function _boolean_icon

### DIFF
--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -195,6 +195,7 @@ def result_headers(cl):
 
 
 def _boolean_icon(field_val):
+    field_val = int(field_val)
     icon_url = static('admin/img/icon-%s.svg' % {True: 'yes', False: 'no', None: 'unknown'}[field_val])
     return format_html('<img src="{}" alt="{}">', icon_url, field_val)
 


### PR DESCRIPTION
The field_val is now working as expected because not always is an int ('0' value instead of 0).