### PR TITLE
Fixed #30980 -- Improved error message when checking uniqueness of admin actions' __name__.

### DIFF
--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -633,7 +633,7 @@ with the admin site:
 * **admin.E129**: ``<modeladmin>`` must define a ``has_<foo>_permission()``
   method for the ``<action>`` action.
 * **admin.E130**: ``__name__`` attributes of actions defined in
-  ``<modeladmin>`` must be unique.
+  ``<modeladmin>`` must be unique. Name ``<name>`` is not unique.
 
 ``InlineModelAdmin``
 ~~~~~~~~~~~~~~~~~~~~

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -1441,9 +1441,8 @@ class ActionsCheckTests(CheckTestCase):
 
         self.assertIsInvalid(
             BandAdmin, Band,
-            "__name__ attributes of actions defined in "
-            "<class 'modeladmin.test_checks.ActionsCheckTests."
-            "test_actions_not_unique.<locals>.BandAdmin'> must be unique.",
+            "__name__ attributes of actions defined in BandAdmin must be "
+            "unique. Name 'action' is not unique.",
             id='admin.E130',
         )
 


### PR DESCRIPTION
Getting #30980 over the line. Credit to the existing work done in https://github.com/django/django/pull/12165 by @keshav2212 as a strong starting point