### PR TITLE
Fixed #24559 -- Made MigrationLoader.load_disk() catch more specific ModuleNotFoundError.

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -79,11 +79,11 @@ class MigrationLoader:
             was_loaded = module_name in sys.modules
             try:
                 module = import_module(module_name)
-            except ImportError as e:
-                # I hate doing this, but I don't want to squash other import errors.
-                # Might be better to try a directory check directly.
-                if ((explicit and self.ignore_no_migrations) or (
-                        not explicit and "No module named" in str(e) and MIGRATIONS_MODULE_NAME in str(e))):
+            except ModuleNotFoundError as e:
+                if (
+                    (explicit and self.ignore_no_migrations) or
+                    (not explicit and MIGRATIONS_MODULE_NAME in e.name.split('.'))
+                ):
                     self.unmigrated_apps.add(app_config.label)
                     continue
                 raise


### PR DESCRIPTION
Avoids inspecting the exception message, which is not considered a
stable API and can change across Python versions.

ModuleNotFoundError was introduced in Python 3.6. It is a subclass of
ImportError that is raised when the imported module does not exist. It
is not raised for other errors that can occur during an import. This
exception instance has the property "name" which holds the name of
module that failed to import.

https://code.djangoproject.com/ticket/24559