### PR TITLE
Improved docs on migration reversibility.

### DIFF
--- a/docs/ref/migration-operations.txt
+++ b/docs/ref/migration-operations.txt
@@ -322,7 +322,7 @@ instance of :class:`SchemaEditor
 The ``reverse_code`` argument is called when unapplying migrations. This
 callable should undo what is done in the ``code`` callable so that the
 migration is reversible. If ``reverse_code`` is ``None`` (the default), the
-``RunPython`` operation will be irreversible.
+``RunPython`` operation is irreversible.
 
 The optional ``hints`` argument will be passed as ``**hints`` to the
 :meth:`allow_migrate` method of database routers to assist them in making a

--- a/docs/ref/migration-operations.txt
+++ b/docs/ref/migration-operations.txt
@@ -263,12 +263,13 @@ queries and parameters in the same way as :ref:`cursor.execute()
 If you want to include literal percent signs in the query, you have to double
 them if you are passing parameters.
 
-The ``reverse_sql`` queries are executed when the migration is unapplied, so
-you can reverse the changes done in the forwards queries::
+``reverse_sql`` is executed when the migration is unapplied. It should undo
+what is done in ``sql``. If it is ``None`` (the default), the operation is
+irreversible. For example, to undo the above insertion with a deletion::
 
     migrations.RunSQL(
-        [("INSERT INTO musician (name) VALUES (%s);", ['Reinhardt'])],
-        [("DELETE FROM musician where name=%s;", ['Reinhardt'])],
+        sql=[("INSERT INTO musician (name) VALUES (%s);", ['Reinhardt'])],
+        reverse_sql=[("DELETE FROM musician where name=%s;", ['Reinhardt'])],
     )
 
 The ``state_operations`` argument is so you can supply operations that are
@@ -317,7 +318,8 @@ instance of :class:`SchemaEditor
 
 The ``reverse_code`` argument is called when unapplying migrations. This
 callable should undo what is done in the ``code`` callable so that the
-migration is reversible.
+migration is reversible. If it is ``None`` (the default), the operation will
+be irreversible.
 
 The optional ``hints`` argument will be passed as ``**hints`` to the
 :meth:`allow_migrate` method of database routers to assist them in making a

--- a/docs/ref/migration-operations.txt
+++ b/docs/ref/migration-operations.txt
@@ -263,14 +263,17 @@ queries and parameters in the same way as :ref:`cursor.execute()
 If you want to include literal percent signs in the query, you have to double
 them if you are passing parameters.
 
-``reverse_sql`` is executed when the migration is unapplied. It should undo
-what is done in ``sql``. If it is ``None`` (the default), the operation is
-irreversible. For example, to undo the above insertion with a deletion::
+The ``reverse_sql`` queries are executed when the migration is unapplied. They
+should undo what is done by the ``sql`` queries. For example, to undo the above
+insertion with a deletion::
 
     migrations.RunSQL(
         sql=[("INSERT INTO musician (name) VALUES (%s);", ['Reinhardt'])],
         reverse_sql=[("DELETE FROM musician where name=%s;", ['Reinhardt'])],
     )
+
+If ``reverse_sql`` is ``None`` (the default), the ``RunSQL`` operation is
+irreversible.
 
 The ``state_operations`` argument is so you can supply operations that are
 equivalent to the SQL in terms of project state; for example, if you are
@@ -318,8 +321,8 @@ instance of :class:`SchemaEditor
 
 The ``reverse_code`` argument is called when unapplying migrations. This
 callable should undo what is done in the ``code`` callable so that the
-migration is reversible. If it is ``None`` (the default), the operation will
-be irreversible.
+migration is reversible. If ``reverse_code`` is ``None`` (the default), the
+``RunPython`` operation will be irreversible.
 
 The optional ``hints`` argument will be passed as ``**hints`` to the
 :meth:`allow_migrate` method of database routers to assist them in making a

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -347,11 +347,15 @@ Note that this only works given two things:
   that your database doesn't match your models, you'll just get errors when
   migrations try to modify those tables.
 
-Reverting migrations
+.. _reversing-migrations:
+
+Reversing migrations
 ====================
 
-Any migration can be reverted with :djadmin:`migrate` by using the number of
-previous migrations::
+Migrations can be reversed with :djadmin:`migrate` and the number of the
+previous migration. For example, to reverse migration ``books.0003``:
+
+.. console::
 
     $ python manage.py migrate books 0002
     Operations to perform:
@@ -360,8 +364,10 @@ previous migrations::
       Rendering model states... DONE
       Unapplying books.0003_auto... OK
 
-If you want to revert all migrations applied for an app, use the name
-``zero``::
+If you want to reverse all migrations applied for an app, use the name
+``zero``:
+
+.. console::
 
     $ python manage.py migrate books zero
     Operations to perform:
@@ -370,6 +376,19 @@ If you want to revert all migrations applied for an app, use the name
       Rendering model states... DONE
       Unapplying books.0002_auto... OK
       Unapplying books.0001_initial... OK
+
+A migration is irreversible if it contains any irreversible operations.
+Attempting to reverse such migrations will raise ``IrreversibleError``:
+
+.. console::
+
+    $ python manage.py migrate books 0002
+    Operations to perform:
+      Target specific migration: 0002_auto, from books
+    Running migrations:
+      Rendering model states... DONE
+      Unapplying books.0003_auto...Traceback (most recent call last):
+    django.db.migrations.exceptions.IrreversibleError: Operation <RunSQL  sql='DROP TABLE demo_books'> in books.0003_auto is not reversible
 
 .. _historical-models:
 

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -352,7 +352,7 @@ Note that this only works given two things:
 Reversing migrations
 ====================
 
-Migrations can be reversed with :djadmin:`migrate` and the number of the
+Migrations can be reversed with :djadmin:`migrate` by passing the number of the
 previous migration. For example, to reverse migration ``books.0003``:
 
 .. console::


### PR DESCRIPTION
* Renamed "reverting" section to "reversing" since every other part of the docs talks about "reversing" migrations/operations
* Gave an example of irreversible migration
* Noted in `RunSQL` and `RunPython` that they default to being irreversible.