### PR TITLE
Removed unused admin:jsi18n <script> element from change_password.html.

### DIFF
--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -2,9 +2,6 @@
 {% load i18n static %}
 {% load admin_urls %}
 
-{% block extrahead %}{{ block.super }}
-<script src="{% url 'admin:jsi18n' %}"></script>
-{% endblock %}
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
 {% block bodyclass %}{{ block.super }} {{ opts.app_label }}-{{ opts.model_name }} change-form{% endblock %}
 {% if not is_popup %}


### PR DESCRIPTION
The view does not contain any other JavaScript and therefore does not
have any user facing JavaScript strings to translate. Avoid the HTTP
request.