### PR TITLE
Link from "Making queries" doc to "QuerySet API reference" doc

### DIFF
--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -9,6 +9,8 @@ automatically gives you a database-abstraction API that lets you create,
 retrieve, update and delete objects. This document explains how to use this
 API. Refer to the :doc:`data model reference </ref/models/index>` for full
 details of all the various model lookup options.
+Refer to the :doc: `QuerySet API reference </ref/models/querysets>` for
+additional details of queryset filter options.
 
 Throughout this guide (and in the reference), we'll refer to the following
 models, which comprise a Weblog application:

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -9,7 +9,7 @@ automatically gives you a database-abstraction API that lets you create,
 retrieve, update and delete objects. This document explains how to use this
 API. Refer to the :doc:`data model reference </ref/models/index>` for full
 details of all the various model lookup options.
-Refer to the :doc: `QuerySet API reference </ref/models/querysets>` for
+Refer to the :doc:`QuerySet API reference </ref/models/querysets>` for
 additional details of queryset filter options.
 
 Throughout this guide (and in the reference), we'll refer to the following


### PR DESCRIPTION
I wanted to filter a `QuerySet` by upper and lower bounds (on a DateTime field).

I found myself searching through "Making queries" and saw sections such as "Field lookups" showing `__gt` examples, but the `__range` section is not mentioned.

My hope is, linking from "Making queries" to "QuerySet API reference", will make it easier to jump from how queries conceptually work to more details around available filters / manager methods.