### PR TITLE
Fixed #31486 -- Deprecated passing unsaved model object to related filters.

### DIFF
--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -1,7 +1,10 @@
+import warnings
+
 from django.db.models.lookups import (
     Exact, GreaterThan, GreaterThanOrEqual, In, IsNull, LessThan,
     LessThanOrEqual,
 )
+from django.utils.deprecation import RemovedInDjango40Warning
 
 
 class MultiColSource:
@@ -26,6 +29,15 @@ class MultiColSource:
 def get_normalized_value(value, lhs):
     from django.db.models import Model
     if isinstance(value, Model):
+        # When the deprecation ends, replace with:
+        # raise ValueError(
+        #     'The passed object to related filter must be an existing model object.'
+        # )
+        if value.pk is None:
+            warnings.warn(
+                'Passing an unsaved model object to related filter is deprecated.',
+                RemovedInDjango40Warning,
+            )
         value_list = []
         sources = lhs.output_field.get_path_info()[-1].target_fields
         for source in sources:

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -75,6 +75,8 @@ details on these changes.
 * Support for passing raw column aliases to ``QuerySet.order_by()`` will be
   removed.
 
+* Passing an unsaved model object to related filter will raise an exception.
+
 See the :ref:`Django 3.1 release notes <deprecated-features-3.1>` for more
 details on these changes.
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -731,6 +731,8 @@ Miscellaneous
   same result can be achieved by passing aliases in a
   :class:`~django.db.models.expressions.RawSQL` instead beforehand.
 
+* Passing an unsaved model object to related filter is deprecated.
+
 .. _removed-features-3.1:
 
 Features removed in 3.1

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from django.core.exceptions import FieldError, MultipleObjectsReturned
 from django.db import IntegrityError, models, transaction
 from django.test import TestCase
+from django.utils.deprecation import RemovedInDjango40Warning
 from django.utils.translation import gettext_lazy
 
 from .models import (
@@ -626,8 +627,13 @@ class ManyToOneTests(TestCase):
         th = Third(name="testing")
         # The object isn't saved and thus the relation field is null - we won't even
         # execute a query in this case.
-        with self.assertNumQueries(0):
-            self.assertEqual(th.child_set.count(), 0)
+        # TODO: Change to assertRaises after the deprecation period.
+        with self.assertWarnsMessage(
+            RemovedInDjango40Warning,
+            'Passing an unsaved model object to related filter is deprecated.',
+        ):
+            with self.assertNumQueries(0):
+                self.assertEqual(th.child_set.count(), 0)
         th.save()
         # Now the model is saved, so we will need to execute a query.
         with self.assertNumQueries(1):

--- a/tests/model_inheritance_regress/tests.py
+++ b/tests/model_inheritance_regress/tests.py
@@ -7,6 +7,7 @@ from unittest import expectedFailure
 
 from django import forms
 from django.test import TestCase
+from django.utils.deprecation import RemovedInDjango40Warning
 
 from .models import (
     ArticleWithAuthor, BachelorParty, BirthdayParty, BusStation, Child,
@@ -186,8 +187,13 @@ class ModelInheritanceTest(TestCase):
         # Regression test for #7488. This looks a little crazy, but it's the
         # equivalent of what the admin interface has to do for the edit-inline
         # case.
-        suppliers = Supplier.objects.filter(
-            restaurant=Restaurant(name='xx', address='yy'))
+        # TODO: Change to assertRaises after the deprecation period.
+        with self.assertWarnsMessage(
+            RemovedInDjango40Warning,
+            'Passing an unsaved model object to related filter is deprecated.',
+        ):
+            suppliers = Supplier.objects.filter(
+                restaurant=Restaurant(name='xx', address='yy'))
         suppliers = list(suppliers)
         self.assertEqual(suppliers, [])
 

--- a/tests/null_queries/tests.py
+++ b/tests/null_queries/tests.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import FieldError
 from django.test import TestCase
+from django.utils.deprecation import RemovedInDjango40Warning
 
 from .models import Choice, Inner, OuterA, OuterB, Poll
 
@@ -42,7 +43,12 @@ class NullQueriesTests(TestCase):
 
         # Related managers use __exact=None implicitly if the object hasn't been saved.
         p2 = Poll(question="How?")
-        self.assertEqual(repr(p2.choice_set.all()), '<QuerySet []>')
+        # TODO: Change to assertRaises after the deprecation period.
+        with self.assertWarnsMessage(
+            RemovedInDjango40Warning,
+            'Passing an unsaved model object to related filter is deprecated.',
+        ):
+            self.assertEqual(repr(p2.choice_set.all()), '<QuerySet []>')
 
     def test_reverse_relations(self):
         """


### PR DESCRIPTION
Fixes [ticket 31486](https://code.djangoproject.com/ticket/31486).