### PR TITLE
Removed invalid value from admin CSS.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -155,7 +155,6 @@
 
 #changelist-filter ul:last-child {
     border-bottom: none;
-    padding-bottom: none;
 }
 
 #changelist-filter li {


### PR DESCRIPTION
The keyword value 'none' is not a valid value for padding-bottom. Fixes
CSS warning in Firefox console:

    Error in parsing value for ‘padding-bottom’.  Declaration dropped.

https://developer.mozilla.org/en-US/docs/Web/CSS/padding-bottom#Syntax