### PR TITLE
Fixed #31160 -- Fixed admin CSS for ordered lists' descendants in unordered list.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -94,7 +94,7 @@ h5 {
     letter-spacing: 1px;
 }
 
-ul li {
+ul > li {
     list-style-type: square;
     padding: 1px 0;
 }


### PR DESCRIPTION
Without this change, an ordered lists nested inside an unordered list will be rendered as if it is unordered. This can occur when using admindocs with nested lists used in docstrings.