### PR TITLE
Fixed #32057 -- Doc'd HttpResponse.get()/items().

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -843,10 +843,19 @@ Methods
 
     Returns the value for the given header name. Case-insensitive.
 
+.. method:: HttpResponse.get(header, alternate=None)
+
+    Returns the value for the given header, or an ``alternate`` if the header
+    doesn't exist.
+
 .. method:: HttpResponse.has_header(header)
 
     Returns ``True`` or ``False`` based on a case-insensitive check for a
     header with the given name.
+
+.. method:: HttpResponse.items()
+
+    Acts like :meth:`dict.items` for HTTP headers on the response.
 
 .. method:: HttpResponse.setdefault(header, value)
 


### PR DESCRIPTION
I have added documentation for HttpResponse objects methods get(headers,alternate=None) and also items().

I'm new to the community so please help me out if i did any mistakes(This will be my first small contribution towards the community)
I don't know whether i have attached the issue to the pull requests ,if not please anyone guide me to do so.