### PR TITLE
Fixed isolation of test_migrate_fake_initial.

### DIFF
--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -161,37 +161,37 @@ class MigrateTests(MigrationTestBase):
             "migrations.0001_initial... faked",
             out.getvalue().lower()
         )
-        # Run migrations all the way
-        call_command("migrate", verbosity=0)
-        call_command("migrate", verbosity=0, database="other")
-        # Make sure the right tables exist
-        self.assertTableExists("migrations_author")
-        self.assertTableNotExists("migrations_tribble")
-        self.assertTableExists("migrations_book")
-        self.assertTableNotExists("migrations_author", using="other")
-        self.assertTableNotExists("migrations_tribble", using="other")
-        self.assertTableNotExists("migrations_book", using="other")
-        # Fake a roll-back
-        call_command("migrate", "migrations", "zero", fake=True, verbosity=0)
-        call_command("migrate", "migrations", "zero", fake=True, verbosity=0, database="other")
-        # Make sure the tables still exist
-        self.assertTableExists("migrations_author")
-        self.assertTableNotExists("migrations_tribble")
-        self.assertTableExists("migrations_book")
-        # Try to run initial migration
-        with self.assertRaises(DatabaseError):
-            call_command("migrate", "migrations", verbosity=0)
-        # Run initial migration with an explicit --fake-initial
-        with self.assertRaises(DatabaseError):
-            # Fails because "migrations_tribble" does not exist but needs to in
-            # order to make --fake-initial work.
-            call_command("migrate", "migrations", fake_initial=True, verbosity=0)
-        # Fake an apply
-        call_command("migrate", "migrations", fake=True, verbosity=0)
-        call_command("migrate", "migrations", fake=True, verbosity=0, database="other")
-        # Unmigrate everything
-        call_command("migrate", "migrations", "zero", verbosity=0)
-        call_command("migrate", "migrations", "zero", verbosity=0, database="other")
+        try:
+            # Run migrations all the way.
+            call_command('migrate', verbosity=0)
+            call_command('migrate', verbosity=0, database="other")
+            self.assertTableExists('migrations_author')
+            self.assertTableNotExists('migrations_tribble')
+            self.assertTableExists('migrations_book')
+            self.assertTableNotExists('migrations_author', using='other')
+            self.assertTableNotExists('migrations_tribble', using='other')
+            self.assertTableNotExists('migrations_book', using='other')
+            # Fake a roll-back.
+            call_command('migrate', 'migrations', 'zero', fake=True, verbosity=0)
+            call_command('migrate', 'migrations', 'zero', fake=True, verbosity=0, database='other')
+            self.assertTableExists('migrations_author')
+            self.assertTableNotExists('migrations_tribble')
+            self.assertTableExists('migrations_book')
+            # Run initial migration.
+            with self.assertRaises(DatabaseError):
+                call_command('migrate', 'migrations', verbosity=0)
+            # Run initial migration with an explicit --fake-initial.
+            with self.assertRaises(DatabaseError):
+                # Fails because "migrations_tribble" does not exist but needs
+                # to in order to make --fake-initial work.
+                call_command('migrate', 'migrations', fake_initial=True, verbosity=0)
+            # Fake an apply.
+            call_command('migrate', 'migrations', fake=True, verbosity=0)
+            call_command('migrate', 'migrations', fake=True, verbosity=0, database='other')
+        finally:
+            # Unmigrate everything.
+            call_command('migrate', 'migrations', 'zero', verbosity=0)
+            call_command('migrate', 'migrations', 'zero', verbosity=0, database='other')
         # Make sure it's all gone
         for db in self.databases:
             self.assertTableNotExists("migrations_author", using=db)


### PR DESCRIPTION
Noticed in [the last build on Oracle](https://djangoci.com/job/django-oracle/lastCompletedBuild/database=oracle18,python=python3.7/testReport/).