### PR TITLE
Fixed #32301 -- Made clearsessions raise CommandError when clear_expired() is not implemented.

### DIFF
--- a/django/contrib/sessions/management/commands/clearsessions.py
+++ b/django/contrib/sessions/management/commands/clearsessions.py
@@ -1,7 +1,7 @@
 from importlib import import_module
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 
 class Command(BaseCommand):
@@ -15,7 +15,7 @@ class Command(BaseCommand):
         try:
             engine.SessionStore.clear_expired()
         except NotImplementedError:
-            self.stderr.write(
+            raise CommandError(
                 "Session engine '%s' doesn't support clearing expired "
                 "sessions." % settings.SESSION_ENGINE
             )

--- a/tests/sessions_tests/no_clear_expired.py
+++ b/tests/sessions_tests/no_clear_expired.py
@@ -1,0 +1,6 @@
+from django.contrib.sessions.backends.base import SessionBase
+
+
+class SessionStore(SessionBase):
+    """Session store without support for clearing expired sessions."""
+    pass

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -910,3 +910,14 @@ class CookieSessionTests(SessionTestsMixin, SimpleTestCase):
     @unittest.skip("CookieSession is stored in the client and there is no way to query it.")
     def test_session_save_does_not_resurrect_session_logged_out_in_other_context(self):
         pass
+
+
+class ClearSessionsCommandTests(SimpleTestCase):
+    def test_clearsessions_unsupported(self):
+        msg = (
+            "Session engine 'tests.sessions_tests.no_clear_expired' doesn't "
+            "support clearing expired sessions."
+        )
+        with self.settings(SESSION_ENGINE='tests.sessions_tests.no_clear_expired'):
+            with self.assertRaisesMessage(management.CommandError, msg):
+                management.call_command('clearsessions')


### PR DESCRIPTION
Raising a CommandError is the recommended way to report errors from
management commands.