### PR TITLE
Fixed #31358 -- Increased salt entropy of password hashers.

### DIFF
--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -212,6 +212,9 @@ Minor features
   constrained environments. If this is the case, the existing hasher can be
   subclassed to override the defaults.
 
+* The default salt entropy for the Argon2, MD5, PBKDF2, SHA-1 password hashers
+  is increased from 71 to 128 bits.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -137,6 +137,26 @@ To use Bcrypt as your default storage algorithm, do the following:
 That's it -- now your Django install will use Bcrypt as the default storage
 algorithm.
 
+Increasing the salt entropy
+---------------------------
+
+.. versionadded:: 3.2
+
+Most password hashes include a salt along with their password hash in order to
+protect against rainbow table attacks. The salt itself is a random value which
+increases the size and thus the cost of the rainbow table and is currently set
+at 128 bits with the ``salt_entropy`` value in the ``BasePasswordHasher``. As
+computing and storage costs decrease this value should be raised. When
+implementing your own password hasher you are free to override this value in
+order to use a desired entropy level for your password hashes. ``salt_entropy``
+is measured in bits.
+
+.. admonition:: Implementation detail
+
+    Due to the method in which salt values are stored the ``salt_entropy``
+    value is effectively a minimum value. For instance a value of 128 would
+    provide a salt which would actually contain 131 bits of entropy.
+
 .. _increasing-password-algorithm-work-factor:
 
 Increasing the work factor

--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -3,9 +3,9 @@ from unittest import mock, skipUnless
 from django.conf.global_settings import PASSWORD_HASHERS
 from django.contrib.auth.hashers import (
     UNUSABLE_PASSWORD_PREFIX, UNUSABLE_PASSWORD_SUFFIX_LENGTH,
-    BasePasswordHasher, PBKDF2PasswordHasher, PBKDF2SHA1PasswordHasher,
-    check_password, get_hasher, identify_hasher, is_password_usable,
-    make_password,
+    BasePasswordHasher, BCryptPasswordHasher, BCryptSHA256PasswordHasher,
+    PBKDF2PasswordHasher, PBKDF2SHA1PasswordHasher, check_password, get_hasher,
+    identify_hasher, is_password_usable, make_password,
 )
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
@@ -304,6 +304,18 @@ class TestUtilsHashPass(SimpleTestCase):
         encoded = hasher.encode('lètmein', 'seasalt2')
         self.assertEqual(encoded, 'pbkdf2_sha1$260000$seasalt2$wAibXvW6jgvatCdONi6SMJ6q7mI=')
         self.assertTrue(hasher.verify('lètmein', encoded))
+
+    @skipUnless(bcrypt, 'bcrypt not installed')
+    def test_bcrypt_salt_check(self):
+        hasher = BCryptPasswordHasher()
+        encoded = hasher.encode('lètmein', hasher.salt())
+        self.assertIs(hasher.must_update(encoded), False)
+
+    @skipUnless(bcrypt, 'bcrypt not installed')
+    def test_bcryptsha256_salt_check(self):
+        hasher = BCryptSHA256PasswordHasher()
+        encoded = hasher.encode('lètmein', hasher.salt())
+        self.assertIs(hasher.must_update(encoded), False)
 
     @override_settings(
         PASSWORD_HASHERS=[

--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -74,6 +74,12 @@ class TestUtilsHashPass(SimpleTestCase):
         self.assertTrue(is_password_usable(blank_encoded))
         self.assertTrue(check_password('', blank_encoded))
         self.assertFalse(check_password(' ', blank_encoded))
+        # Salt entropy check.
+        hasher = get_hasher('pbkdf2_sha256')
+        encoded_weak_salt = make_password('lètmein', 'iodizedsalt', 'pbkdf2_sha256')
+        encoded_strong_salt = make_password('lètmein', hasher.salt(), 'pbkdf2_sha256')
+        self.assertIs(hasher.must_update(encoded_weak_salt), True)
+        self.assertIs(hasher.must_update(encoded_strong_salt), False)
 
     @override_settings(PASSWORD_HASHERS=['django.contrib.auth.hashers.SHA1PasswordHasher'])
     def test_sha1(self):
@@ -89,6 +95,12 @@ class TestUtilsHashPass(SimpleTestCase):
         self.assertTrue(is_password_usable(blank_encoded))
         self.assertTrue(check_password('', blank_encoded))
         self.assertFalse(check_password(' ', blank_encoded))
+        # Salt entropy check.
+        hasher = get_hasher('sha1')
+        encoded_weak_salt = make_password('lètmein', 'iodizedsalt', 'sha1')
+        encoded_strong_salt = make_password('lètmein', hasher.salt(), 'sha1')
+        self.assertIs(hasher.must_update(encoded_weak_salt), True)
+        self.assertIs(hasher.must_update(encoded_strong_salt), False)
 
     @override_settings(PASSWORD_HASHERS=['django.contrib.auth.hashers.MD5PasswordHasher'])
     def test_md5(self):
@@ -104,6 +116,12 @@ class TestUtilsHashPass(SimpleTestCase):
         self.assertTrue(is_password_usable(blank_encoded))
         self.assertTrue(check_password('', blank_encoded))
         self.assertFalse(check_password(' ', blank_encoded))
+        # Salt entropy check.
+        hasher = get_hasher('md5')
+        encoded_weak_salt = make_password('lètmein', 'iodizedsalt', 'md5')
+        encoded_strong_salt = make_password('lètmein', hasher.salt(), 'md5')
+        self.assertIs(hasher.must_update(encoded_weak_salt), True)
+        self.assertIs(hasher.must_update(encoded_strong_salt), False)
 
     @override_settings(PASSWORD_HASHERS=['django.contrib.auth.hashers.UnsaltedMD5PasswordHasher'])
     def test_unsalted_md5(self):
@@ -537,6 +555,12 @@ class TestUtilsHashPassArgon2(SimpleTestCase):
         )
         self.assertIs(check_password('secret', encoded), True)
         self.assertIs(check_password('wrong', encoded), False)
+        # Salt entropy check.
+        hasher = get_hasher('argon2')
+        encoded_weak_salt = make_password('lètmein', 'iodizedsalt', 'argon2')
+        encoded_strong_salt = make_password('lètmein', hasher.salt(), 'argon2')
+        self.assertIs(hasher.must_update(encoded_weak_salt), True)
+        self.assertIs(hasher.must_update(encoded_strong_salt), False)
 
     def test_argon2_decode(self):
         salt = 'abcdefghijk'

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -1269,7 +1269,7 @@ class ChangelistTests(AuthViewsTestCase):
         self.assertContains(
             response,
             '<strong>algorithm</strong>: %s\n\n'
-            '<strong>salt</strong>: %s**********\n\n'
+            '<strong>salt</strong>: %s********************\n\n'
             '<strong>hash</strong>: %s**************************\n\n' % (
                 algo, salt[:2], hash_string[:6],
             ),


### PR DESCRIPTION
The choice of 12 characters (~71bit) seems to stem from 2011 at latest
and may be based off the guidance in rfc 2898 circa 2000 which recommends at least 64 bits
https://www.ietf.org/rfc/rfc2898.txt
The git commit containing the original code is
dce820ff70f00e974afd3e6e310aa825bc55319f

Modern guidance suggests the use of at least 128 bits for salt values
OWASP Guidance: https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Password_Storage_Cheat_Sheet.md#salting
Python guidance for pbkdf2: https://docs.python.org/3/library/hashlib.html#hashlib.pbkdf2_hmac
NIST Guidance: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-132.pdf See: Section 5.1

In the nist case this is actually a hard requirement which could be placing some users out of compliance.

This PR bumps the default length of get_random_string() to 22 which provides approximately 131 bits of entropy
log_2((26+26+10)^22) = 130.9923...