### PR TITLE
Fixed #31718 -- Add update_fields to User.save() in changepassword

### DIFF
--- a/django/contrib/auth/management/commands/changepassword.py
+++ b/django/contrib/auth/management/commands/changepassword.py
@@ -70,6 +70,6 @@ class Command(BaseCommand):
             raise CommandError("Aborting password change for user '%s' after %s attempts" % (u, count))
 
         u.set_password(p1)
-        u.save()
+        u.save(update_fields=("password",))
 
         return "Password changed successfully for user '%s'" % u


### PR DESCRIPTION
[Ticket #31718](https://code.djangoproject.com/ticket/31718#ticket)

Added `update_fields` to the `User.save()` call in `changepassword` command.