### PR TITLE
Refs #31638 -- Add (failing) test to show timezone problem with Now()

### DIFF
--- a/tests/db_functions/datetime/test_now.py
+++ b/tests/db_functions/datetime/test_now.py
@@ -54,7 +54,6 @@ class NowTests(TestCase):
         # Some debug printing, should not be part of the final testcase
         import django.conf
         import django.db
-        import django.db.backends.mysql.base
         a.refresh_from_db()
         print(self.id())
         print("TIME_ZONE:", django.conf.settings.TIME_ZONE, "connection:", django.db.connection.timezone_name)

--- a/tests/db_functions/datetime/test_now.py
+++ b/tests/db_functions/datetime/test_now.py
@@ -58,7 +58,7 @@ class NowTests(TestCase):
         a.refresh_from_db()
         print(self.id())
         print("TIME_ZONE:", django.conf.settings.TIME_ZONE, "connection:", django.db.connection.timezone_name)
-        if isinstance(django.db.connections['default'], django.db.backends.mysql.base.DatabaseWrapper):
+        if django.db.connection.settings_dict.get('ENGINE', False) == 'django.db.backends.mysql':
             with django.db.connection.cursor() as cursor:
                 cursor.execute("SELECT @@global.time_zone, @@session.time_zone, @@system_time_zone;")
                 row = cursor.fetchone()


### PR DESCRIPTION
This is a testcase to show a problem with `db.models.functions.Now`. For full details, see ticket-31638.

Below, the test output with various setups (output was slightly redacted to remove unnecessary cruft from the output).


### Sqlite without database `TIME_ZONE`
```
$ ./runtests.py db_functions.datetime.test_now --settings test_sqlite
.db_functions.datetime.test_now.NowTests.test_with_use_tz
TIME_ZONE: America/Chicago connection: UTC
now: 2020-05-28 11:14:08.703968+00:00 written: 2020-05-28 11:14:08.697957+00:00 published: 2020-05-28 11:14:08+00:00

.db_functions.datetime.test_now.NowTests.test_without_use_tz
TIME_ZONE: America/Chicago connection: America/Chicago
now: 2020-05-28 06:14:08.714462 written: 2020-05-28 06:14:08.712672 published: 2020-05-28 11:14:08

F
======================================================================
FAIL: test_without_use_tz (db_functions.datetime.test_now.NowTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthijs/docs/src/upstream/django/django/test/utils.py", line 381, in inner
    return func(*args, **kwargs)
  File "/home/matthijs/docs/src/upstream/django/tests/db_functions/datetime/test_now.py", line 82, in test_without_use_tz
    self.compare_db_and_py_now()
  File "/home/matthijs/docs/src/upstream/django/tests/db_functions/datetime/test_now.py", line 73, in compare_db_and_py_now
    self.assertSequenceEqual(Article.objects.filter(written__gt=Now() - timedelta(minutes=1)), [a])
AssertionError: Sequences differ: <QuerySet []> != [<Article: Article object (1)>]
```

### Sqlite with database `TIME_ZONE`

This uses the following  db config (it also sets `USE_TZ`, since otherwise `TIME_ZONE` is not accepted):
```
  DATABASES = {                                                                                                           
      'default': {                                                                                                        
          'ENGINE': 'django.db.backends.sqlite3',                                                                         
          'TIME_ZONE': 'Europe/Amsterdam',                                                                                
      },                                                                                                                  
      'other': {                                                                                                          
          'ENGINE': 'django.db.backends.sqlite3',                                                                         
      }                                                                                                                   
  }                                                                                                                       
  USE_TZ=True  
```

```
$ ./runtests.py db_functions.datetime.test_now.NowTests.test_with_use_tz --settings test_sqlite
db_functions.datetime.test_now.NowTests.test_with_use_tz
TIME_ZONE: America/Chicago connection: Europe/Amsterdam
now: 2020-05-28 11:16:58.623102+00:00 written: 2020-05-28 13:16:58.616318+02:00 published: 2020-05-28 11:16:58+02:00

F
======================================================================
FAIL: test_with_use_tz (db_functions.datetime.test_now.NowTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthijs/docs/src/upstream/django/django/test/utils.py", line 381, in inner
    return func(*args, **kwargs)
  File "/home/matthijs/docs/src/upstream/django/tests/db_functions/datetime/test_now.py", line 86, in test_with_use_tz
    self.compare_db_and_py_now()
  File "/home/matthijs/docs/src/upstream/django/tests/db_functions/datetime/test_now.py", line 71, in compare_db_and_py_now
    self.assertSequenceEqual(Article.objects.filter(written__lte=Now() + timedelta(minutes=1)), [a])
AssertionError: Sequences differ: <QuerySet []> != [<Article: Article object (1)>]
```

### Mysql (5.5.5-10.3.22-MariaDB-0ubuntu0.19.10.1)
```
$ ./runtests.py db_functions.datetime.test_now --settings test_mysql
.db_functions.datetime.test_now.NowTests.test_with_use_tz
TIME_ZONE: America/Chicago connection: UTC
global.time_zone: SYSTEM session.time_zone SYSTEM system_time_zone: CEST
now: 2020-05-28 11:15:14.890671+00:00 written: 2020-05-28 11:15:14.887143+00:00 published: 2020-05-28 13:15:14+00:00

Fdb_functions.datetime.test_now.NowTests.test_without_use_tz
TIME_ZONE: America/Chicago connection: America/Chicago
global.time_zone: SYSTEM session.time_zone SYSTEM system_time_zone: CEST
now: 2020-05-28 06:15:14.908754 written: 2020-05-28 06:15:14.903515 published: 2020-05-28 13:15:14

F
======================================================================
FAIL: test_with_use_tz (db_functions.datetime.test_now.NowTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthijs/docs/src/upstream/django/django/test/utils.py", line 381, in inner
    return func(*args, **kwargs)
  File "/home/matthijs/docs/src/upstream/django/tests/db_functions/datetime/test_now.py", line 86, in test_with_use_tz
    self.compare_db_and_py_now()
  File "/home/matthijs/docs/src/upstream/django/tests/db_functions/datetime/test_now.py", line 73, in compare_db_and_py_now
    self.assertSequenceEqual(Article.objects.filter(written__gt=Now() - timedelta(minutes=1)), [a])
AssertionError: Sequences differ: <QuerySet []> != [<Article: Article object (3)>]

======================================================================
FAIL: test_without_use_tz (db_functions.datetime.test_now.NowTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthijs/docs/src/upstream/django/django/test/utils.py", line 381, in inner
    return func(*args, **kwargs)
  File "/home/matthijs/docs/src/upstream/django/tests/db_functions/datetime/test_now.py", line 82, in test_without_use_tz
    self.compare_db_and_py_now()
  File "/home/matthijs/docs/src/upstream/django/tests/db_functions/datetime/test_now.py", line 73, in compare_db_and_py_now
    self.assertSequenceEqual(Article.objects.filter(written__gt=Now() - timedelta(minutes=1)), [a])
AssertionError: Sequences differ: <QuerySet []> != [<Article: Article object (4)>]
```