### PR TITLE
Fixed #30472 -- Made Argon2PasswordHasher use Argon2id.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -302,8 +302,8 @@ class Argon2PasswordHasher(BasePasswordHasher):
     library = 'argon2'
 
     time_cost = 2
-    memory_cost = 512
-    parallelism = 2
+    memory_cost = 102400
+    parallelism = 8
 
     def encode(self, password, salt):
         argon2 = self._load_library()
@@ -363,7 +363,7 @@ class Argon2PasswordHasher(BasePasswordHasher):
         argon2 = self._load_library()
         # salt_len is a noop, because we provide our own salt.
         return argon2.Parameters(
-            type=argon2.low_level.Type.I,
+            type=argon2.low_level.Type.ID,
             version=argon2.low_level.ARGON2_VERSION,
             salt_len=argon2.DEFAULT_RANDOM_SALT_LENGTH,
             hash_len=argon2.DEFAULT_HASH_LENGTH,

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -270,7 +270,7 @@ Running all the tests
 If you want to run the full suite of tests, you'll need to install a number of
 dependencies:
 
-*  argon2-cffi_ 16.1.0+
+*  argon2-cffi_ 19.1.0+
 *  asgiref_ 3.2+ (required)
 *  bcrypt_
 *  docutils_

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -50,6 +50,15 @@ Minor features
 * The default iteration count for the PBKDF2 password hasher is increased from
   216,000 to 260,000.
 
+* The default variant for the Argon2 password hasher is changed to Argon2id.
+  ``memory_cost`` and ``parallelism`` are increased to 102,400 and 8
+  respectively to match the ``argon2-cffi`` defaults.
+
+  Increasing the ``memory_cost`` pushes the required memory from 512 KB to 100
+  MB. This is still rather conservative but can lead to problems in memory
+  constrained environments. If this is the case, the existing hasher can be
+  subclassed to override the defaults.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -324,6 +324,8 @@ Miscellaneous
 * The :tfilter:`intcomma` and :tfilter:`intword` template filters no longer
   depend on the :setting:`USE_L10N` setting.
 
+* Support for ``argon2-cffi`` < 19.1.0 is removed.
+
 .. _deprecated-features-3.2:
 
 Features deprecated in 3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ console_scripts =
     django-admin = django.core.management:execute_from_command_line
 
 [options.extras_require]
-argon2 = argon2-cffi >= 16.1.0
+argon2 = argon2-cffi >= 19.1.0
 bcrypt = bcrypt
 
 [bdist_rpm]

--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -514,6 +514,12 @@ class TestUtilsHashPassArgon2(SimpleTestCase):
         )
         self.assertTrue(check_password('secret', encoded))
         self.assertFalse(check_password('wrong', encoded))
+        # Old hashes with version attribute.
+        encoded = (
+            'argon2$argon2i$v=19$m=8,t=1,p=1$c2FsdHNhbHQ$YC9+jJCrQhs5R6db7LlN8Q'
+        )
+        self.assertIs(check_password('secret', encoded), True)
+        self.assertIs(check_password('wrong', encoded), False)
 
     def test_argon2_upgrade(self):
         self._test_argon2_upgrade('time_cost', 'time cost', 1)

--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -497,13 +497,13 @@ class TestUtilsHashPassArgon2(SimpleTestCase):
     def test_argon2(self):
         encoded = make_password('lètmein', hasher='argon2')
         self.assertTrue(is_password_usable(encoded))
-        self.assertTrue(encoded.startswith('argon2$'))
+        self.assertTrue(encoded.startswith('argon2$argon2id$'))
         self.assertTrue(check_password('lètmein', encoded))
         self.assertFalse(check_password('lètmeinz', encoded))
         self.assertEqual(identify_hasher(encoded).algorithm, 'argon2')
         # Blank passwords
         blank_encoded = make_password('', hasher='argon2')
-        self.assertTrue(blank_encoded.startswith('argon2$'))
+        self.assertTrue(blank_encoded.startswith('argon2$argon2id$'))
         self.assertTrue(is_password_usable(blank_encoded))
         self.assertTrue(check_password('', blank_encoded))
         self.assertFalse(check_password(' ', blank_encoded))
@@ -523,15 +523,15 @@ class TestUtilsHashPassArgon2(SimpleTestCase):
 
     def test_argon2_upgrade(self):
         self._test_argon2_upgrade('time_cost', 'time cost', 1)
-        self._test_argon2_upgrade('memory_cost', 'memory cost', 16)
+        self._test_argon2_upgrade('memory_cost', 'memory cost', 64)
         self._test_argon2_upgrade('parallelism', 'parallelism', 1)
 
     def test_argon2_version_upgrade(self):
         hasher = get_hasher('argon2')
         state = {'upgraded': False}
         encoded = (
-            'argon2$argon2i$m=8,t=1,p=1$c29tZXNhbHQ$gwQOXSNhxiOxPOA0+PY10P9QFO'
-            '4NAYysnqRt1GSQLE55m+2GYDt9FEjPMHhP2Cuf0nOEXXMocVrsJAtNSsKyfg'
+            'argon2$argon2id$v=19$m=102400,t=2,p=8$Y041dExhNkljRUUy$TMa6A8fPJh'
+            'CAUXRhJXCXdw'
         )
 
         def setter(password):


### PR DESCRIPTION
This also updates memory_cost and parallelism to be in line with the
default recommendations.

@hynek Do you think you could give this a review? It certainly is suboptimal in the sense that we still use our own salt, but much of the actual `low_level` usage got removed.