### PR TITLE
Doc'd send_email() behavior when from_email is None.

### DIFF
--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -42,6 +42,7 @@ def send_mail(subject, message, from_email, recipient_list,
     Easy wrapper for sending a single message to a recipient list. All members
     of the recipient list will see the other recipients in the 'To' field.
 
+    If from_email is None, use the DEFAULT_FROM_EMAIL setting.
     If auth_user is None, use the EMAIL_HOST_USER setting.
     If auth_password is None, use the EMAIL_HOST_PASSWORD setting.
 

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -51,7 +51,8 @@ are required.
 
 * ``subject``: A string.
 * ``message``: A string.
-* ``from_email``: A string.
+* ``from_email``: A string. If ``None``, Django will use the value of the
+  :setting:`DEFAULT_FROM_EMAIL` setting.
 * ``recipient_list``: A list of strings, each an email address. Each
   member of ``recipient_list`` will see the other recipients in the "To:"
   field of the email message.


### PR DESCRIPTION
Just a hole I found in the documentation that would've helped me get to my solution faster.