### PR TITLE
Fixed #31640 -- Made Trunc() truncate datetimes to Date/TimeField in a specific timezone.

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -99,11 +99,14 @@ class BaseDatabaseOperations:
         """
         raise NotImplementedError('subclasses of BaseDatabaseOperations may require a date_extract_sql() method')
 
-    def date_trunc_sql(self, lookup_type, field_name):
+    def date_trunc_sql(self, lookup_type, field_name, tzname=None):
         """
         Given a lookup_type of 'year', 'month', or 'day', return the SQL that
-        truncates the given date field field_name to a date object with only
-        the given specificity.
+        truncates the given date or datetime field field_name to a date object
+        with only the given specificity.
+
+        If `tzname` is provided, the given value is truncated in a specific
+        timezone.
         """
         raise NotImplementedError('subclasses of BaseDatabaseOperations may require a date_trunc_sql() method.')
 
@@ -138,11 +141,14 @@ class BaseDatabaseOperations:
         """
         raise NotImplementedError('subclasses of BaseDatabaseOperations may require a datetime_trunc_sql() method')
 
-    def time_trunc_sql(self, lookup_type, field_name):
+    def time_trunc_sql(self, lookup_type, field_name, tzname=None):
         """
         Given a lookup_type of 'hour', 'minute' or 'second', return the SQL
-        that truncates the given time field field_name to a time object with
-        only the given specificity.
+        that truncates the given time or datetime field field_name to a time
+        object with only the given specificity.
+
+        If `tzname` is provided, the given value is truncated in a specific
+        timezone.
         """
         raise NotImplementedError('subclasses of BaseDatabaseOperations may require a time_trunc_sql() method')
 

--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -55,7 +55,8 @@ class DatabaseOperations(BaseDatabaseOperations):
             # EXTRACT returns 1-53 based on ISO-8601 for the week number.
             return "EXTRACT(%s FROM %s)" % (lookup_type.upper(), field_name)
 
-    def date_trunc_sql(self, lookup_type, field_name):
+    def date_trunc_sql(self, lookup_type, field_name, tzname=None):
+        field_name = self._convert_field_to_tz(field_name, tzname)
         fields = {
             'year': '%%Y-01-01',
             'month': '%%Y-%%m-01',
@@ -82,7 +83,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         return tzname
 
     def _convert_field_to_tz(self, field_name, tzname):
-        if settings.USE_TZ and self.connection.timezone_name != tzname:
+        if tzname and settings.USE_TZ and self.connection.timezone_name != tzname:
             field_name = "CONVERT_TZ(%s, '%s', '%s')" % (
                 field_name,
                 self.connection.timezone_name,
@@ -128,7 +129,8 @@ class DatabaseOperations(BaseDatabaseOperations):
             sql = "CAST(DATE_FORMAT(%s, '%s') AS DATETIME)" % (field_name, format_str)
         return sql
 
-    def time_trunc_sql(self, lookup_type, field_name):
+    def time_trunc_sql(self, lookup_type, field_name, tzname=None):
+        field_name = self._convert_field_to_tz(field_name, tzname)
         fields = {
             'hour': '%%H:00:00',
             'minute': '%%H:%%i:00',

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -38,7 +38,8 @@ class DatabaseOperations(BaseDatabaseOperations):
         else:
             return "EXTRACT('%s' FROM %s)" % (lookup_type, field_name)
 
-    def date_trunc_sql(self, lookup_type, field_name):
+    def date_trunc_sql(self, lookup_type, field_name, tzname=None):
+        field_name = self._convert_field_to_tz(field_name, tzname)
         # https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
         return "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
 
@@ -50,7 +51,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         return tzname
 
     def _convert_field_to_tz(self, field_name, tzname):
-        if settings.USE_TZ:
+        if tzname and settings.USE_TZ:
             field_name = "%s AT TIME ZONE '%s'" % (field_name, self._prepare_tzname_delta(tzname))
         return field_name
 
@@ -71,7 +72,8 @@ class DatabaseOperations(BaseDatabaseOperations):
         # https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
         return "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
 
-    def time_trunc_sql(self, lookup_type, field_name):
+    def time_trunc_sql(self, lookup_type, field_name, tzname=None):
+        field_name = self._convert_field_to_tz(field_name, tzname)
         return "DATE_TRUNC('%s', %s)::time" % (lookup_type, field_name)
 
     def deferrable_sql(self):

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -77,14 +77,22 @@ class DatabaseOperations(BaseDatabaseOperations):
         """Do nothing since formatting is handled in the custom function."""
         return sql
 
-    def date_trunc_sql(self, lookup_type, field_name):
-        return "django_date_trunc('%s', %s)" % (lookup_type.lower(), field_name)
+    def date_trunc_sql(self, lookup_type, field_name, tzname=None):
+        return "django_date_trunc('%s', %s, %s, %s)" % (
+            lookup_type.lower(),
+            field_name,
+            *self._convert_tznames_to_sql(tzname),
+        )
 
-    def time_trunc_sql(self, lookup_type, field_name):
-        return "django_time_trunc('%s', %s)" % (lookup_type.lower(), field_name)
+    def time_trunc_sql(self, lookup_type, field_name, tzname=None):
+        return "django_time_trunc('%s', %s, %s, %s)" % (
+            lookup_type.lower(),
+            field_name,
+            *self._convert_tznames_to_sql(tzname),
+        )
 
     def _convert_tznames_to_sql(self, tzname):
-        if settings.USE_TZ:
+        if tzname and settings.USE_TZ:
             return "'%s'" % tzname, "'%s'" % self.connection.timezone_name
         return 'NULL', 'NULL'
 

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -193,13 +193,17 @@ class TruncBase(TimezoneMixin, Transform):
 
     def as_sql(self, compiler, connection):
         inner_sql, inner_params = compiler.compile(self.lhs)
-        if isinstance(self.output_field, DateTimeField):
+        tzname = None
+        if isinstance(self.lhs.output_field, DateTimeField):
             tzname = self.get_tzname()
+        elif self.tzinfo is not None:
+            raise ValueError('tzinfo can only be used with DateTimeField.')
+        if isinstance(self.output_field, DateTimeField):
             sql = connection.ops.datetime_trunc_sql(self.kind, inner_sql, tzname)
         elif isinstance(self.output_field, DateField):
-            sql = connection.ops.date_trunc_sql(self.kind, inner_sql)
+            sql = connection.ops.date_trunc_sql(self.kind, inner_sql, tzname)
         elif isinstance(self.output_field, TimeField):
-            sql = connection.ops.time_trunc_sql(self.kind, inner_sql)
+            sql = connection.ops.time_trunc_sql(self.kind, inner_sql, tzname)
         else:
             raise ValueError('Trunc only valid on DateField, TimeField, or DateTimeField.')
         return sql, inner_params

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -46,6 +46,8 @@ class Extract(TimezoneMixin, Transform):
         if isinstance(lhs_output_field, DateTimeField):
             tzname = self.get_tzname()
             sql = connection.ops.datetime_extract_sql(self.lookup_name, sql, tzname)
+        elif self.tzinfo is not None:
+            raise ValueError('tzinfo can only be used with DateTimeField.')
         elif isinstance(lhs_output_field, DateField):
             sql = connection.ops.date_extract_sql(self.lookup_name, sql)
         elif isinstance(lhs_output_field, TimeField):

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -458,6 +458,10 @@ backends.
 * ``DatabaseOperations.random_function_sql()`` is removed in favor of the new
   :class:`~django.db.models.functions.Random` database function.
 
+* ``DatabaseOperations.date_trunc_sql()`` and
+  ``DatabaseOperations.time_trunc_sql()`` now take the optional ``tzname``
+  argument in order to truncate in a specific timezone.
+
 :mod:`django.contrib.admin`
 ---------------------------
 

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -1111,6 +1111,18 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
             self.assertEqual(model.day_melb, 16)
             self.assertEqual(model.day_utc, 15)
 
+    def test_extract_invalid_field_with_timezone(self):
+        melb = pytz.timezone('Australia/Melbourne')
+        msg = 'tzinfo can only be used with DateTimeField.'
+        with self.assertRaisesMessage(ValueError, msg):
+            DTModel.objects.annotate(
+                day_melb=Extract('start_date', 'day', tzinfo=melb),
+            ).get()
+        with self.assertRaisesMessage(ValueError, msg):
+            DTModel.objects.annotate(
+                hour_melb=Extract('start_time', 'hour', tzinfo=melb),
+            ).get()
+
     def test_trunc_timezone_applied_before_truncation(self):
         start_datetime = datetime(2016, 1, 1, 1, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -1205,38 +1205,6 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
                 lambda m: (m.start_datetime, m.truncated)
             )
 
-        def test_date_kind(kind):
-            self.assertQuerysetEqual(
-                DTModel.objects.annotate(
-                    truncated=Trunc('start_date', kind, output_field=DateField(), tzinfo=melb)
-                ).order_by('start_datetime'),
-                [
-                    (start_datetime, truncate_to(start_datetime.date(), kind)),
-                    (end_datetime, truncate_to(end_datetime.date(), kind))
-                ],
-                lambda m: (m.start_datetime, m.truncated)
-            )
-
-        def test_time_kind(kind):
-            self.assertQuerysetEqual(
-                DTModel.objects.annotate(
-                    truncated=Trunc('start_time', kind, output_field=TimeField(), tzinfo=melb)
-                ).order_by('start_datetime'),
-                [
-                    (start_datetime, truncate_to(start_datetime.time(), kind)),
-                    (end_datetime, truncate_to(end_datetime.time(), kind))
-                ],
-                lambda m: (m.start_datetime, m.truncated)
-            )
-
-        test_date_kind('year')
-        test_date_kind('quarter')
-        test_date_kind('month')
-        test_date_kind('week')
-        test_date_kind('day')
-        test_time_kind('hour')
-        test_time_kind('minute')
-        test_time_kind('second')
         test_datetime_kind('year')
         test_datetime_kind('quarter')
         test_datetime_kind('month')


### PR DESCRIPTION
The ticket: https://code.djangoproject.com/ticket/31640

A commit-by-commit review is probably the most appropriate. The commits:
1. handle doing a Trunc on a DateTimefield to a DateField, with specifying a timezone
2. same, but for DateTimeField to TimeField
3. raise on Trunc when specifying a timezone but the input field is not a DateTimeField
4. same raise, but on Extract

The first two commits are implemented for all supported databases.
The last two commits come from the suggestion in the ticket: https://code.djangoproject.com/ticket/31640#comment:2
> I think we should go as far as raising an exception when Extract(tzinfo) and Trunc(tzinfo) is specified for a left hand side that doesn't have a isinstance(lhs.output_field, DateTimeField).

Since this might break existing usages of these functions, it should probably be specified in the release note (I'm unsure if I should directly add an entry in `docs/releases/3.1.3.txt`)
Also unsure if the error messages are "Django-y" enough :)