### PR TITLE
Fixed #31735 -- Fixed migrations crash on namespaced inline FK addition on PostgreSQL.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -466,8 +466,10 @@ class BaseDatabaseSchemaEditor:
             if self.sql_create_column_inline_fk:
                 to_table = field.remote_field.model._meta.db_table
                 to_column = field.remote_field.model._meta.get_field(field.remote_field.field_name).column
+                namespace, _ = split_identifier(model._meta.db_table)
                 definition += " " + self.sql_create_column_inline_fk % {
                     'name': self._fk_constraint_name(model, field, constraint_suffix),
+                    'namespace': '%s.' % self.quote_name(namespace) if namespace else '',
                     'column': self.quote_name(field.column),
                     'to_table': self.quote_name(to_table),
                     'to_column': self.quote_name(to_column),

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -27,7 +27,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     # transaction.
     sql_create_column_inline_fk = (
         'CONSTRAINT %(name)s REFERENCES %(to_table)s(%(to_column)s)%(deferrable)s'
-        '; SET CONSTRAINTS %(name)s IMMEDIATE'
+        '; SET CONSTRAINTS %(namespace)s%(name)s IMMEDIATE'
     )
     # Setting the constraint to IMMEDIATE runs any deferred checks to allow
     # dropping it in the same transaction.

--- a/docs/releases/3.0.8.txt
+++ b/docs/releases/3.0.8.txt
@@ -18,3 +18,7 @@ Bugfixes
 * Reallowed, following a regression in Django 3.0, non-expressions having a
   ``filterable`` attribute to be used as the right-hand side in queryset
   filters (:ticket:`31664`).
+
+* Fixed a regression in Django 3.0.2 that caused a migration crash on
+  PostgreSQL when adding a foreign key to a model with a namespaced
+  ``db_table`` (:ticket:`31735`).


### PR DESCRIPTION
The namespace of the constraint must be included when making the constraint immediate.

Refs #31106.

Thanks Rodrigo Estevao for the report.