### PR TITLE
Fixed typo in docs/ref/contrib/postgres/fields.txt.

### DIFF
--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -668,9 +668,11 @@ The ``contained_by`` lookup is also available on the non-range field types:
 :class:`~django.db.models.DateTimeField`. For example::
 
     >>> from psycopg2.extras import DateTimeTZRange
-    >>> Event.objects.filter(start__contained_by=DateTimeTZRange(
-    ...     timezone.now() - datetime.timedelta(hours=1),
-    ...     timezone.now() + datetime.timedelta(hours=1),
+    >>> Event.objects.filter(
+    ...     start__contained_by=DateTimeTZRange(
+    ...         timezone.now() - datetime.timedelta(hours=1),
+    ...         timezone.now() + datetime.timedelta(hours=1),
+    ...     ),
     ... )
     <QuerySet [<Event: Soft play>]>
 


### PR DESCRIPTION
I noticed there was a missing parenthesis in the documentation for a code excerpt.

I'm not sure if the indentation is quite right though.