### PR TITLE
Removed unused member Downcoder.chars.

### DIFF
--- a/django/contrib/admin/static/admin/js/urlify.js
+++ b/django/contrib/admin/static/admin/js/urlify.js
@@ -134,8 +134,7 @@
             for (const lookup of ALL_DOWNCODE_MAPS) {
                 Object.assign(Downcoder.map, lookup);
             }
-            Downcoder.chars = Object.keys(Downcoder.map);
-            Downcoder.regex = new RegExp(Downcoder.chars.join('|'), 'g');
+            Downcoder.regex = new RegExp(Object.keys(Downcoder.map).join('|'), 'g');
         }
     };
 


### PR DESCRIPTION
Unused -- other than as a local variable -- since its introduction in
953badbea5a04159adbfa970f5805c0232b6a401