### PR TITLE
Fixed #31370 -- Added support for parallel tests with --buffer.

### DIFF
--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -258,6 +258,9 @@ Tests
   serialized to allow usage of the
   :ref:`serialized_rollback <test-case-serialized-rollback>` feature.
 
+* Django test runner now supports a :option:`--buffer <test --buffer>` option
+  with parallel tests.
+
 URLs
 ~~~~
 

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -269,14 +269,6 @@ class DiscoverRunnerTests(SimpleTestCase):
         with self.assertRaisesMessage(ValueError, msg):
             DiscoverRunner(pdb=True, parallel=2)
 
-    def test_buffer_with_parallel(self):
-        msg = (
-            'You cannot use -b/--buffer with parallel tests; pass '
-            '--parallel=1 to use it.'
-        )
-        with self.assertRaisesMessage(ValueError, msg):
-            DiscoverRunner(buffer=True, parallel=2)
-
     def test_buffer_mode_test_pass(self):
         runner = DiscoverRunner(buffer=True, verbose=0)
         with captured_stdout() as stdout, captured_stderr() as stderr:

--- a/tests/test_runner/test_parallel.py
+++ b/tests/test_runner/test_parallel.py
@@ -52,6 +52,35 @@ class SampleFailingSubtest(SimpleTestCase):
 
 class RemoteTestResultTest(SimpleTestCase):
 
+    def test_was_successful_no_events(self):
+        result = RemoteTestResult()
+        self.assertIs(result.wasSuccessful(), True)
+
+    def test_was_successful_one_success(self):
+        result = RemoteTestResult()
+        result.addSuccess(None)
+        self.assertIs(result.wasSuccessful(), True)
+
+    def test_was_successful_one_expected_failure(self):
+        result = RemoteTestResult()
+        result.addExpectedFailure(None, ValueError('woops'))
+        self.assertIs(result.wasSuccessful(), True)
+
+    def test_was_successful_one_skip(self):
+        result = RemoteTestResult()
+        result.addSkip(None, 'Skipped')
+        self.assertIs(result.wasSuccessful(), True)
+
+    def test_was_successful_one_error(self):
+        result = RemoteTestResult()
+        result.addError(None, ValueError('woops'))
+        self.assertIs(result.wasSuccessful(), False)
+
+    def test_was_successful_one_failure(self):
+        result = RemoteTestResult()
+        result.addFailure(None, ValueError('woops'))
+        self.assertIs(result.wasSuccessful(), False)
+
     def test_picklable(self):
         result = RemoteTestResult()
         loaded_result = pickle.loads(pickle.dumps(result))
@@ -81,6 +110,7 @@ class RemoteTestResultTest(SimpleTestCase):
 
         events = result.events
         self.assertEqual(len(events), 4)
+        self.assertIs(result.wasSuccessful(), False)
 
         event = events[1]
         self.assertEqual(event[0], 'addSubTest')

--- a/tests/test_runner/test_parallel.py
+++ b/tests/test_runner/test_parallel.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 from django.test import SimpleTestCase
@@ -50,6 +51,11 @@ class SampleFailingSubtest(SimpleTestCase):
 
 
 class RemoteTestResultTest(SimpleTestCase):
+
+    def test_picklable(self):
+        result = RemoteTestResult()
+        loaded_result = pickle.loads(pickle.dumps(result))
+        self.assertEqual(result.events, loaded_result.events)
 
     def test_pickle_errors_detection(self):
         picklable_error = RuntimeError('This is fine')


### PR DESCRIPTION
[ticket](https://code.djangoproject.com/ticket/31370#ticket)