### PR TITLE
Fixed #31745 -- Added error messages when using UniqueConstraint.include/opclasses with deferrable.

### DIFF
--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -95,6 +95,14 @@ class UniqueConstraint(BaseConstraint):
             raise ValueError(
                 'UniqueConstraint with conditions cannot be deferred.'
             )
+        if include and deferrable:
+            raise ValueError(
+                'UniqueConstraint with include fields cannot be deferred.'
+            )
+        if opclasses and deferrable:
+            raise ValueError(
+                'UniqueConstraint with opclasses cannot be deferred.'
+            )
         if not isinstance(deferrable, (type(None), Deferrable)):
             raise ValueError(
                 'UniqueConstraint.deferrable must be a Deferrable instance.'

--- a/docs/ref/models/constraints.txt
+++ b/docs/ref/models/constraints.txt
@@ -136,6 +136,10 @@ By default constraints are not deferred. A deferred constraint will not be
 enforced until the end of the transaction. An immediate constraint will be
 enforced immediately after every command.
 
+Note that only constraints can be deferred and thus can not be combined with
+options which require the usage of an explicit unique index, like
+:attr:`~UniqueConstraint.condition` and :attr:`~UniqueConstraint.include`.
+
 .. admonition:: MySQL, MariaDB, and SQLite.
 
     Deferrable unique constraints are ignored on MySQL, MariaDB, and SQLite as

--- a/docs/ref/models/constraints.txt
+++ b/docs/ref/models/constraints.txt
@@ -136,10 +136,6 @@ By default constraints are not deferred. A deferred constraint will not be
 enforced until the end of the transaction. An immediate constraint will be
 enforced immediately after every command.
 
-Note that only constraints can be deferred and thus can not be combined with
-options which require the usage of an explicit unique index, like
-:attr:`~UniqueConstraint.condition` and :attr:`~UniqueConstraint.include`.
-
 .. admonition:: MySQL, MariaDB, and SQLite.
 
     Deferrable unique constraints are ignored on MySQL, MariaDB, and SQLite as

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -406,6 +406,26 @@ class UniqueConstraintTests(TestCase):
                 deferrable=models.Deferrable.DEFERRED,
             )
 
+    def test_deferrable_with_include(self):
+        message = 'UniqueConstraint with include fields cannot be deferred.'
+        with self.assertRaisesMessage(ValueError, message):
+            models.UniqueConstraint(
+                fields=['name'],
+                name='name_inc_color_color_unique',
+                include=['color'],
+                deferrable=models.Deferrable.DEFERRED,
+            )
+
+    def test_deferrable_with_opclasses(self):
+        message = 'UniqueConstraint with opclasses cannot be deferred.'
+        with self.assertRaisesMessage(ValueError, message):
+            models.UniqueConstraint(
+                fields=['name'],
+                name='name_text_pattern_ops_unique',
+                opclasses=['text_pattern_ops'],
+                deferrable=models.Deferrable.DEFERRED,
+            )
+
     def test_invalid_defer_argument(self):
         message = 'UniqueConstraint.deferrable must be a Deferrable instance.'
         with self.assertRaisesMessage(ValueError, message):


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/31745