### PR TITLE
Reverted "Reduced time.sleep() in cache touch() tests."

### DIFF
--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -440,15 +440,15 @@ class BaseCacheTests:
     def test_touch(self):
         # cache.touch() updates the timeout.
         cache.set('expire1', 'very quickly', timeout=1)
-        self.assertIs(cache.touch('expire1', timeout=2), True)
-        time.sleep(1.0)
+        self.assertIs(cache.touch('expire1', timeout=4), True)
+        time.sleep(2)
         self.assertIs(cache.has_key('expire1'), True)
-        time.sleep(1.5)
+        time.sleep(3)
         self.assertIs(cache.has_key('expire1'), False)
         # cache.touch() works without the timeout argument.
         cache.set('expire1', 'very quickly', timeout=1)
         self.assertIs(cache.touch('expire1'), True)
-        time.sleep(1.5)
+        time.sleep(2)
         self.assertIs(cache.has_key('expire1'), True)
 
         self.assertIs(cache.touch('nonexistent'), False)


### PR DESCRIPTION
This reverts commit 177a49e79c882603da64d45995f5fd60dce8c852 which caused more frequent failures of `test_touch()`.