### PR TITLE
Increased test coverage of django.utils.datastructures to 100%.

### DIFF
--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -194,16 +194,15 @@ class MultiValueDict(dict):
         if len(args) > 1:
             raise TypeError("update expected at most 1 argument, got %d" % len(args))
         if args:
-            other_dict = args[0]
-            if isinstance(other_dict, MultiValueDict):
-                for key, value_list in other_dict.lists():
+            arg = args[0]
+            if isinstance(arg, MultiValueDict):
+                for key, value_list in arg.lists():
                     self.setlistdefault(key).extend(value_list)
             else:
-                try:
-                    for key, value in other_dict.items():
-                        self.setlistdefault(key).append(value)
-                except TypeError:
-                    raise ValueError("MultiValueDict.update() takes either a MultiValueDict or dictionary")
+                if isinstance(arg, Mapping):
+                    arg = arg.items()
+                for key, value in arg:
+                    self.setlistdefault(key).append(value)
         for key, value in kwargs.items():
             self.setlistdefault(key).append(value)
 

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -230,11 +230,8 @@ class ImmutableList(tuple):
         self.warning = warning
         return self
 
-    def complain(self, *wargs, **kwargs):
-        if isinstance(self.warning, Exception):
-            raise self.warning
-        else:
-            raise AttributeError(self.warning)
+    def complain(self, *args, **kwargs):
+        raise AttributeError(self.warning)
 
     # All list mutation functions complain.
     __delitem__ = complain

--- a/tests/utils_tests/test_datastructures.py
+++ b/tests/utils_tests/test_datastructures.py
@@ -195,6 +195,35 @@ class MultiValueDictTests(SimpleTestCase):
         x.update(a=4, b=5)
         self.assertEqual(list(x.lists()), [('a', [1, 4]), ('b', [2, 5]), ('c', [3])])
 
+    def test_update_with_empty_iterable(self):
+        for value in ['', b'', (), [], set(), {}]:
+            d = MultiValueDict()
+            d.update(value)
+            self.assertEqual(d, MultiValueDict())
+
+    def test_update_with_iterable_of_pairs(self):
+        for value in [(('a', 1),), [('a', 1)], {('a', 1)}]:
+            d = MultiValueDict()
+            d.update(value)
+            self.assertEqual(d, MultiValueDict({'a': [1]}))
+
+    def test_update_raises_correct_exceptions(self):
+        # MultiValueDict.update() raises equivalent exceptions to
+        # dict.update().
+        # Non-iterable values raise TypeError.
+        for value in [None, True, False, 123, 123.45]:
+            with self.subTest(value), self.assertRaises(TypeError):
+                MultiValueDict().update(value)
+        # Iterables of objects that cannot be unpacked raise TypeError.
+        for value in [b'123', b'abc', (1, 2, 3), [1, 2, 3], {1, 2, 3}]:
+            with self.subTest(value), self.assertRaises(TypeError):
+                MultiValueDict().update(value)
+        # Iterables of unpackable objects with incorrect number of items raise
+        # ValueError.
+        for value in ['123', 'abc', ('a', 'b', 'c'), ['a', 'b', 'c'], {'a', 'b', 'c'}]:
+            with self.subTest(value), self.assertRaises(ValueError):
+                MultiValueDict().update(value)
+
 
 class ImmutableListTests(SimpleTestCase):
 

--- a/tests/utils_tests/test_datastructures.py
+++ b/tests/utils_tests/test_datastructures.py
@@ -13,6 +13,32 @@ from django.utils.datastructures import (
 
 class OrderedSetTests(SimpleTestCase):
 
+    def test_init_with_iterable(self):
+        s = OrderedSet([1, 2, 3])
+        self.assertEqual(list(s.dict.keys()), [1, 2, 3])
+
+    def test_remove(self):
+        s = OrderedSet()
+        self.assertEqual(len(s), 0)
+        s.add(1)
+        s.add(2)
+        s.remove(2)
+        self.assertEqual(len(s), 1)
+        self.assertNotIn(2, s)
+
+    def test_discard(self):
+        s = OrderedSet()
+        self.assertEqual(len(s), 0)
+        s.add(1)
+        s.discard(2)
+        self.assertEqual(len(s), 1)
+
+    def test_contains(self):
+        s = OrderedSet()
+        self.assertEqual(len(s), 0)
+        s.add(1)
+        self.assertIn(1, s)
+
     def test_bool(self):
         # Refs #23664
         s = OrderedSet()


### PR DESCRIPTION
Supersedes #12442. I split out the tests for `MultiValueDict` and `OrderedSet` into two commits and added additional missing test coverage to these. Also in relation to `MultiValueDict.update()`, in that PR, Mads said:

> I don't know how to trigger `TypeError`, and my attempts only triggered an `AttributeError`.

I came to the conclusion that it wasn't possible to trigger `TypeError` as the call to `.items()` was always going to trigger `AttributeError` for every other common type. Further, I noted that the behaviour of `MultiValueDict.update()` was inconsistent with and more strict than `dict.update()`. To my understanding, the main reason for overriding the `.update()` method is to a) ensure that the values are always lists, and b) special case to handle provision of another `MultiValueDict` instance.

So I added a commit that makes the behaviour as consistent with `dict.update()` as possible. A few exceptions are slightly differently worded due to the way `dict.update()` is implemented in C versus this Python implementation for `MultiValueDict.update()`, but they are comparable..

I've also attached a quick script I used to compare output of `dict.update()` and `MultiValueDict.update()` as we'll as before and after output:

<details>
<summary>Script to compare behaviour.</summary>

```python
import sys
import traceback
from django.utils.datastructures import MultiValueDict

def test(values):
    for value in values:
        print(f'>>> dict().update({value!r})')
        try:
            result = dict().update(value)
        except Exception:
            traceback.print_exception(*sys.exc_info()[:-1], None)
        else:
            print(result)
    for value in values:
        print(f'>>> MultiValueDict().update({value!r})')
        try:
            result = MultiValueDict().update(value)
        except Exception:
            traceback.print_exception(*sys.exc_info()[:-1], None)
        else:
            print(result)

non_iterables = [None, True, False, 123, 123.45]
empty_iterables = ['', b'', (), [], set(), {}]
paired_iterables = [(('a', 1),), [('a', 1)], {('a', 1)}]
non_empty_iterables = ['123', b'123', (1, 2, 3), [1, 2, 3], {1, 2, 3}, {'a': 1}]

test(non_iterables)
test(empty_iterables)
test(paired_iterables)
test(non_empty_iterables)
```

</details>
<details>
<summary>Comparison before change in behavior.</summary>

```python
>>> dict().update(None)
TypeError: 'NoneType' object is not iterable
>>> dict().update(True)
TypeError: 'bool' object is not iterable
>>> dict().update(False)
TypeError: 'bool' object is not iterable
>>> dict().update(123)
TypeError: 'int' object is not iterable
>>> dict().update(123.45)
TypeError: 'float' object is not iterable
>>> MultiValueDict().update(None)
AttributeError: 'NoneType' object has no attribute 'items'
>>> MultiValueDict().update(True)
AttributeError: 'bool' object has no attribute 'items'
>>> MultiValueDict().update(False)
AttributeError: 'bool' object has no attribute 'items'
>>> MultiValueDict().update(123)
AttributeError: 'int' object has no attribute 'items'
>>> MultiValueDict().update(123.45)
AttributeError: 'float' object has no attribute 'items'
>>> dict().update('')
None
>>> dict().update(b'')
None
>>> dict().update(())
None
>>> dict().update([])
None
>>> dict().update(set())
None
>>> dict().update({})
None
>>> MultiValueDict().update('')
AttributeError: 'str' object has no attribute 'items'
>>> MultiValueDict().update(b'')
AttributeError: 'bytes' object has no attribute 'items'
>>> MultiValueDict().update(())
AttributeError: 'tuple' object has no attribute 'items'
>>> MultiValueDict().update([])
AttributeError: 'list' object has no attribute 'items'
>>> MultiValueDict().update(set())
AttributeError: 'set' object has no attribute 'items'
>>> MultiValueDict().update({})
None
>>> dict().update((('a', 1),))
None
>>> dict().update([('a', 1)])
None
>>> dict().update({('a', 1)})
None
>>> MultiValueDict().update((('a', 1),))
AttributeError: 'tuple' object has no attribute 'items'
>>> MultiValueDict().update([('a', 1)])
AttributeError: 'list' object has no attribute 'items'
>>> MultiValueDict().update({('a', 1)})
AttributeError: 'set' object has no attribute 'items'
>>> dict().update('123')
ValueError: dictionary update sequence element #0 has length 1; 2 is required
>>> dict().update(b'123')
TypeError: cannot convert dictionary update sequence element #0 to a sequence
>>> dict().update((1, 2, 3))
TypeError: cannot convert dictionary update sequence element #0 to a sequence
>>> dict().update([1, 2, 3])
TypeError: cannot convert dictionary update sequence element #0 to a sequence
>>> dict().update({1, 2, 3})
TypeError: cannot convert dictionary update sequence element #0 to a sequence
>>> dict().update({'a': 1})
None
>>> MultiValueDict().update('123')
AttributeError: 'str' object has no attribute 'items'
>>> MultiValueDict().update(b'123')
AttributeError: 'bytes' object has no attribute 'items'
>>> MultiValueDict().update((1, 2, 3))
AttributeError: 'tuple' object has no attribute 'items'
>>> MultiValueDict().update([1, 2, 3])
AttributeError: 'list' object has no attribute 'items'
>>> MultiValueDict().update({1, 2, 3})
AttributeError: 'set' object has no attribute 'items'
>>> MultiValueDict().update({'a': 1})
None
```

</details>
<details>
<summary>Comparison after change in behavior.</summary>

```python
>>> dict().update(None)
TypeError: 'NoneType' object is not iterable
>>> dict().update(True)
TypeError: 'bool' object is not iterable
>>> dict().update(False)
TypeError: 'bool' object is not iterable
>>> dict().update(123)
TypeError: 'int' object is not iterable
>>> dict().update(123.45)
TypeError: 'float' object is not iterable
>>> MultiValueDict().update(None)
TypeError: 'NoneType' object is not iterable
>>> MultiValueDict().update(True)
TypeError: 'bool' object is not iterable
>>> MultiValueDict().update(False)
TypeError: 'bool' object is not iterable
>>> MultiValueDict().update(123)
TypeError: 'int' object is not iterable
>>> MultiValueDict().update(123.45)
TypeError: 'float' object is not iterable
>>> dict().update('')
None
>>> dict().update(b'')
None
>>> dict().update(())
None
>>> dict().update([])
None
>>> dict().update(set())
None
>>> dict().update({})
None
>>> MultiValueDict().update('')
None
>>> MultiValueDict().update(b'')
None
>>> MultiValueDict().update(())
None
>>> MultiValueDict().update([])
None
>>> MultiValueDict().update(set())
None
>>> MultiValueDict().update({})
None
>>> dict().update((('a', 1),))
None
>>> dict().update([('a', 1)])
None
>>> dict().update({('a', 1)})
None
>>> MultiValueDict().update((('a', 1),))
None
>>> MultiValueDict().update([('a', 1)])
None
>>> MultiValueDict().update({('a', 1)})
None
>>> dict().update('123')
ValueError: dictionary update sequence element #0 has length 1; 2 is required
>>> dict().update(b'123')
TypeError: cannot convert dictionary update sequence element #0 to a sequence
>>> dict().update((1, 2, 3))
TypeError: cannot convert dictionary update sequence element #0 to a sequence
>>> dict().update([1, 2, 3])
TypeError: cannot convert dictionary update sequence element #0 to a sequence
>>> dict().update({1, 2, 3})
TypeError: cannot convert dictionary update sequence element #0 to a sequence
>>> dict().update({'a': 1})
None
>>> MultiValueDict().update('123')
ValueError: not enough values to unpack (expected 2, got 1)
>>> MultiValueDict().update(b'123')
TypeError: cannot unpack non-iterable int object
>>> MultiValueDict().update((1, 2, 3))
TypeError: cannot unpack non-iterable int object
>>> MultiValueDict().update([1, 2, 3])
TypeError: cannot unpack non-iterable int object
>>> MultiValueDict().update({1, 2, 3})
TypeError: cannot unpack non-iterable int object
>>> MultiValueDict().update({'a': 1})
None
```

</details>

Finally, there is an extra commit that removes support for providing an instance of `Exception` to the `warning` argument for `ImmutableList`. This is untested, undocumented and unused in Django itself. It didn't seem worth adding a test and preserving this behavior.