### PR TITLE
Make the URL shade-throwing a bit less pointed in the tutorial

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -50,7 +50,7 @@ Django will choose a view by examining the URL that's requested (to be precise,
 the part of the URL after the domain name).
 
 Now in your time on the web you may have come across such beauties as
-"ME2/Sites/dirmod.asp?sid=&type=gen&mod=Core+Pages&gid=A6CD4967199A42D9B65B1B".
+"ME2/Sites/dirmod.htm?sid=&type=gen&mod=Core+Pages&gid=A6CD4967199A42D9B65B1B".
 You will be pleased to know that Django allows us much more elegant
 *URL patterns* than that.
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -275,6 +275,7 @@ Homebrew
 hostname
 hostnames
 hstore
+htm
 html
 http
 https


### PR DESCRIPTION
Inspired by https://www.reddit.com/r/django/comments/gunzqt/the_jabs_at_asp_just_doesnt_stop_lol/. There is no need to reference ASP specifically for the point that the tutorial is making, so change it to something equally common and gross, but not throwing shade on any particular community.