### PR TITLE
Use UnsafeLoader for fixtures loading in YAML

### DIFF
--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -175,7 +175,7 @@ class Command(BaseCommand):
 
                 objects = serializers.deserialize(
                     ser_fmt, fixture, using=self.using, ignorenonexistent=self.ignore,
-                    handle_forward_references=True,
+                    handle_forward_references=True, load_unsafe=True,
                 )
 
                 for obj in objects:

--- a/django/core/serializers/pyyaml.py
+++ b/django/core/serializers/pyyaml.py
@@ -18,9 +18,9 @@ from django.db import models
 
 # Use the C (faster) implementation if possible
 try:
-    from yaml import CSafeDumper as SafeDumper, CSafeLoader as SafeLoader
+    from yaml import CSafeDumper as SafeDumper, CSafeLoader as SafeLoader, CUnsafeLoader as UnsafeLoader
 except ImportError:
-    from yaml import SafeDumper, SafeLoader
+    from yaml import SafeDumper, SafeLoader, UnsafeLoader
 
 
 class DjangoSafeDumper(SafeDumper):
@@ -73,7 +73,8 @@ def Deserializer(stream_or_string, **options):
     else:
         stream = stream_or_string
     try:
-        yield from PythonDeserializer(yaml.load(stream, Loader=SafeLoader), **options)
+        Loader = UnsafeLoader if options.get('load_unsafe', False) else SafeLoader
+        yield from PythonDeserializer(yaml.load(stream, Loader=Loader), **options)
     except (GeneratorExit, DeserializationError):
         raise
     except Exception as exc:

--- a/django/core/serializers/pyyaml.py
+++ b/django/core/serializers/pyyaml.py
@@ -18,7 +18,10 @@ from django.db import models
 
 # Use the C (faster) implementation if possible
 try:
-    from yaml import CSafeDumper as SafeDumper, CSafeLoader as SafeLoader, CUnsafeLoader as UnsafeLoader
+    from yaml import (
+        CSafeDumper as SafeDumper, CSafeLoader as SafeLoader,
+        CUnsafeLoader as UnsafeLoader,
+    )
 except ImportError:
     from yaml import SafeDumper, SafeLoader, UnsafeLoader
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/31896#ticket

Currently, Django uses PyYAML's SafeLoader to load fixtures which prevent to use some advance utils like `!!python/object/apply`. For example, to create dates related to the current date for example, and not static dates that you have to update over time so that they aren't too old.

Anyway, there could be many reasons why a developer would want to use such an util in features. And I believe it should be safe to use UnsafeLoader for fixtures since this is certainly a data that developers create themselves.