### PR TITLE
Update uploadedfile.py: while uploading file it creates unnecesarry quote

### DIFF
--- a/django/core/files/uploadedfile.py
+++ b/django/core/files/uploadedfile.py
@@ -58,6 +58,7 @@ class TemporaryUploadedFile(UploadedFile):
     """
     def __init__(self, name, content_type, size, charset, content_type_extra=None):
         _, ext = os.path.splitext(name)
+        ext = ext.replace('"', "")
         file = tempfile.NamedTemporaryFile(suffix='.upload' + ext, dir=settings.FILE_UPLOAD_TEMP_DIR)
         super().__init__(file, name, content_type, size, charset, content_type_extra)
 


### PR DESCRIPTION
### while uploading file it creates unnecesarry quote
`_, ext = os.path.splitext(name)` this line rarely creates extensions like  'mp4"' according to name of file
It puts one more unnecessary quote and causes errors

_i recommend to use_ `ext = ext.replace('"', "")` this line to fix after that line
