### PR TITLE
Refs #31614 -- Added test for ordering by OrderBy() of combined queryset with not selected columns.

### DIFF
--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -268,6 +268,8 @@ class QuerySetSetOperationTests(TestCase):
             list(qs1.union(qs2).order_by('num'))
         with self.assertRaisesMessage(DatabaseError, msg):
             list(qs1.union(qs2).order_by(F('num')))
+        with self.assertRaisesMessage(DatabaseError, msg):
+            list(qs1.union(qs2).order_by(F('num').desc()))
         # switched order, now 'exists' again:
         list(qs2.union(qs1).order_by('num'))
 


### PR DESCRIPTION
We missed this test in #12961.