### PR TITLE
Fixed #31943 -- Fixed recreating QuerySet.values()/values_list() when using a pickled Query.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -210,6 +210,8 @@ class QuerySet:
 
     @query.setter
     def query(self, value):
+        if value.values_select:
+            self._iterable_class = ValuesIterable
         self._query = value
 
     def as_manager(cls):

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -106,6 +106,20 @@ the query construction and is not part of the public API. However, it is safe
 (and fully supported) to pickle and unpickle the attribute's contents as
 described here.
 
+.. admonition:: Restrictions on ``QuerySet.values_list()``
+
+    If you recreate :meth:`QuerySet.values_list` using the pickled ``query``
+    attribute, it will be converted to :meth:`QuerySet.values`::
+
+        >>> import pickle
+        >>> qs = Blog.objects.values_list('id', 'name')
+        >>> qs
+        <QuerySet [(1, 'Beatles Blog')]>
+        >>> reloaded_qs = Blog.objects.all()
+        >>> reloaded_qs.query = pickle.loads(pickle.dumps(qs.query))
+        >>> reloaded_qs
+        <QuerySet [{'id': 1, 'name': 'Beatles Blog'}]>
+
 .. admonition:: You can't share pickles between versions
 
     Pickles of ``QuerySets`` are only valid for the version of Django that


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31943
Solution and test case proposed by @felixxm on the ticket.
I just added documentation and another test for this patch
