### PR TITLE
Fixed #25253 -- Made AlterField operation a noop when changing attributes that don't affect the schema.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1063,9 +1063,25 @@ class BaseDatabaseSchemaEditor:
         _, new_path, new_args, new_kwargs = new_field.deconstruct()
         # Don't alter when:
         # - changing only a field name
+        # - changing an attribute that doesn't affect the schema
         # - adding only a db_column and the column name is not changed
-        old_kwargs.pop('db_column', None)
-        new_kwargs.pop('db_column', None)
+        non_database_attrs = [
+            'blank',
+            'db_column',
+            'editable',
+            'error_messages',
+            'help_text',
+            'limit_choices_to',
+            # Database-level options are not supported, see #21961.
+            'on_delete',
+            'related_name',
+            'related_query_name',
+            'validators',
+            'verbose_name',
+        ]
+        for attr in non_database_attrs:
+            old_kwargs.pop(attr, None)
+            new_kwargs.pop(attr, None)
         return (
             self.quote_name(old_field.column) != self.quote_name(new_field.column) or
             (old_path, old_args, old_kwargs) != (new_path, new_args, new_kwargs)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -2758,6 +2758,35 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor, self.assertNumQueries(0):
             editor.alter_field(AuthorWithDefaultHeight, old_field, new_field, strict=True)
 
+    @skipUnlessDBFeature('supports_foreign_keys')
+    def test_alter_field_fk_attributes_noop(self):
+        """
+        No queries are performed when changing field attributes that don't
+        affect the schema.
+        """
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+            editor.create_model(Book)
+        old_field = Book._meta.get_field('author')
+        new_field = ForeignKey(
+            Author,
+            blank=True,
+            editable=False,
+            error_messages={'invalid': 'error message'},
+            help_text='help text',
+            limit_choices_to={'limit': 'choice'},
+            on_delete=PROTECT,
+            related_name='related_name',
+            related_query_name='related_query_name',
+            validators=[lambda x: x],
+            verbose_name='verbose name',
+        )
+        new_field.set_attributes_from_name('author')
+        with connection.schema_editor() as editor, self.assertNumQueries(0):
+            editor.alter_field(Book, old_field, new_field, strict=True)
+        with connection.schema_editor() as editor, self.assertNumQueries(0):
+            editor.alter_field(Book, new_field, old_field, strict=True)
+
     def test_add_textfield_unhashable_default(self):
         # Create the table
         with connection.schema_editor() as editor:


### PR DESCRIPTION
Fixed unnecessary dropping/adding of FK constraints when changing field attributes that don't affect the schema.

Field attributes that don't have an affect on the schema:

blank
on_delete
related_name
verbose_name
editable
help_text
error_messages

This PR edits `_field_should_be_altered` method of `BaseDatabaseSchemaEditor` which is responsible for emitting schema-changing statements to the databases. Above list of field attributes don't have an effect on the schema, so changing these attributes should not trigger a db operation.