### PR TITLE
Proposal of better documentation for dateformat

### DIFF
--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -3,10 +3,9 @@ PHP date() style date formatting
 See http://www.php.net/date for format strings
 
 Usage:
->>> import datetime
->>> d = datetime.datetime.now()
->>> df = DateFormat(d)
->>> print(df.format('jS F Y H:i'))
+>>> from django.utils import dateformat, timezone
+>>> d =  timezone.now()
+>>> print(d.format('jS F Y H:i'))
 7th October 2003 11:39
 >>>
 """


### PR DESCRIPTION
Currently on reading the comments, It seems they haven't been updated because on using `dateformat` with `datetime`, django module settings setup is required, so thought of updating it.  Also `dateformat` is not searchable in django offical documentation.