### PR TITLE
Apply minor fixes to intro documentation

### DIFF
--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -595,7 +595,7 @@ is not:
             The detail view of a question with a pub_date in the future
             returns a 404 not found.
             """
-            future_question = create_question(question_text='Future question.', days=5)
+            future_question = create_question(question_text="Future question.", days=5)
             url = reverse('polls:detail', args=(future_question.id,))
             response = self.client.get(url)
             self.assertEqual(response.status_code, 404)
@@ -605,7 +605,7 @@ is not:
             The detail view of a question with a pub_date in the past
             displays the question's text.
             """
-            past_question = create_question(question_text='Past Question.', days=-5)
+            past_question = create_question(question_text="Past question.", days=-5)
             url = reverse('polls:detail', args=(past_question.id,))
             response = self.client.get(url)
             self.assertContains(response, past_question.question_text)

--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -34,6 +34,7 @@ the ``admin.site.register(Question)`` line with:
     class QuestionAdmin(admin.ModelAdmin):
         fields = ['pub_date', 'question_text']
 
+
     admin.site.register(Question, QuestionAdmin)
 
 You'll follow this pattern -- create a model admin class, then pass it as the
@@ -65,6 +66,7 @@ up into fieldsets:
             (None,               {'fields': ['question_text']}),
             ('Date information', {'fields': ['pub_date']}),
         ]
+
 
     admin.site.register(Question, QuestionAdmin)
 
@@ -139,6 +141,7 @@ registration code to read:
             ('Date information', {'fields': ['pub_date'], 'classes': ['collapse']}),
         ]
         inlines = [ChoiceInline]
+
 
     admin.site.register(Question, QuestionAdmin)
 
@@ -299,7 +302,7 @@ Customizing your *project's* templates
 
 Create a ``templates`` directory in your project directory (the one that
 contains ``manage.py``). Templates can live anywhere on your filesystem that
-Django can access. (Django runs as whatever user your server runs.) However,
+Django can access (Django runs as whatever user your server runs as). However,
 keeping your templates within the project is a good convention to follow.
 
 Open your settings file (:file:`mysite/settings.py`, remember) and add a


### PR DESCRIPTION
This applies some minor style and natural language fixes to the intro pages in the Django documentation. I found them while following the intro tutorial.

This is my first commit to the Django project. I'm not sure if these kind of fixes are appreciated, feel free to close this PR if not.

Btw thanks for the great software and awesome documentation :)