### PR TITLE
Refs #20577 -- Deferred filtering of prefetched related querysets by reverse m2o relation.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -581,6 +581,7 @@ def create_reverse_many_to_one_manager(superclass, rel):
             queryset._add_hints(instance=self.instance)
             if self._db:
                 queryset = queryset.using(self._db)
+            queryset._defer_next_filter = True
             queryset = queryset.filter(**self.core_filters)
             for field in self.field.foreign_related_fields:
                 val = getattr(self.instance, field.attname)

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -294,17 +294,20 @@ class PrefetchRelatedTests(TestDataMixin, TestCase):
 
     def test_filter_deferred(self):
         """
-        Related filtering of prefetched querysets is deferred until necessary.
+        Related filtering of prefetched querysets is deferred on m2m and
+        reverse m2o relations until necessary.
         """
         add_q = Query.add_q
-        with mock.patch.object(
-            Query,
-            'add_q',
-            autospec=True,
-            side_effect=lambda self, q: add_q(self, q),
-        ) as add_q_mock:
-            list(Book.objects.prefetch_related('authors'))
-            self.assertEqual(add_q_mock.call_count, 1)
+        for relation in ['authors', 'first_time_authors']:
+            with self.subTest(relation=relation):
+                with mock.patch.object(
+                    Query,
+                    'add_q',
+                    autospec=True,
+                    side_effect=lambda self, q: add_q(self, q),
+                ) as add_q_mock:
+                    list(Book.objects.prefetch_related(relation))
+                    self.assertEqual(add_q_mock.call_count, 1)
 
 
 class RawQuerySetTests(TestDataMixin, TestCase):


### PR DESCRIPTION
https://github.com/django/django/pull/11916, released in v3.1, introduced the idea of deferring filtering of a QS when prefetching related many to many relations, but the many to one case was left out. This adds the same idea to the many to one case.

I've never really stepped into the django codebase before so please let me know if there's anything else that needs doing. Tests, tickets etc.

Thanks!

