### PR TITLE
Fixed #31732 -- Cached callables signatures in django.utils.inspect methods.

### DIFF
--- a/django/utils/inspect.py
+++ b/django/utils/inspect.py
@@ -1,8 +1,14 @@
+import functools
 import inspect
 
 
+@functools.lru_cache(maxsize=512)
+def _get_signature(func):
+    return inspect.signature(func)
+
+
 def get_func_args(func):
-    sig = inspect.signature(func)
+    sig = _get_signature(func)
     return [
         arg_name for arg_name, param in sig.parameters.items()
         if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
@@ -15,7 +21,7 @@ def get_func_full_args(func):
     does not have a default value, omit it in the tuple. Arguments such as
     *args and **kwargs are also included.
     """
-    sig = inspect.signature(func)
+    sig = _get_signature(func)
     args = []
     for arg_name, param in sig.parameters.items():
         name = arg_name
@@ -35,7 +41,7 @@ def get_func_full_args(func):
 
 def func_accepts_kwargs(func):
     return any(
-        p for p in inspect.signature(func).parameters.values()
+        p for p in _get_signature(func).parameters.values()
         if p.kind == p.VAR_KEYWORD
     )
 
@@ -45,7 +51,7 @@ def func_accepts_var_args(func):
     Return True if function 'func' accepts positional arguments *args.
     """
     return any(
-        p for p in inspect.signature(func).parameters.values()
+        p for p in _get_signature(func).parameters.values()
         if p.kind == p.VAR_POSITIONAL
     )
 
@@ -53,11 +59,11 @@ def func_accepts_var_args(func):
 def method_has_no_args(meth):
     """Return True if a method only accepts 'self'."""
     count = len([
-        p for p in inspect.signature(meth).parameters.values()
+        p for p in _get_signature(meth).parameters.values()
         if p.kind == p.POSITIONAL_OR_KEYWORD
     ])
     return count == 0 if inspect.ismethod(meth) else count == 1
 
 
 def func_supports_parameter(func, parameter):
-    return parameter in inspect.signature(func).parameters
+    return parameter in _get_signature(func).parameters


### PR DESCRIPTION
### Overview
**Ticket:** https://code.djangoproject.com/ticket/31732

Created a wrapper function to perform signature inspect lookup and added `lru_cache` decorator to eliminate repeated function calls. Replaced direct signature inspect calls with the cached wrapper function. 

### Testcases 
I am not sure how to add test cases for this functionality. As a manual check, I ran the existing set of test cases with print statements in the wrapper function, with and without the lru_cache. All duplicated calls are eliminated when using the LRU cache.

**Without LRU Cache**
![Without LRU Cache](https://user-images.githubusercontent.com/51100862/86523035-463cb700-be1b-11ea-98c5-c99b47baa986.png)

**With LRU Cache** 
![With LRU Cache](https://user-images.githubusercontent.com/51100862/86523049-5b194a80-be1b-11ea-9746-f409c5a7d34e.png)