### PR TITLE
Async docs incorrectly stated that async_to_sync runs async function in same thread

### DIFF
--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -196,7 +196,7 @@ as either a direct wrapper or a decorator::
     async def get_other_data(...):
         ...
 
-The async function is run in the event loop for the current thread, if one is
+The async task is added to the event loop for the current thread, if one is
 present. If there is no current event loop, a new event loop is spun up
 specifically for the single async invocation and shut down again once it
 completes. In either situation, the async function will execute on a different


### PR DESCRIPTION
The original docs said in the same paragraph, that when using `async_to_sync`, the async function will be called in the same thread (if a loop is present), and then at the end it said the function will always be called in a new thread. The first statement was incorrect, the async Task is added to the loop in the current thread, but the async function is executed in a new thread, no the same one from the loop.