### PR TITLE
Fixed #31187 -- Fixed detecting of existing total ordering in admin changelist when using Meta.constraints.

### DIFF
--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -367,8 +367,16 @@ class ChangeList:
                     break
                 ordering_fields.add(field.attname)
         else:
-            # No single total ordering field, try unique_together.
-            for field_names in self.lookup_opts.unique_together:
+            # No single total ordering field, try unique_together and total
+            # unique constraints.
+            constraint_field_names = (
+                *self.lookup_opts.unique_together,
+                *(
+                    constraint.fields
+                    for constraint in self.lookup_opts.total_unique_constraints
+                ),
+            )
+            for field_names in constraint_field_names:
                 # Normalize attname references by using get_field().
                 fields = [self.lookup_opts.get_field(field_name) for field_name in field_names]
                 # Composite unique constraints containing a nullable column

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -19,7 +19,7 @@ from django.db.models import (
     NOT_PROVIDED, ExpressionWrapper, IntegerField, Max, Value,
 )
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.constraints import CheckConstraint, UniqueConstraint
+from django.db.models.constraints import CheckConstraint
 from django.db.models.deletion import CASCADE, Collector
 from django.db.models.fields.related import (
     ForeignObjectRel, OneToOneField, lazy_related_operation, resolve_relation,
@@ -1023,12 +1023,14 @@ class Model(metaclass=ModelBase):
         unique_checks = []
 
         unique_togethers = [(self.__class__, self._meta.unique_together)]
-        constraints = [(self.__class__, self._meta.constraints)]
+        constraints = [(self.__class__, self._meta.total_unique_constraints)]
         for parent_class in self._meta.get_parent_list():
             if parent_class._meta.unique_together:
                 unique_togethers.append((parent_class, parent_class._meta.unique_together))
-            if parent_class._meta.constraints:
-                constraints.append((parent_class, parent_class._meta.constraints))
+            if parent_class._meta.total_unique_constraints:
+                constraints.append(
+                    (parent_class, parent_class._meta.total_unique_constraints)
+                )
 
         for model_class, unique_together in unique_togethers:
             for check in unique_together:
@@ -1038,10 +1040,7 @@ class Model(metaclass=ModelBase):
 
         for model_class, model_constraints in constraints:
             for constraint in model_constraints:
-                if (isinstance(constraint, UniqueConstraint) and
-                        # Partial unique constraints can't be validated.
-                        constraint.condition is None and
-                        not any(name in exclude for name in constraint.fields)):
+                if not any(name in exclude for name in constraint.fields):
                     unique_checks.append((model_class, constraint.fields))
 
         # These are checks for the unique_for_<date/year/month>.

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -7,7 +7,7 @@ from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist
 from django.db import connections
-from django.db.models import AutoField, Manager, OrderWrt
+from django.db.models import AutoField, Manager, OrderWrt, UniqueConstraint
 from django.db.models.query_utils import PathInfo
 from django.utils.datastructures import ImmutableList, OrderedSet
 from django.utils.functional import cached_property
@@ -826,6 +826,18 @@ class Options:
         # Store result into cache for later access
         self._get_fields_cache[cache_key] = fields
         return fields
+
+    @cached_property
+    def total_unique_constraints(self):
+        """
+        Return a list of total unique constraints. Useful for determining set
+        of fields guaranteed to be unique for all rows.
+        """
+        return [
+            constraint
+            for constraint in self.constraints
+            if isinstance(constraint, UniqueConstraint) and constraint.condition is None
+        ]
 
     @cached_property
     def _property_names(self):

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1039,10 +1039,6 @@ class ChangeListTests(TestCase):
             (['field', '-other_field'], ['field', '-other_field']),
             # Composite unique nullable.
             (['-field', 'null_field'], ['-field', 'null_field', '-pk']),
-            # Composite unique nullable.
-            (['-field', 'null_field'], ['-field', 'null_field', '-pk']),
-            # Composite unique nullable.
-            (['-field', 'null_field'], ['-field', 'null_field', '-pk']),
             # Composite unique and nullable.
             (['-field', 'null_field', 'other_field'], ['-field', 'null_field', 'other_field']),
             # Composite unique attnames.

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1058,6 +1058,98 @@ class ChangeListTests(TestCase):
             with self.subTest(ordering=ordering):
                 self.assertEqual(change_list._get_deterministic_ordering(ordering), expected)
 
+    @isolate_apps('admin_changelist')
+    def test_total_ordering_optimization_meta_constraints(self):
+        class Related(models.Model):
+            unique_field = models.BooleanField(unique=True)
+
+            class Meta:
+                ordering = ('unique_field',)
+
+        class Model(models.Model):
+            field_1 = models.BooleanField()
+            field_2 = models.BooleanField()
+            field_3 = models.BooleanField()
+            field_4 = models.BooleanField()
+            field_5 = models.BooleanField()
+            field_6 = models.BooleanField()
+            nullable_1 = models.BooleanField(null=True)
+            nullable_2 = models.BooleanField(null=True)
+            related_1 = models.ForeignKey(Related, models.CASCADE)
+            related_2 = models.ForeignKey(Related, models.CASCADE)
+            related_3 = models.ForeignKey(Related, models.CASCADE)
+            related_4 = models.ForeignKey(Related, models.CASCADE)
+
+            class Meta:
+                constraints = [
+                    *[
+                        models.UniqueConstraint(fields=fields, name=''.join(fields))
+                        for fields in (
+                            ['field_1'],
+                            ['nullable_1'],
+                            ['related_1'],
+                            ['related_2_id'],
+                            ['field_2', 'field_3'],
+                            ['field_2', 'nullable_2'],
+                            ['field_2', 'related_3'],
+                            ['field_3', 'related_4_id'],
+                        )
+                    ],
+                    models.CheckConstraint(check=models.Q(id__gt=0), name='foo'),
+                    models.UniqueConstraint(
+                        fields=['field_5'],
+                        condition=models.Q(id__gt=10),
+                        name='total_ordering_1',
+                    ),
+                    models.UniqueConstraint(
+                        fields=['field_6'],
+                        condition=models.Q(),
+                        name='total_ordering',
+                    ),
+                ]
+
+        class ModelAdmin(admin.ModelAdmin):
+            def get_queryset(self, request):
+                return Model.objects.none()
+
+        request = self._mocked_authenticated_request('/', self.superuser)
+        site = admin.AdminSite(name='admin')
+        model_admin = ModelAdmin(Model, site)
+        change_list = model_admin.get_changelist_instance(request)
+        tests = (
+            # Unique non-nullable field.
+            (['field_1'], ['field_1']),
+            # Unique nullable field.
+            (['nullable_1'], ['nullable_1', '-pk']),
+            # Related attname unique.
+            (['related_1_id'], ['related_1_id']),
+            (['related_2_id'], ['related_2_id']),
+            # Related ordering introspection is not implemented.
+            (['related_1'], ['related_1', '-pk']),
+            # Composite unique.
+            (['-field_2', 'field_3'], ['-field_2', 'field_3']),
+            # Composite unique nullable.
+            (['field_2', '-nullable_2'], ['field_2', '-nullable_2', '-pk']),
+            # Composite unique and nullable.
+            (
+                ['field_2', '-nullable_2', 'field_3'],
+                ['field_2', '-nullable_2', 'field_3'],
+            ),
+            # Composite field and related field name.
+            (['field_2', '-related_3'], ['field_2', '-related_3', '-pk']),
+            (['field_3', 'related_4'], ['field_3', 'related_4', '-pk']),
+            # Composite field and related field attname.
+            (['field_2', 'related_3_id'], ['field_2', 'related_3_id']),
+            (['field_3', '-related_4_id'], ['field_3', '-related_4_id']),
+            # Partial unique constraint is ignored.
+            (['field_5'], ['field_5', '-pk']),
+            # Unique constraint with an empty condition.
+            (['field_6'], ['field_6']),
+        )
+        for ordering, expected in tests:
+            with self.subTest(ordering=ordering):
+                self.assertEqual(change_list._get_deterministic_ordering(ordering), expected)
+
     def test_dynamic_list_filter(self):
         """
         Regression tests for ticket #17646: dynamic list_filter support.


### PR DESCRIPTION
Hi,

this PR should fix https://code.djangoproject.com/ticket/31187

A couple of notes:

- `constraint_field_names` could be a `set()`, which would have the nice side effect of de-duplicating common tuples between `unique_together` and `constraints`; at the end I opted for a tuple, giving up on de-duplication in favor of a more predictable outcome provided by order preservation.

- Tests are quite verbose: I added a bunch of fields to the `Model` class in order to have each test case match a very specific `UniqueConstraint` instance. That required having each time different field names, so to avoid unexpected overlaps. IOW, in this case I was more inclined towards correctness than conciseness.

- I didn't touch the docs (namely the file `docs/ref/contrib/admin/index.txt`, which is the only one I've found regarding this context) since they just mention an "unique together set of fields", which in my opinion is an abstract enough wording to include both `Meta.unique_together` and the `UniqueConstraint` instances in `Meta.constraints`.
If you disagree I can add a more specific sentence.

Please let me know if you want me to make changes on things I didn't mention.

Thanks!