### PR TITLE
Fixes ka_GE casing issue for new Unicode 11 standard

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -72,7 +72,7 @@ def addslashes(value):
 @stringfilter
 def capfirst(value):
     """Capitalize the first character of the value."""
-    return value and value[0].upper() + value[1:]
+    return value and value[0].encode('utf-8').upper().decode('utf-8') + value[1:]
 
 
 @register.filter("escapejs")
@@ -302,7 +302,7 @@ def truncatewords_html(value, arg):
 @stringfilter
 def upper(value):
     """Convert a string into all uppercase."""
-    return value.upper()
+    return value.encode('utf-8').upper().decode('utf-8')
 
 
 @register.filter(is_safe=False)

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -2,6 +2,7 @@
 import random as random_module
 import re
 import types
+import unicodedata
 from decimal import ROUND_HALF_UP, Context, Decimal, InvalidOperation
 from functools import wraps
 from operator import itemgetter
@@ -71,8 +72,26 @@ def addslashes(value):
 @register.filter(is_safe=True)
 @stringfilter
 def capfirst(value):
-    """Capitalize the first character of the value."""
-    return value and value[0].encode('utf-8').upper().decode('utf-8') + value[1:]
+    """
+    Capitalize the first character of the value.
+
+    Georgian is that the primary orthography does not use titlecasing,
+    This is unique among bicameral systems in the Unicode Standard,
+    so casing implementations should be prepared for this exception.
+
+    See https://www.unicode.org/versions/Unicode11.0.0/#Migration
+    for documentation of Unicode 11.0 standard.
+
+    casting issue https://bugs.python.org/issue37121
+
+    >>> 'ჯანგო'.capitalize()
+    'Ლანგო'
+    >>> 'ჯანგო'.upper()
+    'ᲚᲚᲚᲚᲚ'
+    """
+    if value and unicodedata.name(value[0]).startswith('GEORGIAN LETTER'):
+        return value
+    return value and value[0].upper() + value[1:]
 
 
 @register.filter("escapejs")
@@ -301,8 +320,27 @@ def truncatewords_html(value, arg):
 @register.filter(is_safe=False)
 @stringfilter
 def upper(value):
-    """Convert a string into all uppercase."""
-    return value.encode('utf-8').upper().decode('utf-8')
+    """
+    Convert a string into all uppercase.
+
+    Georgian is that the primary orthography does not use titlecasing,
+    This is unique among bicameral systems in the Unicode Standard,
+    so casing implementations should be prepared for this exception.
+
+    See https://www.unicode.org/versions/Unicode11.0.0/#Migration
+    for documentation of Unicode 11.0 standard.
+
+    casting issue https://bugs.python.org/issue37121
+
+    >>> 'ჯანგო'.capitalize()
+    'Ლანგო'
+    >>> 'ჯანგო'.upper()
+    'ᲚᲚᲚᲚᲚ'
+    """
+    for val in value:
+        if val and unicodedata.name(val).startswith('GEORGIAN LETTER'):
+            return value
+    return value.upper()
 
 
 @register.filter(is_safe=False)

--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -14,7 +14,7 @@ from django.utils.translation import gettext as _, gettext_lazy, pgettext
 @keep_lazy_text
 def capfirst(x):
     """Capitalize the first letter of a string."""
-    return x and str(x)[0].upper() + str(x)[1:]
+    return x and str(x)[0].encode('utf-8').upper().decode('utf-8') + str(x)[1:]
 
 
 # Set up regular expressions

--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -13,8 +13,26 @@ from django.utils.translation import gettext as _, gettext_lazy, pgettext
 
 @keep_lazy_text
 def capfirst(x):
-    """Capitalize the first letter of a string."""
-    return x and str(x)[0].encode('utf-8').upper().decode('utf-8') + str(x)[1:]
+    """
+    Capitalize the first letter of a string.
+
+    Georgian is that the primary orthography does not use titlecasing,
+    This is unique among bicameral systems in the Unicode Standard,
+    so casing implementations should be prepared for this exception.
+
+    See https://www.unicode.org/versions/Unicode11.0.0/#Migration
+    for documentation of Unicode 11.0 standard.
+
+    casting issue https://bugs.python.org/issue37121
+
+    >>> 'ჯანგო'.capitalize()
+    'Ლანგო'
+    >>> 'ჯანგო'.upper()
+    'ᲚᲚᲚᲚᲚ'
+    """
+    if x and unicodedata.name(str(x)[0]).startswith('GEORGIAN LETTER'):
+        return x
+    return x and str(x)[0].upper() + str(x)[1:]
 
 
 # Set up regular expressions

--- a/tests/template_tests/filter_tests/test_capfirst.py
+++ b/tests/template_tests/filter_tests/test_capfirst.py
@@ -17,8 +17,14 @@ class CapfirstTests(SimpleTestCase):
         output = self.engine.render_to_string('capfirst02', {'a': 'fred>', 'b': mark_safe('fred&gt;')})
         self.assertEqual(output, 'Fred&gt; Fred&gt;')
 
+    @setup({'capfirst03': '{{ a|capfirst }} {{ b|capfirst }}'})
+    def test_capfirst03(self):
+        output = self.engine.render_to_string('capfirst03', {'a': 'სიახლე', 'b': mark_safe('სიახლეები;')})
+        self.assertEqual(output, 'სიახლე სიახლეები;')
+
 
 class FunctionTests(SimpleTestCase):
 
     def test_capfirst(self):
         self.assertEqual(capfirst('hello world'), 'Hello world')
+        self.assertEqual(capfirst('საქართველო'), 'საქართველო')

--- a/tests/template_tests/filter_tests/test_upper.py
+++ b/tests/template_tests/filter_tests/test_upper.py
@@ -21,11 +21,17 @@ class UpperTests(SimpleTestCase):
         output = self.engine.render_to_string('upper02', {'a': 'a & b', 'b': mark_safe('a &amp; b')})
         self.assertEqual(output, 'A &amp; B A &amp;AMP; B')
 
+    @setup({'upper03': '{{ a|upper }} {{ b|upper }}'})
+    def test_upper03(self):
+        output = self.engine.render_to_string('upper03', {'a': 'სიახლე', 'b': mark_safe('სიახლეები;')})
+        self.assertEqual(output, 'სიახლე სიახლეები;')
+
 
 class FunctionTests(SimpleTestCase):
 
     def test_upper(self):
         self.assertEqual(upper('Mixed case input'), 'MIXED CASE INPUT')
+        self.assertEqual(upper('საქართველო'), 'საქართველო')
 
     def test_unicode(self):
         # lowercase e umlaut

--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -13,6 +13,13 @@ IS_WIDE_BUILD = (len('\U0001F4A9') == 1)
 
 class TestUtilsText(SimpleTestCase):
 
+    def test_capfirst(self):
+        self.assertEqual(text.capfirst('english'), 'English')
+        self.assertEqual(text.capfirst('სიახლეები'), 'სიახლეები')
+        self.assertEqual(text.capfirst('a'), 'A')
+        self.assertEqual(text.capfirst('ა'), 'ა')
+        self.assertEqual(text.capfirst(''), '')
+
     def test_get_text_list(self):
         self.assertEqual(text.get_text_list(['a', 'b', 'c', 'd']), 'a, b, c or d')
         self.assertEqual(text.get_text_list(['a', 'b', 'c'], 'and'), 'a, b and c')

--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -19,6 +19,7 @@ class TestUtilsText(SimpleTestCase):
         self.assertEqual(text.capfirst('a'), 'A')
         self.assertEqual(text.capfirst('ა'), 'ა')
         self.assertEqual(text.capfirst(''), '')
+        self.assertEqual(text.capfirst('\xeb'), '\xcb')
 
     def test_get_text_list(self):
         self.assertEqual(text.get_text_list(['a', 'b', 'c', 'd']), 'a, b, c or d')


### PR DESCRIPTION
Georgian Script Casing in Python 3.7 and Unicode 11

The problem is in all versions starting with python 3.7, let's go back a little and follow what happened.
So with the new version of [Unicode 11 (June 5, 2018)](https://unicode.org/versions/Unicode11.0.0/) we have some major changes for the Georgian script. Georgian was considered a monocameral (non-casing) script. Therefore, Georgian letters were gc=Lo(Letter, Other) and starting from the version 11 [Unicode 11.0, those Georgian letters are now gc=Ll(Letter, Lowercase)](https://www.unicode.org/versions/Unicode11.0.0/#Migration). In python 3.7 first release(June 27, 2018), we have implementation of Unicode 11 and manipulation on the Georgian scripts (capitalize, titlecasing, uppercase) gives us strange symbols on the output.


ex. shown below

```
Python 3.7.5 (default, Oct 17 2019, 12:21:00) 
[GCC 8.3.1 20190223 (Red Hat 8.3.1-2)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 'ა'
'ა'
>>> 'ა'.upper()
'Ლ'
>>> print('ა'.upper())
Ლ
>>> print('ლაშა'.upper())
ᲚᲐᲨᲐᲐ
>>> print('ლაშა'.capitalize())
Ლაშა
```
[Casting issue on the Python issue tracker](https://bugs.python.org/issue37121)

The bug is in `capfirst` [link](https://docs.djangoproject.com/en/3.0/ref/templates/builtins/#capfirst) and `upper` [link](https://docs.djangoproject.com/en/3.0/ref/templates/builtins/#upper) methods 

These is django builtin tags, which is used to capitalize the first letter of a string and converts a string into all uppercase. When i used to this tag in  template gives me strange symbols on the output.

Also, this bug affects the Django ain because this filter tag is used in model forms and templates in Django admin.

[fixes implementation](https://gist.github.com/Lh4cKg/16a8433affb1636086ba2c51dcfbe1f3)