### PR TITLE
Fixed #30422 -- Made TemporaryFileUploadHandler handle interrupted uploads.

### DIFF
--- a/django/core/files/uploadhandler.py
+++ b/django/core/files/uploadhandler.py
@@ -1,7 +1,7 @@
 """
 Base file upload handler classes, and the built-in concrete subclasses
 """
-
+import os
 from io import BytesIO
 
 from django.conf import settings
@@ -127,6 +127,13 @@ class FileUploadHandler:
         """
         pass
 
+    def upload_interrupted(self):
+        """
+        Signal that the upload was interrupted. Subclasses should perform
+        cleanup that is necessary for this handler.
+        """
+        pass
+
 
 class TemporaryFileUploadHandler(FileUploadHandler):
     """
@@ -146,6 +153,15 @@ class TemporaryFileUploadHandler(FileUploadHandler):
         self.file.seek(0)
         self.file.size = file_size
         return self.file
+
+    def upload_interrupted(self):
+        if hasattr(self, 'file'):
+            temp_location = self.file.temporary_file_path()
+            try:
+                self.file.close()
+                os.remove(temp_location)
+            except FileNotFoundError:
+                pass
 
 
 class MemoryFileUploadHandler(FileUploadHandler):

--- a/docs/ref/files/uploads.txt
+++ b/docs/ref/files/uploads.txt
@@ -212,6 +212,13 @@ attributes:
 
     Callback signaling that the entire upload (all files) has completed.
 
+.. method:: FileUploadHandler.upload_interrupted()
+
+    .. versionadded:: 3.2
+
+    Callback signaling that the upload was interrupted, e.g. when the user
+    closed their browser during file upload.
+
 .. method:: FileUploadHandler.handle_raw_input(input_data, META, content_length, boundary, encoding)
 
     Allows the handler to completely override the parsing of the raw

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -195,8 +195,9 @@ File Storage
 File Uploads
 ~~~~~~~~~~~~
 
-* ...
-
+* The new :meth:`FileUploadHandler.upload_interrupted()
+  <django.core.files.uploadhandler.FileUploadHandler.upload_interrupted>`
+  callback allows handling interrupted uploads.
 
 Forms
 ~~~~~

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -435,6 +435,14 @@ class FileUploadTests(TestCase):
             with self.assertRaisesMessage(AttributeError, msg):
                 self.client.post('/quota/broken/', {'f': file})
 
+    def test_stop_upload_temporary_file_handler(self):
+        with tempfile.NamedTemporaryFile() as temp_file:
+            temp_file.write(b'a')
+            temp_file.seek(0)
+            response = self.client.post('/temp_file/stop_upload/', {'file': temp_file})
+            temp_path = response.json()['temp_path']
+            self.assertIs(os.path.exists(temp_path), False)
+
     def test_fileupload_getlist(self):
         file = tempfile.NamedTemporaryFile
         with file() as file1, file() as file2, file() as file2a:

--- a/tests/file_uploads/uploadhandler.py
+++ b/tests/file_uploads/uploadhandler.py
@@ -2,7 +2,9 @@
 Upload handlers to test the upload API.
 """
 
-from django.core.files.uploadhandler import FileUploadHandler, StopUpload
+from django.core.files.uploadhandler import (
+    FileUploadHandler, StopUpload, TemporaryFileUploadHandler,
+)
 
 
 class QuotaUploadHandler(FileUploadHandler):
@@ -25,6 +27,12 @@ class QuotaUploadHandler(FileUploadHandler):
 
     def file_complete(self, file_size):
         return None
+
+
+class StopUploadTemporaryFileHandler(TemporaryFileUploadHandler):
+    """A handler that raises a StopUpload exception."""
+    def receive_data_chunk(self, raw_data, start):
+        raise StopUpload()
 
 
 class CustomUploadError(Exception):

--- a/tests/file_uploads/urls.py
+++ b/tests/file_uploads/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('quota/broken/', views.file_upload_quota_broken),
     path('getlist_count/', views.file_upload_getlist_count),
     path('upload_errors/', views.file_upload_errors),
+    path('temp_file/stop_upload/', views.file_stop_upload_temporary_file),
     path('filename_case/', views.file_upload_filename_case_view),
     re_path(r'^fd_closing/(?P<access>t|f)/$', views.file_upload_fd_closing),
 ]

--- a/tests/file_uploads/urls.py
+++ b/tests/file_uploads/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('getlist_count/', views.file_upload_getlist_count),
     path('upload_errors/', views.file_upload_errors),
     path('temp_file/stop_upload/', views.file_stop_upload_temporary_file),
+    path('temp_file/upload_interrupted/', views.file_upload_interrupted_temporary_file),
     path('filename_case/', views.file_upload_filename_case_view),
     re_path(r'^fd_closing/(?P<access>t|f)/$', views.file_upload_fd_closing),
 ]

--- a/tests/file_uploads/views.py
+++ b/tests/file_uploads/views.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 
 from django.core.files.uploadedfile import UploadedFile
+from django.core.files.uploadhandler import TemporaryFileUploadHandler
 from django.http import HttpResponse, HttpResponseServerError, JsonResponse
 
 from .models import FileModel
@@ -105,6 +106,15 @@ def file_upload_quota_broken(request):
 
 def file_stop_upload_temporary_file(request):
     request.upload_handlers.insert(0, StopUploadTemporaryFileHandler())
+    request.upload_handlers.pop(2)
+    request.FILES  # Trigger file parsing.
+    return JsonResponse(
+        {'temp_path': request.upload_handlers[0].file.temporary_file_path()},
+    )
+
+
+def file_upload_interrupted_temporary_file(request):
+    request.upload_handlers.insert(0, TemporaryFileUploadHandler())
     request.upload_handlers.pop(2)
     request.FILES  # Trigger file parsing.
     return JsonResponse(

--- a/tests/file_uploads/views.py
+++ b/tests/file_uploads/views.py
@@ -6,7 +6,9 @@ from django.http import HttpResponse, HttpResponseServerError, JsonResponse
 
 from .models import FileModel
 from .tests import UNICODE_FILENAME, UPLOAD_TO
-from .uploadhandler import ErroringUploadHandler, QuotaUploadHandler
+from .uploadhandler import (
+    ErroringUploadHandler, QuotaUploadHandler, StopUploadTemporaryFileHandler,
+)
 
 
 def file_upload_view(request):
@@ -99,6 +101,15 @@ def file_upload_quota_broken(request):
     response = file_upload_echo(request)
     request.upload_handlers.insert(0, QuotaUploadHandler())
     return response
+
+
+def file_stop_upload_temporary_file(request):
+    request.upload_handlers.insert(0, StopUploadTemporaryFileHandler())
+    request.upload_handlers.pop(2)
+    request.FILES  # Trigger file parsing.
+    return JsonResponse(
+        {'temp_path': request.upload_handlers[0].file.temporary_file_path()},
+    )
 
 
 def file_upload_getlist_count(request):


### PR DESCRIPTION
Patch for [ticket-30422](https://code.djangoproject.com/ticket/30422).
[Original PR](https://github.com/django/django/pull/12475), had to create a new one because I kind of messed up while rebasing.