### PR TITLE
Fixed #32108 -- Made transaction.on_commit() raise TypeError when callback is not a callable.

### DIFF
--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -632,6 +632,8 @@ class BaseDatabaseWrapper:
         return self.SchemaEditorClass(self, *args, **kwargs)
 
     def on_commit(self, func):
+        if not callable(func):
+            raise TypeError("on_commit()'s callback must be a callable.")
         if self.in_atomic_block:
             # Transaction in progress; save for execution on commit.
             self.run_on_commit.append((set(self.savepoint_ids), func))

--- a/tests/transaction_hooks/tests.py
+++ b/tests/transaction_hooks/tests.py
@@ -233,3 +233,8 @@ class TestConnectionOnCommit(TransactionTestCase):
                 transaction.on_commit(should_never_be_called)
         finally:
             connection.set_autocommit(True)
+
+    def test_raises_exception_non_callable(self):
+        msg = "on_commit()'s callback must be a callable."
+        with self.assertRaisesMessage(TypeError, msg):
+            transaction.on_commit(None)


### PR DESCRIPTION
Simple fix for https://code.djangoproject.com/ticket/32108 to catch early `None` parameter to `on_commit` hook.
Implements the [suggested assert guard from the first comment](https://code.djangoproject.com/ticket/32108#comment:1).