### PR TITLE
Removed duplicate non_field_error title

### DIFF
--- a/docs/ref/exceptions.txt
+++ b/docs/ref/exceptions.txt
@@ -152,9 +152,6 @@ Django core exception classes are defined in ``django.core.exceptions``.
     :ref:`Model Field Validation <validating-objects>` and the
     :doc:`Validator Reference </ref/validators>`.
 
-``NON_FIELD_ERRORS``
-~~~~~~~~~~~~~~~~~~~~
-
 .. data:: NON_FIELD_ERRORS
 
 ``ValidationError``\s that don't belong to a particular field in a form


### PR DESCRIPTION
https://docs.djangoproject.com/en/3.0/ref/exceptions/#non-field-errors

The two `NON_FIELD_ERROR` titles here look a bit odd. Do we need both 🤷 ? (I'm not sure what the second title means to me as a reader of the docs)


