### PR TITLE
Skipped GetImageDimensionsTests.test_webp when WEBP not installed.

### DIFF
--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -19,9 +19,11 @@ from django.core.files.uploadedfile import (
 from django.test import override_settings
 
 try:
-    from PIL import Image
+    from PIL import Image, features
+    HAS_WEBP = features.check('webp')
 except ImportError:
     Image = None
+    HAS_WEBP = False
 else:
     from django.core.files import images
 
@@ -367,6 +369,7 @@ class GetImageDimensionsTests(unittest.TestCase):
                 size = images.get_image_dimensions(fh)
                 self.assertEqual(size, (None, None))
 
+    @unittest.skipUnless(HAS_WEBP, 'WEBP not installed')
     def test_webp(self):
         img_path = os.path.join(os.path.dirname(__file__), 'test.webp')
         with open(img_path, 'rb') as fh:


### PR DESCRIPTION
Requires Pillow 4.2.0+