### PR TITLE
Fixed random models_fields.test_uuid.TestQuerying failures.

### DIFF
--- a/tests/model_fields/test_uuid.py
+++ b/tests/model_fields/test_uuid.py
@@ -87,7 +87,9 @@ class TestQuerying(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.objs = [
-            NullableUUIDModel.objects.create(field=uuid.uuid4()),
+            NullableUUIDModel.objects.create(
+                field=uuid.UUID('25d405be-4895-4d50-9b2e-d6695359ce47'),
+            ),
             NullableUUIDModel.objects.create(field='550e8400e29b41d4a716446655440000'),
             NullableUUIDModel.objects.create(field=None),
         ]


### PR DESCRIPTION
Random failures depended on a generated UUID, e.g. tests failed when it contains `0000` or `8400e29b`.