### PR TITLE
Refs #30997 -- Improved HttpRequest.is_ajax() warning message with stacklevel=2.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -262,6 +262,7 @@ class HttpRequest:
             'request.is_ajax() is deprecated. See Django 3.1 release notes '
             'for more details about this deprecation.',
             RemovedInDjango40Warning,
+            stacklevel=2,
         )
         return self.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'
 


### PR DESCRIPTION
For example, changes:
```
site-packages/django/http/request.py:264: RemovedInDjango40Warning: request.is_ajax() is deprecated. See Django 3.1 release notes for more details about this deprecation.
site-packages/django/http/request.py:264: RemovedInDjango40Warning: request.is_ajax() is deprecated. See Django 3.1 release notes for more details about this deprecation.
```
to
```
django-request/request/models.py:62: RemovedInDjango40Warning: request.is_ajax() is deprecated. See Django 3.1 release notes for more details about this deprecation.
  self.is_ajax = request.is_ajax()
django-request/request/middleware.py:26: RemovedInDjango40Warning: request.is_ajax() is deprecated. See Django 3.1 release notes for more details about this deprecation.
  if request.is_ajax() and settings.IGNORE_AJAX:
```