### PR TITLE
Fixes #25113: ORM does not support SQL `NOT IN` clauses

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -406,6 +406,14 @@ class In(FieldGetDbPrepValueIterableMixin, BuiltinLookup):
         return ''.join(in_clause_elements), params
 
 
+@Field.register_lookup
+class NotIn(In):
+    lookup_name = "notin"
+
+    def get_rhs_op(self, connection, rhs):
+        return "NOT IN %s" % rhs
+
+
 class PatternLookup(BuiltinLookup):
     param_pattern = '%%%s%%'
     prepare_rhs = False

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -361,7 +361,12 @@ class In(FieldGetDbPrepValueIterableMixin, BuiltinLookup):
                 rhs = self.rhs
 
             if not rhs:
-                raise EmptyResultSet
+                if self.__class__.__name__ == "NotIn":
+                    # To stay DRY, we return empty strings for NOT IN
+                    # This lets us return all results instead of none.
+                    return("", "")
+                else:
+                    raise EmptyResultSet
 
             # rhs should be an iterable; use batch_process_rhs() to
             # prepare/transform those values.
@@ -411,6 +416,9 @@ class NotIn(In):
     lookup_name = "notin"
 
     def get_rhs_op(self, connection, rhs):
+        # If an empty list is passed to `notin`, return all.
+        if not len(rhs):
+            return ""
         return "NOT IN %s" % rhs
 
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2799,7 +2799,7 @@ extract two field values, where only one is expected::
     the first query. Without it, a nested query would be executed, because
     :ref:`querysets-are-lazy`.
 
-.. fieldlookup:: in
+.. fieldlookup:: notin
 
 ``notin``
 ~~~~~~~~~

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2799,6 +2799,26 @@ extract two field values, where only one is expected::
     the first query. Without it, a nested query would be executed, because
     :ref:`querysets-are-lazy`.
 
+.. fieldlookup:: in
+
+``notin``
+~~~~~~~~~
+
+Not in a given iterable; often a list, tuple, or queryset. It's not a common use
+case, but strings (being iterables) are accepted.
+
+Examples::
+
+    Entry.objects.filter(id__notin=[1, 3, 4])
+    Entry.objects.filter(headline__notin='abc')
+
+SQL equivalents:
+
+.. code-block:: sql
+
+    SELECT ... WHERE id NOT IN (1, 3, 4);
+    SELECT ... WHERE headline NOT IN ('a', 'b', 'c');
+
 .. fieldlookup:: gt
 
 ``gt``

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -552,6 +552,16 @@ class LookupTests(TestCase):
             ]
         )
 
+    def test_notin(self):
+        self.assertQuerysetEqual(
+            Article.objects.filter(id__notin=[4, 5, 6, 7, 999]),
+            [
+                '<Article: Article 2>',
+                '<Article: Article 3>',
+                '<Article: Article 1>',
+            ]
+        )
+
     def test_in_different_database(self):
         with self.assertRaisesMessage(
             ValueError,

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -553,6 +553,19 @@ class LookupTests(TestCase):
         )
 
     def test_notin(self):
+        # using __notin with an empty list should return all records
+        self.assertQuerysetEqual(
+            Article.objects.filter(id__notin=[]),
+            [
+                '<Article: Article 5>',
+                '<Article: Article 6>',
+                '<Article: Article 4>',
+                '<Article: Article 2>',
+                '<Article: Article 3>',
+                '<Article: Article 7>',
+                '<Article: Article 1>',
+            ]
+        )
         self.assertQuerysetEqual(
             Article.objects.filter(id__notin=[4, 5, 6, 7, 999]),
             [


### PR DESCRIPTION
Via `exclude` and `Q` objects, Django currently supports `NOT (id IN (…))`, but does not support `id NOT IN (…)`. These clauses do not necessary produce the same results.

This P.R. adds a `__notin` filter.

Thank you to @adamchainz for pointing me in the right direction on the Django Forum: https://forum.djangoproject.com/t/django-orm-equivalent-of-sql-not-in-query/1480