### PR TITLE
Reverted "Pinned asgiref == 3.2.7 in test requirements."

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,4 +1,4 @@
-asgiref == 3.2.7
+asgiref >= 3.2
 argon2-cffi >= 16.1.0
 bcrypt
 docutils


### PR DESCRIPTION
This reverts commit dcb4d79ef719d824431a8b3ff8ada879bbab21cc.