### PR TITLE
Refs #32120 -- Fixed test_add_inline_fk_index_update_data for DatabaseFeatures.indexes_foreign_keys.

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -321,12 +321,7 @@ class SchemaTests(TransactionTestCase):
             Node._meta.add_field(new_field)
             editor.execute('UPDATE schema_node SET new_parent_fk_id = %s;', [parent.pk])
             editor.add_index(Node, Index(fields=['new_parent_fk'], name='new_parent_inline_fk_idx'))
-        assertIndex = (
-            self.assertIn
-            if connection.features.indexes_foreign_keys
-            else self.assertNotIn
-        )
-        assertIndex('new_parent_fk_id', self.get_indexes(Node._meta.db_table))
+        self.assertIn('new_parent_fk_id', self.get_indexes(Node._meta.db_table))
 
     @skipUnlessDBFeature('supports_foreign_keys')
     def test_char_field_with_db_index_to_fk(self):


### PR DESCRIPTION
This test creates an index with editor.add_index() so it's present regardless
of the database's behavior. Reverted the change from
ede9fac75807fe5810df66280a60e7068cc97e4a.

(sorry for the mistake)