### PR TITLE
Refs #29095 -- Added test for using QuerySet.count() with window expressions ordered by related fields.

### DIFF
--- a/tests/expressions_window/models.py
+++ b/tests/expressions_window/models.py
@@ -1,12 +1,17 @@
 from django.db import models
 
 
+class Classification(models.Model):
+    code = models.CharField(max_length=10)
+
+
 class Employee(models.Model):
     name = models.CharField(max_length=40, blank=False, null=False)
     salary = models.PositiveIntegerField()
     department = models.CharField(max_length=40, blank=False, null=False)
     hire_date = models.DateField(blank=False, null=False)
     age = models.IntegerField(blank=False, null=False)
+    classification = models.ForeignKey('Classification', on_delete=models.CASCADE, null=True)
 
     def __str__(self):
         return '{}, {}, {}, {}'.format(self.name, self.department, self.salary, self.hire_date)

--- a/tests/expressions_window/tests.py
+++ b/tests/expressions_window/tests.py
@@ -537,6 +537,14 @@ class WindowFunctionTests(TestCase):
             ('Brown', 53000, 'Sales', datetime.date(2009, 9, 1), 108000),
         ], transform=lambda row: (row.name, row.salary, row.department, row.hire_date, row.sum))
 
+    def test_related_ordering_with_count(self):
+        qs = Employee.objects.annotate(department_sum=Window(
+            expression=Sum('salary'),
+            partition_by=F('department'),
+            order_by=['classification__code'],
+        ))
+        self.assertEqual(qs.count(), 12)
+
     @skipUnlessDBFeature('supports_frame_range_fixed_distance')
     def test_range_n_preceding_and_following(self):
         qs = Employee.objects.annotate(sum=Window(


### PR DESCRIPTION
Fixed in 3f32154f40a855afa063095e3d091ce6be21f2c5.