### PR TITLE
Fixed #29356 -- Clarified docs for QueryDict.getlist() default. 

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -584,8 +584,8 @@ In addition, ``QueryDict`` has the following methods:
 .. method:: QueryDict.getlist(key, default=None)
 
     Returns a list of the data with the requested key. Returns an empty list if
-    the key doesn't exist and a default value wasn't provided. It's guaranteed
-    to return a list unless the default value provided isn't a list.
+    the key doesn't exist and ``default`` is ``None``. It's guaranteed to
+    return a list unless the default value provided isn't a list.
 
 .. method:: QueryDict.setlist(key, list_)
 


### PR DESCRIPTION
When you do `dict.get('foo', None)` you get `None`, but with `query_params.getlist('foo', None)` you get `[]` which is a bit confusing. I don't think it warrants changing the code, but we can clarify the docs a bit.

I wrote code something like
```
exclude = request.query_params.getlist('exclude[]', None)
if exclude is not None:
   ...
```
This code looks right but it is not.

Clearly saying that a default value of None will give you an empty list should do the trick.

## Issue

https://code.djangoproject.com/ticket/29356

It was closed but I think we can improve this.