### PR TITLE
Improved ReST formatting in docs/README.rst.

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -13,6 +13,6 @@ To create an HTML version of the docs:
 
 The documentation in ``_build/html/index.html`` can then be viewed in a web browser.
 
-[1] http://docutils.sourceforge.net/rst.html
+.. [1] http://docutils.sourceforge.net/rst.html
 
-[2] http://sphinx-doc.org
+.. [2] http://sphinx-doc.org

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -13,6 +13,6 @@ To create an HTML version of the docs:
 
 The documentation in _build/html/index.html can then be viewed in a web browser.
 
-[1] http://docutils.sourceforge.net/rst.html
+[1]_ http://docutils.sourceforge.net/rst.html
 
-[2] http://sphinx-doc.org/
+[2]_ http://sphinx-doc.org/

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,7 +1,7 @@
 The documentation in this tree is in plain text files and can be viewed using
 any text file viewer.
 
-It uses ReST (reStructuredText) [1], and the Sphinx documentation system [2].
+It uses ReST (reStructuredText) [1]. and the Sphinx documentation system [2].
 This allows it to be built into other forms for easier viewing and browsing.
 
 To create an HTML version of the docs:
@@ -13,6 +13,6 @@ To create an HTML version of the docs:
 
 The documentation in _build/html/index.html can then be viewed in a web browser.
 
-[1]_ http://docutils.sourceforge.net/rst.html
+[1] http://docutils.sourceforge.net/rst.html
 
-[2]_ http://sphinx-doc.org/
+[2] http://sphinx-doc.org

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,7 +1,7 @@
 The documentation in this tree is in plain text files and can be viewed using
 any text file viewer.
 
-It uses ReST (reStructuredText) [1]. and the Sphinx documentation system [2].
+It uses `ReST`_ (reStructuredText), and the `Sphinx`_ documentation system.
 This allows it to be built into other forms for easier viewing and browsing.
 
 To create an HTML version of the docs:
@@ -13,6 +13,5 @@ To create an HTML version of the docs:
 
 The documentation in ``_build/html/index.html`` can then be viewed in a web browser.
 
-.. [1] http://docutils.sourceforge.net/rst.html
-
-.. [2] http://sphinx-doc.org
+.. _ReST: http://docutils.sourceforge.net/rst.html
+.. _Sphinx: http://sphinx-doc.org

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -14,4 +14,5 @@ To create an HTML version of the docs:
 The documentation in _build/html/index.html can then be viewed in a web browser.
 
 [1] http://docutils.sourceforge.net/rst.html
+
 [2] http://sphinx-doc.org/

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -14,5 +14,4 @@ To create an HTML version of the docs:
 The documentation in _build/html/index.html can then be viewed in a web browser.
 
 [1] http://docutils.sourceforge.net/rst.html
-
 [2] http://sphinx-doc.org/

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -11,7 +11,8 @@ To create an HTML version of the docs:
 * In this docs/ directory, type ``make html`` (or ``make.bat html`` on
   Windows) at a shell prompt.
 
-The documentation in ``_build/html/index.html`` can then be viewed in a web browser.
+The documentation in ``_build/html/index.html`` can then be viewed in a web
+browser.
 
-.. _ReST: http://docutils.sourceforge.net/rst.html
-.. _Sphinx: http://sphinx-doc.org
+.. _ReST: https://docutils.sourceforge.io/rst.html
+.. _Sphinx: https://sphinx-doc.org

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -15,4 +15,4 @@ The documentation in ``_build/html/index.html`` can then be viewed in a web
 browser.
 
 .. _ReST: https://docutils.sourceforge.io/rst.html
-.. _Sphinx: https://sphinx-doc.org
+.. _Sphinx: http://sphinx-doc.org

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -11,7 +11,7 @@ To create an HTML version of the docs:
 * In this docs/ directory, type ``make html`` (or ``make.bat html`` on
   Windows) at a shell prompt.
 
-The documentation in _build/html/index.html can then be viewed in a web browser.
+The documentation in ``_build/html/index.html`` can then be viewed in a web browser.
 
 [1] http://docutils.sourceforge.net/rst.html
 


### PR DESCRIPTION
In docs/README.rst file two links were written adjacent to each other I changed them and wrote one below other