### PR TITLE
Fixed #32227 -- Prevented crash when setUpTestData() errors with --debug-sql.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -38,6 +38,7 @@ class DebugSQLTextTestResult(unittest.TextTestResult):
     def __init__(self, stream, descriptions, verbosity):
         self.logger = logging.getLogger('django.db.backends')
         self.logger.setLevel(logging.DEBUG)
+        self.debug_sql_stream = None
         super().__init__(stream, descriptions, verbosity)
 
     def startTest(self, test):
@@ -56,8 +57,13 @@ class DebugSQLTextTestResult(unittest.TextTestResult):
 
     def addError(self, test, err):
         super().addError(test, err)
-        self.debug_sql_stream.seek(0)
-        self.errors[-1] = self.errors[-1] + (self.debug_sql_stream.read(),)
+        if self.debug_sql_stream is None:
+            # Error before tests e.g. in setUpTestData().
+            sql = ''
+        else:
+            self.debug_sql_stream.seek(0)
+            sql = self.debug_sql_stream.read()
+        self.errors[-1] = self.errors[-1] + (sql,)
 
     def addFailure(self, test, err):
         super().addFailure(test, err)


### PR DESCRIPTION
ticket-32227

Thanks Mariusz Felisiak for the report.

I don't have PostgreSQL setup for django testing locally so I reproduced instead with:

```patch
diff --git a/tests/timezones/tests.py b/tests/timezones/tests.py
index 8756f87716..3924da4e1a 100644
--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -1162,6 +1162,8 @@ class AdminTests(TestCase):
             email='super@example.com', is_staff=True, is_active=True,
             date_joined=datetime.datetime(2007, 5, 30, 13, 20, 10, tzinfo=UTC),
         )
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT SELECT")
 
     def setUp(self):
         self.client.force_login(self.u1)
```