### PR TITLE
Updated Malayalam language name.

### DIFF
--- a/django/conf/locale/__init__.py
+++ b/django/conf/locale/__init__.py
@@ -372,7 +372,7 @@ LANG_INFO = {
         'bidi': False,
         'code': 'ml',
         'name': 'Malayalam',
-        'name_local': 'Malayalam',
+        'name_local': 'മലയാളം',
     },
     'mn': {
         'bidi': False,


### PR DESCRIPTION
The `name_local` of Malayalam(മലയാളം) was written in English instead of Malayalm. I can confirm that `മലയാളം` is the name_local since I am a native Malayalam speaker.

---
A fun fact about "Mayalam" is that it's a palindrome. And one of the biggest palindromic words :) 

https://en.wikipedia.org/wiki/Palindrome#Long_palindromes