### PR TITLE
Fixed #31249 -- select_for_update 'of' crashed with Multilevel Inherited models

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -969,7 +969,10 @@ class SQLCompiler:
                     'select_fields': [
                         select_index
                         for select_index in klass_info['select_fields']
-                        if self.select[select_index][0].target.model == parent_model
+                        if self.select[select_index][0].target.model in (
+                            parent_model,
+                            *parent_model._meta.get_parent_list(),
+                        )
                     ],
                 }
                 for parent_model, parent_link in klass_info['model']._meta.parents.items()

--- a/tests/select_for_update/models.py
+++ b/tests/select_for_update/models.py
@@ -27,3 +27,15 @@ class Person(models.Model):
 
 class PersonProfile(models.Model):
     person = models.OneToOneField(Person, models.CASCADE, related_name='profile')
+
+
+class GrandParent(models.Model):
+    name = models.CharField(max_length=30)
+
+
+class Parent(GrandParent):
+    pass
+
+
+class Child(Parent):
+    pass

--- a/tests/select_for_update/tests.py
+++ b/tests/select_for_update/tests.py
@@ -163,7 +163,7 @@ class SelectForUpdateTests(TransactionTestCase):
         self.assertTrue(self.has_for_update_sql(ctx.captured_queries, of=expected))
 
     @skipUnlessDBFeature('has_select_for_update_of')
-    def test_for_update_sql_multi_model_intehritance_ptr_generated_of(self):
+    def test_for_update_sql_multilevel_model_intehritance_ptr_generated_of(self):
         with transaction.atomic(), CaptureQueriesContext(connection) as ctx:
             list(Child.objects.select_for_update(of=('parent_ptr', 'parent_ptr__grandparent_ptr')))
         if connection.features.select_for_update_of_column:


### PR DESCRIPTION
Evaluating a queryset, with select_for_update 'of' referencing a
parent model two levels up from the queryset model, crashed with
IndexError.

This PR excepts the patch from PR #12434 (Ticket #31246). Hence, the added test case will fail.