### PR TITLE
Fixed #31124 -- Fixed setting of get_FOO_display() when overriding inherited choices.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -764,7 +764,11 @@ class Field(RegisterLookupMixin):
             if not getattr(cls, self.attname, None):
                 setattr(cls, self.attname, self.descriptor_class(self))
         if self.choices is not None:
-            if not hasattr(cls, 'get_%s_display' % self.name):
+            # Don't override a get_FOO_display() method defined explicitly on
+            # this class, but don't check methods derived from inheritance, to
+            # allow overriding inherited choices. For more complex inheritance
+            # structures users should override contribute_to_class().
+            if 'get_%s_display' % self.name not in cls.__dict__:
                 setattr(
                     cls,
                     'get_%s_display' % self.name,

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -834,6 +834,15 @@ Note that in the case of identical date values, these methods will use the
 primary key as a tie-breaker. This guarantees that no records are skipped or
 duplicated. That also means you cannot use those methods on unsaved objects.
 
+.. admonition:: Overriding extra instance methods
+
+    In most cases overriding or inheriting ``get_FOO_display()``,
+    ``get_next_by_FOO()``, and ``get_previous_by_FOO()` should work as
+    expected. Since they are added by the metaclass however, it is not
+    practical to account for all possible inheritance structures. In more
+    complex cases you should override ``Field.contribute_to_class()`` to set
+    the methods you need.
+
 Other attributes
 ================
 

--- a/docs/releases/3.0.3.txt
+++ b/docs/releases/3.0.3.txt
@@ -31,3 +31,7 @@ Bugfixes
   :class:`~django.contrib.postgres.aggregates.ArrayAgg` and
   :class:`~django.contrib.postgres.aggregates.StringAgg` with ``filter``
   argument when used in a ``Subquery`` (:ticket:`31097`).
+
+* Fixed a regression in Django 2.2.7 that caused
+  :meth:`~django.db.models.Model.get_FOO_display` to work incorrectly when
+  overriding inherited choices (:ticket:`31124`).

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -178,6 +178,19 @@ class GetFieldDisplayTests(SimpleTestCase):
         f = FooBar(foo_bar=1)
         self.assertEqual(f.get_foo_bar_display(), 'something')
 
+    def test_overriding_inherited_FIELD_display(self):
+        class Base(models.Model):
+            foo = models.CharField(max_length=254, choices=[('A', 'Base A')])
+
+            class Meta:
+                abstract = True
+
+        class Child(Base):
+            foo = models.CharField(max_length=254, choices=[('A', 'Child A'), ('B', 'Child B')])
+
+        self.assertEqual(Child(foo='A').get_foo_display(), 'Child A')
+        self.assertEqual(Child(foo='B').get_foo_display(), 'Child B')
+
     def test_iterator_choices(self):
         """
         get_choices() works with Iterators.


### PR DESCRIPTION
(To be squashed and tidied obviously)

Three commits: 

* Test for ticket-31124
* Initial fix, but...
* Further test, since it can come up again. 

@felixxm @claudep @sir-sigurd: What do you all think? 

I [initially suggested](https://github.com/django/django/commit/e3c035ef177d9ed40340b2d294aa55a7e5100529#diff-5b33a9c46f488003c1846ef677f861d3R820-R839) for ticket-30931 that we doc overriding `_get_FIELD_display()`:

```
.. admonition:: Overriding extra instance methods

    In order to customize ``get_FOO_display()``, or either of
    ``get_next_by_FOO()`` or ``get_previous_by_FOO()``, you need to override
    the helper methods ``_get_FIELD_display()``, or
    ``_get_next_or_previous_by_FIELD()``, respectively.

    For example, you might customize ``get_FOO_display()`` like so::

        from django.db import models


        class FooBar(models.Model):
            foo_bar = models.IntegerField(choices=[(1, 'foo'), (2, 'bar')])

            def _get_FIELD_display(self, field):
                if field.attname == 'foo_bar':
                    return 'custom display string'
                return super()._get_FIELD_display(field)
```

I suggested this saying, about the fix in `contribute_to_class()`, that "this way lies madness", i.e. we're in danger of adding ever more complicated logic into `contribute_to_class()`, when there's a clean way to point users to available. 

We decided to add the `hasattr` check, which is OK.

Now we can move to inspecting the `__dict__` directly (to avoid walking the bases). I guess that might be OK too. 

But we need to decide at what point we cut our loses and say that we don't support this. So...

Is this further fix OK? Do we need to support the last test case? If not do we doc it? OR do we back out and doc the non-`__new__()` approach? Or...? (My inclination is towards the simpler code, and so documenting overriding `_get_FIELD_display()`—for me, it's just trying to be too clever here—but happy to go with majority opinion.)

Thanks for the thoughts! 
(And happy new year! 🎊)