### PR TITLE
Fixed #31459 -- Fixed handling invalid indentifiers in URL path conversion.

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -197,7 +197,7 @@ class RegexPattern(CheckURLMixin):
 
 
 _PATH_PARAMETER_COMPONENT_RE = _lazy_re_compile(
-    r'<(?:(?P<converter>[^>:]+):)?(?P<parameter>\w+)>'
+    r'<(?:(?P<converter>[^>:]+):)?(?P<parameter>[^>]+)>'
 )
 
 

--- a/tests/check_framework/test_urls.py
+++ b/tests/check_framework/test_urls.py
@@ -143,7 +143,7 @@ class UpdatedToPathTests(SimpleTestCase):
         self.assertEqual(len(result), 1)
         warning = result[0]
         self.assertEqual(warning.id, '2_0.W001')
-        expected_msg = "Your URL pattern '(?P<named-group>\\d+)' has a route"
+        expected_msg = "Your URL pattern '(?P<named_group>\\d+)' has a route"
         self.assertIn(expected_msg, warning.msg)
 
     @override_settings(ROOT_URLCONF='check_framework.urls.path_compatibility.beginning_with_caret')

--- a/tests/check_framework/urls/path_compatibility/contains_re_named_group.py
+++ b/tests/check_framework/urls/path_compatibility/contains_re_named_group.py
@@ -1,5 +1,5 @@
 from django.urls import path
 
 urlpatterns = [
-    path(r'(?P<named-group>\d+)', lambda x: x),
+    path(r'(?P<named_group>\d+)', lambda x: x),
 ]

--- a/tests/gis_tests/geoapp/urls.py
+++ b/tests/gis_tests/geoapp/urls.py
@@ -20,7 +20,7 @@ urlpatterns += [
         gis_sitemap_views.kml,
         name='django.contrib.gis.sitemaps.views.kml'),
     path(
-        'sitemaps/kml/<label>/<<model>/<field_name>.kmz',
+        'sitemaps/kml/<label>/<model>/<field_name>.kmz',
         gis_sitemap_views.kmz,
         name='django.contrib.gis.sitemaps.views.kmz'),
 ]

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -249,13 +249,21 @@ class SameNameTests(SimpleTestCase):
 
 
 class ParameterRestrictionTests(SimpleTestCase):
-    def test_non_identifier_parameter_name_causes_exception(self):
+    def test_integer_parameter_name_causes_exception(self):
         msg = (
             "URL route 'hello/<int:1>/' uses parameter name '1' which isn't "
             "a valid Python identifier."
         )
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             path(r'hello/<int:1>/', lambda r: None)
+
+    def test_non_identifier_parameter_name_causes_exception(self):
+        msg = (
+            "URL route 'b/<int:book.id>/' uses parameter name 'book.id' which "
+            "isn't a valid Python identifier."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            path(r'b/<int:book.id>/', lambda r: None)
 
     def test_allows_non_ascii_but_valid_identifiers(self):
         # \u0394 is "GREEK CAPITAL LETTER DELTA", a valid identifier.


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/31459).

This found one broken URL in Django's own test suite.