### PR TITLE
Use '.example.com' for cross-subdomain cookies

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -313,7 +313,7 @@ Default: ``None``
 The domain to be used when setting the CSRF cookie.  This can be useful for
 easily allowing cross-subdomain requests to be excluded from the normal cross
 site request forgery protection.  It should be set to a string such as
-``"example.com"`` to allow a POST request from a form on one subdomain to be
+``".example.com"`` to allow a POST request from a form on one subdomain to be
 accepted by a view served from another subdomain.
 
 Please note that the presence of this setting does not imply that Django's CSRF
@@ -1805,7 +1805,7 @@ The age of the language cookie, in seconds.
 Default: ``None``
 
 The domain to use for the language cookie. Set this to a string such as
-``"example.com"`` for cross-domain cookies, or use ``None`` for a standard
+``".example.com"`` for cross-domain cookies, or use ``None`` for a standard
 domain cookie.
 
 Be cautious when updating this setting on a production site. If you update


### PR DESCRIPTION
I believe this documentation is incorrect. To set a cookie that will work across all subdomains of `example.com` you need to specify `.example.com` in these settings.