### PR TITLE
Refs #31040 -- Used 402 HTTP status in middleware_exceptions tests.

### DIFF
--- a/tests/middleware_exceptions/middleware.py
+++ b/tests/middleware_exceptions/middleware.py
@@ -96,18 +96,18 @@ class NotFoundMiddleware(BaseMiddleware):
         raise Http404('not found')
 
 
-class TeapotMiddleware(BaseMiddleware):
+class PaymentMiddleware(BaseMiddleware):
     def __call__(self, request):
         response = self.get_response(request)
-        response.status_code = 418
+        response.status_code = 402
         return response
 
 
 @async_only_middleware
-def async_teapot_middleware(get_response):
+def async_payment_middleware(get_response):
     async def middleware(request):
         response = await get_response(request)
-        response.status_code = 418
+        response.status_code = 402
         return response
 
     return middleware
@@ -119,7 +119,7 @@ class SyncAndAsyncMiddleware(BaseMiddleware):
 
 
 @sync_only_middleware
-class DecoratedTeapotMiddleware(TeapotMiddleware):
+class DecoratedPaymentMiddleware(PaymentMiddleware):
     pass
 
 

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -188,30 +188,30 @@ class MiddlewareNotUsedTests(SimpleTestCase):
 )
 class MiddlewareSyncAsyncTests(SimpleTestCase):
     @override_settings(MIDDLEWARE=[
-        'middleware_exceptions.middleware.TeapotMiddleware',
+        'middleware_exceptions.middleware.PaymentMiddleware',
     ])
-    def test_sync_teapot_middleware(self):
+    def test_sync_middleware(self):
         response = self.client.get('/middleware_exceptions/view/')
-        self.assertEqual(response.status_code, 418)
+        self.assertEqual(response.status_code, 402)
 
     @override_settings(MIDDLEWARE=[
-        'middleware_exceptions.middleware.DecoratedTeapotMiddleware',
+        'middleware_exceptions.middleware.DecoratedPaymentMiddleware',
     ])
-    def test_sync_decorated_teapot_middleware(self):
+    def test_sync_decorated_middleware(self):
         response = self.client.get('/middleware_exceptions/view/')
-        self.assertEqual(response.status_code, 418)
+        self.assertEqual(response.status_code, 402)
 
     @override_settings(MIDDLEWARE=[
-        'middleware_exceptions.middleware.async_teapot_middleware',
+        'middleware_exceptions.middleware.async_payment_middleware',
     ])
-    def test_async_teapot_middleware(self):
+    def test_async_middleware(self):
         with self.assertLogs('django.request', 'DEBUG') as cm:
             response = self.client.get('/middleware_exceptions/view/')
-        self.assertEqual(response.status_code, 418)
+        self.assertEqual(response.status_code, 402)
         self.assertEqual(
             cm.records[0].getMessage(),
             "Synchronous middleware "
-            "middleware_exceptions.middleware.async_teapot_middleware "
+            "middleware_exceptions.middleware.async_payment_middleware "
             "adapted.",
         )
 
@@ -228,28 +228,28 @@ class MiddlewareSyncAsyncTests(SimpleTestCase):
             self.client.get('/middleware_exceptions/view/')
 
     @override_settings(MIDDLEWARE=[
-        'middleware_exceptions.middleware.TeapotMiddleware',
+        'middleware_exceptions.middleware.PaymentMiddleware',
     ])
-    async def test_sync_teapot_middleware_async(self):
+    async def test_sync_middleware_async(self):
         with self.assertLogs('django.request', 'DEBUG') as cm:
             response = await self.async_client.get('/middleware_exceptions/view/')
-        self.assertEqual(response.status_code, 418)
+        self.assertEqual(response.status_code, 402)
         self.assertEqual(
             cm.records[0].getMessage(),
             "Asynchronous middleware "
-            "middleware_exceptions.middleware.TeapotMiddleware adapted.",
+            "middleware_exceptions.middleware.PaymentMiddleware adapted.",
         )
 
     @override_settings(MIDDLEWARE=[
-        'middleware_exceptions.middleware.async_teapot_middleware',
+        'middleware_exceptions.middleware.async_payment_middleware',
     ])
-    async def test_async_teapot_middleware_async(self):
+    async def test_async_middleware_async(self):
         with self.assertLogs('django.request', 'WARNING') as cm:
             response = await self.async_client.get('/middleware_exceptions/view/')
-        self.assertEqual(response.status_code, 418)
+        self.assertEqual(response.status_code, 402)
         self.assertEqual(
             cm.records[0].getMessage(),
-            'Unknown Status Code: /middleware_exceptions/view/',
+            'Payment Required: /middleware_exceptions/view/',
         )
 
     @override_settings(


### PR DESCRIPTION
HTTP status code `418` - "I'm a Teaport" was added to `http.HTTPStatus` in [Python 3.9.0a5](https://docs.python.org/3.9/whatsnew/3.9.html#http) that caused failures in `middleware_exceptions` tests.

```
File "tests\middleware_exceptions\tests.py", line 250, in test_async_teapot_middleware_async
    self.assertEqual(
AssertionError: "I'm a Teapot: /middleware_exceptions/view/" != 'Unknown Status Code: /middleware_exceptions/view/'
- I'm a Teapot: /middleware_exceptions/view/
+ Unknown Status Code: /middleware_exceptions/view/
```

This changes HTTP status used in `middleware_exceptions` tests to `402`, which exists in all supported versions of Python. 