### PR TITLE
Doc'd that Meta.indexes is preferred to Field.db_index.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -351,6 +351,13 @@ looking at your Django code. For example::
 
 If ``True``, a database index will be created for this field.
 
+.. admonition:: Use the :attr:`~Options.indexes` option instead.
+
+    Where possible, use the :attr:`Meta.indexes <Options.indexes>` option
+    instead. In nearly all cases, :attr:`~Options.indexes` provides more
+    functionality than ``db_index``. ``db_index`` may be deprecated in the
+    future.
+
 ``db_tablespace``
 -----------------
 


### PR DESCRIPTION
Copy and adapt the `Meta.index_together` admonition here, to help guide users to controlling their indexes better. I am not sure if "may be deprecated" is valid, but it's been around on `index_together` for many versions now and probably helps guide people to the "better" way of doing things.

Inspired because @hannseman on the mailing list is looking at PostgreSQL extra indexes when an db_index / unique is set for `CharField`s:
https://groups.google.com/forum/#!msg/django-developers/D7qhJzYgow8/DKQ0kEIVBAAJ