### PR TITLE
Fixed #31415 -- Fixed crash when nested OuterRef is used with operators or in database functions.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -585,6 +585,9 @@ class OuterRef(F):
             return self.name
         return ResolvedOuterRef(self.name)
 
+    def relabeled_clone(self, relabels):
+        return self
+
 
 class Func(SQLiteNumericMixin, Expression):
     """An SQL function call."""


### PR DESCRIPTION
Fixes [ticket 31415](https://code.djangoproject.com/ticket/31415).