### PR TITLE
Fixed #31623 -- Allowed specifying number of adjacent time units in timesince()/timeuntil().

### DIFF
--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -298,7 +298,9 @@ URLs
 Utilities
 ~~~~~~~~~
 
-* ...
+* The new ``depth`` parameter of ``django.utils.timesince.timesince()`` and
+  ``django.utils.timesince.timeuntil()`` functions allows specifying the number
+  of adjacent time units to return.
 
 Validators
 ~~~~~~~~~~

--- a/tests/utils_tests/test_timesince.py
+++ b/tests/utils_tests/test_timesince.py
@@ -1,13 +1,13 @@
 import datetime
-import unittest
 
+from django.test import TestCase
 from django.test.utils import requires_tz_support
 from django.utils import timezone, translation
 from django.utils.timesince import timesince, timeuntil
 from django.utils.translation import npgettext_lazy
 
 
-class TimesinceTests(unittest.TestCase):
+class TimesinceTests(TestCase):
 
     def setUp(self):
         self.t = datetime.datetime(2007, 8, 14, 13, 46, 0)
@@ -140,3 +140,31 @@ class TimesinceTests(unittest.TestCase):
         t = datetime.datetime(1007, 8, 14, 13, 46, 0)
         self.assertEqual(timesince(t, self.t), '1000\xa0years')
         self.assertEqual(timeuntil(self.t, t), '1000\xa0years')
+
+    def test_depth(self):
+        t = self.t + self.oneyear + self.onemonth + self.oneweek + self.oneday + self.onehour
+        tests = [
+            (t, 1, '1\xa0year'),
+            (t, 2, '1\xa0year, 1\xa0month'),
+            (t, 3, '1\xa0year, 1\xa0month, 1\xa0week'),
+            (t, 4, '1\xa0year, 1\xa0month, 1\xa0week, 1\xa0day'),
+            (t, 5, '1\xa0year, 1\xa0month, 1\xa0week, 1\xa0day, 1\xa0hour'),
+            (t, 6, '1\xa0year, 1\xa0month, 1\xa0week, 1\xa0day, 1\xa0hour'),
+            (self.t + self.onehour, 5, '1\xa0hour'),
+            (self.t + (4 * self.oneminute), 3, '4\xa0minutes'),
+            (self.t + self.onehour + self.oneminute, 1, '1\xa0hour'),
+            (self.t + self.oneday + self.onehour, 1, '1\xa0day'),
+            (self.t + self.oneweek + self.oneday, 1, '1\xa0week'),
+            (self.t + self.onemonth + self.oneweek, 1, '1\xa0month'),
+            (self.t + self.oneyear + self.onemonth, 1, '1\xa0year'),
+            (self.t + self.oneyear + self.oneweek + self.oneday, 3, '1\xa0year'),
+        ]
+        for value, depth, expected in tests:
+            with self.subTest():
+                self.assertEqual(timesince(self.t, value, depth=depth), expected)
+                self.assertEqual(timeuntil(value, self.t, depth=depth), expected)
+
+    def test_depth_invalid(self):
+        msg = 'depth must be greater than 0.'
+        with self.assertRaisesMessage(ValueError, msg):
+            timesince(self.t, self.t, depth=0)


### PR DESCRIPTION
### **Overview**
**Ticket:** https://code.djangoproject.com/ticket/31623

The `timesince` function returns the time between two datetime objects as a formatted string.

The previous implementation always returned two units of time. This update improves flexibility by allowing the user to specify the number of units to be returned. To preserve existing functionality, the default depth value is set to 2. 

### **Example**
 - depth = 1 returns "2 weeks"
 - depth = 2 returns "2 weeks, 3 days"
 - depth = 3 returns "2 weeks, 3 days, 3 hours"
 - depth = 4 returns "2 weeks, 3 days, 3 hours, 13 minutes"

### **Update includes:**
- New depth functionality 
- New test cases 
- Updated Doc Strings
- Updated Release Notes 

Let me know if you see anything.

Thanks! 