### PR TITLE
fix exist pg jsonb error

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -70,6 +70,8 @@ class JSONField(CheckFieldDefaultMixin, Field):
     def from_db_value(self, value, expression, connection):
         if value is None:
             return value
+        if isinstance(value, dict):
+            return value
         try:
             return json.loads(value, cls=self.decoder)
         except json.JSONDecodeError:


### PR DESCRIPTION
I recently upgrade my side project to django 3.1 , which database use postgres, 


```
class NewsRound(Model):
    class Meta:
        db_table = "news_round"

    ....
    detail = model.JSONField("rule", default=hook_default)
```

when i execute 

```
NewsRound.objects.first()
```

then exception happens like this

![image](https://user-images.githubusercontent.com/5625783/93360204-fdbb6400-f875-11ea-9d9c-1b1692127cad.png)


for now i have to do workaround like this

```
import json

from django.db.models import JSONField as BuiltInJSONField


class JSONField(BuiltInJSONField):

    def from_db_value(self, value, expression, connection):
        if value is None:
            return value
        if isinstance(value, dict):
            return value
        try:
            return json.loads(value, cls=self.decoder)
        except json.JSONDecodeError:
            return value

```

PS: detail field in postgres is jsonb