### PR TITLE
Refs #30372 -- Stopped watching built-in Django translation files by auto-reloader.

### DIFF
--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -683,6 +683,9 @@ Miscellaneous
   the previous behavior, pass ``ensure_ascii=True`` to JSON serializer, or
   ``allow_unicode=False`` to YAML serializer.
 
+* The auto-reloader no longer monitors changes in built-in Django translation
+  files.
+
 .. _deprecated-features-3.1:
 
 Features deprecated in 3.1

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1865,6 +1865,12 @@ class WatchForTranslationChangesTests(SimpleTestCase):
         project_dir = Path(__file__).parent / 'sampleproject' / 'locale'
         mocked_sender.watch_dir.assert_any_call(project_dir, '**/*.mo')
 
+    def test_i18n_app_dirs_ignore_django_apps(self):
+        mocked_sender = mock.MagicMock()
+        with self.settings(INSTALLED_APPS=['django.contrib.admin']):
+            watch_for_translation_changes(mocked_sender)
+        mocked_sender.watch_dir.assert_called_once_with(Path('locale'), '**/*.mo')
+
     def test_i18n_local_locale(self):
         mocked_sender = mock.MagicMock()
         watch_for_translation_changes(mocked_sender)


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/30372

