### PR TITLE
Used temporary directory in FileFieldTests.test_pickle().

### DIFF
--- a/tests/model_fields/test_filefield.py
+++ b/tests/model_fields/test_filefield.py
@@ -106,31 +106,44 @@ class FileFieldTests(TestCase):
                     self.assertTrue(os.path.exists(os.path.join(tmp_dir, 'unused', 'foo.txt')))
 
     def test_pickle(self):
-        with open(__file__, 'rb') as fp:
-            file1 = File(fp, name='test_file.py')
-            document = Document(myfile='test_file.py')
-            document.myfile.save('test_file.py', file1)
-            try:
-                dump = pickle.dumps(document)
-                loaded_document = pickle.loads(dump)
-                self.assertEqual(document.myfile, loaded_document.myfile)
-                self.assertEqual(document.myfile.url, loaded_document.myfile.url)
-                self.assertEqual(
-                    document.myfile.storage,
-                    loaded_document.myfile.storage,
-                )
-                self.assertEqual(
-                    document.myfile.instance,
-                    loaded_document.myfile.instance,
-                )
-                self.assertEqual(document.myfile.field, loaded_document.myfile.field)
-
-                myfile_dump = pickle.dumps(document.myfile)
-                loaded_myfile = pickle.loads(myfile_dump)
-                self.assertEqual(document.myfile, loaded_myfile)
-                self.assertEqual(document.myfile.url, loaded_myfile.url)
-                self.assertEqual(document.myfile.storage, loaded_myfile.storage)
-                self.assertEqual(document.myfile.instance, loaded_myfile.instance)
-                self.assertEqual(document.myfile.field, loaded_myfile.field)
-            finally:
-                document.myfile.delete()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with override_settings(MEDIA_ROOT=Path(tmp_dir)):
+                with open(__file__, 'rb') as fp:
+                    file1 = File(fp, name='test_file.py')
+                    document = Document(myfile='test_file.py')
+                    document.myfile.save('test_file.py', file1)
+                    try:
+                        dump = pickle.dumps(document)
+                        loaded_document = pickle.loads(dump)
+                        self.assertEqual(document.myfile, loaded_document.myfile)
+                        self.assertEqual(
+                            document.myfile.url,
+                            loaded_document.myfile.url,
+                        )
+                        self.assertEqual(
+                            document.myfile.storage,
+                            loaded_document.myfile.storage,
+                        )
+                        self.assertEqual(
+                            document.myfile.instance,
+                            loaded_document.myfile.instance,
+                        )
+                        self.assertEqual(
+                            document.myfile.field,
+                            loaded_document.myfile.field,
+                        )
+                        myfile_dump = pickle.dumps(document.myfile)
+                        loaded_myfile = pickle.loads(myfile_dump)
+                        self.assertEqual(document.myfile, loaded_myfile)
+                        self.assertEqual(document.myfile.url, loaded_myfile.url)
+                        self.assertEqual(
+                            document.myfile.storage,
+                            loaded_myfile.storage,
+                        )
+                        self.assertEqual(
+                            document.myfile.instance,
+                            loaded_myfile.instance,
+                        )
+                        self.assertEqual(document.myfile.field, loaded_myfile.field)
+                    finally:
+                        document.myfile.delete()


### PR DESCRIPTION
Using the current directory caused a `PermissionError` (e.g. in [docker builds](https://travis-ci.org/django/django-docker-box/jobs/635839156?utm_medium=notification&utm_source=github_status)).