### PR TITLE
Fixed #28342 -- Catch exceptions when using pylibmc cache backend

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -446,6 +446,7 @@ answer newbie questions, and generally made Django that much better:
     Joao Oliveira <joaoxsouls@gmail.com>
     Joao Pedro Silva <j.pedro004@gmail.com>
     Joe Heck <http://www.rhonabwy.com/wp/>
+    Joel Andrews <https://github.com/OldSneerJaw>
     Joel Bohman <mail@jbohman.com>
     Joel Heenan <joelh-django@planetjoel.com>
     Joel Watts <joel@joelwatts.com>

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -680,6 +680,11 @@ Miscellaneous
 
 * The :ttag:`{% localize off %} <localize>` tag and :tfilter:`unlocalize`
   filter no longer respect :setting:`DECIMAL_SEPARATOR` setting.
+* The ``PyLibMCCache`` cache backend catches and generates warnings for
+  exceptions raised by pylibmc. Now that they are handled, such exceptions are
+  no longer propagated to callers of the Django cache framework in order to
+  provide consistent behavior with the ``MemcachedCache`` (python-memcached)
+  cache backend.
 
 .. _deprecated-features-3.1:
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -503,6 +503,7 @@ Punycode
 Puthraya
 py
 pyformat
+pylibmc
 pysqlite
 pythonic
 pytz


### PR DESCRIPTION
Resolves https://code.djangoproject.com/ticket/28342 by catching exceptions from pylibmc and logging them rather than propagating them to the caller. This behaviour is consistent with the `MemcachedCache` backend, as described in the issue. Note that this pull request is intended to supersede the previous (stale) pull request for this issue: #8681.