### PR TITLE
Fixed #30563 -- Optimized form Media by removing duplicated assets when adding.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -146,8 +146,14 @@ class Media:
 
     def __add__(self, other):
         combined = Media()
-        combined._css_lists = self._css_lists + other._css_lists
-        combined._js_lists = self._js_lists + other._js_lists
+        combined._css_lists = self._css_lists[:]
+        combined._js_lists = self._js_lists[:]
+        for item in other._css_lists:
+            if item and item not in self._css_lists:
+                combined._css_lists.append(item)
+        for item in other._js_lists:
+            if item and item not in self._js_lists:
+                combined._js_lists.append(item)
         return combined
 
 

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -592,3 +592,57 @@ class FormsMediaTestCase(SimpleTestCase):
         # Media ordering does not matter.
         merged = widget1 + widget4
         self.assertEqual(merged._css, {'screen': ['c.css'], 'all': ['d.css', 'e.css']})
+
+    def test_add_js_deduplication(self):
+        widget1 = Media(js=['a', 'b', 'c'])
+        widget2 = Media(js=['a', 'b'])
+        widget3 = Media(js=['a', 'c', 'b'])
+        merged = widget1 + widget1
+        self.assertEqual(merged._js_lists, [['a', 'b', 'c']])
+        self.assertEqual(merged._js, ['a', 'b', 'c'])
+        merged = widget1 + widget2
+        self.assertEqual(merged._js_lists, [['a', 'b', 'c'], ['a', 'b']])
+        self.assertEqual(merged._js, ['a', 'b', 'c'])
+        # Lists with items in a different order are preserved when added.
+        merged = widget1 + widget3
+        self.assertEqual(merged._js_lists, [['a', 'b', 'c'], ['a', 'c', 'b']])
+        msg = (
+            "Detected duplicate Media files in an opposite order: "
+            "['a', 'b', 'c'], ['a', 'c', 'b']"
+        )
+        with self.assertWarnsMessage(RuntimeWarning, msg):
+            merged._js
+
+    def test_add_css_deduplication(self):
+        widget1 = Media(css={'screen': ['a.css'], 'all': ['b.css']})
+        widget2 = Media(css={'screen': ['c.css']})
+        widget3 = Media(css={'screen': ['a.css'], 'all': ['b.css', 'c.css']})
+        widget4 = Media(css={'screen': ['a.css'], 'all': ['c.css', 'b.css']})
+        merged = widget1 + widget1
+        self.assertEqual(merged._css_lists, [{'screen': ['a.css'], 'all': ['b.css']}])
+        self.assertEqual(merged._css, {'screen': ['a.css'], 'all': ['b.css']})
+        merged = widget1 + widget2
+        self.assertEqual(merged._css_lists, [
+            {'screen': ['a.css'], 'all': ['b.css']},
+            {'screen': ['c.css']},
+        ])
+        self.assertEqual(merged._css, {'screen': ['a.css', 'c.css'], 'all': ['b.css']})
+        merged = widget3 + widget4
+        # Ordering within lists is preserved.
+        self.assertEqual(merged._css_lists, [
+            {'screen': ['a.css'], 'all': ['b.css', 'c.css']},
+            {'screen': ['a.css'], 'all': ['c.css', 'b.css']}
+        ])
+        msg = (
+            "Detected duplicate Media files in an opposite order: "
+            "['b.css', 'c.css'], ['c.css', 'b.css']"
+        )
+        with self.assertWarnsMessage(RuntimeWarning, msg):
+            merged._css
+
+    def test_add_empty(self):
+        media = Media(css={'screen': ['a.css']}, js=['a'])
+        empty_media = Media()
+        merged = media + empty_media
+        self.assertEqual(merged._css_lists, [{'screen': ['a.css']}])
+        self.assertEqual(merged._js_lists, [['a']])

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -581,6 +581,7 @@ class FormsMediaTestCase(SimpleTestCase):
         widget1 = Media(css={'screen': ['c.css'], 'all': ['d.css', 'e.css']})
         widget2 = Media(css={'screen': ['a.css']})
         widget3 = Media(css={'screen': ['a.css', 'b.css', 'c.css'], 'all': ['e.css']})
+        widget4 = Media(css={'all': ['d.css', 'e.css'], 'screen': ['c.css']})
         merged = widget1 + widget2
         # c.css comes before a.css because widget1 + widget2 establishes this
         # order.
@@ -588,3 +589,6 @@ class FormsMediaTestCase(SimpleTestCase):
         merged = merged + widget3
         # widget3 contains an explicit ordering of c.css and a.css.
         self.assertEqual(merged._css, {'screen': ['a.css', 'b.css', 'c.css'], 'all': ['d.css', 'e.css']})
+        # Media ordering does not matter.
+        merged = widget1 + widget4
+        self.assertEqual(merged._css, {'screen': ['c.css'], 'all': ['d.css', 'e.css']})


### PR DESCRIPTION
[Ticket #30563](https://code.djangoproject.com/ticket/30563)

There are a number of ways to solve this some are discussed in some detail on the ticket:

1. Set an arbitrary limit at which point `merge` is called. 

Con : this could result in the wrong order of outputs as it's unclear when the ordering is final. 

2. Use `OrderedSet` (something like comment 5 on the ticket)

Pro : ensures the right order
Con : more complex, a number of conversions between OrderedSets and lists may be required. 

3. Dedupe when items are exactly the same, let merge work out the different ones later

Pro : I _think_ this is simpler than using an `OrderedSet`. 
Con : If items are long the `in` search on a list could be slow.

I've tried to implement option 3. It adds the lists together but removes any items that are exactly the same. This solves the test in the ticket as the time is now very small. 

`100000 additions took: 0:00:00.136388`