### PR TITLE
Reverted "Pinned asgiref == 3.2.5 in test requirements."

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,4 +1,4 @@
-asgiref == 3.2.5
+asgiref >= 3.2
 argon2-cffi >= 16.1.0
 bcrypt
 docutils


### PR DESCRIPTION
This reverts commit aa21020218a2dcd29a03444ad2a77f03f085b04e.

Regression was fixed by https://github.com/django/asgiref/commit/e4367c571fd1833bda0b7ff0bd68d924916352da.