### PR TITLE
Fixed #32072 -- Fixed admin search bar height.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -89,7 +89,7 @@
     color: #333;
 }
 
-#searchbar {
+#toolbar #searchbar {
     height: 19px;
     border: 1px solid #ccc;
     padding: 2px 5px;
@@ -99,7 +99,7 @@
     max-width: 100%;
 }
 
-#searchbar:focus {
+#toolbar #searchbar:focus {
     border-color: #999;
 }
 

--- a/docs/releases/3.1.3.txt
+++ b/docs/releases/3.1.3.txt
@@ -9,4 +9,5 @@ Django 3.1.3 fixes several bugs in 3.1.2.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 3.1.2 that caused the incorrect height of the
+  admin changelist search bar (:ticket:`32072`).


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32072

I'm not sure the `padding: 5px` rule this is overriding is actually used anywhere, but I'm a bit scared of breaking more stuff so just bumped the specificity back up.