### PR TITLE
Fixed #32069 --  Fixed admin change-form layout on small screens.

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -558,6 +558,7 @@ input[type="submit"], button {
     .aligned .form-row,
     .aligned .form-row > div {
         display: flex;
+        flex-wrap: wrap;
         max-width: 100vw;
     }
 

--- a/docs/releases/3.1.3.txt
+++ b/docs/releases/3.1.3.txt
@@ -45,3 +45,6 @@ Bugfixes
   :exc:`RestrictedError.restricted_objects <django.db.models.RestrictedError>`
   attributes returned iterators instead of :py:class:`set` of objects
   (:ticket:`32107`).
+
+* Fixed a regression in Django 3.1.2 that caused incorrect form input layout on
+  small screens in the admin change form view (:ticket:`32069`).


### PR DESCRIPTION
ticket-32069. Alternative to #13514. 

This was present since the responsive admin was introduced in dc37e8846eeedc3a9100ca21fdc9d579bc534c89.
Regression in 8ee4bb6ffcb3346c0fa8fb194986fbf9edadc822, where it was accidentally removed. (That's the question.)

[See diff](https://github.com/django/django/commit/8ee4bb6ffcb3346c0fa8fb194986fbf9edadc822#diff-7285a344253ffcdfea471412505e9523e255d1fb7ad592bbd52a0858b47b2e4fL573) — looking again, this change isn't related to ticket-31986 no?

Reverting that line restores the old behaviour, and I can't see a regression elsewhere. 