### PR TITLE
Removed unused param_dict return from URLResolver.resolve_error_handler().

### DIFF
--- a/django/core/handlers/exception.py
+++ b/django/core/handlers/exception.py
@@ -117,8 +117,8 @@ def response_for_exception(request, exc):
 
 def get_exception_response(request, resolver, status_code, exception):
     try:
-        callback, param_dict = resolver.resolve_error_handler(status_code)
-        response = callback(request, **{**param_dict, 'exception': exception})
+        callback = resolver.resolve_error_handler(status_code)
+        response = callback(request, exception=exception)
     except Exception:
         signals.got_request_exception.send(sender=None, request=request)
         response = handle_uncaught_exception(request, resolver, sys.exc_info())
@@ -138,5 +138,5 @@ def handle_uncaught_exception(request, resolver, exc_info):
         return debug.technical_500_response(request, *exc_info)
 
     # Return an HttpResponse that displays a friendly error message.
-    callback, param_dict = resolver.resolve_error_handler(500)
-    return callback(request, **param_dict)
+    callback = resolver.resolve_error_handler(500)
+    return callback(request)

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -416,7 +416,7 @@ class URLResolver:
         # which takes (request).
         for status_code, num_parameters in [(400, 2), (403, 2), (404, 2), (500, 1)]:
             try:
-                handler, param_dict = self.resolve_error_handler(status_code)
+                handler = self.resolve_error_handler(status_code)
             except (ImportError, ViewDoesNotExist) as e:
                 path = getattr(self.urlconf_module, 'handler%s' % status_code)
                 msg = (
@@ -605,7 +605,7 @@ class URLResolver:
             # django.conf.urls imports this file.
             from django.conf import urls
             callback = getattr(urls, 'handler%s' % view_type)
-        return get_callable(callback), {}
+        return get_callable(callback)
 
     def reverse(self, lookup_view, *args, **kwargs):
         return self._reverse_with_prefix(lookup_view, '', *args, **kwargs)

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -1065,16 +1065,14 @@ class ErrorHandlerResolutionTests(SimpleTestCase):
         self.callable_resolver = URLResolver(RegexPattern(r'^$'), urlconf_callables)
 
     def test_named_handlers(self):
-        handler = (empty_view, {})
         for code in [400, 404, 500]:
             with self.subTest(code=code):
-                self.assertEqual(self.resolver.resolve_error_handler(code), handler)
+                self.assertEqual(self.resolver.resolve_error_handler(code), empty_view)
 
     def test_callable_handlers(self):
-        handler = (empty_view, {})
         for code in [400, 404, 500]:
             with self.subTest(code=code):
-                self.assertEqual(self.callable_resolver.resolve_error_handler(code), handler)
+                self.assertEqual(self.callable_resolver.resolve_error_handler(code), empty_view)
 
 
 @override_settings(ROOT_URLCONF='urlpatterns_reverse.urls_without_handlers')


### PR DESCRIPTION
This empty dict seems to have always been present since a55598cbdd5e8ab58bb58e2178ccbe155526d735, but serves no purpose that I can tell.