### PR TITLE
OLAP functionality. #27646

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -308,6 +308,11 @@ class BaseDatabaseFeatures:
         'cs': None,  # Case-sensitive.
         'swedish-ci': None  # Swedish case-insensitive.
     }
+    # Does the backend support Cube, Roll up, Grouping sets
+    supports_olap_grouping_sets = False
+    supports_olap_cube = False
+    # Should we also introduce a feature flag for partial roll up?
+    supports_olap_rollup = False
 
     def __init__(self, connection):
         self.connection = connection

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -48,6 +48,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'ci': 'utf8_general_ci',
         'swedish-ci': 'utf8_swedish_ci',
     }
+    # MySQL and MariaDB just support WITH ROLLUP
+    # MySQL does not support partial roll up. Just skip it in the tests.
+    supports_olap_rollup = True
 
     @cached_property
     def _mysql_storage_engine(self):

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -61,6 +61,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_boolean_expr_in_select_clause = False
     supports_primitives_in_json_field = False
     supports_json_field_contains = False
+    supports_olap_grouping_sets = True
+    supports_olap_cube = True
+    supports_olap_rollup = True
     test_collations = {
         'ci': 'BINARY_CI',
         'cs': 'BINARY',

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -61,6 +61,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     test_collations = {
         'swedish-ci': 'sv-x-icu',
     }
+    supports_olap_grouping_sets = True
+    supports_olap_cube = True
+    supports_olap_rollup = True
 
     @cached_property
     def introspected_field_types(self):

--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -24,6 +24,8 @@ from django.db.models.indexes import *  # NOQA
 from django.db.models.indexes import __all__ as indexes_all
 from django.db.models.lookups import Lookup, Transform
 from django.db.models.manager import Manager
+from django.db.models.olap import *  # NOQA
+from django.db.models.olap import __all__ as olap_all
 from django.db.models.query import Prefetch, QuerySet, prefetch_related_objects
 from django.db.models.query_utils import FilteredRelation, Q
 
@@ -35,7 +37,7 @@ from django.db.models.fields.related import (  # isort:skip
 )
 
 
-__all__ = aggregates_all + constraints_all + enums_all + fields_all + indexes_all
+__all__ = aggregates_all + constraints_all + enums_all + fields_all + indexes_all + olap_all
 __all__ += [
     'ObjectDoesNotExist', 'signals',
     'CASCADE', 'DO_NOTHING', 'PROTECT', 'RESTRICT', 'SET', 'SET_DEFAULT',

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -9,7 +9,8 @@ from django.db.models.functions.mixins import (
 )
 
 __all__ = [
-    'Aggregate', 'Avg', 'Count', 'Max', 'Min', 'StdDev', 'Sum', 'Variance',
+    'Aggregate', 'Avg', 'Count', 'Grouping', 'Max', 'Min', 'StdDev', 'Sum',
+    'Variance',
 ]
 
 
@@ -117,6 +118,14 @@ class Count(Aggregate):
 
     def convert_value(self, value, expression, connection):
         return 0 if value is None else value
+
+
+class Grouping(Aggregate):
+    function = 'GROUPING'
+    name = 'Grouping'
+    # Grouping is special, and can't be used as a window expression,
+    # however, it can be used as a predicate with HAVING
+    window_compatible = False
 
 
 class Max(Aggregate):

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -158,6 +158,11 @@ class BaseExpression:
     filterable = True
     # Can the expression can be used as a source expression in Window?
     window_compatible = False
+    # It's easier to let users control this manually, rather than
+    # adapting this functionality into the SQLCompiler and
+    # QuerySet/Query classes. It's used to raise warnings if users use
+    # this without
+    requires_custom_group_by = False
 
     def __init__(self, output_field=None):
         if output_field is not None:

--- a/django/db/models/olap.py
+++ b/django/db/models/olap.py
@@ -1,0 +1,46 @@
+from django.db import NotSupportedError
+from django.db.models import Func
+
+__all__ = [
+    'Cube', 'GroupingSets', 'RollUp',
+]
+
+# thoughts for this file:
+# output_field
+# group by functionality
+
+
+class SQLiteOLAPMixin:
+    def as_sql(self, compiler, connection, function=None, template=None, arg_joiner=None, **extra_context):
+        raise NotSupportedError("SQLite does not support %s" % str(self.function))
+
+
+class Cube(SQLiteOLAPMixin, Func):
+    function = "CUBE"
+    template = "cube(%(expression)s)"
+    requires_custom_group_by = True
+
+    def as_mysql(self, compiler, connection, function=None, template=None, arg_joiner=None, **extra_context):
+        return NotSupportedError("MySQL and MariaDB do not support CUBE")
+
+
+class GroupingSets(SQLiteOLAPMixin, Func):
+    function = 'GROUPING SETS'
+    template = 'GROUPING SETS(%(expression)s)'
+    requires_custom_group_by = True
+
+    def as_mysql(self, compiler, connection, function=None, template=None, arg_joiner=None, **extra_context):
+        return NotSupportedError("MySQL and MariaDB do not support GROUPING SETS")
+
+
+class RollUp(SQLiteOLAPMixin, Func):
+    function = 'ROLLUP'
+    template = 'rollup(%(expressions)s)'
+    requires_custom_group_by = True
+
+    def as_mysql(self, compiler, connection, function=None, template='', arg_joiner=None, **extra_context):
+        # https://dev.mysql.com/doc/refman/8.0/en/group-by-modifiers.html
+        return super().as_sql(
+            compiler, connection, function, template='%(expression)s WITH ROLLUP', arg_joiner=arg_joiner,
+            **extra_context,
+        )

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -8,6 +8,7 @@ import warnings
 from collections import namedtuple
 from functools import lru_cache
 from itertools import chain
+from typing import Dict, Optional
 
 import django
 from django.conf import settings
@@ -1136,6 +1137,10 @@ class QuerySet:
                 break
 
         return clone
+
+    def group_by(self, *, expressions):
+        clone = self._chain()
+        return clone.query.group(expressions)
 
     def order_by(self, *field_names):
         """Return a new QuerySet instance with the ordering changed."""

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -26,8 +26,9 @@ class SQLCompiler:
         re.MULTILINE | re.DOTALL,
     )
 
-    def __init__(self, query, connection, using):
-        self.query = query
+    def __init__(self, query: Query, connection, using):
+        self.custom_group_by = False
+        self.query = query  # type: Query
         self.connection = connection
         self.using = using
         self.quote_cache = {'*': '*'}

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -728,7 +728,6 @@ that certain expressions or columns are
     .. code-block::
 
         >>> from django.db.models import Cube, Sum
-        >>>
         >>> Product.objects.annotate(total=Sum("types")).group_by()
 
 .. class:: RollUp(expressions)

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -708,6 +708,51 @@ should avoid them if possible.
     You can read more about how Django's :ref:`SQL injection protection
     <sql-injection-protection>` works.
 
+OLAP functionality
+------------------
+
+.. versionadded:: 3.2
+
+It's possible to combine these three expressions with
+:meth:`QuerySet.group_by()<django.db.models.query.QuerySet.group_by>`.
+to get aggregation result for different combinations of the columns and
+expressions from your query. Please note that since the group by is manually
+controlled, it's easy to get warnings from your database backend informing
+that certain expressions or columns are
+
+.. class:: Cube(expressions)
+
+    This group by modifier generates a permutation of the expressions of
+    size 0 to the length of the expressions.
+
+    .. code-block::
+
+        >>> from django.db.models import Cube, Sum
+        >>>
+        >>> Product.objects.annotate(total=Sum("types")).group_by()
+
+.. class:: RollUp(expressions)
+
+    With this modifier, this
+
+    .. admonition:: MySQL and MariaDB support
+
+        MySQL and MariaDB do not support a partial ``RollUp``.
+        MySQL <https://dev.mysql.com/doc/refman/8.0/en/group-by-modifiers.html>
+        documentation
+
+.. class:: GroupingSets(expressions)
+
+    This modifier is similar to ``Cube`` in many ways, as it's
+
+
+.. admonition:: Limited support
+
+    Django officially supports SQL databases of different vendors. SQLite does
+    not support any of the different ways to group a result set. MariaDB and
+    MySQL do not support partial roll up. Oracle and PostgreSQL are the two
+    backends with support for all of the OLAP functionality.
+
 Window functions
 ----------------
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -681,6 +681,59 @@ You can also refer to fields on related models with reverse relations through
    pronounced if you include multiple such fields in your ``values()`` query,
    in which case all possible combinations will be returned.
 
+``group_by``
+~~~~~~~~~~~~
+
+.. method:: group_by(expressions=None)
+
+    .. versionadded:: 3.2
+
+Django controls the logic of the group by part of the query when either
+:meth:`annotate` or :meth:`aggregate` are used. However, at times, it's
+convenient to control this yourself. A particular use case for this is when
+you'd like to use :class:`~django.db.models.expressions.RollUp` or
+:class:`~django.db.models.expressions.GroupingSets` as part of the query::
+
+    >>> from django.db.models import RollUp, Sum
+    >>> # Cars is a simple model with just one field
+    >>> Cars.objects.annotate(order_val=Sum(value)).group_by(RollUp('line'))
+    <QuerySet [{'line': 'Vintage', 'order_val': 12000},
+        {'line': 'SUV', 'order_val': 25000},
+        {'line': 'Trucks', 'order_val': 20000},
+        {'line': None, 'order_val': 32000}>
+
+Please note that the database backends may have different requirements on
+the group by part of the query. Manually controlling the group by does not
+influence the ability to filter of annotations::
+
+    >>> from django.db.models import RollUp, Sum
+    >>> Cars.objects.annotate(order_val=Sum(value)).group_by(RollUp('line'))
+    <QuerySet [{'line': 'Vintage', 'order_val': 12000},
+        {'line': 'Trucks', 'order_val': 20000},
+        {'line': None, 'order_val': 32000}>
+
+Note that the models define methods that can conveniently be used when defining
+the group by clauses. There are methods
+In addition, it may be desired to use :meth:`values_list` or :meth:`values` to
+limit the number of columns that you retrieve with your query.
+
+.. admonition:: Limited use case for SQLite
+
+The above example does not work on SQLite. If you ask yourself if you need
+to manually add a group by clause to the query, the answer is most likely no.
+It's mainly relevant when combined with
+:class:`~django.db.models.expressions.Cube`,
+:class:`~django.db.models.expressions.GroupingSets` or
+:class:`~django.db.models.expressions.RollUp`.
+
+Please note that a :py:class:`warnings.UserWarning` will be raised if you try
+to use expressions in ``group_by`` because Django generally handles this pretty
+well already. If you're certain that you run into use cases where you'd like
+to use the ``group_by`` method for expressions that aren't in the above list,
+you can use :py:meth:`logging.captureWarnings` with the settings logging
+filter. However, please ensure that you understand that you suppress
+functionality of Django that's both tested and documented well.
+
 ``values_list()``
 ~~~~~~~~~~~~~~~~~
 

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -577,6 +577,7 @@ class ManagerTest(SimpleTestCase):
         'alias',
         'complex_filter',
         'exclude',
+        'group_by',
         'in_bulk',
         'iterator',
         'earliest',

--- a/tests/queries/test_group_by.py
+++ b/tests/queries/test_group_by.py
@@ -1,0 +1,51 @@
+from django.db.models import F, Sum
+from django.db.models.sql import Query
+from django.test import SimpleTestCase, TestCase
+
+from .models import Annotation
+
+
+class CustomGroupByTests(SimpleTestCase):
+
+    # Although the tests are mainly relevant for OLAP functionality,
+    # but not tied to a specific database backend
+    def test_group_by_f(self):
+        query = Query(model=Annotation)
+        query.custom_group_by = True
+        query.group(F('name'))
+        self.assertEqual(query.get_group_by_cols(), (F('name'),))
+
+    def test_group_by_expression(self):
+        query = Query(model=Annotation)
+        query.custom_group_by = True
+        msg = (
+            "The GROUP BY clause is handled already quite well by Django. Please use only "
+            "this method in case you found a short-coming, e.g., grouping sets. You can use"
+            "str(query) to evaluate if Django already translates the ORM query without the use"
+            "of this method."
+        )
+        with self.assertWarnsMessage(UserWarning, msg):
+            query.group(Sum('name'))
+        self.assertEqual(query.get_group_by_cols(), (Sum('name'),))
+
+    # test custom expressions that are not grouping sets or cube for the warning.
+
+    def test_multiple_expressions(self):
+        pass
+
+    def test_grouping_sets(self):
+        pass
+
+    def test_exception(self):
+        msg = 'custom_group_by requires that all expressions are either strings, F-objects or expressions'
+        with self.assertRaisesMessage(ValueError, msg):
+            query = Query(model=Annotation)
+            query.custom_group_by = True
+            query.group(object())
+
+
+class OLAPFunctionTests(TestCase):
+
+    # This needs to be filled in with meaningful data, to check that the
+    # query
+    pass


### PR DESCRIPTION
It's rather in-complete, and basically only an outline of how I think [ticket #27646](https://code.djangoproject.com/ticket/27646) could be approached. I don't see an easy way to solve this ticket, without introducing a manual method for dealing with the group by clause. @adamchainz mentioned on IRC that the name might make people who know SQL to use this without considering that Django by default does a good job of handling this for you, when using `QuerySet.annotate`.

I'll write a post about this to the mailing list later, as Tim Graham requested this.

It's only a draft. I think targeting this at 3.2 would seem possible. No tests are in this draft (it's cumbersome to write them, and I'd like to have some simplicity).