### PR TITLE
Fixed #32222 -- Unbalanced quotes in contrib/admin and contrib/gis templates.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -185,6 +185,7 @@ answer newbie questions, and generally made Django that much better:
     Chris Jerdonek
     Chris Jones <chris@brack3t.com>
     Chris Lamb <chris@chris-lamb.co.uk>
+    Chris Larson <cklarson@gmail.com>
     Chris Streeter <chris@chrisstreeter.com>
     Christian Barcenas <christian@cbarcenas.com>
     Christian Metts

--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -2,7 +2,7 @@
 {% load i18n static %}
 {% load admin_urls %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">{% endblock %}
 {% block bodyclass %}{{ block.super }} {{ opts.app_label }}-{{ opts.model_name }} change-form{% endblock %}
 {% if not is_popup %}
 {% block breadcrumbs %}

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -5,7 +5,7 @@
 <title>{% block title %}{% endblock %}</title>
 <link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
 {% if not is_popup and is_nav_sidebar_enabled %}
-  <link rel="stylesheet" type="text/css" href="{% static "admin/css/nav_sidebar.css" %}">
+  <link rel="stylesheet" type="text/css" href="{% static 'admin/css/nav_sidebar.css' %}">
   <script src="{% static 'admin/js/nav_sidebar.js' %}" defer></script>
 {% endif %}
 {% block extrastyle %}{% endblock %}
@@ -13,15 +13,15 @@
 {% block extrahead %}{% endblock %}
 {% block responsive %}
     <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0">
-    <link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive.css" %}">
-    {% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive_rtl.css" %}">{% endif %}
+    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/responsive.css' %}">
+    {% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% static 'admin/css/responsive_rtl.css' %}">{% endif %}
 {% endblock %}
 {% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE">{% endblock %}
 </head>
 {% load i18n %}
 
 <body class="{% if is_popup %}popup {% endif %}{% block bodyclass %}{% endblock %}"
-  data-admin-utc-offset="{% now "Z" %}">
+  data-admin-utc-offset="{% now 'Z' %}">
 
 <!-- Container -->
 <div id="container">

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -6,7 +6,7 @@
 {{ media }}
 {% endblock %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">{% endblock %}
 
 {% block coltype %}colM{% endblock %}
 

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -3,9 +3,9 @@
 
 {% block extrastyle %}
   {{ block.super }}
-  <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+  <link rel="stylesheet" type="text/css" href="{% static 'admin/css/changelists.css' %}">
   {% if cl.formset %}
-    <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">
   {% endif %}
   {% if cl.formset or action_form %}
     <script src="{% url 'admin:jsi18n' %}"></script>

--- a/django/contrib/admin/templates/admin/change_list_results.html
+++ b/django/contrib/admin/templates/admin/change_list_results.html
@@ -14,9 +14,9 @@
    {% if header.sortable %}
      {% if header.sort_priority > 0 %}
        <div class="sortoptions">
-         <a class="sortremove" href="{{ header.url_remove }}" title="{% translate "Remove from sorting" %}"></a>
+         <a class="sortremove" href="{{ header.url_remove }}" title="{% translate 'Remove from sorting' %}"></a>
          {% if num_sorted_fields > 1 %}<span class="sortpriority" title="{% blocktranslate with priority_number=header.sort_priority %}Sorting priority: {{ priority_number }}{% endblocktranslate %}">{{ header.sort_priority }}</span>{% endif %}
-         <a href="{{ header.url_toggle }}" class="toggle {% if header.ascending %}ascending{% else %}descending{% endif %}" title="{% translate "Toggle sorting" %}"></a>
+         <a href="{{ header.url_toggle }}" class="toggle {% if header.ascending %}ascending{% else %}descending{% endif %}" title="{% translate 'Toggle sorting' %}"></a>
        </div>
      {% endif %}
    {% endif %}

--- a/django/contrib/admin/templates/admin/edit_inline/tabular.html
+++ b/django/contrib/admin/templates/admin/edit_inline/tabular.html
@@ -13,7 +13,7 @@
      {% for field in inline_admin_formset.fields %}
        {% if not field.widget.is_hidden %}
          <th class="column-{{ field.name }}{% if field.required %} required{% endif %}">{{ field.label|capfirst }}
-         {% if field.help_text %}<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">{% endif %}
+         {% if field.help_text %}<img src="{% static 'admin/img/icon-unknown.svg' %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">{% endif %}
          </th>
        {% endif %}
      {% endfor %}

--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/dashboard.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static 'admin/css/dashboard.css' %}">{% endblock %}
 
 {% block coltype %}colMS{% endblock %}
 

--- a/django/contrib/admin/templates/admin/login.html
+++ b/django/contrib/admin/templates/admin/login.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/login.css" %}">
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static 'admin/css/login.css' %}">
 {{ form.media }}
 {% endblock %}
 

--- a/django/contrib/admin/templates/admin/popup_response.html
+++ b/django/contrib/admin/templates/admin/popup_response.html
@@ -3,7 +3,7 @@
   <head><title>{% translate 'Popup closing…' %}</title></head>
   <body>
     <script id="django-admin-popup-response-constants"
-            src="{% static "admin/js/popup_response.js" %}"
+            src="{% static 'admin/js/popup_response.js' %}"
             data-popup-response="{{ popup_response_data }}">
     </script>
   </body>

--- a/django/contrib/admin/templates/admin/prepopulated_fields_js.html
+++ b/django/contrib/admin/templates/admin/prepopulated_fields_js.html
@@ -1,5 +1,5 @@
 {% load l10n static %}
 <script id="django-admin-prepopulated-fields-constants"
-        src="{% static "admin/js/prepopulate_init.js" %}"
+        src="{% static 'admin/js/prepopulate_init.js' %}"
         data-prepopulated-fields="{{ prepopulated_fields_json }}">
 </script>

--- a/django/contrib/admin/templates/admin/search_form.html
+++ b/django/contrib/admin/templates/admin/search_form.html
@@ -2,7 +2,7 @@
 {% if cl.search_fields %}
 <div id="toolbar"><form id="changelist-search" method="get">
 <div><!-- DIV needed for valid HTML -->
-<label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search"></label>
+<label for="searchbar"><img src="{% static 'admin/img/search.svg' %}" alt="Search"></label>
 <input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus>
 <input type="submit" value="{% translate 'Search' %}">
 {% if show_result_count %}

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">{% endblock %}
 {% block userlinks %}{% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% translate 'Documentation' %}</a> / {% endif %} {% translate 'Change password' %} / <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">

--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>

--- a/django/contrib/admin/templates/registration/password_reset_form.html
+++ b/django/contrib/admin/templates/registration/password_reset_form.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>

--- a/django/contrib/gis/templates/gis/admin/openlayers.html
+++ b/django/contrib/gis/templates/gis/admin/openlayers.html
@@ -6,11 +6,11 @@
   #{{ id }}_admin_map { position: relative; vertical-align: top; z-index: 0; float: {{ LANGUAGE_BIDI|yesno:"right,left" }}; }
   {% if not display_wkt %}#{{ id }} { display: none; }{% endif %}
   .olControlEditingToolbar .olControlModifyFeatureItemActive {
-     background-image: url("{% static "admin/img/gis/move_vertex_on.svg" %}");
+     background-image: url("{% static 'admin/img/gis/move_vertex_on.svg' %}");
      background-repeat: no-repeat;
   }
   .olControlEditingToolbar .olControlModifyFeatureItemInactive {
-     background-image: url("{% static "admin/img/gis/move_vertex_off.svg" %}");
+     background-image: url("{% static 'admin/img/gis/move_vertex_off.svg' %}");
      background-repeat: no-repeat;
   }
 </style>

--- a/tests/admin_views/templates/admin/admin_views/article/change_list_results.html
+++ b/tests/admin_views/templates/admin/admin_views/article/change_list_results.html
@@ -14,9 +14,9 @@
    {% if header.sortable %}
      {% if header.sort_priority > 0 %}
        <div class="sortoptions">
-         <a class="sortremove" href="{{ header.url_remove }}" title="{% translate "Remove from sorting" %}"></a>
+         <a class="sortremove" href="{{ header.url_remove }}" title="{% translate 'Remove from sorting' %}"></a>
          {% if num_sorted_fields > 1 %}<span class="sortpriority" title="{% blocktranslate with priority_number=header.sort_priority %}Sorting priority: {{ priority_number }}{% endblocktranslate %}">{{ header.sort_priority }}</span>{% endif %}
-         <a href="{{ header.url_toggle }}" class="toggle {% if header.ascending %}ascending{% else %}descending{% endif %}" title="{% translate "Toggle sorting" %}"></a>
+         <a href="{{ header.url_toggle }}" class="toggle {% if header.ascending %}ascending{% else %}descending{% endif %}" title="{% translate 'Toggle sorting' %}"></a>
        </div>
      {% endif %}
    {% endif %}

--- a/tests/admin_views/templates/admin/admin_views/article/prepopulated_fields_js.html
+++ b/tests/admin_views/templates/admin/admin_views/article/prepopulated_fields_js.html
@@ -1,6 +1,6 @@
 {% load l10n static %}
 <script id="django-admin-prepopulated-fields-constants"
         class="override-prepopulated_fields_js"
-        src="{% static "admin/js/prepopulate_init.js" %}"
+        src="{% static 'admin/js/prepopulate_init.js' %}"
         data-prepopulated-fields="{{ prepopulated_fields_json }}">
 </script>

--- a/tests/admin_views/templates/admin/admin_views/article/search_form.html
+++ b/tests/admin_views/templates/admin/admin_views/article/search_form.html
@@ -2,7 +2,7 @@
 {% if cl.search_fields %}
 <div id="toolbar" class="override-search_form"><form id="changelist-search" method="get">
 <div><!-- DIV needed for valid HTML -->
-<label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search" /></label>
+<label for="searchbar"><img src="{% static 'admin/img/search.svg' %}" alt="Search" /></label>
 <input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus />
 <input type="submit" value="{% translate 'Search' %}" />
 {% if show_result_count %}


### PR DESCRIPTION
Correct quoting in tags with the form:
    "\{% <tag> "<str>" %\}"
To:
    "{% <tag> '<str>' %}"

Corrected templates in:
    django/contrib/admin/templates/
    django/contrib/gis/templates/gis/
    tests/admin_views/templates/

Update AUTHORS