### PR TITLE
Migration operations cleanups.

### DIFF
--- a/django/db/migrations/operations/utils.py
+++ b/django/db/migrations/operations/utils.py
@@ -1,15 +1,6 @@
+from collections import namedtuple
+
 from django.db.models.fields.related import RECURSIVE_RELATIONSHIP_CONSTANT
-
-
-def is_referenced_by_foreign_key(state, model_name_lower, field, field_name):
-    for state_app_label, state_model in state.models:
-        for _, f in state.models[state_app_label, state_model].fields:
-            if (f.related_model and
-                    '%s.%s' % (state_app_label, model_name_lower) == f.related_model.lower() and
-                    hasattr(f, 'to_fields')):
-                if (f.to_fields[0] is None and field.primary_key) or field_name in f.to_fields:
-                    return True
-    return False
 
 
 def resolve_relation(model, app_label=None, model_name=None):
@@ -38,13 +29,73 @@ def resolve_relation(model, app_label=None, model_name=None):
     return model._meta.app_label, model._meta.model_name
 
 
-def field_references_model(model_tuple, field, reference_model_tuple):
-    """Return whether or not field references reference_model_tuple."""
+FieldReference = namedtuple('FieldReference', 'to through')
+
+
+def field_references(
+    model_tuple,
+    field,
+    reference_model_tuple,
+    reference_field_name=None,
+    reference_field=None,
+):
+    """
+    Return either False or a FieldReference if `field` references provided
+    context.
+
+    False positives can be returned if `reference_field_name` is provided
+    without `reference_field` because of the introspection limitation it
+    incurs. This should not be an issue when this function is used to determine
+    whether or not an optimization can take place.
+    """
     remote_field = field.remote_field
-    if remote_field:
-        if resolve_relation(remote_field.model, *model_tuple) == reference_model_tuple:
-            return True
-        through = getattr(remote_field, 'through', None)
-        if through and resolve_relation(through, *model_tuple) == reference_model_tuple:
-            return True
-    return False
+    if not remote_field:
+        return False
+    references_to = None
+    references_through = None
+    if resolve_relation(remote_field.model, *model_tuple) == reference_model_tuple:
+        to_fields = getattr(field, 'to_fields', None)
+        if (
+            reference_field_name is None or
+            # Unspecified to_field(s).
+            to_fields is None or
+            # Reference to primary key.
+            (None in to_fields and (reference_field is None or reference_field.primary_key)) or
+            # Reference to field.
+            reference_field_name in to_fields
+        ):
+            references_to = (remote_field, to_fields)
+    through = getattr(remote_field, 'through', None)
+    if through and resolve_relation(through, *model_tuple) == reference_model_tuple:
+        through_fields = remote_field.through_fields
+        if (
+            reference_field_name is None or
+            # Unspecified through_fields.
+            through_fields is None or
+            # Reference to field.
+            reference_field_name in through_fields
+        ):
+            references_through = (remote_field, through_fields)
+    if not (references_to or references_through):
+        return False
+    return FieldReference(references_to, references_through)
+
+
+def get_references(state, model_tuple, field_tuple=()):
+    """
+    Generator of (model_state, index, name, field, reference) referencing
+    provided context.
+
+    If field_tuple is provided only references to this particular field of
+    model_tuple will be generated.
+    """
+    for state_model_tuple, model_state in state.models.items():
+        for index, (name, field) in enumerate(model_state.fields):
+            reference = field_references(state_model_tuple, field, model_tuple, *field_tuple)
+            if reference:
+                yield model_state, index, name, field, reference
+
+
+def field_is_referenced(state, model_tuple, field_tuple):
+    """Return whether `field_tuple` is referenced by any state models."""
+    return next(get_references(state, model_tuple, field_tuple), None) is not None


### PR DESCRIPTION
While working on making sense out of [#31064](https://code.djangoproject.com/ticket/31064) and working towards cleaning things up for possible GSOC projects.

This PR includes a few commits that moves all reference resolving logs to contained functions in `operations.utils` instead of repeating the same logic in multiple `Operation.state_forwards` implementations.

It gets rid of `ModelTuple` which was added to deal with the special casing of `app_label=None` since this isn't something used internally anyway and was only meant as an easier way to test things out.

---

I would have liked to change the signature of `reduce`, `references_field` and `references_model` to have `app_label` be their first positional argument but it could break compatibility with possible operations that overrode these methods. Given it's a private API I think it would still make sense for the sake of coherency with app model concept and I'd be happy to provide a following PR if that's deemed appropriate.