### PR TITLE
Simplified settings' BASE_DIR definition with pathlib.Path.parent.

### DIFF
--- a/django/conf/project_template/project_name/settings.py-tpl
+++ b/django/conf/project_template/project_name/settings.py-tpl
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve(strict=True).parents[1]
+BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
Suggested by [milliams on reddit](https://www.reddit.com/r/django/comments/fjif7y/use_pathlib_in_your_django_settings_file_adam/fknfc4f/) as simpler on the back of my [pathlib blog post](https://adamj.eu/tech/2020/03/16/use-pathlib-in-your-django-project/). I agree - it's more user friendly. `parents[1]` opens up the questions like "Which order are the parents in?" and "Does 1 mean the first or the 2nd parent?".