### PR TITLE
Docs: clarified development branch name in Install docs

### DIFF
--- a/docs/topics/install.txt
+++ b/docs/topics/install.txt
@@ -187,7 +187,7 @@ latest bug fixes and improvements, follow these instructions:
 #. Make sure that you have Git_ installed and that you can run its commands
    from a shell. (Enter ``git help`` at a shell prompt to test this.)
 
-#. Check out Django's main development branch like so:
+#. Check out Django's ``master`` development branch like so:
 
    .. console::
 


### PR DESCRIPTION
This change helps a contributor identify the branch name without having to click over to GitHub.

The previous documentation wording used "main", which could be interpreted as the branch name, particularly given recent shifts in terminology of primary branch name to ``main``.