### PR TITLE
Fixed #31483 -- Remove admin change_form.js dependency on jQuery.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -501,18 +501,12 @@ body.popup .submit-row {
 
 /* RELATED FIELD ADD ONE / LOOKUP */
 
-.add-another, .related-lookup {
+.related-lookup {
     margin-left: 5px;
     display: inline-block;
     vertical-align: middle;
     background-repeat: no-repeat;
     background-size: 14px;
-}
-
-.add-another {
-    width: 16px;
-    height: 16px;
-    background-image: url(../img/icon-addlink.svg);
 }
 
 .related-lookup {

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -226,7 +226,6 @@ input[type="submit"], button {
         padding-top: 6px;
     }
 
-    .aligned .add-another,
     .aligned .related-lookup,
     .aligned .datetimeshortcuts,
     .aligned .related-lookup + strong {

--- a/django/contrib/admin/static/admin/css/responsive_rtl.css
+++ b/django/contrib/admin/static/admin/css/responsive_rtl.css
@@ -71,7 +71,6 @@
         margin-left: 0;
     }
 
-    [dir="rtl"] .aligned .add-another,
     [dir="rtl"] .aligned .related-lookup,
     [dir="rtl"] .aligned .datetimeshortcuts {
         margin-left: 0;

--- a/django/contrib/admin/static/admin/js/change_form.js
+++ b/django/contrib/admin/static/admin/js/change_form.js
@@ -1,18 +1,7 @@
-/*global showAddAnotherPopup, showRelatedObjectLookupPopup showRelatedObjectPopup updateRelatedObjectLinks*/
-
 (function($) {
     'use strict';
     $(document).ready(function() {
         var modelName = $('#django-admin-form-add-constants').data('modelName');
-        $('body').on('click', '.add-another', function(e) {
-            e.preventDefault();
-            var event = $.Event('django:add-another-related');
-            $(this).trigger(event);
-            if (!event.isDefaultPrevented()) {
-                showAddAnotherPopup(this);
-            }
-        });
-
         if (modelName) {
             $('form#' + modelName + '_form :input:visible:enabled:first').focus();
         }

--- a/django/contrib/admin/static/admin/js/change_form.js
+++ b/django/contrib/admin/static/admin/js/change_form.js
@@ -1,9 +1,17 @@
-(function($) {
+(function() {
     'use strict';
-    $(document).ready(function() {
-        var modelName = $('#django-admin-form-add-constants').data('modelName');
-        if (modelName) {
-            $('form#' + modelName + '_form :input:visible:enabled:first').focus();
+    var inputTags = ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'];
+    var modelName = document.getElementById('django-admin-form-add-constants').dataset.modelName;
+    if (modelName) {
+        var form = document.getElementById(modelName + '_form');
+        for (var i = 0; i < form.elements.length; i++) {
+            var element = form.elements[i];
+            // HTMLElement.offsetParent returns null when the element is not
+            // rendered.
+            if (inputTags.includes(element.tagName) && !element.disabled && element.offsetParent) {
+                element.focus();
+                break;
+            }
         }
-    });
-})(django.jQuery);
+    }
+})();

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -68,7 +68,8 @@
             src="{% static 'admin/js/change_form.js' %}"
             {% if adminform and add %}
                 data-model-name="{{ opts.model_name }}"
-            {% endif %}>
+            {% endif %}
+            async>
     </script>
 {% endblock %}
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31483

---

Removed CSS and JavaScript for unused HTML class add-another.
    
The HTML class was removed in 07988744b347302925bc6cc66511e34224db55ab. As such, the CSS and JavaScript is unused.

---

Rewrote change_form.js without jQuery.
    
The use of `$(document).ready()` was removed. The script is loaded at the end of the document. Therefore, the referenced DOM elements are already available and the script does not need to wait for the full DOM to be ready before continuing.
    
Now that the script has no external dependencies, it can be loaded asynchronously. As such, the async attribute was added to the script element.