### PR TITLE
Fixed #31805 -- Fixed SchemaTests.tearDown() when table names are case-insensitive.

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -88,8 +88,12 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             connection.disable_constraint_checking()
             table_names = connection.introspection.table_names()
+            if connection.features.ignores_table_name_case:
+                table_names = [table_name.lower() for table_name in table_names]
             for model in itertools.chain(SchemaTests.models, self.local_models):
                 tbl = converter(model._meta.db_table)
+                if connection.features.ignores_table_name_case:
+                    tbl = tbl.lower()
                 if tbl in table_names:
                     editor.delete_model(model)
                     table_names.remove(tbl)


### PR DESCRIPTION
ticket-31805