### PR TITLE
Removed unnecessary sentence in QuerySet docs.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -151,8 +151,7 @@ Here's the formal declaration of a ``QuerySet``:
         The ``query`` parameter to :class:`QuerySet` exists so that specialized
         query subclasses can reconstruct internal query state. The value of the
         parameter is an opaque representation of that query state and is not
-        part of a public API. To put it another way: if you need to ask, you
-        don't need to use it.
+        part of a public API.
 
 .. currentmodule:: django.db.models.query.QuerySet
 


### PR DESCRIPTION
The queryset documentation page currently has this note:

> The *query* parameter to *QuerySet* exists so that specialized query subclasses can reconstruct internal query state. The value of the parameter is an opaque representation of that query state and is not part of a public API. To put it another way: if you need to ask, you don’t need to use it.

I think that the last sentence is slightly patronising and perhaps a kind of gatekeeping. It comes across as "If you don't already know this, then you're never going to. This is an expert thing, only for expert people.".

I don't think we want the Django docs to have that kind of vibe . So this pull request makes a very simple change to fix it: remove that sentence. The note still makes complete sense without it.