### PR TITLE
Fixed #32143 -- Used EXISTS to exclude multi-valued relationships.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1083,19 +1083,18 @@ class Subquery(Expression):
     contains_aggregate = False
 
     def __init__(self, queryset, output_field=None, **extra):
-        self.query = queryset.query
+        # Allow the usage of both QuerySet and sql.Query objects.
+        self.query = getattr(queryset, 'query', queryset)
         self.extra = extra
-        # Prevent the QuerySet from being evaluated.
-        self.queryset = queryset._chain(_result_cache=[], prefetch_done=True)
         super().__init__(output_field)
 
     def __getstate__(self):
         state = super().__getstate__()
         args, kwargs = state['_constructor_args']
         if args:
-            args = (self.queryset, *args[1:])
+            args = (self.query, *args[1:])
         else:
-            kwargs['queryset'] = self.queryset
+            kwargs['queryset'] = self.query
         state['_constructor_args'] = args, kwargs
         return state
 

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -12,6 +12,7 @@ from django.db.models.query_utils import RegisterLookupMixin
 from django.utils.datastructures import OrderedSet
 from django.utils.deprecation import RemovedInDjango40Warning
 from django.utils.functional import cached_property
+from django.utils.hashable import make_hashable
 
 
 class Lookup:
@@ -142,6 +143,18 @@ class Lookup:
     @property
     def is_summary(self):
         return self.lhs.is_summary or getattr(self.rhs, 'is_summary', False)
+
+    @property
+    def identity(self):
+        return self.__class__, self.lhs, self.rhs
+
+    def __eq__(self, other):
+        if not isinstance(other, Lookup):
+            return NotImplemented
+        return self.identity == other.identity
+
+    def __hash__(self):
+        return hash(make_hashable(self.identity))
 
 
 class Transform(RegisterLookupMixin, Func):

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -39,6 +39,7 @@ from django.db.models.sql.where import (
 )
 from django.utils.deprecation import RemovedInDjango40Warning
 from django.utils.functional import cached_property
+from django.utils.hashable import make_hashable
 from django.utils.tree import Node
 
 __all__ = ['Query', 'RawQuery']
@@ -245,6 +246,14 @@ class Query(BaseExpression):
     def base_table(self):
         for alias in self.alias_map:
             return alias
+
+    @property
+    def identity(self):
+        identity = (
+            (arg, make_hashable(value))
+            for arg, value in self.__dict__.items()
+        )
+        return (self.__class__, *identity)
 
     def __str__(self):
         """

--- a/tests/lookup/test_lookups.py
+++ b/tests/lookup/test_lookups.py
@@ -1,8 +1,32 @@
 from datetime import datetime
+from unittest import mock
 
 from django.db.models import DateTimeField, Value
-from django.db.models.lookups import YearLookup
+from django.db.models.lookups import Lookup, YearLookup
 from django.test import SimpleTestCase
+
+
+class CustomLookup(Lookup):
+    pass
+
+
+class LookupTests(SimpleTestCase):
+    def test_equality(self):
+        lookup = Lookup(Value(1), Value(2))
+        self.assertEqual(lookup, lookup)
+        self.assertEqual(lookup, Lookup(lookup.lhs, lookup.rhs))
+        self.assertEqual(lookup, mock.ANY)
+        self.assertNotEqual(lookup, Lookup(lookup.lhs, Value(3)))
+        self.assertNotEqual(lookup, Lookup(Value(3), lookup.rhs))
+        self.assertNotEqual(lookup, CustomLookup(lookup.lhs, lookup.rhs))
+
+    def test_hash(self):
+        lookup = Lookup(Value(1), Value(2))
+        self.assertEqual(hash(lookup), hash(lookup))
+        self.assertEqual(hash(lookup), hash(Lookup(lookup.lhs, lookup.rhs)))
+        self.assertNotEqual(hash(lookup), hash(Lookup(lookup.lhs, Value(3))))
+        self.assertNotEqual(hash(lookup), hash(Lookup(Value(3), lookup.rhs)))
+        self.assertNotEqual(hash(lookup), hash(CustomLookup(lookup.lhs, lookup.rhs)))
 
 
 class YearLookupTests(SimpleTestCase):

--- a/tests/queries/test_query.py
+++ b/tests/queries/test_query.py
@@ -150,3 +150,31 @@ class TestQuery(SimpleTestCase):
         msg = 'Cannot filter against a non-conditional expression.'
         with self.assertRaisesMessage(TypeError, msg):
             query.build_where(Func(output_field=CharField()))
+
+    def test_equality(self):
+        self.assertNotEqual(
+            Author.objects.all().query,
+            Author.objects.filter(item__name='foo').query,
+        )
+        self.assertEqual(
+            Author.objects.filter(item__name='foo').query,
+            Author.objects.filter(item__name='foo').query,
+        )
+        self.assertEqual(
+            Author.objects.filter(item__name='foo').query,
+            Author.objects.filter(Q(item__name='foo')).query,
+        )
+
+    def test_hash(self):
+        self.assertNotEqual(
+            hash(Author.objects.all().query),
+            hash(Author.objects.filter(item__name='foo').query)
+        )
+        self.assertEqual(
+            hash(Author.objects.filter(item__name='foo').query),
+            hash(Author.objects.filter(item__name='foo').query),
+        )
+        self.assertEqual(
+            hash(Author.objects.filter(item__name='foo').query),
+            hash(Author.objects.filter(Q(item__name='foo')).query),
+        )

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2807,11 +2807,11 @@ class ExcludeTests(TestCase):
         f1 = Food.objects.create(name='apples')
         Food.objects.create(name='oranges')
         Eaten.objects.create(food=f1, meal='dinner')
-        j1 = Job.objects.create(name='Manager')
+        cls.j1 = Job.objects.create(name='Manager')
         cls.r1 = Responsibility.objects.create(description='Playing golf')
         j2 = Job.objects.create(name='Programmer')
         r2 = Responsibility.objects.create(description='Programming')
-        JobResponsibilities.objects.create(job=j1, responsibility=cls.r1)
+        JobResponsibilities.objects.create(job=cls.j1, responsibility=cls.r1)
         JobResponsibilities.objects.create(job=j2, responsibility=r2)
 
     def test_to_field(self):
@@ -2883,6 +2883,14 @@ class ExcludeTests(TestCase):
             Number.objects.exclude(num=F('another_num')),
             [number],
         )
+
+    def test_exclude_multivalued_exists(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            self.assertSequenceEqual(
+                Job.objects.exclude(responsibilities__description='Programming'),
+                [self.j1],
+            )
+        self.assertIn('exists', captured_queries[0]['sql'].lower())
 
 
 class ExcludeTest17600(TestCase):


### PR DESCRIPTION
ticket-32143

---

A bit of research I did on the subject for PostgreSQL and MySQL

- https://www.percona.com/blog/2020/04/16/sql-optimizations-in-postgresql-in-vs-exists-vs-any-all-vs-join/
- https://dev.mysql.com/doc/refman/8.0/en/subquery-optimization-with-exists.html