### PR TITLE
Refs #31534 -- Improved django.conf.urls.url() warning message with stacklevel=2.

### DIFF
--- a/django/conf/urls/__init__.py
+++ b/django/conf/urls/__init__.py
@@ -17,5 +17,6 @@ def url(regex, view, kwargs=None, name=None):
         'django.conf.urls.url() is deprecated in favor of '
         'django.urls.re_path().',
         RemovedInDjango40Warning,
+        stacklevel=2,
     )
     return re_path(regex, view, kwargs, name)


### PR DESCRIPTION
Use stacklevel=2 to show the calling site.

For example, changes:

    .../django/conf/urls/__init__.py:16: RemovedInDjango40Warning:
    django.conf.urls.url() is deprecated in favor of
    django.urls.re_path().

To:

    .../django-debug-toolbar/debug_toolbar/panels/sql/panel.py:131:
    RemovedInDjango40Warning: django.conf.urls.url() is deprecated in
    favor of django.urls.re_path().

The second version identifies the line containing django.conf.urls.url()
that must be fixed.