### PR TITLE
Fixed #30040 -- Used default permission name in docs examples to avoid confusion.

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -717,13 +717,13 @@ The ``permission_required`` decorator
 
         from django.contrib.auth.decorators import permission_required
 
-        @permission_required('polls.can_vote')
+        @permission_required('polls.add_choice')
         def my_view(request):
             ...
 
     Just like the :meth:`~django.contrib.auth.models.User.has_perm` method,
     permission names take the form ``"<app label>.<permission codename>"``
-    (i.e. ``polls.can_vote`` for a permission on a model in the ``polls``
+    (i.e. ``polls.add_choice`` for a permission on a model in the ``polls``
     application).
 
     The decorator may also take an iterable of permissions, in which case the
@@ -734,7 +734,7 @@ The ``permission_required`` decorator
 
         from django.contrib.auth.decorators import permission_required
 
-        @permission_required('polls.can_vote', login_url='/loginpage/')
+        @permission_required('polls.add_choice', login_url='/loginpage/')
         def my_view(request):
             ...
 
@@ -753,7 +753,7 @@ The ``permission_required`` decorator
         from django.contrib.auth.decorators import login_required, permission_required
 
         @login_required
-        @permission_required('polls.can_vote', raise_exception=True)
+        @permission_required('polls.add_choice', raise_exception=True)
         def my_view(request):
             ...
 
@@ -779,9 +779,9 @@ To apply permission checks to :doc:`class-based views
         from django.contrib.auth.mixins import PermissionRequiredMixin
 
         class MyView(PermissionRequiredMixin, View):
-            permission_required = 'polls.can_vote'
+            permission_required = 'polls.add_choice'
             # Or multiple of permissions:
-            permission_required = ('polls.can_open', 'polls.can_edit')
+            permission_required = ('polls.view_choice', 'polls.change_choice')
 
     You can set any of the parameters of
     :class:`~django.contrib.auth.mixins.AccessMixin` to customize the handling
@@ -1611,9 +1611,9 @@ the logged-in user has any permissions in the ``foo`` app::
 
 Evaluating a two-level-attribute lookup as a boolean is a proxy to
 :meth:`User.has_perm() <django.contrib.auth.models.User.has_perm>`. For example,
-to check if the logged-in user has the permission ``foo.can_vote``::
+to check if the logged-in user has the permission ``foo.add_vote``::
 
-    {% if perms.foo.can_vote %}
+    {% if perms.foo.add_vote %}
 
 Here's a more complete example of checking permissions in a template:
 
@@ -1621,10 +1621,10 @@ Here's a more complete example of checking permissions in a template:
 
     {% if perms.foo %}
         <p>You have permission to do something in the foo app.</p>
-        {% if perms.foo.can_vote %}
+        {% if perms.foo.add_vote %}
             <p>You can vote!</p>
         {% endif %}
-        {% if perms.foo.can_drive %}
+        {% if perms.foo.add_driving %}
             <p>You can drive!</p>
         {% endif %}
     {% else %}
@@ -1637,7 +1637,7 @@ For example:
 .. code-block:: html+django
 
     {% if 'foo' in perms %}
-        {% if 'foo.can_vote' in perms %}
+        {% if 'foo.add_vote' in perms %}
             <p>In lookup works, too.</p>
         {% endif %}
     {% endif %}


### PR DESCRIPTION
Fixes [ticket 30040](https://code.djangoproject.com/ticket/30040).
Continue to [PR](https://github.com/django/django/pull/10757).
Changed previous pr `polls` app related permission `'polls.add_vote'` to `'polls.add_choice'` based on @claudep [comment](https://code.djangoproject.com/timeline?from=2018-12-17T13%3A44%3A06-06%3A00&precision=second).
The remain `add_vote` permissions don't related to `polls` app and I didn't change them.