### PR TITLE
Improved Paginator.count()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -397,6 +397,7 @@ answer newbie questions, and generally made Django that much better:
     Jacob Green
     Jacob Kaplan-Moss <jacob@jacobian.org>
     Jacob Walls <http://www.jacobtylerwalls.com/>
+    Jae Joon Kim 김재준 <ojayyezzir@gmail.com>
     Jakub Paczkowski <jakub@paczkowski.eu>
     Jakub Wilk <jwilk@jwilk.net>
     Jakub Wiśniowski <restless.being@gmail.com>

--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -4,7 +4,7 @@ import warnings
 from math import ceil
 
 from django.utils.functional import cached_property
-from django.utils.inspect import method_has_no_args
+from django.utils.inspect import func_accepts_var_args, method_has_no_args
 from django.utils.translation import gettext_lazy as _
 
 
@@ -93,6 +93,9 @@ class Paginator:
     def count(self):
         """Return the total number of objects, across all pages."""
         c = getattr(self.object_list, 'count', None)
+        v = getattr(self.object_list, 'values', None)
+        if callable(v) and not inspect.isbuiltin(v) and func_accepts_var_args(v):
+            c = getattr(v('pk'), 'count', None)
         if callable(c) and not inspect.isbuiltin(c) and method_has_no_args(c):
             return c()
         return len(self.object_list)


### PR DESCRIPTION
It seems like counting by objects' primary key(when it is possible) is much faster than executing complex query and then counting.

before 
<img width="547" alt="스크린샷 2020-10-25 오후 4 38 50" src="https://user-images.githubusercontent.com/53065945/97101739-1f183700-16e3-11eb-92cc-b4b47e76b443.png">

after
<img width="547" alt="스크린샷 2020-10-25 오후 4 37 17" src="https://user-images.githubusercontent.com/53065945/97101743-27707200-16e3-11eb-9cc2-1f358d4ab52b.png">

