### PR TITLE
Refs #31864 -- Doc'd that DEFAULT_HASHING_ALGORITHM requires 3.1.1+ in release notes.

### DIFF
--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -109,9 +109,9 @@ reset tokens in the admin site, user sessions, and signatures created by
 Support for SHA-256 was added in Django 3.1. If you are upgrading multiple
 instances of the same project to Django 3.1, you should set
 :setting:`DEFAULT_HASHING_ALGORITHM` to ``'sha1'`` during the transition, in
-order to allow compatibility with the older versions of Django. Once the
-transition to 3.1 is complete you can stop overriding
-:setting:`DEFAULT_HASHING_ALGORITHM`.
+order to allow compatibility with the older versions of Django. Note that this
+requires Django 3.1.1+. Once the transition to 3.1 is complete you can stop
+overriding :setting:`DEFAULT_HASHING_ALGORITHM`.
 
 This setting is deprecated as of this release, because support for tokens,
 cookies, sessions, and signatures that use SHA-1 algorithm will be removed in


### PR DESCRIPTION
> Please open a PR after this got merged then, we usually apply doc fixes quite liberally to existing versions.

I'm not that good in English documentation. But what do you think about something like this?

Support for SHA-256 was added in Django 3.1. If you are upgrading multiple
instances of the same project to Django 3.1, you should set
:setting:`DEFAULT_HASHING_ALGORITHM` to ``'sha1'`` during the transition, in
order to allow compatibility with the older versions of Django. Once the
transition to 3.1 is complete you can stop overriding
:setting:`DEFAULT_HASHING_ALGORITHM`. We also recommend doing this with Django version >= 3.1.1, since sessions backward compatibility is not fully supported in Django 3.1 (:ticket:`31864`).

(with a link to [#31864](https://code.djangoproject.com/ticket/31864)).