### PR TITLE
Refs #31670 -- Used allowlist_externals in tox.ini.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@
 # then run "tox" from this directory.
 
 [tox]
+minversion = 3.18
 skipsdist = true
 envlist =
     py3
@@ -40,7 +41,7 @@ commands = flake8 .
 [testenv:docs]
 basepython = python3
 usedevelop = false
-whitelist_externals =
+allowlist_externals =
     make
 deps =
     Sphinx


### PR DESCRIPTION
Tox has deprecated `whitelist_externals` in favour of `allowlist_externals`

https://tox.readthedocs.io/en/latest/config.html#conf-allowlist_externals