### PR TITLE
Refs #23130 -- Added test for BooleanField choices generation.

### DIFF
--- a/tests/model_fields/test_booleanfield.py
+++ b/tests/model_fields/test_booleanfield.py
@@ -47,6 +47,15 @@ class BooleanFieldTests(TestCase):
         f = models.BooleanField(choices=choices, default=1, null=False)
         self.assertEqual(f.formfield().choices, choices)
 
+    def test_booleanfield_choices_blank_desired(self):
+        """
+        BooleanField with choices and no default should generated a formfield
+        with the blank option.
+        """
+        choices = [(1, 'Si'), (2, 'No')]
+        f = models.BooleanField(choices=choices)
+        self.assertEqual(f.formfield().choices, [('', '---------')] + choices)
+
     def test_nullbooleanfield_formfield(self):
         f = models.BooleanField(null=True)
         self.assertIsInstance(f.formfield(), forms.NullBooleanField)


### PR DESCRIPTION
Adjusts @jacobtylerwalls' #13271. 

Nothing to do with `blank` or `null` but `BooleanField` with `choices` and without `default` **should** generate the empty option. 

I think this is Tim's [comment:22](https://code.djangoproject.com/ticket/23130#comment:22):

> Even if no further code changes are required, a test for this use case might be added.

(it's the dual of the test immediately above)

The validation issues are a red-herring. We **can** close the issue — I will write up conclusions and comment on other related PR anon. 