### PR TITLE
Added missing Meta.apps to a schema model.

### DIFF
--- a/tests/schema/models.py
+++ b/tests/schema/models.py
@@ -210,6 +210,7 @@ class Thing(models.Model):
     when = models.CharField(max_length=1, primary_key=True)
 
     class Meta:
+        apps = new_apps
         db_table = 'drop'
 
     def __str__(self):


### PR DESCRIPTION
While running the tests for a third-party backend, I found the table was created outside of the schema tests which resulted in a failure when trying to create the table in the test this model is used. This seems to have just been an oversight in 61cfcec5b7d47232a1d6facbde71d4cca35986eb.