### PR TITLE
Fixed #32179 -- Added JSONObject database function.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -306,6 +306,8 @@ class BaseDatabaseFeatures:
     # Does value__d__contains={'f': 'g'} (without a list around the dict) match
     # {'d': [{'f': 'g'}]}?
     json_key_contains_list_matching_requires_list = False
+    # Does the backend support JSONObject() database function?
+    has_json_object_function = True
 
     # Does the backend support column collations?
     supports_collation_on_charfield = True

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -94,3 +94,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                     return False
                 raise
             return True
+
+    @cached_property
+    def has_json_object_function(self):
+        # Oracle < 18 supports JSON_OBJECT() but it's not fully functional.
+        return self.connection.oracle_version >= (18,)

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -79,3 +79,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         return True
 
     can_introspect_json_field = property(operator.attrgetter('supports_json_field'))
+    has_json_object_function = property(operator.attrgetter('supports_json_field'))

--- a/django/db/models/functions/__init__.py
+++ b/django/db/models/functions/__init__.py
@@ -1,4 +1,6 @@
-from .comparison import Cast, Coalesce, Collate, Greatest, Least, NullIf
+from .comparison import (
+    Cast, Coalesce, Collate, Greatest, JSONObject, Least, NullIf,
+)
 from .datetime import (
     Extract, ExtractDay, ExtractHour, ExtractIsoWeekDay, ExtractIsoYear,
     ExtractMinute, ExtractMonth, ExtractQuarter, ExtractSecond, ExtractWeek,
@@ -22,7 +24,7 @@ from .window import (
 
 __all__ = [
     # comparison and conversion
-    'Cast', 'Coalesce', 'Collate', 'Greatest', 'Least', 'NullIf',
+    'Cast', 'Coalesce', 'Collate', 'Greatest', 'JSONObject', 'Least', 'NullIf',
     # datetime
     'Extract', 'ExtractDay', 'ExtractHour', 'ExtractMinute', 'ExtractMonth',
     'ExtractQuarter', 'ExtractSecond', 'ExtractWeek', 'ExtractIsoWeekDay',

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -148,6 +148,29 @@ and ``comment.modified``.
     The PostgreSQL behavior can be emulated using ``Coalesce`` if you know
     a sensible minimum value to provide as a default.
 
+``JSONObject``
+--------------
+
+.. class:: JSONObject(**fields)
+
+.. versionadded:: 3.2
+
+Takes a list of key-value pairs and returns a JSON object containing those
+pairs.
+
+Usage example::
+
+    >>> from django.db.models import F
+    >>> from django.db.models.functions import JSONObject, Lower
+    >>> Author.objects.create(name='Margaret Smith', alias='msmith', age=25)
+    >>> author = Author.objects.annotate(json_object=JSONObject(
+    ...     name=Lower('name'),
+    ...     alias='alias',
+    ...     age=F('age') * 2,
+    ... )).get()
+    >>> author.json_object
+    {'name': 'margaret smith', 'alias': 'msmith', 'age': 50}
+
 ``Least``
 ---------
 

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -367,6 +367,8 @@ Models
   block exits without errors. A nested atomic block marked as durable will
   raise a ``RuntimeError``.
 
+* Added the :class:`~django.db.models.functions.JSONObject` database function.
+
 Pagination
 ~~~~~~~~~~
 

--- a/tests/db_functions/comparison/test_json_object.py
+++ b/tests/db_functions/comparison/test_json_object.py
@@ -1,0 +1,82 @@
+from django.db import NotSupportedError
+from django.db.models import F, Value
+from django.db.models.functions import JSONObject, Lower
+from django.test import TestCase
+from django.test.testcases import skipIfDBFeature, skipUnlessDBFeature
+from django.utils import timezone
+
+from ..models import Article, Author
+
+
+@skipUnlessDBFeature('has_json_object_function')
+class JSONObjectTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        Author.objects.create(name='Ivan Ivanov', alias='iivanov')
+
+    def test_empty(self):
+        obj = Author.objects.annotate(json_object=JSONObject()).first()
+        self.assertEqual(obj.json_object, {})
+
+    def test_basic(self):
+        obj = Author.objects.annotate(json_object=JSONObject(name='name')).first()
+        self.assertEqual(obj.json_object, {'name': 'Ivan Ivanov'})
+
+    def test_expressions(self):
+        obj = Author.objects.annotate(json_object=JSONObject(
+            name=Lower('name'),
+            alias='alias',
+            goes_by='goes_by',
+            salary=Value(30000.15),
+            age=F('age') * 2,
+        )).first()
+        self.assertEqual(obj.json_object, {
+            'name': 'ivan ivanov',
+            'alias': 'iivanov',
+            'goes_by': None,
+            'salary': 30000.15,
+            'age': 60,
+        })
+
+    def test_nested_json_object(self):
+        obj = Author.objects.annotate(json_object=JSONObject(
+            name='name',
+            nested_json_object=JSONObject(
+                alias='alias',
+                age='age',
+            ),
+        )).first()
+        self.assertEqual(obj.json_object, {
+            'name': 'Ivan Ivanov',
+            'nested_json_object': {
+                'alias': 'iivanov',
+                'age': 30,
+            },
+        })
+
+    def test_nested_empty_json_object(self):
+        obj = Author.objects.annotate(json_object=JSONObject(
+            name='name',
+            nested_json_object=JSONObject(),
+        )).first()
+        self.assertEqual(obj.json_object, {
+            'name': 'Ivan Ivanov',
+            'nested_json_object': {},
+        })
+
+    def test_textfield(self):
+        Article.objects.create(
+            title='The Title',
+            text='x' * 4000,
+            written=timezone.now(),
+        )
+        obj = Article.objects.annotate(json_object=JSONObject(text=F('text'))).first()
+        self.assertEqual(obj.json_object, {'text': 'x' * 4000})
+
+
+@skipIfDBFeature('has_json_object_function')
+class JSONObjectNotSupportedTests(TestCase):
+    def test_not_supported(self):
+        msg = 'JSONObject() is not supported on this database backend.'
+        with self.assertRaisesMessage(NotSupportedError, msg):
+            Author.objects.annotate(json_object=JSONObject()).get()


### PR DESCRIPTION
So for oracle between key and value must be VALUE keyword:
https://docs.oracle.com/en/database/oracle/oracle-database/12.2/sqlrf/JSON_OBJECT.html
