### PR TITLE
Refs #29988 -- Changed simple .format() calls to use f-strings.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1455,8 +1455,8 @@ class ModelAdmin(BaseModelAdmin):
         return TemplateResponse(
             request,
             self.delete_confirmation_template or [
-                "admin/{}/{}/delete_confirmation.html".format(app_label, opts.model_name),
-                "admin/{}/delete_confirmation.html".format(app_label),
+                f"admin/{app_label}/{opts.model_name}/delete_confirmation.html",
+                f"admin/{app_label}/delete_confirmation.html",
                 "admin/delete_confirmation.html",
             ],
             context,
@@ -1959,7 +1959,7 @@ class ModelAdmin(BaseModelAdmin):
                 """Return whether or not the user deleted the form."""
                 return (
                     inline.has_delete_permission(request, obj) and
-                    '{}-{}-DELETE'.format(formset.prefix, index) in request.POST
+                    f'{formset.prefix}-{index}-DELETE' in request.POST
                 )
 
             # Bypass validation of each view-only inline form (since the form's

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -145,7 +145,7 @@ def result_headers(cl):
             continue
 
         # OK, it is sortable if we got this far
-        th_classes = ['sortable', 'column-{}'.format(field_name)]
+        th_classes = ['sortable', f'column-{field_name}']
         order_type = ''
         new_order_type = 'asc'
         sort_priority = 0

--- a/django/contrib/auth/migrations/0011_update_proxy_permissions.py
+++ b/django/contrib/auth/migrations/0011_update_proxy_permissions.py
@@ -46,8 +46,8 @@ def update_proxy_model_permissions(apps, schema_editor, reverse=False):
                     content_type=old_content_type,
                 ).update(content_type=new_content_type)
         except IntegrityError:
-            old = '{}_{}'.format(old_content_type.app_label, old_content_type.model)
-            new = '{}_{}'.format(new_content_type.app_label, new_content_type.model)
+            old = f'{old_content_type.app_label}_{old_content_type.model}'
+            new = f'{new_content_type.app_label}_{new_content_type.model}'
             sys.stdout.write(style.WARNING(WARNING.format(old=old, new=new, query=permissions_query)))
 
 

--- a/django/contrib/auth/mixins.py
+++ b/django/contrib/auth/mixins.py
@@ -93,7 +93,7 @@ class UserPassesTestMixin(AccessMixin):
 
     def test_func(self):
         raise NotImplementedError(
-            '{} is missing the implementation of the test_func() method.'.format(self.__class__.__name__)
+            f'{self.__class__.__name__} is missing the implementation of the test_func() method.'
         )
 
     def get_test_func(self):

--- a/django/contrib/gis/gdal/raster/source.py
+++ b/django/contrib/gis/gdal/raster/source.py
@@ -84,7 +84,7 @@ class GDALRaster(GDALRasterBase):
                 # GDALOpen will auto-detect the data source type.
                 self._ptr = capi.open_ds(force_bytes(ds_input), self._write)
             except GDALException as err:
-                raise GDALException('Could not open the datasource at "{}" ({}).'.format(ds_input, err))
+                raise GDALException(f'Could not open the datasource at "{ds_input}" ({err}).')
         elif isinstance(ds_input, bytes):
             # Create a new raster in write mode.
             self._write = 1
@@ -119,7 +119,7 @@ class GDALRaster(GDALRasterBase):
 
             # For out of memory drivers, check filename argument
             if driver.name != 'MEM' and 'name' not in ds_input:
-                raise GDALException('Specify name for creation of raster with driver "{}".'.format(driver.name))
+                raise GDALException(f'Specify name for creation of raster with driver "{driver.name}".')
 
             # Check if width and height where specified
             if 'width' not in ds_input or 'height' not in ds_input:
@@ -132,7 +132,7 @@ class GDALRaster(GDALRasterBase):
             # Create null terminated gdal options array.
             papsz_options = []
             for key, val in ds_input.get('papsz_options', {}).items():
-                option = '{}={}'.format(key, val)
+                option = f'{key}={val}'
                 papsz_options.append(option.upper().encode())
             papsz_options.append(None)
 

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -117,7 +117,7 @@ class SearchVector(SearchVectorCombinable, Func):
         extra_params = []
         if clone.weight:
             weight_sql, extra_params = compiler.compile(clone.weight)
-            sql = 'setweight({}, {})'.format(sql, weight_sql)
+            sql = f'setweight({sql}, {weight_sql})'
         return sql, config_params + params + extra_params
 
 

--- a/django/core/checks/urls.py
+++ b/django/core/checks/urls.py
@@ -105,6 +105,6 @@ def check_url_settings(app_configs, **kwargs):
 
 def E006(name):
     return Error(
-        'The {} setting must end with a slash.'.format(name),
+        f'The {name} setting must end with a slash.',
         id='urls.E006',
     )

--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -99,4 +99,4 @@ class Command(BaseCommand):
                 return getattr(self, shell)(options)
             except ImportError:
                 pass
-        raise CommandError("Couldn't import {} interface.".format(shell))
+        raise CommandError(f"Couldn't import {shell} interface.")

--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -117,9 +117,9 @@ class Paginator:
         ordered = getattr(self.object_list, 'ordered', None)
         if ordered is not None and not ordered:
             obj_list_repr = (
-                '{} {}'.format(self.object_list.model, self.object_list.__class__.__name__)
+                f'{self.object_list.model} {self.object_list.__class__.__name__}'
                 if hasattr(self.object_list, 'model')
-                else '{!r}'.format(self.object_list)
+                else f'{self.object_list!r}'
             )
             warnings.warn(
                 'Pagination may yield inconsistent results with an unordered '

--- a/django/db/backends/ddl_references.py
+++ b/django/db/backends/ddl_references.py
@@ -87,7 +87,7 @@ class Columns(TableColumns):
             try:
                 suffix = self.col_suffixes[idx]
                 if suffix:
-                    col = '{} {}'.format(col, suffix)
+                    col = f'{col} {suffix}'
             except IndexError:
                 pass
             return col
@@ -120,7 +120,7 @@ class IndexColumns(Columns):
             try:
                 suffix = self.col_suffixes[idx]
                 if suffix:
-                    col = '{} {}'.format(col, suffix)
+                    col = f'{col} {suffix}'
             except IndexError:
                 pass
             return col

--- a/django/db/backends/postgresql/creation.py
+++ b/django/db/backends/postgresql/creation.py
@@ -14,7 +14,7 @@ class DatabaseCreation(BaseDatabaseCreation):
     def _get_database_create_suffix(self, encoding=None, template=None):
         suffix = ""
         if encoding:
-            suffix += " ENCODING '{}'".format(encoding)
+            suffix += f" ENCODING '{encoding}'"
         if template:
             suffix += " TEMPLATE {}".format(self._quote_name(template))
         return suffix and "WITH" + suffix

--- a/django/db/backends/sqlite3/creation.py
+++ b/django/db/backends/sqlite3/creation.py
@@ -55,7 +55,7 @@ class DatabaseCreation(BaseDatabaseCreation):
             return orig_settings_dict
         else:
             root, ext = os.path.splitext(orig_settings_dict['NAME'])
-            return {**orig_settings_dict, 'NAME': '{}_{}.{}'.format(root, suffix, ext)}
+            return {**orig_settings_dict, 'NAME': f'{root}_{suffix}.{ext}'}
 
     def _clone_test_db(self, suffix, verbosity, keepdb=False):
         source_database_name = self.connection.settings_dict['NAME']

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -236,7 +236,7 @@ def format_number(value, max_digits, decimal_places):
     else:
         context.traps[decimal.Rounded] = 1
         value = context.create_decimal(value)
-    return "{:f}".format(value)
+    return f"{value:f}"
 
 
 def strip_quotes(table_name):

--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -124,7 +124,7 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
         print("Type 'exit' to exit this prompt")
         while True:
             if default:
-                prompt = "[default: {}] >>> ".format(default)
+                prompt = f"[default: {default}] >>> "
             else:
                 prompt = ">>> "
             code = input(prompt)

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -129,7 +129,7 @@ class EnumSerializer(BaseSerializer):
 class FloatSerializer(BaseSimpleSerializer):
     def serialize(self):
         if math.isnan(self.value) or math.isinf(self.value):
-            return 'float("{}")'.format(self.value), set()
+            return f'float("{self.value}")', set()
         return super().serialize()
 
 

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -427,10 +427,10 @@ class CombinedExpression(SQLiteNumericMixin, Expression):
         self.rhs = rhs
 
     def __repr__(self):
-        return "<{}: {}>".format(self.__class__.__name__, self)
+        return f"<{self.__class__.__name__}: {self}>"
 
     def __str__(self):
-        return "{} {} {}".format(self.lhs, self.connector, self.rhs)
+        return f"{self.lhs} {self.connector} {self.rhs}"
 
     def get_source_expressions(self):
         return [self.lhs, self.rhs]
@@ -530,7 +530,7 @@ class F(Combinable):
         self.name = name
 
     def __repr__(self):
-        return "{}({})".format(self.__class__.__name__, self.name)
+        return f"{self.__class__.__name__}({self.name})"
 
     def resolve_expression(self, query=None, allow_joins=True, reuse=None,
                            summarize=False, for_save=False):
@@ -612,8 +612,8 @@ class Func(SQLiteNumericMixin, Expression):
         extra = {**self.extra, **self._get_repr_options()}
         if extra:
             extra = ', '.join(str(key) + '=' + str(val) for key, val in sorted(extra.items()))
-            return "{}({}, {})".format(self.__class__.__name__, args, extra)
-        return "{}({})".format(self.__class__.__name__, args)
+            return f"{self.__class__.__name__}({args}, {extra})"
+        return f"{self.__class__.__name__}({args})"
 
     def _get_repr_options(self):
         """Return a dict of extra __init__() options to include in the repr."""
@@ -675,7 +675,7 @@ class Value(Expression):
         self.value = value
 
     def __repr__(self):
-        return "{}({})".format(self.__class__.__name__, self.value)
+        return f"{self.__class__.__name__}({self.value})"
 
     def as_sql(self, compiler, connection):
         connection.ops.check_expression_support(self)
@@ -720,7 +720,7 @@ class RawSQL(Expression):
         super().__init__(output_field=output_field)
 
     def __repr__(self):
-        return "{}({}, {})".format(self.__class__.__name__, self.sql, self.params)
+        return f"{self.__class__.__name__}({self.sql}, {self.params})"
 
     def as_sql(self, compiler, connection):
         return '(%s)' % self.sql, self.params
@@ -804,7 +804,7 @@ class Ref(Expression):
         self.refs, self.source = refs, source
 
     def __repr__(self):
-        return "{}({}, {})".format(self.__class__.__name__, self.refs, self.source)
+        return f"{self.__class__.__name__}({self.refs}, {self.source})"
 
     def get_source_expressions(self):
         return [self.source]
@@ -864,7 +864,7 @@ class ExpressionWrapper(Expression):
         return self.expression.as_sql(compiler, connection)
 
     def __repr__(self):
-        return "{}({})".format(self.__class__.__name__, self.expression)
+        return f"{self.__class__.__name__}({self.expression})"
 
 
 class When(Expression):
@@ -1081,14 +1081,14 @@ class Exists(Subquery):
     def as_sql(self, compiler, connection, template=None, **extra_context):
         sql, params = super().as_sql(compiler, connection, template, **extra_context)
         if self.negated:
-            sql = 'NOT {}'.format(sql)
+            sql = f'NOT {sql}'
         return sql, params
 
     def select_format(self, compiler, sql, params):
         # Wrap EXISTS() with a CASE WHEN expression if a database backend
         # (e.g. Oracle) doesn't support boolean expression in the SELECT list.
         if not compiler.connection.features.supports_boolean_expr_in_select_clause:
-            sql = 'CASE WHEN {} THEN 1 ELSE 0 END'.format(sql)
+            sql = f'CASE WHEN {sql} THEN 1 ELSE 0 END'
         return sql, params
 
 

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -691,7 +691,7 @@ class QuerySet:
         if id_list is not None:
             if not id_list:
                 return {}
-            filter_key = '{}__in'.format(field_name)
+            filter_key = f'{field_name}__in'
             batch_size = connections[self.db].features.max_query_params
             id_list = tuple(id_list)
             # If the database has a limit on the number of query parameters

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -451,11 +451,11 @@ class SQLCompiler:
                     # Wrap in a subquery if wrapping in parentheses isn't
                     # supported.
                     if not features.supports_parentheses_in_compound:
-                        part_sql = 'SELECT * FROM ({})'.format(part_sql)
+                        part_sql = f'SELECT * FROM ({part_sql})'
                     # Add parentheses when combining with compound query if not
                     # already added for all compound queries.
                     elif not features.supports_slicing_ordering_in_compound:
-                        part_sql = '({})'.format(part_sql)
+                        part_sql = f'({part_sql})'
                 parts += ((part_sql, part_args),)
             except EmptyResultSet:
                 # Omit the empty queryset with UNION and with DIFFERENCE if the
@@ -470,7 +470,7 @@ class SQLCompiler:
             combinator_sql += ' ALL'
         braces = '({})' if features.supports_slicing_ordering_in_compound else '{}'
         sql_parts, args_parts = zip(*((braces.format(sql), args) for sql, args in parts))
-        result = [' {} '.format(combinator_sql).join(sql_parts)]
+        result = [f' {combinator_sql} '.join(sql_parts)]
         params = []
         for part in args_parts:
             params.extend(part)
@@ -493,8 +493,8 @@ class SQLCompiler:
             combinator = self.query.combinator
             features = self.connection.features
             if combinator:
-                if not getattr(features, 'supports_select_{}'.format(combinator)):
-                    raise NotSupportedError('{} is not supported on this database backend.'.format(combinator))
+                if not getattr(features, f'supports_select_{combinator}'):
+                    raise NotSupportedError(f'{combinator} is not supported on this database backend.')
                 result, params = self.get_combinator_sql(combinator, self.query.combinator_all)
             else:
                 distinct_fields, distinct_params = self.get_distinct()

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1151,7 +1151,7 @@ class Query(BaseExpression):
         lookup_class = lhs.get_lookup(lookup_name)
         if not lookup_class:
             if lhs.field.is_relation:
-                raise FieldError('Related Field got invalid lookup: {}'.format(lookup_name))
+                raise FieldError(f'Related Field got invalid lookup: {lookup_name}')
             # A lookup wasn't found. Try to interpret the name as a transform
             # and do an Exact lookup against it.
             lhs = self.try_transform(lhs, lookup_name)

--- a/django/forms/utils.py
+++ b/django/forms/utils.py
@@ -87,7 +87,7 @@ class ErrorList(UserList, list):
         if error_class is None:
             self.error_class = 'errorlist'
         else:
-            self.error_class = 'errorlist {}'.format(error_class)
+            self.error_class = f'errorlist {error_class}'
 
     def as_data(self):
         return ValidationError(self.data).error_list

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -1079,6 +1079,6 @@ class SelectDateWidget(Widget):
 
     def value_omitted_from_data(self, data, files, name):
         return not any(
-            ('{}_{}'.format(name, interval) in data)
+            (f'{name}_{interval}' in data)
             for interval in ('year', 'month', 'day')
         )

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -231,7 +231,7 @@ class HttpRequest:
 
     @cached_property
     def _current_scheme_host(self):
-        return '{}://{}'.format(self.scheme, self.get_host())
+        return f'{self.scheme}://{self.get_host()}'
 
     def _get_scheme(self):
         """

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -444,10 +444,10 @@ class FileResponse(StreamingHttpResponse):
             disposition = 'attachment' if self.as_attachment else 'inline'
             try:
                 filename.encode('ascii')
-                file_expr = 'filename="{}"'.format(filename)
+                file_expr = f'filename="{filename}"'
             except UnicodeEncodeError:
                 file_expr = "filename*=utf-8''{}".format(quote(filename))
-            self['Content-Disposition'] = '{}; {}'.format(disposition, file_expr)
+            self['Content-Disposition'] = f'{disposition}; {file_expr}'
         elif self.as_attachment:
             self['Content-Disposition'] = 'attachment'
 

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -970,7 +970,7 @@ def do_if(parser, token):
 
     # {% endif %}
     if token.contents != 'endif':
-        raise TemplateSyntaxError('Malformed template tag at line {}: "{}"'.format(token.lineno, token.contents))
+        raise TemplateSyntaxError(f'Malformed template tag at line {token.lineno}: "{token.contents}"')
 
     return IfNode(conditions_nodelists)
 

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -114,9 +114,9 @@ class CheckURLMixin:
         """
         Format the URL pattern for display in warning messages.
         """
-        description = "'{}'".format(self)
+        description = f"'{self}'"
         if self.name:
-            description += " [name='{}']".format(self.name)
+            description += f" [name='{self.name}']"
         return description
 
     def _check_pattern_startswith_slash(self):
@@ -315,7 +315,7 @@ class LocalePrefixPattern:
         return []
 
     def describe(self):
-        return "'{}'".format(self)
+        return f"'{self}'"
 
     def __str__(self):
         return self.language_prefix

--- a/django/utils/duration.py
+++ b/django/utils/duration.py
@@ -19,11 +19,11 @@ def duration_string(duration):
     """Version of str(timedelta) which is not English specific."""
     days, hours, minutes, seconds, microseconds = _get_duration_components(duration)
 
-    string = '{:02d}:{:02d}:{:02d}'.format(hours, minutes, seconds)
+    string = f'{hours:02d}:{minutes:02d}:{seconds:02d}'
     if days:
-        string = '{} '.format(days) + string
+        string = f'{days} ' + string
     if microseconds:
-        string += '.{:06d}'.format(microseconds)
+        string += f'.{microseconds:06d}'
 
     return string
 
@@ -36,8 +36,8 @@ def duration_iso_string(duration):
         sign = ''
 
     days, hours, minutes, seconds, microseconds = _get_duration_components(duration)
-    ms = '.{:06d}'.format(microseconds) if microseconds else ""
-    return '{}P{}DT{:02d}H{:02d}M{:02d}{}S'.format(sign, days, hours, minutes, seconds, ms)
+    ms = f'.{microseconds:06d}' if microseconds else ""
+    return f'{sign}P{days}DT{hours:02d}H{minutes:02d}M{seconds:02d}{ms}S'
 
 
 def duration_microseconds(delta):

--- a/django/utils/numberformat.py
+++ b/django/utils/numberformat.py
@@ -42,16 +42,16 @@ def format(number, decimal_sep, decimal_pos=None, grouping=0, thousand_sep='',
         # scientific notation to avoid high memory usage in {:f}'.format().
         _, digits, exponent = number.as_tuple()
         if abs(exponent) + len(digits) > 200:
-            number = '{:e}'.format(number)
+            number = f'{number:e}'
             coefficient, exponent = number.split('e')
             # Format the coefficient.
             coefficient = format(
                 coefficient, decimal_sep, decimal_pos, grouping,
                 thousand_sep, force_grouping, use_l10n,
             )
-            return '{}e{}'.format(coefficient, exponent)
+            return f'{coefficient}e{exponent}'
         else:
-            str_number = '{:f}'.format(number)
+            str_number = f'{number:f}'
     else:
         str_number = str(number)
     if str_number[0] == '-':

--- a/django/utils/translation/template.py
+++ b/django/utils/translation/template.py
@@ -184,7 +184,7 @@ def templatize(src, origin=None):
                         ))
                         message_context = None
                     else:
-                        out.write(' gettext({p}{!r}) '.format(g, p=raw_prefix))
+                        out.write(f' gettext({raw_prefix}{g!r}) ')
                 elif bmatch:
                     for fmatch in constant_re.findall(t.contents):
                         out.write(' _(%s) ' % fmatch)

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -175,7 +175,7 @@ class SafeExceptionReporterFilter:
             # MultiValueDicts will have a return value.
             is_multivalue_dict = isinstance(value, MultiValueDict)
         except Exception as e:
-            return '{!r} while evaluating {!r}'.format(e, value)
+            return f'{e!r} while evaluating {value!r}'
 
         if is_multivalue_dict:
             # Cleanse MultiValueDicts (request.POST is the one we usually care about)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5844,7 +5844,7 @@ class AdminKeepChangeListFiltersTests(TestCase):
             'http://testserver{}?_changelist_filters=is_staff__exact%3D0%26is_superuser__exact%3D0'.format(
                 change_user_url
             ),
-            '{}?_changelist_filters=is_staff__exact%3D0%26is_superuser__exact%3D0'.format(change_user_url)
+            f'{change_user_url}?_changelist_filters=is_staff__exact%3D0%26is_superuser__exact%3D0'
         )
 
         # Ignore ordering of querystring.
@@ -5855,8 +5855,8 @@ class AdminKeepChangeListFiltersTests(TestCase):
 
         # Ignore ordering of _changelist_filters.
         self.assertURLEqual(
-            '{}?_changelist_filters=is_staff__exact%3D0%26is_superuser__exact%3D0'.format(change_user_url),
-            '{}?_changelist_filters=is_superuser__exact%3D0%26is_staff__exact%3D0'.format(change_user_url)
+            f'{change_user_url}?_changelist_filters=is_staff__exact%3D0%26is_superuser__exact%3D0',
+            f'{change_user_url}?_changelist_filters=is_superuser__exact%3D0%26is_staff__exact%3D0'
         )
 
     def get_changelist_filters(self):
@@ -5921,7 +5921,7 @@ class AdminKeepChangeListFiltersTests(TestCase):
 
         # Check the `change_view` link has the correct querystring.
         detail_link = re.search(
-            '<a href="(.*?)">{}</a>'.format(self.joepublicuser.username),
+            f'<a href="(.*?)">{self.joepublicuser.username}</a>',
             response.content.decode()
         )
         self.assertURLEqual(detail_link.group(1), self.get_change_url())

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -1039,7 +1039,7 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
 
         # Choose some options ------------------------------------------------
         from_lisa_select_option = self.selenium.find_element_by_css_selector(
-            '{} > option[value="{}"]'.format(from_box, self.lisa.id)
+            f'{from_box} > option[value="{self.lisa.id}"]'
         )
 
         # Check the title attribute is there for tool tips: ticket #20821
@@ -1064,7 +1064,7 @@ class HorizontalVerticalFilterSeleniumTests(AdminWidgetSeleniumTestCase):
 
         # Check the tooltip is still there after moving: ticket #20821
         to_lisa_select_option = self.selenium.find_element_by_css_selector(
-            '{} > option[value="{}"]'.format(to_box, self.lisa.id)
+            f'{to_box} > option[value="{self.lisa.id}"]'
         )
         self.assertEqual(to_lisa_select_option.get_attribute('title'), to_lisa_select_option.get_attribute('text'))
 

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -830,7 +830,7 @@ class AggregateTestCase(TestCase):
         thedate = timezone.now()
         for i in range(10):
             Book.objects.create(
-                isbn="abcde{}".format(i), name="none", pages=10, rating=4.0,
+                isbn=f"abcde{i}", name="none", pages=10, rating=4.0,
                 price=9999.98, contact=a1, publisher=p1, pubdate=thedate)
 
         book = Book.objects.aggregate(price_sum=Sum('price'))

--- a/tests/annotations/models.py
+++ b/tests/annotations/models.py
@@ -83,4 +83,4 @@ class Ticket(models.Model):
     duration = models.DurationField()
 
     def __str__(self):
-        return '{} - {}'.format(self.active_at, self.duration)
+        return f'{self.active_at} - {self.duration}'

--- a/tests/auth_tests/test_basic.py
+++ b/tests/auth_tests/test_basic.py
@@ -61,7 +61,7 @@ class BasicTestCase(TestCase):
         for i, kwargs in enumerate(cases):
             with self.subTest(**kwargs):
                 u = User.objects.create_user(
-                    'testuser{}'.format(i),
+                    f'testuser{i}',
                     **kwargs
                 )
                 self.assertEqual(u.email, '')
@@ -83,7 +83,7 @@ class BasicTestCase(TestCase):
         for i, kwargs in enumerate(cases):
             with self.subTest(**kwargs):
                 superuser = User.objects.create_superuser(
-                    'super{}'.format(i),
+                    f'super{i}',
                     **kwargs
                 )
                 self.assertEqual(superuser.email, '')

--- a/tests/backends/base/test_base.py
+++ b/tests/backends/base/test_base.py
@@ -48,7 +48,7 @@ class ExecuteWrapperTests(TestCase):
     def call_executemany(self, connection, params=None):
         # executemany() must use an update query. Make sure it does nothing
         # by putting a false condition in the WHERE clause.
-        sql = 'DELETE FROM {} WHERE 0=1 AND 0=%s'.format(Square._meta.db_table)
+        sql = f'DELETE FROM {Square._meta.db_table} WHERE 0=1 AND 0=%s'
         if params is None:
             params = [(i,) for i in range(3)]
         with connection.cursor() as cursor:

--- a/tests/backends/postgresql/test_server_side_cursors.py
+++ b/tests/backends/postgresql/test_server_side_cursors.py
@@ -21,7 +21,7 @@ class ServerSideCursorsPostgres(TestCase):
 
     def inspect_cursors(self):
         with connection.cursor() as cursor:
-            cursor.execute('SELECT {fields} FROM pg_cursors;'.format(fields=self.cursor_fields))
+            cursor.execute(f'SELECT {self.cursor_fields} FROM pg_cursors;')
             cursors = cursor.fetchall()
         return [self.PostgresCursor._make(cursor) for cursor in cursors]
 

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -244,7 +244,7 @@ def custom_key_func(key, key_prefix, version):
 
 _caches_setting_base = {
     'default': {},
-    'prefix': {'KEY_PREFIX': 'cacheprefix{}'.format(os.getpid())},
+    'prefix': {'KEY_PREFIX': f'cacheprefix{os.getpid()}'},
     'v2': {'VERSION': 2},
     'custom_key': {'KEY_FUNCTION': custom_key_func},
     'custom_key2': {'KEY_FUNCTION': 'cache.tests.custom_key_func'},

--- a/tests/check_framework/test_urls.py
+++ b/tests/check_framework/test_urls.py
@@ -172,7 +172,7 @@ class CheckCustomErrorHandlersTests(SimpleTestCase):
         result = check_url_config(None)
         self.assertEqual(len(result), 4)
         for code, num_params, error in zip([400, 403, 404, 500], [2, 2, 2, 1], result):
-            with self.subTest('handler{}'.format(code)):
+            with self.subTest(f'handler{code}'):
                 self.assertEqual(error, Error(
                     "The custom handler{} view "
                     "'check_framework.urls.bad_error_handlers.bad_handler' "
@@ -197,9 +197,9 @@ class CheckCustomErrorHandlersTests(SimpleTestCase):
             "Could not import '{}'. The path must be fully qualified.",
         ]
         for code, path, hint, error in zip([400, 403, 404, 500], paths, hints, result):
-            with self.subTest('handler{}'.format(code)):
+            with self.subTest(f'handler{code}'):
                 self.assertEqual(error, Error(
-                    "The custom handler{} view '{}' could not be imported.".format(code, path),
+                    f"The custom handler{code} view '{path}' could not be imported.",
                     hint=hint.format(path),
                     id='urls.E008',
                 ))

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -58,7 +58,7 @@ class CheckConstraintTests(TestCase):
         constraint = models.CheckConstraint(check=check, name=name)
         self.assertEqual(
             repr(constraint),
-            "<CheckConstraint: check='{}' name='{}'>".format(check, name),
+            f"<CheckConstraint: check='{check}' name='{name}'>",
         )
 
     def test_invalid_check_types(self):

--- a/tests/custom_lookups/tests.py
+++ b/tests/custom_lookups/tests.py
@@ -212,7 +212,7 @@ class DateTimeTransform(models.Transform):
 
     def as_sql(self, compiler, connection):
         lhs, params = compiler.compile(self.lhs)
-        return 'from_unixtime({})'.format(lhs), params
+        return f'from_unixtime({lhs})', params
 
 
 class LookupTests(TestCase):

--- a/tests/datetimes/tests.py
+++ b/tests/datetimes/tests.py
@@ -132,7 +132,7 @@ class DateTimesTests(TestCase):
             datetime.datetime(2005, 7, 30, 5, 15),
             datetime.datetime(2005, 7, 31, 19, 15)]
         for i, pub_date in enumerate(pub_dates):
-            Article(pub_date=pub_date, title='title #{}'.format(i)).save()
+            Article(pub_date=pub_date, title=f'title #{i}').save()
 
         self.assertQuerysetEqual(
             Article.objects.datetimes('pub_date', 'year'),
@@ -169,7 +169,7 @@ class DateTimesTests(TestCase):
             datetime.datetime(2005, 7, 30, 5, 15),
             datetime.datetime(2005, 7, 31, 19, 15)]
         for i, pub_date in enumerate(pub_dates):
-            Article(pub_date=pub_date, title='title #{}'.format(i)).save()
+            Article(pub_date=pub_date, title=f'title #{i}').save()
         # Use iterator() with datetimes() to return a generator that lazily
         # requests each result one at a time, to save memory.
         dates = []

--- a/tests/db_functions/models.py
+++ b/tests/db_functions/models.py
@@ -49,7 +49,7 @@ class DTModel(models.Model):
     duration = models.DurationField(null=True, blank=True)
 
     def __str__(self):
-        return 'DTModel({})'.format(self.name)
+        return f'DTModel({self.name})'
 
 
 class DecimalModel(models.Model):

--- a/tests/dbshell/test_mysql.py
+++ b/tests/dbshell/test_mysql.py
@@ -27,7 +27,7 @@ class MySqlDbshellCommandTestCase(SimpleTestCase):
         self.assertNotEqual(settings_port, options_port, 'test pre-req')
         self.assertEqual(
             ['mysql', '--user=optionuser', '--password=optionpassword',
-             '--host=optionhost', '--port={}'.format(options_port), 'optiondbname'],
+             '--host=optionhost', f'--port={options_port}', 'optiondbname'],
             self.get_command_line_arguments({
                 'NAME': 'settingdbname',
                 'USER': 'settinguser',

--- a/tests/expressions_window/models.py
+++ b/tests/expressions_window/models.py
@@ -14,4 +14,4 @@ class Employee(models.Model):
     classification = models.ForeignKey('Classification', on_delete=models.CASCADE, null=True)
 
     def __str__(self):
-        return '{}, {}, {}, {}'.format(self.name, self.department, self.salary, self.hire_date)
+        return f'{self.name}, {self.department}, {self.salary}, {self.hire_date}'

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -318,7 +318,7 @@ class FileUploadTests(TestCase):
         result = response.json()
         for name, _, expected in cases:
             got = result[name]
-            self.assertEqual(expected, got, 'Mismatch for {}'.format(name))
+            self.assertEqual(expected, got, f'Mismatch for {name}')
             self.assertLess(len(got), 256,
                             "Got a long file name (%s characters)." % len(got))
 

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -324,7 +324,7 @@ class EmptyLabelTestCase(TestCase):
                 self.assertTrue(f.is_valid())
                 m = f.save()
                 self.assertEqual(expected, getattr(m, key))
-                self.assertEqual('No Preference', getattr(m, 'get_{}_display'.format(key))())
+                self.assertEqual('No Preference', getattr(m, f'get_{key}_display')())
 
     def test_empty_field_integer(self):
         f = EmptyIntegerLabelChoiceForm()

--- a/tests/generic_views/test_edit.py
+++ b/tests/generic_views/test_edit.py
@@ -143,7 +143,7 @@ class CreateViewTests(TestCase):
         )
         self.assertEqual(res.status_code, 302)
         pk = Author.objects.get(name='John Doe').pk
-        self.assertRedirects(res, '/%C3%A9dit/author/{}/update/'.format(pk))
+        self.assertRedirects(res, f'/%C3%A9dit/author/{pk}/update/')
 
     def test_create_with_special_properties(self):
         res = self.client.get('/edit/authors/create/special/')
@@ -284,7 +284,7 @@ class UpdateViewTests(TestCase):
         )
         self.assertEqual(res.status_code, 302)
         pk = Author.objects.get(name='John Doe').pk
-        self.assertRedirects(res, '/%C3%A9dit/author/{}/update/'.format(pk))
+        self.assertRedirects(res, f'/%C3%A9dit/author/{pk}/update/')
 
     def test_update_with_special_properties(self):
         res = self.client.get('/edit/author/%d/update/special/' % self.author.pk)
@@ -373,9 +373,9 @@ class DeleteViewTests(TestCase):
         self.assertQuerysetEqual(Author.objects.all(), [])
         # Also test with escaped chars in URL
         a = Author.objects.create(**{'name': 'Randall Munroe', 'slug': 'randall-munroe'})
-        res = self.client.post('/edit/author/{}/delete/interpolate_redirect_nonascii/'.format(a.pk))
+        res = self.client.post(f'/edit/author/{a.pk}/delete/interpolate_redirect_nonascii/')
         self.assertEqual(res.status_code, 302)
-        self.assertRedirects(res, '/%C3%A9dit/authors/create/?deleted={}'.format(a.pk))
+        self.assertRedirects(res, f'/%C3%A9dit/authors/create/?deleted={a.pk}')
 
     def test_delete_with_special_properties(self):
         res = self.client.get('/edit/author/%d/delete/special/' % self.author.pk)

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -251,8 +251,8 @@ class BasicExtractorTests(ExtractorTests):
 
             # {% translate %} with a filter
             for minor_part in 'abcdefgh':  # Iterate from #7.1a to #7.1h template markers
-                self.assertIn('msgctxt "context #7.1{}"'.format(minor_part), po_contents)
-                self.assertMsgId('Translatable literal #7.1{}'.format(minor_part), po_contents)
+                self.assertIn(f'msgctxt "context #7.1{minor_part}"', po_contents)
+                self.assertMsgId(f'Translatable literal #7.1{minor_part}', po_contents)
 
             # {% blocktranslate %}
             self.assertIn('msgctxt "Special blocktranslate context #1"', po_contents)

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -98,8 +98,8 @@ class InspectDBTestCase(TestCase):
             assertFieldType('big_int_field', "models.IntegerField()")
 
         bool_field_type = connection.features.introspected_boolean_field_type
-        assertFieldType('bool_field', "models.{}()".format(bool_field_type))
-        assertFieldType('null_bool_field', 'models.{}(blank=True, null=True)'.format(bool_field_type))
+        assertFieldType('bool_field', f"models.{bool_field_type}()")
+        assertFieldType('null_bool_field', f'models.{bool_field_type}(blank=True, null=True)')
 
         if connection.features.can_introspect_decimal_field:
             assertFieldType('decimal_field', "models.DecimalField(max_digits=6, decimal_places=1)")

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -733,7 +733,7 @@ class AutodetectorTests(TestCase):
 
     def test_supports_functools_partial(self):
         def _content_file_name(instance, filename, key, **kwargs):
-            return '{}/{}'.format(instance, filename)
+            return f'{instance}/{filename}'
 
         def content_file_name(key, **kwargs):
             return functools.partial(_content_file_name, key, **kwargs)

--- a/tests/postgres_tests/test_citext.py
+++ b/tests/postgres_tests/test_citext.py
@@ -47,17 +47,17 @@ class CITextTestCase(PostgreSQLTestCase):
     def test_lookups_name_char(self):
         for lookup in self.case_sensitive_lookups:
             with self.subTest(lookup=lookup):
-                query = {'name__{}'.format(lookup): 'john'}
+                query = {f'name__{lookup}': 'john'}
                 self.assertSequenceEqual(CITestModel.objects.filter(**query), [self.john])
 
     def test_lookups_description_text(self):
         for lookup, string in zip(self.case_sensitive_lookups, ('average', 'average joe', 'john', 'Joe.named')):
             with self.subTest(lookup=lookup, string=string):
-                query = {'description__{}'.format(lookup): string}
+                query = {f'description__{lookup}': string}
                 self.assertSequenceEqual(CITestModel.objects.filter(**query), [self.john])
 
     def test_lookups_email(self):
         for lookup, string in zip(self.case_sensitive_lookups, ('john', 'john', 'john.com', 'john.com')):
             with self.subTest(lookup=lookup, string=string):
-                query = {'email__{}'.format(lookup): string}
+                query = {f'email__{lookup}': string}
                 self.assertSequenceEqual(CITestModel.objects.filter(**query), [self.john])

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2359,7 +2359,7 @@ class QuerySetSupportsPythonIdioms(TestCase):
         some_date = datetime.datetime(2014, 5, 16, 12, 1)
         for i in range(1, 8):
             Article.objects.create(
-                name="Article {}".format(i), created=some_date)
+                name=f"Article {i}", created=some_date)
 
     def get_ordered_articles(self):
         return Article.objects.all().order_by('name')

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -250,7 +250,7 @@ class InLookupTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         for i in range(1, 3):
-            group = Group.objects.create(name='Group {}'.format(i))
+            group = Group.objects.create(name=f'Group {i}')
         cls.e1 = Event.objects.create(title='Event 1', group=group)
 
     def test_in_lookup_queryset_evaluation(self):

--- a/tests/responses/tests.py
+++ b/tests/responses/tests.py
@@ -145,7 +145,7 @@ class HttpResponseTests(SimpleTestCase):
         self.assertEqual(r.content, content.encode(UTF8))
 
     def test_generator_cache(self):
-        generator = ("{}".format(i) for i in range(10))
+        generator = (f"{i}" for i in range(10))
         response = HttpResponse(content=generator)
         self.assertEqual(response.content, b'0123456789')
         with self.assertRaises(StopIteration):

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -155,7 +155,7 @@ class SchemaTests(TransactionTestCase):
                                   cast_function=None):
         with connection.cursor() as cursor:
             schema_editor.add_field(model, field)
-            cursor.execute("SELECT {} FROM {};".format(field_name, model._meta.db_table))
+            cursor.execute(f"SELECT {field_name} FROM {model._meta.db_table};")
             database_default = cursor.fetchall()[0][0]
             if cast_function and not type(database_default) == type(expected_default):
                 database_default = cast_function(database_default)

--- a/tests/servers/views.py
+++ b/tests/servers/views.py
@@ -35,14 +35,14 @@ def subview(request):
 
 def subview_calling_view(request):
     with urlopen(request.GET['url'] + '/subview/') as response:
-        return HttpResponse('subview calling view: {}'.format(response.read().decode()))
+        return HttpResponse(f'subview calling view: {response.read().decode()}')
 
 
 def check_model_instance_from_subview(request):
     with urlopen(request.GET['url'] + '/create_model_instance/'):
         pass
     with urlopen(request.GET['url'] + '/model_view/') as response:
-        return HttpResponse('subview calling view: {}'.format(response.read().decode()))
+        return HttpResponse(f'subview calling view: {response.read().decode()}')
 
 
 @csrf_exempt

--- a/tests/template_tests/syntax_tests/i18n/test_blocktranslate.py
+++ b/tests/template_tests/syntax_tests/i18n/test_blocktranslate.py
@@ -256,7 +256,7 @@ class I18nBlockTransTagTests(SimpleTestCase):
 
     @setup({'template': '{% load i18n %}{% blocktranslate asvar %}Yes{% endblocktranslate %}'})
     def test_blocktrans_syntax_error_missing_assignment(self, tag_name):
-        msg = "No argument provided to the '{}' tag for the asvar option.".format(tag_name)
+        msg = f"No argument provided to the '{tag_name}' tag for the asvar option."
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string('template')
 
@@ -267,7 +267,7 @@ class I18nBlockTransTagTests(SimpleTestCase):
 
     @setup({'template': '{% load i18n %}{% blocktranslate %}{% block b %} {% endblock %}{% endblocktranslate %}'})
     def test_with_block(self, tag_name):
-        msg = "'{}' doesn't allow other block tags (seen 'block b') inside it".format(tag_name)
+        msg = f"'{tag_name}' doesn't allow other block tags (seen 'block b') inside it"
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string('template')
 
@@ -277,7 +277,7 @@ class I18nBlockTransTagTests(SimpleTestCase):
         '{% endblocktranslate %}'
     )})
     def test_with_for(self, tag_name):
-        msg = "'{}' doesn't allow other block tags (seen 'for b in [1, 2, 3]') inside it".format(tag_name)
+        msg = f"'{tag_name}' doesn't allow other block tags (seen 'for b in [1, 2, 3]') inside it"
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string('template')
 
@@ -288,13 +288,13 @@ class I18nBlockTransTagTests(SimpleTestCase):
 
     @setup({'template': '{% load i18n %}{% blocktranslate with %}{% endblocktranslate %}'})
     def test_no_args_with(self, tag_name):
-        msg = '"with" in \'{}\' tag needs at least one keyword argument.'.format(tag_name)
+        msg = f'"with" in \'{tag_name}\' tag needs at least one keyword argument.'
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string('template')
 
     @setup({'template': '{% load i18n %}{% blocktranslate count a %}{% endblocktranslate %}'})
     def test_count(self, tag_name):
-        msg = '"count" in \'{}\' tag expected exactly one keyword argument.'.format(tag_name)
+        msg = f'"count" in \'{tag_name}\' tag expected exactly one keyword argument.'
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string('template', {'a': [1, 2, 3]})
 
@@ -304,7 +304,7 @@ class I18nBlockTransTagTests(SimpleTestCase):
         '{% endblocktranslate %}'
     )})
     def test_plural_bad_syntax(self, tag_name):
-        msg = "'{}' doesn't allow other block tags inside it".format(tag_name)
+        msg = f"'{tag_name}' doesn't allow other block tags inside it"
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string('template', {'var': [1, 2, 3]})
 
@@ -316,10 +316,10 @@ class TranslationBlockTranslateTagTests(SimpleTestCase):
         return Template(
             template_string.replace(
                 '{{% blocktranslate ',
-                '{{% {}'.format(self.tag_name)
+                f'{{% {self.tag_name}'
             ).replace(
                 '{{% endblocktranslate %}}',
-                '{{% end{} %}}'.format(self.tag_name)
+                f'{{% end{self.tag_name} %}}'
             )
         )
 
@@ -482,10 +482,10 @@ class MultipleLocaleActivationBlockTranslateTests(MultipleLocaleActivationTestCa
         return Template(
             template_string.replace(
                 '{{% blocktranslate ',
-                '{{% {}'.format(self.tag_name)
+                f'{{% {self.tag_name}'
             ).replace(
                 '{{% endblocktranslate %}}',
-                '{{% end{} %}}'.format(self.tag_name)
+                f'{{% end{self.tag_name} %}}'
             )
         )
 
@@ -530,10 +530,10 @@ class MiscTests(SimpleTestCase):
         return Template(
             template_string.replace(
                 '{{% blocktranslate ',
-                '{{% {}'.format(self.tag_name)
+                f'{{% {self.tag_name}'
             ).replace(
                 '{{% endblocktranslate %}}',
-                '{{% end{} %}}'.format(self.tag_name)
+                f'{{% end{self.tag_name} %}}'
             )
         )
 

--- a/tests/template_tests/syntax_tests/i18n/test_translate.py
+++ b/tests/template_tests/syntax_tests/i18n/test_translate.py
@@ -113,37 +113,37 @@ class I18nTransTagTests(SimpleTestCase):
 
     @setup({'template': '{% load i18n %}{% translate %}A}'})
     def test_syntax_error_no_arguments(self, tag_name):
-        msg = "'{}' takes at least one argument".format(tag_name)
+        msg = f"'{tag_name}' takes at least one argument"
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string('template')
 
     @setup({'template': '{% load i18n %}{% translate "Yes" badoption %}'})
     def test_syntax_error_bad_option(self, tag_name):
-        msg = "Unknown argument for '{}' tag: 'badoption'".format(tag_name)
+        msg = f"Unknown argument for '{tag_name}' tag: 'badoption'"
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string('template')
 
     @setup({'template': '{% load i18n %}{% translate "Yes" as %}'})
     def test_syntax_error_missing_assignment(self, tag_name):
-        msg = "No argument provided to the '{}' tag for the as option.".format(tag_name)
+        msg = f"No argument provided to the '{tag_name}' tag for the as option."
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string('template')
 
     @setup({'template': '{% load i18n %}{% translate "Yes" as var context %}'})
     def test_syntax_error_missing_context(self, tag_name):
-        msg = "No argument provided to the '{}' tag for the context option.".format(tag_name)
+        msg = f"No argument provided to the '{tag_name}' tag for the context option."
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string('template')
 
     @setup({'template': '{% load i18n %}{% translate "Yes" context as var %}'})
     def test_syntax_error_context_as(self, tag_name):
-        msg = "Invalid argument 'as' provided to the '{}' tag for the context option".format(tag_name)
+        msg = f"Invalid argument 'as' provided to the '{tag_name}' tag for the context option"
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string('template')
 
     @setup({'template': '{% load i18n %}{% translate "Yes" context noop %}'})
     def test_syntax_error_context_noop(self, tag_name):
-        msg = "Invalid argument 'noop' provided to the '{}' tag for the context option".format(tag_name)
+        msg = f"Invalid argument 'noop' provided to the '{tag_name}' tag for the context option"
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string('template')
 
@@ -166,7 +166,7 @@ class TranslationTransTagTests(SimpleTestCase):
         return Template(
             template_string.replace(
                 '{{% translate ',
-                '{{% {}'.format(self.tag_name)
+                f'{{% {self.tag_name}'
             )
         )
 
@@ -225,7 +225,7 @@ class MultipleLocaleActivationTransTagTests(MultipleLocaleActivationTestCase):
         return Template(
             template_string.replace(
                 '{{% translate ',
-                '{{% {}'.format(self.tag_name)
+                f'{{% {self.tag_name}'
             )
         )
 

--- a/tests/template_tests/syntax_tests/test_if_changed.py
+++ b/tests/template_tests/syntax_tests/test_if_changed.py
@@ -183,13 +183,13 @@ class IfChangedTests(SimpleTestCase):
             iter2 = iter([1, 2, 3])
             output2 = template.render(Context({'foo': range(3), 'get_value': lambda: next(iter2)}))
             self.assertEqual(
-                output2, '[0,1,2,3]', 'Expected [0,1,2,3] in second parallel template, got {}'.format(output2)
+                output2, '[0,1,2,3]', f'Expected [0,1,2,3] in second parallel template, got {output2}'
             )
             yield 3
 
         gen1 = gen()
         output1 = template.render(Context({'foo': range(3), 'get_value': lambda: next(gen1)}))
-        self.assertEqual(output1, '[0,1,2,3]', 'Expected [0,1,2,3] in first template, got {}'.format(output1))
+        self.assertEqual(output1, '[0,1,2,3]', f'Expected [0,1,2,3] in first template, got {output1}')
 
     def test_ifchanged_render_once(self):
         """

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -917,7 +917,7 @@ class RequestFactoryTest(SimpleTestCase):
         request = self.request_factory.trace(url_path)
         response = trace_view(request)
         protocol = request.META["SERVER_PROTOCOL"]
-        echoed_request_line = "TRACE {} {}".format(url_path, protocol)
+        echoed_request_line = f"TRACE {url_path} {protocol}"
         self.assertContains(response, echoed_request_line)
 
 

--- a/tests/test_client/views.py
+++ b/tests/test_client/views.py
@@ -92,7 +92,7 @@ def json_view(request):
     if request.META.get('CONTENT_TYPE') != 'application/json':
         return HttpResponse()
 
-    t = Template('Viewing {} page. With data {{ data }}.'.format(request.method))
+    t = Template(f'Viewing {request.method} page. With data {{ data }}.')
     data = json.loads(request.body.decode('utf-8'))
     c = Context({'data': data})
     return HttpResponse(t.render(c))

--- a/tests/utils_tests/test_numberformat.py
+++ b/tests/utils_tests/test_numberformat.py
@@ -127,7 +127,7 @@ class TestNumberFormat(SimpleTestCase):
             """
             def __format__(self, specifier, **kwargs):
                 amount = super().__format__(specifier, **kwargs)
-                return '€ {}'.format(amount)
+                return f'€ {amount}'
 
         price = EuroDecimal('1.23')
         self.assertEqual(nformat(price, ','), '€ 1,23')

--- a/tests/utils_tests/test_os_utils.py
+++ b/tests/utils_tests/test_os_utils.py
@@ -18,7 +18,7 @@ class SafeJoinTests(unittest.TestCase):
         drive, path = os.path.splitdrive(safe_join("/", "path"))
         self.assertEqual(
             path,
-            "{}path".format(os.path.sep),
+            f"{os.path.sep}path",
         )
 
         drive, path = os.path.splitdrive(safe_join("/", ""))


### PR DESCRIPTION
Only simple uses of .format() have changed such that the string
expressions are shorter, are not translated strings, and do not nest
quotes.

In addition to the readability improvement, f-strings are also
marginally faster:

    $ python3 -m timeit -s 'a = 42; b = None; c = "foo"' '"{} {} {}".format(a, b, c)'
    500000 loops, best of 5: 430 nsec per loop
    $ python3 -m timeit -s 'a = 42; b = None; c = "foo"' 'f"{a} {b} {c}"'
    1000000 loops, best of 5: 286 nsec per loop

The cases were automatically detected and modified using pyupgrade:
https://github.com/asottile/pyupgrade

https://code.djangoproject.com/ticket/29988