### PR TITLE
Improve naming consistency

### DIFF
--- a/django/db/models/manager.py
+++ b/django/db/models/manager.py
@@ -109,13 +109,13 @@ class BaseManager:
             **cls._get_queryset_methods(queryset_class),
         })
 
-    def contribute_to_class(self, model, name):
+    def contribute_to_class(self, cls, name):
         self.name = self.name or name
-        self.model = model
+        self.model = cls
 
-        setattr(model, name, ManagerDescriptor(self))
+        setattr(cls, name, ManagerDescriptor(self))
 
-        model._meta.add_manager(self)
+        cls._meta.add_manager(self)
 
     def _set_creation_counter(self):
         """


### PR DESCRIPTION
This PR renames the `model` parameter to `cls` parameter, to make it consistent with the `contribute_to_class` method in:

-  `class Option` in `django\db\models\options.py`
https://github.com/django/django/blob/755dbf39fcdc491fe9b588358303e259c7750be4/django/db/models/options.py#L147

- `class Field` in `django\db\models\fields\__init__.py`
https://github.com/django/django/blob/755dbf39fcdc491fe9b588358303e259c7750be4/django/db/models/fields/__init__.py#L775

I believe the consistent naming convention would help us to save a lot of effort in maintaining the source code.





