### PR TITLE
Doc'd return values of as_sql() for Func and query expressions.

### DIFF
--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -314,7 +314,9 @@ The ``Func`` API is as follows:
 
     .. method:: as_sql(compiler, connection, function=None, template=None, arg_joiner=None, **extra_context)
 
-        Generates the SQL for the database function.
+        Generates the SQL fragment for the database function. Returns a tuple
+        ``(sql, params)``, where ``sql`` is the SQL string, and ``params`` is
+        the list or tuple of query parameters.
 
         The ``as_vendor()`` methods should use the ``function``, ``template``,
         ``arg_joiner``, and any other ``**extra_context`` parameters to

--- a/docs/ref/models/lookups.txt
+++ b/docs/ref/models/lookups.txt
@@ -86,10 +86,12 @@ following methods:
 
 .. method:: as_sql(compiler, connection)
 
-    Responsible for producing the query string and parameters for the expression.
-    The ``compiler`` is an ``SQLCompiler`` object, which has a ``compile()``
-    method that can be used to compile other expressions. The ``connection`` is
-    the connection used to execute the query.
+    Generates the SQL fragment for the expression. Returns a tuple
+    ``(sql, params)``, where ``sql`` is the SQL string, and ``params`` is the
+    list or tuple of query parameters. The ``compiler`` is an ``SQLCompiler``
+    object, which has a ``compile()`` method that can be used to compile other
+    expressions. The ``connection`` is the connection used to execute the
+    query.
 
     Calling ``expression.as_sql()`` is usually incorrect - instead
     ``compiler.compile(expression)`` should be used. The ``compiler.compile()``


### PR DESCRIPTION
Mostly to make it clear that `params` may be a list or tuple.