### PR TITLE
- Fix the issue of "__str__ returned non-string (type __proxy__)"

### DIFF
--- a/django/forms/templates/django/forms/widgets/select_option.html
+++ b/django/forms/templates/django/forms/widgets/select_option.html
@@ -1,1 +1,1 @@
-<option value="{{ widget.value|stringformat:'s' }}"{% include "django/forms/widgets/attrs.html" %}>{{ widget.label }}</option>
+<option value="{{ widget.value|stringformat:'s' }}"{% include "django/forms/widgets/attrs.html" %}>{{ widget.label|stringformat:'s' }}</option>


### PR DESCRIPTION
This string format for the label will resolve the non-string issue that occurred in the advanced setting for the page.