### PR TITLE
Fixed #28132 -- Made MultiPartParser ignore filenames with trailing slash.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -621,6 +621,7 @@ answer newbie questions, and generally made Django that much better:
     Maximillian Dornseif <md@hudora.de>
     mccutchen@gmail.com
     Meir Kriheli <http://mksoft.co.il/>
+    Michael S. Brown <michael@msbrown.net>
     Michael Hall <mhall1@ualberta.ca>
     Michael Josephson <http://www.sdjournal.com/>
     Michael Manfre <mmanfre@gmail.com>

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -9,6 +9,7 @@ import binascii
 import cgi
 import collections
 import html
+import os
 from urllib.parse import unquote
 
 from django.conf import settings
@@ -208,6 +209,7 @@ class MultiPartParser:
                     # This is a file, use the handler...
                     file_name = disposition.get('filename')
                     if file_name:
+                        file_name = os.path.basename(file_name)
                         file_name = force_str(file_name, encoding, errors='replace')
                         file_name = self.IE_sanitize(html.unescape(file_name))
                     if not file_name:

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -209,10 +209,14 @@ class FileUploadTests(TestCase):
         Receiving file upload when filename is blank (before and after
         sanitization) should be okay.
         """
-        # The second value is normalized to an empty name by
-        # MultiPartParser.IE_sanitize()
-        filenames = ['', 'C:\\Windows\\']
-
+        filenames = [
+            '',
+            # Normalized by MultiPartParser.IE_sanitize().
+            'C:\\Windows\\',
+            # Normalized by os.path.basename().
+            '/',
+            'ends-with-slash/',
+        ]
         payload = client.FakePayload()
         for i, name in enumerate(filenames):
             payload.write('\r\n'.join([


### PR DESCRIPTION
Trac ticket [#28132](https://code.djangoproject.com/ticket/28132).