### PR TITLE
Completed test coverage for forms.DurationField.to_python().

### DIFF
--- a/tests/forms_tests/field_tests/test_durationfield.py
+++ b/tests/forms_tests/field_tests/test_durationfield.py
@@ -20,6 +20,20 @@ class DurationFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
             datetime.timedelta(days=1, hours=1, minutes=15, seconds=30, milliseconds=300),
             f.clean('1 1:15:30.3')
         )
+        self.assertEqual(
+            datetime.timedelta(0, 10800),
+            f.clean(datetime.timedelta(0, 10800)),
+        )
+        msg = 'This field is required.'
+        with self.assertRaisesMessage(ValidationError, msg):
+            f.clean('')
+        msg = 'Enter a valid duration.'
+        with self.assertRaisesMessage(ValidationError, msg):
+            f.clean('not_a_time')
+
+    def test_durationfield_clean_not_required(self):
+        f = DurationField(required=False)
+        self.assertIsNone(f.clean(''))
 
     def test_overflow(self):
         msg = "The number of days must be between {min_days} and {max_days}.".format(


### PR DESCRIPTION
To increase the test coverage for duration field. 

Specifically it targets the `to_python` function. [Current coverage.](https://djangoci.com/view/%C2%ADCoverage/job/django-coverage/HTML_20Coverage_20Report/_home_jenkins_workspace_django-coverage_django_forms_fields_py.html#t491)

I'm assuming for this type of small change to test coverage it's acceptable to just open the pull request. 🤞
