### PR TITLE
Fixed #30801 -- Added examples of alternatives to signals

### DIFF
--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -234,11 +234,11 @@ method::
 
     class Order(models.Model):
         ...
-        def delete(self, **kwargs):
+        def delete(self, *args, **kwargs):
             if self.status != "PENDING":
                 raise OrderError("Cannot delete processed order")
 
-            return super().delete(**kwargs)
+            return super().delete(*args, **kwargs)
 
 ``post_delete``
 ---------------
@@ -273,8 +273,8 @@ method::
 
     class Order(models.Model):
         ...
-        def delete(self, **kwargs):
-            result = super().delete(**kwargs)
+        def delete(self, *args, **kwargs):
+            result = super().delete(*args, **kwargs)
 
             transaction.on_commit(self.send_order_deleted_email)
 

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -240,6 +240,12 @@ method::
 
             return super().delete(*args, **kwargs)
 
+.. note::
+
+    The alternative method above is not suitable for a bulk delete, since calling
+    ``delete()`` on a :class:`~django.db.models.query.QuerySet` does not call any
+    ``delete()`` methods on your model.
+
 ``post_delete``
 ---------------
 
@@ -279,6 +285,12 @@ method::
             transaction.on_commit(self.send_order_deleted_email)
 
             return result
+
+.. note::
+
+    The alternative method above is not suitable for a bulk delete, since calling
+    ``delete()`` on a :class:`~django.db.models.query.QuerySet` does not call any
+    ``delete()`` methods on your model.
 
 ``m2m_changed``
 ---------------

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -142,22 +142,20 @@ Arguments sent with this signal:
     The set of fields to update as passed to :meth:`.Model.save`, or ``None``
     if ``update_fields`` wasn't passed to ``save()``.
 
-Alternative to the pre_save signal
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Alternative to using ``pre_save``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Unless the model you are targetting is provided by a library and cannot be swapped, a
-more robust and maintainable solution would be to override the model's
-:meth:`~django.db.models.Model.save` method::
+If the model you are targetting is part of your project, a more robust and maintainable
+solution would be to override the model's :meth:`~django.db.models.Model.save` method::
 
     class Article(models.Model):
         ...
         def save(self, update_fields=None, **kwargs):
-            # here goes the pre_save logic
             self.slug = slugify(self.title)
             if update_fields:
-                update_fields += ("slug",)
+                update_fields = set(update_fields) | {"slug"}
 
-            self.save(update_fields=update_fields, **kwargs)
+            super().save(update_fields=update_fields, **kwargs)
 
 ``post_save``
 -------------
@@ -192,24 +190,20 @@ Arguments sent with this signal:
     The set of fields to update as passed to :meth:`.Model.save`, or ``None``
     if ``update_fields`` wasn't passed to ``save()``.
 
-Alternative to the post_save signal
+Alternative to using ``post_save``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Unless the model you are targetting is provided by a library and cannot be swapped, a
-more robust and maintainable solution would be to override the model's
-:meth:`~django.db.models.Model.save` method::
+If the model you are targetting is part of your project, a more robust and maintainable
+solution would be to override the model's :meth:`~django.db.models.Model.save` method::
 
     class Order(models.Model):
         ...
-        @transaction.atomic
         def save(self, **kwargs):
-            is_new = self.pk is None
+            is_new = self._state.adding
             self.save(**kwargs)
 
-            # here goes the post_save logic
             if is_new:
-                self.product.stock -= self.quantity
-                self.product.save(update_fields=("stock",))
+                transaction.on_commit(self.send_new_order_email)
 
 ``pre_delete``
 --------------
@@ -231,17 +225,16 @@ Arguments sent with this signal:
 ``using``
     The database alias being used.
 
-Alternative to the pre_delete signal
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Alternative to using ``pre_delete``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Unless the model you are targetting is provided by a library and cannot be swapped, a
-more robust and maintainable solution would be to override the model's
-:meth:`~django.db.models.Model.delete` method::
+If the model you are targetting is part of your project, a more robust and maintainable
+solution would be to override the model's :meth:`~django.db.models.Model.delete`
+method::
 
     class Order(models.Model):
         ...
         def delete(self, **kwargs):
-            # here goes the pre_delete logic
             if self.status != "PENDING":
                 raise OrderError("Cannot delete processed order")
 
@@ -271,22 +264,19 @@ Arguments sent with this signal:
 ``using``
     The database alias being used.
 
-Alternative to the post_delete signal
+Alternative to using ``post_delete``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Unless the model you are targetting is provided by a library and cannot be swapped, a
-more robust and maintainable solution would be to override the model's
-:meth:`~django.db.models.Model.delete` method::
+If the model you are targetting is part of your project, a more robust and maintainable
+solution would be to override the model's :meth:`~django.db.models.Model.delete`
+method::
 
     class Order(models.Model):
         ...
-        @transaction.atomic
         def delete(self, **kwargs):
             result = super().delete(**kwargs)
 
-            # here goes the post_delete logic
-            self.product.stock += self.quantity
-            self.product.save(update_fields=("stock",))
+            transaction.on_commit(self.send_order_deleted_email)
 
             return result
 
@@ -602,7 +592,7 @@ Signals sent by the core framework when processing a request.
 .. note::
 
     A more robust and maintainable alternative to request/response signals is to provide
-    a :doc:`Middleware. </topics/http/middleware>`
+    a :doc:`middleware. </topics/http/middleware>`
 
 ``request_started``
 -------------------
@@ -688,6 +678,13 @@ Arguments sent with this signal:
 
 ``enter``
     A boolean; ``True`` if the setting is applied, ``False`` if restored.
+
+Here is an example of how this signal is used by many pluggable Django apps::
+
+    @receiver(setting_changed)
+    def reload_my_app_settings(**kwargs):
+        if kwargs['setting'] == 'MY_APP':
+            my_app_settings.reload()
 
 ``template_rendered``
 ---------------------

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -142,6 +142,23 @@ Arguments sent with this signal:
     The set of fields to update as passed to :meth:`.Model.save`, or ``None``
     if ``update_fields`` wasn't passed to ``save()``.
 
+Alternative to the pre_save signal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unless the model you are targetting is provided by a library and cannot be swapped, a
+more robust and maintainable solution would be to override the model's
+:meth:`~django.db.models.Model.save` method::
+
+    class Article(models.Model):
+        ...
+        def save(self, update_fields=None, **kwargs):
+            # here goes the pre_save logic
+            self.slug = slugify(self.title)
+            if update_fields:
+                update_fields += ("slug",)
+
+            self.save(update_fields=update_fields, **kwargs)
+
 ``post_save``
 -------------
 
@@ -175,6 +192,25 @@ Arguments sent with this signal:
     The set of fields to update as passed to :meth:`.Model.save`, or ``None``
     if ``update_fields`` wasn't passed to ``save()``.
 
+Alternative to the post_save signal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unless the model you are targetting is provided by a library and cannot be swapped, a
+more robust and maintainable solution would be to override the model's
+:meth:`~django.db.models.Model.save` method::
+
+    class Order(models.Model):
+        ...
+        @transaction.atomic
+        def save(self, **kwargs):
+            is_new = self.pk is None
+            self.save(**kwargs)
+
+            # here goes the post_save logic
+            if is_new:
+                self.product.stock -= self.quantity
+                self.product.save(update_fields=("stock",))
+
 ``pre_delete``
 --------------
 
@@ -194,6 +230,22 @@ Arguments sent with this signal:
 
 ``using``
     The database alias being used.
+
+Alternative to the pre_delete signal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unless the model you are targetting is provided by a library and cannot be swapped, a
+more robust and maintainable solution would be to override the model's
+:meth:`~django.db.models.Model.delete` method::
+
+    class Order(models.Model):
+        ...
+        def delete(self, **kwargs):
+            # here goes the pre_delete logic
+            if self.status != "PENDING":
+                raise OrderError("Cannot delete processed order")
+
+            return super().delete(**kwargs)
 
 ``post_delete``
 ---------------
@@ -218,6 +270,25 @@ Arguments sent with this signal:
 
 ``using``
     The database alias being used.
+
+Alternative to the post_delete signal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unless the model you are targetting is provided by a library and cannot be swapped, a
+more robust and maintainable solution would be to override the model's
+:meth:`~django.db.models.Model.delete` method::
+
+    class Order(models.Model):
+        ...
+        @transaction.atomic
+        def delete(self, **kwargs):
+            result = super().delete(**kwargs)
+
+            # here goes the post_delete logic
+            self.product.stock += self.quantity
+            self.product.save(update_fields=("stock",))
+
+            return result
 
 ``m2m_changed``
 ---------------
@@ -527,6 +598,11 @@ Request/response signals
    :synopsis: Core signals sent by the request/response system.
 
 Signals sent by the core framework when processing a request.
+
+.. note::
+
+    A more robust and maintainable alternative to request/response signals is to provide
+    a :doc:`Middleware. </topics/http/middleware>`
 
 ``request_started``
 -------------------

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -145,7 +145,7 @@ Arguments sent with this signal:
 Alternative to using ``pre_save``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the model you are targetting is part of your project, a more robust and maintainable
+If the model you are targeting is part of your project, a more robust and maintainable
 solution would be to override the model's :meth:`~django.db.models.Model.save` method::
 
     class Article(models.Model):
@@ -193,7 +193,7 @@ Arguments sent with this signal:
 Alternative to using ``post_save``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the model you are targetting is part of your project, a more robust and maintainable
+If the model you are targeting is part of your project, a more robust and maintainable
 solution would be to override the model's :meth:`~django.db.models.Model.save` method::
 
     class Order(models.Model):
@@ -228,7 +228,7 @@ Arguments sent with this signal:
 Alternative to using ``pre_delete``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the model you are targetting is part of your project, a more robust and maintainable
+If the model you are targeting is part of your project, a more robust and maintainable
 solution would be to override the model's :meth:`~django.db.models.Model.delete`
 method::
 
@@ -267,7 +267,7 @@ Arguments sent with this signal:
 Alternative to using ``post_delete``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the model you are targetting is part of your project, a more robust and maintainable
+If the model you are targeting is part of your project, a more robust and maintainable
 solution would be to override the model's :meth:`~django.db.models.Model.delete`
 method::
 

--- a/docs/topics/signals.txt
+++ b/docs/topics/signals.txt
@@ -38,14 +38,6 @@ useful notifications:
 
   Sent when Django starts or finishes an HTTP request.
 
-This is an example of the ``setting_changed`` signal, which is used by many pluggable
-Django apps::
-
-    @receiver(setting_changed)
-    def reload_my_app_settings(**kwargs):
-        if kwargs['setting'] == 'MY_APP':
-            my_app_settings.reload()
-
 You can also `define and send your own custom signals`_; see below.
 
 .. _define and send your own custom signals: `defining and sending signals`_

--- a/docs/topics/signals.txt
+++ b/docs/topics/signals.txt
@@ -11,8 +11,32 @@ signals allow certain *senders* to notify a set of *receivers* that some action
 has taken place. They're especially useful when many pieces of code may be
 interested in the same events.
 
-Django provides a :doc:`set of built-in signals </ref/signals>` that let user
-code get notified by Django itself of certain actions.
+Django provides a set of built-in signals that let user code get notified by Django
+itself of certain actions. See the :doc:`built-in signal documentation </ref/signals>`
+for a complete list, and a complete explanation of each signal. These include some
+useful notifications:
+
+* :data:`django.db.models.signals.pre_save` &
+  :data:`django.db.models.signals.post_save`
+
+  Sent before or after a model's :meth:`~django.db.models.Model.save` method
+  is called.
+
+* :data:`django.db.models.signals.pre_delete` &
+  :data:`django.db.models.signals.post_delete`
+
+  Sent before or after a model's :meth:`~django.db.models.Model.delete`
+  method or queryset's :meth:`~django.db.models.query.QuerySet.delete`
+  method is called.
+
+* :data:`django.db.models.signals.m2m_changed`
+
+  Sent when a :class:`~django.db.models.ManyToManyField` on a model is changed.
+
+* :data:`django.core.signals.request_started` &
+  :data:`django.core.signals.request_finished`
+
+  Sent when Django starts or finishes an HTTP request.
 
 This is an example of the ``setting_changed`` signal, which is used by many pluggable
 Django apps::
@@ -21,9 +45,6 @@ Django apps::
     def reload_my_app_settings(**kwargs):
         if kwargs['setting'] == 'MY_APP':
             my_app_settings.reload()
-
-See the :doc:`built-in signal documentation </ref/signals>` for a complete list,
-and a complete explanation of each signal.
 
 You can also `define and send your own custom signals`_; see below.
 

--- a/docs/topics/signals.txt
+++ b/docs/topics/signals.txt
@@ -12,30 +12,15 @@ has taken place. They're especially useful when many pieces of code may be
 interested in the same events.
 
 Django provides a :doc:`set of built-in signals </ref/signals>` that let user
-code get notified by Django itself of certain actions. These include some useful
-notifications:
+code get notified by Django itself of certain actions.
 
-* :data:`django.db.models.signals.pre_save` &
-  :data:`django.db.models.signals.post_save`
+This is an example of the ``setting_changed`` signal, which is used by many pluggable
+Django apps::
 
-  Sent before or after a model's :meth:`~django.db.models.Model.save` method
-  is called.
-
-* :data:`django.db.models.signals.pre_delete` &
-  :data:`django.db.models.signals.post_delete`
-
-  Sent before or after a model's :meth:`~django.db.models.Model.delete`
-  method or queryset's :meth:`~django.db.models.query.QuerySet.delete`
-  method is called.
-
-* :data:`django.db.models.signals.m2m_changed`
-
-  Sent when a :class:`~django.db.models.ManyToManyField` on a model is changed.
-
-* :data:`django.core.signals.request_started` &
-  :data:`django.core.signals.request_finished`
-
-  Sent when Django starts or finishes an HTTP request.
+    @receiver(setting_changed)
+    def reload_my_app_settings(**kwargs):
+        if kwargs['setting'] == 'MY_APP':
+            my_app_settings.reload()
 
 See the :doc:`built-in signal documentation </ref/signals>` for a complete list,
 and a complete explanation of each signal.


### PR DESCRIPTION
**Ticket:** https://code.djangoproject.com/ticket/30801

## Added alternative example for `pre_save` signal

<img width="671" alt="Screen Shot 2020-07-17 at 09 48 56" src="https://user-images.githubusercontent.com/55533/87790593-2e036980-c817-11ea-846e-f4a7419ccdbe.png">

## Added alternative example for `post_save` signal

<img width="671" alt="Screen Shot 2020-07-17 at 09 49 32" src="https://user-images.githubusercontent.com/55533/87790604-30fe5a00-c817-11ea-913f-e550e1e14eeb.png">

## Added alternative example for `pre_delete` signal

<img width="668" alt="Screen Shot 2020-07-17 at 09 50 56" src="https://user-images.githubusercontent.com/55533/87790606-322f8700-c817-11ea-8857-3b5277d93c31.png">

## Added alternative example for `post_delete` signal

<img width="673" alt="Screen Shot 2020-07-17 at 09 52 29" src="https://user-images.githubusercontent.com/55533/87790609-322f8700-c817-11ea-80b5-8fb8a44f5380.png">

## Add example of the `setting_changed` signal (reference page)

<img width="667" alt="Screen Shot 2020-07-17 at 10 22 18" src="https://user-images.githubusercontent.com/55533/87790740-73c03200-c817-11ea-98e4-f9f6f8f7fce5.png">


## Add example of the `setting_changed` signal (topic page)

<img width="679" alt="Screen Shot 2020-07-17 at 10 14 50" src="https://user-images.githubusercontent.com/55533/87790611-32c81d80-c817-11ea-9c98-689d0b742740.png">



---
**I didn't put examples for other signals because:**

* Those are not commonly used since they're more specific
* There are not really good alternatives