### PR TITLE
Adds a pre/post migration signal to each migration that runs

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -7,7 +7,8 @@ from django.core.management.base import (
     BaseCommand, CommandError, no_translations,
 )
 from django.core.management.sql import (
-    emit_post_migrate_signal, emit_pre_migrate_signal,
+    emit_post_migrate_signal, emit_pre_migrate_signal, emit_pre_migration_signal, 
+    emit_post_migration_signal,
 )
 from django.db import DEFAULT_DB_ALIAS, connections, router
 from django.db.migrations.autodetector import MigrationAutodetector
@@ -84,7 +85,7 @@ class Command(BaseCommand):
                 import_module('.management', app_config.name)
 
         # Get the database we're operating from
-        connection = connections[database]
+        self.connection = connection = connections[database]
 
         # Hook for backends needing any database preparation
         connection.prepare_database()
@@ -278,7 +279,7 @@ class Command(BaseCommand):
                 self.stdout.write("  Applying %s..." % migration, ending="")
                 self.stdout.flush()
                 emit_pre_migration_signal(
-                    self.verbosity, self.interactive, connection.alias, migration=migration,
+                    self.verbosity, self.interactive, self.connection.alias, migration=migration,
                     fake=fake,
                 )
             elif action == "apply_success":
@@ -288,7 +289,7 @@ class Command(BaseCommand):
                 else:
                     self.stdout.write(self.style.SUCCESS(" OK" + elapsed))
                 emit_post_migration_signal(
-                    self.verbosity, self.interactive, connection.alias, migration=migration,
+                    self.verbosity, self.interactive, self.connection.alias, migration=migration,
                     fake=fake,
                 )
             elif action == "unapply_start":
@@ -297,7 +298,7 @@ class Command(BaseCommand):
                 self.stdout.write("  Unapplying %s..." % migration, ending="")
                 self.stdout.flush()
                 emit_pre_migration_signal(
-                    self.verbosity, self.interactive, connection.alias, migration=migration,
+                    self.verbosity, self.interactive, self.connection.alias, migration=migration,
                     fake=fake,
                 )
             elif action == "unapply_success":
@@ -307,7 +308,7 @@ class Command(BaseCommand):
                 else:
                     self.stdout.write(self.style.SUCCESS(" OK" + elapsed))
                 emit_post_migration_signal(
-                    self.verbosity, self.interactive, connection.alias, migration=migration,
+                    self.verbosity, self.interactive, self.connection.alias, migration=migration,
                     fake=fake,
                 )
             elif action == "render_start":

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -277,23 +277,39 @@ class Command(BaseCommand):
                     self.start = time.monotonic()
                 self.stdout.write("  Applying %s..." % migration, ending="")
                 self.stdout.flush()
+                emit_pre_migration_signal(
+                    self.verbosity, self.interactive, connection.alias, migration=migration,
+                    fake=fake,
+                )
             elif action == "apply_success":
                 elapsed = " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
                 if fake:
                     self.stdout.write(self.style.SUCCESS(" FAKED" + elapsed))
                 else:
                     self.stdout.write(self.style.SUCCESS(" OK" + elapsed))
+                emit_post_migration_signal(
+                    self.verbosity, self.interactive, connection.alias, migration=migration,
+                    fake=fake,
+                )
             elif action == "unapply_start":
                 if compute_time:
                     self.start = time.monotonic()
                 self.stdout.write("  Unapplying %s..." % migration, ending="")
                 self.stdout.flush()
+                emit_pre_migration_signal(
+                    self.verbosity, self.interactive, connection.alias, migration=migration,
+                    fake=fake,
+                )
             elif action == "unapply_success":
                 elapsed = " (%.3fs)" % (time.monotonic() - self.start) if compute_time else ""
                 if fake:
                     self.stdout.write(self.style.SUCCESS(" FAKED" + elapsed))
                 else:
                     self.stdout.write(self.style.SUCCESS(" OK" + elapsed))
+                emit_post_migration_signal(
+                    self.verbosity, self.interactive, connection.alias, migration=migration,
+                    fake=fake,
+                )
             elif action == "render_start":
                 if compute_time:
                     self.start = time.monotonic()

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -7,7 +7,7 @@ from django.core.management.base import (
     BaseCommand, CommandError, no_translations,
 )
 from django.core.management.sql import (
-    emit_post_migrate_signal, emit_pre_migrate_signal, emit_pre_migration_signal, 
+    emit_post_migrate_signal, emit_pre_migrate_signal, emit_pre_migration_signal,
     emit_post_migration_signal,
 )
 from django.db import DEFAULT_DB_ALIAS, connections, router

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -7,8 +7,8 @@ from django.core.management.base import (
     BaseCommand, CommandError, no_translations,
 )
 from django.core.management.sql import (
-    emit_post_migrate_signal, emit_pre_migrate_signal, emit_pre_migration_signal,
-    emit_post_migration_signal,
+    emit_post_migrate_signal, emit_post_migration_signal,
+    emit_pre_migrate_signal, emit_pre_migration_signal,
 )
 from django.db import DEFAULT_DB_ALIAS, connections, router
 from django.db.migrations.autodetector import MigrationAutodetector

--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -35,21 +35,21 @@ def generic_signal_emitter(signal, verbose_message):
 
 
 emit_pre_migrate_signal = generic_signal_emitter(
-    models.signals.pre_migrate, 
+    models.signals.pre_migrate,
     "Running pre-migrate handlers for application %s"
 )
 
 emit_post_migrate_signal = generic_signal_emitter(
-    models.signals.post_migrate, 
+    models.signals.post_migrate,
     "Running post-migrate handlers for application %s"
 )
 
 emit_pre_migration_signal = generic_signal_emitter(
-    models.signals.pre_migration, 
+    models.signals.pre_migration,
     "Running pre-migration handlers for application %s"
 )
 
 emit_post_migration_signal = generic_signal_emitter(
-    models.signals.post_migration, 
+    models.signals.post_migration,
     "Running post-migration handlers for application %s"
 )

--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -43,3 +43,13 @@ emit_post_migrate_signal = generic_signal_emitter(
     models.signals.post_migrate, 
     "Running post-migrate handlers for application %s"
 )
+
+emit_pre_migration_signal = generic_signal_emitter(
+    models.signals.pre_migration, 
+    "Running pre-migrate handlers for application %s"
+)
+
+emit_post_migration_signal = generic_signal_emitter(
+    models.signals.post_migration, 
+    "Running post-migrate handlers for application %s"
+)

--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -46,10 +46,10 @@ emit_post_migrate_signal = generic_signal_emitter(
 
 emit_pre_migration_signal = generic_signal_emitter(
     models.signals.pre_migration, 
-    "Running pre-migrate handlers for application %s"
+    "Running pre-migration handlers for application %s"
 )
 
 emit_post_migration_signal = generic_signal_emitter(
     models.signals.post_migration, 
-    "Running post-migrate handlers for application %s"
+    "Running post-migration handlers for application %s"
 )

--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -17,7 +17,7 @@ def sql_flush(style, connection, reset_sequences=True, allow_cascade=False):
 
 def generic_signal_emitter(signal, verbose_message):
     def emit_signal(verbosity, interactive, db, **kwargs):
-        # Emit the pre_migrate signal for every application.
+        # Emit the signal for every application.
         for app_config in apps.get_app_configs():
             if app_config.models_module is None:
                 continue

--- a/django/db/models/signals.py
+++ b/django/db/models/signals.py
@@ -47,3 +47,6 @@ m2m_changed = ModelSignal(use_caching=True)
 
 pre_migrate = Signal()
 post_migrate = Signal()
+
+pre_migration = Signal()
+post_migration = Signal()

--- a/tests/migrate_signals/tests.py
+++ b/tests/migrate_signals/tests.py
@@ -67,6 +67,8 @@ class MigrateSignalTests(TransactionTestCase):
     def test_args(self):
         pre_migrate_receiver = Receiver(signals.pre_migrate)
         post_migrate_receiver = Receiver(signals.post_migrate)
+        pre_migration_receiver = Receiver(signals.pre_migration)
+        post_migration_receiver = Receiver(signals.post_migration)
         management.call_command(
             'migrate', database=MIGRATE_DATABASE, verbosity=MIGRATE_VERBOSITY,
             interactive=MIGRATE_INTERACTIVE,
@@ -82,6 +84,9 @@ class MigrateSignalTests(TransactionTestCase):
             self.assertEqual(args['using'], 'default')
             self.assertEqual(args['plan'], [])
             self.assertIsInstance(args['apps'], migrations.state.StateApps)
+   
+        self.assertEqual(pre_migration_receiver.call_counter, 1)
+        self.assertEqual(post_migration_receiver.call_counter, 1)
 
     @override_settings(MIGRATION_MODULES={'migrate_signals': 'migrate_signals.custom_migrations'})
     def test_migrations_only(self):
@@ -90,6 +95,8 @@ class MigrateSignalTests(TransactionTestCase):
         """
         pre_migrate_receiver = Receiver(signals.pre_migrate)
         post_migrate_receiver = Receiver(signals.post_migrate)
+        pre_migration_receiver = Receiver(signals.pre_migration)
+        post_migration_receiver = Receiver(signals.post_migration)
         management.call_command(
             'migrate', database=MIGRATE_DATABASE, verbosity=MIGRATE_VERBOSITY,
             interactive=MIGRATE_INTERACTIVE,
@@ -106,6 +113,8 @@ class MigrateSignalTests(TransactionTestCase):
             # The migration isn't applied backward.
             self.assertFalse(args['plan'][0][1])
             self.assertIsInstance(args['apps'], migrations.state.StateApps)
+        self.assertEqual(pre_migration_receiver.call_counter, 1)
+        self.assertEqual(post_migration_receiver.call_counter, 1)
         self.assertEqual(pre_migrate_receiver.call_args['apps'].get_models(), [])
         self.assertEqual(
             [model._meta.label for model in post_migrate_receiver.call_args['apps'].get_models()],
@@ -114,6 +123,8 @@ class MigrateSignalTests(TransactionTestCase):
         # Migrating with an empty plan.
         pre_migrate_receiver = Receiver(signals.pre_migrate)
         post_migrate_receiver = Receiver(signals.post_migrate)
+        pre_migration_receiver = Receiver(signals.pre_migration)
+        post_migration_receiver = Receiver(signals.post_migration)
         management.call_command(
             'migrate', database=MIGRATE_DATABASE, verbosity=MIGRATE_VERBOSITY,
             interactive=MIGRATE_INTERACTIVE,
@@ -126,3 +137,5 @@ class MigrateSignalTests(TransactionTestCase):
             [model._meta.label for model in post_migrate_receiver.call_args['apps'].get_models()],
             ['migrate_signals.Signal']
         )
+        self.assertEqual(pre_migration_receiver.call_counter, 1)
+        self.assertEqual(post_migration_receiver.call_counter, 1)

--- a/tests/migrate_signals/tests.py
+++ b/tests/migrate_signals/tests.py
@@ -84,7 +84,7 @@ class MigrateSignalTests(TransactionTestCase):
             self.assertEqual(args['using'], 'default')
             self.assertEqual(args['plan'], [])
             self.assertIsInstance(args['apps'], migrations.state.StateApps)
-   
+
         self.assertEqual(pre_migration_receiver.call_counter, 1)
         self.assertEqual(post_migration_receiver.call_counter, 1)
 


### PR DESCRIPTION
We're currently using [django-tenant-schemas](https://github.com/bernardopires/django-tenant-schemas) and we're approaching the 300 tanant mark, while deploying 20-30 migrations at a time * ~300 tenants every time we deploy -- it gets a little crazy. Because of this we need a hook to each migration to keep track of them.