### PR TITLE
Fixed #31496 -- Fixed QuerySet.values()/values_list() crash on combined querysets ordered by annotations.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1881,9 +1881,9 @@ class Query(BaseExpression):
         self.select = ()
         self.values_select = ()
 
-    def add_select_col(self, col):
+    def add_select_col(self, col, name):
         self.select += col,
-        self.values_select += col.output_field.name,
+        self.values_select += name,
 
     def set_select(self, cols):
         self.default_cols = False

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -211,6 +211,28 @@ class QuerySetSetOperationTests(TestCase):
             with self.subTest(qs=qs):
                 self.assertEqual(list(qs), expected_result)
 
+    def test_union_with_values_list_and_order_on_annotation(self):
+        qs1 = Number.objects.annotate(
+            annotation=Value(-1),
+            multiplier=F('annotation'),
+        ).filter(num__gte=6)
+        qs2 = Number.objects.annotate(
+            annotation=Value(2),
+            multiplier=F('annotation'),
+        ).filter(num__lte=5)
+        self.assertSequenceEqual(
+            qs1.union(qs2).order_by('annotation', 'num').values_list('num', flat=True),
+            [6, 7, 8, 9, 0, 1, 2, 3, 4, 5],
+        )
+        self.assertQuerysetEqual(
+            qs1.union(qs2).order_by(
+                F('annotation') * F('multiplier'),
+                'num',
+            ).values('num'),
+            [6, 7, 8, 9, 0, 1, 2, 3, 4, 5],
+            operator.itemgetter('num'),
+        )
+
     def test_count_union(self):
         qs1 = Number.objects.filter(num__lte=1).values('num')
         qs2 = Number.objects.filter(num__gte=2, num__lte=3).values('num')


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/31496

Hi all!

I tried tackling this issue, which is rather specific admittedly.
Looking forward comments to improve the patch :)