### PR TITLE
Removed unused and incorrect PossessedCar.__str__() method in test_utils.

### DIFF
--- a/tests/test_utils/models.py
+++ b/tests/test_utils/models.py
@@ -19,6 +19,3 @@ class Person(models.Model):
 class PossessedCar(models.Model):
     car = models.ForeignKey(Car, models.CASCADE)
     belongs_to = models.ForeignKey(Person, models.CASCADE)
-
-    def __str__(self):
-        return self.color


### PR DESCRIPTION
`PossessedCar` doesn't have a color.