### PR TITLE
Fixed a/an typos in "SQL" usage.

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -398,7 +398,7 @@ class BaseDatabaseOperations:
         to tables with foreign keys pointing the tables being truncated.
         PostgreSQL requires a cascade even if these tables are empty.
         """
-        raise NotImplementedError('subclasses of BaseDatabaseOperations must provide a sql_flush() method')
+        raise NotImplementedError('subclasses of BaseDatabaseOperations must provide an sql_flush() method')
 
     def execute_sql_flush(self, sql_list):
         """Execute a list of SQL statements to flush the database."""

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -181,7 +181,7 @@ def typecast_timestamp(s):  # does NOT store time zone information
 
 def split_identifier(identifier):
     """
-    Split a SQL identifier into a two element tuple of (namespace, name).
+    Split an SQL identifier into a two element tuple of (namespace, name).
 
     The identifier could be a table, column, or sequence name might be prefixed
     by a namespace.
@@ -195,7 +195,7 @@ def split_identifier(identifier):
 
 def truncate_name(identifier, length=None, hash_len=4):
     """
-    Shorten a SQL identifier to a repeatable mangled version with the given
+    Shorten an SQL identifier to a repeatable mangled version with the given
     length.
 
     If a quote stripped name contains a namespace, e.g. USERNAME"."TABLE,

--- a/docs/ref/contrib/postgres/constraints.txt
+++ b/docs/ref/contrib/postgres/constraints.txt
@@ -42,7 +42,7 @@ The name of the constraint.
 .. attribute:: ExclusionConstraint.expressions
 
 An iterable of 2-tuples. The first element is an expression or string. The
-second element is a SQL operator represented as a string. To avoid typos, you
+second element is an SQL operator represented as a string. To avoid typos, you
 may use :class:`~django.contrib.postgres.fields.RangeOperators` which maps the
 operators with strings. For example::
 

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -338,7 +338,7 @@ The ``Func`` API is as follows:
                         **extra_context
                     )
 
-        To avoid a SQL injection vulnerability, ``extra_context`` :ref:`must
+        To avoid an SQL injection vulnerability, ``extra_context`` :ref:`must
         not contain untrusted user input <avoiding-sql-injection-in-query-expressions>`
         as these values are interpolated into the SQL string rather than passed
         as query parameters, where the database driver would escape them.
@@ -353,7 +353,7 @@ assumed to be column references and will be wrapped in ``F()`` expressions
 while other values will be wrapped in ``Value()`` expressions.
 
 The ``**extra`` kwargs are ``key=value`` pairs that can be interpolated
-into the ``template`` attribute. To avoid a SQL injection vulnerability,
+into the ``template`` attribute. To avoid an SQL injection vulnerability,
 ``extra`` :ref:`must not contain untrusted user input
 <avoiding-sql-injection-in-query-expressions>` as these values are interpolated
 into the SQL string rather than passed as query parameters, where the database
@@ -1151,12 +1151,12 @@ SQL injection::
         template = "%(function)s('%(substring)s' in %(expressions)s)"
 
         def __init__(self, expression, substring):
-            # substring=substring is a SQL injection vulnerability!
+            # substring=substring is an SQL injection vulnerability!
             super().__init__(expression, substring=substring)
 
-This function generates a SQL string without any parameters. Since ``substring``
-is passed to ``super().__init__()`` as a keyword argument, it's interpolated
-into the SQL string before the query is sent to the database.
+This function generates an SQL string without any parameters. Since
+``substring`` is passed to ``super().__init__()`` as a keyword argument, it's
+interpolated into the SQL string before the query is sent to the database.
 
 Here's a corrected rewrite::
 

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1457,7 +1457,7 @@ relation works.
             null=True,
         )
 
-    ``on_delete`` doesn't create a SQL constraint in the database. Support for
+    ``on_delete`` doesn't create an SQL constraint in the database. Support for
     database-level cascade options :ticket:`may be implemented later <21961>`.
 
 The possible values for :attr:`~ForeignKey.on_delete` are found in

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -247,7 +247,7 @@ backends.
   ``allow_sliced_subqueries_with_in``.
 
 * ``DatabaseOperations.distinct_sql()`` now requires an additional ``params``
-  argument and returns a tuple of SQL and parameters instead of a SQL string.
+  argument and returns a tuple of SQL and parameters instead of an SQL string.
 
 * ``DatabaseFeatures.introspected_boolean_field_type`` is changed from a method
   to a property.

--- a/tests/backends/base/test_operations.py
+++ b/tests/backends/base/test_operations.py
@@ -41,7 +41,7 @@ class SimpleDatabaseOperationTests(SimpleTestCase):
         self.assertEqual(self.ops.set_time_zone_sql(), '')
 
     def test_sql_flush(self):
-        msg = 'subclasses of BaseDatabaseOperations must provide a sql_flush() method'
+        msg = 'subclasses of BaseDatabaseOperations must provide an sql_flush() method'
         with self.assertRaisesMessage(NotImplementedError, msg):
             self.ops.sql_flush(None, None)
 


### PR DESCRIPTION
As pointed out by @laymonage in #12825, we have a [style guideline](https://docs.djangoproject.com/en/dev/internals/contributing/writing-documentation/#commonly-used-terms) for this.