### PR TITLE
Refs #31097 -- Added release notes for 2f565f84aca136d9cc4e4d061f3196ddf9358ab8.

### DIFF
--- a/docs/releases/3.0.3.txt
+++ b/docs/releases/3.0.3.txt
@@ -26,3 +26,8 @@ Bugfixes
 
 * Fixed a system check to ensure the ``max_length`` attribute fits the longest
   choice, when a named group contains only non-string values (:ticket:`31155`).
+
+* Fixed a regression in Django 2.2 that caused a crash of
+  :class:`~django.contrib.postgres.aggregates.ArrayAgg` and
+  :class:`~django.contrib.postgres.aggregates.StringAgg` with ``filter``
+  argument when used in a ``Subquery`` (:ticket:`31097`).


### PR DESCRIPTION
I have 2f565f84aca136d9cc4e4d061f3196ddf9358ab8 backported locally but we need these too. 