### PR TITLE
Fixed #27679 -- Doc'd that empty formsets display extra + min_num forms.

### DIFF
--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -415,6 +415,11 @@ deletion, is greater than or equal to ``min_num``.
     >>> formset.non_form_errors()
     ['Please submit 3 or more forms.']
 
+.. note::
+
+    When a formset contains no initial data, the number of forms displayed is
+    the sum of ``min_num`` and ``extra``.
+
 Dealing with ordering and deletion of forms
 ===========================================
 

--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -417,8 +417,8 @@ deletion, is greater than or equal to ``min_num``.
 
 .. note::
 
-    When a formset contains no initial data, the number of forms displayed is
-    the sum of ``min_num`` and ``extra``.
+    Regardless of ``validate_min``, if a formset contains no data, then
+    ``extra + min_num`` empty forms will be displayed.
 
 Dealing with ordering and deletion of forms
 ===========================================


### PR DESCRIPTION
[Ticket #27679](https://code.djangoproject.com/ticket/27679)

This feature is tested here:
https://github.com/django/django/blob/master/tests/forms_tests/tests/test_formsets.py#L286

I considered making this note near the top where the docs discuss adding extra forms. However, that is an introduction and to mention this specific behavior there is a bit complex and therefore potentially confusing. `min_num` is documented lightly so I thought it best to add this caveat to that section. 