### PR TITLE
Fixed #31114 -- Fixed HttpRequest.build_absolute_uri() crash with reverse_lazy() locations.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -191,6 +191,9 @@ class HttpRequest:
             # Make it an absolute url (but schemeless and domainless) for the
             # edge case that the path starts with '//'.
             location = '//%s' % self.get_full_path()
+        else:
+            # Coerce lazy locations.
+            location = str(location)
         bits = urlsplit(location)
         if not (bits.scheme and bits.netloc):
             # Handle the simple, most common case. If the location is absolute

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -13,7 +13,9 @@ from django.http import (
     HttpRequest, HttpResponsePermanentRedirect, HttpResponseRedirect,
 )
 from django.shortcuts import redirect
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import (
+    RequestFactory, SimpleTestCase, TestCase, override_settings,
+)
 from django.test.utils import override_script_prefix
 from django.urls import (
     NoReverseMatch, Resolver404, ResolverMatch, URLPattern, URLResolver,
@@ -527,6 +529,14 @@ class ReverseLazyTest(TestCase):
         self.assertEqual(
             'Some URL: %s' % reverse_lazy('some-login-page'),
             'Some URL: /login/'
+        )
+
+    def test_build_absolute_uri(self):
+        factory = RequestFactory()
+        request = factory.get('/')
+        self.assertEqual(
+            request.build_absolute_uri(reverse_lazy('some-login-page')),
+            'http://testserver/login/',
         )
 
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31114