### PR TITLE
Fixed #32168 -- Removed serial pk assumption in aggregation_regress tests.

### DIFF
--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -876,7 +876,7 @@ class AggregationTests(TestCase):
         )
 
         # Note: intentionally no order_by(), that case needs tests, too.
-        publishers = Publisher.objects.filter(id__in=[1, 2])
+        publishers = Publisher.objects.filter(id__in=[self.p1.id, self.p2.id])
         self.assertEqual(
             sorted(p.name for p in publishers),
             [
@@ -1450,8 +1450,10 @@ class AggregationTests(TestCase):
         query = Book.objects.annotate(Count('authors')).filter(
             q1 | q2).order_by('pk')
         self.assertQuerysetEqual(
-            query, [1, 4, 5, 6],
-            lambda b: b.pk)
+            query,
+            [self.b1.pk, self.b4.pk, self.b5.pk, self.b6.pk],
+            attrgetter('pk'),
+        )
 
     def test_ticket_11293_q_immutable(self):
         """

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -701,10 +701,10 @@ class AggregationTests(TestCase):
         qs = Book.objects.extra(select={'pub': 'publisher_id'}).values('pub').annotate(Count('id')).order_by('pub')
         self.assertSequenceEqual(
             qs, [
-                {'pub': self.b1.id, 'id__count': 2},
-                {'pub': self.b2.id, 'id__count': 1},
-                {'pub': self.b3.id, 'id__count': 2},
-                {'pub': self.b4.id, 'id__count': 1}
+                {'pub': self.p1.id, 'id__count': 2},
+                {'pub': self.p2.id, 'id__count': 1},
+                {'pub': self.p3.id, 'id__count': 2},
+                {'pub': self.p4.id, 'id__count': 1},
             ],
         )
 


### PR DESCRIPTION
This PR also fixes up a faulty cleanup from https://github.com/django/django/commit/1bf25e9bc6df6c2ae4c0b10fb839e101471e8373
where the test was relying on SQL ids inadvertently being the same between various objects.

Tested vs sqlite and cockroachdb**.

https://code.djangoproject.com/ticket/32168


** [django_cockroachdb](https://pypi.org/project/django-cockroachdb/) is still on version `3.1.1`, so this check will fail [1] when running the test suite (since the library wants to be the same semantic versioning as the Django release for compatibility). Bypassing that check allows these tests to pass and this patch applied to `stable/3.1.x` also passes these tests. This test [2] was failing prior to these changes (I'll figure out next steps for that separately).

[1] https://github.com/cockroachdb/django-cockroachdb/blob/master/django_cockroachdb/utils.py#L13
[2] https://github.com/django/django/blob/156a2138db20abc89933121e4ff2ee2ce56a173a/tests/aggregation_regress/tests.py#L1111