### PR TITLE
Ticket #31848: Add app_name to django.contrib.admindocs

### DIFF
--- a/django/contrib/admindocs/templates/admin_doc/bookmarklets.html
+++ b/django/contrib/admindocs/templates/admin_doc/bookmarklets.html
@@ -19,7 +19,7 @@ from any page in the site.
 {% endblocktranslate %}</p>
 
 <div id="content-main">
-    <h3><a href="javascript:(function(){if(typeof XMLHttpRequest!='undefined'){x=new XMLHttpRequest()}else{return;}x.open('HEAD',location.href,false);x.send(null);try{view=x.getResponseHeader('x-view');}catch(e){alert('No view found for this page');return;}if(view=='undefined'){alert('No view found for this page');}document.location='{% url 'django-admindocs-views-index' %}'+view+'/';})()">{% translate "Documentation for this page" %}</a></h3>
+    <h3><a href="javascript:(function(){if(typeof XMLHttpRequest!='undefined'){x=new XMLHttpRequest()}else{return;}x.open('HEAD',location.href,false);x.send(null);try{view=x.getResponseHeader('x-view');}catch(e){alert('No view found for this page');return;}if(view=='undefined'){alert('No view found for this page');}document.location='{% url 'admindocs:django-admindocs-views-index' %}'+view+'/';})()">{% translate "Documentation for this page" %}</a></h3>
     <p>{% translate "Jumps you from any page to the documentation for the view that generates that page." %}</p>
 </div>
 

--- a/django/contrib/admindocs/templates/admin_doc/bookmarklets.html
+++ b/django/contrib/admindocs/templates/admin_doc/bookmarklets.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
+&rsaquo; <a href="{% url 'admindocs:django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
 &rsaquo; {% translate 'Bookmarklets' %}
 </div>
 {% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/model_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/model_detail.html
@@ -12,8 +12,8 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
-&rsaquo; <a href="{% url 'django-admindocs-models-index' %}">{% translate 'Models' %}</a>
+&rsaquo; <a href="{% url 'admindocs:django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
+&rsaquo; <a href="{% url 'admindocs:django-admindocs-models-index' %}">{% translate 'Models' %}</a>
 &rsaquo; {{ name }}
 </div>
 {% endblock %}
@@ -73,6 +73,6 @@
 </div>
 {% endif %}
 
-<p class="small"><a href="{% url 'django-admindocs-models-index' %}">&lsaquo; {% translate 'Back to Model documentation' %}</a></p>
+<p class="small"><a href="{% url 'admindocs:django-admindocs-models-index' %}">&lsaquo; {% translate 'Back to Model documentation' %}</a></p>
 </div>
 {% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/model_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/model_index.html
@@ -6,7 +6,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
+&rsaquo; <a href="{% url 'admindocs:django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
 &rsaquo; {% translate 'Models' %}
 </div>
 {% endblock %}
@@ -27,7 +27,7 @@
 <table class="xfull">
 {% for model in group.list %}
 <tr>
-<th><a href="{% url 'django-admindocs-models-detail' app_label=model.app_label model_name=model.model_name %}">{{ model.object_name }}</a></th>
+<th><a href="{% url 'admindocs:django-admindocs-models-detail' app_label=model.app_label model_name=model.model_name %}">{{ model.object_name }}</a></th>
 </tr>
 {% endfor %}
 </table>

--- a/django/contrib/admindocs/templates/admin_doc/template_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/template_detail.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
+&rsaquo; <a href="{% url 'admindocs:django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
 &rsaquo; {% translate 'Templates' %}
 &rsaquo; {{ name }}
 </div>
@@ -23,5 +23,5 @@
 {% endfor %}
 </ol>
 
-<p class="small"><a href="{% url 'django-admindocs-docroot' %}">&lsaquo; {% translate 'Back to Documentation' %}</a></p>
+<p class="small"><a href="{% url 'admindocs:django-admindocs-docroot' %}">&lsaquo; {% translate 'Back to Documentation' %}</a></p>
 {% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/template_filter_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/template_filter_index.html
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
+&rsaquo; <a href="{% url 'admindocs:django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
 &rsaquo; {% translate 'Filters' %}
 </div>
 {% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/template_tag_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/template_tag_index.html
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
+&rsaquo; <a href="{% url 'admindocs:django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
 &rsaquo; {% translate 'Tags' %}
 </div>
 {% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/view_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/view_detail.html
@@ -4,8 +4,8 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
-&rsaquo; <a href="{% url 'django-admindocs-views-index' %}">{% translate 'Views' %}</a>
+&rsaquo; <a href="{% url 'admindocs:django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
+&rsaquo; <a href="{% url 'admindocs:django-admindocs-views-index' %}">{% translate 'Views' %}</a>
 &rsaquo; {{ name }}
 </div>
 {% endblock %}
@@ -29,5 +29,5 @@
 <p>{{ meta.Templates }}</p>
 {% endif %}
 
-<p class="small"><a href="{% url 'django-admindocs-views-index' %}">&lsaquo; {% translate 'Back to View documentation' %}</a></p>
+<p class="small"><a href="{% url 'admindocs:django-admindocs-views-index' %}">&lsaquo; {% translate 'Back to View documentation' %}</a></p>
 {% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/view_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/view_index.html
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
+&rsaquo; <a href="{% url 'admindocs:django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
 &rsaquo; {% translate 'Views' %}
 </div>
 {% endblock %}
@@ -45,7 +45,7 @@
 
 {% for view in ns_views.list|dictsort:"url" %}
 {% ifchanged %}
-<h3><a href="{% url 'django-admindocs-views-detail' view=view.full_name %}">{{ view.url }}</a></h3>
+<h3><a href="{% url 'admindocs:django-admindocs-views-detail' view=view.full_name %}">{{ view.url }}</a></h3>
 <p class="small quiet">{% blocktranslate with view.full_name as full_name and view.url_name as url_name %}
     View function: <code>{{ full_name }}</code>. Name: <code>{{ url_name }}</code>.
 {% endblocktranslate %}</p>

--- a/django/contrib/admindocs/urls.py
+++ b/django/contrib/admindocs/urls.py
@@ -1,6 +1,8 @@
 from django.contrib.admindocs import views
 from django.urls import path, re_path
 
+app_name = 'admindocs'
+
 urlpatterns = [
     path(
         '',

--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -61,7 +61,7 @@ def parse_rst(text, default_reference_context, thing_being_parsed=None):
         'doctitle_xform': True,
         'initial_header_level': 3,
         "default_reference_context": default_reference_context,
-        "link_base": reverse('django-admindocs-docroot').rstrip('/'),
+        "link_base": reverse('admindocs:django-admindocs-docroot').rstrip('/'),
         'raw_enabled': False,
         'file_insertion_enabled': False,
     }

--- a/tests/admin_docs/namespace_urls.py
+++ b/tests/admin_docs/namespace_urls.py
@@ -8,7 +8,7 @@ backend_urls = ([
 ], 'backend')
 
 urlpatterns = [
-    path('admin/doc/', include('django.contrib.admindocs.urls')),
+    path('admin/doc/', include('django.contrib.admindocs.urls', namespace='admindocs')),
     path('admin/', admin.site.urls),
     path('api/backend/', include(backend_urls, namespace='backend')),
 ]

--- a/tests/admin_docs/namespace_urls.py
+++ b/tests/admin_docs/namespace_urls.py
@@ -8,7 +8,7 @@ backend_urls = ([
 ], 'backend')
 
 urlpatterns = [
-    path('admin/doc/', include('django.contrib.admindocs.urls', namespace='admindocs')),
+    path('admin/doc/', include('django.contrib.admindocs.urls')),
     path('admin/', admin.site.urls),
     path('api/backend/', include(backend_urls, namespace='backend')),
 ]

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -70,7 +70,10 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         )
 
     def test_view_detail(self):
-        url = reverse('admindocs:django-admindocs-views-detail', args=['django.contrib.admindocs.views.BaseAdminDocsView'])
+        url = reverse(
+            'admindocs:django-admindocs-views-detail', 
+            args=['django.contrib.admindocs.views.BaseAdminDocsView']
+        )
         response = self.client.get(url)
         # View docstring
         self.assertContains(response, 'Base view for admindocs views.')
@@ -104,7 +107,9 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         )
 
     def test_template_detail(self):
-        response = self.client.get(reverse('admindocs:django-admindocs-templates', args=['admin_doc/template_detail.html']))
+        response = self.client.get(
+            reverse('admindocs:django-admindocs-templates', args=['admin_doc/template_detail.html'])
+        )
         self.assertContains(response, '<h1>Template: <q>admin_doc/template_detail.html</q></h1>', html=True)
 
     def test_missing_docutils(self):
@@ -168,7 +173,9 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
     def setUp(self):
         self.client.force_login(self.superuser)
         with captured_stderr() as self.docutils_stderr:
-            self.response = self.client.get(reverse('admindocs:django-admindocs-models-detail', args=['admin_docs', 'Person']))
+            self.response = self.client.get(
+                reverse('admindocs:django-admindocs-models-detail', args=['admin_docs', 'Person'])
+            )
 
     def test_method_excludes(self):
         """
@@ -307,12 +314,16 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
         self.assertContains(self.response, '<h1>admin_docs.Person</h1>', html=True)
 
     def test_app_not_found(self):
-        response = self.client.get(reverse('admindocs:django-admindocs-models-detail', args=['doesnotexist', 'Person']))
+        response = self.client.get(
+            reverse('admindocs:django-admindocs-models-detail', args=['doesnotexist', 'Person'])
+        )
         self.assertEqual(response.context['exception'], "App 'doesnotexist' not found")
         self.assertEqual(response.status_code, 404)
 
     def test_model_not_found(self):
-        response = self.client.get(reverse('admindocs:django-admindocs-models-detail', args=['admin_docs', 'doesnotexist']))
+        response = self.client.get(
+            reverse('admindocs:django-admindocs-models-detail', args=['admin_docs', 'doesnotexist'])
+        )
         self.assertEqual(response.context['exception'], "Model 'doesnotexist' not found in app 'admin_docs'")
         self.assertEqual(response.status_code, 404)
 

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -71,7 +71,7 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
 
     def test_view_detail(self):
         url = reverse(
-            'admindocs:django-admindocs-views-detail', 
+            'admindocs:django-admindocs-views-detail',
             args=['django.contrib.admindocs.views.BaseAdminDocsView']
         )
         response = self.client.get(url)

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -22,28 +22,28 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         self.client.force_login(self.superuser)
 
     def test_index(self):
-        response = self.client.get(reverse('django-admindocs-docroot'))
+        response = self.client.get(reverse('admindocs:django-admindocs-docroot'))
         self.assertContains(response, '<h1>Documentation</h1>', html=True)
         self.assertContains(response, '<h1 id="site-name"><a href="/admin/">Django administration</a></h1>')
         self.client.logout()
-        response = self.client.get(reverse('django-admindocs-docroot'), follow=True)
+        response = self.client.get(reverse('admindocs:django-admindocs-docroot'), follow=True)
         # Should display the login screen
         self.assertContains(response, '<input type="hidden" name="next" value="/admindocs/">', html=True)
 
     def test_bookmarklets(self):
-        response = self.client.get(reverse('django-admindocs-bookmarklets'))
+        response = self.client.get(reverse('admindocs:django-admindocs-bookmarklets'))
         self.assertContains(response, '/admindocs/views/')
 
     def test_templatetag_index(self):
-        response = self.client.get(reverse('django-admindocs-tags'))
+        response = self.client.get(reverse('admindocs:django-admindocs-tags'))
         self.assertContains(response, '<h3 id="built_in-extends">extends</h3>', html=True)
 
     def test_templatefilter_index(self):
-        response = self.client.get(reverse('django-admindocs-filters'))
+        response = self.client.get(reverse('admindocs:django-admindocs-filters'))
         self.assertContains(response, '<h3 id="built_in-first">first</h3>', html=True)
 
     def test_view_index(self):
-        response = self.client.get(reverse('django-admindocs-views-index'))
+        response = self.client.get(reverse('admindocs:django-admindocs-views-index'))
         self.assertContains(
             response,
             '<h3><a href="/admindocs/views/django.contrib.admindocs.views.BaseAdminDocsView/">/admindocs/</a></h3>',
@@ -62,7 +62,7 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         """
         Views that are methods are listed correctly.
         """
-        response = self.client.get(reverse('django-admindocs-views-index'))
+        response = self.client.get(reverse('admindocs:django-admindocs-views-index'))
         self.assertContains(
             response,
             '<h3><a href="/admindocs/views/django.contrib.admin.sites.AdminSite.index/">/admin/</a></h3>',
@@ -70,19 +70,19 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         )
 
     def test_view_detail(self):
-        url = reverse('django-admindocs-views-detail', args=['django.contrib.admindocs.views.BaseAdminDocsView'])
+        url = reverse('admindocs:django-admindocs-views-detail', args=['django.contrib.admindocs.views.BaseAdminDocsView'])
         response = self.client.get(url)
         # View docstring
         self.assertContains(response, 'Base view for admindocs views.')
 
     @override_settings(ROOT_URLCONF='admin_docs.namespace_urls')
     def test_namespaced_view_detail(self):
-        url = reverse('django-admindocs-views-detail', args=['admin_docs.views.XViewClass'])
+        url = reverse('admindocs:django-admindocs-views-detail', args=['admin_docs.views.XViewClass'])
         response = self.client.get(url)
         self.assertContains(response, '<h1>admin_docs.views.XViewClass</h1>')
 
     def test_view_detail_illegal_import(self):
-        url = reverse('django-admindocs-views-detail', args=['urlpatterns_reverse.nonimported_module.view'])
+        url = reverse('admindocs:django-admindocs-views-detail', args=['urlpatterns_reverse.nonimported_module.view'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
         self.assertNotIn("urlpatterns_reverse.nonimported_module", sys.modules)
@@ -91,12 +91,12 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         """
         Views that are methods can be displayed.
         """
-        url = reverse('django-admindocs-views-detail', args=['django.contrib.admin.sites.AdminSite.index'])
+        url = reverse('admindocs:django-admindocs-views-detail', args=['django.contrib.admin.sites.AdminSite.index'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
     def test_model_index(self):
-        response = self.client.get(reverse('django-admindocs-models-index'))
+        response = self.client.get(reverse('admindocs:django-admindocs-models-index'))
         self.assertContains(
             response,
             '<h2 id="app-auth">Authentication and Authorization (django.contrib.auth)</h2>',
@@ -104,13 +104,13 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         )
 
     def test_template_detail(self):
-        response = self.client.get(reverse('django-admindocs-templates', args=['admin_doc/template_detail.html']))
+        response = self.client.get(reverse('admindocs:django-admindocs-templates', args=['admin_doc/template_detail.html']))
         self.assertContains(response, '<h1>Template: <q>admin_doc/template_detail.html</q></h1>', html=True)
 
     def test_missing_docutils(self):
         utils.docutils_is_available = False
         try:
-            response = self.client.get(reverse('django-admindocs-docroot'))
+            response = self.client.get(reverse('admindocs:django-admindocs-docroot'))
             self.assertContains(
                 response,
                 '<h3>The admin documentation system requires Python’s '
@@ -133,7 +133,7 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         """
         Site.objects.all().delete()
         del settings.SITE_ID
-        response = self.client.get(reverse('django-admindocs-views-index'))
+        response = self.client.get(reverse('admindocs:django-admindocs-views-index'))
         self.assertContains(response, 'View documentation')
 
 
@@ -152,13 +152,13 @@ class AdminDocViewWithMultipleEngines(AdminDocViewTests):
     def test_templatefilter_index(self):
         # Overridden because non-trivial TEMPLATES settings aren't supported
         # but the page shouldn't crash (#24125).
-        response = self.client.get(reverse('django-admindocs-filters'))
+        response = self.client.get(reverse('admindocs:django-admindocs-filters'))
         self.assertContains(response, '<title>Template filters</title>', html=True)
 
     def test_templatetag_index(self):
         # Overridden because non-trivial TEMPLATES settings aren't supported
         # but the page shouldn't crash (#24125).
-        response = self.client.get(reverse('django-admindocs-tags'))
+        response = self.client.get(reverse('admindocs:django-admindocs-tags'))
         self.assertContains(response, '<title>Template tags</title>', html=True)
 
 
@@ -168,7 +168,7 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
     def setUp(self):
         self.client.force_login(self.superuser)
         with captured_stderr() as self.docutils_stderr:
-            self.response = self.client.get(reverse('django-admindocs-models-detail', args=['admin_docs', 'Person']))
+            self.response = self.client.get(reverse('admindocs:django-admindocs-models-detail', args=['admin_docs', 'Person']))
 
     def test_method_excludes(self):
         """
@@ -264,7 +264,7 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
     def test_model_with_many_to_one(self):
         link = '<a class="reference external" href="/admindocs/models/%s/">%s</a>'
         response = self.client.get(
-            reverse('django-admindocs-models-detail', args=['admin_docs', 'company'])
+            reverse('admindocs:django-admindocs-models-detail', args=['admin_docs', 'company'])
         )
         self.assertContains(
             response,
@@ -280,7 +280,7 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
         A model with ``related_name`` of `+` shouldn't show backward
         relationship links.
         """
-        response = self.client.get(reverse('django-admindocs-models-detail', args=['admin_docs', 'family']))
+        response = self.client.get(reverse('admindocs:django-admindocs-models-detail', args=['admin_docs', 'family']))
         fields = response.context_data.get('fields')
         self.assertEqual(len(fields), 2)
 
@@ -307,12 +307,12 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
         self.assertContains(self.response, '<h1>admin_docs.Person</h1>', html=True)
 
     def test_app_not_found(self):
-        response = self.client.get(reverse('django-admindocs-models-detail', args=['doesnotexist', 'Person']))
+        response = self.client.get(reverse('admindocs:django-admindocs-models-detail', args=['doesnotexist', 'Person']))
         self.assertEqual(response.context['exception'], "App 'doesnotexist' not found")
         self.assertEqual(response.status_code, 404)
 
     def test_model_not_found(self):
-        response = self.client.get(reverse('django-admindocs-models-detail', args=['admin_docs', 'doesnotexist']))
+        response = self.client.get(reverse('admindocs:django-admindocs-models-detail', args=['admin_docs', 'doesnotexist']))
         self.assertEqual(response.context['exception'], "Model 'doesnotexist' not found in app 'admin_docs'")
         self.assertEqual(response.status_code, 404)
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5470,7 +5470,7 @@ class AdminDocsTest(TestCase):
         self.client.force_login(self.superuser)
 
     def test_tags(self):
-        response = self.client.get(reverse('django-admindocs-tags'))
+        response = self.client.get(reverse('admindocs:django-admindocs-tags'))
 
         # The builtin tag group exists
         self.assertContains(response, "<h2>Built-in tags</h2>", count=2, html=True)
@@ -5491,7 +5491,7 @@ class AdminDocsTest(TestCase):
         self.assertContains(response, '<li><a href="#admin_list-admin_actions">admin_actions</a></li>', html=True)
 
     def test_filters(self):
-        response = self.client.get(reverse('django-admindocs-filters'))
+        response = self.client.get(reverse('admindocs:django-admindocs-filters'))
 
         # The builtin filter group exists
         self.assertContains(response, "<h2>Built-in filters</h2>", count=2, html=True)


### PR DESCRIPTION
Currently, it is not possible to set a namespace to admindocs, as the following line will throw an error due to a missing app_name:

`re_path(r'admin/doc/', include('django.contrib.admindocs.urls'), namespace='docs')`

This PR attributes an app_name to django.contrib.admindocs.urls.

Ticket: https://code.djangoproject.com/ticket/31848#ticket
