### PR TITLE
Refs #31607 -- Added release notes for a125da6a7c79b1d4c55677d0bed6f9b1d7d77353.

### DIFF
--- a/docs/releases/3.0.7.txt
+++ b/docs/releases/3.0.7.txt
@@ -22,3 +22,6 @@ Bugfixes
 * Fixed a regression in Django 3.0 where ``QuerySet.values()`` and
   ``values_list()`` crashed if a queryset contained an aggregation and an
   ``Exists()`` annotation on Oracle (:ticket:`31584`).
+
+* Fixed a regression in Django 3.0 where all resolved ``Subquery()``
+  expressions were considered equal (:ticket:`31607`).


### PR DESCRIPTION
I persuaded myself that it's a regression in Django 3.1 :facepalm:, but it's a regression in Django 3.0 and we need release notes.