### PR TITLE
Set .vUUIDField class on admin UUIDFields used as raw_id_fields

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -353,6 +353,10 @@ body.popup .submit-row {
     width: 2.2em;
 }
 
+.vForeignKeyRawIdAdminField {
+    width: 5em;
+}
+
 .vTextField, .vUUIDField {
     width: 20em;
 }
@@ -363,10 +367,6 @@ body.popup .submit-row {
 
 .vBigIntegerField {
     width: 10em;
-}
-
-.vForeignKeyRawIdAdminField {
-    width: 5em;
 }
 
 /* INLINES */

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -8,7 +8,7 @@ from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
-from django.db.models import CASCADE
+from django.db.models import CASCADE, UUIDField
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.html import smart_urlquote
@@ -150,6 +150,8 @@ class ForeignKeyRawIdWidget(forms.TextInput):
             context['link_title'] = _('Lookup')
             # The JavaScript code looks for this class.
             context['widget']['attrs'].setdefault('class', 'vForeignKeyRawIdAdminField')
+            if isinstance(rel_to._meta.pk, UUIDField):
+                context['widget']['attrs']['class'] += ' ' + 'vUUIDField'
         else:
             context['related_url'] = None
         if context['widget']['value']:


### PR DESCRIPTION
raw_id_fields get the css class vForeignKeyRawIdAdminField, which limits
the width to roughly 9 characters.
UUIDs are often used as primary keys. This commit makes it so that UUIDs
set to be a raw_id_field in the admin also get the vUUIDField css class,
which sets a larger width which can fit 36 characters.