### PR TITLE
Fixed #31303 -- Removed outdated note about symmetrical intermediate table for self-referential ManyToManyField.

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -499,11 +499,6 @@ There are a few restrictions on the intermediate model:
   must also specify ``through_fields`` as above, or a validation error
   will be raised.
 
-* When defining a many-to-many relationship from a model to
-  itself, using an intermediary model, you *must* use
-  :attr:`symmetrical=False <ManyToManyField.symmetrical>` (see
-  :ref:`the model field reference <manytomany-arguments>`).
-
 Now that you have set up your :class:`~django.db.models.ManyToManyField` to use
 your intermediary model (``Membership``, in this case), you're ready to start
 creating some many-to-many relationships. You do this by creating instances of


### PR DESCRIPTION
Previously it was required to set symmetrical=False for m2m
relationship from a model to itself with intermediary model.
But this isn't the case since Django 3.0.