### PR TITLE
Removed an obsolete query test that assumes serial pks.

### DIFF
--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -849,14 +849,6 @@ class Queries1Tests(TestCase):
         self.assertQuerysetEqual(Note.objects.none() & Note.objects.all(), [])
         self.assertQuerysetEqual(Note.objects.all() & Note.objects.none(), [])
 
-    def test_ticket9411(self):
-        # Make sure bump_prefix() (an internal Query method) doesn't (re-)break. It's
-        # sufficient that this query runs without error.
-        qs = Tag.objects.values_list('id', flat=True).order_by('id')
-        qs.query.bump_prefix(qs.query)
-        first = qs[0]
-        self.assertEqual(list(qs), list(range(first, first + 5)))
-
     def test_ticket8439(self):
         # Complex combinations of conjunctions, disjunctions and nullable
         # relations.


### PR DESCRIPTION
The code from the original fix (922aba3def68e57c405a0e50d353a790af85b00a)
was removed in 419de7b00daabf5e9be064198d370cdbf19b5f2d.