### PR TITLE
Fixed #16300 -- Improved singlehtml docs formatting with headers CSS.

### DIFF
--- a/docs/_theme/djangodocs/static/djangodocs.css
+++ b/docs/_theme/djangodocs/static/djangodocs.css
@@ -48,7 +48,8 @@ h1 { font-size:218%; margin-top:0.6em; margin-bottom:.4em; line-height:1.1em; }
 h2 { font-size:175%; margin-bottom:.6em; line-height:1.2em; color:#092e20; }
 h3 { font-size:150%; font-weight:bold; margin-bottom:.2em; color:#487858; }
 h4 { font-size:125%; font-weight:bold; margin-top:1.5em; margin-bottom:3px; }
-h5,h6,h7,h8,h9,h10,h11,h12 { font-size:110%; font-weight:bold; margin-top:1em; margin-bottom:3px; }
+h5 { font-size:110%; font-weight:bold; margin-top:1em; margin-bottom:3px; }
+h6,h7,h8,h9,h10,h11,h12 { font-weight:bold; margin-bottom:3px; }
 div.figure { text-align: center; }
 div.figure p.caption { font-size:1em; margin-top:0; margin-bottom:1.5em; color: #555;}
 hr { color:#ccc; background-color:#ccc; height:1px; border:0; }

--- a/docs/_theme/djangodocs/static/djangodocs.css
+++ b/docs/_theme/djangodocs/static/djangodocs.css
@@ -43,12 +43,12 @@ div.nav { margin: 0; font-size: 11px; text-align: right; color: #487858;}
 
 /*** basic styles ***/
 dd { margin-left:15px; }
-h1,h2,h3,h4,h5 { margin-top:1em; font-family:"Trebuchet MS",sans-serif; font-weight:normal; }
+h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11,h12 { margin-top:1em; font-family:"Trebuchet MS",sans-serif; font-weight:normal; }
 h1 { font-size:218%; margin-top:0.6em; margin-bottom:.4em; line-height:1.1em; }
 h2 { font-size:175%; margin-bottom:.6em; line-height:1.2em; color:#092e20; }
 h3 { font-size:150%; font-weight:bold; margin-bottom:.2em; color:#487858; }
 h4 { font-size:125%; font-weight:bold; margin-top:1.5em; margin-bottom:3px; }
-h5 { font-size:110%; font-weight:bold; margin-top:1em; margin-bottom:3px; }
+h5,h6,h7,h8,h9,h10,h11,h12 { font-size:110%; font-weight:bold; margin-top:1em; margin-bottom:3px; }
 div.figure { text-align: center; }
 div.figure p.caption { font-size:1em; margin-top:0; margin-bottom:1.5em; color: #555;}
 hr { color:#ccc; background-color:#ccc; height:1px; border:0; }


### PR DESCRIPTION
When using "make singlehtml" headings up to "h12" are created. Added some basic
styling to these to distinguish between paragraph text.

[Ticket #16300](https://code.djangoproject.com/ticket/16300)