### PR TITLE
Fixed #31330 -- Corrected catchall URL pattern in flatpages docs.

### DIFF
--- a/docs/ref/contrib/flatpages.txt
+++ b/docs/ref/contrib/flatpages.txt
@@ -79,7 +79,7 @@ to place the pattern at the end of the other urlpatterns::
 
     # Your other patterns here
     urlpatterns += [
-        path('<path:url>/', views.flatpage),
+        re_path(r'^(?P<url>.*/)$', views.flatpage),
     ]
 
 .. warning::


### PR DESCRIPTION
Use re_path() pattern with the regex used before original regression in
df41b5a05d4e00e80e73afe629072e37873e767a.
Regression in a0916d7212aaae634f4388d47d8717abc2cd9036.

It's not worth using `path()` in this kind of context. (You **want** the control of the regex.)