### PR TITLE
Fixed #31750 -- Made models.Field equality compare models for inherited fields.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -517,9 +517,9 @@ class Field(RegisterLookupMixin):
         # Needed for @total_ordering
         if isinstance(other, Field):
             return (
-                self.creation_counter == other.creation_counter
-                and hasattr(self, 'model') == hasattr(other, 'model')
-                and getattr(self, 'model', None) == getattr(other, 'model', None)
+                self.creation_counter == other.creation_counter and
+                hasattr(self, 'model') == hasattr(other, 'model') and
+                getattr(self, 'model', None) == getattr(other, 'model', None)
             )
         return NotImplemented
 

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -527,12 +527,13 @@ class Field(RegisterLookupMixin):
         # This is needed because bisect does not take a comparison function.
         # Order by creation_counter first for backward compatibility.
         if isinstance(other, Field):
-            if self.creation_counter != other.creation_counter:
+            if (
+                self.creation_counter != other.creation_counter or
+                not hasattr(self, 'model') and not hasattr(other, 'model')
+            ):
                 return self.creation_counter < other.creation_counter
             elif hasattr(self, 'model') != hasattr(other, 'model'):
                 return not hasattr(self, 'model')  # Order no-model fields first
-            elif not hasattr(self, 'model') and not hasattr(other, 'model'):
-                return self.creation_counter < other.creation_counter
             else:
                 # models are not directly orderable.
                 return (

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -516,17 +516,46 @@ class Field(RegisterLookupMixin):
     def __eq__(self, other):
         # Needed for @total_ordering
         if isinstance(other, Field):
-            return self.creation_counter == other.creation_counter
+            return (
+                self.creation_counter == other.creation_counter
+                and hasattr(self, 'model') == hasattr(other, 'model')
+                and getattr(self, 'model', None) == getattr(other, 'model', None)
+            )
         return NotImplemented
 
     def __lt__(self, other):
         # This is needed because bisect does not take a comparison function.
+        # Order by creation_counter first for backward compatibility.
         if isinstance(other, Field):
-            return self.creation_counter < other.creation_counter
+            if self.creation_counter != other.creation_counter:
+                return self.creation_counter < other.creation_counter
+            elif hasattr(self, 'model') != hasattr(other, 'model'):
+                return not hasattr(self, 'model')  # Order no-model fields first
+            elif not hasattr(self, 'model') and not hasattr(other, 'model'):
+                return self.creation_counter < other.creation_counter
+            else:
+                # models are not directly orderable.
+                return (
+                    (
+                        self.creation_counter,
+                        self.model._meta.app_label,
+                        self.model._meta.model_name,
+                    ) < (
+                        other.creation_counter,
+                        other.model._meta.app_label,
+                        other.model._meta.model_name,
+                    )
+                )
         return NotImplemented
 
     def __hash__(self):
-        return hash(self.creation_counter)
+        return hash(
+            (
+                self.creation_counter,
+                self.model._meta.app_label if hasattr(self, 'model') else None,
+                self.model._meta.model_name if hasattr(self, 'model') else None,
+            )
+        )
 
     def __deepcopy__(self, memodict):
         # We don't have to deepcopy very much here, since most things are not

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -223,9 +223,9 @@ Models
 * The new :attr:`.UniqueConstraint.opclasses` attribute allows setting
   PostgreSQL operator classes.
 
-* Inherited fields compare unequal when accessed from different models.
-  Field ordering now defines the order between inherited fields accessed
-  on different models.
+* Inherited model field instances, such as those obtained by
+  ``Model._meta.get_fields``, compare unequal when referencing different
+  models. The ordering of these fields is now defined.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -223,6 +223,10 @@ Models
 * The new :attr:`.UniqueConstraint.opclasses` attribute allows setting
   PostgreSQL operator classes.
 
+* Inherited fields compare unequal when accessed from different models.
+  Field ordering now defines the order between inherited fields accessed
+  on different models.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -7,8 +7,8 @@ from django.test import SimpleTestCase, TestCase
 from django.utils.functional import lazy
 
 from .models import (
-    Bar, Choiceful, Foo, RenamedField, VerboseNameField, Whiz, WhizDelayed,
-    WhizIter, WhizIterEmpty, AbstractPersonWithHeight, PersonWithHeight,
+    AbstractPersonWithHeight, Bar, Choiceful, Foo, PersonWithHeight,
+    RenamedField, VerboseNameField, Whiz, WhizDelayed, WhizIter, WhizIterEmpty,
 )
 
 

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -8,7 +8,7 @@ from django.utils.functional import lazy
 
 from .models import (
     Bar, Choiceful, Foo, RenamedField, VerboseNameField, Whiz, WhizDelayed,
-    WhizIter, WhizIterEmpty,
+    WhizIter, WhizIterEmpty, AbstractPersonWithHeight, PersonWithHeight,
 )
 
 
@@ -101,6 +101,13 @@ class BasicFieldTests(SimpleTestCase):
         """deconstruct() uses __qualname__ for nested class support."""
         name, path, args, kwargs = Nested.Field().deconstruct()
         self.assertEqual(path, 'model_fields.tests.Nested.Field')
+
+    def test_field_eq_considers_model(self):
+        """Field instances from abstract models compare different."""
+        self.assertNotEqual(
+            AbstractPersonWithHeight._meta.get_field('mugshot_height'),
+            PersonWithHeight._meta.get_field('mugshot_height'),
+        )
 
 
 class ChoicesTests(SimpleTestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31750

One question I've thought of but not answered is what behavior is best to expect with *concrete* inheritance, or what the behavior in that circumstance is currently and would be after this change.

Arguably, the field would then really be on the base class, but I'm not sure what I might expect to be the case as a consumer of the field. For example, would the field de-duplicate in a set? My intuition is that they really should also be different in that case, unless they all report to have the same model.