### PR TITLE
Refs #32096 -- Made JSONField check respect Meta.required_db_vendor.

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -45,6 +45,11 @@ class JSONField(CheckFieldDefaultMixin, Field):
             if not router.allow_migrate_model(db, self.model):
                 continue
             connection = connections[db]
+            if (
+                self.model._meta.required_db_vendor and
+                self.model._meta.required_db_vendor != connection.vendor
+            ):
+                continue
             if not (
                 'supports_json_field' in self.model._meta.required_db_features or
                 connection.features.supports_json_field


### PR DESCRIPTION
This cause failures on databases without `JSONField` support:
```
django.core.management.base.SystemCheckError: SystemCheckError: System check identified some issues:

ERRORS:
postgres_tests.AggregateTestModel: (fields.E180) SQLite does not support JSONFields.
postgres_tests.AggregateTestModel: (fields.E180) SQLite does not support JSONFields.
postgres_tests.HotelReservation: (fields.E180) SQLite does not support JSONFields.
postgres_tests.HotelReservation: (fields.E180) SQLite does not support JSONFields.
```

See [logs](https://djangoci.com/view/Main/job/django-windows/database=sqlite3,label=windows,python=Python36/1036/console).