### PR TITLE
Refs #27604 -- Fixed loading of legacy cookie hashes when CookieStorage.key_salt is changed.

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -129,7 +129,11 @@ class CookieStorage(BaseStorage):
         Create an HMAC/SHA1 hash based on the value and the project setting's
         SECRET_KEY, modified to make it unique for the present purpose.
         """
-        return salted_hmac(self.key_salt, value).hexdigest()
+        # The class wide key salt is not reused here since older Django
+        # versions had it fixed and making it dynamic would break old hashes if
+        # self.key_salt is changed.
+        key_salt = 'django.contrib.messages'
+        return salted_hmac(key_salt, value).hexdigest()
 
     def _encode(self, messages, encode_empty=False):
         """


### PR DESCRIPTION
This is a partial revert of bcc9fa25285f506666fa5074fc43c7114d61bb79 to
not break legacy hashes when key_salt is actually changed.