### PR TITLE
Refs #29887, Refs #24212 -- Added servers configuration hook for memcached backends.

### DIFF
--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -114,15 +114,6 @@ In this example, Memcached is available through a local Unix socket file
         }
     }
 
-When using the ``pylibmc`` binding, do not include the ``unix:/`` prefix::
-
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
-            'LOCATION': '/tmp/memcached.sock',
-        }
-    }
-
 One excellent feature of Memcached is its ability to share a cache over
 multiple servers. This means you can run Memcached daemons on multiple
 machines, and the program will treat the group of machines as a *single*

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1441,6 +1441,18 @@ class PyLibMCCacheTests(BaseMemcachedTests, TestCase):
         self.assertTrue(cache._cache.binary)
         self.assertEqual(cache._cache.behaviors['tcp_nodelay'], int(True))
 
+    def test_pylibmc_client_servers(self):
+        backend = self.base_params['BACKEND']
+        tests = [
+            ('unix:/run/memcached/socket', '/run/memcached/socket'),
+            ('/run/memcached/socket', '/run/memcached/socket'),
+            ('127.0.0.1:11211', '127.0.0.1:11211'),
+        ]
+        for location, expected in tests:
+            settings = {'default': {'BACKEND': backend, 'LOCATION': location}}
+            with self.subTest(location), self.settings(CACHES=settings):
+                self.assertEqual(cache.client_servers, [expected])
+
 
 @override_settings(CACHES=caches_setting_for_tests(
     BACKEND='django.core.cache.backends.filebased.FileBasedCache',


### PR DESCRIPTION
The servers property can be overridden to allow memcached backends to alter the server configuration prior to it being passed to instantiate the client. This allows avoidance of documentation for per-backend differences, e.g. stripping the 'unix:' prefix for `pylibmc`.