### PR TITLE
Cached ForeignObject.(local/foreign/reverse)_related_fields properties.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -616,21 +616,19 @@ class ForeignObject(RelatedField):
             related_fields.append((from_field, to_field))
         return related_fields
 
-    @property
+    @cached_property
     def related_fields(self):
-        if not hasattr(self, '_related_fields'):
-            self._related_fields = self.resolve_related_fields()
-        return self._related_fields
+        return self.resolve_related_fields()
 
-    @property
+    @cached_property
     def reverse_related_fields(self):
         return [(rhs_field, lhs_field) for lhs_field, rhs_field in self.related_fields]
 
-    @property
+    @cached_property
     def local_related_fields(self):
         return tuple(lhs_field for lhs_field, rhs_field in self.related_fields)
 
-    @property
+    @cached_property
     def foreign_related_fields(self):
         return tuple(rhs_field for lhs_field, rhs_field in self.related_fields if rhs_field)
 


### PR DESCRIPTION
I profiled a test run of a large application with py-spy and noticed `foreign_related_fields` was in the top 20 function calls by execution time. Looking at the code, `related_fields` is re-implementing the `@cached_property` pattern, and the derived properties can be sped up by caching them too.