### PR TITLE
Refs ticket #32191 - compress and base64 encode messages in cookies

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -28,7 +28,7 @@ class MessageEncoder(json.JSONEncoder):
             return message
         return super().default(obj)
 
-    def enocde(self, s):
+    def encode(self, s):
         return signing.compress_b64(super().encode(s))
 
 

--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -29,7 +29,7 @@ class MessageEncoder(json.JSONEncoder):
         return super().default(obj)
 
     def encode(self, s):
-        return signing.Signer().compress_b64(super().encode(s))
+        return signing.compress_b64(super().encode(s))
 
 
 class MessageDecoder(json.JSONDecoder):
@@ -50,7 +50,7 @@ class MessageDecoder(json.JSONDecoder):
         return obj
 
     def decode(self, s, **kwargs):
-        decoded = super().decode(signing.Signer().decompress_b64(s), **kwargs)
+        decoded = super().decode(signing.decompress_b64(s), **kwargs)
         return self.process_messages(decoded)
 
 

--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -28,6 +28,9 @@ class MessageEncoder(json.JSONEncoder):
             return message
         return super().default(obj)
 
+    def enocde(self, s):
+        return signing.compress_b64(super().encode(s))
+
 
 class MessageDecoder(json.JSONDecoder):
     """
@@ -47,7 +50,7 @@ class MessageDecoder(json.JSONDecoder):
         return obj
 
     def decode(self, s, **kwargs):
-        decoded = super().decode(s, **kwargs)
+        decoded = super().decode(signing.decompress_b64(s), **kwargs)
         return self.process_messages(decoded)
 
 

--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -29,7 +29,7 @@ class MessageEncoder(json.JSONEncoder):
         return super().default(obj)
 
     def encode(self, s):
-        return signing.compress_b64(super().encode(s))
+        return signing.Signer().compress_b64(super().encode(s))
 
 
 class MessageDecoder(json.JSONDecoder):
@@ -50,7 +50,7 @@ class MessageDecoder(json.JSONDecoder):
         return obj
 
     def decode(self, s, **kwargs):
-        decoded = super().decode(signing.decompress_b64(s), **kwargs)
+        decoded = super().decode(signing.Signer().decompress_b64(s), **kwargs)
         return self.process_messages(decoded)
 
 

--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -124,28 +124,30 @@ def dumps(obj, key=None, salt='django.core.signing', serializer=JSONSerializer, 
     return TimestampSigner(key, salt=salt).sign(base64d)
 
 
-def compress_b64(s):
+def compress_b64(uncompressed):
     is_compressed = False
-    s = s.encode('utf-8')
-    compressed = zlib.compress(s)
-    if (len(compressed) < len(s) - 1):
-        s = compressed
+    encoded = uncompressed.encode('latin-1')
+    compressed = zlib.compress(encoded)
+    if (len(compressed) < len(uncompressed) - 1):
+        encoded = compressed
         is_compressed = True
-    s = s.decode('utf-8')
+    b64_encoded = b64_encode(encoded)
+    b64_encoded = b64_encoded.decode('latin-1')
     if is_compressed:
-        s = '.' + s
-    return s
+        b64_encoded = '.' + b64_encoded
+    return b64_encoded
 
 
-def decompress_b64(s):
-    decompress = s[:1] == '.'
-    s = s.encode('utf-8')
+def decompress_b64(compressed):
+    decompress = compressed[:1] == '.'
     if decompress:
-        s = s[1:]
+        compressed = compressed[1:]
+    compressed = compressed.encode('latin-1')
+    b64_decoded = b64_decode(compressed)
     if decompress:
-        s = zlib.decompress(s)
-    s = s.decode('utf-8')
-    return s
+        b64_decoded = zlib.decompress(b64_decoded)
+    b64_decoded = b64_decoded.decode('latin-1')
+    return b64_decoded
 
 
 def loads(s, key=None, salt='django.core.signing', serializer=JSONSerializer, max_age=None):

--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -150,15 +150,9 @@ def loads(s, key=None, salt='django.core.signing', serializer=JSONSerializer, ma
     """
     # TimestampSigner.unsign() returns str but base64 and zlib compression
     # operate on bytes.
-    base64d = TimestampSigner(key, salt=salt).unsign(s, max_age=max_age).encode()
-    decompress = base64d[:1] == b'.'
-    if decompress:
-        # It's compressed; uncompress it first
-        base64d = base64d[1:]
-    data = b64_decode(base64d)
-    if decompress:
-        data = zlib.decompress(data)
-    return serializer().loads(data)
+    base64d = TimestampSigner(key, salt=salt).unsign(s, max_age=max_age)
+    data = decompress_b64(base64d)
+    return serializer().loads(data.encode('latin-1'))
 
 
 class Signer:

--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -109,18 +109,10 @@ def dumps(obj, key=None, salt='django.core.signing', serializer=JSONSerializer, 
     """
     data = serializer().dumps(obj)
 
-    # Flag for if it's been compressed or not
-    is_compressed = False
-
     if compress:
-        # Avoid zlib dependency unless compress is being used
-        compressed = zlib.compress(data)
-        if len(compressed) < (len(data) - 1):
-            data = compressed
-            is_compressed = True
-    base64d = b64_encode(data).decode()
-    if is_compressed:
-        base64d = '.' + base64d
+        base64d = compress_b64(data.decode('latin-1'))
+    else:
+        base64d = b64_encode(data).decode('latin-1')
     return TimestampSigner(key, salt=salt).sign(base64d)
 
 

--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -124,6 +124,30 @@ def dumps(obj, key=None, salt='django.core.signing', serializer=JSONSerializer, 
     return TimestampSigner(key, salt=salt).sign(base64d)
 
 
+def compress_b64(s):
+    is_compressed = False
+    s = s.encode('utf-8')
+    compressed = zlib.compress(s)
+    if (len(compressed) < len(s) - 1):
+        s = compressed
+        is_compressed = True
+    s = s.decode('utf-8')
+    if is_compressed:
+        s = '.' + s
+    return s
+
+
+def decompress_b64(s):
+    decompress = s[:1] == '.'
+    s = s.encode('utf-8')
+    if decompress:
+        s = s[1:]
+    if decompress:
+        s = zlib.decompress(s)
+    s = s.decode('utf-8')
+    return s
+
+
 def loads(s, key=None, salt='django.core.signing', serializer=JSONSerializer, max_age=None):
     """
     Reverse of dumps(), raise BadSignature if signature fails.

--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -110,7 +110,7 @@ def dumps(obj, key=None, salt='django.core.signing', serializer=JSONSerializer, 
     data = serializer().dumps(obj)
 
     if compress:
-        base64d = Signer().compress_b64(data.decode('latin-1'))
+        base64d = Signer().compress_b64(data.decode('latin-1'), charset='latin-1')
     else:
         base64d = b64_encode(data).decode('latin-1')
     return TimestampSigner(key, salt=salt).sign(base64d)
@@ -125,7 +125,7 @@ def loads(s, key=None, salt='django.core.signing', serializer=JSONSerializer, ma
     # TimestampSigner.unsign() returns str but base64 and zlib compression
     # operate on bytes.
     base64d = TimestampSigner(key, salt=salt).unsign(s, max_age=max_age)
-    data = Signer().decompress_b64(base64d)
+    data = Signer().decompress_b64(base64d, charset='latin-1')
     return serializer().loads(data.encode('latin-1'))
 
 
@@ -169,28 +169,28 @@ class Signer:
             return value
         raise BadSignature('Signature "%s" does not match' % sig)
 
-    def compress_b64(self, uncompressed):
+    def compress_b64(self, uncompressed, charset='utf-8'):
         is_compressed = False
-        encoded = uncompressed.encode('latin-1')
+        encoded = uncompressed.encode(charset)
         compressed = zlib.compress(encoded)
         if (len(compressed) < len(uncompressed) - 1):
             encoded = compressed
             is_compressed = True
         b64_encoded = b64_encode(encoded)
-        b64_encoded = b64_encoded.decode('latin-1')
+        b64_encoded = b64_encoded.decode(charset)
         if is_compressed:
             b64_encoded = '.' + b64_encoded
         return b64_encoded
 
-    def decompress_b64(self, compressed):
+    def decompress_b64(self, compressed, charset='utf-8'):
         decompress = compressed[:1] == '.'
         if decompress:
             compressed = compressed[1:]
-        compressed = compressed.encode('latin-1')
+        compressed = compressed.encode(charset)
         b64_decoded = b64_decode(compressed)
         if decompress:
             b64_decoded = zlib.decompress(b64_decoded)
-        b64_decoded = b64_decoded.decode('latin-1')
+        b64_decoded = b64_decoded.decode(charset)
         return b64_decoded
 
 

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -131,6 +131,15 @@ class CookieTests(BaseTests, SimpleTestCase):
         self.assertEqual(len(unstored_messages), 1)
         self.assertEqual(unstored_messages[0].message[0], '0')
 
+    def test_cookie_rfc6265_compliant(self):
+        non_compliant_chars = ('\\', ',', ';', '"')
+        messages = ['\\te,st', ';m"e', '\u2019']
+        encoder = MessageEncoder()
+        value = encoder.encode(messages)
+        for message in list(value):
+            for illegal in non_compliant_chars:
+                self.assertEqual(message.find(illegal), -1)
+
     def test_json_encoder_decoder(self):
         """
         A complex nested data structure containing Message

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -131,7 +131,7 @@ class CookieTests(BaseTests, SimpleTestCase):
         self.assertEqual(len(unstored_messages), 1)
         self.assertEqual(unstored_messages[0].message[0], '0')
 
-    def test_cookie_rfc6265_compliant(self):
+    def test_message_rfc6265_compliant(self):
         non_compliant_chars = ('\\', ',', ';', '"')
         messages = ['\\te,st', ';m"e', '\u2019']
         encoder = MessageEncoder()
@@ -139,6 +139,19 @@ class CookieTests(BaseTests, SimpleTestCase):
         for message in list(value):
             for illegal in non_compliant_chars:
                 self.assertEqual(message.find(illegal), -1)
+
+    def test_messages_store_any_string(self):
+        values = [
+            'a string \u2019',
+            'test Ä',
+            '‘’',
+            b'\x91\x80'.decode('latin-1'),
+            b'\xe2\x91'.decode('cp1252'),
+        ]
+        encoder = MessageEncoder()
+        value = encoder.encode(values)
+        decoded_messages = json.loads(value, cls=MessageDecoder)
+        self.assertEqual(values, decoded_messages)
 
     def test_json_encoder_decoder(self):
         """

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -8,7 +8,7 @@ from django.contrib.messages.storage.base import Message
 from django.contrib.messages.storage.cookie import (
     CookieStorage, MessageDecoder, MessageEncoder,
 )
-from django.core.signing import Signer
+from django.core.signing import decompress_b64
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import ignore_warnings
 from django.utils.deprecation import RemovedInDjango40Warning
@@ -74,7 +74,7 @@ class CookieTests(BaseTests, SimpleTestCase):
         response = self.get_response()
         storage.add(constants.INFO, 'test')
         storage.update(response)
-        self.assertIn('test', Signer().decompress_b64(response.cookies['messages'].value, charset='latin-1'))
+        self.assertIn('test', decompress_b64(response.cookies['messages'].value, charset='latin-1'))
         self.assertEqual(response.cookies['messages']['domain'], '.example.com')
         self.assertEqual(response.cookies['messages']['expires'], '')
         self.assertIs(response.cookies['messages']['secure'], True)

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -8,7 +8,7 @@ from django.contrib.messages.storage.base import Message
 from django.contrib.messages.storage.cookie import (
     CookieStorage, MessageDecoder, MessageEncoder,
 )
-from django.core.signing import decompress_b64
+from django.core.signing import Signer
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import ignore_warnings
 from django.utils.deprecation import RemovedInDjango40Warning
@@ -74,7 +74,7 @@ class CookieTests(BaseTests, SimpleTestCase):
         response = self.get_response()
         storage.add(constants.INFO, 'test')
         storage.update(response)
-        self.assertIn('test', decompress_b64(response.cookies['messages'].value))
+        self.assertIn('test', Signer().decompress_b64(response.cookies['messages'].value))
         self.assertEqual(response.cookies['messages']['domain'], '.example.com')
         self.assertEqual(response.cookies['messages']['expires'], '')
         self.assertIs(response.cookies['messages']['secure'], True)

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -74,7 +74,7 @@ class CookieTests(BaseTests, SimpleTestCase):
         response = self.get_response()
         storage.add(constants.INFO, 'test')
         storage.update(response)
-        self.assertIn('test', Signer().decompress_b64(response.cookies['messages'].value))
+        self.assertIn('test', Signer().decompress_b64(response.cookies['messages'].value, charset='latin-1'))
         self.assertEqual(response.cookies['messages']['domain'], '.example.com')
         self.assertEqual(response.cookies['messages']['expires'], '')
         self.assertIs(response.cookies['messages']['secure'], True)

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -119,6 +119,7 @@ class CookieTests(BaseTests, SimpleTestCase):
         # size which will fit 4 messages into the cookie, but not 5.
         # See also FallbackTest.test_session_fallback
         msg_size = int((CookieStorage.max_cookie_size - 54) / 4.5 - 37)
+        random.seed(42)
         for i in range(5):
             s = str(i) + ''.join(random.choice(string.ascii_letters) for _ in range(msg_size - 1))
             storage.add(constants.INFO, s)

--- a/tests/messages_tests/test_fallback.py
+++ b/tests/messages_tests/test_fallback.py
@@ -1,3 +1,6 @@
+import random
+import string
+
 from django.contrib.messages import constants
 from django.contrib.messages.storage.fallback import (
     CookieStorage, FallbackStorage,
@@ -129,7 +132,8 @@ class FallbackTests(BaseTests, SimpleTestCase):
         # see comment in CookieTests.test_cookie_max_length()
         msg_size = int((CookieStorage.max_cookie_size - 54) / 4.5 - 37)
         for i in range(5):
-            storage.add(constants.INFO, str(i) * msg_size)
+            s = str(i) + ''.join(random.choice(string.ascii_letters) for _ in range(msg_size - 1))
+            storage.add(constants.INFO, s)
         storage.update(response)
         cookie_storing = self.stored_cookie_messages_count(storage, response)
         self.assertEqual(cookie_storing, 4)
@@ -143,7 +147,7 @@ class FallbackTests(BaseTests, SimpleTestCase):
         """
         storage = self.get_storage()
         response = self.get_response()
-        storage.add(constants.INFO, 'x' * 5000)
+        storage.add(constants.INFO, ''.join(random.choice(string.ascii_letters) for _ in range(5000)))
         storage.update(response)
         cookie_storing = self.stored_cookie_messages_count(storage, response)
         self.assertEqual(cookie_storing, 0)

--- a/tests/messages_tests/test_fallback.py
+++ b/tests/messages_tests/test_fallback.py
@@ -131,6 +131,7 @@ class FallbackTests(BaseTests, SimpleTestCase):
         response = self.get_response()
         # see comment in CookieTests.test_cookie_max_length()
         msg_size = int((CookieStorage.max_cookie_size - 54) / 4.5 - 37)
+        random.seed(42)
         for i in range(5):
             s = str(i) + ''.join(random.choice(string.ascii_letters) for _ in range(msg_size - 1))
             storage.add(constants.INFO, s)
@@ -147,6 +148,7 @@ class FallbackTests(BaseTests, SimpleTestCase):
         """
         storage = self.get_storage()
         response = self.get_response()
+        random.seed(42)
         storage.add(constants.INFO, ''.join(random.choice(string.ascii_letters) for _ in range(5000)))
         storage.update(response)
         cookie_storing = self.stored_cookie_messages_count(storage, response)

--- a/tests/messages_tests/test_mixins.py
+++ b/tests/messages_tests/test_mixins.py
@@ -1,4 +1,4 @@
-from django.core.signing import Signer
+from django.core.signing import decompress_b64
 from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 
@@ -13,4 +13,4 @@ class SuccessMessageMixinTests(SimpleTestCase):
         add_url = reverse('add_success_msg')
         req = self.client.post(add_url, author)
         self.assertIn(ContactFormViewWithMsg.success_message % author,
-                      Signer().decompress_b64(req.cookies['messages'].value, charset='latin-1'))
+                      decompress_b64(req.cookies['messages'].value, charset='latin-1'))

--- a/tests/messages_tests/test_mixins.py
+++ b/tests/messages_tests/test_mixins.py
@@ -13,4 +13,4 @@ class SuccessMessageMixinTests(SimpleTestCase):
         add_url = reverse('add_success_msg')
         req = self.client.post(add_url, author)
         self.assertIn(ContactFormViewWithMsg.success_message % author,
-                      Signer().decompress_b64(req.cookies['messages'].value))
+                      Signer().decompress_b64(req.cookies['messages'].value, charset='latin-1'))

--- a/tests/messages_tests/test_mixins.py
+++ b/tests/messages_tests/test_mixins.py
@@ -1,3 +1,4 @@
+from django.core.signing import decompress_b64
 from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 
@@ -11,4 +12,4 @@ class SuccessMessageMixinTests(SimpleTestCase):
         author = {'name': 'John Doe', 'slug': 'success-msg'}
         add_url = reverse('add_success_msg')
         req = self.client.post(add_url, author)
-        self.assertIn(ContactFormViewWithMsg.success_message % author, req.cookies['messages'].value)
+        self.assertIn(ContactFormViewWithMsg.success_message % author, decompress_b64(req.cookies['messages'].value))

--- a/tests/messages_tests/test_mixins.py
+++ b/tests/messages_tests/test_mixins.py
@@ -1,4 +1,4 @@
-from django.core.signing import decompress_b64
+from django.core.signing import Signer
 from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 
@@ -12,4 +12,5 @@ class SuccessMessageMixinTests(SimpleTestCase):
         author = {'name': 'John Doe', 'slug': 'success-msg'}
         add_url = reverse('add_success_msg')
         req = self.client.post(add_url, author)
-        self.assertIn(ContactFormViewWithMsg.success_message % author, decompress_b64(req.cookies['messages'].value))
+        self.assertIn(ContactFormViewWithMsg.success_message % author,
+                      Signer().decompress_b64(req.cookies['messages'].value))

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -150,6 +150,32 @@ class TestSigner(SimpleTestCase):
             signed = signing.dumps(value)
         self.assertEqual(signing.loads(signed), value)
 
+    def test_compress64_decompress64(self):
+        "compress_b64 and decompress_b64 be reversible for any string"
+        unicode_values = [
+            'a string \u2019',
+            'test Ä',
+            '‘’',
+            b'\x91\x80'.decode('latin-1'),
+            b'\xe2\x91'.decode('cp1252'),
+        ]
+        for value in unicode_values:
+            compressed = signing.Signer().compress_b64(value)
+            self.assertEqual(signing.Signer().decompress_b64(compressed), value)
+
+        latin_1_value = b'\x91\x80'.decode('latin-1')
+        compressed = signing.Signer().compress_b64(latin_1_value, charset='latin-1')
+        self.assertEqual(signing.Signer().decompress_b64(compressed, charset='latin-1'), latin_1_value)
+
+        with self.assertRaises(UnicodeDecodeError):
+            compressed = signing.Signer().compress_b64(latin_1_value, charset='latin-1')
+            signing.Signer().decompress_b64(compressed)
+
+        with self.assertRaises(AssertionError):
+            # Value will come back garbled if a non-unicode charset is used to decode and it is not used to encode
+            compressed = signing.Signer().compress_b64(latin_1_value)
+            self.assertEqual(signing.Signer().decompress_b64(compressed, charset='latin-1'), latin_1_value)
+
     def test_decode_detects_tampering(self):
         "loads should raise exception for tampered objects"
         transforms = (

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -160,21 +160,21 @@ class TestSigner(SimpleTestCase):
             b'\xe2\x91'.decode('cp1252'),
         ]
         for value in unicode_values:
-            compressed = signing.Signer().compress_b64(value)
-            self.assertEqual(signing.Signer().decompress_b64(compressed), value)
+            compressed = signing.compress_b64(value)
+            self.assertEqual(signing.decompress_b64(compressed), value)
 
         latin_1_value = b'\x91\x80'.decode('latin-1')
-        compressed = signing.Signer().compress_b64(latin_1_value, charset='latin-1')
-        self.assertEqual(signing.Signer().decompress_b64(compressed, charset='latin-1'), latin_1_value)
+        compressed = signing.compress_b64(latin_1_value, charset='latin-1')
+        self.assertEqual(signing.decompress_b64(compressed, charset='latin-1'), latin_1_value)
 
         with self.assertRaises(UnicodeDecodeError):
-            compressed = signing.Signer().compress_b64(latin_1_value, charset='latin-1')
-            signing.Signer().decompress_b64(compressed)
+            compressed = signing.compress_b64(latin_1_value, charset='latin-1')
+            signing.decompress_b64(compressed)
 
         with self.assertRaises(AssertionError):
             # Value will come back garbled if a non-unicode charset is used to decode and it is not used to encode
-            compressed = signing.Signer().compress_b64(latin_1_value)
-            self.assertEqual(signing.Signer().decompress_b64(compressed, charset='latin-1'), latin_1_value)
+            compressed = signing.compress_b64(latin_1_value)
+            self.assertEqual(signing.decompress_b64(compressed, charset='latin-1'), latin_1_value)
 
     def test_decode_detects_tampering(self):
         "loads should raise exception for tampered objects"


### PR DESCRIPTION
This PR is to make messages stored as cookies compliant with RFC 6265.

It uses zlib and base64 to compress and encode the messages. The functions to do so are in the `django.core.signing` module as the aim is to integrate them with the signing base class following advice on the ticket.

Internally, strings are encoded to latin-1 before being compressed and base64 encoded, as this is consistent with other parts of the storage system.