### PR TITLE
Fixed #31661 -- Removed period in makemigrations history check warning.

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -104,7 +104,7 @@ class Command(BaseCommand):
                 except OperationalError as error:
                     warnings.warn(
                         "Got an error checking a consistent migration history "
-                        "performed for database connection '%s': %s."
+                        "performed for database connection '%s': %s"
                         % (alias, error),
                         RuntimeWarning,
                     )

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -1566,8 +1566,9 @@ class MakeMigrationsTests(MigrationTestBase):
             side_effect=OperationalError('could not connect to server'),
         ):
             with self.temporary_migration_module():
-                with self.assertWarnsMessage(RuntimeWarning, msg):
+                with self.assertWarns(RuntimeWarning) as cm:
                     call_command('makemigrations', verbosity=0)
+                self.assertEqual(str(cm.warning), msg)
 
     @mock.patch('builtins.input', return_value='1')
     @mock.patch('django.db.migrations.questioner.sys.stdin', mock.MagicMock(encoding=sys.getdefaultencoding()))


### PR DESCRIPTION
Improved log statement formatting resulting from an OperationalError being caught when manage.py makemigrations is invoked.

Before:
![image](https://user-images.githubusercontent.com/43051848/83956222-c837c100-a818-11ea-91c9-98713d816712.png)

After:
![image](https://user-images.githubusercontent.com/43051848/83956226-d554b000-a818-11ea-9d68-728c7db5fde5.png)
