### PR TITLE
Refs #31055 -- Fixed Model.check() call in ConstraintsTests.test_check_constraints_required_db_features().

### DIFF
--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -1241,4 +1241,4 @@ class ConstraintsTests(TestCase):
                 required_db_features = {'supports_table_check_constraints'}
                 constraints = [models.CheckConstraint(check=models.Q(age__gte=18), name='is_adult')]
 
-        self.assertEqual(Model.check(), [])
+        self.assertEqual(Model.check(databases=self.databases), [])


### PR DESCRIPTION
A system check for `CheckConstraint`'s is ignored without passing `databases`.