### PR TITLE
Fixed #23130 -- Raised IntegrityError when validating blank for BooleanField with choices, without default, and not nullable.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -945,7 +945,7 @@ class BooleanField(Field):
         return "BooleanField"
 
     def to_python(self, value):
-        if self.null and value in self.empty_values:
+        if value in self.empty_values:
             return None
         if value in (True, False):
             # 1/0 are equal to True/False. bool() converts former to latter.


### PR DESCRIPTION
ticket-23130

It is doc'd in two places that unless `default` is provided with `choices`, a blank choice `'--------'` will be provided even if `blank=False`. The blank choice on a `models.BooleanField` should validate with a `django.core.exceptions.ValidationError: This field cannot be null.` if not nullable, or a similar error if nullable but required (`blank=False`).

The nullable fields were behaving correctly, but the not nullable fields raised `django.core.exceptions.ValidationError: “” value must be either True or False.`, which is not as informative as it could be.

Now they raise `django.core.exceptions.ValidationError: This field cannot be null.` because `models.BooleanField.to_python()` now returns `None`.

_Clarification:_ on form field validation, this means `IntegrityError` will propagate first if the field is not nullable and not required, whereas a required field will simply show a form error to the user.