### PR TITLE
Refs #26367 -- Assess if FieldFile can work with stdlib File instead of requiring Django's File

### DIFF
--- a/tests/model_fields/test_filefield.py
+++ b/tests/model_fields/test_filefield.py
@@ -147,3 +147,14 @@ class FileFieldTests(TestCase):
                         self.assertEqual(document.myfile.field, loaded_myfile.field)
                     finally:
                         document.myfile.delete()
+
+    def test_save_python_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with override_settings(MEDIA_ROOT=Path(tmp_dir)):
+                with open(__file__, 'rb') as fp:
+                    document = Document(myfile='test_file.py')
+                    document.myfile.save('test_file.py', fp)
+                    self.assertFalse(isinstance(fp, File))
+                    self.assertTrue(isinstance(document.myfile, File))
+                document.myfile.delete()
+

--- a/tests/model_fields/test_filefield.py
+++ b/tests/model_fields/test_filefield.py
@@ -157,4 +157,3 @@ class FileFieldTests(TestCase):
                     self.assertFalse(isinstance(fp, File))
                     self.assertTrue(isinstance(document.myfile, File))
                 document.myfile.delete()
-


### PR DESCRIPTION
[Ticket #26367](https://code.djangoproject.com/ticket/26367)

I am most likely using this wrong... but... I think this already works? 

The conversion to the Django `File` type happens here:
https://github.com/django/django/blob/master/django/core/files/storage.py#L49

