### PR TITLE
Fixed #31916 -- Fixed combined queryset crash when combining with ordered combined querysets.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -359,7 +359,7 @@ class SQLCompiler:
 
         for expr, is_ref in order_by:
             resolved = expr.resolve_expression(self.query, allow_joins=True, reuse=None)
-            if self.query.combinator:
+            if self.query.combinator and self.select:
                 src = resolved.get_source_expressions()[0]
                 expr_src = expr.get_source_expressions()[0]
                 # Relabel order by columns to raw numbers if this is a combined

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -237,12 +237,15 @@ class QuerySetSetOperationTests(TestCase):
     def test_unsupported_ordering_slicing_raises_db_error(self):
         qs1 = Number.objects.all()
         qs2 = Number.objects.all()
+        qs3 = Number.objects.all()
         msg = 'LIMIT/OFFSET not allowed in subqueries of compound statements'
         with self.assertRaisesMessage(DatabaseError, msg):
             list(qs1.union(qs2[:10]))
         msg = 'ORDER BY not allowed in subqueries of compound statements'
         with self.assertRaisesMessage(DatabaseError, msg):
             list(qs1.order_by('id').union(qs2))
+        with self.assertRaisesMessage(DatabaseError, msg):
+            list(qs1.union(qs2).order_by('id').union(qs3))
 
     @skipIfDBFeature('supports_select_intersection')
     def test_unsupported_intersection_raises_db_error(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31916