### PR TITLE
Fixed #28699 - Get CSRF cookie from user-submitted value rather than modified request.META['CSRF_COOKIE'] value

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -200,6 +200,7 @@ answer newbie questions, and generally made Django that much better:
     Colin Wood <cwood06@gmail.com>
     Collin Anderson <cmawebsite@gmail.com>
     Collin Grady <collin@collingrady.com>
+    Colton Hicks <coltonbhicks@gmail.com>
     Craig Blaszczyk <masterjakul@gmail.com>
     crankycoder@gmail.com
     Curtis Maloney (FunkyBob) <curtis@tinbrain.net>

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -280,7 +280,7 @@ class CsrfViewMiddleware(MiddlewareMixin):
                     reason = REASON_BAD_REFERER % referer.geturl()
                     return self._reject(request, reason)
 
-            csrf_token = request.META.get('CSRF_COOKIE')
+            csrf_token = self._get_token(request)
             if csrf_token is None:
                 # No CSRF cookie. For POST requests, we insist on a CSRF cookie,
                 # and in this way we can avoid all CSRF attacks, including login


### PR DESCRIPTION
While issue #28699 is old, I think it will become more an issue as people migrate to using JWTs from auth providers like Auth0. Following the basic tutorial for securing an API in Django using auth0 causes failure of the CsrfViewMiddleware. Here's why based on the order of execution of middleware events:

```
MIDDLEWARE = [
    ...,
    'django.middleware.csrf.CsrfViewMiddleware',
    'django.contrib.auth.middleware.AuthenticationMiddleware',
    'django.contrib.auth.middleware.RemoteUserMiddleware',
    ...,
]
```

What executes:

1. CsrfViewMiddleware.process_request() which sets request.META['CSRF_COOKIE'] to the value submitted in the cookie by the user. This appears to be an entirely superfluous act and does not contribute to the csrf validation in any fundamental way.
2. RemoteUser.Middleware.process_request() which will login a user, call login(), and set the request.META['CSRF_COOKIE'] to a new csrf string.
3. After all the middleware has executed and a view is about to be run: CsrfViewMiddleware.process_view() will perform the actual csrf validation and will fail because it will access request.META['CSRF_COOKIE'] to get the user submitted csrf cookie string but will find instead the new csrf string set by the RemoteUserMiddleware. This string will not match the value submitted in the header and CSRF validation will fail despite proper inputs by the user. This is where the real csrf validation occurs.

I believe my proposed solution addresses this problem fundamentally without requiring any major changes to the middleware or auth backends. The logic of the code is fundamentally the same as the logic already implemented in the CsrfViewMiddleware.

Additionally, if there is something sacred about accessing the cookie value from request.META then I have another simple solution (it's what I implemented in my own subclass of CsrfViewMiddleware in my production application) that I can propose that respects this access pattern; however, I do believe the one-liner is simpler if changing the source code is a possibility.

Please let me know your thoughts!