### PR TITLE
Fixed #31217 -- Made QuerySet.values()/values_list() group by not selected annotations with aggregations used in order_by().

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -123,8 +123,8 @@ class SQLCompiler:
         for expr, (sql, params, is_ref) in order_by:
             # Skip References to the select clause, as all expressions in the
             # select clause are already part of the group by.
-            if not expr.contains_aggregate and not is_ref:
-                expressions.extend(expr.get_source_expressions())
+            if not is_ref:
+                expressions.extend(expr.get_group_by_cols())
         having_group_by = self.having.get_group_by_cols() if self.having else ()
         for expr in having_group_by:
             expressions.append(expr)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1928,17 +1928,8 @@ class Query(BaseExpression):
         will be made automatically.
         """
         group_by = list(self.select)
-        annotations_group_by = self.annotation_select.copy()
-        # Add not selected annotations used only in the ORDER BY clause.
-        if self.order_by and self.annotations:
-            for item in self.order_by:
-                if not hasattr(item, 'resolve_expression'):
-                    alias = item[1:] if item.startswith('-') else item
-                    if alias in self.annotations and alias not in self.annotation_select:
-                        annotations_group_by[alias] = self.annotations[alias]
-        # Expand the GROUP BY clause by required columns.
-        if annotations_group_by:
-            for alias, annotation in annotations_group_by.items():
+        if self.annotation_select:
+            for alias, annotation in self.annotation_select.items():
                 signature = inspect.signature(annotation.get_group_by_cols)
                 if 'alias' not in signature.parameters:
                     annotation_class = annotation.__class__

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1928,8 +1928,17 @@ class Query(BaseExpression):
         will be made automatically.
         """
         group_by = list(self.select)
-        if self.annotation_select:
-            for alias, annotation in self.annotation_select.items():
+        annotations_group_by = self.annotation_select.copy()
+        # Add not selected annotations used only in the ORDER BY clause.
+        if self.order_by and self.annotations:
+            for item in self.order_by:
+                if not hasattr(item, 'resolve_expression'):
+                    alias = item[1:] if item.startswith('-') else item
+                    if alias in self.annotations and alias not in self.annotation_select:
+                        annotations_group_by[alias] = self.annotations[alias]
+        # Expand the GROUP BY clause by required columns.
+        if annotations_group_by:
+            for alias, annotation in annotations_group_by.items():
                 signature = inspect.signature(annotation.get_group_by_cols)
                 if 'alias' not in signature.parameters:
                     annotation_class = annotation.__class__


### PR DESCRIPTION
ticket-31217

Regression in 59b4e99dd00b9c36d56055b889f96885995e4240.

Thanks Jon Dufresne for the report.