### PR TITLE
Refs #31672 -- Made technical 500 debug page include exceptions without tracebacks.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -439,7 +439,13 @@ class ExceptionReporter:
     def get_exception_traceback_frames(self, exc_value, tb):
         exc_cause = self._get_explicit_or_implicit_cause(exc_value)
         exc_cause_explicit = getattr(exc_value, '__cause__', True)
-
+        if tb is None:
+            yield {
+                'exc_cause': exc_cause,
+                'exc_cause_explicit': exc_cause_explicit,
+                'tb': None,
+                'type': 'user',
+            }
         while tb is not None:
             # Support for __traceback_hide__ which is used by a few libraries
             # to hide internal frames.

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -225,7 +225,11 @@
         </h3></li>
         {% endif %}{% endifchanged %}
         <li class="frame {{ frame.type }}">
-          <code class="fname">{{ frame.filename }}</code>, line {{ frame.lineno }}, in {{ frame.function }}
+          {% if not frame.tb %}
+            {% if forloop.first %}None{% else %}Traceback: None{% endif %}
+          {% else %}
+            <code class="fname">{{ frame.filename }}</code>, line {{ frame.lineno }}, in {{ frame.function }}
+          {% endif %}
 
           {% if frame.context_line %}
             <div class="context" id="c{{ frame.id }}">
@@ -319,8 +323,8 @@ Traceback (most recent call last):{% for frame in frames %}
 The above exception ({{ frame.exc_cause|force_escape }}) was the direct cause of the following exception:
 {% else %}
 During handling of the above exception ({{ frame.exc_cause|force_escape }}), another exception occurred:
-{% endif %}{% endif %}{% endifchanged %}  File "{{ frame.filename }}"{% if frame.context_line %}, line {{ frame.lineno }}{% endif %}, in {{ frame.function }}
-{% if frame.context_line %}    {% spaceless %}{{ frame.context_line }}{% endspaceless %}{% endif %}{% endfor %}
+{% endif %}{% endif %}{% endifchanged %}  {% if frame.tb %}File "{{ frame.filename }}"{% if frame.context_line %}, line {{ frame.lineno }}{% endif %}, in {{ frame.function }}
+{% if frame.context_line %}    {% spaceless %}{{ frame.context_line }}{% endspaceless %}{% endif %}{% else %}{% if forloop.first %}None{% else %}Traceback: None{% endif %}{% endif %}{% endfor %}
 
 Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
 Exception Value: {{ exception_value|force_escape }}

--- a/django/views/templates/technical_500.txt
+++ b/django/views/templates/technical_500.txt
@@ -30,8 +30,8 @@ In template {{ template_info.name }}, error at line {{ template_info.line }}
 Traceback (most recent call last):
 {% for frame in frames %}{% ifchanged frame.exc_cause %}{% if frame.exc_cause %}
 {% if frame.exc_cause_explicit %}The above exception ({{ frame.exc_cause }}) was the direct cause of the following exception:{% else %}During handling of the above exception ({{ frame.exc_cause }}), another exception occurred:{% endif %}
-{% endif %}{% endifchanged %}  File "{{ frame.filename }}"{% if frame.context_line %}, line {{ frame.lineno }}{% endif %}, in {{ frame.function }}
-{% if frame.context_line %}    {% spaceless %}{{ frame.context_line }}{% endspaceless %}{% endif %}
+{% endif %}{% endifchanged %}  {% if frame.tb %}File "{{ frame.filename }}"{% if frame.context_line %}, line {{ frame.lineno }}{% endif %}, in {{ frame.function }}
+{% if frame.context_line %}    {% spaceless %}{{ frame.context_line }}{% endspaceless %}{% endif %}{% else %}{% if forloop.first %}None{% else %}Traceback: None{% endif %}{% endif %}
 {% endfor %}
 {% if exception_type %}Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
 {% if exception_value %}Exception Value: {{ exception_value }}{% endif %}{% endif %}{% endif %}


### PR DESCRIPTION
https://code.djangoproject.com/ticket/31672
Fixes [this comment](https://code.djangoproject.com/ticket/31672#comment:13).

If we return a mostly empty frame when `tb is None`  we don't have something to show on the traceback frame.
Should we don't show the traceback frame in `technical_500.html`?