### PR TITLE
Fixed #31979 -- Made django.test.utils.setup_databases()'s time_keeper argument optional.

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -156,9 +156,12 @@ def teardown_test_environment():
     del mail.outbox
 
 
-def setup_databases(verbosity, interactive, *, time_keeper, keepdb=False, debug_sql=False, parallel=0,
+def setup_databases(verbosity, interactive, *, time_keeper=None, keepdb=False, debug_sql=False, parallel=0,
                     aliases=None):
     """Create the test databases."""
+    if time_keeper is None:
+        time_keeper = NullTimeKeeper()
+
     test_databases, mirrored_aliases = get_unique_databases_and_mirrors(aliases)
 
     old_names = []

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -726,7 +726,7 @@ utility methods in the ``django.test.utils`` module.
     Performs global post-test teardown, such as removing instrumentation from
     the template system and restoring normal email services.
 
-.. function:: setup_databases(verbosity, interactive, *, time_keeper, keepdb=False, debug_sql=False, parallel=0, aliases=None, **kwargs)
+.. function:: setup_databases(verbosity, interactive, *, time_keeper=None, keepdb=False, debug_sql=False, parallel=0, aliases=None, **kwargs)
 
     Creates the test databases.
 


### PR DESCRIPTION
ticket-31979

refs ticket-31811