### PR TITLE
Fixed #31743 -- Doc't that managed=False prevents Django from managing tables modifications.

### DIFF
--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -157,11 +157,12 @@ Django quotes column and table names behind the scenes.
     part of a :djadmin:`flush` management command. That is, Django
     *manages* the database tables' lifecycles.
 
-    If ``False``, no database table creation or deletion operations will be
-    performed for this model. This is useful if the model represents an existing
-    table or a database view that has been created by some other means. This is
-    the *only* difference when ``managed=False``. All other aspects of
-    model handling are exactly the same as normal. This includes
+    If ``False``, no database table creation, modification, or deletion
+    operations will be performed for this model. This is useful if the model
+    represents an existing table or a database view that has been created by
+    some other means. This is the *only* difference when ``managed=False``. All
+    other aspects of model handling are exactly the same as normal. This
+    includes
 
     #. Adding an automatic primary key field to the model if you don't
        declare it.  To avoid confusion for later code readers, it's


### PR DESCRIPTION
Managed = false will also prevent modifications. This is made clear in the comments in the auto-generated output from inspectdb but is not mentioned here.  This PR helps prevent the over half day wasted wondering makemigrations saw no changes when adding a new column to the table.

It would also be nice to add something to the first paragraph to make it clear that managed= True allows for modifications of the schema in the database. 

For this ticket
https://code.djangoproject.com/ticket/31743#ticket