### PR TITLE
Removed wrong admonition in argon2 docs.

### DIFF
--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -203,12 +203,6 @@ follows:
    Pick a ``time_cost`` that takes an acceptable time for you.
    If ``time_cost`` set to 1 is unacceptably slow, lower ``memory_cost``.
 
-.. admonition:: ``memory_cost`` interpretation
-
-    The argon2 command-line utility and some other libraries interpret the
-    ``memory_cost`` parameter differently from the value that Django uses. The
-    conversion is given by ``memory_cost == 2 ** memory_cost_commandline``.
-
 .. _password-upgrades:
 
 Password upgrading


### PR DESCRIPTION
This does not seem to be true, python -m argon2 lists KiB:
```
python -m argon2 -m 512
Running Argon2id 100 times with:
hash_len: 16 bytes
memory_cost: 512 KiB
parallelism: 8 threads
time_cost: 2 iterations
```

And we use them as such:
https://github.com/hynek/argon2-cffi/blob/b42a51818d1180637bd3a9e99c0d1de87d511a51/src/argon2/_password_hasher.py#L40
https://github.com/django/django/blob/258c88a913fe1e7704cdb6f61c6ceb7493f6092a/django/contrib/auth/hashers.py#L311-L319