### PR TITLE
Fixed #29129 -- Skipped UPDATE when adding a model instance with primary key that has a default.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -855,8 +855,8 @@ class Model(metaclass=ModelBase):
             not raw and
             not force_insert and
             self._state.adding and
-            self._meta.pk.default and
-            self._meta.pk.default is not NOT_PROVIDED
+            meta.pk.default and
+            meta.pk.default is not NOT_PROVIDED
         ):
             force_insert = True
         # If possible, try an UPDATE. If that doesn't update anything, do an INSERT.

--- a/tests/basic/models.py
+++ b/tests/basic/models.py
@@ -46,3 +46,7 @@ class SelfRef(models.Model):
 
 class PrimaryKeyWithDefault(models.Model):
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4)
+
+
+class ChildPrimaryKeyWithDefault(PrimaryKeyWithDefault):
+    pass

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -12,8 +12,8 @@ from django.test import (
 from django.utils.translation import gettext_lazy
 
 from .models import (
-    Article, ArticleSelectOnSave, FeaturedArticle, PrimaryKeyWithDefault,
-    SelfRef,
+    Article, ArticleSelectOnSave, ChildPrimaryKeyWithDefault, FeaturedArticle,
+    PrimaryKeyWithDefault, SelfRef,
 )
 
 
@@ -138,6 +138,12 @@ class ModelInstanceCreationTests(TestCase):
         # An UPDATE attempt is skipped when a primary key has default.
         with self.assertNumQueries(1):
             PrimaryKeyWithDefault().save()
+
+    def test_save_parent_primary_with_default(self):
+        # An UPDATE attempt is skipped when an inherited primary key has
+        # default.
+        with self.assertNumQueries(2):
+            ChildPrimaryKeyWithDefault().save()
 
 
 class ModelTest(TestCase):


### PR DESCRIPTION
[ticket 29129](https://code.djangoproject.com/ticket/29129)

Couldn't think of a better model name for the testcase.