### PR TITLE
Refs #30678 -- Added support for GDAL 3.1.

### DIFF
--- a/django/contrib/gis/gdal/prototypes/srs.py
+++ b/django/contrib/gis/gdal/prototypes/srs.py
@@ -32,7 +32,7 @@ destroy_srs = void_output(std_call('OSRDestroySpatialReference'), [c_void_p], er
 srs_validate = void_output(lgdal.OSRValidate, [c_void_p])
 
 if GDAL_VERSION >= (3, 0):
-    set_axis_strategy = void_output(lgdal.OSRSetAxisMappingStrategy, [c_void_p, c_int])
+    set_axis_strategy = void_output(lgdal.OSRSetAxisMappingStrategy, [c_void_p, c_int], errcheck=False)
 
 # Getting the semi_major, semi_minor, and flattening functions.
 semi_major = srs_double(lgdal.OSRGetSemiMajor)

--- a/docs/ref/contrib/gis/install/geolibs.txt
+++ b/docs/ref/contrib/gis/install/geolibs.txt
@@ -10,7 +10,7 @@ Program                   Description                           Required        
 ========================  ====================================  ================================  ===================================
 :doc:`GEOS <../geos>`     Geometry Engine Open Source           Yes                               3.8, 3.7, 3.6, 3.5
 `PROJ.4`_                 Cartographic Projections library      Yes (PostgreSQL and SQLite only)  6.3, 6.2, 6.1, 6.0, 5.x, 4.x
-:doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               3.0, 2.4, 2.3, 2.2, 2.1, 2.0
+:doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               3.1, 3.0, 2.4, 2.3, 2.2, 2.1, 2.0
 :doc:`GeoIP <../geoip2>`  IP-based geolocation library          No                                2
 `PostGIS`__               Spatial extensions for PostgreSQL     Yes (PostgreSQL only)             3.0, 2.5, 2.4, 2.3, 2.2
 `SpatiaLite`__            Spatial extensions for SQLite         Yes (SQLite only)                 4.3
@@ -31,6 +31,7 @@ totally fine with GeoDjango. Your mileage may vary.
     GDAL 2.3.0 2018-05
     GDAL 2.4.0 2018-12
     GDAL 3.0.0 2019-05
+    GDAL 3.1.0 2020-05-07
     PostGIS 2.2.0 2015-10-17
     PostGIS 2.3.0 2016-09-26
     PostGIS 2.4.0 2017-09-30


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30678

OSRSetAxisMappingStrategy() really returns void, so no errcheck is needed.
Previously set errcheck was raising positive false exceptions on GDAL 3.1.

Default behavior of `void_output` is misleading and probably should be reworked.