### PR TITLE
Fixed #28041 -- Added prefix matching for PostgreSQL full text search

### DIFF
--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -358,6 +358,9 @@ class Lexeme(LexemeCombinable, Value):
         params = [param]
         return template, params
 
+    def __invert__(self):
+        return type(self)(self.value, invert=not self.invert, prefix=self.prefix, weight=self.weight)
+
 
 class CombinedLexeme(LexemeCombinable):
     _output_field = SearchQueryField()
@@ -379,6 +382,11 @@ class CombinedLexeme(LexemeCombinable):
         combined_sql = '({} {} {})'.format(lsql, self.connector, rsql)
         combined_value = combined_sql % tuple(value_params)
         return '%s', [combined_value]
+
+    def __invert__(self):
+        # Swap the connector and invert the lhs and rhs.
+        # This generates a query that's equvilant to what we expect (thanks to De Morgan's theorem)
+        return type(self)(~self.lhs, self.BITAND if self.connector == self.BITOR else self.BITOR, ~self.rhs)
 
 
 class RawSearchQuery(SearchQueryCombinable, Expression):

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -300,3 +300,113 @@ class TrigramSimilarity(TrigramBase):
 class TrigramDistance(TrigramBase):
     function = ''
     arg_joiner = ' <-> '
+
+
+class LexemeCombinable(Expression):
+    BITAND = '&'
+    BITOR = '|'
+
+    def _combine(self, other, connector, reversed, node=None):
+        if not isinstance(other, LexemeCombinable):
+            raise TypeError(
+                'Lexeme can only be combined with other Lexemes, '
+                'got {}.'.format(type(other))
+            )
+        if reversed:
+            return CombinedLexeme(other, connector, self)
+        return CombinedLexeme(self, connector, other)
+
+    # On Combinable, these are not implemented to reduce confusion with Q. In
+    # this case we are actually (ab)using them to do logical combination so
+    # it's consistent with other usage in Django.
+    def bitand(self, other):
+        return self._combine(other, self.BITAND, False)
+
+    def bitor(self, other):
+        return self._combine(other, self.BITOR, False)
+
+    def __or__(self, other):
+        return self._combine(other, self.BITOR, False)
+
+    def __and__(self, other):
+        return self._combine(other, self.BITAND, False)
+
+
+class Lexeme(LexemeCombinable, Value):
+    _output_field = SearchQueryField()
+
+    def __init__(self, value, output_field=None, *, invert=False, prefix=False):
+        self.prefix = prefix
+        self.invert = invert
+        super().__init__(value, output_field=output_field)
+
+    def as_sql(self, compiler, connection):
+        param = self.value
+        template = '%s'
+        if self.prefix:
+            param = '{}:*'.format(param)
+        if self.invert:
+            param = '!{}'.format(param)
+        params = [param]
+        return template, params
+
+
+class CombinedLexeme(LexemeCombinable):
+    _output_field = SearchQueryField()
+
+    def __init__(self, lhs, connector, rhs, output_field=None):
+        super().__init__(output_field=output_field)
+        self.connector = connector
+        self.lhs = lhs
+        self.rhs = rhs
+
+    def as_sql(self, compiler, connection):
+        value_params = []
+        lsql, params = compiler.compile(self.lhs)
+        value_params.extend(params)
+
+        rsql, params = compiler.compile(self.rhs)
+        value_params.extend(params)
+
+        combined_sql = '{} {} {}'.format(lsql, self.connector, rsql)
+        combined_value = combined_sql % tuple(value_params)
+        return '(%s)', [combined_value]
+
+
+class RawSearchQuery(SearchQueryCombinable, Expression):
+    _output_field = SearchQueryField()
+
+    def __init__(self, expressions, output_field=None, *, config=None, invert=False):
+        self.config = config
+        self.invert = invert
+        self.expressions = expressions
+        super().__init__(output_field=output_field)
+
+    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
+        resolved = super().resolve_expression(query, allow_joins, reuse, summarize, for_save)
+        if self.config:
+            if not hasattr(self.config, 'resolve_expression'):
+                resolved.config = Value(self.config).resolve_expression(query, allow_joins, reuse, summarize, for_save)
+            else:
+                resolved.config = self.config.resolve_expression(query, allow_joins, reuse, summarize, for_save)
+        return resolved
+
+    def as_sql(self, compiler, connection):
+        sql, params, = compiler.compile(self.expressions, connection)
+        if self.config:
+            config_sql, config_params = compiler.compile(self.config)
+            template = 'to_tsquery({}::regconfig, {})'.format(config_sql, sql)
+            params = config_params + [self.expressions]
+        else:
+            template = 'to_tsquery({})'.format(sql)
+        if self.invert:
+            template = '!!({})'.format(template)
+        return template, params
+
+    def _combine(self, other, connector, reversed, node=None):
+        combined = super()._combine(other, connector, reversed, node)
+        combined.output_field = SearchQueryField()
+        return combined
+
+    def __invert__(self):
+        return type(self)(self.lexeme, config=self.config, invert=not self.invert)

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -342,7 +342,7 @@ class Lexeme(LexemeCombinable, Value):
         super().__init__(value, output_field=output_field)
 
     def as_sql(self, compiler, connection):
-        param = self.value
+        param = "'%s'" % self.value.replace("'", "''").replace("\\", "\\\\")
         template = '%s'
 
         label = ''
@@ -376,9 +376,9 @@ class CombinedLexeme(LexemeCombinable):
         rsql, params = compiler.compile(self.rhs)
         value_params.extend(params)
 
-        combined_sql = '{} {} {}'.format(lsql, self.connector, rsql)
+        combined_sql = '({} {} {})'.format(lsql, self.connector, rsql)
         combined_value = combined_sql % tuple(value_params)
-        return '(%s)', [combined_value]
+        return '%s', [combined_value]
 
 
 class RawSearchQuery(SearchQueryCombinable, Expression):

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -312,7 +312,7 @@ class LexemeCombinable(Expression):
     def _combine(self, other, connector, reversed, node=None):
         if not isinstance(other, LexemeCombinable):
             raise TypeError(
-                'Lexeme can only be combined with other Lexemes, '
+                'A Lexeme can only be combined with another Lexeme, '
                 'got {}.'.format(type(other))
             )
         if reversed:
@@ -388,5 +388,5 @@ class CombinedLexeme(LexemeCombinable):
 
     def __invert__(self):
         # Swap the connector and invert the lhs and rhs.
-        # This generates a query that's equvilant to what we expect (thanks to De Morgan's theorem)
+        # This generates a query that's equivalent to what we expect (thanks to De Morgan's theorem)
         return type(self)(~self.lhs, self.BITAND if self.connector == self.BITOR else self.BITOR, ~self.rhs)

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -335,16 +335,24 @@ class LexemeCombinable(Expression):
 class Lexeme(LexemeCombinable, Value):
     _output_field = SearchQueryField()
 
-    def __init__(self, value, output_field=None, *, invert=False, prefix=False):
+    def __init__(self, value, output_field=None, *, invert=False, prefix=False, weight=None):
         self.prefix = prefix
         self.invert = invert
+        self.weight = weight
         super().__init__(value, output_field=output_field)
 
     def as_sql(self, compiler, connection):
         param = self.value
         template = '%s'
+
+        label = ''
         if self.prefix:
-            param = '{}:*'.format(param)
+            label += '*'
+        if self.weight:
+            label += self.weight
+
+        if label:
+            param = '{}:{}'.format(param, label)
         if self.invert:
             param = '!{}'.format(param)
         params = [param]

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -396,7 +396,7 @@ class RawSearchQuery(SearchQueryCombinable, Expression):
         if self.config:
             config_sql, config_params = compiler.compile(self.config)
             template = 'to_tsquery({}::regconfig, {})'.format(config_sql, sql)
-            params = config_params + [self.expressions]
+            params = params + config_params
         else:
             template = 'to_tsquery({})'.format(sql)
         if self.invert:

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -400,7 +400,7 @@ class RawSearchQuery(SearchQueryCombinable, Expression):
         return resolved
 
     def as_sql(self, compiler, connection):
-        sql, params, = compiler.compile(self.expressions, connection)
+        sql, params, = compiler.compile(self.expressions)
         if self.config:
             config_sql, config_params = compiler.compile(self.config)
             template = 'to_tsquery({}::regconfig, {})'.format(config_sql, sql)

--- a/docs/ref/contrib/postgres/search.txt
+++ b/docs/ref/contrib/postgres/search.txt
@@ -92,13 +92,14 @@ Examples:
 
 .. _Full Text Search docs: https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
 
-    >>> from django.contrib.postgres.search import SearchQuery
+    >>> from django.contrib.postgres.search import SearchQuery, Lexeme
     >>> SearchQuery('red tomato')  # two keywords
     >>> SearchQuery('tomato red')  # same results as above
     >>> SearchQuery('red tomato', search_type='phrase')  # a phrase
     >>> SearchQuery('tomato red', search_type='phrase')  # a different phrase
     >>> SearchQuery("'tomato' & ('red' | 'green')", search_type='raw')  # boolean operators
     >>> SearchQuery("'tomato' ('red' OR 'green')", search_type='websearch')  # websearch operators
+    >>> SearchQuery(Lexeme('tomato') & (Lexeme('red') | Lexeme('green')))  # Lexeme objects
 
 ``SearchQuery`` terms can be combined logically to provide more flexibility::
 
@@ -114,6 +115,10 @@ See :ref:`postgresql-fts-search-configuration` for an explanation of the
 
     Support for ``'websearch'`` search type and query expressions in
     ``SearchQuery.value`` were added.
+
+.. versionchanged:: 3.1
+
+    ``Lexeme`` objects were added
 
 ``SearchRank``
 ==============
@@ -260,6 +265,23 @@ floats to :class:`SearchRank` as ``weights`` in the same order above::
 
     >>> rank = SearchRank(vector, query, weights=[0.2, 0.4, 0.6, 0.8])
     >>> Entry.objects.annotate(rank=rank).filter(rank__gte=0.3).order_by('-rank')
+
+Lexeme objects
+==============
+
+Lexeme objects allow search operators to be used along with strings from an untrusted source. The contents
+of each lexeme is excaped so cannot contain any operators that PostgreSQL will recognise, but they support
+combining with other Lexemes using the & and | operators and also negation with the ~ operator.
+
+    >>> from django.contrib.postgres.search import SearchQuery, Lexeme
+    >>> SearchRank(Lexeme("The user's search query") & Lexeme("Something else") & ~Lexeme("Exclude documents that match this"))
+    >>> SearchRank(Lexeme("The user's search query") | Lexeme("Something else"))
+
+Lexeme objects also support weighting and prefixes::
+
+    >>> from django.contrib.postgres.search import SearchQuery, Lexeme
+    >>> SearchRank(Lexeme("These terms have lower weight", weight='D') & Lexeme("than these terms")
+    >>> SearchRank(Lexeme("Djan", prefix=True)
 
 Performance
 ===========

--- a/docs/ref/contrib/postgres/search.txt
+++ b/docs/ref/contrib/postgres/search.txt
@@ -116,7 +116,7 @@ See :ref:`postgresql-fts-search-configuration` for an explanation of the
     Support for ``'websearch'`` search type and query expressions in
     ``SearchQuery.value`` were added.
 
-.. versionchanged:: 3.1
+.. versionchanged:: 3.2
 
     ``Lexeme`` objects were added
 
@@ -269,9 +269,12 @@ floats to :class:`SearchRank` as ``weights`` in the same order above::
 Lexeme objects
 ==============
 
-Lexeme objects allow search operators to be used along with strings from an untrusted source. The contents
-of each lexeme is excaped so cannot contain any operators that PostgreSQL will recognise, but they support
-combining with other Lexemes using the & and | operators and also negation with the ~ operator.
+Lexeme objects allow search operators to be used with strings from an
+untrusted source. The content of each lexeme is escaped so any operators that
+exist in the string itself will not be interpreted.
+
+You can combine lexemes with other lexemes in Python using the ``&`` and ``|``
+operators and also negate them with the ``~`` operator. For example::
 
     >>> from django.contrib.postgres.search import SearchQuery, Lexeme
     >>> SearchRank(Lexeme("The user's search query") & Lexeme("Something else") & ~Lexeme("Exclude documents that match this"))

--- a/tests/postgres_tests/test_search.py
+++ b/tests/postgres_tests/test_search.py
@@ -14,7 +14,7 @@ from .models import Character, Line, LineSavedSearch, Scene
 
 try:
     from django.contrib.postgres.search import (
-        Lexeme, RawSearchQuery, SearchConfig, SearchHeadline, SearchQuery, SearchRank, SearchVector,
+        Lexeme, SearchConfig, SearchHeadline, SearchQuery, SearchRank, SearchVector,
     )
 except ImportError:
     pass
@@ -671,7 +671,7 @@ class SearchHeadlineTests(GrailTestData, PostgreSQLTestCase):
         )
 
 
-class TestRawSearchQuery(GrailTestData, PostgreSQLTestCase):
+class TestLexemes(GrailTestData, PostgreSQLTestCase):
 
     def test_simple(self):
         pass
@@ -679,27 +679,27 @@ class TestRawSearchQuery(GrailTestData, PostgreSQLTestCase):
     def test_and(self):
         searched = Line.objects.annotate(
             search=SearchVector('scene__setting', 'dialogue'),
-        ).filter(search=RawSearchQuery(Lexeme('bedemir') & Lexeme('scales')))
+        ).filter(search=SearchQuery(Lexeme('bedemir') & Lexeme('scales')))
         self.assertSequenceEqual(searched, [self.bedemir0])
 
     def test_multiple_and(self):
         searched = Line.objects.annotate(
             search=SearchVector('scene__setting', 'dialogue'),
-        ).filter(search=RawSearchQuery(Lexeme('bedemir') & Lexeme('scales') & Lexeme('nostrils')))
+        ).filter(search=SearchQuery(Lexeme('bedemir') & Lexeme('scales') & Lexeme('nostrils')))
         self.assertSequenceEqual(searched, [])
 
         searched = Line.objects.annotate(
             search=SearchVector('scene__setting', 'dialogue'),
-        ).filter(search=RawSearchQuery(Lexeme('shall') & Lexeme('use') & Lexeme('larger')))
+        ).filter(search=SearchQuery(Lexeme('shall') & Lexeme('use') & Lexeme('larger')))
         self.assertSequenceEqual(searched, [self.bedemir0])
 
     def test_or(self):
-        searched = Line.objects.filter(dialogue__search=RawSearchQuery(Lexeme('kneecaps') | Lexeme('nostrils')))
+        searched = Line.objects.filter(dialogue__search=SearchQuery(Lexeme('kneecaps') | Lexeme('nostrils')))
         self.assertCountEqual(searched, [self.verse1, self.verse2])
 
     def test_multiple_or(self):
         searched = Line.objects.filter(
-            dialogue__search=RawSearchQuery(Lexeme('kneecaps') | Lexeme('nostrils') | Lexeme('Sir Robin'))
+            dialogue__search=SearchQuery(Lexeme('kneecaps') | Lexeme('nostrils') | Lexeme('Sir Robin'))
         )
         self.assertCountEqual(searched, [self.verse1, self.verse2, self.verse0])
 
@@ -707,19 +707,19 @@ class TestRawSearchQuery(GrailTestData, PostgreSQLTestCase):
         # Test cominbation of & and |
         # This is mainly helpful for checking the test_advanced_invert below
         searched = Line.objects.filter(
-            dialogue__search=RawSearchQuery(Lexeme('shall') & Lexeme('use') & Lexeme('larger') | Lexeme('nostrils'))
+            dialogue__search=SearchQuery(Lexeme('shall') & Lexeme('use') & Lexeme('larger') | Lexeme('nostrils'))
         )
         self.assertCountEqual(searched, [self.bedemir0, self.verse2])
 
     def test_invert(self):
-        searched = Line.objects.filter(character=self.minstrel, dialogue__search=RawSearchQuery(~Lexeme('kneecaps')))
+        searched = Line.objects.filter(character=self.minstrel, dialogue__search=SearchQuery(~Lexeme('kneecaps')))
         self.assertCountEqual(searched, [self.verse0, self.verse2])
 
     def test_advanced_invert(self):
         # Test inverting a query that uses a cominbation of & and |
         # Should return the opposite of test_advanced
         searched = Line.objects.filter(
-            dialogue__search=RawSearchQuery(~(Lexeme('shall') & Lexeme('use') & Lexeme('larger') | Lexeme('nostrils')))
+            dialogue__search=SearchQuery(~(Lexeme('shall') & Lexeme('use') & Lexeme('larger') | Lexeme('nostrils')))
         )
         expected_result = Line.objects.exclude(id__in=[self.bedemir0.id, self.verse2.id])
         self.assertCountEqual(searched, expected_result)
@@ -757,7 +757,7 @@ class TestRawSearchQuery(GrailTestData, PostgreSQLTestCase):
         searched = Line.objects.annotate(
             search=SearchVector('scene__setting', 'dialogue'),
         ).filter(
-            search=RawSearchQuery(Lexeme('hear', prefix=True))
+            search=SearchQuery(Lexeme('hear', prefix=True))
         )
 
         self.assertSequenceEqual(searched, [self.verse2])
@@ -766,7 +766,7 @@ class TestRawSearchQuery(GrailTestData, PostgreSQLTestCase):
         searched = Line.objects.annotate(
             search=SearchVector('scene__setting', 'dialogue'),
         ).filter(
-            search=RawSearchQuery(Lexeme('Robi', prefix=True, invert=True))
+            search=SearchQuery(Lexeme('Robi', prefix=True, invert=True))
         )
         self.assertEqual(set(searched), {self.verse2, self.bedemir0, self.bedemir1, self.french,
                                          self.crowd, self.witch, self.duck})
@@ -775,7 +775,7 @@ class TestRawSearchQuery(GrailTestData, PostgreSQLTestCase):
         searched = Line.objects.annotate(
             search=SearchVector('scene__setting', 'dialogue'),
         ).filter(
-            search=RawSearchQuery(
+            search=SearchQuery(
                 Lexeme('Robi', prefix=True) & Lexeme('Camel', prefix=True)
             )
         )
@@ -786,7 +786,7 @@ class TestRawSearchQuery(GrailTestData, PostgreSQLTestCase):
         searched = Line.objects.annotate(
             search=SearchVector('scene__setting', 'dialogue'),
         ).filter(
-            search=RawSearchQuery(
+            search=SearchQuery(
                 Lexeme('kneecap', prefix=True) | Lexeme('afrai', prefix=True)
             )
         )

--- a/tests/postgres_tests/test_search.py
+++ b/tests/postgres_tests/test_search.py
@@ -739,12 +739,13 @@ class TestLexemes(GrailTestData, PostgreSQLTestCase):
             (~(Lexeme('a') | Lexeme('b') & ~Lexeme('c')), '%s', ["(!'a' & (!'b' | 'c'))"]),
 
             # Some escaping tests
-            (Lexeme("L'amour piqué par une abeille"), '%s', ["'L''amour piqué par une abeille'"]),
-            (Lexeme("'starting quote"), '%s', ["'''starting quote'"]),
-            (Lexeme("ending quote'"), '%s', ["'ending quote'''"]),
-            (Lexeme("double quo''te"), '%s', ["'double quo''''te'"]),
-            (Lexeme("triple quo'''te"), '%s', ["'triple quo''''''te'"]),
-            (Lexeme("backslash\\"), '%s', ["'backslash\\\\'"]),
+            (Lexeme("L'amour piqué par une abeille"), '%s', ["'L amour piqué par une abeille'"]),
+            (Lexeme("'starting quote"), '%s', ["'starting quote'"]),
+            (Lexeme("ending quote'"), '%s', ["'ending quote'"]),
+            (Lexeme("double quo''te"), '%s', ["'double quo te'"]),
+            (Lexeme("triple quo'''te"), '%s', ["'triple quo te'"]),
+            (Lexeme("backslash\\"), '%s', ["'backslash'"]),
+            (Lexeme("exclamation!"), '%s', ["'exclamation'"]),
         )
         for expression, expected_sql, expected_params in tests:
             with self.subTest(expression=expression):

--- a/tests/postgres_tests/test_search.py
+++ b/tests/postgres_tests/test_search.py
@@ -701,3 +701,14 @@ class TestPrefixMatching(GrailTestData, PostgreSQLTestCase):
         )
 
         self.assertSequenceEqual(searched, [self.verse0])
+
+    def test_lexemes_multiple_or(self):
+        searched = Line.objects.annotate(
+            search=SearchVector('scene__setting', 'dialogue'),
+        ).filter(
+            search=RawSearchQuery(
+                Lexeme('kneecap', prefix=True) | Lexeme('afrai', prefix=True)
+            )
+        )
+
+        self.assertSequenceEqual(searched, [self.verse0, self.verse1])


### PR DESCRIPTION
This pull request is based on an earlier one: https://github.com/django/django/pull/8313

I've rebased it on the latest master and made the following tweaks:
 - Added some tests and docs
 - Added escaping for quotes and backslashes
 - Added support for the `~`  operator on Lexemes
 - Replaced the `RawSearchQuery` with the new `SearchQuery(search_type='raw')`