### PR TITLE
Refs #32191 Initial approach for RFC6265 compliant messages

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -26,7 +26,7 @@ class MessageEncoder(json.JSONEncoder):
         return super().default(obj)
 
     def encode(self, obj):
-        return signing.compress_encode_serialize(super().encode(obj))
+        return signing.serialize_compress_encode(super().encode(obj))
 
 
 class MessageDecoder(json.JSONDecoder):
@@ -47,7 +47,7 @@ class MessageDecoder(json.JSONDecoder):
         return obj
 
     def decode(self, s, **kwargs):
-        decoded = super().decode(signing.decompress_decode_unserialize(s), **kwargs)
+        decoded = super().decode(signing.decode_decompress_unserialize(s), **kwargs)
         return self.process_messages(decoded)
 
 

--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -1,5 +1,4 @@
 import json
-from urllib.parse import quote, unquote
 
 from django.conf import settings
 from django.contrib.messages.storage.base import BaseStorage, Message

--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -26,7 +26,7 @@ class MessageEncoder(json.JSONEncoder):
         return super().default(obj)
 
     def encode(self, obj):
-        return signing.serialize_compress_encode(super().encode(obj))
+        return signing.compress_b64encode(bytes(super().encode(obj), 'utf-8'))
 
 
 class MessageDecoder(json.JSONDecoder):
@@ -47,7 +47,7 @@ class MessageDecoder(json.JSONDecoder):
         return obj
 
     def decode(self, s, **kwargs):
-        decoded = super().decode(signing.decode_decompress_unserialize(s), **kwargs)
+        decoded = super().decode(signing.b64decode_decompress(s).decode(), **kwargs)
         return self.process_messages(decoded)
 
 

--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -1,4 +1,5 @@
 import json
+from urllib.parse import quote, unquote
 
 from django.conf import settings
 from django.contrib.messages.storage.base import BaseStorage, Message
@@ -24,6 +25,9 @@ class MessageEncoder(json.JSONEncoder):
             return message
         return super().default(obj)
 
+    def encode(self, obj):
+        return quote(super().encode(obj), safe="!#$%&'()*+/:<=>?@[]^{|}")
+
 
 class MessageDecoder(json.JSONDecoder):
     """
@@ -43,7 +47,7 @@ class MessageDecoder(json.JSONDecoder):
         return obj
 
     def decode(self, s, **kwargs):
-        decoded = super().decode(s, **kwargs)
+        decoded = super().decode(unquote(s), **kwargs)
         return self.process_messages(decoded)
 
 

--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -25,7 +25,7 @@ class MessageEncoder(json.JSONEncoder):
         return super().default(obj)
 
     def encode(self, obj):
-        return signing.compress_b64encode(bytes(super().encode(obj), 'utf-8'))
+        return signing.compress_b64(bytes(super().encode(obj), 'utf-8'))
 
 
 class MessageDecoder(json.JSONDecoder):
@@ -46,7 +46,7 @@ class MessageDecoder(json.JSONDecoder):
         return obj
 
     def decode(self, s, **kwargs):
-        decoded = super().decode(signing.b64decode_decompress(s).decode(), **kwargs)
+        decoded = super().decode(signing.decompress_b64(s).decode(), **kwargs)
         return self.process_messages(decoded)
 
 

--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -26,7 +26,7 @@ class MessageEncoder(json.JSONEncoder):
         return super().default(obj)
 
     def encode(self, obj):
-        return quote(super().encode(obj), safe="!#$%&'()*+/:<=>?@[]^{|}")
+        return signing.compress_encode_serialize(super().encode(obj))
 
 
 class MessageDecoder(json.JSONDecoder):
@@ -47,7 +47,7 @@ class MessageDecoder(json.JSONDecoder):
         return obj
 
     def decode(self, s, **kwargs):
-        decoded = super().decode(unquote(s), **kwargs)
+        decoded = super().decode(signing.decompress_decode_unserialize(s), **kwargs)
         return self.process_messages(decoded)
 
 

--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -108,16 +108,18 @@ def dumps(obj, key=None, salt='django.core.signing', serializer=JSONSerializer, 
     The serializer is expected to return a bytestring.
     """
     data = serializer().dumps(obj)
-    base64d = compress_b64encode(data)
+    base64d = compress_b64(data)
     return TimestampSigner(key, salt=salt).sign(base64d)
 
 
-def compress_b64encode(data):
+def compress_b64(data):
     """
     Return compressed data as a base 64 string.
 
     The input data is expected as a bytestring.
     """
+
+    # TODO encode the data so it can accept a string
     is_compressed = False
     compressed = zlib.compress(data)
     if len(compressed) < (len(data) - 1):
@@ -129,7 +131,7 @@ def compress_b64encode(data):
     return base64d
 
 
-def b64decode_decompress(base64str):
+def decompress_b64(base64str):
     """
     The input is a base64 string.
 
@@ -143,6 +145,7 @@ def b64decode_decompress(base64str):
     data = b64_decode(base64d)
     if decompress:
         data = zlib.decompress(data)
+    # TODO decode the data to return a string
     return data
 
 
@@ -155,7 +158,7 @@ def loads(s, key=None, salt='django.core.signing', serializer=JSONSerializer, ma
     # TimestampSigner.unsign() returns str but base64 and zlib compression
     # operate on bytes.
     unsigned = TimestampSigner(key, salt=salt).unsign(s, max_age=max_age)
-    data = b64decode_decompress(unsigned)
+    data = decompress_b64(unsigned)
     return serializer().loads(data)
 
 

--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -146,7 +146,6 @@ def b64decode_decompress(base64str):
     return data
 
 
-
 def loads(s, key=None, salt='django.core.signing', serializer=JSONSerializer, max_age=None):
     """
     Reverse of dumps(), raise BadSignature if signature fails.
@@ -156,7 +155,7 @@ def loads(s, key=None, salt='django.core.signing', serializer=JSONSerializer, ma
     # TimestampSigner.unsign() returns str but base64 and zlib compression
     # operate on bytes.
     unsigned = TimestampSigner(key, salt=salt).unsign(s, max_age=max_age)
-    data =  b64decode_decompress(unsigned)
+    data = b64decode_decompress(unsigned)
     return serializer().loads(data)
 
 

--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -107,11 +107,11 @@ def dumps(obj, key=None, salt='django.core.signing', serializer=JSONSerializer, 
 
     The serializer is expected to return a bytestring.
     """
-    base64d = compress_encode_serialize(obj, serializer)
+    base64d = serialize_compress_encode(obj, serializer)
     return TimestampSigner(key, salt=salt).sign(base64d)
 
 
-def compress_encode_serialize(obj, serializer=JSONSerializer):
+def serialize_compress_encode(obj, serializer=JSONSerializer):
     """
     Return compressed data as a base 64 string.
 
@@ -129,7 +129,7 @@ def compress_encode_serialize(obj, serializer=JSONSerializer):
     return base64d
 
 
-def decompress_decode_unserialize(base64str, serializer=JSONSerializer):
+def decode_decompress_unserialize(base64str, serializer=JSONSerializer):
     """
     The input is a base64 string.
 
@@ -156,7 +156,7 @@ def loads(s, key=None, salt='django.core.signing', serializer=JSONSerializer, ma
     # TimestampSigner.unsign() returns str but base64 and zlib compression
     # operate on bytes.
     unsigned = TimestampSigner(key, salt=salt).unsign(s, max_age=max_age)
-    return decompress_decode_unserialize(unsigned, serializer)
+    return decode_decompress_unserialize(unsigned, serializer)
 
 
 class Signer:

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -8,7 +8,7 @@ from django.contrib.messages.storage.base import Message
 from django.contrib.messages.storage.cookie import (
     CookieStorage, MessageDecoder, MessageEncoder,
 )
-from django.core.signing import b64decode_decompress
+from django.core.signing import decompress_b64
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import ignore_warnings
 from django.utils.deprecation import RemovedInDjango40Warning
@@ -74,7 +74,7 @@ class CookieTests(BaseTests, SimpleTestCase):
         response = self.get_response()
         storage.add(constants.INFO, 'test')
         storage.update(response)
-        self.assertIn(b'test', b64decode_decompress(response.cookies['messages'].value))
+        self.assertIn(b'test', decompress_b64(response.cookies['messages'].value))
         self.assertEqual(response.cookies['messages']['domain'], '.example.com')
         self.assertEqual(response.cookies['messages']['expires'], '')
         self.assertIs(response.cookies['messages']['secure'], True)

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -63,7 +63,7 @@ class CookieTests(BaseTests, SimpleTestCase):
         self.assertEqual(list(storage), example_messages)
 
     @override_settings(SESSION_COOKIE_SAMESITE='Strict')
-    def test_cookie_setings(self):
+    def test_cookie_settings(self):
         """
         CookieStorage honors SESSION_COOKIE_DOMAIN, SESSION_COOKIE_SECURE, and
         SESSION_COOKIE_HTTPONLY (#15618, #20972).

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -161,6 +161,16 @@ class CookieTests(BaseTests, SimpleTestCase):
         self.assertIsInstance(encode_decode(mark_safe("<b>Hello Django!</b>")), SafeData)
         self.assertNotIsInstance(encode_decode("<b>Hello Django!</b>"), SafeData)
 
+    def test_rfc6265_compliant(self):
+        storage = self.storage_class(self.get_request())
+        msg_1 = Message(constants.INFO, 'Test me')
+        msg_2 = Message(constants.INFO, 'Test me \\again')
+        example_messages = [msg_1, msg_2]
+        encoded = storage._encode(example_messages)
+        expected = ('[[%22__json_message%22%2C0%2C20%2C%22Test%20me%22]%2C'
+                    '[%22__json_message%22%2C0%2C20%2C%22Test%20me%20%5C%5Cagain%22]]')
+        self.assertEqual(encoded.split(':')[0], expected)
+
     def test_legacy_hash_decode(self):
         # RemovedInDjango40Warning: pre-Django 3.1 hashes will be invalid.
         storage = self.storage_class(self.get_request())

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -8,6 +8,7 @@ from django.contrib.messages.storage.base import Message
 from django.contrib.messages.storage.cookie import (
     CookieStorage, MessageDecoder, MessageEncoder,
 )
+from django.core.signing import b64decode_decompress
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import ignore_warnings
 from django.utils.deprecation import RemovedInDjango40Warning
@@ -73,7 +74,7 @@ class CookieTests(BaseTests, SimpleTestCase):
         response = self.get_response()
         storage.add(constants.INFO, 'test')
         storage.update(response)
-        self.assertIn('test', response.cookies['messages'].value)
+        self.assertIn(b'test', b64decode_decompress(response.cookies['messages'].value))
         self.assertEqual(response.cookies['messages']['domain'], '.example.com')
         self.assertEqual(response.cookies['messages']['expires'], '')
         self.assertIs(response.cookies['messages']['secure'], True)
@@ -171,7 +172,7 @@ class CookieTests(BaseTests, SimpleTestCase):
         example_messages = [msg_1, msg_2]
         encoded = storage._encode(example_messages)
         # We expect the value to be serialized, compressed, and base64 encoded
-        expected = '.eJxTio6OUYqPzyrOz4vPTS0uTkxPjVHSMdAxMtCJUQpJLS5RyAUKxOoQVqUQAwSJ6YmZeUD1sUoAHdwc4Q'
+        expected = '.eJyLjlaKj88qzs-Lz00tLk5MT1XSMdAxMtBRCkktLlHITVWK1SGgQiEmJjE9MTNPKTYWANpSGQU'
         self.assertEqual(encoded.split(':')[0], expected)
 
     def test_legacy_hash_decode(self):

--- a/tests/messages_tests/test_fallback.py
+++ b/tests/messages_tests/test_fallback.py
@@ -1,3 +1,6 @@
+import random
+import string
+
 from django.contrib.messages import constants
 from django.contrib.messages.storage.fallback import (
     CookieStorage, FallbackStorage,
@@ -129,7 +132,8 @@ class FallbackTests(BaseTests, SimpleTestCase):
         # see comment in CookieTests.test_cookie_max_length()
         msg_size = int((CookieStorage.max_cookie_size - 54) / 4.5 - 37)
         for i in range(5):
-            storage.add(constants.INFO, str(i) * msg_size)
+            # see comment in test_session_fallback_only
+            storage.add(constants.INFO, ''.join(random.choice(string.ascii_letters) for _ in range(msg_size)))
         storage.update(response)
         cookie_storing = self.stored_cookie_messages_count(storage, response)
         self.assertEqual(cookie_storing, 4)
@@ -143,7 +147,8 @@ class FallbackTests(BaseTests, SimpleTestCase):
         """
         storage = self.get_storage()
         response = self.get_response()
-        storage.add(constants.INFO, 'x' * 5000)
+        # Cookie compression for messages requires us to use a random uncompressable string here
+        storage.add(constants.INFO, ''.join(random.choice(string.ascii_letters) for _ in range(5000)))
         storage.update(response)
         cookie_storing = self.stored_cookie_messages_count(storage, response)
         self.assertEqual(cookie_storing, 0)

--- a/tests/messages_tests/test_mixins.py
+++ b/tests/messages_tests/test_mixins.py
@@ -1,3 +1,5 @@
+from urllib.parse import unquote
+
 from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 
@@ -11,4 +13,4 @@ class SuccessMessageMixinTests(SimpleTestCase):
         author = {'name': 'John Doe', 'slug': 'success-msg'}
         add_url = reverse('add_success_msg')
         req = self.client.post(add_url, author)
-        self.assertIn(ContactFormViewWithMsg.success_message % author, req.cookies['messages'].value)
+        self.assertIn(ContactFormViewWithMsg.success_message % author, unquote(req.cookies['messages'].value))

--- a/tests/messages_tests/test_mixins.py
+++ b/tests/messages_tests/test_mixins.py
@@ -1,6 +1,6 @@
+from django.core.signing import b64decode_decompress
 from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
-from django.core.signing import b64decode_decompress
 
 from .urls import ContactFormViewWithMsg
 

--- a/tests/messages_tests/test_mixins.py
+++ b/tests/messages_tests/test_mixins.py
@@ -12,8 +12,6 @@ class SuccessMessageMixinTests(SimpleTestCase):
         author = {'name': 'John Doe', 'slug': 'success-msg'}
         add_url = reverse('add_success_msg')
         req = self.client.post(add_url, author)
-        print(type(req.cookies['messages'].value))
-        print(req.cookies['messages'].value)
         self.assertIn(
             bytes(ContactFormViewWithMsg.success_message % author, 'utf-8'),
             b64decode_decompress(req.cookies['messages'].value))

--- a/tests/messages_tests/test_mixins.py
+++ b/tests/messages_tests/test_mixins.py
@@ -1,5 +1,3 @@
-from urllib.parse import unquote
-
 from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 from django.core.signing import b64decode_decompress
@@ -16,5 +14,6 @@ class SuccessMessageMixinTests(SimpleTestCase):
         req = self.client.post(add_url, author)
         print(type(req.cookies['messages'].value))
         print(req.cookies['messages'].value)
-        self.assertIn(bytes(ContactFormViewWithMsg.success_message % author, 'utf-8'),
-                b64decode_decompress(req.cookies['messages'].value))
+        self.assertIn(
+            bytes(ContactFormViewWithMsg.success_message % author, 'utf-8'),
+            b64decode_decompress(req.cookies['messages'].value))

--- a/tests/messages_tests/test_mixins.py
+++ b/tests/messages_tests/test_mixins.py
@@ -1,4 +1,4 @@
-from django.core.signing import b64decode_decompress
+from django.core.signing import decompress_b64
 from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 
@@ -14,4 +14,4 @@ class SuccessMessageMixinTests(SimpleTestCase):
         req = self.client.post(add_url, author)
         self.assertIn(
             bytes(ContactFormViewWithMsg.success_message % author, 'utf-8'),
-            b64decode_decompress(req.cookies['messages'].value))
+            decompress_b64(req.cookies['messages'].value))

--- a/tests/messages_tests/test_mixins.py
+++ b/tests/messages_tests/test_mixins.py
@@ -2,6 +2,7 @@ from urllib.parse import unquote
 
 from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
+from django.core.signing import b64decode_decompress
 
 from .urls import ContactFormViewWithMsg
 
@@ -13,4 +14,7 @@ class SuccessMessageMixinTests(SimpleTestCase):
         author = {'name': 'John Doe', 'slug': 'success-msg'}
         add_url = reverse('add_success_msg')
         req = self.client.post(add_url, author)
-        self.assertIn(ContactFormViewWithMsg.success_message % author, unquote(req.cookies['messages'].value))
+        print(type(req.cookies['messages'].value))
+        print(req.cookies['messages'].value)
+        self.assertIn(bytes(ContactFormViewWithMsg.success_message % author, 'utf-8'),
+                b64decode_decompress(req.cookies['messages'].value))

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -151,12 +151,9 @@ class TestSigner(SimpleTestCase):
         self.assertEqual(signing.loads(signed), value)
 
     def test_compress_decompress(self):
-        value = ['a list', 2]
-        compressed = signing.serialize_compress_encode(value)
-        self.assertEqual(signing.decode_decompress_unserialize(compressed), value)
-        value = 'a string'
-        compressed = signing.serialize_compress_encode(value)
-        self.assertEqual(signing.decode_decompress_unserialize(compressed), value)
+        value = b'a string'
+        compressed = signing.compress_b64encode(value)
+        self.assertEqual(signing.b64decode_decompress(compressed), value)
 
     def test_decode_detects_tampering(self):
         "loads should raise exception for tampered objects"

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -150,6 +150,14 @@ class TestSigner(SimpleTestCase):
             signed = signing.dumps(value)
         self.assertEqual(signing.loads(signed), value)
 
+    def test_compress_decompress(self):
+        value = ['a list', 2]
+        compressed = signing.serialize_compress_encode(value)
+        self.assertEqual(signing.decode_decompress_unserialize(compressed), value)
+        value = 'a string'
+        compressed = signing.serialize_compress_encode(value)
+        self.assertEqual(signing.decode_decompress_unserialize(compressed), value)
+
     def test_decode_detects_tampering(self):
         "loads should raise exception for tampered objects"
         transforms = (

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -152,8 +152,8 @@ class TestSigner(SimpleTestCase):
 
     def test_compress_decompress(self):
         value = b'a string'
-        compressed = signing.compress_b64encode(value)
-        self.assertEqual(signing.b64decode_decompress(compressed), value)
+        compressed = signing.compress_b64(value)
+        self.assertEqual(signing.decompress_b64(compressed), value)
 
     def test_decode_detects_tampering(self):
         "loads should raise exception for tampered objects"


### PR DESCRIPTION
[WIP] In Django messages are often stored in cookies. This means that they should comply with the IETF's RFC 6265 which excludes backslashes from the cookie value. Currently, backslashes are included.

The initial approach is to use `urllib.parse.quote` and `unquote`. But the aim is to compress the messages also, and to base64 encode them. That's the bit that's in progress, that's a bit tricky.

Changing the way messages are stored might impact some users who access them in Javascript. Similarly, some back-end code that accesses the `req.cookie['message'].value` attribute might be impacted too. So, any ideas on how to reduce or eliminate this impact are welcome - as are any other pointers.