### PR TITLE
[3.0.x] Refs #31660 -- Fixed annotations.tests crash on MySQL

### DIFF
--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -636,7 +636,7 @@ class NonAggregateAnnotationTestCase(TestCase):
         ])
 
     @skipIf(
-        connection.vendor == 'mysql' and 'ONLY_FULL_GROUP_BY' in connection.sql_mode,
+        connection.vendor == 'mysql',
         'GROUP BY optimization does not work properly when ONLY_FULL_GROUP_BY '
         'mode is enabled on MySQL, see #31331.',
     )


### PR DESCRIPTION
Follow up to be7a295141337189b9eceea506489bdfe07f199e. `sql_mode` is not available in Django 3.0.