### PR TITLE
Disabled management commands output with verbosity 0 in various tests.

### DIFF
--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -990,7 +990,7 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
         'DJANGO_SUPERUSER_FIRST_NAME': 'ignored_first_name',
     })
     def test_environment_variable_non_interactive(self):
-        call_command('createsuperuser', interactive=False, stdout=StringIO())
+        call_command('createsuperuser', interactive=False, verbosity=0)
         user = User.objects.get(username='test_superuser')
         self.assertEqual(user.email, 'joe@somewhere.org')
         self.assertTrue(user.check_password('test_password'))
@@ -1009,7 +1009,7 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
             interactive=False,
             username='cmd_superuser',
             email='cmd@somewhere.org',
-            stdout=StringIO(),
+            verbosity=0,
         )
         user = User.objects.get(username='cmd_superuser')
         self.assertEqual(user.email, 'cmd@somewhere.org')
@@ -1030,7 +1030,7 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
                 username='cmd_superuser',
                 email='cmd@somewhere.org',
                 stdin=MockTTY(),
-                stdout=StringIO(),
+                verbosity=0,
             )
             user = User.objects.get(username='cmd_superuser')
             self.assertEqual(user.email, 'cmd@somewhere.org')

--- a/tests/i18n/test_compilation.py
+++ b/tests/i18n/test_compilation.py
@@ -38,7 +38,7 @@ class PoFileTests(MessageCompilationTests):
     def test_bom_rejection(self):
         stderr = StringIO()
         with self.assertRaisesMessage(CommandError, 'compilemessages generated one or more errors.'):
-            call_command('compilemessages', locale=[self.LOCALE], stdout=StringIO(), stderr=stderr)
+            call_command('compilemessages', locale=[self.LOCALE], verbosity=0, stderr=stderr)
         self.assertIn('file has a BOM (Byte Order Mark)', stderr.getvalue())
         self.assertFalse(os.path.exists(self.MO_FILE))
 
@@ -63,7 +63,7 @@ class PoFileContentsTests(MessageCompilationTests):
     MO_FILE = 'locale/%s/LC_MESSAGES/django.mo' % LOCALE
 
     def test_percent_symbol_in_po_file(self):
-        call_command('compilemessages', locale=[self.LOCALE], stdout=StringIO())
+        call_command('compilemessages', locale=[self.LOCALE], verbosity=0)
         self.assertTrue(os.path.exists(self.MO_FILE))
 
 
@@ -80,13 +80,13 @@ class MultipleLocaleCompilationTests(MessageCompilationTests):
 
     def test_one_locale(self):
         with override_settings(LOCALE_PATHS=[os.path.join(self.test_dir, 'locale')]):
-            call_command('compilemessages', locale=['hr'], stdout=StringIO())
+            call_command('compilemessages', locale=['hr'], verbosity=0)
 
             self.assertTrue(os.path.exists(self.MO_FILE_HR))
 
     def test_multiple_locales(self):
         with override_settings(LOCALE_PATHS=[os.path.join(self.test_dir, 'locale')]):
-            call_command('compilemessages', locale=['hr', 'fr'], stdout=StringIO())
+            call_command('compilemessages', locale=['hr', 'fr'], verbosity=0)
 
             self.assertTrue(os.path.exists(self.MO_FILE_HR))
             self.assertTrue(os.path.exists(self.MO_FILE_FR))
@@ -110,26 +110,25 @@ class ExcludedLocaleCompilationTests(MessageCompilationTests):
             execute_from_command_line(['django-admin', 'help', 'compilemessages'])
 
     def test_one_locale_excluded(self):
-        call_command('compilemessages', exclude=['it'], stdout=StringIO())
+        call_command('compilemessages', exclude=['it'], verbosity=0)
         self.assertTrue(os.path.exists(self.MO_FILE % 'en'))
         self.assertTrue(os.path.exists(self.MO_FILE % 'fr'))
         self.assertFalse(os.path.exists(self.MO_FILE % 'it'))
 
     def test_multiple_locales_excluded(self):
-        call_command('compilemessages', exclude=['it', 'fr'], stdout=StringIO())
+        call_command('compilemessages', exclude=['it', 'fr'], verbosity=0)
         self.assertTrue(os.path.exists(self.MO_FILE % 'en'))
         self.assertFalse(os.path.exists(self.MO_FILE % 'fr'))
         self.assertFalse(os.path.exists(self.MO_FILE % 'it'))
 
     def test_one_locale_excluded_with_locale(self):
-        call_command('compilemessages', locale=['en', 'fr'], exclude=['fr'], stdout=StringIO())
+        call_command('compilemessages', locale=['en', 'fr'], exclude=['fr'], verbosity=0)
         self.assertTrue(os.path.exists(self.MO_FILE % 'en'))
         self.assertFalse(os.path.exists(self.MO_FILE % 'fr'))
         self.assertFalse(os.path.exists(self.MO_FILE % 'it'))
 
     def test_multiple_locales_excluded_with_locale(self):
-        call_command('compilemessages', locale=['en', 'fr', 'it'], exclude=['fr', 'it'],
-                     stdout=StringIO())
+        call_command('compilemessages', locale=['en', 'fr', 'it'], exclude=['fr', 'it'], verbosity=0)
         self.assertTrue(os.path.exists(self.MO_FILE % 'en'))
         self.assertFalse(os.path.exists(self.MO_FILE % 'fr'))
         self.assertFalse(os.path.exists(self.MO_FILE % 'it'))
@@ -177,7 +176,7 @@ class CompilationErrorHandling(MessageCompilationTests):
     def test_error_reported_by_msgfmt(self):
         # po file contains wrong po formatting.
         with self.assertRaises(CommandError):
-            call_command('compilemessages', locale=['ja'], verbosity=0, stderr=StringIO())
+            call_command('compilemessages', locale=['ja'], verbosity=0)
 
     def test_msgfmt_error_including_non_ascii(self):
         # po file contains invalid msgstr content (triggers non-ascii error content).
@@ -208,14 +207,14 @@ class FuzzyTranslationTest(ProjectAndAppTests):
 
     def test_nofuzzy_compiling(self):
         with override_settings(LOCALE_PATHS=[os.path.join(self.test_dir, 'locale')]):
-            call_command('compilemessages', locale=[self.LOCALE], stdout=StringIO())
+            call_command('compilemessages', locale=[self.LOCALE], verbosity=0)
             with translation.override(self.LOCALE):
                 self.assertEqual(gettext('Lenin'), 'Ленин')
                 self.assertEqual(gettext('Vodka'), 'Vodka')
 
     def test_fuzzy_compiling(self):
         with override_settings(LOCALE_PATHS=[os.path.join(self.test_dir, 'locale')]):
-            call_command('compilemessages', locale=[self.LOCALE], fuzzy=True, stdout=StringIO())
+            call_command('compilemessages', locale=[self.LOCALE], fuzzy=True, verbosity=0)
             with translation.override(self.LOCALE):
                 self.assertEqual(gettext('Lenin'), 'Ленин')
                 self.assertEqual(gettext('Vodka'), 'Водка')
@@ -224,7 +223,7 @@ class FuzzyTranslationTest(ProjectAndAppTests):
 class AppCompilationTest(ProjectAndAppTests):
 
     def test_app_locale_compiled(self):
-        call_command('compilemessages', locale=[self.LOCALE], stdout=StringIO())
+        call_command('compilemessages', locale=[self.LOCALE], verbosity=0)
         self.assertTrue(os.path.exists(self.PROJECT_MO_FILE))
         self.assertTrue(os.path.exists(self.APP_MO_FILE))
 
@@ -234,5 +233,5 @@ class PathLibLocaleCompilationTests(MessageCompilationTests):
 
     def test_locale_paths_pathlib(self):
         with override_settings(LOCALE_PATHS=[Path(self.test_dir) / 'canned_locale']):
-            call_command('compilemessages', locale=['fr'], stdout=StringIO())
+            call_command('compilemessages', locale=['fr'], verbosity=0)
             self.assertTrue(os.path.exists('canned_locale/fr/LC_MESSAGES/django.mo'))

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -715,26 +715,25 @@ class ExcludedLocaleExtractionTests(ExtractorTests):
             execute_from_command_line(['django-admin', 'help', 'makemessages'])
 
     def test_one_locale_excluded(self):
-        management.call_command('makemessages', exclude=['it'], stdout=StringIO())
+        management.call_command('makemessages', exclude=['it'], verbosity=0)
         self.assertRecentlyModified(self.PO_FILE % 'en')
         self.assertRecentlyModified(self.PO_FILE % 'fr')
         self.assertNotRecentlyModified(self.PO_FILE % 'it')
 
     def test_multiple_locales_excluded(self):
-        management.call_command('makemessages', exclude=['it', 'fr'], stdout=StringIO())
+        management.call_command('makemessages', exclude=['it', 'fr'], verbosity=0)
         self.assertRecentlyModified(self.PO_FILE % 'en')
         self.assertNotRecentlyModified(self.PO_FILE % 'fr')
         self.assertNotRecentlyModified(self.PO_FILE % 'it')
 
     def test_one_locale_excluded_with_locale(self):
-        management.call_command('makemessages', locale=['en', 'fr'], exclude=['fr'], stdout=StringIO())
+        management.call_command('makemessages', locale=['en', 'fr'], exclude=['fr'], verbosity=0)
         self.assertRecentlyModified(self.PO_FILE % 'en')
         self.assertNotRecentlyModified(self.PO_FILE % 'fr')
         self.assertNotRecentlyModified(self.PO_FILE % 'it')
 
     def test_multiple_locales_excluded_with_locale(self):
-        management.call_command('makemessages', locale=['en', 'fr', 'it'], exclude=['fr', 'it'],
-                                stdout=StringIO())
+        management.call_command('makemessages', locale=['en', 'fr', 'it'], exclude=['fr', 'it'], verbosity=0)
         self.assertRecentlyModified(self.PO_FILE % 'en')
         self.assertNotRecentlyModified(self.PO_FILE % 'fr')
         self.assertNotRecentlyModified(self.PO_FILE % 'it')

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -43,9 +43,8 @@ class CommandTests(SimpleTestCase):
         self.assertIn("I don't feel like dancing Jive.\n", out.getvalue())
 
     def test_language_preserved(self):
-        out = StringIO()
         with translation.override('fr'):
-            management.call_command('dance', stdout=out)
+            management.call_command('dance', verbosity=0)
             self.assertEqual(translation.get_language(), 'fr')
 
     def test_explode(self):
@@ -76,7 +75,7 @@ class CommandTests(SimpleTestCase):
         """
         current_locale = translation.get_language()
         with translation.override('pl'):
-            result = management.call_command('no_translations', stdout=StringIO())
+            result = management.call_command('no_translations')
             self.assertIsNone(result)
         self.assertEqual(translation.get_language(), current_locale)
 
@@ -140,7 +139,7 @@ class CommandTests(SimpleTestCase):
 
     def test_calling_a_command_with_no_app_labels_and_parameters_should_raise_a_command_error(self):
         with self.assertRaises(CommandError):
-            management.call_command('hal', stdout=StringIO())
+            management.call_command('hal')
 
     def test_output_transaction(self):
         output = management.call_command('transaction', stdout=StringIO(), no_color=True)


### PR DESCRIPTION
Instead of capturing the command output and discard it immediately, tell
the command not to log.

Output capturing was maintained for commands outputting lines despite
verbosity=0.