### PR TITLE
Fixed #32144 -- Made makemessages remove temporary files when locale path doesn't exist.

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -510,6 +510,13 @@ class Command(BaseCommand):
         Use the xgettext GNU gettext utility.
         """
         build_files = []
+        try:
+            self._process_locale_dir(locale_dir, files, build_files)
+        finally:
+            for build_file in build_files:
+                build_file.cleanup()
+
+    def _process_locale_dir(self, locale_dir, files, build_files):
         for translatable in files:
             if self.verbosity > 1:
                 self.stdout.write('processing file %s in %s' % (
@@ -569,8 +576,6 @@ class Command(BaseCommand):
 
         if errors:
             if status != STATUS_OK:
-                for build_file in build_files:
-                    build_file.cleanup()
                 raise CommandError(
                     'errors happened while running xgettext on %s\n%s' %
                     ('\n'.join(input_files), errors)
@@ -591,9 +596,6 @@ class Command(BaseCommand):
                 msgs = build_file.postprocess_messages(msgs)
             potfile = os.path.join(locale_dir, '%s.pot' % self.domain)
             write_pot_file(potfile, msgs)
-
-        for build_file in build_files:
-            build_file.cleanup()
 
     def write_po_file(self, potfile, locale):
         """

--- a/tests/i18n/commands/templates/template_0_with_no_error.tpl
+++ b/tests/i18n/commands/templates/template_0_with_no_error.tpl
@@ -1,0 +1,6 @@
+{% load i18n %}
+{% blocktranslate %}Hello{% endblocktranslate %}
+
+This file has a name that should be lexicographically before
+'template_with_error.tpl' so that we can test the cleanup case
+of the first file being successful, but the second failing.

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -226,8 +226,9 @@ class BasicExtractorTests(ExtractorTests):
         )
         with self.assertRaisesMessage(SyntaxError, msg):
             management.call_command('makemessages', locale=[LOCALE], extensions=['tpl'], verbosity=0)
-        # The temporary file was cleaned up
+        # The temporary files were cleaned up
         self.assertFalse(os.path.exists('./templates/template_with_error.tpl.py'))
+        self.assertFalse(os.path.exists('./templates/template_0_with_no_error.tpl.py'))
 
     def test_unicode_decode_error(self):
         shutil.copyfile('./not_utf8.sample', './not_utf8.txt')


### PR DESCRIPTION
The error case "Unable to find a locale path to store translations..." didn't clean up its files.

https://code.djangoproject.com/ticket/32144#ticket