### PR TITLE
Ref #31169: Rewrite ParallelTestRunner to use `spawn` as start method

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -284,7 +284,8 @@ class ActionSelenium(argparse.Action):
 def django_tests(verbosity, interactive, failfast, keepdb, reverse,
                  test_labels, debug_sql, parallel, tags, exclude_tags,
                  test_name_patterns, start_at, start_after, pdb, buffer):
-    state = setup(verbosity, test_labels, parallel, start_at, start_after)
+    setup_args = (verbosity, test_labels, parallel, start_at, start_after)
+    state = setup(*setup_args)
     extra_tests = []
 
     # Run the test suite, including the extra validation tests.
@@ -309,6 +310,8 @@ def django_tests(verbosity, interactive, failfast, keepdb, reverse,
     failures = test_runner.run_tests(
         test_labels or get_installed(),
         extra_tests=extra_tests,
+        setup_callback=setup,
+        setup_args=setup_args,
     )
     teardown(state)
     return failures


### PR DESCRIPTION
This PR is no where close to being finished. There even might be some naive coding decisions I've made. I've tested it on Windows and on Linux, both running Postgres.

This patch doesn't support spawn with SQLite since the database is in-memory. There are two workarounds I can think of:
1. Don't allow in-memory databases, parallel, and spawn together. 
2. SQL Dump the in-memory database and then re-create the database in the child processes.

The problem with the second one is, afaik, there isn't a way to dump an SQLite DB with the ORM. However, the sqlite3 module provides a method for it (`Connection.iterdump()`). I wasn't sure how to tackle that, hence left it out of the patch.

Please test out this patch on your primary OS and database.
