### PR TITLE
Fixed #31371 -- Increased User.first_name max_length to 150 characters.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -785,6 +785,7 @@ answer newbie questions, and generally made Django that much better:
     ryankanno
     Ryan Kelly <ryan@rfk.id.au>
     Ryan Niemeyer <https://profiles.google.com/ryan.niemeyer/about>
+    Ryan Petrello <ryan@ryanpetrello.com>
     Ryan Rubin <ryanmrubin@gmail.com>
     Ryno Mathee <rmathee@gmail.com>
     Sachin Jat <sanch.jat@gmail.com>

--- a/django/contrib/auth/migrations/0012_alter_user_first_name_max_length.py
+++ b/django/contrib/auth/migrations/0012_alter_user_first_name_max_length.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0011_update_proxy_permissions'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='user',
+            name='first_name',
+            field=models.CharField(blank=True, max_length=150, verbose_name='first name'),
+        ),
+    ]

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -331,7 +331,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
             'unique': _("A user with that username already exists."),
         },
     )
-    first_name = models.CharField(_('first name'), max_length=30, blank=True)
+    first_name = models.CharField(_('first name'), max_length=150, blank=True)
     last_name = models.CharField(_('last name'), max_length=150, blank=True)
     email = models.EmailField(_('email address'), blank=True)
     is_staff = models.BooleanField(

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -42,8 +42,12 @@ Fields
 
     .. attribute:: first_name
 
-        Optional (:attr:`blank=True <django.db.models.Field.blank>`). 30
+        Optional (:attr:`blank=True <django.db.models.Field.blank>`). 150
         characters or fewer.
+
+        .. versionchanged:: 3.1
+
+            The ``max_length`` increased from 30 to 150 characters.
 
     .. attribute:: last_name
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -427,6 +427,34 @@ MariaDB 10.2 and higher.
 The admin no longer supports the legacy Internet Explorer browser. See
 :ref:`the admin FAQ <admin-browser-support>` for details on supported browsers.
 
+:attr:`AbstractUser.first_name <django.contrib.auth.models.User.first_name>` ``max_length`` increased to 150
+------------------------------------------------------------------------------------------------------------
+
+A migration for :attr:`django.contrib.auth.models.User.first_name` is included.
+If you have a custom user model inheriting from ``AbstractUser``, you'll need
+to generate and apply a database migration for your user model.
+
+If you want to preserve the 30 character limit for first names, use a custom
+form::
+
+    from django import forms
+    from django.contrib.auth.forms import UserChangeForm
+
+    class MyUserChangeForm(UserChangeForm):
+        first_name = forms.CharField(max_length=30, required=False)
+
+If you wish to keep this restriction in the admin when editing users, set
+``UserAdmin.form`` to use this form::
+
+    from django.contrib.auth.admin import UserAdmin
+    from django.contrib.auth.models import User
+
+    class MyUserAdmin(UserAdmin):
+        form = MyUserChangeForm
+
+    admin.site.unregister(User)
+    admin.site.register(User, MyUserAdmin)
+
 Miscellaneous
 -------------
 


### PR DESCRIPTION
Increases the max_length of first_name in django.contrib.auth to 150 characters to facilitate longer first names.

Fixes ticket-31371