### PR TITLE
Refs #30116 -- Simplified regex match group access with Match.__getitem__().

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -74,7 +74,7 @@ def quote(s):
 
 def unquote(s):
     """Undo the effects of quote()."""
-    return UNQUOTE_RE.sub(lambda m: UNQUOTE_MAP[m.group(0)], s)
+    return UNQUOTE_RE.sub(lambda m: UNQUOTE_MAP[m[0]], s)
 
 
 def flatten(fields):

--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -148,7 +148,7 @@ def replace_named_groups(pattern):
     4. ^(?P<a>\w+)/b/(?P<c>\w+) ==> ^<a>/b/<c>
     """
     named_group_indices = [
-        (m.start(0), m.end(0), m.group(1))
+        (m.start(0), m.end(0), m[1])
         for m in named_group_matcher.finditer(pattern)
     ]
     # Tuples of (named capture group pattern, group name).

--- a/django/contrib/gis/db/backends/base/features.py
+++ b/django/contrib/gis/db/backends/base/features.py
@@ -94,6 +94,6 @@ class BaseSpatialFeatures:
     def __getattr__(self, name):
         m = re.match(r'has_(\w*)_function$', name)
         if m:
-            func_name = m.group(1)
+            func_name = m[1]
             return func_name not in self.connection.ops.unsupported_functions
         raise AttributeError

--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -342,7 +342,7 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
         proj_ver_str = self.postgis_proj_version()
         m = proj_regex.search(proj_ver_str)
         if m:
-            return tuple(map(int, [m.group(1), m.group(2), m.group(3)]))
+            return tuple(map(int, m.groups()))
         else:
             raise Exception('Could not determine PROJ.4 version from PostGIS.')
 

--- a/django/contrib/gis/gdal/geometries.py
+++ b/django/contrib/gis/gdal/geometries.py
@@ -74,16 +74,16 @@ class OGRGeometry(GDALBase):
             wkt_m = wkt_regex.match(geom_input)
             json_m = json_regex.match(geom_input)
             if wkt_m:
-                if wkt_m.group('srid'):
+                if wkt_m['srid']:
                     # If there's EWKT, set the SRS w/value of the SRID.
-                    srs = int(wkt_m.group('srid'))
-                if wkt_m.group('type').upper() == 'LINEARRING':
+                    srs = int(wkt_m['srid'])
+                if wkt_m['type'].upper() == 'LINEARRING':
                     # OGR_G_CreateFromWkt doesn't work with LINEARRING WKT.
                     #  See https://trac.osgeo.org/gdal/ticket/1992.
-                    g = capi.create_geom(OGRGeomType(wkt_m.group('type')).num)
-                    capi.import_wkt(g, byref(c_char_p(wkt_m.group('wkt').encode())))
+                    g = capi.create_geom(OGRGeomType(wkt_m['type']).num)
+                    capi.import_wkt(g, byref(c_char_p(wkt_m['wkt'].encode())))
                 else:
-                    g = capi.from_wkt(byref(c_char_p(wkt_m.group('wkt').encode())), None, byref(c_void_p()))
+                    g = capi.from_wkt(byref(c_char_p(wkt_m['wkt'].encode())), None, byref(c_void_p()))
             elif json_m:
                 g = self._from_json(geom_input.encode())
             else:

--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -122,7 +122,7 @@ class GEOSGeometryBase(GEOSBase):
             match = re.match(br'SRID=(?P<srid>\-?\d+)', srid_part)
             if not match:
                 raise ValueError('EWKT has invalid SRID part.')
-            srid = int(match.group('srid'))
+            srid = int(match['srid'])
         else:
             wkt = ewkt
         if not wkt:
@@ -700,9 +700,9 @@ class GEOSGeometry(GEOSGeometryBase, ListMixin):
             wkt_m = wkt_regex.match(geo_input)
             if wkt_m:
                 # Handle WKT input.
-                if wkt_m.group('srid'):
-                    input_srid = int(wkt_m.group('srid'))
-                g = self._from_wkt(force_bytes(wkt_m.group('wkt')))
+                if wkt_m['srid']:
+                    input_srid = int(wkt_m['srid'])
+                g = self._from_wkt(force_bytes(wkt_m['wkt']))
             elif hex_regex.match(geo_input):
                 # Handle HEXEWKB input.
                 g = wkb_r().read(force_bytes(geo_input))

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -135,7 +135,7 @@ class BuildFile:
 
         return re.sub(
             r'^(#: .*)(' + re.escape(old_path) + r')',
-            lambda match: match.group().replace(old_path, new_path),
+            lambda match: match[0].replace(old_path, new_path),
             msgs,
             flags=re.MULTILINE
         )
@@ -647,7 +647,7 @@ class Command(BaseCommand):
                 with open(django_po, encoding='utf-8') as fp:
                     m = plural_forms_re.search(fp.read())
                 if m:
-                    plural_form_line = m.group('value')
+                    plural_form_line = m['value']
                     if self.verbosity > 1:
                         self.stdout.write('copying plural forms: %s' % plural_form_line)
                     lines = []

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -126,7 +126,7 @@ class URLValidator(RegexValidator):
             # Now verify IPv6 in the netloc part
             host_match = re.search(r'^\[(.+)\](?::\d{2,5})?$', urlsplit(value).netloc)
             if host_match:
-                potential_ip = host_match.groups()[0]
+                potential_ip = host_match[1]
                 try:
                     validate_ipv6_address(potential_ip)
                 except ValidationError:
@@ -204,7 +204,7 @@ class EmailValidator:
 
         literal_match = self.literal_regex.match(domain_part)
         if literal_match:
-            ip_address = literal_match.group(1)
+            ip_address = literal_match[1]
             try:
                 validate_ipv46_address(ip_address)
                 return True

--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -17,7 +17,7 @@ field_size_re = _lazy_re_compile(r'^\s*(?:var)?char\s*\(\s*(\d+)\s*\)\s*$')
 def get_field_size(name):
     """ Extract the size number from a "varchar(11)" type name """
     m = field_size_re.search(name)
-    return int(m.group(1)) if m else None
+    return int(m[1]) if m else None
 
 
 # This light wrapper "fakes" a dictionary interface, because some SQLite data
@@ -147,7 +147,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             if field_desc.startswith("FOREIGN KEY"):
                 # Find name of the target FK field
                 m = re.match(r'FOREIGN KEY\s*\(([^\)]*)\).*', field_desc, re.I)
-                field_name = m.groups()[0].strip('"')
+                field_name = m[1].strip('"')
             else:
                 field_name = field_desc.split()[0].strip('"')
 
@@ -218,7 +218,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             field_desc = field_desc.strip()
             m = re.match(r'(?:(?:["`\[])(.*)(?:["`\]])|(\w+)).*PRIMARY KEY.*', field_desc)
             if m:
-                return m.group(1) if m.group(1) else m.group(2)
+                return m[1] if m[1] else m[2]
         return None
 
     def _get_foreign_key_constraints(self, cursor, table_name):

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1325,5 +1325,5 @@ class MigrationAutodetector:
         """
         match = re.match(r'^\d+', name)
         if match:
-            return int(match.group())
+            return int(match[0])
         return None

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -383,7 +383,7 @@ class SQLCompiler:
             # not taken into account so we strip it. When this entire method
             # is refactored into expressions, then we can check each part as we
             # generate it.
-            without_ordering = self.ordering_parts.search(sql).group(1)
+            without_ordering = self.ordering_parts.search(sql)[1]
             params_hash = make_hashable(params)
             if (without_ordering, params_hash) in seen:
                 continue
@@ -396,7 +396,7 @@ class SQLCompiler:
         if self.query.distinct and not self.query.distinct_fields:
             select_sql = [t[1] for t in select]
             for expr, (sql, params, is_ref) in order_by:
-                without_ordering = self.ordering_parts.search(sql).group(1)
+                without_ordering = self.ordering_parts.search(sql)[1]
                 if not is_ref and (without_ordering, params) not in select_sql:
                     extra_select.append((expr, (without_ordering, params), None))
         return extra_select

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -81,7 +81,7 @@ class HttpResponseBase:
         matched = _charset_from_content_type_re.search(content_type)
         if matched:
             # Extract the charset and strip its double quotes
-            return matched.group('charset').replace('"', '')
+            return matched['charset'].replace('"', '')
         return settings.DEFAULT_CHARSET
 
     @charset.setter

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -635,7 +635,7 @@ class FilterExpression:
                                           (token[:upto], token[upto:start],
                                            token[start:]))
             if var_obj is None:
-                var, constant = match.group("var", "constant")
+                var, constant = match['var'], match['constant']
                 if constant:
                     try:
                         var_obj = Variable(constant).resolve({})
@@ -647,9 +647,9 @@ class FilterExpression:
                 else:
                     var_obj = Variable(var)
             else:
-                filter_name = match.group("filter_name")
+                filter_name = match['filter_name']
                 args = []
-                constant_arg, var_arg = match.group("constant_arg", "var_arg")
+                constant_arg, var_arg = match['constant_arg'], match['var_arg']
                 if constant_arg:
                     args.append((False, Variable(constant_arg).resolve({})))
                 elif var_arg:
@@ -1017,7 +1017,7 @@ def token_kwargs(bits, parser, support_legacy=False):
     if not bits:
         return {}
     match = kwarg_re.match(bits[0])
-    kwarg_format = match and match.group(1)
+    kwarg_format = match and match[1]
     if not kwarg_format:
         if not support_legacy:
             return {}
@@ -1028,7 +1028,7 @@ def token_kwargs(bits, parser, support_legacy=False):
     while bits:
         if kwarg_format:
             match = kwarg_re.match(bits[0])
-            if not match or not match.group(1):
+            if not match or not match[1]:
                 return kwargs
             key, value = match.groups()
             del bits[:1]

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -241,8 +241,8 @@ def stringformat(value, arg):
 @stringfilter
 def title(value):
     """Convert a string into titlecase."""
-    t = re.sub("([a-z])'([A-Z])", lambda m: m.group(0).lower(), value.title())
-    return re.sub(r"\d([A-Z])", lambda m: m.group(0).lower(), t)
+    t = re.sub("([a-z])'([A-Z])", lambda m: m[0].lower(), value.title())
+    return re.sub(r'\d([A-Z])', lambda m: m[0].lower(), t)
 
 
 @register.filter(is_safe=True)

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -363,7 +363,7 @@ class RequestFactory:
             # Encode the content so that the byte representation is correct.
             match = CONTENT_TYPE_RE.match(content_type)
             if match:
-                charset = match.group(1)
+                charset = match[1]
             else:
                 charset = settings.DEFAULT_CHARSET
             return force_bytes(data, encoding=charset)

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -220,13 +220,13 @@ def _route_to_regex(route, is_endpoint=False):
             break
         parts.append(re.escape(route[:match.start()]))
         route = route[match.end():]
-        parameter = match.group('parameter')
+        parameter = match['parameter']
         if not parameter.isidentifier():
             raise ImproperlyConfigured(
                 "URL route '%s' uses parameter name %r which isn't a valid "
                 "Python identifier." % (original_route, parameter)
             )
-        raw_converter = match.group('converter')
+        raw_converter = match['converter']
         if raw_converter is None:
             # If a converter isn't specified, the default is `str`.
             raw_converter = 'str'

--- a/django/utils/datetime_safe.py
+++ b/django/utils/datetime_safe.py
@@ -76,7 +76,7 @@ def strftime(dt, fmt):
         return super(type(dt), dt).strftime(fmt)
     illegal_formatting = _illegal_formatting.search(fmt)
     if illegal_formatting:
-        raise TypeError("strftime of dates before 1000 does not handle " + illegal_formatting.group(0))
+        raise TypeError('strftime of dates before 1000 does not handle ' + illegal_formatting[0])
 
     year = dt.year
     # For every non-leap year century, advance by

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -175,7 +175,7 @@ def parse_http_date(date):
     else:
         raise ValueError("%r is not in a valid HTTP date format" % date)
     try:
-        year = int(m.group('year'))
+        year = int(m['year'])
         if year < 100:
             current_year = datetime.datetime.utcnow().year
             current_century = current_year - (current_year % 100)
@@ -185,11 +185,11 @@ def parse_http_date(date):
                 year += current_century - 100
             else:
                 year += current_century
-        month = MONTHS.index(m.group('mon').lower()) + 1
-        day = int(m.group('day'))
-        hour = int(m.group('hour'))
-        min = int(m.group('min'))
-        sec = int(m.group('sec'))
+        month = MONTHS.index(m['mon'].lower()) + 1
+        day = int(m['day'])
+        hour = int(m['hour'])
+        min = int(m['min'])
+        sec = int(m['sec'])
         result = datetime.datetime(year, month, day, hour, min, sec)
         return calendar.timegm(result.utctimetuple())
     except Exception as exc:
@@ -266,7 +266,7 @@ def parse_etags(etag_str):
     else:
         # Parse each ETag individually, and return any that are valid.
         etag_matches = (ETAG_MATCH.match(etag.strip()) for etag in etag_str.split(','))
-        return [match.group(1) for match in etag_matches if match]
+        return [match[1] for match in etag_matches if match]
 
 
 def quote_etag(etag_str):

--- a/django/utils/jslex.py
+++ b/django/utils/jslex.py
@@ -62,7 +62,7 @@ class Lexer:
             for match in regexes[state].finditer(text, start):
                 name = match.lastgroup
                 tok = toks[name]
-                toktext = match.group(name)
+                toktext = match[name]
                 start += len(toktext)
                 yield (tok.name, toktext)
 
@@ -192,7 +192,7 @@ def prepare_js_for_gettext(js):
     """
     def escape_quotes(m):
         """Used in a regex to properly escape double quotes."""
-        s = m.group(0)
+        s = m[0]
         if s == '"':
             return r'\"'
         else:

--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -175,14 +175,14 @@ class Truncator(SimpleLazyObject):
                 # Checked through whole string
                 break
             pos = m.end(0)
-            if m.group(1):
+            if m[1]:
                 # It's an actual non-HTML word or char
                 current_len += 1
                 if current_len == truncate_len:
                     end_text_pos = pos
                 continue
             # Check for tag
-            tag = re_tag.match(m.group(0))
+            tag = re_tag.match(m[0])
             if not tag or current_len >= truncate_len:
                 # Don't worry about non tags or tags after our truncate point
                 continue
@@ -334,11 +334,11 @@ def smart_split(text):
     ['A', '"\\"funky\\" style"', 'test.']
     """
     for bit in smart_split_re.finditer(str(text)):
-        yield bit.group(0)
+        yield bit[0]
 
 
 def _replace_entity(match):
-    text = match.group(1)
+    text = match[1]
     if text[0] == '#':
         text = text[1:]
         try:
@@ -348,12 +348,12 @@ def _replace_entity(match):
                 c = int(text)
             return chr(c)
         except ValueError:
-            return match.group(0)
+            return match[0]
     else:
         try:
             return chr(html.entities.name2codepoint[text])
         except KeyError:
-            return match.group(0)
+            return match[0]
 
 
 _entity_re = _lazy_re_compile(r"&(#?[xX]?(?:[0-9a-fA-F]+|\w{1,8}));")

--- a/django/utils/translation/template.py
+++ b/django/utils/translation/template.py
@@ -165,16 +165,16 @@ def templatize(src, origin=None):
                 bmatch = block_re.match(t.contents)
                 cmatches = constant_re.findall(t.contents)
                 if imatch:
-                    g = imatch.group(1)
+                    g = imatch[1]
                     if g[0] == '"':
                         g = g.strip('"')
                     elif g[0] == "'":
                         g = g.strip("'")
                     g = g.replace('%', '%%')
-                    if imatch.group(2):
+                    if imatch[2]:
                         # A context is provided
-                        context_match = context_re.match(imatch.group(2))
-                        message_context = context_match.group(1)
+                        context_match = context_re.match(imatch[2])
+                        message_context = context_match[1]
                         if message_context[0] == '"':
                             message_context = message_context.strip('"')
                         elif message_context[0] == "'":
@@ -188,10 +188,10 @@ def templatize(src, origin=None):
                 elif bmatch:
                     for fmatch in constant_re.findall(t.contents):
                         out.write(' _(%s) ' % fmatch)
-                    if bmatch.group(1):
+                    if bmatch[1]:
                         # A context is provided
-                        context_match = context_re.match(bmatch.group(1))
-                        message_context = context_match.group(1)
+                        context_match = context_re.match(bmatch[1])
+                        message_context = context_match[1]
                         if message_context[0] == '"':
                             message_context = message_context.strip('"')
                         elif message_context[0] == "'":
@@ -212,7 +212,7 @@ def templatize(src, origin=None):
                 parts = t.contents.split('|')
                 cmatch = constant_re.match(parts[0])
                 if cmatch:
-                    out.write(' _(%s) ' % cmatch.group(1))
+                    out.write(' _(%s) ' % cmatch[1])
                 for p in parts[1:]:
                     if p.find(':_(') >= 0:
                         out.write(' %s ' % p.split(':', 1)[1])

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -505,7 +505,7 @@ def get_language_from_path(path, strict=False):
     regex_match = language_code_prefix_re.match(path)
     if not regex_match:
         return None
-    lang_code = regex_match.group(1)
+    lang_code = regex_match[1]
     try:
         return get_supported_language_variant(lang_code, strict=strict)
     except LookupError:

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -373,7 +373,7 @@ class ExceptionReporter:
                 # (https://www.python.org/dev/peps/pep-0263/)
                 match = re.search(br'coding[:=]\s*([-\w.]+)', line)
                 if match:
-                    encoding = match.group(1).decode('ascii')
+                    encoding = match[1].decode('ascii')
                     break
             source = [str(sline, encoding, 'replace') for sline in source]
 

--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -237,7 +237,7 @@ class JavaScriptCatalog(View):
         """
         match = re.search(r'nplurals=\s*(\d+)', self._plural_string or '')
         if match:
-            return int(match.groups()[0])
+            return int(match[1])
         return 2
 
     @property

--- a/django/views/static.py
+++ b/django/views/static.py
@@ -124,8 +124,8 @@ def was_modified_since(header=None, mtime=0, size=0):
             raise ValueError
         matches = re.match(r"^([^;]+)(; length=([0-9]+))?$", header,
                            re.IGNORECASE)
-        header_mtime = parse_http_date(matches.group(1))
-        header_len = matches.group(3)
+        header_mtime = parse_http_date(matches[1])
+        header_len = matches[3]
         if header_len and int(header_len) != size:
             raise ValueError
         if int(mtime) > header_mtime:

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5030,7 +5030,7 @@ class RawIdFieldsTest(TestCase):
         # Find the link
         m = re.search(br'<a href="([^"]*)"[^>]* id="lookup_id_inquisition"', response.content)
         self.assertTrue(m)  # Got a match
-        popup_url = m.groups()[0].decode().replace("&amp;", "&")
+        popup_url = m[1].decode().replace('&amp;', '&')
 
         # Handle relative links
         popup_url = urljoin(response.request['PATH_INFO'], popup_url)
@@ -5053,7 +5053,7 @@ class RawIdFieldsTest(TestCase):
         # Find the link
         m = re.search(br'<a href="([^"]*)"[^>]* id="lookup_id_defendant0"', response.content)
         self.assertTrue(m)  # Got a match
-        popup_url = m.groups()[0].decode().replace("&amp;", "&")
+        popup_url = m[1].decode().replace('&amp;', '&')
 
         # Handle relative links
         popup_url = urljoin(response.request['PATH_INFO'], popup_url)
@@ -5073,7 +5073,7 @@ class RawIdFieldsTest(TestCase):
         # Find the link
         m = re.search(br'<a href="([^"]*)"[^>]* id="lookup_id_defendant1"', response.content)
         self.assertTrue(m)  # Got a match
-        popup_url = m.groups()[0].decode().replace("&amp;", "&")
+        popup_url = m[1].decode().replace('&amp;', '&')
 
         # Handle relative links
         popup_url = urljoin(response.request['PATH_INFO'], popup_url)
@@ -5924,7 +5924,7 @@ class AdminKeepChangeListFiltersTests(TestCase):
             '<a href="(.*?)">{}</a>'.format(self.joepublicuser.username),
             response.content.decode()
         )
-        self.assertURLEqual(detail_link.group(1), self.get_change_url())
+        self.assertURLEqual(detail_link[1], self.get_change_url())
 
     def test_change_view(self):
         # Get the `change_view`.
@@ -5936,21 +5936,21 @@ class AdminKeepChangeListFiltersTests(TestCase):
             '<form action="(.*?)" method="post" id="user_form" novalidate>',
             response.content.decode()
         )
-        self.assertURLEqual(form_action.group(1), '?%s' % self.get_preserved_filters_querystring())
+        self.assertURLEqual(form_action[1], '?%s' % self.get_preserved_filters_querystring())
 
         # Check the history link.
         history_link = re.search(
             '<a href="(.*?)" class="historylink">History</a>',
             response.content.decode()
         )
-        self.assertURLEqual(history_link.group(1), self.get_history_url())
+        self.assertURLEqual(history_link[1], self.get_history_url())
 
         # Check the delete link.
         delete_link = re.search(
             '<a href="(.*?)" class="deletelink">Delete</a>',
             response.content.decode()
         )
-        self.assertURLEqual(delete_link.group(1), self.get_delete_url())
+        self.assertURLEqual(delete_link[1], self.get_delete_url())
 
         # Test redirect on "Save".
         post_data = {
@@ -5993,7 +5993,7 @@ class AdminKeepChangeListFiltersTests(TestCase):
             '<form action="(.*?)" method="post" id="user_form" novalidate>',
             response.content.decode()
         )
-        self.assertURLEqual(form_action.group(1), '?%s' % self.get_preserved_filters_querystring())
+        self.assertURLEqual(form_action[1], '?%s' % self.get_preserved_filters_querystring())
 
         post_data = {
             'username': 'dummy',

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -392,42 +392,42 @@ class AdminURLWidgetTest(SimpleTestCase):
         w = widgets.AdminURLFieldWidget()
         output = w.render('test', 'http://example.com/<sometag>some-text</sometag>')
         self.assertEqual(
-            HREF_RE.search(output).groups()[0],
+            HREF_RE.search(output)[1],
             'http://example.com/%3Csometag%3Esome-text%3C/sometag%3E',
         )
         self.assertEqual(
-            TEXT_RE.search(output).groups()[0],
+            TEXT_RE.search(output)[1],
             'http://example.com/&lt;sometag&gt;some-text&lt;/sometag&gt;',
         )
         self.assertEqual(
-            VALUE_RE.search(output).groups()[0],
+            VALUE_RE.search(output)[1],
             'http://example.com/&lt;sometag&gt;some-text&lt;/sometag&gt;',
         )
         output = w.render('test', 'http://example-äüö.com/<sometag>some-text</sometag>')
         self.assertEqual(
-            HREF_RE.search(output).groups()[0],
+            HREF_RE.search(output)[1],
             'http://xn--example--7za4pnc.com/%3Csometag%3Esome-text%3C/sometag%3E',
         )
         self.assertEqual(
-            TEXT_RE.search(output).groups()[0],
+            TEXT_RE.search(output)[1],
             'http://example-äüö.com/&lt;sometag&gt;some-text&lt;/sometag&gt;',
         )
         self.assertEqual(
-            VALUE_RE.search(output).groups()[0],
+            VALUE_RE.search(output)[1],
             'http://example-äüö.com/&lt;sometag&gt;some-text&lt;/sometag&gt;',
         )
         output = w.render('test', 'http://www.example.com/%C3%A4"><script>alert("XSS!")</script>"')
         self.assertEqual(
-            HREF_RE.search(output).groups()[0],
+            HREF_RE.search(output)[1],
             'http://www.example.com/%C3%A4%22%3E%3Cscript%3Ealert(%22XSS!%22)%3C/script%3E%22',
         )
         self.assertEqual(
-            TEXT_RE.search(output).groups()[0],
+            TEXT_RE.search(output)[1],
             'http://www.example.com/%C3%A4&quot;&gt;&lt;script&gt;'
             'alert(&quot;XSS!&quot;)&lt;/script&gt;&quot;'
         )
         self.assertEqual(
-            VALUE_RE.search(output).groups()[0],
+            VALUE_RE.search(output)[1],
             'http://www.example.com/%C3%A4&quot;&gt;&lt;script&gt;alert(&quot;XSS!&quot;)&lt;/script&gt;&quot;',
         )
 

--- a/tests/auth_tests/client.py
+++ b/tests/auth_tests/client.py
@@ -9,7 +9,7 @@ from django.test import Client
 def extract_token_from_url(url):
     token_search = re.search(r'/reset/.*/(.+?)/', url)
     if token_search:
-        return token_search.group(1)
+        return token_search[1]
 
 
 class PasswordResetConfirmClient(Client):

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -201,7 +201,7 @@ class PasswordResetTest(AuthViewsTestCase):
     def _read_signup_email(self, email):
         urlmatch = re.search(r"https?://[^/]*(/.*reset/\S*)", email.body)
         self.assertIsNotNone(urlmatch, "No URL found in sent email")
-        return urlmatch.group(), urlmatch.groups()[0]
+        return urlmatch[0], urlmatch[1]
 
     def test_confirm_valid(self):
         url, path = self._test_confirm_start()
@@ -414,7 +414,7 @@ class CustomUserPasswordResetTest(AuthViewsTestCase):
     def _read_signup_email(self, email):
         urlmatch = re.search(r"https?://[^/]*(/.*reset/\S*)", email.body)
         self.assertIsNotNone(urlmatch, "No URL found in sent email")
-        return urlmatch.group(), urlmatch.groups()[0]
+        return urlmatch[0], urlmatch[1]
 
     def test_confirm_valid_custom_user(self):
         url, path = self._test_confirm_start()
@@ -1215,7 +1215,7 @@ class ChangelistTests(AuthViewsTestCase):
         rel_link = re.search(
             r'you can change the password using <a href="([^"]*)">this form</a>',
             response.content.decode()
-        ).groups()[0]
+        )[1]
         self.assertEqual(
             os.path.normpath(user_change_url + rel_link),
             os.path.normpath(password_change_url)

--- a/tests/backends/sqlite/tests.py
+++ b/tests/backends/sqlite/tests.py
@@ -131,7 +131,7 @@ class SchemaTests(TransactionTestCase):
         self.assertIsNotNone(match)
         self.assertEqual(
             'integer NOT NULL PRIMARY KEY AUTOINCREMENT',
-            match.group(1),
+            match[1],
             'Wrong SQL used to create an auto-increment column on SQLite'
         )
 

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -64,7 +64,7 @@ class CsrfViewMiddlewareTestMixin:
         match = re.search('name="csrfmiddlewaretoken" value="(.*?)"', text)
         csrf_token = csrf_id or self._csrf_id
         self.assertTrue(
-            match and equivalent_tokens(csrf_token, match.group(1)),
+            match and equivalent_tokens(csrf_token, match[1]),
             "Could not find csrfmiddlewaretoken to match %s" % csrf_token
         )
 

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -136,7 +136,7 @@ class GeometryFieldTest(SimpleTestCase):
 
         # The first point can't use assertInHTML() due to non-deterministic
         # ordering of the rendered dictionary.
-        pt1_serialized = re.search(r'<textarea [^>]*>({[^<]+})<', output).groups()[0]
+        pt1_serialized = re.search(r'<textarea [^>]*>({[^<]+})<', output)[1]
         pt1_json = pt1_serialized.replace('&quot;', '"')
         pt1_expected = GEOSGeometry(form.data['pt1']).transform(3857, clone=True)
         self.assertJSONEqual(pt1_json, pt1_expected.json)

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -52,7 +52,7 @@ class InspectDBTestCase(TestCase):
         output = out.getvalue()
 
         def assertFieldType(name, definition):
-            out_def = re.search(r'^\s*%s = (models.*)$' % name, output, re.MULTILINE).groups()[0]
+            out_def = re.search(r'^\s*%s = (models.*)$' % name, output, re.MULTILINE)[1]
             self.assertEqual(definition, out_def)
 
         return assertFieldType

--- a/tests/template_backends/test_dummy.py
+++ b/tests/template_backends/test_dummy.py
@@ -84,7 +84,7 @@ class TemplateStringsTests(SimpleTestCase):
         expected = '<input type="hidden" name="csrfmiddlewaretoken" value="([^"]+)">'
         match = re.match(expected, content) or re.match(expected.replace('"', "'"), content)
         self.assertTrue(match, "hidden csrftoken field not found in output")
-        self.assertTrue(equivalent_tokens(match.group(1), get_token(request)))
+        self.assertTrue(equivalent_tokens(match[1], get_token(request)))
 
     def test_no_directory_traversal(self):
         with self.assertRaises(TemplateDoesNotExist):

--- a/tests/test_client_regress/views.py
+++ b/tests/test_client_regress/views.py
@@ -117,7 +117,7 @@ def return_text_file(request):
     "A view that parses and returns text as a file."
     match = CONTENT_TYPE_RE.match(request.META['CONTENT_TYPE'])
     if match:
-        charset = match.group(1)
+        charset = match[1]
     else:
         charset = settings.DEFAULT_CHARSET
 

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -154,7 +154,7 @@ class DebugViewTests(SimpleTestCase):
             self.assertContains(response, '<div class="context" id="', status_code=500)
             match = re.search(b'<div class="context" id="(?P<id>[^"]+)">', response.content)
             self.assertIsNotNone(match)
-            id_repr = match.group('id')
+            id_repr = match['id']
             self.assertFalse(
                 re.search(b'[^c0-9]', id_repr),
                 "Numeric IDs in debug response HTML page shouldn't be localized (value: %s)." % id_repr.decode()


### PR DESCRIPTION
The method has been available since Python 3.6. The shorter syntax is
also marginally faster:

    $ python -m timeit -s 'import re; m = re.match(r"a(\d+)", "a50")' 'm.group()'
    5000000 loops, best of 5: 57.8 nsec per loop
    $ python -m timeit -s 'import re; m = re.match(r"a(\d+)", "a50")' 'm[0]'
    10000000 loops, best of 5: 37.3 nsec per loop

    $ python3 -m timeit -s 'import re; m = re.match(r"a(\d+)", "a50")' 'm.group(1)'
    5000000 loops, best of 5: 90.9 nsec per loop
    $ python3 -m timeit -s 'import re; m = re.match(r"a(\d+)", "a50")' 'm[1]'
    5000000 loops, best of 5: 56.7 nsec per loop

https://docs.python.org/3/library/re.html#re.Match.__getitem__