### PR TITLE
Refs #27095 -- Allowed (non-nested) arrays containing expressions for ArrayField lookups.

### DIFF
--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -143,6 +143,9 @@ Minor features
   allow creating and dropping collations on PostgreSQL. See
   :ref:`manage-postgresql-collations` for more details.
 
+* Lookups for :class:`~django.contrib.postgres.fields.ArrayField` now allow
+  (non-nested) arrays containing expressions as right-hand sides.
+
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/27095

Note that this PR does not fix the issue of using expressions in nested arrays, it only brings the other ArrayField lookups in line with `__in`. I think we should create a new separate ticket for the nested arrays  _or_ create a new ticket for the cases that this PR solve. I’m not really sure what makes most sense here, let me know and I'll sort it out.

This PR makes use of the `ARRAY[..]` literal  since we can’t pass identifiers in a python list to psycopg2 since they’ll end up being quoted .
