### PR TITLE
Don't require a dict to shortcuts.render iff you are using the django template engine

### DIFF
--- a/django/template/backends/django.py
+++ b/django/template/backends/django.py
@@ -56,7 +56,8 @@ class Template:
         return self.template.origin
 
     def render(self, context=None, request=None):
-        context = make_context(context, request, autoescape=self.backend.engine.autoescape)
+        if not isinstance(context, Context):
+            context = make_context(context, request, autoescape=self.backend.engine.autoescape)
         try:
             return self.template.render(context)
         except TemplateDoesNotExist as exc:

--- a/django/template/backends/django.py
+++ b/django/template/backends/django.py
@@ -4,7 +4,7 @@ from pkgutil import walk_packages
 from django.apps import apps
 from django.conf import settings
 from django.template import TemplateDoesNotExist
-from django.template.context import make_context
+from django.template.context import make_context, Context
 from django.template.engine import Engine
 from django.template.library import InvalidTemplateLibrary
 


### PR DESCRIPTION


Currently I need to build a request context if I'm, going to render a template to a string, but then I can't pass that same context to shortcuts.render because of a blind call to make_context which would be so simple to skip.  This only affects django templates not jinja templates.