### PR TITLE
Make sure ValidationError is properly thrown when DecimalField.to_python() is called with a dictionary as a parameter to convert.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1501,7 +1501,7 @@ class DecimalField(Field):
             return self.context.create_decimal_from_float(value)
         try:
             return decimal.Decimal(value)
-        except decimal.InvalidOperation:
+        except (decimal.InvalidOperation,TypeError):
             raise exceptions.ValidationError(
                 self.error_messages['invalid'],
                 code='invalid',

--- a/tests/model_fields/test_decimalfield.py
+++ b/tests/model_fields/test_decimalfield.py
@@ -21,9 +21,11 @@ class DecimalFieldTests(TestCase):
         # Uses default rounding of ROUND_HALF_EVEN.
         self.assertEqual(f.to_python(2.0625), Decimal('2.062'))
         self.assertEqual(f.to_python(2.1875), Decimal('2.188'))
-        msg = '“abc” value must be a decimal number.'
-        with self.assertRaisesMessage(ValidationError, msg):
-            f.to_python('abc')
+        bad_values = ["abc", {}]
+        for bad_value in bad_values:
+            msg = '“{}” value must be a decimal number.'.format(bad_value)
+            with self.assertRaisesMessage(ValidationError, msg):
+                f.to_python(bad_value)
 
     def test_default(self):
         f = models.DecimalField(default=Decimal('0.00'))


### PR DESCRIPTION
If a dictionary was being passed to DecimalField.to_python() it failed to generate the ValidationError, and instead was propagating the TypeError from the lower-level code, thus hiding the specifics of which value exacly caused the error. This - for example - affects debugging a save() on an improperly initialized object with many fields.