### PR TITLE
Fixed #31136 -- Disabled grouping by aliases on QuerySet.values()/values_list().

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2095,7 +2095,9 @@ class Query(BaseExpression):
 
         if self.group_by is True:
             self.add_fields((f.attname for f in self.model._meta.concrete_fields), False)
-            self.set_group_by()
+            # Disable GROUP BY aliases to avoid orphaning references to the
+            # SELECT clause which is about to be cleared.
+            self.set_group_by(allow_aliases=False)
             self.clear_select_fields()
 
         if fields:

--- a/docs/releases/3.0.3.txt
+++ b/docs/releases/3.0.3.txt
@@ -12,3 +12,7 @@ Bugfixes
 * Fixed a regression in Django 3.0 that caused a crash when subtracting
   ``DateField``, ``DateTimeField``, or ``TimeField`` from a ``Subquery()``
   annotation (:ticket:`31133`).
+
+* Fixed a regression in Django 3.0 where ``QuerySet.values()`` and
+  ``values_list()`` crashed if a queryset contained an aggregation and
+  ``Exists()`` annotation (:ticket:`31136`).

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -1151,6 +1151,20 @@ class AggregateTestCase(TestCase):
         )
         self.assertTrue(publisher_qs.exists())
 
+    def test_aggregation_exists_annotation(self):
+        published_books = Book.objects.filter(publisher=OuterRef('pk'))
+        publisher_qs = Publisher.objects.annotate(
+            published_book=Exists(published_books),
+            count=Count('book'),
+        ).values_list('name', flat=True)
+        self.assertCountEqual(list(publisher_qs), [
+            'Apress',
+            'Morgan Kaufmann',
+            "Jonno's House of Books",
+            'Prentice Hall',
+            'Sams',
+        ])
+
     @skipUnlessDBFeature('supports_subqueries_in_group_by')
     def test_group_by_subquery_annotation(self):
         """


### PR DESCRIPTION
Regression in fb3f034f1c63160c0ff13c609acd01c18be12f80.

Thanks Sigurd Ljødal for the report.

ticket-31136