### PR TITLE
Fixed #31286 -- Made database specific fields checks databases aware.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -335,12 +335,15 @@ class Field(RegisterLookupMixin):
         else:
             return []
 
-    def _check_backend_specific_checks(self, **kwargs):
+    def _check_backend_specific_checks(self, databases=None, **kwargs):
+        if databases is None:
+            return []
         app_label = self.model._meta.app_label
-        for db in connections:
-            if router.allow_migrate(db, app_label, model_name=self.model._meta.model_name):
-                return connections[db].validation.check_field(self, **kwargs)
-        return []
+        errors = []
+        for alias in databases:
+            if router.allow_migrate(alias, app_label, model_name=self.model._meta.model_name):
+                errors.extend(connections[alias].validation.check_field(self, **kwargs))
+        return errors
 
     def _check_validators(self):
         errors = []

--- a/tests/check_framework/test_multi_db.py
+++ b/tests/check_framework/test_multi_db.py
@@ -27,7 +27,7 @@ class TestMultiDBChecks(SimpleTestCase):
         model = Model()
         with self._patch_check_field_on('default') as mock_check_field_default:
             with self._patch_check_field_on('other') as mock_check_field_other:
-                model.check()
+                model.check(databases={'default', 'other'})
                 self.assertTrue(mock_check_field_default.called)
                 self.assertFalse(mock_check_field_other.called)
 
@@ -38,6 +38,6 @@ class TestMultiDBChecks(SimpleTestCase):
         model = OtherModel()
         with self._patch_check_field_on('other') as mock_check_field_other:
             with self._patch_check_field_on('default') as mock_check_field_default:
-                model.check()
+                model.check(databases={'default', 'other'})
                 self.assertTrue(mock_check_field_other.called)
                 self.assertFalse(mock_check_field_default.called)

--- a/tests/invalid_models_tests/test_backend_specific.py
+++ b/tests/invalid_models_tests/test_backend_specific.py
@@ -25,4 +25,4 @@ class BackendSpecificChecksTests(SimpleTestCase):
 
         field = Model._meta.get_field('field')
         with mock.patch.object(connections['default'].validation, 'check_field', return_value=[error]):
-            self.assertEqual(field.check(), [error])
+            self.assertEqual(field.check(databases={'default'}), [error])

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -758,7 +758,7 @@ class TextFieldTests(TestCase):
             value = models.TextField(db_index=True)
         field = Model._meta.get_field('value')
         field_type = field.db_type(connection)
-        self.assertEqual(field.check(), [
+        self.assertEqual(field.check(databases=self.databases), [
             DjangoWarning(
                 '%s does not support a database index on %s columns.'
                 % (connection.display_name, field_type),


### PR DESCRIPTION
Further tests required(or not?).
Current test cases don't cover the case when the user provides multiple databases, e.g.:
```python manage.py check --database dba --database dbb```
