### PR TITLE
Fix i18n for Russian and other languages

### DIFF
--- a/django/contrib/admin/locale/af/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/af/LC_MESSAGES/django.po
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Objekte"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Ja, ek is seker"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/am/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/am/LC_MESSAGES/django.po
@@ -384,7 +384,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "አዎ,እርግጠኛ ነኝ"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/ar/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/ar/LC_MESSAGES/django.po
@@ -428,7 +428,7 @@ msgstr ""
 msgid "Objects"
 msgstr "عناصر"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "نعم، أنا متأكد"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/ast/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/ast/LC_MESSAGES/django.po
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr ""
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/bg/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/bg/LC_MESSAGES/django.po
@@ -416,7 +416,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Обекти"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Да, сигурен съм"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/bn/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/bn/LC_MESSAGES/django.po
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "হ্যা়ঁ, আমি নিশ্চিত"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/br/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/br/LC_MESSAGES/django.po
@@ -411,7 +411,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Ya, sur on"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/bs/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/bs/LC_MESSAGES/django.po
@@ -399,7 +399,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Da, siguran sam"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/cy/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/cy/LC_MESSAGES/django.po
@@ -406,7 +406,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Ydw, rwy'n sicr"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/dsb/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/dsb/LC_MESSAGES/django.po
@@ -428,7 +428,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Objekty"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Jo, som se wěsty"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/el/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/el/LC_MESSAGES/django.po
@@ -441,7 +441,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Αντικείμενα"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Ναι, είμαι βέβαιος"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/en_AU/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/en_AU/LC_MESSAGES/django.po
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr ""
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/en_GB/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/en_GB/LC_MESSAGES/django.po
@@ -416,8 +416,8 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
-msgstr "Yes, I'm sure"
+msgid "Yes, I’m sure"
+msgstr "Yes, I’m sure"
 
 msgid "No, take me back"
 msgstr ""

--- a/django/contrib/admin/locale/eo/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/eo/LC_MESSAGES/django.po
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Objektoj"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Jes, mi certas"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/es/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/es/LC_MESSAGES/django.po
@@ -447,7 +447,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Objetos"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Sí, estoy seguro"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/es_CO/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/es_CO/LC_MESSAGES/django.po
@@ -417,7 +417,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Objetos"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Sí, estoy seguro"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/es_MX/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/es_MX/LC_MESSAGES/django.po
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Sí, estoy seguro"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/es_VE/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/es_VE/LC_MESSAGES/django.po
@@ -417,7 +417,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Objetos"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Sí, Yo estoy seguro"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/eu/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/eu/LC_MESSAGES/django.po
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Objetuak"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Bai, ziur nago"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/fa/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/fa/LC_MESSAGES/django.po
@@ -434,7 +434,7 @@ msgstr ""
 msgid "Objects"
 msgstr "اشیاء"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "بله، مطمئن هستم."
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/fi/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/fi/LC_MESSAGES/django.po
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Kohteet"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Kyllä, olen varma"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/fy/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/fy/LC_MESSAGES/django.po
@@ -364,7 +364,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr ""
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/ga/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/ga/LC_MESSAGES/django.po
@@ -434,7 +434,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Oibiachtaí"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Táim cinnte"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/gl/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/gl/LC_MESSAGES/django.po
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Obxectos"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Si, estou seguro"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/he/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/he/LC_MESSAGES/django.po
@@ -421,7 +421,7 @@ msgstr ""
 msgid "Objects"
 msgstr "אובייקטים"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "כן, אני בטוח/ה"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/hi/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/hi/LC_MESSAGES/django.po
@@ -400,7 +400,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "हाँ, मैंने पक्का तय किया हैं "
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/hr/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/hr/LC_MESSAGES/django.po
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Objekti"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Da, siguran sam"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/hy/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/hy/LC_MESSAGES/django.po
@@ -419,7 +419,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Օբյեկտներ"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Այո, ես համոզված եմ"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/ia/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/ia/LC_MESSAGES/django.po
@@ -397,7 +397,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Si, io es secur"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/io/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/io/LC_MESSAGES/django.po
@@ -400,7 +400,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Yes, me esas certa"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/it/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/it/LC_MESSAGES/django.po
@@ -441,7 +441,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Oggetti"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Sì, sono sicuro"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/ja/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/ja/LC_MESSAGES/django.po
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Objects"
 msgstr "オブジェクト"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "はい"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/ka/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/ka/LC_MESSAGES/django.po
@@ -419,7 +419,7 @@ msgstr ""
 msgid "Objects"
 msgstr "ობიექტები"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "კი, ნამდვილად"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/kab/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/kab/LC_MESSAGES/django.po
@@ -384,7 +384,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Tiɣawsiwin"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr ""
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/kk/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/kk/LC_MESSAGES/django.po
@@ -425,7 +425,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Иә, сенімдімін"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/km/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/km/LC_MESSAGES/django.po
@@ -387,7 +387,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "ខ្ញុំច្បាស់​ជាចង់លប់"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/kn/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/kn/LC_MESSAGES/django.po
@@ -388,7 +388,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "ಹೌದು,ನನಗೆ ಖಚಿತವಿದೆ"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/lb/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/lb/LC_MESSAGES/django.po
@@ -385,7 +385,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr ""
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/lt/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/lt/LC_MESSAGES/django.po
@@ -433,7 +433,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Objektai"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Taip, esu tikras"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/ml/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/ml/LC_MESSAGES/django.po
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Objects"
 msgstr "വസ്തുക്കൾ"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "അതെ, തീര്‍ച്ചയാണ്"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/mn/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/mn/LC_MESSAGES/django.po
@@ -428,7 +428,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Бичлэгүүд"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Тийм, итгэлтэй байна."
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/mr/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/mr/LC_MESSAGES/django.po
@@ -364,7 +364,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr ""
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/my/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/my/LC_MESSAGES/django.po
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr ""
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/nn/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/nn/LC_MESSAGES/django.po
@@ -401,7 +401,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Ja, eg er sikker"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/os/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/os/LC_MESSAGES/django.po
@@ -399,7 +399,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "О, ӕцӕг мӕ фӕнды"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/pa/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/pa/LC_MESSAGES/django.po
@@ -402,7 +402,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "ਹਾਂ, ਮੈਂ ਚਾਹੁੰਦਾ ਹਾਂ"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/pt/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/pt/LC_MESSAGES/django.po
@@ -436,7 +436,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Objectos"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Sim, tenho a certeza"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/ro/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/ro/LC_MESSAGES/django.po
@@ -435,7 +435,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Obiecte"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Da, cu siguranță"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/ru/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/ru/LC_MESSAGES/django.po
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Объекты"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Да, я уверен"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/sk/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/sk/LC_MESSAGES/django.po
@@ -438,7 +438,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Objekty"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Áno, som si istý"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/sl/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/sl/LC_MESSAGES/django.po
@@ -415,7 +415,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Objekti"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Ja, prepričan sem"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/sr/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/sr/LC_MESSAGES/django.po
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Објекти"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Да, сигуран сам"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/sr_Latn/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/sr_Latn/LC_MESSAGES/django.po
@@ -419,7 +419,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Da, siguran sam"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/sw/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/sw/LC_MESSAGES/django.po
@@ -404,7 +404,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Viumbile"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Ndiyo, Nina uhakika"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/ta/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/ta/LC_MESSAGES/django.po
@@ -390,7 +390,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "ஆம், எனக்கு உறுதி"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/te/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/te/LC_MESSAGES/django.po
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "అవును "
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/tt/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/tt/LC_MESSAGES/django.po
@@ -394,7 +394,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Әйе, мин инандым"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/udm/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/udm/LC_MESSAGES/django.po
@@ -362,7 +362,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr ""
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/uk/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/uk/LC_MESSAGES/django.po
@@ -443,7 +443,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Об'єкти"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Так, я впевнений"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/ur/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/ur/LC_MESSAGES/django.po
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Objects"
 msgstr ""
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "ھاں، مجھے یقین ھے"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/vi/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/vi/LC_MESSAGES/django.po
@@ -421,7 +421,7 @@ msgstr ""
 msgid "Objects"
 msgstr "Đối tượng"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "Có, tôi chắc chắn."
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/zh_Hans/LC_MESSAGES/django.po
@@ -428,7 +428,7 @@ msgstr ""
 msgid "Objects"
 msgstr "对象"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "是的，我确定"
 
 msgid "No, take me back"

--- a/django/contrib/admin/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/zh_Hant/LC_MESSAGES/django.po
@@ -400,7 +400,7 @@ msgstr ""
 msgid "Objects"
 msgstr "物件"
 
-msgid "Yes, I'm sure"
+msgid "Yes, I’m sure"
 msgstr "是的，我確定"
 
 msgid "No, take me back"


### PR DESCRIPTION
Templates use ’ but in some files use ' and translation does not occur