### PR TITLE
Fixed #31226 -- Fixed typo in docs/internals/contributing/writing-code/submitting-patches.txt.

### DIFF
--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -158,7 +158,7 @@ the ticket for opinions.
 Deprecating a feature
 =====================
 
-There are a couple reasons that code in Django might be deprecated:
+There are a couple of reasons that code in Django might be deprecated:
 
 * If a feature has been improved or modified in a backwards-incompatible way,
   the old feature or behavior will be deprecated.


### PR DESCRIPTION
[Ticket #31226](https://code.djangoproject.com/ticket/31226)

Inserted **of** (missing preposition) in the mentioned line:

> There are a couple reasons that code in Django might be deprecated: