### PR TITLE
Fixed #31318 -- Allowed sqlmigrate to inspect squashed migrations.

### DIFF
--- a/django/core/management/commands/sqlmigrate.py
+++ b/django/core/management/commands/sqlmigrate.py
@@ -32,8 +32,9 @@ class Command(BaseCommand):
         # Get the database we're operating from
         connection = connections[options['database']]
 
-        # Load up an loader to get all the migration data
-        loader = MigrationLoader(connection)
+        # Load up an loader to get all the migration data, but don't replace
+        # migrations.
+        loader = MigrationLoader(connection, replace_migrations=False)
 
         # Resolve command-line arguments into a migration
         app_label, migration_name = options['app_label'], options['migration_name']

--- a/django/core/management/commands/sqlmigrate.py
+++ b/django/core/management/commands/sqlmigrate.py
@@ -1,8 +1,7 @@
 from django.apps import apps
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
-from django.db.migrations.executor import MigrationExecutor
-from django.db.migrations.loader import AmbiguityError
+from django.db.migrations.loader import AmbiguityError, MigrationLoader
 
 
 class Command(BaseCommand):
@@ -33,8 +32,8 @@ class Command(BaseCommand):
         # Get the database we're operating from
         connection = connections[options['database']]
 
-        # Load up an executor to get all the migration data
-        executor = MigrationExecutor(connection)
+        # Load up an loader to get all the migration data
+        loader = MigrationLoader(connection)
 
         # Resolve command-line arguments into a migration
         app_label, migration_name = options['app_label'], options['migration_name']
@@ -43,10 +42,10 @@ class Command(BaseCommand):
             apps.get_app_config(app_label)
         except LookupError as err:
             raise CommandError(str(err))
-        if app_label not in executor.loader.migrated_apps:
+        if app_label not in loader.migrated_apps:
             raise CommandError("App '%s' does not have migrations" % app_label)
         try:
-            migration = executor.loader.get_migration_by_prefix(app_label, migration_name)
+            migration = loader.get_migration_by_prefix(app_label, migration_name)
         except AmbiguityError:
             raise CommandError("More than one migration matches '%s' in app '%s'. Please be more specific." % (
                 migration_name, app_label))
@@ -61,8 +60,8 @@ class Command(BaseCommand):
 
         # Make a plan that represents just the requested migrations and show SQL
         # for it
-        plan = [(executor.loader.graph.nodes[target], options['backwards'])]
-        sql_statements = executor.loader.collect_sql(plan)
+        plan = [(loader.graph.nodes[target], options['backwards'])]
+        sql_statements = loader.collect_sql(plan)
         if not sql_statements and options['verbosity'] >= 1:
             self.stderr.write('No operations found.')
         return '\n'.join(sql_statements)

--- a/django/core/management/commands/sqlmigrate.py
+++ b/django/core/management/commands/sqlmigrate.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
         # Make a plan that represents just the requested migrations and show SQL
         # for it
         plan = [(executor.loader.graph.nodes[target], options['backwards'])]
-        sql_statements = executor.collect_sql(plan)
+        sql_statements = executor.loader.collect_sql(plan)
         if not sql_statements and options['verbosity'] >= 1:
             self.stderr.write('No operations found.')
         return '\n'.join(sql_statements)

--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -210,24 +210,6 @@ class MigrationExecutor:
 
         return state
 
-    def collect_sql(self, plan):
-        """
-        Take a migration plan and return a list of collected SQL statements
-        that represent the best-efforts version of that plan.
-        """
-        statements = []
-        state = None
-        for migration, backwards in plan:
-            with self.connection.schema_editor(collect_sql=True, atomic=migration.atomic) as schema_editor:
-                if state is None:
-                    state = self.loader.project_state((migration.app_label, migration.name), at_end=False)
-                if not backwards:
-                    state = migration.apply(state, schema_editor, collect_sql=True)
-                else:
-                    state = migration.unapply(state, schema_editor, collect_sql=True)
-            statements.extend(schema_editor.collected_sql)
-        return statements
-
     def apply_migration(self, state, migration, fake=False, fake_initial=False):
         """Run a migration forwards."""
         migration_recorded = False

--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -320,3 +320,21 @@ class MigrationLoader:
         See graph.make_state() for the meaning of "nodes" and "at_end".
         """
         return self.graph.make_state(nodes=nodes, at_end=at_end, real_apps=list(self.unmigrated_apps))
+
+    def collect_sql(self, plan):
+        """
+        Take a migration plan and return a list of collected SQL statements
+        that represent the best-efforts version of that plan.
+        """
+        statements = []
+        state = None
+        for migration, backwards in plan:
+            with self.connection.schema_editor(collect_sql=True, atomic=migration.atomic) as schema_editor:
+                if state is None:
+                    state = self.project_state((migration.app_label, migration.name), at_end=False)
+                if not backwards:
+                    state = migration.apply(state, schema_editor, collect_sql=True)
+                else:
+                    state = migration.unapply(state, schema_editor, collect_sql=True)
+            statements.extend(schema_editor.collected_sql)
+        return statements

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -713,6 +713,14 @@ class MigrateTests(MigrationTestBase):
         self.assertIn('-- create model book', output)
         self.assertNotIn('-- create model tribble', output)
 
+    @override_settings(MIGRATION_MODULES={'migrations': 'migrations.test_migrations_squashed'})
+    def test_sqlmigrate_replaced_migration(self):
+        out = io.StringIO()
+        call_command('sqlmigrate', 'migrations', '0001_initial', stdout=out)
+        output = out.getvalue().lower()
+        self.assertIn('-- create model author', output)
+        self.assertIn('-- create model tribble', output)
+
     @override_settings(MIGRATION_MODULES={'migrations': 'migrations.test_migrations_no_operations'})
     def test_migrations_no_operations(self):
         err = io.StringIO()


### PR DESCRIPTION
Hi!

https://code.djangoproject.com/ticket/31318
Currently when calling `sqlmigrate` on a migration that is being replaced by a squash migration (because the migration is in the `replaces` class attribute of the squad migration), then we get a KeyError.

I tackled the patch and I suggest a **commit-by-commit** review.

The approach I took is interfere as less as possible with the existing migration graph and keep its logic as it is. Currently, the migration graph seems to represent one migration hierarchy and database evolution schema. Intervening in the "forward state" logic in the graph would have affected lots of logic in the Django migration system.
Instead, I added a flag enabling loading the migration graph (by the migration loader obviously) without replacing the migrations by squashed migrations. This flag enables to keep entire logic as it is, but just have another representation of the migration graph that we will use instead and just for `sqlmigration`.