### PR TITLE
Fixed #17664 -- Deprecated silencing exceptions in the {% if %} template tag.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -59,7 +59,6 @@ def check_dependencies(**kwargs):
     """
     Check that the admin's dependencies are correctly installed.
     """
-    from django.contrib.admin.sites import all_sites
     if not apps.is_installed('django.contrib.admin'):
         return []
     errors = []
@@ -105,15 +104,6 @@ def check_dependencies(**kwargs):
                 "be enabled in DjangoTemplates (TEMPLATES) in order to use "
                 "the admin application.",
                 id='admin.E404',
-            ))
-        sidebar_enabled = any(site.enable_nav_sidebar for site in all_sites)
-        if (sidebar_enabled and 'django.template.context_processors.request'
-                not in django_templates_instance.context_processors):
-            errors.append(checks.Warning(
-                "'django.template.context_processors.request' must be enabled "
-                "in DjangoTemplates (TEMPLATES) in order to use the admin "
-                "navigation sidebar.",
-                id='admin.W411',
             ))
 
     if not _contains_subclass('django.contrib.auth.middleware.AuthenticationMiddleware', settings.MIDDLEWARE):

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -305,6 +305,7 @@ class AdminSite:
         script_name = request.META['SCRIPT_NAME']
         site_url = script_name if self.site_url == '/' and script_name else self.site_url
         return {
+            'request': request,
             'site_title': self.site_title,
             'site_header': self.site_header,
             'site_url': site_url,

--- a/django/contrib/admin/templates/admin/app_list.html
+++ b/django/contrib/admin/templates/admin/app_list.html
@@ -8,7 +8,7 @@
           <a href="{{ app.app_url }}" class="section" title="{% blocktranslate with name=app.name %}Models in the {{ name }} application{% endblocktranslate %}">{{ app.name }}</a>
         </caption>
         {% for model in app.models %}
-          <tr class="model-{{ model.object_name|lower }}{% if model.admin_url in request.path %} current-model{% endif %}">
+          <tr class="model-{{ model.object_name|lower }}{% if model.admin_url and model.admin_url in request.path %} current-model{% endif %}">
             {% if model.admin_url %}
               <th scope="row"><a href="{{ model.admin_url }}"{% if model.admin_url in request.path %} aria-current="page"{% endif %}>{{ model.name }}</a></th>
             {% else %}

--- a/django/template/smartif.py
+++ b/django/template/smartif.py
@@ -7,6 +7,10 @@ Parser and utilities for the smart 'if' tag
 # 'nud' = null denotation
 # 'bp' = binding power (left = lbp, right = rbp)
 
+import warnings
+
+from django.utils.deprecation import RemovedInDjango41Warning
+
 
 class TokenBase:
     """
@@ -56,10 +60,18 @@ def infix(bp, func):
         def eval(self, context):
             try:
                 return func(context, self.first, self.second)
-            except Exception:
-                # Templates shouldn't throw exceptions when rendering.  We are
-                # most likely to get exceptions for things like {% if foo in bar
-                # %} where 'bar' does not support 'in', so default to False
+            except Exception as e:
+                exception_str = type(e).__name__
+                msg = str(e)
+                if msg:
+                    exception_str = "%s: %s" % (exception_str, msg)
+                warnings.warn(
+                    "Evaluating an {%% if %%} in a template raised an "
+                    "exception. In Django 4.1, this exception will be raised "
+                    "rather than silenced. The exception was:\n%s" %
+                    exception_str,
+                    RemovedInDjango41Warning,
+                )
                 return False
 
     return Operator
@@ -81,7 +93,18 @@ def prefix(bp, func):
         def eval(self, context):
             try:
                 return func(context, self.first)
-            except Exception:
+            except Exception as e:
+                exception_str = type(e).__name__
+                msg = str(e)
+                if msg:
+                    exception_str = "%s: %s" % (exception_str, msg)
+                warnings.warn(
+                    "Evaluating an {%% if %%} in a template raised an "
+                    "exception. In Django 4.1, this exception will be raised "
+                    "rather than silenced. The exception was:\n%s" %
+                    exception_str,
+                    RemovedInDjango41Warning,
+                )
                 return False
 
     return Operator

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -26,6 +26,9 @@ details on these changes.
 
 * The ``default_app_config`` module variable will be removed.
 
+* Silencing exceptions raised while evaluating the ``{% if %}`` template tag
+  will be removed.
+
 .. _deprecation-removed-in-4.0:
 
 4.0

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -752,7 +752,8 @@ The following checks are performed on the default
   must be in :setting:`MIDDLEWARE` in order to use the admin application.
 * **admin.W411**: ``django.template.context_processors.request`` must be
   enabled in :class:`~django.template.backends.django.DjangoTemplates`
-  (:setting:`TEMPLATES`) in order to use the admin navigation sidebar.
+  (:setting:`TEMPLATES`) in order to use the admin navigation sidebar. *This
+  check appeared in Django 3.1*.
 
 ``auth``
 --------

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -34,17 +34,10 @@ If you're not using the default project template, here are the requirements:
 
 #. Configure a :class:`~django.template.backends.django.DjangoTemplates`
    backend in your :setting:`TEMPLATES` setting with
-   ``django.template.context_processors.request``,
-   ``django.contrib.auth.context_processors.auth``, and
+   ``django.contrib.auth.context_processors.auth`` and
    ``django.contrib.messages.context_processors.messages`` in
    the ``'context_processors'`` option of :setting:`OPTIONS
    <TEMPLATES-OPTIONS>`.
-
-   .. versionchanged:: 3.1
-
-       ``django.template.context_processors.request`` was added as a
-       requirement in the ``'context_processors'`` option to support the new
-       :attr:`.AdminSite.enable_nav_sidebar`.
 
 #. If you've customized the :setting:`MIDDLEWARE` setting,
    :class:`django.contrib.auth.middleware.AuthenticationMiddleware` and

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -357,10 +357,14 @@ Filters that are applied to an invalid variable will only be applied if
 ``string_if_invalid`` is set to any other value, variable filters will be
 ignored.
 
-This behavior is slightly different for the ``if``, ``for`` and ``regroup``
-template tags. If an invalid variable is provided to one of these template
-tags, the variable will be interpreted as ``None``. Filters are always
-applied to invalid variables within these template tags.
+This behavior is slightly different for the ``for`` and ``regroup`` template
+tags. If an invalid variable is provided to one of these template tags, the
+variable will be interpreted as ``None``. Filters are always applied to invalid
+variables within these template tags.
+
+As ``if`` template tags are used to hide sensitive or private data, they too
+behave differently. For them, operations on invalid variables will raise an
+exception.
 
 If ``string_if_invalid`` contains a ``'%s'``, the format marker will be
 replaced with the name of the invalid variable.

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -408,6 +408,11 @@ As you can see, the ``if`` tag may take one or several ``{% elif %}``
 clauses, as well as an ``{% else %}`` clause that will be displayed if all
 previous conditions fail. These clauses are optional.
 
+.. deprecated:: 3.2
+
+    Silencing exceptions raised while evaluating the ``{% if %}`` template tag
+    is deprecated. In Django 4.1, the exception will be raised.
+
 Boolean operators
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -523,3 +523,6 @@ Miscellaneous
 * The ``default_app_config`` application configuration variable is deprecated,
   due to the now automatic ``AppConfig`` discovery. See :ref:`whats-new-3.2`
   for more details.
+
+* Silencing exceptions raised while evaluating the :ttag:`{% if %}<if>`
+  template tag is deprecated.

--- a/tests/admin_checks/tests.py
+++ b/tests/admin_checks/tests.py
@@ -135,12 +135,6 @@ class SystemChecksTestCase(SimpleTestCase):
                 "the admin application.",
                 id='admin.E404',
             ),
-            checks.Warning(
-                "'django.template.context_processors.request' must be enabled "
-                "in DjangoTemplates (TEMPLATES) in order to use the admin "
-                "navigation sidebar.",
-                id='admin.W411',
-            )
         ]
         self.assertEqual(admin.checks.check_dependencies(), expected)
         # The first error doesn't happen if

--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -73,9 +73,8 @@ class AdminSidebarTests(TestCase):
         url = reverse('test_with_sidebar:auth_user_changelist')
         response = self.client.get(url)
         self.assertContains(response, '<nav class="sticky" id="nav-sidebar">')
-        # Does not include aria-current attribute.
-        self.assertContains(response, '<a href="%s">Users</a>' % url)
-        self.assertNotContains(response, 'aria-current')
+        # Still includes aria-current attribute.
+        self.assertContains(response, '<a href="%s" aria-current="page">Users</a>' % url)
 
     @override_settings(DEBUG=True)
     def test_included_app_list_template_context_fully_set(self):

--- a/tests/auth_tests/templates/context_processors/auth_attrs_perms.html
+++ b/tests/auth_tests/templates/context_processors/auth_attrs_perms.html
@@ -1,4 +1,4 @@
 {% if perms.auth %}Has auth permissions{% endif %}
 {% if perms.auth.add_permission %}Has auth.add_permission permissions{% endif %}
 {% if perms.nonexistent %}nonexistent perm found{% endif %}
-{% if perms.auth.nonexistent in perms %}auth.nonexistent perm found{% endif %}
+{% if perms.auth.nonexistent and perms.auth.nonexistent in perms %}auth.nonexistent perm found{% endif %}

--- a/tests/template_tests/syntax_tests/test_if.py
+++ b/tests/template_tests/syntax_tests/test_if.py
@@ -1,6 +1,7 @@
 from django.template import TemplateSyntaxError
 from django.template.defaulttags import IfNode
 from django.test import SimpleTestCase
+from django.utils.deprecation import RemovedInDjango41Warning
 
 from ..utils import TestObj, setup
 
@@ -618,6 +619,36 @@ class IfTagExceptionsTests(SimpleTestCase):
 
         with self.assertRaises(RuntimeError):
             self.engine.render_to_string('template', {'foo': _raise_exception})
+
+    @setup({'template': '{% if not foo %}yes{% else %}no{% endif %}'})
+    def test_if_prefix_operator_exception(self):
+        def _raise_runtime_error():
+            raise RuntimeError
+
+        msg = (
+            "Evaluating an {% if %} in a template raised an exception. In "
+            "Django 4.1, this exception will be raised rather than silenced. "
+            "The exception was:\nRuntimeError"
+        )
+        # TODO: Change to assertRaises after the deprecation period.
+        with self.assertWarnsMessage(RemovedInDjango41Warning, msg):
+            output = self.engine.render_to_string('template', {'foo': _raise_runtime_error})
+        self.assertEqual(output, 'no')
+
+    @setup({'template': '{% if foo == 1 %}yes{% else %}no{% endif %}'})
+    def test_if_infix_operator_exception(self):
+        def _raise_exception():
+            raise RuntimeError
+
+        msg = (
+            "Evaluating an {% if %} in a template raised an exception. In "
+            "Django 4.1, this exception will be raised rather than silenced. "
+            "The exception was:\nRuntimeError"
+        )
+        # TODO: Change to assertRaises after the deprecation period.
+        with self.assertWarnsMessage(RemovedInDjango41Warning, msg):
+            output = self.engine.render_to_string('template', {'foo': _raise_exception})
+        self.assertEqual(output, 'no')
 
 
 class IfNodeTests(SimpleTestCase):

--- a/tests/template_tests/syntax_tests/test_if.py
+++ b/tests/template_tests/syntax_tests/test_if.py
@@ -602,6 +602,24 @@ class IfTagTests(SimpleTestCase):
         self.assertEqual(output, 'no')
 
 
+class IfTagExceptionsTests(SimpleTestCase):
+    @setup({'template': '{% if foo %}yes{% else %}no{% endif %}'})
+    def test_if_raises_exception(self):
+        def _raise_runtime_error():
+            raise RuntimeError
+
+        with self.assertRaises(RuntimeError):
+            self.engine.render_to_string('template', {'foo': _raise_runtime_error})
+
+    @setup({'template': '{% if foo|length %}yes{% else %}no{% endif %}'})
+    def test_if_length_exception(self):
+        def _raise_exception():
+            raise RuntimeError
+
+        with self.assertRaises(RuntimeError):
+            self.engine.render_to_string('template', {'foo': _raise_exception})
+
+
 class IfNodeTests(SimpleTestCase):
     def test_repr(self):
         node = IfNode(conditions_nodelists=[])

--- a/tests/template_tests/test_smartif.py
+++ b/tests/template_tests/test_smartif.py
@@ -1,9 +1,9 @@
-import unittest
-
 from django.template.smartif import IfParser
+from django.test import SimpleTestCase
+from django.utils.deprecation import RemovedInDjango41Warning
 
 
-class SmartIfTests(unittest.TestCase):
+class SmartIfTests(SimpleTestCase):
 
     def assertCalcEqual(self, expected, tokens):
         self.assertEqual(expected, IfParser(tokens).parse().eval({}))
@@ -26,15 +26,31 @@ class SmartIfTests(unittest.TestCase):
     def test_in(self):
         list_ = [1, 2, 3]
         self.assertCalcEqual(True, [1, 'in', list_])
-        self.assertCalcEqual(False, [1, 'in', None])
         self.assertCalcEqual(False, [None, 'in', list_])
+        msg = (
+            "Evaluating an {% if %} in a template raised an exception. In "
+            "Django 4.1, this exception will be raised rather than silenced. "
+            "The exception was:\n"
+            "TypeError: argument of type 'NoneType' is not iterable"
+        )
+        # TODO: Change to assertRaisesMessage after the deprecation period.
+        with self.assertWarnsMessage(RemovedInDjango41Warning, msg):
+            self.assertCalcEqual(False, [1, 'in', None])
 
     def test_not_in(self):
         list_ = [1, 2, 3]
         self.assertCalcEqual(False, [1, 'not', 'in', list_])
         self.assertCalcEqual(True, [4, 'not', 'in', list_])
-        self.assertCalcEqual(False, [1, 'not', 'in', None])
         self.assertCalcEqual(True, [None, 'not', 'in', list_])
+        msg = (
+            "Evaluating an {% if %} in a template raised an exception. In "
+            "Django 4.1, this exception will be raised rather than silenced. "
+            "The exception was:\n"
+            "TypeError: argument of type 'NoneType' is not iterable"
+        )
+        # TODO: Change to assertRaisesMessage after the deprecation period.
+        with self.assertWarnsMessage(RemovedInDjango41Warning, msg):
+            self.assertCalcEqual(False, [1, 'not', 'in', None])
 
     def test_precedence(self):
         # (False and False) or True == True   <- we want this one, like Python


### PR DESCRIPTION
Thanks @raiderrobert for the orignal PR #9713.

https://code.djangoproject.com/ticket/17664