### PR TITLE
Fix #27060: Add indexes identified in constraints to Meta.indexes

### DIFF
--- a/tests/inspectdb/models.py
+++ b/tests/inspectdb/models.py
@@ -81,3 +81,16 @@ class UniqueTogether(models.Model):
             ('from_field', 'field1'),
             ('non_unique', 'non_unique_0'),
         ]
+
+
+class Indexes(models.Model):
+    field1 = models.IntegerField()
+    field2 = models.CharField(max_length=5)
+    from_field = models.IntegerField(unique=True, db_column='from')
+
+    class Meta:
+        indexes = [
+            models.Index(fields=['field1', 'field2'], name='my_index'),
+            models.Index(fields=['field2', 'from_field'], name='my_other_index'),
+            models.Index(fields=['from_field']),
+        ]

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -235,6 +235,22 @@ class InspectDBTestCase(TestCase):
         # are given an integer suffix.
         self.assertIn("('non_unique_column', 'non_unique_column_0')", fields)
 
+    def test_indexes(self):
+        out = StringIO()
+        call_command('inspectdb', 'inspectdb_indexes', stdout=out)
+        output = out.getvalue()
+        self.assertIn('    indexes = (', output)
+        # our two named indexes are there
+        self.assertIn('my_index', output)
+        self.assertIn('my_other_index', output)
+        # we have a total of three indexes
+        matches = re.findall(r'models.Index\(', output)
+        self.assertEqual(len(matches), 3)
+        # and our three column defs are in place
+        self.assertIn("['from_field']", output)
+        self.assertIn("['field1', 'field2']", output)
+        self.assertIn("['field2', 'from_field']", output)
+
     @skipUnless(connection.vendor == 'postgresql', 'PostgreSQL specific SQL')
     def test_unsupported_unique_together(self):
         """Unsupported index types (COALESCE here) are skipped."""


### PR DESCRIPTION
When inspecting tables, the process creates a constraints dict
that identifies indexes. If we have any such indexes, let's add
them to `Meta.indexes` using the base `Index` class.

At this point, it does not support identifying the index type and
substituting in the proper index class, and I don't believe we have
the information at this time to select the right class anyway.

Ref: https://code.djangoproject.com/ticket/27060