### PR TITLE
Updated how to install Django on windows docs. 

### DIFF
--- a/docs/howto/windows.txt
+++ b/docs/howto/windows.txt
@@ -38,13 +38,10 @@ matches the version you installed by executing::
 About ``pip``
 =============
 
-`pip`_ is a package manage for Python. It makes installing and uninstalling
-Python packages (such as Django!) very easy. For the rest of the installation,
-we'll use ``pip`` to install Python packages from the command line.
-
-To install pip on your machine, go to
-https://pip.pypa.io/en/latest/installing/, and follow the ``Installing with
-get-pip.py`` instructions.
+`pip`_ is a package manager for Python and is included by default with the
+Python installer. It helps to install and uninstall Python packages
+(such as Django!). For the rest of the installation, we'll use ``pip`` to
+install Python packages from the command line.
 
 .. _pip: https://pypi.org/project/pip/
 

--- a/docs/howto/windows.txt
+++ b/docs/howto/windows.txt
@@ -22,8 +22,8 @@ machine. At the time of writing, Python 3.8 is the latest version.
 
 To install Python on your machine go to https://python.org/downloads/. The
 website should offer you a download button for the latest Python version.
-Download the executable installer and run it. Check the boxes next to ``Install
-launcher for all users (recommended)`` then click ``Install Now``.
+Download the executable installer and run it. Check the boxes next to "Install
+launcher for all users (recommended)" then click "Install Now".
 
 After installation, open the command prompt and check that the Python version
 matches the version you installed by executing::

--- a/docs/howto/windows.txt
+++ b/docs/howto/windows.txt
@@ -4,7 +4,7 @@ How to install Django on Windows
 
 .. highlight:: doscon
 
-This document will guide you through installing Python 3.7 and Django on
+This document will guide you through installing Python 3.8 and Django on
 Windows. It also provides instructions for setting up a virtual environment,
 which makes it easier to work on Python projects. This is meant as a beginner's
 guide for users working on Django projects and does not reflect how Django
@@ -18,12 +18,12 @@ Install Python
 ==============
 
 Django is a Python web framework, thus requiring Python to be installed on your
-machine. At the time of writing, Python 3.7 is the latest version.
+machine. At the time of writing, Python 3.8 is the latest version.
 
 To install Python on your machine go to https://python.org/downloads/. The
 website should offer you a download button for the latest Python version.
 Download the executable installer and run it. Check the boxes next to ``Install
-launcher for all users (recommended)`` and ``Add Python 3.7 to PATH`` then
+launcher for all users (recommended)`` and ``Add Python 3.8 to PATH`` then
 click ``Install Now``.
 
 After installation, open the command prompt and check that the Python version

--- a/docs/howto/windows.txt
+++ b/docs/howto/windows.txt
@@ -14,6 +14,8 @@ The steps in this guide have been tested with Windows 10. In other
 versions, the steps would be similar. You will need to be familiar with using
 the Windows command prompt.
 
+.. _install_python_windows:
+
 Install Python
 ==============
 

--- a/docs/howto/windows.txt
+++ b/docs/howto/windows.txt
@@ -10,7 +10,7 @@ which makes it easier to work on Python projects. This is meant as a beginner's
 guide for users working on Django projects and does not reflect how Django
 should be installed when developing patches for Django itself.
 
-The steps in this guide have been tested with Windows 7, 8, and 10. In other
+The steps in this guide have been tested with Windows 10. In other
 versions, the steps would be similar. You will need to be familiar with using
 the Windows command prompt.
 

--- a/docs/howto/windows.txt
+++ b/docs/howto/windows.txt
@@ -23,8 +23,7 @@ machine. At the time of writing, Python 3.8 is the latest version.
 To install Python on your machine go to https://python.org/downloads/. The
 website should offer you a download button for the latest Python version.
 Download the executable installer and run it. Check the boxes next to ``Install
-launcher for all users (recommended)`` and ``Add Python 3.8 to PATH`` then
-click ``Install Now``.
+launcher for all users (recommended)`` then click ``Install Now``.
 
 After installation, open the command prompt and check that the Python version
 matches the version you installed by executing::

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -77,8 +77,7 @@ probably got the answers.
 
 .. admonition:: For Windows users
 
-    When installing Python on Windows, make sure you check the option "Add
-    python.exe to Path", so that it is always available on the command line.
+    See :ref:`install_python_windows` on Windows docs for additional guidance.
 
 Code of Conduct
 ===============


### PR DESCRIPTION
I bumped version numbers of python, removed legacy versions of windows (Windows 10 is only version with mainstream support) and removed link to install pip as it's been included since Python 3.4.