### PR TITLE
Doc'd country part of locale name with more than 2 characters.

### DIFF
--- a/docs/topics/i18n/index.txt
+++ b/docs/topics/i18n/index.txt
@@ -66,9 +66,10 @@ Here are some other terms that will help us to handle a common language:
     locale name
       A locale name, either a language specification of the form ``ll`` or a
       combined language and country specification of the form ``ll_CC``.
-      Examples: ``it``, ``de_AT``, ``es``, ``pt_BR``. The language part is
-      always in lowercase and the country part in upper case. The separator is
-      an underscore.
+      Examples: ``it``, ``de_AT``, ``es``, ``pt_BR``, ``sr_Latn``. The language
+      part is always in lowercase. The country part is in titlecase if it has
+      more than 2 characters, otherwise it's in uppercase. The separator is an
+      underscore.
 
     language code
       Represents the name of a language. Browsers send the names of the


### PR DESCRIPTION
I don't think the comments in https://github.com/django/django/blob/e0998a460ac15464bcdb048ebc52eae0bb1cbd38/django/utils/translation/__init__.py#L273-L284 is documented anywhere, so I add it in the locale name section.