### PR TITLE
FIxed typo in docs/ref/contrib/postgres/forms.txt.

### DIFF
--- a/docs/ref/contrib/postgres/forms.txt
+++ b/docs/ref/contrib/postgres/forms.txt
@@ -244,4 +244,4 @@ Widgets
 
         Takes a single "compressed" value of a field, for example a
         :class:`~django.contrib.postgres.fields.DateRangeField`,
-        and returns a tuple representing an lower and upper bound.
+        and returns a tuple representing a lower and upper bound.

--- a/docs/ref/contrib/postgres/forms.txt
+++ b/docs/ref/contrib/postgres/forms.txt
@@ -244,4 +244,4 @@ Widgets
 
         Takes a single "compressed" value of a field, for example a
         :class:`~django.contrib.postgres.fields.DateRangeField`,
-        and returns a tuple representing and lower and upper bound.
+        and returns a tuple representing an lower and upper bound.


### PR DESCRIPTION
Fix typo of "and" when "an" is meant.