### PR TITLE
Fixes #11836 -- Missing django.forms.widgets.MultiWidget hidden counterpart

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -341,6 +341,10 @@ class MultipleHiddenInput(HiddenInput):
     """
     template_name = 'django/forms/widgets/multiple_hidden.html'
 
+    def __init__(self, attrs=None, unique_names=True):
+        self.unique_names = unique_names
+        super().__init__(attrs)
+
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         final_attrs = context['widget']['attrs']
@@ -353,9 +357,13 @@ class MultipleHiddenInput(HiddenInput):
                 # An ID attribute was given. Add a numeric index as a suffix
                 # so that the inputs don't all have the same ID attribute.
                 widget_attrs['id'] = '%s_%s' % (id_, index)
+            if self.unique_names:
+                widget_name = '%s_%s' % (name, index)
+            else:
+                widget_name = name
             widget = HiddenInput()
             widget.is_required = self.is_required
-            subwidgets.append(widget.get_context(name, value_, widget_attrs)['widget'])
+            subwidgets.append(widget.get_context(widget_name, value_, widget_attrs)['widget'])
 
         context['widget']['subwidgets'] = subwidgets
         return context

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -341,10 +341,6 @@ class MultipleHiddenInput(HiddenInput):
     """
     template_name = 'django/forms/widgets/multiple_hidden.html'
 
-    def __init__(self, attrs=None, unique_names=True):
-        self.unique_names = unique_names
-        super().__init__(attrs)
-
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         final_attrs = context['widget']['attrs']
@@ -357,10 +353,7 @@ class MultipleHiddenInput(HiddenInput):
                 # An ID attribute was given. Add a numeric index as a suffix
                 # so that the inputs don't all have the same ID attribute.
                 widget_attrs['id'] = '%s_%s' % (id_, index)
-            if self.unique_names:
-                widget_name = '%s_%s' % (name, index)
-            else:
-                widget_name = name
+            widget_name = '%s_%s' % (name, index)
             widget = HiddenInput()
             widget.is_required = self.is_required
             subwidgets.append(widget.get_context(widget_name, value_, widget_attrs)['widget'])

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -262,6 +262,11 @@ Forms
   now uses ``DATE_INPUT_FORMATS`` in addition to ``DATETIME_INPUT_FORMATS``
   when converting a field input to a ``datetime`` value.
 
+
+* :class:`django.forms.MultipleHiddenInput` now accepts a
+  ``unique_names`` attribute. When set to True this results in index being
+  appended to the field name. Defaults to True.
+
 Generic Views
 ~~~~~~~~~~~~~
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -262,11 +262,6 @@ Forms
   now uses ``DATE_INPUT_FORMATS`` in addition to ``DATETIME_INPUT_FORMATS``
   when converting a field input to a ``datetime`` value.
 
-
-* :class:`django.forms.MultipleHiddenInput` now accepts a
-  ``unique_names`` attribute. When set to True this results in index being
-  appended to the field name. Defaults to True.
-
 Generic Views
 ~~~~~~~~~~~~~
 
@@ -584,6 +579,10 @@ Miscellaneous
 
 * The admin CSS classes ``row1`` and ``row2`` are removed in favor of
   ``:nth-child(odd)`` and ``:nth-child(even)`` pseudo-classes.
+
+* :class:`django.forms.MultipleHiddenInput` now gives each input a unique
+  ``name`` by appending an index to appended to the field name. This is the
+  same approach as ``Multiwidget``.
 
 .. _deprecated-features-3.1:
 

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -836,10 +836,10 @@ Java</label></li>
         # have multiple values, its as_hidden() renders multiple <input type="hidden">
         # tags.
         f = SongForm({'name': 'Yesterday', 'composers': ['P']}, auto_id=False)
-        self.assertHTMLEqual(f['composers'].as_hidden(), '<input type="hidden" name="composers" value="P">')
+        self.assertHTMLEqual(f['composers'].as_hidden(), '<input type="hidden" name="composers_0" value="P">')
         f = SongForm({'name': 'From Me To You', 'composers': ['P', 'J']}, auto_id=False)
-        self.assertHTMLEqual(f['composers'].as_hidden(), """<input type="hidden" name="composers" value="P">
-<input type="hidden" name="composers" value="J">""")
+        self.assertHTMLEqual(f['composers'].as_hidden(), """<input type="hidden" name="composers_0" value="P">
+<input type="hidden" name="composers_1" value="J">""")
 
         # DateTimeField rendered as_hidden() is special too
         class MessageForm(Form):
@@ -959,8 +959,8 @@ Java</label></li>
         self.assertHTMLEqual(
             f.as_ul(),
             """<li>Name: <input type="text" name="name" value="Yesterday" required>
-<input type="hidden" name="composers" value="J">
-<input type="hidden" name="composers" value="P"></li>"""
+<input type="hidden" name="composers_0" value="J">
+<input type="hidden" name="composers_1" value="P"></li>"""
         )
 
         # When using CheckboxSelectMultiple, the framework expects a list of input and

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -100,16 +100,17 @@ class ModelFormCallableModelDefault(TestCase):
 <option value="1" selected>ChoiceOption 1</option>
 <option value="2">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
-</select><input type="hidden" name="initial-multi_choice" value="1" id="initial-id_multi_choice_0"></p>
+</select><input type="hidden" name="initial-multi_choice_0" value="1" id="initial-id_multi_choice_0"></p>
 <p><label for="id_multi_choice_int">Multi choice int:</label>
 <select multiple name="multi_choice_int" id="id_multi_choice_int" required>
 <option value="1" selected>ChoiceOption 1</option>
 <option value="2">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
-</select><input type="hidden" name="initial-multi_choice_int" value="1" id="initial-id_multi_choice_int_0"></p>"""
+</select><input type="hidden" name="initial-multi_choice_int_0" value="1" id="initial-id_multi_choice_int_0"></p>"""
         )
 
     def test_initial_instance_value(self):
+        self.maxDiff = None
         "Initial instances for model fields may also be instances (refs #7287)"
         ChoiceOptionModel.objects.create(id=1, name='default')
         obj2 = ChoiceOptionModel.objects.create(id=2, name='option 2')
@@ -136,15 +137,15 @@ class ModelFormCallableModelDefault(TestCase):
 <option value="1">ChoiceOption 1</option>
 <option value="2" selected>ChoiceOption 2</option>
 <option value="3" selected>ChoiceOption 3</option>
-</select><input type="hidden" name="initial-multi_choice" value="2" id="initial-id_multi_choice_0">
-<input type="hidden" name="initial-multi_choice" value="3" id="initial-id_multi_choice_1"></p>
+</select><input type="hidden" name="initial-multi_choice_0" value="2" id="initial-id_multi_choice_0">
+<input type="hidden" name="initial-multi_choice_1" value="3" id="initial-id_multi_choice_1"></p>
 <p><label for="id_multi_choice_int">Multi choice int:</label>
 <select multiple name="multi_choice_int" id="id_multi_choice_int" required>
 <option value="1">ChoiceOption 1</option>
 <option value="2" selected>ChoiceOption 2</option>
 <option value="3" selected>ChoiceOption 3</option>
-</select><input type="hidden" name="initial-multi_choice_int" value="2" id="initial-id_multi_choice_int_0">
-<input type="hidden" name="initial-multi_choice_int" value="3" id="initial-id_multi_choice_int_1"></p>"""
+</select><input type="hidden" name="initial-multi_choice_int_0" value="2" id="initial-id_multi_choice_int_0">
+<input type="hidden" name="initial-multi_choice_int_1" value="3" id="initial-id_multi_choice_int_1"></p>"""
         )
 
 

--- a/tests/forms_tests/widget_tests/test_multiplehiddeninput.py
+++ b/tests/forms_tests/widget_tests/test_multiplehiddeninput.py
@@ -5,34 +5,35 @@ from .base import WidgetTest
 
 class MultipleHiddenInputTest(WidgetTest):
     widget = MultipleHiddenInput()
+    no_unique_names = MultipleHiddenInput(unique_names=False)
 
     def test_render_single(self):
         self.check_html(
             self.widget, 'email', ['test@example.com'],
-            html='<input type="hidden" name="email" value="test@example.com">',
+            html='<input type="hidden" name="email_0" value="test@example.com">',
         )
 
     def test_render_multiple(self):
         self.check_html(
             self.widget, 'email', ['test@example.com', 'foo@example.com'],
             html=(
-                '<input type="hidden" name="email" value="test@example.com">\n'
-                '<input type="hidden" name="email" value="foo@example.com">'
+                '<input type="hidden" name="email_0" value="test@example.com">\n'
+                '<input type="hidden" name="email_1" value="foo@example.com">'
             ),
         )
 
     def test_render_attrs(self):
         self.check_html(
             self.widget, 'email', ['test@example.com'], attrs={'class': 'fun'},
-            html='<input type="hidden" name="email" value="test@example.com" class="fun">',
+            html='<input type="hidden" name="email_0" value="test@example.com" class="fun">',
         )
 
     def test_render_attrs_multiple(self):
         self.check_html(
             self.widget, 'email', ['test@example.com', 'foo@example.com'], attrs={'class': 'fun'},
             html=(
-                '<input type="hidden" name="email" value="test@example.com" class="fun">\n'
-                '<input type="hidden" name="email" value="foo@example.com" class="fun">'
+                '<input type="hidden" name="email_0" value="test@example.com" class="fun">\n'
+                '<input type="hidden" name="email_1" value="foo@example.com" class="fun">'
             ),
         )
 
@@ -41,18 +42,18 @@ class MultipleHiddenInputTest(WidgetTest):
         self.check_html(widget, 'email', [], '')
         self.check_html(
             widget, 'email', ['foo@example.com'],
-            html='<input type="hidden" class="fun" value="foo@example.com" name="email">',
+            html='<input type="hidden" class="fun" value="foo@example.com" name="email_0">',
         )
         self.check_html(
             widget, 'email', ['foo@example.com', 'test@example.com'],
             html=(
-                '<input type="hidden" class="fun" value="foo@example.com" name="email">\n'
-                '<input type="hidden" class="fun" value="test@example.com" name="email">'
+                '<input type="hidden" class="fun" value="foo@example.com" name="email_0">\n'
+                '<input type="hidden" class="fun" value="test@example.com" name="email_1">'
             ),
         )
         self.check_html(
             widget, 'email', ['foo@example.com'], attrs={'class': 'special'},
-            html='<input type="hidden" class="special" value="foo@example.com" name="email">',
+            html='<input type="hidden" class="special" value="foo@example.com" name="email_0">',
         )
 
     def test_render_empty(self):
@@ -68,8 +69,30 @@ class MultipleHiddenInputTest(WidgetTest):
         self.check_html(
             self.widget, 'letters', ['a', 'b', 'c'], attrs={'id': 'hideme'},
             html=(
-                '<input type="hidden" name="letters" value="a" id="hideme_0">\n'
-                '<input type="hidden" name="letters" value="b" id="hideme_1">\n'
-                '<input type="hidden" name="letters" value="c" id="hideme_2">'
+                '<input type="hidden" name="letters_0" value="a" id="hideme_0">\n'
+                '<input type="hidden" name="letters_1" value="b" id="hideme_1">\n'
+                '<input type="hidden" name="letters_2" value="c" id="hideme_2">'
             ),
         )
+
+    def test_unique_names_single(self):
+        self.check_html(
+            self.no_unique_names, 'email', ['test@example.com'],
+            html='<input type="hidden" name="email" value="test@example.com">',
+        )
+
+    def test_unique_names_multiple(self):
+        self.check_html(
+            self.no_unique_names, 'email', ['test@example.com', 'foo@example.com'],
+            html=(
+                '<input type="hidden" name="email" value="test@example.com">\n'
+                '<input type="hidden" name="email" value="foo@example.com">'
+            ),
+        )
+
+    def test_unique_names_render_attrs(self):
+        self.check_html(
+            self.no_unique_names, 'email', ['test@example.com'], attrs={'class': 'fun'},
+            html='<input type="hidden" name="email" value="test@example.com" class="fun">',
+        )
+

--- a/tests/forms_tests/widget_tests/test_multiplehiddeninput.py
+++ b/tests/forms_tests/widget_tests/test_multiplehiddeninput.py
@@ -5,7 +5,6 @@ from .base import WidgetTest
 
 class MultipleHiddenInputTest(WidgetTest):
     widget = MultipleHiddenInput()
-    no_unique_names = MultipleHiddenInput(unique_names=False)
 
     def test_render_single(self):
         self.check_html(
@@ -73,25 +72,4 @@ class MultipleHiddenInputTest(WidgetTest):
                 '<input type="hidden" name="letters_1" value="b" id="hideme_1">\n'
                 '<input type="hidden" name="letters_2" value="c" id="hideme_2">'
             ),
-        )
-
-    def test_unique_names_single(self):
-        self.check_html(
-            self.no_unique_names, 'email', ['test@example.com'],
-            html='<input type="hidden" name="email" value="test@example.com">',
-        )
-
-    def test_unique_names_multiple(self):
-        self.check_html(
-            self.no_unique_names, 'email', ['test@example.com', 'foo@example.com'],
-            html=(
-                '<input type="hidden" name="email" value="test@example.com">\n'
-                '<input type="hidden" name="email" value="foo@example.com">'
-            ),
-        )
-
-    def test_unique_names_render_attrs(self):
-        self.check_html(
-            self.no_unique_names, 'email', ['test@example.com'], attrs={'class': 'fun'},
-            html='<input type="hidden" name="email" value="test@example.com" class="fun">',
         )

--- a/tests/forms_tests/widget_tests/test_multiplehiddeninput.py
+++ b/tests/forms_tests/widget_tests/test_multiplehiddeninput.py
@@ -95,4 +95,3 @@ class MultipleHiddenInputTest(WidgetTest):
             self.no_unique_names, 'email', ['test@example.com'], attrs={'class': 'fun'},
             html='<input type="hidden" name="email" value="test@example.com" class="fun">',
         )
-


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/11836)

Currently `MultipleHiddenInput` gives each subwidget the same name. This pull request appends an index reference and therefore gives consistency to other widgets. 

I've added an attribute so that the new behaviour can be turned off, to enable backwards compatibility. I've currently defaulted to `True` as I think this is the right thing to do (it improves consistency) and it also shows the impact on the entire test suite. 

I think the key 'design' decisions are:

- Do we need the flag to enable the behaviour to be change at all
- Do we put this on a deprecation path, to remove the flag in future
- Do we default to True/False

