### PR TITLE
Fixed #31720 -- Defined default output_field of BoolAnd() and BoolOr() aggregate functions and added examples to docs.

### DIFF
--- a/django/contrib/postgres/aggregates/general.py
+++ b/django/contrib/postgres/aggregates/general.py
@@ -1,5 +1,5 @@
 from django.contrib.postgres.fields import ArrayField
-from django.db.models import Aggregate, JSONField, Value
+from django.db.models import Aggregate, BooleanField, JSONField, Value
 
 from .mixins import OrderableAggMixin
 
@@ -33,10 +33,12 @@ class BitOr(Aggregate):
 
 class BoolAnd(Aggregate):
     function = 'BOOL_AND'
+    output_field = BooleanField()
 
 
 class BoolOr(Aggregate):
     function = 'BOOL_OR'
+    output_field = BooleanField()
 
 
 class JSONBAgg(OrderableAggMixin, Aggregate):

--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -82,11 +82,11 @@ General-purpose aggregation functions
             published = models.BooleanField()
             rank = models.IntegerField()
 
-        >>> from django.db.models import BooleanField, Q
+        >>> from django.db.models import Q
         >>> from django.contrib.postgres.aggregates import BoolAnd
         >>> Comment.objects.aggregate(booland=BoolAnd('published'))
         {'booland': False}
-        >>> Comment.objects.aggregate(booland=BoolAnd(Q(rank__lt=100), output_field=BooleanField()))
+        >>> Comment.objects.aggregate(booland=BoolAnd(Q(rank__lt=100)))
         {'booland': True}
 
 ``BoolOr``
@@ -104,11 +104,11 @@ General-purpose aggregation functions
             published = models.BooleanField()
             rank = models.IntegerField()
 
-        >>> from django.db.models import BooleanField, Q
+        >>> from django.db.models import Q
         >>> from django.contrib.postgres.aggregates import BoolOr
         >>> Comment.objects.aggregate(boolor=BoolOr('published'))
         {'boolor': True}
-        >>> Comment.objects.aggregate(boolor=BoolOr(Q(rank__gt=2), output_field=BooleanField()))
+        >>> Comment.objects.aggregate(boolor=BoolOr(Q(rank__gt=2)))
         {'boolor': False}
 
 ``JSONBAgg``

--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -75,6 +75,20 @@ General-purpose aggregation functions
     Returns ``True``, if all input values are true, ``None`` if all values are
     null or if there are no values, otherwise ``False`` .
 
+    Usage example::
+
+        class Comment(models.Model):
+            body = models.TextField()
+            published = models.BooleanField()
+            rank = models.IntegerField()
+
+        >>> from django.db.models import BooleanField, Q
+        >>> from django.contrib.postgres.aggregates import BoolAnd
+        >>> Comment.objects.aggregate(booland=BoolAnd('published'))
+        {'booland': False}
+        >>> Comment.objects.aggregate(booland=BoolAnd(Q(rank__lt=100), output_field=BooleanField()))
+        {'booland': True}
+
 ``BoolOr``
 ----------
 
@@ -82,6 +96,20 @@ General-purpose aggregation functions
 
     Returns ``True`` if at least one input value is true, ``None`` if all
     values are null or if there are no values, otherwise ``False``.
+
+    Usage example::
+
+        class Comment(models.Model):
+            body = models.TextField()
+            published = models.BooleanField()
+            rank = models.IntegerField()
+
+        >>> from django.db.models import BooleanField, Q
+        >>> from django.contrib.postgres.aggregates import BoolOr
+        >>> Comment.objects.aggregate(boolor=BoolOr('published'))
+        {'boolor': True}
+        >>> Comment.objects.aggregate(boolor=BoolOr(Q(rank__gt=2), output_field=BooleanField()))
+        {'boolor': False}
 
 ``JSONBAgg``
 ------------

--- a/tests/postgres_tests/test_aggregates.py
+++ b/tests/postgres_tests/test_aggregates.py
@@ -155,6 +155,12 @@ class TestGeneralAggregate(PostgreSQLTestCase):
         values = AggregateTestModel.objects.aggregate(booland=BoolAnd('boolean_field'))
         self.assertEqual(values, {'booland': None})
 
+    def test_bool_and_q_object(self):
+        values = AggregateTestModel.objects.aggregate(
+            booland=BoolAnd(Q(integer_field__gt=2)),
+        )
+        self.assertEqual(values, {'booland': False})
+
     def test_bool_or_general(self):
         values = AggregateTestModel.objects.aggregate(boolor=BoolOr('boolean_field'))
         self.assertEqual(values, {'boolor': True})
@@ -163,6 +169,12 @@ class TestGeneralAggregate(PostgreSQLTestCase):
         AggregateTestModel.objects.all().delete()
         values = AggregateTestModel.objects.aggregate(boolor=BoolOr('boolean_field'))
         self.assertEqual(values, {'boolor': None})
+
+    def test_bool_or_q_object(self):
+        values = AggregateTestModel.objects.aggregate(
+            boolor=BoolOr(Q(integer_field__gt=2)),
+        )
+        self.assertEqual(values, {'boolor': False})
 
     def test_string_agg_requires_delimiter(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31720

Added defaults to BoolOr and BoolAnd classes and made documentation improvements by adding examples.
