### PR TITLE
Fixed #20935 -- ePub documentation not valid

### DIFF
--- a/docs/_theme/djangodocs/static/djangodocs.css
+++ b/docs/_theme/djangodocs/static/djangodocs.css
@@ -59,6 +59,7 @@ blockquote { padding: 0 1em; margin: 1em 0; font:125%/1.2em "Trebuchet MS", sans
 strong { font-weight: bold; }
 em { font-style: italic; }
 ins { font-weight: bold; text-decoration: none; }
+.rubric > .heading { font-size:175%; margin-bottom:.6em; line-height:1.2em; color:#092e20; }
 
 /*** lists ***/
 ul { padding-left:30px; }

--- a/docs/ref/class-based-views/index.txt
+++ b/docs/ref/class-based-views/index.txt
@@ -15,8 +15,10 @@ Class-based views API reference. For introductory material, see the
    mixins
    flattened-index
 
-Specification
-=============
+.. role:: h2
+    :class: heading
+
+.. rubric:: :h2:`Specification`
 
 Each request served by a class-based view has an independent state; therefore,
 it is safe to store state variables on the instance (i.e., ``self.foo = 3`` is
@@ -43,8 +45,7 @@ previous example, this means that every request on ``MyView`` is able to use
 ``self.size``. Arguments must correspond to attributes that already exist on
 the class (return ``True`` on a ``hasattr`` check).
 
-Base vs Generic views
-=====================
+.. rubric:: :h2:`Base vs Generic views`
 
 Base class-based views can be thought of as *parent* views, which can be
 used by themselves or inherited from. They may not provide all the

--- a/docs/ref/contrib/index.txt
+++ b/docs/ref/contrib/index.txt
@@ -34,85 +34,81 @@ those packages have.
    staticfiles
    syndication
 
-``admin``
-=========
+.. role:: h2
+    :class: heading
+
+.. rubric:: :h2:`admin`
 
 The automatic Django administrative interface. For more information, see
 :doc:`Tutorial 2 </intro/tutorial02>` and the
 :doc:`admin documentation </ref/contrib/admin/index>`.
 
-Requires the auth_ and contenttypes_ contrib packages to be installed.
+Requires the
+:doc:`auth </topics/auth/index>` and
+:doc:`contenttypes </ref/contrib/contenttypes>`
+contrib packages to be installed.
 
-``auth``
-========
+.. rubric:: :h2:`auth`
 
 Django's authentication framework.
 
 See :doc:`/topics/auth/index`.
 
-``contenttypes``
-================
+.. rubric:: :h2:`contenttypes`
 
 A light framework for hooking into "types" of content, where each installed
 Django model is a separate content type.
 
 See the :doc:`contenttypes documentation </ref/contrib/contenttypes>`.
 
-``flatpages``
-=============
+.. rubric:: :h2:`flatpages`
 
 A framework for managing "flat" HTML content in a database.
 
 See the :doc:`flatpages documentation </ref/contrib/flatpages>`.
 
-Requires the sites_ contrib package to be installed as well.
+Requires the
+:doc:`sites </ref/contrib/sites>` contrib package to be installed as well.
 
-``gis``
-=======
+.. rubric:: :h2:`gis`
 
 A world-class geospatial framework built on top of Django, that enables
 storage, manipulation and display of spatial data.
 
 See the :doc:`/ref/contrib/gis/index` documentation for more.
 
-``humanize``
-============
+.. rubric:: :h2:`humanize`
 
 A set of Django template filters useful for adding a "human touch" to data.
 
 See the :doc:`humanize documentation </ref/contrib/humanize>`.
 
-``messages``
-============
+.. rubric:: :h2:`messages`
 
 A framework for storing and retrieving temporary cookie- or session-based
 messages
 
 See the :doc:`messages documentation </ref/contrib/messages>`.
 
-``postgres``
-============
+.. rubric:: :h2:`postgres`
 
 A collection of PostgreSQL specific features.
 
 See the :doc:`contrib.postgres documentation </ref/contrib/postgres/index>`.
 
-``redirects``
-=============
+.. rubric:: :h2:`redirects`
 
 A framework for managing redirects.
 
 See the :doc:`redirects documentation </ref/contrib/redirects>`.
 
-``sessions``
-============
+.. rubric:: :h2:`sessions`
 
 A framework for storing data in anonymous sessions.
 
 See the :doc:`sessions documentation </topics/http/sessions>`.
 
-``sites``
-=========
+.. rubric:: :h2:`sites`
 
 A light framework that lets you operate multiple websites off of the same
 database and Django installation. It gives you hooks for associating objects to
@@ -120,22 +116,19 @@ one or more sites.
 
 See the :doc:`sites documentation </ref/contrib/sites>`.
 
-``sitemaps``
-============
+.. rubric:: :h2:`sitemaps`
 
 A framework for generating Google sitemap XML files.
 
 See the :doc:`sitemaps documentation </ref/contrib/sitemaps>`.
 
-``syndication``
-===============
+.. rubric:: :h2:`syndication`
 
 A framework for generating syndication feeds, in RSS and Atom, quite easily.
 
 See the :doc:`syndication documentation </ref/contrib/syndication>`.
 
-Other add-ons
-=============
+.. rubric:: :h2:`Other add-ons`
 
 If you have an idea for functionality to include in ``contrib``, let us know!
 Code it up, and post it to the |django-users| mailing list.

--- a/docs/topics/class-based-views/index.txt
+++ b/docs/topics/class-based-views/index.txt
@@ -19,8 +19,10 @@ documentation</ref/class-based-views/index>`.
    generic-editing
    mixins
 
-Basic examples
-==============
+.. role:: h2
+    :class: heading
+
+.. rubric:: :h2:`Basic examples`
 
 Django provides base view classes which will suit a wide range of applications.
 All views inherit from the :class:`~django.views.generic.base.View` class, which
@@ -30,8 +32,7 @@ HTTP redirect, and :class:`~django.views.generic.base.TemplateView` extends the
 base class to make it also render a template.
 
 
-Usage in your URLconf
-=====================
+.. rubric:: :h2:`Usage in your URLconf`
 
 The most direct way to use generic views is to create them directly in your
 URLconf. If you're only changing a few attributes on a class-based view, you
@@ -51,8 +52,7 @@ on the ``TemplateView``. A similar overriding pattern can be used for the
 ``url`` attribute on :class:`~django.views.generic.base.RedirectView`.
 
 
-Subclassing generic views
-=========================
+.. rubric:: :h2:`Subclassing generic views`
 
 The second, more powerful way to use generic views is to inherit from an
 existing view and override attributes (such as the ``template_name``) or
@@ -87,8 +87,7 @@ topic on :doc:`generic class-based views</topics/class-based-views/generic-displ
 
 .. _supporting-other-http-methods:
 
-Supporting other HTTP methods
------------------------------
+.. rubric:: :h2:`Supporting other HTTP methods`
 
 Suppose somebody wants to access our book library over HTTP using the views
 as an API. The API client would connect every now and then and download book


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/20935)

This fixes "NAV-011" errors in the epub file. 

My approach here has been to add :rubric: headings. They are styled as H2 headings but are not included in the TOC. 

I felt this approach resulted in a lower impact than having a large restructure of the documentation. The downside of this approach is these headings are no longer included in the TOC and therefore the heading's no longer generate a link. 

Having run epub check this leaves the following errors.
{'HTM-003': 72, 'OPF-029': 4, 'PKG-021': 4, 'OPF-073': 2}
