### PR TITLE
Fixed #30934: Include database alias in `django.db.backends` debug output 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -242,6 +242,7 @@ answer newbie questions, and generally made Django that much better:
     David Sanders <dsanders11@ucsbalum.com>
     David Schein
     David Tulig <david.tulig@gmail.com>
+    David Winterbottom <david.winterbottom@gmail.com>
     David Wobrock <david.wobrock@gmail.com>
     Davide Ceretti <dav.ceretti@gmail.com>
     Deepak Thukral <deep.thukral@gmail.com>

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -121,11 +121,12 @@ class CursorDebugWrapper(CursorWrapper):
                 'time': '%.3f' % duration,
             })
             logger.debug(
-                '(%.3f) %s; args=%s',
+                '(%.3f) %s; args=%s; alias=%s',
                 duration,
                 sql,
                 params,
-                extra={'duration': duration, 'sql': sql, 'params': params},
+                self.db.alias,
+                extra={'duration': duration, 'sql': sql, 'params': params, 'alias': self.db.alias},
             )
 
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -194,7 +194,8 @@ Internationalization
 Logging
 ~~~~~~~
 
-* ...
+* Included database context ``alias`` to the ``django.db.backends`` logger
+  output.
 
 Management Commands
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -527,6 +527,7 @@ Messages to this logger have the following extra context:
 * ``duration``: The time taken to execute the SQL statement.
 * ``sql``: The SQL statement that was executed.
 * ``params``: The parameters that were used in the SQL call.
+* ``alias``: The alias of the database used in the SQL call.
 
 For performance reasons, SQL logging is only enabled when
 ``settings.DEBUG`` is set to ``True``, regardless of the logging

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -538,6 +538,10 @@ This logging does not include framework-level initialization (e.g.
 ``COMMIT``, and ``ROLLBACK``). Turn on query logging in your database if you
 wish to view all database queries.
 
+.. versionadded:: 3.1
+
+    The ``alias`` context was added.
+
 .. _django-security-logger:
 
 ``django.security.*``


### PR DESCRIPTION
Original PR: #11994 

Went through the patch checklist and changed patch notes and added version added admonition to documentation.

Thanks to @codeinthehole for the ticket and patch. I simply added the documentation. 