### PR TITLE
Fixed #32088 -- Django Database Sessions, Can't Retrieve expire_date

### DIFF
--- a/django/contrib/sessions/backends/db.py
+++ b/django/contrib/sessions/backends/db.py
@@ -43,7 +43,10 @@ class SessionStore(SessionBase):
 
     def load(self):
         s = self._get_session_from_db()
-        return self.decode(s.session_data) if s else {}
+        if s:
+            self._expire_date = s.expire_date
+            return self.decode(s.session_data)
+        return {}
 
     def exists(self, session_key):
         return self.model.objects.filter(session_key=session_key).exists()

--- a/django/contrib/sessions/backends/db.py
+++ b/django/contrib/sessions/backends/db.py
@@ -131,7 +131,7 @@ class SessionStore(SessionBase):
         self.__expire_date = None
         if isinstance(value, datetime):
             self.__expire_date = value
-        else:
+        elif value is not None:
             self.__expire_date = self.expire_date
 
     expire_date = property(_get_expire_date)

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -143,8 +143,8 @@ Minor features
 :mod:`django.contrib.sessions`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* The new :attr:`.SessionStore.expire_date` property allows getting the
-  current session's expire date.
+* The new ``~django.contrib.sessions.backends.db.SessionStore.expire_date``
+  property allows getting the current session's expire date.
 
 :mod:`django.contrib.sitemaps`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -143,7 +143,8 @@ Minor features
 :mod:`django.contrib.sessions`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The new :attr:`.SessionStore.expire_date` property allows getting the
+  current session's expire date.
 
 :mod:`django.contrib.sitemaps`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -474,6 +474,38 @@ class DatabaseSessionTests(SessionTestsMixin, TestCase):
         # ... and one is deleted.
         self.assertEqual(1, self.model.objects.count())
 
+    def test_session_expire_date(self):
+        """
+        Test set and get expire date for current session.
+        """
+        # assert initial expire date without session being set
+        self.assertIsNone(self.session.expire_date)
+
+        # Create a session
+        self.session['y'] = 1
+        self.session.save()
+        self.assertIsNotNone(self.session.expire_date)
+
+        # set new expire date
+        current_expire_date = self.session.expire_date
+        new_exp_date = self.session.expire_date + timedelta(days=2)
+        self.session._expire_date = new_exp_date
+
+        # get current session from database
+        session = self.session._get_session_from_db()
+        self.assertEqual(session.expire_date, current_expire_date)
+
+        # update db session object
+        self.session.save()
+
+        # get current updated session from database should have new expire_date
+        session = self.session._get_session_from_db()
+        self.assertEqual(session.expire_date, new_exp_date)
+
+        # set invalid expire date should keep expire_date unchanged
+        self.session._expire_date = "Invalid value"
+        self.assertEqual(self.session.expire_date, session.expire_date)
+
 
 @override_settings(USE_TZ=True)
 class DatabaseSessionWithTimeZoneTests(DatabaseSessionTests):


### PR DESCRIPTION
added expire date property for SessionStore object for current session instance