### PR TITLE
[2.2.x] Fixed ForeignKeyRawIdWidgetTest.test_render_unsafe_limit_choices_to on Python 3.5.

### DIFF
--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -592,7 +592,7 @@ class ForeignKeyRawIdWidgetTest(TestCase):
         w = widgets.ForeignKeyRawIdWidget(rel, widget_admin_site)
         self.assertHTMLEqual(
             w.render('test', None),
-            '<input type="text" name="test" class="vForeignKeyRawIdAdminField">\n'
+            '<input type="text" name="test" class="vForeignKeyRawIdAdminField">'
             '<a href="/admin_widgets/band/?name=%22%26%3E%3Cescapeme&amp;_to_field=id" '
             'class="related-lookup" id="lookup_id_test" title="Lookup"></a>'
         )


### PR DESCRIPTION
https://djangoci.com/job/django-2.2/lastCompletedBuild/testReport/