### PR TITLE
Fixed #31270 -- Doc'd RedirectView.get_redirect_url() arguments.

### DIFF
--- a/docs/ref/class-based-views/base.txt
+++ b/docs/ref/class-based-views/base.txt
@@ -260,6 +260,10 @@ MRO is an acronym for Method Resolution Order.
 
         Constructs the target URL for redirection.
 
+        The ``args`` and ``kwargs`` arguments are positional and/or keyword
+        arguments :ref:`captured from the URL pattern
+        <how-django-processes-a-request>`, respectively.
+
         The default implementation uses :attr:`url` as a starting
         string and performs expansion of ``%`` named parameters in that string
         using the named groups captured in the URL.


### PR DESCRIPTION
Fixes [ticket 31270](https://code.djangoproject.com/ticket/31270)