### PR TITLE
Pin Sphinx version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ usedevelop = false
 whitelist_externals =
     make
 deps =
-    Sphinx
+    Sphinx == 3.0.4
     pyenchant
     sphinxcontrib-spelling
 changedir = docs


### PR DESCRIPTION
Hi @felixxm It looks like the most recent release of Sphinx is causing build errors (this seems to have happened a few times recently?). 

I _think_ that this should pin it to the previous version which works. Which _may_ be a short term solution?

I have spent some time looking into the issue. I thought that #12135 may have helped but I struggled to get that to work...