### PR TITLE
Removed unnecessary __str__() methods in tests models.

### DIFF
--- a/tests/admin_changelist/models.py
+++ b/tests/admin_changelist/models.py
@@ -32,16 +32,10 @@ class Musician(models.Model):
     name = models.CharField(max_length=30)
     age = models.IntegerField(null=True, blank=True)
 
-    def __str__(self):
-        return self.name
-
 
 class Group(models.Model):
     name = models.CharField(max_length=30)
     members = models.ManyToManyField(Musician, through='Membership')
-
-    def __str__(self):
-        return self.name
 
 
 class Concert(models.Model):

--- a/tests/admin_custom_urls/models.py
+++ b/tests/admin_custom_urls/models.py
@@ -10,9 +10,6 @@ class Action(models.Model):
     name = models.CharField(max_length=50, primary_key=True)
     description = models.CharField(max_length=70)
 
-    def __str__(self):
-        return self.name
-
 
 class ActionAdmin(admin.ModelAdmin):
     """

--- a/tests/admin_filters/models.py
+++ b/tests/admin_filters/models.py
@@ -69,9 +69,6 @@ class TaggedItem(models.Model):
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey('content_type', 'object_id')
 
-    def __str__(self):
-        return self.tag
-
 
 class Bookmark(models.Model):
     url = models.URLField()
@@ -83,6 +80,3 @@ class Bookmark(models.Model):
         ('', '-'),
     ]
     none_or_null = models.CharField(max_length=20, choices=CHOICES, blank=True, null=True)
-
-    def __str__(self):
-        return self.url

--- a/tests/admin_utils/models.py
+++ b/tests/admin_utils/models.py
@@ -42,9 +42,6 @@ class Count(models.Model):
     num = models.PositiveSmallIntegerField()
     parent = models.ForeignKey('self', models.CASCADE, null=True)
 
-    def __str__(self):
-        return str(self.num)
-
 
 class Event(models.Model):
     date = models.DateTimeField(auto_now_add=True)

--- a/tests/aggregation/models.py
+++ b/tests/aggregation/models.py
@@ -7,17 +7,11 @@ class Author(models.Model):
     friends = models.ManyToManyField('self', blank=True)
     rating = models.FloatField(null=True)
 
-    def __str__(self):
-        return self.name
-
 
 class Publisher(models.Model):
     name = models.CharField(max_length=255)
     num_awards = models.IntegerField()
     duration = models.DurationField(blank=True, null=True)
-
-    def __str__(self):
-        return self.name
 
 
 class Book(models.Model):
@@ -31,15 +25,9 @@ class Book(models.Model):
     publisher = models.ForeignKey(Publisher, models.CASCADE)
     pubdate = models.DateField()
 
-    def __str__(self):
-        return self.name
-
 
 class Store(models.Model):
     name = models.CharField(max_length=255)
     books = models.ManyToManyField(Book)
     original_opening = models.DateTimeField()
     friday_night_closing = models.TimeField()
-
-    def __str__(self):
-        return self.name

--- a/tests/backends/models.py
+++ b/tests/backends/models.py
@@ -9,16 +9,10 @@ class Square(models.Model):
     root = models.IntegerField()
     square = models.PositiveIntegerField()
 
-    def __str__(self):
-        return "%s ** 2 == %s" % (self.root, self.square)
-
 
 class Person(models.Model):
     first_name = models.CharField(max_length=20)
     last_name = models.CharField(max_length=20)
-
-    def __str__(self):
-        return '%s %s' % (self.first_name, self.last_name)
 
 
 class SchoolClass(models.Model):
@@ -53,9 +47,6 @@ class Reporter(models.Model):
     first_name = models.CharField(max_length=30)
     last_name = models.CharField(max_length=30)
 
-    def __str__(self):
-        return "%s %s" % (self.first_name, self.last_name)
-
 
 class ReporterProxy(Reporter):
     class Meta:
@@ -73,9 +64,6 @@ class Article(models.Model):
         related_name='reporter_proxy',
     )
 
-    def __str__(self):
-        return self.headline
-
 
 class Item(models.Model):
     name = models.CharField(max_length=30)
@@ -83,23 +71,14 @@ class Item(models.Model):
     time = models.TimeField()
     last_modified = models.DateTimeField()
 
-    def __str__(self):
-        return self.name
-
 
 class Object(models.Model):
     related_objects = models.ManyToManyField("self", db_constraint=False, symmetrical=False)
     obj_ref = models.ForeignKey('ObjectReference', models.CASCADE, null=True)
 
-    def __str__(self):
-        return str(self.id)
-
 
 class ObjectReference(models.Model):
     obj = models.ForeignKey(Object, models.CASCADE, db_constraint=False)
-
-    def __str__(self):
-        return str(self.obj_id)
 
 
 class ObjectSelfReference(models.Model):

--- a/tests/custom_columns/models.py
+++ b/tests/custom_columns/models.py
@@ -27,9 +27,6 @@ class Author(models.Model):
         db_table = 'my_author_table'
         ordering = ('last_name', 'first_name')
 
-    def __str__(self):
-        return '%s %s' % (self.first_name, self.last_name)
-
 
 class Article(models.Model):
     Article_ID = models.AutoField(primary_key=True, db_column='Article ID')
@@ -45,6 +42,3 @@ class Article(models.Model):
 
     class Meta:
         ordering = ('headline',)
-
-    def __str__(self):
-        return self.headline

--- a/tests/custom_columns/tests.py
+++ b/tests/custom_columns/tests.py
@@ -16,12 +16,7 @@ class CustomColumnsTests(TestCase):
         cls.article.authors.set(cls.authors)
 
     def test_query_all_available_authors(self):
-        self.assertQuerysetEqual(
-            Author.objects.all(), [
-                "Peter Jones", "John Smith",
-            ],
-            str
-        )
+        self.assertSequenceEqual(Author.objects.all(), [self.a2, self.a1])
 
     def test_get_first_name(self):
         self.assertEqual(
@@ -30,11 +25,9 @@ class CustomColumnsTests(TestCase):
         )
 
     def test_filter_first_name(self):
-        self.assertQuerysetEqual(
-            Author.objects.filter(first_name__exact="John"), [
-                "John Smith",
-            ],
-            str
+        self.assertSequenceEqual(
+            Author.objects.filter(first_name__exact="John"),
+            [self.a1],
         )
 
     def test_field_error(self):
@@ -53,13 +46,7 @@ class CustomColumnsTests(TestCase):
             self.a1.last
 
     def test_get_all_authors_for_an_article(self):
-        self.assertQuerysetEqual(
-            self.article.authors.all(), [
-                "Peter Jones",
-                "John Smith",
-            ],
-            str
-        )
+        self.assertSequenceEqual(self.article.authors.all(), [self.a2, self.a1])
 
     def test_get_all_articles_for_an_author(self):
         self.assertQuerysetEqual(
@@ -70,11 +57,9 @@ class CustomColumnsTests(TestCase):
         )
 
     def test_get_author_m2m_relation(self):
-        self.assertQuerysetEqual(
-            self.article.authors.filter(last_name='Jones'), [
-                "Peter Jones"
-            ],
-            str
+        self.assertSequenceEqual(
+            self.article.authors.filter(last_name='Jones'),
+            [self.a2],
         )
 
     def test_author_querying(self):

--- a/tests/custom_lookups/models.py
+++ b/tests/custom_lookups/models.py
@@ -7,9 +7,6 @@ class Author(models.Model):
     birthdate = models.DateField(null=True)
     average_rating = models.FloatField(null=True)
 
-    def __str__(self):
-        return self.name
-
 
 class Article(models.Model):
     author = models.ForeignKey(Author, on_delete=models.CASCADE)

--- a/tests/custom_methods/models.py
+++ b/tests/custom_methods/models.py
@@ -13,9 +13,6 @@ class Article(models.Model):
     headline = models.CharField(max_length=100)
     pub_date = models.DateField()
 
-    def __str__(self):
-        return self.headline
-
     def was_published_today(self):
         return self.pub_date == datetime.date.today()
 

--- a/tests/custom_pk/models.py
+++ b/tests/custom_pk/models.py
@@ -18,9 +18,6 @@ class Employee(models.Model):
     class Meta:
         ordering = ('last_name', 'first_name')
 
-    def __str__(self):
-        return "%s %s" % (self.first_name, self.last_name)
-
 
 class Business(models.Model):
     name = models.CharField(max_length=20, primary_key=True)

--- a/tests/custom_pk/tests.py
+++ b/tests/custom_pk/tests.py
@@ -20,35 +20,16 @@ class BasicCustomPKTests(TestCase):
         """
         Both pk and custom attribute_name can be used in filter and friends
         """
-        self.assertQuerysetEqual(
-            Employee.objects.filter(pk=123), [
-                "Dan Jones",
-            ],
-            str
+        self.assertSequenceEqual(Employee.objects.filter(pk=123), [self.dan])
+        self.assertSequenceEqual(
+            Employee.objects.filter(employee_code=123),
+            [self.dan],
         )
-
-        self.assertQuerysetEqual(
-            Employee.objects.filter(employee_code=123), [
-                "Dan Jones",
-            ],
-            str
+        self.assertSequenceEqual(
+            Employee.objects.filter(pk__in=[123, 456]),
+            [self.fran, self.dan],
         )
-
-        self.assertQuerysetEqual(
-            Employee.objects.filter(pk__in=[123, 456]), [
-                "Fran Bones",
-                "Dan Jones",
-            ],
-            str
-        )
-
-        self.assertQuerysetEqual(
-            Employee.objects.all(), [
-                "Fran Bones",
-                "Dan Jones",
-            ],
-            str
-        )
+        self.assertSequenceEqual(Employee.objects.all(), [self.fran, self.dan])
 
         self.assertQuerysetEqual(
             Business.objects.filter(name="Sears"), [
@@ -67,12 +48,9 @@ class BasicCustomPKTests(TestCase):
         """
         Custom pk doesn't affect related_name based lookups
         """
-        self.assertQuerysetEqual(
-            self.business.employees.all(), [
-                "Fran Bones",
-                "Dan Jones",
-            ],
-            str
+        self.assertSequenceEqual(
+            self.business.employees.all(),
+            [self.fran, self.dan],
         )
         self.assertQuerysetEqual(
             self.fran.business_set.all(), [
@@ -85,19 +63,13 @@ class BasicCustomPKTests(TestCase):
         """
         Queries across tables, involving primary key
         """
-        self.assertQuerysetEqual(
-            Employee.objects.filter(business__name="Sears"), [
-                "Fran Bones",
-                "Dan Jones",
-            ],
-            str,
+        self.assertSequenceEqual(
+            Employee.objects.filter(business__name="Sears"),
+            [self.fran, self.dan],
         )
-        self.assertQuerysetEqual(
-            Employee.objects.filter(business__pk="Sears"), [
-                "Fran Bones",
-                "Dan Jones",
-            ],
-            str,
+        self.assertSequenceEqual(
+            Employee.objects.filter(business__pk="Sears"),
+            [self.fran, self.dan],
         )
 
         self.assertQuerysetEqual(
@@ -167,12 +139,9 @@ class BasicCustomPKTests(TestCase):
         fran.last_name = "Jones"
         fran.save()
 
-        self.assertQuerysetEqual(
-            Employee.objects.filter(last_name="Jones"), [
-                "Dan Jones",
-                "Fran Jones",
-            ],
-            str
+        self.assertSequenceEqual(
+            Employee.objects.filter(last_name="Jones"),
+            [self.dan, self.fran],
         )
 
 

--- a/tests/datetimes/models.py
+++ b/tests/datetimes/models.py
@@ -8,18 +8,12 @@ class Article(models.Model):
 
     categories = models.ManyToManyField("Category", related_name="articles")
 
-    def __str__(self):
-        return self.title
-
 
 class Comment(models.Model):
     article = models.ForeignKey(Article, models.CASCADE, related_name="comments")
     text = models.TextField()
     pub_date = models.DateTimeField()
     approval_date = models.DateTimeField(null=True)
-
-    def __str__(self):
-        return 'Comment to %s (%s)' % (self.article.title, self.pub_date)
 
 
 class Category(models.Model):

--- a/tests/defer/models.py
+++ b/tests/defer/models.py
@@ -15,9 +15,6 @@ class Primary(models.Model):
     value = models.CharField(max_length=50)
     related = models.ForeignKey(Secondary, models.CASCADE)
 
-    def __str__(self):
-        return self.name
-
 
 class Child(Primary):
     pass

--- a/tests/distinct_on_fields/models.py
+++ b/tests/distinct_on_fields/models.py
@@ -14,9 +14,6 @@ class Tag(models.Model):
     class Meta:
         ordering = ['name']
 
-    def __str__(self):
-        return self.name
-
 
 class Celebrity(models.Model):
     name = models.CharField("Name", max_length=20)
@@ -26,9 +23,6 @@ class Celebrity(models.Model):
         null=True,
         unique=True,
     )
-
-    def __str__(self):
-        return self.name
 
 
 class Fan(models.Model):
@@ -42,13 +36,7 @@ class Staff(models.Model):
     tags = models.ManyToManyField(Tag, through='StaffTag')
     coworkers = models.ManyToManyField('self')
 
-    def __str__(self):
-        return self.name
-
 
 class StaffTag(models.Model):
     staff = models.ForeignKey(Staff, models.CASCADE)
     tag = models.ForeignKey(Tag, models.CASCADE)
-
-    def __str__(self):
-        return "%s -> %s" % (self.tag, self.staff)

--- a/tests/expressions/models.py
+++ b/tests/expressions/models.py
@@ -41,16 +41,10 @@ class Company(models.Model):
     )
     based_in_eu = models.BooleanField(default=False)
 
-    def __str__(self):
-        return self.name
-
 
 class Number(models.Model):
     integer = models.BigIntegerField(db_column='the_integer')
     float = models.FloatField(null=True, db_column='the_float')
-
-    def __str__(self):
-        return '%i, %.3f' % (self.integer, self.float)
 
 
 class Experiment(models.Model):
@@ -73,24 +67,15 @@ class Result(models.Model):
     experiment = models.ForeignKey(Experiment, models.CASCADE)
     result_time = models.DateTimeField()
 
-    def __str__(self):
-        return "Result at %s" % self.result_time
-
 
 class Time(models.Model):
     time = models.TimeField(null=True)
-
-    def __str__(self):
-        return str(self.time)
 
 
 class SimulationRun(models.Model):
     start = models.ForeignKey(Time, models.CASCADE, null=True, related_name='+')
     end = models.ForeignKey(Time, models.CASCADE, null=True, related_name='+')
     midpoint = models.TimeField()
-
-    def __str__(self):
-        return "%s (%s to %s)" % (self.midpoint, self.start, self.end)
 
 
 class UUIDPK(models.Model):

--- a/tests/extra_regress/models.py
+++ b/tests/extra_regress/models.py
@@ -31,6 +31,3 @@ class TestObject(models.Model):
     first = models.CharField(max_length=20)
     second = models.CharField(max_length=20)
     third = models.CharField(max_length=20)
-
-    def __str__(self):
-        return 'TestObject: %s,%s,%s' % (self.first, self.second, self.third)

--- a/tests/field_defaults/models.py
+++ b/tests/field_defaults/models.py
@@ -17,6 +17,3 @@ from django.db import models
 class Article(models.Model):
     headline = models.CharField(max_length=100, default='Default headline')
     pub_date = models.DateTimeField(default=datetime.now)
-
-    def __str__(self):
-        return self.headline

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -23,9 +23,6 @@ class Category(models.Model):
     class Meta:
         ordering = ('title',)
 
-    def __str__(self):
-        return self.title
-
 
 class Article(models.Model):
     headline = models.CharField(max_length=100, default='Default headline')
@@ -43,9 +40,6 @@ class Blog(models.Model):
     featured = models.ForeignKey(Article, models.CASCADE, related_name='fixtures_featured_set')
     articles = models.ManyToManyField(Article, blank=True,
                                       related_name='fixtures_articles_set')
-
-    def __str__(self):
-        return self.name
 
 
 class Tag(models.Model):
@@ -70,9 +64,6 @@ class Person(models.Model):
 
     class Meta:
         ordering = ('name',)
-
-    def __str__(self):
-        return self.name
 
     def natural_key(self):
         return (self.name,)
@@ -132,9 +123,6 @@ class NaturalKeyThing(models.Model):
 
     def natural_key(self):
         return (self.key,)
-
-    def __str__(self):
-        return self.key
 
 
 class CircularA(models.Model):

--- a/tests/fixtures_regress/models.py
+++ b/tests/fixtures_regress/models.py
@@ -11,9 +11,6 @@ class Animal(models.Model):
     # use a non-default name for the default manager
     specimens = models.Manager()
 
-    def __str__(self):
-        return self.name
-
 
 class Plant(models.Model):
     name = models.CharField(max_length=150)
@@ -26,9 +23,6 @@ class Plant(models.Model):
 class Stuff(models.Model):
     name = models.CharField(max_length=20, null=True)
     owner = models.ForeignKey(User, models.SET_NULL, null=True)
-
-    def __str__(self):
-        return self.name + ' is owned by ' + str(self.owner)
 
 
 class Absolute(models.Model):
@@ -82,9 +76,6 @@ class Widget(models.Model):
     class Meta:
         ordering = ('name',)
 
-    def __str__(self):
-        return self.name
-
 
 class WidgetProxy(Widget):
     class Meta:
@@ -106,9 +97,6 @@ class Store(models.Model):
     class Meta:
         ordering = ('name',)
 
-    def __str__(self):
-        return self.name
-
     def natural_key(self):
         return (self.name,)
 
@@ -120,9 +108,6 @@ class Person(models.Model):
 
     class Meta:
         ordering = ('name',)
-
-    def __str__(self):
-        return self.name
 
     # Person doesn't actually have a dependency on store, but we need to define
     # one to test the behavior of the dependency resolution algorithm.
@@ -159,21 +144,11 @@ class NKChild(Parent):
     def natural_key(self):
         return (self.data,)
 
-    def __str__(self):
-        return 'NKChild %s:%s' % (self.name, self.data)
-
 
 class RefToNKChild(models.Model):
     text = models.CharField(max_length=10)
     nk_fk = models.ForeignKey(NKChild, models.CASCADE, related_name='ref_fks')
     nk_m2m = models.ManyToManyField(NKChild, related_name='ref_m2ms')
-
-    def __str__(self):
-        return '%s: Reference to %s [%s]' % (
-            self.text,
-            self.nk_fk,
-            ', '.join(str(o) for o in self.nk_m2m.all())
-        )
 
 
 # ome models with pathological circular dependencies
@@ -252,9 +227,6 @@ class BaseNKModel(models.Model):
 
     class Meta:
         abstract = True
-
-    def __str__(self):
-        return self.data
 
     def natural_key(self):
         return (self.data,)

--- a/tests/generic_inline_admin/models.py
+++ b/tests/generic_inline_admin/models.py
@@ -22,9 +22,6 @@ class Media(models.Model):
     description = models.CharField(max_length=100, blank=True)
     keywords = models.CharField(max_length=100, blank=True)
 
-    def __str__(self):
-        return self.url
-
 
 #
 # Generic inline with unique_together

--- a/tests/generic_relations/models.py
+++ b/tests/generic_relations/models.py
@@ -54,9 +54,6 @@ class Comparison(AbstractComparison):
 
     other_obj = GenericForeignKey(ct_field="content_type2", fk_field="object_id2")
 
-    def __str__(self):
-        return "%s is %s than %s" % (self.first_obj, self.comparative, self.other_obj)
-
 
 class Animal(models.Model):
     common_name = models.CharField(max_length=150)
@@ -77,9 +74,6 @@ class Vegetable(models.Model):
 
     tags = GenericRelation(TaggedItem)
 
-    def __str__(self):
-        return self.name
-
 
 class Carrot(Vegetable):
     pass
@@ -90,9 +84,6 @@ class Mineral(models.Model):
     hardness = models.PositiveSmallIntegerField()
 
     # note the lack of an explicit GenericRelation here...
-
-    def __str__(self):
-        return self.name
 
 
 class GeckoManager(models.Manager):

--- a/tests/generic_views/models.py
+++ b/tests/generic_views/models.py
@@ -12,9 +12,6 @@ class Artist(models.Model):
         verbose_name = 'professional artist'
         verbose_name_plural = 'professional artists'
 
-    def __str__(self):
-        return self.name
-
     def get_absolute_url(self):
         return reverse('artist_detail', kwargs={'pk': self.id})
 
@@ -25,9 +22,6 @@ class Author(models.Model):
 
     class Meta:
         ordering = ['name']
-
-    def __str__(self):
-        return self.name
 
 
 class DoesNotExistQuerySet(QuerySet):
@@ -50,9 +44,6 @@ class Book(models.Model):
 
     class Meta:
         ordering = ['-pubdate']
-
-    def __str__(self):
-        return self.name
 
 
 class Page(models.Model):

--- a/tests/inline_formsets/models.py
+++ b/tests/inline_formsets/models.py
@@ -19,9 +19,6 @@ class Child(models.Model):
 class Poet(models.Model):
     name = models.CharField(max_length=100)
 
-    def __str__(self):
-        return self.name
-
 
 class Poem(models.Model):
     poet = models.ForeignKey(Poet, models.CASCADE)
@@ -29,6 +26,3 @@ class Poem(models.Model):
 
     class Meta:
         unique_together = ('poet', 'name')
-
-    def __str__(self):
-        return self.name

--- a/tests/lookup/models.py
+++ b/tests/lookup/models.py
@@ -12,9 +12,6 @@ class Alarm(models.Model):
     desc = models.CharField(max_length=100)
     time = models.TimeField()
 
-    def __str__(self):
-        return '%s (%s)' % (self.time, self.desc)
-
 
 class Author(models.Model):
     name = models.CharField(max_length=100)
@@ -71,9 +68,6 @@ class Season(models.Model):
         constraints = [
             models.UniqueConstraint(fields=['year'], name='season_year_unique'),
         ]
-
-    def __str__(self):
-        return str(self.year)
 
 
 class Game(models.Model):

--- a/tests/m2m_and_m2o/models.py
+++ b/tests/m2m_and_m2o/models.py
@@ -18,9 +18,6 @@ class Issue(models.Model):
     class Meta:
         ordering = ('num',)
 
-    def __str__(self):
-        return str(self.num)
-
 
 class StringReferenceModel(models.Model):
     others = models.ManyToManyField('StringReferenceModel')

--- a/tests/m2m_multiple/models.py
+++ b/tests/m2m_multiple/models.py
@@ -16,9 +16,6 @@ class Category(models.Model):
     class Meta:
         ordering = ('name',)
 
-    def __str__(self):
-        return self.name
-
 
 class Article(models.Model):
     headline = models.CharField(max_length=50)
@@ -28,6 +25,3 @@ class Article(models.Model):
 
     class Meta:
         ordering = ('pub_date',)
-
-    def __str__(self):
-        return self.headline

--- a/tests/m2m_recursive/models.py
+++ b/tests/m2m_recursive/models.py
@@ -25,9 +25,6 @@ class Person(models.Model):
     colleagues = models.ManyToManyField('self', symmetrical=True, through='Colleague')
     idols = models.ManyToManyField('self', symmetrical=False, related_name='stalkers')
 
-    def __str__(self):
-        return self.name
-
 
 class Colleague(models.Model):
     first = models.ForeignKey(Person, models.CASCADE)

--- a/tests/m2m_regress/models.py
+++ b/tests/m2m_regress/models.py
@@ -9,23 +9,14 @@ class SelfRefer(models.Model):
     references = models.ManyToManyField('self')
     related = models.ManyToManyField('self')
 
-    def __str__(self):
-        return self.name
-
 
 class Tag(models.Model):
     name = models.CharField(max_length=10)
-
-    def __str__(self):
-        return self.name
 
 
 # Regression for #11956 -- a many to many to the base class
 class TagCollection(Tag):
     tags = models.ManyToManyField(Tag, related_name='tag_collections')
-
-    def __str__(self):
-        return self.name
 
 
 # A related_name is required on one of the ManyToManyField entries here because
@@ -34,9 +25,6 @@ class Entry(models.Model):
     name = models.CharField(max_length=10)
     topics = models.ManyToManyField(Tag)
     related = models.ManyToManyField(Tag, related_name="similar")
-
-    def __str__(self):
-        return self.name
 
 
 # Two models both inheriting from a base model with a self-referential m2m field
@@ -51,9 +39,6 @@ class SelfReferChildSibling(SelfRefer):
 # Many-to-Many relation between models, where one of the PK's isn't an Autofield
 class Line(models.Model):
     name = models.CharField(max_length=100)
-
-    def __str__(self):
-        return self.name
 
 
 class Worksheet(models.Model):

--- a/tests/m2m_through_regress/models.py
+++ b/tests/m2m_through_regress/models.py
@@ -20,18 +20,12 @@ class UserMembership(models.Model):
 class Person(models.Model):
     name = models.CharField(max_length=128)
 
-    def __str__(self):
-        return self.name
-
 
 class Group(models.Model):
     name = models.CharField(max_length=128)
     # Membership object defined as a class
     members = models.ManyToManyField(Person, through=Membership)
     user_members = models.ManyToManyField(User, through='UserMembership')
-
-    def __str__(self):
-        return self.name
 
 
 # Using to_field on the through model
@@ -56,9 +50,6 @@ class Driver(models.Model):
 class CarDriver(models.Model):
     car = models.ForeignKey('Car', models.CASCADE, to_field='make')
     driver = models.ForeignKey('Driver', models.CASCADE, to_field='name')
-
-    def __str__(self):
-        return "pk=%s car=%s driver=%s" % (str(self.pk), self.car, self.driver)
 
 
 # Through models using multi-table inheritance

--- a/tests/m2o_recursive/models.py
+++ b/tests/m2o_recursive/models.py
@@ -17,14 +17,8 @@ class Category(models.Model):
     name = models.CharField(max_length=20)
     parent = models.ForeignKey('self', models.SET_NULL, blank=True, null=True, related_name='child_set')
 
-    def __str__(self):
-        return self.name
-
 
 class Person(models.Model):
     full_name = models.CharField(max_length=20)
     mother = models.ForeignKey('self', models.SET_NULL, null=True, related_name='mothers_child_set')
     father = models.ForeignKey('self', models.SET_NULL, null=True, related_name='fathers_child_set')
-
-    def __str__(self):
-        return self.full_name

--- a/tests/managers_regress/models.py
+++ b/tests/managers_regress/models.py
@@ -59,9 +59,6 @@ class Parent(models.Model):
 
     manager = OnlyFred()
 
-    def __str__(self):
-        return self.name
-
 
 # Managers from base classes are inherited and, if no manager is specified
 # *and* the parent has a manager specified, the first one (in the MRO) will
@@ -69,22 +66,13 @@ class Parent(models.Model):
 class Child1(AbstractBase1):
     data = models.CharField(max_length=25)
 
-    def __str__(self):
-        return self.data
-
 
 class Child2(AbstractBase1, AbstractBase2):
     data = models.CharField(max_length=25)
 
-    def __str__(self):
-        return self.data
-
 
 class Child3(AbstractBase1, AbstractBase3):
     data = models.CharField(max_length=25)
-
-    def __str__(self):
-        return self.data
 
 
 class Child4(AbstractBase1):
@@ -94,18 +82,12 @@ class Child4(AbstractBase1):
     # inherited.
     default = models.Manager()
 
-    def __str__(self):
-        return self.data
-
 
 class Child5(AbstractBase3):
     name = models.CharField(max_length=25)
 
     default = OnlyFred()
     objects = models.Manager()
-
-    def __str__(self):
-        return self.name
 
 
 class Child6(Child4):
@@ -120,9 +102,6 @@ class Child7(Parent):
 class RelatedModel(models.Model):
     test_gfk = GenericRelation('RelationModel', content_type_field='gfk_ctype', object_id_field='gfk_id')
     exact = models.BooleanField(null=True)
-
-    def __str__(self):
-        return str(self.pk)
 
 
 class RelationModel(models.Model):

--- a/tests/many_to_many/models.py
+++ b/tests/many_to_many/models.py
@@ -15,16 +15,10 @@ class Publication(models.Model):
     class Meta:
         ordering = ('title',)
 
-    def __str__(self):
-        return self.title
-
 
 class Tag(models.Model):
     id = models.BigAutoField(primary_key=True)
     name = models.CharField(max_length=50)
-
-    def __str__(self):
-        return self.name
 
 
 class NoDeletedArticleManager(models.Manager):
@@ -51,9 +45,6 @@ class Article(models.Model):
 
 class User(models.Model):
     username = models.CharField(max_length=20, unique=True)
-
-    def __str__(self):
-        return self.username
 
 
 class UserArticle(models.Model):

--- a/tests/many_to_one/models.py
+++ b/tests/many_to_one/models.py
@@ -42,9 +42,6 @@ class District(models.Model):
     city = models.ForeignKey(City, models.CASCADE, related_name='districts', null=True)
     name = models.CharField(max_length=50)
 
-    def __str__(self):
-        return self.name
-
 
 # If ticket #1578 ever slips back in, these models will not be able to be
 # created (the field names being lowercased versions of their opposite classes
@@ -85,9 +82,6 @@ class ToFieldChild(models.Model):
 class Category(models.Model):
     name = models.CharField(max_length=20)
 
-    def __str__(self):
-        return self.name
-
 
 class Record(models.Model):
     category = models.ForeignKey(Category, models.CASCADE)
@@ -96,9 +90,6 @@ class Record(models.Model):
 class Relation(models.Model):
     left = models.ForeignKey(Record, models.CASCADE, related_name='left_set')
     right = models.ForeignKey(Record, models.CASCADE, related_name='right_set')
-
-    def __str__(self):
-        return "%s - %s" % (self.left.category.name, self.right.category.name)
 
 
 # Test related objects visibility.

--- a/tests/many_to_one_null/models.py
+++ b/tests/many_to_one_null/models.py
@@ -19,9 +19,6 @@ class Article(models.Model):
     class Meta:
         ordering = ('headline',)
 
-    def __str__(self):
-        return self.headline
-
 
 class Car(models.Model):
     make = models.CharField(max_length=100, null=True, unique=True)

--- a/tests/model_forms/models.py
+++ b/tests/model_forms/models.py
@@ -67,9 +67,6 @@ class Article(models.Model):
             self.created = datetime.date.today()
         return super().save(*args, **kwargs)
 
-    def __str__(self):
-        return self.headline
-
 
 class ImprovedArticle(models.Model):
     article = models.OneToOneField(Article, models.CASCADE)
@@ -86,9 +83,6 @@ class BetterWriter(Writer):
 class Publication(models.Model):
     title = models.CharField(max_length=30)
     date_published = models.DateField()
-
-    def __str__(self):
-        return self.title
 
 
 def default_mode():
@@ -137,9 +131,6 @@ class TextFile(models.Model):
     description = models.CharField(max_length=20)
     file = models.FileField(storage=temp_storage, upload_to='tests', max_length=15)
 
-    def __str__(self):
-        return self.description
-
 
 class CustomFileField(models.FileField):
     def save_form_data(self, instance, data):
@@ -176,9 +167,6 @@ try:
                                   width_field='width', height_field='height')
         path = models.CharField(max_length=16, blank=True, default='')
 
-        def __str__(self):
-            return self.description
-
     class OptionalImageFile(models.Model):
         def custom_upload_path(self, filename):
             path = self.path or 'tests'
@@ -192,18 +180,12 @@ try:
         height = models.IntegerField(editable=False, null=True)
         path = models.CharField(max_length=16, blank=True, default='')
 
-        def __str__(self):
-            return self.description
-
     class NoExtensionImageFile(models.Model):
         def upload_to(self, filename):
             return 'tests/no_extension'
 
         description = models.CharField(max_length=20)
         image = models.ImageField(storage=temp_storage, upload_to=upload_to)
-
-        def __str__(self):
-            return self.description
 
 except ImportError:
     test_images = False
@@ -216,9 +198,6 @@ class Homepage(models.Model):
 class Product(models.Model):
     slug = models.SlugField(unique=True)
 
-    def __str__(self):
-        return self.slug
-
 
 class Price(models.Model):
     price = models.DecimalField(max_digits=10, decimal_places=2)
@@ -226,9 +205,6 @@ class Price(models.Model):
 
     class Meta:
         unique_together = (('price', 'quantity'),)
-
-    def __str__(self):
-        return "%s for %s" % (self.quantity, self.price)
 
 
 class Triple(models.Model):
@@ -294,18 +270,12 @@ class ExplicitPK(models.Model):
     class Meta:
         unique_together = ('key', 'desc')
 
-    def __str__(self):
-        return self.key
-
 
 class Post(models.Model):
     title = models.CharField(max_length=50, unique_for_date='posted', blank=True)
     slug = models.CharField(max_length=50, unique_for_year='posted', blank=True)
     subtitle = models.CharField(max_length=50, unique_for_month='posted', blank=True)
     posted = models.DateField()
-
-    def __str__(self):
-        return self.title
 
 
 class DateTimePost(models.Model):
@@ -314,9 +284,6 @@ class DateTimePost(models.Model):
     subtitle = models.CharField(max_length=50, unique_for_month='posted', blank=True)
     posted = models.DateTimeField(editable=False)
 
-    def __str__(self):
-        return self.title
-
 
 class DerivedPost(Post):
     pass
@@ -324,9 +291,6 @@ class DerivedPost(Post):
 
 class BigInt(models.Model):
     biggie = models.BigIntegerField()
-
-    def __str__(self):
-        return str(self.biggie)
 
 
 class MarkupField(models.CharField):

--- a/tests/model_formsets/models.py
+++ b/tests/model_formsets/models.py
@@ -10,9 +10,6 @@ class Author(models.Model):
     class Meta:
         ordering = ('name',)
 
-    def __str__(self):
-        return self.name
-
 
 class BetterAuthor(Author):
     write_speed = models.IntegerField()
@@ -28,9 +25,6 @@ class Book(models.Model):
         )
         ordering = ['id']
 
-    def __str__(self):
-        return self.title
-
     def clean(self):
         # Ensure author is always accessible in clean method
         assert self.author.name is not None
@@ -40,9 +34,6 @@ class BookWithCustomPK(models.Model):
     my_pk = models.DecimalField(max_digits=5, decimal_places=0, primary_key=True)
     author = models.ForeignKey(Author, models.CASCADE)
     title = models.CharField(max_length=100)
-
-    def __str__(self):
-        return '%s: %s' % (self.my_pk, self.title)
 
 
 class Editor(models.Model):
@@ -60,24 +51,15 @@ class BookWithOptionalAltEditor(models.Model):
             ('author', 'title', 'alt_editor'),
         )
 
-    def __str__(self):
-        return self.title
-
 
 class AlternateBook(Book):
     notes = models.CharField(max_length=100)
-
-    def __str__(self):
-        return '%s - %s' % (self.title, self.notes)
 
 
 class AuthorMeeting(models.Model):
     name = models.CharField(max_length=100)
     authors = models.ManyToManyField(Author)
     created = models.DateField(editable=False)
-
-    def __str__(self):
-        return self.name
 
 
 class CustomPrimaryKey(models.Model):
@@ -116,9 +98,6 @@ class OwnerProfile(models.Model):
     owner = models.OneToOneField(Owner, models.CASCADE, primary_key=True)
     age = models.PositiveIntegerField()
 
-    def __str__(self):
-        return "%s is %d" % (self.owner.name, self.age)
-
 
 class Restaurant(Place):
     serves_pizza = models.BooleanField(default=False)
@@ -127,9 +106,6 @@ class Restaurant(Place):
 class Product(models.Model):
     slug = models.SlugField(unique=True)
 
-    def __str__(self):
-        return self.slug
-
 
 class Price(models.Model):
     price = models.DecimalField(max_digits=10, decimal_places=2)
@@ -137,9 +113,6 @@ class Price(models.Model):
 
     class Meta:
         unique_together = (('price', 'quantity'),)
-
-    def __str__(self):
-        return "%s for %s" % (self.quantity, self.price)
 
 
 class MexicanRestaurant(Restaurant):
@@ -156,9 +129,6 @@ class ClassyMexicanRestaurant(MexicanRestaurant):
 class Repository(models.Model):
     name = models.CharField(max_length=25)
 
-    def __str__(self):
-        return self.name
-
 
 class Revision(models.Model):
     repository = models.ForeignKey(Repository, models.CASCADE)
@@ -166,9 +136,6 @@ class Revision(models.Model):
 
     class Meta:
         unique_together = (("repository", "revision"),)
-
-    def __str__(self):
-        return "%s (%s)" % (self.revision, str(self.repository))
 
 
 # models for testing callable defaults (see bug #7975). If you define a model
@@ -193,24 +160,15 @@ class Player(models.Model):
     team = models.ForeignKey(Team, models.SET_NULL, null=True)
     name = models.CharField(max_length=100)
 
-    def __str__(self):
-        return self.name
-
 
 # Models for testing custom ModelForm save methods in formsets and inline formsets
 class Poet(models.Model):
     name = models.CharField(max_length=100)
 
-    def __str__(self):
-        return self.name
-
 
 class Poem(models.Model):
     poet = models.ForeignKey(Poet, models.CASCADE)
     name = models.CharField(max_length=100)
-
-    def __str__(self):
-        return self.name
 
 
 class Post(models.Model):
@@ -218,9 +176,6 @@ class Post(models.Model):
     slug = models.CharField(max_length=50, unique_for_year='posted', blank=True)
     subtitle = models.CharField(max_length=50, unique_for_month='posted', blank=True)
     posted = models.DateField()
-
-    def __str__(self):
-        return self.title
 
 
 # Models for testing UUID primary keys

--- a/tests/model_formsets_regress/models.py
+++ b/tests/model_formsets_regress/models.py
@@ -51,6 +51,3 @@ class Network(models.Model):
 class Host(models.Model):
     network = models.ForeignKey(Network, models.CASCADE)
     hostname = models.CharField(max_length=25)
-
-    def __str__(self):
-        return self.hostname

--- a/tests/modeladmin/models.py
+++ b/tests/modeladmin/models.py
@@ -19,9 +19,6 @@ class Song(models.Model):
     band = models.ForeignKey(Band, models.CASCADE)
     featuring = models.ManyToManyField(Band, related_name='featured')
 
-    def __str__(self):
-        return self.name
-
 
 class Concert(models.Model):
     main_band = models.ForeignKey(Band, models.CASCADE, related_name='main_concerts')

--- a/tests/order_with_respect_to/models.py
+++ b/tests/order_with_respect_to/models.py
@@ -16,9 +16,6 @@ class Answer(models.Model):
     class Meta:
         order_with_respect_to = 'question'
 
-    def __str__(self):
-        return self.text
-
 
 class Post(models.Model):
     title = models.CharField(max_length=200)
@@ -26,9 +23,6 @@ class Post(models.Model):
 
     class Meta:
         order_with_respect_to = "parent"
-
-    def __str__(self):
-        return self.title
 
 
 # order_with_respect_to points to a model with a OneToOneField primary key.

--- a/tests/pagination/models.py
+++ b/tests/pagination/models.py
@@ -4,6 +4,3 @@ from django.db import models
 class Article(models.Model):
     headline = models.CharField(max_length=100, default='Default headline')
     pub_date = models.DateTimeField()
-
-    def __str__(self):
-        return self.headline

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -34,9 +34,6 @@ class Tag(models.Model):
     class Meta:
         ordering = ['name']
 
-    def __str__(self):
-        return self.name
-
 
 class Note(models.Model):
     note = models.CharField(max_length=100)
@@ -47,17 +44,11 @@ class Note(models.Model):
     class Meta:
         ordering = ['note']
 
-    def __str__(self):
-        return self.note
-
 
 class Annotation(models.Model):
     name = models.CharField(max_length=10)
     tag = models.ForeignKey(Tag, models.CASCADE)
     notes = models.ManyToManyField(Note)
-
-    def __str__(self):
-        return self.name
 
 
 class DateTimePK(models.Model):
@@ -74,9 +65,6 @@ class ExtraInfo(models.Model):
     class Meta:
         ordering = ['info']
 
-    def __str__(self):
-        return self.info
-
 
 class Author(models.Model):
     name = models.CharField(max_length=10)
@@ -85,9 +73,6 @@ class Author(models.Model):
 
     class Meta:
         ordering = ['name']
-
-    def __str__(self):
-        return self.name
 
 
 class Item(models.Model):
@@ -101,16 +86,10 @@ class Item(models.Model):
     class Meta:
         ordering = ['-note', 'name']
 
-    def __str__(self):
-        return self.name
-
 
 class Report(models.Model):
     name = models.CharField(max_length=10)
     creator = models.ForeignKey(Author, models.SET_NULL, to_field='num', null=True)
-
-    def __str__(self):
-        return self.name
 
 
 class ReportComment(models.Model):
@@ -125,9 +104,6 @@ class Ranking(models.Model):
         # A complex ordering specification. Should stress the system a bit.
         ordering = ('author__extra__note', 'author__name', 'rank')
 
-    def __str__(self):
-        return '%d: %s' % (self.rank, self.author.name)
-
 
 class Cover(models.Model):
     title = models.CharField(max_length=50)
@@ -136,17 +112,11 @@ class Cover(models.Model):
     class Meta:
         ordering = ['item']
 
-    def __str__(self):
-        return self.title
-
 
 class Number(models.Model):
     num = models.IntegerField()
     other_num = models.IntegerField(null=True)
     another_num = models.IntegerField(null=True)
-
-    def __str__(self):
-        return str(self.num)
 
 # Symmetrical m2m field with a normal field using the reverse accessor name
 # ("valid").
@@ -212,9 +182,6 @@ class ManagedModel(models.Model):
     objects = CustomManager()
     normal_manager = models.Manager()
 
-    def __str__(self):
-        return self.data
-
 # An inter-related setup with multiple paths from Child to Detail.
 
 
@@ -266,9 +233,6 @@ class Celebrity(models.Model):
     name = models.CharField("Name", max_length=20)
     greatest_fan = models.ForeignKey("Fan", models.SET_NULL, null=True, unique=True)
 
-    def __str__(self):
-        return self.name
-
 
 class TvChef(Celebrity):
     pass
@@ -282,9 +246,6 @@ class Fan(models.Model):
 
 class LeafA(models.Model):
     data = models.CharField(max_length=10)
-
-    def __str__(self):
-        return self.data
 
 
 class LeafB(models.Model):
@@ -300,17 +261,11 @@ class ReservedName(models.Model):
     name = models.CharField(max_length=20)
     order = models.IntegerField()
 
-    def __str__(self):
-        return self.name
-
 # A simpler shared-foreign-key setup that can expose some problems.
 
 
 class SharedConnection(models.Model):
     data = models.CharField(max_length=10)
-
-    def __str__(self):
-        return self.data
 
 
 class PointerA(models.Model):
@@ -329,9 +284,6 @@ class SingleObject(models.Model):
     class Meta:
         ordering = ['name']
 
-    def __str__(self):
-        return self.name
-
 
 class RelatedObject(models.Model):
     single = models.ForeignKey(SingleObject, models.SET_NULL, null=True)
@@ -348,48 +300,30 @@ class Plaything(models.Model):
     class Meta:
         ordering = ['others']
 
-    def __str__(self):
-        return self.name
-
 
 class Article(models.Model):
     name = models.CharField(max_length=20)
     created = models.DateTimeField()
 
-    def __str__(self):
-        return self.name
-
 
 class Food(models.Model):
     name = models.CharField(max_length=20, unique=True)
-
-    def __str__(self):
-        return self.name
 
 
 class Eaten(models.Model):
     food = models.ForeignKey(Food, models.SET_NULL, to_field="name", null=True)
     meal = models.CharField(max_length=20)
 
-    def __str__(self):
-        return "%s at %s" % (self.food, self.meal)
-
 
 class Node(models.Model):
     num = models.IntegerField(unique=True)
     parent = models.ForeignKey("self", models.SET_NULL, to_field="num", null=True)
-
-    def __str__(self):
-        return str(self.num)
 
 # Bug #12252
 
 
 class ObjectA(models.Model):
     name = models.CharField(max_length=50)
-
-    def __str__(self):
-        return self.name
 
     def __iter__(self):
         # Ticket #23721
@@ -410,9 +344,6 @@ class ObjectB(models.Model):
     objecta = models.ForeignKey(ObjectA, models.CASCADE)
     num = models.PositiveIntegerField()
 
-    def __str__(self):
-        return self.name
-
 
 class ProxyObjectB(ObjectB):
     class Meta:
@@ -425,29 +356,17 @@ class ObjectC(models.Model):
     objectb = models.ForeignKey(ObjectB, models.SET_NULL, null=True)
     childobjecta = models.ForeignKey(ChildObjectA, models.SET_NULL, null=True, related_name='ca_pk')
 
-    def __str__(self):
-        return self.name
-
 
 class SimpleCategory(models.Model):
     name = models.CharField(max_length=25)
-
-    def __str__(self):
-        return self.name
 
 
 class SpecialCategory(SimpleCategory):
     special_name = models.CharField(max_length=35)
 
-    def __str__(self):
-        return self.name + " " + self.special_name
-
 
 class CategoryItem(models.Model):
     category = models.ForeignKey(SimpleCategory, models.CASCADE)
-
-    def __str__(self):
-        return "category item: " + str(self.category)
 
 
 class MixedCaseFieldCategoryItem(models.Model):
@@ -461,9 +380,6 @@ class MixedCaseDbColumnCategoryItem(models.Model):
 class OneToOneCategory(models.Model):
     new_name = models.CharField(max_length=15)
     category = models.OneToOneField(SimpleCategory, models.CASCADE)
-
-    def __str__(self):
-        return "one2one " + self.new_name
 
 
 class CategoryRelationship(models.Model):
@@ -506,9 +422,6 @@ class ModelA(models.Model):
 class Job(models.Model):
     name = models.CharField(max_length=20, unique=True)
 
-    def __str__(self):
-        return self.name
-
 
 class JobResponsibilities(models.Model):
     job = models.ForeignKey(Job, models.CASCADE, to_field='name')
@@ -519,9 +432,6 @@ class Responsibility(models.Model):
     description = models.CharField(max_length=20, unique=True)
     jobs = models.ManyToManyField(Job, through=JobResponsibilities,
                                   related_name='responsibilities')
-
-    def __str__(self):
-        return self.description
 
 # Models for disjunction join promotion low level testing.
 
@@ -549,9 +459,6 @@ class BaseA(models.Model):
 
 class Identifier(models.Model):
     name = models.CharField(max_length=100)
-
-    def __str__(self):
-        return self.name
 
 
 class Program(models.Model):
@@ -597,9 +504,6 @@ class Order(models.Model):
     class Meta:
         ordering = ('pk',)
 
-    def __str__(self):
-        return str(self.pk)
-
 
 class OrderItem(models.Model):
     order = models.ForeignKey(Order, models.CASCADE, related_name='items')
@@ -607,9 +511,6 @@ class OrderItem(models.Model):
 
     class Meta:
         ordering = ('pk',)
-
-    def __str__(self):
-        return str(self.pk)
 
 
 class BaseUser(models.Model):
@@ -621,22 +522,13 @@ class Task(models.Model):
     owner = models.ForeignKey(BaseUser, models.CASCADE, related_name='owner')
     creator = models.ForeignKey(BaseUser, models.CASCADE, related_name='creator')
 
-    def __str__(self):
-        return self.title
-
 
 class Staff(models.Model):
     name = models.CharField(max_length=10)
 
-    def __str__(self):
-        return self.name
-
 
 class StaffUser(BaseUser):
     staff = models.OneToOneField(Staff, models.CASCADE, related_name='user')
-
-    def __str__(self):
-        return self.staff
 
 
 class Ticket21203Parent(models.Model):
@@ -657,9 +549,6 @@ class Person(models.Model):
 class Company(models.Model):
     name = models.CharField(max_length=128)
     employees = models.ManyToManyField(Person, related_name='employers', through='Employment')
-
-    def __str__(self):
-        return self.name
 
 
 class Employment(models.Model):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -497,8 +497,8 @@ class Queries1Tests(TestCase):
 
         # This is also a good select_related() test because there are multiple
         # Note entries in the SQL. The two Note items should be different.
-        self.assertEqual(repr(qs[0].note), '<Note: n2>')
-        self.assertEqual(repr(qs[0].creator.extra.note), '<Note: n1>')
+        self.assertEqual(qs[0].note, self.n2)
+        self.assertEqual(qs[0].creator.extra.note, self.n1)
 
     def test_ticket3037(self):
         self.assertSequenceEqual(
@@ -1780,12 +1780,12 @@ class Queries6Tests(TestCase):
         # Parallel iterators work.
         qs = Tag.objects.all()
         i1, i2 = iter(qs), iter(qs)
-        self.assertEqual(repr(next(i1)), '<Tag: t1>')
-        self.assertEqual(repr(next(i1)), '<Tag: t2>')
-        self.assertEqual(repr(next(i2)), '<Tag: t1>')
-        self.assertEqual(repr(next(i2)), '<Tag: t2>')
-        self.assertEqual(repr(next(i2)), '<Tag: t3>')
-        self.assertEqual(repr(next(i1)), '<Tag: t3>')
+        self.assertEqual(next(i1), self.t1)
+        self.assertEqual(next(i1), self.t2)
+        self.assertEqual(next(i2), self.t1)
+        self.assertEqual(next(i2), self.t2)
+        self.assertEqual(next(i2), self.t3)
+        self.assertEqual(next(i1), self.t3)
 
         qs = X.objects.all()
         self.assertFalse(qs)

--- a/tests/reserved_names/models.py
+++ b/tests/reserved_names/models.py
@@ -22,6 +22,3 @@ class Thing(models.Model):
 
     class Meta:
         db_table = 'select'
-
-    def __str__(self):
-        return self.when

--- a/tests/schema/models.py
+++ b/tests/schema/models.py
@@ -213,9 +213,6 @@ class Thing(models.Model):
         apps = new_apps
         db_table = 'drop'
 
-    def __str__(self):
-        return self.when
-
 
 class UniqueTest(models.Model):
     year = models.IntegerField()

--- a/tests/select_related_regress/models.py
+++ b/tests/select_related_regress/models.py
@@ -100,9 +100,6 @@ class Item(models.Model):
     name = models.CharField(max_length=10)
     child = models.ForeignKey(Child, models.SET_NULL, null=True)
 
-    def __str__(self):
-        return self.name
-
 # Models for testing bug #19870.
 
 

--- a/tests/transactions/models.py
+++ b/tests/transactions/models.py
@@ -16,6 +16,3 @@ class Reporter(models.Model):
 
     class Meta:
         ordering = ('first_name', 'last_name')
-
-    def __str__(self):
-        return ("%s %s" % (self.first_name, self.last_name)).strip()


### PR DESCRIPTION
This also changes `assertQuerysetEqual()`s to `assertSequenceEqual()` where appropriate.

Follow up to 555e3a848e7ac13580371c7eafbc89195fee6ea9 and 6461583b6cc257d25880ef9a9fd7e2125ac53ce1.