### PR TITLE
Allow empty form value for nullable fields

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -888,7 +888,7 @@ class Field(RegisterLookupMixin):
     def formfield(self, form_class=None, choices_form_class=None, **kwargs):
         """Return a django.forms.Field instance for this field."""
         defaults = {
-            'required': not self.blank,
+            'required': not self.blank and not self.null,
             'label': capfirst(self.verbose_name),
             'help_text': self.help_text,
         }


### PR DESCRIPTION
## The Problem

The following DB model field cannot be set to NULL from Django Admin:

```
    my_field = models.CharField(
        max_length=100,
        blank=False,
        null=True,
    )
```

Current implementation makes this field `required`.
This will change boldness of the field in HTML and backend
validator will deny empty data.

After the change it is possible to pass empty string value
from web browser and backend will treat it as NULL for DB.