### PR TITLE
[2.2.x] Pinned geoip2 < 4.0.0 in test requirements.

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,7 +1,7 @@
 argon2-cffi >= 16.1.0
 bcrypt
 docutils
-geoip2
+geoip2 < 4.0.0
 jinja2 >= 2.9.2
 numpy
 Pillow != 5.4.0


### PR DESCRIPTION
`geoip2` 4+ doesn't support Python 3.5, example logs:
```
======================================================================
ERROR [0.001s]: gis_tests.test_geoip2 (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: gis_tests.test_geoip2
Traceback (most recent call last):
  File "/usr/lib/python3.5/unittest/loader.py", line 428, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.5/unittest/loader.py", line 369, in _get_module_from_name
    __import__(name)
  File "/home/jenkins/workspace/django-oracle-2.2/database/oragis18/label/bionic/python/python3.5/tests/gis_tests/test_geoip2.py", line 5, in <module>
    from django.contrib.gis.geoip2 import HAS_GEOIP2
  File "/home/jenkins/workspace/django-oracle-2.2/database/oragis18/label/bionic/python/python3.5/django/contrib/gis/geoip2/__init__.py", line 21, in <module>
    from .base import GeoIP2, GeoIP2Exception
  File "/home/jenkins/workspace/django-oracle-2.2/database/oragis18/label/bionic/python/python3.5/django/contrib/gis/geoip2/base.py", line 4, in <module>
    import geoip2.database
  File "/home/jenkins/workspace/django-oracle-2.2/database/oragis18/label/bionic/python/python3.5/tests/.env/lib/python3.5/site-packages/geoip2/database.py", line 9, in <module>
    import maxminddb
  File "/home/jenkins/workspace/django-oracle-2.2/database/oragis18/label/bionic/python/python3.5/tests/.env/lib/python3.5/site-packages/maxminddb/__init__.py", line 5, in <module>
    import maxminddb.reader
  File "/home/jenkins/workspace/django-oracle-2.2/database/oragis18/label/bionic/python/python3.5/tests/.env/lib/python3.5/site-packages/maxminddb/reader.py", line 36
    _buffer: Union[bytes, FileBuffer, "mmap.mmap"]
           ^
SyntaxError: invalid syntax
```

See [release notes](https://github.com/maxmind/GeoIP2-python/releases/tag/v4.0.0).