### PR TITLE
Fixed #31155 -- Fixed a system check for the longest choice when a named group contains only non-string values.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -269,10 +269,10 @@ class Field(RegisterLookupMixin):
                 ):
                     break
                 if self.max_length is not None and group_choices:
-                    choice_max_length = max(
+                    choice_max_length = max([
                         choice_max_length,
                         *(len(value) for value, _ in group_choices if isinstance(value, str)),
-                    )
+                    ])
             except (TypeError, ValueError):
                 # No groups, choices in the form [value, display]
                 value, human_name = group_name, group_choices

--- a/docs/releases/3.0.3.txt
+++ b/docs/releases/3.0.3.txt
@@ -23,3 +23,6 @@ Bugfixes
 
 * Added support for using enumeration types ``TextChoices``,
   ``IntegerChoices``, and ``Choices`` in templates (:ticket:`31154`).
+
+* Fixed a system check to ensure the ``max_length`` attribute fits the longest
+  choice, when a named group contains only non-string values (:ticket:`31155`).

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -1,4 +1,5 @@
 import unittest
+import uuid
 
 from django.core.checks import Error, Warning as DjangoWarning
 from django.db import connection, models
@@ -769,3 +770,20 @@ class TextFieldTests(TestCase):
                 id='fields.W162',
             )
         ])
+
+
+@isolate_apps('invalid_models_tests')
+class UUIDFieldTests(TestCase):
+    def test_choices_named_group(self):
+        class Model(models.Model):
+            field = models.UUIDField(
+                choices=[
+                    ['knights', [
+                        [uuid.UUID('5c859437-d061-4847-b3f7-e6b78852f8c8'), 'Lancelot'],
+                        [uuid.UUID('c7853ec1-2ea3-4359-b02d-b54e8f1bcee2'), 'Galahad'],
+                    ]],
+                    [uuid.UUID('25d405be-4895-4d50-9b2e-d6695359ce47'), 'Other'],
+                ],
+            )
+
+        self.assertEqual(Model._meta.get_field('field').check(), [])


### PR DESCRIPTION
Regression in b6251956b69512bf230322bd7a49b629ca8455c6.

Thanks Murat Guchetl for the report.

ticket-31155