### PR TITLE
Fixed #32094 -- Fixed flush() calls on management command self.stdout/err proxies.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -140,6 +140,10 @@ class OutputWrapper(TextIOBase):
     def __getattr__(self, name):
         return getattr(self._out, name)
 
+    def flush(self):
+        if hasattr(self._out, 'flush'):
+            self._out.flush()
+
     def isatty(self):
         return hasattr(self._out, 'isatty') and self._out.isatty()
 

--- a/tests/user_commands/management/commands/outputwrapper.py
+++ b/tests/user_commands/management/commands/outputwrapper.py
@@ -1,0 +1,8 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    def handle(self, **options):
+        self.stdout.write('Working...')
+        self.stdout.flush()
+        self.stdout.write('OK')

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -341,6 +341,13 @@ class CommandTests(SimpleTestCase):
         parser = BaseCommand().create_parser('prog_name', 'subcommand', epilog=epilog)
         self.assertEqual(parser.epilog, epilog)
 
+    def test_outputwrapper_flush(self):
+        out = StringIO()
+        with mock.patch.object(out, 'flush') as mocked_flush:
+            management.call_command('outputwrapper', stdout=out)
+        self.assertIn('Working...', out.getvalue())
+        self.assertIs(mocked_flush.called, True)
+
 
 class CommandRunTests(AdminScriptTestCase):
     """


### PR DESCRIPTION
## Issue
`flush()` is notably called during `migrate` command; it didn't work, and a long migration effectively printed to `stderr` no relevant information up until the end:
```
Operations to perform:
  Apply all migrations: myapp
Running migrations:
```
Then nothing more, but the migration is being done.
Then at the end of the real migration, the rest is flushed:
```
  Applying myapp.0002_auto_20200817_1030... OK
```

Expected behavior:
```
Operations to perform:
  Apply all migrations: myapp
Running migrations:
  Applying myapp.0002_auto_20200817_1030...
```
then work
then `OK`


## Reason
`self.stdout/stderr` in management commands are wrapped with `OutputWrapper`, commands assume the wrapping is transparent, but it is not: it inherits `TextIOBase` but doesn't implement most of the methods, only `write` and `isatty`; others either raise `not implemented` from `TextIOBase` (OK), or silently do nothing (KO, that's what happens with `flush`).

## Fix
I forward the `flush()` call to `self._out`, with a test verifying it's called.

I'm not sure if `if hasattr(self._out, 'flush'):` is really necessary, it's part of `IOBase` (but so is `isatty`).

I checked all django management commands and no other method seems called, so a more generic fix may wait for later (it may  still be useful for users commands).