### PR TITLE
Fixed #24533 -- Dropped PostgreSQL sequence and Oracle identity when migrating away from AutoField.

### DIFF
--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -122,6 +122,17 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # Rename and possibly make the new field NOT NULL
         super().alter_field(model, new_temp_field, new_field)
 
+    def _alter_column_type_sql(self, model, old_field, new_field, new_type):
+        auto_field_types = {'AutoField', 'BigAutoField', 'SmallAutoField'}
+        # Drop the identity if migrating away from AutoField.
+        if (
+            old_field.get_internal_type() in auto_field_types and
+            new_field.get_internal_type() not in auto_field_types and
+            self._is_identity_column(model._meta.db_table, new_field.column)
+        ):
+            self._drop_identity(model._meta.db_table, new_field.column)
+        return super()._alter_column_type_sql(model, old_field, new_field, new_type)
+
     def normalize_name(self, name):
         """
         Get the properly shortened and uppercased identifier as returned by

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -677,6 +677,11 @@ class SchemaTests(TransactionTestCase):
         new_field.model = Author
         with connection.schema_editor() as editor:
             editor.alter_field(Author, old_field, new_field, strict=True)
+        # Now that ID is an IntegerField, the database raises an error if it
+        # isn't provided.
+        if not connection.features.supports_unspecified_pk:
+            with self.assertRaises(DatabaseError):
+                Author.objects.create()
 
     def test_alter_auto_field_to_char_field(self):
         # Create the table


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24533