### PR TITLE
Stopped adapting DecimalField values to strings on Oracle.

### DIFF
--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -570,6 +570,9 @@ END;
         return Oracle_datetime(1900, 1, 1, value.hour, value.minute,
                                value.second, value.microsecond)
 
+    def adapt_decimalfield_value(self, value, max_digits=None, decimal_places=None):
+        return value
+
     def combine_expression(self, connector, sub_expressions):
         lhs, rhs = sub_expressions
         if connector == '%%':


### PR DESCRIPTION
`cx_Oracle` handles `decimal.Decimal`.

`expressions_case.tests.CaseExpressionTests.test_update_decimal` fails without this change, see [logs](https://djangoci.com/job/django-oracle/lastCompletedBuild/database=oracle18,python=python3.6/testReport/expressions_case.tests/CaseExpressionTests/test_update_decimal/).

Follow up to 9c5c9bd7091b60fdccc405890dc4f44a8010e954.