### PR TITLE
Fixed #26430, Refs #24462 -- Added BaseSubquery datastructure.

### DIFF
--- a/django/db/backends/mysql/compiler.py
+++ b/django/db/backends/mysql/compiler.py
@@ -37,7 +37,3 @@ class SQLDeleteCompiler(compiler.SQLDeleteCompiler, SQLCompiler):
 
 class SQLUpdateCompiler(compiler.SQLUpdateCompiler, SQLCompiler):
     pass
-
-
-class SQLAggregateCompiler(compiler.SQLAggregateCompiler, SQLCompiler):
-    pass

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1553,6 +1553,7 @@ class SQLUpdateCompiler(SQLCompiler):
         self.query.reset_refcounts(refcounts_before)
 
 
+# RemovedInDjango40Warning: this class will be removed.
 class SQLAggregateCompiler(SQLCompiler):
     def as_sql(self):
         """

--- a/django/db/models/sql/datastructures.py
+++ b/django/db/models/sql/datastructures.py
@@ -166,3 +166,25 @@ class BaseTable:
             self.table_name == other.table_name and
             self.table_alias == other.table_alias
         )
+
+
+class BaseSubquery:
+    join_type = None
+    parent_alias = None
+    filtered_relation = None
+
+    def __init__(self, query, alias):
+        self.query = query
+        assert self.query.subquery is True
+        self.table_name = self.table_alias = alias
+
+    def as_sql(self, compiler, connection):
+        subquery_sql, subquery_params = self.query.as_sql(
+            compiler, connection, with_col_aliases=True
+        )
+        return '%s %s' % (subquery_sql, self.table_alias), subquery_params
+
+    def relabeled_clone(self, change_map):
+        return self.__class__(
+            self.query, change_map.get(self.table_alias, self.table_alias)
+        )

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -17,9 +17,7 @@ from collections.abc import Iterator, Mapping
 from itertools import chain, count, product
 from string import ascii_uppercase
 
-from django.core.exceptions import (
-    EmptyResultSet, FieldDoesNotExist, FieldError,
-)
+from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import DEFAULT_DB_ALIAS, NotSupportedError, connections
 from django.db.models.aggregates import Count
 from django.db.models.constants import LOOKUP_SEP
@@ -34,7 +32,7 @@ from django.db.models.sql.constants import (
     INNER, LOUTER, ORDER_DIR, ORDER_PATTERN, SINGLE,
 )
 from django.db.models.sql.datastructures import (
-    BaseTable, Empty, Join, MultiJoin,
+    BaseSubquery, BaseTable, Empty, Join, MultiJoin,
 )
 from django.db.models.sql.where import (
     AND, OR, ExtraWhere, NothingNode, WhereNode,
@@ -436,9 +434,8 @@ class Query(BaseExpression):
         # the distinct and limit after the aggregation.
         if (isinstance(self.group_by, tuple) or self.is_sliced or existing_annotations or
                 self.distinct or self.combinator):
-            from django.db.models.sql.subqueries import AggregateQuery
-            outer_query = AggregateQuery(self.model)
             inner_query = self.clone()
+            inner_query.subquery = True
             inner_query.select_for_update = False
             inner_query.select_related = False
             inner_query.set_annotation_mask(self.annotation_select)
@@ -463,8 +460,14 @@ class Query(BaseExpression):
 
             relabels = {t: 'subquery' for t in inner_query.alias_map}
             relabels[None] = 'subquery'
+
+            outer_query = Query(self.model)
+            outer_query.join(BaseSubquery(inner_query, 'subquery'))
+            outer_query.select = ()
+            outer_query.default_cols = None
+
             # Remove any aggregates marked for reduction from the subquery
-            # and move them to the outer AggregateQuery.
+            # and move them to the outer query.
             col_cnt = 0
             for alias, expression in list(inner_query.annotation_select.items()):
                 annotation_select_mask = inner_query.annotation_select_mask
@@ -480,13 +483,6 @@ class Query(BaseExpression):
                 # field selected in the inner query, yet we must use a subquery.
                 # So, make sure at least one field is selected.
                 inner_query.select = (self.model._meta.pk.get_col(inner_query.get_initial_alias()),)
-            try:
-                outer_query.add_subquery(inner_query, using)
-            except EmptyResultSet:
-                return {
-                    alias: None
-                    for alias in outer_query.annotation_select
-                }
         else:
             outer_query = self
             self.select = ()
@@ -1053,8 +1049,8 @@ class Query(BaseExpression):
             if col.alias in self.external_aliases
         ]
 
-    def as_sql(self, compiler, connection):
-        sql, params = self.get_compiler(connection=connection).as_sql()
+    def as_sql(self, compiler, connection, **kwargs):
+        sql, params = self.get_compiler(connection=connection).as_sql(**kwargs)
         if self.subquery:
             sql = '(%s)' % sql
         return sql, params

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -1,6 +1,7 @@
 """
 Query subclasses which provide extra functionality beyond simple data retrieval.
 """
+import warnings
 
 from django.core.exceptions import FieldError
 from django.db.models.query_utils import Q
@@ -8,6 +9,7 @@ from django.db.models.sql.constants import (
     CURSOR, GET_ITERATOR_CHUNK_SIZE, NO_RESULTS,
 )
 from django.db.models.sql.query import Query
+from django.utils.deprecation import RemovedInDjango40Warning
 
 __all__ = ['DeleteQuery', 'UpdateQuery', 'InsertQuery', 'AggregateQuery']
 
@@ -156,6 +158,14 @@ class AggregateQuery(Query):
     """
 
     compiler = 'SQLAggregateCompiler'
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            'AggregateQuery is deprecated, read more in Django 3.1 release notes.',
+            RemovedInDjango40Warning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
     def add_subquery(self, query, using):
         query.subquery = True

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -457,6 +457,9 @@ backends.
   yields a cursor and automatically closes the cursor and connection upon
   exiting the ``with`` statement.
 
+* ``AggregateQuery`` is deprecated. A normal ``Query`` is created instead and
+  is joined with a ``BaseSubquery`` containing the inner query.
+
 Dropped support for MariaDB 10.1
 --------------------------------
 

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -972,10 +972,11 @@ class AggregationTests(TestCase):
         )
 
     def test_empty_filter_aggregate(self):
-        self.assertEqual(
-            Author.objects.filter(id__in=[]).annotate(Count("friends")).aggregate(Count("pk")),
-            {"pk__count": None}
-        )
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                Author.objects.filter(id__in=[]).annotate(Count("friends")).aggregate(Count("pk")),
+                {"pk__count": 0}
+            )
 
     def test_none_call_before_aggregate(self):
         # Regression for #11789


### PR DESCRIPTION
Added new Join-like class BaseSubquery which is meant to be used in
FROM clauses. Rewrote Query.get_aggregation with it. Deprecated
AggregateQuery and SQLAggregateCompiler as redundant.