### PR TITLE
Fixed #31181 -- Added links to related models for admin's readonly fields.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -3,12 +3,15 @@ import json
 from django import forms
 from django.contrib.admin.utils import (
     display_for_field, flatten_fieldsets, help_text_for_field, label_for_field,
-    lookup_field,
+    lookup_field, quote,
 )
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import ManyToManyRel
+from django.db.models.fields.related import (
+    ForeignObjectRel, ManyToManyRel, OneToOneField,
+)
 from django.forms.utils import flatatt
 from django.template.defaultfilters import capfirst, linebreaksbr
+from django.urls import NoReverseMatch, reverse
 from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext, gettext_lazy as _
@@ -187,6 +190,17 @@ class AdminReadonlyField:
         label = self.field['label']
         return format_html('<label{}>{}{}</label>', flatatt(attrs), capfirst(label), self.form.label_suffix)
 
+    def get_admin_url(self, remote_field, remote_obj):
+        url_name = 'admin:%s_%s_change' % (
+            remote_field.model._meta.app_label,
+            remote_field.model._meta.model_name,
+        )
+        try:
+            url = reverse(url_name, args=[quote(remote_obj.pk)])
+            return format_html('<a href="{}">{}</a>', url, remote_obj)
+        except NoReverseMatch:
+            return str(remote_obj)
+
     def contents(self):
         from django.contrib.admin.templatetags.admin_list import _boolean_icon
         field, obj, model_admin = self.field['field'], self.form.instance, self.model_admin
@@ -212,6 +226,11 @@ class AdminReadonlyField:
             else:
                 if isinstance(f.remote_field, ManyToManyRel) and value is not None:
                     result_repr = ", ".join(map(str, value.all()))
+                elif (
+                    isinstance(f.remote_field, (ForeignObjectRel, OneToOneField)) and
+                    value is not None
+                ):
+                    result_repr = self.get_admin_url(f.remote_field, value)
                 else:
                     result_repr = display_for_field(value, f, self.empty_value_display)
                 result_repr = linebreaksbr(result_repr)

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -72,6 +72,9 @@ Minor features
 * :attr:`.ModelAdmin.search_fields` now allows searching against quoted phrases
   with spaces.
 
+* Read-only related fields are now rendered as navigable links if target models
+  are registered in the admin.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -37,8 +37,8 @@ from .models import (
     Person, Persona, Picture, Pizza, Plot, PlotDetails, PlotProxy,
     PluggableSearchPerson, Podcast, Post, PrePopulatedPost,
     PrePopulatedPostLargeSlug, PrePopulatedSubPost, Promo, Question,
-    ReadablePizza, ReadOnlyPizza, Recipe, Recommendation, Recommender,
-    ReferencedByGenRel, ReferencedByInline, ReferencedByParent,
+    ReadablePizza, ReadOnlyPizza, ReadOnlyRelatedField, Recipe, Recommendation,
+    Recommender, ReferencedByGenRel, ReferencedByInline, ReferencedByParent,
     RelatedPrepopulated, RelatedWithUUIDPKModel, Report, Reservation,
     Restaurant, RowLevelChangePermissionModel, Section, ShortMessage, Simple,
     Sketch, Song, State, Story, StumpJoke, Subscriber, SuperVillain, Telegram,
@@ -537,6 +537,10 @@ class ToppingAdmin(admin.ModelAdmin):
 
 class PizzaAdmin(admin.ModelAdmin):
     readonly_fields = ('toppings',)
+
+
+class ReadOnlyRelatedFieldAdmin(admin.ModelAdmin):
+    readonly_fields = ('chapter', 'language', 'user')
 
 
 class StudentAdmin(admin.ModelAdmin):
@@ -1061,6 +1065,7 @@ site.register(GenRelReference)
 site.register(ParentWithUUIDPK)
 site.register(RelatedPrepopulated, search_fields=['name'])
 site.register(RelatedWithUUIDPKModel)
+site.register(ReadOnlyRelatedField, ReadOnlyRelatedFieldAdmin)
 
 # We intentionally register Promo and ChapterXtra1 but not Chapter nor ChapterXtra2.
 # That way we cover all four cases:

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -365,6 +365,9 @@ class Language(models.Model):
     english_name = models.CharField(max_length=50)
     shortlist = models.BooleanField(default=False)
 
+    def __str__(self):
+        return self.iso
+
     class Meta:
         ordering = ('iso',)
 
@@ -999,3 +1002,9 @@ class UserProxy(User):
     """Proxy a model with a different app_label."""
     class Meta:
         proxy = True
+
+
+class ReadOnlyRelatedField(models.Model):
+    chapter = models.ForeignKey(Chapter, models.CASCADE)
+    language = models.ForeignKey(Language, models.CASCADE)
+    user = models.ForeignKey(User, models.CASCADE)


### PR DESCRIPTION
In the django admin, readonly relationship fields (e.g. ForeignKey, ManyToMany) were rendered as plaintext of the target object.
This changes this to render them as links instead, making it possible to navigate through the relationship.

## Before
<img width="200" alt="Screenshot 2020-01-21 at 21 59 59" src="https://user-images.githubusercontent.com/506602/72842969-e356c980-3c99-11ea-8c7a-9b70e9689efb.png">

## After
<img width="200" alt="Screenshot 2020-01-21 at 22 00 12" src="https://user-images.githubusercontent.com/506602/72842981-e81b7d80-3c99-11ea-82b0-925cf8e0cebd.png">



Based on [feedback](https://groups.google.com/forum/#!topic/django-developers/XFoaohDpqZE) / [discussion](https://github.com/julienr/django/commit/01bba0b714f831a669b271c1192e93fc3ef011b8#commitcomment-36862302) with @aaugustin , things to decide:

- [x] Should this stop rendering links for ManyToMany if there are more than say 20 remote objects ? The current plaintext behavior already renders all objects ? Is the concern here the number of calls to `reverse` ? Should I make 20 a config option or just hardcode it ?

- [x] The link should only be rendered if the user has permission to view the target model. This would be nice, but the current `master` behavior with raw_id fields is to render the link even if the user cannot view the target model. So I feel changing this would be another issue. I looked a bit into it and it seems fixing this would require passing the `request` all the way down to be able to check for permissions. Basically from `ModelAdmin._changeform_view` =>  `AdminForm` => `Fieldset` => `Fieldline` => `AdminReadonlyField`. Should I open a separate ticket for this ?

- [x] In the [contribution guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/submitting-patches/#patch-review-checklist), it says new features should have an entry in the release notes. Is this considered a new feature ? I feel this is pretty minor, but not sure what the policy is