### PR TITLE
Fixed #31516 -- Removed date-based automatic migration names

### DIFF
--- a/django/db/migrations/migration.py
+++ b/django/db/migrations/migration.py
@@ -1,4 +1,3 @@
-from django.db.migrations import operations
 from django.db.migrations.utils import get_migration_name_timestamp
 from django.db.transaction import atomic
 
@@ -183,16 +182,21 @@ class Migration:
         are not guaranteed to be unique, but put some effort into the fallback
         name to avoid VCS conflicts if possible.
         """
-        name = None
-        if len(self.operations) == 1:
-            name = self.operations[0].migration_name_fragment
-        elif (
-            len(self.operations) > 1 and
-            all(isinstance(o, operations.CreateModel) for o in self.operations)
-        ):
-            name = '_'.join(sorted(o.migration_name_fragment for o in self.operations))
-        if name is None:
-            name = 'initial' if self.initial else 'auto_%s' % get_migration_name_timestamp()
+        if self.initial:
+            return "initial"
+
+        raw_fragments = (op.migration_name_fragment for op in self.operations)
+        fragments = [name for name in raw_fragments if name]
+
+        if not fragments:
+            return f"auto_{get_migration_name_timestamp()}"
+
+        name = fragments[0]
+        for fragment in fragments[1:]:
+            new_name = name + f"_{fragment}"
+            if len(new_name) > 52:
+                break
+            name = new_name
         return name
 
 

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -600,16 +600,16 @@ class AutodetectorTests(TestCase):
         graph.add_dependency("testapp.0002_foobar", ("testapp", "0002_foobar"), ("testapp", "0001_initial"))
         graph.add_dependency("testapp.0002_foobar", ("testapp", "0002_foobar"), ("otherapp", "0001_initial"))
         # Use project state to make a new migration change set
-        before = self.make_project_state([])
-        after = self.make_project_state([self.author_empty, self.other_pony, self.other_stable])
+        before = self.make_project_state([self.author_empty, self.other_pony])
+        after = self.make_project_state([self.author_name, self.other_pony, self.other_stable])
         autodetector = MigrationAutodetector(before, after)
         changes = autodetector._detect_changes()
         # Run through arrange_for_graph
         changes = autodetector.arrange_for_graph(changes, graph)
         # Make sure there's a new name, deps match, etc.
-        self.assertEqual(changes["testapp"][0].name, "0003_author")
+        self.assertEqual(changes["testapp"][0].name, "0003_author_name")
         self.assertEqual(changes["testapp"][0].dependencies, [("testapp", "0002_foobar")])
-        self.assertEqual(changes["otherapp"][0].name, "0002_pony_stable")
+        self.assertEqual(changes["otherapp"][0].name, "0002_stable")
         self.assertEqual(changes["otherapp"][0].dependencies, [("otherapp", "0001_initial")])
 
     def test_arrange_for_graph_with_multiple_initial(self):
@@ -2502,57 +2502,70 @@ class AutodetectorTests(TestCase):
 
 
 class MigrationSuggestNameTests(SimpleTestCase):
-    def test_single_operation(self):
-        class Migration(migrations.Migration):
-            operations = [migrations.CreateModel('Person', fields=[])]
 
-        migration = Migration('0001_initial', 'test_app')
-        self.assertEqual(migration.suggest_name(), 'person')
-
-        class Migration(migrations.Migration):
-            operations = [migrations.DeleteModel('Person')]
-
-        migration = Migration('0002_initial', 'test_app')
-        self.assertEqual(migration.suggest_name(), 'delete_person')
-
-    def test_two_create_models(self):
-        class Migration(migrations.Migration):
-            operations = [
-                migrations.CreateModel('Person', fields=[]),
-                migrations.CreateModel('Animal', fields=[]),
-            ]
-
-        migration = Migration('0001_initial', 'test_app')
-        self.assertEqual(migration.suggest_name(), 'animal_person')
-
-    def test_two_create_models_with_initial_true(self):
+    def test_initial(self):
         class Migration(migrations.Migration):
             initial = True
+
+        migration = Migration("some_migration", "test_app")
+        self.assertEqual(migration.suggest_name(), "initial")
+
+    def test_empty(self):
+        class Migration(migrations.Migration):
+            operations = []
+
+        migration = Migration("some_migration", "test_app")
+        self.assertTrue(migration.suggest_name().startswith("auto_"))
+
+    def test_no_fragments(self):
+        class Migration(migrations.Migration):
+            operations = [migrations.RunSQL("SELECT 1")]
+
+        migration = Migration('some_migration', "test_app")
+        self.assertTrue(migration.suggest_name().startswith("auto_"))
+
+    def test_single_create_model(self):
+        class Migration(migrations.Migration):
+            operations = [migrations.CreateModel("Person", fields=[])]
+
+        migration = Migration("some_migration", "test_app")
+        self.assertEqual(migration.suggest_name(), "person")
+
+    def test_single_create_model_long_name(self):
+        """
+        Check that the first migration_name_fragment values isn't cut when
+        exceeding the limit.
+        """
+        class Migration(migrations.Migration):
+            operations = [migrations.CreateModel("A" * 60, fields=[])]
+
+        migration = Migration('some_migration', 'test_app')
+        self.assertEqual(migration.suggest_name(), "a" * 60)
+
+    def test_two_operations(self):
+        class Migration(migrations.Migration):
             operations = [
-                migrations.CreateModel('Person', fields=[]),
-                migrations.CreateModel('Animal', fields=[]),
+                migrations.CreateModel("Person", fields=[]),
+                migrations.DeleteModel("Animal"),
             ]
 
-        migration = Migration('0001_initial', 'test_app')
-        self.assertEqual(migration.suggest_name(), 'animal_person')
+        migration = Migration("some_migration", "test_app")
+        self.assertEqual(migration.suggest_name(), "person_delete_animal")
 
-    def test_none_name(self):
+    def test_many_create_models(self):
         class Migration(migrations.Migration):
-            operations = [migrations.RunSQL('SELECT 1 FROM person;')]
+            operations = [
+                migrations.CreateModel("Person1", fields=[]),
+                migrations.CreateModel("Person2", fields=[]),
+                migrations.CreateModel("Person3", fields=[]),
+                migrations.CreateModel("Person4", fields=[]),
+                migrations.CreateModel("Person5", fields=[]),
+                migrations.CreateModel("Person6", fields=[]),
+                migrations.CreateModel("Person7", fields=[]),
+            ]
 
-        migration = Migration('0001_initial', 'test_app')
-        suggest_name = migration.suggest_name()
-        self.assertIs(suggest_name.startswith('auto_'), True)
-
-    def test_none_name_with_initial_true(self):
-        class Migration(migrations.Migration):
-            initial = True
-            operations = [migrations.RunSQL('SELECT 1 FROM person;')]
-
-        migration = Migration('0001_initial', 'test_app')
-        self.assertEqual(migration.suggest_name(), 'initial')
-
-    def test_auto(self):
-        migration = migrations.Migration('0001_initial', 'test_app')
-        suggest_name = migration.suggest_name()
-        self.assertIs(suggest_name.startswith('auto_'), True)
+        migration = Migration("some_migration", "test_app")
+        self.assertEqual(
+            migration.suggest_name(),
+            "person1_person2_person3_person4_person5_person6",
+        )


### PR DESCRIPTION
[ticket](https://code.djangoproject.com/ticket/31516)

Depends on #12131 .