### PR TITLE
Fixed #31172 -- Noted that yesno can be affected by extra spaces in translations.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -786,6 +786,7 @@ def yesno(value, arg=None):
     ==========  ======================  ==================================
     """
     if arg is None:
+        # Translators: Please do not add spaces around commas.
         arg = gettext('yes,no,maybe')
     bits = arg.split(',')
     if len(bits) < 2:


### PR DESCRIPTION
Fixes [ticket 31172](https://code.djangoproject.com/ticket/31172).
Based on @bmispelon [comment](https://code.djangoproject.com/ticket/31172#comment:8).