### PR TITLE
Added notes related to security pre-notify list requests

### DIFF
--- a/docs/internals/security.txt
+++ b/docs/internals/security.txt
@@ -191,6 +191,12 @@ groups:
    demonstrated ability to responsibly receive, keep confidential and
    act on these notifications.
 
+.. admonition:: Security audit and scanning entities
+
+    As a policy, we do not add these types of entities to the notification
+    list. We are unable to approve all requests and it is not fair to give
+    some a competitive advantage.
+
 Requesting notifications
 ========================
 
@@ -235,3 +241,9 @@ Please also bear in mind that for any individual or organization,
 receiving security notifications is a privilege granted at the sole
 discretion of the Django development team, and that this privilege can
 be revoked at any time, with or without explanation.
+
+.. admonition:: Provide all required information
+
+    A failure to provide the required information in your initial contact
+    will count against you when making the decision on whether or not to
+    approve your request.

--- a/docs/internals/security.txt
+++ b/docs/internals/security.txt
@@ -194,8 +194,7 @@ groups:
 .. admonition:: Security audit and scanning entities
 
     As a policy, we do not add these types of entities to the notification
-    list. We are unable to approve all requests and it is not fair to give
-    some a competitive advantage.
+    list.
 
 Requesting notifications
 ========================


### PR DESCRIPTION
Documented the existing policy of not accepting security audit/scanning entities to the pre-notification list. Also added a note to help emphasize that people really need to read the instructions if they want to get approved for the list.