### PR TITLE
Fixed #31228 -- Reallowed aggregates to be used with multiple expressions and no DISTINCT on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -56,7 +56,11 @@ class DatabaseOperations(BaseDatabaseOperations):
                             'aggregations on date/time fields in sqlite3 '
                             'since date/time is saved as text.'
                         )
-        if isinstance(expression, models.Aggregate) and len(expression.source_expressions) > 1:
+        if (
+            isinstance(expression, models.Aggregate) and
+            expression.distinct and
+            len(expression.source_expressions) > 1
+        ):
             raise NotSupportedError(
                 "SQLite doesn't support DISTINCT on aggregate functions "
                 "accepting multiple arguments."

--- a/tests/backends/sqlite/tests.py
+++ b/tests/backends/sqlite/tests.py
@@ -63,6 +63,15 @@ class Tests(TestCase):
         with self.assertRaisesMessage(NotSupportedError, msg):
             connection.ops.check_expression_support(aggregate)
 
+    def test_distinct_aggregation_multiple_args_no_distinct(self):
+        # Aggregate functions accept multiple arguments when DISTINCT isn't
+        # used, e.g. GROUP_CONCAT().
+        class DistinctAggregate(Aggregate):
+            allow_distinct = True
+
+        aggregate = DistinctAggregate('first', 'second', distinct=False)
+        connection.ops.check_expression_support(aggregate)
+
     def test_memory_db_test_name(self):
         """A named in-memory db should be allowed where supported."""
         from django.db.backends.sqlite3.base import DatabaseWrapper


### PR DESCRIPTION
Aggregation with multiple expressions and no DISTINCT raises NotSupported Error on sqlite backend.
