### PR TITLE
Fixed #31880 -- Handled overlapping annotations and aggregations

### DIFF
--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -991,6 +991,16 @@ class AggregateTestCase(TestCase):
 
         self.assertEqual(alias_age['sum_age'], age['sum_age'])
 
+    def test_overlapping_annotate_aggregate_alias(self):
+        alias_age = Author.objects.annotate(
+            age_alias=F('age')
+        ).aggregate(age_alias=Sum(F('age')), avg_age=Avg(F('age_alias')))
+
+        age = Author.objects.values('age').aggregate(sum_age=Sum('age'), avg_age=Avg('age'))
+
+        self.assertEqual(alias_age['age_alias'], age['sum_age'])
+        self.assertEqual(alias_age['avg_age'], age['avg_age'])
+
     def test_annotate_over_annotate(self):
         author = Author.objects.annotate(
             age_alias=F('age')


### PR DESCRIPTION
Tackles https://code.djangoproject.com/ticket/31880

Annotating and aggregating are actually using the same dictionary behind the scenes. Therefore, when annotating a field that should be used in the subquery, and then defining an aggregation with the same alias, the subquery will not query the initial annotation.

In order to fix that with the minimal change, we introduce a dict that will only kick in, in this special case, and keep track of the overridden aliases that should be in the subquery.