### PR TITLE
'DIRS' BASE_DIR  typo in settings.py

### DIFF
--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -311,7 +311,7 @@ Open your settings file (:file:`mysite/settings.py`, remember) and add a
     TEMPLATES = [
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': [BASE_DIR / 'templates'],
+            'DIRS': [BASE_DIR, 'templates'],
             'APP_DIRS': True,
             'OPTIONS': {
                 'context_processors': [


### PR DESCRIPTION
 'DIRS': [BASE_DIR / 'templates'],

throws the following error

"\settings.py", line 58, in <module>
    'DIRS': [BASE_DIR /  'templates'],
TypeError: unsupported operand type(s) for /: 'str' and 'str'"

Fixed as: 'DIRS': [BASE_DIR, 'templates'],

