### PR TITLE
Refs #31913 -- Corrected comment in PasswordResetTokenGenerator.

### DIFF
--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -73,7 +73,7 @@ class PasswordResetTokenGenerator:
             # legacy argument and replace with:
             #   algorithm=self.algorithm,
             algorithm='sha1' if legacy else self.algorithm,
-        ).hexdigest()[::2]  # Limit to 20 characters to shorten the URL.
+        ).hexdigest()[::2]  # Limit to shorten the URL.
         return "%s-%s" % (ts_b36, hash_string)
 
     def _make_hash_value(self, user, timestamp):


### PR DESCRIPTION
The token used to be limited to 20 characters in length but for some time it's been longer (32 characters currently, I think).

The URL conf rule that used to match it for "password_reset_confirm" was once matching a token up to 20 characters long but these days it has no limit.

Re https://code.djangoproject.com/ticket/31913#comment:2