### PR TITLE
Fixed #31910 -- Fixed crash of GIS aggregations over subqueries.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1596,8 +1596,11 @@ class SQLAggregateCompiler(SQLCompiler):
         sql = ', '.join(sql)
         params = tuple(params)
 
-        sql = 'SELECT %s FROM (%s) subquery' % (sql, self.query.subquery)
-        params = params + self.query.sub_params
+        inner_query_sql, inner_query_params = self.query.inner_query.get_compiler(
+            self.using
+        ).as_sql(with_col_aliases=True)
+        sql = 'SELECT %s FROM (%s) subquery' % (sql, inner_query_sql)
+        params = params + inner_query_params
         return sql, params
 
 

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -157,6 +157,6 @@ class AggregateQuery(Query):
 
     compiler = 'SQLAggregateCompiler'
 
-    def add_subquery(self, query, using):
-        query.subquery = True
-        self.subquery, self.sub_params = query.get_compiler(using).as_sql(with_col_aliases=True)
+    def __init__(self, model, inner_query):
+        self.inner_query = inner_query
+        super().__init__(model)

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -974,7 +974,7 @@ class AggregationTests(TestCase):
     def test_empty_filter_aggregate(self):
         self.assertEqual(
             Author.objects.filter(id__in=[]).annotate(Count("friends")).aggregate(Count("pk")),
-            {"pk__count": None}
+            {"pk__count": 0}
         )
 
     def test_none_call_before_aggregate(self):


### PR DESCRIPTION
`AggregateQuery` was abusing `Query.subquery: bool` by stashing its compiled inner query SQL for later use in its compiler which made `select_format` checks for `Query.subquery` wrongly assume the provide `query` was a subquery.

This patch prevents that from happening by using a dedicated `.inner_query` attribute which is compiled at a later time by `SQLAggregateCompiler`.

Moving the inner query's compilation to `SQLAggregateCompiler.compile` had the side effect of addressing a long standing issue with aggregation subquery pushdown which prevented converters from being run. This is now fixed as the `aggregation_regress` adjustments demonstrate.

Regression was introduced by fff5186.

Refs ticket-25367.

Thanks Eran Keydar for the report.