### PR TITLE
Fixed #31504 -- Allowed calling makemigrations without an active database connection.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -824,6 +824,12 @@ Generate migration files without Django version and timestamp header.
 Makes ``makemigrations`` exit with a non-zero status when model changes without
 migrations are detected.
 
+.. versionchanged:: 3.2
+
+    Support for calling ``makemigrations`` without an active database
+    connection was added. In that case, check for a consistent migration
+    history is skipped.
+
 ``migrate``
 -----------
 

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -157,6 +157,10 @@ Management Commands
 * :djadmin:`loaddata` now supports fixtures stored in XZ archives (``.xz``) and
   LZMA archives (``.lzma``).
 
+* :djadmin:`makemigrations` can now be called without an active database
+  connection. In that case, check for a consistent migration history is
+  skipped.
+
 Migrations
 ~~~~~~~~~~
 


### PR DESCRIPTION
[Ticket 31504](https://code.djangoproject.com/ticket/31504)

I updated the makemigrations command to catch any `OperationalErrors` encountered while checking migration history consistency and issue a warning -- allowing the command to continue even if an error occurs when connecting to the database.