### PR TITLE
Fixed #31989 -- Fixed return value of django.core.files.locks.lock()/unlock() on POSIX systems.

### DIFF
--- a/django/core/files/locks.py
+++ b/django/core/files/locks.py
@@ -107,9 +107,12 @@ else:
             return True
     else:
         def lock(f, flags):
-            ret = fcntl.flock(_fd(f), flags)
-            return ret == 0
+            try:
+                fcntl.flock(_fd(f), flags)
+                return True
+            except BlockingIOError:
+                return False
 
         def unlock(f):
-            ret = fcntl.flock(_fd(f), fcntl.LOCK_UN)
-            return ret == 0
+            fcntl.flock(_fd(f), fcntl.LOCK_UN)
+            return True

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -504,6 +504,10 @@ Miscellaneous
   distinguishes inherited field instances across models. Additionally, the
   ordering of such fields is now defined.
 
+* The undocumented ``django.core.files.locks.lock()`` function now returns
+  ``False`` if the file cannot be locked, instead of raising
+  :exc:`BlockingIOError`.
+
 .. _deprecated-features-3.2:
 
 Features deprecated in 3.2


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31989