### PR TITLE
Fixed #32116 -- Fixed QuerySet.order_by() crash on EmptyQuerySet with union() on a single non-empty ordered queryset.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -995,7 +995,11 @@ class QuerySet:
         # If the query is an EmptyQuerySet, combine all nonempty querysets.
         if isinstance(self, EmptyQuerySet):
             qs = [q for q in other_qs if not isinstance(q, EmptyQuerySet)]
-            return qs[0]._combinator_query('union', *qs[1:], all=all) if qs else self
+            if not qs:
+                return self
+            if len(qs) == 1:
+                return qs[0]
+            return qs[0]._combinator_query('union', *qs[1:], all=all)
         return self._combinator_query('union', *other_qs, all=all)
 
     def intersection(self, *other_qs):

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -106,6 +106,11 @@ class QuerySetSetOperationTests(TestCase):
         self.assertEqual(len(qs2.union(qs2)), 0)
         self.assertEqual(len(qs3.union(qs3)), 0)
 
+    def test_empty_qs_union_with_ordered_qs(self):
+        qs1 = Number.objects.all().order_by('num')
+        qs2 = Number.objects.none().union(qs1).order_by('num')
+        self.assertEqual(list(qs1), list(qs2))
+
     def test_limits(self):
         qs1 = Number.objects.all()
         qs2 = Number.objects.all()


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/32116
