### PR TITLE
Fixed #26962 -- Doc'd running migrations in transactions.

### DIFF
--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -169,6 +169,27 @@ migrations for you. If not, you'll have to go in and modify the migrations
 yourself - don't worry, this isn't difficult, and is explained more in
 :ref:`migration-files` below.
 
+Transactions
+============
+
+On databases that support DDL transactions (SQLite and PostgreSQL), all
+migration operations will run inside a single transaction by default. In
+contrast, if a database doesn't support DDL transactions (e.g. MySQL, Oracle)
+then all operations will run without a transaction.
+
+You can prevent a migration from running in a transaction by setting the
+``atomic`` attribute to ``False``. For example::
+
+    from django.db import migrations
+
+    class Migration(migrations.Migration):
+        atomic = False
+
+It's also possible to execute parts of the migration inside a transaction using
+:func:`~django.db.transaction.atomic()` or by passing ``atomic=True`` to
+:class:`~django.db.migrations.operations.RunPython`. See
+:ref:`non-atomic-migrations` for more details.
+
 Dependencies
 ============
 


### PR DESCRIPTION
Discussion: https://code.djangoproject.com/ticket/26962

The text was copied (with small modifications) from a [how to section](https://docs.djangoproject.com/en/dev/howto/writing-migrations/#non-atomic-migrations)

---

<img width="671" alt="Screen Shot 2020-10-28 at 09 21 29" src="https://user-images.githubusercontent.com/55533/97435318-fec4c400-18fe-11eb-8ba9-913bdd62ffc8.png">
