### PR TITLE
Fixed #31765 -- Disabled bundled SQLite renaming atomic references on macOS 10.15. 

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -1,4 +1,5 @@
 import operator
+import platform
 
 from django.db import transaction
 from django.db.backends.base.features import BaseDatabaseFeatures
@@ -21,7 +22,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_transactions = True
     atomic_transactions = False
     can_rollback_ddl = True
-    supports_atomic_references_rename = Database.sqlite_version_info >= (3, 26, 0)
     can_create_inline_fk = False
     supports_paramstyle_pyformat = False
     can_clone_databases = True
@@ -43,6 +43,14 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_aggregate_filter_clause = Database.sqlite_version_info >= (3, 30, 1)
     supports_order_by_nulls_modifier = Database.sqlite_version_info >= (3, 30, 0)
     order_by_nulls_first = True
+
+    @cached_property
+    def supports_atomic_references_rename(self):
+        # SQLite 3.28.0 bundled with MacOS 10.15 does not support renaming
+        # references atomically.
+        if platform.mac_ver()[0].startswith('10.15.') and Database.sqlite_version_info == (3, 28, 0):
+            return False
+        return Database.sqlite_version_info >= (3, 26, 0)
 
     @cached_property
     def introspected_field_types(self):


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/31765

tl;dr Python compiled with SQLite 3.28.0 that is bundled with MacOS Catalina fails the `schema.tests.SchemaTests.test_db_table` test on master. Python compiled with SQLite 3.28.0 installed through Homebrew passes.

