### PR TITLE
Fixed #31491 -- Allowed 'password' option in DATABASES['OPTIONS'] on MySQL.

### DIFF
--- a/django/db/backends/mysql/client.py
+++ b/django/db/backends/mysql/client.py
@@ -11,7 +11,10 @@ class DatabaseClient(BaseDatabaseClient):
         args = [cls.executable_name]
         db = settings_dict['OPTIONS'].get('db', settings_dict['NAME'])
         user = settings_dict['OPTIONS'].get('user', settings_dict['USER'])
-        passwd = settings_dict['OPTIONS'].get('passwd', settings_dict['PASSWORD'])
+        password = settings_dict['OPTIONS'].get(
+            'password',
+            settings_dict['OPTIONS'].get('passwd', settings_dict['PASSWORD'])
+        )
         host = settings_dict['OPTIONS'].get('host', settings_dict['HOST'])
         port = settings_dict['OPTIONS'].get('port', settings_dict['PORT'])
         server_ca = settings_dict['OPTIONS'].get('ssl', {}).get('ca')
@@ -24,8 +27,8 @@ class DatabaseClient(BaseDatabaseClient):
             args += ["--defaults-file=%s" % defaults_file]
         if user:
             args += ["--user=%s" % user]
-        if passwd:
-            args += ["--password=%s" % passwd]
+        if password:
+            args += ["--password=%s" % password]
         if host:
             if '/' in host:
                 args += ["--socket=%s" % host]

--- a/tests/dbshell/test_mysql.py
+++ b/tests/dbshell/test_mysql.py
@@ -43,6 +43,24 @@ class MySqlDbshellCommandTestCase(SimpleTestCase):
                 },
             }))
 
+    def test_options_password(self):
+        self.assertEqual(
+            [
+                'mysql', '--user=someuser', '--password=optionpassword',
+                '--host=somehost', '--port=444', 'somedbname',
+            ],
+            self.get_command_line_arguments({
+                'NAME': 'somedbname',
+                'USER': 'someuser',
+                'PASSWORD': 'settingpassword',
+                'HOST': 'somehost',
+                'PORT': 444,
+                'OPTIONS': {
+                    'password': 'optionpassword',
+                },
+            }),
+        )
+
     def test_can_connect_using_sockets(self):
         self.assertEqual(
             ['mysql', '--user=someuser', '--password=somepassword',


### PR DESCRIPTION
[ticket](https://code.djangoproject.com/ticket/31491)

Do we need to address [this comment](https://github.com/django/django/pull/12763/commits/bfdc25f85174f671cfcdc58fcf00530c3cc8f451#r412015975) :thinking:  ? because keys in `OPTIONS` are lowercase and keys in `settings_dict` are uppercase and also for `db` we have `db` in `OPTIONS` and `NAME` in `settings_dict`.
maybe something like:
```python
        conn_params = {**settings_dict, **settings_dict['OPTIONS']}
        db = conn_params.get('db', conn_params['NAME'])
        user = conn_params['OPTIONS'].get('user', conn_params['USER'])
        password = conn_params['OPTIONS'].get('password', conn_params['PASSWORD'])
        host = conn_params['OPTIONS'].get('host', conn_params['HOST'])
        port = conn_params['OPTIONS'].get('port', conn_params['PORT'])
        server_ca = conn_params['OPTIONS'].get('ssl', {}).get('ca')
        client_cert = conn_params['OPTIONS'].get('ssl', {}).get('cert')
        client_key = conn_params['OPTIONS'].get('ssl', {}).get('key')
        defaults_file = conn_params['OPTIONS'].get('read_default_file')
```