### PR TITLE
Fix maximum and minimum value validators

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -364,7 +364,7 @@ class MaxValueValidator(BaseValidator):
     code = 'max_value'
 
     def compare(self, a, b):
-        return a > b
+        return a >= b
 
 
 @deconstructible
@@ -373,7 +373,7 @@ class MinValueValidator(BaseValidator):
     code = 'min_value'
 
     def compare(self, a, b):
-        return a < b
+        return a <= b
 
 
 @deconstructible


### PR DESCRIPTION
According to the validator's message the result has to be something like greater or equal and less or equal, but this was not happening in the code.