### PR TITLE
Fixed #31126 -- Doc'd STATICFILES_DIRS namespacing in static files how-to.

### DIFF
--- a/docs/howto/static-files/index.txt
+++ b/docs/howto/static-files/index.txt
@@ -71,6 +71,9 @@ details on how ``staticfiles`` finds your files.
     by putting those static files inside *another* directory named for the
     application itself.
 
+    You can namespace static assets in :setting:`STATICFILES_DIRS` by
+    specifying :ref:`prefixes <staticfiles-dirs-prefixes>`.
+
 .. _serving-static-files-in-development:
 
 Serving static files during development

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -3430,6 +3430,8 @@ your additional files directory(ies) e.g.::
 Note that these paths should use Unix-style forward slashes, even on Windows
 (e.g. ``"C:/Users/user/mysite/extra_static_content"``).
 
+.. _staticfiles-dirs-prefixes:
+
 Prefixes (optional)
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/31126

I've added information regarding prefixes (as part of namespacing) in the `Static file namespacing` admonition. 