### PR TITLE
Refs #32365 -- [PoC] Remove dependency on pytz

### DIFF
--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -6,7 +6,7 @@ from collections import deque
 from contextlib import contextmanager
 
 import _thread
-import pytz
+import pytz_deprecation_shim as pds
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -135,7 +135,7 @@ class BaseDatabaseWrapper:
         elif self.settings_dict['TIME_ZONE'] is None:
             return timezone.utc
         else:
-            return pytz.timezone(self.settings_dict['TIME_ZONE'])
+            return pds.timezone(self.settings_dict['TIME_ZONE'])
 
     @cached_property
     def timezone_name(self):

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -14,7 +14,7 @@ import warnings
 from itertools import chain
 from sqlite3 import dbapi2 as Database
 
-import pytz
+import pytz_deprecation_shim as pds
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db import IntegrityError
@@ -430,7 +430,7 @@ def _sqlite_datetime_parse(dt, tzname=None, conn_tzname=None):
     except (TypeError, ValueError):
         return None
     if conn_tzname:
-        dt = dt.replace(tzinfo=pytz.timezone(conn_tzname))
+        dt = dt.replace(tzinfo=pds.timezone(conn_tzname))
     if tzname is not None and tzname != conn_tzname:
         sign_index = tzname.find('+') + tzname.find('-') + 1
         if sign_index > -1:
@@ -440,7 +440,7 @@ def _sqlite_datetime_parse(dt, tzname=None, conn_tzname=None):
                 hours, minutes = offset.split(':')
                 offset_delta = datetime.timedelta(hours=int(hours), minutes=int(minutes))
                 dt += offset_delta if sign == '+' else -offset_delta
-        dt = timezone.localtime(dt, pytz.timezone(tzname))
+        dt = timezone.localtime(dt, pds.timezone(tzname))
     return dt
 
 

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -65,7 +65,7 @@ class DatetimeDatetimeSerializer(BaseSerializer):
         imports = ["import datetime"]
         if self.value.tzinfo is not None:
             imports.append("from django.utils.timezone import utc")
-        return repr(self.value).replace('<UTC>', 'utc'), set(imports)
+        return repr(self.value).replace(repr(utc), 'utc'), set(imports)
 
 
 class DecimalSerializer(BaseSerializer):

--- a/django/templatetags/tz.py
+++ b/django/templatetags/tz.py
@@ -1,6 +1,6 @@
 from datetime import datetime, tzinfo
 
-import pytz
+import pytz_deprecation_shim as pds
 
 from django.template import Library, Node, TemplateSyntaxError
 from django.utils import timezone
@@ -51,8 +51,7 @@ def do_timezone(value, arg):
         if timezone.is_naive(value):
             default_timezone = timezone.get_default_timezone()
             value = timezone.make_aware(value, default_timezone)
-    # Filters must never raise exceptions, and pytz' exceptions inherit
-    # Exception directly, not a specific subclass. So catch everything.
+    # Filters must never raise exceptions, so catch everything.
     except Exception:
         return ''
 
@@ -61,8 +60,8 @@ def do_timezone(value, arg):
         tz = arg
     elif isinstance(arg, str):
         try:
-            tz = pytz.timezone(arg)
-        except pytz.UnknownTimeZoneError:
+            tz = pds.timezone(arg)
+        except KeyError:
             return ''
     else:
         return ''

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,8 @@ include_package_data = true
 zip_safe = false
 install_requires =
     asgiref >= 3.2
-    pytz
+    pytz_deprecation_shim
+    tzdata >= 2020.1
     sqlparse >= 0.2.2
 
 [options.entry_points]

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -543,7 +543,7 @@ class NewDatabaseTests(TestCase):
             with connection.cursor() as cursor:
                 cursor.execute('SELECT CURRENT_TIMESTAMP')
                 now = cursor.fetchone()[0]
-                self.assertEqual(now.tzinfo.zone, 'Europe/Paris')
+                self.assertEqual(str(now.tzinfo), 'Europe/Paris')
 
     @requires_tz_support
     def test_filter_date_field_with_aware_datetime(self):


### PR DESCRIPTION
**Update**: see ticket-32365

Now that [PEP 495](https://www.python.org/dev/peps/pep-0495/) and [PEP 615](https://www.python.org/dev/peps/pep-0615/) have been accepted, there's not much reason to continue using `pytz`, and its [non-standard interface is a major source of bugs](https://blog.ganssle.io/articles/2018/03/pytz-fastest-footgun.html).

This PR is an attempt to see how difficult it would be to remove the dependency on `pytz` and replace it with a PEP 495-compatible time zone library.

Because I expect you'll have a bunch of end users who will be relying on `pytz`'s specific interface, instead of going straight for `backports.zoneinfo`, I've replaced it with [`pytz_deprecation_shim`](https://pytz-deprecation-shim.readthedocs.io/en/latest/), which is a library I wrote for the purpose of allowing libraries to gracefully deprecate `pytz` wherever it has leaked into their public interface. There are some semantic differences between the shims and `pytz` (as evidenced by some of the changes I've had to make here), but I've kept the semantics of all `pytz`-specific functions as close as possible (without being bug-for-bug compatible, mind you). End users using the `.localize` and `.normalize` functions or accessing the `.zone` attribute will get a warning.

This PR is still a draft while I work out some of the kinks. Since it's a proof-of-concept, I haven't tried re-writing the documentation.

I am also not really a Django user, so I'm not super sure whether users are allowed to supply their own time zones for some of this stuff. If so, it may be necessary to make some adjustments to account for the possibility that they would set a `pytz` time zone.