### PR TITLE
Added note about culling in database cache backend docs.

### DIFF
--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -195,6 +195,10 @@ In this example, the cache table's name is ``my_cache_table``::
         }
     }
 
+Unlike other cache backends, the database cache does not support automatic
+culling of expired entries at the database level. Instead, expired cache
+entries are culled each time ``add()``, ``set()``, or ``touch()`` is called.
+
 Creating the cache table
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I was quite confused how the DB cache was able to cull expired cache entries, asked on IRC and received this response. I think it'd be good to include this because others like me might be concerned that the timeout totally doesn't work on some backends. It does, of course (django is wonderful), and the implementation is clever enough to note.