### PR TITLE
Fixed #31285 -- Fixed inherited Meta.ordering of "-pk".

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -709,9 +709,9 @@ class SQLCompiler:
         field, targets, alias, joins, path, opts, transform_function = self._setup_joins(pieces, opts, alias)
 
         # If we get to this point and the field is a relation to another model,
-        # append the default ordering for that model unless the attribute name
-        # of the field is specified.
-        if field.is_relation and opts.ordering and getattr(field, 'attname', None) != name:
+        # append the default ordering for that model unless it is the pk
+        # shortcut or the attribute name of the field that is specified.
+        if field.is_relation and opts.ordering and getattr(field, 'attname', None) != name and name != 'pk':
             # Firstly, avoid infinite loops.
             already_seen = already_seen or set()
             join_tuple = tuple(getattr(self.query.alias_map[j], 'join_cols', None) for j in joins)

--- a/tests/model_inheritance/models.py
+++ b/tests/model_inheritance/models.py
@@ -181,6 +181,8 @@ class GrandParent(models.Model):
     place = models.ForeignKey(Place, models.CASCADE, null=True, related_name='+')
 
     class Meta:
+        # Ordering used by test_inherited_ordering_pk_desc.
+        ordering = ['-pk']
         unique_together = ('first_name', 'last_name')
 
 

--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -7,7 +7,7 @@ from django.test.utils import CaptureQueriesContext, isolate_apps
 
 from .models import (
     Base, Chef, CommonInfo, GrandChild, GrandParent, ItalianRestaurant,
-    MixinModel, ParkingLot, Place, Post, Restaurant, Student, SubBase,
+    MixinModel, Parent, ParkingLot, Place, Post, Restaurant, Student, SubBase,
     Supplier, Title, Worker,
 )
 
@@ -203,6 +203,19 @@ class ModelInheritanceTests(TestCase):
             attr = ClassAttr()
 
         self.assertEqual(A.attr.called, (A, 'attr'))
+
+    def test_inherited_ordering_pk_desc(self):
+        p1 = Parent.objects.create(first_name='Joe', email='joe@email.com')
+        p2 = Parent.objects.create(first_name='Jon', email='jon@email.com')
+        expected_order_by_sql = 'ORDER BY %s.%s DESC' % (
+            connection.ops.quote_name(Parent._meta.db_table),
+            connection.ops.quote_name(
+                Parent._meta.get_field('grandparent_ptr').column
+            ),
+        )
+        qs = Parent.objects.all()
+        self.assertSequenceEqual(qs, [p2, p1])
+        self.assertIn(expected_order_by_sql, str(qs.query))
 
 
 class ModelInheritanceDataTests(TestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31285