### PR TITLE
Fixed #31162 GIS error logging when using WKT string as input to filter() query

### DIFF
--- a/django/contrib/gis/gdal/raster/source.py
+++ b/django/contrib/gis/gdal/raster/source.py
@@ -73,6 +73,8 @@ class GDALRaster(GDALRasterBase):
 
         # If input is a valid file path, try setting file as source.
         if isinstance(ds_input, str):
+            if not os.path.exists(ds_input):
+                raise GDALException('Unable to read raster source input "{}"'.format(ds_input))
             try:
                 # GDALOpen will auto-detect the data source type.
                 self._ptr = capi.open_ds(force_bytes(ds_input), self._write)

--- a/django/contrib/gis/gdal/raster/source.py
+++ b/django/contrib/gis/gdal/raster/source.py
@@ -227,7 +227,7 @@ class GDALRaster(GDALRasterBase):
 
     @cached_property
     def is_vsi_based(self):
-        return self.name.startswith(VSI_FILESYSTEM_BASE_PATH)
+        return self._ptr and self.name.startswith(VSI_FILESYSTEM_BASE_PATH)
 
     @property
     def name(self):

--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -750,3 +750,7 @@ class GDALBandTests(SimpleTestCase):
                 numpy.testing.assert_equal(band.data(), numpy.array(combo[2]).reshape(3, 3))
             else:
                 self.assertEqual(band.data(), list(combo[2]))
+
+    def test_path_not_exists(self):
+        with self.assertRaises(GDALException, 'Unable to read raster source input /path/not/exist'):
+            p = GDALRaster('/path/not/exist')


### PR DESCRIPTION
Restored an ```os.path.exists``` check in __init__ and added an extra check to ```is_vsi_based()``` following @felixxm's suggestion. 