### PR TITLE
Fixed #8760 -- Changed ModelMultipleChoiceField to use invalid_list as a error message key.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -2,7 +2,7 @@
 Helper functions for creating Form classes from Django models
 and database field objects.
 """
-
+import warnings
 from itertools import chain
 
 from django.core.exceptions import (
@@ -15,6 +15,7 @@ from django.forms.utils import ErrorList
 from django.forms.widgets import (
     HiddenInput, MultipleHiddenInput, RadioSelect, SelectMultiple,
 )
+from django.utils.deprecation import RemovedInDjango40Warning
 from django.utils.text import capfirst, get_text_list
 from django.utils.translation import gettext, gettext_lazy as _
 
@@ -1291,7 +1292,7 @@ class ModelMultipleChoiceField(ModelChoiceField):
     widget = SelectMultiple
     hidden_widget = MultipleHiddenInput
     default_error_messages = {
-        'list': _('Enter a list of values.'),
+        'invalid_list': _('Enter a list of values.'),
         'invalid_choice': _('Select a valid choice. %(value)s is not one of the'
                             ' available choices.'),
         'invalid_pk_value': _('“%(pk)s” is not a valid value.')
@@ -1299,6 +1300,13 @@ class ModelMultipleChoiceField(ModelChoiceField):
 
     def __init__(self, queryset, **kwargs):
         super().__init__(queryset, empty_label=None, **kwargs)
+        if self.error_messages.get('list') is not None:
+            warnings.warn(
+                "The 'list' error message key is deprecated in favor of "
+                "'invalid_list'.",
+                RemovedInDjango40Warning, stacklevel=2,
+            )
+            self.error_messages['invalid_list'] = self.error_messages['list']
 
     def to_python(self, value):
         if not value:
@@ -1312,7 +1320,10 @@ class ModelMultipleChoiceField(ModelChoiceField):
         elif not self.required and not value:
             return self.queryset.none()
         if not isinstance(value, (list, tuple)):
-            raise ValidationError(self.error_messages['list'], code='list')
+            raise ValidationError(
+                self.error_messages['invalid_list'],
+                code='invalid_list',
+            )
         qs = self._check_values(value)
         # Since this overrides the inherited ModelChoiceField.clean
         # we run custom validators here
@@ -1333,8 +1344,8 @@ class ModelMultipleChoiceField(ModelChoiceField):
         except TypeError:
             # list of lists isn't hashable, for example
             raise ValidationError(
-                self.error_messages['list'],
-                code='list',
+                self.error_messages['invalid_list'],
+                code='invalid_list',
             )
         for pk in value:
             try:

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -64,6 +64,8 @@ details on these changes.
 * The ``length`` argument for ``django.utils.crypto.get_random_string()`` will
   be required.
 
+* The ``list`` message for ``ModelMultipleChoiceField`` will be removed.
+
 See the :ref:`Django 3.1 release notes <deprecated-features-3.1>` for more
 details on these changes.
 

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -1255,7 +1255,7 @@ generating choices. See :ref:`iterating-relationship-choices` for details.
     * Normalizes to: A ``QuerySet`` of model instances.
     * Validates that every id in the given list of values exists in the
       queryset.
-    * Error message keys: ``required``, ``list``, ``invalid_choice``,
+    * Error message keys: ``required``, ``invalid_list``, ``invalid_choice``,
       ``invalid_pk_value``
 
     The ``invalid_choice`` message may contain ``%(value)s`` and the
@@ -1284,6 +1284,10 @@ generating choices. See :ref:`iterating-relationship-choices` for details.
     .. attribute:: iterator
 
         Same as :class:`ModelChoiceField.iterator`.
+
+.. deprecated:: 3.1
+
+    The ``list`` message is deprecated, use ``invalid_list`` instead.
 
 .. _iterating-relationship-choices:
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -557,6 +557,9 @@ Miscellaneous
 * Calling ``django.utils.crypto.get_random_string()`` without a ``length``
   argument is deprecated.
 
+* The ``list`` message for :class:`~django.forms.ModelMultipleChoiceField` is
+  deprecated in favor of ``invalid_list``.
+
 .. _removed-features-3.1:
 
 Features removed in 3.1


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/8760)

This longstanding issue had a patch provided by some years ago. However, Tim raised the question about if and how this should be implemented. e.g. if we accept this change is it ok as a backwards incompatible change or do we try a deprecation path. 

I've put together this PR to help this discussion. Making this change only broke one minor test which I've provided a fix for, hopefully this can help the debate. 

I'm not sure if this is a simple decision that can be made here or if wider discussion (on the mailing list) is warranted. 

Appreciate your views & guidance. 