### PR TITLE
Fixed backends.oracle.test_operations.

### DIFF
--- a/tests/backends/oracle/test_operations.py
+++ b/tests/backends/oracle/test_operations.py
@@ -2,12 +2,14 @@ import unittest
 
 from django.core.management.color import no_style
 from django.db import connection
+from django.test import TransactionTestCase
 
 from ..models import Person, Tag
 
 
 @unittest.skipUnless(connection.vendor == 'oracle', 'Oracle tests')
-class OperationsTests(unittest.TestCase):
+class OperationsTests(TransactionTestCase):
+    available_apps = ['backends']
 
     def test_sequence_name_truncation(self):
         seq_name = connection.ops._get_no_autofield_sequence_name('schema_authorwithevenlongee869')


### PR DESCRIPTION
Using `unittest.TestCase` doesn't work properly when we perform db queries. Moreover introspection is extremely slow on Oracle without limiting models to a "backends" app.

Follow up to 8bcca47e8356521f52f0738d9633befd53007cae.

Before:
- `test_sql_flush_sequences (backends.oracle.test_operations.OperationsTests)` (**761.919s**)
- `test_sql_flush_sequences_allow_cascade (backends.oracle.test_operations.OperationsTests)` (**780.015s**)

after:

_TBC_