### PR TITLE
Fixed #27417 -- Made RenameField operation a noop for field name case changes on Oracle.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1045,7 +1045,7 @@ class BaseDatabaseSchemaEditor:
         old_kwargs.pop('db_column', None)
         new_kwargs.pop('db_column', None)
         return (
-            old_field.column != new_field.column or
+            self.quote_name(old_field.column) != self.quote_name(new_field.column) or
             (old_path, old_args, old_kwargs) != (new_path, new_args, new_kwargs)
         )
 

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1727,6 +1727,28 @@ class OperationTests(OperationTestBase):
                 operation.database_backwards('test_rfwdbc', editor, new_state, project_state)
         self.assertColumnExists('test_rfwdbc_pony', 'db_fk_field')
 
+    def test_rename_field_case(self):
+        project_state = self.apply_operations('test_rfmx', ProjectState(), operations=[
+            migrations.CreateModel('Pony', fields=[
+                ('id', models.AutoField(primary_key=True)),
+                ('field', models.IntegerField()),
+            ]),
+        ])
+        new_state = project_state.clone()
+        operation = migrations.RenameField('Pony', 'field', 'FiElD')
+        operation.state_forwards('test_rfmx', new_state)
+        self.assertIn('FiElD', new_state.models['test_rfmx', 'pony'].fields)
+        self.assertColumnExists('test_rfmx_pony', 'field')
+        with connection.schema_editor() as editor:
+            operation.database_forwards('test_rfmx', editor, project_state, new_state)
+        self.assertColumnExists(
+            'test_rfmx_pony',
+            connection.introspection.identifier_converter('FiElD'),
+        )
+        with connection.schema_editor() as editor:
+            operation.database_backwards('test_rfmx', editor, new_state, project_state)
+        self.assertColumnExists('test_rfmx_pony', 'field')
+
     def test_rename_missing_field(self):
         state = ProjectState()
         state.add_model(ModelState('app', 'model', []))


### PR DESCRIPTION
Field names are always uppercased in the Oracle backend. Changing case should be a noop to avoid database errors: _"ORA-00957: duplicate column name"_.

ticket-27417