### PR TITLE
Fixed #31624 -- Avoided subquery usage on QuerySet.all().delete().

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1407,6 +1407,8 @@ class SQLInsertCompiler(SQLCompiler):
 class SQLDeleteCompiler(SQLCompiler):
     @cached_property
     def single_alias(self):
+        # Ensure base table is in aliases.
+        self.query.get_initial_alias()
         return sum(self.query.alias_refcount[t] > 0 for t in self.query.alias_map) == 1
 
     def _as_sql(self, query):

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -605,6 +605,12 @@ class DeletionTests(TestCase):
 
 
 class FastDeleteTests(TestCase):
+    def test_fast_delete_all(self):
+        with self.assertNumQueries(1) as ctx:
+            User.objects.all().delete()
+        sql = ctx.captured_queries[0]['sql']
+        # No subqueries is used when performing a full delete.
+        self.assertNotIn('SELECT', sql)
 
     def test_fast_delete_fk(self):
         u = User.objects.create(


### PR DESCRIPTION
This addresses a regression introduced by 7acef095d73322.

Refs #23576.

Thanks Adam Johnson for the report.