### PR TITLE
Fixed #31517 -- Fixed HashedFilesMixin.hashed_name() if hash of the file is None.

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -98,8 +98,7 @@ class HashedFilesMixin:
                 content.close()
         path, filename = os.path.split(clean_name)
         root, ext = os.path.splitext(filename)
-        if file_hash is not None:
-            file_hash = ".%s" % file_hash
+        file_hash = ('.%s' % file_hash) if file_hash else ''
         hashed_name = os.path.join(path, "%s%s%s" %
                                    (root, file_hash, ext))
         unparsed_name = list(parsed_name)

--- a/tests/staticfiles_tests/storage.py
+++ b/tests/staticfiles_tests/storage.py
@@ -88,3 +88,8 @@ class ExtraPatternsStorage(ManifestStaticFilesStorage):
             ),
         ),
     )
+
+
+class NoneHashStorage(ManifestStaticFilesStorage):
+    def file_hash(self, name, content=None):
+        return None

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -386,6 +386,15 @@ class TestCollectionManifestStorage(TestHashedFiles, CollectionTestCase):
         )
 
 
+@override_settings(STATICFILES_STORAGE='staticfiles_tests.storage.NoneHashStorage')
+class TestCollectionNoneHashStorage(CollectionTestCase):
+    hashed_file_path = hashed_file_path
+
+    def test_hashed_name(self):
+        relpath = self.hashed_file_path('cached/styles.css')
+        self.assertEqual(relpath, 'cached/styles.css')
+
+
 @override_settings(STATICFILES_STORAGE='staticfiles_tests.storage.SimpleStorage')
 class TestCollectionSimpleStorage(CollectionTestCase):
     hashed_file_path = hashed_file_path


### PR DESCRIPTION
… if file_hash returns None