### PR TITLE
Made small improvement to docs/topics/db/multi-db.txt.

### DIFF
--- a/docs/topics/db/multi-db.txt
+++ b/docs/topics/db/multi-db.txt
@@ -373,8 +373,8 @@ from::
             Relations between objects are allowed if both objects are
             in the primary/replica pool.
             """
-            db_list = ('primary', 'replica1', 'replica2')
-            if obj1._state.db in db_list and obj2._state.db in db_list:
+            db_set = {'primary', 'replica1', 'replica2'}
+            if obj1._state.db in db_set and obj2._state.db in db_set:
                 return True
             return None
 


### PR DESCRIPTION
It really caught my eye today.

```python
db_list = ('primary', 'replica1', 'replica2')
```

1. `db_list` is not a list, it is a tuple
2. It is recommended to use `set` with `in` operations

So, it becomes:

```python
db_set = {'primary', 'replica1', 'replica2'}
```