### PR TITLE
Fixed #32029 -- Removed unnecessary margin from admin CSS for horizontal radio inputs.

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -667,7 +667,7 @@ input[type="submit"], button {
         margin-bottom: -3px;
     }
 
-    form .aligned ul.radiolist li + li {
+    form .aligned ul.radiolist:not(.inline) li + li {
         margin-top: 5px;
     }
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32029#ticket

Before:
![image](https://user-images.githubusercontent.com/2627/93574996-5d5e6000-f999-11ea-8cd2-35ca41c5d22d.png)

After:
![image](https://user-images.githubusercontent.com/2627/93574946-51729e00-f999-11ea-850a-86e250ddb146.png)

(Sorry for the missing ticket etc. I hope it's fine in this case.)