### PR TITLE
Fixed #31986 Django Admin filter sidebar does not scroll.

### DIFF
--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -99,15 +99,6 @@
     background: #ffc;
 }
 
-@media (max-width: 767px) {
-    #nav-sidebar, #toggle-nav-sidebar {
-        display: none;
-    }
-    .change-list .main > #nav-sidebar+.content,
-    .change-list .main.shifted > #nav-sidebar+.content {
-        left: 0;
-    }
-}
 .change-list .main > #nav-sidebar+.content {
     position: absolute;
     left: 23px;
@@ -117,4 +108,14 @@
 
 .change-list .main.shifted > #nav-sidebar+.content {
     left: 298px;
+}
+
+@media (max-width: 767px) {
+    #nav-sidebar, #toggle-nav-sidebar {
+        display: none;
+    }
+    .change-list .main > #nav-sidebar+.content,
+    .change-list .main.shifted > #nav-sidebar+.content {
+        left: 0;
+    }
 }

--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -103,8 +103,18 @@
     #nav-sidebar, #toggle-nav-sidebar {
         display: none;
     }
+    .change-list .main > #nav-sidebar+.content,
+    .change-list .main.shifted > #nav-sidebar+.content {
+        left: 0;
+    }
+}
+.change-list .main > #nav-sidebar+.content {
+    position: absolute;
+    left: 23px;
+    right: 0;
+
 }
 
-.change-list .main > #nav-sidebar+.content {
-    overflow: hidden;
+.change-list .main.shifted > #nav-sidebar+.content {
+    left: 298px;
 }


### PR DESCRIPTION
At first, I solved the problem with absolute positioning. But it doesn't look very beautiful. So we use `overflow:hidden` to trigger  [BFC](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context) solve the problem. But unfortunately it led to other problems. So go back to the absolute positioning solution