### PR TITLE
Refs #27996 -- Doc'd no extension required for RandomUUID() on PostgreSQL 13+.

### DIFF
--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -79,6 +79,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     def is_postgresql_12(self):
         return self.connection.pg_version >= 120000
 
+    @cached_property
+    def is_postgresql_13(self):
+        return self.connection.pg_version >= 130000
+
     has_brin_autosummarize = property(operator.attrgetter('is_postgresql_10'))
     has_websearch_to_tsquery = property(operator.attrgetter('is_postgresql_11'))
     supports_table_partitions = property(operator.attrgetter('is_postgresql_10'))

--- a/docs/ref/contrib/postgres/functions.txt
+++ b/docs/ref/contrib/postgres/functions.txt
@@ -14,8 +14,8 @@ All of these functions are available from the
 
 Returns a version 4 UUID.
 
-The `pgcrypto extension`_ must be installed. You can use the
-:class:`~django.contrib.postgres.operations.CryptoExtension` migration
+On PostgreSQL < 13, the `pgcrypto extension`_ must be installed. You can use
+the :class:`~django.contrib.postgres.operations.CryptoExtension` migration
 operation to install it.
 
 .. _pgcrypto extension: https://www.postgresql.org/docs/current/pgcrypto.html

--- a/tests/postgres_tests/migrations/0001_setup_extensions.py
+++ b/tests/postgres_tests/migrations/0001_setup_extensions.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from django.db import migrations
+from django.db import connection, migrations
 
 try:
     from django.contrib.postgres.operations import (
@@ -14,10 +14,12 @@ except ImportError:
     BtreeGistExtension = mock.Mock()
     CITextExtension = mock.Mock()
     CreateExtension = mock.Mock()
-    CryptoExtension = mock.Mock()
     HStoreExtension = mock.Mock()
     TrigramExtension = mock.Mock()
     UnaccentExtension = mock.Mock()
+    needs_crypto_extension = False
+else:
+    needs_crypto_extension = not connection.features.is_postgresql_13
 
 
 class Migration(migrations.Migration):
@@ -30,7 +32,8 @@ class Migration(migrations.Migration):
         # Ensure CreateExtension quotes extension names by creating one with a
         # dash in its name.
         CreateExtension('uuid-ossp'),
-        CryptoExtension(),
+        # CryptoExtension is required for RandomUUID() on PostgreSQL < 13.
+        CryptoExtension() if needs_crypto_extension else mock.Mock(),
         HStoreExtension(),
         TrigramExtension(),
         UnaccentExtension(),


### PR DESCRIPTION
PostgreSQL 13 adds support for the `GEN_RANDOM_UUID` function without the `PgCrypto` extension:

- https://www.postgresql.org/docs/13/functions-uuid.html
- https://www.postgresql.org/docs/13/pgcrypto.html#id-1.11.7.34.10.5