### PR TITLE
Fixed #31987 -- Fixed Cast() with DurationField on MySQL.

### DIFF
--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -29,6 +29,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         'PositiveBigIntegerField': 'unsigned integer',
         'PositiveIntegerField': 'unsigned integer',
         'PositiveSmallIntegerField': 'unsigned integer',
+        'DurationField': 'signed integer',
     }
     cast_char_field_without_max_length = 'char'
     explain_prefix = 'EXPLAIN'

--- a/tests/db_functions/comparison/test_cast.py
+++ b/tests/db_functions/comparison/test_cast.py
@@ -65,6 +65,16 @@ class CastTests(TestCase):
                 numbers = Author.objects.annotate(cast_int=Cast('alias', field_class()))
                 self.assertEqual(numbers.get().cast_int, 1)
 
+    def test_cast_to_duration(self):
+        duration = datetime.timedelta(days=1, seconds=2, microseconds=3)
+        DTModel.objects.create(duration=duration)
+        dtm = DTModel.objects.annotate(
+            cast_duration=Cast('duration', models.DurationField()),
+            cast_neg_duration=Cast(-duration, models.DurationField()),
+        ).get()
+        self.assertEqual(dtm.cast_duration, duration)
+        self.assertEqual(dtm.cast_neg_duration, -duration)
+
     def test_cast_from_db_datetime_to_date(self):
         dt_value = datetime.datetime(2018, 9, 28, 12, 42, 10, 234567)
         DTModel.objects.create(start_datetime=dt_value)


### PR DESCRIPTION
Cast datatype for DurationField was mising for MySQL. It was not possible to use:

    django.db.models.functions.Cast(x, output_field=DurationField())

because it generated `CAST(xxx AS bigint)` which is not valid MySQL syntax.

Fixes #31987