### PR TITLE
Fixed #31330 -- Updated flatpages URLconf example to work with APPEND_SLASH.

### DIFF
--- a/docs/ref/contrib/flatpages.txt
+++ b/docs/ref/contrib/flatpages.txt
@@ -79,7 +79,7 @@ to place the pattern at the end of the other urlpatterns::
 
     # Your other patterns here
     urlpatterns += [
-        path('<path:url>', views.flatpage),
+        path('<path:url>/', views.flatpage),
     ]
 
 .. warning::


### PR DESCRIPTION
Fixes [ticket 31330](https://code.djangoproject.com/ticket/31330).