### PR TITLE
Fixed the link documenting the de_CH numbers format

### DIFF
--- a/django/conf/locale/de_CH/formats.py
+++ b/django/conf/locale/de_CH/formats.py
@@ -26,8 +26,8 @@ DATETIME_INPUT_FORMATS = [
 # these are the separators for non-monetary numbers. For monetary numbers,
 # the DECIMAL_SEPARATOR is a . (decimal point) and the THOUSAND_SEPARATOR is a
 # ' (single quote).
-# For details, please refer to https://www.bk.admin.ch/bk/de/home/dokumentation/sprachen/hilfsmittel-textredaktion/schreibweisungen.html
-# (in German) and the documentation
+# For details, please refer to the documentation and the following link:
+# https://www.bk.admin.ch/bk/de/home/dokumentation/sprachen/hilfsmittel-textredaktion/schreibweisungen.html
 DECIMAL_SEPARATOR = ','
 THOUSAND_SEPARATOR = '\xa0'  # non-breaking space
 NUMBER_GROUPING = 3

--- a/django/conf/locale/de_CH/formats.py
+++ b/django/conf/locale/de_CH/formats.py
@@ -26,7 +26,7 @@ DATETIME_INPUT_FORMATS = [
 # these are the separators for non-monetary numbers. For monetary numbers,
 # the DECIMAL_SEPARATOR is a . (decimal point) and the THOUSAND_SEPARATOR is a
 # ' (single quote).
-# For details, please refer to http://www.bk.admin.ch/dokumentation/sprachen/04915/05016/index.html?lang=de
+# For details, please refer to https://www.bk.admin.ch/bk/de/home/dokumentation/sprachen/hilfsmittel-textredaktion/schreibweisungen.html
 # (in German) and the documentation
 DECIMAL_SEPARATOR = ','
 THOUSAND_SEPARATOR = '\xa0'  # non-breaking space


### PR DESCRIPTION
The old link points to a page which has been moved or deleted in the meantime.