### PR TITLE
Removed unsupported third-party database backends from docs.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -1059,9 +1059,7 @@ by 3rd parties that allow you to use other databases with Django:
 
 * `CockroachDB`_
 * `Firebird`_
-* `IBM DB2`_
 * `Microsoft SQL Server`_
-* `ODBC`_
 
 The Django versions and ORM features supported by these unofficial backends
 vary considerably. Queries regarding the specific capabilities of these
@@ -1070,6 +1068,4 @@ the support channels provided by each 3rd party project.
 
 .. _CockroachDB: https://pypi.org/project/django-cockroachdb/
 .. _Firebird: https://pypi.org/project/django-firebird/
-.. _IBM DB2: https://pypi.org/project/ibm_db_django/
 .. _Microsoft SQL Server: https://pypi.org/project/django-mssql-backend/
-.. _ODBC: https://pypi.org/project/django-pyodbc/


### PR DESCRIPTION
Follow up to #12948

These are all looking unmaintained: 

* https://pypi.org/project/ibm_db_django/#history
* https://pypi.org/project/django-firebird/#history
* https://pypi.org/project/django-pyodbc/#history

They don't support the latest versions and there is no significant activity on the repos. If they come to life it's easy enough to re-add. 