### PR TITLE
Fixed a typo. "da" suffix should be separated.

### DIFF
--- a/django/contrib/auth/locale/tr/LC_MESSAGES/django.po
+++ b/django/contrib/auth/locale/tr/LC_MESSAGES/django.po
@@ -86,7 +86,7 @@ msgid ""
 "Please enter a correct %(username)s and password. Note that both fields may "
 "be case-sensitive."
 msgstr ""
-"Lütfen doğru %(username)s ve parola girin. Her iki alanında büyük küçük "
+"Lütfen doğru %(username)s ve parola girin. Her iki alanın da büyük küçük "
 "harfe duyarlı olabileceğini unutmayın."
 
 msgid "This account is inactive."


### PR DESCRIPTION
This is the grammatically correct way in Turkish. 