### PR TITLE
Fixed #32073 -- Skipped collation tests on PostgreSQL < 10.

### DIFF
--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -58,10 +58,16 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_deferrable_unique_constraints = True
     has_json_operators = True
     json_key_contains_list_matching_requires_list = True
-    test_collations = {
-        'non_default': 'sv-x-icu',
-        'swedish_ci': 'sv-x-icu',
-    }
+
+    @cached_property
+    def test_collations(self):
+        # PostgreSQL < 10 doesn't support ICU collations.
+        if self.is_postgresql_10:
+            return {
+                'non_default': 'sv-x-icu',
+                'swedish_ci': 'sv-x-icu',
+            }
+        return {}
 
     @cached_property
     def introspected_field_types(self):

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -105,6 +105,7 @@ class InspectDBTestCase(TestCase):
         self.assertIn('null_json_field = models.JSONField(blank=True, null=True)', output)
 
     @skipUnlessDBFeature('supports_collation_on_charfield')
+    @skipUnless(test_collation, 'Language collations are not supported.')
     def test_char_field_db_collation(self):
         out = StringIO()
         call_command('inspectdb', 'inspectdb_charfielddbcollation', stdout=out)
@@ -123,6 +124,7 @@ class InspectDBTestCase(TestCase):
             )
 
     @skipUnlessDBFeature('supports_collation_on_textfield')
+    @skipUnless(test_collation, 'Language collations are not supported.')
     def test_text_field_db_collation(self):
         out = StringIO()
         call_command('inspectdb', 'inspectdb_textfielddbcollation', stdout=out)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -3236,7 +3236,9 @@ class SchemaTests(TransactionTestCase):
     @isolate_apps('schema')
     @skipUnlessDBFeature('supports_collation_on_charfield')
     def test_db_collation_charfield(self):
-        collation = connection.features.test_collations['non_default']
+        collation = connection.features.test_collations.get('non_default')
+        if not collation:
+            self.skipTest('Language collations are not supported.')
 
         class Foo(Model):
             field = CharField(max_length=255, db_collation=collation)
@@ -3256,7 +3258,9 @@ class SchemaTests(TransactionTestCase):
     @isolate_apps('schema')
     @skipUnlessDBFeature('supports_collation_on_textfield')
     def test_db_collation_textfield(self):
-        collation = connection.features.test_collations['non_default']
+        collation = connection.features.test_collations.get('non_default')
+        if not collation:
+            self.skipTest('Language collations are not supported.')
 
         class Foo(Model):
             field = TextField(db_collation=collation)
@@ -3275,10 +3279,13 @@ class SchemaTests(TransactionTestCase):
 
     @skipUnlessDBFeature('supports_collation_on_charfield')
     def test_add_field_db_collation(self):
+        collation = connection.features.test_collations.get('non_default')
+        if not collation:
+            self.skipTest('Language collations are not supported.')
+
         with connection.schema_editor() as editor:
             editor.create_model(Author)
 
-        collation = connection.features.test_collations['non_default']
         new_field = CharField(max_length=255, db_collation=collation)
         new_field.set_attributes_from_name('alias')
         with connection.schema_editor() as editor:
@@ -3292,10 +3299,13 @@ class SchemaTests(TransactionTestCase):
 
     @skipUnlessDBFeature('supports_collation_on_charfield')
     def test_alter_field_db_collation(self):
+        collation = connection.features.test_collations.get('non_default')
+        if not collation:
+            self.skipTest('Language collations are not supported.')
+
         with connection.schema_editor() as editor:
             editor.create_model(Author)
 
-        collation = connection.features.test_collations['non_default']
         old_field = Author._meta.get_field('name')
         new_field = CharField(max_length=255, db_collation=collation)
         new_field.set_attributes_from_name('name')
@@ -3312,10 +3322,13 @@ class SchemaTests(TransactionTestCase):
 
     @skipUnlessDBFeature('supports_collation_on_charfield')
     def test_alter_field_type_and_db_collation(self):
+        collation = connection.features.test_collations.get('non_default')
+        if not collation:
+            self.skipTest('Language collations are not supported.')
+
         with connection.schema_editor() as editor:
             editor.create_model(Note)
 
-        collation = connection.features.test_collations['non_default']
         old_field = Note._meta.get_field('info')
         new_field = CharField(max_length=255, db_collation=collation)
         new_field.set_attributes_from_name('info')


### PR DESCRIPTION
ticket-32073

PostgreSQL < 10 doesn't support ICU collations.