### PR TITLE
Fixed #31608 -- Doc'd that form ISO 8601 datetime parsing retains tzinfo when USE_TZ is False.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2782,7 +2782,10 @@ Default: ``False``
 
 A boolean that specifies if datetimes will be timezone-aware by default or not.
 If this is set to ``True``, Django will use timezone-aware datetimes internally.
-Otherwise, Django will use naive datetimes in local time.
+
+When ``USE_TZ`` is False, Django will use naive datetimes in local time, except
+when parsing ISO 8601 formatted strings, where timezone information will always
+be retained if present.
 
 See also :setting:`TIME_ZONE`, :setting:`USE_I18N` and :setting:`USE_L10N`.
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -274,10 +274,14 @@ Forms
   details.
 
 * :class:`django.forms.DateTimeField` now accepts dates in a subset of ISO 8601
-  datetime formats, including optional timezone (e.g. ``2019-10-10T06:47``,
-  ``2019-10-10T06:47:23+04:00``, or ``2019-10-10T06:47:23Z``). Additionally, it
-  now uses ``DATE_INPUT_FORMATS`` in addition to ``DATETIME_INPUT_FORMATS``
-  when converting a field input to a ``datetime`` value.
+  datetime formats, including optional timezone, e.g. ``2019-10-10T06:47``,
+  ``2019-10-10T06:47:23+04:00``, or ``2019-10-10T06:47:23Z``. The timezone will
+  always be retained if provided, with timezone-aware datetimes being returned
+  even when :setting:`USE_TZ` is ``False``.
+
+  Additionally, ``DateTimeField`` now uses ``DATE_INPUT_FORMATS`` in addition
+  to ``DATETIME_INPUT_FORMATS`` when converting a field input to a ``datetime``
+  value.
 
 * :attr:`.MultiWidget.widgets` now accepts a dictionary which allows
   customizing subwidget ``name`` attributes.


### PR DESCRIPTION
Added release note for [ticket 31608](https://code.djangoproject.com/ticket/31608)