### PR TITLE
Fixed #31185 -- Fixed detecting of unique fields in ForeignKey/ForeignObject checks when using Meta.constraints.

### DIFF
--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -220,7 +220,7 @@ Related fields
   ``'__'``.
 * **fields.E310**: No subset of the fields ``<field1>``, ``<field2>``, ... on
   model ``<model>`` is unique.
-* **fields.E311**: ``<model>`` must set ``unique=True`` because it is
+* **fields.E311**: ``<model>.<field name>`` must be unique because it is
   referenced by a ``ForeignKey``.
 * **fields.E312**: The ``to_field`` ``<field name>`` doesn't exist on the
   related model ``<app label>.<model>``.

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -352,7 +352,11 @@ class RelativeFieldTests(SimpleTestCase):
         field = Model._meta.get_field('foreign_key')
         self.assertEqual(field.check(), [
             Error(
-                "'Target.bad' must set unique=True because it is referenced by a foreign key.",
+                "'Target.bad' must be unique because it is referenced by a foreign key.",
+                hint=(
+                    'Add unique=True to this field or add a UniqueConstraint '
+                    '(without condition) in the model Meta.constraints.'
+                ),
                 obj=field,
                 id='fields.E311',
             ),
@@ -368,11 +372,63 @@ class RelativeFieldTests(SimpleTestCase):
         field = Model._meta.get_field('field')
         self.assertEqual(field.check(), [
             Error(
-                "'Target.bad' must set unique=True because it is referenced by a foreign key.",
+                "'Target.bad' must be unique because it is referenced by a foreign key.",
+                hint=(
+                    'Add unique=True to this field or add a UniqueConstraint '
+                    '(without condition) in the model Meta.constraints.'
+                ),
                 obj=field,
                 id='fields.E311',
             ),
         ])
+
+    def test_foreign_key_to_partially_unique_field(self):
+        class Target(models.Model):
+            source = models.IntegerField()
+
+            class Meta:
+                constraints = [
+                    models.UniqueConstraint(
+                        fields=['source'],
+                        name='tfktpuf_partial_unique',
+                        condition=models.Q(pk__gt=2),
+                    ),
+                ]
+
+        class Model(models.Model):
+            field = models.ForeignKey(Target, models.CASCADE, to_field='source')
+
+        field = Model._meta.get_field('field')
+        self.assertEqual(field.check(), [
+            Error(
+                "'Target.source' must be unique because it is referenced by a "
+                "foreign key.",
+                hint=(
+                    'Add unique=True to this field or add a UniqueConstraint '
+                    '(without condition) in the model Meta.constraints.'
+                ),
+                obj=field,
+                id='fields.E311',
+            ),
+        ])
+
+    def test_foreign_key_to_unique_field_with_meta_constraint(self):
+        class Target(models.Model):
+            source = models.IntegerField()
+
+            class Meta:
+                constraints = [
+                    models.UniqueConstraint(
+                        fields=['source'],
+                        name='tfktufwmc_unique',
+                    ),
+                ]
+
+        class Model(models.Model):
+            field = models.ForeignKey(Target, models.CASCADE, to_field='source')
+
+        field = Model._meta.get_field('field')
+        self.assertEqual(field.check(), [])
 
     def test_foreign_object_to_non_unique_fields(self):
         class Person(models.Model):
@@ -396,13 +452,81 @@ class RelativeFieldTests(SimpleTestCase):
             Error(
                 "No subset of the fields 'country_id', 'city_id' on model 'Person' is unique.",
                 hint=(
-                    "Add unique=True on any of those fields or add at least "
-                    "a subset of them to a unique_together constraint."
+                    'Mark a single field as unique=True or add a set of '
+                    'fields to a unique constraint (via unique_together or a '
+                    'UniqueConstraint (without condition) in the model '
+                    'Meta.constraints).'
                 ),
                 obj=field,
                 id='fields.E310',
             )
         ])
+
+    def test_foreign_object_to_partially_unique_field(self):
+        class Person(models.Model):
+            country_id = models.IntegerField()
+            city_id = models.IntegerField()
+
+            class Meta:
+                constraints = [
+                    models.UniqueConstraint(
+                        fields=['country_id', 'city_id'],
+                        name='tfotpuf_partial_unique',
+                        condition=models.Q(pk__gt=2),
+                    ),
+                ]
+
+        class MMembership(models.Model):
+            person_country_id = models.IntegerField()
+            person_city_id = models.IntegerField()
+            person = models.ForeignObject(
+                Person,
+                on_delete=models.CASCADE,
+                from_fields=['person_country_id', 'person_city_id'],
+                to_fields=['country_id', 'city_id'],
+            )
+
+        field = MMembership._meta.get_field('person')
+        self.assertEqual(field.check(), [
+            Error(
+                "No subset of the fields 'country_id', 'city_id' on model "
+                "'Person' is unique.",
+                hint=(
+                    'Mark a single field as unique=True or add a set of '
+                    'fields to a unique constraint (via unique_together or a '
+                    'UniqueConstraint (without condition) in the model '
+                    'Meta.constraints).'
+                ),
+                obj=field,
+                id='fields.E310',
+            ),
+        ])
+
+    def test_foreign_object_to_unique_field_with_meta_constraint(self):
+        class Person(models.Model):
+            country_id = models.IntegerField()
+            city_id = models.IntegerField()
+
+            class Meta:
+                constraints = [
+                    models.UniqueConstraint(
+                        fields=['country_id', 'city_id'],
+                        name='tfotpuf_unique',
+                    ),
+                ]
+
+        class MMembership(models.Model):
+            person_country_id = models.IntegerField()
+            person_city_id = models.IntegerField()
+            person = models.ForeignObject(
+                Person,
+                on_delete=models.CASCADE,
+                from_fields=['person_country_id', 'person_city_id'],
+                to_fields=['country_id', 'city_id'],
+            )
+
+        field = MMembership._meta.get_field('person')
+        self.assertEqual(field.check(), [])
 
     def test_on_delete_set_null_on_non_nullable_field(self):
         class Person(models.Model):
@@ -1453,8 +1577,10 @@ class M2mThroughFieldsTests(SimpleTestCase):
             Error(
                 "No subset of the fields 'a', 'b' on model 'Parent' is unique.",
                 hint=(
-                    "Add unique=True on any of those fields or add at least "
-                    "a subset of them to a unique_together constraint."
+                    'Mark a single field as unique=True or add a set of '
+                    'fields to a unique constraint (via unique_together or a '
+                    'UniqueConstraint (without condition) in the model '
+                    'Meta.constraints).'
                 ),
                 obj=field,
                 id='fields.E310',
@@ -1489,8 +1615,10 @@ class M2mThroughFieldsTests(SimpleTestCase):
             Error(
                 "No subset of the fields 'a', 'b', 'd' on model 'Parent' is unique.",
                 hint=(
-                    "Add unique=True on any of those fields or add at least "
-                    "a subset of them to a unique_together constraint."
+                    'Mark a single field as unique=True or add a set of '
+                    'fields to a unique constraint (via unique_together or a '
+                    'UniqueConstraint (without condition) in the model '
+                    'Meta.constraints).'
                 ),
                 obj=field,
                 id='fields.E310',


### PR DESCRIPTION
Fixed #31185 -- Adjusted model check for UniqueConstraints without conditions
.
Changed _check_unique_target to take into account UniqueConstraints without conditions. Added test in invalid_models_tests, and changed code to take into account pre-existing method total_unique_constraints
Ticket number is [31185](https://code.djangoproject.com/ticket/31185)