### PR TITLE
Move technical_500 template paths to class-level variables

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -235,6 +235,10 @@ class SafeExceptionReporterFilter:
 
 class ExceptionReporter:
     """Organize and coordinate reporting on exceptions."""
+
+    html_template_path = CURRENT_DIR / 'templates' / 'technical_500.html'
+    text_template_path = CURRENT_DIR / 'templates' / 'technical_500.txt'
+
     def __init__(self, request, exc_type, exc_value, tb, is_email=False):
         self.request = request
         self.filter = get_exception_reporter_filter(self.request)
@@ -321,14 +325,14 @@ class ExceptionReporter:
 
     def get_traceback_html(self):
         """Return HTML version of debug 500 HTTP error page."""
-        with Path(CURRENT_DIR, 'templates', 'technical_500.html').open(encoding='utf-8') as fh:
+        with self.html_template_path.open(encoding='utf-8') as fh:
             t = DEBUG_ENGINE.from_string(fh.read())
         c = Context(self.get_traceback_data(), use_l10n=False)
         return t.render(c)
 
     def get_traceback_text(self):
         """Return plain text version of debug 500 HTTP error page."""
-        with Path(CURRENT_DIR, 'templates', 'technical_500.txt').open(encoding='utf-8') as fh:
+        with self.text_template_path.open(encoding='utf-8') as fh:
             t = DEBUG_ENGINE.from_string(fh.read())
         c = Context(self.get_traceback_data(), autoescape=False, use_l10n=False)
         return t.render(c)


### PR DESCRIPTION
This allows effortless replacement of the debugging templates without having to copy-paste the `get_traceback_html` and `get_traceback_text` functions into a deriving class.