### PR TITLE
Fixed #31219 -- Fixed object deletion crash for nested protected related objects.

### DIFF
--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -296,10 +296,7 @@ class Collector:
                     try:
                         field.remote_field.on_delete(self, field, sub_objs, self.using)
                     except ProtectedError as error:
-                        key = "'%s.%s'" % (
-                            error.protected_objects[0].__class__.__name__,
-                            field.name,
-                        )
+                        key = "'%s.%s'" % (field.model.__name__, field.name)
                         protected_objects[key] += error.protected_objects
         if protected_objects:
             raise ProtectedError(

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -90,6 +90,17 @@ class OnDeleteTests(TestCase):
         with self.assertRaisesMessage(ProtectedError, msg):
             a.protect.delete()
 
+    def test_protect_path(self):
+        a = create_a('protect')
+        a.protect.p = P.objects.create()
+        a.protect.save()
+        msg = (
+            "Cannot delete some instances of model 'P' because they are "
+            "referenced through protected foreign keys: 'R.p'."
+        )
+        with self.assertRaisesMessage(ProtectedError, msg):
+            a.protect.p.delete()
+
     def test_do_nothing(self):
         # Testing DO_NOTHING is a bit harder: It would raise IntegrityError for a normal model,
         # so we connect to pre_delete and set the fk to a known value.


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/31219#ticket