### PR TITLE
Refs #29998 -- Corrected auto-created OneToOneField parent_link in MTI docs.

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1092,6 +1092,7 @@ The automatically-created :class:`~django.db.models.OneToOneField` on
     place_ptr = models.OneToOneField(
         Place, on_delete=models.CASCADE,
         parent_link=True,
+        primary_key=True,
     )
 
 You can override that field by declaring your own


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29998#comment:1