### PR TITLE
Add maxsize=None to lru_cache functions with no arguments

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -82,7 +82,7 @@ def make_password(password, salt=None, hasher='default'):
     return hasher.encode(password, salt)
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_hashers():
     hashers = []
     for hasher_path in settings.PASSWORD_HASHERS:
@@ -95,7 +95,7 @@ def get_hashers():
     return hashers
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_hashers_by_algorithm():
     return {hasher.algorithm: hasher for hasher in get_hashers()}
 

--- a/django/forms/renderers.py
+++ b/django/forms/renderers.py
@@ -16,7 +16,7 @@ except ImportError:
 ROOT = Path(__file__).parent
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_default_renderer():
     renderer_class = import_string(settings.FORM_RENDERER)
     return renderer_class()

--- a/django/template/engine.py
+++ b/django/template/engine.py
@@ -53,7 +53,7 @@ class Engine:
         self.template_builtins = self.get_template_builtins(self.builtins)
 
     @staticmethod
-    @functools.lru_cache()
+    @functools.lru_cache(maxsize=None)
     def get_default():
         """
         Return the first DjangoTemplates backend that's configured, or raise

--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -37,7 +37,7 @@ def get_fixed_timezone(offset):
 
 # In order to avoid accessing settings at compile time,
 # wrap the logic in a function and cache the result.
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_default_timezone():
     """
     Return the default time zone as a tzinfo instance.

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -452,7 +452,7 @@ def check_for_language(lang_code):
     )
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_languages():
     """
     Cache of settings.LANGUAGES in a dictionary for easy lookups by key.

--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -68,7 +68,7 @@ def get_docs_version(version=None):
         return '%d.%d' % version[:2]
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_git_changeset():
     """Return a numeric identifier of the latest git changeset.
 

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -61,7 +61,7 @@ def technical_500_response(request, exc_type, exc_value, tb, status_code=500):
         return HttpResponse(text, status=status_code, content_type='text/plain; charset=utf-8')
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_default_exception_reporter_filter():
     # Instantiate the default filter for the first time and cache it.
     return import_string(settings.DEFAULT_EXCEPTION_REPORTER_FILTER)()


### PR DESCRIPTION
There is a small overhead with using an `lru_cache` with a `maxsize` value (the default). This overhead doesn't make sense with functions that have no parameters at all.

I've added a [ticket to CPython](https://bugs.python.org/issue41280) to see if this can be made the default, but right now it is not.