### PR TITLE
Fixed #28699 -- Fixed CSRF validation with remote user middleware.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -201,6 +201,7 @@ answer newbie questions, and generally made Django that much better:
     Colin Wood <cwood06@gmail.com>
     Collin Anderson <cmawebsite@gmail.com>
     Collin Grady <collin@collingrady.com>
+    Colton Hicks <coltonbhicks@gmail.com>
     Craig Blaszczyk <masterjakul@gmail.com>
     crankycoder@gmail.com
     Curtis Maloney (FunkyBob) <curtis@tinbrain.net>

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -280,7 +280,10 @@ class CsrfViewMiddleware(MiddlewareMixin):
                     reason = REASON_BAD_REFERER % referer.geturl()
                     return self._reject(request, reason)
 
-            csrf_token = request.META.get('CSRF_COOKIE')
+            # Access csrf_token via self._get_token() as rotate_token() may
+            # have been called by an authentication middleware during the
+            # process_request() phase.
+            csrf_token = self._get_token(request)
             if csrf_token is None:
                 # No CSRF cookie. For POST requests, we insist on a CSRF cookie,
                 # and in this way we can avoid all CSRF attacks, including login

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -5,7 +5,8 @@ from django.contrib.auth import authenticate
 from django.contrib.auth.backends import RemoteUserBackend
 from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.contrib.auth.models import User
-from django.test import TestCase, modify_settings, override_settings
+from django.middleware.csrf import _get_new_csrf_string, _mask_cipher_secret
+from django.test import Client, TestCase, modify_settings, override_settings
 from django.utils import timezone
 
 
@@ -49,6 +50,35 @@ class RemoteUserTest(TestCase):
         response = self.client.get('/remote_user/', **{self.header: ''})
         self.assertTrue(response.context['user'].is_anonymous)
         self.assertEqual(User.objects.count(), num_users)
+
+    def test_csrf_validation_passes_after_process_request_login(self):
+        """
+        CSRF check must access the CSRF token from the session or cookie,
+        rather than the request, as rotate_token() may have been called by an
+        authentication middleware during the process_request() phase.
+        """
+        csrf_client = Client(enforce_csrf_checks=True)
+        csrf_secret = _get_new_csrf_string()
+        csrf_token = _mask_cipher_secret(csrf_secret)
+        csrf_token_form = _mask_cipher_secret(csrf_secret)
+        headers = {self.header: 'fakeuser'}
+        data = {'csrfmiddlewaretoken': csrf_token_form}
+
+        # Verify that CSRF is configured for the view
+        csrf_client.cookies.load({settings.CSRF_COOKIE_NAME: csrf_token})
+        response = csrf_client.post('/remote_user/', **headers)
+        self.assertEqual(response.status_code, 403)
+        self.assertIn(b'CSRF verification failed.', response.content)
+
+        # This request will call django.contrib.auth.login() which will call
+        # django.middleware.csrf.rotate_token() thus changing the value of
+        # request.META['CSRF_COOKIE'] from the user submitted value set by
+        # CsrfViewMiddleware.process_request() to the new csrftoken value set
+        # by rotate_token(). Csrf validation should still pass when the view is
+        # later processed by CsrfViewMiddleware.process_view()
+        csrf_client.cookies.load({settings.CSRF_COOKIE_NAME: csrf_token})
+        response = csrf_client.post('/remote_user/', data, **headers)
+        self.assertEqual(response.status_code, 200)
 
     def test_unknown_user(self):
         """


### PR DESCRIPTION
Modified how the `process_view` function accesses the csrf cookie string
so that it always accesses the user-submitted value, even when the user
authenticated via RemoteUserMiddleware.

When a user authenticates via RemoteUserMiddleware the value of
`request.META['CSRF_COOKIE']` gets rotated by a call to
`django.middleware.csrf.rotate_token` triggered by a call to
`django.contrib.auth.login()`. When the process_view function executes, after
all middlewares, including RemoteUserMiddleware, and immediately prior
to the view function, the value in `request.META['CSRF_COOKIE']` no longer
represents the user-submitted value but rather the new, rotated csrf
token string and csrf validation mistakenly fails. Accessing the token
via `self.get_token(request)` fixes this problem.

While issue ticket-28699 is old, I think it will become more an issue as people migrate to using JWTs from auth providers like Auth0. Following the basic tutorial for securing an API in Django using auth0 causes failure of the CsrfViewMiddleware. Here's why based on the order of execution of middleware events:

```
MIDDLEWARE = [
    ...,
    'django.middleware.csrf.CsrfViewMiddleware',
    'django.contrib.auth.middleware.AuthenticationMiddleware',
    'django.contrib.auth.middleware.RemoteUserMiddleware',
    ...,
]
```

What executes:

1. `CsrfViewMiddleware.process_request()` which sets `request.META['CSRF_COOKIE']` to the value submitted in the cookie by the user. This act does not seem essential to the CSRF validation process (we could simply pass on this method and run the process_view() method since it contains all the actual CSRF validation logic). However, as pointed out by @carltongibson below, the behavior of the process_request() method "is required so that, for example, 404 error handlers do not incorrectly regenerate the CSRF token, prior to CsrfViewMiddleware.process_view() ever being executed."
1. RemoteUser.Middleware.process_request() which will login a user, call login(), and set the `request.META['CSRF_COOKIE']` to a new csrf string.
3. After all the middleware has executed and a view is about to be run, CsrfViewMiddleware.process_view() will perform the actual csrf validation and will fail because it will access `request.META['CSRF_COOKIE']` to get the user submitted csrf cookie string but will find instead the new csrf string set by the RemoteUserMiddleware. This string will not match the value submitted in the header and CSRF validation will fail despite proper inputs by the user. This is where the real csrf validation occurs.

I believe my proposed solution addresses this problem fundamentally without requiring any major changes to the middleware or auth backends. The logic of the code is fundamentally the same as the logic already implemented in the CsrfViewMiddleware.

Additionally, if there is something functionally important to django about accessing the cookie value from `request.META` then I have another simple solution (it's what I implemented in my own subclass of CsrfViewMiddleware in my production application) that I can propose that respects this access pattern; however, I do believe the one-liner is simpler if changing the source code is a possibility. I mention this because I do not know what should/shouldn't be in request.META and if there are access patterns that are important to be maintained by getting the CSRF_COOKIE value from request.META instead of from the request.cookie directly.

Please let me know your thoughts!
