### PR TITLE
Fixed #25281 -- Make permission strings unique to identify permissions.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -480,7 +480,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         """
         opts = self.opts
         codename = get_permission_codename('add', opts)
-        return request.user.has_perm("%s.%s" % (opts.app_label, codename))
+        return request.user.has_perm("%s.%s.%s" % (opts.app_label, opts.model_name, codename))
 
     def has_change_permission(self, request, obj=None):
         """
@@ -495,7 +495,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         """
         opts = self.opts
         codename = get_permission_codename('change', opts)
-        return request.user.has_perm("%s.%s" % (opts.app_label, codename))
+        return request.user.has_perm("%s.%s.%s" % (opts.app_label, opts.model_name, codename))
 
     def has_delete_permission(self, request, obj=None):
         """
@@ -510,7 +510,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         """
         opts = self.opts
         codename = get_permission_codename('delete', opts)
-        return request.user.has_perm("%s.%s" % (opts.app_label, codename))
+        return request.user.has_perm("%s.%s.%s" % (opts.app_label, opts.model_name, codename))
 
     def has_view_permission(self, request, obj=None):
         """
@@ -527,8 +527,8 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         codename_view = get_permission_codename('view', opts)
         codename_change = get_permission_codename('change', opts)
         return (
-            request.user.has_perm('%s.%s' % (opts.app_label, codename_view)) or
-            request.user.has_perm('%s.%s' % (opts.app_label, codename_change))
+            request.user.has_perm('%s.%s.%s' % (opts.app_label, opts.model_name, codename_view)) or
+            request.user.has_perm('%s.%s.%s' % (opts.app_label, opts.model_name, codename_change))
         )
 
     def has_view_or_change_permission(self, request, obj=None):
@@ -2159,7 +2159,7 @@ class InlineModelAdmin(BaseModelAdmin):
                 opts = field.remote_field.model._meta
                 break
         return any(
-            request.user.has_perm('%s.%s' % (opts.app_label, get_permission_codename(perm, opts)))
+            request.user.has_perm('%s.%s.%s' % (opts.app_label, opts.model_name, get_permission_codename(perm, opts)))
             for perm in perms
         )
 

--- a/django/contrib/auth/context_processors.py
+++ b/django/contrib/auth/context_processors.py
@@ -1,16 +1,16 @@
-# PermWrapper and PermLookupDict proxy the permissions system into objects that
+# PermAppLabelWrapper, PermModelWrapper and PermLookupDict proxy the permissions system into objects that
 # the template system can understand.
 
 
 class PermLookupDict:
-    def __init__(self, user, app_label):
-        self.user, self.app_label = user, app_label
+    def __init__(self, user, app_label, model):
+        self.user, self.app_label, self.model = user, app_label, model
 
     def __repr__(self):
         return str(self.user.get_all_permissions())
 
     def __getitem__(self, perm_name):
-        return self.user.has_perm("%s.%s" % (self.app_label, perm_name))
+        return self.user.has_perm("%s.%s.%s" % (self.app_label, self.model, perm_name))
 
     def __iter__(self):
         # To fix 'item in perms.someapp' and __getitem__ interaction we need to
@@ -18,29 +18,56 @@ class PermLookupDict:
         raise TypeError("PermLookupDict is not iterable.")
 
     def __bool__(self):
+        return self.user.has_model_perms('%s.%s' % (self.app_label, self.model))
+
+
+class PermModelWrapper:
+    def __init__(self, user, app_label):
+        self.user, self.app_label = user, app_label
+
+    def __getitem__(self, model):
+        return PermLookupDict(self.user, self.app_label, model)
+
+    def __iter__(self):
+        raise TypeError("PermModelWrapper is not iterable.")
+
+    def __contains__(self, perm_name):
+        """
+        Lookup by "somemodel" or "somemodel.someperm" in perms.
+        """
+        if '.' not in perm_name:
+            # The name refers to model.
+            return bool(self[perm_name])
+        model, perm_name = perm_name.split('.', 1)
+        return self[model][perm_name]
+
+    def __bool__(self):
         return self.user.has_module_perms(self.app_label)
 
 
-class PermWrapper:
+class PermAppLabelWrapper:
     def __init__(self, user):
         self.user = user
 
     def __getitem__(self, app_label):
-        return PermLookupDict(self.user, app_label)
+        return PermModelWrapper(self.user, app_label)
 
     def __iter__(self):
         # I am large, I contain multitudes.
-        raise TypeError("PermWrapper is not iterable.")
+        raise TypeError("PermAppLabelWrapper is not iterable.")
 
     def __contains__(self, perm_name):
         """
-        Lookup by "someapp" or "someapp.someperm" in perms.
+        Lookup by "someapp", "someapp.somemodel" or "someapp.somemodel.someperm" in perms.
         """
         if '.' not in perm_name:
             # The name refers to module.
             return bool(self[perm_name])
-        app_label, perm_name = perm_name.split('.', 1)
-        return self[app_label][perm_name]
+        elif perm_name.count('.') == 1:
+            app_label, model = perm_name.split('.')
+            return self[app_label][model]
+        app_label, model, perm_name = perm_name.split('.', 2)
+        return self[app_label][model][perm_name]
 
 
 def auth(request):
@@ -59,5 +86,5 @@ def auth(request):
 
     return {
         'user': user,
-        'perms': PermWrapper(user),
+        'perms': PermAppLabelWrapper(user),
     }

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -1080,6 +1080,11 @@ authentication app::
             # Simplest possible answer: Yes, always
             return True
 
+        def has_model_perms(self, app_label_model):
+            "Does the user have permissions to view the `app_label.model`?"
+            # Simplest possible answer: Yes, always
+            return True
+
         @property
         def is_staff(self):
             "Is the user a member of staff?"

--- a/tests/admin_ordering/tests.py
+++ b/tests/admin_ordering/tests.py
@@ -21,6 +21,9 @@ class MockSuperUser:
     def has_module_perms(self, module):
         return True
 
+    def has_model_perms(self, module_model):
+        return True
+
 
 request = MockRequest()
 request.user = MockSuperUser()

--- a/tests/admin_views/custom_has_permission_admin.py
+++ b/tests/admin_views/custom_has_permission_admin.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ValidationError
 
 from . import admin as base_admin, models
 
-PERMISSION_NAME = 'admin_views.%s' % get_permission_codename('change', models.Article._meta)
+PERMISSION_NAME = 'admin_views.article.%s' % get_permission_codename('change', models.Article._meta)
 
 
 class PermissionAdminAuthenticationForm(AuthenticationForm):

--- a/tests/auth_tests/models/custom_user.py
+++ b/tests/auth_tests/models/custom_user.py
@@ -64,6 +64,9 @@ class CustomUser(AbstractBaseUser):
     def has_module_perms(self, app_label):
         return True
 
+    def has_model_perms(self, app_label_model):
+        return True
+
     # Admin required fields
     @property
     def is_staff(self):

--- a/tests/auth_tests/templates/context_processors/auth_attrs_perm_in_perms.html
+++ b/tests/auth_tests/templates/context_processors/auth_attrs_perm_in_perms.html
@@ -1,4 +1,6 @@
 {% if 'auth' in perms %}Has auth permissions{% endif %}
-{% if 'auth.add_permission' in perms %}Has auth.add_permission permissions{% endif %}
+{% if 'auth.permission' in perms %}Has auth.permission permissions{% endif %}
+{% if 'auth.permission.add_permission' in perms %}Has auth.permission.add_permission permissions{% endif %}
 {% if 'nonexistent' in perms %}nonexistent perm found{% endif %}
 {% if 'auth.nonexistent' in perms %}auth.nonexistent perm found{% endif %}
+{% if 'auth.permission.nonexistent' in perms %}auth.permission.nonexistent perm found{% endif %}

--- a/tests/auth_tests/templates/context_processors/auth_attrs_perms.html
+++ b/tests/auth_tests/templates/context_processors/auth_attrs_perms.html
@@ -1,4 +1,6 @@
 {% if perms.auth %}Has auth permissions{% endif %}
-{% if perms.auth.add_permission %}Has auth.add_permission permissions{% endif %}
+{% if perms.auth.permission %}Has auth.permission permissions{% endif %}
+{% if perms.auth.permission.add_permission %}Has auth.permission.add_permission permissions{% endif %}
 {% if perms.nonexistent %}nonexistent perm found{% endif %}
 {% if perms.auth.nonexistent in perms %}auth.nonexistent perm found{% endif %}
+{% if perms.auth.permission.nonexistent in perms %}auth.permission.nonexistent perm found{% endif %}

--- a/tests/auth_tests/test_decorators.py
+++ b/tests/auth_tests/test_decorators.py
@@ -69,7 +69,7 @@ class PermissionsRequiredDecoratorTest(TestCase):
 
     def test_many_permissions_pass(self):
 
-        @permission_required(['auth_tests.add_customuser', 'auth_tests.change_customuser'])
+        @permission_required(['auth_tests.customuser.add_customuser', 'auth_tests.customuser.change_customuser'])
         def a_view(request):
             return HttpResponse()
         request = self.factory.get('/rand')
@@ -79,7 +79,7 @@ class PermissionsRequiredDecoratorTest(TestCase):
 
     def test_many_permissions_in_set_pass(self):
 
-        @permission_required({'auth_tests.add_customuser', 'auth_tests.change_customuser'})
+        @permission_required({'auth_tests.customuser.add_customuser', 'auth_tests.customuser.change_customuser'})
         def a_view(request):
             return HttpResponse()
         request = self.factory.get('/rand')
@@ -89,7 +89,7 @@ class PermissionsRequiredDecoratorTest(TestCase):
 
     def test_single_permission_pass(self):
 
-        @permission_required('auth_tests.add_customuser')
+        @permission_required('auth_tests.customuser.add_customuser')
         def a_view(request):
             return HttpResponse()
         request = self.factory.get('/rand')
@@ -99,7 +99,10 @@ class PermissionsRequiredDecoratorTest(TestCase):
 
     def test_permissioned_denied_redirect(self):
 
-        @permission_required(['auth_tests.add_customuser', 'auth_tests.change_customuser', 'nonexistent-permission'])
+        @permission_required([
+            'auth_tests.customuser.add_customuser', 'auth_tests.customuser.change_customuser',
+            'nonexistent-permission',
+        ])
         def a_view(request):
             return HttpResponse()
         request = self.factory.get('/rand')
@@ -110,7 +113,7 @@ class PermissionsRequiredDecoratorTest(TestCase):
     def test_permissioned_denied_exception_raised(self):
 
         @permission_required([
-            'auth_tests.add_customuser', 'auth_tests.change_customuser', 'nonexistent-permission'
+            'auth_tests.customuser.add_customuser', 'auth_tests.customuser.change_customuser', 'nonexistent-permission'
         ], raise_exception=True)
         def a_view(request):
             return HttpResponse()

--- a/tests/auth_tests/test_migrations.py
+++ b/tests/auth_tests/test_migrations.py
@@ -54,15 +54,18 @@ class ProxyModelWithDifferentAppLabelTests(TransactionTestCase):
         user.user_permissions.add(self.default_permission)
         user.user_permissions.add(self.custom_permission)
         for permission in [self.default_permission, self.custom_permission]:
-            self.assertTrue(user.has_perm('auth.' + permission.codename))
-            self.assertFalse(user.has_perm('auth_tests.' + permission.codename))
+            self.assertTrue(user.has_perm('auth.%s.%s' % (permission.content_type.model, permission.codename)))
+            self.assertFalse(user.has_perm('auth_tests.%s.%s' % (permission.content_type.model, permission.codename)))
         with connection.schema_editor() as editor:
             update_proxy_permissions.update_proxy_model_permissions(apps, editor)
         # Reload user to purge the _perm_cache.
         user = User._default_manager.get(pk=user.pk)
+        # Reload permissions to update related content_type obj.
+        self.default_permission.refresh_from_db()
+        self.custom_permission.refresh_from_db()
         for permission in [self.default_permission, self.custom_permission]:
-            self.assertFalse(user.has_perm('auth.' + permission.codename))
-            self.assertTrue(user.has_perm('auth_tests.' + permission.codename))
+            self.assertFalse(user.has_perm('auth.%s.%s' % (permission.content_type.model, permission.codename)))
+            self.assertTrue(user.has_perm('auth_tests.%s.%s' % (permission.content_type.model, permission.codename)))
 
     def test_migrate_backwards(self):
         with connection.schema_editor() as editor:
@@ -78,16 +81,19 @@ class ProxyModelWithDifferentAppLabelTests(TransactionTestCase):
         user.user_permissions.add(self.default_permission)
         user.user_permissions.add(self.custom_permission)
         for permission in [self.default_permission, self.custom_permission]:
-            self.assertTrue(user.has_perm('auth.' + permission.codename))
-            self.assertFalse(user.has_perm('auth_tests.' + permission.codename))
+            self.assertTrue(user.has_perm('auth.%s.%s' % (permission.content_type.model, permission.codename)))
+            self.assertFalse(user.has_perm('auth_tests.%s.%s' % (permission.content_type.model, permission.codename)))
         with connection.schema_editor() as editor:
             update_proxy_permissions.update_proxy_model_permissions(apps, editor)
             update_proxy_permissions.revert_proxy_model_permissions(apps, editor)
         # Reload user to purge the _perm_cache.
         user = User._default_manager.get(pk=user.pk)
+        # Reload permissions to update related content_type obj.
+        self.default_permission.refresh_from_db()
+        self.custom_permission.refresh_from_db()
         for permission in [self.default_permission, self.custom_permission]:
-            self.assertTrue(user.has_perm('auth.' + permission.codename))
-            self.assertFalse(user.has_perm('auth_tests.' + permission.codename))
+            self.assertTrue(user.has_perm('auth.%s.%s' % (permission.content_type.model, permission.codename)))
+            self.assertFalse(user.has_perm('auth_tests.%s.%s' % (permission.content_type.model, permission.codename)))
 
 
 class ProxyModelWithSameAppLabelTests(TransactionTestCase):
@@ -132,13 +138,16 @@ class ProxyModelWithSameAppLabelTests(TransactionTestCase):
         user.user_permissions.add(self.default_permission)
         user.user_permissions.add(self.custom_permission)
         for permission in [self.default_permission, self.custom_permission]:
-            self.assertTrue(user.has_perm('auth_tests.' + permission.codename))
+            self.assertTrue(user.has_perm('auth_tests.%s.%s' % (permission.content_type.model, permission.codename)))
         with connection.schema_editor() as editor:
             update_proxy_permissions.update_proxy_model_permissions(apps, editor)
         # Reload user to purge the _perm_cache.
         user = User._default_manager.get(pk=user.pk)
+        # Reload permissions to update related content_type obj.
+        self.default_permission.refresh_from_db()
+        self.custom_permission.refresh_from_db()
         for permission in [self.default_permission, self.custom_permission]:
-            self.assertTrue(user.has_perm('auth_tests.' + permission.codename))
+            self.assertTrue(user.has_perm('auth_tests.%s.%s' % (permission.content_type.model, permission.codename)))
 
     def test_migrate_backwards(self):
         with connection.schema_editor() as editor:
@@ -154,14 +163,17 @@ class ProxyModelWithSameAppLabelTests(TransactionTestCase):
         user.user_permissions.add(self.default_permission)
         user.user_permissions.add(self.custom_permission)
         for permission in [self.default_permission, self.custom_permission]:
-            self.assertTrue(user.has_perm('auth_tests.' + permission.codename))
+            self.assertTrue(user.has_perm('auth_tests.%s.%s' % (permission.content_type.model, permission.codename)))
         with connection.schema_editor() as editor:
             update_proxy_permissions.update_proxy_model_permissions(apps, editor)
             update_proxy_permissions.revert_proxy_model_permissions(apps, editor)
         # Reload user to purge the _perm_cache.
         user = User._default_manager.get(pk=user.pk)
+        # Reload permissions to update related content_type obj.
+        self.default_permission.refresh_from_db()
+        self.custom_permission.refresh_from_db()
         for permission in [self.default_permission, self.custom_permission]:
-            self.assertTrue(user.has_perm('auth_tests.' + permission.codename))
+            self.assertTrue(user.has_perm('auth_tests.%s.%s' % (permission.content_type.model, permission.codename)))
 
     def test_migrate_with_existing_target_permission(self):
         """

--- a/tests/auth_tests/test_mixins.py
+++ b/tests/auth_tests/test_mixins.py
@@ -37,12 +37,12 @@ class AlwaysFalseView(AlwaysFalseMixin, EmptyResponseView):
 
 
 class StackedMixinsView1(LoginRequiredMixin, PermissionRequiredMixin, EmptyResponseView):
-    permission_required = ['auth_tests.add_customuser', 'auth_tests.change_customuser']
+    permission_required = ['auth_tests.customuser.add_customuser', 'auth_tests.customuser.change_customuser']
     raise_exception = True
 
 
 class StackedMixinsView2(PermissionRequiredMixin, LoginRequiredMixin, EmptyResponseView):
-    permission_required = ['auth_tests.add_customuser', 'auth_tests.change_customuser']
+    permission_required = ['auth_tests.customuser.add_customuser', 'auth_tests.customuser.change_customuser']
     raise_exception = True
 
 
@@ -231,7 +231,7 @@ class PermissionsRequiredMixinTests(TestCase):
 
     def test_many_permissions_pass(self):
         class AView(PermissionRequiredMixin, EmptyResponseView):
-            permission_required = ['auth_tests.add_customuser', 'auth_tests.change_customuser']
+            permission_required = ['auth_tests.customuser.add_customuser', 'auth_tests.customuser.change_customuser']
 
         request = self.factory.get('/rand')
         request.user = self.user
@@ -240,7 +240,7 @@ class PermissionsRequiredMixinTests(TestCase):
 
     def test_single_permission_pass(self):
         class AView(PermissionRequiredMixin, EmptyResponseView):
-            permission_required = 'auth_tests.add_customuser'
+            permission_required = 'auth_tests.customuser.add_customuser'
 
         request = self.factory.get('/rand')
         request.user = self.user
@@ -250,7 +250,8 @@ class PermissionsRequiredMixinTests(TestCase):
     def test_permissioned_denied_redirect(self):
         class AView(PermissionRequiredMixin, EmptyResponseView):
             permission_required = [
-                'auth_tests.add_customuser', 'auth_tests.change_customuser', 'nonexistent-permission',
+                'auth_tests.customuser.add_customuser', 'auth_tests.customuser.change_customuser',
+                'nonexistent-permission',
             ]
 
         # Authenticated users receive PermissionDenied.
@@ -266,7 +267,8 @@ class PermissionsRequiredMixinTests(TestCase):
     def test_permissioned_denied_exception_raised(self):
         class AView(PermissionRequiredMixin, EmptyResponseView):
             permission_required = [
-                'auth_tests.add_customuser', 'auth_tests.change_customuser', 'nonexistent-permission',
+                'auth_tests.customuser.add_customuser', 'auth_tests.customuser.change_customuser',
+                'nonexistent-permission',
             ]
             raise_exception = True
 

--- a/tests/modeladmin/test_actions.py
+++ b/tests/modeladmin/test_actions.py
@@ -31,7 +31,7 @@ class AdminActionsTests(TestCase):
                 pass
 
             def has_custom_permission(self, request):
-                return request.user.has_perm('%s.custom_band' % self.opts.app_label)
+                return request.user.has_perm('%s.%s.custom_band' % (self.opts.app_label, self.opts.model_name))
 
         ma = BandAdmin(Band, admin.AdminSite())
         mock_request = MockRequest()

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -729,21 +729,24 @@ class ModelAdminPermissionTests(SimpleTestCase):
         def has_module_perms(self, app_label):
             return app_label == 'modeladmin'
 
+        def has_model_perms(self, app_label_model):
+            return app_label_model == 'modeladmin.band'
+
     class MockViewUser(MockUser):
         def has_perm(self, perm):
-            return perm == 'modeladmin.view_band'
+            return perm == 'modeladmin.band.view_band'
 
     class MockAddUser(MockUser):
         def has_perm(self, perm):
-            return perm == 'modeladmin.add_band'
+            return perm == 'modeladmin.band.add_band'
 
     class MockChangeUser(MockUser):
         def has_perm(self, perm):
-            return perm == 'modeladmin.change_band'
+            return perm == 'modeladmin.band.change_band'
 
     class MockDeleteUser(MockUser):
         def has_perm(self, perm):
-            return perm == 'modeladmin.delete_band'
+            return perm == 'modeladmin.band.delete_band'
 
     def test_has_view_permission(self):
         """


### PR DESCRIPTION
Fix not unique permission strings. From '"**app_label.permission**" to "**app_label.model.permission**". I used info from the [ticket](https://code.djangoproject.com/ticket/25281) + [google groups](https://groups.google.com/forum/#!searchin/django-developers/permissions/django-developers/ngV5KhLXUrQ/DTfqhG0LRG4J).