### PR TITLE
Fixed #31310 -- Fixed hints in checks for using intermediate model with ambiguous foreign key.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1309,7 +1309,7 @@ class ManyToManyField(RelatedField):
                              "through_fields keyword argument.") % (self, from_model_name),
                             hint=(
                                 'If you want to create a recursive relationship, '
-                                'use ForeignKey("%s", symmetrical=False, through="%s").'
+                                'use ManyToManyField("%s", through="%s").'
                             ) % (
                                 RECURSIVE_RELATIONSHIP_CONSTANT,
                                 relationship_model_name,
@@ -1329,7 +1329,7 @@ class ManyToManyField(RelatedField):
                             "through_fields keyword argument." % (self, to_model_name),
                             hint=(
                                 'If you want to create a recursive relationship, '
-                                'use ForeignKey("%s", symmetrical=False, through="%s").'
+                                'use ManyToManyField("%s", through="%s").'
                             ) % (
                                 RECURSIVE_RELATIONSHIP_CONSTANT,
                                 relationship_model_name,

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -128,6 +128,36 @@ class RelativeFieldTests(SimpleTestCase):
             ),
         ])
 
+    def test_ambiguous_relationship_model_from(self):
+        class Person(models.Model):
+            pass
+
+        class Group(models.Model):
+            field = models.ManyToManyField('Person', through='AmbiguousRelationship')
+
+        class AmbiguousRelationship(models.Model):
+            person = models.ForeignKey(Person, models.CASCADE)
+            first_group = models.ForeignKey(Group, models.CASCADE, related_name='first')
+            second_group = models.ForeignKey(Group, models.CASCADE, related_name='second')
+
+        field = Group._meta.get_field('field')
+        self.assertEqual(field.check(from_model=Group), [
+            Error(
+                "The model is used as an intermediate model by "
+                "'invalid_models_tests.Group.field', but it has more than one "
+                "foreign key from 'Group', which is ambiguous. You must "
+                "specify which foreign key Django should use via the "
+                "through_fields keyword argument.",
+                hint=(
+                    'If you want to create a recursive relationship, use '
+                    'ForeignKey("self", symmetrical=False, '
+                    'through="AmbiguousRelationship").'
+                ),
+                obj=field,
+                id='fields.E334',
+            ),
+        ])
+
     def test_ambiguous_relationship_model(self):
 
         class Person(models.Model):

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -150,15 +150,14 @@ class RelativeFieldTests(SimpleTestCase):
                 "through_fields keyword argument.",
                 hint=(
                     'If you want to create a recursive relationship, use '
-                    'ForeignKey("self", symmetrical=False, '
-                    'through="AmbiguousRelationship").'
+                    'ManyToManyField("self", through="AmbiguousRelationship").'
                 ),
                 obj=field,
                 id='fields.E334',
             ),
         ])
 
-    def test_ambiguous_relationship_model(self):
+    def test_ambiguous_relationship_model_to(self):
 
         class Person(models.Model):
             pass
@@ -182,7 +181,7 @@ class RelativeFieldTests(SimpleTestCase):
                 "keyword argument.",
                 hint=(
                     'If you want to create a recursive relationship, use '
-                    'ForeignKey("self", symmetrical=False, through="AmbiguousRelationship").'
+                    'ManyToManyField("self", through="AmbiguousRelationship").'
                 ),
                 obj=field,
                 id='fields.E335',


### PR DESCRIPTION
Changed ForeignKey to ManyToManyField and removed outdated symmetrical=False keyword argument.