### PR TITLE
Fixed #31906 -- Fixed typo in docs/ref/forms/fields.txt.

### DIFF
--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -1425,7 +1425,7 @@ customize the yielded 2-tuple choices.
     .. attribute:: field
 
         The instance of ``ModelChoiceField`` or ``ModelMultipleChoiceField`` to
-        iterator and yield choice.
+        iterate and yield choices.
 
     ``ModelChoiceIterator`` has the following method:
 


### PR DESCRIPTION
Fixed #31906 -- Replaced 'iterator' to 'iterate' and 'choice' to 'choices'