### PR TITLE
Refs #31351 -- Made partial constraints tests use required_db_features.

### DIFF
--- a/tests/constraints/models.py
+++ b/tests/constraints/models.py
@@ -41,6 +41,16 @@ class UniqueConstraintProduct(models.Model):
     class Meta:
         constraints = [
             models.UniqueConstraint(fields=['name', 'color'], name='name_color_uniq'),
+        ]
+
+
+class UniqueConstraintConditionProduct(models.Model):
+    name = models.CharField(max_length=255)
+    color = models.CharField(max_length=32, null=True)
+
+    class Meta:
+        required_db_features = {'supports_partial_indexes'}
+        constraints = [
             models.UniqueConstraint(
                 fields=['name'],
                 name='name_without_color_uniq',


### PR DESCRIPTION
This will notably silence the warnings issued when running the test suite on MySQL and MariaDB:
```
constraints.UniqueConstraintProduct: (models.W036) MariaDB does not support unique constraints with conditions.
    HINT: A constraint won't be created. Silence this warning if you don't care about it.
```