### PR TITLE
Refs #31502 -- Made minor edits to Model._state docs.

### DIFF
--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -101,10 +101,10 @@ Arguments sent with this signal:
 
     .. note::
 
-        ``instance._state`` isn't set before sending the ``post_init`` signal,
-        so ``_state`` attributes always have their default values. For example,
-        ``_state.db`` is ``None`` and cannot be used to check an ``instance``
-        database.
+        :attr:`instance._state <django.db.models.Model._state>` isn't set
+        before sending the ``post_init`` signal, so ``_state`` attributes
+        always have their default values. For example, ``_state.db`` is
+        ``None``.
 
 .. warning::
 

--- a/docs/topics/db/multi-db.txt
+++ b/docs/topics/db/multi-db.txt
@@ -239,9 +239,10 @@ database usage. Whenever a query needs to know which database to use,
 it calls the master router, providing a model and a hint (if
 available). Django then tries each router in turn until a database
 suggestion can be found. If no suggestion can be found, it tries the
-current ``_state.db`` of the hint instance. If a hint instance wasn't
-provided, or the instance doesn't currently have database state, the
-master router will allocate the ``default`` database.
+current :attr:`instance._state.db <django.db.models.Model._state>` of the hint
+instance. If a hint instance wasn't provided, or :attr:`instance._state.db
+<django.db.models.Model._state>` is ``None``, the master router will allocate
+the ``default`` database.
 
 An example
 ----------


### PR DESCRIPTION
* Add note about them being not really private
* Also mention `Model._meta`, since nothing currently links to its documentation page apart from ToC's!
* Add links from other mentions of `_state`