### PR TITLE
Refs #27852 -- Fixed object deletion to show all protected related objects rather than just the first one.

### DIFF
--- a/tests/delete/models.py
+++ b/tests/delete/models.py
@@ -68,6 +68,10 @@ class A(models.Model):
     o2o_setnull = models.ForeignKey(R, models.SET_NULL, null=True, related_name="o2o_nullable_set")
 
 
+class B(models.Model):
+    protect = models.ForeignKey(R, models.PROTECT)
+
+
 def create_a(name):
     a = A(name=name)
     for name in ('auto', 'auto_nullable', 'setvalue', 'setnull', 'setdefault',

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -1,6 +1,6 @@
 from math import ceil
 
-from django.db import IntegrityError, connection, models
+from django.db import connection, models
 from django.db.models.deletion import (
     Collector, ProtectedError, RestrictedError,
 )
@@ -76,7 +76,7 @@ class OnDeleteTests(TestCase):
             "Cannot delete some instances of model 'R' because they are "
             "referenced through protected foreign keys: 'A.protect'."
         )
-        with self.assertRaisesMessage(IntegrityError, msg):
+        with self.assertRaisesMessage(ProtectedError, msg):
             a.protect.delete()
 
     def test_protect_multiple(self):


### PR DESCRIPTION
Fixes [Ticket 27852](https://code.djangoproject.com/ticket/27852).
Continue the [PR](https://github.com/django/django/pull/8160)