### PR TITLE
Corrected custom model fields how-to.

### DIFF
--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -541,8 +541,8 @@ Converting Python objects to query values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Since using a database requires conversion in both ways, if you override
-:meth:`~Field.to_python` you also have to override :meth:`~Field.get_prep_value`
-to convert Python objects back to query values.
+:meth:`~Field.from_db_value` you also have to override
+:meth:`~Field.get_prep_value` to convert Python objects back to query values.
 
 For example::
 


### PR DESCRIPTION
Since Django 1.8, `get_prep_value()` method is complementary of
`from_db_value()`, not `to_python()`.