### PR TITLE
Updated logging calls to use arguments instead of string interpolation.

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -117,7 +117,7 @@ class BaseHandler:
                 return sync_to_async(method, thread_sensitive=True)
         elif method_is_async:
             if debug:
-                logger.debug('Asynchronous %s adapted.' % name)
+                logger.debug('Asynchronous %s adapted.', name)
             return async_to_sync(method)
         return method
 

--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -145,7 +145,7 @@ def iter_modules_and_files(modules, extra_files):
             continue
         except ValueError as e:
             # Network filesystems may return null bytes in file paths.
-            logger.debug('"%s" raised when resolving path: "%s"' % (str(e), path))
+            logger.debug('"%s" raised when resolving path: "%s"', e, path)
             continue
         results.add(resolved_path)
     return frozenset(results)


### PR DESCRIPTION
Variable data should be logged separately, the logger does the
interpolation. Follows established pattern and best practices from
https://docs.python.org/3/howto/logging.html#logging-variable-data