### PR TITLE
Fixed #31420 -- Fixed crash when filtering subquery annotation against a SimpleLazyObject.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -233,7 +233,8 @@ class Query(BaseExpression):
     @property
     def output_field(self):
         if len(self.select) == 1:
-            return self.select[0].field
+            select = self.select[0]
+            return getattr(select, 'target', None) or select.field
         elif len(self.annotation_select) == 1:
             return next(iter(self.annotation_select.values())).output_field
 

--- a/docs/releases/3.0.6.txt
+++ b/docs/releases/3.0.6.txt
@@ -9,4 +9,6 @@ Django 3.0.6 fixes several bugs in 3.0.5.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 3.0 that caused a crash when filtering a
+  ``Subquery()`` annotation of a queryset containing a single related field
+  against a ``SimpleLazyObject`` (:ticket:`31420`).

--- a/tests/expressions/models.py
+++ b/tests/expressions/models.py
@@ -6,10 +6,15 @@ import uuid
 from django.db import models
 
 
+class Manager(models.Model):
+    name = models.CharField(max_length=50)
+
+
 class Employee(models.Model):
     firstname = models.CharField(max_length=50)
     lastname = models.CharField(max_length=50)
     salary = models.IntegerField(blank=True, null=True)
+    manager = models.ForeignKey(Manager, models.CASCADE, null=True)
 
     def __str__(self):
         return '%s %s' % (self.firstname, self.lastname)


### PR DESCRIPTION
Fixes [ticket 31420](https://code.djangoproject.com/ticket/31420).
Thanks, @charettes for the solution and @felixxm for the test case.