### PR TITLE
Add ModelBase._state variable annotation

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -402,6 +402,7 @@ class ModelState:
 
 
 class Model(metaclass=ModelBase):
+    _state: ModelState
 
     def __init__(self, *args, **kwargs):
         # Alias some things as locals to avoid repeat global lookups


### PR DESCRIPTION
This is [a publicly documented field of `Model`](https://docs.djangoproject.com/en/3.1/ref/models/instances/#django.db.models.Model._state) but libraries such as unittest.mock cannot detect this field because it is only declared within `__init__()`. By adding a variable annotation, they will be able to detect it, making it compatible with unittest.mock's `spec_set`, for example.

I'm not sure whether this qualifies as a "trivial" change (being a one-line change), so I haven't yet created a Trac ticket for it.