### PR TITLE
Fixed #10929 -- Support a default value for Sum

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -145,6 +145,19 @@ class Sum(FixDurationInputMixin, Aggregate):
     name = 'Sum'
     allow_distinct = True
 
+    def __init__(self, *expressions, default=None, **extra):
+        self.default_value = default
+        super().__init__(*expressions, **extra)
+
+    def convert_value(self, value, expression, connection):
+        value = self.default_value if value is None else value
+
+        import datetime
+        if isinstance(value, datetime.timedelta):
+            value = value.microseconds
+
+        return super().convert_value(value, expression, connection)
+
 
 class Variance(NumericOutputFieldMixin, Aggregate):
     name = 'Variance'

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -3637,14 +3637,20 @@ by the aggregate.
 ``Sum``
 ~~~~~~~
 
-.. class:: Sum(expression, output_field=None, distinct=False, filter=None, **extra)
+.. class:: Sum(expression, output_field=None, default=None, distinct=False, filter=None, **extra)
 
     Computes the sum of all values of the given expression.
 
     * Default alias: ``<field>__sum``
     * Return type: same as input field, or ``output_field`` if supplied
 
-    Has one optional argument:
+    Has two optional arguments:
+
+    .. versionchanged:: 3.2
+    .. attribute:: default
+
+        If ``default`` is set, ``Sum`` will return this value instead of ``None``
+        if the ``QuerySet`` to be summed, or its values, are empty.
 
     .. attribute:: distinct
 

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -343,6 +343,8 @@ Models
 
 * Added the :class:`~django.db.models.functions.Random` database function.
 
+* Added ``default`` kwarg to :class:`~django.db.models.Sum` aggregation function.
+
 Pagination
 ~~~~~~~~~~
 

--- a/docs/topics/db/aggregation.txt
+++ b/docs/topics/db/aggregation.txt
@@ -54,6 +54,9 @@ above::
     >>> Book.objects.filter(publisher__name='BaloneyPress').count()
     73
 
+    # Total price for all books with "Web" in name, default to zero if no books can be found.
+    >>> Book.objects.filter(name__contains="Web").aggregate(Sum('price', default=0))
+
     # Average price across all books.
     >>> from django.db.models import Avg
     >>> Book.objects.all().aggregate(Avg('price'))
@@ -133,6 +136,11 @@ by providing that name when you specify the aggregate clause::
 
     >>> Book.objects.aggregate(average_price=Avg('price'))
     {'average_price': 34.35}
+
+.. versionchanged:: 3.2
+
+The ``Sum()`` function takes a keyword argument, ``default`` that specifies
+what value to return in case no items are in the ``QuerySet`` to sum.
 
 If you want to generate more than one aggregate, you add another argument to
 the ``aggregate()`` clause. So, if we also wanted to know the maximum and

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -485,6 +485,29 @@ class AggregateTestCase(TestCase):
             {'duration__sum': datetime.timedelta(days=3)}
         )
 
+    def test_sum_default_value(self):
+        self.assertEqual(
+            Book.objects.filter(name="IMAGINARY BOOK").aggregate(price_sum=Sum('price', default=0)),
+            {'price_sum': Decimal('0')}
+        )
+
+        self.assertEqual(
+            Book.objects.filter(name="IMAGINARY BOOK").aggregate(rating_sum=Sum('rating', default=0)),
+            {'rating_sum': 0.0}
+        )
+
+        self.assertEqual(
+            Book.objects.filter(name="IMAGINARY BOOK").aggregate(pages_sum=Sum('pages', default=0)),
+            {'pages_sum': 0}
+        )
+
+        self.assertEqual(
+            Publisher.objects.filter(
+                name="IMAGINARY PUBLISHER"
+            ).aggregate(Sum('duration', default=datetime.timedelta(0), output_field=DurationField())),
+            {'duration__sum': datetime.timedelta(seconds=0)}
+        )
+
     def test_sum_distinct_aggregate(self):
         """
         Sum on a distinct() QuerySet should aggregate only the distinct items.


### PR DESCRIPTION
Added default=None keyword argument to Sum

Added tests for each supported output_field type

Update docs/topics/db/aggregation.txt

https://code.djangoproject.com/ticket/10929