### PR TITLE
Fixed #31986 -- Fixed admin filter sidebar scrolling.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -1,8 +1,14 @@
 /* CHANGELISTS */
 
 #changelist {
-    position: relative;
-    width: 100%;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+}
+
+#changelist .changelist-form-container {
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 #changelist table {
@@ -21,7 +27,6 @@
 
 .change-list .filtered .results, .change-list .filtered .paginator,
 .filtered #toolbar, .filtered div.xfull {
-    margin-right: 280px;
     width: auto;
 }
 
@@ -30,7 +35,8 @@
 }
 
 #changelist-form .results {
-  overflow-x: auto;
+    overflow-x: auto;
+    width: 100%;
 }
 
 #changelist .toplinks {
@@ -67,7 +73,7 @@
 
 /* TOOLBAR */
 
-#changelist #toolbar {
+#toolbar {
     padding: 8px 10px;
     margin-bottom: 15px;
     border-top: 1px solid #eee;
@@ -76,28 +82,28 @@
     color: #666;
 }
 
-#changelist #toolbar form input {
+#toolbar form input {
     border-radius: 4px;
     font-size: 14px;
     padding: 5px;
     color: #333;
 }
 
-#changelist #toolbar form #searchbar {
+#searchbar {
     height: 19px;
     border: 1px solid #ccc;
     padding: 2px 5px;
     margin: 0;
     vertical-align: top;
     font-size: 13px;
-    max-width: 230px;
+    max-width: 100%;
 }
 
-#changelist #toolbar form #searchbar:focus {
+#searchbar:focus {
     border-color: #999;
 }
 
-#changelist #toolbar form input[type="submit"] {
+#toolbar form input[type="submit"] {
     border: 1px solid #ccc;
     font-size: 13px;
     padding: 4px 8px;
@@ -109,12 +115,12 @@
     color: #333;
 }
 
-#changelist #toolbar form input[type="submit"]:focus,
-#changelist #toolbar form input[type="submit"]:hover {
+#toolbar form input[type="submit"]:focus,
+#toolbar form input[type="submit"]:hover {
     border-color: #999;
 }
 
-#changelist #changelist-search img {
+#changelist-search img {
     vertical-align: middle;
     margin-right: 4px;
 }
@@ -122,14 +128,11 @@
 /* FILTER COLUMN */
 
 #changelist-filter {
-    position: absolute;
-    top: 0;
-    right: 0;
-    z-index: 1000;
+    order: 1;
     width: 240px;
     background: #f8f8f8;
     border-left: none;
-    margin: 0;
+    margin: 0 0 0 30px;
 }
 
 #changelist-filter h2 {
@@ -227,6 +230,7 @@
     line-height: 22px;
     margin: 0;
     border-top: 1px solid #ddd;
+    width: 100%;
 }
 
 .paginator a:link, .paginator a:visited {
@@ -266,7 +270,6 @@
 /* ACTIONS */
 
 .filtered .actions {
-    margin-right: 280px;
     border-right: none;
 }
 
@@ -286,6 +289,7 @@
     border-bottom: none;
     line-height: 24px;
     color: #999;
+    width: 100%;
 }
 
 #changelist .actions.selected {

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -426,6 +426,7 @@ body.popup .submit-row {
 
 .inline-related.tabular fieldset.module table {
     width: 100%;
+    overflow-x: scroll;
 }
 
 .last-related fieldset {

--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -99,12 +99,21 @@
     background: #ffc;
 }
 
+.main > #nav-sidebar + .content {
+    max-width: calc(100% - 23px);
+}
+
+.main.shifted > #nav-sidebar + .content {
+    max-width: calc(100% - 299px);
+}
+
 @media (max-width: 767px) {
     #nav-sidebar, #toggle-nav-sidebar {
         display: none;
     }
-}
 
-.change-list .main > #nav-sidebar+.content {
-    overflow: hidden;
+    .main > #nav-sidebar + .content,
+    .main.shifted > #nav-sidebar + .content {
+        max-width: 100%;
+    }
 }

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -93,14 +93,14 @@ input[type="submit"], button {
 
     /* Changelist */
 
-    #changelist #toolbar {
+    #toolbar {
         border: none;
         padding: 15px;
     }
 
     #changelist-search > div {
         display: flex;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         max-width: 480px;
     }
 
@@ -108,11 +108,15 @@ input[type="submit"], button {
         line-height: 22px;
     }
 
-    #changelist #toolbar form #searchbar {
+    #toolbar form #searchbar {
         flex: 1 0 auto;
         width: 0;
         height: 22px;
         margin: 0 10px 0 6px;
+    }
+
+    #toolbar form input[type=submit] {
+        flex: 0 1 auto;
     }
 
     #changelist-search .quiet {
@@ -159,9 +163,6 @@ input[type="submit"], button {
     .change-list .filtered .paginator,
     .filtered #toolbar,
     .filtered .actions,
-    .filtered div.xfull {
-        margin-right: 230px;
-    }
 
     #changelist .paginator {
         border-top-color: #eee;
@@ -500,25 +501,16 @@ input[type="submit"], button {
     /* Changelist */
 
     #changelist {
-        display: flex;
+        align-items: stretch;
         flex-direction: column;
     }
 
-    #changelist #toolbar {
-        order: 1;
+    #toolbar {
         padding: 10px;
     }
 
-    #changelist .xfull {
-        order: 2;
-    }
-
-    #changelist-form {
-        order: 3;
-    }
-
     #changelist-filter {
-        order: 4;
+        margin-left: 0;
     }
 
     #changelist .actions label {
@@ -532,11 +524,6 @@ input[type="submit"], button {
 
     #changelist .actions span {
         flex: 1 0 100%;
-    }
-
-    .change-list .filtered .results, .change-list .filtered .paginator,
-    .filtered #toolbar, .filtered .actions, .filtered div.xfull {
-        margin-right: 0;
     }
 
     #changelist-filter {
@@ -570,7 +557,6 @@ input[type="submit"], button {
     .aligned .form-row,
     .aligned .form-row > div {
         display: flex;
-        flex-wrap: wrap;
         max-width: 100vw;
     }
 

--- a/django/contrib/admin/static/admin/css/responsive_rtl.css
+++ b/django/contrib/admin/static/admin/css/responsive_rtl.css
@@ -23,9 +23,9 @@
     [dir="rtl"] .change-list .filtered .paginator,
     [dir="rtl"] .filtered #toolbar,
     [dir="rtl"] .filtered div.xfull,
-    [dir="rtl"] .filtered .actions {
-        margin-right: 0;
-        margin-left: 230px;
+    [dir="rtl"] .filtered .actions,
+    [dir="rtl"] #changelist-filter {
+        margin-left: 0;
     }
 
     [dir="rtl"] .inline-group ul.tools a.add,
@@ -63,14 +63,6 @@
 /* MOBILE */
 
 @media (max-width: 767px) {
-    [dir="rtl"] .change-list .filtered .results,
-    [dir="rtl"] .change-list .filtered .paginator,
-    [dir="rtl"] .filtered #toolbar,
-    [dir="rtl"] .filtered div.xfull,
-    [dir="rtl"] .filtered .actions {
-        margin-left: 0;
-    }
-
     [dir="rtl"] .aligned .related-lookup,
     [dir="rtl"] .aligned .datetimeshortcuts {
         margin-left: 0;
@@ -78,6 +70,11 @@
     }
 
     [dir="rtl"] .aligned ul {
+        margin-right: 0;
+    }
+
+    [dir="rtl"] #changelist-filter {
+        margin-left: 0;
         margin-right: 0;
     }
 }

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -87,15 +87,10 @@ thead th.sorted .text {
 }
 
 #changelist-filter {
-    right: auto;
-    left: 0;
     border-left: none;
     border-right: none;
-}
-
-.change-list .filtered .results, .change-list .filtered .paginator, .filtered #toolbar, .filtered div.xfull {
-    margin-right: 0;
-    margin-left: 280px;
+    margin-left: 0;
+    margin-right: 30px;
 }
 
 #changelist-filter li.selected {
@@ -105,11 +100,6 @@ thead th.sorted .text {
     border-right: 5px solid #eaeaea;
     padding-right: 10px;
     margin-right: -15px;
-}
-
-.filtered .actions {
-    margin-left: 280px;
-    margin-right: 0;
 }
 
 #changelist table tbody td:first-child, #changelist table tbody th:first-child {

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -53,9 +53,23 @@
         {{ cl.formset.non_form_errors }}
     {% endif %}
     <div class="module{% if cl.has_filters %} filtered{% endif %}" id="changelist">
-      {% block search %}{% search_form cl %}{% endblock %}
-      {% block date_hierarchy %}{% if cl.date_hierarchy %}{% date_hierarchy cl %}{% endif %}{% endblock %}
+      <div class="changelist-form-container">
+        {% block search %}{% search_form cl %}{% endblock %}
+        {% block date_hierarchy %}{% if cl.date_hierarchy %}{% date_hierarchy cl %}{% endif %}{% endblock %}
 
+        <form id="changelist-form" method="post"{% if cl.formset and cl.formset.is_multipart %} enctype="multipart/form-data"{% endif %} novalidate>{% csrf_token %}
+        {% if cl.formset %}
+          <div>{{ cl.formset.management_form }}</div>
+        {% endif %}
+
+        {% block result_list %}
+          {% if action_form and actions_on_top and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+          {% result_list cl %}
+          {% if action_form and actions_on_bottom and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+        {% endblock %}
+        {% block pagination %}{% pagination cl %}{% endblock %}
+        </form>
+      </div>
       {% block filters %}
         {% if cl.has_filters %}
           <div id="changelist-filter">
@@ -67,19 +81,6 @@
           </div>
         {% endif %}
       {% endblock %}
-
-      <form id="changelist-form" method="post"{% if cl.formset and cl.formset.is_multipart %} enctype="multipart/form-data"{% endif %} novalidate>{% csrf_token %}
-      {% if cl.formset %}
-        <div>{{ cl.formset.management_form }}</div>
-      {% endif %}
-
-      {% block result_list %}
-          {% if action_form and actions_on_top and cl.show_admin_actions %}{% admin_actions %}{% endif %}
-          {% result_list cl %}
-          {% if action_form and actions_on_bottom and cl.show_admin_actions %}{% admin_actions %}{% endif %}
-      {% endblock %}
-      {% block pagination %}{% pagination cl %}{% endblock %}
-      </form>
     </div>
   </div>
 {% endblock %}

--- a/docs/releases/3.1.2.txt
+++ b/docs/releases/3.1.2.txt
@@ -26,3 +26,6 @@ Bugfixes
 
 * Fixed a ``django.contrib.admin.EmptyFieldListFilter`` crash when using on a
   ``GenericRelation`` (:ticket:`32038`).
+
+* Fixed a regression in Django 3.1.1 where the admin changelist filter sidebar
+  would not scroll for a long list of available filters (:ticket:`31986`).


### PR DESCRIPTION
Alternative to https://github.com/django/django/pull/13397

This gets rid of all horizontal scrollbars I can find, works reasonably well at all sizes, and doesn't come with any extra issues as far as I can tell. It is quite a bit more code than the other PR, however.

I've tested everything I can think of - RTL, all screen sizes, inlines, with the various extra stuff (actions, date hierarchy, search, very long list filter), with and without nav sidebar... That said, I'm sure there are things I didn't think of.

I had to move out the date hierarchy and search bar from the container to outside of it to accommodate flexbox. I could have added yet another container div but I feel like there are enough of those already. So there is a small change, the search and date hierarchy are positioned slightly further up relative to the list filter than they were before, but I don't think it looks any worse.