### PR TITLE
Allow autocomplete widgets to derive the model from the ModelChoiceIterator

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -223,7 +223,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
 
         if 'widget' not in kwargs:
             if db_field.name in self.get_autocomplete_fields(request):
-                kwargs['widget'] = AutocompleteSelect(db_field.remote_field, self.admin_site, using=db)
+                kwargs['widget'] = AutocompleteSelect(self.admin_site, using=db)
             elif db_field.name in self.raw_id_fields:
                 kwargs['widget'] = widgets.ForeignKeyRawIdWidget(db_field.remote_field, self.admin_site, using=db)
             elif db_field.name in self.radio_fields:
@@ -252,11 +252,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         if 'widget' not in kwargs:
             autocomplete_fields = self.get_autocomplete_fields(request)
             if db_field.name in autocomplete_fields:
-                kwargs['widget'] = AutocompleteSelectMultiple(
-                    db_field.remote_field,
-                    self.admin_site,
-                    using=db,
-                )
+                kwargs['widget'] = AutocompleteSelectMultiple(self.admin_site, using=db)
             elif db_field.name in self.raw_id_fields:
                 kwargs['widget'] = widgets.ManyToManyRawIdWidget(
                     db_field.remote_field,

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -382,15 +382,17 @@ class AutocompleteMixin:
     """
     url_name = '%s:%s_%s_autocomplete'
 
-    def __init__(self, rel, admin_site, attrs=None, choices=(), using=None):
-        self.rel = rel
+    def __init__(self, admin_site, attrs=None, choices=(), using=None):
         self.admin_site = admin_site
         self.db = using
         self.choices = choices
         self.attrs = {} if attrs is None else attrs.copy()
 
+    def get_model(self):
+        return self.choices.queryset.model
+
     def get_url(self):
-        model = self.rel.model
+        model = self.get_model()
         return reverse(self.url_name % (self.admin_site.name, model._meta.app_label, model._meta.model_name))
 
     def build_attrs(self, base_attrs, extra_attrs=None):


### PR DESCRIPTION
Both widgets can instead derive the relevant model from `self.choices` (a `ModelChoiceIterator`), which is set by the `ModelChoiceField`.

We're [already banking on](https://github.com/django/django/blob/3.1a1/django/contrib/admin/widgets.py#L423-L431) `self.choices` being a `ModelChoiceIterator` at the time of rendering, so I can't see any downsides to the change. However, this will make the widgets far easier to reuse elsewhere.

Technically, we could also make `admin_site` optional, and have the widget cycle through `wagtail.contrib.admin.sites.all_sites` until it finds one where the model is registered (with `search_fields` set), but that one's a little more contentious.