### PR TITLE
Fixed #31314 -- Raised CommandError when locale is not specified in makemessages.

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -329,7 +329,7 @@ class Command(BaseCommand):
             exts = extensions or ['html', 'txt', 'py']
         self.extensions = handle_extensions(exts)
 
-        if (locale is None and not exclude and not process_all) or self.domain is None:
+        if (not locale and not exclude and not process_all) or self.domain is None:
             raise CommandError(
                 "Type '%s help %s' for usage information."
                 % (os.path.basename(sys.argv[0]), sys.argv[1])

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -142,6 +142,16 @@ class BasicExtractorTests(ExtractorTests):
             self.assertIn('#. Translators: One-line translator comment #1', po_contents)
             self.assertIn('msgctxt "Special trans context #1"', po_contents)
 
+    def test_no_option(self):
+        # One of either the --locale, --exclude, or --all options is required.
+        msg = "Type 'manage.py help makemessages' for usage information."
+        with mock.patch(
+            'django.core.management.commands.makemessages.sys.argv',
+            ['manage.py', 'makemessages'],
+        ):
+            with self.assertRaisesRegex(CommandError, msg):
+                management.call_command('makemessages')
+
     def test_comments_extractor(self):
         management.call_command('makemessages', locale=[LOCALE], verbosity=0)
         self.assertTrue(os.path.exists(self.PO_FILE))


### PR DESCRIPTION
`makemessages` needs either the `--locale`, `--exclude`, or the  `--all` flag to work properly. Failure to pass one of those three flags should result in `CommandError`, but that is currently broken because of a small bug.

This PR fixes this issue, which has been reported as ticket #31314 in the issue tracker.

https://code.djangoproject.com/ticket/31314