### PR TITLE
Fixed #32219 -- Made InlineModelAdmin.verbose_name_plural fallback to its verbose_name.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2037,10 +2037,13 @@ class InlineModelAdmin(BaseModelAdmin):
         self.opts = self.model._meta
         self.has_registered_model = admin_site.is_registered(self.model)
         super().__init__()
+        if self.verbose_name_plural is None:
+            if self.verbose_name is None:
+                self.verbose_name_plural = self.model._meta.verbose_name_plural
+            else:
+                self.verbose_name_plural = format_lazy('{}s', self.verbose_name)
         if self.verbose_name is None:
             self.verbose_name = self.model._meta.verbose_name
-        if self.verbose_name_plural is None:
-            self.verbose_name_plural = self.model._meta.verbose_name_plural
 
     @property
     def media(self):

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2453,13 +2453,19 @@ The ``InlineModelAdmin`` class adds or customizes:
 
 .. attribute:: InlineModelAdmin.verbose_name
 
-    An override to the ``verbose_name`` found in the model's inner ``Meta``
-    class.
+    An override to the :attr:`~django.db.models.Options.verbose_name` from the
+    model's inner ``Meta`` class.
 
 .. attribute:: InlineModelAdmin.verbose_name_plural
 
-    An override to the ``verbose_name_plural`` found in the model's inner
-    ``Meta`` class.
+    An override to the :attr:`~django.db.models.Options.verbose_name_plural`
+    from the model's inner ``Meta`` class. If this isn't given and the
+    :attr:`.InlineModelAdmin.verbose_name` is defined, Django will use
+    :attr:`.InlineModelAdmin.verbose_name` + ``'s'``.
+
+    .. versionchanged:: 4.0
+
+        The fallback to :attr:`.InlineModelAdmin.verbose_name` was added.
 
 .. attribute:: InlineModelAdmin.can_delete
 

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -85,6 +85,9 @@ Minor features
 * The new :attr:`.ModelAdmin.search_help_text` attribute allows specifying a
   descriptive text for the search box.
 
+* The :attr:`.InlineModelAdmin.verbose_name_plural` attribute now fallbacks to
+  the :attr:`.InlineModelAdmin.verbose_name` + ``'s'``.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Based default verbose_name_plural for an inline admin class on its verbose_name if that is specified.