### PR TITLE
Completed test coverage for BoundField.css_classes().

### DIFF
--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -1009,7 +1009,7 @@ Methods of ``BoundField``
     ``only_initial`` is used by Django internals and should not be set
     explicitly.
 
-.. method:: BoundField.css_classes()
+.. method:: BoundField.css_classes(extra_classes=None)
 
     When you use Django's rendering shortcuts, CSS classes are used to
     indicate required form fields or fields that contain errors. If you're

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -3151,6 +3151,14 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
         self.assertEqual(f['first_name'].widget_type, 'text')
         self.assertEqual(f['birthday'].widget_type, 'splithiddendatetime')
 
+    def test_boundfield_css_classes(self):
+        form = Person()
+        field = form['first_name']
+        self.assertEqual(field.css_classes(), '')
+        self.assertEqual(field.css_classes(extra_classes=''), '')
+        self.assertEqual(field.css_classes(extra_classes='test'), 'test')
+        self.assertEqual(field.css_classes(extra_classes='test test'), 'test')
+
     def test_label_tag_override(self):
         """
         BoundField label_suffix (if provided) overrides Form label_suffix


### PR DESCRIPTION
This is to improve the test coverage for `css_classes()`. 
Here is the [current test coverage.](https://djangoci.com/view/%C2%ADCoverage/job/django-coverage/HTML_20Coverage_20Report/_home_jenkins_workspace_django-coverage_django_forms_boundfield_py.html#t173)

There are a couple of current tests which cover css_classes but they don't test the various options. Hopefully what I've done is reasonable.

I also added the argument into the docs which is missing. Not sure if that is deliberately so?

Looking forward to your comments 👍 