### PR TITLE
Fixed #31117 -- Isolated backends.base.test_creation.TestDbCreationTests

### DIFF
--- a/tests/backends/base/test_creation.py
+++ b/tests/backends/base/test_creation.py
@@ -8,19 +8,21 @@ from django.db.backends.base.creation import (
 from django.test import SimpleTestCase
 
 
+def get_connection_copy():
+    # Get a copy of the default connection. (Can't use django.db.connection
+    # because it'll modify the default connection itself.)
+    test_connection = copy.copy(connections[DEFAULT_DB_ALIAS])
+    test_connection.settings_dict = copy.deepcopy(
+        connections[DEFAULT_DB_ALIAS].settings_dict
+    )
+    return test_connection
+
+
 class TestDbSignatureTests(SimpleTestCase):
-
-    def get_connection_copy(self):
-        # Get a copy of the default connection. (Can't use django.db.connection
-        # because it'll modify the default connection itself.)
-        test_connection = copy.copy(connections[DEFAULT_DB_ALIAS])
-        test_connection.settings_dict = copy.copy(connections[DEFAULT_DB_ALIAS].settings_dict)
-        return test_connection
-
     def test_default_name(self):
         # A test db name isn't set.
         prod_name = 'hodor'
-        test_connection = self.get_connection_copy()
+        test_connection = get_connection_copy()
         test_connection.settings_dict['NAME'] = prod_name
         test_connection.settings_dict['TEST'] = {'NAME': None}
         signature = BaseDatabaseCreation(test_connection).test_db_signature()
@@ -29,7 +31,7 @@ class TestDbSignatureTests(SimpleTestCase):
     def test_custom_test_name(self):
         # A regular test db name is set.
         test_name = 'hodor'
-        test_connection = self.get_connection_copy()
+        test_connection = get_connection_copy()
         test_connection.settings_dict['TEST'] = {'NAME': test_name}
         signature = BaseDatabaseCreation(test_connection).test_db_signature()
         self.assertEqual(signature[3], test_name)
@@ -37,7 +39,7 @@ class TestDbSignatureTests(SimpleTestCase):
     def test_custom_test_name_with_test_prefix(self):
         # A test db name prefixed with TEST_DATABASE_PREFIX is set.
         test_name = TEST_DATABASE_PREFIX + 'hodor'
-        test_connection = self.get_connection_copy()
+        test_connection = get_connection_copy()
         test_connection.settings_dict['TEST'] = {'NAME': test_name}
         signature = BaseDatabaseCreation(test_connection).test_db_signature()
         self.assertEqual(signature[3], test_name)


### PR DESCRIPTION
(Commit replaced with different fix, see comments below)

~~This lets TestDbCreationTests properly clean up by not only calling `create_test_db`, but also `destroy_test_db`.~~

~~Since we cannot call `destroy_test_db` on the 'default' database, which is used by other tests, and since calling `create_test_db` on a database that is already created is fragile in any case, this also changes the test to use the 'unused' database that is introduced in this PR.~~

~~Additionally, this changes the restoration of the connection settings to restore just the `MIGRATE` setting, rather than the entire dict, since that prevents issues when the same dict is referenced from multiple places (as detailed in #31117).~~

~~Before this PR can be merged, https://code.djangoproject.com/ticket/31055 must be fixed (work underway in #12201). Until then, this PR contains a hack to disable checking entirely.~~

~~I am not entirely happy with the name of the new database. I called it 'unused', since it is *normally* unused by testcases (e.g. not used directly), but can be used by testcases that need to go through the full create/destroy cycle. Any suggestions?~~

~~Also, when this database will be used for multiple tests (e.g. I also need it for #12166), I'm afraid there might be concurrency issues when both tests end up running at the same time. Is there any standard way to deal with this? Maybe simply add a lock for using this third database?~~