### PR TITLE
Fixed #32114 -- Subtest pickle issue with ParallelTestRunner

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -116,26 +116,26 @@ class TestCaseDTO:
     """
 
     def __init__(self, test):
-        self.__id = test.id()
-        self.__str = str(test)
-        self.__shortDescription = test.shortDescription()
+        self._inner_id = test.id()
+        self._inner_str = str(test)
+        self._inner_shortDescription = test.shortDescription()
         if hasattr(test, "test_case"):
             self.test_case = TestCaseDTO(test.test_case)
         if hasattr(test, "_subDescription"):
-            self.__subDescription = test._subDescription()
+            self._inner_subDescription = test._subDescription()
 
     def _subDescription(self):
         """conforming to _SubTest"""
-        return self.__subDescription
+        return self._inner_subDescription
 
     def id(self):
-        return self.__id
+        return self._inner_id
 
     def shortDescription(self):
-        return self.__shortDescription
+        return self._inner_shortDescription
 
     def __str__(self):
-        return self.__str
+        return self._inner_str
 
 
 class RemoteTestResult:

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -100,6 +100,41 @@ class PDBDebugResult(unittest.TextTestResult):
         print("\nOpening PDB: %r" % exc_value)
         pdb.post_mortem(traceback)
 
+class TestCaseDTO:
+    """
+    The ParallelTestSuite requires that all test cases be pickleable. When a
+    SubTest fails with an exception, it's pickled and shipped back to the main
+    process to be displayed to the user. Unfortunately, Django's TestCases
+    aren't always pickleable (for example, they may contain an instance of
+    django.test.Client, which can't be cleanly pickled if an exception was
+    raised by the view).
+
+    Luckily the outer TestRunner only cares about a small subset of the fields
+    on TestCase, and those are usually pickleable. We use this object to pluck
+    out those fields, discarding extra unpickleable members.
+    """
+
+    def __init__(self, test):
+        self.__id = test.id()
+        self.__str = str(test)
+        self.__shortDescription = test.shortDescription()
+        if hasattr(test, "test_case"):
+            self.test_case = TestCaseDTO(test.test_case)
+        if hasattr(test, "_subDescription"):
+            self.__subDescription = test._subDescription()
+
+    def _subDescription(self):
+        """conforming to _SubTest"""
+        return self.__subDescription
+
+    def id(self):
+        return self.__id
+
+    def shortDescription(self):
+        return self.__shortDescription
+
+    def __str__(self):
+        return self.__str
 
 class RemoteTestResult:
     """
@@ -237,6 +272,7 @@ failure and get a correct traceback.
         # Follow Python 3.5's implementation of unittest.TestResult.addSubTest()
         # by not doing anything when a subtest is successful.
         if err is not None:
+            subtest = TestCaseDTO(subtest)
             # Call check_picklable() before check_subtest_picklable() since
             # check_picklable() performs the tblib check.
             self.check_picklable(test, err)

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -100,6 +100,7 @@ class PDBDebugResult(unittest.TextTestResult):
         print("\nOpening PDB: %r" % exc_value)
         pdb.post_mortem(traceback)
 
+
 class TestCaseDTO:
     """
     The ParallelTestSuite requires that all test cases be pickleable. When a
@@ -135,6 +136,7 @@ class TestCaseDTO:
 
     def __str__(self):
         return self.__str
+
 
 class RemoteTestResult:
     """

--- a/tests/test_runner/test_parallel.py
+++ b/tests/test_runner/test_parallel.py
@@ -115,6 +115,7 @@ class RemoteTestResultTest(SimpleTestCase):
 
 
 class TestCaseDTOTest(SimpleTestCase):
+    @unittest.skipUnless(tblib is not None, 'requires tblib to be installed')
     def test_fields_are_set(self):
         """
         TestCaseDTO picks up the right fields from the wrapped TestCase.

--- a/tests/test_runner/test_parallel.py
+++ b/tests/test_runner/test_parallel.py
@@ -50,9 +50,10 @@ class SampleFailingSubtest(SimpleTestCase):
                 self.assertEqual(i, 1)
 
     def pickle_error_test(self):
-        """
-        A dummy test for testing TestCaseDTO.
-        """
+        """A dummy test for testing TestCaseDTO."""
+        # ^ note: 3.6's implementation of TestCase.shortDescription()
+        #   doesn't strip whitespace before taking the first line of the
+        #   docstring, so the single-line docstring is part of this test
         with self.subTest("I should fail"):
             self.not_pickleable = lambda: 0
             self.assertTrue(False)


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/32114

### Summary
When a subtest fails during a parallel test run, it gets pickled and 
sent back to the main thread to be added to the RemoteTestResult. 

The issue is that the entire TestCase needs to be pickleable. Often 
it is not, in which case the original error message  is never displayed to 
the user. Instead of trying to pickle the entire TestCase, which can contain
all sorts of weird and unexpected things, we can restrict  the pickled fields 
to a subset of the original (basically just the stuff that `unittest.TestCase` 
declares as part of the public API, plus `_subDescription` which is from 
`unittest._SubTest`).

### Further thoughts
This could be opt-in (or out) via a setting, as it's possible some users use customized
TestRunners that rely on accessing private fields of the TestCase. I've confirmed that
this works in PyCharm (which uses a modified TestRunner based on Django's 
DiscoverRunner), but can't rule out the possibility that other tools might rely on
private/undocumented behavior. 

We could also do something smarter in TestCaseDTO, like try to dynamically determine
which fields are pickelable and only copy those. This could potentially be more robust, but 
also comes with extra cognitive overhead (and could have some negative performance 
implications).
