### PR TITLE
Fixed #31731 -- Removed unreachable code for resetting sequences of auto-created m2m tables in sequence_reset_sql().

### DIFF
--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -494,18 +494,6 @@ END;
                     # Only one AutoField is allowed per model, so don't
                     # continue to loop
                     break
-            for f in model._meta.many_to_many:
-                if not f.remote_field.through:
-                    no_autofield_sequence_name = self._get_no_autofield_sequence_name(f.m2m_db_table())
-                    table = self.quote_name(f.m2m_db_table())
-                    column = self.quote_name('id')
-                    output.append(query % {
-                        'no_autofield_sequence_name': no_autofield_sequence_name,
-                        'table': table,
-                        'column': column,
-                        'table_name': strip_quotes(table),
-                        'column_name': 'ID',
-                    })
         return output
 
     def start_transaction_sql(self):

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -185,21 +185,6 @@ class DatabaseOperations(BaseDatabaseOperations):
                         )
                     )
                     break  # Only one AutoField is allowed per model, so don't bother continuing.
-            for f in model._meta.many_to_many:
-                if not f.remote_field.through:
-                    output.append(
-                        "%s setval(pg_get_serial_sequence('%s','%s'), "
-                        "coalesce(max(%s), 1), max(%s) %s null) %s %s;" % (
-                            style.SQL_KEYWORD('SELECT'),
-                            style.SQL_TABLE(qn(f.m2m_db_table())),
-                            style.SQL_FIELD('id'),
-                            style.SQL_FIELD(qn('id')),
-                            style.SQL_FIELD(qn('id')),
-                            style.SQL_KEYWORD('IS NOT'),
-                            style.SQL_KEYWORD('FROM'),
-                            style.SQL_TABLE(qn(f.m2m_db_table()))
-                        )
-                    )
         return output
 
     def prep_for_iexact_query(self, x):


### PR DESCRIPTION
Removed dead code for condition check on model._meta.many_to_many for 'f.remote_field.through' from postgres/Oracle operations.py