### PR TITLE
Fixed #31177 -- Used "raise from" when wrapping exceptions, all over the codebase

### DIFF
--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -147,19 +147,19 @@ class AppConfig:
         # all error checking for entries in INSTALLED_APPS in one place.
         try:
             app_name = cls.name
-        except AttributeError:
+        except AttributeError as e:
             raise ImproperlyConfigured(
-                "'%s' must supply a name attribute." % entry)
+                "'%s' must supply a name attribute." % entry) from e
 
         # Ensure app_name points to a valid module.
         try:
             app_module = import_module(app_name)
-        except ImportError:
+        except ImportError as e:
             raise ImproperlyConfigured(
                 "Cannot import '%s'. Check that '%s.%s.name' is correct." % (
                     app_name, mod_path, cls_name,
                 )
-            )
+            ) from e
 
         # Entry is a path to an app config class.
         return cls(app_name, app_module)
@@ -176,9 +176,9 @@ class AppConfig:
             self.apps.check_apps_ready()
         try:
             return self.models[model_name.lower()]
-        except KeyError:
+        except KeyError as e:
             raise LookupError(
-                "App '%s' doesn't have a '%s' model." % (self.label, model_name))
+                "App '%s' doesn't have a '%s' model." % (self.label, model_name)) from e
 
     def get_models(self, include_auto_created=False, include_swapped=False):
         """

--- a/django/bin/django-admin.py
+++ b/django/bin/django-admin.py
@@ -6,12 +6,12 @@ from django.core import management
 
 try:
     from django.utils.deprecation import RemovedInDjango40Warning
-except ImportError:
+except ImportError as e:
     raise ImportError(
         'django-admin.py was deprecated in Django 3.1 and removed in Django '
         '4.0. Please manually remove this script from your virtual environment '
         'and use django-admin instead.'
-    )
+    ) from e
 
 if __name__ == "__main__":
     warnings.warn(

--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -138,7 +138,7 @@ class FieldListFilter(ListFilter):
         except (ValueError, ValidationError) as e:
             # Fields may raise a ValueError or ValidationError when converting
             # the parameters to the correct type.
-            raise IncorrectLookupParameters(e)
+            raise IncorrectLookupParameters(e) from e
 
     @classmethod
     def register(cls, test, list_filter_class, take_priority=False):

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -704,7 +704,7 @@ class ModelAdmin(BaseModelAdmin):
             raise FieldError(
                 '%s. Check fields/fieldsets/exclude attributes of class %s.'
                 % (e, self.__class__.__name__)
-            )
+            ) from e
 
     def get_changelist(self, request, **kwargs):
         """

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -240,8 +240,8 @@ class ChangeList:
         else:
             try:
                 result_list = paginator.page(self.page_num + 1).object_list
-            except InvalidPage:
-                raise IncorrectLookupParameters
+            except InvalidPage as e:
+                raise IncorrectLookupParameters from e
 
         self.result_count = result_count
         self.show_full_result_count = self.model_admin.show_full_result_count

--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -188,12 +188,12 @@ class ModelDetailView(BaseAdminDocsView):
         # Get the model class.
         try:
             app_config = apps.get_app_config(self.kwargs['app_label'])
-        except LookupError:
-            raise Http404(_("App %(app_label)r not found") % self.kwargs)
+        except LookupError as e:
+            raise Http404(_("App %(app_label)r not found") % self.kwargs) from e
         try:
             model = app_config.get_model(model_name)
-        except LookupError:
-            raise Http404(_("Model %(model_name)r not found in app %(app_label)r") % self.kwargs)
+        except LookupError as e:
+            raise Http404(_("Model %(model_name)r not found in app %(app_label)r") % self.kwargs) from e
 
         opts = model._meta
 

--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -155,12 +155,12 @@ def get_user_model():
     """
     try:
         return django_apps.get_model(settings.AUTH_USER_MODEL, require_ready=False)
-    except ValueError:
-        raise ImproperlyConfigured("AUTH_USER_MODEL must be of the form 'app_label.model_name'")
-    except LookupError:
+    except ValueError as value_error:
+        raise ImproperlyConfigured("AUTH_USER_MODEL must be of the form 'app_label.model_name'") from value_error
+    except LookupError as lookup_error:
         raise ImproperlyConfigured(
             "AUTH_USER_MODEL refers to model '%s' that has not been installed" % settings.AUTH_USER_MODEL
-        )
+        ) from lookup_error
 
 
 def get_user(request):

--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -124,11 +124,11 @@ class ModelBackend(BaseBackend):
         if isinstance(perm, str):
             try:
                 app_label, codename = perm.split('.')
-            except ValueError:
+            except ValueError as e:
                 raise ValueError(
                     'Permission name should be in the form '
                     'app_label.permission_codename.'
-                )
+                ) from e
         elif not isinstance(perm, Permission):
             raise TypeError(
                 'The `perm` argument must be a string or a permission instance.'

--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -119,10 +119,10 @@ def get_hasher(algorithm='default'):
         hashers = get_hashers_by_algorithm()
         try:
             return hashers[algorithm]
-        except KeyError:
+        except KeyError as e:
             raise ValueError("Unknown password hashing algorithm '%s'. "
                              "Did you specify it in the PASSWORD_HASHERS "
-                             "setting?" % algorithm)
+                             "setting?" % algorithm) from e
 
 
 def identify_hasher(encoded):
@@ -178,7 +178,7 @@ class BasePasswordHasher:
                 module = importlib.import_module(mod_path)
             except ImportError as e:
                 raise ValueError("Couldn't load %r algorithm library: %s" %
-                                 (self.__class__.__name__, e))
+                                 (self.__class__.__name__, e)) from e
             return module
         raise ValueError("Hasher %r doesn't specify a library attribute" %
                          self.__class__.__name__)

--- a/django/contrib/auth/management/commands/changepassword.py
+++ b/django/contrib/auth/management/commands/changepassword.py
@@ -41,8 +41,8 @@ class Command(BaseCommand):
             u = UserModel._default_manager.using(options['database']).get(**{
                 UserModel.USERNAME_FIELD: username
             })
-        except UserModel.DoesNotExist:
-            raise CommandError("user '%s' does not exist" % username)
+        except UserModel.DoesNotExist as e:
+            raise CommandError("user '%s' does not exist" % username) from e
 
         self.stdout.write("Changing password for user '%s'\n" % u)
 

--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -193,7 +193,7 @@ class Command(BaseCommand):
             self.stderr.write('\nOperation cancelled.')
             sys.exit(1)
         except exceptions.ValidationError as e:
-            raise CommandError('; '.join(e.messages))
+            raise CommandError('; '.join(e.messages)) from e
         except NotRunningInTTYException:
             self.stdout.write(
                 'Superuser creation skipped due to not running in a TTY. '

--- a/django/contrib/contenttypes/views.py
+++ b/django/contrib/contenttypes/views.py
@@ -19,19 +19,19 @@ def shortcut(request, content_type_id, object_id):
                 {'ct_id': content_type_id}
             )
         obj = content_type.get_object_for_this_type(pk=object_id)
-    except (ObjectDoesNotExist, ValueError):
+    except (ObjectDoesNotExist, ValueError) as e:
         raise Http404(
             _('Content type %(ct_id)s object %(obj_id)s doesn’t exist') %
             {'ct_id': content_type_id, 'obj_id': object_id}
-        )
+        ) from e
 
     try:
         get_absolute_url = obj.get_absolute_url
-    except AttributeError:
+    except AttributeError as e:
         raise Http404(
             _('%(ct_name)s objects don’t have a get_absolute_url() method') %
             {'ct_name': content_type.name}
-        )
+        ) from e
     absurl = get_absolute_url()
 
     # Try to figure out the object's domain, so we can do a cross-site redirect

--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -176,14 +176,14 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
 
             try:
                 vtup = self.postgis_version_tuple()
-            except ProgrammingError:
+            except ProgrammingError as e:
                 raise ImproperlyConfigured(
                     'Cannot determine PostGIS version for database "%s" '
                     'using command "SELECT postgis_lib_version()". '
                     'GeoDjango requires at least PostGIS version 2.2. '
                     'Was the database created from a spatial database '
                     'template?' % self.connection.settings_dict['NAME']
-                )
+                ) from e
             version = vtup[1:]
         return version
 

--- a/django/contrib/gis/db/backends/spatialite/base.py
+++ b/django/contrib/gis/db/backends/spatialite/base.py
@@ -40,21 +40,21 @@ class DatabaseWrapper(SQLiteDatabaseWrapper):
         # Enabling extension loading on the SQLite connection.
         try:
             conn.enable_load_extension(True)
-        except AttributeError:
+        except AttributeError as e:
             raise ImproperlyConfigured(
                 'SpatiaLite requires SQLite to be configured to allow '
                 'extension loading.'
-            )
+            ) from e
         # Load the SpatiaLite library extension on the connection.
         for path in self.lib_spatialite_paths:
             try:
                 conn.load_extension(path)
-            except Exception:
+            except Exception as e:
                 if getattr(settings, 'SPATIALITE_LIBRARY_PATH', None):
                     raise ImproperlyConfigured(
                         'Unable to load the SpatiaLite library extension '
                         'as specified in your SPATIALITE_LIBRARY_PATH setting.'
-                    )
+                    ) from e
                 continue
             else:
                 break

--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -162,8 +162,8 @@ class BaseSpatialField(Field):
         elif isinstance(value, dict):
             try:
                 return gdal.GDALRaster(value)
-            except GDALException:
-                raise ValueError("Couldn't create spatial object from lookup value '%s'." % value)
+            except GDALException as e:
+                raise ValueError("Couldn't create spatial object from lookup value '%s'." % value) from e
 
     def get_prep_value(self, value):
         obj = super().get_prep_value(value)
@@ -184,8 +184,8 @@ class BaseSpatialField(Field):
             elif is_candidate:
                 try:
                     obj = GEOSGeometry(obj)
-                except (GEOSException, GDALException):
-                    raise ValueError("Couldn't create spatial object from lookup value '%s'." % obj)
+                except (GEOSException, GDALException) as e:
+                    raise ValueError("Couldn't create spatial object from lookup value '%s'." % obj) from e
             else:
                 raise ValueError('Cannot use object with type %s for a spatial lookup parameter.' % type(obj).__name__)
 

--- a/django/contrib/gis/forms/fields.py
+++ b/django/contrib/gis/forms/fields.py
@@ -77,9 +77,9 @@ class GeometryField(forms.Field):
         if self.srid and self.srid != -1 and self.srid != geom.srid:
             try:
                 geom.transform(self.srid)
-            except GEOSException:
+            except GEOSException as e:
                 raise forms.ValidationError(
-                    self.error_messages['transform_error'], code='transform_error')
+                    self.error_messages['transform_error'], code='transform_error') from e
 
         return geom
 

--- a/django/contrib/gis/gdal/datasource.py
+++ b/django/contrib/gis/gdal/datasource.py
@@ -89,8 +89,8 @@ class DataSource(GDALBase):
         if isinstance(index, str):
             try:
                 layer = capi.get_layer_by_name(self.ptr, force_bytes(index))
-            except GDALException:
-                raise IndexError('Invalid OGR layer name given: %s.' % index)
+            except GDALException as e:
+                raise IndexError('Invalid OGR layer name given: %s.' % index) from e
         elif isinstance(index, int):
             if 0 <= index < self.layer_count:
                 layer = capi.get_layer(self._ptr, index)

--- a/django/contrib/gis/gdal/raster/band.py
+++ b/django/contrib/gis/gdal/raster/band.py
@@ -248,5 +248,5 @@ class BandList(list):
     def __getitem__(self, index):
         try:
             return GDALBand(self.source, index + 1)
-        except GDALException:
-            raise GDALException('Unable to get band index %d' % index)
+        except GDALException as e:
+            raise GDALException('Unable to get band index %d' % index) from e

--- a/django/contrib/gis/gdal/raster/source.py
+++ b/django/contrib/gis/gdal/raster/source.py
@@ -84,7 +84,7 @@ class GDALRaster(GDALRasterBase):
                 # GDALOpen will auto-detect the data source type.
                 self._ptr = capi.open_ds(force_bytes(ds_input), self._write)
             except GDALException as err:
-                raise GDALException('Could not open the datasource at "{}" ({}).'.format(ds_input, err))
+                raise GDALException('Could not open the datasource at "{}" ({}).'.format(ds_input, err)) from err
         elif isinstance(ds_input, bytes):
             # Create a new raster in write mode.
             self._write = 1

--- a/django/contrib/gis/geos/mutable_list.py
+++ b/django/contrib/gis/geos/mutable_list.py
@@ -243,8 +243,8 @@ class ListMixin:
         "Assign values to a slice of the object"
         try:
             valueList = list(values)
-        except TypeError:
-            raise TypeError('can only assign an iterable to a slice')
+        except TypeError as e:
+            raise TypeError('can only assign an iterable to a slice') from e
 
         self._check_allowed(valueList)
 

--- a/django/contrib/gis/geos/polygon.py
+++ b/django/contrib/gis/geos/polygon.py
@@ -106,8 +106,8 @@ class Polygon(GEOSGeometry):
         try:
             ring = LinearRing(param)
             return ring
-        except TypeError:
-            raise TypeError(msg)
+        except TypeError as e:
+            raise TypeError(msg) from e
 
     def _set_list(self, length, items):
         # Getting the current pointer, replacing with the newly constructed

--- a/django/contrib/gis/management/commands/ogrinspect.py
+++ b/django/contrib/gis/management/commands/ogrinspect.py
@@ -101,8 +101,8 @@ class Command(BaseCommand):
         # Getting the OGR DataSource from the string parameter.
         try:
             ds = gdal.DataSource(data_source)
-        except gdal.GDALException as msg:
-            raise CommandError(msg)
+        except gdal.GDALException as e:
+            raise CommandError(e) from e
 
         # Returning the output of ogrinspect with the given arguments
         # and options.

--- a/django/contrib/gis/sitemaps/views.py
+++ b/django/contrib/gis/sitemaps/views.py
@@ -16,16 +16,16 @@ def kml(request, label, model, field_name=None, compress=False, using=DEFAULT_DB
     placemarks = []
     try:
         klass = apps.get_model(label, model)
-    except LookupError:
-        raise Http404('You must supply a valid app label and module name.  Got "%s.%s"' % (label, model))
+    except LookupError as e:
+        raise Http404('You must supply a valid app label and module name.  Got "%s.%s"' % (label, model)) from e
 
     if field_name:
         try:
             field = klass._meta.get_field(field_name)
             if not isinstance(field, GeometryField):
                 raise FieldDoesNotExist
-        except FieldDoesNotExist:
-            raise Http404('Invalid geometry field.')
+        except FieldDoesNotExist as e:
+            raise Http404('Invalid geometry field.') from e
 
     connection = connections[using]
 

--- a/django/contrib/gis/views.py
+++ b/django/contrib/gis/views.py
@@ -10,8 +10,8 @@ def feed(request, url, feed_dict=None):
     slug = url.partition('/')[0]
     try:
         f = feed_dict[slug]
-    except KeyError:
-        raise Http404(_('Slug %r isn’t registered.') % slug)
+    except KeyError as e:
+        raise Http404(_('Slug %r isn’t registered.') % slug) from e
 
     instance = f()
     instance.feed_url = getattr(f, 'feed_url', None) or request.path

--- a/django/contrib/messages/api.py
+++ b/django/contrib/messages/api.py
@@ -19,17 +19,17 @@ def add_message(request, level, message, extra_tags='', fail_silently=False):
     """
     try:
         messages = request._messages
-    except AttributeError:
+    except AttributeError as e:
         if not hasattr(request, 'META'):
             raise TypeError(
                 "add_message() argument must be an HttpRequest object, not "
                 "'%s'." % request.__class__.__name__
-            )
+            ) from e
         if not fail_silently:
             raise MessageFailure(
                 'You cannot add messages without installing '
                 'django.contrib.messages.middleware.MessageMiddleware'
-            )
+            ) from e
     else:
         return messages.add(level, message, extra_tags)
 

--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -38,8 +38,8 @@ class ArrayField(CheckFieldDefaultMixin, Field):
     def model(self):
         try:
             return self.__dict__['model']
-        except KeyError:
-            raise AttributeError("'%s' object has no attribute 'model'" % self.__class__.__name__)
+        except KeyError as e:
+            raise AttributeError("'%s' object has no attribute 'model'" % self.__class__.__name__) from e
 
     @model.setter
     def model(self, model):
@@ -168,7 +168,7 @@ class ArrayField(CheckFieldDefaultMixin, Field):
                     prefix=self.error_messages['item_invalid'],
                     code='item_invalid',
                     params={'nth': index + 1},
-                )
+                ) from error
         if isinstance(self.base_field, ArrayField):
             if len({len(i) for i in value}) > 1:
                 raise exceptions.ValidationError(
@@ -187,7 +187,7 @@ class ArrayField(CheckFieldDefaultMixin, Field):
                     prefix=self.error_messages['item_invalid'],
                     code='item_invalid',
                     params={'nth': index + 1},
-                )
+                ) from error
 
     def formfield(self, **kwargs):
         return super().formfield(**{

--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -65,12 +65,12 @@ class JSONField(CheckFieldDefaultMixin, Field):
         options = {'cls': self.encoder} if self.encoder else {}
         try:
             json.dumps(value, **options)
-        except TypeError:
+        except TypeError as e:
             raise exceptions.ValidationError(
                 self.error_messages['invalid'],
                 code='invalid',
                 params={'value': value},
-            )
+            ) from e
 
     def value_to_string(self, obj):
         return self.value_from_object(obj)

--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -52,8 +52,8 @@ class RangeField(models.Field):
     def model(self):
         try:
             return self.__dict__['model']
-        except KeyError:
-            raise AttributeError("'%s' object has no attribute 'model'" % self.__class__.__name__)
+        except KeyError as e:
+            raise AttributeError("'%s' object has no attribute 'model'" % self.__class__.__name__) from e
 
     @model.setter
     def model(self, model):

--- a/django/contrib/postgres/forms/hstore.py
+++ b/django/contrib/postgres/forms/hstore.py
@@ -28,11 +28,11 @@ class HStoreField(forms.CharField):
         if not isinstance(value, dict):
             try:
                 value = json.loads(value)
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as e:
                 raise ValidationError(
                     self.error_messages['invalid_json'],
                     code='invalid_json',
-                )
+                ) from e
 
         if not isinstance(value, dict):
             raise ValidationError(

--- a/django/contrib/postgres/forms/jsonb.py
+++ b/django/contrib/postgres/forms/jsonb.py
@@ -29,12 +29,12 @@ class JSONField(forms.CharField):
             return value
         try:
             converted = json.loads(value)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
             raise forms.ValidationError(
                 self.error_messages['invalid'],
                 code='invalid',
                 params={'value': value},
-            )
+            ) from e
         if isinstance(converted, str):
             return JSONString(converted)
         else:

--- a/django/contrib/postgres/forms/ranges.py
+++ b/django/contrib/postgres/forms/ranges.py
@@ -69,11 +69,11 @@ class BaseRangeField(forms.MultiValueField):
             )
         try:
             range_value = self.range_type(lower, upper)
-        except TypeError:
+        except TypeError as e:
             raise exceptions.ValidationError(
                 self.error_messages['invalid'],
                 code='invalid',
-            )
+            ) from e
         else:
             return range_value
 

--- a/django/contrib/sessions/backends/db.py
+++ b/django/contrib/sessions/backends/db.py
@@ -85,13 +85,13 @@ class SessionStore(SessionBase):
         try:
             with transaction.atomic(using=using):
                 obj.save(force_insert=must_create, force_update=not must_create, using=using)
-        except IntegrityError:
+        except IntegrityError as e:
             if must_create:
-                raise CreateError
+                raise CreateError from e
             raise
-        except DatabaseError:
+        except DatabaseError as e:
             if not must_create:
-                raise UpdateError
+                raise UpdateError from e
             raise
 
     def delete(self, session_key=None):

--- a/django/contrib/sessions/backends/file.py
+++ b/django/contrib/sessions/backends/file.py
@@ -125,12 +125,12 @@ class SessionStore(SessionBase):
                 flags |= os.O_EXCL | os.O_CREAT
             fd = os.open(session_file_name, flags)
             os.close(fd)
-        except FileNotFoundError:
+        except FileNotFoundError as e:
             if not must_create:
-                raise UpdateError
-        except FileExistsError:
+                raise UpdateError from e
+        except FileExistsError as e:
             if must_create:
-                raise CreateError
+                raise CreateError from e
 
         # Write the session file without interfering with other threads
         # or processes.  By writing to an atomically generated temporary

--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -56,12 +56,12 @@ class SessionMiddleware(MiddlewareMixin):
                 if response.status_code != 500:
                     try:
                         request.session.save()
-                    except UpdateError:
+                    except UpdateError as e:
                         raise SuspiciousOperation(
                             "The request's session was deleted before the "
                             "request completed. The user may have logged "
                             "out in a concurrent request, for example."
-                        )
+                        ) from e
                     response.set_cookie(
                         settings.SESSION_COOKIE_NAME,
                         request.session.session_key, max_age=max_age,

--- a/django/contrib/sitemaps/views.py
+++ b/django/contrib/sitemaps/views.py
@@ -79,10 +79,10 @@ def sitemap(request, sitemaps, section=None,
                     lastmod = site_lastmod if lastmod is None else max(lastmod, site_lastmod)
                 else:
                     all_sites_lastmod = False
-        except EmptyPage:
-            raise Http404("Page %s empty" % page)
-        except PageNotAnInteger:
-            raise Http404("No page '%s'" % page)
+        except EmptyPage as e:
+            raise Http404("Page %s empty" % page) from e
+        except PageNotAnInteger as e:
+            raise Http404("No page '%s'" % page) from e
     response = TemplateResponse(request, template_name, {'urlset': urls},
                                 content_type=content_type)
     if all_sites_lastmod and lastmod is not None:

--- a/django/contrib/staticfiles/management/commands/collectstatic.py
+++ b/django/contrib/staticfiles/management/commands/collectstatic.py
@@ -314,16 +314,16 @@ class Command(BaseCommand):
                 if os.path.lexists(full_path):
                     os.unlink(full_path)
                 os.symlink(source_path, full_path)
-            except AttributeError:
+            except AttributeError as e:
                 import platform
                 raise CommandError("Symlinking is not supported by Python %s." %
-                                   platform.python_version())
-            except NotImplementedError:
+                                   platform.python_version()) from e
+            except NotImplementedError as e:
                 import platform
                 raise CommandError("Symlinking is not supported in this "
-                                   "platform (%s)." % platform.platform())
+                                   "platform (%s)." % platform.platform()) from e
             except OSError as e:
-                raise CommandError(e)
+                raise CommandError(e) from e
         if prefixed_path not in self.symlinked_files:
             self.symlinked_files.append(prefixed_path)
 

--- a/django/contrib/syndication/views.py
+++ b/django/contrib/syndication/views.py
@@ -35,8 +35,8 @@ class Feed:
     def __call__(self, request, *args, **kwargs):
         try:
             obj = self.get_object(request, *args, **kwargs)
-        except ObjectDoesNotExist:
-            raise Http404('Feed object does not exist.')
+        except ObjectDoesNotExist as e:
+            raise Http404('Feed object does not exist.') from e
         feedgen = self.get_feed(obj, request)
         response = HttpResponse(content_type=feedgen.content_type)
         if hasattr(self, 'item_pubdate') or hasattr(self, 'item_updateddate'):
@@ -57,11 +57,11 @@ class Feed:
     def item_link(self, item):
         try:
             return item.get_absolute_url()
-        except AttributeError:
+        except AttributeError as e:
             raise ImproperlyConfigured(
                 'Give your %s class a get_absolute_url() method, or define an '
                 'item_link() method in your Feed class.' % item.__class__.__name__
-            )
+            ) from e
 
     def item_enclosures(self, item):
         enc_url = self._get_dynamic_attr('item_enclosure_url', item)

--- a/django/core/cache/__init__.py
+++ b/django/core/cache/__init__.py
@@ -40,7 +40,7 @@ def _create_cache(backend, **kwargs):
                 import_string(backend)
             except ImportError as e:
                 raise InvalidCacheBackendError("Could not find backend '%s': %s" % (
-                    backend, e))
+                    backend, e)) from e
             location = kwargs.pop('LOCATION', '')
             params = kwargs
         else:
@@ -50,7 +50,7 @@ def _create_cache(backend, **kwargs):
         backend_cls = import_string(backend)
     except ImportError as e:
         raise InvalidCacheBackendError(
-            "Could not find backend '%s': %s" % (backend, e))
+            "Could not find backend '%s': %s" % (backend, e)) from e
     return backend_cls(location, params)
 
 

--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -246,8 +246,8 @@ class FileSystemStorage(Storage):
                     os.umask(old_umask)
             else:
                 os.makedirs(directory, exist_ok=True)
-        except FileExistsError:
-            raise FileExistsError('%s exists and is not a directory.' % directory)
+        except FileExistsError as e:
+            raise FileExistsError('%s exists and is not a directory.' % directory) from e
 
         # There's a potential race condition between get_available_name and
         # saving the file; it's possible that two threads might return the

--- a/django/core/mail/backends/filebased.py
+++ b/django/core/mail/backends/filebased.py
@@ -20,14 +20,14 @@ class EmailBackend(ConsoleEmailBackend):
         self.file_path = os.path.abspath(self.file_path)
         try:
             os.makedirs(self.file_path, exist_ok=True)
-        except FileExistsError:
+        except FileExistsError as e:
             raise ImproperlyConfigured(
                 'Path for saving email messages exists, but is not a directory: %s' % self.file_path
-            )
+            ) from e
         except OSError as err:
             raise ImproperlyConfigured(
                 'Could not create directory for saving email messages: %s (%s)' % (self.file_path, err)
-            )
+            ) from err
         # Make sure that self.file_path is writable.
         if not os.access(self.file_path, os.W_OK):
             raise ImproperlyConfigured('Could not write to directory: %s' % self.file_path)

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -80,8 +80,8 @@ def sanitize_address(addr, encoding):
         addr = force_str(addr)
         try:
             token, rest = parser.get_mailbox(addr)
-        except (HeaderParseError, ValueError, IndexError):
-            raise ValueError('Invalid address "%s"' % addr)
+        except (HeaderParseError, ValueError, IndexError) as e:
+            raise ValueError('Invalid address "%s"' % addr) from e
         else:
             if rest:
                 # The entire email address must be parsed.

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -101,8 +101,8 @@ def call_command(command_name, *args, **options):
         # Load the command object by name.
         try:
             app_name = get_commands()[command_name]
-        except KeyError:
-            raise CommandError("Unknown command: %r" % command_name)
+        except KeyError as e:
+            raise CommandError("Unknown command: %r" % command_name) from e
 
         if isinstance(app_name, BaseCommand):
             # If the command is already loaded, use it directly.

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -501,7 +501,7 @@ class AppCommand(BaseCommand):
         try:
             app_configs = [apps.get_app_config(app_label) for app_label in app_labels]
         except (LookupError, ImportError) as e:
-            raise CommandError("%s. Are you sure your INSTALLED_APPS setting is correct?" % e)
+            raise CommandError("%s. Are you sure your INSTALLED_APPS setting is correct?" % e) from e
         output = []
         for app_config in app_configs:
             app_output = self.handle_app_config(app_config, **options)

--- a/django/core/management/commands/createcachetable.py
+++ b/django/core/management/commands/createcachetable.py
@@ -100,7 +100,7 @@ class Command(BaseCommand):
                 except DatabaseError as e:
                     raise CommandError(
                         "Cache table '%s' could not be created.\nThe error was: %s." %
-                        (tablename, e))
+                        (tablename, e)) from e
                 for statement in index_output:
                     curs.execute(statement)
 

--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -100,13 +100,13 @@ class Command(BaseCommand):
                     try:
                         app_config = apps.get_app_config(app_label)
                     except LookupError as e:
-                        raise CommandError(str(e))
+                        raise CommandError(str(e)) from e
                     if app_config.models_module is None or app_config in excluded_apps:
                         continue
                     try:
                         model = app_config.get_model(model_label)
-                    except LookupError:
-                        raise CommandError("Unknown model: %s.%s" % (app_label, model_label))
+                    except LookupError as e:
+                        raise CommandError("Unknown model: %s.%s" % (app_label, model_label)) from e
 
                     app_list_value = app_list.setdefault(app_config, [])
 
@@ -116,15 +116,15 @@ class Command(BaseCommand):
                     if app_list_value is not None:
                         if model not in app_list_value:
                             app_list_value.append(model)
-                except ValueError:
+                except ValueError as value_error:
                     if primary_keys:
-                        raise CommandError("You can only use --pks option with one model")
+                        raise CommandError("You can only use --pks option with one model") from value_error
                     # This is just an app - no model qualifier
                     app_label = label
                     try:
                         app_config = apps.get_app_config(app_label)
-                    except LookupError as e:
-                        raise CommandError(str(e))
+                    except LookupError as lookup_error:
+                        raise CommandError(str(lookup_error)) from lookup_error
                     if app_config.models_module is None or app_config in excluded_apps:
                         continue
                     app_list[app_config] = None
@@ -190,4 +190,4 @@ class Command(BaseCommand):
         except Exception as e:
             if show_traceback:
                 raise
-            raise CommandError("Unable to serialize database: %s" % e)
+            raise CommandError("Unable to serialize database: %s" % e) from e

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -32,8 +32,9 @@ class Command(BaseCommand):
         try:
             for line in self.handle_inspection(options):
                 self.stdout.write("%s\n" % line)
-        except NotImplementedError:
-            raise CommandError("Database inspection isn't supported for the currently selected database backend.")
+        except NotImplementedError as e:
+            raise CommandError("Database inspection isn't supported for the "
+                               "currently selected database backend.") from e
 
     def handle_inspection(self, options):
         connection = connections[options['database']]

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -111,7 +111,7 @@ class Command(BaseCommand):
             try:
                 apps.get_app_config(app_label)
             except LookupError as err:
-                raise CommandError(str(err))
+                raise CommandError(str(err)) from err
             if run_syncdb:
                 if app_label in executor.loader.migrated_apps:
                     raise CommandError("Can't use run_syncdb with app '%s' as it has migrations." % app_label)
@@ -125,15 +125,15 @@ class Command(BaseCommand):
             else:
                 try:
                     migration = executor.loader.get_migration_by_prefix(app_label, migration_name)
-                except AmbiguityError:
+                except AmbiguityError as e:
                     raise CommandError(
                         "More than one migration matches '%s' in app '%s'. "
                         "Please be more specific." %
                         (migration_name, app_label)
-                    )
-                except KeyError:
+                    ) from e
+                except KeyError as e:
                     raise CommandError("Cannot find a migration matching '%s' from app '%s'." % (
-                        migration_name, app_label))
+                        migration_name, app_label)) from e
                 targets = [(app_label, migration.name)]
             target_app_labels_only = False
         elif options['app_label']:

--- a/django/core/management/commands/sqlmigrate.py
+++ b/django/core/management/commands/sqlmigrate.py
@@ -42,17 +42,17 @@ class Command(BaseCommand):
         try:
             apps.get_app_config(app_label)
         except LookupError as err:
-            raise CommandError(str(err))
+            raise CommandError(str(err)) from err
         if app_label not in executor.loader.migrated_apps:
             raise CommandError("App '%s' does not have migrations" % app_label)
         try:
             migration = executor.loader.get_migration_by_prefix(app_label, migration_name)
-        except AmbiguityError:
+        except AmbiguityError as e:
             raise CommandError("More than one migration matches '%s' in app '%s'. Please be more specific." % (
-                migration_name, app_label))
-        except KeyError:
+                migration_name, app_label)) from e
+        except KeyError as e:
             raise CommandError("Cannot find a migration matching '%s' from app '%s'. Is it in INSTALLED_APPS?" % (
-                migration_name, app_label))
+                migration_name, app_label)) from e
         targets = [(app_label, migration.name)]
 
         # Show begin/end around output for atomic migrations, if the database

--- a/django/core/management/commands/squashmigrations.py
+++ b/django/core/management/commands/squashmigrations.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
         try:
             apps.get_app_config(app_label)
         except LookupError as err:
-            raise CommandError(str(err))
+            raise CommandError(str(err)) from err
         # Load the current graph state, check the app and migration they asked for exists
         loader = MigrationLoader(connections[DEFAULT_DB_ALIAS])
         if app_label not in loader.migrated_apps:
@@ -80,14 +80,14 @@ class Command(BaseCommand):
             try:
                 start_index = migrations_to_squash.index(start)
                 migrations_to_squash = migrations_to_squash[start_index:]
-            except ValueError:
+            except ValueError as e:
                 raise CommandError(
                     "The migration '%s' cannot be found. Maybe it comes after "
                     "the migration '%s'?\n"
                     "Have a look at:\n"
                     "  python manage.py showmigrations %s\n"
                     "to debug this issue." % (start_migration, migration, app_label)
-                )
+                ) from e
 
         # Tell them what we're doing and optionally ask if we should proceed
         if self.verbosity > 0 or self.interactive:
@@ -202,13 +202,13 @@ class Command(BaseCommand):
     def find_migration(self, loader, app_label, name):
         try:
             return loader.get_migration_by_prefix(app_label, name)
-        except AmbiguityError:
+        except AmbiguityError as e:
             raise CommandError(
                 "More than one migration matches '%s' in app '%s'. Please be "
                 "more specific." % (name, app_label)
-            )
-        except KeyError:
+            ) from e
+        except KeyError as e:
             raise CommandError(
                 "Cannot find a migration matching '%s' from app '%s'." %
                 (name, app_label)
-            )
+            ) from e

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -68,10 +68,10 @@ class TemplateCommand(BaseCommand):
             top_dir = os.path.join(os.getcwd(), name)
             try:
                 os.makedirs(top_dir)
-            except FileExistsError:
-                raise CommandError("'%s' already exists" % top_dir)
+            except FileExistsError as e:
+                raise CommandError("'%s' already exists" % top_dir) from e
             except OSError as e:
-                raise CommandError(e)
+                raise CommandError(e) from e
         else:
             if app_or_project == 'app':
                 self.validate_name(os.path.basename(target), 'directory')
@@ -264,7 +264,7 @@ class TemplateCommand(BaseCommand):
             the_path, info = urlretrieve(url, os.path.join(tempdir, filename))
         except OSError as e:
             raise CommandError("couldn't download URL %s to %s: %s" %
-                               (url, filename, e))
+                               (url, filename, e)) from e
 
         used_name = the_path.split('/')[-1]
 
@@ -319,7 +319,7 @@ class TemplateCommand(BaseCommand):
             return tempdir
         except (archive.ArchiveException, OSError) as e:
             raise CommandError("couldn't extract file %s to %s: %s" %
-                               (filename, tempdir, e))
+                               (filename, tempdir, e)) from e
 
     def is_url(self, template):
         """Return True if the name looks like a URL."""

--- a/django/core/management/utils.py
+++ b/django/core/management/utils.py
@@ -96,14 +96,14 @@ def parse_apps_and_model_labels(labels):
         if '.' in label:
             try:
                 model = installed_apps.get_model(label)
-            except LookupError:
-                raise CommandError('Unknown model: %s' % label)
+            except LookupError as e:
+                raise CommandError('Unknown model: %s' % label) from e
             models.add(model)
         else:
             try:
                 app_config = installed_apps.get_app_config(label)
             except LookupError as e:
-                raise CommandError(str(e))
+                raise CommandError(str(e)) from e
             apps.add(app_config)
 
     return models, apps

--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -44,8 +44,8 @@ class Paginator:
             if isinstance(number, float) and not number.is_integer():
                 raise ValueError
             number = int(number)
-        except (TypeError, ValueError):
-            raise PageNotAnInteger(_('That page number is not an integer'))
+        except (TypeError, ValueError) as e:
+            raise PageNotAnInteger(_('That page number is not an integer')) from e
         if number < 1:
             raise EmptyPage(_('That page number is less than 1'))
         if number > self.num_pages:

--- a/django/core/serializers/base.py
+++ b/django/core/serializers/base.py
@@ -238,13 +238,13 @@ class DeserializedObject:
                 try:
                     values = deserialize_m2m_values(field, field_value, using, handle_forward_references=False)
                 except M2MDeserializationError as e:
-                    raise DeserializationError.WithData(e.original_exc, label, self.object.pk, e.pk)
+                    raise DeserializationError.WithData(e.original_exc, label, self.object.pk, e.pk) from e
                 self.m2m_data[field.name] = values
             elif isinstance(field.remote_field, models.ManyToOneRel):
                 try:
                     value = deserialize_fk_value(field, field_value, using, handle_forward_references=False)
                 except Exception as e:
-                    raise DeserializationError.WithData(e, label, self.object.pk, field_value)
+                    raise DeserializationError.WithData(e, label, self.object.pk, field_value) from e
                 setattr(self.object, field.attname, value)
         self.save()
 
@@ -285,7 +285,7 @@ def deserialize_m2m_values(field, field_value, using, handle_forward_references)
     try:
         pks_iter = iter(field_value)
     except TypeError as e:
-        raise M2MDeserializationError(e, field_value)
+        raise M2MDeserializationError(e, field_value) from e
     try:
         values = []
         for pk in pks_iter:

--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -99,7 +99,7 @@ def Deserializer(object_list, *, using=DEFAULT_DB_ALIAS, ignorenonexistent=False
             try:
                 data[Model._meta.pk.attname] = Model._meta.pk.to_python(d.get('pk'))
             except Exception as e:
-                raise base.DeserializationError.WithData(e, d['model'], d.get('pk'), None)
+                raise base.DeserializationError.WithData(e, d['model'], d.get('pk'), None) from e
         m2m_data = {}
         deferred_fields = {}
 
@@ -121,7 +121,7 @@ def Deserializer(object_list, *, using=DEFAULT_DB_ALIAS, ignorenonexistent=False
                 try:
                     values = base.deserialize_m2m_values(field, field_value, using, handle_forward_references)
                 except base.M2MDeserializationError as e:
-                    raise base.DeserializationError.WithData(e.original_exc, d['model'], d.get('pk'), e.pk)
+                    raise base.DeserializationError.WithData(e.original_exc, d['model'], d.get('pk'), e.pk) from e
                 if values == base.DEFER_FIELD:
                     deferred_fields[field] = field_value
                 else:
@@ -131,7 +131,7 @@ def Deserializer(object_list, *, using=DEFAULT_DB_ALIAS, ignorenonexistent=False
                 try:
                     value = base.deserialize_fk_value(field, field_value, using, handle_forward_references)
                 except Exception as e:
-                    raise base.DeserializationError.WithData(e, d['model'], d.get('pk'), field_value)
+                    raise base.DeserializationError.WithData(e, d['model'], d.get('pk'), field_value) from e
                 if value == base.DEFER_FIELD:
                     deferred_fields[field] = field_value
                 else:
@@ -141,7 +141,7 @@ def Deserializer(object_list, *, using=DEFAULT_DB_ALIAS, ignorenonexistent=False
                 try:
                     data[field.name] = field.to_python(field_value)
                 except Exception as e:
-                    raise base.DeserializationError.WithData(e, d['model'], d.get('pk'), field_value)
+                    raise base.DeserializationError.WithData(e, d['model'], d.get('pk'), field_value) from e
 
         obj = base.build_instance(Model, data, using)
         yield base.DeserializedObject(obj, m2m_data, deferred_fields)
@@ -151,5 +151,5 @@ def _get_model(model_identifier):
     """Look up a model from an "app_label.model_name" string."""
     try:
         return apps.get_model(model_identifier)
-    except (LookupError, TypeError):
-        raise base.DeserializationError("Invalid model identifier: '%s'" % model_identifier)
+    except (LookupError, TypeError) as e:
+        raise base.DeserializationError("Invalid model identifier: '%s'" % model_identifier) from e

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -77,9 +77,9 @@ class Serializer(base.Serializer):
         if getattr(obj, field.name) is not None:
             try:
                 self.xml.characters(field.value_to_string(obj))
-            except UnserializableContentError:
+            except UnserializableContentError as e:
                 raise ValueError("%s.%s (pk:%s) contains unserializable characters" % (
-                    obj.__class__.__name__, field.name, obj.pk))
+                    obj.__class__.__name__, field.name, obj.pk)) from e
         else:
             self.xml.addQuickElement("None")
 
@@ -314,10 +314,10 @@ class Deserializer(base.Deserializer):
                 % (node.nodeName, attr))
         try:
             return apps.get_model(model_identifier)
-        except (LookupError, TypeError):
+        except (LookupError, TypeError) as e:
             raise base.DeserializationError(
                 "<%s> node has invalid model identifier: '%s'"
-                % (node.nodeName, model_identifier))
+                % (node.nodeName, model_identifier)) from e
 
 
 def getInnerText(node):

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -110,8 +110,8 @@ class URLValidator(RegexValidator):
             if value:
                 try:
                     scheme, netloc, path, query, fragment = urlsplit(value)
-                except ValueError:  # for example, "Invalid IPv6 URL"
-                    raise ValidationError(self.message, code=self.code)
+                except ValueError as e:  # for example, "Invalid IPv6 URL"
+                    raise ValidationError(self.message, code=self.code) from e
                 try:
                     netloc = punycode(netloc)  # IDN -> ACE
                 except UnicodeError:  # invalid domain part
@@ -127,8 +127,8 @@ class URLValidator(RegexValidator):
                 potential_ip = host_match.groups()[0]
                 try:
                     validate_ipv6_address(potential_ip)
-                except ValidationError:
-                    raise ValidationError(self.message, code=self.code)
+                except ValidationError as e:
+                    raise ValidationError(self.message, code=self.code) from e
 
         # The maximum length of a full host name is 253 characters per RFC 1034
         # section 3.1. It's defined to be 255 bytes or less, but this includes
@@ -240,8 +240,8 @@ validate_unicode_slug = RegexValidator(
 def validate_ipv4_address(value):
     try:
         ipaddress.IPv4Address(value)
-    except ValueError:
-        raise ValidationError(_('Enter a valid IPv4 address.'), code='invalid')
+    except ValueError as e:
+        raise ValidationError(_('Enter a valid IPv4 address.'), code='invalid') from e
 
 
 def validate_ipv6_address(value):
@@ -255,8 +255,8 @@ def validate_ipv46_address(value):
     except ValidationError:
         try:
             validate_ipv6_address(value)
-        except ValidationError:
-            raise ValidationError(_('Enter a valid IPv4 or IPv6 address.'), code='invalid')
+        except ValidationError as e:
+            raise ValidationError(_('Enter a valid IPv4 or IPv6 address.'), code='invalid') from e
 
 
 ip_address_validator_map = {
@@ -276,9 +276,9 @@ def ip_address_validators(protocol, unpack_ipv4):
             "You can only use `unpack_ipv4` if `protocol` is set to 'both'")
     try:
         return ip_address_validator_map[protocol.lower()]
-    except KeyError:
+    except KeyError as e:
         raise ValueError("The protocol '%s' is unknown. Supported: %s"
-                         % (protocol, list(ip_address_validator_map)))
+                         % (protocol, list(ip_address_validator_map))) from e
 
 
 def int_list_validator(sep=',', message=None, code='invalid', allow_negative=False):

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -27,7 +27,7 @@ def _setup_environment(environ):
         except ImportError as e:
             raise ImproperlyConfigured("Error loading ctypes: %s; "
                                        "the Oracle backend requires ctypes to "
-                                       "operate correctly under Cygwin." % e)
+                                       "operate correctly under Cygwin." % e) from e
         kernel32 = ctypes.CDLL('kernel32')
         for name, value in environ:
             kernel32.SetEnvironmentVariableA(name, value)
@@ -47,7 +47,7 @@ _setup_environment([
 try:
     import cx_Oracle as Database
 except ImportError as e:
-    raise ImproperlyConfigured("Error loading cx_Oracle module: %s" % e)
+    raise ImproperlyConfigured("Error loading cx_Oracle module: %s" % e) from e
 
 # Some of these import cx_Oracle, so import them after checking if it's installed.
 from .client import DatabaseClient                          # NOQA isort:skip
@@ -74,7 +74,7 @@ def wrap_oracle_errors():
         # Convert that case to Django's IntegrityError exception.
         x = e.args[0]
         if hasattr(x, 'code') and hasattr(x, 'message') and x.code == 2091 and 'ORA-02291' in x.message:
-            raise utils.IntegrityError(*tuple(e.args))
+            raise utils.IntegrityError(*tuple(e.args)) from e
         raise
 
 

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -26,7 +26,7 @@ try:
     import psycopg2.extensions
     import psycopg2.extras
 except ImportError as e:
-    raise ImproperlyConfigured("Error loading psycopg2 module: %s" % e)
+    raise ImproperlyConfigured("Error loading psycopg2 module: %s" % e) from e
 
 
 def psycopg2_version():

--- a/django/db/migrations/recorder.py
+++ b/django/db/migrations/recorder.py
@@ -66,7 +66,7 @@ class MigrationRecorder:
             with self.connection.schema_editor() as editor:
                 editor.create_model(self.Migration)
         except DatabaseError as exc:
-            raise MigrationSchemaMissing("Unable to create the django_migrations table (%s)" % exc)
+            raise MigrationSchemaMissing("Unable to create the django_migrations table (%s)" % exc) from exc
 
     def applied_migrations(self):
         """

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -416,7 +416,7 @@ class ModelState:
                     name,
                     model._meta.label,
                     e,
-                ))
+                )) from e
         if not exclude_rels:
             for field in model._meta.local_many_to_many:
                 name = field.name
@@ -427,7 +427,7 @@ class ModelState:
                         name,
                         model._meta.object_name,
                         e,
-                    ))
+                    )) from e
         # Extract the options
         options = {}
         for name in DEFAULT_NAMES:
@@ -565,8 +565,8 @@ class ModelState:
                 (apps.get_model(base) if isinstance(base, str) else base)
                 for base in self.bases
             )
-        except LookupError:
-            raise InvalidBasesError("Cannot resolve one or more bases from %r" % (self.bases,))
+        except LookupError as e:
+            raise InvalidBasesError("Cannot resolve one or more bases from %r" % (self.bases,)) from e
         # Turn fields into a dict for the body, add other bits
         body = {name: field.clone() for name, field in self.fields}
         body['Meta'] = meta

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -962,8 +962,8 @@ class Model(metaclass=ModelBase):
         )
         try:
             return qs[0]
-        except IndexError:
-            raise self.DoesNotExist("%s matching query does not exist." % self.__class__._meta.object_name)
+        except IndexError as e:
+            raise self.DoesNotExist("%s matching query does not exist." % self.__class__._meta.object_name) from e
 
     def _get_next_or_previous_in_order(self, is_next):
         cachename = "__%s_order_cache" % is_next

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1174,12 +1174,12 @@ class DateField(DateTimeCheckMixin, Field):
             parsed = parse_date(value)
             if parsed is not None:
                 return parsed
-        except ValueError:
+        except ValueError as e:
             raise exceptions.ValidationError(
                 self.error_messages['invalid_date'],
                 code='invalid_date',
                 params={'value': value},
-            )
+            ) from e
 
         raise exceptions.ValidationError(
             self.error_messages['invalid'],
@@ -1313,23 +1313,23 @@ class DateTimeField(DateField):
             parsed = parse_datetime(value)
             if parsed is not None:
                 return parsed
-        except ValueError:
+        except ValueError as e:
             raise exceptions.ValidationError(
                 self.error_messages['invalid_datetime'],
                 code='invalid_datetime',
                 params={'value': value},
-            )
+            ) from e
 
         try:
             parsed = parse_date(value)
             if parsed is not None:
                 return datetime.datetime(parsed.year, parsed.month, parsed.day)
-        except ValueError:
+        except ValueError as e:
             raise exceptions.ValidationError(
                 self.error_messages['invalid_date'],
                 code='invalid_date',
                 params={'value': value},
-            )
+            ) from e
 
         raise exceptions.ValidationError(
             self.error_messages['invalid'],
@@ -1496,12 +1496,12 @@ class DecimalField(Field):
             return self.context.create_decimal_from_float(value)
         try:
             return decimal.Decimal(value)
-        except decimal.InvalidOperation:
+        except decimal.InvalidOperation as e:
             raise exceptions.ValidationError(
                 self.error_messages['invalid'],
                 code='invalid',
                 params={'value': value},
-            )
+            ) from e
 
     def get_db_prep_save(self, value, connection):
         return connection.ops.adapt_decimalfield_value(self.to_python(value), self.max_digits, self.decimal_places)
@@ -1693,12 +1693,12 @@ class FloatField(Field):
             return value
         try:
             return float(value)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as e:
             raise exceptions.ValidationError(
                 self.error_messages['invalid'],
                 code='invalid',
                 params={'value': value},
-            )
+            ) from e
 
     def formfield(self, **kwargs):
         return super().formfield(**{
@@ -1780,12 +1780,12 @@ class IntegerField(Field):
             return value
         try:
             return int(value)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as e:
             raise exceptions.ValidationError(
                 self.error_messages['invalid'],
                 code='invalid',
                 params={'value': value},
-            )
+            ) from e
 
     def formfield(self, **kwargs):
         return super().formfield(**{
@@ -2154,12 +2154,12 @@ class TimeField(DateTimeCheckMixin, Field):
             parsed = parse_time(value)
             if parsed is not None:
                 return parsed
-        except ValueError:
+        except ValueError as e:
             raise exceptions.ValidationError(
                 self.error_messages['invalid_time'],
                 code='invalid_time',
                 params={'value': value},
-            )
+            ) from e
 
         raise exceptions.ValidationError(
             self.error_messages['invalid'],
@@ -2321,12 +2321,12 @@ class UUIDField(Field):
             input_form = 'int' if isinstance(value, int) else 'hex'
             try:
                 return uuid.UUID(**{input_form: value})
-            except (AttributeError, ValueError):
+            except (AttributeError, ValueError) as e:
                 raise exceptions.ValidationError(
                     self.error_messages['invalid'],
                     code='invalid',
                     params={'value': value},
-                )
+                ) from e
         return value
 
     def formfield(self, **kwargs):

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -229,8 +229,8 @@ class Options:
                     f for f in self._get_fields(reverse=False)
                     if f.name == query or f.attname == query
                 )
-            except StopIteration:
-                raise FieldDoesNotExist("%s has no field named '%s'" % (self.object_name, query))
+            except StopIteration as e:
+                raise FieldDoesNotExist("%s has no field named '%s'" % (self.object_name, query)) from e
 
             self.ordering = ('_order',)
             if not any(isinstance(field, OrderWrt) for field in model._meta.local_fields):
@@ -394,13 +394,13 @@ class Options:
         if base_manager_name:
             try:
                 return self.managers_map[base_manager_name]
-            except KeyError:
+            except KeyError as e:
                 raise ValueError(
                     "%s has no manager named %r" % (
                         self.object_name,
                         base_manager_name,
                     )
-                )
+                ) from e
 
         manager = Manager()
         manager.name = '_base_manager'
@@ -421,13 +421,13 @@ class Options:
         if default_manager_name:
             try:
                 return self.managers_map[default_manager_name]
-            except KeyError:
+            except KeyError as e:
                 raise ValueError(
                     "%s has no manager named %r" % (
                         self.object_name,
                         default_manager_name,
                     )
-                )
+                ) from e
 
         if self.managers:
             return self.managers[0]
@@ -575,8 +575,8 @@ class Options:
             # Retrieve field instance by name from cached or just-computed
             # field map.
             return self.fields_map[field_name]
-        except KeyError:
-            raise FieldDoesNotExist("%s has no field named '%s'" % (self.object_name, field_name))
+        except KeyError as e:
+            raise FieldDoesNotExist("%s has no field named '%s'" % (self.object_name, field_name)) from e
 
     def get_base_chain(self, model):
         """

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -384,8 +384,8 @@ class QuerySet:
             # attribute.
             try:
                 arg.default_alias
-            except (AttributeError, TypeError):
-                raise TypeError("Complex aggregates require an alias")
+            except (AttributeError, TypeError) as e:
+                raise TypeError("Complex aggregates require an alias") from e
             kwargs[arg.default_alias] = arg
 
         query = self.query.chain()
@@ -1072,8 +1072,8 @@ class QuerySet:
                     raise ValueError("The named annotation '%s' conflicts with the "
                                      "default name for another annotation."
                                      % arg.default_alias)
-            except TypeError:
-                raise TypeError("Complex annotations require an alias")
+            except TypeError as e:
+                raise TypeError("Complex annotations require an alias") from e
             annotations[arg.default_alias] = arg
         annotations.update(kwargs)
 

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1868,9 +1868,9 @@ class Query(BaseExpression):
                     cols.append(join_info.transform_function(target, final_alias))
             if cols:
                 self.set_select(cols)
-        except MultiJoin:
-            raise FieldError("Invalid field name: '%s'" % name)
-        except FieldError:
+        except MultiJoin as e:
+            raise FieldError("Invalid field name: '%s'" % name) from e
+        except FieldError as e:
             if LOOKUP_SEP in name:
                 # For lookups spanning over relationships, show the error
                 # from the model on which the lookup failed.
@@ -1881,7 +1881,7 @@ class Query(BaseExpression):
                     *self.annotation_select, *self._filtered_relations
                 ])
                 raise FieldError("Cannot resolve keyword %r into field. "
-                                 "Choices are: %s" % (name, ", ".join(names)))
+                                 "Choices are: %s" % (name, ", ".join(names))) from e
 
     def add_ordering(self, *ordering):
         """

--- a/django/db/models/utils.py
+++ b/django/db/models/utils.py
@@ -14,11 +14,11 @@ def make_model_tuple(model):
             model_tuple = model._meta.app_label, model._meta.model_name
         assert len(model_tuple) == 2
         return model_tuple
-    except (ValueError, AssertionError):
+    except (ValueError, AssertionError) as e:
         raise ValueError(
             "Invalid model reference '%s'. String model references "
             "must be of the form 'app_label.ModelName'." % model
-        )
+        ) from e
 
 
 def resolve_callables(mapping):

--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -170,8 +170,8 @@ class ConnectionHandler:
         """
         try:
             conn = self.databases[alias]
-        except KeyError:
-            raise ConnectionDoesNotExist("The connection %s doesn't exist" % alias)
+        except KeyError as e:
+            raise ConnectionDoesNotExist("The connection %s doesn't exist" % alias) from e
 
         conn.setdefault('ATOMIC_REQUESTS', False)
         conn.setdefault('AUTOCOMMIT', True)
@@ -190,8 +190,8 @@ class ConnectionHandler:
         """
         try:
             conn = self.databases[alias]
-        except KeyError:
-            raise ConnectionDoesNotExist("The connection %s doesn't exist" % alias)
+        except KeyError as e:
+            raise ConnectionDoesNotExist("The connection %s doesn't exist" % alias) from e
 
         test_settings = conn.setdefault('TEST', {})
         default_test_settings = [

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -153,14 +153,14 @@ class BaseForm:
         """Return a BoundField with the given name."""
         try:
             field = self.fields[name]
-        except KeyError:
+        except KeyError as e:
             raise KeyError(
                 "Key '%s' not found in '%s'. Choices are: %s." % (
                     name,
                     self.__class__.__name__,
                     ', '.join(sorted(self.fields)),
                 )
-            )
+            ) from e
         if name not in self._bound_fields_cache:
             self._bound_fields_cache[name] = field.get_bound_field(self, name)
         return self._bound_fields_cache[name]

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -69,8 +69,9 @@ class MultiPartParser:
         # Parse the header to get the boundary to split the parts.
         try:
             ctypes, opts = parse_header(content_type.encode('ascii'))
-        except UnicodeEncodeError:
-            raise MultiPartParserError('Invalid non-ASCII Content-Type in multipart: %s' % force_str(content_type))
+        except UnicodeEncodeError as e:
+            raise MultiPartParserError('Invalid non-ASCII Content-Type in multipart: %s' %
+                                       force_str(content_type)) from e
         boundary = opts.get('boundary')
         if not boundary or not cgi.valid_boundary(boundary):
             raise MultiPartParserError('Invalid boundary in multipart: %s' % force_str(boundary))
@@ -437,8 +438,8 @@ class ChunkIter:
     def __next__(self):
         try:
             data = self.flo.read(self.chunk_size)
-        except InputStreamExhausted:
-            raise StopIteration()
+        except InputStreamExhausted as e:
+            raise StopIteration() from e
         if data:
             return data
         else:
@@ -462,8 +463,8 @@ class InterBoundaryIter:
     def __next__(self):
         try:
             return LazyStream(BoundaryIter(self._stream, self._boundary))
-        except InputStreamExhausted:
-            raise StopIteration()
+        except InputStreamExhausted as e:
+            raise StopIteration() from e
 
 
 class BoundaryIter:
@@ -589,8 +590,8 @@ def parse_boundary_stream(stream, max_header_size):
         main_value_pair, params = parse_header(line)
         try:
             name, value = main_value_pair.split(':', 1)
-        except ValueError:
-            raise ValueError("Invalid header: %r" % line)
+        except ValueError as e:
+            raise ValueError("Invalid header: %r" % line) from e
         return name, (value, params)
 
     if header_end == -1:

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -230,10 +230,10 @@ class HttpRequest:
         if settings.SECURE_PROXY_SSL_HEADER:
             try:
                 header, secure_value = settings.SECURE_PROXY_SSL_HEADER
-            except ValueError:
+            except ValueError as e:
                 raise ImproperlyConfigured(
                     'The SECURE_PROXY_SSL_HEADER setting must be a tuple containing two values.'
-                )
+                ) from e
             header_value = self.META.get(header)
             if header_value is not None:
                 return 'https' if header_value == secure_value else 'http'

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -159,12 +159,12 @@ class CsrfViewMiddleware(MiddlewareMixin):
         if settings.CSRF_USE_SESSIONS:
             try:
                 return request.session.get(CSRF_SESSION_KEY)
-            except AttributeError:
+            except AttributeError as e:
                 raise ImproperlyConfigured(
                     'CSRF_USE_SESSIONS is enabled, but request.session is not '
                     'set. SessionMiddleware must appear before CsrfViewMiddleware '
                     'in MIDDLEWARE.'
-                )
+                ) from e
         else:
             try:
                 cookie_token = request.COOKIES[settings.CSRF_COOKIE_NAME]

--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -74,8 +74,8 @@ def get_object_or_404(klass, *args, **kwargs):
         )
     try:
         return queryset.get(*args, **kwargs)
-    except queryset.model.DoesNotExist:
-        raise Http404('No %s matches the given query.' % queryset.model._meta.object_name)
+    except queryset.model.DoesNotExist as e:
+        raise Http404('No %s matches the given query.' % queryset.model._meta.object_name) from e
 
 
 def get_list_or_404(klass, *args, **kwargs):

--- a/django/template/backends/django.py
+++ b/django/template/backends/django.py
@@ -123,7 +123,7 @@ def get_package_libraries(pkg):
             raise InvalidTemplateLibrary(
                 "Invalid template library specified. ImportError raised when "
                 "trying to load '%s': %s" % (entry[1], e)
-            )
+            ) from e
 
         if hasattr(module, 'register'):
             yield entry[1]

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -446,14 +446,14 @@ class Parser:
                 try:
                     filter_expression = self.compile_filter(token.contents)
                 except TemplateSyntaxError as e:
-                    raise self.error(token, e)
+                    raise self.error(token, e) from e
                 var_node = VariableNode(filter_expression)
                 self.extend_nodelist(nodelist, var_node, token)
             elif token.token_type.value == 2:  # TokenType.BLOCK
                 try:
                     command = token.contents.split()[0]
-                except IndexError:
-                    raise self.error(token, 'Empty block tag on line %d' % token.lineno)
+                except IndexError as e:
+                    raise self.error(token, 'Empty block tag on line %d' % token.lineno) from e
                 if command in parse_until:
                     # A matching token has been reached. Return control to
                     # the caller. Put the token back on the token list so the
@@ -475,7 +475,7 @@ class Parser:
                 try:
                     compiled_result = compile_func(self, token)
                 except Exception as e:
-                    raise self.error(token, e)
+                    raise self.error(token, e) from e
                 self.extend_nodelist(nodelist, compiled_result, token)
                 # Compile success. Remove the token from the command stack.
                 self.command_stack.pop()

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -477,8 +477,8 @@ class WidthRatioNode(Node):
             max_width = int(self.max_width.resolve(context))
         except VariableDoesNotExist:
             return ''
-        except (ValueError, TypeError):
-            raise TemplateSyntaxError("widthratio final argument must be a number")
+        except (ValueError, TypeError) as e:
+            raise TemplateSyntaxError("widthratio final argument must be a number") from e
         try:
             value = float(value)
             max_value = float(max_value)
@@ -1020,12 +1020,12 @@ def ifchanged(parser, token):
 def find_library(parser, name):
     try:
         return parser.libraries[name]
-    except KeyError:
+    except KeyError as e:
         raise TemplateSyntaxError(
             "'%s' is not a registered tag library. Must be one of:\n%s" % (
                 name, "\n".join(sorted(parser.libraries)),
             ),
-        )
+        ) from e
 
 
 def load_from_library(library, label, names):
@@ -1238,12 +1238,12 @@ def resetcycle(parser, token):
         name = args[1]
         try:
             return ResetCycleNode(parser._named_cycle_nodes[name])
-        except (AttributeError, KeyError):
-            raise TemplateSyntaxError("Named cycle '%s' does not exist." % name)
+        except (AttributeError, KeyError) as e:
+            raise TemplateSyntaxError("Named cycle '%s' does not exist." % name) from e
     try:
         return ResetCycleNode(parser._last_cycle_node)
-    except AttributeError:
-        raise TemplateSyntaxError("No cycles in template.")
+    except AttributeError as e:
+        raise TemplateSyntaxError("No cycles in template.") from e
 
 
 @register.tag

--- a/django/template/library.py
+++ b/django/template/library.py
@@ -292,11 +292,11 @@ def parse_bits(parser, bits, params, varargs, varkw, defaults,
                 try:
                     # Consume from the list of expected positional arguments
                     unhandled_params.pop(0)
-                except IndexError:
+                except IndexError as e:
                     if varargs is None:
                         raise TemplateSyntaxError(
                             "'%s' received too many positional arguments" %
-                            name)
+                            name) from e
     if defaults is not None:
         # Consider the last n params handled, where n is the
         # number of defaults.
@@ -319,10 +319,10 @@ def import_library(name):
         raise InvalidTemplateLibrary(
             "Invalid template library specified. ImportError raised when "
             "trying to load '%s': %s" % (name, e)
-        )
+        ) from e
     try:
         return module.register
-    except AttributeError:
+    except AttributeError as e:
         raise InvalidTemplateLibrary(
             "Module  %s does not have a variable named 'register'" % name,
-        )
+        ) from e

--- a/django/template/loaders/filesystem.py
+++ b/django/template/loaders/filesystem.py
@@ -22,8 +22,8 @@ class Loader(BaseLoader):
         try:
             with open(origin.name, encoding=self.engine.file_charset) as fp:
                 return fp.read()
-        except FileNotFoundError:
-            raise TemplateDoesNotExist(origin)
+        except FileNotFoundError as e:
+            raise TemplateDoesNotExist(origin) from e
 
     def get_template_sources(self, template_name):
         """

--- a/django/template/loaders/locmem.py
+++ b/django/template/loaders/locmem.py
@@ -16,8 +16,8 @@ class Loader(BaseLoader):
     def get_contents(self, origin):
         try:
             return self.templates_dict[origin.name]
-        except KeyError:
-            raise TemplateDoesNotExist(origin)
+        except KeyError as e:
+            raise TemplateDoesNotExist(origin) from e
 
     def get_template_sources(self, template_name):
         yield Origin(

--- a/django/template/utils.py
+++ b/django/template/utils.py
@@ -34,11 +34,11 @@ class EngineHandler:
                 # This will raise an exception if 'BACKEND' doesn't exist or
                 # isn't a string containing at least one dot.
                 default_name = tpl['BACKEND'].rsplit('.', 2)[-2]
-            except Exception:
+            except Exception as e:
                 invalid_backend = tpl.get('BACKEND', '<not defined>')
                 raise ImproperlyConfigured(
                     "Invalid BACKEND for a template engine: {}. Check "
-                    "your TEMPLATES setting.".format(invalid_backend))
+                    "your TEMPLATES setting.".format(invalid_backend)) from e
 
             tpl = {
                 'NAME': default_name,
@@ -67,10 +67,10 @@ class EngineHandler:
         except KeyError:
             try:
                 params = self.templates[alias]
-            except KeyError:
+            except KeyError as e:
                 raise InvalidTemplateEngineError(
                     "Could not find config for '{}' "
-                    "in settings.TEMPLATES".format(alias))
+                    "in settings.TEMPLATES".format(alias)) from e
 
             # If importing or initializing the backend raises an exception,
             # self._engines[alias] isn't set and this code may get executed

--- a/django/templatetags/cache.py
+++ b/django/templatetags/cache.py
@@ -18,22 +18,22 @@ class CacheNode(Node):
     def render(self, context):
         try:
             expire_time = self.expire_time_var.resolve(context)
-        except VariableDoesNotExist:
-            raise TemplateSyntaxError('"cache" tag got an unknown variable: %r' % self.expire_time_var.var)
+        except VariableDoesNotExist as e:
+            raise TemplateSyntaxError('"cache" tag got an unknown variable: %r' % self.expire_time_var.var) from e
         if expire_time is not None:
             try:
                 expire_time = int(expire_time)
-            except (ValueError, TypeError):
-                raise TemplateSyntaxError('"cache" tag got a non-integer timeout value: %r' % expire_time)
+            except (ValueError, TypeError) as e:
+                raise TemplateSyntaxError('"cache" tag got a non-integer timeout value: %r' % expire_time) from e
         if self.cache_name:
             try:
                 cache_name = self.cache_name.resolve(context)
-            except VariableDoesNotExist:
-                raise TemplateSyntaxError('"cache" tag got an unknown variable: %r' % self.cache_name.var)
+            except VariableDoesNotExist as e:
+                raise TemplateSyntaxError('"cache" tag got an unknown variable: %r' % self.cache_name.var) from e
             try:
                 fragment_cache = caches[cache_name]
-            except InvalidCacheBackendError:
-                raise TemplateSyntaxError('Invalid cache name specified for cache tag: %r' % cache_name)
+            except InvalidCacheBackendError as e:
+                raise TemplateSyntaxError('Invalid cache name specified for cache tag: %r' % cache_name) from e
         else:
             try:
                 fragment_cache = caches['template_fragments']

--- a/django/templatetags/i18n.py
+++ b/django/templatetags/i18n.py
@@ -380,10 +380,10 @@ def do_translate(parser, token):
         elif option == 'context':
             try:
                 value = remaining.pop(0)
-            except IndexError:
+            except IndexError as e:
                 raise TemplateSyntaxError(
                     "No argument provided to the '%s' tag for the context option." % bits[0]
-                )
+                ) from e
             if value in invalid_context:
                 raise TemplateSyntaxError(
                     "Invalid argument '%s' provided to the '%s' tag for the context option" % (value, bits[0]),
@@ -392,10 +392,10 @@ def do_translate(parser, token):
         elif option == 'as':
             try:
                 value = remaining.pop(0)
-            except IndexError:
+            except IndexError as e:
                 raise TemplateSyntaxError(
                     "No argument provided to the '%s' tag for the as option." % bits[0]
-                )
+                ) from e
             asvar = value
         else:
             raise TemplateSyntaxError(
@@ -476,19 +476,19 @@ def do_block_translate(parser, token):
             try:
                 value = remaining_bits.pop(0)
                 value = parser.compile_filter(value)
-            except Exception:
+            except Exception as e:
                 raise TemplateSyntaxError(
                     '"context" in %r tag expected exactly one argument.' % bits[0]
-                )
+                ) from e
         elif option == "trimmed":
             value = True
         elif option == "asvar":
             try:
                 value = remaining_bits.pop(0)
-            except IndexError:
+            except IndexError as e:
                 raise TemplateSyntaxError(
                     "No argument provided to the '%s' tag for the asvar option." % bits[0]
-                )
+                ) from e
             asvar = value
         else:
             raise TemplateSyntaxError('Unknown argument for %r tag: %r.' %

--- a/django/urls/base.py
+++ b/django/urls/base.py
@@ -73,14 +73,14 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
                 resolved_path.append(ns)
                 ns_pattern = ns_pattern + extra
                 ns_converters.update(resolver.pattern.converters)
-            except KeyError as key:
+            except KeyError as key_error:
                 if resolved_path:
                     raise NoReverseMatch(
                         "%s is not a registered namespace inside '%s'" %
-                        (key, ':'.join(resolved_path))
-                    )
+                        (key_error, ':'.join(resolved_path))
+                    ) from key_error
                 else:
-                    raise NoReverseMatch("%s is not a registered namespace" % key)
+                    raise NoReverseMatch("%s is not a registered namespace" % key_error)
         if ns_pattern:
             resolver = get_ns_resolver(ns_pattern, resolver, tuple(ns_converters.items()))
 

--- a/django/urls/conf.py
+++ b/django/urls/conf.py
@@ -15,17 +15,17 @@ def include(arg, namespace=None):
         # Callable returning a namespace hint.
         try:
             urlconf_module, app_name = arg
-        except ValueError:
+        except ValueError as e:
             if namespace:
                 raise ImproperlyConfigured(
                     'Cannot override the namespace for a dynamic module that '
                     'provides a namespace.'
-                )
+                ) from e
             raise ImproperlyConfigured(
                 'Passing a %d-tuple to include() is not supported. Pass a '
                 '2-tuple containing the list of patterns and app_name, and '
                 'provide the namespace argument to include() instead.' % len(arg)
-            )
+            ) from e
     else:
         # No namespace hint - use manually provided namespace.
         urlconf_module = arg

--- a/django/urls/utils.py
+++ b/django/urls/utils.py
@@ -38,11 +38,11 @@ def get_callable(lookup_view):
     else:
         try:
             view_func = getattr(mod, func_name)
-        except AttributeError:
+        except AttributeError as e:
             raise ViewDoesNotExist(
                 "Could not import '%s'. View does not exist in module %s." %
                 (lookup_view, mod_name)
-            )
+            ) from e
         else:
             if not callable(view_func):
                 raise ViewDoesNotExist(

--- a/django/utils/archive.py
+++ b/django/utils/archive.py
@@ -64,9 +64,9 @@ class Archive:
         else:
             try:
                 filename = file.name
-            except AttributeError:
+            except AttributeError as e:
                 raise UnrecognizedArchiveFormat(
-                    "File object not a recognized archive format.")
+                    "File object not a recognized archive format.") from e
         base, tail_ext = os.path.splitext(filename.lower())
         cls = extension_map.get(tail_ext)
         if not cls:

--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -551,9 +551,9 @@ class WatchmanReloader(BaseReloader):
         client = pywatchman.client(timeout=0.1)
         try:
             result = client.capabilityCheck()
-        except Exception:
+        except Exception as e:
             # The service is down?
-            raise WatchmanUnavailable('Cannot connect to the watchman service.')
+            raise WatchmanUnavailable('Cannot connect to the watchman service.') from e
         version = get_version_tuple(result['version'])
         # Watchman 4.9 includes multiple improvements to watching project
         # directories as well as case insensitive filesystems.

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -74,8 +74,8 @@ class MultiValueDict(dict):
         """
         try:
             list_ = super().__getitem__(key)
-        except KeyError:
-            raise MultiValueDictKeyError(key)
+        except KeyError as e:
+            raise MultiValueDictKeyError(key) from e
         try:
             return list_[-1]
         except IndexError:
@@ -202,8 +202,8 @@ class MultiValueDict(dict):
                 try:
                     for key, value in other_dict.items():
                         self.setlistdefault(key).append(value)
-                except TypeError:
-                    raise ValueError("MultiValueDict.update() takes either a MultiValueDict or dictionary")
+                except TypeError as e:
+                    raise ValueError("MultiValueDict.update() takes either a MultiValueDict or dictionary") from e
         for key, value in kwargs.items():
             self.setlistdefault(key).append(value)
 

--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -63,7 +63,7 @@ def force_str(s, encoding='utf-8', strings_only=False, errors='strict'):
         else:
             s = str(s)
     except UnicodeDecodeError as e:
-        raise DjangoUnicodeDecodeError(s, *e.args)
+        raise DjangoUnicodeDecodeError(s, *e.args) from e
     return s
 
 

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -252,7 +252,7 @@ def urlsafe_base64_decode(s):
     try:
         return base64.urlsafe_b64decode(s.ljust(len(s) + len(s) % 4, b'='))
     except (LookupError, BinasciiError) as e:
-        raise ValueError(e)
+        raise ValueError(e) from e
 
 
 def parse_etags(etag_str):

--- a/django/utils/ipv6.py
+++ b/django/utils/ipv6.py
@@ -24,8 +24,8 @@ def clean_ipv6_address(ip_str, unpack_ipv4=False,
     """
     try:
         addr = ipaddress.IPv6Address(int(ipaddress.IPv6Address(ip_str)))
-    except ValueError:
-        raise ValidationError(error_message, code='invalid')
+    except ValueError as e:
+        raise ValidationError(error_message, code='invalid') from e
 
     if unpack_ipv4 and addr.ipv4_mapped:
         return str(addr.ipv4_mapped)

--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -161,12 +161,12 @@ def lazy_number(func, resultclass, number=None, **kwargs):
             def _get_number_value(self, values):
                 try:
                     return values[number]
-                except KeyError:
+                except KeyError as e:
                     raise KeyError(
                         "Your dictionary lacks key '%s\'. Please provide "
                         "it, because it is required to determine whether "
                         "string is singular or plural." % number
-                    )
+                    ) from e
 
             def _translate(self, number_value):
                 kwargs['number'] = number_value
@@ -314,14 +314,15 @@ def get_language_info(lang_code):
             info = get_language_info(lang_info['fallback'][0])
         else:
             info = lang_info
-    except KeyError:
+    except KeyError as key_error_1:
         if '-' not in lang_code:
-            raise KeyError("Unknown language code %s." % lang_code)
+            raise KeyError("Unknown language code %s." % lang_code) from key_error_1
         generic_lang_code = lang_code.split('-')[0]
         try:
             info = LANG_INFO[generic_lang_code]
-        except KeyError:
-            raise KeyError("Unknown language code %s and %s." % (lang_code, generic_lang_code))
+        except KeyError as key_error_2:
+            raise KeyError("Unknown language code %s and %s." %
+                           (lang_code, generic_lang_code)) from key_error_2
 
     if info:
         info['name_translated'] = gettext_lazy(info['name'])

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -135,11 +135,11 @@ class DjangoTranslation(gettext_module.GNUTranslations):
         """Merge translations from each installed app."""
         try:
             app_configs = reversed(list(apps.get_app_configs()))
-        except AppRegistryNotReady:
+        except AppRegistryNotReady as e:
             raise AppRegistryNotReady(
                 "The translation infrastructure cannot be initialized before the "
                 "apps registry is ready. Check that you don't make non-lazy "
-                "gettext calls at import time.")
+                "gettext calls at import time.") from e
         for app_config in app_configs:
             localedir = os.path.join(app_config.path, 'locale')
             if os.path.exists(localedir):

--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -37,8 +37,8 @@ class YearMixin:
             except KeyError:
                 try:
                     year = self.request.GET['year']
-                except KeyError:
-                    raise Http404(_("No year specified"))
+                except KeyError as e:
+                    raise Http404(_("No year specified")) from e
         return year
 
     def get_next_year(self, date):
@@ -57,8 +57,8 @@ class YearMixin:
         """
         try:
             return date.replace(year=date.year + 1, month=1, day=1)
-        except ValueError:
-            raise Http404(_("Date out of range"))
+        except ValueError as e:
+            raise Http404(_("Date out of range")) from e
 
     def _get_current_year(self, date):
         """Return the start date of the current interval."""
@@ -86,8 +86,8 @@ class MonthMixin:
             except KeyError:
                 try:
                     month = self.request.GET['month']
-                except KeyError:
-                    raise Http404(_("No month specified"))
+                except KeyError as e:
+                    raise Http404(_("No month specified")) from e
         return month
 
     def get_next_month(self, date):
@@ -107,8 +107,8 @@ class MonthMixin:
         if date.month == 12:
             try:
                 return date.replace(year=date.year + 1, month=1, day=1)
-            except ValueError:
-                raise Http404(_("Date out of range"))
+            except ValueError as e:
+                raise Http404(_("Date out of range")) from e
         else:
             return date.replace(month=date.month + 1, day=1)
 
@@ -138,8 +138,8 @@ class DayMixin:
             except KeyError:
                 try:
                     day = self.request.GET['day']
-                except KeyError:
-                    raise Http404(_("No day specified"))
+                except KeyError as e:
+                    raise Http404(_("No day specified")) from e
         return day
 
     def get_next_day(self, date):
@@ -184,8 +184,8 @@ class WeekMixin:
             except KeyError:
                 try:
                     week = self.request.GET['week']
-                except KeyError:
-                    raise Http404(_("No week specified"))
+                except KeyError as e:
+                    raise Http404(_("No week specified")) from e
         return week
 
     def get_next_week(self, date):
@@ -204,8 +204,8 @@ class WeekMixin:
         """
         try:
             return date + datetime.timedelta(days=7 - self._get_weekday(date))
-        except OverflowError:
-            raise Http404(_("Date out of range"))
+        except OverflowError as e:
+            raise Http404(_("Date out of range")) from e
 
     def _get_current_week(self, date):
         """Return the start date of the current interval."""
@@ -488,11 +488,11 @@ class BaseWeekArchiveView(YearMixin, WeekMixin, BaseDateListView):
         week_choices = {'%W': '1', '%U': '0'}
         try:
             week_start = week_choices[week_format]
-        except KeyError:
+        except KeyError as e:
             raise ValueError('Unknown week format %r. Choices are: %s' % (
                 week_format,
                 ', '.join(sorted(week_choices)),
-            ))
+            )) from e
         date = _date_from_string(year, self.get_year_format(),
                                  week_start, '%w',
                                  week, week_format)
@@ -619,11 +619,11 @@ def _date_from_string(year, year_format, month='', month_format='', day='', day_
     datestr = str(year) + delim + str(month) + delim + str(day)
     try:
         return datetime.datetime.strptime(datestr, format).date()
-    except ValueError:
+    except ValueError as e:
         raise Http404(_('Invalid date string “%(datestr)s” given format “%(format)s”') % {
             'datestr': datestr,
             'format': format,
-        })
+        }) from e
 
 
 def _get_next_prev(generic_view, date, is_previous, period):

--- a/django/views/generic/detail.py
+++ b/django/views/generic/detail.py
@@ -50,9 +50,9 @@ class SingleObjectMixin(ContextMixin):
         try:
             # Get the single item from the filtered queryset
             obj = queryset.get()
-        except queryset.model.DoesNotExist:
+        except queryset.model.DoesNotExist as e:
             raise Http404(_("No %(verbose_name)s found matching the query") %
-                          {'verbose_name': queryset.model._meta.verbose_name})
+                          {'verbose_name': queryset.model._meta.verbose_name}) from e
         return obj
 
     def get_queryset(self):

--- a/django/views/generic/edit.py
+++ b/django/views/generic/edit.py
@@ -114,10 +114,10 @@ class ModelFormMixin(FormMixin, SingleObjectMixin):
         else:
             try:
                 url = self.object.get_absolute_url()
-            except AttributeError:
+            except AttributeError as e:
                 raise ImproperlyConfigured(
                     "No URL to redirect to.  Either provide a url or define"
-                    " a get_absolute_url method on the Model.")
+                    " a get_absolute_url method on the Model.") from e
         return url
 
     def form_valid(self, form):

--- a/django/views/generic/list.py
+++ b/django/views/generic/list.py
@@ -72,7 +72,7 @@ class MultipleObjectMixin(ContextMixin):
             raise Http404(_('Invalid page (%(page_number)s): %(message)s') % {
                 'page_number': page_number,
                 'message': str(e)
-            })
+            }) from e
 
     def get_paginate_by(self, queryset):
         """

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -274,8 +274,9 @@ class ActionSelenium(argparse.Action):
         for browser in browsers:
             try:
                 SeleniumTestCaseBase.import_webdriver(browser)
-            except ImportError:
-                raise argparse.ArgumentError(self, "Selenium browser specification '%s' is not valid." % browser)
+            except ImportError as e:
+                raise argparse.ArgumentError(self, "Selenium browser specification '%s' is not valid." %
+                                             browser) from e
         setattr(namespace, self.dest, browsers)
 
 


### PR DESCRIPTION
Following [31166](https://code.djangoproject.com/ticket/31166) , I made a regex search to find 90% of places where we use "raise" and should use "raise from".

Trac ticket: https://code.djangoproject.com/ticket/31177

If this is too big for one PR, I could split it to smaller chunks.

@shaib @felixxm If you're interested in giving your opinion here, that'll be helpful.