### PR TITLE
Refs #23097 -- Used new octal format in FILE_UPLOAD_PERMISSIONS docs.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1554,12 +1554,12 @@ when using the :djadmin:`collectstatic` management command. See
 
 .. warning::
 
-    **Always prefix the mode with a 0.**
+    **Always prefix the mode with** ``0o`` **.**
 
-    If you're not familiar with file modes, please note that the leading
-    ``0`` is very important: it indicates an octal number, which is the
-    way that modes must be specified. If you try to use ``644``, you'll
-    get totally incorrect behavior.
+    If you're not familiar with file modes, please note that the ``0o`` prefix
+    is very important: it indicates an octal number, which is the way that
+    modes must be specified. If you try to use ``644``, you'll get totally
+    incorrect behavior.
 
 .. setting:: FILE_UPLOAD_TEMP_DIR
 


### PR DESCRIPTION
``0644`` is a syntax error on Python 3. Octal numbers must be specified with the ``0o`` prefix.