### PR TITLE
Removed reference to unsupported versions of Django and Python.

### DIFF
--- a/docs/faq/install.txt
+++ b/docs/faq/install.txt
@@ -67,9 +67,6 @@ Django 1.8 is the last version to support Python 3.3.
 What Python version should I use with Django?
 =============================================
 
-Python 3 is recommended. Django 1.11 is the last version to support Python 2.7.
-Support for Python 2.7 and Django 1.11 ends in 2020.
-
 Since newer versions of Python are often faster, have more features, and are
 better supported, the latest version of Python 3 is recommended.
 


### PR DESCRIPTION
Now that Python 2 support has ended I wondered if we should remove this paragraph. I think it also simplifies the recomendation - use the latest version. 
