### PR TITLE
Refs #31358 -- Change salt measurement from characters to bits of entropy

### DIFF
--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -137,6 +137,28 @@ To use Bcrypt as your default storage algorithm, do the following:
 That's it -- now your Django install will use Bcrypt as the default storage
 algorithm.
 
+Increasing the salt entropy
+---------------------------
+
+BasePasswordHasher
+~~~~~~~~~~~~~~~~~~
+
+Most password hashes include a salt along with their password hash in order
+to protect against rainbow table attacks. The salt itself is a random value
+which increases the size and thus the cost of the rainbow table and is currently
+set at 71 bits with the ``salt_entropy`` value in the ``BasePasswordHasher``. As
+computing and storage costs decrease this value should be raised. When implementing
+your own password hasher you are free to override this value in order to use
+a desired entropy level for your password hashes. ``salt_entropy`` is measured in
+bits.
+
+Implementation detail
+~~~~~~~~~~~~~~~~~~~~~
+
+Due to the method in which salt values are stored the ``salt_entropy`` value is
+effectively a minimum value. For instance a value of 128 would provide a salt
+which would actually contain 131 bits of entropy.
+
 .. _increasing-password-algorithm-work-factor:
 
 Increasing the work factor


### PR DESCRIPTION
This commit is in partial service of ticket
https://code.djangoproject.com/ticket/31358
It changes the measurement of the BasePasswordHasher salt
from character length to bits of entropy. Given the current
ascii encoding this code returns a salt with entropy greater than
or equal to the new `salt_entropy` value which has been set to ~128bits~ 71bits