### PR TITLE
Fixed #32028: Less padding around top-level form rows

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -4,7 +4,7 @@
 
 .form-row {
     overflow: hidden;
-    padding: 10px;
+    padding: 10px 2px;
     font-size: 13px;
     border-bottom: 1px solid #eee;
 }
@@ -20,6 +20,11 @@
 
 form .form-row p {
     padding-left: 0;
+}
+
+.inline-related .form-row {
+    padding-left: 10px;
+    padding-right: 10px;
 }
 
 /* FORM LABELS */


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32028#ticket

I think it would be an improvement if the h1, h2, fieldset labels and individual labels were aligned. It didn't bother me before but since updating to Django@master with the new h2 ("Startseite") subtitle (which I like!) it hasn't stopped bothering me.

I have checked collapsible fieldsets, tabular and stacked inlines – they all look alright.

Before: 

![image](https://user-images.githubusercontent.com/2627/93712262-15843800-fb55-11ea-939f-7181f1c6b960.png)

After:

![image](https://user-images.githubusercontent.com/2627/93712282-2e8ce900-fb55-11ea-9782-99edadd7394e.png)
