### PR TITLE
Refs #32061 -- Prevented password leak on MySQL dbshell crash.

### DIFF
--- a/django/db/backends/mysql/client.py
+++ b/django/db/backends/mysql/client.py
@@ -7,6 +7,7 @@ class DatabaseClient(BaseDatabaseClient):
     @classmethod
     def settings_to_cmd_args_env(cls, settings_dict, parameters):
         args = [cls.executable_name]
+        env = None
         db = settings_dict['OPTIONS'].get('db', settings_dict['NAME'])
         user = settings_dict['OPTIONS'].get('user', settings_dict['USER'])
         password = settings_dict['OPTIONS'].get(
@@ -27,7 +28,14 @@ class DatabaseClient(BaseDatabaseClient):
         if user:
             args += ["--user=%s" % user]
         if password:
-            args += ["--password=%s" % password]
+            # The MYSQL_PWD environment variable usage is discouraged per
+            # MySQL's documentation due to the possibility of exposure through
+            # `ps` on old Unix flavors but --password suffers from the same
+            # flaw on even more systems. Usage of an environment variable also
+            # prevents password exposure if the subprocess.run(check=True) call
+            # raises a CalledProcessError since the string representation of
+            # the latter includes all of the provided `args`.
+            env = {'MYSQL_PWD': password}
         if host:
             if '/' in host:
                 args += ["--socket=%s" % host]
@@ -46,4 +54,4 @@ class DatabaseClient(BaseDatabaseClient):
         if db:
             args += [db]
         args.extend(parameters)
-        return args, None
+        return args, env

--- a/tests/dbshell/fake_client.py
+++ b/tests/dbshell/fake_client.py
@@ -1,0 +1,3 @@
+import sys
+
+sys.exit(1)


### PR DESCRIPTION
The usage of the --password flag when invoking the mysql CLI has the potential
of exposing the password in plain text if the command happens to crash due
to the inclusion of args provided to subprocess.run(check=True) in the string
representation of the subprocess.CalledProcessError exception raised on
non-zero return code.

Since this has the potential of leaking the password to logging facilities
configured to capture crashes (e.g. sys.excepthook, Sentry) it's safer to
rely on the MYSQL_PWD environment variable instead even if its usage is
discouraged due to potential leak through the `ps` command on old flavors
of Unix.

Thanks Charlie Denton for reporting the issue to the security team.

Refs #24999