### PR TITLE
Fixes #23318. Apply postgres DB options to dbshell

### DIFF
--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -15,6 +15,7 @@ class DatabaseClient(BaseDatabaseClient):
         host = conn_params.get('host', '')
         port = conn_params.get('port', '')
         dbname = conn_params.get('database', '')
+        options = conn_params.get('options', '')
         user = conn_params.get('user', '')
         passwd = conn_params.get('password', '')
         sslmode = conn_params.get('sslmode', '')
@@ -32,6 +33,8 @@ class DatabaseClient(BaseDatabaseClient):
 
         sigint_handler = signal.getsignal(signal.SIGINT)
         subprocess_env = os.environ.copy()
+        if options:
+            subprocess_env['PGOPTIONS'] = str(options)
         if passwd:
             subprocess_env['PGPASSWORD'] = str(passwd)
         if sslmode:

--- a/tests/dbshell/test_postgresql.py
+++ b/tests/dbshell/test_postgresql.py
@@ -110,7 +110,6 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
             self._run_it({
                 'database': 'dbname',
                 'user': 'someuser',
-                'password': 'somepassword',
                 'host': 'somehost',
                 'port': '444',
                 'options': options,

--- a/tests/dbshell/test_postgresql.py
+++ b/tests/dbshell/test_postgresql.py
@@ -104,6 +104,22 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
             )
         )
 
+    def test_options(self):
+        options = '-c default_text_search_config=simple'
+        self.assertEqual(
+            self._run_it({
+                'database': 'dbname',
+                'user': 'someuser',
+                'password': 'somepassword',
+                'host': 'somehost',
+                'port': '444',
+                'options': options,
+            }), (
+                ['psql', '-U', 'someuser', '-h', 'somehost', '-p', '444', 'dbname'],
+                {'PGOPTIONS': options},
+            )
+        )
+
     def test_sigint_handler(self):
         """SIGINT is ignored in Python and passed to psql to abort queries."""
         def _mock_subprocess_run(*args, **kwargs):

--- a/tests/dbshell/test_postgresql.py
+++ b/tests/dbshell/test_postgresql.py
@@ -120,6 +120,7 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
                 ['psql', '-U', 'someuser', '-h', 'somehost', '-p', '444', 'dbname'],
                 {'PGOPTIONS': options},
             )
+        )
 
     def test_parameters(self):
         self.assertEqual(


### PR DESCRIPTION
When I use *django.db.backends.postgresql*, and set OPTIONS like below, it would apply to psycopg2 connections, but not dbshell. This PR fixes the inconsistency, thus improve DX.

```python
DATABASES = {
    "default": {
        "ENGINE": "django.db.backends.postgresql",
        "NAME": "db",
        "HOST": "127.0.0.1",
        "OPTIONS": {"options": "-c default_text_search_config=simple"}
    }
}
```

Without this patch entering below command in dbshell would show pg_catalog.english instead of pg_catalog.simple.

```sql
SHOW default_text_search_config;
```