### PR TITLE
Fixed #31766 -- Made GDALRaster.transform() return a clone for the same SRID and driver.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -110,6 +110,7 @@ answer newbie questions, and generally made Django that much better:
     Baptiste Mispelon <bmispelon@gmail.com>
     Barry Pederson <bp@barryp.org>
     Bartolome Sanchez Salado <i42sasab@uco.es>
+    Barton Ip <notbartonip@gmail.com>
     Bartosz Grabski <bartosz.grabski@gmail.com>
     Bashar Al-Abdulhadi
     Bastian Kleineidam <calvin@debian.org>


### PR DESCRIPTION
Implemented a clone method using ds_copy to clone GDALRaster objects. 
Added conditional to simply return a clone of GDALRaster if SRID matches with transform srs argument.