### PR TITLE
Refs #31117 -- Made various tests properly handle unexpected databases aliases.

### DIFF
--- a/tests/admin_views/test_multidb.py
+++ b/tests/admin_views/test_multidb.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 from django.contrib import admin
 from django.contrib.auth.models import User
-from django.db import connections
 from django.test import TestCase, override_settings
 from django.urls import path, reverse
 
@@ -34,7 +33,7 @@ class MultiDatabaseTests(TestCase):
     def setUpTestData(cls):
         cls.superusers = {}
         cls.test_book_ids = {}
-        for db in connections:
+        for db in cls.databases:
             Router.target_db = db
             cls.superusers[db] = User.objects.create_superuser(
                 username='admin', password='something', email='test@test.org',
@@ -45,7 +44,7 @@ class MultiDatabaseTests(TestCase):
 
     @mock.patch('django.contrib.admin.options.transaction')
     def test_add_view(self, mock):
-        for db in connections:
+        for db in self.databases:
             with self.subTest(db=db):
                 Router.target_db = db
                 self.client.force_login(self.superusers[db])
@@ -57,7 +56,7 @@ class MultiDatabaseTests(TestCase):
 
     @mock.patch('django.contrib.admin.options.transaction')
     def test_change_view(self, mock):
-        for db in connections:
+        for db in self.databases:
             with self.subTest(db=db):
                 Router.target_db = db
                 self.client.force_login(self.superusers[db])
@@ -69,7 +68,7 @@ class MultiDatabaseTests(TestCase):
 
     @mock.patch('django.contrib.admin.options.transaction')
     def test_delete_view(self, mock):
-        for db in connections:
+        for db in self.databases:
             with self.subTest(db=db):
                 Router.target_db = db
                 self.client.force_login(self.superusers[db])

--- a/tests/auth_tests/test_admin_multidb.py
+++ b/tests/auth_tests/test_admin_multidb.py
@@ -3,7 +3,6 @@ from unittest import mock
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
-from django.db import connections
 from django.test import TestCase, override_settings
 from django.urls import path, reverse
 
@@ -32,7 +31,7 @@ class MultiDatabaseTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.superusers = {}
-        for db in connections:
+        for db in cls.databases:
             Router.target_db = db
             cls.superusers[db] = User.objects.create_superuser(
                 username='admin', password='something', email='test@test.org',
@@ -40,7 +39,7 @@ class MultiDatabaseTests(TestCase):
 
     @mock.patch('django.contrib.auth.admin.transaction')
     def test_add_view(self, mock):
-        for db in connections:
+        for db in self.databases:
             with self.subTest(db_connection=db):
                 Router.target_db = db
                 self.client.force_login(self.superusers[db])

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -687,11 +687,15 @@ class ThreadTests(TransactionTestCase):
                 conn.inc_thread_sharing()
                 connections_dict[id(conn)] = conn
         try:
-            for x in range(2):
+            num_new_threads = 2
+            for x in range(num_new_threads):
                 t = threading.Thread(target=runner)
                 t.start()
                 t.join()
-            self.assertEqual(len(connections_dict), 6)
+            self.assertEqual(
+                len(connections_dict),
+                len(connections.all()) * (num_new_threads + 1),
+            )
         finally:
             # Finish by closing the connections opened by the other threads
             # (the connection opened in the main thread will automatically be

--- a/tests/migrations/routers.py
+++ b/tests/migrations/routers.py
@@ -1,5 +1,6 @@
-class EmptyRouter:
-    pass
+class DefaultOtherRouter:
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        return db in {'default', 'other'}
 
 
 class TestRouter:
@@ -9,5 +10,5 @@ class TestRouter:
         """
         if model_name == 'tribble':
             return db == 'other'
-        elif db == 'other':
+        elif db != 'default':
             return False

--- a/tests/migrations/test_base.py
+++ b/tests/migrations/test_base.py
@@ -24,7 +24,7 @@ class MigrationTestBase(TransactionTestCase):
 
     def tearDown(self):
         # Reset applied-migrations state.
-        for db in connections:
+        for db in self.databases:
             recorder = MigrationRecorder(connections[db])
             recorder.migration_qs.filter(app='migrations').delete()
 

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core import management
-from django.db import DEFAULT_DB_ALIAS, connections, router, transaction
+from django.db import DEFAULT_DB_ALIAS, router, transaction
 from django.db.models import signals
 from django.db.utils import ConnectionRouter
 from django.test import SimpleTestCase, TestCase, override_settings
@@ -1632,7 +1632,7 @@ class PickleQuerySetTestCase(TestCase):
     databases = {'default', 'other'}
 
     def test_pickling(self):
-        for db in connections:
+        for db in self.databases:
             Book.objects.using(db).create(title='Dive into Python', published=datetime.date(2009, 5, 4))
             qs = Book.objects.all()
             self.assertEqual(qs.db, pickle.loads(pickle.dumps(qs)).db)

--- a/tests/test_utils/test_transactiontestcase.py
+++ b/tests/test_utils/test_transactiontestcase.py
@@ -44,7 +44,7 @@ class TransactionTestCaseDatabasesTests(TestCase):
         so that it's less likely to overflow. An overflow causes
         assertNumQueries() to fail.
         """
-        for alias in connections:
+        for alias in self.databases:
             self.assertEqual(len(connections[alias].queries_log), 0, 'Failed for alias %s' % alias)
 
 


### PR DESCRIPTION
Quite some test in the testsuite assumed that the test configuration
only contains a 'default' and 'other' database, for no good reason. This
commit removes these assumptions.

This commit was originally written to allow a third database to be used
for testing database creation, but that turned out to be infeasible for
other reasons (see https://github.com/django/django/pull/12247). Still,
cleaning up these assumptions makes the code slightly cleaner and makes it easier to add an additional database in the future.

The fixed assumptions are as follows.
 - In most cases, a testcase would use the `databases = [...]` to
   declare it used 'default' and 'other', but then access all databases
   through `django.db.connections`. If a third database is added,
   accessing it is prevented by the test environment, resulting in a
   failing testcase. This is easy to fix by simply iterating over the
   `databases` value rather than `django.db.connections`.
 - `backends.tests` would hardcode the number of connections to 2, now
    it uses `len(connections)` instead.
 - `migrations` had some database routers that assumed only two
   databases. These were slightly changed to keep equivalent behaviour,
   without trying to migrate anything other than 'default' and 'other'.
 - `test_runner.test_discover_runner` would make assumptions about skip
   messages that were not necessarily true. These were adapted by
   autogenerating any skipped connections.