### PR TITLE
Added link to contributing docs in deprecation policy.

### DIFF
--- a/docs/internals/release-process.txt
+++ b/docs/internals/release-process.txt
@@ -116,6 +116,8 @@ A more generic example:
   LTS to LTS upgrades).
 * Z.0: Drop deprecation shims added in Y.0 and Y.1.
 
+See also the :ref:`deprecating-a-feature` guide.
+
 .. _supported-versions-policy:
 
 Supported versions


### PR DESCRIPTION
I often go to one and mean the other, and I think the how-to reveals some extra detail that is useful for users.