### PR TITLE
Refs #30943 -- Fixed postgres_tests on PostgreSQL 9.5.

### DIFF
--- a/tests/postgres_tests/migrations/0001_setup_extensions.py
+++ b/tests/postgres_tests/migrations/0001_setup_extensions.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from django.db import migrations
+from django.db import connection, migrations
 
 try:
     from django.contrib.postgres.operations import (
@@ -23,7 +23,11 @@ except ImportError:
 class Migration(migrations.Migration):
 
     operations = [
-        BloomExtension(),
+        (
+            BloomExtension()
+            if getattr(connection.features, 'has_bloom_index', False)
+            else mock.Mock()
+        ),
         BtreeGinExtension(),
         BtreeGistExtension(),
         CITextExtension(),


### PR DESCRIPTION
Bloom extension is available on PostgreSQL 9.6+ (see related failure in [django-docker-box](https://travis-ci.org/django/django-docker-box/jobs/635839167?utm_medium=notification&utm_source=github_status)).