### PR TITLE
Grammatically updated the techdoc for tutorial 1

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -330,7 +330,7 @@ text "*Hello, world. You're at the polls index.*", which you defined in the
     If you get an error page here, check that you're going to
     http://localhost:8000/polls/ and not http://localhost:8000/.
 
-The :func:`~django.urls.path` function is passed four arguments, two required:
+The :func:`~django.urls.path` function passes four arguments, two required:
 ``route`` and ``view``, and two optional: ``kwargs``, and ``name``.
 At this point, it's worth reviewing what these arguments are for.
 


### PR DESCRIPTION
<img width="468" alt="django" src="https://user-images.githubusercontent.com/46643006/99885234-803b1800-2c59-11eb-9baf-dc96c5e2e2ef.PNG">
I made a small grammatical update to the tech doc of django. 
The location for this change is django/docs/intro/tutorial01.txt/Line number 333