### PR TITLE
Updated {% static %} tag examples in docs to use single quotes where appropriate.

### DIFF
--- a/docs/howto/static-files/index.txt
+++ b/docs/howto/static-files/index.txt
@@ -26,7 +26,7 @@ Configuring static files
    .. code-block:: html+django
 
         {% load static %}
-        <img src="{% static "my_app/example.jpg" %}" alt="My image">
+        <img src="{% static 'my_app/example.jpg' %}" alt="My image">
 
 #. Store your static files in a folder called ``static`` in your app. For
    example ``my_app/static/my_app/example.jpg``.

--- a/docs/intro/overview.txt
+++ b/docs/intro/overview.txt
@@ -307,7 +307,7 @@ Here's what the "base.html" template, including the use of :doc:`static files
         <title>{% block title %}{% endblock %}</title>
     </head>
     <body>
-        <img src="{% static "images/sitelogo.png" %}" alt="Logo">
+        <img src="{% static 'images/sitelogo.png' %}" alt="Logo">
         {% block content %}{% endblock %}
     </body>
     </html>

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -3471,7 +3471,7 @@ This would allow you to refer to the local file
 
 .. code-block:: html+django
 
-    <a href="{% static "downloads/polls_20101022.tar.gz" %}">
+    <a href="{% static 'downloads/polls_20101022.tar.gz' %}">
 
 .. setting:: STATICFILES_STORAGE
 

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -2618,7 +2618,7 @@ app is installed, the tag will serve files using ``url()`` method of the
 storage specified by :setting:`STATICFILES_STORAGE`. For example::
 
     {% load static %}
-    <img src="{% static "images/hi.jpg" %}" alt="Hi!">
+    <img src="{% static 'images/hi.jpg' %}" alt="Hi!">
 
 It is also able to consume standard context variables, e.g. assuming a
 ``user_stylesheet`` variable is passed to the template::


### PR DESCRIPTION
The example was using nested double quotes which is:
1. Breaking editor integrations
2. Hard to read
3. Not consistent with other code samples in the docs