### PR TITLE
Fixed #29249 -- Added --allow_unicode option to dumpdata to allow unicode JSON or YAML.

### DIFF
--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -63,6 +63,10 @@ class Command(BaseCommand):
             '-o', '--output',
             help='Specifies file to which the output is written.'
         )
+        parser.add_argument(
+            '--allow-unicode', action='store_true',
+            help="Allows for Unicode characters in output."
+        )
 
     def handle(self, *app_labels, **options):
         format = options['format']
@@ -75,6 +79,7 @@ class Command(BaseCommand):
         use_natural_primary_keys = options['use_natural_primary_keys']
         use_base_manager = options['use_base_manager']
         pks = options['primary_keys']
+        allow_unicode = options['allow_unicode']
 
         if pks:
             primary_keys = [pk.strip() for pk in pks.split(',')]
@@ -192,7 +197,7 @@ class Command(BaseCommand):
                     use_natural_foreign_keys=use_natural_foreign_keys,
                     use_natural_primary_keys=use_natural_primary_keys,
                     stream=stream or self.stdout, progress_output=progress_output,
-                    object_count=object_count,
+                    object_count=object_count, allow_unicode=allow_unicode,
                 )
             finally:
                 if stream:

--- a/django/core/serializers/json.py
+++ b/django/core/serializers/json.py
@@ -28,6 +28,7 @@ class Serializer(PythonSerializer):
         if self.options.get('indent'):
             # Prevent trailing spaces
             self.json_kwargs['separators'] = (',', ': ')
+        self.json_kwargs['ensure_ascii'] = not self.json_kwargs.pop('allow_unicode', False)
         self.json_kwargs.setdefault('cls', DjangoJSONEncoder)
 
     def start_serialization(self):

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -366,6 +366,12 @@ standard output.
 When this option is set and ``--verbosity`` is greater than 0 (the default), a
 progress bar is shown in the terminal.
 
+.. django-admin-option:: --allow-unicode
+
+.. versionadded:: 3.1
+
+Allows for Unicode characters in output.
+
 ``flush``
 ---------
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -319,6 +319,8 @@ Management Commands
 
 * The new :option:`dbshell -- ARGUMENTS <dbshell -->` option allows passing
   extra arguments to the command-line client for the database.
+* The new :option:`dumpdata --allow-unicode` option allows for Unicode
+  characters in output.
 
 Migrations
 ~~~~~~~~~~

--- a/tests/serializers/test_yaml.py
+++ b/tests/serializers/test_yaml.py
@@ -162,3 +162,42 @@ class YamlSerializerTransactionTestCase(SerializersTransactionTestBase, Transact
   pk: 1
   fields:
     name: Agnes"""
+
+
+@unittest.skipUnless(HAS_YAML, "No yaml library detected")
+class UnicodeSerializerTestCase(SimpleTestCase):
+    def test_allow_unicode(self):
+        tests = (  # (allow_unicode, expected)
+            (False, '\\u05D9\\u05D5\\u05E0\\u05D9\\u05E7\\u05D5\\u05D3'),
+            (True, 'יוניקוד')
+        )
+        for allow_unicode, expected in tests:
+            with self.subTest(allow_unicode=allow_unicode, expected=expected):
+                yaml_string = serializers.serialize(
+                    'yaml',
+                    [Author(name='יוניקוד')],
+                    allow_unicode=allow_unicode,
+                )
+                self.assertIn(expected, yaml_string)
+
+
+@unittest.skipUnless(HAS_YAML, "No yaml library detected")
+class DumpdataUnicodeTestCase(TestCase):
+    def test_allow_unicode(self):
+        Author.objects.create(name='יוניקוד')
+
+        tests = (  # (allow_unicode, expected)
+            (False, '\\u05D9\\u05D5\\u05E0\\u05D9\\u05E7\\u05D5\\u05D3'),
+            (True, 'יוניקוד')
+        )
+        for allow_unicode, expected in tests:
+            with self.subTest(allow_unicode=allow_unicode, expected=expected):
+                out = StringIO()
+                management.call_command(
+                    'dumpdata',
+                    'serializers.author',
+                    format='yaml',
+                    allow_unicode=allow_unicode,
+                    stdout=out,
+                )
+                self.assertIn(expected, out.getvalue().strip())


### PR DESCRIPTION
[Ticket 29249](https://code.djangoproject.com/ticket/29249).
Continue #9818. I added documentation.

According to [this comment](https://code.djangoproject.com/ticket/29249#comment:3), please suggest the new option name I'll change it.