### PR TITLE
Fixed #31816 -- Corrected the expected content type in StreamingHttpResponse docs.

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1116,7 +1116,7 @@ The :class:`StreamingHttpResponse` is not a subclass of :class:`HttpResponse`,
 because it features a slightly different API. However, it is almost identical,
 with the following notable differences:
 
-* It should be given an iterator that yields strings as content.
+* It should be given an iterator that yields bytestrings as content.
 
 * You cannot access its content, except by iterating the response object
   itself. This should only occur when the response is returned to the client.


### PR DESCRIPTION
Changed "strings" to "bytestrings". When this documentation was first written. "strings" referred to python 2 strings.