### PR TITLE
Refs #31136 -- Made QuerySet.values()/values_list() group only by selected annotation.

### DIFF
--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -1165,6 +1165,31 @@ class AggregateTestCase(TestCase):
             'Sams',
         ])
 
+    def test_aggregation_subquery_annotation_values(self):
+        """
+        Subquery annotations and external aliases are excluded from the GROUP
+        BY if they are not selected.
+        """
+        books_qs = Book.objects.annotate(
+            first_author_the_same_age=Subquery(
+                Author.objects.filter(
+                    age=OuterRef('contact__friends__age'),
+                ).order_by('age').values('id')[:1],
+            )
+        ).filter(
+            publisher=self.p1,
+            first_author_the_same_age__isnull=False,
+        ).annotate(
+            min_age=Min('contact__friends__age'),
+        ).values('name', 'min_age').order_by('name')
+        self.assertEqual(list(books_qs), [
+            {'name': 'Practical Django Projects', 'min_age': 34},
+            {
+                'name': 'The Definitive Guide to Django: Web Development Done Right',
+                'min_age': 29,
+            },
+        ])
+
     @skipUnlessDBFeature('supports_subqueries_in_group_by')
     def test_group_by_subquery_annotation(self):
         """


### PR DESCRIPTION
ticket-31136

Regression in 0f843fdd5b9b2f2307148465cd60f4e1b2befbb4.

IMO `QuerySet.values()/values_list()` should use only selected annotations in a `GROUP BY` clause.

Before 0f843fdd5b9b2f2307148465cd60f4e1b2befbb4 we had:
```sql
SELECT DISTINCT "aggregation_book"."name", MIN(T4."age") AS "min_age" 
...
GROUP BY
    "aggregation_book"."id", "aggregation_book"."isbn", "aggregation_book"."name",
    "aggregation_book"."pages", "aggregation_book"."rating", "aggregation_book"."price",
    "aggregation_book"."contact_id", "aggregation_book"."publisher_id",
    "aggregation_book"."pubdate", "first_author_the_same_age"
```
After 0f843fdd5b9b2f2307148465cd60f4e1b2befbb4 we have:
```sql
SELECT DISTINCT "aggregation_book"."name", MIN(T4."age") AS "min_age" 
...
GROUP BY
    "aggregation_book"."id", "aggregation_book"."isbn", "aggregation_book"."name",
    "aggregation_book"."pages", "aggregation_book"."rating", "aggregation_book"."price",
    "aggregation_book"."contact_id", "aggregation_book"."publisher_id",
    "aggregation_book"."pubdate",  T4."age"
```
with this patch we'll get:
```sql
SELECT DISTINCT "aggregation_book"."name", MIN(T4."age") AS "min_age" 
...
GROUP BY
    "aggregation_book"."id", "aggregation_book"."isbn", "aggregation_book"."name",
    "aggregation_book"."pages", "aggregation_book"."rating", "aggregation_book"."price",
    "aggregation_book"."contact_id", "aggregation_book"."publisher_id",
    "aggregation_book"."pubdate"
```