### PR TITLE
Add helpers to get settings values from env variables

### DIFF
--- a/django/conf/project_template/project_name/settings.py-tpl
+++ b/django/conf/project_template/project_name/settings.py-tpl
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/
 """
 
 from pathlib import Path
+from django.core.env_helpers import from_env, boolable
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
@@ -20,10 +21,10 @@ BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 # See https://docs.djangoproject.com/en/{{ docs_version }}/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '{{ secret_key }}'
+SECRET_KEY = from_env("DJANGO_SECRET_KEY", default='{{ secret_key }}')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = from_env("DJANGO_DEBUG", kind=boolable, default=True)
 
 ALLOWED_HOSTS = []
 

--- a/django/core/env_helpers.py
+++ b/django/core/env_helpers.py
@@ -1,0 +1,49 @@
+import os
+from .exceptions import ImproperlyConfigured
+
+
+class NoDefaultValue:
+    pass
+
+
+def from_env(name, default=NoDefaultValue, kind=str):
+    """
+    Get a configuration value from the environment.
+
+    Arguments
+    ---------
+    name : str
+        The name of the environment variable to pull from for this
+        setting.
+    default : any
+        A default value of the return type in case the intended
+        environment variable is not set. If this argument is not passed,
+        the environment variable is considered to be required, and
+        ``ImproperlyConfigured`` may be raised.
+    kind : callable
+        A callable that takes a string and returns a value of the return
+        type.
+
+    Returns
+    -------
+    any
+        A value of the type returned by ``kind``.
+
+    Raises
+    ------
+    ImproperlyConfigured
+        If there is no ``default``, and the environment variable is not
+        set.
+    """
+    try:
+        val = os.environ[name]
+    except KeyError:
+        if default == NoDefaultValue:
+            raise ImproperlyConfigured("Missing environment variable {}.".format(name))
+        val = default
+    val = kind(val)
+    return val
+
+
+def boolable(val):
+    return val in ("True", "true", "T", "t", "1", 1, True)

--- a/django/core/env_helpers.py
+++ b/django/core/env_helpers.py
@@ -1,4 +1,5 @@
 import os
+
 from .exceptions import ImproperlyConfigured
 
 

--- a/django/core/env_helpers.py
+++ b/django/core/env_helpers.py
@@ -39,7 +39,7 @@ def from_env(name, default=NoDefaultValue, kind=str):
     try:
         val = os.environ[name]
     except KeyError:
-        if default == NoDefaultValue:
+        if default is NoDefaultValue:
             raise ImproperlyConfigured("Missing environment variable {}.".format(name))
         val = default
     val = kind(val)

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -3494,6 +3494,30 @@ setting.
 Static file finders are currently considered a private interface, and this
 interface is thus undocumented.
 
+Getting settings values from the environment
+============================================
+
+It's often the case that you want to define some settings in your app's
+running environment, *à la* `section III of the 12 Factor App`_. In
+fact, Django does this by default with two settings: ``SECRET_KEY`` and
+``DEBUG``. To facilitate this, Django offers a helper function:
+``from_env``. This function requires a single positional argument, the
+name of the environment variable to check for the setting value, and two
+optional arguments: ``default``, a default value if the environment variable is
+missing (otherwise ``ImproperlyConfigured`` is raised) and ``kind``, a
+callable that will convert the string value from the environment into an
+appropriate value in Python. It also provides a single helper value for
+``kind``, that will parse any value that could be interpreted as a
+boolean.
+
+For example::
+
+   from django.core.env_helpers import from_env, boolable
+
+   DEBUG = from_env("DJANGO_DEBUG", default=True, kind=boolable)
+
+.. _section III of the 12 Factor App: https://12factor.net/config
+
 Core Settings Topical Index
 ===========================
 

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -5,6 +5,7 @@ from types import ModuleType, SimpleNamespace
 from unittest import mock
 
 from django.conf import ENVIRONMENT_VARIABLE, LazySettings, Settings, settings
+from django.core.env_helpers import from_env, boolable
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 from django.test import (
@@ -616,3 +617,21 @@ class MediaURLStaticURLPrefixTest(SimpleTestCase):
                             self.assertEqual(getattr(settings, setting), expected_path)
                         finally:
                             clear_script_prefix()
+
+
+class FromEnvTest(SimpleTestCase):
+    def test_boolable(self):
+        self.assertTrue(boolable("true"))
+        self.assertFalse(boolable("false"))
+        self.assertFalse(boolable("banana"))
+
+    def test_from_env__no_default(self):
+        with self.assertRaises(ImproperlyConfigured):
+            from_env("FROM_ENV__NO_DEFAULT")
+
+    def test_from_env__missing_but_default(self):
+        self.assertEqual(from_env("FROM_ENV__HAS_DEFAULT", default="default"), "default")
+
+    def test_from_env__happy_path(self):
+        os.environ.setdefault("FROM_ENV__HAPPY_PATH", "happy")
+        self.assertEqual(from_env("FROM_ENV__HAPPY_PATH"), "happy")

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -5,7 +5,7 @@ from types import ModuleType, SimpleNamespace
 from unittest import mock
 
 from django.conf import ENVIRONMENT_VARIABLE, LazySettings, Settings, settings
-from django.core.env_helpers import from_env, boolable
+from django.core.env_helpers import boolable, from_env
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 from django.test import (

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -620,10 +620,23 @@ class MediaURLStaticURLPrefixTest(SimpleTestCase):
 
 
 class FromEnvTest(SimpleTestCase):
+    env_var_name = "FROM_ENV__HAPPY_PATH"
+
+    def setUp(self):
+        self.original = os.environ.get(self.env_var_name, None)
+        os.environ[self.env_var_name] = "happy"
+
+    def tearDown(self):
+        # Teardown:
+        if self.original is not None:
+            os.environ[self.env_var_name] = self.original
+        else:
+            del os.environ[self.env_var_name]
+
     def test_boolable(self):
-        self.assertTrue(boolable("true"))
-        self.assertFalse(boolable("false"))
-        self.assertFalse(boolable("banana"))
+        self.assertIs(boolable("true"), True)
+        self.assertIs(boolable("false"), False)
+        self.assertIs(boolable("banana"), False)
 
     def test_from_env__no_default(self):
         with self.assertRaises(ImproperlyConfigured):
@@ -633,5 +646,4 @@ class FromEnvTest(SimpleTestCase):
         self.assertEqual(from_env("FROM_ENV__HAS_DEFAULT", default="default"), "default")
 
     def test_from_env__happy_path(self):
-        os.environ.setdefault("FROM_ENV__HAPPY_PATH", "happy")
-        self.assertEqual(from_env("FROM_ENV__HAPPY_PATH"), "happy")
+        self.assertEqual(from_env(self.env_var_name), "happy")


### PR DESCRIPTION
I'm interested in reducing the distance from running `startproject` to having a deployable Django app, having recently had a number of interactions with junior devs interested in using Django but finding deployment a nightmare. Some of this is of course on the other side, on the PaaS of choice, but some of it can (and I think should) be done on the Django side.

I'd like to start small. This just adds a helper to get variables from the environment, with type conversion and defaults handled, and uses that helper on two values in `startproject`'s settings.

https://groups.google.com/d/topic/django-developers/CIPgeTetYpk/discussion