### PR TITLE
Corrected FAQ link in docs/faq/help.txt.

### DIFF
--- a/docs/faq/help.txt
+++ b/docs/faq/help.txt
@@ -5,9 +5,9 @@ FAQ: Getting Help
 How do I do X? Why doesn't Y work? Where can I go to get help?
 ==============================================================
 
-First, please check if your question is answered on the :doc:`FAQ <faq/index>`.
-Also, search for answers using your favorite search engine, and in `the
-forum`_.
+First, please check if your question is answered on the :doc:`FAQ
+</faq/index>`. Also, search for answers using your favorite search engine, and
+in `the forum`_.
 
 .. _`the forum`: https://forum.djangoproject.com/
 


### PR DESCRIPTION
Without the leading slash, was pointing to Python's FAQ
https://docs.python.org/3/faq/index.html.