### PR TITLE
Fixed 31207 -- Prevented references to non-local remote fields in ForeignKey.to_field.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -923,6 +923,21 @@ class ForeignKey(ForeignObject):
                 },  # 'pk' is included for backwards compatibility
             )
 
+    def resolve_related_fields(self):
+        related_fields = super().resolve_related_fields()
+        for from_field, to_field in related_fields:
+            if to_field and to_field.model != self.remote_field.model._meta.concrete_model:
+                raise exceptions.FieldError(
+                    "'%s.%s' refers to field '%s' which is not local to model "
+                    "'%s'." % (
+                        self.model._meta.label,
+                        self.name,
+                        to_field.name,
+                        self.remote_field.model._meta.concrete_model._meta.label,
+                    )
+                )
+        return related_fields
+
     def get_attname(self):
         return '%s_id' % self.name
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -449,6 +449,9 @@ Miscellaneous
   decorator now takes precedence over the ``max-age`` directive from the
   ``Cache-Control`` header.
 
+* Providing a non-local remote field in the :attr:`.ForeignKey.to_field`
+  argument now raises :class:`~django.core.exceptions.FieldError`.
+
 .. _deprecated-features-3.1:
 
 Features deprecated in 3.1


### PR DESCRIPTION
[Ticket 31207](https://code.djangoproject.com/ticket/31207)
Solution was proposed by @charettes on the [comment](https://code.djangoproject.com/ticket/31207#comment:3)