### PR TITLE
Fixed #31706 -- Removed unnecessary getattr() call in FileDescriptor.__get__().

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -173,11 +173,9 @@ class FileDescriptor:
 
         # The instance dict contains whatever was originally assigned
         # in __set__.
-        if self.field.name in instance.__dict__:
-            file = instance.__dict__[self.field.name]
-        else:
+        if self.field.name not in instance.__dict__:
             instance.refresh_from_db(fields=[self.field.name])
-            file = getattr(instance, self.field.name)
+        file = instance.__dict__[self.field.name]
 
         # If this value is a string (instance.file = "path/to/file") or None
         # then we simply wrap it with the appropriate attribute class according


### PR DESCRIPTION
To retrieve a deferred model attributes, the `__get__` method is called twice. This is because it uses the `getattr()` function, which in turn causes the `__get__` method to be called again.

To prevent this unnecessary call, we can simply delete it (since at that moment the instance dict already contains the reloaded value). This reduces the number of method calls.