### PR TITLE
Fixed #31282 -- Corrected RelatedManager docs for using add/remove/set with PKs.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -697,6 +697,10 @@ def create_reverse_many_to_one_manager(superclass, rel):
                 val = self.field.get_foreign_related_value(self.instance)
                 old_ids = set()
                 for obj in objs:
+                    if not isinstance(obj, self.model):
+                        raise TypeError("'%s' instance expected, got %r" % (
+                            self.model._meta.object_name, obj,
+                        ))
                     # Is obj actually part of this descriptor set?
                     if self.field.get_local_related_value(obj) == val:
                         old_ids.add(obj.pk)

--- a/docs/ref/models/relations.txt
+++ b/docs/ref/models/relations.txt
@@ -66,8 +66,8 @@ Related objects reference
         Using ``add()`` on a relation that already exists won't duplicate the
         relation, but it will still trigger signals.
 
-        ``add()`` also accepts the field the relation points to as an argument.
-        The above example can be rewritten as ``b.entry_set.add(234)``.
+        For many-to-many relationships ``add()`` accepts either model instances
+        or field values, normally primary keys, as the ``*objs`` argument.
 
         Use the ``through_defaults`` argument to specify values for the new
         :ref:`intermediate model <intermediary-manytomany>` instance(s), if
@@ -134,9 +134,9 @@ Related objects reference
         :data:`~django.db.models.signals.m2m_changed` signal if you wish to
         execute custom code when a relationship is deleted.
 
-        Similarly to :meth:`add()`, ``remove()`` also accepts the field the
-        relation points to as an argument. The above example can be rewritten
-        as ``b.entry_set.remove(234)``.
+        For many-to-many relationships ``remove()`` accepts either model
+        instances or field values, normally primary keys, as the ``*objs``
+        argument.
 
         For :class:`~django.db.models.ForeignKey` objects, this method only
         exists if ``null=True``. If the related field can't be set to ``None``
@@ -198,9 +198,9 @@ Related objects reference
         race conditions. For instance, new objects may be added to the database
         in between the call to ``clear()`` and the call to ``add()``.
 
-        Similarly to :meth:`add()`, ``set()`` also accepts the field the
-        relation points to as an argument. The above example can be rewritten
-        as ``e.related_set.set([obj1.pk, obj2.pk, obj3.pk])``.
+        For many-to-many relationships ``set()`` accepts a list of either model
+        instances or field values, normally primary keys, as the ``objs``
+        argument.
 
         Use the ``through_defaults`` argument to specify values for the new
         :ref:`intermediate model <intermediary-manytomany>` instance(s), if

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -733,3 +733,14 @@ class ManyToOneTests(TestCase):
         child = parent.to_field_children.get()
         with self.assertNumQueries(0):
             self.assertIs(child.parent, parent)
+
+    def test_add_remove_set_by_pk_raises(self):
+        usa = Country.objects.create(name='United States')
+        chicago = City.objects.create(name='Chicago')
+        msg = "'City' instance expected, got %s" % chicago.pk
+        with self.assertRaisesMessage(TypeError, msg):
+            usa.cities.add(chicago.pk)
+        with self.assertRaisesMessage(TypeError, msg):
+            usa.cities.remove(chicago.pk)
+        with self.assertRaisesMessage(TypeError, msg):
+            usa.cities.set([chicago.pk])


### PR DESCRIPTION
Using add/remove/set with PKs is only valid for M2M.
Added tests showing errors for FK.

Regression in a44a21a22f20c1a710670676fcca798dd6bb5ac0