### PR TITLE
Fixed #31148 -- Added error messages on update()/delete() operations following union(), intersection(), and difference().

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -711,6 +711,7 @@ class QuerySet:
 
     def delete(self):
         """Delete the records in the current QuerySet."""
+        self._not_support_combined_queries('delete')
         assert not self.query.is_sliced, \
             "Cannot use 'limit' or 'offset' with delete."
 
@@ -756,6 +757,7 @@ class QuerySet:
         Update all elements in the current QuerySet, setting all the given
         fields to the appropriate values.
         """
+        self._not_support_combined_queries('update')
         assert not self.query.is_sliced, \
             "Cannot update a query once a slice has been taken."
         self._for_write = True

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -272,12 +272,14 @@ class QuerySetSetOperationTests(TestCase):
             for operation in (
                 'annotate',
                 'defer',
+                'delete',
                 'exclude',
                 'extra',
                 'filter',
                 'only',
                 'prefetch_related',
                 'select_related',
+                'update',
             ):
                 with self.subTest(combinator=combinator, operation=operation):
                     with self.assertRaisesMessage(


### PR DESCRIPTION
[Ticket 31148](https://code.djangoproject.com/ticket/31148)