### PR TITLE
Fixed #31853 -- Fixed wrapping of translated action labels in admin sidebar.

### DIFF
--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -78,6 +78,10 @@
     padding-left: 16px;
 }
 
+#nav-sidebar .module td {
+    white-space: nowrap;
+}
+
 [dir="rtl"] #nav-sidebar .module th,
 [dir="rtl"] #nav-sidebar .module caption {
     padding-left: 8px;

--- a/docs/releases/3.1.1.txt
+++ b/docs/releases/3.1.1.txt
@@ -9,4 +9,5 @@ Django 3.1.1 fixes several bugs in 3.1.
 Bugfixes
 ========
 
-* ...
+* Fixed wrapping of translated action labels in the admin's navigation sidebar
+  for East Asian languages (:ticket:`31853`).


### PR DESCRIPTION
In some languages, such as Chinese, the Add button text of the navigation bar is wrapped

ticket-31853