### PR TITLE
Fixed #31863 -- Prevented mutating model state by copies of model instances.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -546,7 +546,10 @@ class Model(metaclass=ModelBase):
 
     def __getstate__(self):
         """Hook to allow choosing the attributes to pickle."""
-        return self.__dict__
+        state = self.__dict__.copy()
+        state['_state'] = copy.copy(state['_state'])
+        state['_state'].fields_cache = state['_state'].fields_cache.copy()
+        return state
 
     def __setstate__(self, state):
         pickled_version = state.get(DJANGO_VERSION_PICKLE_KEY)

--- a/tests/model_regress/tests.py
+++ b/tests/model_regress/tests.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 from operator import attrgetter
 
@@ -256,3 +257,17 @@ class EvaluateMethodTest(TestCase):
         dept = Department.objects.create(pk=1, name='abc')
         dept.evaluate = 'abc'
         Worker.objects.filter(department=dept)
+
+
+class ModelFieldsCacheTest(TestCase):
+    def test_fields_cache_reset_on_copy(self):
+        department1 = Department.objects.create(id=1, name='department1')
+        department2 = Department.objects.create(id=2, name='department2')
+        worker1 = Worker.objects.create(name='worker', department=department1)
+        worker2 = copy.copy(worker1)
+
+        self.assertEqual(worker2.department, department1)
+        # Changing related fields doesn't mutate the base object.
+        worker2.department = department2
+        self.assertEqual(worker2.department, department2)
+        self.assertEqual(worker1.department, department1)


### PR DESCRIPTION
ticket-31863
Discussion at https://groups.google.com/g/django-developers/c/QMhVPIqVVP4/m/kcvbnCn0AwAJ

Django 2.0 introduced a fields cache for model fields which ends up being copied during a model instance copy. This results in changes to the new model instance unexpectedly affecting the original model instance (last 2 asserts in test fails). In Django 1.11 and earlier the behavior was as expected when using copy.

This is my first PR to the Django project so please point out any thing I missed whilst reading the contributor guidelines. CLA was submitted last night.