### PR TITLE
Used :pep:, :mimetype:, and :envvar: roles in various docs.

### DIFF
--- a/docs/faq/usage.txt
+++ b/docs/faq/usage.txt
@@ -2,12 +2,12 @@
 FAQ: Using Django
 =================
 
-Why do I get an error about importing DJANGO_SETTINGS_MODULE?
-=============================================================
+Why do I get an error about importing :envvar:`DJANGO_SETTINGS_MODULE`?
+=======================================================================
 
 Make sure that:
 
-* The environment variable DJANGO_SETTINGS_MODULE is set to a
+* The environment variable :envvar:`DJANGO_SETTINGS_MODULE` is set to a
   fully-qualified Python module (i.e. "mysite.settings").
 
 * Said module is on ``sys.path`` (``import mysite.settings`` should work).

--- a/docs/howto/deployment/wsgi/index.txt
+++ b/docs/howto/deployment/wsgi/index.txt
@@ -70,8 +70,10 @@ If this variable isn't set, the default :file:`wsgi.py` sets it to
 Applying WSGI middleware
 ========================
 
-To apply `WSGI middleware`_ you can wrap the application object. For instance
-you could add these lines at the bottom of :file:`wsgi.py`::
+To apply :pep:`WSGI middleware
+<3333#middleware-components-that-play-both-sides>` you can wrap the application
+object. For instance you could add these lines at the bottom of
+:file:`wsgi.py`::
 
     from helloworld.wsgi import HelloWorldApplication
     application = HelloWorldApplication(application)
@@ -79,5 +81,3 @@ you could add these lines at the bottom of :file:`wsgi.py`::
 You could also replace the Django WSGI application with a custom WSGI
 application that later delegates to the Django WSGI application, if you want
 to combine a Django application with a WSGI application of another framework.
-
-.. _`WSGI middleware`: https://www.python.org/dev/peps/pep-3333/#middleware-components-that-play-both-sides

--- a/docs/howto/deployment/wsgi/uwsgi.txt
+++ b/docs/howto/deployment/wsgi/uwsgi.txt
@@ -77,7 +77,7 @@ The Django-specific options here are:
   path -- i.e., the directory containing the ``mysite`` package.
 * ``module``: The WSGI module to use -- probably the ``mysite.wsgi`` module
   that :djadmin:`startproject` creates.
-* ``env``: Should probably contain at least ``DJANGO_SETTINGS_MODULE``.
+* ``env``: Should probably contain at least :envvar:`DJANGO_SETTINGS_MODULE`.
 * ``home``: Optional path to your project virtualenv.
 
 Example ini configuration file::

--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -283,8 +283,8 @@ at the top level (i.e. evaluated when the module is imported). The explanation
 for this is as follows:
 
 Manual configuration of settings (i.e. not relying on the
-``DJANGO_SETTINGS_MODULE`` environment variable) is allowed and possible as
-follows::
+:envvar:`DJANGO_SETTINGS_MODULE` environment variable) is allowed and possible
+as follows::
 
     from django.conf import settings
 

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -105,8 +105,8 @@ The remainder of this documentation shows commands for running tests without
 ``tox``, however, any option passed to ``runtests.py`` can also be passed to
 ``tox`` by prefixing the argument list with ``--``, as above.
 
-Tox also respects the ``DJANGO_SETTINGS_MODULE`` environment variable, if set.
-For example, the following is equivalent to the command above:
+Tox also respects the :envvar:`DJANGO_SETTINGS_MODULE` environment variable, if
+set. For example, the following is equivalent to the command above:
 
 .. code-block:: console
 
@@ -156,7 +156,7 @@ those for ``contrib.postgres``, are specific to a particular database backend
 and will be skipped if run with a different backend.
 
 To run the tests with different settings, ensure that the module is on your
-``PYTHONPATH`` and pass the module with ``--settings``.
+:envvar:`PYTHONPATH` and pass the module with ``--settings``.
 
 The :setting:`DATABASES` setting in any test settings module needs to define
 two databases:
@@ -495,8 +495,8 @@ test failures. You can adjust this behavior with the ``--parallel`` option:
 
     $ ./runtests.py basic --parallel=1
 
-You can also use the ``DJANGO_TEST_PROCESSES`` environment variable for this
-purpose.
+You can also use the :envvar:`DJANGO_TEST_PROCESSES` environment variable for
+this purpose.
 
 Tips for writing tests
 ======================

--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -246,6 +246,10 @@ documentation:
 * Use :rst:role:`:mimetype:<mimetype>` to refer to a MIME Type unless the value
   is quoted for a code example.
 
+* Use :rst:role:`:envvar:<envvar>` to refer to an environment variable. You may
+  also need to define a reference to the documentation for that environment
+  variable using :rst:dir:`.. envvar:: <envvar>`.
+
 Django-specific markup
 ======================
 

--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -243,6 +243,9 @@ documentation:
   and try to link to the relevant section if possible. For example, use
   ``:pep:`20#easter-egg``` or ``:pep:`Easter Egg <20#easter-egg>```.
 
+* Use :rst:role:`:mimetype:<mimetype>` to refer to a MIME Type unless the value
+  is quoted for a code example.
+
 Django-specific markup
 ======================
 

--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -239,6 +239,10 @@ documentation:
   section if possible. For example, use ``:rfc:`2324#section-2.3.2``` or
   ``:rfc:`Custom link text <2324#section-2.3.2>```.
 
+* Use :rst:role:`:pep:<pep>` to reference a Python Enhancement Proposal (PEP)
+  and try to link to the relevant section if possible. For example, use
+  ``:pep:`20#easter-egg``` or ``:pep:`Easter Egg <20#easter-egg>```.
+
 Django-specific markup
 ======================
 

--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -378,8 +378,8 @@ API Django gives you. To invoke the Python shell, use this command:
     $ python manage.py shell
 
 We're using this instead of simply typing "python", because :file:`manage.py`
-sets the ``DJANGO_SETTINGS_MODULE`` environment variable, which gives Django
-the Python import path to your :file:`mysite/settings.py` file.
+sets the :envvar:`DJANGO_SETTINGS_MODULE` environment variable, which gives
+Django the Python import path to your :file:`mysite/settings.py` file.
 
 Once you're in the shell, explore the :doc:`database API </topics/db/queries>`::
 

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -111,7 +111,7 @@ Asynchronous support
 
 The following checks verify your setup for :doc:`/topics/async`:
 
-* **async.E001**: You should not set the ``DJANGO_ALLOW_ASYNC_UNSAFE``
+* **async.E001**: You should not set the :envvar:`DJANGO_ALLOW_ASYNC_UNSAFE`
   environment variable in deployment. This disables :ref:`async safety
   protection <async-safety>`.
 

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -32,7 +32,7 @@ features include:
   in Python using ``ctypes``.
 * Loosely-coupled to GeoDjango.  For example, :class:`GEOSGeometry` objects
   may be used outside of a Django project/application.  In other words,
-  no need to have ``DJANGO_SETTINGS_MODULE`` set or use a database, etc.
+  no need to have :envvar:`DJANGO_SETTINGS_MODULE` set or use a database, etc.
 * Mutability: :class:`GEOSGeometry` objects may be modified.
 * Cross-platform and tested; compatible with Windows, Linux, Solaris, and
   macOS platforms.

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -127,8 +127,8 @@ Activates some additional checks that are only relevant in a deployment setting.
 You can use this option in your local development environment, but since your
 local development settings module may not have many of your production settings,
 you will probably want to point the ``check`` command at a different settings
-module, either by setting the ``DJANGO_SETTINGS_MODULE`` environment variable,
-or by passing the ``--settings`` option::
+module, either by setting the :envvar:`DJANGO_SETTINGS_MODULE` environment
+variable, or by passing the ``--settings`` option::
 
     django-admin check --deploy --settings=production_settings
 
@@ -940,8 +940,10 @@ more robust change detection, and a reduction in power usage. Django supports
 
 .. admonition:: Watchman timeout
 
+    .. envvar:: DJANGO_WATCHMAN_TIMEOUT
+
     The default timeout of ``Watchman`` client is 5 seconds. You can change it
-    by setting the ``DJANGO_WATCHMAN_TIMEOUT`` environment variable.
+    by setting the :envvar:`DJANGO_WATCHMAN_TIMEOUT` environment variable.
 
 .. _Watchman: https://facebook.github.io/watchman/
 .. _pywatchman: https://pypi.org/project/pywatchman/
@@ -1420,13 +1422,15 @@ Enables :ref:`SQL logging <django-db-logger>` for failing tests. If
 
 .. django-admin-option:: --parallel [N]
 
+.. envvar:: DJANGO_TEST_PROCESSES
+
 Runs tests in separate parallel processes. Since modern processors have
 multiple cores, this allows running tests significantly faster.
 
 By default ``--parallel`` runs one process per core according to
 :func:`multiprocessing.cpu_count()`. You can adjust the number of processes
 either by providing it as the option's value, e.g. ``--parallel=4``, or by
-setting the ``DJANGO_TEST_PROCESSES`` environment variable.
+setting the :envvar:`DJANGO_TEST_PROCESSES` environment variable.
 
 Django distributes test cases — :class:`unittest.TestCase` subclasses — to
 subprocesses. If there are fewer test cases than configured processes, Django
@@ -1599,6 +1603,8 @@ Example usage::
 
 .. django-admin:: createsuperuser
 
+.. envvar:: DJANGO_SUPERUSER_PASSWORD
+
 This command is only available if Django's :doc:`authentication system
 </topics/auth/index>` (``django.contrib.auth``) is installed.
 
@@ -1608,9 +1614,9 @@ programmatically generate superuser accounts for your site(s).
 
 When run interactively, this command will prompt for a password for
 the new superuser account. When run non-interactively, you can provide
-a password by setting the ``DJANGO_SUPERUSER_PASSWORD`` environment variable.
-Otherwise, no password will be set, and the superuser account will not be able
-to log in until a password has been manually set for it.
+a password by setting the :envvar:`DJANGO_SUPERUSER_PASSWORD` environment
+variable. Otherwise, no password will be set, and the superuser account will
+not be able to log in until a password has been manually set for it.
 
 In non-interactive mode, the
 :attr:`~django.contrib.auth.models.CustomUser.USERNAME_FIELD` and required
@@ -1738,7 +1744,7 @@ allows for the following options:
 .. django-admin-option:: --pythonpath PYTHONPATH
 
 Adds the given filesystem path to the Python `import search path`_. If this
-isn't provided, ``django-admin`` will use the ``PYTHONPATH`` environment
+isn't provided, ``django-admin`` will use the :envvar:`PYTHONPATH` environment
 variable.
 
 This option is unnecessary in ``manage.py``, because it takes care of setting
@@ -1754,7 +1760,8 @@ Example usage::
 
 Specifies the settings module to use. The settings module should be in Python
 package syntax, e.g. ``mysite.settings``. If this isn't provided,
-``django-admin`` will use the ``DJANGO_SETTINGS_MODULE`` environment variable.
+``django-admin`` will use the :envvar:`DJANGO_SETTINGS_MODULE` environment
+variable.
 
 This option is unnecessary in ``manage.py``, because it uses
 ``settings.py`` from the current project by default.
@@ -1822,6 +1829,8 @@ Extra niceties
 Syntax coloring
 ---------------
 
+.. envvar:: DJANGO_COLORS
+
 The ``django-admin`` / ``manage.py`` commands will use pretty
 color-coded output if your terminal supports ANSI-colored output. It
 won't use the color codes if you're piping the command's output to
@@ -1843,7 +1852,7 @@ ships with three color palettes:
 
 * ``nocolor``, which disables syntax highlighting.
 
-You select a palette by setting a ``DJANGO_COLORS`` environment
+You select a palette by setting a :envvar:`DJANGO_COLORS` environment
 variable to specify the palette you want to use. For example, to
 specify the ``light`` palette under a Unix or OS/X BASH shell, you
 would run the following at a command prompt::

--- a/docs/ref/files/uploads.txt
+++ b/docs/ref/files/uploads.txt
@@ -76,11 +76,9 @@ Here are some useful attributes of ``UploadedFile``:
         for line in uploadedfile:
             do_something_with(line)
 
-    Lines are split using `universal newlines`_. The following are recognized
-    as ending a line: the Unix end-of-line convention ``'\n'``, the Windows
-    convention ``'\r\n'``, and the old Macintosh convention ``'\r'``.
-
-    .. _universal newlines: https://www.python.org/dev/peps/pep-0278
+    Lines are split using :pep:`universal newlines <278>`. The following are
+    recognized as ending a line: the Unix end-of-line convention ``'\n'``, the
+    Windows convention ``'\r\n'``, and the old Macintosh convention ``'\r'``.
 
 Subclasses of ``UploadedFile`` include:
 

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1161,8 +1161,9 @@ Attributes
 .. class:: FileResponse(open_file, as_attachment=False, filename='', **kwargs)
 
     :class:`FileResponse` is a subclass of :class:`StreamingHttpResponse`
-    optimized for binary files. It uses `wsgi.file_wrapper`_ if provided by the
-    wsgi server, otherwise it streams the file out in small chunks.
+    optimized for binary files. It uses :pep:`wsgi.file_wrapper
+    <3333#optional-platform-specific-file-handling>` if provided by the wsgi
+    server, otherwise it streams the file out in small chunks.
 
     If ``as_attachment=True``, the ``Content-Disposition`` header is set to
     ``attachment``, which asks the browser to offer the file to the user as a
@@ -1177,8 +1178,6 @@ Attributes
 
     The ``Content-Length`` and ``Content-Type`` headers are automatically set
     when they can be guessed from contents of ``open_file``.
-
-.. _wsgi.file_wrapper: https://www.python.org/dev/peps/pep-3333/#optional-platform-specific-file-handling
 
 ``FileResponse`` accepts any file-like object with binary content, for example
 a file open in binary mode like so::

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1028,7 +1028,7 @@ can create it with the help of :py:class:`http.HTTPStatus`. For example::
     response. It inherits most behavior from its superclass with a couple
     differences:
 
-    Its default ``Content-Type`` header is set to ``application/json``.
+    Its default ``Content-Type`` header is set to :mimetype:`application/json`.
 
     The first parameter, ``data``, should be a ``dict`` instance. If the
     ``safe`` parameter is set to ``False`` (see below) it can be any

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -275,8 +275,8 @@ Email
   headers in the local time zone rather than in UTC.
 
 * ``EmailMessage.attach()`` and ``attach_file()`` now fall back to MIME type
-  ``application/octet-stream`` when binary content that can't be decoded as
-  UTF-8 is specified for a ``text/*`` attachment.
+  :mimetype:`application/octet-stream` when binary content that can't be
+  decoded as UTF-8 is specified for a :mimetype:`text/*` attachment.
 
 File Storage
 ~~~~~~~~~~~~

--- a/docs/releases/1.2.txt
+++ b/docs/releases/1.2.txt
@@ -321,9 +321,9 @@ and calculated values can be displayed alongside editable fields.
 Customizable syntax highlighting
 --------------------------------
 
-You can now use a ``DJANGO_COLORS`` environment variable to modify or disable
-the colors used by ``django-admin.py`` to provide :ref:`syntax highlighting
-<syntax-coloring>`.
+You can now use a :envvar:`DJANGO_COLORS` environment variable to modify or
+disable the colors used by ``django-admin.py`` to provide :ref:`syntax
+highlighting <syntax-coloring>`.
 
 Syndication feeds as views
 --------------------------

--- a/docs/releases/1.4.txt
+++ b/docs/releases/1.4.txt
@@ -1257,7 +1257,7 @@ needed with the new ``manage.py`` and default project layout.
 
 This function was never documented or part of the public API, but it was widely
 recommended for use in setting up a "Django environment" for a user script.
-These uses should be replaced by setting the ``DJANGO_SETTINGS_MODULE``
+These uses should be replaced by setting the :envvar:`DJANGO_SETTINGS_MODULE`
 environment variable or using :func:`django.conf.settings.configure`.
 
 ``django.core.management.execute_manager``

--- a/docs/releases/1.5.txt
+++ b/docs/releases/1.5.txt
@@ -424,11 +424,11 @@ Non-form data in HTTP requests
 :attr:`request.POST <django.http.HttpRequest.POST>` will no longer include data
 posted via HTTP requests with non form-specific content-types in the header.
 In prior versions, data posted with content-types other than
-``multipart/form-data`` or ``application/x-www-form-urlencoded`` would still
-end up represented in the :attr:`request.POST <django.http.HttpRequest.POST>`
-attribute. Developers wishing to access the raw POST data for these cases,
-should use the :attr:`request.body <django.http.HttpRequest.body>` attribute
-instead.
+:mimetype:`multipart/form-data` or
+:mimetype:`application/x-www-form-urlencoded` would still end up represented in
+the :attr:`request.POST <django.http.HttpRequest.POST>` attribute. Developers
+wishing to access the raw POST data for these cases, should use the
+:attr:`request.body <django.http.HttpRequest.body>` attribute instead.
 
 :data:`~django.core.signals.request_finished` signal
 ----------------------------------------------------

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -173,7 +173,7 @@ Minor features
 * In addition to :lookup:`year`, :lookup:`month` and :lookup:`day`, the ORM
   now supports :lookup:`hour`, :lookup:`minute` and :lookup:`second` lookups.
 
-* Django now wraps all PEP-249 exceptions.
+* Django now wraps all :pep:`249` exceptions.
 
 * The default widgets for :class:`~django.forms.EmailField`,
   :class:`~django.forms.URLField`, :class:`~django.forms.IntegerField`,

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -557,7 +557,9 @@ Email
 ~~~~~
 
 * :func:`~django.core.mail.send_mail` now accepts an ``html_message``
-  parameter for sending a multipart ``text/plain`` and ``text/html`` email.
+  parameter for sending a multipart :mimetype:`text/plain` and
+  :mimetype:`text/html` email.
+
 * The SMTP :class:`~django.core.mail.backends.smtp.EmailBackend` now accepts a
   ``timeout`` parameter.
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -1123,11 +1123,9 @@ Miscellaneous
   check framework (unless you pass it ``skip_checks=False``).
 
 * When iterating over lines, :class:`~django.core.files.File` now uses
-  `universal newlines`_. The following are recognized as ending a line: the
-  Unix end-of-line convention ``'\n'``, the Windows convention ``'\r\n'``, and
-  the old Macintosh convention ``'\r'``.
-
-  .. _universal newlines: https://www.python.org/dev/peps/pep-0278
+  :pep:`universal newlines <278>`. The following are recognized as ending a
+  line: the Unix end-of-line convention ``'\n'``, the Windows convention
+  ``'\r\n'``, and the old Macintosh convention ``'\r'``.
 
 * The Memcached cache backends ``MemcachedCache`` and ``PyLibMCCache`` will
   delete a key if ``set()`` fails. This is necessary to ensure the ``cache_db``

--- a/docs/releases/2.2.1.txt
+++ b/docs/releases/2.2.1.txt
@@ -58,7 +58,8 @@ Bugfixes
 
 * Increased the default timeout when using ``Watchman`` to 5 seconds to prevent
   falling back to ``StatReloader`` on larger projects and made it customizable
-  via the ``DJANGO_WATCHMAN_TIMEOUT`` environment variable (:ticket:`30361`).
+  via the :envvar:`DJANGO_WATCHMAN_TIMEOUT` environment variable
+  (:ticket:`30361`).
 
 * Fixed a regression in Django 2.2 that caused a crash when migrating
   permissions for proxy models if the target permissions already existed. For

--- a/docs/releases/3.0.1.txt
+++ b/docs/releases/3.0.1.txt
@@ -28,7 +28,7 @@ Bugfixes
 * Fixed a regression in Django 3.0 by restoring the ability to use Django
   inside Jupyter and other environments that force an async context, by adding
   an option to disable :ref:`async-safety` mechanism with
-  ``DJANGO_ALLOW_ASYNC_UNSAFE`` environment variable (:ticket:`31056`).
+  :envvar:`DJANGO_ALLOW_ASYNC_UNSAFE` environment variable (:ticket:`31056`).
 
 * Fixed a regression in Django 3.0 where ``RegexPattern``, used by
   :func:`~django.urls.re_path`, returned positional arguments to be passed to

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -118,6 +118,8 @@ mode if you have asynchronous code in your project.
 Async safety
 ============
 
+.. envvar:: DJANGO_ALLOW_ASYNC_UNSAFE
+
 Certain key parts of Django are not able to operate safely in an async
 environment, as they have global state that is not coroutine-aware. These parts
 of Django are classified as "async-unsafe", and are protected from execution in
@@ -144,7 +146,7 @@ if the requirement is forced on you by an external environment, such as in a
 Jupyter_ notebook. If you are sure there is no chance of the code being run
 concurrently, and you *absolutely* need to run this sync code from an async
 context, then you can disable the warning by setting the
-``DJANGO_ALLOW_ASYNC_UNSAFE`` environment variable to any value.
+:envvar:`DJANGO_ALLOW_ASYNC_UNSAFE` environment variable to any value.
 
 .. warning::
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1287,8 +1287,8 @@ implementation details see :ref:`using-the-views`.
       default context data passed to the template.
 
     * ``html_email_template_name``: The full name of a template to use
-      for generating a ``text/html`` multipart email with the password reset
-      link. By default, HTML email is not sent.
+      for generating a :mimetype:`text/html` multipart email with the password
+      reset link. By default, HTML email is not sent.
 
     * ``extra_email_context``: A dictionary of context data that will be
       available in the email template. It can be used to override default

--- a/docs/topics/db/transactions.txt
+++ b/docs/topics/db/transactions.txt
@@ -369,8 +369,8 @@ etc.), this should be fine. If it's not (if your follow-up action is so
 critical that its failure should mean the failure of the transaction itself),
 then you don't want to use the :func:`on_commit` hook. Instead, you may want
 `two-phase commit`_ such as the :ref:`psycopg Two-Phase Commit protocol support
-<psycopg2:tpc>` and the `optional Two-Phase Commit Extensions in the Python
-DB-API specification`_.
+<psycopg2:tpc>` and the :pep:`optional Two-Phase Commit Extensions in the
+Python DB-API specification <249#optional-two-phase-commit-extensions>`.
 
 Callbacks are not run until autocommit is restored on the connection following
 the commit (because otherwise any queries done in a callback would open an
@@ -387,7 +387,6 @@ autocommit is disabled and you are not within an atomic block will result in an
 error.
 
 .. _two-phase commit: https://en.wikipedia.org/wiki/Two-phase_commit_protocol
-.. _optional Two-Phase Commit Extensions in the Python DB-API specification: https://www.python.org/dev/peps/pep-0249/#optional-two-phase-commit-extensions
 
 Use in tests
 ------------

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -341,15 +341,16 @@ The class has the following methods:
 
        message.attach('design.png', img_data, 'image/png')
 
-    If you specify a ``mimetype`` of ``message/rfc822``, it will also accept
-    :class:`django.core.mail.EmailMessage` and :py:class:`email.message.Message`.
+    If you specify a ``mimetype`` of :mimetype:`message/rfc822`, it will also
+    accept :class:`django.core.mail.EmailMessage` and
+    :py:class:`email.message.Message`.
 
-    For a ``mimetype`` starting with ``text/``, content is expected to be a
-    string. Binary data will be decoded using UTF-8, and if that fails, the
-    MIME type will be changed to ``application/octet-stream`` and the data will
-    be attached unchanged.
+    For a ``mimetype`` starting with :mimetype:`text/`, content is expected to
+    be a string. Binary data will be decoded using UTF-8, and if that fails,
+    the MIME type will be changed to :mimetype:`application/octet-stream` and
+    the data will be attached unchanged.
 
-    In addition, ``message/rfc822`` attachments will no longer be
+    In addition, :mimetype:`message/rfc822` attachments will no longer be
     base64-encoded in violation of :rfc:`2046#section-5.2.1`, which can cause
     issues with displaying the attachments in `Evolution`__ and `Thunderbird`__.
 
@@ -363,7 +364,7 @@ The class has the following methods:
 
     message.attach_file('/images/weather_map.png')
 
-  For MIME types starting with ``text/``, binary data is handled as in
+  For MIME types starting with :mimetype:`text/`, binary data is handled as in
   ``attach()``.
 
 Sending alternative content types

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -40,10 +40,10 @@ Designating the settings
 .. envvar:: DJANGO_SETTINGS_MODULE
 
 When you use Django, you have to tell it which settings you're using. Do this
-by using an environment variable, ``DJANGO_SETTINGS_MODULE``.
+by using an environment variable, :envvar:`DJANGO_SETTINGS_MODULE`.
 
-The value of ``DJANGO_SETTINGS_MODULE`` should be in Python path syntax, e.g.
-``mysite.settings``. Note that the settings module should be on the
+The value of :envvar:`DJANGO_SETTINGS_MODULE` should be in Python path syntax,
+e.g. ``mysite.settings``. Note that the settings module should be on the
 Python `import search path`_.
 
 .. _import search path: https://www.diveinto.org/python3/your-first-python-program.html#importsearchpath
@@ -170,10 +170,10 @@ a convention.
 
 .. _settings-without-django-settings-module:
 
-Using settings without setting ``DJANGO_SETTINGS_MODULE``
-=========================================================
+Using settings without setting :envvar:`DJANGO_SETTINGS_MODULE`
+===============================================================
 
-In some cases, you might want to bypass the ``DJANGO_SETTINGS_MODULE``
+In some cases, you might want to bypass the :envvar:`DJANGO_SETTINGS_MODULE`
 environment variable. For example, if you're using the template system by
 itself, you likely don't want to have to set up an environment variable
 pointing to a settings module.
@@ -234,19 +234,19 @@ defaults, so you must specify a value for every possible setting that might be
 used in that code you are importing. Check in
 ``django.conf.settings.global_settings`` for the full list.
 
-Either ``configure()`` or ``DJANGO_SETTINGS_MODULE`` is required
-----------------------------------------------------------------
+Either ``configure()`` or :envvar:`DJANGO_SETTINGS_MODULE` is required
+----------------------------------------------------------------------
 
-If you're not setting the ``DJANGO_SETTINGS_MODULE`` environment variable, you
-*must* call ``configure()`` at some point before using any code that reads
-settings.
+If you're not setting the :envvar:`DJANGO_SETTINGS_MODULE` environment
+variable, you *must* call ``configure()`` at some point before using any code
+that reads settings.
 
-If you don't set ``DJANGO_SETTINGS_MODULE`` and don't call ``configure()``,
-Django will raise an ``ImportError`` exception the first time a setting
-is accessed.
+If you don't set :envvar:`DJANGO_SETTINGS_MODULE` and don't call
+``configure()``, Django will raise an ``ImportError`` exception the first time
+a setting is accessed.
 
-If you set ``DJANGO_SETTINGS_MODULE``, access settings values somehow, *then*
-call ``configure()``, Django will raise a ``RuntimeError`` indicating
+If you set :envvar:`DJANGO_SETTINGS_MODULE`, access settings values somehow,
+*then* call ``configure()``, Django will raise a ``RuntimeError`` indicating
 that settings have already been configured. There is a property for this
 purpose:
 
@@ -262,7 +262,7 @@ Also, it's an error to call ``configure()`` more than once, or to call
 ``configure()`` after any setting has been accessed.
 
 It boils down to this: Use exactly one of either ``configure()`` or
-``DJANGO_SETTINGS_MODULE``. Not both, and not neither.
+:envvar:`DJANGO_SETTINGS_MODULE`. Not both, and not neither.
 
 Calling ``django.setup()`` is required for "standalone" Django usage
 --------------------------------------------------------------------


### PR DESCRIPTION
Updated to use `:pep:`, `:mimetype:`, and `:envvar:` roles in more places.

- For `:mimetype:` I didn't change where the value in double backticks was wrapped in quotes.
- For `:envvar:` I added the `.. envvar::` directive as required where missing.

I've also updated `docs/internals/contributing/writing-documentation.txt` to mention use of these roles.