### PR TITLE
Removed duplicated sqlite3 converter.

### DIFF
--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -74,7 +74,6 @@ Database.register_converter("bool", b'1'.__eq__)
 Database.register_converter("time", decoder(parse_time))
 Database.register_converter("datetime", decoder(parse_datetime))
 Database.register_converter("timestamp", decoder(parse_datetime))
-Database.register_converter("TIMESTAMP", decoder(parse_datetime))
 
 Database.register_adapter(decimal.Decimal, str)
 


### PR DESCRIPTION
Converters typenames are case-insensitive. See
https://docs.python.org/3/library/sqlite3.html#sqlite3.register_converter.