### PR TITLE
Refs #31926 -- Made test_pickle_filteredrelation_m2m do not depend on auto-PK.

### DIFF
--- a/tests/queryset_pickle/models.py
+++ b/tests/queryset_pickle/models.py
@@ -57,6 +57,7 @@ class Container:
 
 
 class M2MModel(models.Model):
+    added = models.DateField(default=datetime.date.today)
     groups = models.ManyToManyField(Group)
 
 

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -240,12 +240,12 @@ class PickleabilityTestCase(TestCase):
 
     def test_pickle_filteredrelation_m2m(self):
         group = Group.objects.create(name='group')
-        m2mmodel = M2MModel.objects.create()
+        m2mmodel = M2MModel.objects.create(added=datetime.date(2020, 1, 1))
         m2mmodel.groups.add(group)
         groups = Group.objects.annotate(
             first_m2mmodels=models.FilteredRelation(
                 'm2mmodel',
-                condition=models.Q(m2mmodel__pk__lt=10),
+                condition=models.Q(m2mmodel__added__year=2020),
             ),
         ).annotate(count_groups=models.Count('first_m2mmodels__groups'))
         groups_query = pickle.loads(pickle.dumps(groups.query))


### PR DESCRIPTION
This caused failures on CockroachDB that use random rather than serial pk values, see https://github.com/django/django/pull/13484#discussion_r502799872.