### PR TITLE
Refs #21181 -- Corrected DatabaseFeatures.test_collations for Swedish collation.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -306,7 +306,7 @@ class BaseDatabaseFeatures:
     test_collations = {
         'ci': None,  # Case-insensitive.
         'cs': None,  # Case-sensitive.
-        'swedish-ci': None  # Swedish case-insensitive.
+        'swedish_ci': None  # Swedish case-insensitive.
     }
 
     def __init__(self, connection):

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -46,7 +46,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     order_by_nulls_first = True
     test_collations = {
         'ci': 'utf8_general_ci',
-        'swedish-ci': 'utf8_swedish_ci',
+        'swedish_ci': 'utf8_swedish_ci',
     }
 
     @cached_property

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -59,7 +59,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_json_operators = True
     json_key_contains_list_matching_requires_list = True
     test_collations = {
-        'swedish-ci': 'sv-x-icu',
+        'swedish_ci': 'sv-x-icu',
     }
 
     @cached_property

--- a/tests/db_functions/comparison/test_collate.py
+++ b/tests/db_functions/comparison/test_collate.py
@@ -31,7 +31,7 @@ class CollateTests(TestCase):
         self.assertSequenceEqual(qs, [self.author2, self.author1])
 
     def test_language_collation_order_by(self):
-        collation = connection.features.test_collations.get('swedish-ci')
+        collation = connection.features.test_collations.get('swedish_ci')
         if not collation:
             self.skipTest('This backend does not support language collations.')
         author3 = Author.objects.create(alias='O', name='Jones')


### PR DESCRIPTION
Previously, backends used different keys "swedish-ci" or "swedish_ci".