### PR TITLE
Fixed #31385 -- Improved wording in tutorial 1.

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -213,9 +213,9 @@ rather than creating directories.
     multiple apps. An app can be in multiple projects.
 
 Your apps can live anywhere on your :ref:`Python path <tut-searchpath>`. In
-this tutorial, we'll create our poll app right next to your :file:`manage.py`
-file so that it can be imported as its own top-level module, rather than a
-submodule of ``mysite``.
+this tutorial, we'll create our poll app in the same directory as your
+:file:`manage.py` file so that it can be imported as its own top-level module,
+rather than a submodule of ``mysite``.
 
 To create your app, make sure you're in the same directory as :file:`manage.py`
 and type this command:


### PR DESCRIPTION
In tutorial 01, it mentioned that it would create a project "next to" the existant
manage.py. Changed the text to instruct it is creating the project "in the same directory"
as the existant manage.py.