### PR TITLE
Fixed #32203 -- Fixed QuerySet.values()/values_list() crash on key transforms with non-string values on SQLite.

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -75,6 +75,10 @@ class JSONField(CheckFieldDefaultMixin, Field):
     def from_db_value(self, value, expression, connection):
         if value is None:
             return value
+        # Some backends (SQLite at least) extract non-string values in their
+        # SQL datatypes.
+        if isinstance(expression, KeyTransform) and not isinstance(value, str):
+            return value
         try:
             return json.loads(value, cls=self.decoder)
         except json.JSONDecodeError:

--- a/docs/releases/3.1.4.txt
+++ b/docs/releases/3.1.4.txt
@@ -28,3 +28,7 @@ Bugfixes
 * Fixed a regression in Django 3.1 that caused suppressing connection errors
   when :class:`~django.db.models.JSONField` is used on SQLite
   (:ticket:`32224`).
+
+* Fixed a crash on SQLite, when ``QuerySet.values()/values_list()`` contained
+  key transforms for :class:`~django.db.models.JSONField` returning non-string
+  primitive values (:ticket:`32203`).

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -749,6 +749,19 @@ class TestQuerying(TestCase):
                     expected,
                 )
 
+    def test_key_values(self):
+        qs = NullableJSONModel.objects.filter(value__h=True)
+        tests = [
+            ('value__a', 'b'),
+            ('value__d', ['e', {'f': 'g'}]),
+            ('value__j', None),
+            ('value__k', {'l': 'm'}),
+            ('value__n', [None]),
+        ]
+        for lookup, expected in tests:
+            with self.subTest(lookup=lookup):
+                self.assertEqual(qs.values_list(lookup, flat=True).get(), expected)
+
     @skipUnlessDBFeature('supports_json_field_contains')
     def test_key_contains(self):
         self.assertIs(NullableJSONModel.objects.filter(value__foo__contains='ar').exists(), False)

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -277,6 +277,7 @@ class TestQuerying(TestCase):
                 'k': {'l': 'm'},
                 'n': [None],
                 'o': '"quoted"',
+                'p': 4.2,
             },
             [1, [2]],
             {'k': True, 'l': False, 'foo': 'bax'},
@@ -753,10 +754,14 @@ class TestQuerying(TestCase):
         qs = NullableJSONModel.objects.filter(value__h=True)
         tests = [
             ('value__a', 'b'),
+            ('value__c', 14),
             ('value__d', ['e', {'f': 'g'}]),
+            ('value__h', True),
+            ('value__i', False),
             ('value__j', None),
             ('value__k', {'l': 'm'}),
             ('value__n', [None]),
+            ('value__p', 4.2),
         ]
         for lookup, expected in tests:
             with self.subTest(lookup=lookup):


### PR DESCRIPTION
ticket-32203.

I was thinking about using `JSON_QUOTE` instead, but that will break ordering (and other stuff). I *think* this will also fix the issue some people are having when using the `json` data type on PostgreSQL.

I'm not sure how to proceed with the `'"quoted"'` vs. `'unquoted'` thing... I don't think we can properly determine whether the string retrieved from SQLite (and it seems Oracle as well) is a JSON string that's also enclosed in double quotes (e.g. `'"\"some string\""'`) vs. JSON object/array (e.g. `'{"key": "value"}'`. I don't think checking for `"` prefix and suffix prior to calling `json.loads()` is enough (?)