### PR TITLE
Made minor edits to TemplateResponseMixin.get_template_names() docs.

### DIFF
--- a/docs/ref/class-based-views/mixins-simple.txt
+++ b/docs/ref/class-based-views/mixins-simple.txt
@@ -102,5 +102,5 @@ Simple mixins
         Returns a list of template names to search for when rendering the
         template. The first template that is found will be used.
 
-        If :attr:`template_name` is specified, the default implementation will
-        return a list containing :attr:`template_name` (if it is specified).
+        The default implementation will return a list containing
+        :attr:`template_name` (if it is specified).


### PR DESCRIPTION
This PR rewords `TemplateResponseMixin.get_template_names()` docs to avoid some redundancy.