### PR TITLE
Fixed #32038 -- Fixed EmptyFieldListFilter crash with GenericRelation.

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -277,6 +277,7 @@ class GenericRelation(ForeignObject):
 
     # Field flags
     auto_created = False
+    empty_strings_allowed = False
 
     many_to_many = False
     many_to_one = False
@@ -295,6 +296,9 @@ class GenericRelation(ForeignObject):
             limit_choices_to=limit_choices_to,
         )
 
+        # Reverse relations are always nullable (Django can't enforce that a
+        # foreign key on the related model points to this model).
+        kwargs['null'] = True
         kwargs['blank'] = True
         kwargs['on_delete'] = models.CASCADE
         kwargs['editable'] = False

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -992,6 +992,11 @@ subclass::
         The ``FieldListFilter`` API is considered internal and might be
         changed.
 
+      .. note::
+
+        The :class:`~django.contrib.contenttypes.fields.GenericForeignKey`
+        field is not supported.
+
       .. versionadded:: 3.1
 
           The ``EmptyFieldListFilter`` class was added.

--- a/docs/releases/3.1.2.txt
+++ b/docs/releases/3.1.2.txt
@@ -23,3 +23,6 @@ Bugfixes
 * Fixed a bug in Django 3.1 where a test database was not synced during
   creation when using the :setting:`MIGRATE <TEST_MIGRATE>` test database
   setting (:ticket:`32012`).
+
+* Fixed a ``django.contrib.admin.EmptyFieldListFilter`` crash when using on a
+  ``GenericRelation`` (:ticket:`32038`).

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -1535,6 +1535,32 @@ class ListFiltersTests(TestCase):
                 queryset = changelist.get_queryset(request)
                 self.assertCountEqual(queryset, expected_result)
 
+    def test_emptylistfieldfilter_genericrelation(self):
+        class BookmarkGenericRelation(ModelAdmin):
+            list_filter = (
+                ('tags', EmptyFieldListFilter),
+            )
+
+        modeladmin = BookmarkGenericRelation(Bookmark, site)
+
+        django_bookmark = Bookmark.objects.create(url='https://www.djangoproject.com/')
+        python_bookmark = Bookmark.objects.create(url='https://www.python.org/')
+        none_tags = Bookmark.objects.create(url='https://www.kernel.org/')
+        TaggedItem.objects.create(content_object=django_bookmark, tag='python')
+        TaggedItem.objects.create(content_object=python_bookmark, tag='python')
+
+        tests = [
+            ({'tags__isempty': '1'}, [none_tags]),
+            ({'tags__isempty': '0'}, [django_bookmark, python_bookmark]),
+        ]
+        for query_string, expected_result in tests:
+            with self.subTest(query_string=query_string):
+                request = self.request_factory.get('/', query_string)
+                request.user = self.alfred
+                changelist = modeladmin.get_changelist_instance(request)
+                queryset = changelist.get_queryset(request)
+                self.assertCountEqual(queryset, expected_result)
+
     def test_emptylistfieldfilter_choices(self):
         modeladmin = BookAdminWithEmptyFieldListFilter(Book, site)
         request = self.request_factory.get('/')


### PR DESCRIPTION
ticket-32038

Thanks Javier Matos Odut for the report.