### PR TITLE
Fixed #32053 -- Fixed accessibility issues on the 'Congrats' page.

### DIFF
--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -1,6 +1,6 @@
 {% load i18n static %}<!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
-<html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
+<html lang="{{ LANGUAGE_CODE|default:"en-us" }}" dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr,auto' }}">
 <head>
 <title>{% block title %}{% endblock %}</title>
 <link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">

--- a/django/contrib/gis/templates/gis/admin/openlayers.html
+++ b/django/contrib/gis/templates/gis/admin/openlayers.html
@@ -21,7 +21,7 @@
 {% block openlayers %}{% include "gis/admin/openlayers.js" %}{% endblock %}
 //]]>
 </script>
-<div id="{{ id }}_map"{% if LANGUAGE_BIDI %} dir="ltr"{% endif %}></div>
+<div id="{{ id }}_map" dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr,auto' }}"></div>
 {% if editable %}
 <a href="javascript:{{ module }}.clearFeatures()">{% translate "Delete all Features" %}</a>
 {% endif %}

--- a/django/views/templates/default_urlconf.html
+++ b/django/views/templates/default_urlconf.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <!doctype html>
 {% get_current_language_bidi as LANGUAGE_BIDI %}
-<html{% if LANGUAGE_BIDI %} dir="rtl"{% endif %}>
+<html dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr,auto' }}">
     <head>
         <meta charset="utf-8">
         <title>{% translate "Django: the Web framework for perfectionists with deadlines." %}</title>

--- a/django/views/templates/default_urlconf.html
+++ b/django/views/templates/default_urlconf.html
@@ -1,19 +1,18 @@
 {% load i18n %}
 <!doctype html>
-{% get_current_language_bidi as LANGUAGE_BIDI %}
-<html dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr,auto' }}">
+{% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
+<html lang="{{ LANGUAGE_CODE|default:'en-us' }}" dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr,auto' }}">
     <head>
         <meta charset="utf-8">
-        <title>{% translate "Django: the Web framework for perfectionists with deadlines." %}</title>
+        <title>{% translate "The install worked successfully! Congratulations!" %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" type="text/css" href="/static/admin/css/fonts.css">
-        <style type="text/css">
+        <style>
           html {
             line-height: 1.15;
           }
           a {
             color: #19865C;
-            text-decoration: none;
           }
           header {
             border-bottom: 1px solid #efefef;
@@ -43,22 +42,16 @@
           }
           .logo {
             float: left;
-          }
-          .logo h2 {
             font-weight: 700;
-            margin-top: 0px;
+            font-size: 1.375rem;
+            text-decoration: none;
           }
           .release-notes {
             float: right;
             margin-top: 7px;
           }
-          .release-notes p {
-            font-size: 14px;
-          }
           .figure {
             margin-top: 19vh;
-          }
-          .figure__animation {
             max-width: 265px;
             position: relative;
             z-index: -9;
@@ -104,17 +97,15 @@
               animation: none;
             }
           }
-          h2 {
-            font-size: 22px;
-            max-width: 500px;
+          h1 {
+            font-size: 1.375rem;
+            max-width: 32rem;
             margin: 5px auto 0;
           }
           main p {
-            font-size: 16px;
-            line-height: 20px;
-            max-width: 410px;
+            line-height: 1.25;
+            max-width: 26rem;
             margin: 15px auto 0;
-            color: #888888;
           }
           footer {
             padding: 25px 0;
@@ -127,14 +118,16 @@
             border-top: 1px solid #efefef;
           }
           .option {
+            display: block;
             float: left;
             width: 33.33%;
             box-sizing: border-box;
             padding-right: 5px;
+            text-decoration: none;
           }
           .option svg {
-            width: 25px;
-            height: 25px;
+            width: 1.5rem;
+            height: 1.5rem;
             fill: gray;
             border: 1px solid #d6d6d6;
             padding: 5px;
@@ -142,25 +135,20 @@
             float: left;
             margin-right: 10px;
           }
-          .option div {
-            display: table;
-          }
-          .option h4 {
-            color: #19865C;
-            font-size: 19px;
-          }
           .option p {
             font-weight: 300;
-            font-size: 15px;
-            padding-top: 3px;
-            color: #757575;
+            line-height: 1.25;
+            color: #525252;
+            display: table;
+          }
+          .option .option__heading {
+            color: #19865C;
+            font-size: 1.25rem;
+            font-weight: 400;
           }
           @media (max-width: 996px) {
             body, footer {
               max-width: 780px;
-            }
-            .logo h2 {
-              margin-left: 0px;
             }
           }
           @media (max-width: 800px) {
@@ -192,11 +180,8 @@
             main {
               padding: 0 25px;
             }
-            main h2 {
-              font-size: 18px;
-            }
-            main p {
-              font-size: 14px;
+            main h1 {
+              font-size: 1.25rem;
             }
             header {
               padding-left: 20px;
@@ -222,78 +207,69 @@
               margin-top: 50px;
             }
           }
+          .sr-only {
+            clip: rect(1px, 1px, 1px, 1px);
+            clip-path: inset(50%);
+            height: 1px;
+            overflow: hidden;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+          }
         </style>
     </head>
     <body>
       <header class="u-clearfix">
-          <div class="logo">
-            <a href="https://www.djangoproject.com/" target="_blank" rel="noopener">
-              <h2>django</h2>
-            </a>
-          </div>
+          <a class="logo" href="https://www.djangoproject.com/" target="_blank" rel="noopener">
+            django
+          </a>
           <div class="release-notes">
             <p>{% blocktranslate %}View <a href="https://docs.djangoproject.com/en/{{ version }}/releases/" target="_blank" rel="noopener">release notes</a> for Django {{ version }}{% endblocktranslate %}</p>
           </div>
       </header>
       <main>
-        <div class="figure">
-          <svg class="figure__animation" viewBox="0 0 508 268">
-            <path d="M305.2 156.6c0 4.6-.5 9-1.6 13.2-2.5-4.4-5.6-8.4-9.2-12-4.6-4.6-10-8.4-16-11.2 2.8-11.2 4.5-22.9 5-34.6 1.8 1.4 3.5 2.9 5 4.5 10.5 10.3 16.8 24.5 16.8 40.1zm-75-10c-6 2.8-11.4 6.6-16 11.2-3.5 3.6-6.6 7.6-9.1 12-1-4.3-1.6-8.7-1.6-13.2 0-15.7 6.3-29.9 16.6-40.1 1.6-1.6 3.3-3.1 5.1-4.5.6 11.8 2.2 23.4 5 34.6z" fill="#2E3B39" fill-rule="nonzero"/>
-            <path d="M282.981 152.6c16.125-48.1 6.375-104-29.25-142.6-35.625 38.5-45.25 94.5-29.25 142.6h58.5z" stroke="#FFF" stroke-width="3.396" fill="#6DDCBD"/>
-            <path d="M271 29.7c-4.4-10.6-9.9-20.6-16.6-29.7-6.7 9-12.2 19-16.6 29.7H271z" stroke="#FFF" stroke-width="3" fill="#2E3B39"/>
-            <circle fill="#FFF" cx="254.3" cy="76.8" r="15.5"/>
-            <circle stroke="#FFF" stroke-width="7" fill="#6DDCBD" cx="254.3" cy="76.8" r="12.2"/>
-            <path class="smoke" d="M507.812 234.24c0-2.16-.632-4.32-1.58-6.24-3.318-6.72-11.85-11.52-21.804-11.52-1.106 0-2.212.12-3.318.24-.474-11.52-12.956-20.76-28.282-20.76-3.318 0-6.636.48-9.638 1.32-4.74-6.72-14.062-11.28-24.806-11.28-.79 0-1.58 0-2.37.12-.79 0-1.58-.12-2.37-.12-10.744 0-20.066 4.56-24.806 11.28a35.326 35.326 0 00-9.638-1.32c-15.642 0-28.282 9.6-28.282 21.48 0 1.32.158 2.76.474 3.96a26.09 26.09 0 00-4.424-.36c-8.058 0-15.01 3.12-19.118 7.8-3.476-1.68-7.742-2.76-12.324-2.76-12.008 0-21.804 7.08-22.752 15.96h-.158c-9.322 0-17.38 4.32-20.856 10.44-4.108-3.6-10.27-6-17.222-6h-1.264c-6.794 0-12.956 2.28-17.222 6-3.476-6.12-11.534-10.44-20.856-10.44h-.158c-.948-9-10.744-15.96-22.752-15.96-4.582 0-8.69.96-12.324 2.76-4.108-4.68-11.06-7.8-19.118-7.8-1.422 0-3.002.12-4.424.36.316-1.32.474-2.64.474-3.96 0-11.88-12.64-21.48-28.282-21.48-3.318 0-6.636.48-9.638 1.32-4.74-6.72-14.062-11.28-24.806-11.28-.79 0-1.58 0-2.37.12-.79 0-1.58-.12-2.37-.12-10.744 0-20.066 4.56-24.806 11.28a35.326 35.326 0 00-9.638-1.32c-15.326 0-27.808 9.24-28.282 20.76-1.106-.12-2.212-.24-3.318-.24-9.954 0-18.486 4.8-21.804 11.52-.948 1.92-1.58 4.08-1.58 6.24 0 4.8 2.528 9.12 6.636 12.36-.79 1.44-1.264 3.12-1.264 4.8 0 7.2 7.742 13.08 17.222 13.08h462.15c9.48 0 17.222-5.88 17.222-13.08 0-1.68-.474-3.36-1.264-4.8 4.582-3.24 7.11-7.56 7.11-12.36z" fill="#E6E9EE"/>
-            <path fill="#6DDCBD" d="M239 152h30v8h-30z"/>
-            <path class="exhaust__line" fill="#E6E9EE" d="M250 172h7v90h-7z"/>
-            <path class="flame" d="M250.27 178.834l-5.32-8.93s-2.47-5.7 3.458-6.118h10.26s6.232.266 3.306 6.194l-5.244 8.93s-3.23 4.37-6.46 0v-.076z" fill="#AA2247"/>
-          </svg>
-        </div>
-        <h2>{% translate "The install worked successfully! Congratulations!" %}</h2>
+        <svg class="figure" viewBox="0 0 508 268" aria-hidden="true">
+          <path d="M305.2 156.6c0 4.6-.5 9-1.6 13.2-2.5-4.4-5.6-8.4-9.2-12-4.6-4.6-10-8.4-16-11.2 2.8-11.2 4.5-22.9 5-34.6 1.8 1.4 3.5 2.9 5 4.5 10.5 10.3 16.8 24.5 16.8 40.1zm-75-10c-6 2.8-11.4 6.6-16 11.2-3.5 3.6-6.6 7.6-9.1 12-1-4.3-1.6-8.7-1.6-13.2 0-15.7 6.3-29.9 16.6-40.1 1.6-1.6 3.3-3.1 5.1-4.5.6 11.8 2.2 23.4 5 34.6z" fill="#2E3B39" fill-rule="nonzero"/>
+          <path d="M282.981 152.6c16.125-48.1 6.375-104-29.25-142.6-35.625 38.5-45.25 94.5-29.25 142.6h58.5z" stroke="#FFF" stroke-width="3.396" fill="#6DDCBD"/>
+          <path d="M271 29.7c-4.4-10.6-9.9-20.6-16.6-29.7-6.7 9-12.2 19-16.6 29.7H271z" stroke="#FFF" stroke-width="3" fill="#2E3B39"/>
+          <circle fill="#FFF" cx="254.3" cy="76.8" r="15.5"/>
+          <circle stroke="#FFF" stroke-width="7" fill="#6DDCBD" cx="254.3" cy="76.8" r="12.2"/>
+          <path class="smoke" d="M507.812 234.24c0-2.16-.632-4.32-1.58-6.24-3.318-6.72-11.85-11.52-21.804-11.52-1.106 0-2.212.12-3.318.24-.474-11.52-12.956-20.76-28.282-20.76-3.318 0-6.636.48-9.638 1.32-4.74-6.72-14.062-11.28-24.806-11.28-.79 0-1.58 0-2.37.12-.79 0-1.58-.12-2.37-.12-10.744 0-20.066 4.56-24.806 11.28a35.326 35.326 0 00-9.638-1.32c-15.642 0-28.282 9.6-28.282 21.48 0 1.32.158 2.76.474 3.96a26.09 26.09 0 00-4.424-.36c-8.058 0-15.01 3.12-19.118 7.8-3.476-1.68-7.742-2.76-12.324-2.76-12.008 0-21.804 7.08-22.752 15.96h-.158c-9.322 0-17.38 4.32-20.856 10.44-4.108-3.6-10.27-6-17.222-6h-1.264c-6.794 0-12.956 2.28-17.222 6-3.476-6.12-11.534-10.44-20.856-10.44h-.158c-.948-9-10.744-15.96-22.752-15.96-4.582 0-8.69.96-12.324 2.76-4.108-4.68-11.06-7.8-19.118-7.8-1.422 0-3.002.12-4.424.36.316-1.32.474-2.64.474-3.96 0-11.88-12.64-21.48-28.282-21.48-3.318 0-6.636.48-9.638 1.32-4.74-6.72-14.062-11.28-24.806-11.28-.79 0-1.58 0-2.37.12-.79 0-1.58-.12-2.37-.12-10.744 0-20.066 4.56-24.806 11.28a35.326 35.326 0 00-9.638-1.32c-15.326 0-27.808 9.24-28.282 20.76-1.106-.12-2.212-.24-3.318-.24-9.954 0-18.486 4.8-21.804 11.52-.948 1.92-1.58 4.08-1.58 6.24 0 4.8 2.528 9.12 6.636 12.36-.79 1.44-1.264 3.12-1.264 4.8 0 7.2 7.742 13.08 17.222 13.08h462.15c9.48 0 17.222-5.88 17.222-13.08 0-1.68-.474-3.36-1.264-4.8 4.582-3.24 7.11-7.56 7.11-12.36z" fill="#E6E9EE"/>
+          <path fill="#6DDCBD" d="M239 152h30v8h-30z"/>
+          <path class="exhaust__line" fill="#E6E9EE" d="M250 172h7v90h-7z"/>
+          <path class="flame" d="M250.27 178.834l-5.32-8.93s-2.47-5.7 3.458-6.118h10.26s6.232.266 3.306 6.194l-5.244 8.93s-3.23 4.37-6.46 0v-.076z" fill="#AA2247"/>
+        </svg>
+        <h1>{% translate "The install worked successfully! Congratulations!" %}</h1>
         <p>{% blocktranslate %}You are seeing this page because <a href="https://docs.djangoproject.com/en/{{ version }}/ref/settings/#debug" target="_blank" rel="noopener">DEBUG=True</a> is in your settings file and you have not configured any URLs.{% endblocktranslate %}</p>
       </main>
       <footer class="u-clearfix">
-        <a href="https://docs.djangoproject.com/en/{{ version }}/" target="_blank" rel="noopener">
-        <div class="option one">
-            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                <defs>
-                    <path d="M0 0h24v24H0V0z" id="a"></path>
-                </defs>
-                <clipPath id="b">
-                    <use overflow="visible" xlink:href="#a"></use>
-                </clipPath>
-                <path clip-path="url(#b)" d="M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7zm2.85 11.1l-.85.6V16h-4v-2.3l-.85-.6C7.8 12.16 7 10.63 7 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.63-.8 3.16-2.15 4.1z"></path>
-            </svg>
-            <div>
-                <h4>{% translate "Django Documentation" %}</h4>
-                <p>{% translate 'Topics, references, &amp; how-to’s' %}</p>
-            </div>
-        </div>
-      </a>
-      <a href="https://docs.djangoproject.com/en/{{ version }}/intro/tutorial01/" target="_blank" rel="noopener">
-        <div class="option two">
-          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path d="M0 0h24v24H0V0z" fill="none"></path>
+        <a class="option one" href="https://docs.djangoproject.com/en/{{ version }}/" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7zm2.85 11.1l-.85.6V16h-4v-2.3l-.85-.6A4.997 4.997 0 017 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.63-.8 3.16-2.15 4.1z"></path>
+          </svg>
+          <p>
+            <span class="option__heading">{% translate "Django Documentation" %}</span><span class="sr-only">.</span><br>
+            {% translate 'Topics, references, &amp; how-to’s' %}
+          </p>
+        </a>
+        <a class="option two" href="https://docs.djangoproject.com/en/{{ version }}/intro/tutorial01/" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
             <path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"></path>
           </svg>
-          <div>
-            <h4>{% translate "Tutorial: A Polling App" %}</h4>
-            <p>{% translate "Get started with Django" %}</p>
-          </div>
-        </div>
-      </a>
-      <a href="https://www.djangoproject.com/community/" target="_blank" rel="noopener">
-        <div class="option three">
-          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path d="M0 0h24v24H0z" fill="none"></path>
+          <p>
+            <span class="option__heading">{% translate "Tutorial: A Polling App" %}</span><span class="sr-only">.</span><br>
+            {% translate "Get started with Django" %}
+          </p>
+        </a>
+        <a class="option three" href="https://www.djangoproject.com/community/" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
             <path d="M16.5 13c-1.2 0-3.07.34-4.5 1-1.43-.67-3.3-1-4.5-1C5.33 13 1 14.08 1 16.25V19h22v-2.75c0-2.17-4.33-3.25-6.5-3.25zm-4 4.5h-10v-1.25c0-.54 2.56-1.75 5-1.75s5 1.21 5 1.75v1.25zm9 0H14v-1.25c0-.46-.2-.86-.52-1.22.88-.3 1.96-.53 3.02-.53 2.44 0 5 1.21 5 1.75v1.25zM7.5 12c1.93 0 3.5-1.57 3.5-3.5S9.43 5 7.5 5 4 6.57 4 8.5 5.57 12 7.5 12zm0-5.5c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zm9 5.5c1.93 0 3.5-1.57 3.5-3.5S18.43 5 16.5 5 13 6.57 13 8.5s1.57 3.5 3.5 3.5zm0-5.5c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2z"></path>
           </svg>
-          <div>
-            <h4>{% translate "Django Community" %}</h4>
-            <p>{% translate "Connect, get help, or contribute" %}</p>
-          </div>
-        </div>
-      </a>
+          <p>
+            <span class="option__heading">{% translate "Django Community" %}</span><span class="sr-only">.</span><br>
+            {% translate "Connect, get help, or contribute" %}
+          </p>
+        </a>
       </footer>
     </body>
 </html>

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -243,7 +243,7 @@ class DebugViewTests(SimpleTestCase):
         response = self.client.get('/')
         self.assertContains(
             response,
-            "<h2>The install worked successfully! Congratulations!</h2>"
+            "<h1>The install worked successfully! Congratulations!</h1>"
         )
 
     @override_settings(ROOT_URLCONF='view_tests.regression_21530_urls')


### PR DESCRIPTION
~This depends on #13463.~ This addresses all known accessibility issues with the "new project" placeholder / Congratulations page, reported in [#32053](https://code.djangoproject.com/ticket/32053).

Each of these could be its own ticket / PR, but they are all quite small so it made sense to batch them. I’m happy to split the changes if this makes it easier to review.

## Testing guidelines

The issues are spread across different scenarios so worth keeping in mind what to test this with when reviewing:

- The V.Nu HTML validator
- Axe 3.5 (via Accessibility Insights)
- Color blind variant via Accessibility Insights
- VoiceOver in Safari 13 on macOS 10.14
- VoiceOver in Safari 14 on iOS 14
- Manual keyboard testing in latest Chrome, Firefox, Safari on macOS 10.14
- Manual zoom testing in Chrome, with browser-level zoom from 100% to 400%
- Manual zoom testing in Chrome, with font size increase to Very Large

## Markup issues

-   Missing a `lang` attribute, so screen reader users would potentially have the page announced in the wrong language.
-   It would be better for the page title to directly state what the page is about, and match the main heading.
-   There shouldn’t be an `h2` used for the Django docs link – this isn’t a section of the page.
-   The main rocket launch visual should be hidden for screen reader users
-   The main heading should be a `h1` (the page has no h1 currently)
-   SVG icons should be hidden for screen reader users.
-   SVG icons in links should be set to `focusable="false"` for screen reader users in IE11
-   For some reason the footer links don’t have a focus outline for me in Firefox & Safari
-   Footer links shouldn’t be using h4 headings

## Styles issues

-   The links in text are only distinguished by their color – this is problematic for colorblind users, who might not realize there are links.
-   The animation should respect `@media (prefers-reduced-motion: reduce)` ([https://code.djangoproject.com/ticket/32051 #32051])
-   The main paragraph text needs to pass color contrast checks
-   (It would be nice for all text on the page to pass AAA contrast requirements, considering it’s such a simple page. Currently, the footer’s p tags only pass AA).
-   Text font size and line heights shouldn’t be defined in pixels, so users can resize text if desired

### Other changes

There are a couple of optional changes I chose to do at the same time:

- Removing unneeded attributes from SVG tags in the markup, to declutter the page
- Removed a few elements that have no semantics, and aren’t for styles
- Removed the `type` attribute on the style tag, so the page passes HTML validation without warning

---

Visually the page hasn’t changed much, apart from the color contrast tweaks, and slightly larger font size. Tested the final output in latest Chrome, Firefox, Safari on macOS 10.14, and IE11:

![32053-ie11](https://user-images.githubusercontent.com/877585/94506628-bf269180-0205-11eb-871a-7e6b0cfcdae3.png)
