### PR TITLE
Removed unused ExceptionReporterFilter class.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -67,23 +67,7 @@ def get_exception_reporter_filter(request):
     return getattr(request, 'exception_reporter_filter', default_filter)
 
 
-class ExceptionReporterFilter:
-    """
-    Base for all exception reporter filter classes. All overridable hooks
-    contain lenient default behaviors.
-    """
-
-    def get_post_parameters(self, request):
-        if request is None:
-            return {}
-        else:
-            return request.POST
-
-    def get_traceback_frame_variables(self, request, tb_frame):
-        return list(tb_frame.f_locals.items())
-
-
-class SafeExceptionReporterFilter(ExceptionReporterFilter):
+class SafeExceptionReporterFilter:
     """
     Use annotations made by the sensitive_post_parameters and
     sensitive_variables decorators to filter out sensitive information.

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -425,6 +425,11 @@ Miscellaneous
 * The :class:`~django.forms.FileInput` widget no longer renders with the
   ``required`` HTML attribute when initial data exists.
 
+* The undocumented ``django.views.debug.ExceptionReporterFilter`` class is
+  removed. As per the :ref:`custom-error-reports` documentation, classes to be
+  used with :setting:`DEFAULT_EXCEPTION_REPORTER_FILTER` needs to inherit from
+  :class:`django.views.debug.SafeExceptionReporterFilter`.
+
 .. _deprecated-features-3.1:
 
 Features deprecated in 3.1


### PR DESCRIPTION
It's undocumented, untested, and unused. The [docs explicitly state that `DEFAULT_EXCEPTION_REPORTER_FILTER` requires a `SafeExceptionReporterFilter` subclass](https://docs.djangoproject.com/en/3.0/howto/error-reporting/#custom-error-reports). 

(I'm guessing it was intended as a base class folks would extend, but just never turned out that way.)

We have [precedent for removing code here without deprecation from 1.9](https://docs.djangoproject.com/en/dev/releases/1.9/#httprequest-details-in-error-reporting).