### PR TITLE
Refs #31615 -- Restored EXISTS clauses in extension operations.

### DIFF
--- a/django/contrib/postgres/operations.py
+++ b/django/contrib/postgres/operations.py
@@ -23,7 +23,7 @@ class CreateExtension(Operation):
             return
         if not self.extension_exists(schema_editor, self.name):
             schema_editor.execute(
-                'CREATE EXTENSION %s' % schema_editor.quote_name(self.name)
+                'CREATE EXTENSION IF NOT EXISTS %s' % schema_editor.quote_name(self.name)
             )
         # Clear cached, stale oids.
         get_hstore_oids.cache_clear()
@@ -38,7 +38,7 @@ class CreateExtension(Operation):
             return
         if self.extension_exists(schema_editor, self.name):
             schema_editor.execute(
-                'DROP EXTENSION %s' % schema_editor.quote_name(self.name)
+                'DROP EXTENSION IF EXISTS %s' % schema_editor.quote_name(self.name)
             )
         # Clear cached, stale oids.
         get_hstore_oids.cache_clear()

--- a/tests/postgres_tests/test_operations.py
+++ b/tests/postgres_tests/test_operations.py
@@ -183,13 +183,13 @@ class CreateExtensionTests(PostgreSQLTestCase):
             with connection.schema_editor(atomic=False) as editor:
                 operation.database_forwards(self.app_label, editor, project_state, new_state)
         self.assertEqual(len(captured_queries), 4)
-        self.assertIn('CREATE EXTENSION', captured_queries[1]['sql'])
+        self.assertIn('CREATE EXTENSION IF NOT EXISTS', captured_queries[1]['sql'])
         # Reversal.
         with CaptureQueriesContext(connection) as captured_queries:
             with connection.schema_editor(atomic=False) as editor:
                 operation.database_backwards(self.app_label, editor, new_state, project_state)
         self.assertEqual(len(captured_queries), 2)
-        self.assertIn('DROP EXTENSION', captured_queries[1]['sql'])
+        self.assertIn('DROP EXTENSION IF EXISTS', captured_queries[1]['sql'])
 
     def test_create_existing_extension(self):
         operation = BloomExtension()


### PR DESCRIPTION
Removed in original PR #12952 with comment from Mariusz: https://github.com/django/django/pull/12952#discussion_r430308740

I think leaving these clauses in here is good to prevent TOCTTOU bugs. Although not the recommended workflow, I've seen setups where migrations are run in parallel by all webservers during deployment, so if we can prevent errors there we should.