### PR TITLE
Refs #26445 -- Allowed using UserManager.create_user()/create_superuser() in migrations.

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -1,5 +1,7 @@
+from django.apps import apps
 from django.contrib import auth
 from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
+from django.contrib.auth.hashers import make_password
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
@@ -134,9 +136,13 @@ class UserManager(BaseUserManager):
         if not username:
             raise ValueError('The given username must be set')
         email = self.normalize_email(email)
-        username = self.model.normalize_username(username)
+        # Lookup the real model class from the global app registry so this
+        # manager method can be used in migrations. This is fine because
+        # managers are by definition working on the real model.
+        GlobalUserModel = apps.get_model(self.model._meta.app_label, self.model._meta.object_name)
+        username = GlobalUserModel.normalize_username(username)
         user = self.model(username=username, email=email, **extra_fields)
-        user.set_password(password)
+        user.password = make_password(password)
         user.save(using=self._db)
         return user
 


### PR DESCRIPTION
[Ticket 26445](https://code.djangoproject.com/ticket/26445)
Continue @felixxm [PR](https://github.com/django/django/pull/8268).
Try to address @charettes [comment](https://github.com/django/django/pull/8268#discussion_r109012729)