### PR TITLE
Refs #27095 -- Fixed test_contained_by_including_F_object when run in reverse.

### DIFF
--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -99,6 +99,7 @@ class Migration(migrations.Migration):
                     'field_nested',
                     ArrayField(ArrayField(models.IntegerField(), size=None, null=True), size=None, null=True),
                 ),
+                ('order', models.IntegerField(null=True)),
             ],
             options={
                 'required_db_vendor': 'postgresql',

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -46,6 +46,7 @@ class IntegerArrayModel(PostgreSQLModel):
 class NullableIntegerArrayModel(PostgreSQLModel):
     field = ArrayField(models.IntegerField(), blank=True, null=True)
     field_nested = ArrayField(ArrayField(models.IntegerField(null=True)), null=True)
+    order = models.IntegerField(null=True)
 
 
 class CharArrayModel(PostgreSQLModel):

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -205,11 +205,11 @@ class TestQuerying(PostgreSQLTestCase):
     @classmethod
     def setUpTestData(cls):
         cls.objs = NullableIntegerArrayModel.objects.bulk_create([
-            NullableIntegerArrayModel(field=[1]),
-            NullableIntegerArrayModel(field=[2]),
-            NullableIntegerArrayModel(field=[2, 3]),
-            NullableIntegerArrayModel(field=[20, 30, 40]),
-            NullableIntegerArrayModel(field=None),
+            NullableIntegerArrayModel(order=1, field=[1]),
+            NullableIntegerArrayModel(order=2, field=[2]),
+            NullableIntegerArrayModel(order=3, field=[2, 3]),
+            NullableIntegerArrayModel(order=4, field=[20, 30, 40]),
+            NullableIntegerArrayModel(order=5, field=None),
         ])
 
     def test_empty_list(self):
@@ -304,7 +304,7 @@ class TestQuerying(PostgreSQLTestCase):
 
     def test_contained_by_including_F_object(self):
         self.assertSequenceEqual(
-            NullableIntegerArrayModel.objects.filter(field__contained_by=[models.F('id'), 2]),
+            NullableIntegerArrayModel.objects.filter(field__contained_by=[models.F('order'), 2]),
             self.objs[:3],
         )
 


### PR DESCRIPTION
Tests should not rely on auto PKs.

Test regression in 33403bf80f635577a18426bc99c8a65e31fd8dfa.

See [logs](https://djangoci.com/view/Main/job/master-reverse/database=postgres,label=bionic,python=python3.9/lastCompletedBuild/testReport/postgres_tests.test_array/TestQuerying/test_contained_by_including_F_object/).

You can reproduce the failure with `./runtests.py postgres_tests.test_array --reverse --parallel=1`.