### PR TITLE
Fixed #31866 -- Fixed locking proxy models in QuerySet.select_for_update(of=())

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -982,7 +982,8 @@ class SQLCompiler:
         the query.
         """
         def _get_parent_klass_info(klass_info):
-            for parent_model, parent_link in klass_info['model']._meta.parents.items():
+            concrete_model = klass_info['model']._meta.concrete_model
+            for parent_model, parent_link in concrete_model._meta.parents.items():
                 parent_list = parent_model._meta.get_parent_list()
                 yield {
                     'model': parent_model,
@@ -1007,8 +1008,9 @@ class SQLCompiler:
             select_fields is filled recursively, so it also contains fields
             from the parent models.
             """
+            concrete_model = klass_info['model']._meta.concrete_model
             for select_index in klass_info['select_fields']:
-                if self.select[select_index][0].target.model == klass_info['model']:
+                if self.select[select_index][0].target.model == concrete_model:
                     return self.select[select_index][0]
 
         def _get_field_choices():

--- a/docs/releases/2.2.16.txt
+++ b/docs/releases/2.2.16.txt
@@ -9,4 +9,7 @@ Django 2.2.16 fixes a data loss bug in 2.2.15.
 Bugfixes
 ========
 
-* ...
+* Fixed a data loss possibility in the
+  :meth:`~django.db.models.query.QuerySet.select_for_update()`. When using
+  related fields pointing to a proxy model in the ``of`` argument, the
+  corresponding model was not locked (:ticket:`31866`).

--- a/docs/releases/3.0.10.txt
+++ b/docs/releases/3.0.10.txt
@@ -9,4 +9,7 @@ Django 3.0.10 fixes a data loss bug in 3.0.9.
 Bugfixes
 ========
 
-* ...
+* Fixed a data loss possibility in the
+  :meth:`~django.db.models.query.QuerySet.select_for_update()`. When using
+  related fields pointing to a proxy model in the ``of`` argument, the
+  corresponding model was not locked (:ticket:`31866`).

--- a/docs/releases/3.1.1.txt
+++ b/docs/releases/3.1.1.txt
@@ -20,3 +20,8 @@ Bugfixes
 
 * Adjusted admin's navigation sidebar template to reduce debug logging when
   rendering (:ticket:`31865`).
+
+* Fixed a data loss possibility in the
+  :meth:`~django.db.models.query.QuerySet.select_for_update()`. When using
+  related fields pointing to a proxy model in the ``of`` argument, the
+  corresponding model was not locked (:ticket:`31866`).

--- a/tests/select_for_update/models.py
+++ b/tests/select_for_update/models.py
@@ -23,6 +23,20 @@ class EUCity(models.Model):
     country = models.ForeignKey(EUCountry, models.CASCADE)
 
 
+class CountryProxy(Country):
+    class Meta:
+        proxy = True
+
+
+class CountryProxyProxy(CountryProxy):
+    class Meta:
+        proxy = True
+
+
+class CityCountryProxy(models.Model):
+    country = models.ForeignKey(CountryProxyProxy, models.CASCADE)
+
+
 class Person(models.Model):
     name = models.CharField(max_length=30)
     born = models.ForeignKey(City, models.CASCADE, related_name='+')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31866