### PR TITLE
Removed unnecessary admin CSS.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -224,7 +224,6 @@ td, th {
     border-bottom: 1px solid #eee;
     vertical-align: top;
     padding: 8px;
-    font-family: "Roboto", "Lucida Grande", Verdana, Arial, sans-serif;
 }
 
 th {
@@ -611,7 +610,6 @@ div.breadcrumbs {
     background: #79aec8;
     padding: 10px 40px;
     border: none;
-    font-size: 14px;
     color: #c4dce8;
     text-align: left;
 }
@@ -666,14 +664,6 @@ a.deletelink:focus, a.deletelink:hover {
     margin-top: -48px;
 }
 
-.form-row .object-tools {
-    margin-top: 5px;
-    margin-bottom: 5px;
-    float: none;
-    height: 2em;
-    padding-left: 3.5em;
-}
-
 .object-tools li {
     display: block;
     float: left;
@@ -705,13 +695,13 @@ a.deletelink:focus, a.deletelink:hover {
     text-decoration: none;
 }
 
-.object-tools a.viewsitelink, .object-tools a.golink,.object-tools a.addlink {
+.object-tools a.viewsitelink, .object-tools a.addlink {
     background-repeat: no-repeat;
     background-position: right 7px center;
     padding-right: 26px;
 }
 
-.object-tools a.viewsitelink, .object-tools a.golink {
+.object-tools a.viewsitelink {
     background-image: url(../img/tooltag-arrowright.svg);
 }
 
@@ -886,7 +876,6 @@ table#change-history tbody th {
 }
 
 #content-related h3 {
-    font-size: 14px;
     color: #666;
     padding: 0 16px;
     margin: 0 0 16px;

--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -142,7 +142,6 @@
 
 #changelist-filter h3 {
     font-weight: 400;
-    font-size: 14px;
     padding: 0 15px;
     margin-bottom: 10px;
 }

--- a/django/contrib/admin/static/admin/css/login.css
+++ b/django/contrib/admin/static/admin/css/login.css
@@ -34,10 +34,6 @@
     height: auto;
 }
 
-.login #content-main {
-    width: 100%;
-}
-
 .login .form-row {
     padding: 4px 0;
     float: left;
@@ -48,9 +44,7 @@
 .login .form-row label {
     padding-right: 0.5em;
     line-height: 2em;
-    font-size: 1em;
     clear: both;
-    color: #333;
 }
 
 .login .form-row #id_username, .login .form-row #id_password {
@@ -58,11 +52,6 @@
     padding: 8px;
     width: 100%;
     box-sizing: border-box;
-}
-
-.login span.help {
-    font-size: 10px;
-    display: block;
 }
 
 .login .submit-row {

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -907,7 +907,7 @@ input[type="submit"], button {
         padding: 15px 0 0;
     }
 
-    .login br, .login .submit-row label {
+    .login br {
         display: none;
     }
 

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -1,7 +1,3 @@
-body {
-    direction: rtl;
-}
-
 /* LOGIN */
 
 .login .form-row {

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4802,6 +4802,23 @@ class SeleniumTests(AdminSeleniumTestCase):
         value = self.selenium.find_element_by_id('id_form-0-parent').get_attribute('value')
         self.assertEqual(value, str(parent2.pk))
 
+    def test_input_element_font(self):
+        """
+        Browsers' default stylesheets override the font of inputs. The admin
+        adds additional CSS to handle this.
+        """
+        self.selenium.get(self.live_server_url + reverse('admin:login'))
+        element = self.selenium.find_element_by_id('id_username')
+        # Some browsers quotes the fonts, some don't.
+        fonts = [
+            font.strip().strip('"')
+            for font in element.value_of_css_property('font-family').split(',')
+        ]
+        self.assertEqual(
+            fonts,
+            ['Roboto', 'Lucida Grande', 'Verdana', 'Arial', 'sans-serif'],
+        )
+
 
 @override_settings(ROOT_URLCONF='admin_views.urls')
 class ReadonlyTest(AdminFieldExtractionMixin, TestCase):


### PR DESCRIPTION
The "object-tools" container is never rendered as a descendant of
.form-row.

The "golink" CSS class is unused.

A `<label>` element has not been included in the login .submit-row since
5869afe32b9c252cacd327f18c58e38c36d1f530.

The "help" CSS class from login.css has been unused since
0e5faf225c5cd1acf2ab653c74f5b161470403b9.

The <label> color in login.css is already inherited from the `<body>`
element and so does not need to be re-specified.

The #content-main container already has the property 'width: 100%' from
base.css and so does not need to be re-specified in login.css.

The `<td>` and `<th>` font-family property is inherited from the <body>
element and so does not need to be re-specified.

The `<html>` element has the attribute dir which automatically sets
the text direction in the layout. Adding the direction CSS property was
necessary to support IE which does not support the dir attribute, but IE
is no longer supported, so drop the direction property.

The 'font-size: 1em' property re-specifies the same font size. It
creates no visual difference.

The 'font-size: 14px' property often re-specifies the inherited value.
Avoid re-specifying it.
