### PR TITLE
Refs #31224 -- Removed incorrect @sync_to_async(thread_sensitive=True) example.

### DIFF
--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -227,10 +227,6 @@ as either a direct wrapper or a decorator::
     def sync_function(...):
         ...
 
-    @sync_to_async(thread_sensitive=True)
-    def sensitive_sync_function(...):
-        ...
-
 Threadlocals and contextvars values are preserved across the boundary in both
 directions.
 


### PR DESCRIPTION
It does not support thread_sensitive when used as a decorator, yet.