### PR TITLE
Refs #6903 -- Adjusted ModelAdmin.preserve_filters docs.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1112,9 +1112,9 @@ subclass::
 
 .. attribute:: ModelAdmin.preserve_filters
 
-    The admin now preserves filters on the list view after creating, editing
-    or deleting an object. You can restore the previous behavior of clearing
-    filters by setting this attribute to ``False``.
+    By default, applied filters are preserved on the list view after creating,
+    editing, or deleting an object. You can have filters cleared by setting
+    this attribute to ``False``.
 
 .. attribute:: ModelAdmin.radio_fields
 


### PR DESCRIPTION
Docs were added in c86a9b63984f6692d478f6f70e3c78de4ec41814 as the same as the 1.6 release note entry. Much later the `now` no longer reads as appropriate. 