### PR TITLE
Refs #31670 -- Removed whitelist/blacklist terminology in docs and comments.

### DIFF
--- a/django/contrib/gis/db/backends/base/operations.py
+++ b/django/contrib/gis/db/backends/base/operations.py
@@ -36,7 +36,7 @@ class BaseSpatialOperations:
     # match; used in spatial_function_name().
     function_names = {}
 
-    # Blacklist/set of known unsupported functions of the backend
+    # Set of known unsupported functions of the backend
     unsupported_functions = {
         'Area', 'AsGeoJSON', 'AsGML', 'AsKML', 'AsSVG', 'Azimuth',
         'BoundingCircle', 'Centroid', 'Difference', 'Distance', 'Envelope',

--- a/docs/releases/1.1.3.txt
+++ b/docs/releases/1.1.3.txt
@@ -45,6 +45,6 @@ password hashes.
 To remedy this, ``django.contrib.admin`` will now validate that
 querystring lookup arguments either specify only fields on the model
 being viewed, or cross relations which have been explicitly
-whitelisted by the application developer using the pre-existing
+allowed by the application developer using the pre-existing
 mechanism mentioned above. This is backwards-incompatible for any
 users relying on the prior ability to insert arbitrary lookups.

--- a/docs/releases/1.2.4.txt
+++ b/docs/releases/1.2.4.txt
@@ -45,7 +45,7 @@ password hashes.
 To remedy this, ``django.contrib.admin`` will now validate that
 querystring lookup arguments either specify only fields on the model
 being viewed, or cross relations which have been explicitly
-whitelisted by the application developer using the pre-existing
+allowed by the application developer using the pre-existing
 mechanism mentioned above. This is backwards-incompatible for any
 users relying on the prior ability to insert arbitrary lookups.
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -10,7 +10,6 @@ affordances
 aggregator
 Ai
 Alchin
-allowlist
 alphanumerics
 amet
 analytics
@@ -156,7 +155,6 @@ decrementing
 deduplicates
 deepcopy
 deferrable
-denylist
 deprecations
 deserialization
 deserialize
@@ -781,6 +779,7 @@ vertices
 viewable
 virtualized
 Weblog
+whitelist
 whitespace
 whitespaces
 whizbang

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -10,6 +10,7 @@ affordances
 aggregator
 Ai
 Alchin
+allowlist
 alphanumerics
 amet
 analytics
@@ -155,6 +156,7 @@ decrementing
 deduplicates
 deepcopy
 deferrable
+denylist
 deprecations
 deserialization
 deserialize
@@ -779,8 +781,6 @@ vertices
 viewable
 virtualized
 Weblog
-whitelist
-whitelisted
 whitespace
 whitespaces
 whizbang

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -420,7 +420,7 @@ fields, especially when new fields are added to a model. Depending on how the
 form is rendered, the problem may not even be visible on the web page.
 
 The alternative approach would be to include all fields automatically, or
-blacklist only some. This fundamental approach is known to be much less secure
+remove only some. This fundamental approach is known to be much less secure
 and has led to serious exploits on major websites (e.g. `GitHub
 <https://github.com/blog/1068-public-key-security-vulnerability-and-mitigation>`_).
 

--- a/docs/topics/security.txt
+++ b/docs/topics/security.txt
@@ -261,7 +261,7 @@ User-uploaded content
      from something like ``usercontent-example.com``. It's *not* sufficient to
      serve content from a subdomain like ``usercontent.example.com``.
 
-  #. Beyond this, applications may choose to define a whitelist of allowable
+  #. Beyond this, applications may choose to define a list of allowable
      file extensions for user uploaded files and configure the web server
      to only serve such files.
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -791,7 +791,7 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         self.assertEqual(response.status_code, 200)
 
         # Filters should be allowed if they involve a local field without the
-        # need to whitelist them in list_filter or date_hierarchy.
+        # need to allow them in list_filter or date_hierarchy.
         response = self.client.get("%s?age__gt=30" % reverse('admin:admin_views_person_changelist'))
         self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
[Ticket #31670](https://code.djangoproject.com/ticket/31670#ticket)

Hi @adamchainz here is the updated PR (previously #12755). 

Probably a little bit of thought needed on "allow list" vs "allowlist" and "deny list" vs "denylist". I went without the spaces as that's what Microsoft/Google/Rails did (see links in ticket), but 🤷.