### PR TITLE
Fixed #31662 -- Added detection for GDAL 3.0 and 3.1 on Windows.

### DIFF
--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -20,10 +20,14 @@ if lib_path:
     lib_names = None
 elif os.name == 'nt':
     # Windows NT shared libraries
-    lib_names = ['gdal204', 'gdal203', 'gdal202', 'gdal201', 'gdal20']
+    lib_names = ['gdal301', 'gdal300', 'gdal204', 'gdal203', 'gdal202', 'gdal201', 'gdal20']
 elif os.name == 'posix':
     # *NIX library names.
-    lib_names = ['gdal', 'GDAL', 'gdal2.4.0', 'gdal2.3.0', 'gdal2.2.0', 'gdal2.1.0', 'gdal2.0.0']
+    lib_names = [
+        'gdal', 'GDAL',
+        'gdal3.1.0', 'gdal3.0.0',
+        'gdal2.4.0', 'gdal2.3.0', 'gdal2.2.0', 'gdal2.1.0', 'gdal2.0.0',
+    ]
 else:
     raise ImproperlyConfigured('GDAL is unsupported on OS "%s".' % os.name)
 


### PR DESCRIPTION
I think the `lib_names` need updating for GDAL3 support. I've updated it for windows but am unsure for *nix. 

Having made this amend I can runmigrations following the gis tutorial. 