### PR TITLE
Fixed #7664 -- Allowed customizing suffixes of MultiWidget.widgets' names.

### DIFF
--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -354,7 +354,27 @@ foundation for custom widgets.
 
     .. attribute:: MultiWidget.widgets
 
-        An iterable containing the widgets needed.
+        An iterable containing the widgets needed. For example::
+
+            >>> from django.forms import MultiWidget, TextInput
+            >>> widget = MultiWidget(widgets=[TextInput, TextInput])
+            >>> widget.render('name', ['john', 'paul'])
+            '<input type="text" name="name_0" value="john"><input type="text" name="name_1" value="paul">'
+
+        You may provide a dictionary in order to specify custom suffixes for
+        the ``name`` attribute on each subwidget. In this case, for each
+        ``(key, widget)`` pair, the key will be appended to the ``name`` of the
+        widget in order to generate the attribute value. You may provide the
+        empty string (`''`) for a single key, in order to suppress the suffix
+        for one widget. For example::
+
+            >>> widget = MultiWidget(widgets={'': TextInput, 'last': TextInput})
+            >>> widget.render('name', ['john', 'lennon'])
+            '<input type="text" name="name" value="john"><input type="text" name="name_last" value="paul">'
+
+        .. versionchanged::3.1
+
+            Support for using a dictionary was added.
 
     And one required method:
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -270,6 +270,9 @@ Forms
   now uses ``DATE_INPUT_FORMATS`` in addition to ``DATETIME_INPUT_FORMATS``
   when converting a field input to a ``datetime`` value.
 
+* :attr:`.MultiWidget.widgets` now accepts a dictionary which allows
+  customizing subwidget ``name`` attributes.
+
 Generic Views
 ~~~~~~~~~~~~~
 

--- a/tests/forms_tests/widget_tests/test_multiwidget.py
+++ b/tests/forms_tests/widget_tests/test_multiwidget.py
@@ -79,6 +79,19 @@ class DeepCopyWidget(MultiWidget):
 
 
 class MultiWidgetTest(WidgetTest):
+    def test_subwidgets_name(self):
+        widget = MultiWidget(
+            widgets={
+                '': TextInput(),
+                'big': TextInput(attrs={'class': 'big'}),
+                'small': TextInput(attrs={'class': 'small'}),
+            },
+        )
+        self.check_html(widget, 'name', ['John', 'George', 'Paul'], html=(
+            '<input type="text" name="name" value="John">'
+            '<input type="text" name="name_big" value="George" class="big">'
+            '<input type="text" name="name_small" value="Paul" class="small">'
+        ))
 
     def test_text_inputs(self):
         widget = MyMultiWidget(
@@ -132,6 +145,36 @@ class MultiWidgetTest(WidgetTest):
         self.assertIs(widget.value_omitted_from_data({'field_0': 'x'}, {}, 'field'), False)
         self.assertIs(widget.value_omitted_from_data({'field_1': 'y'}, {}, 'field'), False)
         self.assertIs(widget.value_omitted_from_data({'field_0': 'x', 'field_1': 'y'}, {}, 'field'), False)
+
+    def test_value_from_datadict_subwidgets_name(self):
+        widget = MultiWidget(widgets={'x': TextInput(), '': TextInput()})
+        tests = [
+            ({}, [None, None]),
+            ({'field': 'x'}, [None, 'x']),
+            ({'field_x': 'y'}, ['y', None]),
+            ({'field': 'x', 'field_x': 'y'}, ['y', 'x']),
+        ]
+        for data, expected in tests:
+            with self.subTest(data):
+                self.assertEqual(
+                    widget.value_from_datadict(data, {}, 'field'),
+                    expected,
+                )
+
+    def test_value_omitted_from_data_subwidgets_name(self):
+        widget = MultiWidget(widgets={'x': TextInput(), '': TextInput()})
+        tests = [
+            ({}, True),
+            ({'field': 'x'}, False),
+            ({'field_x': 'y'}, False),
+            ({'field': 'x', 'field_x': 'y'}, False),
+        ]
+        for data, expected in tests:
+            with self.subTest(data):
+                self.assertIs(
+                    widget.value_omitted_from_data(data, {}, 'field'),
+                    expected,
+                )
 
     def test_needs_multipart_true(self):
         """


### PR DESCRIPTION
Allows names to be passed into MultiWidget and name it's sub widgets. [Ticket #7664.](https://code.djangoproject.com/ticket/7664)

This ticket had a patch written some time ago. I've therefore created this pull request with the original patch to try and close this ticket. 
