### PR TITLE
fix #31550 correct content-type in test_file_response

### DIFF
--- a/tests/asgi/tests.py
+++ b/tests/asgi/tests.py
@@ -76,7 +76,7 @@ class ASGITest(SimpleTestCase):
             set(response_start['headers']),
             {
                 (b'Content-Length', str(len(test_file_contents)).encode('ascii')),
-                (b'Content-Type', b'text/plain' if sys.platform == 'win32' else b'text/x-python'),
+                (b'Content-Type', b'text/x-python'),
                 (b'Content-Disposition', b'inline; filename="urls.py"'),
             },
         )


### PR DESCRIPTION
The test expects a `text/plain` content-type on a response containing a python file on Windows platforms, but the content type should be `text/x-python` as it is for other platforms.

See [#31550](https://code.djangoproject.com/ticket/31550) in the Django issue tracker.