### PR TITLE
Fixed #31905 -- Made MiddlewareMixin call process_request()/process_response() with thread sensitive.

### DIFF
--- a/django/utils/deprecation.py
+++ b/django/utils/deprecation.py
@@ -126,10 +126,16 @@ class MiddlewareMixin:
         """
         response = None
         if hasattr(self, 'process_request'):
-            response = await sync_to_async(self.process_request)(request)
+            response = await sync_to_async(
+                self.process_request,
+                thread_sensitive=True,
+            )(request)
         response = response or await self.get_response(request)
         if hasattr(self, 'process_response'):
-            response = await sync_to_async(self.process_response)(request, response)
+            response = await sync_to_async(
+                self.process_response,
+                thread_sensitive=True,
+            )(request, response)
         return response
 
     def _get_response_none_deprecation(self, get_response):

--- a/docs/releases/3.1.1.txt
+++ b/docs/releases/3.1.1.txt
@@ -35,3 +35,7 @@ Bugfixes
 * Reverted a deprecation in Django 3.1 that caused a crash when passing
   deprecated keyword arguments to a queryset in
   ``TemplateView.get_context_data()`` (:ticket:`31877`).
+
+* Enforced thread sensitivity of the :class:`MiddlewareMixin.process_request()
+  <django.utils.deprecation.MiddlewareMixin>` and ``process_response()`` hooks
+  when in an async context (:ticket:`31905`).


### PR DESCRIPTION
MiddlewareMixin use sync_to_async with thread_sensitive to prevent errors in database connection clearance.
https://code.djangoproject.com/ticket/31905