### PR TITLE
Fixed #30807 -- Fixed TestArchive.test_extract_file_permissions() when umask is 0o000.

### DIFF
--- a/tests/utils_tests/test_archive.py
+++ b/tests/utils_tests/test_archive.py
@@ -44,4 +44,4 @@ class TestArchive(unittest.TestCase):
                 self.assertEqual(os.stat(filepath).st_mode & mask, 0o775)
                 # A file is readable even if permission data is missing.
                 filepath = os.path.join(tmpdir, 'no_permissions')
-                self.assertEqual(os.stat(filepath).st_mode & mask, 0o664 & ~umask)
+                self.assertEqual(os.stat(filepath).st_mode & mask, 0o666 & ~umask)


### PR DESCRIPTION
Fix test that checks permissions on files extracted from archives with
no permissions set to not assume a default umask of 0002.

This specifically broke tests on Windows Subsystem for Linux that
defaults to an umask of 0000.