### PR TITLE
Removed unused 'flex' class from admin changelist.

### DIFF
--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -35,7 +35,7 @@
 {% endblock %}
 {% endif %}
 
-{% block coltype %}flex{% endblock %}
+{% block coltype %}{% endblock %}
 
 {% block content %}
   <div id="content-main">


### PR DESCRIPTION
I loaded a Tailwind CSS into the admin (well, a subset) to help with some layout tweaks. The `flex` class from Tailwind broke the layout of the changelist content, since it has a `flex` class. This was added in 9dda4abee1225db7a7b195b84c915fdd141a7260 but I can't find any reference to it having associated CSS rules. I think we can remove it to avoid conflict with other CSS like Tailwind, and confusion with the CSS flexbox concept.