### PR TITLE
Fixed #31407 -- Fixed unawaited coroutine warning for Python  3.8+.

### DIFF
--- a/tests/handlers/views.py
+++ b/tests/handlers/views.py
@@ -58,5 +58,8 @@ class CoroutineClearingView:
         self._unawaited_coroutine = asyncio.sleep(0)
         return self._unawaited_coroutine
 
+    def __del__(self):
+        self._unawaited_coroutine.close()
+
 
 async_unawaited = CoroutineClearingView()


### PR DESCRIPTION
Follow-up to  #12661

Co-authored-by: Mark Korput <dr.theman@gmail.com> (@markkorput)

No warning on Python 3.7. Warning on Python 3.8. Adding the `__del__` back seems to clear it. 
(Let's see what the CI says.) I'm guessing a GC'd but not closed/awaited coroutine is the trigger on Python 3.8, but [still](https://docs.python.org/3/reference/datamodel.html#coroutine.close):

> Coroutine objects are automatically closed using the above process when they are about to be destroyed.

So 🤷‍♂️

Can't find a note on the change in behavior here. Probably ref https://bugs.python.org/issue32591