### PR TITLE
Fixed #31992 -- Made admin password reset templates use title/content_title blocks from the base template. 

### DIFF
--- a/django/contrib/admin/templates/registration/password_change_done.html
+++ b/django/contrib/admin/templates/registration/password_change_done.html
@@ -8,8 +8,6 @@
 </div>
 {% endblock %}
 
-{% block title %}{{ title }}{% endblock %}
-{% block content_title %}<h1>{{ title }}</h1>{% endblock %}
 {% block content %}
 <p>{% translate 'Your password was changed.' %}</p>
 {% endblock %}

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -9,9 +9,6 @@
 </div>
 {% endblock %}
 
-{% block title %}{{ title }}{% endblock %}
-{% block content_title %}<h1>{{ title }}</h1>{% endblock %}
-
 {% block content %}<div id="content-main">
 
 <form method="post">{% csrf_token %}

--- a/django/contrib/admin/templates/registration/password_reset_complete.html
+++ b/django/contrib/admin/templates/registration/password_reset_complete.html
@@ -8,9 +8,6 @@
 </div>
 {% endblock %}
 
-{% block title %}{{ title }}{% endblock %}
-{% block content_title %}<h1>{{ title }}</h1>{% endblock %}
-
 {% block content %}
 
 <p>{% translate "Your password has been set.  You may go ahead and log in now." %}</p>

--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -9,8 +9,6 @@
 </div>
 {% endblock %}
 
-{% block title %}{{ title }}{% endblock %}
-{% block content_title %}<h1>{{ title }}</h1>{% endblock %}
 {% block content %}
 
 {% if validlink %}

--- a/django/contrib/admin/templates/registration/password_reset_done.html
+++ b/django/contrib/admin/templates/registration/password_reset_done.html
@@ -8,8 +8,6 @@
 </div>
 {% endblock %}
 
-{% block title %}{{ title }}{% endblock %}
-{% block content_title %}<h1>{{ title }}</h1>{% endblock %}
 {% block content %}
 
 <p>{% translate 'We’ve emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly.' %}</p>

--- a/django/contrib/admin/templates/registration/password_reset_form.html
+++ b/django/contrib/admin/templates/registration/password_reset_form.html
@@ -9,8 +9,6 @@
 </div>
 {% endblock %}
 
-{% block title %}{{ title }}{% endblock %}
-{% block content_title %}<h1>{{ title }}</h1>{% endblock %}
 {% block content %}
 
 <p>{% translate 'Forgotten your password? Enter your email address below, and we’ll email instructions for setting a new one.' %}</p>

--- a/tests/auth_tests/test_templates.py
+++ b/tests/auth_tests/test_templates.py
@@ -26,12 +26,12 @@ class AuthTemplateTests(TestCase):
 
     def test_PasswordResetView(self):
         response = PasswordResetView.as_view(success_url='dummy/')(self.request)
-        self.assertContains(response, '<title>Password reset</title>')
+        self.assertContains(response, '<title>Password reset | Django site admin</title>')
         self.assertContains(response, '<h1>Password reset</h1>')
 
     def test_PasswordResetDoneView(self):
         response = PasswordResetDoneView.as_view()(self.request)
-        self.assertContains(response, '<title>Password reset sent</title>')
+        self.assertContains(response, '<title>Password reset sent | Django site admin</title>')
         self.assertContains(response, '<h1>Password reset sent</h1>')
 
     def test_PasswordResetConfirmView_invalid_token(self):
@@ -39,7 +39,7 @@ class AuthTemplateTests(TestCase):
         client = PasswordResetConfirmClient()
         url = reverse('password_reset_confirm', kwargs={'uidb64': 'Bad', 'token': 'Bad-Token'})
         response = client.get(url)
-        self.assertContains(response, '<title>Password reset unsuccessful</title>')
+        self.assertContains(response, '<title>Password reset unsuccessful | Django site admin</title>')
         self.assertContains(response, '<h1>Password reset unsuccessful</h1>')
 
     def test_PasswordResetConfirmView_valid_token(self):
@@ -50,7 +50,7 @@ class AuthTemplateTests(TestCase):
         uidb64 = urlsafe_base64_encode(str(self.user.pk).encode())
         url = reverse('password_reset_confirm', kwargs={'uidb64': uidb64, 'token': token})
         response = client.get(url)
-        self.assertContains(response, '<title>Enter new password</title>')
+        self.assertContains(response, '<title>Enter new password | Django site admin</title>')
         self.assertContains(response, '<h1>Enter new password</h1>')
         # The username is added to the password reset confirmation form to help
         # browser's password managers.
@@ -61,15 +61,15 @@ class AuthTemplateTests(TestCase):
 
     def test_PasswordResetCompleteView(self):
         response = PasswordResetCompleteView.as_view()(self.request)
-        self.assertContains(response, '<title>Password reset complete</title>')
+        self.assertContains(response, '<title>Password reset complete | Django site admin</title>')
         self.assertContains(response, '<h1>Password reset complete</h1>')
 
     def test_PasswordResetChangeView(self):
         response = PasswordChangeView.as_view(success_url='dummy/')(self.request)
-        self.assertContains(response, '<title>Password change</title>')
+        self.assertContains(response, '<title>Password change | Django site admin</title>')
         self.assertContains(response, '<h1>Password change</h1>')
 
     def test_PasswordChangeDoneView(self):
         response = PasswordChangeDoneView.as_view()(self.request)
-        self.assertContains(response, '<title>Password change successful</title>')
+        self.assertContains(response, '<title>Password change successful | Django site admin</title>')
         self.assertContains(response, '<h1>Password change successful</h1>')


### PR DESCRIPTION
ticket-31992