### PR TITLE
Fixed #26761 -- Made admin changelist and readonly fields display help_text.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -165,7 +165,7 @@ class AdminReadonlyField:
         if form._meta.help_texts and class_name in form._meta.help_texts:
             help_text = form._meta.help_texts[class_name]
         else:
-            help_text = help_text_for_field(class_name, form._meta.model)
+            help_text = help_text_for_field(field, form._meta.model, model_admin)
 
         self.field = {
             'name': class_name,

--- a/django/contrib/admin/templates/admin/change_list_results.html
+++ b/django/contrib/admin/templates/admin/change_list_results.html
@@ -10,7 +10,7 @@
 <thead>
 <tr>
 {% for header in result_headers %}
-<th scope="col"{{ header.class_attrib }}>
+<th scope="col"{{ header.class_attrib }}{% if header.help_text %} title="{{ header.help_text }}"{% endif %}>
    {% if header.sortable %}
      {% if header.sort_priority > 0 %}
        <div class="sortoptions">

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -3,7 +3,7 @@ import datetime
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 from django.contrib.admin.utils import (
     display_for_field, display_for_value, get_fields_from_path,
-    label_for_field, lookup_field,
+    help_text_for_field, label_for_field, lookup_field,
 )
 from django.contrib.admin.views.main import (
     ALL_VAR, ORDER_VAR, PAGE_VAR, SEARCH_VAR,
@@ -114,6 +114,7 @@ def result_headers(cl):
             model_admin=cl.model_admin,
             return_attr=True
         )
+        help_text = help_text_for_field(field_name, cl.model, cl.model_admin)
         is_field_sortable = cl.sortable_by is None or field_name in cl.sortable_by
         if attr:
             field_name = _coerce_field_name(field_name, i)
@@ -123,6 +124,7 @@ def result_headers(cl):
             if field_name == 'action_checkbox':
                 yield {
                     "text": text,
+                    "help_text": help_text,
                     "class_attrib": mark_safe(' class="action-checkbox-column"'),
                     "sortable": False,
                 }
@@ -139,6 +141,7 @@ def result_headers(cl):
             # Not sortable
             yield {
                 'text': text,
+                'help_text': help_text,
                 'class_attrib': format_html(' class="column-{}"', field_name),
                 'sortable': False,
             }
@@ -184,6 +187,7 @@ def result_headers(cl):
 
         yield {
             "text": text,
+            "help_text": help_text,
             "sortable": True,
             "sorted": is_sorted,
             "ascending": order_type == "asc",

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -365,12 +365,27 @@ def label_for_field(name, model, model_admin=None, return_attr=False, form=None)
         return label
 
 
-def help_text_for_field(name, model):
+def help_text_for_field(name, model, model_admin=None):
     help_text = ""
     try:
         field = _get_non_gfk_field(model._meta, name)
     except (FieldDoesNotExist, FieldIsAForeignKeyColumnName):
-        pass
+        attr = None
+        if callable(name):
+            attr = name
+        elif hasattr(model_admin, name):
+            attr = getattr(model_admin, name)
+        elif hasattr(model, name):
+            attr = getattr(model, name)
+
+        if hasattr(attr, 'help_text'):
+            help_text = attr.help_text
+        elif (
+            isinstance(attr, property) and
+            hasattr(attr, 'fget') and
+            hasattr(attr.fget, 'help_text')
+        ):
+            help_text = attr.fget.help_text
     else:
         if hasattr(field, 'help_text'):
             help_text = field.help_text

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -684,6 +684,11 @@ subclass::
           class PersonAdmin(admin.ModelAdmin):
               list_display = ('name', 'born_in_fifties')
 
+    * Django displays the :attr:`~django.forms.Field.help_text` of the model
+      field as a column tooltip in the changelist view. When using a callable,
+      a model method, or a ``ModelAdmin`` method, you can customize the column
+      tooltip by adding a ``help_text`` attribute to the callable.
+
     * The ``__str__()`` method is just as valid in ``list_display`` as any
       other model method, so it's perfectly OK to do this::
 
@@ -760,9 +765,9 @@ subclass::
 
     * Elements of ``list_display`` can also be properties. Please note however,
       that due to the way properties work in Python, setting
-      ``short_description`` or ``admin_order_field`` on a property is only
-      possible when using the ``property()`` function and **not** with the
-      ``@property`` decorator.
+      ``short_description``, ``help_text``, or ``admin_order_field`` on a
+      property is only possible when using the ``property()`` function and
+      **not** with the ``@property`` decorator.
 
       For example::
 
@@ -773,6 +778,7 @@ subclass::
               def my_property(self):
                   return self.first_name + ' ' + self.last_name
               my_property.short_description = "Full name of the person"
+              my_property.help_text = 'First name and last name'
               my_property.admin_order_field = 'last_name'
 
               full_name = property(my_property)
@@ -796,6 +802,9 @@ subclass::
       For example if you have ``first_name`` as a model field and
       as a ``ModelAdmin`` attribute, the model field will be used.
 
+    .. versionadded:: 3.2
+
+        Support for setting ``help_text`` was added.
 
 .. attribute:: ModelAdmin.list_display_links
 

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -394,7 +394,12 @@ These error messages often don't propagate to forms. See
 .. attribute:: Field.help_text
 
 Extra "help" text to be displayed with the form widget. It's useful for
-documentation even if your field isn't used on a form.
+documentation even if your field isn't used on a form. This property will be
+displayed as a tooltip in the admin changelist view.
+
+.. versionadded:: 3.2
+
+Display as a tooltip in the admin changelist view was added.
 
 Note that this value is *not* HTML-escaped in automatically-generated
 forms. This lets you include HTML in :attr:`~Field.help_text` if you so

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -40,6 +40,11 @@ Minor features
 * :attr:`.ModelAdmin.search_fields` now allows searching against quoted phrases
   with spaces.
 
+* The admin changelist now displays :attr:`~django.forms.Field.help_text` as a
+  column tooltip. You can specify it also for :attr:`.ModelAdmin.list_display`
+  value when using a callable, a model method, or a ``ModelAdmin`` method by
+  adding a ``help_text`` attribute to the callable.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -689,6 +689,7 @@ tokenized
 toolbar
 toolkits
 toolset
+tooltip
 Tox
 trac
 tracebacks

--- a/tests/admin_utils/models.py
+++ b/tests/admin_utils/models.py
@@ -15,7 +15,11 @@ class Article(models.Model):
     """
     site = models.ForeignKey(Site, models.CASCADE, related_name="admin_articles")
     title = models.CharField(max_length=100)
-    hist = models.CharField(max_length=100, verbose_name=_("History"))
+    hist = models.CharField(
+        max_length=100,
+        verbose_name=_('History'),
+        help_text=_('History help text'),
+    )
     created = models.DateTimeField(null=True)
 
     def __str__(self):

--- a/tests/admin_utils/models.py
+++ b/tests/admin_utils/models.py
@@ -31,6 +31,13 @@ class Article(models.Model):
     def test_from_model_with_override(self):
         return "nothing"
     test_from_model_with_override.short_description = "not What you Expect"
+    test_from_model_with_override.help_text = 'Callable help text'
+
+    def article_property(self):
+        return 'property'
+
+    article_property.help_text = 'Property help text'
+    test_from_model_property = property(article_property)
 
 
 class ArticleProxy(Article):

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -6,7 +6,8 @@ from django.conf import settings
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import (
     NestedObjects, display_for_field, display_for_value, flatten,
-    flatten_fieldsets, label_for_field, lookup_field, quote,
+    flatten_fieldsets, help_text_for_field, label_for_field, lookup_field,
+    quote,
 )
 from django.db import DEFAULT_DB_ALIAS, models
 from django.test import SimpleTestCase, TestCase, override_settings
@@ -333,6 +334,16 @@ class UtilsTests(SimpleTestCase):
             label_for_field("test_from_property", Article, model_admin=MockModelAdmin),
             'property short description'
         )
+
+    def test_help_text_for_field(self):
+        tests = [
+            ('article', ''),
+            ('unknown', ''),
+            ('hist', 'History help text'),
+        ]
+        for name, help_text in tests:
+            with self.subTest(name=name):
+                self.assertEqual(help_text_for_field(name, Article), help_text)
 
     def test_related_name(self):
         """

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -340,10 +340,34 @@ class UtilsTests(SimpleTestCase):
             ('article', ''),
             ('unknown', ''),
             ('hist', 'History help text'),
+            ('test_from_model_with_override', 'Callable help text'),
+            ('test_from_model_property', 'Property help text'),
         ]
         for name, help_text in tests:
             with self.subTest(name=name):
                 self.assertEqual(help_text_for_field(name, Article), help_text)
+
+    def test_help_text_for_field_modeladmin(self):
+        class MockModelAdmin:
+            def my_property(self):
+                return 'admin property'
+
+            my_property.help_text = 'Admin property help text'
+            admin_property = property(my_property)
+
+            def admin_callable(self):
+                return 'admin callable'
+
+            admin_callable.help_text = 'Admin callable help text'
+
+        self.assertEqual(
+            help_text_for_field('admin_property', Article, model_admin=MockModelAdmin),
+            'Admin property help text',
+        )
+        self.assertEqual(
+            help_text_for_field('admin_callable', Article, model_admin=MockModelAdmin),
+            'Admin callable help text',
+        )
 
     def test_related_name(self):
         """

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -56,6 +56,7 @@ def callable_year(dt_value):
 
 
 callable_year.admin_order_field = 'date'
+callable_year.help_text = 'Some help text for callable year'
 
 
 class ArticleInline(admin.TabularInline):
@@ -477,11 +478,13 @@ class PrePopulatedPostReadOnlyAdmin(admin.ModelAdmin):
 
 
 class PostAdmin(admin.ModelAdmin):
-    list_display = ['title', 'public']
+    list_display = [
+        'title', 'public', 'awesomeness_level', callable_year, 'posted_year',
+    ]
     readonly_fields = (
         'posted', 'awesomeness_level', 'coolness', 'value',
         'multiline', 'multiline_html', lambda obj: "foo",
-        'readonly_content',
+        'readonly_content', callable_year, 'posted_year',
     )
 
     inlines = [

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -470,6 +470,14 @@ class Post(models.Model):
     def awesomeness_level(self):
         return "Very awesome."
 
+    awesomeness_level.help_text = 'Some help text for awesomeness level'
+
+    def post_posted_year(self):
+        return self.posted.year
+
+    post_posted_year.help_text = 'Some help text for posted year'
+    posted_year = property(post_posted_year)
+
 
 # Proxy model to test overridden fields attrs on Post model so as not to
 # interfere with other tests.

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -744,6 +744,30 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         response = self.client.get(reverse('admin:admin_views_post_changelist'))
         self.assertContains(response, 'icon-unknown.svg')
 
+    def test_change_list_help_text(self):
+        Post.objects.create(public=None)
+        response = self.client.get(reverse('admin:admin_views_post_changelist'))
+        self.assertContains(
+            response,
+            '<th scope="col" class="sortable column-title" '
+            'title="Some help text for the title (with Unicode ŠĐĆŽćžšđ)"',
+        )
+        self.assertContains(
+            response,
+            '<th scope="col" class="column-awesomeness_level" '
+            'title="Some help text for awesomeness level"',
+        )
+        self.assertContains(
+            response,
+            '<th scope="col" class="column-posted_year" '
+            'title="Some help text for posted year"',
+        )
+        self.assertContains(
+            response,
+            '<th scope="col" class="sortable column-callable_year" '
+            'title="Some help text for callable year"',
+        )
+
     def test_i18n_language_non_english_default(self):
         """
         Check if the JavaScript i18n view returns an empty language catalog
@@ -4858,7 +4882,7 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
         self.assertContains(response, '<div class="form-row field-posted">')
         self.assertContains(response, '<div class="form-row field-value">')
         self.assertContains(response, '<div class="form-row">')
-        self.assertContains(response, '<div class="help">', 3)
+        self.assertContains(response, '<div class="help">', 6)
         self.assertContains(
             response,
             '<div class="help">Some help text for the title (with Unicode ŠĐĆŽćžšđ)</div>',
@@ -4874,7 +4898,21 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
             '<div class="help">Some help text for the date (with Unicode ŠĐĆŽćžšđ)</div>',
             html=True
         )
-
+        self.assertContains(
+            response,
+            '<div class="help">Some help text for awesomeness level</div>',
+            html=True
+        )
+        self.assertContains(
+            response,
+            '<div class="help">Some help text for posted year</div>',
+            html=True
+        )
+        self.assertContains(
+            response,
+            '<div class="help">Some help text for callable year</div>',
+            html=True
+        )
         p = Post.objects.create(title="I worked on readonly_fields", content="Its good stuff")
         response = self.client.get(reverse('admin:admin_views_post_change', args=(p.pk,)))
         self.assertContains(response, "%d amount of cool" % p.pk)


### PR DESCRIPTION
[Ticket 26761](https://code.djangoproject.com/ticket/26761)