### PR TITLE
Reverted "Fixed #30300 -- Allowed migrations to be loaded from directories without __init__.py file."

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -88,6 +88,11 @@ class MigrationLoader:
                     continue
                 raise
             else:
+                # Empty directories are namespaces.
+                # getattr() needed on PY36 and older (replace w/attribute access).
+                if getattr(module, '__file__', None) is None:
+                    self.unmigrated_apps.add(app_config.label)
+                    continue
                 # Module is not a package (e.g. migrations.py).
                 if not hasattr(module, '__path__'):
                     self.unmigrated_apps.add(app_config.label)
@@ -95,14 +100,11 @@ class MigrationLoader:
                 # Force a reload if it's already loaded (tests need this)
                 if was_loaded:
                     reload(module)
+            self.migrated_apps.add(app_config.label)
             migration_names = {
                 name for _, name, is_pkg in pkgutil.iter_modules(module.__path__)
                 if not is_pkg and name[0] not in '_~'
             }
-            if migration_names or self.ignore_no_migrations:
-                self.migrated_apps.add(app_config.label)
-            else:
-                self.unmigrated_apps.add(app_config.label)
             # Load migrations
             for migration_name in migration_names:
                 migration_path = '%s.%s' % (module_name, migration_name)

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -337,12 +337,6 @@ Management Commands
 * The :djadmin:`flush` and :djadmin:`sqlflush` commands now include SQL to
   reset sequences on SQLite.
 
-Migrations
-~~~~~~~~~~
-
-* Migrations are now loaded also from directories without ``__init__.py``
-  files.
-
 Models
 ~~~~~~
 

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -506,12 +506,11 @@ class LoaderTests(TestCase):
         MIGRATION_MODULES={'migrations': 'migrations.test_migrations_namespace_package'},
     )
     def test_loading_namespace_package(self):
-        """Migration directories without an __init__.py file are loaded."""
-        migration_loader = MigrationLoader(connection)
-        self.assertEqual(
-            migration_loader.graph.forwards_plan(('migrations', '0001_initial')),
-            [('migrations', '0001_initial')],
-        )
+        """Migration directories without an __init__.py file are ignored."""
+        loader = MigrationLoader(connection)
+        loader.load_disk()
+        migrations = [name for app, name in loader.disk_migrations if app == 'migrations']
+        self.assertEqual(migrations, [])
 
 
 class PycLoaderTests(MigrationTestBase):


### PR DESCRIPTION
This reverts commit 3cd3bebe8921e14b911b36b2a1cbceef8fb6294e.

https://groups.google.com/g/django-developers/c/GVHMH2ciAnk/m/vbIPbZuSBQAJ