### PR TITLE
Refs #30489 -- Fixed RasterFieldTest.test_deserialize_with_pixeltype_flags() when run without numpy.

### DIFF
--- a/tests/gis_tests/rasterapp/test_rasterfield.py
+++ b/tests/gis_tests/rasterapp/test_rasterfield.py
@@ -68,7 +68,10 @@ class RasterFieldTest(TransactionTestCase):
             rast=Func(F('rast'), function='ST_SetBandIsNoData'),
         )
         r.refresh_from_db()
-        self.assertEqual(r.rast.bands[0].data(), [[no_data]])
+        band = r.rast.bands[0].data()
+        if numpy:
+            band = band.flatten().tolist()
+        self.assertEqual(band, [no_data])
         self.assertEqual(r.rast.bands[0].nodata_value, no_data)
 
     def test_model_creation(self):

--- a/tests/gis_tests/rasterapp/test_rasterfield.py
+++ b/tests/gis_tests/rasterapp/test_rasterfield.py
@@ -68,8 +68,8 @@ class RasterFieldTest(TransactionTestCase):
             rast=Func(F('rast'), function='ST_SetBandIsNoData'),
         )
         r.refresh_from_db()
-        self.assertEquals(r.rast.bands[0].data(), [[no_data]])
-        self.assertEquals(r.rast.bands[0].nodata_value, no_data)
+        self.assertEqual(r.rast.bands[0].data(), [[no_data]])
+        self.assertEqual(r.rast.bands[0].nodata_value, no_data)
 
     def test_model_creation(self):
         """


### PR DESCRIPTION
See [test failure](https://djangoci.com/job/master-no-requirements/database=postgis,label=bionic,python=python3.8/lastCompletedBuild/testReport/gis_tests.rasterapp.test_rasterfield/RasterFieldTest/test_deserialize_with_pixeltype_flags/).