### PR TITLE
Fixed #32087 -- Made technical 500 debug page use HTTPS for sharing traceback.

### DIFF
--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -278,7 +278,7 @@
       {% endfor %}
     </ul>
   </div>
-  <form action="http://dpaste.com/" name="pasteform" id="pasteform" method="post">
+  <form action="https://dpaste.com/" name="pasteform" id="pasteform" method="post">
 {% if not is_email %}
   <div id="pastebinTraceback" class="pastebin">
     <input type="hidden" name="language" value="PythonConsole">

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -401,6 +401,19 @@ class ExceptionReporterTests(SimpleTestCase):
         self.assertIn('<h2>Request information</h2>', html)
         self.assertIn('<p>Request data not supplied</p>', html)
 
+    def test_sharing_traceback(self):
+        try:
+            raise ValueError('Oops')
+        except ValueError:
+            exc_type, exc_value, tb = sys.exc_info()
+        reporter = ExceptionReporter(None, exc_type, exc_value, tb)
+        html = reporter.get_traceback_html()
+        self.assertIn(
+            '<form action="https://dpaste.com/" name="pasteform" '
+            'id="pasteform" method="post">',
+            html,
+        )
+
     def test_eol_support(self):
         """The ExceptionReporter supports Unix, Windows and Macintosh EOL markers"""
         LINES = ['print %d' % i for i in range(1, 6)]


### PR DESCRIPTION
In django/views/templates/technical_500.html line 281 I did this
changed form action="http://dpaste.com/" name="pasteform" id="pasteform" method="post"
to  form action="https://dpaste.com/" name="pasteform" id="pasteform" method="post"