### PR TITLE
Fixed #32240 -- Made runserver suppress ConnectionAbortedError/ConnectionResetError errors.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -736,6 +736,7 @@ answer newbie questions, and generally made Django that much better:
     Peter Zsoldos <http://zsoldosp.eu>
     Pete Shinners <pete@shinners.org>
     Petr Marhoun <petr.marhoun@gmail.com>
+    Petter Strandmark
     pgross@thoughtworks.com
     phaedo <http://phaedo.cx/>
     phil.h.smith@gmail.com

--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -52,7 +52,11 @@ def get_internal_wsgi_application():
 
 def is_broken_pipe_error():
     exc_type, _, _ = sys.exc_info()
-    return issubclass(exc_type, BrokenPipeError)
+    return issubclass(exc_type, (
+        BrokenPipeError,
+        ConnectionAbortedError,
+        ConnectionResetError,
+    ))
 
 
 class WSGIServer(simple_server.WSGIServer):


### PR DESCRIPTION
People are having issues with exessive stack traces on Windows; see last comments in
https://github.com/python/cpython/pull/9713

These exceptions arise when browsing normally. The web browser may close the connection at any time if the user decides to do something different in the middle of a request. We should not print long stack traces when that happens. I previously fixed a similar issue in CPython (https://github.com/python/cpython/pull/9713).