### PR TITLE
Fixed #32045 -- Doc'd GenericRelatedObjectManager methods.

### DIFF
--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -391,6 +391,36 @@ be used to retrieve their associated ``TaggedItems``::
     >>> b.tags.all()
     <QuerySet [<TaggedItem: django>, <TaggedItem: python>]>
 
+You can also use ``add()``, ``create()``, or ``set()`` to create
+relationships::
+
+    >>> t3 = TaggedItem(tag='Web development')
+    >>> b.tags.add(t3, bulk=False)
+    >>> b.tags.create(tag='Web framework')
+    <TaggedItem: Web framework>
+    >>> b.tags.all()
+    <QuerySet [<TaggedItem: django>, <TaggedItem: python>, <TaggedItem: Web development>, <TaggedItem: Web framework>]>
+    >>> b.tags.set([t1, t3])
+    >>> b.tags.all()
+    <QuerySet [<TaggedItem: django>, <TaggedItem: Web development>]>
+
+The ``remove()`` call will bulk delete the specified model objects::
+
+    >>> b.tags.remove(t3)
+    >>> b.tags.all()
+    <QuerySet [<TaggedItem: django>]>
+    >>> TaggedItem.objects.all()
+    <QuerySet [<TaggedItem: django>]>
+
+The ``clear()`` method can be used to bulk delete all related objects for an
+instance::
+
+    >>> b.tags.clear()
+    >>> b.tags.all()
+    <QuerySet []>
+    >>> TaggedItem.objects.all()
+    <QuerySet []>
+
 Defining :class:`~django.contrib.contenttypes.fields.GenericRelation` with
 ``related_query_name`` set allows querying from the related object::
 

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -320,6 +320,30 @@ class GenericRelationsTests(TestCase):
         self.assertEqual(1, bacon.tags.count())
         self.assertEqual(1, qs.count())
 
+    def test_clear(self):
+        self.assertSequenceEqual(
+            TaggedItem.objects.order_by('tag'),
+            [self.fatty, self.hairy, self.salty, self.yellow],
+        )
+        self.bacon.tags.clear()
+        self.assertSequenceEqual(self.bacon.tags.all(), [])
+        self.assertSequenceEqual(
+            TaggedItem.objects.order_by('tag'),
+            [self.hairy, self.yellow],
+        )
+
+    def test_remove(self):
+        self.assertSequenceEqual(
+            TaggedItem.objects.order_by('tag'),
+            [self.fatty, self.hairy, self.salty, self.yellow],
+        )
+        self.bacon.tags.remove(self.fatty)
+        self.assertSequenceEqual(self.bacon.tags.all(), [self.salty])
+        self.assertSequenceEqual(
+            TaggedItem.objects.order_by('tag'),
+            [self.hairy, self.salty, self.yellow],
+        )
+
     def test_generic_relation_related_name_default(self):
         # GenericRelation isn't usable from the reverse side by default.
         msg = (


### PR DESCRIPTION
Add brief description of the effect of remove() and clear() methods in
the GenericRelation manager. Specifically highlighting that these
methods delete the related  objects from the database.

Add tests for GenericRelation manager

Test that remove() and clear() will delete related objects as stated in
documentation.

Refactor tests

Set up the test objects in the setUp method.