### PR TITLE
Refs #30446 -- Defined output_field of BoundingCircle() GIS database functions.

### DIFF
--- a/django/contrib/gis/db/models/functions.py
+++ b/django/contrib/gis/db/models/functions.py
@@ -223,7 +223,7 @@ class AsWKT(GeoFunc):
     arity = 1
 
 
-class BoundingCircle(OracleToleranceMixin, GeoFunc):
+class BoundingCircle(OracleToleranceMixin, GeomOutputGeoFunc):
     def __init__(self, expression, num_seg=48, **extra):
         super().__init__(expression, num_seg, **extra)
 


### PR DESCRIPTION
Moved from #11359.

I removed `output_field` from `Reverse()` because it accepts a single expression and added tests for `BoundingCircle()`.