### PR TITLE
Fix AttributeError Exception

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -69,7 +69,7 @@ class MultiPartParser:
         ctypes, opts = parse_header(content_type.encode('ascii'))
         boundary = opts.get('boundary')
         if not boundary or not cgi.valid_boundary(boundary):
-            raise MultiPartParserError('Invalid boundary in multipart: %s' % boundary.decode())
+            raise MultiPartParserError('Invalid boundary in multipart: %s' % force_text(boundary))
 
         # Content-Length should contain the length of the body we are about
         # to receive.


### PR DESCRIPTION
Our vulnerability scanner recently started triggering an AttributeError exception in MultiPartParser.

```
  File "lib/python3.5/site-packages/django/http/multipartparser.py", line 72, in __init__
    raise MultiPartParserError('Invalid boundary in multipart: %s' % boundary.decode())
AttributeError: 'NoneType' object has no attribute 'decode'
```

This is already fixed in HEAD, but we're running the 2.2 LTS. Patch is based on HEAD.

I don't believe this is a vulnerability, just a source of noise when monitoring exceptions.