### PR TITLE
Corrected opts argument of colorize in TermColorTests.test_colorize_empty_text().

### DIFF
--- a/tests/utils_tests/test_termcolors.py
+++ b/tests/utils_tests/test_termcolors.py
@@ -181,5 +181,5 @@ class TermColorTests(unittest.TestCase):
         self.assertEqual(colorize(text=None), '\x1b[m\x1b[0m')
         self.assertEqual(colorize(text=''), '\x1b[m\x1b[0m')
 
-        self.assertEqual(colorize(text=None, opts=('noreset')), '\x1b[m')
-        self.assertEqual(colorize(text='', opts=('noreset')), '\x1b[m')
+        self.assertEqual(colorize(text=None, opts=('noreset',)), '\x1b[m')
+        self.assertEqual(colorize(text='', opts=('noreset',)), '\x1b[m')


### PR DESCRIPTION
From the code below we can clearly see that `opts` is supposed to be a tuple.

https://github.com/django/django/blob/8f10ceaa907f3f608494f782f65070d0bb8b9587/django/utils/termcolors.py#L37  

The check below still works if `opts` is a string, so this has been testing the right part of the code all this time (a happy little accident).

https://github.com/django/django/blob/8f10ceaa907f3f608494f782f65070d0bb8b9587/django/utils/termcolors.py#L53