### PR TITLE
Refs #31910 -- Fixed GeoQuerySetTest.test_geoagg_subquery() test on Oracle 18c.

### DIFF
--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -596,12 +596,12 @@ class GeoQuerySetTest(TestCase):
 
     @skipUnlessDBFeature('supports_union_aggr')
     def test_geoagg_subquery(self):
-        ks = State.objects.get(name='Kansas')
-        union = GEOSGeometry('MULTIPOINT(-95.235060 38.971823)')
+        tx = Country.objects.get(name='Texas')
+        union = GEOSGeometry('MULTIPOINT(-96.801611 32.782057,-95.363151 29.763374)')
         # Use distinct() to force the usage of a subquery for aggregation.
         with CaptureQueriesContext(connection) as ctx:
             self.assertIs(union.equals(
-                City.objects.filter(point__within=ks.poly).distinct().aggregate(
+                City.objects.filter(point__within=tx.mpoly).distinct().aggregate(
                     Union('point'),
                 )['point__union'],
             ), True)


### PR DESCRIPTION
See [logs](https://djangoci.com/view/Main/job/django-oracle/database=oragis18,python=python3.6/401/testReport/gis_tests.geoapp.tests/GeoQuerySetTest/test_geoagg_subquery/).