### PR TITLE
Made AppConfig.ready example show class

### DIFF
--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -256,15 +256,20 @@ Methods
 
     Example::
 
+        from django.apps import AppConfig
         from django.db.models.signals import pre_save
 
-        def ready(self):
-            # importing model classes
-            from .models import MyModel  # or...
-            MyModel = self.get_model('MyModel')
 
-            # registering signals with the model's string label
-            pre_save.connect(receiver, sender='app_label.MyModel')
+        class RockNRollConfig(AppConfig):
+            # ...
+
+            def ready(self):
+                # importing model classes
+                from .models import MyModel  # or...
+                MyModel = self.get_model('MyModel')
+
+                # registering signals with the model's string label
+                pre_save.connect(receiver, sender='app_label.MyModel')
 
     .. warning::
 


### PR DESCRIPTION
By showing the import at the same level as the function definition, the example was a little unclear that it needs to be implemented inside the `AppConfig` subclass. I think this improves it.