### PR TITLE
Removed unnecessary check in BaseModelAdmin.get_view_on_site_url().

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -296,7 +296,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
 
         if callable(self.view_on_site):
             return self.view_on_site(obj)
-        elif self.view_on_site and hasattr(obj, 'get_absolute_url'):
+        elif hasattr(obj, 'get_absolute_url'):
             # use the ContentType lookup if view_on_site is True
             return reverse('admin:view_on_site', kwargs={
                 'content_type_id': get_content_type_for_model(obj).pk,


### PR DESCRIPTION
As talked with Andrew Godwin in the [Django forum](https://forum.djangoproject.com/t/unnecessary-check-for-thruthiness-in-view-on-site-generation/4639), this check is unnecessary as it always evaluates to `True` in the elif statement.