### PR TITLE
Fixed #32062 -- Added %b support to Date.strftime.

### DIFF
--- a/django/contrib/admin/static/admin/js/calendar.js
+++ b/django/contrib/admin/static/admin/js/calendar.js
@@ -21,6 +21,20 @@ depends on core.js for utility functions like removeChildren or quickElement
             gettext('November'),
             gettext('December')
         ],
+        monthsOfYearAbbrev: [
+            pgettext('abbrev. month January', 'Jan'),
+            pgettext('abbrev. month February', 'Feb'),
+            pgettext('abbrev. month March', 'Mar'),
+            pgettext('abbrev. month April', 'Apr'),
+            pgettext('abbrev. month May', 'May'),
+            pgettext('abbrev. month June', 'Jun'),
+            pgettext('abbrev. month July', 'Jul'),
+            pgettext('abbrev. month August', 'Aug'),
+            pgettext('abbrev. month September', 'Sep'),
+            pgettext('abbrev. month October', 'Oct'),
+            pgettext('abbrev. month November', 'Nov'),
+            pgettext('abbrev. month December', 'Dec')
+        ],
         daysOfWeek: [
             pgettext('one letter Sunday', 'S'),
             pgettext('one letter Monday', 'M'),

--- a/django/contrib/admin/static/admin/js/core.js
+++ b/django/contrib/admin/static/admin/js/core.js
@@ -85,6 +85,12 @@ function findPosY(obj) {
         return (this.getSeconds() < 10) ? '0' + this.getSeconds() : this.getSeconds();
     };
 
+    Date.prototype.getAbbrevMonthName = function() {
+        return typeof window.CalendarNamespace === "undefined"
+            ? this.getTwoDigitMonth()
+            : window.CalendarNamespace.monthsOfYearAbbrev[this.getMonth()];
+    };
+
     Date.prototype.getFullMonthName = function() {
         return typeof window.CalendarNamespace === "undefined"
             ? this.getTwoDigitMonth()
@@ -93,6 +99,7 @@ function findPosY(obj) {
 
     Date.prototype.strftime = function(format) {
         const fields = {
+            b: this.getAbbrevMonthName(),
             B: this.getFullMonthName(),
             c: this.toString(),
             d: this.getTwoDigitDate(),

--- a/js_tests/admin/core.test.js
+++ b/js_tests/admin/core.test.js
@@ -40,6 +40,11 @@ QUnit.test('Date.getTwoDigitSecond', function(assert) {
     assert.equal(new Date(2014, 6, 1, 0, 0, 20).getTwoDigitSecond(), '20', '12:00:20 am is 20');
 });
 
+QUnit.test('Date.getAbbrevMonthName', function(assert) {
+    assert.equal(new Date(2020, 0, 26).getAbbrevMonthName(), 'Jan', 'jan 26');
+    assert.equal(new Date(2020, 9, 26).getAbbrevMonthName(), 'Oct', 'oct 26');
+});
+
 QUnit.test('Date.getFullMonthName', function(assert) {
     assert.equal(new Date(2020, 0, 26).getFullMonthName(), 'January', 'jan 26');
     assert.equal(new Date(2020, 9, 26).getFullMonthName(), 'October', 'oct 26');
@@ -49,6 +54,7 @@ QUnit.test('Date.strftime', function(assert) {
     const date = new Date(2014, 6, 1, 11, 0, 5);
     assert.equal(date.strftime('%Y-%m-%d %H:%M:%S'), '2014-07-01 11:00:05');
     assert.equal(date.strftime('%B %d, %Y'), 'July 01, 2014');
+    assert.equal(date.strftime('%b %d, %Y'), 'Jul 01, 2014');
 });
 
 QUnit.test('String.strptime', function(assert) {

--- a/js_tests/admin/core.test.js
+++ b/js_tests/admin/core.test.js
@@ -40,6 +40,11 @@ QUnit.test('Date.getTwoDigitSecond', function(assert) {
     assert.equal(new Date(2014, 6, 1, 0, 0, 20).getTwoDigitSecond(), '20', '12:00:20 am is 20');
 });
 
+QUnit.test('Date.getFullMonthName', function(assert) {
+    assert.equal(new Date(2020, 0, 26).getFullMonthName(), 'January', 'jan 26');
+    assert.equal(new Date(2020, 9, 26).getFullMonthName(), 'October', 'oct 26');
+});
+
 QUnit.test('Date.strftime', function(assert) {
     const date = new Date(2014, 6, 1, 11, 0, 5);
     assert.equal(date.strftime('%Y-%m-%d %H:%M:%S'), '2014-07-01 11:00:05');


### PR DESCRIPTION
Added "%b" option in "Date.strftime" method to render abbreviated
month name in Associated Press style