### PR TITLE
Add asgi support to runserver

### DIFF
--- a/django/contrib/staticfiles/handlers.py
+++ b/django/contrib/staticfiles/handlers.py
@@ -52,6 +52,12 @@ class StaticFilesHandlerMixin:
         except Http404 as e:
             return response_for_exception(request, e)
 
+    async def get_response_async(self, request):
+        try:
+            return self.serve(request)
+        except Http404 as e:
+            return response_for_exception(request, e)
+
 
 class StaticFilesHandler(StaticFilesHandlerMixin, WSGIHandler):
     """

--- a/django/contrib/staticfiles/handlers.py
+++ b/django/contrib/staticfiles/handlers.py
@@ -1,6 +1,8 @@
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
+from asgiref.sync import sync_to_async
+
 from django.conf import settings
 from django.contrib.staticfiles import utils
 from django.contrib.staticfiles.views import serve
@@ -54,7 +56,7 @@ class StaticFilesHandlerMixin:
 
     async def get_response_async(self, request):
         try:
-            return self.serve(request)
+            return await sync_to_async(self.serve)(request)
         except Http404 as e:
             return response_for_exception(request, e)
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1234,6 +1234,16 @@ class ManageRunserver(SimpleTestCase):
         self.assertEqual(self.cmd.port, port)
         self.assertEqual(self.cmd.use_ipv6, ipv6)
         self.assertEqual(self.cmd._raw_ipv6, raw_ipv6)
+        self.assertEqual(self.cmd.server_type, 'WSGI')
+
+    def test_runserver_asgi_raises_commanderror_without_daphne(self):
+        with self.assertRaises(CommandError):
+            call_command(self.cmd, asgi=True)
+
+    @unittest.skip("Daphne must be installed to run this test")
+    def test_runserver_asgi_with_daphne(self):
+        call_command(self.cmd, asgi=True)
+        self.assertEqual(self.cmd.server_type, 'ASGI')
 
     def test_runserver_addrport(self):
         call_command(self.cmd)
@@ -1370,7 +1380,9 @@ class ManageTestserver(SimpleTestCase):
         call_command('testserver', 'blah.json')
         mock_runserver_handle.assert_called_with(
             addrport='',
+            asgi=False,
             force_color=False,
+            http_timeout=None,
             insecure_serving=False,
             no_color=False,
             pythonpath=None,

--- a/tests/asgi/asgi.py
+++ b/tests/asgi/asgi.py
@@ -1,0 +1,2 @@
+# This is just to test finding, it doesn't have to be a real ASGI callable
+application = object()

--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -1,12 +1,9 @@
-from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
 from django.core.exceptions import ImproperlyConfigured
-from django.core.handlers.asgi import ASGIHandler
 from django.core.handlers.wsgi import WSGIHandler, WSGIRequest, get_script_name
 from django.core.signals import request_finished, request_started
 from django.db import close_old_connections, connection
 from django.test import (
-    RequestFactory, SimpleTestCase, TransactionTestCase, modify_settings,
-    override_settings,
+    RequestFactory, SimpleTestCase, TransactionTestCase, override_settings,
 )
 from django.utils.version import PY37
 
@@ -89,17 +86,6 @@ class HandlerTests(SimpleTestCase):
         response = handler(environ, lambda *a, **k: None)
         # Expect "bad request" response
         self.assertEqual(response.status_code, 400)
-
-
-class TestASGIStaticFilesHandler(SimpleTestCase):
-    request_factory = RequestFactory()
-
-    @modify_settings(INSTALLED_APPS={'append': 'staticfiles_tests.apps.test'})
-    async def test_get_async_response(self):
-        request = self.request_factory.post('/static/test/file.txt')
-        handler = ASGIStaticFilesHandler(ASGIHandler())
-        response = await handler.get_response_async(request)
-        self.assertEqual(response.status_code, 200)
 
 
 @override_settings(ROOT_URLCONF='handlers.urls', MIDDLEWARE=[])

--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -1,9 +1,12 @@
+from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
 from django.core.exceptions import ImproperlyConfigured
+from django.core.handlers.asgi import ASGIHandler
 from django.core.handlers.wsgi import WSGIHandler, WSGIRequest, get_script_name
 from django.core.signals import request_finished, request_started
 from django.db import close_old_connections, connection
 from django.test import (
-    RequestFactory, SimpleTestCase, TransactionTestCase, override_settings,
+    RequestFactory, SimpleTestCase, TransactionTestCase, modify_settings,
+    override_settings,
 )
 from django.utils.version import PY37
 
@@ -86,6 +89,17 @@ class HandlerTests(SimpleTestCase):
         response = handler(environ, lambda *a, **k: None)
         # Expect "bad request" response
         self.assertEqual(response.status_code, 400)
+
+
+class TestASGIStaticFilesHandler(SimpleTestCase):
+    request_factory = RequestFactory()
+
+    @modify_settings(INSTALLED_APPS={'append': 'staticfiles_tests.apps.test'})
+    async def test_get_async_response(self):
+        request = self.request_factory.post('/static/test/file.txt')
+        handler = ASGIStaticFilesHandler(ASGIHandler())
+        response = await handler.get_response_async(request)
+        self.assertEqual(response.status_code, 200)
 
 
 @override_settings(ROOT_URLCONF='handlers.urls', MIDDLEWARE=[])

--- a/tests/staticfiles_tests/test_handlers.py
+++ b/tests/staticfiles_tests/test_handlers.py
@@ -1,0 +1,15 @@
+from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
+from django.core.handlers.asgi import ASGIHandler
+from django.test import AsyncRequestFactory, SimpleTestCase, modify_settings
+
+
+class TestASGIStaticFilesHandler(SimpleTestCase):
+    async_request_factory = AsyncRequestFactory()
+
+    @modify_settings(INSTALLED_APPS={'append': 'staticfiles_tests.apps.test'})
+    async def test_get_async_response(self):
+        request = self.async_request_factory.get('/static/test/file.txt')
+        handler = ASGIStaticFilesHandler(ASGIHandler())
+        response = await handler.get_response_async(request)
+        response.close()
+        self.assertEqual(response.status_code, 200)

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -42,12 +42,12 @@ class TestRunserver(StaticFilesTestCase):
     def test_middleware_loaded_only_once(self):
         command = runserver.Command()
         with mock.patch('django.middleware.common.CommonMiddleware') as mocked:
-            command.get_handler(use_static_handler=True, insecure_serving=True)
+            command.get_handler(use_static_handler=True, insecure_serving=True, asgi=False)
             self.assertEqual(mocked.call_count, 1)
 
     def test_404_response(self):
         command = runserver.Command()
-        handler = command.get_handler(use_static_handler=True, insecure_serving=True)
+        handler = command.get_handler(use_static_handler=True, insecure_serving=True, asgi=False)
         missing_static_file = os.path.join(settings.STATIC_URL, 'unknown.css')
         req = RequestFactory().get(missing_static_file)
         with override_settings(DEBUG=False):


### PR DESCRIPTION
This code adds support to run an asgi daphne based development server while leaving the default wsgi.

`./manage.py runserver --asgi`

https://code.djangoproject.com/ticket/31626