### PR TITLE
Refs #30165 -- Removed obsolete doc references to deprecated ugettext() & co.

### DIFF
--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -1027,10 +1027,6 @@ appropriate entities.
 For a complete discussion on the usage of the following see the
 :doc:`translation documentation </topics/i18n/translation>`.
 
-The ``u`` prefix on the functions below comes from a difference in Python 2
-between unicode and bytestrings. If your code doesn't support Python 2, use the
-functions without the ``u``.
-
 .. function:: gettext(message)
 
     Translates ``message`` and returns it as a string.

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -53,12 +53,6 @@ Specify a translation string by using the function
 as a shorter alias, ``_``, to save typing.
 
 .. note::
-    The ``u`` prefixing of ``gettext`` functions was originally to distinguish
-    usage between unicode strings and bytestrings on Python 2. For code that
-    supports only Python 3, they can be used interchangeably. A deprecation for
-    the prefixed functions may happen in a future Django release.
-
-.. note::
     Python's standard library ``gettext`` module installs ``_()`` into the
     global namespace, as an alias for ``gettext()``. In Django, we have chosen
     not to follow this practice, for a couple of reasons:


### PR DESCRIPTION
The u-prefixed variants were removed from the documentation in
6eb4996672ca5ccaba20e468d91a83d1cd019801.

https://code.djangoproject.com/ticket/30165