### PR TITLE
Fixed #32165 -- Added pre-commit hooks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 **/vendor/**/*.js
 django/contrib/gis/templates/**/*.js
 node_modules/**.js
+tests/**/*.js

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.6.4
+    hooks:
+      - id: isort
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v7.16.0
+    hooks:
+      - id: eslint

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,6 @@
-var globalThreshold = 50;  // Global code coverage threshold (as a percentage)
+'use strict';
+
+const globalThreshold = 50; // Global code coverage threshold (as a percentage)
 
 module.exports = function(grunt) {
     grunt.initConfig({

--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -4,6 +4,32 @@ Coding style
 
 Please follow these coding standards when writing code for inclusion in Django.
 
+.. _coding-style-pre-commit:
+
+Pre-commit checks
+=================
+
+`pre-commit <https://pre-commit.com>`_ is a framework for managing pre-commit
+hooks. These hooks help to identify simple issues before committing code for
+review. By checking for these issues before code review it allows the reviewer
+to focus on the change itself, and it can also help to reduce the number CI
+runs.
+
+To use the tool, first install ``pre-commit`` and then the git hooks::
+
+.. console::
+
+    $ pip install pre-commit
+    $ pre-commit install
+
+On the first commit ``pre-commit`` will install the hooks, these are
+installed in their own environments and will take a short while to
+install on the first run. Subsequent checks will be significantly faster.
+If the an error is found an appropriate error message will be displayed.
+If the error was with ``isort`` then the tool will go ahead and fix them for
+you. Review the changes and re-stage for commit if you are happy with
+them.
+
 .. _coding-style-python:
 
 Python style

--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -290,7 +290,9 @@ All code changes
 
 * Does the :doc:`coding style
   </internals/contributing/writing-code/coding-style>` conform to our
-  guidelines? Are there any ``flake8`` errors?
+  guidelines? Are there any ``flake8`` errors? You can install the
+  :ref:`pre-commit <coding-style-pre-commit>` hooks to automatically catch
+  these errors.
 * If the change is backwards incompatible in any way, is there a note
   in the release notes (``docs/releases/A.B.txt``)?
 * Is Django's test suite passing?


### PR DESCRIPTION
ticket-32165

* Added pre-commit hooks for isort, flake8 and a number of other code style checks.
* Added documentation on how to use the tool in the introduction guide.

Following the conversation on the [mailing list](https://groups.google.com/g/django-developers/c/LVWssSldjVs) I've opened this PR. I've added a couple of extra hooks from the `pre-commit-hooks` repo as suggested by Adam. I've looked through the list again and don't think we need anything else but easy to add more :shrug: 

Documentation is added, only to the docs at this stage as I think a pull request template is out of scope here.

Finally, while I like @adamchainz suggestion about having the tools installed in tox environments. Personally, I feel this is too hard to explain in the contributing guide (we're already at nearly 600 lines of docs to submit a pull request). 