### PR TITLE
Fixed #31335 - [mysql]Added logic to rename FKs also present in an index

### DIFF
--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -107,7 +107,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 constraint_names = self._constraint_names(model, [field.column], index=True)
                 if not constraint_names:
                     self.execute(self._create_index_sql(model, [field]))
-        self.execute(constraint.remove_sql(model, self))
+        sql = constraint.remove_sql(model, self)
+        if sql:
+            self.execute(sql)
 
     def _field_should_be_indexed(self, model, field):
         create_index = super()._field_should_be_indexed(model, field)

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -94,6 +94,15 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 field = field[1:]
             if model._meta.get_field(field).get_internal_type() == 'ForeignKey':
                 self.execute(self._create_index_sql(model, [model._meta.get_field(field)]))
+            else:
+                for idx in model._meta.indexes:
+                    if idx == index:
+                        continue
+                    elif idx.fields[0] == field:
+                        continue
+                    else:
+                        self.execute(self._create_index_sql(model, [model._meta.get_field(field)]))
+
         self.execute(index.remove_sql(model, self))
 
     def _field_should_be_indexed(self, model, field):

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -88,6 +88,14 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 'column': self.quote_name(field.column),
             }, [effective_default])
 
+    def remove_index(self, model, index):
+        for field in index.fields:
+            if field.startswith("-"):
+                field = field[1:]
+            if model._meta.get_field(field).get_internal_type() == 'ForeignKey':
+                self.execute(self._create_index_sql(model, [model._meta.get_field(field)]))
+        self.execute(index.remove_sql(model, self))
+
     def _field_should_be_indexed(self, model, field):
         create_index = super()._field_should_be_indexed(model, field)
         storage = self.connection.introspection.get_storage_engine(

--- a/tests/schema/models.py
+++ b/tests/schema/models.py
@@ -147,6 +147,17 @@ class BookForeignObj(models.Model):
         apps = new_apps
 
 
+class BookWithIndex(models.Model):
+    author = models.ForeignKey(Author, models.CASCADE)
+    title = models.CharField(max_length=100)
+
+    class Meta:
+        apps = new_apps
+        indexes = [
+            models.Index(fields=['author', 'title'], name='index_with_fk')
+        ]
+
+
 class IntegerPK(models.Model):
     i = models.IntegerField(primary_key=True)
     j = models.IntegerField(unique=True)


### PR DESCRIPTION
Overrode remove_index() in mysql/schema.py, to handle renaming ForeignKeys which are also present in an index.