### PR TITLE
Made compress.py script use the officially released google-closure-compiler.

### DIFF
--- a/django/contrib/admin/bin/compress.py
+++ b/django/contrib/admin/bin/compress.py
@@ -4,36 +4,18 @@ import subprocess
 import sys
 from pathlib import Path
 
-try:
-    import closure
-except ImportError:
-    closure_compiler = None
-else:
-    closure_compiler = closure.get_jar_filename()
-
 js_path = Path(__file__).parents[1] / 'static' / 'admin' / 'js'
 
 
 def main():
     description = """With no file paths given this script will automatically
-compress all jQuery-based files of the admin app. Requires the Google Closure
-Compiler library and Java version 6 or later."""
+compress files of the admin app. Requires the Google Closure Compiler library
+and Java version 7 or later."""
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('file', nargs='*')
-    parser.add_argument(
-        "-c", dest="compiler", default="~/bin/compiler.jar",
-        help="path to Closure Compiler jar file",
-    )
     parser.add_argument("-v", "--verbose", action="store_true", dest="verbose")
     parser.add_argument("-q", "--quiet", action="store_false", dest="verbose")
     options = parser.parse_args()
-
-    compiler = Path(closure_compiler or options.compiler).expanduser()
-    if not compiler.exists():
-        sys.exit(
-            "Google Closure compiler jar file %s not found. Please use the -c "
-            "option to specify the path." % compiler
-        )
 
     if not options.file:
         if options.verbose:
@@ -49,13 +31,15 @@ Compiler library and Java version 6 or later."""
         to_compress = file_path.expanduser()
         if to_compress.exists():
             to_compress_min = to_compress.with_suffix('.min.js')
-            cmd = [
-                'java',
-                '-jar', str(compiler),
+            cmd = ['npx']
+            if not options.verbose:
+                cmd.append('-q')
+            cmd.extend([
+                'google-closure-compiler',
                 '--rewrite_polyfills=false',
                 '--js', str(to_compress),
                 '--js_output_file', str(to_compress_min),
-            ]
+            ])
             if options.verbose:
                 sys.stdout.write("Running: %s\n" % ' '.join(cmd))
             subprocess.run(cmd)

--- a/docs/internals/contributing/writing-code/javascript.txt
+++ b/docs/internals/contributing/writing-code/javascript.txt
@@ -55,12 +55,11 @@ version. To run it:
 
 .. console::
 
-    $ python -m pip install closure
     $ python django/contrib/admin/bin/compress.py
 
 Behind the scenes, ``compress.py`` is a front-end for Google's
 `Closure Compiler`_ which is written in Java. The Closure Compiler library is
-not bundled with Django, but you can install it using pip as done above. The
+not bundled with Django, but will be installed automatically by ``npm``. The
 Closure Compiler library requires `Java`_ 7 or higher.
 
 Please don't forget to run ``compress.py`` and include the ``diff`` of the


### PR DESCRIPTION
The script previously used the PyPI package closure, which is slightly
out of date and not maintained by Google.

The JavaScript contribution docs and the compress.py script now runs the
google-closure-compiler package in the recommended way. Google's
documentation on usage and installation can be found at:

https://github.com/google/closure-compiler-npm/tree/master/packages/google-closure-compiler#usage

This also makes the usage simpler as the package now runs through npm's
npx utility, which will automatically install google-closure-compiler to
a per-user cache.