### PR TITLE
Fixed numbered list in admin overview docs.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -44,7 +44,7 @@ If you're not using the default project template, here are the requirements:
    :class:`django.contrib.messages.middleware.MessageMiddleware` must be
    included.
 
-5. :ref:`Hook the admin's URLs into your URLconf
+#. :ref:`Hook the admin's URLs into your URLconf
    <hooking-adminsite-to-urlconf>`.
 
 After you've taken these steps, you'll be able to use the admin site by


### PR DESCRIPTION
https://docs.djangoproject.com/en/dev/ref/contrib/admin/

![django-admin](https://user-images.githubusercontent.com/347634/81763439-1957cd80-9484-11ea-8919-0ef9941dc339.png)

There is a more complete version of this in #11546. I think reconsidering the original PR would make these kind of oversights less likely to happen.