### PR TITLE
Fixed #32109 -- Added additional sidebar block to admin index template

### DIFF
--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -19,6 +19,7 @@
 
 {% block sidebar %}
 <div id="content-related">
+    {% block sidebar_content %}
     <div class="module" id="recent-actions-module">
         <h2>{% translate 'Recent actions' %}</h2>
         <h3>{% translate 'My actions' %}</h3>
@@ -46,5 +47,6 @@
             </ul>
             {% endif %}
     </div>
+    {% endblock %}
 </div>
 {% endblock %}


### PR DESCRIPTION
This fixes issue [#32109](https://code.djangoproject.com/ticket/32109), allowing template authors to customize sidebar content in the admin index.