### PR TITLE
Fixed #29052 -- Made test database creation preserve alias order and prefer the "default" database.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -361,6 +361,7 @@ answer newbie questions, and generally made Django that much better:
     Hang Park <hangpark@kaist.ac.kr>
     Hannes Ljungberg <hannes.ljungberg@gmail.com>
     Hannes Struß <x@hannesstruss.de>
+    Harm Geerts <hgeerts@gmail.com>
     Hasan Ramezani <hasan.r67@gmail.com>
     Hawkeye
     Helen Sherwood-Taylor <helen@rrdlabs.co.uk>

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -280,9 +280,14 @@ def get_unique_databases_and_mirrors(aliases=None):
             # we only need to create the test database once.
             item = test_databases.setdefault(
                 connection.creation.test_db_signature(),
-                (connection.settings_dict['NAME'], set())
+                (connection.settings_dict['NAME'], []),
             )
-            item[1].add(alias)
+            # The default database must be the first because data migrations
+            # use the default alias by default.
+            if alias == DEFAULT_DB_ALIAS:
+                item[1].insert(0, alias)
+            else:
+                item[1].append(alias)
 
             if 'DEPENDENCIES' in test_settings:
                 dependencies[alias] = test_settings['DEPENDENCIES']


### PR DESCRIPTION
Use a list() to store the test database aliases so the order remains
mostly stable by following the order of the connections. Always use
the default database alias as the first alias to accommodate migrate.

Previously migrate could be executed on a secondary alias on a separate
connection/transaction which caused data migrations to fail because they
would write to the default database.

Introduce a new function ``initialize_test_db`` which can be executed
after all test databases have been created and all settings patched and
it is safe for migrations to access any database they want.