### PR TITLE
Fixed #32208 -- fixed misinterpretation of "__proxy__" as TypeError. 

### DIFF
--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -138,3 +138,4 @@ def resolve_url(to, *args, **kwargs):
 
     # Finally, fall back and assume it's a URL
     return to
+

--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -138,4 +138,3 @@ def resolve_url(to, *args, **kwargs):
 
     # Finally, fall back and assume it's a URL
     return to
-    

--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -138,3 +138,4 @@ def resolve_url(to, *args, **kwargs):
 
     # Finally, fall back and assume it's a URL
     return to
+    

--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -138,4 +138,4 @@ def resolve_url(to, *args, **kwargs):
 
     # Finally, fall back and assume it's a URL
     return to
-
+    

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -680,7 +680,19 @@ def add(value, arg):
         try:
             return value + arg
         except Exception:
-            return ''
+            try:
+                 int(arg)
+                 return ''
+            except:
+                try:
+                    proxy_arg = str(arg)
+                        
+                    return value + proxy_arg
+                except:
+                    return ''
+       
+       
+        
 
 
 @register.filter(is_safe=False)

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -689,7 +689,7 @@ def add(value, arg):
                     return value + proxy_arg
                 except Exception:
                     return ''
-       
+
 
 @register.filter(is_safe=False)
 def get_digit(value, arg):

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -681,19 +681,15 @@ def add(value, arg):
             return value + arg
         except Exception:
             try:
-                 int(arg)
-                 return ''
-            except:
+                int(arg)
+                return ''
+            except Exception:
                 try:
                     proxy_arg = str(arg)
-                        
                     return value + proxy_arg
-                except:
+                except Exception:
                     return ''
        
-       
-        
-
 
 @register.filter(is_safe=False)
 def get_digit(value, arg):

--- a/tests/template_tests/filter_tests/test_add.py
+++ b/tests/template_tests/filter_tests/test_add.py
@@ -45,7 +45,7 @@ class AddTests(SimpleTestCase):
     def test_add07(self):
         output = self.engine.render_to_string('add07', {'d': date(2000, 1, 1), 't': timedelta(10)})
         self.assertEqual(output, 'Jan. 11, 2000')
-    
+
     @setup({'add08': '{{ s1|add:lazy_s2 }}'})
     def test_add08(self):
         from django.utils.translation import gettext_lazy

--- a/tests/template_tests/filter_tests/test_add.py
+++ b/tests/template_tests/filter_tests/test_add.py
@@ -45,6 +45,12 @@ class AddTests(SimpleTestCase):
     def test_add07(self):
         output = self.engine.render_to_string('add07', {'d': date(2000, 1, 1), 't': timedelta(10)})
         self.assertEqual(output, 'Jan. 11, 2000')
+    
+    @setup({'add08': '{{ s1|add:lazy_s2 }}'})
+    def test_add08(self):
+        from django.utils.translation import gettext_lazy
+        output = self.engine.render_to_string('add08', {'s1': 'string', 'lazy_s2': gettext_lazy('lazy')})
+        self.assertEqual(output, 'stringlazy')
 
 
 class FunctionTests(SimpleTestCase):


### PR DESCRIPTION
tweaked exception handling of add built in filter , to support (gettext
_lazy). as previously it was taking it as a TypeError and used to
return a string.