### PR TITLE
Prevented creation of 3D test models if not supported.

### DIFF
--- a/tests/gis_tests/geo3d/models.py
+++ b/tests/gis_tests/geo3d/models.py
@@ -15,6 +15,9 @@ class City3D(NamedModel):
     point = models.PointField(dim=3)
     pointg = models.PointField(dim=3, geography=True)
 
+    class Meta:
+        required_db_features = {'supports_3d_storage'}
+
 
 class Interstate2D(NamedModel):
     line = models.LineStringField(srid=4269)
@@ -22,6 +25,9 @@ class Interstate2D(NamedModel):
 
 class Interstate3D(NamedModel):
     line = models.LineStringField(dim=3, srid=4269)
+
+    class Meta:
+        required_db_features = {'supports_3d_storage'}
 
 
 class InterstateProj2D(NamedModel):
@@ -31,6 +37,9 @@ class InterstateProj2D(NamedModel):
 class InterstateProj3D(NamedModel):
     line = models.LineStringField(dim=3, srid=32140)
 
+    class Meta:
+        required_db_features = {'supports_3d_storage'}
+
 
 class Polygon2D(NamedModel):
     poly = models.PolygonField(srid=32140)
@@ -38,6 +47,9 @@ class Polygon2D(NamedModel):
 
 class Polygon3D(NamedModel):
     poly = models.PolygonField(dim=3, srid=32140)
+
+    class Meta:
+        required_db_features = {'supports_3d_storage'}
 
 
 class SimpleModel(models.Model):
@@ -53,6 +65,12 @@ class Point2D(SimpleModel):
 class Point3D(SimpleModel):
     point = models.PointField(dim=3)
 
+    class Meta:
+        required_db_features = {'supports_3d_storage'}
+
 
 class MultiPoint3D(SimpleModel):
     mpoint = models.MultiPointField(dim=3)
+
+    class Meta:
+        required_db_features = {'supports_3d_storage'}

--- a/tests/gis_tests/inspectapp/models.py
+++ b/tests/gis_tests/inspectapp/models.py
@@ -19,3 +19,6 @@ class Fields3D(models.Model):
     pointg = models.PointField(dim=3, geography=True)
     line = models.LineStringField(dim=3)
     poly = models.PolygonField(dim=3)
+
+    class Meta:
+        required_db_features = {'supports_3d_storage'}


### PR DESCRIPTION
There's no problem creating the models on MySQL and Oracle
(which don't support 3D storage) but CockroachDB currently
crashes with a syntax error.