### PR TITLE
Allowed selected Choice values as a set

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -661,7 +661,7 @@ class ChoiceWidget(Widget):
         """Return selected values as a list."""
         if value is None and self.allow_multiple_selected:
             return []
-        if not isinstance(value, (tuple, list)):
+        if not isinstance(value, (tuple, list, set)):
             value = [value]
         return [str(v) if v is not None else '' for v in value]
 


### PR DESCRIPTION
This commit changes the `ChoiceWidget`'s value formatting to accept sets, and not just lists and tuples. "set" was thus added to the `isinstance()` test used.

This would allow sets of options to be specified without explicit re-casting to a list.