### PR TITLE
Fixed #31978 -- Added username hint to admin's password reset confirmation form.

### DIFF
--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -19,6 +19,7 @@
 
 <form method="post">{% csrf_token %}
 <fieldset class="module aligned">
+    <input style="display: none;" autocomplete="username" value="{{ form.user.username }}">
     <div class="form-row field-password1">
         {{ form.new_password1.errors }}
         <label for="id_new_password1">{% translate 'New password:' %}</label>

--- a/tests/auth_tests/test_templates.py
+++ b/tests/auth_tests/test_templates.py
@@ -52,6 +52,12 @@ class AuthTemplateTests(TestCase):
         response = client.get(url)
         self.assertContains(response, '<title>Enter new password</title>')
         self.assertContains(response, '<h1>Enter new password</h1>')
+        # The username is added to the password reset confirmation form to help
+        # browser's password managers.
+        self.assertContains(
+            response,
+            '<input style="display: none;" autocomplete="username" value="jsmith">',
+        )
 
     def test_PasswordResetCompleteView(self):
         response = PasswordResetCompleteView.as_view()(self.request)


### PR DESCRIPTION
Include hidden username field on password reset to help password managers

https://code.djangoproject.com/ticket/31978