### PR TITLE
WIP: Fixed #32001 -- Pass obj in user.has_perm() in ModelAdmin

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -495,7 +495,10 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         """
         opts = self.opts
         codename = get_permission_codename('change', opts)
-        return request.user.has_perm("%s.%s" % (opts.app_label, codename))
+        return (
+            request.user.has_perm("%s.%s" % (opts.app_label, codename)) or
+            request.user.has_perm("%s.%s" % (opts.app_label, codename), obj=obj)
+        )
 
     def has_delete_permission(self, request, obj=None):
         """
@@ -510,7 +513,10 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         """
         opts = self.opts
         codename = get_permission_codename('delete', opts)
-        return request.user.has_perm("%s.%s" % (opts.app_label, codename))
+        return (
+            request.user.has_perm("%s.%s" % (opts.app_label, codename)) or
+            request.user.has_perm("%s.%s" % (opts.app_label, codename), obj=obj)
+        )
 
     def has_view_permission(self, request, obj=None):
         """
@@ -528,7 +534,9 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         codename_change = get_permission_codename('change', opts)
         return (
             request.user.has_perm('%s.%s' % (opts.app_label, codename_view)) or
-            request.user.has_perm('%s.%s' % (opts.app_label, codename_change))
+            request.user.has_perm('%s.%s' % (opts.app_label, codename_change)) or
+            request.user.has_perm('%s.%s' % (opts.app_label, codename_view), obj=obj) or
+            request.user.has_perm('%s.%s' % (opts.app_label, codename_change), obj=obj)
         )
 
     def has_view_or_change_permission(self, request, obj=None):


### PR DESCRIPTION
to facilitate integration between backends providing object level
permissions, like django-guardian and applications that heavily
utilize the admin panel.