### PR TITLE
Fixed #31926 -- Fixed recreating queryset with FilteredRelation when using a pickled Query.

### DIFF
--- a/django/db/models/fields/reverse_related.py
+++ b/django/db/models/fields/reverse_related.py
@@ -11,6 +11,7 @@ they're the closest concept currently available.
 
 from django.core import exceptions
 from django.utils.functional import cached_property
+from django.utils.hashable import make_hashable
 
 from . import BLANK_CHOICE_DASH
 from .mixins import FieldCacheMixin
@@ -115,6 +116,28 @@ class ForeignObjectRel(FieldCacheMixin):
             self.related_model._meta.model_name,
         )
 
+    @property
+    def identity(self):
+        return (
+            self.field,
+            self.model,
+            self.related_name,
+            self.related_query_name,
+            tuple(sorted(make_hashable(self.limit_choices_to))),
+            self.parent_link,
+            self.on_delete,
+            self.symmetrical,
+            self.multiple,
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.identity == other.identity
+
+    def __hash__(self):
+        return hash(self.identity)
+
     def get_choices(
         self, include_blank=True, blank_choice=BLANK_CHOICE_DASH,
         limit_choices_to=None, ordering=(),
@@ -215,6 +238,10 @@ class ManyToOneRel(ForeignObjectRel):
         state.pop('related_model', None)
         return state
 
+    @property
+    def identity(self):
+        return super().identity + (self.field_name,)
+
     def get_related_field(self):
         """
         Return the Field in the 'to' object to which this relationship is tied.
@@ -278,6 +305,14 @@ class ManyToManyRel(ForeignObjectRel):
 
         self.symmetrical = symmetrical
         self.db_constraint = db_constraint
+
+    @property
+    def identity(self):
+        return super().identity + (
+            self.through,
+            self.through_fields,
+            self.db_constraint,
+        )
 
     def get_related_field(self):
         """


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/31926

Hi !

Details about the PR:

The test method comes from a suggested patch https://code.djangoproject.com/attachment/ticket/31926/test-31926.diff that reproduces the issue.

When tracking down the issue, it comes down to the alias of the table in the join that will be needed for the filtered relation condition.
Without pickling: `db.models.sql.query.Query.join` =>
would find the necessary join in the `self.alias_map` => and use the `reuse_alias` => `big_events`
With pickling:
we don't find the join in `self.alias_map`, even though the content seems to be the same, and the parameters are also the same.
https://github.com/django/django/blob/master/django/db/models/sql/query.py#L960-L963

The difference is when doing the `equals` call between both `Join` objects
=> `db.models.sql.datastructures.Join.equals` https://github.com/django/django/blob/master/django/db/models/sql/datastructures.py#L122

The condition that changed is `self.join_field == other.join_field` which was True without pickling, and False with pickling.
And in both cases, the join_field on both sides is a `ManyToOneRel`, with the same attributes.
The difference?
Without pickling => they are the **same object**, meaning their `id()` calls gave the same result
With pickling => not the same objects, different `id()` values

Since they have the same attributes, they should match. And I guessed that they weren't the same object in memory because of the pickling, which re-allocated the object.

So I implemented `__eq__` methods for the different ForeignObjectRel objects in order to cover them all.
So the join now matches, and the generated SQL is correct, with the right table alias

The `__hash__` methods have been added so that be can still use the `field in field_dict`.
The error that occurs if not specified:
```
  File "mypath/django/django/db/models/base.py", line 1274, in check
   *cls._check_field_name_clashes(),
  File "mypath/django/django/db/models/base.py", line 1434, in _check_field_name_clashes
    if f not in used_fields:
```

I hope the explanations are clear and there is not nasty side-effect of having those defined :)