### PR TITLE
bugfix: hardcoded User, fails with custom User model

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -7,7 +7,6 @@ from django.contrib.auth import (
 from django.contrib.auth.hashers import (
     UNUSABLE_PASSWORD_PREFIX, identify_hasher,
 )
-from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import EmailMultiAlternatives
@@ -100,7 +99,7 @@ class UserCreationForm(forms.ModelForm):
     )
 
     class Meta:
-        model = User
+        model = UserModel
         fields = ("username",)
         field_classes = {'username': UsernameField}
 
@@ -149,7 +148,7 @@ class UserChangeForm(forms.ModelForm):
     )
 
     class Meta:
-        model = User
+        model = UserModel
         fields = '__all__'
         field_classes = {'username': UsernameField}
 


### PR DESCRIPTION
In django/contrib/auth/forms.py:
I think hardcoded 'User' should not be used to avoid failure with custom User model: "Manager isn't available; User has been swapped for .."
Instead get_user_model() is correct.
This function is in the top part of a forms.py assigned as 
UserModel = get_user_model()
.... so I have changed:
User -> UserModel

Best regards,
Mirek