### PR TITLE
Refs #32096 -- Removed JSONBAgg from 3.1.3 release notes.

### DIFF
--- a/docs/releases/3.1.3.txt
+++ b/docs/releases/3.1.3.txt
@@ -22,8 +22,7 @@ Bugfixes
   (:ticket:`32080`).
 
 * Fixed a regression in Django 3.1 that caused a crash of
-  :class:`~django.contrib.postgres.aggregates.ArrayAgg`,
-  :class:`~django.contrib.postgres.aggregates.JSONBAgg`, and
+  :class:`~django.contrib.postgres.aggregates.ArrayAgg` and
   :class:`~django.contrib.postgres.aggregates.StringAgg` with ``ordering``
   on key transforms for :class:`~django.db.models.JSONField` (:ticket:`32096`).
 


### PR DESCRIPTION
I missed that `JSONBAgg` doesn't support ordering in Django 3.1 :facepalm: . Noticed when backporting (see d94e777b6658701b6d9beea2c7be864bee4f6d59).

Follow up to 1f31027bb3ad460864fbcbbb89eeb328c0a2f184.