### PR TITLE
Fixed #31841 -- Make DecimalField respect decimal_places when converting floats

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1498,7 +1498,12 @@ class DecimalField(Field):
         if value is None:
             return value
         if isinstance(value, float):
-            return self.context.create_decimal_from_float(value)
+            v = self.context.create_decimal_from_float(value)
+            if self.decimal_places is not None:
+                # Make sure to respect max decimal_places here but only if it
+                # is defined (lookups will have them as None)
+                v = round(v, self.decimal_places)
+            return v
         try:
             return decimal.Decimal(value)
         except (decimal.InvalidOperation, TypeError, ValueError):

--- a/tests/model_fields/test_decimalfield.py
+++ b/tests/model_fields/test_decimalfield.py
@@ -15,12 +15,13 @@ class DecimalFieldTests(TestCase):
         f = models.DecimalField(max_digits=4, decimal_places=2)
         self.assertEqual(f.to_python(3), Decimal('3'))
         self.assertEqual(f.to_python('3.14'), Decimal('3.14'))
-        # to_python() converts floats and honors max_digits.
-        self.assertEqual(f.to_python(3.1415926535897), Decimal('3.142'))
+        # to_python() converts floats and honors max_digits and decimal_places
+        self.assertEqual(f.to_python(3.1415926535897), Decimal('3.14'))
+        self.assertEqual(f.to_python(0.2), Decimal('0.20'))
         self.assertEqual(f.to_python(2.4), Decimal('2.400'))
         # Uses default rounding of ROUND_HALF_EVEN.
-        self.assertEqual(f.to_python(2.0625), Decimal('2.062'))
-        self.assertEqual(f.to_python(2.1875), Decimal('2.188'))
+        self.assertEqual(f.to_python(2.0625), Decimal('2.06'))
+        self.assertEqual(f.to_python(2.1875), Decimal('2.19'))
 
     def test_invalid_value(self):
         field = models.DecimalField(max_digits=4, decimal_places=2)


### PR DESCRIPTION
Note that in the tests the model itself defined `decimal_places=2` and the conversion produced 3 decimal places. Setting something like that on postgresql would fail.