### PR TITLE
Fixed #31368 -- Doc'd 'expression' parameter of Field.from_db_value()/Expression.convert_value().

### DIFF
--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -985,6 +985,8 @@ calling the appropriate methods on the wrapped expression.
         A hook allowing the expression to coerce ``value`` into a more
         appropriate type.
 
+        ``expression`` is the same as ``self``.
+
     .. method:: get_group_by_cols(alias=None)
 
         Responsible for returning the list of columns references by

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -2075,6 +2075,8 @@ Field API reference
         backend already returns the correct Python type, or the backend itself
         does the conversion.
 
+        ``expression`` is the same as ``self``.
+
         See :ref:`converting-values-to-python-objects` for usage.
 
         .. note::


### PR DESCRIPTION
Fixes [ticket 31368](https://code.djangoproject.com/ticket/31368).
I've added @felixxm [comment on the ticket](https://code.djangoproject.com/ticket/31368#comment:1) to documentation.
Unfortunately, I couldn't add anything to it :pensive: 