### PR TITLE
Fixed #32080 -- Fixed displaying Unicode chars in forms.JSONField and read-only JSONField values in admin.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -749,6 +749,7 @@ answer newbie questions, and generally made Django that much better:
     Priyansh Saxena <askpriyansh@gmail.com>
     Przemysław Buczkowski <przemub@przemub.pl>
     Przemysław Suliga <http://suligap.net>
+    Qi Zhao <zhaoqi99@outlook.com>
     Rachel Tobin <rmtobin@me.com>
     Rachel Willmer <http://www.willmer.com/kb/>
     Radek Švarz <https://www.svarz.cz/translate/>

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import decimal
+import json
 from collections import defaultdict
 
 from django.core.exceptions import FieldDoesNotExist
@@ -400,7 +401,7 @@ def display_for_field(value, field, empty_value_display):
         return format_html('<a href="{}">{}</a>', value.url, value)
     elif isinstance(field, models.JSONField) and value:
         try:
-            return field.get_prep_value(value)
+            return json.dumps(value, ensure_ascii=False, cls=field.encoder)
         except TypeError:
             return display_for_value(value, empty_value_display)
     else:

--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1258,7 +1258,7 @@ class JSONField(CharField):
     def prepare_value(self, value):
         if isinstance(value, InvalidJSONInput):
             return value
-        return json.dumps(value, cls=self.encoder)
+        return json.dumps(value, ensure_ascii=False, cls=self.encoder)
 
     def has_changed(self, initial, data):
         if super().has_changed(initial, data):

--- a/docs/releases/3.1.3.txt
+++ b/docs/releases/3.1.3.txt
@@ -11,3 +11,8 @@ Bugfixes
 
 * Fixed a regression in Django 3.1.2 that caused the incorrect height of the
   admin changelist search bar (:ticket:`32072`).
+
+* Fixed displaying Unicode characters in
+  :class:`forms.JSONField <django.forms.JSONField>` and read-only
+  :class:`models.JSONField <django.db.models.JSONField>` values in the admin
+  (:ticket:`32080`).

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -186,6 +186,7 @@ class UtilsTests(SimpleTestCase):
             ({'a': {'b': 'c'}}, '{"a": {"b": "c"}}'),
             (['a', 'b'], '["a", "b"]'),
             ('a', '"a"'),
+            ({'a': '你好 世界'}, '{"a": "你好 世界"}'),
             ({('a', 'b'): 'c'}, "{('a', 'b'): 'c'}"),  # Invalid JSON.
         ]
         for value, display_value in tests:

--- a/tests/forms_tests/field_tests/test_jsonfield.py
+++ b/tests/forms_tests/field_tests/test_jsonfield.py
@@ -29,6 +29,12 @@ class JSONFieldTest(SimpleTestCase):
         self.assertEqual(field.prepare_value({'a': 'b'}), '{"a": "b"}')
         self.assertEqual(field.prepare_value(None), 'null')
         self.assertEqual(field.prepare_value('foo'), '"foo"')
+        self.assertEqual(field.prepare_value('你好，世界'), '"你好，世界"')
+        self.assertEqual(field.prepare_value({'a': '😀🐱'}), '{"a": "😀🐱"}')
+        self.assertEqual(
+            field.prepare_value(["你好，世界", "jaźń"]),
+            '["你好，世界", "jaźń"]',
+        )
 
     def test_widget(self):
         field = JSONField()


### PR DESCRIPTION
[ticket-32080](https://code.djangoproject.com/ticket/32080)