### PR TITLE
Translated content becomes ugly due to line-down on new admin side-bar

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -633,21 +633,25 @@ div.breadcrumbs a:focus, div.breadcrumbs a:hover {
 .viewlink, .inlineviewlink {
     padding-left: 16px;
     background: url(../img/icon-viewlink.svg) 0 1px no-repeat;
+    word-break: keep-all;
 }
 
 .addlink {
     padding-left: 16px;
     background: url(../img/icon-addlink.svg) 0 1px no-repeat;
+    word-break: keep-all;
 }
 
 .changelink, .inlinechangelink {
     padding-left: 16px;
     background: url(../img/icon-changelink.svg) 0 1px no-repeat;
+    word-break: keep-all;
 }
 
 .deletelink {
     padding-left: 16px;
     background: url(../img/icon-deletelink.svg) 0 1px no-repeat;
+    word-break: keep-all;
 }
 
 a.deletelink:link, a.deletelink:visited {


### PR DESCRIPTION
![django](https://user-images.githubusercontent.com/9462045/97103882-bcc73280-16f2-11eb-8820-59510447d711.png)
[https://code.djangoproject.com/ticket/32141](Ticket #32141)

The first line is the result of the change.
The second line is the original version.
The third line is the original translated version