### PR TITLE
Refs #32061 -- Fixed test_crash_password_does_not_leak() crash on Windows.

### DIFF
--- a/tests/dbshell/test_mysql.py
+++ b/tests/dbshell/test_mysql.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -190,6 +191,8 @@ class MySqlDbshellCommandTestCase(SimpleTestCase):
             },
             [],
         )
+        if env:
+            env = {**os.environ, **env}
         fake_client = Path(__file__).with_name('fake_client.py')
         args[0:1] = [sys.executable, str(fake_client)]
         with self.assertRaises(subprocess.CalledProcessError) as ctx:

--- a/tests/dbshell/test_postgresql.py
+++ b/tests/dbshell/test_postgresql.py
@@ -1,3 +1,4 @@
+import os
 import signal
 import subprocess
 import sys
@@ -121,6 +122,8 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
         # The password doesn't leak in an exception that results from a client
         # crash.
         args, env = self.settings_to_cmd_args_env({'PASSWORD': 'somepassword'}, [])
+        if env:
+            env = {**os.environ, **env}
         fake_client = Path(__file__).with_name('fake_client.py')
         args[0:1] = [sys.executable, str(fake_client)]
         with self.assertRaises(subprocess.CalledProcessError) as ctx:


### PR DESCRIPTION
When `env` is passed to `subprocess.run()` we should pass all existing environment variables. This fixes crash on Windows:

- Python 3.6:
  `Fatal Python error: failed to get random numbers to initialize Python`
- Python 3.7+:
  ```
  Fatal Python error: _Py_HashRandomization_Init: failed to get random numbers to initialize Python
  Python runtime state: preinitialized
  ```

See [CI logs](https://djangoci.com/job/django-windows/1077/database=sqlite3,label=windows,python=Python36/console).