### PR TITLE
Fixed #31779 -- Bumped MariaDB requirement for JSONField to 10.2.16.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -149,7 +149,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def supports_json_field(self):
         if self.connection.mysql_is_mariadb:
-            return self.connection.mysql_version >= (10, 2, 7)
+            return self.connection.mysql_version >= (10, 2, 16)
         return self.connection.mysql_version >= (5, 7, 8)
 
     @cached_property

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1174,7 +1174,7 @@ A field for storing JSON encoded data. In Python the data is represented in its
 Python native format: dictionaries, lists, strings, numbers, booleans and
 ``None``.
 
-``JSONField`` is supported on MariaDB 10.2.7+, MySQL 5.7.8+, Oracle,
+``JSONField`` is supported on MariaDB 10.2.16+, MySQL 5.7.8+, Oracle,
 PostgreSQL, and SQLite 3.9.0+ (with the :ref:`JSON1 extension enabled
 <sqlite-json1>`).
 


### PR DESCRIPTION
Ticket [#31779](https://code.djangoproject.com/ticket/31779).