### PR TITLE
Fixed some queries tests when primary key values are large.

### DIFF
--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -40,7 +40,7 @@ class Tag(models.Model):
 
 class Note(models.Model):
     note = models.CharField(max_length=100)
-    misc = models.CharField(max_length=10)
+    misc = models.CharField(max_length=25)
     tag = models.ForeignKey(Tag, models.SET_NULL, blank=True, null=True)
     negate = models.BooleanField(default=True)
 
@@ -408,7 +408,7 @@ class ChildObjectA(ObjectA):
 class ObjectB(models.Model):
     name = models.CharField(max_length=50)
     objecta = models.ForeignKey(ObjectA, models.CASCADE)
-    num = models.PositiveSmallIntegerField()
+    num = models.PositiveIntegerField()
 
     def __str__(self):
         return self.name
@@ -430,14 +430,14 @@ class ObjectC(models.Model):
 
 
 class SimpleCategory(models.Model):
-    name = models.CharField(max_length=15)
+    name = models.CharField(max_length=25)
 
     def __str__(self):
         return self.name
 
 
 class SpecialCategory(SimpleCategory):
-    special_name = models.CharField(max_length=15)
+    special_name = models.CharField(max_length=35)
 
     def __str__(self):
         return self.name + " " + self.special_name


### PR DESCRIPTION
On CockroachDB, primary key values stored in these fields are larger than
they accept. Fixes
queries.test_bulk_update.BulkUpdateNoteTests.test_multiple_fields,
queries.test_bulk_update.BulkUpdateNoteTests.test_inherited_fields, and
queries.tests.RelatedLookupTypeTests.test_values_queryset_lookup.