### PR TITLE
Refs #29983 -- Fixed displaying pathlib.Path database name in flush command's inputs.

### DIFF
--- a/django/core/management/commands/flush.py
+++ b/django/core/management/commands/flush.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
 
         if interactive:
             confirm = input("""You have requested a flush of the database.
-This will IRREVERSIBLY DESTROY all data currently in the %r database,
+This will IRREVERSIBLY DESTROY all data currently in the "%s" database,
 and return each table to an empty state.
 Are you sure you want to do this?
 


### PR DESCRIPTION
Before:
```
This will IRREVERSIBLY DESTROY all data currently in the PosixPath('/tickets_projects/ticket_31479/db.sqlite3') database`
```
after:
```
This will IRREVERSIBLY DESTROY all data currently in the "/tickets_projects/ticket_31479/db.sqlite3" database`
```