### PR TITLE
Corrected learn_cache_key() signature in docs.

### DIFF
--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -97,7 +97,7 @@ need to distinguish caches by the ``Accept-language`` header.
     If there is no headerlist stored, the page needs to be rebuilt, so this
     function returns ``None``.
 
-.. function:: learn_cache_key(request, response, cache_timeout=None, key_prefix=None)
+.. function:: learn_cache_key(request, response, cache_timeout=None, key_prefix=None, cache=None)
 
     Learns what headers to take into account for some request path from the
     response object. It stores those headers in a global path registry so that


### PR DESCRIPTION
Follow up to b22415214a7bdeaf8ccd7b8b21872038ab865991.