### PR TITLE
Fixed typo in docs/ref/templates/language.txt.

### DIFF
--- a/docs/ref/templates/language.txt
+++ b/docs/ref/templates/language.txt
@@ -706,5 +706,5 @@ This is a feature for the sake of maintainability and sanity.
 .. seealso::
 
     :doc:`The Templates Reference </ref/templates/index>`
-        Covers built-in tags, built-in filters, using an alternative template,
+        Covers built-in tags, built-in filters, using an alternative template
         language, and more.


### PR DESCRIPTION
Reading the documentation for the template language, I noticed what I believe to be an extra comma splitting the term "alternative template language" to  "alternative template, language".

I reviewed the first-time contributing guidelines, and I think I shouldn't need to set up a Trac on this, but I would be happy to if that makes things easier on your end.