### PR TITLE
Fixed #31885 -- Updated SMTP Email Backend to use an SSLContext. 

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -208,6 +208,9 @@ EMAIL_USE_TLS = False
 EMAIL_USE_SSL = False
 EMAIL_SSL_CERTFILE = None
 EMAIL_SSL_KEYFILE = None
+EMAIL_SSL_CAFILE = None
+EMAIL_SSL_CAPATH = None
+EMAIL_SSL_CADATA = None
 EMAIL_TIMEOUT = None
 
 # List of strings representing installed apps.

--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -19,7 +19,6 @@ class EmailBackend(BaseEmailBackend):
                  ssl_cafile=None, ssl_capath=None, ssl_cadata=None,
                  **kwargs):
         super().__init__(fail_silently=fail_silently)
-
         # server connection
         self.host = host or settings.EMAIL_HOST
         self.port = port or settings.EMAIL_PORT
@@ -30,30 +29,14 @@ class EmailBackend(BaseEmailBackend):
         self.use_tls = settings.EMAIL_USE_TLS if use_tls is None else use_tls
         self.use_ssl = settings.EMAIL_USE_SSL if use_ssl is None else use_ssl
         # client cert
-        self.ssl_keyfile = (
-            settings.EMAIL_SSL_KEYFILE if ssl_keyfile is None
-            else ssl_keyfile
-        )
-        self.ssl_certfile = (
-            settings.EMAIL_SSL_CERTFILE if ssl_certfile is None
-            else ssl_certfile
-        )
+        self.ssl_keyfile = settings.EMAIL_SSL_KEYFILE if ssl_keyfile is None else ssl_keyfile
+        self.ssl_certfile = settings.EMAIL_SSL_CERTFILE if ssl_certfile is None else ssl_certfile
         # server cert
-        self.ssl_cafile = (
-            settings.EMAIL_SSL_CAFILE if ssl_cafile is None
-            else ssl_cafile
-        )
-        self.ssl_capath = (
-            settings.EMAIL_SSL_CAPATH if ssl_capath is None
-            else ssl_capath
-        )
-        self.ssl_cadata = (
-            settings.EMAIL_SSL_CADATA if ssl_cadata is None
-            else ssl_cadata
-        )
+        self.ssl_cafile = settings.EMAIL_SSL_CAFILE if ssl_cafile is None else ssl_cafile
+        self.ssl_capath = settings.EMAIL_SSL_CAPATH if ssl_capath is None else ssl_capath
+        self.ssl_cadata = settings.EMAIL_SSL_CADATA if ssl_cadata is None else ssl_cadata
         # timeout
         self.timeout = settings.EMAIL_TIMEOUT if timeout is None else timeout
-
         if self.use_ssl and self.use_tls:
             raise ValueError(
                 "EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive, so only set "
@@ -79,15 +62,12 @@ class EmailBackend(BaseEmailBackend):
         context = ssl.create_default_context(
             cafile=self.ssl_cafile,
             capath=self.ssl_capath,
-            cadata=self.ssl_cadata
+            cadata=self.ssl_cadata,
         )
         if self.ssl_keyfile and not self.ssl_certfile:
             raise ValueError('certfile must be specified')
         if self.ssl_certfile:
-            context.load_cert_chain(
-                self.ssl_certfile,
-                self.ssl_keyfile
-            )
+            context.load_cert_chain(self.ssl_certfile, self.ssl_keyfile)
 
         # If local_hostname is not specified, socket.getfqdn() gets used.
         # For performance, we use the cached FQDN for local_hostname.
@@ -95,9 +75,7 @@ class EmailBackend(BaseEmailBackend):
         if self.timeout is not None:
             connection_params['timeout'] = self.timeout
         if self.use_ssl:
-            connection_params.update({
-                'context': context
-            })
+            connection_params['context'] = context
         try:
             self.connection = self.connection_class(self.host, self.port, **connection_params)
 

--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -19,18 +19,41 @@ class EmailBackend(BaseEmailBackend):
                  ssl_cafile=None, ssl_capath=None, ssl_cadata=None,
                  **kwargs):
         super().__init__(fail_silently=fail_silently)
+
+        # server connection
         self.host = host or settings.EMAIL_HOST
         self.port = port or settings.EMAIL_PORT
+        # user identity
         self.username = settings.EMAIL_HOST_USER if username is None else username
         self.password = settings.EMAIL_HOST_PASSWORD if password is None else password
+        # type of TLS (implicit=ssl, explicit=tls)
         self.use_tls = settings.EMAIL_USE_TLS if use_tls is None else use_tls
         self.use_ssl = settings.EMAIL_USE_SSL if use_ssl is None else use_ssl
+        # client cert
+        self.ssl_keyfile = (
+            settings.EMAIL_SSL_KEYFILE if ssl_keyfile is None
+            else ssl_keyfile
+        )
+        self.ssl_certfile = (
+            settings.EMAIL_SSL_CERTFILE if ssl_certfile is None
+            else ssl_certfile
+        )
+        # server cert
+        self.ssl_cafile = (
+            settings.EMAIL_SSL_CAFILE if ssl_cafile is None
+            else ssl_cafile
+        )
+        self.ssl_capath = (
+            settings.EMAIL_SSL_CAPATH if ssl_capath is None
+            else ssl_capath
+        )
+        self.ssl_cadata = (
+            settings.EMAIL_SSL_CADATA if ssl_cadata is None
+            else ssl_cadata
+        )
+        # timeout
         self.timeout = settings.EMAIL_TIMEOUT if timeout is None else timeout
-        self.ssl_keyfile = settings.EMAIL_SSL_KEYFILE if ssl_keyfile is None else ssl_keyfile
-        self.ssl_certfile = settings.EMAIL_SSL_CERTFILE if ssl_certfile is None else ssl_certfile
-        self.ssl_cafile = ssl_cafile or getattr(settings, 'EMAIL_SSL_CAFILE', None)
-        self.ssl_capath = ssl_capath or getattr(settings, 'EMAIL_SSL_CAPATH', None)
-        self.ssl_cadata = ssl_cadata or getattr(settings, 'EMAIL_SSL_CADATA', None)
+
         if self.use_ssl and self.use_tls:
             raise ValueError(
                 "EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive, so only set "

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1490,7 +1490,9 @@ file and private key file are handled.
 .. setting:: EMAIL_SSL_CAFILE
 
 ``EMAIL_SSL_CAFILE``
----------------------
+--------------------
+
+.. versionadded:: 4.0
 
 Default: ``None``
 
@@ -1502,7 +1504,9 @@ information about how to arrange the certificates in this file.
 .. setting:: EMAIL_SSL_CAPATH
 
 ``EMAIL_SSL_CAPATH``
----------------------
+--------------------
+
+.. versionadded:: 4.0
 
 Default: ``None``
 
@@ -1515,7 +1519,9 @@ in PEM format, following an `OpenSSL_specific_layout`_.
 .. setting:: EMAIL_SSL_CADATA
 
 ``EMAIL_SSL_CADATA``
----------------------
+--------------------
+
+.. versionadded:: 4.0
 
 Default: ``None``
 
@@ -3571,6 +3577,9 @@ Email
 * :setting:`EMAIL_HOST_PASSWORD`
 * :setting:`EMAIL_HOST_USER`
 * :setting:`EMAIL_PORT`
+* :setting:`EMAIL_SSL_CADATA`
+* :setting:`EMAIL_SSL_CAFILE`
+* :setting:`EMAIL_SSL_CAPATH`
 * :setting:`EMAIL_SSL_CERTFILE`
 * :setting:`EMAIL_SSL_KEYFILE`
 * :setting:`EMAIL_SUBJECT_PREFIX`

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1487,6 +1487,44 @@ connection. Please refer to the documentation of Python's
 :func:`python:ssl.wrap_socket` function for details on how the certificate chain
 file and private key file are handled.
 
+.. setting:: EMAIL_SSL_CAFILE
+
+``EMAIL_SSL_CAFILE``
+---------------------
+
+Default: ``None``
+
+If :setting:`EMAIL_USE_SSL` or :setting:`EMAIL_USE_TLS` is ``True``, you can
+optionally specify the path to a file of concatenated CA certificates in PEM
+format. See the discussion of :ref:`python:ssl-certificates` for more
+information about how to arrange the certificates in this file.
+
+.. setting:: EMAIL_SSL_CAPATH
+
+``EMAIL_SSL_CAPATH``
+---------------------
+
+Default: ``None``
+
+If :setting:`EMAIL_USE_SSL` or :setting:`EMAIL_USE_TLS` is ``True``, you can
+optionally specify the path to a directory containing several CA certificates
+in PEM format, following an `OpenSSL_specific_layout`_.
+
+.. _OpenSSL_specific_layout: https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+
+.. setting:: EMAIL_SSL_CADATA
+
+``EMAIL_SSL_CADATA``
+---------------------
+
+Default: ``None``
+
+If :setting:`EMAIL_USE_SSL` or :setting:`EMAIL_USE_TLS` is ``True``, you can
+optionally specify is either an ASCII string of one or more PEM-encoded
+certificates or a bytes-like object of DER-encoded certificates. Like with
+:setting:`EMAIL_SSL_CAFILE` extra lines around PEM-encoded certificates are
+ignored but at least one certificate must be present.
+
 .. setting:: EMAIL_TIMEOUT
 
 ``EMAIL_TIMEOUT``

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -157,6 +157,7 @@ deduplicates
 deepcopy
 deferrable
 deprecations
+DER
 deserialization
 deserialize
 deserialized

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -497,6 +497,11 @@ SMTP backend
     If unspecified, the default ``timeout`` will be the one provided by
     :func:`socket.getdefaulttimeout()`, which defaults to ``None`` (no timeout).
 
+    .. versionchanged:: 4.0
+
+        The ``ssl_cafile``, ``ssl_capath``, and ``ssl_cadata`` keyword
+        arguments were added.
+
 .. _topic-email-console-backend:
 
 Console backend

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -469,7 +469,7 @@ can :ref:`write your own email backend <topic-custom-email-backend>`.
 SMTP backend
 ~~~~~~~~~~~~
 
-.. class:: backends.smtp.EmailBackend(host=None, port=None, username=None, password=None, use_tls=None, fail_silently=False, use_ssl=None, timeout=None, ssl_keyfile=None, ssl_certfile=None, **kwargs)
+.. class:: backends.smtp.EmailBackend(host=None, port=None, username=None, password=None, use_tls=None, fail_silently=False, use_ssl=None, timeout=None, ssl_keyfile=None, ssl_certfile=None, ssl_cafile=None, ssl_capath=None, ssl_cadata=None, **kwargs)
 
     This is the default backend. Email will be sent through a SMTP server.
 
@@ -485,6 +485,9 @@ SMTP backend
     * ``timeout``: :setting:`EMAIL_TIMEOUT`
     * ``ssl_keyfile``: :setting:`EMAIL_SSL_KEYFILE`
     * ``ssl_certfile``: :setting:`EMAIL_SSL_CERTFILE`
+    * ``ssl_cafile``: :setting:`EMAIL_SSL_CAFILE`
+    * ``ssl_capath``: :setting:`EMAIL_SSL_CAPATH`
+    * ``ssl_cadata``: :setting:`EMAIL_SSL_CADATA`
 
     The SMTP backend is the default configuration inherited by Django. If you
     want to specify it explicitly, put the following in your settings::

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -1599,6 +1599,48 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
         backend = smtp.EmailBackend()
         self.assertIsNone(backend.ssl_keyfile)
 
+    @override_settings(EMAIL_SSL_CAFILE='foo')
+    def test_email_ssl_cafile_use_settings(self):
+        backend = smtp.EmailBackend()
+        self.assertEqual(backend.ssl_cafile, 'foo')
+
+    @override_settings(EMAIL_SSL_CAFILE='foo')
+    def test_email_ssl_cafile_override_settings(self):
+        backend = smtp.EmailBackend(ssl_cafile='bar')
+        self.assertEqual(backend.ssl_cafile, 'bar')
+
+    def test_email_ssl_cafile_default_disabled(self):
+        backend = smtp.EmailBackend()
+        self.assertIsNone(backend.ssl_cafile)
+
+    @override_settings(EMAIL_SSL_CAPATH='foo')
+    def test_email_ssl_capath_use_settings(self):
+        backend = smtp.EmailBackend()
+        self.assertEqual(backend.ssl_capath, 'foo')
+
+    @override_settings(EMAIL_SSL_CAPATH='foo')
+    def test_email_ssl_capath_override_settings(self):
+        backend = smtp.EmailBackend(ssl_capath='bar')
+        self.assertEqual(backend.ssl_capath, 'bar')
+
+    def test_email_ssl_capath_default_disabled(self):
+        backend = smtp.EmailBackend()
+        self.assertIsNone(backend.ssl_capath)
+
+    @override_settings(EMAIL_SSL_CADATA='foo')
+    def test_email_ssl_cadata_use_settings(self):
+        backend = smtp.EmailBackend()
+        self.assertEqual(backend.ssl_cadata, 'foo')
+
+    @override_settings(EMAIL_SSL_CADATA='foo')
+    def test_email_ssl_cadata_override_settings(self):
+        backend = smtp.EmailBackend(ssl_cadata='bar')
+        self.assertEqual(backend.ssl_cadata, 'bar')
+
+    def test_email_ssl_cadata_default_disabled(self):
+        backend = smtp.EmailBackend()
+        self.assertIsNone(backend.ssl_cadata)
+
     @override_settings(EMAIL_USE_TLS=True)
     def test_email_tls_attempts_starttls(self):
         backend = smtp.EmailBackend()


### PR DESCRIPTION
ticket-31885

set ssl cert and key outside a SSLContext object are deprecated and we need add CA parameters to make the server authentication