### PR TITLE
Enabled GitHub security policy.

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Django Security Policies
+
+Please see https://www.djangoproject.com/security/.


### PR DESCRIPTION
As per: https://help.github.com/en/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository

The "Security" tab has become more prominent with the [announcements from Satellite](https://github.blog/2020-05-06-new-from-satellite-2020-github-codespaces-github-discussions-securing-code-in-private-repositories-and-more/) yesterday.