### PR TITLE
Improved wording in async views docs.

### DIFF
--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -39,7 +39,7 @@ class-based view, this means making its ``__call__()`` method an ``async def``
     to ``asyncio.coroutines._is_coroutine`` so this function returns ``True``.
 
 Under a WSGI server, async views will run in their own, one-off event loop.
-This means you can use async features, like parallel async HTTP requests,
+This means you can use async features, like concurrent async HTTP requests,
 without any issues, but you will not get the benefits of an async stack.
 
 The main benefits are the ability to service hundreds of connections without
@@ -63,7 +63,7 @@ If you want to use these, you will need to deploy Django using
     messages about *"Synchronous middleware ... adapted"*.
 
 In both ASGI and WSGI mode, you can still safely use asynchronous support to
-run code in parallel rather than serially. This is especially handy when
+run code concurrently rather than serially. This is especially handy when
 dealing with external APIs or data stores.
 
 If you want to call a part of Django that is still synchronous, like the ORM,


### PR DESCRIPTION
I think this could prevent some confusion, since parallelism means something a little different to what async does, and the difference is usually a point of difficulty when learning about async.