### PR TITLE
Removed unnecessary urlsplit() call and added missing items to __all__.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -30,7 +30,10 @@ from django.utils.http import urlencode
 from django.utils.itercompat import is_iterable
 from django.utils.regex_helper import _lazy_re_compile
 
-__all__ = ('Client', 'RedirectCycleError', 'RequestFactory', 'encode_file', 'encode_multipart')
+__all__ = (
+    'AsyncClient', 'AsyncRequestFactory', 'Client', 'RedirectCycleError',
+    'RequestFactory', 'encode_file', 'encode_multipart',
+)
 
 
 BOUNDARY = 'BoUnDaRyStRiNg'

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -345,7 +345,6 @@ class SimpleTestCase(unittest.TestCase):
             )
 
             url, status_code = response.redirect_chain[-1]
-            scheme, netloc, path, query, fragment = urlsplit(url)
 
             self.assertEqual(
                 response.status_code, target_status_code,

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -35,9 +35,11 @@ except ImportError:
 
 __all__ = (
     'Approximate', 'ContextList', 'isolate_lru_cache', 'get_runner',
-    'modify_settings', 'override_settings',
+    'CaptureQueriesContext',
+    'ignore_warnings', 'isolate_apps', 'modify_settings', 'override_settings',
+    'override_system_checks', 'tag',
     'requires_tz_support',
-    'setup_test_environment', 'teardown_test_environment',
+    'setup_databases', 'setup_test_environment', 'teardown_test_environment',
 )
 
 TZ_SUPPORT = hasattr(time, 'tzset')


### PR DESCRIPTION
The statement `scheme, netloc, path, query, fragment = urlsplit(url)` is in both branches, but only actively used in the `else`-branch. Probably the commit message should be changed as well. I think the code style guide could be updated to cover cases like this.

PyCharm highlighted that some of the imports from different places within `django.test` were not declared in `__all__`. I'm not sure if it's a problem; it seems to be good style to have names in there that are public API. Which I believe that the names I added are. It's not complete, as I haven't asked why they were left out. 