### PR TITLE
Fixed #31292 -- Fixed django.contrib.gis.gdal.gdal_full_version() crash.

### DIFF
--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -80,7 +80,7 @@ def gdal_version():
 
 def gdal_full_version():
     "Return the full GDAL version information."
-    return _version_info('')
+    return _version_info(b'')
 
 
 version_regex = _lazy_re_compile(r'^(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<subminor>\d+))?')

--- a/tests/gis_tests/gdal_tests/tests.py
+++ b/tests/gis_tests/gdal_tests/tests.py
@@ -1,6 +1,8 @@
 import unittest
 
-from django.contrib.gis.gdal import GDAL_VERSION, gdal_version
+from django.contrib.gis.gdal import (
+    GDAL_VERSION, gdal_full_version, gdal_version,
+)
 
 
 class GDALTest(unittest.TestCase):
@@ -9,3 +11,8 @@ class GDALTest(unittest.TestCase):
             self.assertEqual(gdal_version(), ('%s.%s.%s' % GDAL_VERSION).encode())
         else:
             self.assertIn(b'.', gdal_version())
+
+    def test_gdal_full_version(self):
+        full_version = gdal_full_version()
+        self.assertIn(gdal_version(), full_version)
+        self.assertTrue(full_version.startswith(b'GDAL'))

--- a/tests/gis_tests/gdal_tests/tests.py
+++ b/tests/gis_tests/gdal_tests/tests.py
@@ -1,0 +1,11 @@
+import unittest
+
+from django.contrib.gis.gdal import GDAL_VERSION, gdal_version
+
+
+class GDALTest(unittest.TestCase):
+    def test_gdal_version(self):
+        if GDAL_VERSION:
+            self.assertEqual(gdal_version(), ('%s.%s.%s' % GDAL_VERSION).encode())
+        else:
+            self.assertIn(b'.', gdal_version())


### PR DESCRIPTION
The ctypes signature uses a 'c_char_p' type. The `gdal_version()` was updated in 5330cd50cdb to reflect that, but `gdal_full_version()` wasn't updated. It currently raises:

```
ctypes.ArgumentError: argument 1: <class 'TypeError'>: wrong type
```