### PR TITLE
Refs #32074 -- Fixed handling memoryview content by HttpResponse on Python 3.10+.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -351,7 +351,10 @@ class HttpResponse(HttpResponseBase):
     @content.setter
     def content(self, value):
         # Consume iterators upon assignment to allow repeated iteration.
-        if hasattr(value, '__iter__') and not isinstance(value, (bytes, str)):
+        if (
+            hasattr(value, '__iter__') and
+            not isinstance(value, (bytes, memoryview, str))
+        ):
             content = b''.join(self.make_bytes(chunk) for chunk in value)
             if hasattr(value, 'close'):
                 try:


### PR DESCRIPTION
ticket-32074

An iterator was added to `memoryview` in Python 3.10, see [bpo-41732](https://bugs.python.org/issue41732).

See also ticket-30294.