### PR TITLE
Refs #31032 -- Removed obsolete CSS workaround for IE in openlayers template.

### DIFF
--- a/django/contrib/gis/templates/gis/admin/openlayers.html
+++ b/django/contrib/gis/templates/gis/admin/openlayers.html
@@ -14,15 +14,6 @@
      background-repeat: no-repeat;
   }
 </style>
-<!--[if IE]>
-<style type="text/css">
-  /* This fixes the mouse offset issues in IE. */
-  #{{ id }}_admin_map { position: static; vertical-align: top; }
-  /* `font-size: 0` fixes the 1px border between tiles, but borks LayerSwitcher.
-      Thus, this is disabled until a better fix is found.
-  #{{ id }}_map { width: {{ map_width }}px; height: {{ map_height }}px; font-size: 0; } */
-</style>
-<![endif]-->
 {% endblock %}
 <span id="{{ id }}_admin_map">
 <script>


### PR DESCRIPTION
We don't support IE anymore.