### PR TITLE
Fixed #31822 -- Added support for comments URL per feed item.

### DIFF
--- a/django/contrib/syndication/views.py
+++ b/django/contrib/syndication/views.py
@@ -212,6 +212,7 @@ class Feed:
                 author_name=author_name,
                 author_email=author_email,
                 author_link=author_link,
+                comments=self._get_dynamic_attr('item_comments', item),
                 categories=self._get_dynamic_attr('item_categories', item),
                 item_copyright=self._get_dynamic_attr('item_copyright', item),
                 **self.item_extra_kwargs(item)

--- a/docs/ref/contrib/syndication.txt
+++ b/docs/ref/contrib/syndication.txt
@@ -889,6 +889,27 @@ This example illustrates all possible attributes and methods for a
 
         item_copyright = 'Copyright (c) 2007, Sally Smith' # Hard-coded copyright notice.
 
+        # ITEM COMMENTS URL -- It's optional to use one of these three. This is
+        # a hook that specifies how to get the URL of a page for comments for a
+        # given item.
+
+        def item_comments(self, obj):
+            """
+            Takes an item, as returned by items(), and returns the item's
+            comments URL as a normal Python string.
+            """
+
+        def item_comments(self):
+            """
+            Returns the comments URL for every item in the feed.
+            """
+
+        item_comments = 'https://www.example.com/comments' # Hard-coded comments URL
+
+.. versionchanged:: 3.2
+
+    Support for a comments URL per feed item was added through the
+    ``item_comments`` hook.
 
 The low-level framework
 =======================

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -144,7 +144,8 @@ Minor features
 :mod:`django.contrib.syndication`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The new ``item_comments`` hook allows specifying a comments URL per feed
+  item.
 
 Cache
 ~~~~~

--- a/tests/syndication_tests/feeds.py
+++ b/tests/syndication_tests/feeds.py
@@ -29,6 +29,9 @@ class TestRss2Feed(views.Feed):
     def item_updateddate(self, item):
         return item.updated
 
+    def item_comments(self, item):
+        return "%scomments" % item.get_absolute_url()
+
     item_author_name = 'Sally Smith'
     item_author_email = 'test@example.com'
     item_author_link = 'http://www.example.com/'

--- a/tests/syndication_tests/tests.py
+++ b/tests/syndication_tests/tests.py
@@ -136,10 +136,20 @@ class SyndicationFeedTest(FeedTestCase):
             'guid': 'http://example.com/blog/1/',
             'pubDate': pub_date,
             'author': 'test@example.com (Sally Smith)',
+            'comments': '/blog/1/comments',
         })
         self.assertCategories(items[0], ['python', 'testing'])
         for item in items:
-            self.assertChildNodes(item, ['title', 'link', 'description', 'guid', 'category', 'pubDate', 'author'])
+            self.assertChildNodes(item, [
+                'title',
+                'link',
+                'description',
+                'guid',
+                'category',
+                'pubDate',
+                'author',
+                'comments',
+            ])
             # Assert that <guid> does not have any 'isPermaLink' attribute
             self.assertIsNone(item.getElementsByTagName(
                 'guid')[0].attributes.get('isPermaLink'))


### PR DESCRIPTION
Add support for the dynamic attribute item_comments in syndication feeds
as this is already explicitly implemented in the feedparser.

This change enables a direct comment URL hook without without having to
take the detour via item_extra_kwargs.