### PR TITLE
Fixed #31477 -- Removed "using" argument from DatabaseOperations.execute_sql_flush().

### DIFF
--- a/django/core/management/commands/flush.py
+++ b/django/core/management/commands/flush.py
@@ -60,7 +60,7 @@ Are you sure you want to do this?
 
         if confirm == 'yes':
             try:
-                connection.ops.execute_sql_flush(database, sql_list)
+                connection.ops.execute_sql_flush(sql_list)
             except Exception as exc:
                 raise CommandError(
                     "Database %s couldn't be flushed. Possible reasons:\n"

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -400,9 +400,12 @@ class BaseDatabaseOperations:
         """
         raise NotImplementedError('subclasses of BaseDatabaseOperations must provide a sql_flush() method')
 
-    def execute_sql_flush(self, using, sql_list):
+    def execute_sql_flush(self, sql_list):
         """Execute a list of SQL statements to flush the database."""
-        with transaction.atomic(using=using, savepoint=self.connection.features.can_rollback_ddl):
+        with transaction.atomic(
+            using=self.connection.alias,
+            savepoint=self.connection.features.can_rollback_ddl,
+        ):
             with self.connection.cursor() as cursor:
                 for sql in sql_list:
                     cursor.execute(sql)

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -526,6 +526,10 @@ backends.
 * The ``allow_cascade`` argument of ``DatabaseOperations.sql_flush()`` is now a
   keyword-only argument.
 
+* The ``using`` positional argument of
+  ``DatabaseOperations.execute_sql_flush()`` is removed. The method now uses
+  the database of the called instance.
+
 Dropped support for MariaDB 10.1
 --------------------------------
 

--- a/tests/backends/base/test_operations.py
+++ b/tests/backends/base/test_operations.py
@@ -172,7 +172,7 @@ class SqlFlushTests(TransactionTestCase):
             reset_sequences=True,
             allow_cascade=True,
         )
-        connection.ops.execute_sql_flush(connection.alias, sql_list)
+        connection.ops.execute_sql_flush(sql_list)
 
         with transaction.atomic():
             self.assertIs(Author.objects.exists(), False)

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -162,7 +162,7 @@ class LongNameTest(TransactionTestCase):
             VLM_m2m._meta.db_table,
         ]
         sql_list = connection.ops.sql_flush(no_style(), tables, reset_sequences=True)
-        connection.ops.execute_sql_flush(connection.alias, sql_list)
+        connection.ops.execute_sql_flush(sql_list)
 
 
 class SequenceResetTest(TestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31477