### PR TITLE
Fixed #31166 -- Used "raise from" when raising ImproperlyConfigured exceptions in django.urls.resolvers.

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -190,7 +190,7 @@ class RegexPattern(CheckURLMixin):
         except re.error as e:
             raise ImproperlyConfigured(
                 '"%s" is not a valid regular expression: %s' % (regex, e)
-            )
+            ) from e
 
     def __str__(self):
         return str(self._regex)
@@ -234,8 +234,9 @@ def _route_to_regex(route, is_endpoint=False):
             converter = get_converter(raw_converter)
         except KeyError as e:
             raise ImproperlyConfigured(
-                "URL route '%s' uses invalid converter %s." % (original_route, e)
-            )
+                'URL route %r uses invalid converter %r.'
+                % (original_route, raw_converter)
+            ) from e
         converters[parameter] = converter
         parts.append('(?P<' + parameter + '>' + converter.regex + ')')
     if is_endpoint:
@@ -588,13 +589,13 @@ class URLResolver:
         patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
         try:
             iter(patterns)
-        except TypeError:
+        except TypeError as e:
             msg = (
                 "The included URLconf '{name}' does not appear to have any "
                 "patterns in it. If you see valid patterns in the file then "
                 "the issue is probably caused by a circular import."
             )
-            raise ImproperlyConfigured(msg.format(name=self.urlconf_name))
+            raise ImproperlyConfigured(msg.format(name=self.urlconf_name)) from e
         return patterns
 
     def resolve_error_handler(self, view_type):


### PR DESCRIPTION
This will make it have a text of "this exception is the direct result of" instead of "During handling of the above exception, another exception occurred" 

This is more accurate for the case of this exception.