### PR TITLE
Fixed #31474 -- Made QuerySet.delete() not return the number of deleted objects if it's zero.

### DIFF
--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -408,7 +408,8 @@ class Collector:
             # fast deletes
             for qs in self.fast_deletes:
                 count = qs._raw_delete(using=self.using)
-                deleted_counter[qs.model._meta.label] += count
+                if count:
+                    deleted_counter[qs.model._meta.label] += count
 
             # update fields
             for model, instances_for_fieldvalues in self.field_updates.items():
@@ -426,7 +427,8 @@ class Collector:
                 query = sql.DeleteQuery(model)
                 pk_list = [obj.pk for obj in instances]
                 count = query.delete_batch(pk_list, self.using)
-                deleted_counter[model._meta.label] += count
+                if count:
+                    deleted_counter[model._meta.label] += count
 
                 if not model._meta.auto_created:
                     for obj in instances:

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -522,11 +522,10 @@ class DeletionTests(TestCase):
         existed_objs = {
             R._meta.label: R.objects.count(),
             HiddenUser._meta.label: HiddenUser.objects.count(),
-            A._meta.label: A.objects.count(),
-            MR._meta.label: MR.objects.count(),
             HiddenUserProfile._meta.label: HiddenUserProfile.objects.count(),
         }
         deleted, deleted_objs = R.objects.all().delete()
+        self.assertCountEqual(deleted_objs.keys(), existed_objs.keys())
         for k, v in existed_objs.items():
             self.assertEqual(deleted_objs[k], v)
 
@@ -550,13 +549,13 @@ class DeletionTests(TestCase):
         existed_objs = {
             R._meta.label: R.objects.count(),
             HiddenUser._meta.label: HiddenUser.objects.count(),
-            A._meta.label: A.objects.count(),
             MR._meta.label: MR.objects.count(),
             HiddenUserProfile._meta.label: HiddenUserProfile.objects.count(),
             M.m2m.through._meta.label: M.m2m.through.objects.count(),
         }
         deleted, deleted_objs = r.delete()
         self.assertEqual(deleted, sum(existed_objs.values()))
+        self.assertCountEqual(deleted_objs.keys(), existed_objs.keys())
         for k, v in existed_objs.items():
             self.assertEqual(deleted_objs[k], v)
 
@@ -694,7 +693,7 @@ class FastDeleteTests(TestCase):
         with self.assertNumQueries(1):
             self.assertEqual(
                 User.objects.filter(avatar__desc='missing').delete(),
-                (0, {'delete.User': 0})
+                (0, {}),
             )
 
     def test_fast_delete_combined_relationships(self):


### PR DESCRIPTION
Fixes [ticket 31474](https://code.djangoproject.com/ticket/31474).