### PR TITLE
Refs #32007 -- Skipped test_q_expression_annotation_with_aggregation on Oracle.

### DIFF
--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -183,6 +183,7 @@ class NonAggregateAnnotationTestCase(TestCase):
         self.assertEqual(book.combined, 13410.0)
         self.assertEqual(book.rating_count, 1)
 
+    @skipUnlessDBFeature('supports_boolean_expr_in_select_clause')
     def test_q_expression_annotation_with_aggregation(self):
         book = Book.objects.filter(isbn='159059725').annotate(
             isnull_pubdate=ExpressionWrapper(


### PR DESCRIPTION
Boolean expressions are not supported in `SELECT` and `GROUP BY` on Oracle.

```
Traceback (most recent call last):
  File "/home/jenkins/workspace/django-oracle-3.1/database/oracle18/python/python3.6/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/home/jenkins/workspace/django-oracle-3.1/database/oracle18/python/python3.6/django/db/backends/oracle/base.py", line 534, in execute
    return self.cursor.execute(query, self._param_generator(params))
cx_Oracle.DatabaseError: ORA-00923: FROM keyword not found where expected
```