### PR TITLE
Fixed #31858 -- Reallowed whitespaces in URL paths outside of parameters.

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -208,8 +208,6 @@ def _route_to_regex(route, is_endpoint=False):
     For example, 'foo/<int:pk>' returns '^foo\\/(?P<pk>[0-9]+)'
     and {'pk': <django.urls.converters.IntConverter>}.
     """
-    if not set(route).isdisjoint(string.whitespace):
-        raise ImproperlyConfigured("URL route '%s' cannot contain whitespace." % route)
     original_route = route
     parts = ['^']
     converters = {}
@@ -218,6 +216,11 @@ def _route_to_regex(route, is_endpoint=False):
         if not match:
             parts.append(re.escape(route))
             break
+        elif not set(match.group()).isdisjoint(string.whitespace):
+            raise ImproperlyConfigured(
+                "URL route '%s' cannot contain whitespace in angle brackets "
+                "<…>." % original_route
+            )
         parts.append(re.escape(route[:match.start()]))
         route = route[match.end():]
         parameter = match['parameter']


### PR DESCRIPTION
**Ticket:** https://code.djangoproject.com/ticket/31858

**Background**
[Ticket 29667](https://github.com/django/django/pull/11688) implemented an exception if there was whitespace found in the URL path converter. 

This ticket updates that implementation by specifying invalid white spaces only between the `<` and `>` characters.  

**Implementation**
Instead of passing the entire `route` string into the exception check on Line 212, we only pass the part of the route between the`<` and `>` characters. To do this, we find the positions of those 2 characters and string index between them. 

`.find()` returns the index of the first occurrence of a character in a string.

![Screen Shot 2020-08-29 at 12 30 07 PM](https://user-images.githubusercontent.com/51100862/91644697-6d66cd80-e9f3-11ea-8dd7-a49780c6305e.png)


We could also do this in a 1 liner but that would sacrifice some readability. 
![Screen Shot 2020-08-29 at 12 32 58 PM](https://user-images.githubusercontent.com/51100862/91644738-cd5d7400-e9f3-11ea-9e62-1764ea1a92e0.png)


I also updated the error message to be more specific to this new implementation: 
Old Error: `URL route 'space/<int: num>' cannot contain whitespace.`
New Error: `URL route 'space/<int: num>' cannot contain whitespace between the < and > characters.`
