### PR TITLE
Fixed #32224 -- Avoided suppressing connection errors in supports_json_field on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -70,11 +70,12 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     @cached_property
     def supports_json_field(self):
-        try:
-            with self.connection.cursor() as cursor, transaction.atomic():
-                cursor.execute('SELECT JSON(\'{"a": "b"}\')')
-        except OperationalError:
-            return False
+        with self.connection.cursor() as cursor:
+            try:
+                with transaction.atomic(self.connection.alias):
+                    cursor.execute('SELECT JSON(\'{"a": "b"}\')')
+            except OperationalError:
+                return False
         return True
 
     can_introspect_json_field = property(operator.attrgetter('supports_json_field'))

--- a/docs/releases/3.1.4.txt
+++ b/docs/releases/3.1.4.txt
@@ -24,3 +24,7 @@ Bugfixes
 
 * Fixed a regression in Django 3.1 that caused the incorrect grouping by a
   ``Q`` object annotation (:ticket:`32200`).
+
+* Fixed a regression in Django 3.1 that caused suppressing connection errors
+  when :class:`~django.db.models.JSONField` is used on SQLite
+  (:ticket:`32224`).

--- a/tests/backends/sqlite/test_features.py
+++ b/tests/backends/sqlite/test_features.py
@@ -1,0 +1,18 @@
+from unittest import mock, skipUnless
+
+from django.db import OperationalError, connection
+from django.test import TestCase
+
+
+@skipUnless(connection.vendor == 'sqlite', 'SQLite tests.')
+class FeaturesTests(TestCase):
+    def test_supports_json_field_operational_error(self):
+        if hasattr(connection.features, 'supports_json_field'):
+            del connection.features.supports_json_field
+        msg = 'unable to open database file'
+        with mock.patch(
+            'django.db.backends.base.base.BaseDatabaseWrapper.cursor',
+            side_effect=OperationalError(msg),
+        ):
+            with self.assertRaisesMessage(OperationalError, msg):
+                connection.features.supports_json_field


### PR DESCRIPTION
Regression in 6789ded0a6ab797f0dcdfa6ad5d1cfa46e23abcd.

Thanks Juan Garcia Alvite for the report.

ticket-32224