### PR TITLE
Fixed #32095 -- Changed `update_or_create` to only save fields listed in `defaults`.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -609,7 +609,10 @@ class QuerySet:
             for k, v in resolve_callables(defaults):
                 setattr(obj, k, v)
             # `update_fields` does not support non-concrete fields yet (#31382)
-            fnames = map(lambda f: f.name, self.model._meta.concrete_fields)
+            fnames = set()
+            for f in self.model._meta.local_concrete_fields:
+                fnames.add(f.name)
+                fnames.add(f.attname)
             if set(defaults).issubset(fnames):
                 obj.save(using=self.db, update_fields=defaults.keys())
             else:

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -614,7 +614,7 @@ class QuerySet:
                 fnames.add(f.name)
                 fnames.add(f.attname)
             if set(defaults).issubset(fnames):
-                obj.save(using=self.db, update_fields=defaults.keys())
+                obj.save(using=self.db, update_fields=defaults)
             else:
                 obj.save(using=self.db)
         return obj, False

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -608,7 +608,12 @@ class QuerySet:
                 return obj, created
             for k, v in resolve_callables(defaults):
                 setattr(obj, k, v)
-            obj.save(using=self.db)
+            # `update_fields` does not support non-concrete fields yet (#31382)
+            fnames = map(lambda f: f.name, self.model._meta.concrete_fields)
+            if set(defaults).issubset(fnames):
+                obj.save(using=self.db, update_fields=defaults.keys())
+            else:
+                obj.save(using=self.db)
         return obj, False
 
     def _extract_model_params(self, defaults, **kwargs):


### PR DESCRIPTION
Before this change all fields where saved all the time which results in
more (and unneeded) data transmitted over the wire and possibly more
work for the database.

If the listed defaults also contains non-concrete fields it will still
save the whole model because currently `update_fields` does not support
non-concrete fields.