### PR TITLE
Removed redundant pyenchant dependency in spelling check docs.

### DIFF
--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -496,16 +496,10 @@ Spelling check
 ==============
 
 Before you commit your docs, it's a good idea to run the spelling checker.
-You'll need to install a couple packages first:
-
-* `pyenchant <https://pypi.org/project/pyenchant/>`_ (which requires
-  `enchant <https://www.abisource.com/projects/enchant/>`_)
-
-* `sphinxcontrib-spelling
-  <https://pypi.org/project/sphinxcontrib-spelling/>`_
-
-Then from the ``docs`` directory, run ``make spelling``. Wrong words (if any)
-along with the file and line number where they occur will be saved to
+You'll need to install `sphinxcontrib-spelling
+<https://pypi.org/project/sphinxcontrib-spelling/>`_ first. Then from the
+``docs`` directory, run ``make spelling``. Wrong words (if any) along with the
+file and line number where they occur will be saved to
 ``_build/spelling/output.txt``.
 
 If you encounter false-positives (error output that actually is correct), do


### PR DESCRIPTION
Docs currently advise to install `pyenchant` and `sphinxcontrib-spelling`. However, only sphinxcontrib-spelling is needed to be installed (pyenchant is installed as a dependency).
 