### PR TITLE
Refs #31901 -- Fixed SeleniumTests.test_list_editable_popups with headless mode.

### DIFF
--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4739,6 +4739,9 @@ class SeleniumTests(AdminSeleniumTestCase):
         name_input.send_keys('<i>edited section</i>')
         self.selenium.find_element_by_xpath('//input[@value="Save"]').click()
         self.selenium.switch_to.window(self.selenium.window_handles[0])
+        # Hide sidebar.
+        toggle_button = self.selenium.find_element_by_css_selector('#toggle-nav-sidebar')
+        toggle_button.click()
         select = Select(self.selenium.find_element_by_id('id_form-0-section'))
         self.assertEqual(select.first_selected_option.text, '<i>edited section</i>')
         # Rendered select2 input.


### PR DESCRIPTION
See [logs](https://djangoci.com/job/django-selenium/lastCompletedBuild/testReport/).