### PR TITLE
Improved action message example in admin documentation.

### DIFF
--- a/docs/ref/contrib/admin/actions.txt
+++ b/docs/ref/contrib/admin/actions.txt
@@ -189,16 +189,19 @@ provided by the admin.
 For example, we can use ``self`` to flash a message to the user informing her
 that the action was successful::
 
+    from django.contrib import messages
+    from django.utils.translation import ngettext
+
     class ArticleAdmin(admin.ModelAdmin):
         ...
 
         def make_published(self, request, queryset):
-            rows_updated = queryset.update(status='p')
-            if rows_updated == 1:
-                message_bit = "1 story was"
-            else:
-                message_bit = "%s stories were" % rows_updated
-            self.message_user(request, "%s successfully marked as published." % message_bit)
+            updated = queryset.update(status='p')
+            self.message_user(request, ngettext(
+                '%d story was successfully marked as published.',
+                '%d stories were successfully marked as published.',
+                updated,
+            ) % updated, messages.SUCCESS)
 
 This make the action match what the admin itself does after successfully
 performing an action:


### PR DESCRIPTION
Avoid partial string construction and make use of ``ngettext`` to show example of how to handle plural variants with translations. Also make use of ``messages.SUCCESS`` to highlight customizing the style of the message - in this case it better fits what the message is conveying.