### PR TITLE
Fixed #31850 -- Fixed BasicExtractorTests.test_extraction_warning with xgettext 0.21+.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -622,6 +622,7 @@ answer newbie questions, and generally made Django that much better:
     mattycakes@gmail.com
     Max Burstein <http://maxburstein.com>
     Max Derkachev <mderk@yandex.ru>
+    Max Smolens <msmolens@gmail.com>
     Maxime Lorant <maxime.lorant@gmail.com>
     Maxime Turcotte <maxocub@riseup.net>
     Maximilian Merz <django@mxmerz.de>

--- a/tests/i18n/commands/code.sample
+++ b/tests/i18n/commands/code.sample
@@ -1,4 +1,4 @@
 from django.utils.translation import gettext
 
-# This will generate an xgettext warning
-my_string = gettext("This string contain two placeholders: %s and %s" % ('a', 'b'))
+# This will generate an xgettext "Empty msgid" warning.
+my_string = gettext('')


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/31850

test_extraction_warning (i18n.test_extraction.BasicExtractorTests) failed with xgettext 0.21 because the "format string with unnamed arguments cannot be properly localized" warning is not displayed.

Fixed the test failure by using a message that causes an xgettext warning regardless of the version.