### PR TITLE
Refs #27888 -- Removed redundant {% if %} in admin changelist filters.

### DIFF
--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -60,11 +60,9 @@
         {% if cl.has_filters %}
           <div id="changelist-filter">
             <h2>{% translate 'Filter' %}</h2>
-            {% if cl.has_filters or cl.search_fields %}
-              {% if cl.preserved_filters %}<h3 id="changelist-filter-clear">
-                <a href="?{% if cl.is_popup %}_popup=1{% endif %}">&#10006; {% translate "Clear all filters" %}</a>
-              </h3>{% endif %}
-            {% endif %}
+            {% if cl.preserved_filters %}<h3 id="changelist-filter-clear">
+              <a href="?{% if cl.is_popup %}_popup=1{% endif %}">&#10006; {% translate "Clear all filters" %}</a>
+            </h3>{% endif %}
             {% for spec in cl.filter_specs %}{% admin_list_filter cl spec %}{% endfor %}
           </div>
         {% endif %}


### PR DESCRIPTION
We have the `if cl.has_filters` above this condition:
https://github.com/django/django/blob/d66d72f95655312c413d916add61a62928639514/django/contrib/admin/templates/admin/change_list.html#L60
