### PR TITLE
Fixes #31511 -- Remove the part of URLify that removes English stop words

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ answer newbie questions, and generally made Django that much better:
     Andrew Pinkham <http://AndrewsForge.com>
     Andrews Medina <andrewsmedina@gmail.com>
     Andriy Sokolovskiy <me@asokolovskiy.com>
+    Andy Chosak <andy@chosak.org>
     Andy Dustman <farcepest@gmail.com>
     Andy Gayton <andy-django@thecablelounge.com>
     andy@jadedplanet.net
@@ -800,6 +801,7 @@ answer newbie questions, and generally made Django that much better:
     schwank@gmail.com
     Scot Hacker <shacker@birdhouse.org>
     Scott Barr <scott@divisionbyzero.com.au>
+    Scott Cranfill <scott@scottcranfill.com>
     Scott Fitsimones <scott@airgara.ge>
     Scott Pashley <github@scottpashley.co.uk>
     scott@staplefish.com

--- a/django/contrib/admin/static/admin/js/urlify.js
+++ b/django/contrib/admin/static/admin/js/urlify.js
@@ -160,22 +160,8 @@
 
     function URLify(s, num_chars, allowUnicode) {
         // changes, e.g., "Petty theft" to "petty-theft"
-        // remove all these words from the string before urlifying
         if (!allowUnicode) {
             s = downcode(s);
-        }
-        var hasUnicodeChars = /[^\u0000-\u007f]/.test(s);
-        // Remove English words only if the string contains ASCII (English)
-        // characters.
-        if (!hasUnicodeChars) {
-            var removeList = [
-                "a", "an", "as", "at", "before", "but", "by", "for", "from",
-                "is", "in", "into", "like", "of", "off", "on", "onto", "per",
-                "since", "than", "the", "this", "that", "to", "up", "via",
-                "with"
-            ];
-            var r = new RegExp('\\b(' + removeList.join('|') + ')\\b', 'gi');
-            s = s.replace(r, '');
         }
         s = s.toLowerCase(); // convert to lowercase
         // if downcode doesn't hit, the char will be stripped here

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1089,8 +1089,7 @@ subclass::
     automatically generate the value for ``SlugField`` fields from one or more
     other fields. The generated value is produced by concatenating the values
     of the source fields, and then by transforming that result into a valid
-    slug (e.g. substituting dashes for spaces; lowercasing ASCII letters; and
-    removing various English stop words such as 'a', 'an', 'as', and similar).
+    slug (e.g. substituting dashes for spaces and lowercasing ASCII letters).
 
     Prepopulated fields aren't modified by JavaScript after a value has been
     saved. It's usually undesired that slugs change (which would cause an

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -668,6 +668,11 @@ Miscellaneous
 * The undocumented ``version`` parameter to the
   :class:`~django.contrib.gis.db.models.functions.AsKML` function is removed.
 
+* The ``URLify`` JavaScript function that is used by
+  :attr:`ModelAdmin.prepopulated_fields
+  <django.contrib.admin.ModelAdmin.prepopulated_fields>` no longer strips
+  English stop words such as 'a', 'an', 'as', and similar.
+
 .. _deprecated-features-3.1:
 
 Features deprecated in 3.1

--- a/js_tests/admin/URLify.test.js
+++ b/js_tests/admin/URLify.test.js
@@ -8,10 +8,6 @@ QUnit.test('empty string', function(assert) {
     assert.strictEqual(URLify('', 8, true), '');
 });
 
-QUnit.test('strip nonessential words', function(assert) {
-    assert.strictEqual(URLify('the D is silent', 8, true), 'd-silent');
-});
-
 QUnit.test('strip non-URL characters', function(assert) {
     assert.strictEqual(URLify('D#silent@', 7, true), 'dsilent');
 });
@@ -22,9 +18,4 @@ QUnit.test('merge adjacent whitespace', function(assert) {
 
 QUnit.test('trim trailing hyphens', function(assert) {
     assert.strictEqual(URLify('D silent always', 9, true), 'd-silent');
-});
-
-QUnit.test('do not remove English words if the string contains non-ASCII', function(assert) {
-    // If removing English words wasn't skipped, the last 'a' would be removed.
-    assert.strictEqual(URLify('Kaupa-miða', 255, true), 'kaupa-miða');
 });


### PR DESCRIPTION
This patch will close ticket #31511: [Allow stopwords in slugs generated by ModelAdmin.prepopulated_fields](https://code.djangoproject.com/ticket/31511).

With: @chosak

