### PR TITLE
Update help_text for NumericPasswordValidator

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -200,4 +200,4 @@ class NumericPasswordValidator:
             )
 
     def get_help_text(self):
-        return _('Your password can’t be entirely numeric.')
+        return _('Your password can’t be entirely numeric or entirely alphabetic')


### PR DESCRIPTION
The NumberPasswordValidator also checks for entirely alphabetic in its current implementation and therefore this help_text should be displayed to the user.