### PR TITLE
Closed caches in clear_cache_handlers() signal handler.

### DIFF
--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -26,7 +26,8 @@ COMPLEX_OVERRIDE_SETTINGS = {'DATABASES'}
 @receiver(setting_changed)
 def clear_cache_handlers(**kwargs):
     if kwargs['setting'] == 'CACHES':
-        from django.core.cache import caches
+        from django.core.cache import caches, close_caches
+        close_caches()
         caches._caches = Local()
 
 


### PR DESCRIPTION
When running the Django test suite, fixes warnings of the form:

    Exception ignored in: <socket.socket fd=11, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 39112), raddr=('127.0.0.1', 11211)>
    Traceback (most recent call last):
      File ".../django/test/signals.py", line 30, in clear_cache_handlers
        caches._caches = Local()
    ResourceWarning: unclosed <socket.socket fd=11, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 39112), raddr=('127.0.0.1', 11211)>