### PR TITLE
Fix #32035 -- AbstractUser.clean assumes default manager is named objects

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -368,7 +368,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
 
     def clean(self):
         super().clean()
-        self.email = self.__class__.objects.normalize_email(self.email)
+        self.email = self.__class__._default_manager.normalize_email(self.email)
 
     def get_full_name(self):
         """


### PR DESCRIPTION
See ticket: https://code.djangoproject.com/ticket/32035#ticket