### PR TITLE
Fixed #31470 -- Fixed fieldset admin CSS to prevent overflowing <pre> elements.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -124,6 +124,7 @@ form {
 
 fieldset {
     margin: 0;
+    min-width: 0;
     padding: 0;
     border: none;
     border-top: 1px solid #eee;
@@ -141,6 +142,7 @@ code, pre {
     font-family: "Bitstream Vera Sans Mono", Monaco, "Courier New", Courier, monospace;
     color: #666;
     font-size: 12px;
+    overflow-x: auto;
 }
 
 pre.literal-block {


### PR DESCRIPTION
This resolved issues with overflowing ``<pre>`` elements not being contained properly within ``<fieldset>``.

See ticket-31470.

Before:
![without-fix](https://user-images.githubusercontent.com/2855582/79346285-140d6e80-7f2a-11ea-83b2-5f22ee6b9053.png)

After:
![with-fix](https://user-images.githubusercontent.com/2855582/79346299-196ab900-7f2a-11ea-9c0f-105c213f5861.png)
