### PR TITLE
Made jinja2 import in django.forms lazy

### DIFF
--- a/django/forms/renderers.py
+++ b/django/forms/renderers.py
@@ -7,12 +7,6 @@ from django.template.loader import get_template
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 
-try:
-    from django.template.backends.jinja2 import Jinja2
-except ImportError:
-    def Jinja2(params):
-        raise ImportError("jinja2 isn't installed")
-
 ROOT = Path(__file__).parent
 
 
@@ -58,7 +52,10 @@ class Jinja2(EngineMixin, BaseRenderer):
     Load Jinja2 templates from the built-in widget templates in
     django/forms/jinja2 and from apps' 'jinja2' directory.
     """
-    backend = Jinja2
+    @cached_property
+    def backend(self):
+        from django.template.backends.jinja2 import Jinja2
+        return Jinja2
 
 
 class TemplatesSetting(BaseRenderer):


### PR DESCRIPTION
I benchmarked the startup of a very simple (single file) django project to run `manage.py --help` using my Django test virtual environment.

I noticed that about 22% of the startup time was spent importing jinja2, which the project doesn't use.

I found this was from this one path in `django.forms.renderers` that imported the jinja2 backend ahead of use. I think it's therefore reasonable to make this import lazy. This will only affect projects where jinja2 is installed but not used, but given the prevalence of jinja2 that's likely to be many environments (e.g. if Ansible is installed, or the global Python install is used).

Timing (using [hyperfine](https://github.com/sharkdp/hyperfine)) shows about 20ms saved, or ~10%.

Before:

```
$ hyperfine --warmup 3 './manage.py --help'
Benchmark #1: ./manage.py --help
  Time (mean ± σ):     260.4 ms ±   5.5 ms    [User: 215.6 ms, System: 41.2 ms]
  Range (min … max):   252.4 ms … 270.3 ms    11 runs
```

After:

```
$ hyperfine --warmup 3 './manage.py --help'
Benchmark #1: ./manage.py --help
  Time (mean ± σ):     243.8 ms ±   4.6 ms    [User: 200.7 ms, System: 39.8 ms]
  Range (min … max):   237.7 ms … 254.9 ms    12 runs
```
