### PR TITLE
 Fixed #32172 -- Adapted signals to allow async handlers.

### DIFF
--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -151,7 +151,7 @@ class ASGIHandler(base.BaseHandler):
             return
         # Request is complete and can be served.
         set_script_prefix(self.get_script_prefix(scope))
-        await sync_to_async(signals.request_started.send, thread_sensitive=True)(sender=self.__class__, scope=scope)
+        await signals.request_started.send_async(sender=self.__class__, scope=scope)
         # Get the request and check for basic issues.
         request, error_response = self.create_request(scope, body_file)
         if request is None:

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -140,7 +140,7 @@ def complex_setting_changed(**kwargs):
         # Considering the current implementation of the signals framework,
         # this stacklevel shows the line containing the override_settings call.
         warnings.warn("Overriding setting %s can lead to unexpected behavior."
-                      % kwargs['setting'], stacklevel=6)
+                      % kwargs['setting'], stacklevel=5)
 
 
 @receiver(setting_changed)

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -386,7 +386,9 @@ Serialization
 Signals
 ~~~~~~~
 
-* ...
+* The new :meth:`django.dispatch.Signal.send_async` allows asynchronous signal
+  dispatch. Signal receivers may be synchronous or asynchronous, and will be
+  automatically adapted to the correct calling style.
 
 Templates
 ~~~~~~~~~

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -88,6 +88,8 @@ from an async view, you will trigger Django's
 :ref:`asynchronous safety protection <async-safety>` to protect your data from
 corruption.
 
+.. _async_performance:
+
 Performance
 -----------
 

--- a/docs/topics/signals.txt
+++ b/docs/topics/signals.txt
@@ -100,16 +100,20 @@ This would be wrong -- in fact, Django will throw an error if you do so. That's
 because at any point arguments could get added to the signal and your receiver
 must be able to handle those new arguments.
 
-.. versionchanged:: 3.2
-
-Receiver function can be simple function or coroutine::
+Receivers may also be asynchronous functions, with the same signature but
+declared using ``async def``::
 
     async def my_callback(sender, **kwargs):
         await asyncio.sleep(5)
         print("Request finished!")
 
-If needed, receiver will be adapted for way signal exactly send. See
-:ref:`sending signals <sending-signals>` for more information.
+Signals can be sent either synchronously or asynchronously, and receivers will
+automatically be adapted to the correct call-style. See :ref:`sending signals
+<sending-signals>` for more information.
+
+.. versionchanged:: 3.2
+
+    Support for asynchronous receivers was added.
 
 .. _connecting-receiver-functions:
 
@@ -248,15 +252,21 @@ This declares a ``pizza_done`` signal.
 Sending signals
 ---------------
 
-There are three ways to send signals in Django.
+
+
+There are two ways to send signals synchronously in Django.
 
 .. method:: Signal.send(sender, **kwargs)
-.. method:: Signal.send_async(sender, **kwargs)
 .. method:: Signal.send_robust(sender, **kwargs)
 
-To send a signal, call one of this methods. You must provide the ``sender``
-argument (which is a class most of the time) and may provide as many other
-keyword arguments as you like.
+Signals may also be sent asynchronously.
+
+.. method:: Signal.send_async(sender, **kwargs)
+
+To send a signal, call either :meth:`Signal.send` or
+:meth:`Signal.send_robust`, or ``await`` :meth:`Signal.send_async`. You must
+provide the ``sender`` argument (which is a class most of the time) and may
+provide as many other keyword arguments as you like.
 
 For example, here's how sending our ``pizza_done`` signal might look::
 
@@ -277,26 +287,34 @@ be notified of a signal in the face of an error.
 
 ``send_robust()`` catches all errors derived from Python's ``Exception`` class,
 and ensures all receivers are notified of the signal. If an error occurs, the
-error instance is returned in the tuple pair for the receiver that raised the error.
+error instance is returned in the tuple pair for the receiver that raised the
+error.
 
 The tracebacks are present on the ``__traceback__`` attribute of the errors
 returned when calling ``send_robust()``.
 
-.. versionchanged:: 3.2
-
-``send_async()`` is similar as ``send()``, but it is coroutine that should be
+``send_async()`` is similar as ``send()``, but it is coroutine that must be
 awaited::
 
     async def send_pizza_async(self, toppings, size):
         await pizza_done.send_async(
-            sender=self.__class__, toppings=toppings, size=size)
+            sender=self.__class__, toppings=toppings, size=size
+        )
         ...
 
-All sync receivers will be called using
-:doc:`async_to_sync </topics/async>` adoption. In opposite, ``send()`` and
-``send_robust()`` use :doc:`sync_to_async </topics/async>` to adapt async
-receivers.
+Whether synchronous or asynchronous, receivers will be correctly adapted to
+whether ``send()`` or ``send_async()`` is used. Synchronous receivers will be
+called using :func:`sync_to_async` when invoked via ``send_async()``.
+Asynchronous receivers will be called using :func:`async_to_sync` when invoked
+via ``sync()``. Similar to the :ref:`case for middleware <async_performance>`,
+there is a small performance cost to adapting receivers in this way.
 
+All built-in signals, except those in the async request-response pathway, are
+dispatched using :meth:`Signal.send`.
+
+.. versionchanged:: 3.2
+
+    Support for asynchronous signals was added.
 
 Disconnecting signals
 =====================

--- a/docs/topics/signals.txt
+++ b/docs/topics/signals.txt
@@ -100,6 +100,17 @@ This would be wrong -- in fact, Django will throw an error if you do so. That's
 because at any point arguments could get added to the signal and your receiver
 must be able to handle those new arguments.
 
+.. versionchanged:: 3.2
+
+Receiver function can be simple function or coroutine::
+
+    async def my_callback(sender, **kwargs):
+        await asyncio.sleep(5)
+        print("Request finished!")
+
+If needed, receiver will be adapted for way signal exactly send. See
+:ref:`sending signals <sending-signals>` for more information.
+
 .. _connecting-receiver-functions:
 
 Connecting receiver functions
@@ -232,18 +243,20 @@ For example::
 
 This declares a ``pizza_done`` signal.
 
+.. _sending-signals:
+
 Sending signals
 ---------------
 
-There are two ways to send signals in Django.
+There are three ways to send signals in Django.
 
 .. method:: Signal.send(sender, **kwargs)
+.. method:: Signal.send_async(sender, **kwargs)
 .. method:: Signal.send_robust(sender, **kwargs)
 
-To send a signal, call either :meth:`Signal.send` (all built-in signals use
-this) or :meth:`Signal.send_robust`. You must provide the ``sender`` argument
-(which is a class most of the time) and may provide as many other keyword
-arguments as you like.
+To send a signal, call one of this methods. You must provide the ``sender``
+argument (which is a class most of the time) and may provide as many other
+keyword arguments as you like.
 
 For example, here's how sending our ``pizza_done`` signal might look::
 
@@ -254,9 +267,8 @@ For example, here's how sending our ``pizza_done`` signal might look::
             pizza_done.send(sender=self.__class__, toppings=toppings, size=size)
             ...
 
-Both ``send()`` and ``send_robust()`` return a list of tuple pairs
-``[(receiver, response), ... ]``, representing the list of called receiver
-functions and their response values.
+All three methods return a list of tuple pairs ``[(receiver, response), ... ]``,
+representing the list of called receiver functions and their response values.
 
 ``send()`` differs from ``send_robust()`` in how exceptions raised by receiver
 functions are handled. ``send()`` does *not* catch any exceptions raised by
@@ -269,6 +281,22 @@ error instance is returned in the tuple pair for the receiver that raised the er
 
 The tracebacks are present on the ``__traceback__`` attribute of the errors
 returned when calling ``send_robust()``.
+
+.. versionchanged:: 3.2
+
+``send_async()`` is similar as ``send()``, but it is coroutine that should be
+awaited::
+
+    async def send_pizza_async(self, toppings, size):
+        await pizza_done.send_async(
+            sender=self.__class__, toppings=toppings, size=size)
+        ...
+
+All sync receivers will be called using
+:doc:`async_to_sync </topics/async>` adoption. In opposite, ``send()`` and
+``send_robust()`` use :doc:`sync_to_async </topics/async>` to adapt async
+receivers.
+
 
 Disconnecting signals
 =====================

--- a/tests/signals/tests.py
+++ b/tests/signals/tests.py
@@ -1,5 +1,7 @@
+import asyncio
 from unittest import mock
 
+from django import dispatch
 from django.apps.registry import Apps
 from django.db import models
 from django.db.models import signals
@@ -351,3 +353,61 @@ class LazyModelRefTests(BaseSignalSetup, SimpleTestCase):
         apps2 = Apps()
         signals.post_init.connect(self.receiver, sender=Book, apps=apps2)
         self.assertEqual(list(apps2._pending_operations), [])
+
+
+class SyncHandler:
+    param = 0
+
+    def __call__(self, **kwargs):
+        self.param += 1
+        return self.param
+
+
+class AsyncHandler:
+    _is_coroutine = asyncio.coroutines._is_coroutine
+    param = 0
+
+    async def __call__(self, **kwargs):
+        self.param += 1
+        return self.param
+
+
+class AsyncReceiversTests(SimpleTestCase):
+    async def test_send_async(self):
+        sync_handler = SyncHandler()
+        async_handler = AsyncHandler()
+        signal = dispatch.Signal()
+        signal.connect(sync_handler)
+        signal.connect(async_handler)
+        result = await signal.send_async(self.__class__)
+        self.assertListEqual(result, [(sync_handler, 1), (async_handler, 1)])
+
+    def test_send(self):
+        sync_handler = SyncHandler()
+        async_handler = AsyncHandler()
+        signal = dispatch.Signal()
+        signal.connect(sync_handler)
+        signal.connect(async_handler)
+        result = signal.send(self.__class__)
+        self.assertListEqual(result, [(sync_handler, 1), (async_handler, 1)])
+
+    def test_send_robust(self):
+        class ReceiverException(Exception):
+            pass
+
+        class FailingAsyncHandler:
+            _is_coroutine = asyncio.coroutines._is_coroutine
+
+            async def __call__(self, **kwargs):
+                raise ReceiverException()
+
+        sync_handler = SyncHandler()
+        async_handler = AsyncHandler()
+        failing_handler = FailingAsyncHandler()
+        signal = dispatch.Signal()
+        signal.connect(failing_handler)
+        signal.connect(async_handler)
+        signal.connect(sync_handler)
+        result = signal.send_robust(self.__class__)
+        self.assertTrue(isinstance(result[0][1], ReceiverException))
+        self.assertListEqual(result[1:], [(async_handler, 1), (sync_handler, 1)])


### PR DESCRIPTION
Proposed implementation for ticket https://code.djangoproject.com/ticket/32172

I tried different options:
1.  Make adoption inside of "send" method. 
In this case  implementation became very complex. We need to send information about what kind of call (sync or async) we expect, and we can do that only through kwargs. However kwargs are preserved for signal needs, and adding new one possibly can clash with names on django-based projects. So I decided to make separate implementation.

2. Parallel execution.
In asyncio way it will be logical to run all receivers in parallel to get full power of asyncio. However, as sync_to_async creates a thread for every sync handler in receivers, it possibly can create much of threads that can completely kill performance. 

So finally - that is separate method with almost same logic, adapted for asyncio.