### PR TITLE
Fixed #31411 -- Used RENAME COLUMN on MariaDB 10.5.2+.

### DIFF
--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -13,8 +13,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     # No 'CASCADE' which works as a no-op in MySQL but is undocumented
     sql_delete_column = "ALTER TABLE %(table)s DROP COLUMN %(column)s"
 
-    sql_rename_column = "ALTER TABLE %(table)s CHANGE %(old_column)s %(new_column)s %(type)s"
-
     sql_delete_unique = "ALTER TABLE %(table)s DROP INDEX %(name)s"
     sql_create_column_inline_fk = (
         ', ADD CONSTRAINT %(name)s FOREIGN KEY (%(column)s) '
@@ -37,6 +35,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # crash. Constraint is removed during a "MODIFY" column statement.
             return 'ALTER TABLE %(table)s DROP CONSTRAINT IF EXISTS %(name)s'
         return 'ALTER TABLE %(table)s DROP CHECK %(name)s'
+
+    @property
+    def sql_rename_column(self):
+        if self.connection.mysql_is_mariadb and self.connection.mysql_version >= (10, 5, 2):
+            return super().sql_rename_column
+        return 'ALTER TABLE %(table)s CHANGE %(old_column)s %(new_column)s %(type)s'
 
     def quote_value(self, value):
         self.connection.ensure_connection()


### PR DESCRIPTION
Fixes [ticket 31411](https://code.djangoproject.com/ticket/31411).