### PR TITLE
Added 'encoding' option to the 'dumpdata' command

### DIFF
--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
             help='Specifies file to which the output is written.'
         )
         parser.add_argument(
-            '--encoding', default='cp949',
+            '--encoding',
             help='Which encoder to use'
         )
 

--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -63,6 +63,10 @@ class Command(BaseCommand):
             '-o', '--output',
             help='Specifies file to which the output is written.'
         )
+        parser.add_argument(
+            '--encoding', default='cp949',
+            help='Which encoder to use'
+        )
 
     def handle(self, *app_labels, **options):
         format = options['format']
@@ -70,6 +74,7 @@ class Command(BaseCommand):
         using = options['database']
         excludes = options['exclude']
         output = options['output']
+        encoding = options['encoding']
         show_traceback = options['traceback']
         use_natural_foreign_keys = options['use_natural_foreign_keys']
         use_natural_primary_keys = options['use_natural_primary_keys']
@@ -184,7 +189,7 @@ class Command(BaseCommand):
             if output and self.stdout.isatty() and options['verbosity'] > 0:
                 progress_output = self.stdout
                 object_count = sum(get_objects(count_only=True))
-            stream = open(output, 'w') if output else None
+            stream = open(output, 'w', encoding=encoding) if output else None
             try:
                 serializers.serialize(
                     format, get_objects(), indent=indent,


### PR DESCRIPTION
I encountered an encoding error when using the command 'dumpdata'.

```
$ python manage.py dumpdata movies.company > test.json
CommandError: Unable to serialize database: 'cp949' codec can't encode character '\xe9' in position 16: illegal multibyte sequence
Exception ignored in: <generator object cursor_iter at 0x0000012FEE25DEC8>
Traceback (most recent call last):
  File "(....)\venv\lib\site-packages\django\db\models\sql\compiler.py", line 1609, in cursor_iter
    cursor.close()
sqlite3.ProgrammingError: Cannot operate on a closed database.
```

However, there is no encoding option for the command.
So I added the option 'encoding'.

```
$ py manage.py dumpdata movies.Company --indent=4 --traceback --output test.json --encoding utf-8
```

Its default value is 'None', which is the same as the default value for the function 'open'.