### PR TITLE
Update password_validation.py

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -72,6 +72,7 @@ def password_validators_help_texts(password_validators=None):
         password_validators = get_default_password_validators()
     for validator in password_validators:
         help_texts.append(validator.get_help_text())
+    help_text.append('Your password can’t be entirely alphabetic')
     return help_texts
 
 


### PR DESCRIPTION
Adding "Your password can’t be entirely alphabetic" to help_text as currently entirely alphabetic password is also not being accepted and the current user does not get registered in the process. If user is allowed to put an entirely alphabetic password, this help_text is not needed.