### PR TITLE
Fixed #31897 -- Tweaked Settings docs to better explain settings.DEBUG example

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -319,6 +319,7 @@ answer newbie questions, and generally made Django that much better:
     Gabriel Grant <g@briel.ca>
     Gabriel Hurley <gabriel@strikeawe.com>
     gandalf@owca.info
+    Garrett Edel <edelgm6@gmail.com>
     Garry Lawrence
     Garry Polley <garrympolley@gmail.com>
     Garth Kidd <http://www.deadlybloodyserious.com/>

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -17,7 +17,7 @@ Here are a couple of example settings::
     DEBUG = False
     DEFAULT_FROM_EMAIL = 'webmaster@example.com'
 
-.. note::
+.. admonition:: DEBUG and ALLOWED_HOSTS
 
     If you set :setting:`DEBUG` to ``False``, you also need to properly set
     the :setting:`ALLOWED_HOSTS` setting.
@@ -120,10 +120,16 @@ In your Django apps, use settings by importing the object
     if settings.DEBUG:
         # Do something
 
+.. admonition:: settings.DEBUG in testing
+
+    ``settings.DEBUG`` will always return ``False`` while :ref:`running tests <other-test-conditions>`.
+
 Note that ``django.conf.settings`` isn't a module -- it's an object. So
 importing individual settings is not possible::
 
     from django.conf.settings import DEBUG  # This won't work.
+
+Additionally,
 
 Also note that your code should *not* import from either ``global_settings`` or
 your own settings file. ``django.conf.settings`` abstracts the concepts of

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -122,7 +122,7 @@ In your Django apps, use settings by importing the object
 
 .. admonition:: settings.DEBUG in testing
 
-    ``settings.DEBUG`` will always return ``False`` while :ref:`running tests <other-test-conditions>`.
+    ``settings.DEBUG`` will always return ``False`` while :ref:`running tests <other-test-conditions>`. Use ``override_settings()`` to override this functionality.
 
 Note that ``django.conf.settings`` isn't a module -- it's an object. So
 importing individual settings is not possible::

--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -264,6 +264,8 @@ To prevent serialized data from being loaded twice, setting
 :data:`~django.db.models.signals.post_migrate` signal when flushing the test
 database.
 
+.. _other-test-conditions:
+
 Other test conditions
 ---------------------
 


### PR DESCRIPTION
Tweaked Settings docs to better explain settings.DEBUG example

The current example for how to use `from django.conf import settings` includes the example of using `settings.DEBUG`.

The example is fine, but if a user tries to replicate this in their test scripts `settings.DEBUG` will always return `False` [as intended](https://docs.djangoproject.com/en/3.1/topics/testing/overview/#other-test-conditions). This PR simply adds an `admonition` in the docs to warn users about this and offer an alternative with `override_settings()`.