### PR TITLE
Removed unused link in docs/faq/help.txt.

### DIFF
--- a/docs/faq/help.txt
+++ b/docs/faq/help.txt
@@ -89,5 +89,3 @@ or one of the public mailing lists. Django has a
 :ref:`policy for handling security issues <reporting-security-issues>`;
 while a defect is outstanding, we would like to minimize any damage that
 could be inflicted through public knowledge of that defect.
-
-.. _`policy for handling security issues`: ../contributing/#reporting-security-issues


### PR DESCRIPTION
Unused since its introduction in 97cb07c3a10ff0e584a260a7ee1001614691eb1d.