### PR TITLE
Fixed #30952 -- Log out users when they access a password reset link

### DIFF
--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -276,6 +276,7 @@ class PasswordResetConfirmView(PasswordContextMixin, FormView):
                     # password reset form at a URL without the token. That
                     # avoids the possibility of leaking the token in the
                     # HTTP Referer header.
+                    auth_logout(self.request)
                     self.request.session[INTERNAL_RESET_SESSION_TOKEN] = token
                     redirect_url = self.request.path.replace(token, self.reset_url_token)
                     return HttpResponseRedirect(redirect_url)


### PR DESCRIPTION
PasswordResetConfirmView relies on a token in the session. But
user code (e.g. for logging) might access request.user and so
inadvertently flush the session. This then causes a KeyError when
PasswordResetConfirmView tries to delete the token.

To fix this, explicitly call auth_logout, so that the session is a
clean slate.