### PR TITLE
Add super call in postgres' JSONField.get_prep_value

### DIFF
--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -56,6 +56,7 @@ class JSONField(CheckFieldDefaultMixin, Field):
         return KeyTransformFactory(name)
 
     def get_prep_value(self, value):
+        value = super().get_prep_value(value)
         if value is not None:
             return JsonAdapter(value, encoder=self.encoder)
         return value


### PR DESCRIPTION
currently we can't monkeypatch base classes of `django.contrib.postgres.fields.JSONField`. 
for example:
```
class NullBytesSanitizerMixin:
    def get_prep_value(self, value):
        value = remove_null_bytest(value)  # say it removes \u0000
        return super().get_prep_value(value)

JSONField.__bases__ = (NullBytesSanitizerMixn, *JSONField.__bases__)
# __mro__ is (<class 'django.contrib.postgres.fields.jsonb.JSONField'>, NullBytesSanitizerMixin, .... <class 'object'>)

``` 
 by doing above monkeypatch,
```
>>> JSONField().get_prep_value({"foo": "b\u0000ar"}).adapted
>>> {'foo': 'b\x00ar'}   # this is being returned

>>> # but the expected behavior after monkeypatching __bases__, is that 
>>> # {'foo': 'bar'} should have been returned instead, because JSONField.get_prep_value
>>> # doesn't call super().get_prep_value(value), hence mixin's get_prep_value doesn't get
>>> # called.
```

