### PR TITLE
Fixed #31949 -- Made builtin decorator async compatible

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -135,6 +135,7 @@ answer newbie questions, and generally made Django that much better:
     Ben Godfrey <http://aftnn.org>
     Benjamin Wohlwend <piquadrat@gmail.com>
     Ben Khoo <khoobks@westnet.com.au>
+    Ben Lomax <lomax.on.the.run@gmail.com>
     Ben Slavin <benjamin.slavin@gmail.com>
     Ben Sturmfels <ben@sturm.com.au>
     Berker Peksag <berker.peksag@gmail.com>
@@ -387,6 +388,7 @@ answer newbie questions, and generally made Django that much better:
     Hasan Ramezani <hasan.r67@gmail.com>
     Hawkeye
     Helen Sherwood-Taylor <helen@rrdlabs.co.uk>
+    Hendrik Frentrup <hendrik.frentrup@gmail.com>
     Henrique Romano <onaiort@gmail.com>
     Henry Dang <henrydangprg@gmail.com>
     Hidde Bultsma

--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -72,6 +72,7 @@ def login_required(
     return actual_decorator
 
 
+@sync_and_async_middleware
 def permission_required(perm, login_url=None, raise_exception=False):
     """
     Decorator for views that checks whether a user has a particular permission

--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -54,6 +54,7 @@ def user_passes_test(
     return decorator
 
 
+@sync_and_async_middleware
 def login_required(
     function=None, redirect_field_name=REDIRECT_FIELD_NAME, login_url=None
 ):

--- a/django/views/decorators/cache.py
+++ b/django/views/decorators/cache.py
@@ -9,6 +9,7 @@ from django.utils.decorators import (
 )
 
 
+@sync_and_async_middleware
 def cache_page(timeout, *, cache=None, key_prefix=None):
     """
     Decorator for views that tries getting the page from the cache and

--- a/django/views/decorators/clickjacking.py
+++ b/django/views/decorators/clickjacking.py
@@ -1,6 +1,10 @@
+import asyncio
 from functools import wraps
 
+from django.utils.decorators import sync_and_async_middleware
 
+
+@sync_and_async_middleware
 def xframe_options_deny(view_func):
     """
     Modify a view function so its response has the X-Frame-Options HTTP
@@ -12,14 +16,25 @@ def xframe_options_deny(view_func):
         ...
     """
 
-    @wraps(view_func)
-    def wrapper_view(*args, **kwargs):
-        resp = view_func(*args, **kwargs)
-        if resp.get("X-Frame-Options") is None:
-            resp["X-Frame-Options"] = "DENY"
-        return resp
+    def _process_response(response):
+        if response.get("X-Frame-Options") is None:
+            response["X-Frame-Options"] = "DENY"
 
-    return wrapper_view
+    @wraps(view_func)
+    def _wrapper_view_sync(*args, **kwargs):
+        response = view_func(*args, **kwargs)
+        _process_response(response)
+        return response
+
+    @wraps(view_func)
+    async def _wrapper_view_async(*args, **kwargs):
+        response = await view_func(*args, **kwargs)
+        _process_response(response)
+        return response
+
+    if asyncio.iscoroutinefunction(view_func):
+        return _wrapper_view_async
+    return _wrapper_view_sync
 
 
 def xframe_options_sameorigin(view_func):

--- a/django/views/decorators/common.py
+++ b/django/views/decorators/common.py
@@ -1,6 +1,10 @@
+import asyncio
 from functools import wraps
 
+from django.utils.decorators import sync_and_async_middleware
 
+
+@sync_and_async_middleware
 def no_append_slash(view_func):
     """
     Mark a view function as excluded from CommonMiddleware's APPEND_SLASH
@@ -9,8 +13,17 @@ def no_append_slash(view_func):
     # view_func.should_append_slash = False would also work, but decorators are
     # nicer if they don't have side effects, so return a new function.
     @wraps(view_func)
-    def wrapper_view(*args, **kwargs):
+    def _wrapper_view_sync(*args, **kwargs):
         return view_func(*args, **kwargs)
+
+    @wraps(view_func)
+    async def _wrapper_view_async(*args, **kwargs):
+        return await view_func(*args, **kwargs)
+
+    if asyncio.iscoroutinefunction(view_func):
+        wrapper_view = _wrapper_view_async
+    else:
+        wrapper_view = _wrapper_view_sync
 
     wrapper_view.should_append_slash = False
     return wrapper_view

--- a/django/views/decorators/csrf.py
+++ b/django/views/decorators/csrf.py
@@ -11,6 +11,7 @@ This decorator adds CSRF protection in exactly the same way as
 CsrfViewMiddleware, but it can be used on a per view basis.  Using both, or
 using the decorator multiple times, is harmless and efficient.
 """
+csrf_protect = sync_and_async_middleware(csrf_protect)
 
 
 class _EnsureCsrfToken(CsrfViewMiddleware):
@@ -26,6 +27,7 @@ Use this decorator on views that need a correct csrf_token available to
 RequestContext, but without the CSRF protection that csrf_protect
 enforces.
 """
+requires_csrf_token = sync_and_async_middleware(requires_csrf_token)
 
 
 class _EnsureCsrfCookie(CsrfViewMiddleware):
@@ -45,6 +47,7 @@ ensure_csrf_cookie.__doc__ = """
 Use this decorator to ensure that a view sets a CSRF cookie, whether or not it
 uses the csrf_token template tag, or the CsrfViewMiddleware is used.
 """
+ensure_csrf_cookie = sync_and_async_middleware(ensure_csrf_cookie)
 
 
 @sync_and_async_middleware

--- a/django/views/decorators/debug.py
+++ b/django/views/decorators/debug.py
@@ -5,6 +5,7 @@ from django.http import HttpRequest
 from django.utils.decorators import sync_and_async_middleware
 
 
+@sync_and_async_middleware
 def sensitive_variables(*variables):
     """
     Indicate which variables used in the decorated function are sensitive so

--- a/django/views/decorators/gzip.py
+++ b/django/views/decorators/gzip.py
@@ -1,5 +1,6 @@
 from django.middleware.gzip import GZipMiddleware
-from django.utils.decorators import decorator_from_middleware
+from django.utils.decorators import decorator_from_middleware, sync_and_async_middleware
 
 gzip_page = decorator_from_middleware(GZipMiddleware)
 gzip_page.__doc__ = "Decorator for views that gzips pages if the client supports it."
+gzip_page = sync_and_async_middleware(gzip_page)

--- a/django/views/decorators/http.py
+++ b/django/views/decorators/http.py
@@ -14,6 +14,7 @@ from django.utils.http import http_date, quote_etag
 from django.utils.log import log_response
 
 conditional_page = decorator_from_middleware(ConditionalGetMiddleware)
+conditional_page = sync_and_async_middleware(conditional_page)
 
 
 @sync_and_async_middleware

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -151,7 +151,8 @@ CSRF
 Decorators
 ~~~~~~~~~~
 
-* ...
+* All the documented :doc:`view decorators </topics/http/decorators>` are now
+  compatible with both synchronous and asynchronous views.
 
 Email
 ~~~~~

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -135,6 +135,32 @@ a purely synchronous codebase under ASGI because the request-handling code is
 still all running asynchronously. In general you will only want to enable ASGI
 mode if you have asynchronous code in your project.
 
+Async view decorators
+=====================
+
+.. versionadded:: 4.2
+
+All the documented :doc:`view decorators </topics/http/decorators>` are
+compatible with both synchronous and asynchronous views. Note that only the
+view itself can be asynchronous; any functions passed to a decorator (e.g. with
+:meth:`~django.views.decorators.http.condition`) must be synchronous. Usage::
+
+    from django.views.decorators.http import condition
+
+    # The function passed to the decorator must be a synchronous function
+    def etag_func(request, *args, **kwargs):
+        return '"abc123"'
+
+    # The view itself can be synchronous...
+    @condition(etag_func=etag_func)
+    def my_sync_view(request):
+        return HttpResponse()
+
+    # ... or it can be asynchronous
+    @condition(etag_func=etag_func)
+    async def my_async_view(request):
+        return HttpResponse()
+
 .. _async-safety:
 
 Async safety

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -27,7 +27,7 @@ from django.views.decorators.csrf import (
     ensure_csrf_cookie,
     requires_csrf_token,
 )
-from django.views.decorators.debug import sensitive_post_parameters
+from django.views.decorators.debug import sensitive_post_parameters, sensitive_variables
 from django.views.decorators.gzip import gzip_page
 from django.views.decorators.http import (
     condition,
@@ -507,6 +507,7 @@ class SyncAndAsyncDecoratorTests(TestCase):
             ensure_csrf_cookie,
             csrf_exempt,
             gzip_page,
+            sensitive_variables,
             sensitive_post_parameters,
             conditional_page,
             require_http_methods,
@@ -980,6 +981,42 @@ class DebugDecoratorsTests(SimpleTestCase):
     """
     Tests for the debug decorators.
     """
+
+    def test_sensitive_variables_without_parameters(self):
+        @sensitive_variables()
+        def a_view(request):
+            return HttpResponse()
+
+        response = a_view(HttpRequest())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(a_view.sensitive_variables, "__ALL__")
+
+    async def test_sensitive_variables_without_parameters_with_async_view(self):
+        @sensitive_variables()
+        async def an_async_view(request):
+            return HttpResponse()
+
+        response = await an_async_view(HttpRequest())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(an_async_view.sensitive_variables, "__ALL__")
+
+    def test_sensitive_variables_with_parameters(self):
+        @sensitive_variables("a", "b")
+        def a_view(request):
+            return HttpResponse()
+
+        response = a_view(HttpRequest())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(a_view.sensitive_variables, ("a", "b"))
+
+    async def test_sensitive_variables_with_parameters_with_async_view(self):
+        @sensitive_variables("a", "b")
+        async def an_async_view(request):
+            return HttpResponse()
+
+        response = await an_async_view(HttpRequest())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(an_async_view.sensitive_variables, ("a", "b"))
 
     def test_sensitive_post_parameters_without_parameters(self):
         @sensitive_post_parameters()

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -485,6 +485,7 @@ class SyncAndAsyncDecoratorTests(TestCase):
             cache_control,
             never_cache,
             xframe_options_deny,
+            xframe_options_sameorigin,
         )
 
         for decorator in decorators:
@@ -532,8 +533,21 @@ class XFrameOptionsDecoratorsTests(SimpleTestCase):
         def a_view(request):
             return HttpResponse()
 
-        r = a_view(HttpRequest())
-        self.assertEqual(r.headers["X-Frame-Options"], "SAMEORIGIN")
+        response = a_view(HttpRequest())
+        self.assertEqual(response.headers["X-Frame-Options"], "SAMEORIGIN")
+
+    async def test_sameorigin_decorator_with_async_view(self):
+        """
+        Ensures @xframe_options_sameorigin properly sets the X-Frame-Options
+        header.
+        """
+
+        @xframe_options_sameorigin
+        async def an_async_view(request):
+            return HttpResponse()
+
+        response = await an_async_view(HttpRequest())
+        self.assertEqual(response.headers["X-Frame-Options"], "SAMEORIGIN")
 
     def test_exempt_decorator(self):
         """

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -491,6 +491,10 @@ class SyncAndAsyncDecoratorTests(TestCase):
             xframe_options_exempt,
             no_append_slash,
             csrf_exempt,
+            require_http_methods,
+            require_GET,
+            require_POST,
+            require_safe,
             vary_on_headers,
             vary_on_cookie,
         )
@@ -848,3 +852,169 @@ class CsrfDecoratorTests(SimpleTestCase):
 
         self.assertIs(an_async_view.csrf_exempt, True)
         await an_async_view(HttpRequest())
+
+
+class RequireHttpMethodsDecoratorTests(SimpleTestCase):
+    def test_require_http_methods_decorator_successful(self):
+        @require_http_methods(["HEAD"])
+        def a_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "HEAD"
+        response = a_view(request)
+        self.assertEqual(response.status_code, 200)
+
+    async def test_require_http_methods_decorator_successful_with_async_view(self):
+        @require_http_methods(["HEAD"])
+        async def an_async_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "HEAD"
+        response = await an_async_view(request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_require_http_methods_decorator_unsuccessful(self):
+        @require_http_methods(["HEAD"])
+        def a_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "GET"
+        response = a_view(request)
+        self.assertEqual(response.status_code, 405)
+
+    async def test_require_http_methods_decorator_unsuccessful_with_async_view(self):
+        @require_http_methods(["HEAD"])
+        async def an_async_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "GET"
+        response = await an_async_view(request)
+        self.assertEqual(response.status_code, 405)
+
+    def test_require_get_decorator_successful(self):
+        @require_GET
+        def a_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "GET"
+        response = a_view(request)
+        self.assertEqual(response.status_code, 200)
+
+    async def test_require_get_decorator_successful_with_async_view(self):
+        @require_GET
+        async def an_async_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "GET"
+        response = await an_async_view(request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_require_get_decorator_unsuccessful(self):
+        @require_GET
+        def a_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "POST"
+        response = a_view(request)
+        self.assertEqual(response.status_code, 405)
+
+    async def test_require_get_decorator_unsuccessful_with_async_view(self):
+        @require_GET
+        async def an_async_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "POST"
+        response = await an_async_view(request)
+        self.assertEqual(response.status_code, 405)
+
+    def test_require_post_decorator_successful(self):
+        @require_POST
+        def a_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "POST"
+        response = a_view(request)
+        self.assertEqual(response.status_code, 200)
+
+    async def test_require_post_decorator_successful_with_async_view(self):
+        @require_POST
+        async def an_async_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "POST"
+        response = await an_async_view(request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_require_post_decorator_unsuccessful(self):
+        @require_POST
+        def a_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "GET"
+        response = a_view(request)
+        self.assertEqual(response.status_code, 405)
+
+    async def test_require_post_decorator_unsuccessful_with_async_view(self):
+        @require_POST
+        async def an_async_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "GET"
+        response = await an_async_view(request)
+        self.assertEqual(response.status_code, 405)
+
+    def test_require_safe_decorator_successful(self):
+        @require_safe
+        def a_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        # Only GET and HEAD are safe methods
+        request.method = "HEAD"
+        response = a_view(request)
+        self.assertEqual(response.status_code, 200)
+
+    async def test_require_safe_decorator_successful_with_async_view(self):
+        @require_safe
+        async def an_async_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        # Only GET and HEAD are safe methods
+        request.method = "HEAD"
+        response = await an_async_view(request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_require_safe_decorator_unsuccessful(self):
+        @require_safe
+        def a_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        # Only GET and HEAD are safe methods
+        request.method = "POST"
+        response = a_view(request)
+        self.assertEqual(response.status_code, 405)
+
+    async def test_require_safe_decorator_unsuccessful_with_async_view(self):
+        @require_safe
+        async def an_async_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        # Only GET and HEAD are safe methods
+        request.method = "POST"
+        response = await an_async_view(request)
+        self.assertEqual(response.status_code, 405)

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -20,6 +20,7 @@ from django.views.decorators.clickjacking import (
     xframe_options_sameorigin,
 )
 from django.views.decorators.common import no_append_slash
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import (
     condition,
     require_GET,
@@ -489,6 +490,7 @@ class SyncAndAsyncDecoratorTests(TestCase):
             xframe_options_sameorigin,
             xframe_options_exempt,
             no_append_slash,
+            csrf_exempt,
             vary_on_headers,
             vary_on_cookie,
         )
@@ -823,4 +825,26 @@ class CommonDecoratorTest(SimpleTestCase):
             return HttpResponse()
 
         self.assertIs(an_async_view.should_append_slash, False)
+        await an_async_view(HttpRequest())
+
+
+class CsrfDecoratorTests(SimpleTestCase):
+    """
+    Tests for the CSRF decorators.
+    """
+
+    def test_csrf_exempt_decorator(self):
+        @csrf_exempt
+        def a_view(request):
+            return HttpResponse()
+
+        self.assertIs(a_view.csrf_exempt, True)
+        a_view(HttpRequest())
+
+    async def test_csrf_exempt_decorator_with_async_view(self):
+        @csrf_exempt
+        async def an_async_view(request):
+            return HttpResponse()
+
+        self.assertIs(an_async_view.csrf_exempt, True)
         await an_async_view(HttpRequest())

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -488,6 +488,7 @@ class SyncAndAsyncDecoratorTests(TestCase):
             xframe_options_sameorigin,
             xframe_options_exempt,
             vary_on_headers,
+            vary_on_cookie,
         )
 
         for decorator in decorators:
@@ -778,3 +779,24 @@ class VaryDecoratorsTests(SimpleTestCase):
         vary_items_set = {item.strip() for item in response.get("Vary").split(",")}
         self.assertIn("Header", vary_items_set)
         self.assertIn("Another-header", vary_items_set)
+
+    def test_vary_on_cookie_decorator(self):
+        @vary_on_cookie
+        def a_view(request):
+            return HttpResponse()
+
+        response = a_view(HttpRequest())
+        self.assertEqual(response.status_code, 200)
+        vary_items_set = {item.strip() for item in response.get("Vary").split(",")}
+        self.assertIn("Cookie", vary_items_set)
+
+    async def test_vary_on_cookie_decorator_with_async_view(self):
+        @vary_on_cookie
+        async def an_async_view(request):
+            return HttpResponse()
+
+        response = await an_async_view(HttpRequest())
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Cookie", response.get("Vary"))
+        vary_items_set = {item.strip() for item in response.get("Vary").split(",")}
+        self.assertIn("Cookie", vary_items_set)

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -19,6 +19,7 @@ from django.views.decorators.clickjacking import (
     xframe_options_exempt,
     xframe_options_sameorigin,
 )
+from django.views.decorators.common import no_append_slash
 from django.views.decorators.http import (
     condition,
     require_GET,
@@ -487,6 +488,7 @@ class SyncAndAsyncDecoratorTests(TestCase):
             xframe_options_deny,
             xframe_options_sameorigin,
             xframe_options_exempt,
+            no_append_slash,
             vary_on_headers,
             vary_on_cookie,
         )
@@ -800,3 +802,25 @@ class VaryDecoratorsTests(SimpleTestCase):
         self.assertIn("Cookie", response.get("Vary"))
         vary_items_set = {item.strip() for item in response.get("Vary").split(",")}
         self.assertIn("Cookie", vary_items_set)
+
+
+class CommonDecoratorTest(SimpleTestCase):
+    """
+    Tests for the common decorators.
+    """
+
+    def test_no_append_slash_decorator(self):
+        @no_append_slash
+        def a_view(request):
+            return HttpResponse()
+
+        self.assertIs(a_view.should_append_slash, False)
+        a_view(HttpRequest())
+
+    async def test_no_append_slash_decorator_with_async_view(self):
+        @no_append_slash
+        async def an_async_view(request):
+            return HttpResponse()
+
+        self.assertIs(an_async_view.should_append_slash, False)
+        await an_async_view(HttpRequest())

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -487,6 +487,7 @@ class SyncAndAsyncDecoratorTests(TestCase):
             xframe_options_deny,
             xframe_options_sameorigin,
             xframe_options_exempt,
+            vary_on_headers,
         )
 
         for decorator in decorators:
@@ -747,3 +748,33 @@ class CacheControlDecoratorTest(SimpleTestCase):
         self.assertEqual(
             set(cache_control_items), {"max-age=123", "private", "public", "custom=456"}
         )
+
+
+class VaryDecoratorsTests(SimpleTestCase):
+    """
+    Tests for the vary decorators.
+    """
+
+    def test_vary_on_headers_decorator(self):
+        @vary_on_headers("Header", "Another-header")
+        def a_view(request):
+            return HttpResponse()
+
+        response = a_view(HttpRequest())
+        self.assertEqual(response.status_code, 200)
+        # Assert each decorator argument is in the response header
+        vary_items_set = {item.strip() for item in response.get("Vary").split(",")}
+        self.assertIn("Header", vary_items_set)
+        self.assertIn("Another-header", vary_items_set)
+
+    async def test_vary_on_headers_decorator_with_async_view(self):
+        @vary_on_headers("Header", "Another-header")
+        async def an_async_view(request):
+            return HttpResponse()
+
+        response = await an_async_view(HttpRequest())
+        self.assertEqual(response.status_code, 200)
+        # Assert each decorator argument is in the response header
+        vary_items_set = {item.strip() for item in response.get("Vary").split(",")}
+        self.assertIn("Header", vary_items_set)
+        self.assertIn("Another-header", vary_items_set)

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -490,6 +490,7 @@ class SyncAndAsyncDecoratorTests(TestCase):
 
     def test_decorators_syanc_and_async_capable(self):
         decorators = (
+            cache_page,
             cache_control,
             never_cache,
             xframe_options_deny,
@@ -513,6 +514,44 @@ class SyncAndAsyncDecoratorTests(TestCase):
             with self.subTest(decorator):
                 self.assertTrue(decorator.sync_capable)
                 self.assertTrue(decorator.async_capable)
+
+
+class CachePageDecoratorTests(SimpleTestCase):
+    """
+    Tests for the caching decorators.
+    """
+
+    def test_cache_page_decorator(self):
+        @cache_page(123)
+        def a_view(request):
+            return "response"
+
+        response = a_view(HttpRequest())
+        self.assertEqual(response, "response")
+
+    async def test_cache_page_decorator_with_async_view(self):
+        @cache_page(123)
+        async def an_async_view(request):
+            return "response"
+
+        response = await an_async_view(HttpRequest())
+        self.assertEqual(response, "response")
+
+    def test_cache_page_decorator_with_key_prefix(self):
+        @cache_page(123, key_prefix="test")
+        def a_view(request):
+            return "response"
+
+        response = a_view(HttpRequest())
+        self.assertEqual(response, "response")
+
+    async def test_cache_page_decorator_with_key_prefix_with_async_view(self):
+        @cache_page(123, key_prefix="test")
+        async def an_async_view(request):
+            return "response"
+
+        response = await an_async_view(HttpRequest())
+        self.assertEqual(response, "response")
 
 
 class XFrameOptionsDecoratorsTests(SimpleTestCase):

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -484,6 +484,7 @@ class SyncAndAsyncDecoratorTests(TestCase):
         decorators = (
             cache_control,
             never_cache,
+            xframe_options_deny,
         )
 
         for decorator in decorators:
@@ -492,7 +493,7 @@ class SyncAndAsyncDecoratorTests(TestCase):
                 self.assertTrue(decorator.async_capable)
 
 
-class XFrameOptionsDecoratorsTests(TestCase):
+class XFrameOptionsDecoratorsTests(SimpleTestCase):
     """
     Tests for the X-Frame-Options decorators.
     """
@@ -506,8 +507,20 @@ class XFrameOptionsDecoratorsTests(TestCase):
         def a_view(request):
             return HttpResponse()
 
-        r = a_view(HttpRequest())
-        self.assertEqual(r.headers["X-Frame-Options"], "DENY")
+        response = a_view(HttpRequest())
+        self.assertEqual(response.headers["X-Frame-Options"], "DENY")
+
+    async def test_deny_decorator_with_async_view(self):
+        """
+        Ensures @xframe_options_deny properly sets the X-Frame-Options header.
+        """
+
+        @xframe_options_deny
+        async def an_async_view(request):
+            return HttpResponse()
+
+        response = await an_async_view(HttpRequest())
+        self.assertEqual(response.headers["X-Frame-Options"], "DENY")
 
     def test_sameorigin_decorator(self):
         """

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -30,6 +30,7 @@ from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.gzip import gzip_page
 from django.views.decorators.http import (
     condition,
+    conditional_page,
     require_GET,
     require_http_methods,
     require_POST,
@@ -504,6 +505,7 @@ class SyncAndAsyncDecoratorTests(TestCase):
             csrf_exempt,
             gzip_page,
             sensitive_post_parameters,
+            conditional_page,
             require_http_methods,
             require_GET,
             require_POST,
@@ -1043,6 +1045,28 @@ class GzipDecoratorsTests(SimpleTestCase):
         response = await an_async_view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get("Content-Encoding"), "gzip")
+
+
+class ConditionalTests(SimpleTestCase):
+    def test_conditional_page_decorator_successful(self):
+        @conditional_page
+        def a_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "HEAD"
+        response = a_view(request)
+        self.assertEqual(response.status_code, 200)
+
+    async def test_conditional_page_decorator_successful_with_async_view(self):
+        @conditional_page
+        async def an_async_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "HEAD"
+        response = await an_async_view(request)
+        self.assertEqual(response.status_code, 200)
 
 
 class RequireHttpMethodsDecoratorTests(SimpleTestCase):


### PR DESCRIPTION
Fix for [#31949](https://code.djangoproject.com/ticket/31949).

Makes builtin decorators async compatible so that they can be applied directly to async views without having to be wrapped in additional `@async_to_sync` and `@sync_to_async` decorators.

The two main changes are the creation of `sync_async_wrapper` and the update to `make_middleware_decorator` which allow for most of the decorators to be simply converted to having a sync and an async implementation. The `sync_async_wrapper` works by offering "hooks" where calling code can pass in functions which affect the request and the response, in a cut down but very similar way to how `make_middleware_decorator` currently works.

Decorators:
- [x] `@cache_page` (uses `decorator_from_middleware_with_args`)
- [x] `@cache_control`
- [x] `@never_cache`
- [x] `@xframe_options_deny`
- [x] `@xframe_options_sameorigin`
- [x] `@xframe_options_exempt`
- [x] `no_append_slash`
- [x] `@csrf_protect` (uses `decorator_from_middleware`)
- [x] `@requires_csrf_token` (uses `decorator_from_middleware`)
- [x] `@ensure_csrf_cookie` (uses `decorator_from_middleware`)
- [x] `@csrf_exempt`
- [x] `@sensitive_variables`
- [x] `@sensitive_post_parameters`
- [x] `@gzip_page` (uses `decorator_from_middleware`)
- [x] `conditional_page` (uses `decorator_from_middleware`)
- [x] `@require_http_methods`
- [x] `@require_GET`
- [x] `@require_POST`
- [x] `@require_safe`
- [x] `@condition`
- [x] `@etag`
- [x] `@last_modified`
- [x] `@vary_on_headers`
- [x] `@vary_on_cookie`
- [x] `@user_passes_test`
- [x] `@login_required`
- [x] `@permission_required`