### PR TITLE
Fixed #31653 -- Added AddConstraintNotValid()/ValidateConstraint() operations for PostgreSQL.

### DIFF
--- a/django/contrib/postgres/operations.py
+++ b/django/contrib/postgres/operations.py
@@ -2,8 +2,9 @@ from django.contrib.postgres.signals import (
     get_citext_oids, get_hstore_oids, register_type_handlers,
 )
 from django.db import NotSupportedError, router
-from django.db.migrations import AddIndex, RemoveIndex
+from django.db.migrations import AddConstraint, AddIndex, RemoveIndex
 from django.db.migrations.operations.base import Operation
+from django.db.models.constraints import CheckConstraint
 
 
 class CreateExtension(Operation):
@@ -256,3 +257,73 @@ class RemoveCollation(CollationOperation):
     @property
     def migration_name_fragment(self):
         return 'remove_collation_%s' % self.name.lower()
+
+
+class AddConstraintNotValid(AddConstraint):
+    """
+    Add a table constraint without enforcing validation, using PostgreSQL's
+    NOT VALID syntax.
+    """
+
+    def __init__(self, model_name, constraint):
+        if not isinstance(constraint, CheckConstraint):
+            raise TypeError(
+                'AddConstraintNotValid.constraint must be a check constraint.'
+            )
+        super().__init__(model_name, constraint)
+
+    def describe(self):
+        return 'Create not valid constraint %s on model %s' % (
+            self.constraint.name,
+            self.model_name,
+        )
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            constraint_sql = self.constraint.create_sql(model, schema_editor)
+            if constraint_sql:
+                # Constraint.create_sql returns interpolated SQL which makes
+                # params=None a necessity to avoid escaping attempts on
+                # execution.
+                schema_editor.execute(str(constraint_sql) + ' NOT VALID', params=None)
+
+    @property
+    def migration_name_fragment(self):
+        return super().migration_name_fragment + '_not_valid'
+
+
+class ValidateConstraint(Operation):
+    """Validate a table NOT VALID constraint."""
+
+    def __init__(self, model_name, name):
+        self.model_name = model_name
+        self.name = name
+
+    def describe(self):
+        return 'Validate constraint %s on model %s' % (self.name, self.model_name)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            schema_editor.execute('ALTER TABLE %s VALIDATE CONSTRAINT %s' % (
+                schema_editor.quote_name(model._meta.db_table),
+                schema_editor.quote_name(self.name),
+            ))
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        # PostgreSQL does not provide a way to make a constraint invalid.
+        pass
+
+    def state_forwards(self, app_label, state):
+        pass
+
+    @property
+    def migration_name_fragment(self):
+        return '%s_validate_%s' % (self.model_name.lower(), self.name.lower())
+
+    def deconstruct(self):
+        return self.__class__.__name__, [], {
+            'model_name': self.model_name,
+            'name': self.name,
+        }

--- a/docs/ref/contrib/postgres/operations.txt
+++ b/docs/ref/contrib/postgres/operations.txt
@@ -188,3 +188,39 @@ database.
 
     The ``CONCURRENTLY`` option is not supported inside a transaction (see
     :ref:`non-atomic migration <non-atomic-migrations>`).
+
+Adding constraints without enforcing validation
+===============================================
+
+.. versionadded:: 4.0
+
+PostgreSQL supports the ``NOT VALID`` option with the ``ADD CONSTRAINT``
+statement to add check constraints without enforcing validation on existing
+rows. This option is useful if you want to skip the potentially lengthy scan of
+the table to verify that all existing rows satisfy the constraint.
+
+To validate check constraints created with the ``NOT VALID`` option at a later
+point of time, use the
+:class:`~django.contrib.postgres.operations.ValidateConstraint` operation.
+
+See `the PostgreSQL documentation <https://www.postgresql.org/docs/current/
+sql-altertable.html#SQL-ALTERTABLE-NOTES>`__ for more details.
+
+.. class:: AddConstraintNotValid(model_name, constraint)
+
+    Like :class:`~django.db.migrations.operations.AddConstraint`, but avoids
+    validating the constraint on existing rows.
+
+.. class:: ValidateConstraint(model_name, name)
+
+    Scans through the table and validates the given check constraint on
+    existing rows.
+
+.. note::
+
+    ``AddConstraintNotValid`` and ``ValidateConstraint`` operations should be
+    performed in two separate migrations. Performing both operations in the
+    same atomic migration has the same effect as
+    :class:`~django.db.migrations.operations.AddConstraint`, whereas performing
+    them in a single non-atomic migration, may leave your database in an
+    inconsistent state if the ``ValidateConstraint`` operation fails.

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -122,6 +122,15 @@ Minor features
 * The PostgreSQL backend now supports connecting by a service name. See
   :ref:`postgresql-connection-settings` for more details.
 
+* The new :class:`~django.contrib.postgres.operations.AddConstraintNotValid`
+  operation allows creating check constraints on PostgreSQL without verifying
+  that all existing rows satisfy the new constraint.
+
+* The new :class:`~django.contrib.postgres.operations.ValidateConstraint`
+  operation allows validating check constraints which were created using
+  :class:`~django.contrib.postgres.operations.AddConstraintNotValid` on
+  PostgreSQL.
+
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
PR for [#31563](https://code.djangoproject.com/ticket/31653).