### PR TITLE
Use stdout for StreamHandler logging documetation instead of default stderr

### DIFF
--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -287,6 +287,7 @@ verbose as it includes all database queries:
         'handlers': {
             'console': {
                 'class': 'logging.StreamHandler',
+                'stream': 'ext://sys.stdout',
             },
         },
         'loggers': {
@@ -330,7 +331,7 @@ Finally, here's an example of a fairly complex logging setup:
                 'filters': ['require_debug_true'],
                 'class': 'logging.StreamHandler',
                 'formatter': 'simple',
-                'stream': 'ext://sys.stdout'
+                'stream': 'ext://sys.stdout',
             },
             'mail_admins': {
                 'level': 'ERROR',

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -390,7 +390,7 @@ This logging configuration does the following things:
 * Defines two handlers:
 
   * ``console``, a :class:`~logging.StreamHandler`, which prints any ``INFO``
-    (or higher) message to ``sys.stderr``. This handler uses the ``simple``
+    (or higher) message to ``sys.stdout``. This handler uses the ``simple``
     output format.
 
   * ``mail_admins``, an :class:`AdminEmailHandler`, which emails any ``ERROR``

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -329,7 +329,8 @@ Finally, here's an example of a fairly complex logging setup:
                 'level': 'INFO',
                 'filters': ['require_debug_true'],
                 'class': 'logging.StreamHandler',
-                'formatter': 'simple'
+                'formatter': 'simple',
+                'stream': 'ext://sys.stdout'
             },
             'mail_admins': {
                 'level': 'ERROR',


### PR DESCRIPTION
By default, if `stream` is not set in `StreamHandler`, everything goes to `sys.stderr` - which is not  ideal - specially for users who are trying to learn this for the first time.

Doc page: https://docs.djangoproject.com/en/3.0/topics/logging/#examples
Python StreamHandler: https://docs.python.org/3.7/library/logging.handlers.html#logging.StreamHandler