### PR TITLE
Fixed #31680 -- Removed unnecessary getattr() call in DeferredAttribute.__get__().

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -147,8 +147,8 @@ class DeferredAttribute:
             val = self._check_parent_chain(instance)
             if val is None:
                 instance.refresh_from_db(fields=[field_name])
-                val = getattr(instance, field_name)
-            data[field_name] = val
+            else:
+                data[field_name] = val
         return data[field_name]
 
     def _check_parent_chain(self, instance):


### PR DESCRIPTION
To retrieve a deferred model attributes, the `__get__` method is called twice. This is because it uses the `getattr()` function, which in turn causes the `__get__` method to be called again.

To prevent this unnecessary call, we can simply extract the value direct from the instance dict (since at that moment it already contains the reloaded value). This reduces the number of method calls.