### PR TITLE
[3.0.x] Fixed #31790 -- Fixed setting SameSite cookies flags in HttpResponse.delete_cookie().

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -89,7 +89,11 @@ class CookieStorage(BaseStorage):
                 samesite=settings.SESSION_COOKIE_SAMESITE,
             )
         else:
-            response.delete_cookie(self.cookie_name, domain=settings.SESSION_COOKIE_DOMAIN)
+            response.delete_cookie(
+                self.cookie_name,
+                domain=settings.SESSION_COOKIE_DOMAIN,
+                samesite=settings.SESSION_COOKIE_SAMESITE,
+            )
 
     def _store(self, messages, response, remove_oldest=True, *args, **kwargs):
         """

--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -38,6 +38,7 @@ class SessionMiddleware(MiddlewareMixin):
                 settings.SESSION_COOKIE_NAME,
                 path=settings.SESSION_COOKIE_PATH,
                 domain=settings.SESSION_COOKIE_DOMAIN,
+                samesite=settings.SESSION_COOKIE_SAMESITE,
             )
             patch_vary_headers(response, ('Cookie',))
         else:

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -209,13 +209,13 @@ class HttpResponseBase:
         value = signing.get_cookie_signer(salt=key + salt).sign(value)
         return self.set_cookie(key, value, **kwargs)
 
-    def delete_cookie(self, key, path='/', domain=None):
+    def delete_cookie(self, key, path='/', domain=None, samesite=None):
         # Most browsers ignore the Set-Cookie header if the cookie name starts
         # with __Host- or __Secure- and the cookie doesn't use the secure flag.
         secure = key.startswith(('__Secure-', '__Host-'))
         self.set_cookie(
             key, max_age=0, path=path, domain=domain, secure=secure,
-            expires='Thu, 01 Jan 1970 00:00:00 GMT',
+            expires='Thu, 01 Jan 1970 00:00:00 GMT', samesite=samesite,
         )
 
     # Common methods used by subclasses

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -858,7 +858,7 @@ Methods
     you will need to remember to pass it to the corresponding
     :meth:`HttpRequest.get_signed_cookie` call.
 
-.. method:: HttpResponse.delete_cookie(key, path='/', domain=None)
+.. method:: HttpResponse.delete_cookie(key, path='/', domain=None, samesite=None)
 
     Deletes the cookie with the given key. Fails silently if the key doesn't
     exist.
@@ -866,6 +866,10 @@ Methods
     Due to the way cookies work, ``path`` and ``domain`` should be the same
     values you used in ``set_cookie()`` -- otherwise the cookie may not be
     deleted.
+
+    .. versionchanged:: 2.2.15
+
+        The ``samesite`` argument was added.
 
 .. method:: HttpResponse.close()
 

--- a/docs/releases/2.2.15.txt
+++ b/docs/releases/2.2.15.txt
@@ -1,10 +1,10 @@
-==========================
-Django 3.0.9 release notes
-==========================
+===========================
+Django 2.2.15 release notes
+===========================
 
 *Expected August 3, 2020*
 
-Django 3.0.9 fixes several bugs in 3.0.8.
+Django 2.2.15 fixes a bug in 2.2.14.
 
 Bugfixes
 ========

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -41,6 +41,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   2.2.15
    2.2.14
    2.2.13
    2.2.12

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.contrib.messages import constants
 from django.contrib.messages.storage.base import Message
 from django.contrib.messages.storage.cookie import (
@@ -85,6 +86,10 @@ class CookieTests(BaseTests, SimpleTestCase):
         self.assertEqual(response.cookies['messages'].value, '')
         self.assertEqual(response.cookies['messages']['domain'], '.example.com')
         self.assertEqual(response.cookies['messages']['expires'], 'Thu, 01 Jan 1970 00:00:00 GMT')
+        self.assertEqual(
+            response.cookies['messages']['samesite'],
+            settings.SESSION_COOKIE_SAMESITE,
+        )
 
     def test_get_bad_cookie(self):
         request = self.get_request()

--- a/tests/responses/test_cookie.py
+++ b/tests/responses/test_cookie.py
@@ -102,6 +102,7 @@ class DeleteCookieTests(SimpleTestCase):
         self.assertEqual(cookie['path'], '/')
         self.assertEqual(cookie['secure'], '')
         self.assertEqual(cookie['domain'], '')
+        self.assertEqual(cookie['samesite'], '')
 
     def test_delete_cookie_secure_prefix(self):
         """
@@ -115,3 +116,8 @@ class DeleteCookieTests(SimpleTestCase):
                 cookie_name = '__%s-c' % prefix
                 response.delete_cookie(cookie_name)
                 self.assertEqual(response.cookies[cookie_name]['secure'], True)
+
+    def test_delete_cookie_samesite(self):
+        response = HttpResponse()
+        response.delete_cookie('c', samesite='lax')
+        self.assertEqual(response.cookies['c']['samesite'], 'lax')

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -755,8 +755,9 @@ class SessionMiddlewareTests(TestCase):
         #  Set-Cookie: sessionid=; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/
         self.assertEqual(
             'Set-Cookie: {}=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; '
-            'Max-Age=0; Path=/'.format(
+            'Max-Age=0; Path=/; SameSite={}'.format(
                 settings.SESSION_COOKIE_NAME,
+                settings.SESSION_COOKIE_SAMESITE,
             ),
             str(response.cookies[settings.SESSION_COOKIE_NAME])
         )
@@ -787,8 +788,9 @@ class SessionMiddlewareTests(TestCase):
         #              Path=/example/
         self.assertEqual(
             'Set-Cookie: {}=""; Domain=.example.local; expires=Thu, '
-            '01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/example/'.format(
+            '01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/example/; SameSite={}'.format(
                 settings.SESSION_COOKIE_NAME,
+                settings.SESSION_COOKIE_SAMESITE,
             ),
             str(response.cookies[settings.SESSION_COOKIE_NAME])
         )


### PR DESCRIPTION
Cookies with the "SameSite" flag set to None and without the "secure"
flag will be soon rejected by latest browser versions.

This affects sessions and messages cookies.

Backport of 240cbb63bf9965c63d7a3cc9032f91410f414d46 from master.