### PR TITLE
Fixed #31556 -- Remove useless list comprehension

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -155,7 +155,7 @@ commas, according to publication date:
 
     def index(request):
         latest_question_list = Question.objects.order_by('-pub_date')[:5]
-        output = ', '.join([q.question_text for q in latest_question_list])
+        output = ', '.join(q.question_text for q in latest_question_list)
         return HttpResponse(output)
 
     # Leave the rest of the views (detail, results, vote) unchanged


### PR DESCRIPTION
The `join` string method accepts an iterator.