### PR TITLE
Fixed #32206 -- Fixed incorrect migration generated if field has been renamed when it has verbose_name set.

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -834,6 +834,8 @@ class MigrationAutodetector:
                             old_field_dec[2]['to'] = self.renamed_models_rel[old_rel_to]
                     old_field.set_attributes_from_name(rem_field_name)
                     old_db_column = old_field.get_attname_column()[1]
+                    old_field_dec[2].pop('verbose_name', None)
+                    field_dec[2].pop('verbose_name', None)
                     if (old_field_dec == field_dec or (
                             # Was the field renamed and db_column equal to the
                             # old field's column added?

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1037,6 +1037,26 @@ class AutodetectorTests(TestCase):
             {'to': 'app.foo', 'on_delete': models.CASCADE, 'db_column': 'foo_id'},
         ))
 
+    def test_rename_change_verbose_name(self):
+        before = [
+            ModelState('app', 'Foo', [
+                ('id', models.CharField(primary_key=True)),
+                ('name', models.CharField(max_length=10, verbose_name="name")),
+            ]),
+        ]
+        after = [
+            ModelState('app', 'Foo', [
+                ('id', models.CharField(primary_key=True)),
+                ('label', models.CharField(max_length=10, verbose_name="labels")),
+            ]),
+        ]
+        changes = self.get_changes(before, after, MigrationQuestioner({'ask_rename': True}))
+        self.assertNumberMigrations(changes, 'app', 1)
+        self.assertOperationTypes(changes, 'app', 0, ['RenameField', 'AlterField'])
+        self.assertOperationAttributes(changes, 'app', 0, 0, old_name='name', new_name='label')
+        self.assertOperationAttributes(changes, "app", 0, 1, name='label')
+        self.assertEqual(changes['app'][0].operations[1].field.verbose_name, 'labels')
+
     def test_rename_model(self):
         """Tests autodetection of renamed models."""
         changes = self.get_changes(


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32206