### PR TITLE
Fixed #27719 -- Added QuerySet.alias() to allow creating reusable aliases.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,7 +41,7 @@ answer newbie questions, and generally made Django that much better:
     Aleksi Häkli <aleksi.hakli@iki.fi>
     Alexander Dutton <dev@alexdutton.co.uk>
     Alexander Myodov <alex@myodov.com>
-    Alexandr Tatarinov <tatarinov1997@gmail.com>
+    Alexandr Tatarinov <tatarinov.dev@gmail.com>
     Alex Aktsipetrov <alex.akts@gmail.com>
     Alex Becker <https://alexcbecker.net/>
     Alex Couper <http://alexcouper.com/>

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1085,6 +1085,16 @@ class QuerySet:
         with extra data or aggregations.
         """
         self._not_support_combined_queries('annotate')
+        return self._annotate(args, kwargs, select=True)
+
+    def alias(self, *args, **kwargs):
+        """
+        Return a query set with added aliases for extra data or aggregations.
+        """
+        self._not_support_combined_queries('alias')
+        return self._annotate(args, kwargs, select=False)
+
+    def _annotate(self, args, kwargs, select=True):
         self._validate_values_are_expressions(args + tuple(kwargs.values()), method_name='annotate')
         annotations = {}
         for arg in args:
@@ -1114,8 +1124,9 @@ class QuerySet:
             if isinstance(annotation, FilteredRelation):
                 clone.query.add_filtered_relation(annotation, alias)
             else:
-                clone.query.add_annotation(annotation, alias, is_summary=False)
-
+                clone.query.add_annotation(
+                    annotation, alias, is_summary=False, select=select,
+                )
         for alias, annotation in clone.query.annotations.items():
             if alias in annotations and annotation.contains_aggregate:
                 if clone._fields is None:

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1015,11 +1015,14 @@ class Query(BaseExpression):
             alias = seen[int_model] = join_info.joins[-1]
         return alias or seen[None]
 
-    def add_annotation(self, annotation, alias, is_summary=False):
+    def add_annotation(self, annotation, alias, is_summary=False, select=True):
         """Add a single annotation expression to the Query."""
         annotation = annotation.resolve_expression(self, allow_joins=True, reuse=None,
                                                    summarize=is_summary)
-        self.append_annotation_mask([alias])
+        if select:
+            self.append_annotation_mask([alias])
+        else:
+            self.set_annotation_mask(set(self.annotation_select).difference({alias}))
         self.annotations[alias] = annotation
 
     def resolve_expression(self, query, *args, **kwargs):
@@ -1707,6 +1710,11 @@ class Query(BaseExpression):
                 # which is executed as a wrapped subquery if any of the
                 # aggregate() elements reference an existing annotation. In
                 # that case we need to return a Ref to the subquery's annotation.
+                if name not in self.annotation_select:
+                    raise FieldError(
+                        "Cannot aggregate over the '%s' alias. Use annotate() "
+                        "to promote it." % name
+                    )
                 return Ref(name, self.annotation_select[name])
             else:
                 return annotation
@@ -1911,6 +1919,11 @@ class Query(BaseExpression):
                 # For lookups spanning over relationships, show the error
                 # from the model on which the lookup failed.
                 raise
+            elif name in self.annotations:
+                raise FieldError(
+                    "Cannot select the '%s' alias. Use annotate() to promote "
+                    "it." % name
+                )
             else:
                 names = sorted([
                     *get_field_names_from_opts(opts), *self.extra,

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -268,6 +268,42 @@ control the name of the annotation::
 For an in-depth discussion of aggregation, see :doc:`the topic guide on
 Aggregation </topics/db/aggregation>`.
 
+``alias()``
+~~~~~~~~~~~
+
+.. method:: alias(*args, **kwargs)
+
+.. versionadded:: 3.2
+
+Same as :meth:`annotate`, but instead of annotating objects in the
+``QuerySet``, saves the expression for later reuse with other ``QuerySet``
+methods. This is useful when the result of the expression itself is not needed
+but it is used for filtering, ordering, or as a part of a complex expression.
+Not selecting the unused value removes redundant work from the database which
+should result in better performance.
+
+For example, if you want to find blogs with more than 5 entries, but are not
+interested in the exact number of entries, you could do this::
+
+    >>> from django.db.models import Count
+    >>> blogs = Blog.objects.alias(entries=Count('entry')).filter(entries__gt=5)
+
+``alias()`` can be used in conjunction with :meth:`annotate`, :meth:`exclude`,
+:meth:`filter`, :meth:`order_by`, and :meth:`update`. To use aliased expression
+with other methods (e.g. :meth:`aggregate`), you must promote it to an
+annotation::
+
+    Blog.objects.alias(entries=Count('entry')).annotate(
+        entries=F('entries'),
+    ).aggregate(Sum('entries'))
+
+:meth:`filter` and :meth:`order_by` can take expressions directly, but
+expression construction and usage often does not happen in the same place (for
+example, ``QuerySet`` method creates expressions, for later use in views).
+``alias()`` allows building complex expressions incrementally, possibly
+spanning multiple methods and modules, refer to the expression parts by their
+aliases and only use :meth:`annotate` for the final result.
+
 ``order_by()``
 ~~~~~~~~~~~~~~
 

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -269,6 +269,10 @@ Models
   :py:class:`datetime.time`, :py:class:`datetime.timedelta`,
   :py:class:`decimal.Decimal`, and :py:class:`uuid.UUID` instances.
 
+* The new :meth:`.QuerySet.alias` method allows creating reusable aliases for
+  expressions that don't need to be selected but are used for filtering,
+  ordering, or as a part of complex expressions.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -574,6 +574,7 @@ class ManagerTest(SimpleTestCase):
         'filter',
         'aggregate',
         'annotate',
+        'alias',
         'complex_filter',
         'exclude',
         'in_bulk',

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -303,6 +303,7 @@ class QuerySetSetOperationTests(TestCase):
             combinators.append('intersection')
         for combinator in combinators:
             for operation in (
+                'alias',
                 'annotate',
                 'defer',
                 'delete',


### PR DESCRIPTION
Added queryset.alias() method to allow creating an alias for the expression
without including the expression in the select clause and later reuse.
Using .alias() will produce the same side effects (joins and group by) as .annotate() immediately,
to avoid different query results depending on the alias used later.
The allowed use of an alias is limited intentionally to methods that can use the expression
without including it into the select clause.