### PR TITLE
Completed test coverage for forms.RegexField.

### DIFF
--- a/tests/forms_tests/field_tests/test_regexfield.py
+++ b/tests/forms_tests/field_tests/test_regexfield.py
@@ -65,3 +65,12 @@ class RegexFieldTest(SimpleTestCase):
         self.assertEqual('1234', f.clean('1234'))
         with self.assertRaisesMessage(ValidationError, "'Enter a valid value.'"):
             f.clean('abcd')
+
+    def test_get_regex(self):
+        f = RegexField('^[a-z]+$')
+        self.assertEqual(f.regex, re.compile('^[a-z]+$'))
+
+    def test_regexfield_strip(self):
+        f = RegexField('^[a-z]+$', strip=True)
+        self.assertEqual(f.clean(' a'), 'a')
+        self.assertEqual(f.clean('a '), 'a')


### PR DESCRIPTION
Completes test coverage for `RegexField`.
Current test coverage is [here](https://djangoci.com/view/%C2%ADCoverage/job/django-coverage/HTML_20Coverage_20Report/_home_jenkins_workspace_django-coverage_django_forms_fields_py.html#t518).

The [docs](https://docs.djangoproject.com/en/3.0/ref/forms/fields/#django.forms.RegexField.strip) for `RegexField`  explain that `strip` happens before validation when `strip=true`. I didn't see a test for this scenario so I've added one now. It it only covers examples where we expect a different behaviour to the default setting. 