### PR TITLE
Fixed #31907 -- Fixed missing validate_key() calls in cache backends.

### DIFF
--- a/django/core/cache/backends/locmem.py
+++ b/django/core/cache/backends/locmem.py
@@ -59,6 +59,7 @@ class LocMemCache(BaseCache):
 
     def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None):
         key = self.make_key(key, version=version)
+        self.validate_key(key)
         with self._lock:
             if self._has_expired(key):
                 return False

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -656,6 +656,7 @@ class BaseCacheTests:
             ('set', [key, 1]),
             ('incr', [key]),
             ('decr', [key]),
+            ('touch', [key]),
             ('delete', [key]),
             ('get_many', [[key, 'b']]),
             ('set_many', [{key: 1, 'b': 2}]),
@@ -1306,11 +1307,15 @@ class BaseMemcachedTests(BaseCacheTests):
         msg = expected_warning.replace(key, cache.make_key(key))
         tests = [
             ('add', [key, 1]),
+            ('get', [key]),
             ('set', [key, 1]),
             ('incr', [key]),
             ('decr', [key]),
+            ('touch', [key]),
+            ('delete', [key]),
             ('get_many', [[key, 'b']]),
             ('set_many', [{key: 1, 'b': 2}]),
+            ('delete_many', [{key: 1, 'b': 2}]),
         ]
         for operation, args in tests:
             with self.subTest(operation=operation):


### PR DESCRIPTION
ticket-31907