### PR TITLE
Fixed #31909 -- Fixed typo in docs/ref/contrib/admin/index.txt.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -34,15 +34,15 @@ If you're not using the default project template, here are the requirements:
 
 #. Configure a :class:`~django.template.backends.django.DjangoTemplates`
    backend in your :setting:`TEMPLATES` setting with
-   ``django.contrib.auth.context_processors.auth``,
-   ``django.contrib.messages.context_processors.request``, and
+   ``django.template.context_processors.request``,
+   ``django.contrib.auth.context_processors.auth``, and
    ``django.contrib.messages.context_processors.messages`` in
    the ``'context_processors'`` option of :setting:`OPTIONS
    <TEMPLATES-OPTIONS>`.
 
    .. versionchanged:: 3.1
 
-       ``django.contrib.messages.context_processors.request`` was added as a
+       ``django.template.context_processors.request`` was added as a
        requirement in the ``'context_processors'`` option to support the new
        :attr:`.AdminSite.enable_nav_sidebar`.
 


### PR DESCRIPTION
This is my first PR here, I read some examples of people who helped correct the documentation before, I hope I am not doing anything wrong. I encountered this error when I was looking for solutions to a Stackoverflow issue.

https://github.com/django/django/pull/12159