### PR TITLE
Fixed #31954 -- Fixed migration optimization for MTI model creation with parent model with mixed case app label.

### DIFF
--- a/django/db/migrations/operations/utils.py
+++ b/django/db/migrations/operations/utils.py
@@ -19,7 +19,8 @@ def resolve_relation(model, app_label=None, model_name=None):
                 )
             return app_label, model_name
         if '.' in model:
-            return tuple(model.lower().split('.', 1))
+            app_label, model_name = model.split('.', 1)
+            return app_label, model_name.lower()
         if app_label is None:
             raise TypeError(
                 'app_label must be provided to resolve unscoped model '

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -2322,6 +2322,26 @@ class AutodetectorTests(TestCase):
         self.assertOperationAttributes(changes, 'testapp', 0, 0, name="Author")
         self.assertOperationAttributes(changes, 'testapp', 0, 1, name="Aardvark")
 
+    def test_bases_first_mixed_case_app_label(self):
+        app_label = 'MiXedCaseApp'
+        changes = self.get_changes([], [
+            ModelState(app_label, 'owner', [
+                ('id', models.AutoField(primary_key=True)),
+            ]),
+            ModelState(app_label, 'place', [
+                ('id', models.AutoField(primary_key=True)),
+                ('owner', models.ForeignKey('MiXedCaseApp.owner', models.CASCADE)),
+            ]),
+            ModelState(app_label, 'restaurant', [], bases=('MiXedCaseApp.place',)),
+        ])
+        self.assertNumberMigrations(changes, app_label, 1)
+        self.assertOperationTypes(changes, app_label, 0, [
+            'CreateModel', 'CreateModel', 'CreateModel',
+        ])
+        self.assertOperationAttributes(changes, app_label, 0, 0, name='owner')
+        self.assertOperationAttributes(changes, app_label, 0, 1, name='place')
+        self.assertOperationAttributes(changes, app_label, 0, 2, name='restaurant')
+
     def test_multiple_bases(self):
         """#23956 - Inheriting models doesn't move *_ptr fields into AddField operations."""
         A = ModelState("app", "A", [("a_id", models.AutoField(primary_key=True))])


### PR DESCRIPTION
resolve_relation() should not convert the app name to lowercase, otherwise the references_model() function in db/migrations/operations/models.py will not recognize model dependencies if the app name has uppercase letters.