### PR TITLE
Update tutorial04.txt

### DIFF
--- a/docs/intro/tutorial04.txt
+++ b/docs/intro/tutorial04.txt
@@ -303,7 +303,7 @@ We're using two generic views here:
 two views abstract the concepts of "display a list of objects" and
 "display a detail page for a particular type of object."
 
-* Each generic view needs to know what model it will be acting
+* Each :class:`~django.views.generic.detail.DetailView` generic view needs to know what model it will be acting
   upon. This is provided using the ``model`` attribute.
 
 * The :class:`~django.views.generic.detail.DetailView` generic view


### PR DESCRIPTION
The modified tutorial bullet makes it look as if setting the model attribute was necessary for both ListView and DetailView generic views, but it is not necessary for ListView, as shown by the [tutorial code for the class IndexView](https://docs.djangoproject.com/en/3.0/intro/tutorial04/#amend-views).
