### PR TITLE
Fixed #29712 -- Made makemessages warn if locales have hyphens and skip them.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -564,6 +564,7 @@ answer newbie questions, and generally made Django that much better:
     Mads Jensen <https://github.com/atombrella>
     Makoto Tsuyuki <mtsuyuki@gmail.com>
     Malcolm Tredinnick
+    Manav Agarwal <dpsman13016@gmail.com>
     Manuel Saelices <msaelices@yaco.es>
     Manuzhai
     Marc Aymerich Gubern

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -383,6 +383,14 @@ class Command(BaseCommand):
 
             # Build po files for each selected locale
             for locale in locales:
+                if '-' in locale:
+                    self.stdout.write(
+                        'invalid locale %s, did you mean %s?' % (
+                            locale,
+                            locale.replace('-', '_'),
+                        ),
+                    )
+                    continue
                 if self.verbosity > 0:
                     self.stdout.write('processing locale %s' % locale)
                 for potfile in potfiles:

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -600,6 +600,10 @@ Miscellaneous
 * The password reset mechanism now invalidates tokens when the user email is
   changed.
 
+* :djadmin:`makemessages` command no longer processes invalid locales specified
+  using :option:`makemessages --locale` option, when they contain hyphens
+  (``'-'``).
+
 .. _deprecated-features-3.2:
 
 Features deprecated in 3.2

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -152,6 +152,20 @@ class BasicExtractorTests(ExtractorTests):
             with self.assertRaisesRegex(CommandError, msg):
                 management.call_command('makemessages')
 
+    def test_valid_locale(self):
+        out = StringIO()
+        management.call_command('makemessages', locale=['de'], stdout=out, verbosity=1)
+        self.assertNotIn('invalid locale de', out.getvalue())
+        self.assertIn('processing locale de', out.getvalue())
+        self.assertIs(Path(self.PO_FILE).exists(), True)
+
+    def test_invalid_locale(self):
+        out = StringIO()
+        management.call_command('makemessages', locale=['pl-PL'], stdout=out, verbosity=1)
+        self.assertIn('invalid locale pl-PL, did you mean pl_PL?', out.getvalue())
+        self.assertNotIn('processing locale pl-PL', out.getvalue())
+        self.assertIs(Path('locale/pl-PL/LC_MESSAGES/django.po').exists(), False)
+
     def test_comments_extractor(self):
         management.call_command('makemessages', locale=[LOCALE], verbosity=0)
         self.assertTrue(os.path.exists(self.PO_FILE))


### PR DESCRIPTION
[ticket-29712](https://code.djangoproject.com/ticket/29712)

Supersedes [#10365](https://github.com/django/django/pull/10365) and [#10345](https://github.com/django/django/pull/10345)

I have added a warning in makemessages command if the locale code with `l` flag is not correct.