### PR TITLE
Changed admin templates to use POST for logout

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -910,8 +910,9 @@ table#change-history tbody th {
   border: none;
   border-bottom: 1px solid rgba(255, 255, 255, 0.25);
   cursor: pointer;
-  font-size: 1em;
-  font-weight: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
   padding: 0;
 }
 

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -893,10 +893,26 @@ table#change-history tbody th {
     border-bottom: 1px solid rgba(255, 255, 255, 0.25);
 }
 
-#user-tools a:focus, #user-tools a:hover {
+#user-tools a:focus, #user-tools a:hover,
+#user-tools #logout-form button:focus, #user-tools #logout-form button:hover {
     text-decoration: none;
     border-bottom-color: #79aec8;
     color: #79aec8;
+}
+
+#user-tools #logout-form {
+  display: inline;
+}
+
+#user-tools #logout-form button {
+  color: #fff;
+  background: none;
+  border: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.25);
+  cursor: pointer;
+  font-size: 1em;
+  font-weight: inherit;
+  padding: 0;
 }
 
 /* SIDEBAR */

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -56,7 +56,7 @@ input[type="submit"], button {
         text-align: left;
     }
 
-    #user-tools a {
+    #user-tools a, #user-tools #logout-form button {
         display: inline-block;
         line-height: 1.4;
     }

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -48,7 +48,10 @@
                 {% if user.has_usable_password %}
                 <a href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a> /
                 {% endif %}
-                <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>
+                <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
+                  {% csrf_token %}
+                  <button type='submit'>{% translate 'Log out' %}</button>
+                </form>
             {% endblock %}
         </div>
         {% endif %}

--- a/django/contrib/admin/templates/registration/password_change_done.html
+++ b/django/contrib/admin/templates/registration/password_change_done.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
-{% block userlinks %}{% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% translate 'Documentation' %}</a> / {% endif %}{% translate 'Change password' %} / <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>{% endblock %}
+{% block userlinks %}{% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% translate 'Documentation' %}</a> / {% endif %}{% translate 'Change password' %} / <form id="logout-form" method="post" action="{% url 'admin:logout' %}">{% csrf_token %}<button type='submit'>{% translate 'Log out' %}</button></form>{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
-{% block userlinks %}{% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% translate 'Documentation' %}</a> / {% endif %} {% translate 'Change password' %} / <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>{% endblock %}
+{% block userlinks %}{% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% translate 'Documentation' %}</a> / {% endif %} {% translate 'Change password' %} / <form id="logout-form" method="post" action="{% url 'admin:logout' %}">{% csrf_token %}<button type='submit'>{% translate 'Log out' %}</button></form>{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>


### PR DESCRIPTION
This changes the admin templates to use ``POST`` for logging out. See https://github.com/django/django/pull/12504.

I turned the log out link into a form with a button element styled as a link. I am not that good with CSS, so any suggestions for improvements would be highly appreciated.

It seemed to be the least intrusive approach to me. On https://code.djangoproject.com/ticket/15619 there has been some talk about adding an intermediate page instead, but I am not sure if we want to go there.

I am unsure if I got the color / font-weight of the button right. On my screen it seems to look slightly different to the other ``#user-tools`` links, but when I increase the font size, it seems to look the same. Maybe that is just me / my screen?


Thanks to VectorX from #regex on freenode for helping me adjust the failing test!