### PR TITLE
Don't raise E004 on a sublanguage if the base language is available

### DIFF
--- a/django/core/checks/translation.py
+++ b/django/core/checks/translation.py
@@ -56,6 +56,9 @@ def check_setting_languages_bidi(app_configs, **kwargs):
 def check_language_settings_consistent(app_configs, **kwargs):
     """Error if language settings are not consistent with each other."""
     available_tags = {i for i, _ in settings.LANGUAGES} | {'en-us'}
-    if settings.LANGUAGE_CODE not in available_tags:
+    if not any(
+        tag in available_tags
+        for tag in [settings.LANGUAGE_CODE, settings.LANGUAGE_CODE.split('-')[0]]
+    ):
         return [E004]
     return []


### PR DESCRIPTION
fixes: #31141