### PR TITLE
Fixed #32162 -- Fixed setting Content-Length header in AsyncRequestFactory.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -540,7 +540,7 @@ class AsyncRequestFactory(RequestFactory):
         }
         if data:
             s['headers'].extend([
-                (b'content-length', bytes(len(data))),
+                (b'content-length', str(len(data)).encode('ascii')),
                 (b'content-type', content_type.encode('ascii')),
             ])
             s['_body_file'] = FakePayload(data)

--- a/docs/releases/3.1.4.txt
+++ b/docs/releases/3.1.4.txt
@@ -9,4 +9,5 @@ Django 3.1.4 fixes several bugs in 3.1.3.
 Bugfixes
 ========
 
-* ...
+* Fixed setting the ``Content-Length`` HTTP header in ``AsyncRequestFactory``
+  (:ticket:`32162`).

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -997,3 +997,18 @@ class AsyncRequestFactoryTest(SimpleTestCase):
                 request = method('/somewhere/')
                 response = await async_generic_view(request)
                 self.assertEqual(response.status_code, 200)
+
+    async def test_request_factory_data(self):
+        async def async_generic_view(request):
+            return HttpResponse(status=200, content=request.body)
+
+        request = self.request_factory.post(
+            '/somewhere/',
+            data={'example': 'data'},
+            content_type='application/json',
+        )
+        self.assertEqual(request.headers['content-length'], '19')
+        self.assertEqual(request.headers['content-type'], 'application/json')
+        response = await async_generic_view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b'{"example": "data"}')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32164#ticket