### PR TITLE
Changed ` to ', because ` broke all localisations

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -154,7 +154,7 @@ class UserAttributeSimilarityValidator:
                     )
 
     def get_help_text(self):
-        return _('Your password can’t be too similar to your other personal information.')
+        return _("Your password can't be too similar to your other personal information.")
 
 
 class CommonPasswordValidator:
@@ -185,7 +185,7 @@ class CommonPasswordValidator:
             )
 
     def get_help_text(self):
-        return _('Your password can’t be a commonly used password.')
+        return _("Your password can't be a commonly used password.")
 
 
 class NumericPasswordValidator:
@@ -200,4 +200,4 @@ class NumericPasswordValidator:
             )
 
     def get_help_text(self):
-        return _('Your password can’t be entirely numeric.')
+        return _("Your password can't be entirely numeric.")


### PR DESCRIPTION
Changed \` to ', because ` broke all localisations
before -
[http://i.imgur.com/cBJdXSf.png](url)
after -
[http://i.imgur.com/0uciFaS.png](url)