### PR TITLE
Added file cleanup in FileFieldTests.test_pickle().

### DIFF
--- a/tests/model_fields/test_filefield.py
+++ b/tests/model_fields/test_filefield.py
@@ -110,19 +110,27 @@ class FileFieldTests(TestCase):
             file1 = File(fp, name='test_file.py')
             document = Document(myfile='test_file.py')
             document.myfile.save('test_file.py', file1)
+            try:
+                dump = pickle.dumps(document)
+                loaded_document = pickle.loads(dump)
+                self.assertEqual(document.myfile, loaded_document.myfile)
+                self.assertEqual(document.myfile.url, loaded_document.myfile.url)
+                self.assertEqual(
+                    document.myfile.storage,
+                    loaded_document.myfile.storage,
+                )
+                self.assertEqual(
+                    document.myfile.instance,
+                    loaded_document.myfile.instance,
+                )
+                self.assertEqual(document.myfile.field, loaded_document.myfile.field)
 
-            dump = pickle.dumps(document)
-            loaded_document = pickle.loads(dump)
-            self.assertEqual(document.myfile, loaded_document.myfile)
-            self.assertEqual(document.myfile.url, loaded_document.myfile.url)
-            self.assertEqual(document.myfile.storage, loaded_document.myfile.storage)
-            self.assertEqual(document.myfile.instance, loaded_document.myfile.instance)
-            self.assertEqual(document.myfile.field, loaded_document.myfile.field)
-
-            myfile_dump = pickle.dumps(document.myfile)
-            loaded_myfile = pickle.loads(myfile_dump)
-            self.assertEqual(document.myfile, loaded_myfile)
-            self.assertEqual(document.myfile.url, loaded_myfile.url)
-            self.assertEqual(document.myfile.storage, loaded_myfile.storage)
-            self.assertEqual(document.myfile.instance, loaded_myfile.instance)
-            self.assertEqual(document.myfile.field, loaded_myfile.field)
+                myfile_dump = pickle.dumps(document.myfile)
+                loaded_myfile = pickle.loads(myfile_dump)
+                self.assertEqual(document.myfile, loaded_myfile)
+                self.assertEqual(document.myfile.url, loaded_myfile.url)
+                self.assertEqual(document.myfile.storage, loaded_myfile.storage)
+                self.assertEqual(document.myfile.instance, loaded_myfile.instance)
+                self.assertEqual(document.myfile.field, loaded_myfile.field)
+            finally:
+                document.myfile.delete()


### PR DESCRIPTION
Resolves lingering file after aaea9deac4dea08ada934a930cfc27765358d8da. 

Wasn't 100% sure if a tmp file wouldn't be better, but wasn't convinced it was worth the time to set up the Storage. Maybe @felixxm or @hramezani would be able to do that quicker, since you have the relevant logic more fresh in mind. 

(Wouldn't block on it though... — not worth the investment unless it's instantly obvious to you.) 