### PR TITLE
Fixed tests isolation in logging_tests.

### DIFF
--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -21,25 +21,6 @@ from django.views.debug import ExceptionReporter
 from . import views
 from .logconfig import MyEmailBackend
 
-# logging config prior to using filter with mail_admins
-OLD_LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'mail_admins': {
-            'level': 'ERROR',
-            'class': 'django.utils.log.AdminEmailHandler'
-        }
-    },
-    'loggers': {
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'ERROR',
-            'propagate': True,
-        },
-    }
-}
-
 
 class LoggingFiltersTest(SimpleTestCase):
     def test_require_debug_false_filter(self):
@@ -483,13 +464,16 @@ class SetupConfigureLogging(SimpleTestCase):
     """
     Calling django.setup() initializes the logging configuration.
     """
-    @override_settings(
-        LOGGING_CONFIG='logging_tests.tests.dictConfig',
-        LOGGING=OLD_LOGGING,
-    )
     def test_configure_initializes_logging(self):
         from django import setup
-        setup()
+        try:
+            with override_settings(
+                LOGGING_CONFIG='logging_tests.tests.dictConfig',
+            ):
+                setup()
+        finally:
+            # Restore logging from settings.
+            setup()
         self.assertTrue(dictConfig.called)
 
 


### PR DESCRIPTION
Running the following command

```console
$ ./runtests.py logging_tests.tests.SetupConfigureLogging \
    logging_tests.tests.SecurityLoggerTest --parallel=1
```

results in output:

```
Testing against Django installed in '…/django'
System check identified no issues (0 silenced).
..Bad Request: /suspicious/
.Bad Request: /suspicious_spec/
.
```

The `SetupConfigureLogging` test case does not restore the logging config after its execution. It leaves the logger `django.request` with an empty handlers array.

From `logging.Logger.callHandlers()` docstring:

> If no handler was found, output a one-off error message to sys.stderr.

That causes the string “Bad Request: /suspicious/” to be logged to `stderr` by `django.core.handlers.BaseHandler.get_response()`, because the response status code is >= 400.

---

Removes the last use of `LOGGING_CONFIG`, introduced in 43503b093a35ca4707c16d865f10929960bfa0b8 for ticket #16288, originally to test a backward compatibility shim.