### PR TITLE
Fixed #31690 -- Added note about fuzzy entries in translation docs.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -160,7 +160,7 @@ are excluded.
 
 .. django-admin-option:: --use-fuzzy, -f
 
-Includes fuzzy translations into compiled files.
+Includes `fuzzy translations`_ into compiled files.
 
 Example usage::
 
@@ -172,6 +172,8 @@ Example usage::
     django-admin compilemessages --exclude=pt_BR --exclude=fr
     django-admin compilemessages -x pt_BR
     django-admin compilemessages -x pt_BR -x fr
+
+.. _fuzzy translations: https://www.gnu.org/software/gettext/manual/html_node/Fuzzy-Entries.html
 
 .. django-admin-option:: --ignore PATTERN, -i PATTERN
 

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1619,6 +1619,13 @@ otherwise, they'll be tacked together without whitespace!
     files are created).  This means that everybody will be using the same
     encoding, which is important when Django processes the PO files.
 
+.. admonition:: Fuzzy entries
+
+    :djadmin:`makemessages` sometimes generates translation entries marked as
+    fuzzy, e.g. when translations are inferred from previously translated
+    strings. By default, fuzzy entries are **not** processed by
+    :djadmin:`compilemessages`.
+
 To reexamine all source code and templates for new translation strings and
 update all message files for **all** languages, run this::
 


### PR DESCRIPTION
Related to https://code.djangoproject.com/ticket/31690