### PR TITLE
Fixed #31391 -- Removed jQuery usage in cancel.js

### DIFF
--- a/django/contrib/admin/static/admin/js/cancel.js
+++ b/django/contrib/admin/static/admin/js/cancel.js
@@ -1,13 +1,29 @@
-(function($) {
+(function() {
     'use strict';
-    $(function() {
-        $('.cancel-link').on('click', function(e) {
-            e.preventDefault();
+
+    // Call function fn when the DOM is loaded and ready. If it is already
+    // loaded, call the function now.
+    // http://youmightnotneedjquery.com/#ready
+    function ready(fn) {
+        if (document.readyState !== 'loading') {
+            fn();
+        } else {
+            document.addEventListener('DOMContentLoaded', fn);
+        }
+    }
+
+    ready(function() {
+        function handleClick(event) {
+            event.preventDefault();
             if (window.location.search.indexOf('&_popup=1') === -1) {
                 window.history.back(); // Go back if not a popup.
             } else {
                 window.close(); // Otherwise, close the popup.
             }
+        }
+
+        document.querySelectorAll('.cancel-link').forEach(function(el) {
+            el.addEventListener('click', handleClick);
         });
     });
-})(django.jQuery);
+})();

--- a/django/contrib/admin/templates/admin/delete_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_confirmation.html
@@ -4,7 +4,7 @@
 {% block extrahead %}
     {{ block.super }}
     {{ media }}
-    <script src="{% static 'admin/js/cancel.js' %}"></script>
+    <script src="{% static 'admin/js/cancel.js' %}" async></script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation{% endblock %}

--- a/django/contrib/admin/templates/admin/delete_selected_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_selected_confirmation.html
@@ -4,7 +4,7 @@
 {% block extrahead %}
     {{ block.super }}
     {{ media }}
-    <script src="{% static 'admin/js/cancel.js' %}"></script>
+    <script src="{% static 'admin/js/cancel.js' %}" async></script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation delete-selected-confirmation{% endblock %}


### PR DESCRIPTION
Now that cancel.js has no dependencies, it can be loaded asynchronously.

https://code.djangoproject.com/ticket/31391