### PR TITLE
Fixed intermittent SeleniumTests.test_prepopulated_fields failure.

### DIFF
--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4499,7 +4499,10 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.assertEqual(slug2, 'option-two-and-now-tabular-inline')
 
         # Add an inline
-        self.selenium.find_elements_by_link_text('Add another Related prepopulated')[1].click()
+        # Button may be outside the browser frame.
+        element = self.selenium.find_elements_by_link_text('Add another Related prepopulated')[1]
+        self.selenium.execute_script('window.scrollTo(0, %s);' % element.location['y'])
+        element.click()
         self.assertEqual(
             len(self.selenium.find_elements_by_class_name('select2-selection')),
             num_initial_select2_inputs + 4


### PR DESCRIPTION
Element would occasionally be outside of frame.

Not [the error I'm after](https://djangoci.com/job/pull-requests-selenium/database=postgres,label=bionic-pr,python=python3.7/117/testReport/junit/admin_views.test_autocomplete_view/SeleniumTests/test_select_multiple/) (which won't reproduce for me) but another one... 