### PR TITLE
Added cast_template to allow non-explicit cast in custom fields.

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -40,6 +40,9 @@ class BaseDatabaseOperations:
     # name) to the data type to use for the Cast() function, if different from
     # DatabaseWrapper.data_types.
     cast_data_types = {}
+    # Like above, but some database backends may not support explicit CAST to
+    # certain fields and need specific templates for the Cast() function.
+    cast_templates = {}
     # CharField data type if the max_length argument isn't provided.
     cast_char_field_without_max_length = None
 

--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
 from django.utils import timezone
 from django.utils.encoding import force_str
+from django.utils.functional import cached_property
 
 
 class DatabaseOperations(BaseDatabaseOperations):
@@ -32,6 +33,15 @@ class DatabaseOperations(BaseDatabaseOperations):
     }
     cast_char_field_without_max_length = 'char'
     explain_prefix = 'EXPLAIN'
+
+    @cached_property
+    def cast_templates(self):
+        templates = {
+            'FloatField': '(%(expressions)s + 0.0)',
+        }
+        if self.connection.mysql_is_mariadb:
+            templates['JSONField'] = "JSON_EXTRACT(%(expressions)s, '$')"
+        return templates
 
     def date_extract_sql(self, lookup_type, field_name):
         # https://dev.mysql.com/doc/mysql/en/date-and-time-functions.html

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -68,6 +68,9 @@ END;
         'SmallAutoField': 'NUMBER(5)',
         'TextField': cast_char_field_without_max_length,
     }
+    cast_templates = {
+        'JSONField': "JSON_QUERY(%(expressions)s, '$')",
+    }
 
     def cache_key_culling_sql(self):
         return 'SELECT cache_key FROM %s ORDER BY cache_key OFFSET %%s ROWS FETCH FIRST 1 ROWS ONLY'

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -708,6 +708,9 @@ class Field(RegisterLookupMixin):
             return db_type % self.db_type_parameters(connection)
         return self.db_type(connection)
 
+    def cast_template(self, connection):
+        return connection.ops.cast_templates.get(self.get_internal_type())
+
     def db_parameters(self, connection):
         """
         Extension of db_type(), providing a range of different return values

--- a/django/db/models/functions/comparison.py
+++ b/django/db/models/functions/comparison.py
@@ -12,6 +12,7 @@ class Cast(Func):
 
     def as_sql(self, compiler, connection, **extra_context):
         extra_context['db_type'] = self.output_field.cast_db_type(connection)
+        extra_context['template'] = self.output_field.cast_template(connection) or extra_context.get('template')
         return super().as_sql(compiler, connection, **extra_context)
 
     def as_sqlite(self, compiler, connection, **extra_context):
@@ -28,29 +29,11 @@ class Cast(Func):
             return super().as_sql(compiler, connection, template=template, **extra_context)
         return self.as_sql(compiler, connection, **extra_context)
 
-    def as_mysql(self, compiler, connection, **extra_context):
-        template = None
-        output_type = self.output_field.get_internal_type()
-        # MySQL doesn't support explicit cast to float.
-        if output_type == 'FloatField':
-            template = '(%(expressions)s + 0.0)'
-        # MariaDB doesn't support explicit cast to JSON.
-        elif output_type == 'JSONField' and connection.mysql_is_mariadb:
-            template = "JSON_EXTRACT(%(expressions)s, '$')"
-        return self.as_sql(compiler, connection, template=template, **extra_context)
-
     def as_postgresql(self, compiler, connection, **extra_context):
         # CAST would be valid too, but the :: shortcut syntax is more readable.
         # 'expressions' is wrapped in parentheses in case it's a complex
         # expression.
         return self.as_sql(compiler, connection, template='(%(expressions)s)::%(db_type)s', **extra_context)
-
-    def as_oracle(self, compiler, connection, **extra_context):
-        if self.output_field.get_internal_type() == 'JSONField':
-            # Oracle doesn't support explicit cast to JSON.
-            template = "JSON_QUERY(%(expressions)s, '$')"
-            return super().as_sql(compiler, connection, template=template, **extra_context)
-        return self.as_sql(compiler, connection, **extra_context)
 
 
 class Coalesce(Func):


### PR DESCRIPTION
While working on https://github.com/laymonage/django-jsonfield-backport/pull/2, I noticed that I'm unable to define custom templates for casting custom model fields. This fixes it by adding another mapping like `cast_data_types`, but for templates. I think this also looks better as this gives better separation between `Cast` and model fields.