### PR TITLE
Update signing.py for encode error

### DIFF
--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -84,10 +84,10 @@ class JSONSerializer:
     signing.loads.
     """
     def dumps(self, obj):
-        return json.dumps(obj, separators=(',', ':')).encode('latin-1')
+        return json.dumps(obj, separators=(',', ':')).encode('utf-8')
 
     def loads(self, data):
-        return json.loads(data.decode('latin-1'))
+        return json.loads(data.decode('utf-8'))
 
 
 def dumps(obj, key=None, salt='django.core.signing', serializer=JSONSerializer, compress=False):


### PR DESCRIPTION
When session_dict has Chinese charactors, Encoded error occur.
change  django.core.signing.JSONSerializer encoded mode from latin-1 to utf-8