### PR TITLE
Small simplifies template/library.py:filter, templatetags/cache.py: render, utils/log.py:emit

### DIFF
--- a/django/template/library.py
+++ b/django/template/library.py
@@ -59,12 +59,18 @@ class Library:
         def lower(value):
             return value.lower()
         """
-        if name is None and filter_func is None:
+        if name is None and filter_func is not None:
+            raise ValueError(
+                "Unsupported arguments to Library.filter: (%r, %r)" %
+                (name, filter_func),
+            )
+
+        if name is None:
             # @register.filter()
             def dec(func):
                 return self.filter_function(func, **flags)
             return dec
-        elif name is not None and filter_func is None:
+        elif filter_func is None:
             if callable(name):
                 # @register.filter
                 return self.filter_function(name, **flags)
@@ -73,7 +79,7 @@ class Library:
                 def dec(func):
                     return self.filter(name, func, **flags)
                 return dec
-        elif name is not None and filter_func is not None:
+        else:
             # register.filter('somename', somefunc)
             self.filters[name] = filter_func
             for attr in ('expects_localtime', 'is_safe', 'needs_autoescape'):
@@ -87,11 +93,6 @@ class Library:
                         setattr(filter_func._decorated_function, attr, value)
             filter_func._filter_name = name
             return filter_func
-        else:
-            raise ValueError(
-                "Unsupported arguments to Library.filter: (%r, %r)" %
-                (name, filter_func),
-            )
 
     def filter_function(self, func, **flags):
         name = getattr(func, "_decorated_function", func).__name__

--- a/django/templatetags/cache.py
+++ b/django/templatetags/cache.py
@@ -25,20 +25,20 @@ class CacheNode(Node):
                 expire_time = int(expire_time)
             except (ValueError, TypeError):
                 raise TemplateSyntaxError('"cache" tag got a non-integer timeout value: %r' % expire_time)
+
+        cache_name = 'template_fragments'
         if self.cache_name:
             try:
                 cache_name = self.cache_name.resolve(context)
             except VariableDoesNotExist:
                 raise TemplateSyntaxError('"cache" tag got an unknown variable: %r' % self.cache_name.var)
-            try:
-                fragment_cache = caches[cache_name]
-            except InvalidCacheBackendError:
+
+        try:
+            fragment_cache = caches[cache_name]
+        except InvalidCacheBackendError:
+            if self.cache_name:
                 raise TemplateSyntaxError('Invalid cache name specified for cache tag: %r' % cache_name)
-        else:
-            try:
-                fragment_cache = caches['template_fragments']
-            except InvalidCacheBackendError:
-                fragment_cache = caches['default']
+            fragment_cache = caches['default']
 
         vary_on = [var.resolve(context) for var in self.vary_on]
         cache_key = make_template_fragment_key(self.fragment_name, vary_on)

--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -91,18 +91,19 @@ class AdminEmailHandler(logging.Handler):
     def emit(self, record):
         try:
             request = record.request
-            subject = '%s (%s IP): %s' % (
-                record.levelname,
-                ('internal' if request.META.get('REMOTE_ADDR') in settings.INTERNAL_IPS
-                 else 'EXTERNAL'),
-                record.getMessage()
-            )
+            ip_type_msg = ' (%s IP)' % (
+                'internal' if request.META.get('REMOTE_ADDR') in settings.INTERNAL_IPS
+                else 'EXTERNAL')
         except Exception:
-            subject = '%s: %s' % (
-                record.levelname,
-                record.getMessage()
-            )
+            ip_type_msg = ''
             request = None
+
+        subject = '%s%s: %s' % (
+            record.levelname,
+            ip_type_msg,
+            record.getMessage()
+        )
+
         subject = self.format_subject(subject)
 
         # Since we add a nicely formatted traceback on our own, create a copy


### PR DESCRIPTION
Simplified try/catch block in utils/log:emit

Join two try/catch into one, remove code duplication

Make if conditions easier to read (they was too complicated) in template/library:filter