### PR TITLE
Refs #31304 -- Made __search lookup default to its rhs' config.

### DIFF
--- a/django/contrib/postgres/lookups.py
+++ b/django/contrib/postgres/lookups.py
@@ -57,7 +57,8 @@ class SearchLookup(SearchVectorExact):
 
     def process_lhs(self, qn, connection):
         if not isinstance(self.lhs.output_field, SearchVectorField):
-            self.lhs = SearchVector(self.lhs)
+            config = getattr(self.rhs, 'config', None)
+            self.lhs = SearchVector(self.lhs, config=config)
         lhs, lhs_params = super().process_lhs(qn, connection)
         return lhs, lhs_params
 

--- a/tests/postgres_tests/test_search.py
+++ b/tests/postgres_tests/test_search.py
@@ -104,6 +104,12 @@ class SimpleSearchTest(GrailTestData, PostgreSQLTestCase):
         searched = Line.objects.filter(dialogue__search='Robin killed')
         self.assertSequenceEqual(searched, [self.verse0])
 
+    def test_search_query_config(self):
+        searched = Line.objects.filter(
+            dialogue__search=SearchQuery('nostrils', config='simple'),
+        )
+        self.assertSequenceEqual(searched, [self.verse2])
+
 
 @modify_settings(INSTALLED_APPS={'append': 'django.contrib.postgres'})
 class SearchVectorFieldTest(GrailTestData, PostgreSQLTestCase):


### PR DESCRIPTION
This make the `SearchLookup` lookup more coherent with its `SearchVectorExact` base which configures its rhs `SearchQuery` with its lhs' config.

---

Follow up to https://code.djangoproject.com/ticket/31304#comment:10