### PR TITLE
Fixed #32158 -- Fixed crash in loaddata when table name is a SQL keyword

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -332,6 +332,7 @@ answer newbie questions, and generally made Django that much better:
     Ge Hanbin <xiaomiba0904@gmail.com>
     geber@datacollect.com
     Geert Vanderkelen
+    George Bezerra <georgelione@gmail.com>
     George Karpenkov <george@metaworld.ru>
     George Song <george@damacy.net>
     George Vilches <gav@thataddress.com>

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -327,19 +327,21 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                     violations = cursor.execute('PRAGMA foreign_key_check').fetchall()
                 else:
                     violations = chain.from_iterable(
-                        cursor.execute('PRAGMA foreign_key_check(%s)' % table_name).fetchall()
+                        cursor.execute(
+                            'PRAGMA foreign_key_check(%s)' % self.ops.quote_name(table_name)
+                        ).fetchall()
                         for table_name in table_names
                     )
                 # See https://www.sqlite.org/pragma.html#pragma_foreign_key_check
                 for table_name, rowid, referenced_table_name, foreign_key_index in violations:
                     foreign_key = cursor.execute(
-                        'PRAGMA foreign_key_list(%s)' % table_name
+                        'PRAGMA foreign_key_list(%s)' % self.ops.quote_name(table_name)
                     ).fetchall()[foreign_key_index]
                     column_name, referenced_column_name = foreign_key[3:5]
                     primary_key_column_name = self.introspection.get_primary_key_column(cursor, table_name)
                     primary_key_value, bad_value = cursor.execute(
                         'SELECT %s, %s FROM %s WHERE rowid = %%s' % (
-                            primary_key_column_name, column_name, table_name
+                            primary_key_column_name, column_name, self.ops.quote_name(table_name)
                         ),
                         (rowid,),
                     ).fetchone()

--- a/tests/fixtures_regress/fixtures/order.json
+++ b/tests/fixtures_regress/fixtures/order.json
@@ -1,0 +1,9 @@
+[
+    {
+        "pk": "1",
+        "model": "fixtures_regress.order",
+        "fields": {
+            "name": "Order 1"
+        }
+    }
+]

--- a/tests/fixtures_regress/fixtures/order_invalid_fk.json
+++ b/tests/fixtures_regress/fixtures/order_invalid_fk.json
@@ -1,0 +1,10 @@
+[
+    {
+        "pk": "1",
+        "model": "fixtures_regress.order",
+        "fields": {
+            "name": "Order 1",
+            "customer": 1
+        }
+    }
+]

--- a/tests/fixtures_regress/models.py
+++ b/tests/fixtures_regress/models.py
@@ -238,6 +238,15 @@ class Thingy(models.Model):
     name = models.CharField(max_length=255)
 
 
+# Model with table purposely named as a SQL reserved keyword
+class Order(models.Model):
+    name = models.CharField(max_length=255, unique=True)
+    customer = models.ForeignKey(Person, models.SET_NULL, null=True)
+
+    class Meta:
+        db_table = 'order'
+
+
 class M2MToSelf(models.Model):
     parent = models.ManyToManyField("self", blank=True)
 

--- a/tests/fixtures_regress/tests.py
+++ b/tests/fixtures_regress/tests.py
@@ -505,12 +505,8 @@ class TestFixtures(TestCase):
         error instead of an operation error for invalid FKs when table names
         are SQL keywords.
         """
-        message = (
-            "Problem installing fixtures: The row in table 'order' with primary key '1' has an "
-            "invalid foreign key: order.customer_id contains a value '1' that does not have a "
-            "corresponding value in fixtures_regress_person.id."
-        )
-        with self.assertRaisesMessage(IntegrityError, message):
+        message_regex = '^Problem installing fixtures'
+        with self.assertRaisesRegex(IntegrityError, message_regex):
             management.call_command(
                 'loaddata',
                 'order_invalid_fk',


### PR DESCRIPTION
On SQLite, if one tried to load a fixture using loaddata for a model with table name "order", or any other SQL reserved word, it would raise a `sqlite3.OperationalError`.

That happened because, when constructing the SQL query to check constraints, the table name was not being quoted.

Ticket: https://code.djangoproject.com/ticket/32158