### PR TITLE
Improve error message for missing locale directory

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -579,7 +579,7 @@ class Command(BaseCommand):
                 file_path = os.path.normpath(build_files[0].path)
                 raise CommandError(
                     'Unable to find a locale path to store translations for '
-                    'file %s' % file_path
+                    'file %s\n\nWe are looking for a directory called "locale".' % file_path
                 )
             for build_file in build_files:
                 msgs = build_file.postprocess_messages(msgs)


### PR DESCRIPTION
I had to google the error message today and got to this: https://stackoverflow.com/questions/24937133/unable-to-find-a-locale-path-to-store-translations-for-file-init-py It would be better if the error message was simple and obvious so you could solve the problem yourself directly instead.