### PR TITLE
Simplified label element CSS in admin login.css.

### DIFF
--- a/django/contrib/admin/static/admin/css/login.css
+++ b/django/contrib/admin/static/admin/css/login.css
@@ -42,7 +42,7 @@
 }
 
 .login .form-row label {
-    padding-right: 0.5em;
+    display: block;
     line-height: 2em;
     clear: both;
 }

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -897,9 +897,7 @@ input[type="submit"], button {
     }
 
     .login .form-row label {
-        display: block;
         margin: 0 0 5px;
-        padding: 0;
         line-height: 1.2;
     }
 

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -6,8 +6,6 @@
 
 .login .form-row label {
     float: right;
-    padding-left: 0.5em;
-    padding-right: 0;
     text-align: left;
 }
 


### PR DESCRIPTION
Don't add horizontal padding as the label is always displayed on its own
line. This padding added no visual difference.

Move the 'display: block' property from responsive.css to base.css. The
label is already displayed on its own line in all viewports, so reduce
differences in rendering. Using block also allows the label to consume
the width of its container, creating a larger clickable area for a
slight a11y improvement.