### PR TITLE
Changed selected attribute to HTML5 boolean syntax in SelectBox.js.

### DIFF
--- a/django/contrib/admin/static/admin/js/SelectBox.js
+++ b/django/contrib/admin/static/admin/js/SelectBox.js
@@ -102,7 +102,7 @@
         select_all: function(id) {
             const box = document.getElementById(id);
             for (const option of box.options) {
-                option.selected = 'selected';
+                option.selected = true;
             }
         }
     };


### PR DESCRIPTION
Per MDN, HTMLOptionElement.selected is a Boolean attribute.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement#Properties,