### PR TITLE
Fixed #31769 -- Improved default naming of merged migrations.

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -295,10 +295,17 @@ class Command(BaseCommand):
                 subclass = type("Migration", (Migration,), {
                     "dependencies": [(app_label, migration.name) for migration in merge_migrations],
                 })
-                migration_name = "%04i_%s" % (
-                    biggest_number + 1,
-                    self.migration_name or ("merge_%s" % get_migration_name_timestamp())
-                )
+                parts = ['%04i' % (biggest_number + 1)]
+                if self.migration_name:
+                    parts.append(self.migration_name)
+                else:
+                    parts.append('merge')
+                    leaf_names = '_'.join(sorted(migration.name for migration in merge_migrations))
+                    if len(leaf_names) > 47:
+                        parts.append(get_migration_name_timestamp())
+                    else:
+                        parts.append(leaf_names)
+                migration_name = '_'.join(parts)
                 new_migration = subclass(migration_name, app_label)
                 writer = MigrationWriter(new_migration, self.include_header)
 

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -1208,12 +1208,27 @@ class MakeMigrationsTests(MigrationTestBase):
                 self.assertTrue(os.path.exists(merge_file))
             self.assertIn("Created new merge migration", out.getvalue())
 
+    def test_makemigrations_default_merge_name(self):
+        out = io.StringIO()
+        with self.temporary_migration_module(
+            module='migrations.test_migrations_conflict'
+        ) as migration_dir:
+            call_command('makemigrations', 'migrations', merge=True, interactive=False, stdout=out)
+            merge_file = os.path.join(
+                migration_dir,
+                '0003_merge_0002_conflicting_second_0002_second.py',
+            )
+            self.assertIs(os.path.exists(merge_file), True)
+        self.assertIn('Created new merge migration %s' % merge_file, out.getvalue())
+
     @mock.patch('django.db.migrations.utils.datetime')
-    def test_makemigrations_default_merge_name(self, mock_datetime):
+    def test_makemigrations_auto_merge_name(self, mock_datetime):
         mock_datetime.datetime.now.return_value = datetime.datetime(2016, 1, 2, 3, 4)
         with mock.patch('builtins.input', mock.Mock(return_value='y')):
             out = io.StringIO()
-            with self.temporary_migration_module(module="migrations.test_migrations_conflict") as migration_dir:
+            with self.temporary_migration_module(
+                module='migrations.test_migrations_conflict_long_name'
+            ) as migration_dir:
                 call_command("makemigrations", "migrations", merge=True, interactive=True, stdout=out)
                 merge_file = os.path.join(migration_dir, '0003_merge_20160102_0304.py')
                 self.assertTrue(os.path.exists(merge_file))

--- a/tests/migrations/test_migrations_conflict_long_name/0001_initial.py
+++ b/tests/migrations/test_migrations_conflict_long_name/0001_initial.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    operations = [
+        migrations.CreateModel(
+            'Author',
+            [
+                ('id', models.AutoField(primary_key=True)),
+            ],
+        ),
+    ]

--- a/tests/migrations/test_migrations_conflict_long_name/0002_conflicting_second_migration_with_long_name.py
+++ b/tests/migrations/test_migrations_conflict_long_name/0002_conflicting_second_migration_with_long_name.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [('migrations', '0001_initial')]
+
+    operations = [
+        migrations.CreateModel(
+            'SomethingElse',
+            [
+                ('id', models.AutoField(primary_key=True)),
+            ],
+        ),
+    ]

--- a/tests/migrations/test_migrations_conflict_long_name/0002_second.py
+++ b/tests/migrations/test_migrations_conflict_long_name/0002_second.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [('migrations', '0001_initial')]
+
+    operations = [
+        migrations.CreateModel(
+            'Something',
+            [
+                ('id', models.AutoField(primary_key=True)),
+            ],
+        ),
+    ]


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31769