### PR TITLE
Optimized Model and QuerySet pickling version comparison.

### DIFF
--- a/tests/model_regress/test_pickle.py
+++ b/tests/model_regress/test_pickle.py
@@ -1,8 +1,8 @@
 import pickle
 
+import django
 from django.db import DJANGO_VERSION_PICKLE_KEY, models
 from django.test import SimpleTestCase
-from django.utils.version import get_version
 
 
 class ModelPickleTests(SimpleTestCase):
@@ -40,7 +40,10 @@ class ModelPickleTests(SimpleTestCase):
                 return reduce_list
 
         p = DifferentDjangoVersion(title="FooBar")
-        msg = "Pickled model instance's Django version 1.0 does not match the current version %s." % get_version()
+        msg = (
+            "Pickled model instance's Django version 1.0 does not match the "
+            "current version %s." % django.__version__
+        )
         with self.assertRaisesMessage(RuntimeWarning, msg):
             pickle.loads(pickle.dumps(p))
 

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -1,9 +1,9 @@
 import datetime
 import pickle
 
+import django
 from django.db import models
 from django.test import TestCase
-from django.utils.version import get_version
 
 from .models import Container, Event, Group, Happening, M2MModel, MyEvent
 
@@ -234,7 +234,10 @@ class PickleabilityTestCase(TestCase):
         unpickled with a different Django version than the current
         """
         qs = Group.previous_django_version_objects.all()
-        msg = "Pickled queryset instance's Django version 1.0 does not match the current version %s." % get_version()
+        msg = (
+            "Pickled queryset instance's Django version 1.0 does not match "
+            "the current version %s." % django.__version__
+        )
         with self.assertRaisesMessage(RuntimeWarning, msg):
             pickle.loads(pickle.dumps(qs))
 


### PR DESCRIPTION
`get_version()` does a lot of unnecessary work to get at the pre-computed result in `__version__`. Also remove the `msg` variable to bypass its assignment and checking during the happy path.