### PR TITLE
Fixed #31216 -- Added support for colorama terminal colors on Windows.

### DIFF
--- a/django/core/management/color.py
+++ b/django/core/management/color.py
@@ -22,16 +22,13 @@ def supports_color():
     Return True if the running system's terminal supports color,
     and False otherwise.
     """
-
     def vt_codes_enabled_in_windows_registry():
         """
         Check the Windows Registry to see if VT code handling has been enabled
-        by default.
+        by default, see https://superuser.com/a/1300251/447564.
         """
-        # see https://superuser.com/a/1300251/447564
-
         try:
-            # winreg is only available on Windows
+            # winreg is only available on Windows.
             import winreg
         except ImportError:
             return False

--- a/django/core/management/color.py
+++ b/django/core/management/color.py
@@ -8,17 +8,55 @@ import sys
 
 from django.utils import termcolors
 
+try:
+    import colorama
+except ImportError:
+    HAS_COLORAMA = False
+else:
+    colorama.init()
+    HAS_COLORAMA = True
+
 
 def supports_color():
     """
     Return True if the running system's terminal supports color,
     and False otherwise.
     """
-    supported_platform = sys.platform != 'win32' or 'ANSICON' in os.environ
+
+    def vt_codes_enabled_in_windows_registry():
+        """
+        Check the Windows Registry to see if VT code handling has been enabled
+        by default.
+        """
+        # see https://superuser.com/a/1300251/447564
+
+        try:
+            # winreg is only available on Windows
+            import winreg
+        except ImportError:
+            return False
+        else:
+            reg_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, 'Console')
+            try:
+                reg_key_value, _ = winreg.QueryValueEx(reg_key, 'VirtualTerminalLevel')
+            except FileNotFoundError:
+                return False
+            else:
+                return reg_key_value == 1
 
     # isatty is not always implemented, #6223.
     is_a_tty = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
-    return supported_platform and is_a_tty
+
+    return is_a_tty and (
+        sys.platform != 'win32' or
+        HAS_COLORAMA or
+        'ANSICON' in os.environ or
+        # Windows Terminal supports VT codes.
+        'WT_SESSION' in os.environ or
+        # Microsoft Visual Studio Code's built-in terminal supports colors.
+        os.environ.get('TERM_PROGRAM') == 'vscode' or
+        vt_codes_enabled_in_windows_registry()
+    )
 
 
 class Style:

--- a/docs/howto/windows.txt
+++ b/docs/howto/windows.txt
@@ -91,6 +91,22 @@ by executing ``django-admin --version`` in the command prompt.
 See :ref:`database-installation` for information on database installation
 with Django.
 
+Colored Terminal Output
+=======================
+
+.. versionadded: 3.2
+
+A quality-of-life feature is to output colored (rather than monochrome) output
+on the terminal. This should work both on CMD and PowerShell. If for some
+reason this needs to be disabled, set the environmental variable
+:envvar:`DJANGO_COLORS` to ``nocolor``.
+
+To enable this, colorama_ must be installed:
+
+    ...\> py -m pip install colorama
+
+See :ref:`syntax-coloring` for more information on color settings.
+
 Common pitfalls
 ===============
 
@@ -106,3 +122,5 @@ Common pitfalls
 
     ...\> set http_proxy=http://username:password@proxyserver:proxyport
     ...\> set https_proxy=https://username:password@proxyserver:proxyport
+
+.. _colorama: https://pypi.org/project/colorama/

--- a/docs/howto/windows.txt
+++ b/docs/howto/windows.txt
@@ -91,7 +91,7 @@ by executing ``django-admin --version`` in the command prompt.
 See :ref:`database-installation` for information on database installation
 with Django.
 
-Colored Terminal Output
+Colored terminal output
 =======================
 
 .. versionadded: 3.2
@@ -101,11 +101,13 @@ on the terminal. This should work both on CMD and PowerShell. If for some
 reason this needs to be disabled, set the environmental variable
 :envvar:`DJANGO_COLORS` to ``nocolor``.
 
-To enable this, colorama_ must be installed:
+To enable this, colorama_ must be installed::
 
     ...\> py -m pip install colorama
 
 See :ref:`syntax-coloring` for more information on color settings.
+
+.. _colorama: https://pypi.org/project/colorama/
 
 Common pitfalls
 ===============
@@ -122,5 +124,3 @@ Common pitfalls
 
     ...\> set http_proxy=http://username:password@proxyserver:proxyport
     ...\> set https_proxy=https://username:password@proxyserver:proxyport
-
-.. _colorama: https://pypi.org/project/colorama/

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -273,6 +273,7 @@ dependencies:
 *  argon2-cffi_ 19.1.0+
 *  asgiref_ 3.2.10+ (required)
 *  bcrypt_
+*  colorama_
 *  docutils_
 *  geoip2_
 *  jinja2_ 2.7+
@@ -319,6 +320,7 @@ service.
 .. _argon2-cffi: https://pypi.org/project/argon2_cffi/
 .. _asgiref: https://pypi.org/project/asgiref/
 .. _bcrypt: https://pypi.org/project/bcrypt/
+.. _colorama: https://pypi.org/project/colorama/
 .. _docutils: https://pypi.org/project/docutils/
 .. _geoip2: https://pypi.org/project/geoip2/
 .. _jinja2: https://pypi.org/project/jinja2/

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1890,15 +1890,14 @@ but which are not automatically detected as supported by Django, may "fake" the
 installation of ``ANSICON`` by setting the appropriate environmental variable,
 ``ANSICON="on"``.
 
-
-.. _`Windows Terminal`: https://www.microsoft.com/en-us/p/windows-terminal-preview/9n0dx20hk701
-.. _VS Code: https://code.visualstudio.com
-.. _ANSICON: http://adoxa.altervista.org/ansicon/
-.. _colorama: https://pypi.org/project/colorama/
-
 .. versionchanged:: 3.2
 
     Updated support for syntax coloring on Windows.
+
+.. _`Windows Terminal`: https://www.microsoft.com/en-us/p/windows-terminal-preview/9n0dx20hk701
+.. _`VS Code`: https://code.visualstudio.com
+.. _ANSICON: http://adoxa.altervista.org/ansicon/
+.. _colorama: https://pypi.org/project/colorama/
 
 Custom colors
 ~~~~~~~~~~~~~

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1863,10 +1863,45 @@ color-coded output if your terminal supports ANSI-colored output. It
 won't use the color codes if you're piping the command's output to
 another program unless the :option:`--force-color` option is used.
 
-Under Windows, the native console doesn't support ANSI escape sequences so by
-default there is no color output. But you can install the `ANSICON`_
-third-party tool, the Django commands will detect its presence and will make
-use of its services to color output just like on Unix-based platforms.
+Windows support
+~~~~~~~~~~~~~~~
+
+On Windows 10, the `Windows Terminal`_ application, `VS Code`_, and PowerShell
+(where virtual terminal processing is enabled) allow colored output, and are
+supported by default.
+
+Under Windows, the legacy ``cmd.exe`` native console doesn't support ANSI
+escape sequences so by default there is no color output. In this case either of
+two third-party libraries are needed:
+
+* Install colorama_, a Python package that translates ANSI color codes into
+  Windows API calls. Django commands will detect its presence and will make use
+  of its services to color output just like on Unix-based platforms.
+  ``colorama`` can be installed via pip::
+
+    ...\> py -m pip install colorama
+
+* Install `ANSICON`_, a third-party tool that allows ``cmd.exe`` to process
+  ANSI color codes. Django commands will detect its presence and will make use
+  of its services to color output just like on Unix-based platforms.
+
+Other modern terminal environments on Windows, that support terminal colors,
+but which are not automatically detected as supported by Django, may "fake" the
+installation of ``ANSICON`` by setting the appropriate environmental variable,
+``ANSICON="on"``.
+
+
+.. _`Windows Terminal`: https://www.microsoft.com/en-us/p/windows-terminal-preview/9n0dx20hk701
+.. _VS Code: https://code.visualstudio.com
+.. _ANSICON: http://adoxa.altervista.org/ansicon/
+.. _colorama: https://pypi.org/project/colorama/
+
+.. versionchanged:: 3.2
+
+    Updated support for syntax coloring on Windows.
+
+Custom colors
+~~~~~~~~~~~~~
 
 The colors used for syntax highlighting can be customized. Django
 ships with three color palettes:
@@ -1955,8 +1990,6 @@ palette will be loaded. So::
 would specify the use of all the colors in the light color palette,
 *except* for the colors for errors and notices which would be
 overridden as specified.
-
-.. _ANSICON: http://adoxa.altervista.org/ansicon/
 
 Bash completion
 ---------------

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -272,6 +272,11 @@ Management Commands
   prior to executing the command. In previous versions, either all or none
   of the system checks were performed.
 
+* Support for colored terminal output on Windows is updated. Various modern
+  terminal environments are automatically detected, and the options for
+  enabling support in other cases are improved. See :ref:`syntax-coloring` for
+  more details.
+
 Migrations
 ~~~~~~~~~~
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -110,7 +110,6 @@ codec
 codename
 codenamed
 coercible
-colorama
 commenters
 committer
 committers

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -110,6 +110,7 @@ codec
 codename
 codenamed
 coercible
+colorama
 commenters
 committer
 committers
@@ -476,6 +477,7 @@ postfix
 postgis
 postgres
 postgresql
+PowerShell
 pq
 pre
 precisions

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -16,3 +16,4 @@ PyYAML
 selenium
 sqlparse >= 0.2.2
 tblib >= 1.5.0
+colorama; sys.platform == 'win32'


### PR DESCRIPTION
If colorama is installed (as on Windows), support colored terminal output.

There is a very old ticket (https://code.djangoproject.com/ticket/13476) discussing how to support colorized terminal output on Windows. At the time, ANSICON was chosen as a solution over `colorama`. However, the link provided for ANSICON (http://adoxa.hostmyway.net/ansicon/) no longer works, and, personally, I struggled to install it previously (it involved messing around with DLL's and some fairly low level Windows functionality). `colorama`, on the other hand, is a current Python package that provides color on Windows by converting the ANSI cods to Windows native color "codes"; on other platforms, it just passes through the ANSI codes through. `colorama` is also very popular: for example, it is vendored by `pip` (https://github.com/pypa/pip/tree/master/src/pip/_vendor).

What this change does is test to see if `colorama` is available, and activate color (on Windows) if it is. It is not a hard dependency or even added to the "install_requires" of `setup.py`. Personally, I would support adding `colorama` as a dependency on Windows, but I wasn't sure how much support there would be for that.

No documentation changes have been added, although I think this would be wise to mention in the installation instructions for Windows. No tests have been added either, but I'm not really sure what to test directly. If someone could point me to where to make those changes, I would be happy to.