### PR TITLE
Fix MultipleObjectMixin for paginator-specific page number

### DIFF
--- a/django/views/generic/list.py
+++ b/django/views/generic/list.py
@@ -59,7 +59,7 @@ class MultipleObjectMixin(ContextMixin):
         page_kwarg = self.page_kwarg
         page = self.kwargs.get(page_kwarg) or self.request.GET.get(page_kwarg) or 1
         try:
-            page_number = int(page)
+            page_number = paginator.validate_number(page)
         except ValueError:
             if page == 'last':
                 page_number = paginator.num_pages


### PR DESCRIPTION
In a real worlds it is possible to use a different pagination than one based on number. Examples are described at https://www.django-rest-framework.org/api-guide/pagination/.

Verifying the correctness of the page number is the responsibility of Paginator, not the class responsible for its use.

I even think that it is worth eliminating ```last``` from ```MultipleObjectMixin```. I believe it should be handled by the paginator, which accepts "last" as the page number. Not every paginator allows you to effectively identify the ID of the last page.