### PR TITLE
Fixed tests when run in reverse.

### DIFF
--- a/tests/backends/base/test_creation.py
+++ b/tests/backends/base/test_creation.py
@@ -5,7 +5,7 @@ from django.db import DEFAULT_DB_ALIAS, connection, connections
 from django.db.backends.base.creation import (
     TEST_DATABASE_PREFIX, BaseDatabaseCreation,
 )
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TransactionTestCase
 
 from ..models import Object, ObjectReference
 
@@ -77,8 +77,8 @@ class TestDbCreationTests(SimpleTestCase):
                 creation.destroy_test_db(old_database_name, verbosity=0)
 
 
-class TestDeserializeDbFromString(SimpleTestCase):
-    databases = {'default'}
+class TestDeserializeDbFromString(TransactionTestCase):
+    available_apps = ['backends']
 
     def test_circular_reference(self):
         # deserialize_db_from_string() handles circular references.


### PR DESCRIPTION
See https://djangoci.com/view/Main/job/master-reverse/45/.

To reproduce an isolation issue, run:

```
./runtests.py mail backends --noinput --reverse --parallel=1
```

Regression in 98f23a8af0be7e87535426c5c83058e2682bfdf8.