### PR TITLE
Fixed broken test_clean_does_deduplicate_values on Oracle after e13cfc6dfd4212ef7a40db1a41d3ae6ac4b97de0.

### DIFF
--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1863,11 +1863,11 @@ class ModelMultipleChoiceFieldTests(TestCase):
             self.assertTrue(form.has_changed())
 
     def test_clean_does_deduplicate_values(self):
-        class WriterForm(forms.Form):
-            persons = forms.ModelMultipleChoiceField(queryset=Writer.objects.all())
+        class PersonForm(forms.Form):
+            persons = forms.ModelMultipleChoiceField(queryset=Person.objects.all())
 
-        person1 = Writer.objects.create(name="Person 1")
-        form = WriterForm(data={})
+        person1 = Person.objects.create(name='Person 1')
+        form = PersonForm(data={})
         queryset = form.fields['persons'].clean([str(person1.pk)] * 50)
         sql, params = queryset.query.sql_with_params()
         self.assertEqual(len(params), 1)


### PR DESCRIPTION
Boolean filters are passed in `params` on Oracle. I switched to models without extra filters. 

See [logs](https://djangoci.com/job/pull-requests-oracle/database=oracle18,label=bionic4,python=python3.8/161/testReport/junit/model_forms.tests/ModelMultipleChoiceFieldTests/test_clean_does_deduplicate_values/).