### PR TITLE
Fixed #32132 -- Fixed column types in m2m intermediary tables for Positive(Big/Small)IntegerFields.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1864,6 +1864,13 @@ class BigIntegerField(IntegerField):
         })
 
 
+class SmallIntegerField(IntegerField):
+    description = _('Small integer')
+
+    def get_internal_type(self):
+        return 'SmallIntegerField'
+
+
 class IPAddressField(Field):
     empty_strings_allowed = False
     description = _("IPv4 address")
@@ -2006,6 +2013,17 @@ class NullBooleanField(BooleanField):
 
 
 class PositiveIntegerRelDbTypeMixin:
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if not hasattr(cls, 'integer_field_class'):
+            cls.integer_field_class = next(
+                (
+                    parent
+                    for parent in cls.__mro__[1:]
+                    if issubclass(parent, IntegerField)
+                ),
+                None,
+            )
 
     def rel_db_type(self, connection):
         """
@@ -2019,10 +2037,10 @@ class PositiveIntegerRelDbTypeMixin:
         if connection.features.related_fields_match_type:
             return self.db_type(connection)
         else:
-            return IntegerField().db_type(connection=connection)
+            return self.integer_field_class().db_type(connection=connection)
 
 
-class PositiveBigIntegerField(PositiveIntegerRelDbTypeMixin, IntegerField):
+class PositiveBigIntegerField(PositiveIntegerRelDbTypeMixin, BigIntegerField):
     description = _('Positive big integer')
 
     def get_internal_type(self):
@@ -2048,7 +2066,7 @@ class PositiveIntegerField(PositiveIntegerRelDbTypeMixin, IntegerField):
         })
 
 
-class PositiveSmallIntegerField(PositiveIntegerRelDbTypeMixin, IntegerField):
+class PositiveSmallIntegerField(PositiveIntegerRelDbTypeMixin, SmallIntegerField):
     description = _("Positive small integer")
 
     def get_internal_type(self):
@@ -2092,13 +2110,6 @@ class SlugField(CharField):
             'allow_unicode': self.allow_unicode,
             **kwargs,
         })
-
-
-class SmallIntegerField(IntegerField):
-    description = _("Small integer")
-
-    def get_internal_type(self):
-        return "SmallIntegerField"
 
 
 class TextField(Field):

--- a/tests/model_fields/test_autofield.py
+++ b/tests/model_fields/test_autofield.py
@@ -9,14 +9,17 @@ from .test_integerfield import (
 
 class AutoFieldTests(IntegerFieldTests):
     model = AutoModel
+    rel_db_type_class = models.IntegerField
 
 
 class BigAutoFieldTests(BigIntegerFieldTests):
     model = BigAutoModel
+    rel_db_type_class = models.BigIntegerField
 
 
 class SmallAutoFieldTests(SmallIntegerFieldTests):
     model = SmallAutoModel
+    rel_db_type_class = models.SmallIntegerField
 
 
 class AutoFieldInheritanceTests(SimpleTestCase):

--- a/tests/model_fields/test_integerfield.py
+++ b/tests/model_fields/test_integerfield.py
@@ -14,6 +14,7 @@ from .models import (
 class IntegerFieldTests(TestCase):
     model = IntegerModel
     documented_range = (-2147483648, 2147483647)
+    rel_db_type_class = models.IntegerField
 
     @property
     def backend_range(self):
@@ -154,15 +155,22 @@ class IntegerFieldTests(TestCase):
                 with self.assertRaisesMessage(exception, msg):
                     self.model.objects.create(value=value)
 
+    def test_rel_db_type(self):
+        field = self.model._meta.get_field('value')
+        rel_db_type = field.rel_db_type(connection)
+        self.assertEqual(rel_db_type, self.rel_db_type_class().db_type(connection))
+
 
 class SmallIntegerFieldTests(IntegerFieldTests):
     model = SmallIntegerModel
     documented_range = (-32768, 32767)
+    rel_db_type_class = models.SmallIntegerField
 
 
 class BigIntegerFieldTests(IntegerFieldTests):
     model = BigIntegerModel
     documented_range = (-9223372036854775808, 9223372036854775807)
+    rel_db_type_class = models.BigIntegerField
 
 
 class PositiveSmallIntegerFieldTests(IntegerFieldTests):
@@ -173,6 +181,11 @@ class PositiveSmallIntegerFieldTests(IntegerFieldTests):
 class PositiveIntegerFieldTests(IntegerFieldTests):
     model = PositiveIntegerModel
     documented_range = (0, 2147483647)
+    rel_db_type_class = (
+        models.PositiveIntegerField
+        if connection.features.related_fields_match_type
+        else models.IntegerField
+    )
 
     @unittest.skipIf(connection.vendor == 'sqlite', "SQLite doesn't have a constraint.")
     def test_negative_values(self):

--- a/tests/model_fields/test_integerfield.py
+++ b/tests/model_fields/test_integerfield.py
@@ -176,6 +176,11 @@ class BigIntegerFieldTests(IntegerFieldTests):
 class PositiveSmallIntegerFieldTests(IntegerFieldTests):
     model = PositiveSmallIntegerModel
     documented_range = (0, 32767)
+    rel_db_type_class = (
+        models.PositiveSmallIntegerField
+        if connection.features.related_fields_match_type
+        else models.SmallIntegerField
+    )
 
 
 class PositiveIntegerFieldTests(IntegerFieldTests):
@@ -198,6 +203,11 @@ class PositiveIntegerFieldTests(IntegerFieldTests):
 class PositiveBigIntegerFieldTests(IntegerFieldTests):
     model = PositiveBigIntegerModel
     documented_range = (0, 9223372036854775807)
+    rel_db_type_class = (
+        models.PositiveBigIntegerField
+        if connection.features.related_fields_match_type
+        else models.BigIntegerField
+    )
 
 
 class ValidationTests(SimpleTestCase):


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/32132

Hello 👋 

I basically added a type switching when getting the related field type for the PositiveBigIntegerField and PositiveSmallIntegerField, as they are defined/used by the BigIntegerField and SmallIntegerField, instead of hard-coding the IntegerField :)

I'm not 100% of the side-effects linked to inheriting from BigIntegerField and SmallIntegerField. But I would expect it to be rather limited and in the end more beneficial than harmful.

The PR is also missing unit tests. Please let me know if I should add some (and if yes, where those are located, I had trouble finding this logic in the tests)