### PR TITLE
Correct single quote symbol in vietnamese localization

### DIFF
--- a/django/contrib/auth/locale/vi/LC_MESSAGES/django.po
+++ b/django/contrib/auth/locale/vi/LC_MESSAGES/django.po
@@ -56,7 +56,7 @@ msgstr "Chưa đặt mật khẩu"
 msgid "Invalid password format or unknown hashing algorithm."
 msgstr "Định dạng của mật khẩu không đúng hoặc thuật toán hash chưa rõ ràng."
 
-msgid "The two password fields didn't match."
+msgid "The two password fields didn’t match."
 msgstr "Hai trường mật khẩu không giống nhau"
 
 msgid "Password"


### PR DESCRIPTION
References: `django/contrib/auth/forms.py` at lines 88, 335, 408

P/s: Need somebody compile `.mo` file for me
