### PR TITLE
Fixed #28009 -- Doc'd empty_value for CharField subclasses.

### DIFF
--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -89,7 +89,8 @@ To specify that a field is *not* required, pass ``required=False`` to the
 
 If a ``Field`` has ``required=False`` and you pass ``clean()`` an empty value,
 then ``clean()`` will return a *normalized* empty value rather than raising
-``ValidationError``. For ``CharField``, this will be an empty string. For other
+``ValidationError``. For ``CharField``, this will return
+:attr:`~CharField.empty_value` which defaults to an empty string. For other
 ``Field`` classes, it might be ``None``. (This varies from field to field.)
 
 Widgets of required form fields have the ``required`` HTML attribute. Set the
@@ -582,16 +583,15 @@ For each field, we describe the default widget used if you don't specify
 .. class:: EmailField(**kwargs)
 
     * Default widget: :class:`EmailInput`
-    * Empty value: ``''`` (an empty string)
+    * Empty value: Whatever you've given as ``empty_value``.
     * Normalizes to: A string.
     * Uses :class:`~django.core.validators.EmailValidator` to validate that
       the given value is a valid email address, using a moderately complex
       regular expression.
     * Error message keys: ``required``, ``invalid``
 
-    Has two optional arguments for validation, ``max_length`` and ``min_length``.
-    If provided, these arguments ensure that the string is at most or at least the
-    given length.
+    Has three optional arguments ``max_length``, ``min_length``, and
+    ``empty_value`` which work just as they do for :class:`CharField`.
 
 ``FileField``
 -------------
@@ -919,7 +919,7 @@ For each field, we describe the default widget used if you don't specify
 .. class:: RegexField(**kwargs)
 
     * Default widget: :class:`TextInput`
-    * Empty value: ``''`` (an empty string)
+    * Empty value: Whatever you've given as ``empty_value``.
     * Normalizes to: A string.
     * Uses :class:`~django.core.validators.RegexValidator` to validate that
       the given value matches a certain regular expression.
@@ -932,8 +932,8 @@ For each field, we describe the default widget used if you don't specify
         A regular expression specified either as a string or a compiled regular
         expression object.
 
-    Also takes ``max_length``, ``min_length``, and ``strip``, which work just
-    as they do for :class:`CharField`.
+    Also takes ``max_length``, ``min_length``, ``strip``, and ``empty_value``
+    which work just as they do for :class:`CharField`.
 
     .. attribute:: strip
 
@@ -946,7 +946,7 @@ For each field, we describe the default widget used if you don't specify
 .. class:: SlugField(**kwargs)
 
    * Default widget: :class:`TextInput`
-   * Empty value: ``''`` (an empty string)
+   * Empty value: Whatever you've given as :attr:`empty_value`.
    * Normalizes to: A string.
    * Uses :class:`~django.core.validators.validate_slug` or
      :class:`~django.core.validators.validate_unicode_slug` to validate that
@@ -956,12 +956,16 @@ For each field, we describe the default widget used if you don't specify
    This field is intended for use in representing a model
    :class:`~django.db.models.SlugField` in forms.
 
-   Takes an optional parameter:
+   Takes two optional parameters:
 
    .. attribute:: allow_unicode
 
        A boolean instructing the field to accept Unicode letters in addition
        to ASCII letters. Defaults to ``False``.
+
+   .. attribute:: empty_value
+
+       The value to use to represent "empty". Defaults to an empty string.
 
 ``TimeField``
 -------------
@@ -994,19 +998,14 @@ For each field, we describe the default widget used if you don't specify
 .. class:: URLField(**kwargs)
 
     * Default widget: :class:`URLInput`
-    * Empty value: ``''`` (an empty string)
+    * Empty value: Whatever you've given as ``empty_value``.
     * Normalizes to: A string.
     * Uses :class:`~django.core.validators.URLValidator` to validate that the
       given value is a valid URL.
     * Error message keys: ``required``, ``invalid``
 
-    Takes the following optional arguments:
-
-    .. attribute:: max_length
-    .. attribute:: min_length
-
-        These are the same as ``CharField.max_length`` and
-        ``CharField.min_length``.
+    Has three optional arguments ``max_length``, ``min_length``, and
+    ``empty_value`` which work just as they do for :class:`CharField`.
 
 ``UUIDField``
 -------------

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -787,7 +787,7 @@ For each field, we describe the default widget used if you don't specify
     :class:`~django.db.models.JSONField`.
 
     * Default widget: :class:`Textarea`
-    * Empty value: ``''`` (an empty string)
+    * Empty value: ``None``
     * Normalizes to: A Python representation of the JSON value (usually as a
       ``dict``, ``list``, or ``None``), depending on :attr:`JSONField.decoder`.
     * Validates that the given value is a valid JSON.
@@ -1014,7 +1014,7 @@ For each field, we describe the default widget used if you don't specify
 .. class:: UUIDField(**kwargs)
 
     * Default widget: :class:`TextInput`
-    * Empty value: ``''`` (an empty string)
+    * Empty value: ``None``
     * Normalizes to: A :class:`~python:uuid.UUID` object.
     * Error message keys: ``required``, ``invalid``
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -288,8 +288,10 @@ File Storage
 Forms
 ~~~~~
 
-* The new :attr:`CharField.empty_value <django.forms.CharField.empty_value>`
-  attribute allows specifying the Python value to use to represent "empty".
+* The new ``empty_value`` attribute on :class:`~django.forms.CharField`,
+  :class:`~django.forms.EmailField`, :class:`~django.forms.RegexField`,
+  :class:`~django.forms.SlugField`, and :class:`~django.forms.URLField` allows
+  specifying the Python value to use to represent "empty".
 
 * The new :meth:`Form.get_initial_for_field()
   <django.forms.Form.get_initial_for_field>` method returns initial data for a

--- a/tests/forms_tests/field_tests/test_emailfield.py
+++ b/tests/forms_tests/field_tests/test_emailfield.py
@@ -52,6 +52,7 @@ class EmailFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_emailfield_strip_on_none_value(self):
         f = EmailField(required=False, empty_value=None)
+        self.assertIsNone(f.clean(''))
         self.assertIsNone(f.clean(None))
 
     def test_emailfield_unable_to_set_strip_kwarg(self):

--- a/tests/forms_tests/field_tests/test_jsonfield.py
+++ b/tests/forms_tests/field_tests/test_jsonfield.py
@@ -16,8 +16,8 @@ class JSONFieldTest(SimpleTestCase):
 
     def test_valid_empty(self):
         field = JSONField(required=False)
-        value = field.clean('')
-        self.assertIsNone(value)
+        self.assertIsNone(field.clean(''))
+        self.assertIsNone(field.clean(None))
 
     def test_invalid(self):
         field = JSONField()

--- a/tests/forms_tests/field_tests/test_regexfield.py
+++ b/tests/forms_tests/field_tests/test_regexfield.py
@@ -75,3 +75,11 @@ class RegexFieldTest(SimpleTestCase):
         f = RegexField('^[a-z]+$', strip=True)
         self.assertEqual(f.clean(' a'), 'a')
         self.assertEqual(f.clean('a '), 'a')
+
+    def test_empty_value(self):
+        f = RegexField('', required=False)
+        self.assertEqual(f.clean(''), '')
+        self.assertEqual(f.clean(None), '')
+        f = RegexField('', empty_value=None, required=False)
+        self.assertIsNone(f.clean(''))
+        self.assertIsNone(f.clean(None))

--- a/tests/forms_tests/field_tests/test_slugfield.py
+++ b/tests/forms_tests/field_tests/test_slugfield.py
@@ -17,3 +17,11 @@ class SlugFieldTest(SimpleTestCase):
         self.assertEqual(f.clean('  你-好  '), '你-好')
         self.assertEqual(f.clean('ıçğüş'), 'ıçğüş')
         self.assertEqual(f.clean('foo-ıç-bar'), 'foo-ıç-bar')
+
+    def test_empty_value(self):
+        f = SlugField(required=False)
+        self.assertEqual(f.clean(''), '')
+        self.assertEqual(f.clean(None), '')
+        f = SlugField(required=False, empty_value=None)
+        self.assertIsNone(f.clean(''))
+        self.assertIsNone(f.clean(None))

--- a/tests/forms_tests/field_tests/test_urlfield.py
+++ b/tests/forms_tests/field_tests/test_urlfield.py
@@ -154,6 +154,7 @@ class URLFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_urlfield_strip_on_none_value(self):
         f = URLField(required=False, empty_value=None)
+        self.assertIsNone(f.clean(''))
         self.assertIsNone(f.clean(None))
 
     def test_urlfield_unable_to_set_strip_kwarg(self):

--- a/tests/forms_tests/field_tests/test_uuidfield.py
+++ b/tests/forms_tests/field_tests/test_uuidfield.py
@@ -19,8 +19,8 @@ class UUIDFieldTest(SimpleTestCase):
 
     def test_uuidfield_2(self):
         field = UUIDField(required=False)
-        value = field.clean('')
-        self.assertIsNone(value)
+        self.assertIsNone(field.clean(''))
+        self.assertIsNone(field.clean(None))
 
     def test_uuidfield_3(self):
         field = UUIDField()

--- a/tests/model_fields/test_charfield.py
+++ b/tests/model_fields/test_charfield.py
@@ -61,7 +61,8 @@ class ValidationTests(SimpleTestCase):
 
     def test_charfield_raises_error_on_empty_string(self):
         f = models.CharField()
-        with self.assertRaises(ValidationError):
+        msg = 'This field cannot be blank.'
+        with self.assertRaisesMessage(ValidationError, msg):
             f.clean('', None)
 
     def test_charfield_cleans_empty_string_when_blank_true(self):
@@ -74,7 +75,8 @@ class ValidationTests(SimpleTestCase):
 
     def test_charfield_with_choices_raises_error_on_invalid_choice(self):
         f = models.CharField(choices=[('a', 'A'), ('b', 'B')])
-        with self.assertRaises(ValidationError):
+        msg = "Value 'not a' is not a valid choice."
+        with self.assertRaisesMessage(ValidationError, msg):
             f.clean('not a', None)
 
     def test_enum_choices_cleans_valid_string(self):
@@ -83,10 +85,12 @@ class ValidationTests(SimpleTestCase):
 
     def test_enum_choices_invalid_input(self):
         f = models.CharField(choices=self.Choices.choices, max_length=1)
-        with self.assertRaises(ValidationError):
+        msg = "Value 'a' is not a valid choice."
+        with self.assertRaisesMessage(ValidationError, msg):
             f.clean('a', None)
 
     def test_charfield_raises_error_on_empty_input(self):
         f = models.CharField(null=False)
-        with self.assertRaises(ValidationError):
+        msg = 'This field cannot be null.'
+        with self.assertRaisesMessage(ValidationError, msg):
             f.clean(None, None)

--- a/tests/model_forms/models.py
+++ b/tests/model_forms/models.py
@@ -472,3 +472,6 @@ class Award(models.Model):
 
 class NullableUniqueCharFieldModel(models.Model):
     codename = models.CharField(max_length=50, blank=True, null=True, unique=True)
+    email = models.EmailField(blank=True, null=True)
+    slug = models.SlugField(blank=True, null=True)
+    url = models.URLField(blank=True, null=True)

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -301,19 +301,30 @@ class ModelFormBaseTest(TestCase):
         self.assertEqual(obj.name, '')
 
     def test_save_blank_null_unique_charfield_saves_null(self):
-        form_class = modelform_factory(model=NullableUniqueCharFieldModel, fields=['codename'])
+        form_class = modelform_factory(model=NullableUniqueCharFieldModel, fields='__all__')
         empty_value = '' if connection.features.interprets_empty_strings_as_nulls else None
-
-        form = form_class(data={'codename': ''})
+        data = {
+            'codename': '',
+            'email': '',
+            'slug': '',
+            'url': '',
+        }
+        form = form_class(data=data)
         self.assertTrue(form.is_valid())
         form.save()
         self.assertEqual(form.instance.codename, empty_value)
+        self.assertEqual(form.instance.email, empty_value)
+        self.assertEqual(form.instance.slug, empty_value)
+        self.assertEqual(form.instance.url, empty_value)
 
         # Save a second form to verify there isn't a unique constraint violation.
-        form = form_class(data={'codename': ''})
+        form = form_class(data=data)
         self.assertTrue(form.is_valid())
         form.save()
         self.assertEqual(form.instance.codename, empty_value)
+        self.assertEqual(form.instance.email, empty_value)
+        self.assertEqual(form.instance.slug, empty_value)
+        self.assertEqual(form.instance.url, empty_value)
 
     def test_missing_fields_attribute(self):
         message = (


### PR DESCRIPTION
[Ticket #28009](https://code.djangoproject.com/ticket/28009)

This is a partial fix for this ticket. If focuses on the form fields rather (model fields also need to be looked at). I've paused as this point to get some wider input. 

The ticket explains that the `CharField` subclasses should also return `empty_value`; however, the docs explain that the subclass fields return an empty string. 

What is happening in practice is a bit of a mixture. Some fields do return `empty_value` (email, regex, slug, url). However, `GenericIPAddressField` always returns an empty string and `JSONField` and `UUIDField` always return none. I've added tests for all of these to show the behavior. 

So question is - is this inconsistency right (that's how I've written the docs), or is there further work to ensure all of the fields return `empty_value`. 

Appreciate thoughts. 