### PR TITLE
Refs #27468 -- Fixed TestSigner.test_dumps_loads_legacy_signature.

### DIFF
--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -130,7 +130,8 @@ class TestSigner(SimpleTestCase):
         # RemovedInDjango40Warning: pre-Django 3.1 signatures won't be
         # supported.
         value = 'a string \u2020'
-        signed = signing.dumps(value, algorithm='sha1')
+        # SHA-1 signed value.
+        signed = 'ImEgc3RyaW5nIFx1MjAyMCI:1k1beT:ZfNhN1kdws7KosUleOvuYroPHEc'
         self.assertEqual(signing.loads(signed), value)
 
     def test_decode_detects_tampering(self):


### PR DESCRIPTION
`signing.dumps()` doesn't have the `algorithm` parameter :facepalm: 

Added in 1d6fdca557e674b9a789b51caadca8985e588492.