### PR TITLE
Simplified TimeFormat.g().

### DIFF
--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -100,11 +100,7 @@ class TimeFormat(Formatter):
 
     def g(self):
         "Hour, 12-hour format without leading zeros; i.e. '1' to '12'"
-        if self.data.hour == 0:
-            return 12
-        if self.data.hour > 12:
-            return self.data.hour - 12
-        return self.data.hour
+        return self.data.hour % 12 or 12
 
     def G(self):
         "Hour, 24-hour format without leading zeros; i.e. '0' to '23'"

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -178,3 +178,19 @@ class DateFormatTests(SimpleTestCase):
                     dateformat.format(datetime(year, 9, 8, 5, 0), 'y'),
                     expected_date,
                 )
+
+    def test_twelve_hour_format(self):
+        tests = [
+            (0, '12'),
+            (1, '1'),
+            (11, '11'),
+            (12, '12'),
+            (13, '1'),
+            (23, '11'),
+        ]
+        for hour, expected in tests:
+            with self.subTest(hour=hour):
+                self.assertEqual(
+                    dateformat.format(datetime(2000, 1, 1, hour), 'g'),
+                    expected,
+                )


### PR DESCRIPTION
Similar to 311395712367ecc168d634e39d56783626666e78.