### PR TITLE
Fixed #31032 -- Updated admin browser support FAQ for 2020.

### DIFF
--- a/docs/faq/admin.txt
+++ b/docs/faq/admin.txt
@@ -94,14 +94,18 @@ presentation by editing the CSS stylesheet and/or associated image files. The
 site is built using semantic HTML and plenty of CSS hooks, so any changes you'd
 like to make should be possible by editing the stylesheet.
 
+.. _admin-browser-support:
+
 What browsers are supported for using the admin?
 ================================================
 
-The admin provides a fully-functional experience to `YUI's A-grade`_ browsers,
-with the notable exception of IE6, which is not supported.
+The admin provides a fully-functional experience to the recent versions of
+modern, web standards compliant browsers. On desktop this means Chrome, Edge,
+Firefox, Opera, Safari, and others.
 
-There *may* be minor stylistic differences between supported browsers—for
-example, some browsers may not support rounded corners. These are considered
-acceptable variations in rendering.
+On mobile and tablet devices, the admin provides a responsive experience for
+web standards compliant browsers. This includes the major browsers on both
+Android and iOS.
 
-.. _YUI's A-grade: https://github.com/yui/yui3/wiki/Graded-Browser-Support
+Depending on feature support, there *may* be minor stylistic differences
+between browsers. These are considered acceptable variations in rendering.

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -408,6 +408,12 @@ Dropped support for MariaDB 10.1
 Upstream support for MariaDB 10.1 ends in October 2020. Django 3.1 supports
 MariaDB 10.2 and higher.
 
+``contrib.admin`` browser support
+---------------------------------
+
+The admin no longer supports the legacy Internet Explorer browser. See
+:ref:`the admin FAQ <admin-browser-support>` for details on supported browsers.
+
 Miscellaneous
 -------------
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -294,6 +294,7 @@ interdependencies
 internet
 interoperability
 intranet
+iOS
 ip
 ipsum
 IPv


### PR DESCRIPTION
ticket-31032

Following web standards, the modern _evergreen_ browsers are all supported.
This applies equally to mobile platforms. Assuming current trends continue,
this should be a sustainable policy.

Microsoft deprecated all versions of Internet Explorer. IE 11, the last
version, is described as a "compatibility solution" rather than a web browser.
Whilst it will receive security updates for the lifetime of Windows 10 it's use
is actively discouraged.

The IE 11 downloads page makes it clear:

> We recommend you use the new Microsoft Edge.

References:

* https://techcommunity.microsoft.com/t5/windows-it-pro-blog/the-perils-of-using-internet-explorer-as-your-default-browser/ba-p/331732
* https://support.microsoft.com/en-us/help/17454/lifecycle-faq-internet-explorer-and-edge
* https://support.microsoft.com/en-gb/help/17621/internet-explorer-downloads