### PR TITLE
Removed hardcoded paths to SpatialRefSys models in tests.

### DIFF
--- a/tests/gis_tests/utils.py
+++ b/tests/gis_tests/utils.py
@@ -52,21 +52,6 @@ spatialite = _default_db == 'spatialite'
 # MySQL spatial indices can't handle NULL geometries.
 gisfield_may_be_null = not mysql
 
-if oracle and 'gis' in settings.DATABASES[DEFAULT_DB_ALIAS]['ENGINE']:
-    from django.contrib.gis.db.backends.oracle.models import (
-        OracleSpatialRefSys as SpatialRefSys,
-    )
-elif postgis:
-    from django.contrib.gis.db.backends.postgis.models import (
-        PostGISSpatialRefSys as SpatialRefSys,
-    )
-elif spatialite:
-    from django.contrib.gis.db.backends.spatialite.models import (
-        SpatialiteSpatialRefSys as SpatialRefSys,
-    )
-else:
-    SpatialRefSys = None
-
 
 class FuncTestMixin:
     """Assert that Func expressions aren't mutated during their as_sql()."""


### PR DESCRIPTION
(Third-party backends deserve a chance to be tested.)