### PR TITLE
Stable/1.8.19-fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tests/coverage_html/
 tests/.coverage
 build/
 tests/report/
+.idea
+venv


### PR DESCRIPTION
This fork avoids the urgent need to upgrade to django 1.11

Products and its versions:
- Python 2.7.x
- Instant Client 18.3.0.0.0-1
- cx-Oracle=6.4.1
- Oracle 12c