### PR TITLE
Fixed #27445 -- RadioSelect widget does not work for NullBooleanField.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -734,6 +734,15 @@ class NullBooleanField(BooleanField):
     """
     widget = NullBooleanSelect
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if not isinstance(self.widget, NullBooleanSelect):
+            self.choices = self.widget.choices = [
+                ('', _('Unknown')),
+                (True, _('Yes')),
+                (False, _('No')),
+            ]
+
     def to_python(self, value):
         """
         Explicitly check for the string 'True' and 'False', which is what a

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -913,6 +913,11 @@ For each field, we describe the default widget used if you don't specify
     * Normalizes to: A Python ``True``, ``False`` or ``None`` value.
     * Validates nothing (i.e., it never raises a ``ValidationError``).
 
+.. versionchanged:: 3.2
+
+    ``NullBooleanField`` can now be used with widgets other than
+    :class:`NullBooleanSelect` e.g. :class:`RadioSelect`
+
 ``RegexField``
 --------------
 

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -190,6 +190,8 @@ Forms
   :func:`.inlineformset_factory`, and :func:`.modelformset_factory` allows
   removal of the option to delete extra forms. See
   :attr:`~.BaseFormSet.can_delete_extra` for more information.
+* :class:`~django.forms.NullBooleanField` now works with other widgets
+  e.g :class:`~django.forms.RadioSelect`.
 
 Generic Views
 ~~~~~~~~~~~~~

--- a/tests/forms_tests/field_tests/test_nullbooleanfield.py
+++ b/tests/forms_tests/field_tests/test_nullbooleanfield.py
@@ -72,3 +72,30 @@ class NullBooleanFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         self.assertTrue(f.has_changed(False, 'True'))
         self.assertTrue(f.has_changed(True, 'False'))
         self.assertTrue(f.has_changed(None, 'False'))
+
+    def test_nullbooleanfield_radio_widget(self):
+        f = NullBooleanField(widget=RadioSelect)
+
+        html_output = f.widget.render('field_name', True)
+        html_expected = """
+        <ul><li><label><input type="radio" name="field_name" value="">Unknown</label></li>
+        <li><label><input type="radio" name="field_name" value="True" checked>Yes</label></li>
+        <li><label><input type="radio" name="field_name" value="False"> No</label></li></ul>
+        """
+        self.assertHTMLEqual(html_output, html_expected)
+
+        html_output = f.widget.render('field_name', 'True')
+        html_expected = """
+        <ul><li><label><input type="radio" name="field_name" value="">Unknown</label></li>
+        <li><label><input type="radio" name="field_name" value="True" checked>Yes</label></li>
+        <li><label><input type="radio" name="field_name" value="False"> No</label></li></ul>
+        """
+        self.assertHTMLEqual(html_output, html_expected)
+
+        html_output = f.widget.render('field_name', '')
+        html_expected = """
+        <ul><li><label><input checked type="radio" name="field_name" value="">Unknown</label></li>
+        <li><label><input type="radio" name="field_name" value="True">Yes</label></li>
+        <li><label><input type="radio" name="field_name" value="False"> No</label></li></ul>
+        """
+        self.assertHTMLEqual(html_output, html_expected)


### PR DESCRIPTION
[Ticket #27445](https://code.djangoproject.com/ticket/27445)

There was discussion recently on the [mailing list](https://groups.google.com/forum/m/#!searchin/django-developers/nullbooleanfield/django-developers/pSvFXcUUkRs) and it was decided that `forms.NullBooleanField` should be kept. I therefore think we can progress to fix this ticket. I've investiaged this so far but there are a few options and so I am looking for some guidance. 

The issue is that `NullBooleanField` doesn't set `choices` -  it relies on the `choices` within the `NullBooleanSelect` widget. To allow other widgets (e.g. Radio) we should set choices on the field and the widget. The PR that I've opened does this and therefore allows other widgets to be used. 

However... Should we allow choices descriptions to be customised? Ticket [#23681](https://code.djangoproject.com/ticket/23681) discusses this and there is even a suggestion to deprecate `NullBooleanSelect`. 

The tricky bit with changing names on `NullBooleanField` is `RadioSelect` / `Select` needs ('', 'True', 'False') as the first items in the choice tuples, but `NullBooleanSelect()` needs ('unknown', 'true', 'false'). Hence I can see why just using a select was sugested work, but I don't know about deprecating the current widget 😬 

In summary I think this patch solves part of the use case whilst maintaining backward compatibility. I think other options may be technically better but appear to change existing functionality.

Appreciate thoughts and guidance.

(p.s. The last example on ticket #23681 shows passing names into a `model.NullBooleanField`. Whilst this field is deprecated the same works for `model.BooleanField`. However, this gives a `TypedChoiceField`, not a `NullBooleanField` with updated names)