### PR TITLE
Fixed #31275 -- Optimized sql_flush() without resetting sequence on MySQL.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -585,6 +585,7 @@ answer newbie questions, and generally made Django that much better:
     Martin von Gagern <gagern@google.com>
     Mart Sõmermaa <http://mrts.pri.ee/>
     Marty Alchin <gulopine@gamemusic.org>
+    Masashi Shibata <m.shibata1020@gmail.com>
     masonsimon+django@gmail.com
     Massimiliano Ravelli <massimiliano.ravelli@gmail.com>
     Massimo Scamarcia <massimo.scamarcia@gmail.com>

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -347,6 +347,10 @@ Models
 * :meth:`.QuerySet.bulk_create` now sets the primary key on objects when using
   MariaDB 10.5+.
 
+* The ``DatabaseOperations.sql_flush()`` method now generates more efficient
+  SQL on MySQL by using ``DELETE`` instead of ``TRUNCATE`` statements for
+  tables which don't require resetting sequences.
+
 Pagination
 ~~~~~~~~~~
 
@@ -414,6 +418,12 @@ Tests
 
 * :class:`~django.test.runner.DiscoverRunner` now skips running the system
   checks on databases not :ref:`referenced by tests<testing-multi-db>`.
+
+* :class:`~django.test.TransactionTestCase` teardown is now faster on MySQL
+  due to :djadmin:`flush` command improvements. As a side effect the latter
+  doesn't automatically reset sequences on teardown anymore. Enable
+  :attr:`.TransactionTestCase.reset_sequences` if your tests require this
+  feature.
 
 URLs
 ~~~~


### PR DESCRIPTION
I checked the time taken by `flush` command with 100 tables. See the source code at https://github.com/c-bata/django-fast-mysql-flush

| number of records on each table | before | after `reset_sequences=False` (default) | after `reset_sequences=True` (optional) |
|--- | --- | --- | --- |
| 10|  3.302 sec (+/- 0.076) | 0.517 sec (+/- 0.019) | 3.658 sec (+/- 0.080) |
| 100 | 3.323 sec (+/- 0.047) | 0.575 sec (+/- 0.025) | 3.571 sec (+/- 0.077) |
| 1000 | 3.577 sec (+/- 0.106) | 1.046 sec (+/- 0.029) | 3.813 sec (+/- 0.073) |

Please note that the benchmark script was run on my laptop. So the times should not be taken precisely.


Ticket URL is https://code.djangoproject.com/ticket/31275