### PR TITLE
Fixed #29112 -- Allowed using QuerySet.update() to update specific keys in nested JSONField.

### DIFF
--- a/django/contrib/postgres/functions.py
+++ b/django/contrib/postgres/functions.py
@@ -1,4 +1,15 @@
 from django.db.models import DateTimeField, Func, UUIDField
+from django.db.models.fields import CharField
+
+
+class JSONBSet(Func):
+    """
+    Update the value of a JSONField for a specific key.
+    Works with nested JSON fields as well.
+    """
+    function = 'JSONB_SET'
+    arity = 4
+    output_field = CharField()
 
 
 class RandomUUID(Func):

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -218,6 +218,13 @@ class Migration(migrations.Migration):
             ]
         ),
         migrations.CreateModel(
+            name='JSONBSetTestModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('nested', models.JSONField(default=None)),
+            ]
+        ),
+        migrations.CreateModel(
             name='NowTestModel',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -172,6 +172,10 @@ class StatTestModel(models.Model):
     related_field = models.ForeignKey(AggregateTestModel, models.SET_NULL, null=True)
 
 
+class JSONBSetTestModel(models.Model):
+    nested = models.JSONField()
+
+
 class NowTestModel(models.Model):
     when = models.DateTimeField(null=True, default=None)
 

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -173,7 +173,7 @@ class StatTestModel(models.Model):
 
 
 class JSONBSetTestModel(models.Model):
-    nested = models.JSONField()
+    nested = models.JSONField(default=None)
 
 
 class NowTestModel(models.Model):

--- a/tests/postgres_tests/test_functions.py
+++ b/tests/postgres_tests/test_functions.py
@@ -5,10 +5,17 @@ from time import sleep
 from django.contrib.postgres.functions import RandomUUID, TransactionNow
 
 from . import PostgreSQLTestCase
-from .models import NowTestModel, UUIDTestModel
+from .models import JSONBSetTestModel, NowTestModel, UUIDTestModel
 
 
 class TestTransactionNow(PostgreSQLTestCase):
+
+    def test_jsonbset(self):
+        m1 = JSONBSetTestModel.objects.create(nested={'a': {'b': 'c'}})
+        self.assertTrue(JSONBSetTestModel.objects.filter(nested__a__b='c').exists())
+
+        m1.objects.update(nested__a__b='d')
+        self.assertTrue(JSONBSetTestModel.objects.filter(nested__a__b='d').exists())
 
     def test_transaction_now(self):
         """

--- a/tests/postgres_tests/test_functions.py
+++ b/tests/postgres_tests/test_functions.py
@@ -11,10 +11,10 @@ from .models import JSONBSetTestModel, NowTestModel, UUIDTestModel
 class TestTransactionNow(PostgreSQLTestCase):
 
     def test_jsonbset(self):
-        m1 = JSONBSetTestModel.objects.create(nested={'a': {'b': 'c'}})
+        JSONBSetTestModel.objects.create(nested={'a': {'b': 'c'}})
         self.assertTrue(JSONBSetTestModel.objects.filter(nested__a__b='c').exists())
 
-        m1.objects.update(nested__a__b='d')
+        JSONBSetTestModel.objects.filter(nested__a__b='c').update(nested__a__b='d')
         self.assertTrue(JSONBSetTestModel.objects.filter(nested__a__b='d').exists())
 
     def test_transaction_now(self):


### PR DESCRIPTION
Specific keys can be updated within a nested JSONField  by specifying
the path and new value as arguments to the update() method, just like
the syntax used in Lookups.