### PR TITLE
[german translaction] fix german translation of "the same"

### DIFF
--- a/django/contrib/auth/locale/de/LC_MESSAGES/django.po
+++ b/django/contrib/auth/locale/de/LC_MESSAGES/django.po
@@ -67,7 +67,7 @@ msgid "Password confirmation"
 msgstr "Passwort bestätigen"
 
 msgid "Enter the same password as before, for verification."
-msgstr "Bitte das selbe Passwort zur Bestätigung erneut eingeben."
+msgstr "Bitte dasselbe Passwort zur Bestätigung erneut eingeben."
 
 msgid ""
 "Raw passwords are not stored, so there is no way to see this user’s "


### PR DESCRIPTION
According to german Duden the translation of "the same" is written as "dasselbe" [0]

[0] https://www.duden.de/rechtschreibung/derselbe