### PR TITLE
Fixed #23004 -- Added request.META filtering to SafeExceptionReporterFilter.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -123,6 +123,14 @@ class SafeExceptionReporterFilter(ExceptionReporterFilter):
                 settings_dict[k] = self.cleanse_setting(k, getattr(settings, k))
         return settings_dict
 
+    def get_safe_request_meta(self, request):
+        """
+        Return a dictionary of request.META with sensitive values redacted.
+        """
+        if not hasattr(request, 'META'):
+            return {}
+        return {k: self.cleanse_setting(k, v) for k, v in request.META.items()}
+
     def is_active(self, request):
         """
         This filter is to add safety in production environments (i.e. DEBUG
@@ -296,6 +304,7 @@ class ExceptionReporter:
             'unicode_hint': unicode_hint,
             'frames': frames,
             'request': self.request,
+            'request_meta': self.filter.get_safe_request_meta(self.request),
             'user_str': user_str,
             'filtered_POST_items': list(self.filter.get_post_parameters(self.request).items()),
             'settings': self.filter.get_safe_settings(),

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -438,7 +438,7 @@ Exception Value: {{ exception_value|force_escape }}
       </tr>
     </thead>
     <tbody>
-      {% for var in request.META.items|dictsort:0 %}
+      {% for var in request_meta.items|dictsort:0 %}
         <tr>
           <td>{{ var.0 }}</td>
           <td class="code"><pre>{{ var.1|pprint }}</pre></td>

--- a/django/views/templates/technical_500.txt
+++ b/django/views/templates/technical_500.txt
@@ -50,7 +50,7 @@ FILES:{% for k, v in request_FILES_items %}
 COOKIES:{% for k, v in request_COOKIES_items %}
 {{ k }} = {{ v|stringformat:"r" }}{% empty %} No cookie data{% endfor %}
 
-META:{% for k, v in request.META.items|dictsort:0 %}
+META:{% for k, v in request_meta.items|dictsort:0 %}
 {{ k }} = {{ v|stringformat:"r" }}{% endfor %}
 {% else %}Request data not supplied
 {% endif %}

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -262,25 +262,46 @@ attribute::
 
 Your custom filter class needs to inherit from
 :class:`django.views.debug.SafeExceptionReporterFilter` and may override the
-following methods:
+following attributes and methods:
 
 .. class:: SafeExceptionReporterFilter
 
-.. method:: SafeExceptionReporterFilter.is_active(request)
+    .. attribute:: cleansed_substitute
 
-    Returns ``True`` to activate the filtering operated in the other methods.
-    By default the filter is active if :setting:`DEBUG` is ``False``.
+        .. versionadded:: 3.1
 
-.. method:: SafeExceptionReporterFilter.get_post_parameters(request)
+        The string value to replace sensitive value with. By default it
+        replaces the values of sensitive variables with stars (`**********`).
 
-    Returns the filtered dictionary of POST parameters. By default it replaces
-    the values of sensitive parameters with stars (`**********`).
+    .. attribute:: hidden_settings
 
-.. method:: SafeExceptionReporterFilter.get_traceback_frame_variables(request, tb_frame)
+        .. versionadded:: 3.1
 
-    Returns the filtered dictionary of local variables for the given traceback
-    frame. By default it replaces the values of sensitive variables with stars
-    (`**********`).
+        A compiled regular expression object used to match settings considered
+        as sensitive. By default equivalent to::
+
+            import re
+
+            re.compile(r'API|TOKEN|KEY|SECRET|PASS|SIGNATURE', flags=re.IGNORECASE)
+
+    .. method:: is_active(request)
+
+        Returns ``True`` to activate the filtering in
+        :meth:`get_post_parameters` and :meth:`get_traceback_frame_variables`.
+        By default the filter is active if :setting:`DEBUG` is ``False``. Note
+        that sensitive settings are always filtered, as described in the
+        :setting:`DEBUG` documentation.
+
+    .. method:: get_post_parameters(request)
+
+        Returns the filtered dictionary of POST parameters. Sensitive values
+        are replaced with :attr:`cleansed_substitute`.
+
+    .. method:: get_traceback_frame_variables(request, tb_frame)
+
+        Returns the filtered dictionary of local variables for the given
+        traceback frame. Sensitive values are replaced with
+        :attr:`cleansed_substitute`.
 
 .. seealso::
 

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -277,8 +277,9 @@ following attributes and methods:
 
         .. versionadded:: 3.1
 
-        A compiled regular expression object used to match settings considered
-        as sensitive. By default equivalent to::
+        A compiled regular expression object used to match settings and
+        ``request.META`` values considered as sensitive. By default equivalent
+        to::
 
             import re
 
@@ -289,8 +290,9 @@ following attributes and methods:
         Returns ``True`` to activate the filtering in
         :meth:`get_post_parameters` and :meth:`get_traceback_frame_variables`.
         By default the filter is active if :setting:`DEBUG` is ``False``. Note
-        that sensitive settings are always filtered, as described in the
-        :setting:`DEBUG` documentation.
+        that sensitive ``request.META`` values are always filtered along with
+        sensitive setting values, as described in the :setting:`DEBUG`
+        documentation.
 
     .. method:: get_post_parameters(request)
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -158,6 +158,17 @@ Email
 * The :setting:`EMAIL_FILE_PATH` setting, used by the :ref:`file email backend
   <topic-email-file-backend>`, now supports :class:`pathlib.Path`.
 
+Error Reporting
+~~~~~~~~~~~~~~~
+
+* The new :attr:`.SafeExceptionReporterFilter.cleansed_substitute` and
+  :attr:`.SafeExceptionReporterFilter.hidden_settings` attributes allow
+  customization of sensitive settings filtering in exception reports.
+
+* The technical 404 debug view now respects
+  :setting:`DEFAULT_EXCEPTION_REPORTER_FILTER` when applying settings
+  filtering.
+
 File Storage
 ~~~~~~~~~~~~
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -161,9 +161,13 @@ Email
 Error Reporting
 ~~~~~~~~~~~~~~~
 
+* :class:`django.views.debug.SafeExceptionReporterFilter` now filters sensitive
+  values from ``request.META`` in exception reports.
+
 * The new :attr:`.SafeExceptionReporterFilter.cleansed_substitute` and
   :attr:`.SafeExceptionReporterFilter.hidden_settings` attributes allow
-  customization of sensitive settings filtering in exception reports.
+  customization of sensitive settings and ``request.META`` filtering in
+  exception reports.
 
 * The technical 404 debug view now respects
   :setting:`DEFAULT_EXCEPTION_REPORTER_FILTER` when applying settings


### PR DESCRIPTION
Two commits:

1. Implements Tim's old suggestion from the ticket to move the setting values and functions to the filter class to allow overriding. Co-authored-by @maxsond from #10748. 
2. Add the request.META filtering itself. Co-authored-by @audiolion originally from #7996. 

Hopefully we can get this in now. It should be a good 50% of the flexibility folks are looking for in the error reporting.  