### PR TITLE
Fixed typo in ref/forms/widgets.txt.

### DIFF
--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -326,7 +326,7 @@ foundation for custom widgets.
 
         By default, returns ``False`` for hidden widgets and ``True``
         otherwise. Special cases are :class:`~django.forms.ClearableFileInput`,
-        which returns ``False`` when ``initial`` is not set, and
+        which returns ``False`` when ``initial`` is set, and
         :class:`~django.forms.CheckboxSelectMultiple`, which always returns
         ``False`` because browser validation would require all checkboxes to be
         checked instead of at least one.


### PR DESCRIPTION
@jdufresne Can you take a look? IMO it's typo in c74378bb77db5bbeac1bd48c0cd31154f96a81d6.