### PR TITLE
Fixed #32177 -- Made execute_from_command_line() use program name from the argv argument.

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -344,7 +344,12 @@ class ManagementUtility:
         # Preprocess options to extract --settings and --pythonpath.
         # These options could affect the commands that are available, so they
         # must be processed early.
-        parser = CommandParser(usage='%(prog)s subcommand [options] [args]', add_help=False, allow_abbrev=False)
+        parser = CommandParser(
+            prog=self.prog_name,
+            usage='%(prog)s subcommand [options] [args]',
+            add_help=False,
+            allow_abbrev=False,
+        )
         parser.add_argument('--settings')
         parser.add_argument('--pythonpath')
         parser.add_argument('args', nargs='*')  # catch-all


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32177

Rather than parsing the program name once in `ManagementUtility` from explicit arguments passed to its constructor and again in `CommandParser` from `sys.argv`, allow `CommandParser` to to re-use `ManagementUtility`'s determination of the
program name and thereby respect the arguments to `ManagementUtility`.

If @itisDouglas doesn't mind, this supersedes django/django#13652 because this PR has a regression test. I didn't add any documentation because this effects an undocumented feature.