### PR TITLE
Removed redundant assertions in fixtures tests.

### DIFF
--- a/tests/fixtures/tests.py
+++ b/tests/fixtures/tests.py
@@ -27,7 +27,6 @@ class TestCaseFixtureLoadingTests(TestCase):
 
     def test_class_fixtures(self):
         "Test case has installed 3 fixture objects"
-        self.assertEqual(Article.objects.count(), 3)
         self.assertQuerysetEqual(Article.objects.all(), [
             '<Article: Django conquers world!>',
             '<Article: Copyright is fine the way it is>',
@@ -702,7 +701,6 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
 
         with mock.patch('django.core.management.commands.loaddata.sys.stdin', open(fixture_json)):
             management.call_command('loaddata', '--format=json', '-', verbosity=0)
-            self.assertEqual(Article.objects.count(), 2)
             self.assertQuerysetEqual(Article.objects.all(), [
                 '<Article: Time to reform copyright>',
                 '<Article: Poker has no place on ESPN>',
@@ -710,7 +708,6 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
 
         with mock.patch('django.core.management.commands.loaddata.sys.stdin', open(fixture_xml)):
             management.call_command('loaddata', '--format=xml', '-', verbosity=0)
-            self.assertEqual(Article.objects.count(), 3)
             self.assertQuerysetEqual(Article.objects.all(), [
                 '<Article: XML identified as leading cause of cancer>',
                 '<Article: Time to reform copyright>',
@@ -791,7 +788,6 @@ class FixtureTransactionTests(DumpDataAssertMixin, TransactionTestCase):
 class ForwardReferenceTests(DumpDataAssertMixin, TestCase):
     def test_forward_reference_fk(self):
         management.call_command('loaddata', 'forward_reference_fk.json', verbosity=0)
-        self.assertEqual(NaturalKeyThing.objects.count(), 2)
         t1, t2 = NaturalKeyThing.objects.all()
         self.assertEqual(t1.other_thing, t2)
         self.assertEqual(t2.other_thing, t1)
@@ -809,7 +805,6 @@ class ForwardReferenceTests(DumpDataAssertMixin, TestCase):
             'forward_reference_fk_natural_key.json',
             verbosity=0,
         )
-        self.assertEqual(NaturalKeyThing.objects.count(), 2)
         t1, t2 = NaturalKeyThing.objects.all()
         self.assertEqual(t1.other_thing, t2)
         self.assertEqual(t2.other_thing, t1)

--- a/tests/fixtures_model_package/tests.py
+++ b/tests/fixtures_model_package/tests.py
@@ -10,7 +10,6 @@ class SampleTestCase(TestCase):
 
     def test_class_fixtures(self):
         "Test cases can load fixture objects into models defined in packages"
-        self.assertEqual(Article.objects.count(), 3)
         self.assertQuerysetEqual(
             Article.objects.all(), [
                 "Django conquers world!",


### PR DESCRIPTION
The `assertQuerysetEqual` assertion fails when the Queryset contains a
different number of items than the list it is compared to.