### PR TITLE
Fixed #23797 -- Fixed QuerySet.exclude() when rhs is a nullable column.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -392,6 +392,7 @@ answer newbie questions, and generally made Django that much better:
     Jacob Burch <jacobburch@gmail.com>
     Jacob Green
     Jacob Kaplan-Moss <jacob@jacobian.org>
+    Jacob Walls <http://www.jacobtylerwalls.com/>
     Jakub Paczkowski <jakub@paczkowski.eu>
     Jakub Wilk <jwilk@jwilk.net>
     Jakub Wiśniowski <restless.being@gmail.com>

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1324,9 +1324,7 @@ class Query(BaseExpression):
         require_outer = lookup_type == 'isnull' and condition.rhs is True and not current_negated
         if current_negated and (lookup_type != 'isnull' or condition.rhs is False) and condition.rhs is not None:
             require_outer = True
-            if (lookup_type != 'isnull' and (
-                    self.is_nullable(targets[0]) or
-                    self.alias_map[join_list[-1]].join_type == LOUTER)):
+            if lookup_type != 'isnull':
                 # The condition added here will be SQL like this:
                 # NOT (col IS NOT NULL), where the first NOT is added in
                 # upper layers of code. The reason for addition is that if col
@@ -1336,9 +1334,18 @@ class Query(BaseExpression):
                 # (col IS NULL OR col != someval)
                 #   <=>
                 # NOT (col IS NOT NULL AND col = someval).
-                lookup_class = targets[0].get_lookup('isnull')
-                col = self._get_col(targets[0], join_info.targets[0], alias)
-                clause.add(lookup_class(col, False), AND)
+                if (
+                    self.is_nullable(targets[0]) or
+                    self.alias_map[join_list[-1]].join_type == LOUTER
+                ):
+                    lookup_class = targets[0].get_lookup('isnull')
+                    col = self._get_col(targets[0], join_info.targets[0], alias)
+                    clause.add(lookup_class(col, False), AND)
+                # If someval is a nullable column, someval IS NOT NULL is
+                # added.
+                if isinstance(value, Col) and self.is_nullable(value.target):
+                    lookup_class = value.target.get_lookup('isnull')
+                    clause.add(lookup_class(value, False), AND)
         return clause, used_joins if not require_outer else ()
 
     def add_filter(self, filter_clause):

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -142,6 +142,7 @@ class Cover(models.Model):
 class Number(models.Model):
     num = models.IntegerField()
     other_num = models.IntegerField(null=True)
+    another_num = models.IntegerField(null=True)
 
     def __str__(self):
         return str(self.num)


### PR DESCRIPTION
Fixes https://code.djangoproject.com/ticket/23797

The referenced ticket demonstrates that `exclude()` and `filter()` are not complementary when the value of an `F()` expression is NULL. The discussion on the ticket reports that:
 • `exclude()` and `filter()` should be complementary, and thus that `exclude()` should return a record where the `F()` expression evaluates to NULL
 • The requisite query should be: ``NOT ((length = width) AND (length IS NOT NULL) AND (width IS NOT NULL))`` to avoid performance problems with `IS TRUE`, which is to say, for `exclude()` to return a record, one of three things must obtain: the comparison test fails, the tested value is null, or the comparison value is null.
 • The change should happen directly in `build_filter()`

Then discussion trails off. This was straightforward to implement; I just needed to check if the value (in the place of the F expression) was an instance of a `Col` before adding the `IS NOT NULL` clause. I look forward to your feedback. :-)
