### PR TITLE
Fixed #32091 -- Fixed admin search bar width on filtered admin page.

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -120,7 +120,8 @@ input[type="submit"], button {
     }
 
     #changelist-search .quiet {
-        width: 100%;
+        width: 0;
+        flex: 1 0 auto;
         margin: 5px 0 0 25px;
     }
 

--- a/docs/releases/3.1.3.txt
+++ b/docs/releases/3.1.3.txt
@@ -12,6 +12,9 @@ Bugfixes
 * Fixed a regression in Django 3.1.2 that caused the incorrect height of the
   admin changelist search bar (:ticket:`32072`).
 
+* Fixed a regression in Django 3.1.2 that caused the incorrect width of the
+  admin changelist search bar on a filtered page (:ticket:`32091`).
+
 * Fixed displaying Unicode characters in
   :class:`forms.JSONField <django.forms.JSONField>` and read-only
   :class:`models.JSONField <django.db.models.JSONField>` values in the admin

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4931,6 +4931,17 @@ class SeleniumTests(AdminSeleniumTestCase):
             ['Roboto', 'Lucida Grande', 'Verdana', 'Arial', 'sans-serif'],
         )
 
+    def test_search_input_filtered_page(self):
+        Person.objects.create(name='Guido van Rossum', gender=1, alive=True)
+        Person.objects.create(name='Grace Hopper', gender=1, alive=False)
+        self.admin_login(username='super', password='secret', login_url=reverse('admin:index'))
+        person_url = reverse('admin:admin_views_person_changelist') + '?q=Gui'
+        self.selenium.get(self.live_server_url + person_url)
+        self.assertGreater(
+            self.selenium.find_element_by_id('searchbar').rect['width'],
+            50,
+        )
+
 
 @override_settings(ROOT_URLCONF='admin_views.urls')
 class ReadonlyTest(AdminFieldExtractionMixin, TestCase):


### PR DESCRIPTION
The search input will now show as a reasonable width with a list
filter value selected on a skinny window.