### PR TITLE
Fixed #31736 -- Fixed InspectDBTransactionalTests.test_foreign_data_wrapper crash on Windows.

### DIFF
--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -1,3 +1,4 @@
+import os
 import re
 from io import StringIO
 from unittest import mock, skipUnless
@@ -381,9 +382,9 @@ class InspectDBTransactionalTests(TransactionTestCase):
                     sepal_length real,
                     sepal_width real
                 ) SERVER inspectdb_server OPTIONS (
-                    filename '/dev/null'
+                    filename %s
                 )
-            ''')
+            ''', [os.devnull])
         out = StringIO()
         foreign_table_model = 'class InspectdbIrisForeignTable(models.Model):'
         foreign_table_managed = 'managed = False'


### PR DESCRIPTION
Changed filename used in test_foreign_data_wrapper from constant '/dev/null' to os.devnull to work on Windows