### PR TITLE
Fixed #6517 -- Made dbshell use charset option on MySQL.

### DIFF
--- a/django/db/backends/mysql/client.py
+++ b/django/db/backends/mysql/client.py
@@ -21,6 +21,7 @@ class DatabaseClient(BaseDatabaseClient):
         client_cert = settings_dict['OPTIONS'].get('ssl', {}).get('cert')
         client_key = settings_dict['OPTIONS'].get('ssl', {}).get('key')
         defaults_file = settings_dict['OPTIONS'].get('read_default_file')
+        charset = settings_dict['OPTIONS'].get('charset')
         # Seems to be no good way to set sql_mode with CLI.
 
         if defaults_file:
@@ -42,6 +43,8 @@ class DatabaseClient(BaseDatabaseClient):
             args += ["--ssl-cert=%s" % client_cert]
         if client_key:
             args += ["--ssl-key=%s" % client_key]
+        if charset:
+            args += ['--default-character-set=%s' % charset]
         if db:
             args += [db]
         args.extend(parameters)

--- a/tests/dbshell/test_mysql.py
+++ b/tests/dbshell/test_mysql.py
@@ -59,6 +59,23 @@ class MySqlDbshellCommandTestCase(SimpleTestCase):
             }),
         )
 
+    def test_options_charset(self):
+        self.assertEqual(
+            [
+                'mysql', '--user=someuser', '--password=somepassword',
+                '--host=somehost', '--port=444',
+                '--default-character-set=utf8', 'somedbname',
+            ],
+            self.get_command_line_arguments({
+                'NAME': 'somedbname',
+                'USER': 'someuser',
+                'PASSWORD': 'somepassword',
+                'HOST': 'somehost',
+                'PORT': 444,
+                'OPTIONS': {'charset': 'utf8'},
+            }),
+        )
+
     def test_can_connect_using_sockets(self):
         self.assertEqual(
             ['mysql', '--user=someuser', '--password=somepassword',


### PR DESCRIPTION
[ticket-6517](https://code.djangoproject.com/ticket/6517)

I have added charset option in django\db\backends\mysql\client.py and it's respective tests in tests\dbshell\test_mysql.py