### PR TITLE
set_cookie method in SessionMiddleware

### DIFF
--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -65,7 +65,8 @@ class SessionMiddleware(MiddlewareMixin):
                             "request completed. The user may have logged "
                             "out in a concurrent request, for example."
                         )
-                    response.set_cookie(
+                    self.set_cookie(
+                        response,
                         settings.SESSION_COOKIE_NAME,
                         request.session.session_key, max_age=max_age,
                         expires=expires, domain=settings.SESSION_COOKIE_DOMAIN,
@@ -75,3 +76,6 @@ class SessionMiddleware(MiddlewareMixin):
                         samesite=settings.SESSION_COOKIE_SAMESITE,
                     )
         return response
+
+    def set_cookie(self, response, *args, **kwargs):
+        response.set_cookie(*args, **kwargs)


### PR DESCRIPTION
Recently, I found that some browsers cannot handle **SameSite=None** cookies, and proposed a solution but was rejected https://code.djangoproject.com/ticket/32101.

This change will make it easy to override cookie setting logic by extending SessionMiddleware, or just set_cookie method.