### PR TITLE
Fixed #31829 -- Used JSONField __contains lookup on key transforms.

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -431,10 +431,6 @@ class KeyTransformIContains(CaseInsensitiveMixin, KeyTransformTextLookupMixin, l
     pass
 
 
-class KeyTransformContains(KeyTransformTextLookupMixin, lookups.Contains):
-    pass
-
-
 class KeyTransformStartsWith(KeyTransformTextLookupMixin, lookups.StartsWith):
     pass
 
@@ -486,7 +482,6 @@ class KeyTransformGte(KeyTransformNumericLookupMixin, lookups.GreaterThanOrEqual
 KeyTransform.register_lookup(KeyTransformExact)
 KeyTransform.register_lookup(KeyTransformIExact)
 KeyTransform.register_lookup(KeyTransformIsNull)
-KeyTransform.register_lookup(KeyTransformContains)
 KeyTransform.register_lookup(KeyTransformIContains)
 KeyTransform.register_lookup(KeyTransformStartsWith)
 KeyTransform.register_lookup(KeyTransformIStartsWith)

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -905,10 +905,10 @@ To query for missing keys, use the ``isnull`` lookup::
 
     The lookup examples given above implicitly use the :lookup:`exact` lookup.
     Key, index, and path transforms can also be chained with:
-    :lookup:`contains`, :lookup:`icontains`, :lookup:`endswith`,
-    :lookup:`iendswith`, :lookup:`iexact`, :lookup:`regex`, :lookup:`iregex`,
-    :lookup:`startswith`, :lookup:`istartswith`, :lookup:`lt`, :lookup:`lte`,
-    :lookup:`gt`, and :lookup:`gte` lookups.
+    :lookup:`icontains`, :lookup:`endswith`, :lookup:`iendswith`,
+    :lookup:`iexact`, :lookup:`regex`, :lookup:`iregex`, :lookup:`startswith`,
+    :lookup:`istartswith`, :lookup:`lt`, :lookup:`lte`, :lookup:`gt`, and
+    :lookup:`gte`, as well as with :ref:`containment-and-key-lookups`.
 
 .. warning::
 
@@ -937,8 +937,10 @@ To query for missing keys, use the ``isnull`` lookup::
     On PostgreSQL, if only one key or index is used, the SQL operator ``->`` is
     used. If multiple operators are used then the ``#>`` operator is used.
 
-Containment and key operations
-------------------------------
+.. _containment-and-key-lookups:
+
+Containment and key lookups
+---------------------------
 
 .. fieldlookup:: jsonfield.contains
 


### PR DESCRIPTION
[Ticket #31829](https://code.djangoproject.com/ticket/31829).

I made a mistake and created a `KeyTransformContains` that's based on `lookup.Contains`. This makes the `contains` lookup to not use JSON containment logic when it's performed on a `KeyTransform`. Therefore, it's incompatible with the previous PostgreSQL implementation, which uses the overridden lookup.

This PR fixes that by removing `KeyTransformContains`. The custom `JSON_CONTAINS` function on SQLite has also been extended to follow the rules of `JSON_CONTAINS` on MySQL. On Oracle, the implementation is turned into a chained `KeyTransformExact` lookup if the `rhs` is a `dict`, otherwise it falls back to the builtin `lookup.Contains`.

I also added notes to the docs, but I'm not sure if that's necessary.