### PR TITLE
Fixed #31313 -- Fixed is_upperclass() example in enumeration types docs.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -204,7 +204,10 @@ choices in a concise way::
         )
 
         def is_upperclass(self):
-            return self.year_in_school in {YearInSchool.JUNIOR, YearInSchool.SENIOR}
+            return self.year_in_school in {
+                self.YearInSchool.JUNIOR,
+                self.YearInSchool.SENIOR,
+            }
 
 These work similar to :mod:`enum` from Python's standard library, but with some
 modifications:


### PR DESCRIPTION
In `docs/ref/models/fields.txt` documentation example fixed, class instance
was lost for Field.choices Enumeration types.