### PR TITLE
Fixed #31458 -- Allowed changing executable_name for dbshell management command.

### DIFF
--- a/django/core/management/commands/dbshell.py
+++ b/django/core/management/commands/dbshell.py
@@ -1,3 +1,6 @@
+import os
+
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS, connections
 
@@ -18,8 +21,14 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         connection = connections[options['database']]
+
         try:
-            connection.client.runshell()
+            executable_name = getattr(settings, "DBSHELL_EXECUTABLE")
+        except AttributeError:
+            executable_name = os.environ.get("DJANGO_DBSHELL_EXECUTABLE")
+
+        try:
+            connection.client.runshell(executable_name=executable_name)
         except OSError:
             # Note that we're assuming OSError means that the client program
             # isn't installed. There's a possibility OSError would be raised

--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -8,10 +8,13 @@ from django.db.backends.base.client import BaseDatabaseClient
 class DatabaseClient(BaseDatabaseClient):
     executable_name = 'psql'
 
-    @classmethod
-    def runshell_db(cls, conn_params):
-        args = [cls.executable_name]
+    def runshell(self, executable_name=None):
+        if executable_name is not None:
+            self.executable_name = executable_name
 
+        args = [self.executable_name]
+
+        conn_params = self.connection.get_connection_params()
         host = conn_params.get('host', '')
         port = conn_params.get('port', '')
         dbname = conn_params.get('database', '')
@@ -49,6 +52,3 @@ class DatabaseClient(BaseDatabaseClient):
         finally:
             # Restore the original SIGINT handler.
             signal.signal(signal.SIGINT, sigint_handler)
-
-    def runshell(self):
-        DatabaseClient.runshell_db(self.connection.get_connection_params())


### PR DESCRIPTION
This is a proof of concept to make the dbshell executable configurable either in `settings.py` (`DBSHELL_EXECUTABLE`) or through an environment variable (`DJANGO_DBSHELL_EXECUTABLE`).  The new executable must accept the same command line parameters.

If there is interest in this, i'll be happy to provide the bits for the other backends and the documentation.

`$ DJANGO_DBSHELL_EXECUTABLE=pgcli python manage.py dbshell`