### PR TITLE
Fixed #31141 -- Relaxed system check of translation settings for sublanguages.

### DIFF
--- a/django/core/checks/translation.py
+++ b/django/core/checks/translation.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils.translation import get_supported_language_variant
 from django.utils.translation.trans_real import language_code_re
 
 from . import Error, Tags, register
@@ -55,7 +56,9 @@ def check_setting_languages_bidi(app_configs, **kwargs):
 @register(Tags.translation)
 def check_language_settings_consistent(app_configs, **kwargs):
     """Error if language settings are not consistent with each other."""
-    available_tags = {i for i, _ in settings.LANGUAGES} | {'en-us'}
-    if settings.LANGUAGE_CODE not in available_tags:
+    try:
+        get_supported_language_variant(settings.LANGUAGE_CODE)
+    except LookupError:
         return [E004]
-    return []
+    else:
+        return []

--- a/docs/releases/3.0.3.txt
+++ b/docs/releases/3.0.3.txt
@@ -16,3 +16,7 @@ Bugfixes
 * Fixed a regression in Django 3.0 where ``QuerySet.values()`` and
   ``values_list()`` crashed if a queryset contained an aggregation and
   ``Exists()`` annotation (:ticket:`31136`).
+
+* Relaxed the system check added in Django 3.0 to reallow use of a sublanguage
+  in the :setting:`LANGUAGE_CODE` setting, when a base language is available in
+  Django but the sublanguage is not (:ticket:`31141`).


### PR DESCRIPTION
Regression in 4400d8296d268f5a8523cd02ddc33b12219b2535.

Thanks Enrique Matías Sánchez for the report.