### PR TITLE
Fixed #31863: Reset model fields cache on copy

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -50,6 +50,10 @@ class Deferred:
 DEFERRED = Deferred()
 
 
+class Empty:
+    pass
+
+
 def subclass_exception(name, bases, module, attached_to):
     """
     Create exception subclass. Used by ModelBase below.
@@ -535,6 +539,18 @@ class Model(metaclass=ModelBase):
         if self.pk is None:
             raise TypeError("Model instances without primary key value are unhashable")
         return hash(self.pk)
+
+    def __copy__(self):
+        # We need to avoid hitting __reduce__, so define this
+        # slightly weird copy construct.
+        obj = Empty()
+        obj.__class__ = self.__class__
+        obj.__dict__ = self.__dict__.copy()
+
+        obj._state = copy.copy(obj._state)
+        obj._state.fields_cache = {}
+
+        return obj
 
     def __reduce__(self):
         data = self.__getstate__()


### PR DESCRIPTION
ticket-31863
Discussion at https://groups.google.com/g/django-developers/c/QMhVPIqVVP4/m/kcvbnCn0AwAJ

Django 2.0 introduced a fields cache for model fields which ends up being copied during a model instance copy. This results in changes to the new model instance unexpectedly affecting the original model instance (last 2 asserts in test fails). In Django 1.11 and earlier the behavior was as expected when using `copy`.

This is my first PR to the Django project so please point out any thing I missed whilst reading the contributor guidelines. CLA was submitted last night.