### PR TITLE
Fixed #31739 -- Documented dependency between HttpRequest stream IO methods and body.

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -45,7 +45,7 @@ All attributes should be considered read-only, unless stated otherwise.
 
     You can also read from an ``HttpRequest`` using a file-like interface with
     :meth:`HttpRequest.read` or :meth:`HttpRequest.readline`. Accessing
-    the body attribute *after* reading the request with either of these I/O
+    the ``body`` attribute *after* reading the request with either of these I/O
     stream methods will produce a ``RawPostDataException``.
 
 .. attribute:: HttpRequest.path

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -43,8 +43,10 @@ All attributes should be considered read-only, unless stated otherwise.
     XML payload etc. For processing conventional form data, use
     :attr:`HttpRequest.POST`.
 
-    You can also read from an ``HttpRequest`` using a file-like interface. See
-    :meth:`HttpRequest.read()`.
+    You can also read from an ``HttpRequest`` using a file-like interface with
+    :meth:`HttpRequest.read` or :meth:`HttpRequest.readline`. Accessing
+    the body attribute *after* reading the request with either of these I/O
+    stream methods will produce a ``RawPostDataException``.
 
 .. attribute:: HttpRequest.path
 


### PR DESCRIPTION
**Ticket:** https://code.djangoproject.com/ticket/31739

Wrote the documentation for this ticket within `HttpRequest.body` because both `.read()` and `readlines()` methods can cause the `PostRawDataException` to occur when accessing `body`. See link [here](https://github.com/django/django/blob/ae8338daf34fd746771e0678081999b656177bae/django/http/request.py#L44) for implementation of `HttpRequest`.

![Screen Shot 2020-07-07 at 9 09 23 PM](https://user-images.githubusercontent.com/51100862/86874884-311f8c80-c096-11ea-833b-72bc20cbef9d.png)

Currently, zero results are returned when searching the Django docs for `PostRawDataException`. This sentence should help point users in the right direction.

Let me know your thoughts! 