### PR TITLE
Fixed term warnings on Sphinx 3.0.1+.

### DIFF
--- a/docs/internals/contributing/localizing.txt
+++ b/docs/internals/contributing/localizing.txt
@@ -46,11 +46,12 @@ translating or add a language that isn't yet translated, here's what to do:
      `Transifex User Guide`_.
 
 Translations from Transifex are only integrated into the Django repository at
-the time of a new :term:`feature release`. We try to update them a second time
-during one of the following :term:`patch release`\s, but that depends on the
-translation manager's availability. So don't miss the string freeze period
-(between the release candidate and the feature release) to take the opportunity
-to complete and fix the translations for your language!
+the time of a new :term:`feature release <Feature release>`. We try to update
+them a second time during one of the following :term:`patch release
+<Patch release>`\s, but that depends on the translation manager's availability.
+So don't miss the string freeze period (between the release candidate and the
+feature release) to take the opportunity to complete and fix the translations
+for your language!
 
 Formats
 =======

--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -223,8 +223,8 @@ Finally, there are a couple of updates to Django's documentation to make:
    under the appropriate version describing what code will be removed.
 
 Once you have completed these steps, you are finished with the deprecation.
-In each :term:`feature release`, all ``RemovedInDjangoXXWarning``\s matching
-the new version are removed.
+In each :term:`feature release <Feature release>`, all
+``RemovedInDjangoXXWarning``\s matching the new version are removed.
 
 JavaScript patches
 ==================

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -194,8 +194,8 @@ Differences between versions
 The text documentation in the master branch of the Git repository contains the
 "latest and greatest" changes and additions. These changes include
 documentation of new features targeted for Django's next :term:`feature
-release`. For that reason, it's worth pointing out our policy to highlight
-recent changes and additions to Django.
+release <Feature release>`. For that reason, it's worth pointing out our policy
+to highlight recent changes and additions to Django.
 
 We follow this policy:
 

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1219,7 +1219,7 @@ databases supported by Django.
 
 .. class:: SlugField(max_length=50, **options)
 
-:term:`Slug` is a newspaper term. A slug is a short label for something,
+:term:`Slug <slug>` is a newspaper term. A slug is a short label for something,
 containing only letters, numbers, underscores or hyphens. They're generally used
 in URLs.
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -15,9 +15,10 @@ want to be aware of when upgrading from Django 1.10 or older versions. We've
 See the :doc:`/howto/upgrade-version` guide if you're updating an existing
 project.
 
-Django 1.11 is designated as a :term:`long-term support release`. It will
-receive security updates for at least three years after its release. Support
-for the previous LTS, Django 1.8, will end in April 2018.
+Django 1.11 is designated as a :term:`long-term support release
+<Long-term support release>`. It will receive security updates for at least
+three years after its release. Support for the previous LTS, Django 1.8, will
+end in April 2018.
 
 Python compatibility
 ====================

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -17,9 +17,9 @@ See the :doc:`/howto/upgrade-version` guide if you're updating an existing
 project.
 
 Django 1.8 has been designated as Django's second :term:`long-term support
-release`. It will receive security updates for at least three years after its
-release. Support for the previous LTS, Django 1.4, will end 6 months from the
-release date of Django 1.8.
+release <Long-term support release>`. It will receive security updates for at
+least three years after its release. Support for the previous LTS, Django 1.4,
+will end 6 months from the release date of Django 1.8.
 
 Python compatibility
 ====================

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -15,9 +15,10 @@ want to be aware of when upgrading from Django 2.1 or earlier. We've
 See the :doc:`/howto/upgrade-version` guide if you're updating an existing
 project.
 
-Django 2.2 is designated as a :term:`long-term support release`. It will
-receive security updates for at least three years after its release. Support
-for the previous LTS, Django 1.11, will end in April 2020.
+Django 2.2 is designated as a :term:`long-term support release
+<Long-term support release>`. It will receive security updates for at least
+three years after its release. Support for the previous LTS, Django 1.11, will
+end in April 2020.
 
 Python compatibility
 ====================


### PR DESCRIPTION
`term` role became case sensitive in Sphinx 3.0.1 (see https://github.com/sphinx-doc/sphinx/issues/7418).