### PR TITLE
Refs #28622 -- Corrected PASSWORD_RESET_TIMEOUT/PASSWORD_RESET_TIMEOUT_DAYS docs.

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -505,8 +505,7 @@ LOGOUT_REDIRECT_URL = None
 # The number of days a password reset link is valid for
 PASSWORD_RESET_TIMEOUT_DAYS = 3
 
-# The minimum number of seconds a password reset link is valid for
-# (default: 3 days).
+# The number of seconds a password reset link is valid for (default: 3 days).
 PASSWORD_RESET_TIMEOUT = 60 * 60 * 24 * 3
 
 # the first hasher in this list is the preferred algorithm.  any

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2971,7 +2971,7 @@ rendered.
 
 Default: ``259200`` (3 days, in seconds)
 
-The minimum number of seconds a password reset link is valid for.
+The number of seconds a password reset link is valid for.
 
 Used by the :class:`~django.contrib.auth.views.PasswordResetConfirmView`.
 
@@ -2992,8 +2992,7 @@ Used by the :class:`~django.contrib.auth.views.PasswordResetConfirmView`.
 
 Default: ``3``
 
-The minimum number of days a password reset link is valid for. Depending on
-when the link is generated, it will be valid for up to a day longer.
+The number of days a password reset link is valid for.
 
 Used by the :class:`~django.contrib.auth.views.PasswordResetConfirmView`.
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -90,10 +90,10 @@ Minor features
 * The default iteration count for the PBKDF2 password hasher is increased from
   180,000 to 216,000.
 
-* Added the :setting:`PASSWORD_RESET_TIMEOUT` setting to define the minimum
-  number of seconds a password reset link is valid for. This is encouraged
-  instead of deprecated ``PASSWORD_RESET_TIMEOUT_DAYS``, which will be removed
-  in Django 4.0.
+* Added the :setting:`PASSWORD_RESET_TIMEOUT` setting to define the number of
+  seconds a password reset link is valid for. This is encouraged instead of
+  deprecated ``PASSWORD_RESET_TIMEOUT_DAYS``, which will be removed in Django
+  4.0.
 
 * The password reset mechanism now uses the SHA-256 hashing algorithm. Support
   for tokens that use the old hashing algorithm remains until Django 4.0.


### PR DESCRIPTION
In the 3.1 release notes, the description for the new PASSWORD_RESET_TIMEOUT setting describes it as the minimum number of seconds a reset link is valid for, but it's really the _maximum_ number of seconds.