### PR TITLE
Fixed #26607 -- Allowed customizing formset kwargs with ModelAdmin.get_formset_kwargs().

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2088,6 +2088,22 @@ templates used by the :class:`ModelAdmin` views:
     ``obj_id`` is the serialized identifier used to retrieve the object to be
     deleted.
 
+.. method:: ModelAdmin.get_formset_kwargs(request, obj, inline, prefix)
+
+    .. versionadded:: 4.0
+
+    A hook for customizing the keyword arguments passed to the constructor of a
+    formset. For example, to pass ``request`` to formset forms::
+
+        class MyModelAdmin(admin.ModelAdmin):
+            def get_formset_kwargs(self, request, obj, inline, prefix):
+                return {
+                    **super().get_formset_kwargs(request, obj, inline, prefix),
+                    'form_kwargs': {'request': request},
+                }
+
+    You can also used it to set ``initial`` for formset forms.
+
 .. method:: ModelAdmin.get_changeform_initial_data(request)
 
     A hook for the initial data on admin change forms. By default, fields are

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -37,6 +37,9 @@ Minor features
 * The ``admin/base.html`` template now has a new block ``header`` which
   contains the admin site header.
 
+* The new :meth:`.ModelAdmin.get_formset_kwargs` method allows customizing the
+  keyword arguments passed to the constructor of a formset.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -951,6 +951,12 @@ class CityAdmin(admin.ModelAdmin):
     inlines = [RestaurantInlineAdmin]
     view_on_site = True
 
+    def get_formset_kwargs(self, request, obj, inline, prefix):
+        return {
+            **super().get_formset_kwargs(request, obj, inline, prefix),
+            'form_kwargs': {'initial': {'name': 'overridden_name'}},
+        }
+
 
 class WorkerAdmin(admin.ModelAdmin):
     def view_on_site(self, obj):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1117,6 +1117,10 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         self.assertContains(response, '<h1>View article</h1>')
         self.assertContains(response, '<h2>Article 2</h2>')
 
+    def test_formset_kwargs_can_be_overridden(self):
+        response = self.client.get(reverse('admin:admin_views_city_add'))
+        self.assertContains(response, 'overridden_name')
+
 
 @override_settings(TEMPLATES=[{
     'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
[ticket-26607](https://code.djangoproject.com/ticket/26607)

Supersedes [#6590 ](https://github.com/django/django/pull/6590)

I have added a hook to set the initial parameters for formset values in admin.

**Steps to reproduce**
1. Let the models.py be as follows:
```
class Author(models.Model):
    name = models.CharField(max_length=100)
    price = models.IntegerField()
    def __str__(self):
        return self.name

class Book(models.Model):
    author = models.ForeignKey(Author, on_delete=models.CASCADE)
    name = models.CharField(max_length=100)
    price = models.IntegerField()
    def __str__(self):
        return self.name
```
2. Let admin.py be as follows:
```
class BookInline(admin.StackedInline):
    model = Book
class AuthorAdmin(admin.ModelAdmin):
    inlines = [
        BookInline,
    ]
admin.site.register(Author, AuthorAdmin)
```
3. Visiting [http://localhost:8000/admin/polls/author/add/?name=author_name&price=120&book__1_name=book1name&book__1_price=122&book__2_name=book2name&book__2_price=123](http://localhost:8000/admin/polls/author/add/?name=author_name&price=120&book__1_name=book1name&book__1_price=122&book__2_name=book2name&book__2_price=123) will give the following results
![26607](https://user-images.githubusercontent.com/51242628/100391110-7dc12f80-3058-11eb-8ca4-85b74c017929.png)
