### PR TITLE
fieldset attribute description example added

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -421,6 +421,13 @@ subclass::
         rendered for :class:`~django.contrib.admin.TabularInline` due to its
         layout.
 
+        Example::
+
+            {
+            'description': 'these fields are mandatory/optional',
+            }
+
+
         Note that this value is *not* HTML-escaped when it's displayed in
         the admin interface. This lets you include HTML if you so desire.
         Alternatively you can use plain text and


### PR DESCRIPTION
fieldset attribute: `description` example added.
I test it by making a new project for it according to the documentation added

Note: I am new to contribution and this is my first PR, I created this to add little tweak in documentation as well as learn the contribution flow. I am excited to work more on this! Please guide me if I am doing something wrong.