### PR TITLE
Fixed #31616 -- Added hint about middleware ordering for SessionMiddleware admin check.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -132,6 +132,12 @@ def check_dependencies(**kwargs):
         errors.append(checks.Error(
             "'django.contrib.sessions.middleware.SessionMiddleware' must "
             "be in MIDDLEWARE in order to use the admin application.",
+            hint=(
+                "Insert "
+                "'django.contrib.sessions.middleware.SessionMiddleware' "
+                "before "
+                "'django.contrib.auth.middleware.AuthenticationMiddleware'."
+            ),
             id='admin.E410',
         ))
     return errors

--- a/tests/admin_checks/tests.py
+++ b/tests/admin_checks/tests.py
@@ -214,6 +214,12 @@ class SystemChecksTestCase(SimpleTestCase):
             checks.Error(
                 "'django.contrib.sessions.middleware.SessionMiddleware' "
                 "must be in MIDDLEWARE in order to use the admin application.",
+                hint=(
+                    "Insert "
+                    "'django.contrib.sessions.middleware.SessionMiddleware' "
+                    "before "
+                    "'django.contrib.auth.middleware.AuthenticationMiddleware'."
+                ),
                 id='admin.E410',
             ),
         ]


### PR DESCRIPTION
Fixes https://code.djangoproject.com/ticket/31616