### PR TITLE
Fixed #31162 -- Prevented error logs when using WKT strings in lookups.

### DIFF
--- a/django/contrib/gis/gdal/raster/source.py
+++ b/django/contrib/gis/gdal/raster/source.py
@@ -73,6 +73,13 @@ class GDALRaster(GDALRasterBase):
 
         # If input is a valid file path, try setting file as source.
         if isinstance(ds_input, str):
+            if (
+                not ds_input.startswith(VSI_FILESYSTEM_BASE_PATH) and
+                not os.path.exists(ds_input)
+            ):
+                raise GDALException(
+                    'Unable to read raster source input "%s".' % ds_input
+                )
             try:
                 # GDALOpen will auto-detect the data source type.
                 self._ptr = capi.open_ds(force_bytes(ds_input), self._write)
@@ -225,7 +232,7 @@ class GDALRaster(GDALRasterBase):
 
     @cached_property
     def is_vsi_based(self):
-        return self.name.startswith(VSI_FILESYSTEM_BASE_PATH)
+        return self._ptr and self.name.startswith(VSI_FILESYSTEM_BASE_PATH)
 
     @property
     def name(self):

--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -156,6 +156,11 @@ class GDALRasterTests(SimpleTestCase):
         else:
             self.assertEqual(restored_raster.bands[0].data(), self.rs.bands[0].data())
 
+    def test_nonexistent_file(self):
+        msg = 'Unable to read raster source input "nonexistent.tif".'
+        with self.assertRaisesMessage(GDALException, msg):
+            GDALRaster('nonexistent.tif')
+
     def test_vsi_raster_creation(self):
         # Open a raster as a file object.
         with open(self.rs_path, 'rb') as dat:

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -430,6 +430,12 @@ class GeoLookupTest(TestCase):
             with self.subTest(lookup=lookup):
                 self.assertNotIn(null, State.objects.filter(**{'poly__%s' % lookup: geom}))
 
+    def test_wkt_string_in_lookup(self):
+        # Valid WKT strings don't emit error logs.
+        with self.assertRaisesMessage(AssertionError, 'no logs'):
+            with self.assertLogs('django.contrib.gis', 'ERROR'):
+                State.objects.filter(poly__intersects='LINESTRING(0 0, 1 1, 5 5)')
+
     @skipUnlessDBFeature("supports_relate_lookup")
     def test_relate_lookup(self):
         "Testing the 'relate' lookup type."


### PR DESCRIPTION
ticket-31162

Regression in 6f44f714c92d2966dca390ebd3054e5fb0bb0c80.