### PR TITLE
Fixed #31538 -- Fixed Meta.ordering validation lookups that are not transforms.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1747,7 +1747,9 @@ class Model(metaclass=ModelBase):
                     else:
                         _cls = None
                 except (FieldDoesNotExist, AttributeError):
-                    if fld is None or fld.get_transform(part) is None:
+                    if fld is None or (
+                        fld.get_transform(part) is None and fld.get_lookup(part) is None
+                    ):
                         errors.append(
                             checks.Error(
                                 "'ordering' refers to the nonexistent field, "

--- a/docs/releases/3.0.7.txt
+++ b/docs/releases/3.0.7.txt
@@ -9,4 +9,5 @@ Django 3.0.7 fixes several bugs in 3.0.6.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 3.0 by restoring the ability to use field
+  lookups in ``Meta.ordering`` (:ticket:`31538`).

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -893,6 +893,15 @@ class OtherModelTests(SimpleTestCase):
         with register_lookup(models.CharField, Lower):
             self.assertEqual(Model.check(), [])
 
+    def test_ordering_pointing_to_lookup_not_transform(self):
+        class Model(models.Model):
+            test = models.CharField(max_length=100)
+
+            class Meta:
+                ordering = ('test__isnull',)
+
+        self.assertEqual(Model.check(), [])
+
     def test_ordering_pointing_to_related_model_pk(self):
         class Parent(models.Model):
             pass


### PR DESCRIPTION
ticket-31538