### PR TITLE
user.get_abbreviated_name()

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -371,6 +371,18 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         full_name = '%s %s' % (self.first_name, self.last_name)
         return full_name.strip()
 
+    def get_abbreviated_name(self):
+        """
+        Return the first_name plus the capitalised initial of the last_name,
+        with a space in between and dot(.) following it.
+        Eg John D. for John Doe
+        """
+        if self.last_name:
+            abbreviated_name = '%s %s.' % (self.first_name.title(), self.last_name.title()[0])
+            return abbreviated_name
+        else:
+            return self.first_name
+
     def get_short_name(self):
         """Return the short name for the user."""
         return self.first_name

--- a/tests/admin_docs/models.py
+++ b/tests/admin_docs/models.py
@@ -44,6 +44,13 @@ class Person(models.Model):
     def _get_full_name(self):
         return "%s %s" % (self.first_name, self.last_name)
 
+    def _get_abbreviated_name(self):
+        if self.last_name:
+            abbreviated_name = '%s %s.' % (self.first_name.title(), self.last_name.title()[0])
+            return abbreviated_name
+        else:
+            return self.first_name
+
     def rename_company(self, new_name):
         self.company.name = new_name
         self.company.save()
@@ -76,6 +83,13 @@ class Person(models.Model):
         Get the full name of the person
         """
         return self._get_full_name()
+
+    def get_abbreviated_name(self):
+        """
+        Get the abbreviated name of the person.
+        Eg. John D. for John Doe
+        """
+        return self._get_abbreviated_name()
 
     def get_status_count(self):
         return 0

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -175,6 +175,8 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
         """
         self.assertContains(self.response, "<td>get_full_name</td>")
         self.assertNotContains(self.response, "<td>_get_full_name</td>")
+        self.assertContains(self.response, "<td>get_abbreviated_name</td>")
+        self.assertNotContains(self.response, "<td>_get_abbreviated_name</td>")
         self.assertNotContains(self.response, "<td>add_image</td>")
         self.assertNotContains(self.response, "<td>delete_image</td>")
         self.assertNotContains(self.response, "<td>set_status</td>")


### PR DESCRIPTION
I was working on something that needed to have abbreviated names instead of getting full_names. I think most of people would like to have this feature built in into django. Would love to see the comments/feedback.

```
>>>user.first_name = "John"
>>>user.last_name = "Doe"
user.save()

>>>user.get_abbreviated_name() gives you
"John D."
```