### PR TITLE
Ticket 31597 - New "Clear all filters" shown always in raw_id_fields popup

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1813,6 +1813,7 @@ class ModelAdmin(BaseModelAdmin):
             'title': cl.title,
             'is_popup': cl.is_popup,
             'to_field': cl.to_field,
+            'no_filters_params': urlencode(cl.no_filters_params),
             'cl': cl,
             'media': media,
             'has_add_permission': self.has_add_permission(request),

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -60,8 +60,8 @@
         {% if cl.has_filters %}
           <div id="changelist-filter">
             <h2>{% translate 'Filter' %}</h2>
-            {% if cl.preserved_filters %}<h3 id="changelist-filter-clear">
-              <a href="?{% if cl.is_popup %}_popup=1{% endif %}">&#10006; {% translate "Clear all filters" %}</a>
+            {% if cl.has_active_filters or cl.query %}<h3 id="changelist-filter-clear">
+              <a href="?{{ no_filters_params }}">&#10006; {% translate "Clear all filters" %}</a>
             </h3>{% endif %}
             {% for spec in cl.filter_specs %}{% admin_list_filter cl spec %}{% endfor %}
           </div>

--- a/tests/admin_changelist/test_date_hierarchy.py
+++ b/tests/admin_changelist/test_date_hierarchy.py
@@ -21,7 +21,7 @@ class DateHierarchyTests(TestCase):
         request = self.factory.get('/', query)
         request.user = self.superuser
         changelist = EventAdmin(Event, custom_site).get_changelist_instance(request)
-        _, _, lookup_params, _ = changelist.get_filters(request)
+        _, _, lookup_params, _, _ = changelist.get_filters(request)
         self.assertEqual(lookup_params['date__gte'], expected_from_date)
         self.assertEqual(lookup_params['date__lt'], expected_to_date)
 

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -2,7 +2,9 @@ import datetime
 
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry
-from django.contrib.admin.options import IncorrectLookupParameters, IS_POPUP_VAR, TO_FIELD_VAR
+from django.contrib.admin.options import (
+    IS_POPUP_VAR, TO_FIELD_VAR, IncorrectLookupParameters,
+)
 from django.contrib.admin.templatetags.admin_list import pagination
 from django.contrib.admin.tests import AdminSeleniumTestCase
 from django.contrib.admin.views.main import ALL_VAR, SEARCH_VAR


### PR DESCRIPTION
Ticket https://code.djangoproject.com/ticket/31597

## raw_id_fields popup

The new feature (PR #12351 ) has 2 issues with `raw_id_fields`:

 1. the new link is shown when `_popup=1` is present in the URL query, regardless of any actual filters
 2. clicking on the link will preserve `_popup` query param (which is correct) but it will remove `_to_field` param, which should probably also be preserved

