### PR TITLE
Fixed #32130 -- Fixed pre-Django 3.1 password reset tokens validation.

### DIFF
--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, time
 
 from django.conf import settings
 from django.utils.crypto import constant_time_compare, salted_hmac
@@ -36,6 +36,8 @@ class PasswordResetTokenGenerator:
         # Parse the token
         try:
             ts_b36, _ = token.split("-")
+            # RemovedInDjango40Warning.
+            legacy_token = len(ts_b36) < 4
         except ValueError:
             return False
 
@@ -55,8 +57,14 @@ class PasswordResetTokenGenerator:
             ):
                 return False
 
+        # RemovedInDjango40Warning: convert days to seconds and round to
+        # midnight (server time) for pre-Django 3.1 tokens.
+        now = self._now()
+        if legacy_token:
+            ts *= 24 * 60 * 60
+            ts += int((now - datetime.combine(now.date(), time.min)).total_seconds())
         # Check the timestamp is within limit.
-        if (self._num_seconds(self._now()) - ts) > settings.PASSWORD_RESET_TIMEOUT:
+        if (self._num_seconds(now) - ts) > settings.PASSWORD_RESET_TIMEOUT:
             return False
 
         return True

--- a/docs/releases/3.1.3.txt
+++ b/docs/releases/3.1.3.txt
@@ -48,3 +48,6 @@ Bugfixes
 
 * Fixed a regression in Django 3.1.2 that caused incorrect form input layout on
   small screens in the admin change form view (:ticket:`32069`).
+
+* Fixed a regression in Django 3.1 that invalidated pre-Django 3.1 password
+  reset tokens (:ticket:`32130`).


### PR DESCRIPTION
ticket-32130

Thanks Gordon Wrigley for the report and implementation idea.

Regression in 226ebb17290b604ef29e82fb5c1fbac3594ac163.