### PR TITLE
Fixed #31835 -- Dropped support for JSONField __contains lookup on Oracle.

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -146,24 +146,7 @@ class DataContains(PostgresOperatorLookup):
         return 'JSON_CONTAINS(%s, %s)' % (lhs, rhs), params
 
     def as_oracle(self, compiler, connection):
-        if isinstance(self.rhs, KeyTransform):
-            return HasKey(self.lhs, self.rhs).as_oracle(compiler, connection)
-        lhs, lhs_params = self.process_lhs(compiler, connection)
-        params = tuple(lhs_params)
-        sql = (
-            "JSON_QUERY(%s, '$%s' WITH WRAPPER) = "
-            "JSON_QUERY('%s', '$.value' WITH WRAPPER)"
-        )
-        rhs = json.loads(self.rhs)
-        if isinstance(rhs, dict):
-            if not rhs:
-                return "DBMS_LOB.SUBSTR(%s) LIKE '{%%%%}'" % lhs, params
-            return ' AND '.join([
-                sql % (
-                    lhs, '.%s' % json.dumps(key), json.dumps({'value': value}),
-                ) for key, value in rhs.items()
-            ]), params
-        return sql % (lhs, '', json.dumps({'value': rhs})), params
+        raise NotSupportedError('contains lookup is not supported on Oracle.')
 
 
 class ContainedBy(PostgresOperatorLookup):

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -960,6 +960,10 @@ contained in the top-level of the field. For example::
     >>> Dog.objects.filter(data__contains={'breed': 'collie'})
     <QuerySet [<Dog: Meg>]>
 
+.. admonition:: Oracle
+
+    ``contains`` is not supported on Oracle.
+
 .. fieldlookup:: jsonfield.contained_by
 
 ``contained_by``


### PR DESCRIPTION
The current implementation works only for basic examples without supporting nested structures and doesn't follow _"the general principle that the contained object must match the containing object as to structure and data contents, possibly after discarding some non-matching array elements or object key/value pairs from the containing object"_.

ticket-31835