### PR TITLE
Fixed #31901 -- Prevented content overflowing in the admin changelist with navigation sidebar.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -90,6 +90,7 @@
     margin: 0;
     vertical-align: top;
     font-size: 13px;
+    max-width: 230px;
 }
 
 #changelist #toolbar form #searchbar:focus {

--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -104,3 +104,7 @@
         display: none;
     }
 }
+
+.change-list .main > #nav-sidebar+.content {
+    overflow: hidden;
+}

--- a/docs/releases/3.1.1.txt
+++ b/docs/releases/3.1.1.txt
@@ -62,3 +62,6 @@ Bugfixes
 
 * Fixed a ``django.contrib.admin.EmptyFieldListFilter`` crash when using on
   reverse relations (:ticket:`31952`).
+
+* Prevented content overflowing in the admin changelist view when the
+  navigation sidebar is enabled (:ticket:`31901`).


### PR DESCRIPTION
[ticket_31901](https://code.djangoproject.com/ticket/31901)