### PR TITLE
Refs #31040 -- Fixed crypt.crypt() call in test_hashers.py.

### DIFF
--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -16,7 +16,7 @@ except ImportError:
     crypt = None
 else:
     # On some platforms (e.g. OpenBSD), crypt.crypt() always return None.
-    if crypt.crypt('', '') is None:
+    if crypt.crypt('') is None:
         crypt = None
 
 try:


### PR DESCRIPTION
An empty string is invalid for the `salt` argument in Python 3 and raises exception since Python 3.9, see https://bugs.python.org/issue38402.