### PR TITLE
Fixed #29403 -- Made PyLibMCCache backend handle TooBig exception from pylibmc.

### DIFF
--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -213,3 +213,14 @@ class PyLibMCCache(BaseMemcachedCache):
         # libmemcached manages its own connections. Don't call disconnect_all()
         # as it resets the failover state and creates unnecessary reconnects.
         pass
+
+    def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+        """
+        PyLibMC throws an exception if the stored value is too large,
+        python-memcache instead returns False. We need to override set
+        here to account for the difference.
+        """
+        try:
+            super().set(key, value, timeout=timeout, version=version)
+        except self._lib.TooBig:
+            pass

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -122,7 +122,7 @@ Minor features
 Cache
 ~~~~~
 
-* ...
+* Support for ``pylibmc`` < 1.5.2 is removed.
 
 CSRF
 ~~~~

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1327,15 +1327,7 @@ class BaseMemcachedTests(BaseCacheTests):
         self.assertEqual(cache.get('small_value'), 'a')
 
         large_value = 'a' * (max_value_length + 1)
-        try:
-            cache.set('small_value', large_value)
-        except Exception:
-            # Some clients (e.g. pylibmc) raise when the value is too large,
-            # while others (e.g. python-memcached) intentionally return True
-            # indicating success. This test is primarily checking that the key
-            # was deleted, so the return/exception behavior for the set()
-            # itself is not important.
-            pass
+        cache.set('small_value', large_value)
         # small_value should be deleted, or set if configured to accept larger values
         value = cache.get('small_value')
         self.assertTrue(value is None or value == large_value)

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -7,7 +7,7 @@ jinja2 >= 2.9.2
 numpy
 Pillow >= 6.2.0
 # pylibmc/libmemcached can't be built on Windows.
-pylibmc; sys.platform != 'win32'
+pylibmc >= 1.5.2; sys.platform != 'win32'
 python-memcached >= 1.59
 pytz
 pywatchman; sys.platform != 'win32'


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/29403
Continue to https://github.com/django/django/pull/9811

I removed the [`self._cache.delete(key)`](https://github.com/django/django/pull/9811/files#diff-d603fa6afef1a44825847ccd4e9683a6R189) and it seems we don't need it. if I add a test in `PyLibMCCacheTests` like:
```python
    def test_large_value(self):
        cache.set('key', 'a')
        large_value = 'a' * (1024 * 1024)
        cache.set('key', large_value)
        value = cache.get('key')
        self.assertIsNone(value)
```
It will be passed successfully. Do we need to add this test?