### PR TITLE
Fixed #31354: Properly reconstruct host header in presence of X-Forwarded-* header.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -2,6 +2,7 @@ import cgi
 import codecs
 import copy
 import warnings
+from collections import namedtuple
 from io import BytesIO
 from itertools import chain
 from urllib.parse import quote, urlencode, urljoin, urlsplit
@@ -25,7 +26,9 @@ from django.utils.regex_helper import _lazy_re_compile
 from .multipartparser import parse_header
 
 RAISE_ERROR = object()
-host_validation_re = _lazy_re_compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(?::(\d+))?$")
+host_validation_re = _lazy_re_compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(?::([0-9]+))?$")
+
+ParsedHostHeader = namedtuple('ParsedHostHeader', ['domain', 'port', 'combined'])
 
 
 class UnreadablePostError(OSError):
@@ -97,58 +100,60 @@ class HttpRequest:
             else:
                 self.encoding = self.content_params['charset']
 
-    @cached_property
-    def _parsed_host_header(self):
-        use_x_fw_host = settings.USE_X_FORWARDED_HOST
-        use_x_fw_port = settings.USE_X_FORWARDED_PORT
+    def _get_parsed_host_header(self, validate=True):
+        if not hasattr(self, '_parsed_host_obj'):
+            use_x_fw_host = settings.USE_X_FORWARDED_HOST
+            use_x_fw_port = settings.USE_X_FORWARDED_PORT
 
-        port_in_x_fw_host = False
-        default_port = ('443' if self.is_secure() else '80')
+            port_in_x_fw_host = False
+            default_port = ('443' if self.is_secure() else '80')
 
-        if use_x_fw_host and 'HTTP_X_FORWARDED_HOST' in self.META:
-            host, port = _parse_host_header(self.META['HTTP_X_FORWARDED_HOST'])
-            port_in_x_fw_host = port != ''
-        elif 'HTTP_HOST' in self.META:
-            host, port = _parse_host_header(self.META['HTTP_HOST'])
+            if use_x_fw_host and 'HTTP_X_FORWARDED_HOST' in self.META:
+                host, port = _parse_host_header(self.META['HTTP_X_FORWARDED_HOST'])
+                port_in_x_fw_host = port != ''
+            elif 'HTTP_HOST' in self.META:
+                host, port = _parse_host_header(self.META['HTTP_HOST'])
+            else:
+                # Reconstruct the host using the algorithm from PEP 333.
+                host, port = self.META['SERVER_NAME'], str(self.META['SERVER_PORT'])
+                if port == default_port:
+                    port = ''
+
+            if use_x_fw_port and 'HTTP_X_FORWARDED_PORT' in self.META:
+                if port_in_x_fw_host:
+                    raise ImproperlyConfigured('HTTP_X_FORWARDED_HOST contains a port number '
+                                               'and USE_X_FORWARDED_PORT is set to True')
+                port = self.META['HTTP_X_FORWARDED_PORT']
+
+            reconstructed = '%s:%s' % (host, port) if port else host
+
+            domain, port = split_domain_port(reconstructed)
+            parsed_host = self._parsed_host_obj = ParsedHostHeader(domain, port or default_port, reconstructed)
         else:
-            # Reconstruct the host using the algorithm from PEP 333.
-            host, port = self.META['SERVER_NAME'], str(self.META['SERVER_PORT'])
-            if port == default_port:
-                port = ''
-
-        if use_x_fw_port and 'HTTP_X_FORWARDED_PORT' in self.META:
-            if port_in_x_fw_host:
-                raise ImproperlyConfigured('HTTP_X_FORWARDED_HOST contains a port number '
-                                           'and USE_X_FORWARDED_PORT is set to True')
-            port = self.META['HTTP_X_FORWARDED_PORT']
-
-        reconstructed = '%s:%s' % (host, port) if port else host
-        return host, port or default_port, reconstructed
-
-    def get_host(self):
-        """Return the HTTP host using the environment or request headers."""
-        _, _, host_header = self._parsed_host_header
+            parsed_host = self._parsed_host_obj
 
         # Allow variants of localhost if ALLOWED_HOSTS is empty and DEBUG=True.
         allowed_hosts = settings.ALLOWED_HOSTS
         if settings.DEBUG and not allowed_hosts:
             allowed_hosts = ['.localhost', '127.0.0.1', '[::1]']
 
-        domain, port = split_domain_port(host_header)
-        if domain and validate_host(domain, allowed_hosts):
-            return host_header
-        else:
-            msg = "Invalid HTTP_HOST header: %r." % host_header
-            if domain:
-                msg += " You may need to add %r to ALLOWED_HOSTS." % domain
+        msg = "Invalid HTTP_HOST header: %r." % parsed_host.combined
+        if validate and not (parsed_host.domain and validate_host(parsed_host.domain, allowed_hosts)):
+            if parsed_host.domain:
+                msg += " You may need to add %r to ALLOWED_HOSTS." % parsed_host.domain
             else:
                 msg += " The domain name provided is not valid according to RFC 1034/1035."
             raise DisallowedHost(msg)
 
+        return parsed_host
+
+    def get_host(self):
+        """Return the HTTP host using the environment or request headers."""
+        return self._get_parsed_host_header().combined
+
     def get_port(self):
         """Return the port number for the request as a string."""
-        _, port, _ = self._parsed_host_header
-        return port
+        return self._get_parsed_host_header().port
 
     def get_full_path(self, force_append_slash=False):
         return self._get_full_path(self.path, force_append_slash)
@@ -193,10 +198,9 @@ class HttpRequest:
         Return an absolute URI from variables available in this request. Skip
         allowed hosts protection, so may return insecure URI.
         """
-        _, _, host_header = self._parsed_host_header
         return '{scheme}://{host}{path}'.format(
             scheme=self.scheme,
-            host=host_header,
+            host=self._get_parsed_host_header(validate=False).combined,
             path=self.get_full_path(),
         )
 

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -25,7 +25,7 @@ from django.utils.regex_helper import _lazy_re_compile
 from .multipartparser import parse_header
 
 RAISE_ERROR = object()
-host_validation_re = _lazy_re_compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(:\d+)?$")
+host_validation_re = _lazy_re_compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(?::(\d+))?$")
 
 
 class UnreadablePostError(OSError):
@@ -97,39 +97,48 @@ class HttpRequest:
             else:
                 self.encoding = self.content_params['charset']
 
-    def _get_raw_host(self):
-        """
-        Return the HTTP host using the environment or request headers. Skip
-        allowed hosts protection, so may return an insecure host.
-        """
-        # We try three options, in order of decreasing preference.
-        if settings.USE_X_FORWARDED_HOST and (
-                'HTTP_X_FORWARDED_HOST' in self.META):
-            host = self.META['HTTP_X_FORWARDED_HOST']
+    @cached_property
+    def _parsed_host_header(self):
+        use_x_fw_host = settings.USE_X_FORWARDED_HOST
+        use_x_fw_port = settings.USE_X_FORWARDED_PORT
+
+        port_in_x_fw_host = False
+        default_port = ('443' if self.is_secure() else '80')
+
+        if use_x_fw_host and 'HTTP_X_FORWARDED_HOST' in self.META:
+            host, port = _parse_host_header(self.META['HTTP_X_FORWARDED_HOST'])
+            port_in_x_fw_host = port != ''
         elif 'HTTP_HOST' in self.META:
-            host = self.META['HTTP_HOST']
+            host, port = _parse_host_header(self.META['HTTP_HOST'])
         else:
             # Reconstruct the host using the algorithm from PEP 333.
-            host = self.META['SERVER_NAME']
-            server_port = self.get_port()
-            if server_port != ('443' if self.is_secure() else '80'):
-                host = '%s:%s' % (host, server_port)
-        return host
+            host, port = self.META['SERVER_NAME'], str(self.META['SERVER_PORT'])
+            if port == default_port:
+                port = ''
+
+        if use_x_fw_port and 'HTTP_X_FORWARDED_PORT' in self.META:
+            if port_in_x_fw_host:
+                raise ImproperlyConfigured('HTTP_X_FORWARDED_HOST contains a port number '
+                                           'and USE_X_FORWARDED_PORT is set to True')
+            port = self.META['HTTP_X_FORWARDED_PORT']
+
+        reconstructed = '%s:%s' % (host, port) if port else host
+        return host, port or default_port, reconstructed
 
     def get_host(self):
         """Return the HTTP host using the environment or request headers."""
-        host = self._get_raw_host()
+        _, _, host_header = self._parsed_host_header
 
         # Allow variants of localhost if ALLOWED_HOSTS is empty and DEBUG=True.
         allowed_hosts = settings.ALLOWED_HOSTS
         if settings.DEBUG and not allowed_hosts:
             allowed_hosts = ['.localhost', '127.0.0.1', '[::1]']
 
-        domain, port = split_domain_port(host)
+        domain, port = split_domain_port(host_header)
         if domain and validate_host(domain, allowed_hosts):
-            return host
+            return host_header
         else:
-            msg = "Invalid HTTP_HOST header: %r." % host
+            msg = "Invalid HTTP_HOST header: %r." % host_header
             if domain:
                 msg += " You may need to add %r to ALLOWED_HOSTS." % domain
             else:
@@ -138,11 +147,8 @@ class HttpRequest:
 
     def get_port(self):
         """Return the port number for the request as a string."""
-        if settings.USE_X_FORWARDED_PORT and 'HTTP_X_FORWARDED_PORT' in self.META:
-            port = self.META['HTTP_X_FORWARDED_PORT']
-        else:
-            port = self.META['SERVER_PORT']
-        return str(port)
+        _, port, _ = self._parsed_host_header
+        return port
 
     def get_full_path(self, force_append_slash=False):
         return self._get_full_path(self.path, force_append_slash)
@@ -187,9 +193,10 @@ class HttpRequest:
         Return an absolute URI from variables available in this request. Skip
         allowed hosts protection, so may return insecure URI.
         """
+        _, _, host_header = self._parsed_host_header
         return '{scheme}://{host}{path}'.format(
             scheme=self.scheme,
-            host=self._get_raw_host(),
+            host=host_header,
             path=self.get_full_path(),
         )
 
@@ -629,6 +636,20 @@ def bytes_to_text(s, encoding):
         return s
 
 
+def _parse_host_header(host_header):
+    """
+    Returns a (domain, port) tuple for a given host.
+
+    Neither domain name nor port are validated.
+    """
+
+    if host_header[-1] == ']':
+        # It's an IPv6 address without a port.
+        return host_header, ''
+    bits = host_header.rsplit(':', 1)
+    return tuple(bits) if len(bits) == 2 else (bits[0], '')
+
+
 def split_domain_port(host):
     """
     Return a (domain, port) tuple from a given host.
@@ -638,14 +659,12 @@ def split_domain_port(host):
     """
     host = host.lower()
 
-    if not host_validation_re.match(host):
+    host_match = host_validation_re.match(host)
+    if not host_match:
         return '', ''
 
-    if host[-1] == ']':
-        # It's an IPv6 address without a port.
-        return host, ''
-    bits = host.rsplit(':', 1)
-    domain, port = bits if len(bits) == 2 else (bits[0], '')
+    domain, port = host_match.groups()
+    port = port or ''
     # Remove a trailing dot (if present) from the domain.
     domain = domain[:-1] if domain.endswith('.') else domain
     return domain, port

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -641,10 +641,15 @@ class CsrfViewMiddlewareTests(CsrfViewMiddlewareTestMixin, SimpleTestCase):
         self.assertEqual(len(csrf_cookie.value), CSRF_TOKEN_LENGTH)
         self._check_token_present(resp, csrf_id=csrf_cookie.value)
 
-    @override_settings(ALLOWED_HOSTS=['www.example.com'], CSRF_COOKIE_DOMAIN='.example.com', USE_X_FORWARDED_PORT=True)
+    @override_settings(
+        ALLOWED_HOSTS=['www.example.com'],
+        CSRF_COOKIE_DOMAIN='.example.com',
+        USE_X_FORWARDED_PORT=True,
+        USE_X_FORWARDED_HOST=True
+    )
     def test_https_good_referer_behind_proxy(self):
         """
-        A POST HTTPS request is accepted when USE_X_FORWARDED_PORT=True.
+        A POST HTTPS request is accepted when USE_X_FORWARDED_*=True.
         """
         self._test_https_good_referer_behind_proxy()
 
@@ -752,11 +757,12 @@ class CsrfViewMiddlewareUseSessionsTests(CsrfViewMiddlewareTestMixin, SimpleTest
         ALLOWED_HOSTS=['www.example.com'],
         SESSION_COOKIE_DOMAIN='.example.com',
         USE_X_FORWARDED_PORT=True,
+        USE_X_FORWARDED_HOST=True,
         DEBUG=True,
     )
     def test_https_good_referer_behind_proxy(self):
         """
-        A POST HTTPS request is accepted when USE_X_FORWARDED_PORT=True.
+        A POST HTTPS request is accepted when USE_X_FORWARDED_*=True.
         """
         self._test_https_good_referer_behind_proxy()
 

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -432,8 +432,8 @@ class CsrfViewMiddlewareTestMixin:
     def _test_https_good_referer_matches_cookie_domain(self):
         req = self._get_POST_request_with_token()
         req._is_secure_override = True
+        req.META['HTTP_HOST'] = 'www.example.com'
         req.META['HTTP_REFERER'] = 'https://foo.example.com/'
-        req.META['SERVER_PORT'] = '443'
         mw = CsrfViewMiddleware(post_form_view)
         mw.process_request(req)
         response = mw.process_view(req, post_form_view, (), {})
@@ -442,9 +442,8 @@ class CsrfViewMiddlewareTestMixin:
     def _test_https_good_referer_matches_cookie_domain_with_different_port(self):
         req = self._get_POST_request_with_token()
         req._is_secure_override = True
-        req.META['HTTP_HOST'] = 'www.example.com'
+        req.META['HTTP_HOST'] = 'www.example.com:4443'
         req.META['HTTP_REFERER'] = 'https://foo.example.com:4443/'
-        req.META['SERVER_PORT'] = '4443'
         mw = CsrfViewMiddleware(post_form_view)
         mw.process_request(req)
         response = mw.process_view(req, post_form_view, (), {})

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -792,7 +792,8 @@ class HostValidationTests(SimpleTestCase):
             'HTTP_X_FORWARDED_HOST': 'example.com:8000',
         }
         # Should use the X-Forwarded-Host header
-        self.assertEqual(request.get_port(), '8000')
+        with override_settings(ALLOWED_HOSTS=['example.com']):
+            self.assertEqual(request.get_port(), '8000')
 
         request = HttpRequest()
         request.META = {
@@ -810,7 +811,8 @@ class HostValidationTests(SimpleTestCase):
             'HTTP_X_FORWARDED_HOST': '[2001:19f0:feee::dead:beef:cafe]:8000',
         }
         # Should use the X-Forwarded-Host header
-        self.assertEqual(request.get_port(), '8000')
+        with override_settings(ALLOWED_HOSTS=['[2001:19f0:feee::dead:beef:cafe]']):
+            self.assertEqual(request.get_port(), '8000')
 
         request = HttpRequest()
         request.META = {
@@ -829,8 +831,9 @@ class HostValidationTests(SimpleTestCase):
             'HTTP_X_FORWARDED_HOST': 'example.com',
             'HTTP_X_FORWARDED_PORT': '8010',
         }
-        # Should use the X-Forwarded-Port header
-        self.assertEqual(request.get_port(), '8010')
+        with override_settings(ALLOWED_HOSTS=['example.com']):
+            # Should use the X-Forwarded-Port header
+            self.assertEqual(request.get_port(), '8010')
 
         request = HttpRequest()
         request.META = {

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -2,7 +2,7 @@ from io import BytesIO
 from itertools import chain
 from urllib.parse import urlencode
 
-from django.core.exceptions import DisallowedHost
+from django.core.exceptions import DisallowedHost, ImproperlyConfigured
 from django.core.handlers.wsgi import LimitedStream, WSGIRequest
 from django.http import HttpRequest, RawPostDataException, UnreadablePostError
 from django.http.multipartparser import MultiPartParserError
@@ -669,6 +669,17 @@ class HostValidationTests(SimpleTestCase):
         # X_FORWARDED_HOST is obeyed.
         self.assertEqual(request.get_host(), 'forward.com')
 
+        # Check if X_FORWARDED_HOST is provided with a port.
+        request = HttpRequest()
+        request.META = {
+            'HTTP_X_FORWARDED_HOST': 'forward.com:8080',
+            'HTTP_HOST': 'example.com',
+            'SERVER_NAME': 'internal.com',
+            'SERVER_PORT': 80,
+        }
+        # X_FORWARDED_HOST is obeyed.
+        self.assertEqual(request.get_host(), 'forward.com:8080')
+
         # Check if X_FORWARDED_HOST isn't provided.
         request = HttpRequest()
         request.META = {
@@ -720,10 +731,27 @@ class HostValidationTests(SimpleTestCase):
                 }
                 request.get_host()
 
+    @override_settings(
+        USE_X_FORWARDED_PORT=True,
+        USE_X_FORWARDED_HOST=False,
+        ALLOWED_HOSTS=['*'])
+    def test_get_host_with_use_x_forwarded_port_and_http_host(self):
+        request = HttpRequest()
+        request.META = {
+            'HTTP_HOST': 'original.com',
+            'SERVER_PORT': '8000',
+            'HTTP_X_FORWARDED_HOST': 'example.com',
+            'HTTP_X_FORWARDED_PORT': '8080',
+        }
+        # Should NOT use the X-Forwarded-Port header
+        self.assertEqual(request.get_host(), 'original.com:8080')
+        self.assertEqual(request.get_port(), '8080')
+
     @override_settings(USE_X_FORWARDED_PORT=False)
     def test_get_port(self):
         request = HttpRequest()
         request.META = {
+            'SERVER_NAME': 'testserver',
             'SERVER_PORT': '8080',
             'HTTP_X_FORWARDED_PORT': '80',
         }
@@ -732,6 +760,7 @@ class HostValidationTests(SimpleTestCase):
 
         request = HttpRequest()
         request.META = {
+            'SERVER_NAME': 'testserver',
             'SERVER_PORT': '8080',
         }
         self.assertEqual(request.get_port(), '8080')
@@ -740,6 +769,7 @@ class HostValidationTests(SimpleTestCase):
     def test_get_port_with_x_forwarded_port(self):
         request = HttpRequest()
         request.META = {
+            'SERVER_NAME': 'testserver',
             'SERVER_PORT': '8080',
             'HTTP_X_FORWARDED_PORT': '80',
         }
@@ -748,9 +778,95 @@ class HostValidationTests(SimpleTestCase):
 
         request = HttpRequest()
         request.META = {
+            'SERVER_NAME': 'testserver',
             'SERVER_PORT': '8080',
         }
         self.assertEqual(request.get_port(), '8080')
+
+    @override_settings(USE_X_FORWARDED_HOST=True)
+    def test_get_port_with_x_forwarded_host(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+            'HTTP_X_FORWARDED_HOST': 'example.com:8000',
+        }
+        # Should use the X-Forwarded-Host header
+        self.assertEqual(request.get_port(), '8000')
+
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+        }
+        self.assertEqual(request.get_port(), '8080')
+
+    @override_settings(USE_X_FORWARDED_HOST=True)
+    def test_get_port_with_x_forwarded_host_ipv6(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+            'HTTP_X_FORWARDED_HOST': '[2001:19f0:feee::dead:beef:cafe]:8000',
+        }
+        # Should use the X-Forwarded-Host header
+        self.assertEqual(request.get_port(), '8000')
+
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+        }
+        self.assertEqual(request.get_port(), '8080')
+
+    @override_settings(USE_X_FORWARDED_HOST=True,
+                       USE_X_FORWARDED_PORT=True)
+    def test_get_port_with_x_forwarded_host_and_port(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+            'HTTP_X_FORWARDED_HOST': 'example.com',
+            'HTTP_X_FORWARDED_PORT': '8010',
+        }
+        # Should use the X-Forwarded-Port header
+        self.assertEqual(request.get_port(), '8010')
+
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+        }
+        self.assertEqual(request.get_port(), '8080')
+
+    @override_settings(
+        USE_X_FORWARDED_PORT=True,
+        USE_X_FORWARDED_HOST=True,
+        ALLOWED_HOSTS=['*'])
+    def test_get_host_with_x_forwarded_port(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_PORT': '80',
+            'HTTP_X_FORWARDED_HOST': 'example.com',
+            'HTTP_X_FORWARDED_PORT': '8080',
+        }
+        # Should use the X-Forwarded-Port header
+        self.assertEqual(request.get_host(), 'example.com:8080')
+
+    @override_settings(
+        USE_X_FORWARDED_PORT=True,
+        USE_X_FORWARDED_HOST=True,
+        ALLOWED_HOSTS=['*'])
+    def test_get_host_with_use_x_forwarded_port_and_port_in_host(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_PORT': '80',
+            'HTTP_X_FORWARDED_HOST': 'example.com:8081',
+            'HTTP_X_FORWARDED_PORT': '8080',
+        }
+        # Should use the X-Forwarded-Port header
+        with self.assertRaises(ImproperlyConfigured):
+            request.get_host()
 
     @override_settings(DEBUG=True, ALLOWED_HOSTS=[])
     def test_host_validation_in_debug_mode(self):

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -108,36 +108,41 @@ class SitesFrameworkTests(TestCase):
 
     @override_settings(SITE_ID='', ALLOWED_HOSTS=['example.com', 'example.net'])
     def test_get_current_site_no_site_id_and_handle_port_fallback(self):
-        request = HttpRequest()
         s1 = self.site
         s2 = Site.objects.create(domain='example.com:80', name='example.com:80')
 
         # Host header without port
+        request = HttpRequest()
         request.META = {'HTTP_HOST': 'example.com'}
         site = get_current_site(request)
         self.assertEqual(site, s1)
 
         # Host header with port - match, no fallback without port
+        request = HttpRequest()
         request.META = {'HTTP_HOST': 'example.com:80'}
         site = get_current_site(request)
         self.assertEqual(site, s2)
 
         # Host header with port - no match, fallback without port
+        request = HttpRequest()
         request.META = {'HTTP_HOST': 'example.com:81'}
         site = get_current_site(request)
         self.assertEqual(site, s1)
 
         # Host header with non-matching domain
+        request = HttpRequest()
         request.META = {'HTTP_HOST': 'example.net'}
         with self.assertRaises(ObjectDoesNotExist):
             get_current_site(request)
 
         # Ensure domain for RequestSite always matches host header
         with self.modify_settings(INSTALLED_APPS={'remove': 'django.contrib.sites'}):
+            request = HttpRequest()
             request.META = {'HTTP_HOST': 'example.com'}
             site = get_current_site(request)
             self.assertEqual(site.name, 'example.com')
 
+            request = HttpRequest()
             request.META = {'HTTP_HOST': 'example.com:80'}
             site = get_current_site(request)
             self.assertEqual(site.name, 'example.com:80')


### PR DESCRIPTION
Follow up to #12550 