### PR TITLE
Fixed #28290 -- Enabled Sphinx auto-label generation for title and section headers.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ needs_sphinx = '1.6.0'
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "djangodocs",
-    "sphinx.ext.extlinks",
+    'sphinx.ext.extlinks',
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,10 +38,17 @@ needs_sphinx = '1.6.0'
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "djangodocs",
-    'sphinx.ext.extlinks',
+    "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "sphinx.ext.autosectionlabel"
 ]
+
+# AutosectionLabel settings.
+# Uses a <page>:<label> schema which doesn't work for duplicate sub-section
+# labels, so set max depth.
+autosectionlabel_prefix_document = True
+autosectionlabel_maxdepth = 2
 
 # Spelling check needs an additional module that is not installed by default.
 # Add it only if spelling check is requested so docs can be generated without it.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
-    "sphinx.ext.autosectionlabel"
+    "sphinx.ext.autosectionlabel",
 ]
 
 # AutosectionLabel settings.


### PR DESCRIPTION
Certain sections don't have labels which makes it difficult to refer them
from other Sphinx documents using InterSphinx. The AutoSectionLabel does
what it says.

Asked for opinion regarding a particular setting of the extension here: https://groups.google.com/forum/#!topic/django-developers/sRfq48rD-Ao