### PR TITLE
Refs #31790 -- Removed incorrect item from 2.2.15 and 3.0.9 release notes.

### DIFF
--- a/docs/releases/2.2.15.txt
+++ b/docs/releases/2.2.15.txt
@@ -11,7 +11,3 @@ Bugfixes
 
 * Allowed setting the ``SameSite`` cookie flag in
   :meth:`.HttpResponse.delete_cookie` (:ticket:`31790`).
-
-* Fixed setting the ``Secure`` cookie flag in
-  :meth:`.HttpResponse.delete_cookie` for cookies that use ``samesite='none'``
-  (:ticket:`31790`).

--- a/docs/releases/3.0.9.txt
+++ b/docs/releases/3.0.9.txt
@@ -11,7 +11,3 @@ Bugfixes
 
 * Allowed setting the ``SameSite`` cookie flag in
   :meth:`.HttpResponse.delete_cookie` (:ticket:`31790`).
-
-* Fixed setting the ``Secure`` cookie flag in
-  :meth:`.HttpResponse.delete_cookie` for cookies that use ``samesite='none'``
-  (:ticket:`31790`).


### PR DESCRIPTION
Django 2.2 and 3.0 don't support settings `samesite='None'` in `HttpResponse.set_cookie()` so fix is not necessary and will not be backported. :facepalm: 