### PR TITLE
Fixed #31473 -- Made sql_flush() use RESTART IDENTITY to reset sequences on PostgreSQL.

### DIFF
--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -13,8 +13,12 @@ def sql_flush(style, connection, only_django=False, reset_sequences=True, allow_
         tables = connection.introspection.django_table_names(only_existing=True, include_views=False)
     else:
         tables = connection.introspection.table_names(include_views=False)
-    seqs = connection.introspection.sequence_list() if reset_sequences else ()
-    return connection.ops.sql_flush(style, tables, seqs, allow_cascade)
+    return connection.ops.sql_flush(
+        style,
+        tables,
+        reset_sequences=reset_sequences,
+        allow_cascade=allow_cascade,
+    )
 
 
 def emit_pre_migrate_signal(verbosity, interactive, db, **kwargs):

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -382,15 +382,17 @@ class BaseDatabaseOperations:
         """
         return ''
 
-    def sql_flush(self, style, tables, sequences, allow_cascade=False):
+    def sql_flush(self, style, tables, *, reset_sequences=False, allow_cascade=False):
         """
         Return a list of SQL statements required to remove all data from
         the given database tables (without actually removing the tables
-        themselves) and the SQL statements required to reset the sequences
-        passed in `sequences`.
+        themselves).
 
         The `style` argument is a Style object as returned by either
         color_style() or no_style() in django.core.management.color.
+
+        If `reset_sequences` is True, the list includes SQL statements required
+        to reset the sequences.
 
         The `allow_cascade` argument determines whether truncation may cascade
         to tables with foreign keys pointing the tables being truncated.

--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -193,29 +193,30 @@ class DatabaseOperations(BaseDatabaseOperations):
         ]
         return 'RETURNING %s' % ', '.join(columns), ()
 
-    def sql_flush(self, style, tables, sequences, allow_cascade=False):
+    def sql_flush(self, style, tables, *, reset_sequences=False, allow_cascade=False):
         if not tables:
             return []
+
         sql = ['SET FOREIGN_KEY_CHECKS = 0;']
-        tables = set(tables)
-        with_sequences = set(s['table'] for s in sequences)
-        # It's faster to TRUNCATE tables that require a sequence reset since
-        # ALTER TABLE AUTO_INCREMENT is slower than TRUNCATE.
-        sql.extend(
-            '%s %s;' % (
-                style.SQL_KEYWORD('TRUNCATE'),
-                style.SQL_FIELD(self.quote_name(table_name)),
-            ) for table_name in tables.intersection(with_sequences)
-        )
-        # Otherwise issue a simple DELETE since it's faster than TRUNCATE
-        # and preserves sequences.
-        sql.extend(
-            '%s %s %s;' % (
-                style.SQL_KEYWORD('DELETE'),
-                style.SQL_KEYWORD('FROM'),
-                style.SQL_FIELD(self.quote_name(table_name)),
-            ) for table_name in tables.difference(with_sequences)
-        )
+        if reset_sequences:
+            # It's faster to TRUNCATE tables that require a sequence reset
+            # since ALTER TABLE AUTO_INCREMENT is slower than TRUNCATE.
+            sql.extend(
+                '%s %s;' % (
+                    style.SQL_KEYWORD('TRUNCATE'),
+                    style.SQL_FIELD(self.quote_name(table_name)),
+                ) for table_name in tables
+            )
+        else:
+            # Otherwise issue a simple DELETE since it's faster than TRUNCATE
+            # and preserves sequences.
+            sql.extend(
+                '%s %s %s;' % (
+                    style.SQL_KEYWORD('DELETE'),
+                    style.SQL_KEYWORD('FROM'),
+                    style.SQL_FIELD(self.quote_name(table_name)),
+                ) for table_name in tables
+            )
         sql.append('SET FOREIGN_KEY_CHECKS = 1;')
         return sql
 

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -405,52 +405,51 @@ END;
         return lru_cache(maxsize=512)(self.__foreign_key_constraints)
 
     def sql_flush(self, style, tables, sequences, allow_cascade=False):
-        if tables:
-            truncated_tables = {table.upper() for table in tables}
-            constraints = set()
-            # Oracle's TRUNCATE CASCADE only works with ON DELETE CASCADE
-            # foreign keys which Django doesn't define. Emulate the
-            # PostgreSQL behavior which truncates all dependent tables by
-            # manually retrieving all foreign key constraints and resolving
-            # dependencies.
-            for table in tables:
-                for foreign_table, constraint in self._foreign_key_constraints(table, recursive=allow_cascade):
-                    if allow_cascade:
-                        truncated_tables.add(foreign_table)
-                    constraints.add((foreign_table, constraint))
-            sql = [
-                "%s %s %s %s %s %s %s %s;" % (
-                    style.SQL_KEYWORD('ALTER'),
-                    style.SQL_KEYWORD('TABLE'),
-                    style.SQL_FIELD(self.quote_name(table)),
-                    style.SQL_KEYWORD('DISABLE'),
-                    style.SQL_KEYWORD('CONSTRAINT'),
-                    style.SQL_FIELD(self.quote_name(constraint)),
-                    style.SQL_KEYWORD('KEEP'),
-                    style.SQL_KEYWORD('INDEX'),
-                ) for table, constraint in constraints
-            ] + [
-                "%s %s %s;" % (
-                    style.SQL_KEYWORD('TRUNCATE'),
-                    style.SQL_KEYWORD('TABLE'),
-                    style.SQL_FIELD(self.quote_name(table)),
-                ) for table in truncated_tables
-            ] + [
-                "%s %s %s %s %s %s;" % (
-                    style.SQL_KEYWORD('ALTER'),
-                    style.SQL_KEYWORD('TABLE'),
-                    style.SQL_FIELD(self.quote_name(table)),
-                    style.SQL_KEYWORD('ENABLE'),
-                    style.SQL_KEYWORD('CONSTRAINT'),
-                    style.SQL_FIELD(self.quote_name(constraint)),
-                ) for table, constraint in constraints
-            ]
-            # Since we've just deleted all the rows, running our sequence
-            # ALTER code will reset the sequence to 0.
-            sql.extend(self.sequence_reset_by_name_sql(style, sequences))
-            return sql
-        else:
+        if not tables:
             return []
+
+        truncated_tables = {table.upper() for table in tables}
+        constraints = set()
+        # Oracle's TRUNCATE CASCADE only works with ON DELETE CASCADE foreign
+        # keys which Django doesn't define. Emulate the PostgreSQL behavior
+        # which truncates all dependent tables by manually retrieving all
+        # foreign key constraints and resolving dependencies.
+        for table in tables:
+            for foreign_table, constraint in self._foreign_key_constraints(table, recursive=allow_cascade):
+                if allow_cascade:
+                    truncated_tables.add(foreign_table)
+                constraints.add((foreign_table, constraint))
+        sql = [
+            '%s %s %s %s %s %s %s %s;' % (
+                style.SQL_KEYWORD('ALTER'),
+                style.SQL_KEYWORD('TABLE'),
+                style.SQL_FIELD(self.quote_name(table)),
+                style.SQL_KEYWORD('DISABLE'),
+                style.SQL_KEYWORD('CONSTRAINT'),
+                style.SQL_FIELD(self.quote_name(constraint)),
+                style.SQL_KEYWORD('KEEP'),
+                style.SQL_KEYWORD('INDEX'),
+            ) for table, constraint in constraints
+        ] + [
+            '%s %s %s;' % (
+                style.SQL_KEYWORD('TRUNCATE'),
+                style.SQL_KEYWORD('TABLE'),
+                style.SQL_FIELD(self.quote_name(table)),
+            ) for table in truncated_tables
+        ] + [
+            '%s %s %s %s %s %s;' % (
+                style.SQL_KEYWORD('ALTER'),
+                style.SQL_KEYWORD('TABLE'),
+                style.SQL_FIELD(self.quote_name(table)),
+                style.SQL_KEYWORD('ENABLE'),
+                style.SQL_KEYWORD('CONSTRAINT'),
+                style.SQL_FIELD(self.quote_name(constraint)),
+            ) for table, constraint in constraints
+        ]
+        # Since we've just deleted all the rows, running our sequence ALTER
+        # code will reset the sequence to 0.
+        sql.extend(self.sequence_reset_by_name_sql(style, sequences))
+        return sql
 
     def sequence_reset_by_name_sql(self, style, sequences):
         sql = []

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -118,27 +118,27 @@ class DatabaseOperations(BaseDatabaseOperations):
         return "SET TIME ZONE %s"
 
     def sql_flush(self, style, tables, sequences, allow_cascade=False):
-        if tables:
-            # Perform a single SQL 'TRUNCATE x, y, z...;' statement.  It allows
-            # us to truncate tables referenced by a foreign key in any other
-            # table.
-            tables_sql = ', '.join(
-                style.SQL_FIELD(self.quote_name(table)) for table in tables)
-            if allow_cascade:
-                sql = ['%s %s %s;' % (
-                    style.SQL_KEYWORD('TRUNCATE'),
-                    tables_sql,
-                    style.SQL_KEYWORD('CASCADE'),
-                )]
-            else:
-                sql = ['%s %s;' % (
-                    style.SQL_KEYWORD('TRUNCATE'),
-                    tables_sql,
-                )]
-            sql.extend(self.sequence_reset_by_name_sql(style, sequences))
-            return sql
-        else:
+        if not tables:
             return []
+
+        # Perform a single SQL 'TRUNCATE x, y, z...;' statement. It allows us
+        # to truncate tables referenced by a foreign key in any other table.
+        tables_sql = ', '.join(
+            style.SQL_FIELD(self.quote_name(table)) for table in tables
+        )
+        if allow_cascade:
+            sql = ['%s %s %s;' % (
+                style.SQL_KEYWORD('TRUNCATE'),
+                tables_sql,
+                style.SQL_KEYWORD('CASCADE'),
+            )]
+        else:
+            sql = ['%s %s;' % (
+                style.SQL_KEYWORD('TRUNCATE'),
+                tables_sql,
+            )]
+        sql.extend(self.sequence_reset_by_name_sql(style, sequences))
+        return sql
 
     def sequence_reset_by_name_sql(self, style, sequences):
         # 'ALTER SEQUENCE sequence_name RESTART WITH 1;'... style SQL statements

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -196,7 +196,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         # Django's test suite.
         return lru_cache(maxsize=512)(self.__references_graph)
 
-    def sql_flush(self, style, tables, sequences, allow_cascade=False):
+    def sql_flush(self, style, tables, *, reset_sequences=False, allow_cascade=False):
         if tables and allow_cascade:
             # Simulate TRUNCATE CASCADE by recursively collecting the tables
             # referencing the tables to be flushed.

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -519,6 +519,13 @@ backends.
 * ``DatabaseClient.runshell()`` now requires an additional ``parameters``
   argument as a list of extra arguments to pass on to the command-line client.
 
+* The ``sequences`` positional argument of ``DatabaseOperations.sql_flush()``
+  is replaced by the boolean keyword-only argument ``reset_sequences``. If
+  ``True``, the sequences of the truncated tables will be reset.
+
+* The ``allow_cascade`` argument of ``DatabaseOperations.sql_flush()`` is now a
+  keyword-only argument.
+
 Dropped support for MariaDB 10.1
 --------------------------------
 

--- a/tests/backends/mysql/test_operations.py
+++ b/tests/backends/mysql/test_operations.py
@@ -4,7 +4,7 @@ from django.core.management.color import no_style
 from django.db import connection
 from django.test import SimpleTestCase
 
-from ..models import Person, Square, Tag
+from ..models import Person, Tag
 
 
 @unittest.skipUnless(connection.vendor == 'mysql', 'MySQL tests.')
@@ -13,50 +13,35 @@ class MySQLOperationsTests(SimpleTestCase):
         # allow_cascade doesn't change statements on MySQL.
         for allow_cascade in [False, True]:
             with self.subTest(allow_cascade=allow_cascade):
-                statements = connection.ops.sql_flush(
-                    no_style(),
-                    [Person._meta.db_table, Tag._meta.db_table],
-                    [],
-                    allow_cascade=allow_cascade,
-                )
-                self.assertEqual(statements[0], 'SET FOREIGN_KEY_CHECKS = 0;')
-                # The tables are processed in an unordered set.
                 self.assertEqual(
-                    sorted(statements[1:-1]),
+                    connection.ops.sql_flush(
+                        no_style(),
+                        [Person._meta.db_table, Tag._meta.db_table],
+                        allow_cascade=allow_cascade,
+                    ),
                     [
+                        'SET FOREIGN_KEY_CHECKS = 0;',
                         'DELETE FROM `backends_person`;',
                         'DELETE FROM `backends_tag`;',
+                        'SET FOREIGN_KEY_CHECKS = 1;',
                     ],
                 )
-                self.assertEqual(statements[-1], 'SET FOREIGN_KEY_CHECKS = 1;')
 
     def test_sql_flush_sequences(self):
         # allow_cascade doesn't change statements on MySQL.
         for allow_cascade in [False, True]:
             with self.subTest(allow_cascade=allow_cascade):
-                statements = connection.ops.sql_flush(
-                    no_style(),
-                    [Person._meta.db_table, Square._meta.db_table, Tag._meta.db_table],
-                    [
-                        {
-                            'table': Person._meta.db_table,
-                            'column': Person._meta.pk.db_column,
-                        },
-                        {
-                            'table': Tag._meta.db_table,
-                            'column': Tag._meta.pk.db_column,
-                        },
-                    ],
-                    allow_cascade=allow_cascade,
-                )
-                self.assertEqual(statements[0], 'SET FOREIGN_KEY_CHECKS = 0;')
-                # The tables are processed in an unordered set.
                 self.assertEqual(
-                    sorted(statements[1:-1]),
+                    connection.ops.sql_flush(
+                        no_style(),
+                        [Person._meta.db_table, Tag._meta.db_table],
+                        reset_sequences=True,
+                        allow_cascade=allow_cascade,
+                    ),
                     [
-                        'DELETE FROM `backends_square`;',
+                        'SET FOREIGN_KEY_CHECKS = 0;',
                         'TRUNCATE `backends_person`;',
                         'TRUNCATE `backends_tag`;',
+                        'SET FOREIGN_KEY_CHECKS = 1;',
                     ],
                 )
-                self.assertEqual(statements[-1], 'SET FOREIGN_KEY_CHECKS = 1;')

--- a/tests/backends/oracle/test_operations.py
+++ b/tests/backends/oracle/test_operations.py
@@ -31,7 +31,6 @@ class OperationsTests(unittest.TestCase):
         statements = connection.ops.sql_flush(
             no_style(),
             [Person._meta.db_table, Tag._meta.db_table],
-            [],
         )
         # The tables and constraints are processed in an unordered set.
         self.assertEqual(
@@ -56,7 +55,6 @@ class OperationsTests(unittest.TestCase):
         statements = connection.ops.sql_flush(
             no_style(),
             [Person._meta.db_table, Tag._meta.db_table],
-            [],
             allow_cascade=True,
         )
         # The tables and constraints are processed in an unordered set.
@@ -83,16 +81,7 @@ class OperationsTests(unittest.TestCase):
         statements = connection.ops.sql_flush(
             no_style(),
             [Person._meta.db_table, Tag._meta.db_table],
-            [
-                {
-                    'table': Person._meta.db_table,
-                    'column': Person._meta.pk.db_column,
-                },
-                {
-                    'table': Tag._meta.db_table,
-                    'column': Tag._meta.pk.db_column,
-                },
-            ],
+            reset_sequences=True,
         )
         # The tables and constraints are processed in an unordered set.
         self.assertEqual(
@@ -121,16 +110,7 @@ class OperationsTests(unittest.TestCase):
         statements = connection.ops.sql_flush(
             no_style(),
             [Person._meta.db_table, Tag._meta.db_table],
-            [
-                {
-                    'table': Person._meta.db_table,
-                    'column': Person._meta.pk.db_column,
-                },
-                {
-                    'table': Tag._meta.db_table,
-                    'column': Tag._meta.pk.db_column,
-                },
-            ],
+            reset_sequences=True,
             allow_cascade=True,
         )
         # The tables and constraints are processed in an unordered set.
@@ -153,6 +133,7 @@ class OperationsTests(unittest.TestCase):
             '"BACKENDS__PERSON_ID_1DD5E829_F";',
         )
         # Sequences.
-        self.assertEqual(len(statements[5:]), 2)
+        self.assertEqual(len(statements[5:]), 3)
         self.assertIn('BACKENDS_PERSON_SQ', statements[5])
-        self.assertIn('BACKENDS_TAG_SQ', statements[6])
+        self.assertIn('BACKENDS_VERYLONGMODELN7BE2_SQ', statements[6])
+        self.assertIn('BACKENDS_TAG_SQ', statements[7])

--- a/tests/backends/postgresql/test_operations.py
+++ b/tests/backends/postgresql/test_operations.py
@@ -14,7 +14,6 @@ class PostgreSQLOperationsTests(SimpleTestCase):
             connection.ops.sql_flush(
                 no_style(),
                 [Person._meta.db_table, Tag._meta.db_table],
-                [],
             ),
             ['TRUNCATE "backends_person", "backends_tag";'],
         )
@@ -24,61 +23,28 @@ class PostgreSQLOperationsTests(SimpleTestCase):
             connection.ops.sql_flush(
                 no_style(),
                 [Person._meta.db_table, Tag._meta.db_table],
-                [],
                 allow_cascade=True,
             ),
             ['TRUNCATE "backends_person", "backends_tag" CASCADE;'],
         )
 
     def test_sql_flush_sequences(self):
-        sequence_reset_sql = (
-            "SELECT setval(pg_get_serial_sequence('%s','id'), 1, false);"
-        )
         self.assertEqual(
             connection.ops.sql_flush(
                 no_style(),
                 [Person._meta.db_table, Tag._meta.db_table],
-                [
-                    {
-                        'table': Person._meta.db_table,
-                        'column': Person._meta.pk.db_column,
-                    },
-                    {
-                        'table': Tag._meta.db_table,
-                        'column': Tag._meta.pk.db_column,
-                    },
-                ],
+                reset_sequences=True,
             ),
-            [
-                'TRUNCATE "backends_person", "backends_tag";',
-                sequence_reset_sql % '"backends_person"',
-                sequence_reset_sql % '"backends_tag"',
-            ],
+            ['TRUNCATE "backends_person", "backends_tag" RESTART IDENTITY;'],
         )
 
     def test_sql_flush_sequences_allow_cascade(self):
-        sequence_reset_sql = (
-            "SELECT setval(pg_get_serial_sequence('%s','id'), 1, false);"
-        )
         self.assertEqual(
             connection.ops.sql_flush(
                 no_style(),
                 [Person._meta.db_table, Tag._meta.db_table],
-                [
-                    {
-                        'table': Person._meta.db_table,
-                        'column': Person._meta.pk.db_column,
-                    },
-                    {
-                        'table': Tag._meta.db_table,
-                        'column': Tag._meta.pk.db_column,
-                    },
-                ],
+                reset_sequences=True,
                 allow_cascade=True,
             ),
-            [
-                'TRUNCATE "backends_person", "backends_tag" CASCADE;',
-                sequence_reset_sql % '"backends_person"',
-                sequence_reset_sql % '"backends_tag"',
-            ],
+            ['TRUNCATE "backends_person", "backends_tag" RESTART IDENTITY CASCADE;'],
         )

--- a/tests/backends/sqlite/test_operations.py
+++ b/tests/backends/sqlite/test_operations.py
@@ -14,7 +14,6 @@ class SQLiteOperationsTests(TestCase):
             connection.ops.sql_flush(
                 no_style(),
                 [Person._meta.db_table, Tag._meta.db_table],
-                [],
             ),
             [
                 'DELETE FROM "backends_person";',
@@ -26,7 +25,6 @@ class SQLiteOperationsTests(TestCase):
         statements = connection.ops.sql_flush(
             no_style(),
             [Person._meta.db_table, Tag._meta.db_table],
-            [],
             allow_cascade=True,
         )
         self.assertEqual(
@@ -47,16 +45,7 @@ class SQLiteOperationsTests(TestCase):
             connection.ops.sql_flush(
                 no_style(),
                 [Person._meta.db_table, Tag._meta.db_table],
-                [
-                    {
-                        'table': Person._meta.db_table,
-                        'column': Person._meta.pk.db_column,
-                    },
-                    {
-                        'table': Tag._meta.db_table,
-                        'column': Tag._meta.pk.db_column,
-                    },
-                ],
+                reset_sequences=True,
             ),
             [
                 'DELETE FROM "backends_person";',
@@ -69,16 +58,7 @@ class SQLiteOperationsTests(TestCase):
         statements = connection.ops.sql_flush(
             no_style(),
             [Person._meta.db_table, Tag._meta.db_table],
-            [
-                {
-                    'table': Person._meta.db_table,
-                    'column': Person._meta.pk.db_column,
-                },
-                {
-                    'table': Tag._meta.db_table,
-                    'column': Tag._meta.pk.db_column,
-                },
-            ],
+            reset_sequences=True,
             allow_cascade=True,
         )
         self.assertEqual(

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -161,13 +161,7 @@ class LongNameTest(TransactionTestCase):
             VLM._meta.db_table,
             VLM_m2m._meta.db_table,
         ]
-        sequences = [
-            {
-                'column': VLM._meta.pk.column,
-                'table': VLM._meta.db_table
-            },
-        ]
-        sql_list = connection.ops.sql_flush(no_style(), tables, sequences)
+        sql_list = connection.ops.sql_flush(no_style(), tables, reset_sequences=True)
         with connection.cursor() as cursor:
             for statement in sql_list:
                 cursor.execute(statement)


### PR DESCRIPTION
The sql_flush() positional argument sequences is replaced by the boolean
keyword-only argument reset_sequences. This ensures that the old
function signature can't be used by mistake when upgrading Django. When
the new argument is True, the sequences of the truncated tables will
reset. Using a single boolean value, rather than a list, allows making a
binary yes/no choice as to whether to reset all sequences rather than a
working on a completely different set.

https://code.djangoproject.com/ticket/31473