### PR TITLE
Improved LANGUAGES setting documentation

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1899,8 +1899,15 @@ The list is a list of two-tuples in the format
 This specifies which languages are available for language selection. See
 :doc:`/topics/i18n/index`.
 
-Generally, the default value should suffice. Only set this setting if you want
-to restrict language selection to a subset of the Django-provided languages.
+Generally, the default value should suffice. You can set this setting if you
+want to restrict language selection to a subset of the Django-provided
+languages. You can also extend this setting to add languages that are
+not currently supported by Django. For instance you can do::
+
+  from django.utils.translation import gettext_lazy as _
+  from django.conf import global_settings
+
+  LANGUAGES = global_settings.LANGUAGES + [('oc', _('Occitan'))]
 
 If you define a custom :setting:`LANGUAGES` setting, you can mark the
 language names as translation strings using the


### PR DESCRIPTION
According to the discussion that happened on Django developers Google group about Occitan language support, the documentation about `LANGUAGES` was said to need a bit of improvement to state that it can both be restricted *and* expanded.