### PR TITLE
Fixed #28528 -- Allowed combining SearchVectors with different configs.

### DIFF
--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -56,7 +56,7 @@ class SearchVectorCombinable:
     ADD = '||'
 
     def _combine(self, other, connector, reversed):
-        if not isinstance(other, SearchVectorCombinable) or not self.config == other.config:
+        if not isinstance(other, SearchVectorCombinable):
             raise TypeError(
                 'SearchVector can only be combined with other SearchVector '
                 'instances, got %s.' % type(other).__name__

--- a/tests/postgres_tests/test_search.py
+++ b/tests/postgres_tests/test_search.py
@@ -297,6 +297,17 @@ class TestCombinations(GrailTestData, PostgreSQLTestCase):
         with self.assertRaisesMessage(TypeError, msg):
             Line.objects.filter(dialogue__search=None + SearchVector('character__name'))
 
+    def test_combine_different_vector_configs(self):
+        searched = Line.objects.annotate(
+            search=(
+                SearchVector('dialogue', config='english') +
+                SearchVector('dialogue', config='french')
+            ),
+        ).filter(
+            search=SearchQuery('cadeaux', config='french') | SearchQuery('nostrils')
+        )
+        self.assertCountEqual(searched, [self.french, self.verse2])
+
     def test_query_and(self):
         searched = Line.objects.annotate(
             search=SearchVector('scene__setting', 'dialogue'),


### PR DESCRIPTION
[code.djangoproject.com/ticket/28528](https://code.djangoproject.com/ticket/28528)