### PR TITLE
Fixed #31362 -- Removed nonexistent choices attribute from MultipleHiddenInput's docs.

### DIFF
--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -846,12 +846,6 @@ Composite widgets
     A widget that handles multiple hidden widgets for fields that have a list
     of values.
 
-    .. attribute:: MultipleHiddenInput.choices
-
-        This attribute is optional when the form field does not have a
-        ``choices`` attribute. If it does, it will override anything you set
-        here when the attribute is updated on the :class:`Field`.
-
 ``SplitDateTimeWidget``
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This [commit](https://github.com/django/django/commit/65c13f9675d2ca7fc1c925e7182a2e35d07ff5fb#diff-aee6730bae795d31efec3c5d014804a9) removed the choices attribute from `MultipleHiddenInput`.

Therefore lets remove the reference to it in the docs.