### PR TITLE
Fixed #32235 -- Made ReadOnlyPasswordHashField disabled by default.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -56,15 +56,8 @@ class ReadOnlyPasswordHashField(forms.Field):
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("required", False)
+        kwargs.setdefault('disabled', True)
         super().__init__(*args, **kwargs)
-
-    def bound_data(self, data, initial):
-        # Always return initial because the widget doesn't
-        # render an input field.
-        return initial
-
-    def has_changed(self, initial, data):
-        return False
 
 
 class UsernameField(forms.CharField):
@@ -162,12 +155,6 @@ class UserChangeForm(forms.ModelForm):
         user_permissions = self.fields.get('user_permissions')
         if user_permissions:
             user_permissions.queryset = user_permissions.queryset.select_related('content_type')
-
-    def clean_password(self):
-        # Regardless of what the user provides, return the initial value.
-        # This is done here, rather than on the field, because the
-        # field does not have access to the initial value
-        return self.initial.get('password')
 
 
 class AuthenticationForm(forms.Form):

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -625,6 +625,11 @@ Miscellaneous
   using :option:`makemessages --locale` option, when they contain hyphens
   (``'-'``).
 
+* The ``django.contrib.auth.forms.ReadOnlyPasswordHashField`` form field is now
+  :attr:`~django.forms.Field.disabled` by default. Therefore
+  ``UserChangeForm.clean_password()`` is no longer required to return the
+  initial value.
+
 .. _deprecated-features-3.2:
 
 Features deprecated in 3.2

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -1129,19 +1129,13 @@ code would be required in the app's ``admin.py`` file::
     class UserChangeForm(forms.ModelForm):
         """A form for updating users. Includes all the fields on
         the user, but replaces the password field with admin's
-        password hash display field.
+        disabled password hash display field.
         """
         password = ReadOnlyPasswordHashField()
 
         class Meta:
             model = MyUser
             fields = ('email', 'password', 'date_of_birth', 'is_active', 'is_admin')
-
-        def clean_password(self):
-            # Regardless of what the user provides, return the initial value.
-            # This is done here, rather than on the field, because the
-            # field does not have access to the initial value
-            return self.initial["password"]
 
 
     class UserAdmin(BaseUserAdmin):
@@ -1182,3 +1176,10 @@ Finally, specify the custom model as the default user model for your project
 using the :setting:`AUTH_USER_MODEL` setting in your ``settings.py``::
 
     AUTH_USER_MODEL = 'customauth.MyUser'
+
+.. versionchanged:: 3.2
+
+    In older versions, ``ReadOnlyPasswordHashField`` is not
+    :attr:`~django.forms.Field.disabled` by default and
+    ``UserChangeForm.clean_password()`` is required to return the initial
+    value, whatever the user provides.

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -1022,6 +1022,7 @@ class ReadOnlyPasswordHashTest(SimpleTestCase):
 
     def test_readonly_field_has_changed(self):
         field = ReadOnlyPasswordHashField()
+        self.assertIs(field.disabled, True)
         self.assertFalse(field.has_changed('aaa', 'bbb'))
 
 


### PR DESCRIPTION
Ticket: [#32235](https://code.djangoproject.com/ticket/32235)

Set `disabled=True` in contrib.auth's `ReadOnlyPasswordHashField` which made the custom `bound_data()` and `has_changed()` methods obsolete. This also eliminated the need for a `clean_password()` method in the form using that field, e.g. the `UserChangeForm`.

I'm not sure whether my test is reasonable - technically, there are other tests which fail if the methods are removed without setting the disabled flag. Is the disabled property a valid requirement here or just an implementation detail and what really matters is that the disabled-functionality is achieved (`has_changed = False` and `bound_data/cleaned_data = initial`)?

Thanks in advance for your feedback!