### PR TITLE
Avoided direct styles in admin templates.

### DIFF
--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -17,7 +17,7 @@
 {% endif %}
 {% block content %}<div id="content-main">
 <form{% if form_url %} action="{{ form_url }}"{% endif %} method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
-<input type="text" name="username" value="{{ original.get_username }}" style="display: none">
+<input type="text" name="username" value="{{ original.get_username }}" class="hidden">
 <div>
 {% if is_popup %}<input type="hidden" name="_popup" value="1">{% endif %}
 {% if form.errors %}

--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -17,7 +17,7 @@
 
 <form method="post">{% csrf_token %}
 <fieldset class="module aligned">
-    <input style="display: none;" autocomplete="username" value="{{ form.user.username }}">
+    <input class="hidden" autocomplete="username" value="{{ form.user.username }}">
     <div class="form-row field-password1">
         {{ form.new_password1.errors }}
         <label for="id_new_password1">{% translate 'New password:' %}</label>

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1170,7 +1170,7 @@ class AdminCustomTemplateTests(AdminViewBasicTestCase):
         # When a site has multiple passwords in the browser's password manager,
         # a browser pop up asks which user the new password is for. To prevent
         # this, the username is added to the change password form.
-        self.assertContains(response, '<input type="text" name="username" value="super" style="display: none">')
+        self.assertContains(response, '<input type="text" name="username" value="super" class="hidden">')
 
     def test_extended_bodyclass_template_index(self):
         """

--- a/tests/auth_tests/test_templates.py
+++ b/tests/auth_tests/test_templates.py
@@ -56,7 +56,7 @@ class AuthTemplateTests(TestCase):
         # browser's password managers.
         self.assertContains(
             response,
-            '<input style="display: none;" autocomplete="username" value="jsmith">',
+            '<input class="hidden" autocomplete="username" value="jsmith">',
         )
 
     def test_PasswordResetCompleteView(self):


### PR DESCRIPTION
Direct styles might be forbidden by Content Security Policies.