### PR TITLE
Fixed #31679 -- Made query.aggregate() raise ValueError when conflicting alias supplied.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -392,6 +392,9 @@ class QuerySet:
 
         query = self.query.chain()
         for (alias, aggregate_expr) in kwargs.items():
+            if alias in self.query.annotations:
+                raise ValueError(
+                    f'The named aggregate {alias} conflicts with another identically named annotation.')
             query.add_annotation(aggregate_expr, alias, is_summary=True)
             if not query.annotations[alias].contains_aggregate:
                 raise TypeError("%s is not an aggregate expression" % alias)

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -468,6 +468,11 @@ class AggregateTestCase(TestCase):
         vals = Book.objects.annotate(num_authors=Count("authors__id")).aggregate(Avg("num_authors"))
         self.assertEqual(vals, {"num_authors__avg": Approximate(1.66, places=1)})
 
+    def test_aggregate_annotation_keyword_conflict(self):
+        msg = 'The named aggregate num_authors conflicts with another identically named annotation.'
+        with self.assertRaisesMessage(ValueError, msg):
+            Book.objects.annotate(num_authors=Count("authors__id")).aggregate(num_authors=Avg("num_authors"))
+
     def test_avg_duration_field(self):
         # Explicit `output_field`.
         self.assertEqual(


### PR DESCRIPTION
ticket-31679