### PR TITLE
Fixed #32055 – Add Surrogate-Control header to the 304 response

### DIFF
--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -138,7 +138,8 @@ def _not_modified(request, response=None):
     if response:
         # Preserve the headers required by Section 4.1 of RFC 7232, as well as
         # Last-Modified.
-        for header in ('Cache-Control', 'Content-Location', 'Date', 'ETag', 'Expires', 'Last-Modified', 'Vary'):
+        for header in ('Cache-Control', 'Content-Location', 'Date', 'ETag',
+                       'Expires', 'Last-Modified', 'Surrogate-Control', 'Vary'):
             if header in response:
                 new_response.headers[header] = response.headers[header]
 

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -597,6 +597,7 @@ class ConditionalGetMiddlewareTest(SimpleTestCase):
             resp['Cache-Control'] = 'public'
             resp['Content-Location'] = '/alt'
             resp['Content-Language'] = 'en'  # shouldn't be preserved
+            resp['Surrogate-Control'] = 'max-age=300'
             resp['ETag'] = '"spam"'
             resp.set_cookie('key', 'value')
             return resp
@@ -606,7 +607,8 @@ class ConditionalGetMiddlewareTest(SimpleTestCase):
         new_response = ConditionalGetMiddleware(get_response)(self.req)
         self.assertEqual(new_response.status_code, 304)
         base_response = get_response(self.req)
-        for header in ('Cache-Control', 'Content-Location', 'Date', 'ETag', 'Expires', 'Last-Modified', 'Vary'):
+        for header in ('Cache-Control', 'Content-Location', 'Date', 'ETag', 'Expires',
+                       'Last-Modified', 'Surrogate-Control', 'Vary'):
             self.assertEqual(new_response.headers[header], base_response.headers[header])
         self.assertEqual(new_response.cookies, base_response.cookies)
         self.assertNotIn('Content-Language', new_response)


### PR DESCRIPTION
[ticket-32055](https://code.djangoproject.com/ticket/32055)