### PR TITLE
Fixed #31369 -- Deprecated NullBooleanField.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -969,11 +969,11 @@ class BooleanField(Field):
             include_blank = not (self.has_default() or 'initial' in kwargs)
             defaults = {'choices': self.get_choices(include_blank=include_blank)}
         else:
-            form_class = forms.NullBooleanField if self.null else forms.BooleanField
+            form_class = forms.BooleanField
             # In HTML checkboxes, 'required' means "must be checked" which is
             # different from the choices case ("must select some value").
             # required=False allows unchecked checkboxes.
-            defaults = {'form_class': form_class, 'required': False}
+            defaults = {'form_class': form_class, 'required': False, 'null': self.null}
         return super().formfield(**{**defaults, **kwargs})
 
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -78,6 +78,8 @@ details on these changes.
 * The model ``NullBooleanField`` will be removed. A stub field will remain for
   compatibility with historical migrations.
 
+* ``django.forms.fields.NullBooleanField`` will be removed.
+
 See the :ref:`Django 3.1 release notes <deprecated-features-3.1>` for more
 details on these changes.
 

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -344,7 +344,7 @@ For each field, we describe the default widget used if you don't specify
 
 .. class:: BooleanField(**kwargs)
 
-    * Default widget: :class:`CheckboxInput`
+    * Default widget: :class:`CheckboxInput` if ``null=False`` else :class:`NullBooleanSelect`
     * Empty value: ``False``
     * Normalizes to: A Python ``True`` or ``False`` value.
     * Validates that the value is ``True`` (e.g. the check box is checked) if
@@ -857,6 +857,10 @@ For each field, we describe the default widget used if you don't specify
     * Empty value: ``None``
     * Normalizes to: A Python ``True``, ``False`` or ``None`` value.
     * Validates nothing (i.e., it never raises a ``ValidationError``).
+
+.. deprecated:: 3.1
+
+    ``NullBooleanField`` is deprecated in favor of ``BooleanField(null=True)``.
 
 ``RegexField``
 --------------

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -736,6 +736,9 @@ Miscellaneous
 * The ``NullBooleanField`` model field is deprecated in favor of
   ``BooleanField(null=True)``.
 
+* The form field ``NullBooleanField`` is deprecated in favor of
+  ``BooleanField(null=True)``.
+
 .. _removed-features-3.1:
 
 Features removed in 3.1

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -64,9 +64,7 @@ Model field                         Form field
                                     ``True`` on the model field, otherwise not
                                     represented in the form.
 
-:class:`BooleanField`               :class:`~django.forms.BooleanField`, or
-                                    :class:`~django.forms.NullBooleanField` if
-                                    ``null=True``.
+:class:`BooleanField`               :class:`~django.forms.BooleanField`
 
 :class:`CharField`                  :class:`~django.forms.CharField` with
                                     ``max_length`` set to the model field's
@@ -104,7 +102,7 @@ Model field                         Form field
 :class:`ManyToManyField`            :class:`~django.forms.ModelMultipleChoiceField`
                                     (see below)
 
-:class:`NullBooleanField`           :class:`~django.forms.NullBooleanField`
+:class:`NullBooleanField`           :class:`~django.forms.BooleanField`
 
 :class:`PositiveBigIntegerField`    :class:`~django.forms.IntegerField`
 

--- a/tests/forms_tests/field_tests/test_booleanfield.py
+++ b/tests/forms_tests/field_tests/test_booleanfield.py
@@ -1,6 +1,8 @@
 import pickle
 
-from django.forms import BooleanField, ValidationError
+from django.forms import (
+    BooleanField, Form, HiddenInput, RadioSelect, ValidationError,
+)
 from django.test import SimpleTestCase
 
 
@@ -38,6 +40,20 @@ class BooleanFieldTest(SimpleTestCase):
         self.assertIs(f.clean('false'), False)
         self.assertIs(f.clean('FaLsE'), False)
 
+    def test_booleanfield_clean_null(self):
+        f = BooleanField(null=True)
+        self.assertIsNone(f.clean(''))
+        self.assertTrue(f.clean(True))
+        self.assertFalse(f.clean(False))
+        self.assertIsNone(f.clean(None))
+        self.assertFalse(f.clean('0'))
+        self.assertTrue(f.clean('1'))
+        self.assertIsNone(f.clean('2'))
+        self.assertIsNone(f.clean('3'))
+        self.assertIsNone(f.clean('hello'))
+        self.assertTrue(f.clean('true'))
+        self.assertFalse(f.clean('false'))
+
     def test_boolean_picklable(self):
         self.assertIsInstance(pickle.loads(pickle.dumps(BooleanField())), BooleanField)
 
@@ -58,6 +74,64 @@ class BooleanFieldTest(SimpleTestCase):
         self.assertTrue(f.has_changed(False, 'True'))
         self.assertTrue(f.has_changed(True, 'False'))
 
+    def test_nullbooleanfield_changed_null(self):
+        f = BooleanField(null=True)
+        self.assertTrue(f.has_changed(False, None))
+        self.assertTrue(f.has_changed(None, False))
+        self.assertFalse(f.has_changed(None, None))
+        self.assertFalse(f.has_changed(False, False))
+        self.assertTrue(f.has_changed(True, False))
+        self.assertTrue(f.has_changed(True, None))
+        self.assertTrue(f.has_changed(True, False))
+        # Initial value may have mutated to a string due to show_hidden_initial (#19537)
+        self.assertTrue(f.has_changed('False', 'on'))
+        # HiddenInput widget sends string values for boolean but doesn't clean them in value_from_datadict
+        self.assertFalse(f.has_changed(False, 'False'))
+        self.assertFalse(f.has_changed(True, 'True'))
+        self.assertFalse(f.has_changed(None, ''))
+        self.assertTrue(f.has_changed(False, 'True'))
+        self.assertTrue(f.has_changed(True, 'False'))
+        self.assertTrue(f.has_changed(None, 'False'))
+
     def test_disabled_has_changed(self):
         f = BooleanField(disabled=True)
         self.assertIs(f.has_changed('True', 'False'), False)
+
+    def test_booleanfield_null1(self):
+        # The internal value is preserved if using HiddenInput (#7753).
+        class HiddenBooleanForm(Form):
+            hidden_bool1 = BooleanField(null=True, widget=HiddenInput, initial=True)
+            hidden_bool2 = BooleanField(null=True, widget=HiddenInput, initial=False)
+
+        f = HiddenBooleanForm()
+        self.assertHTMLEqual(
+            '<input type="hidden" name="hidden_bool1" value="True" id="id_hidden_bool1">'
+            '<input type="hidden" name="hidden_bool2" value="False" id="id_hidden_bool2">',
+            str(f)
+        )
+
+    def test_booleanfield_null2(self):
+        class HiddenBooleanForm(Form):
+            hidden_bool1 = BooleanField(null=True, widget=HiddenInput, initial=True)
+            hidden_bool2 = BooleanField(null=True, widget=HiddenInput, initial=False)
+
+        f = HiddenBooleanForm({'hidden_bool1': 'True', 'hidden_bool2': 'False'})
+        self.assertIsNone(f.full_clean())
+        self.assertTrue(f.cleaned_data['hidden_bool1'])
+        self.assertFalse(f.cleaned_data['hidden_bool2'])
+
+    def test_booleanfield_null3(self):
+        # Make sure we're compatible with MySQL, which uses 0 and 1 for its
+        # boolean values (#9609).
+        NULLBOOL_CHOICES = (('1', 'Yes'), ('0', 'No'), ('', 'Unknown'))
+
+        class MySQLBooleanForm(Form):
+            bool0 = BooleanField(null=True, widget=RadioSelect(choices=NULLBOOL_CHOICES))
+            bool1 = BooleanField(null=True, widget=RadioSelect(choices=NULLBOOL_CHOICES))
+            bool2 = BooleanField(null=True, widget=RadioSelect(choices=NULLBOOL_CHOICES))
+
+        f = MySQLBooleanForm({'bool0': '1', 'bool1': '0', 'bool2': ''})
+        self.assertIsNone(f.full_clean())
+        self.assertTrue(f.cleaned_data['bool0'])
+        self.assertFalse(f.cleaned_data['bool1'])
+        self.assertIsNone(f.cleaned_data['bool2'])

--- a/tests/forms_tests/field_tests/test_nullbooleanfield.py
+++ b/tests/forms_tests/field_tests/test_nullbooleanfield.py
@@ -1,11 +1,22 @@
 from django.forms import Form, HiddenInput, NullBooleanField, RadioSelect
 from django.test import SimpleTestCase
+from django.test.utils import ignore_warnings
+from django.utils.deprecation import RemovedInDjango40Warning
 
 from . import FormFieldAssertionsMixin
 
 
 class NullBooleanFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
+    def test_nullbooleanfield_deprecation_warning(self):
+        msg = (
+            "The NullBooleanField is deprecated, BooleanField(null=True) "
+            "instead."
+        )
+        with self.assertWarnsMessage(RemovedInDjango40Warning, msg):
+            NullBooleanField()
+
+    @ignore_warnings(category=RemovedInDjango40Warning)
     def test_nullbooleanfield_clean(self):
         f = NullBooleanField()
         self.assertIsNone(f.clean(''))
@@ -20,6 +31,7 @@ class NullBooleanFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         self.assertTrue(f.clean('true'))
         self.assertFalse(f.clean('false'))
 
+    @ignore_warnings(category=RemovedInDjango40Warning)
     def test_nullbooleanfield_2(self):
         # The internal value is preserved if using HiddenInput (#7753).
         class HiddenNullBooleanForm(Form):
@@ -32,6 +44,7 @@ class NullBooleanFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
             str(f)
         )
 
+    @ignore_warnings(category=RemovedInDjango40Warning)
     def test_nullbooleanfield_3(self):
         class HiddenNullBooleanForm(Form):
             hidden_nullbool1 = NullBooleanField(widget=HiddenInput, initial=True)
@@ -41,6 +54,7 @@ class NullBooleanFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         self.assertTrue(f.cleaned_data['hidden_nullbool1'])
         self.assertFalse(f.cleaned_data['hidden_nullbool2'])
 
+    @ignore_warnings(category=RemovedInDjango40Warning)
     def test_nullbooleanfield_4(self):
         # Make sure we're compatible with MySQL, which uses 0 and 1 for its
         # boolean values (#9609).
@@ -56,6 +70,7 @@ class NullBooleanFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         self.assertFalse(f.cleaned_data['nullbool1'])
         self.assertIsNone(f.cleaned_data['nullbool2'])
 
+    @ignore_warnings(category=RemovedInDjango40Warning)
     def test_nullbooleanfield_changed(self):
         f = NullBooleanField()
         self.assertTrue(f.has_changed(False, None))

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -19,7 +19,9 @@ from django.forms.utils import ErrorList
 from django.http import QueryDict
 from django.template import Context, Template
 from django.test import SimpleTestCase
+from django.test.utils import ignore_warnings
 from django.utils.datastructures import MultiValueDict
+from django.utils.deprecation import RemovedInDjango40Warning
 from django.utils.safestring import mark_safe
 
 
@@ -2372,6 +2374,7 @@ Password: <input type="password" name="password" required>
         p = Person(prefix='bar')
         self.assertEqual(p.prefix, 'bar')
 
+    @ignore_warnings(category=RemovedInDjango40Warning)
     def test_forms_with_null_boolean(self):
         # NullBooleanField is a bit of a special case because its presentation (widget)
         # is different than its data. This is handled transparently, though.
@@ -2803,6 +2806,7 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
             '<input type="hidden" name="initial-field1" id="initial-id_field1"></td></tr>'
         )
 
+    @ignore_warnings(category=RemovedInDjango40Warning)
     def test_error_html_required_html_classes(self):
         class Person(Form):
             name = CharField()

--- a/tests/model_fields/test_booleanfield.py
+++ b/tests/model_fields/test_booleanfield.py
@@ -49,9 +49,10 @@ class BooleanFieldTests(TestCase):
 
     def test_nullbooleanfield_formfield(self):
         f = models.BooleanField(null=True)
-        self.assertIsInstance(f.formfield(), forms.NullBooleanField)
+        self.assertIsInstance(f.formfield(), forms.BooleanField)
+        self.assertIsInstance(f.formfield().widget, forms.NullBooleanSelect)
         f = models.NullBooleanField()
-        self.assertIsInstance(f.formfield(), forms.NullBooleanField)
+        self.assertIsInstance(f.formfield(), forms.BooleanField)
 
     def test_return_type(self):
         b = BooleanModel.objects.create(bfield=True)


### PR DESCRIPTION
Deprecated models.fields.NullBooleanField and
forms.field.NullBooleanField. The replacement for both
is BooleanField(null=True).