### PR TITLE
Fixed #31769 -- Improved default naming of merged migrations created by makemigrations.

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -17,7 +17,6 @@ from django.db.migrations.questioner import (
     NonInteractiveMigrationQuestioner,
 )
 from django.db.migrations.state import ProjectState
-from django.db.migrations.utils import get_migration_name_timestamp
 from django.db.migrations.writer import MigrationWriter
 
 
@@ -295,10 +294,13 @@ class Command(BaseCommand):
                 subclass = type("Migration", (Migration,), {
                     "dependencies": [(app_label, migration.name) for migration in merge_migrations],
                 })
-                migration_name = "%04i_%s" % (
-                    biggest_number + 1,
-                    self.migration_name or ("merge_%s" % get_migration_name_timestamp())
-                )
+                parts = ['%04i' % (biggest_number + 1)]
+                if self.migration_name:
+                    parts.append(self.migration_name)
+                else:
+                    parts.append('merge')
+                    parts += sorted(migration.name for migration in merge_migrations)
+                migration_name = '_'.join(parts)
                 new_migration = subclass(migration_name, app_label)
                 writer = MigrationWriter(new_migration, self.include_header)
 

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -1,4 +1,3 @@
-import datetime
 import importlib
 import io
 import os
@@ -1205,16 +1204,14 @@ class MakeMigrationsTests(MigrationTestBase):
                 self.assertTrue(os.path.exists(merge_file))
             self.assertIn("Created new merge migration", out.getvalue())
 
-    @mock.patch('django.db.migrations.utils.datetime')
-    def test_makemigrations_default_merge_name(self, mock_datetime):
-        mock_datetime.datetime.now.return_value = datetime.datetime(2016, 1, 2, 3, 4)
+    def test_makemigrations_default_merge_name(self):
         with mock.patch('builtins.input', mock.Mock(return_value='y')):
             out = io.StringIO()
             with self.temporary_migration_module(module="migrations.test_migrations_conflict") as migration_dir:
                 call_command("makemigrations", "migrations", merge=True, interactive=True, stdout=out)
-                merge_file = os.path.join(migration_dir, '0003_merge_20160102_0304.py')
+                merge_file = os.path.join(migration_dir, '0003_merge_0002_conflicting_second_0002_second.py')
                 self.assertTrue(os.path.exists(merge_file))
-            self.assertIn("Created new merge migration", out.getvalue())
+            self.assertIn("Created new merge migration %s" % merge_file, out.getvalue())
 
     def test_makemigrations_non_interactive_not_null_addition(self):
         """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31769