### PR TITLE
Removed redundant MiddlewareTest.test_old_style_request() test.

### DIFF
--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -327,14 +327,6 @@ class CreateDefaultSiteTests(TestCase):
 
 
 class MiddlewareTest(TestCase):
-
-    def test_old_style_request(self):
-        """The request has correct `site` attribute."""
-        middleware = CurrentSiteMiddleware()
-        request = HttpRequest()
-        middleware.process_request(request)
-        self.assertEqual(request.site.id, settings.SITE_ID)
-
     def test_request(self):
         def get_response(request):
             return HttpResponse(str(request.site.id))


### PR DESCRIPTION
`CurrentSiteMiddleware.process_request()` is already covered by `MiddlewareTest.test_request()`.