### PR TITLE
Fixed #31854 -- Fixed wrapping long model names in admin's sidebar.

### DIFF
--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -71,6 +71,7 @@
 
 #nav-sidebar .module th {
     width: 100%;
+    overflow-wrap: anywhere;
 }
 
 #nav-sidebar .module th,

--- a/docs/releases/3.1.1.txt
+++ b/docs/releases/3.1.1.txt
@@ -11,3 +11,6 @@ Bugfixes
 
 * Fixed wrapping of translated action labels in the admin's navigation sidebar
   for East Asian languages (:ticket:`31853`).
+
+* Fixed wrapping of long model names in the admin's navigation sidebar
+  (:ticket:`31854`).


### PR DESCRIPTION
Before:
![obraz](https://user-images.githubusercontent.com/2865885/89383250-74543600-d6fc-11ea-8e53-f7e8a6ecf2e8.png)

After:
![obraz](https://user-images.githubusercontent.com/2865885/89383172-54247700-d6fc-11ea-803c-294fd2cd901b.png)

ticket-31854