### PR TITLE
Fixed #31405 -- Added LoginRequiredAuthenticationMiddleware force all views to require authentication by default.

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -5,6 +5,7 @@ from weakref import WeakSet
 from django.apps import apps
 from django.contrib.admin import ModelAdmin, actions
 from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.decorators import login_not_required
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.base import ModelBase
 from django.http import Http404, HttpResponseRedirect
@@ -376,6 +377,7 @@ class AdminSite:
         return LogoutView.as_view(**defaults)(request)
 
     @never_cache
+    @login_not_required
     def login(self, request, extra_context=None):
         """
         Display the login form for the given HttpRequest.
@@ -494,6 +496,7 @@ class AdminSite:
         return app_list
 
     @never_cache
+    @login_not_required
     def index(self, request, extra_context=None):
         """
         Display the main admin index page, which lists all of the installed

--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -57,7 +57,7 @@ def login_not_required(view_func):
     """
     def wrapped_view(*args, **kwargs):
         return view_func(*args, **kwargs)
-    wrapped_view.login_not_required = True
+    wrapped_view.login_required = False
     return wraps(view_func)(wrapped_view)
 
 

--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -55,10 +55,8 @@ def login_not_required(view_func):
     Decorator for views that marks that the view is accessible by
     unauthenticated users.
     """
-    def wrapped_view(*args, **kwargs):
-        return view_func(*args, **kwargs)
-    wrapped_view.login_required = False
-    return wraps(view_func)(wrapped_view)
+    view_func.login_required = False
+    return view_func
 
 
 def permission_required(perm, login_url=None, raise_exception=False):

--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -50,6 +50,17 @@ def login_required(function=None, redirect_field_name=REDIRECT_FIELD_NAME, login
     return actual_decorator
 
 
+def login_not_required(view_func):
+    """
+    Decorator for views that marks that the view is accessible by
+    unauthenticated users.
+    """
+    def wrapped_view(*args, **kwargs):
+        return view_func(*args, **kwargs)
+    wrapped_view.login_not_required = True
+    return wraps(view_func)(wrapped_view)
+
+
 def permission_required(perm, login_url=None, raise_exception=False):
     """
     Decorator for views that checks whether a user has a particular permission

--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -28,12 +28,12 @@ class LoginRequiredAuthenticationMiddleware(AuthenticationMiddleware):
     """
     Middleware that force all views to require athentication by default.
 
-    Views that have @login_not_required decorator or LoginNotRequiredMixin mixin
-    will be able to pass through without this validation. Otherwise, it will
-    direct user to the login.
+    Views that have @login_not_required decorator or LoginNotRequiredMixin
+    mixin will be able to pass through without this validation. Otherwise, it
+    will direct user to the login.
     """
     def process_view(self, request, view_func, view_args, view_kwargs):
-        # If it's authenticated user we don't have to do anything.
+        # No need to take any action if the user is already authenticated.
         if request.user.is_authenticated:
             return None
 
@@ -42,7 +42,7 @@ class LoginRequiredAuthenticationMiddleware(AuthenticationMiddleware):
         if view_class and not getattr(view_class, 'login_required', True):
             return None
 
-        # If the view is FBV or CBV with login_not_required usage on dispatch method,
+        # If the view is FBV or CBV with login_not_required usage on dispatch
         if not getattr(view_func, 'login_required', True):
             return None
         return redirect_to_login(request.get_full_path())

--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -39,11 +39,11 @@ class LoginRequiredAuthenticationMiddleware(AuthenticationMiddleware):
 
         # In case of we have CBV
         view_class = getattr(view_func, 'view_class', None)
-        if view_class and getattr(view_class, 'login_not_required', False):
+        if view_class and not getattr(view_class, 'login_required', True):
             return None
 
         # If the view is FBV or CBV with login_not_required usage on dispatch method,
-        if getattr(view_func, 'login_not_required', False):
+        if not getattr(view_func, 'login_required', True):
             return None
         return redirect_to_login(request.get_full_path())
 

--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -28,7 +28,7 @@ class LoginRequiredAuthenticationMiddleware(AuthenticationMiddleware):
     """
     Middleware that force all views to require athentication by default.
 
-    Views that has @login_not_required decorator or LoginNotRequiredMixin mixin
+    Views that have @login_not_required decorator or LoginNotRequiredMixin mixin
     will be able to pass through without this validation. Otherwise, it will
     direct user to the login.
     """

--- a/django/contrib/auth/mixins.py
+++ b/django/contrib/auth/mixins.py
@@ -2,7 +2,6 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.shortcuts import resolve_url
 
@@ -56,6 +55,7 @@ class AccessMixin:
             (not login_netloc or login_netloc == current_netloc)
         ):
             path = self.request.get_full_path()
+        from django.contrib.auth.views import redirect_to_login
         return redirect_to_login(
             path,
             resolved_login_url,

--- a/django/contrib/auth/mixins.py
+++ b/django/contrib/auth/mixins.py
@@ -76,7 +76,7 @@ class LoginNotRequiredMixin:
     Mixin for CBV that marks that the view is accessible by
     unauthenticated users.
     """
-    login_not_required = True
+    login_required = False
 
 
 class PermissionRequiredMixin(AccessMixin):

--- a/django/contrib/auth/mixins.py
+++ b/django/contrib/auth/mixins.py
@@ -71,6 +71,14 @@ class LoginRequiredMixin(AccessMixin):
         return super().dispatch(request, *args, **kwargs)
 
 
+class LoginNotRequiredMixin:
+    """
+    Mixin for CBV that marks that the view is accessible by
+    unauthenticated users.
+    """
+    login_not_required = True
+
+
 class PermissionRequiredMixin(AccessMixin):
     """Verify that the current user has all specified permissions."""
     permission_required = None

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -6,7 +6,7 @@ from django.contrib.auth import (
     REDIRECT_FIELD_NAME, get_user_model, login as auth_login,
     logout as auth_logout, update_session_auth_hash,
 )
-from django.contrib.auth.decorators import login_not_required, login_required
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import (
     AuthenticationForm, PasswordChangeForm, PasswordResetForm, SetPasswordForm,
 )

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -6,10 +6,11 @@ from django.contrib.auth import (
     REDIRECT_FIELD_NAME, get_user_model, login as auth_login,
     logout as auth_logout, update_session_auth_hash,
 )
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, login_not_required
 from django.contrib.auth.forms import (
     AuthenticationForm, PasswordChangeForm, PasswordResetForm, SetPasswordForm,
 )
+from django.contrib.auth.mixins import LoginNotRequiredMixin
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ValidationError
@@ -37,7 +38,7 @@ class SuccessURLAllowedHostsMixin:
         return {self.request.get_host(), *self.success_url_allowed_hosts}
 
 
-class LoginView(SuccessURLAllowedHostsMixin, FormView):
+class LoginView(SuccessURLAllowedHostsMixin, LoginNotRequiredMixin, FormView):
     """
     Display the login form and handle the login action.
     """
@@ -171,6 +172,7 @@ def logout_then_login(request, login_url=None):
     return LogoutView.as_view(next_page=login_url)(request)
 
 
+@login_not_required
 def redirect_to_login(next, login_url=None, redirect_field_name=REDIRECT_FIELD_NAME):
     """
     Redirect the user to the login page, passing the given 'next' page.
@@ -205,7 +207,7 @@ class PasswordContextMixin:
         return context
 
 
-class PasswordResetView(PasswordContextMixin, FormView):
+class PasswordResetView(PasswordContextMixin, LoginNotRequiredMixin, FormView):
     email_template_name = 'registration/password_reset_email.html'
     extra_email_context = None
     form_class = PasswordResetForm
@@ -239,12 +241,12 @@ class PasswordResetView(PasswordContextMixin, FormView):
 INTERNAL_RESET_SESSION_TOKEN = '_password_reset_token'
 
 
-class PasswordResetDoneView(PasswordContextMixin, TemplateView):
+class PasswordResetDoneView(PasswordContextMixin, LoginNotRequiredMixin, TemplateView):
     template_name = 'registration/password_reset_done.html'
     title = _('Password reset sent')
 
 
-class PasswordResetConfirmView(PasswordContextMixin, FormView):
+class PasswordResetConfirmView(PasswordContextMixin, LoginNotRequiredMixin, FormView):
     form_class = SetPasswordForm
     post_reset_login = False
     post_reset_login_backend = None
@@ -317,7 +319,7 @@ class PasswordResetConfirmView(PasswordContextMixin, FormView):
         return context
 
 
-class PasswordResetCompleteView(PasswordContextMixin, TemplateView):
+class PasswordResetCompleteView(PasswordContextMixin, LoginNotRequiredMixin, TemplateView):
     template_name = 'registration/password_reset_complete.html'
     title = _('Password reset complete')
 

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -6,7 +6,7 @@ from django.contrib.auth import (
     REDIRECT_FIELD_NAME, get_user_model, login as auth_login,
     logout as auth_logout, update_session_auth_hash,
 )
-from django.contrib.auth.decorators import login_required, login_not_required
+from django.contrib.auth.decorators import login_not_required, login_required
 from django.contrib.auth.forms import (
     AuthenticationForm, PasswordChangeForm, PasswordResetForm, SetPasswordForm,
 )

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -172,7 +172,6 @@ def logout_then_login(request, login_url=None):
     return LogoutView.as_view(next_page=login_url)(request)
 
 
-@login_not_required
 def redirect_to_login(next, login_url=None, redirect_field_name=REDIRECT_FIELD_NAME):
     """
     Redirect the user to the login page, passing the given 'next' page.

--- a/tests/auth_tests/test_middleware.py
+++ b/tests/auth_tests/test_middleware.py
@@ -88,7 +88,8 @@ class TestLoginRequiredAuthenticationMiddleware(TestCase):
 
     def test_user_access_to_login_no_required_view(self):
         """
-        Middleware returns None for authenticated user becuase of
+        Middleware returns None for authenticated user because of
+        PasswordChangeView does NOT have LoginNotRequiredMixin.
         """
         self.request.user = self.user
         res = self.middleware.process_view(self.request, PasswordChangeView.as_view(), (), {})

--- a/tests/auth_tests/test_middleware.py
+++ b/tests/auth_tests/test_middleware.py
@@ -73,10 +73,6 @@ class TestLoginRequiredAuthenticationMiddleware(TestCase):
         res = self.middleware.process_view(self.request, LoginView.as_view(), (), {})
         self.assertIsNone(res)
 
-        # redirect_to_login has @login_not_required decorator so middleware returns None
-        res = self.middleware.process_view(self.request, redirect_to_login, (), {})
-        self.assertIsNone(res)
-
     def test_anonymous_access_to_login_required_view(self):
         """
         Middleware redirects unauthenticated user with 302 because of


### PR DESCRIPTION
Hi,

I tried to do implemented what we have discussed on the mailing list 👀 This PR adds `LoginRequiredAuthenticationMiddleware`  which forces all views to use proper decorator/mixins if it requires to be accessible by unauthenticated user. 

Ticket
[https://code.djangoproject.com/ticket/31405#ticket](https://code.djangoproject.com/ticket/31405#ticket)

Discussion on mailin list.
[https://groups.google.com/forum/#!topic/django-developers/PUQQUHIxEXQ.](https://groups.google.com/forum/#!topic/django-developers/PUQQUHIxEXQ.)