### PR TITLE
Fixed #32027 -- Fixed wrapping of long words in admin error messages.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -554,6 +554,7 @@ ul.messagelist li.error {
     border-radius: 4px;
     background-color: #fff;
     background-position: 5px 12px;
+    overflow-wrap: break-word;
 }
 
 ul.errorlist {
@@ -567,6 +568,7 @@ ul.errorlist li {
     font-size: 13px;
     display: block;
     margin-bottom: 4px;
+    overflow-wrap: break-word;
 }
 
 ul.errorlist li:first-child {


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32027#comment:1

Before:
![image](https://user-images.githubusercontent.com/2627/93783940-9f530480-fc2c-11ea-974f-dbf67376fc1a.png)


After:
![image](https://user-images.githubusercontent.com/2627/93783877-8a767100-fc2c-11ea-9163-9b6763816526.png)
