### PR TITLE
Fixed #21021 -- Changed BaseGeometryWidget's default geometry type to 'Geometry'.

### DIFF
--- a/django/contrib/gis/forms/widgets.py
+++ b/django/contrib/gis/forms/widgets.py
@@ -61,11 +61,12 @@ class BaseGeometryWidget(Widget):
                         value.srid, self.map_srid, err
                     )
 
+        geom_type = gdal.OGRGeomType(self.attrs['geom_type']).name
         context.update(self.build_attrs(self.attrs, {
             'name': name,
             'module': 'geodjango_%s' % name.replace('-', '_'),  # JS-safe
             'serialized': self.serialize(value),
-            'geom_type': gdal.OGRGeomType(self.attrs['geom_type']),
+            'geom_type': 'Geometry' if geom_type == 'Unknown' else geom_type,
             'STATIC_URL': settings.STATIC_URL,
             'LANGUAGE_BIDI': translation.get_language_bidi(),
             **(attrs or {}),

--- a/django/contrib/gis/static/gis/js/OLMapWidget.js
+++ b/django/contrib/gis/static/gis/js/OLMapWidget.js
@@ -133,7 +133,7 @@ ol.inherits(GeometryTypeControl, ol.control.Control);
 
         // Initialize the draw interaction
         let geomType = this.options.geom_name;
-        if (geomType === "Unknown" || geomType === "GeometryCollection") {
+        if (geomType === "Geometry" || geomType === "GeometryCollection") {
             // Default to Point, but create icons to switch type
             geomType = "Point";
             this.currentGeometryType = new GeometryTypeControl({widget: this, type: "Point", active: true});

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -382,6 +382,10 @@ class GeometryWidgetTests(SimpleTestCase):
         widget = BaseGeometryWidget(attrs={'geom_type': 'POLYGON'})
         context = widget.get_context('polygon', None, None)
         self.assertEqual(context['geom_type'], 'Polygon')
+        # Widget.get_context() returns 'Geometry' instead of 'Unknown'.
+        widget = BaseGeometryWidget(attrs={'geom_type': 'GEOMETRY'})
+        context = widget.get_context('geometry', None, None)
+        self.assertEqual(context['geom_type'], 'Geometry')
 
     def test_subwidgets(self):
         widget = forms.BaseGeometryWidget()

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -374,10 +374,14 @@ class OSMWidgetTest(SimpleTestCase):
 class GeometryWidgetTests(SimpleTestCase):
 
     def test_get_context_attrs(self):
-        """The Widget.get_context() attrs argument overrides self.attrs."""
+        # The Widget.get_context() attrs argument overrides self.attrs.
         widget = BaseGeometryWidget(attrs={'geom_type': 'POINT'})
         context = widget.get_context('point', None, attrs={'geom_type': 'POINT2'})
         self.assertEqual(context['geom_type'], 'POINT2')
+        # Widget.get_context() returns expected name for geom_type.
+        widget = BaseGeometryWidget(attrs={'geom_type': 'POLYGON'})
+        context = widget.get_context('polygon', None, None)
+        self.assertEqual(context['geom_type'], 'Polygon')
 
     def test_subwidgets(self):
         widget = forms.BaseGeometryWidget()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/21021

BaseGeometryWidget passes "Unknown" as the default value for geom_type whereas we expect it to be "Geometry".

In OGRGeomType 'geometry' is explicitly converted to 'unknown' so I hesitated to change this class and opted to do the conversion in BaseGeometryWidget.
