### PR TITLE
Fixed backends tests on Oracle.

### DIFF
--- a/tests/backends/oracle/test_introspection.py
+++ b/tests/backends/oracle/test_introspection.py
@@ -3,7 +3,7 @@ import unittest
 from django.db import connection
 from django.test import TransactionTestCase
 
-from ..models import Person
+from ..models import Square
 
 
 @unittest.skipUnless(connection.vendor == 'oracle', 'Oracle tests')
@@ -12,18 +12,18 @@ class DatabaseSequenceTests(TransactionTestCase):
 
     def test_get_sequences(self):
         with connection.cursor() as cursor:
-            seqs = connection.introspection.get_sequences(cursor, Person._meta.db_table, Person._meta.local_fields)
+            seqs = connection.introspection.get_sequences(cursor, Square._meta.db_table, Square._meta.local_fields)
             self.assertEqual(len(seqs), 1)
             self.assertIsNotNone(seqs[0]['name'])
-            self.assertEqual(seqs[0]['table'], Person._meta.db_table)
+            self.assertEqual(seqs[0]['table'], Square._meta.db_table)
             self.assertEqual(seqs[0]['column'], 'id')
 
     def test_get_sequences_manually_created_index(self):
         with connection.cursor() as cursor:
             with connection.schema_editor() as editor:
-                editor._drop_identity(Person._meta.db_table, 'id')
-                seqs = connection.introspection.get_sequences(cursor, Person._meta.db_table, Person._meta.local_fields)
-                self.assertEqual(seqs, [{'table': Person._meta.db_table, 'column': 'id'}])
+                editor._drop_identity(Square._meta.db_table, 'id')
+                seqs = connection.introspection.get_sequences(cursor, Square._meta.db_table, Square._meta.local_fields)
+                self.assertEqual(seqs, [{'table': Square._meta.db_table, 'column': 'id'}])
                 # Recreate model, because adding identity is impossible.
-                editor.delete_model(Person)
-                editor.create_model(Person)
+                editor.delete_model(Square)
+                editor.create_model(Square)


### PR DESCRIPTION
Using `Person` in `test_introspection` caused removing constraints in intermediate table for `ManyToManyField` in `VeryLongModelNameZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ` that were expected by other transaction tests. A model without any constraints was used to prevent isolation issues.