### PR TITLE
Improved sessions notes in deployment checklist.

### DIFF
--- a/docs/howto/deployment/checklist.txt
+++ b/docs/howto/deployment/checklist.txt
@@ -109,9 +109,6 @@ and in production. Django defaults to per-process :ref:`local-memory caching
 Cache servers often have weak authentication. Make sure they only accept
 connections from your application servers.
 
-If you're using Memcached, consider using :ref:`cached sessions
-<cached-sessions-backend>` to improve performance.
-
 :setting:`DATABASES`
 --------------------
 
@@ -186,6 +183,15 @@ Performance optimizations
 
 Setting :setting:`DEBUG = False <DEBUG>` disables several features that are
 only useful in development. In addition, you can tune the following settings.
+
+Sessions
+--------
+
+Consider using :ref:`cached sessions <cached-sessions-backend>` to improve
+performance.
+
+If using database-backed sessions, regularly :ref:`clear old sessions
+<clearing-the-session-store>` to avoid storing unnecessary data.
 
 :setting:`CONN_MAX_AGE`
 -----------------------

--- a/docs/topics/http/sessions.txt
+++ b/docs/topics/http/sessions.txt
@@ -599,6 +599,8 @@ of ``request.session`` as described above in `using sessions in views`_.
     Django applications which have the
     :setting:`SESSION_EXPIRE_AT_BROWSER_CLOSE` setting enabled.
 
+.. _clearing-the-session-store:
+
 Clearing the session store
 ==========================
 


### PR DESCRIPTION
Nearly every django project I audit has this missing and often GB's of old sessions sitting around that can be cleared. Hopefully this helps users find this.

Also removing the 'memcached' only distinction for cached sessions, since other cache backends can be appropriate, from `DatabaseBackend` to third party backends in django-mysql or django-redis.