### PR TITLE
Added link to Mozilla's infosec page on web security.

### DIFF
--- a/docs/topics/security.txt
+++ b/docs/topics/security.txt
@@ -290,6 +290,9 @@ security protection of the Web server, operating system and other components.
   list`_ which identifies some common vulnerabilities in web applications. While
   Django has tools to address some of the issues, other issues must be
   accounted for in the design of your project.
+* Mozilla discusses various topics regarding `web security`_. Their
+  pages also include security principles that apply to any system.
 
 .. _LimitRequestBody: https://httpd.apache.org/docs/2.4/mod/core.html#limitrequestbody
 .. _Top 10 list: https://www.owasp.org/index.php/Top_10-2017_Top_10
+.. _web security: https://infosec.mozilla.org/guidelines/web_security.html


### PR DESCRIPTION
I think it merits to include a reference to those pages from Django's official documentation. Under those pages, there's a document with OpenSSH configuration, some general security principles (make sure services that you don't use are closed, grant only necessary access, have a patch strategy etc.).

There are many who don't tweak the configuration of their web server to order the TLS cipher suites correctly.

I'm not sure if this little addition requires a ticket.