### PR TITLE
Fixed #31934 -- Added note about the default of SameSite cookie flag in modern browsers.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -3241,6 +3241,11 @@ Possible values for the setting are:
 
 * ``False``: disables the flag.
 
+.. note::
+
+    Modern browsers provide a more secure default policy for the ``SameSite``
+    flag and will assume ``Lax`` for cookies without an explicit value set.
+
 .. versionchanged:: 3.1
 
     Setting ``SESSION_COOKIE_SAMESITE = 'None'`` was allowed.


### PR DESCRIPTION
ticket-31934
Just created a PR based on @felixxm [comment on the ticket](https://code.djangoproject.com/ticket/31934#comment:4).