### PR TITLE
Fixed #28073 -- RemoveField.state_forwards() gives AttributeError.

### DIFF
--- a/django/db/migrations/operations/fields.py
+++ b/django/db/migrations/operations/fields.py
@@ -133,15 +133,14 @@ class RemoveField(FieldOperation):
 
     def state_forwards(self, app_label, state):
         new_fields = []
-        old_field = None
+        delay = False
         for name, instance in state.models[app_label, self.model_name_lower].fields:
             if name != self.name:
                 new_fields.append((name, instance))
             else:
-                old_field = instance
+                # Delay rendering of relationships if it's not a relational field
+                delay = not instance.is_relation
         state.models[app_label, self.model_name_lower].fields = new_fields
-        # Delay rendering of relationships if it's not a relational field
-        delay = not old_field.is_relation if old_field else False
         state.reload_model(app_label, self.model_name_lower, delay=delay)
 
     def database_forwards(self, app_label, schema_editor, from_state, to_state):

--- a/django/db/migrations/operations/fields.py
+++ b/django/db/migrations/operations/fields.py
@@ -141,7 +141,7 @@ class RemoveField(FieldOperation):
                 old_field = instance
         state.models[app_label, self.model_name_lower].fields = new_fields
         # Delay rendering of relationships if it's not a relational field
-        delay = not old_field.is_relation
+        delay = not old_field.is_relation if old_field else False
         state.reload_model(app_label, self.model_name_lower, delay=delay)
 
     def database_forwards(self, app_label, schema_editor, from_state, to_state):

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1137,7 +1137,7 @@ class OperationTests(OperationTestBase):
         self.assertEqual(definition[1], [])
         self.assertEqual(definition[2], {'model_name': "Pony", 'name': 'pink'})
 
-    def test_remove_field_without_old_field_invalid(self):
+    def test_remove_field_with_non_existent_field_invalid(self):
         """
         Tests the RemoveField with failed database operation as old_field does not exist..
         """


### PR DESCRIPTION
Added a check if old_field exist, otherwise delay is set to False