### PR TITLE
Fixed all accidental use of single backticks in docs

### DIFF
--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -11,10 +11,11 @@ from docutils.statemachine import ViewList
 from sphinx import addnodes
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.directives import CodeBlock
+from sphinx.errors import SphinxError
 from sphinx.domains.std import Cmdoption
 from sphinx.errors import ExtensionError
 from sphinx.util import logging
-from sphinx.util.console import bold
+from sphinx.util.console import bold, red
 from sphinx.writers.html import HTMLTranslator
 
 logger = logging.getLogger(__name__)
@@ -67,6 +68,7 @@ def setup(app):
     )
     app.add_directive('console', ConsoleDirective)
     app.connect('html-page-context', html_page_context_hook)
+    app.add_role('default-role-error', default_role_error)
     return {'parallel_read_safe': True}
 
 
@@ -371,3 +373,14 @@ def html_page_context_hook(app, pagename, templatename, context, doctree):
     # This way it's include only from HTML files rendered from reST files where
     # the ConsoleDirective is used.
     context['include_console_assets'] = getattr(doctree, '_console_directive_used_flag', False)
+
+
+def default_role_error(
+    name, rawtext, text, lineno, inliner, options=None, content=None
+):
+    msg = (
+        "Default role used (`single backticks`) at line %s: %s. Did you mean "
+        "to use two backticks for ``code``, or miss an underscore for a "
+        "`link`_ ?" % (lineno, rawtext)
+    )
+    raise SphinxError(red(msg))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,7 +127,7 @@ today_fmt = '%B %d, %Y'
 exclude_patterns = ['_build', '_theme']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-# default_role = None
+default_role = "default-role-error"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = True

--- a/docs/faq/help.txt
+++ b/docs/faq/help.txt
@@ -36,7 +36,7 @@ your choice of words.
 
 .. _message-does-not-appear-on-django-users:
 
-Why hasn't my message appeared on `django-users`?
+Why hasn't my message appeared on *django-users*?
 =================================================
 
 |django-users| has a lot of subscribers. This is good for the community, as

--- a/docs/faq/troubleshooting.txt
+++ b/docs/faq/troubleshooting.txt
@@ -10,7 +10,7 @@ during the development of Django applications.
 Problems running ``django-admin``
 =================================
 
-"command not found: `django-admin`"
+``command not found: django-admin``
 -----------------------------------
 
 :doc:`django-admin </ref/django-admin>` should be on your system path if you

--- a/docs/howto/deployment/wsgi/uwsgi.txt
+++ b/docs/howto/deployment/wsgi/uwsgi.txt
@@ -38,7 +38,7 @@ uWSGI model
 -----------
 
 uWSGI operates on a client-server model. Your Web server (e.g., nginx, Apache)
-communicates with a `django-uwsgi` "worker" process to serve dynamic content.
+communicates with a ``django-uwsgi`` "worker" process to serve dynamic content.
 
 Configuring and starting the uWSGI server for Django
 ----------------------------------------------------

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -166,8 +166,8 @@ filtered out of error reports in a production environment (that is, where
             ...
 
     In the above example, the values for the ``user``, ``pw`` and ``cc``
-    variables will be hidden and replaced with stars (`**********`) in the
-    error reports, whereas the value of the ``name`` variable will be
+    variables will be hidden and replaced with stars (``**********``)
+    in the error reports, whereas the value of the ``name`` variable will be
     disclosed.
 
     To systematically hide all local variables of a function from error logs,
@@ -213,8 +213,9 @@ filtered out of error reports in a production environment (that is, where
 
     In the above example, the values for the ``pass_word`` and
     ``credit_card_number`` POST parameters will be hidden and replaced with
-    stars (`**********`) in the request's representation inside the error
-    reports, whereas the value of the ``name`` parameter will be disclosed.
+    stars (``**********``) in the request's representation inside the
+    error reports, whereas the value of the ``name`` parameter will be
+    disclosed.
 
     To systematically hide all POST parameters of a request in error reports,
     do not provide any argument to the ``sensitive_post_parameters`` decorator::
@@ -242,9 +243,9 @@ of reports when an error occurs. The actual filtering is done by Django's
 default error reporter filter:
 :class:`django.views.debug.SafeExceptionReporterFilter`. This filter uses the
 decorators' annotations to replace the corresponding values with stars
-(`**********`) when the error reports are produced. If you wish to override or
-customize this default behavior for your entire site, you need to define your
-own filter class and tell Django to use it via the
+(``**********``) when the error reports are produced. If you wish to
+override or customize this default behavior for your entire site, you need to
+define your own filter class and tell Django to use it via the
 :setting:`DEFAULT_EXCEPTION_REPORTER_FILTER` setting::
 
     DEFAULT_EXCEPTION_REPORTER_FILTER = 'path.to.your.CustomExceptionReporterFilter'
@@ -271,7 +272,8 @@ following attributes and methods:
         .. versionadded:: 3.1
 
         The string value to replace sensitive value with. By default it
-        replaces the values of sensitive variables with stars (`**********`).
+        replaces the values of sensitive variables with stars
+        (``**********``).
 
     .. attribute:: hidden_settings
 

--- a/docs/howto/outputting-pdf.txt
+++ b/docs/howto/outputting-pdf.txt
@@ -75,8 +75,8 @@ mention:
 
 * The response will automatically set the MIME type :mimetype:`application/pdf`
   based on the filename extension. This tells browsers that the document is a
-  PDF file, rather than an HTML file or a generic `application/octet-stream`
-  binary content.
+  PDF file, rather than an HTML file or a generic
+  :mimetype:`application/octet-stream` binary content.
 
 * When ``as_attachment=True`` is passed to ``FileResponse``, it sets the
   appropriate ``Content-Disposition`` header and that tells Web browsers to

--- a/docs/internals/contributing/new-contributors.txt
+++ b/docs/internals/contributing/new-contributors.txt
@@ -146,7 +146,7 @@ FAQ
    (except the Django fellow), and sometimes folks just don't have time. The
    best thing to do is to send a gentle reminder to the |django-developers|
    mailing list asking for review on the ticket, or to bring it up in the
-   `#django-dev` IRC channel.
+   ``#django-dev`` IRC channel.
 
 2. **I'm sure my ticket is absolutely 100% perfect, can I mark it as RFC
    myself?**

--- a/docs/internals/contributing/writing-code/javascript.txt
+++ b/docs/internals/contributing/writing-code/javascript.txt
@@ -131,8 +131,8 @@ Testing from the command line
 
 To run the tests from the command line, you need to have `Node.js`_ installed.
 
-After installing `Node.js`, install the JavaScript test dependencies by running
-the following from the root of your Django checkout:
+After installing ``Node.js``, install the JavaScript test dependencies by
+running the following from the root of your Django checkout:
 
 .. console::
 

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -124,7 +124,7 @@ Running the JavaScript tests
 
 Django includes a set of :ref:`JavaScript unit tests <javascript-tests>` for
 functions in certain contrib apps. The JavaScript tests aren't run by default
-using ``tox`` because they require `Node.js` to be installed and aren't
+using ``tox`` because they require ``Node.js`` to be installed and aren't
 necessary for the majority of patches. To run the JavaScript tests using
 ``tox``:
 

--- a/docs/internals/howto-release-django.txt
+++ b/docs/internals/howto-release-django.txt
@@ -379,7 +379,7 @@ Now you're ready to actually put the release out there. To do this:
    message body should include the vulnerability details, for example, the
    announcement blog post text. Include a link to the announcement blog post.
 
-#. Add a link to the blog post in the topic of the `#django` IRC channel:
+#. Add a link to the blog post in the topic of the ``#django`` IRC channel:
    ``/msg chanserv TOPIC #django new topic goes here``.
 
 Post-release

--- a/docs/ref/contrib/gis/geoip2.txt
+++ b/docs/ref/contrib/gis/geoip2.txt
@@ -9,8 +9,8 @@ The :class:`GeoIP2` object is a wrapper for the `MaxMind geoip2 Python
 library`__. [#]_
 
 In order to perform IP-based geolocation, the :class:`GeoIP2` object requires
-the `geoip2 Python library`__ and the GeoIP `Country` and/or `City` `datasets
-in binary format`__ (the CSV files will not work!). Grab the
+the `geoip2 Python library`__ and the GeoIP ``Country`` and/or ``City``
+`datasets in binary format`__ (the CSV files will not work!). Grab the
 ``GeoLite2-Country.mmdb.gz`` and ``GeoLite2-City.mmdb.gz`` files and unzip them
 in a directory corresponding to the :setting:`GEOIP_PATH` setting.
 

--- a/docs/ref/contrib/gis/geoquerysets.txt
+++ b/docs/ref/contrib/gis/geoquerysets.txt
@@ -743,9 +743,9 @@ Distance lookups take the following form::
 The value passed into a distance lookup is a tuple; the first two
 values are mandatory, and are the geometry to calculate distances to,
 and a distance value (either a number in units of the field, a
-:class:`~django.contrib.gis.measure.Distance` object, or a `query expression
-<ref/models/expressions>`). To pass a band index to the lookup, use a 3-tuple
-where the second entry is the band index.
+:class:`~django.contrib.gis.measure.Distance` object, or a :doc:`query
+expression </ref/models/expressions>`). To pass a band index to the lookup, use
+a 3-tuple where the second entry is the band index.
 
 On every distance lookup except :lookup:`dwithin`, an optional element,
 ``'spheroid'``, may be included to use the more accurate spheroid distance

--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -531,7 +531,7 @@ Is it a problem that Django's CSRF protection isn't linked to a session by defau
 -----------------------------------------------------------------------------------
 
 No, this is by design. Not linking CSRF protection to a session allows using
-the protection on sites such as a `pastebin` that allow submissions from
+the protection on sites such as a *pastebin* that allow submissions from
 anonymous users which don't have a session.
 
 If you wish to store the CSRF token in the user's session, use the

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -206,7 +206,7 @@ cursor query is controlled with the `cursor_tuple_fraction`_ option.
 Transaction pooling and server-side cursors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Using a connection pooler in transaction pooling mode (e.g. `pgBouncer`_)
+Using a connection pooler in transaction pooling mode (e.g. `PgBouncer`_)
 requires disabling server-side cursors for that connection.
 
 Server-side cursors are local to a connection and remain open at the end of a
@@ -232,7 +232,7 @@ Another option is to wrap each ``QuerySet`` using server-side cursors in an
 for the duration of the transaction. This way, the server-side cursor will only
 live for the duration of the transaction.
 
-.. _pgBouncer: https://pgbouncer.github.io/
+.. _PgBouncer: https://pgbouncer.github.io/
 
 .. _manually-specified-autoincrement-pk:
 

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -365,7 +365,7 @@ foundation for custom widgets.
         the ``name`` attribute on each subwidget. In this case, for each
         ``(key, widget)`` pair, the key will be appended to the ``name`` of the
         widget in order to generate the attribute value. You may provide the
-        empty string (`''`) for a single key, in order to suppress the suffix
+        empty string (``''``) for a single key, in order to suppress the suffix
         for one widget. For example::
 
             >>> widget = MultiWidget(widgets={'': TextInput, 'last': TextInput})

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -153,7 +153,7 @@ The first element in each tuple is the name to apply to the group. The
 second element is an iterable of 2-tuples, with each 2-tuple containing
 a value and a human-readable name for an option. Grouped options may be
 combined with ungrouped options within a single list (such as the
-`unknown` option in this example).
+``'unknown'`` option in this example).
 
 For each model field that has :attr:`~Field.choices` set, Django will add a
 method to retrieve the human-readable name for the field's current value. See

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -798,7 +798,8 @@ Methods
     ``content_type`` is the MIME type optionally completed by a character set
     encoding and is used to fill the HTTP ``Content-Type`` header. If not
     specified, it is formed by ``'text/html'`` and the
-    :setting:`DEFAULT_CHARSET` settings, by default: "`text/html; charset=utf-8`".
+    :setting:`DEFAULT_CHARSET` settings, by default:
+    ``"text/html; charset=utf-8"``.
 
     ``status`` is the :rfc:`HTTP status code <7231#section-6>` for the response.
     You can use Python's :py:class:`http.HTTPStatus` for meaningful aliases,

--- a/docs/releases/0.95.txt
+++ b/docs/releases/0.95.txt
@@ -109,7 +109,7 @@ many common questions appear with some regularity, and any particular problem
 may already have been answered.
 
 Finally, for those who prefer the more immediate feedback offered by IRC,
-there's a `#django` channel on irc.freenode.net that is regularly populated
+there's a ``#django`` channel on irc.freenode.net that is regularly populated
 by Django users and developers from around the world. Friendly people are
 usually available at any hour of the day -- to help, or just to chat.
 

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -10,7 +10,7 @@ Allowed disabling server-side cursors on PostgreSQL
 ===================================================
 
 The change in Django 1.11 to make :meth:`.QuerySet.iterator()` use server-side
-cursors on PostgreSQL prevents running Django with pgBouncer in transaction
+cursors on PostgreSQL prevents running Django with PgBouncer in transaction
 pooling mode. To reallow that, use the :setting:`DISABLE_SERVER_SIDE_CURSORS
 <DATABASE-DISABLE_SERVER_SIDE_CURSORS>` setting in :setting:`DATABASES`.
 

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -10,7 +10,7 @@ Allowed disabling server-side cursors on PostgreSQL
 ===================================================
 
 The change in Django 1.11 to make :meth:`.QuerySet.iterator()` use server-side
-cursors on PostgreSQL prevents running Django with `pgBouncer` in transaction
+cursors on PostgreSQL prevents running Django with pgBouncer in transaction
 pooling mode. To reallow that, use the :setting:`DISABLE_SERVER_SIDE_CURSORS
 <DATABASE-DISABLE_SERVER_SIDE_CURSORS>` setting in :setting:`DATABASES`.
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -185,8 +185,8 @@ Minor features
 
 * PostGIS migrations can now change field dimensions.
 
-* Added the ability to pass the `size`, `shape`, and `offset` parameter when
-  creating :class:`~django.contrib.gis.gdal.GDALRaster` objects.
+* Added the ability to pass the ``size``, ``shape``, and ``offset`` parameters
+  when creating :class:`~django.contrib.gis.gdal.GDALRaster` objects.
 
 * Added SpatiaLite support for the
   :class:`~django.contrib.gis.db.models.functions.IsValid` function,
@@ -644,8 +644,8 @@ Server-side cursors on PostgreSQL
 ---------------------------------
 
 The change to make :meth:`.QuerySet.iterator()` use server-side cursors on
-PostgreSQL prevents running Django with `pgBouncer` in transaction pooling
-mode. To reallow that, use the :setting:`DISABLE_SERVER_SIDE_CURSORS
+PostgreSQL prevents running Django with pgBouncer in transaction pooling mode.
+To reallow that, use the :setting:`DISABLE_SERVER_SIDE_CURSORS
 <DATABASE-DISABLE_SERVER_SIDE_CURSORS>` setting (added in Django 1.11.1) in
 :setting:`DATABASES`.
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -644,7 +644,7 @@ Server-side cursors on PostgreSQL
 ---------------------------------
 
 The change to make :meth:`.QuerySet.iterator()` use server-side cursors on
-PostgreSQL prevents running Django with pgBouncer in transaction pooling mode.
+PostgreSQL prevents running Django with PgBouncer in transaction pooling mode.
 To reallow that, use the :setting:`DISABLE_SERVER_SIDE_CURSORS
 <DATABASE-DISABLE_SERVER_SIDE_CURSORS>` setting (added in Django 1.11.1) in
 :setting:`DATABASES`.

--- a/docs/releases/1.2.txt
+++ b/docs/releases/1.2.txt
@@ -811,16 +811,16 @@ This affects the following settings:
 =========================================  ==========================
  Old setting                                New Setting
 =========================================  ==========================
-`DATABASE_ENGINE`                          :setting:`ENGINE <DATABASE-ENGINE>`
-`DATABASE_HOST`                            :setting:`HOST`
-`DATABASE_NAME`                            :setting:`NAME`
-`DATABASE_OPTIONS`                         :setting:`OPTIONS`
-`DATABASE_PASSWORD`                        :setting:`PASSWORD`
-`DATABASE_PORT`                            :setting:`PORT`
-`DATABASE_USER`                            :setting:`USER`
-`TEST_DATABASE_CHARSET`                    :setting:`TEST_CHARSET`
-`TEST_DATABASE_COLLATION`                  :setting:`TEST_COLLATION`
-`TEST_DATABASE_NAME`                       :setting:`TEST_NAME`
+``DATABASE_ENGINE``                        :setting:`ENGINE <DATABASE-ENGINE>`
+``DATABASE_HOST``                          :setting:`HOST`
+``DATABASE_NAME``                          :setting:`NAME`
+``DATABASE_OPTIONS``                       :setting:`OPTIONS`
+``DATABASE_PASSWORD``                      :setting:`PASSWORD`
+``DATABASE_PORT``                          :setting:`PORT`
+``DATABASE_USER``                          :setting:`USER`
+``TEST_DATABASE_CHARSET``                  :setting:`TEST_CHARSET`
+``TEST_DATABASE_COLLATION``                :setting:`TEST_COLLATION`
+``TEST_DATABASE_NAME``                     :setting:`TEST_NAME`
 =========================================  ==========================
 
 These changes are also required if you have manually created a database

--- a/docs/releases/1.4.13.txt
+++ b/docs/releases/1.4.13.txt
@@ -40,8 +40,8 @@ Django relies on user input in some cases (e.g.
 :doc:`i18n </topics/i18n/index>`) to redirect the user to an "on success" URL.
 The security checks for these redirects (namely
 ``django.utils.http.is_safe_url()``) did not correctly validate some malformed
-URLs, such as `http:\\\\\\djangoproject.com`, which are accepted by some browsers
-with more liberal URL parsing.
+URLs, such as ``http:\\\\\\djangoproject.com``, which are accepted by some
+browsers with more liberal URL parsing.
 
 To remedy this, the validation in ``is_safe_url()`` has been tightened to be able
 to handle and correctly validate these malformed URLs.

--- a/docs/releases/1.4.18.txt
+++ b/docs/releases/1.4.18.txt
@@ -12,7 +12,7 @@ WSGI header spoofing via underscore/dash conflation
 
 When HTTP headers are placed into the WSGI environ, they are normalized by
 converting to uppercase, converting all dashes to underscores, and prepending
-`HTTP_`. For instance, a header ``X-Auth-User`` would become
+``HTTP_``. For instance, a header ``X-Auth-User`` would become
 ``HTTP_X_AUTH_USER`` in the WSGI environ (and thus also in Django's
 ``request.META`` dictionary).
 

--- a/docs/releases/1.4.txt
+++ b/docs/releases/1.4.txt
@@ -634,9 +634,9 @@ Django 1.4 also includes several smaller improvements worth noting:
   :meth:`~django.db.models.query.QuerySet.distinct`.
 
 * The admin login page will add a password reset link if you include a URL with
-  the name `'admin_password_reset'` in your urls.py, so plugging in the built-in
-  password reset mechanism and making it available is now much easier. For
-  details, see :ref:`auth_password_reset`.
+  the name ``'admin_password_reset'`` in your urls.py, so plugging in the
+  built-in password reset mechanism and making it available is now much easier.
+  For details, see :ref:`auth_password_reset`.
 
 * The MySQL database backend can now make use of the savepoint feature
   implemented by MySQL version 5.0.3 or newer with the InnoDB storage engine.
@@ -671,9 +671,9 @@ vulnerabilities. No Django site should ever be run without a
 :setting:`SECRET_KEY`.
 
 In Django 1.4, starting Django with an empty :setting:`SECRET_KEY` will raise a
-`DeprecationWarning`. In Django 1.5, it will raise an exception and Django will
-refuse to start. This is slightly accelerated from the usual deprecation path
-due to the severity of the consequences of running Django with no
+``DeprecationWarning``. In Django 1.5, it will raise an exception and Django
+will refuse to start. This is slightly accelerated from the usual deprecation
+path due to the severity of the consequences of running Django with no
 :setting:`SECRET_KEY`.
 
 ``django.contrib.admin``
@@ -909,8 +909,8 @@ doesn't make any effort to synchronize access to the underlying backend.
 Concurrency behavior is defined by the underlying backend implementation.
 Check their documentation for details.
 
-`COMMENTS_BANNED_USERS_GROUP` setting
--------------------------------------
+``COMMENTS_BANNED_USERS_GROUP`` setting
+---------------------------------------
 
 Django's comments has historically
 supported excluding the comments of a special user group, but we've never
@@ -946,8 +946,8 @@ Save this model manager in your custom comment app (e.g., in
 
         objects = BanningCommentManager()
 
-`IGNORABLE_404_STARTS` and `IGNORABLE_404_ENDS` settings
---------------------------------------------------------
+``IGNORABLE_404_STARTS`` and ``IGNORABLE_404_ENDS`` settings
+------------------------------------------------------------
 
 Until Django 1.3, it was possible to exclude some URLs from Django's
 :doc:`404 error reporting</howto/error-reporting>` by adding prefixes to
@@ -1294,8 +1294,8 @@ Now, the flags are keyword arguments of :meth:`@register.filter
 
 See :ref:`filters and auto-escaping <filters-auto-escaping>` for more information.
 
-Wildcard expansion of application names in `INSTALLED_APPS`
------------------------------------------------------------
+Wildcard expansion of application names in ``INSTALLED_APPS``
+-------------------------------------------------------------
 
 Until Django 1.3, :setting:`INSTALLED_APPS` accepted wildcards in application
 names, like ``django.contrib.*``. The expansion was performed by a

--- a/docs/releases/1.5.8.txt
+++ b/docs/releases/1.5.8.txt
@@ -40,8 +40,8 @@ Django relies on user input in some cases (e.g.
 :doc:`i18n </topics/i18n/index>`) to redirect the user to an "on success" URL.
 The security checks for these redirects (namely
 ``django.utils.http.is_safe_url()``) did not correctly validate some malformed
-URLs, such as `http:\\\\\\djangoproject.com`, which are accepted by some browsers
-with more liberal URL parsing.
+URLs, such as ``http:\\\\\\djangoproject.com``, which are accepted by some
+browsers with more liberal URL parsing.
 
 To remedy this, the validation in ``is_safe_url()`` has been tightened to be able
 to handle and correctly validate these malformed URLs.

--- a/docs/releases/1.5.txt
+++ b/docs/releases/1.5.txt
@@ -615,8 +615,8 @@ database state behind or unit tests that rely on some form of state being
 preserved after the execution of other tests. Such tests are already very
 fragile, and must now be changed to be able to run independently.
 
-`cleaned_data` dictionary kept for invalid forms
-------------------------------------------------
+``cleaned_data`` dictionary kept for invalid forms
+--------------------------------------------------
 
 The :attr:`~django.forms.Form.cleaned_data` dictionary is now always present
 after form validation. When the form doesn't validate, it contains only the

--- a/docs/releases/1.6.10.txt
+++ b/docs/releases/1.6.10.txt
@@ -11,7 +11,7 @@ WSGI header spoofing via underscore/dash conflation
 
 When HTTP headers are placed into the WSGI environ, they are normalized by
 converting to uppercase, converting all dashes to underscores, and prepending
-`HTTP_`. For instance, a header ``X-Auth-User`` would become
+``HTTP_``. For instance, a header ``X-Auth-User`` would become
 ``HTTP_X_AUTH_USER`` in the WSGI environ (and thus also in Django's
 ``request.META`` dictionary).
 

--- a/docs/releases/1.6.5.txt
+++ b/docs/releases/1.6.5.txt
@@ -40,8 +40,8 @@ Django relies on user input in some cases (e.g.
 :doc:`i18n </topics/i18n/index>`) to redirect the user to an "on success" URL.
 The security checks for these redirects (namely
 ``django.utils.http.is_safe_url()``) did not correctly validate some malformed
-URLs, such as `http:\\\\\\djangoproject.com`, which are accepted by some browsers
-with more liberal URL parsing.
+URLs, such as ``http:\\\\\\djangoproject.com``, which are accepted by some
+browsers with more liberal URL parsing.
 
 To remedy this, the validation in ``is_safe_url()`` has been tightened to be able
 to handle and correctly validate these malformed URLs.

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -731,7 +731,7 @@ Admin views ``_changelist_filters`` GET parameter
 -------------------------------------------------
 
 To achieve preserving and restoring list view filters, admin views now
-pass around the `_changelist_filters` GET parameter. It's important that you
+pass around the ``_changelist_filters`` GET parameter. It's important that you
 account for that change if you have custom admin templates or if your tests
 rely on the previous URLs. If you want to revert to the original behavior you
 can set the
@@ -924,7 +924,7 @@ Miscellaneous
 
     url(r'^reset/done/$', 'django.contrib.auth.views.password_reset_complete', name='password_reset_complete')
 
-* :class:`~django.views.generic.base.RedirectView` now has a `pattern_name`
+* :class:`~django.views.generic.base.RedirectView` now has a ``pattern_name``
   attribute which allows it to choose the target by reversing the URL.
 
 * In Django 1.4 and 1.5, a blank string was unintentionally not considered to

--- a/docs/releases/1.7.1.txt
+++ b/docs/releases/1.7.1.txt
@@ -38,7 +38,7 @@ Bugfixes
   adds a ``get_absolute_url()`` method to any model that appears in
   ``ABSOLUTE_URL_OVERRIDES`` but doesn't define ``get_absolute_url()``.
 
-* Avoided masking some `ImportError` exceptions during application loading
+* Avoided masking some ``ImportError`` exceptions during application loading
   (:ticket:`22920`).
 
 * Empty ``index_together`` or ``unique_together`` model options no longer

--- a/docs/releases/1.7.3.txt
+++ b/docs/releases/1.7.3.txt
@@ -11,7 +11,7 @@ WSGI header spoofing via underscore/dash conflation
 
 When HTTP headers are placed into the WSGI environ, they are normalized by
 converting to uppercase, converting all dashes to underscores, and prepending
-`HTTP_`. For instance, a header ``X-Auth-User`` would become
+``HTTP_``. For instance, a header ``X-Auth-User`` would become
 ``HTTP_X_AUTH_USER`` in the WSGI environ (and thus also in Django's
 ``request.META`` dictionary).
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -479,7 +479,7 @@ Minor features
 
 * The ``"django.contrib.sessions.backends.cached_db"`` session backend now
   respects :setting:`SESSION_CACHE_ALIAS`. In previous versions, it always used
-  the `default` cache.
+  the ``default`` cache.
 
 :mod:`django.contrib.sitemaps`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1121,9 +1121,9 @@ as ``error_list``; ``error_dict``; or the return value of
 would have previously found strings.
 
 Also if you directly assigned the return value of ``update_error_dict()``
-to ``Form._errors`` you may inadvertently add `list` instances where
+to ``Form._errors`` you may inadvertently add ``list`` instances where
 ``ErrorList`` instances are expected. This is a problem because unlike a
-simple `list`, an ``ErrorList`` knows how to handle instances of
+simple ``list``, an ``ErrorList`` knows how to handle instances of
 ``ValidationError``.
 
 Most use-cases that warranted using these private APIs are now covered by

--- a/docs/releases/1.8.1.txt
+++ b/docs/releases/1.8.1.txt
@@ -84,7 +84,7 @@ Bugfixes
   ``ModelAdmin.filter_horizontal`` and ``filter_vertical`` options
   (:ticket:`24676`).
 
-* Fixed `AttributeError: function 'GDALAllRegister' not found` error when
+* Fixed ``AttributeError: function 'GDALAllRegister' not found`` error when
   initializing ``contrib.gis`` on Windows.
 
 Optimizations

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -152,4 +152,4 @@ Bugfixes
 * Fixed a regression in ``URLValidator`` that invalidated Punycode TLDs
   (:ticket:`25059`).
 
-* Improved `pyinotify` ``runserver`` polling (:ticket:`23882`).
+* Improved ``pyinotify`` ``runserver`` polling (:ticket:`23882`).

--- a/docs/releases/1.8.6.txt
+++ b/docs/releases/1.8.6.txt
@@ -36,7 +36,7 @@ Bugfixes
   migrations using ``QuerySet.defer()`` from leaking to test and application
   code.
 
-* Fixed a typo in the name of the `strictly_above` PostGIS lookup
+* Fixed a typo in the name of the ``strictly_above`` PostGIS lookup
   (:ticket:`25592`).
 
 * Fixed crash with ``contrib.postgres.forms.SplitArrayField`` and

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -753,10 +753,10 @@ in :doc:`/howto/custom-management-commands`.
 Custom test management command arguments through test runner
 ------------------------------------------------------------
 
-The method to add custom arguments to the `test` management command through the
-test runner has changed. Previously, you could provide an `option_list` class
-variable on the test runner to add more arguments (à la :py:mod:`optparse`).
-Now to implement the same behavior, you have to create an
+The method to add custom arguments to the ``test`` management command through
+the test runner has changed. Previously, you could provide an ``option_list``
+class variable on the test runner to add more arguments (à la
+:py:mod:`optparse`). Now to implement the same behavior, you have to create an
 ``add_arguments(cls, parser)`` class method on the test runner and call
 ``parser.add_argument`` to add any custom arguments, as parser is now an
 :py:class:`argparse.ArgumentParser` instance.

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -1115,7 +1115,7 @@ Miscellaneous
   :attr:`~django.forms.CharField.strip` argument to ``False``.
 
 * Template text that is translated and uses two or more consecutive percent
-  signs, e.g. ``"%%"``, may have a new `msgid` after ``makemessages`` is run
+  signs, e.g. ``"%%"``, may have a new ``msgid`` after ``makemessages`` is run
   (most likely the translation will be marked fuzzy). The new ``msgid`` will be
   marked ``"#, python-format"``.
 
@@ -1506,7 +1506,7 @@ remove usage of these features.
 * Database test settings as independent entries in the database settings,
   prefixed by ``TEST_``, are no longer supported.
 
-* The `cache_choices` option to :class:`~django.forms.ModelChoiceField` and
+* The ``cache_choices`` option to :class:`~django.forms.ModelChoiceField` and
   :class:`~django.forms.ModelMultipleChoiceField` is removed.
 
 * The default value of the

--- a/docs/releases/2.0.4.txt
+++ b/docs/releases/2.0.4.txt
@@ -12,8 +12,8 @@ Bugfixes
 * Fixed a crash when filtering with an ``Exists()`` annotation of a queryset
   containing a single field (:ticket:`29195`).
 
-* Fixed admin autocomplete widget's translations for `zh-hans` and `zh-hant`
-  languages (:ticket:`29213`).
+* Fixed admin autocomplete widget's translations for ``zh-hans`` and
+  ``zh-hant`` languages (:ticket:`29213`).
 
 * Corrected admin's autocomplete widget to add a space after custom classes
   (:ticket:`29221`).

--- a/docs/releases/2.2.8.txt
+++ b/docs/releases/2.2.8.txt
@@ -49,7 +49,7 @@ Bugfixes
 
 * Fixed a data loss possibility in the admin changelist view when a custom
   :ref:`formset's prefix <formset-prefix>` contains regular expression special
-  characters, e.g. `'$'` (:ticket:`31031`).
+  characters, e.g. ``'$'`` (:ticket:`31031`).
 
 * Fixed a regression in Django 2.2.1 that caused a crash when migrating
   permissions for proxy models with a multiple database setup if the

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -458,7 +458,7 @@ Miscellaneous
   :func:`~django.contrib.sitemaps.ping_google` function, set the new
   ``sitemap_uses_https`` argument to ``False``.
 
-* :djadmin:`runserver` no longer supports `pyinotify` (replaced by Watchman).
+* :djadmin:`runserver` no longer supports ``pyinotify`` (replaced by Watchman).
 
 * The :class:`~django.db.models.Avg`, :class:`~django.db.models.StdDev`, and
   :class:`~django.db.models.Variance` aggregate functions now return a

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -446,6 +446,7 @@ permalink
 pessimization
 Peucker
 pgAdmin
+pgBouncer
 PGRaster
 phishing
 php

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -446,7 +446,7 @@ permalink
 pessimization
 Peucker
 pgAdmin
-pgBouncer
+PgBouncer
 PGRaster
 phishing
 php

--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -124,7 +124,7 @@ The following path converters are available by default:
 * ``str`` - Matches any non-empty string, excluding the path separator, ``'/'``.
   This is the default if a converter isn't included in the expression.
 
-* ``int`` - Matches zero or any positive integer. Returns an `int`.
+* ``int`` - Matches zero or any positive integer. Returns an ``int``.
 
 * ``slug`` - Matches any slug string consisting of ASCII letters or numbers,
   plus the hyphen and underscore characters. For example,


### PR DESCRIPTION
Add a custom role via [`Sphinx.add_role()`](https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.sphinx.add_role) that errors if used, and set it as the "default role", used by the single backtick syntax.

Also add a custom [pyenchant spellchecker filter](https://pyenchant.github.io/pyenchant/tutorial.html#filters) via [sphinxcontrib-spelling](https://sphinxcontrib-spelling.readthedocs.io/en/latest/customize.html#custom-word-filters) to allow "Node.js" as a word.

The default default role is undefined by Sphinx, but comes out as italics. All of the existing uses were not for italics, but rather:
* Mistaken code syntax, since Markdown uses single backticks
* Forgotten roles like `:ref:`
* Forgotten trailing underscores for links
* Subverting the spellchecker

This will prevent such busy work / fixes as #12639 and #12536, plus the numerous fixes here.