### PR TITLE
Refs #24474 -- Changed AdminSite.empty_value_display property to an attribute.

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -52,7 +52,7 @@ class AdminSite:
 
     enable_nav_sidebar = True
 
-    _empty_value_display = '-'
+    empty_value_display = '-'
 
     login_form = None
     index_template = None
@@ -179,14 +179,6 @@ class AdminSite:
         Get all the enabled actions as an iterable of (name, func).
         """
         return self._actions.items()
-
-    @property
-    def empty_value_display(self):
-        return self._empty_value_display
-
-    @empty_value_display.setter
-    def empty_value_display(self, empty_value_display):
-        self._empty_value_display = empty_value_display
 
     def has_permission(self, request):
         """


### PR DESCRIPTION
This was implemented with a property getter and setter when introduced in 0207bdd2d4157c542c981264c86706b78ca246e9.

There is nothing special occurring here though - a simple read from and assign to the underlying private attribute.

Extracted from #13532.