### PR TITLE
Fixed #31276 Add 'flush' option to only clear non-empty tables

### DIFF
--- a/django/core/management/commands/flush.py
+++ b/django/core/management/commands/flush.py
@@ -23,12 +23,17 @@ class Command(BaseCommand):
             '--database', default=DEFAULT_DB_ALIAS,
             help='Nominates a database to flush. Defaults to the "default" database.',
         )
+        parser.add_argument(
+            '--skip-empty', action='store_true',
+            help='Only delete from tables containing rows.',
+        )
 
     def handle(self, **options):
         database = options['database']
         connection = connections[database]
         verbosity = options['verbosity']
         interactive = options['interactive']
+        skip_empty = options['skip_empty']
         # The following are stealth options used by Django's internals.
         reset_sequences = options.get('reset_sequences', True)
         allow_cascade = options.get('allow_cascade', False)
@@ -46,7 +51,8 @@ class Command(BaseCommand):
 
         sql_list = sql_flush(self.style, connection,
                              reset_sequences=reset_sequences,
-                             allow_cascade=allow_cascade)
+                             allow_cascade=allow_cascade,
+                             skip_empty=skip_empty)
 
         if interactive:
             confirm = input("""You have requested a flush of the database.

--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -2,11 +2,16 @@ from django.apps import apps
 from django.db import models
 
 
-def sql_flush(style, connection, reset_sequences=True, allow_cascade=False):
+def sql_flush(style, connection, reset_sequences=True, allow_cascade=False,
+              skip_empty=False):
     """
     Return a list of the SQL statements used to flush the database.
     """
-    tables = connection.introspection.django_table_names(only_existing=True, include_views=False)
+    tables = connection.introspection.django_table_names(
+        only_existing=True,
+        include_views=False,
+        skip_empty=skip_empty
+    )
     return connection.ops.sql_flush(
         style,
         tables,

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1038,7 +1038,8 @@ class TransactionTestCase(SimpleTestCase):
             call_command('flush', verbosity=0, interactive=False,
                          database=db_name, reset_sequences=False,
                          allow_cascade=self.available_apps is not None,
-                         inhibit_post_migrate=inhibit_post_migrate)
+                         inhibit_post_migrate=inhibit_post_migrate,
+                         skip_empty=True)
 
     def assertQuerysetEqual(self, qs, values, transform=repr, ordered=True, msg=None):
         items = map(transform, qs)

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -385,6 +385,12 @@ Suppresses all user prompts.
 
 Specifies the database to flush. Defaults to ``default``.
 
+.. django-admin-option:: --skip-empty
+
+.. versionadded:: 3.2
+
+Only delete from tables containing rows.
+
 ``inspectdb``
 -------------
 

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -251,6 +251,8 @@ Management Commands
   prior to executing the command. In previous versions, either all or none
   of the system checks were performed.
 
+* :djadmin:`flush` now supports ``skip-empty``.
+
 Migrations
 ~~~~~~~~~~
 
@@ -397,6 +399,9 @@ Tests
   functions passed to :func:`transaction.on_commit()
   <django.db.transaction.on_commit>` in a list. This allows you to test such
   callbacks without using the slower :class:`.TransactionTestCase`.
+
+* :class:`.TransactionTestCase` now uses ``--skip-empty=True`` when calling
+  :djadmin:`flush`.
 
 URLs
 ~~~~

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -53,6 +53,15 @@ class IntrospectionTests(TransactionTestCase):
             with connection.cursor() as cursor:
                 cursor.execute('DROP VIEW introspection_article_view')
 
+    def test_only_empty_tables_zero_rows(self):
+        tables = connection.introspection.django_table_names(skip_empty=True)
+        self.assertEqual(tables, [])
+
+    def test_skip_empty_tables_one_row(self):
+        City.objects.create(name="London")
+        tables = connection.introspection.django_table_names(skip_empty=True)
+        self.assertEqual(tables, ['introspection_city'])
+
     def test_unmanaged_through_model(self):
         tables = connection.introspection.django_table_names()
         self.assertNotIn(ArticleReporter._meta.db_table, tables)

--- a/tests/test_utils/test_transactiontestcase.py
+++ b/tests/test_utils/test_transactiontestcase.py
@@ -29,7 +29,7 @@ class TestSerializedRollbackInhibitsPostMigrate(TransactionTestCase):
         call_command.assert_called_with(
             'flush', interactive=False, allow_cascade=False,
             reset_sequences=False, inhibit_post_migrate=True,
-            database='default', verbosity=0,
+            database='default', verbosity=0, skip_empty=True,
         )
 
 


### PR DESCRIPTION
[Ticket 31276](https://code.djangoproject.com/ticket/31276)
There's probably something I've missed as it's my first Django contribution.