### PR TITLE
Fixed #32252 -- Fixed __isnull=True on key transforms on SQLite and Oracle.

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -366,14 +366,25 @@ class CaseInsensitiveMixin:
 class KeyTransformIsNull(lookups.IsNull):
     # key__isnull=False is the same as has_key='key'
     def as_oracle(self, compiler, connection):
+        sql, params = HasKey(
+            self.lhs.lhs,
+            self.lhs.key_name,
+        ).as_oracle(compiler, connection)
         if not self.rhs:
-            return HasKey(self.lhs.lhs, self.lhs.key_name).as_oracle(compiler, connection)
-        return super().as_sql(compiler, connection)
+            return sql, params
+        # Column doesn't have a key or IS NULL.
+        lhs, lhs_params, _ = self.lhs.preprocess_lhs(compiler, connection)
+        return '(NOT %s OR %s IS NULL)' % (sql, lhs), tuple(params) + tuple(lhs_params)
 
     def as_sqlite(self, compiler, connection):
+        template = 'JSON_TYPE(%s, %%s) IS NULL'
         if not self.rhs:
-            return HasKey(self.lhs.lhs, self.lhs.key_name).as_sqlite(compiler, connection)
-        return super().as_sql(compiler, connection)
+            template = 'JSON_TYPE(%s, %%s) IS NOT NULL'
+        return HasKey(self.lhs.lhs, self.lhs.key_name).as_sql(
+            compiler,
+            connection,
+            template=template,
+        )
 
 
 class KeyTransformIn(lookups.In):

--- a/docs/releases/3.1.5.txt
+++ b/docs/releases/3.1.5.txt
@@ -9,4 +9,6 @@ Django 3.1.5 fixes several bugs in 3.1.4.
 Bugfixes
 ========
 
-* ...
+* Fixed ``__isnull=True`` lookup on key transforms for
+  :class:`~django.db.models.JSONField` with Oracle and SQLite
+  (:ticket:`32252`).

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -587,6 +587,10 @@ class TestQuerying(TestCase):
             self.objs[:3] + self.objs[5:],
         )
         self.assertSequenceEqual(
+            NullableJSONModel.objects.filter(value__j__isnull=True),
+            self.objs[:4] + self.objs[5:],
+        )
+        self.assertSequenceEqual(
             NullableJSONModel.objects.filter(value__a__isnull=False),
             [self.objs[3], self.objs[4]],
         )


### PR DESCRIPTION
ticket-32252.

I remember fixing this behavior before and writing something about it in [my blog post](https://gsoc.laymonage.com/posts/2019/08/transforms/) (albeit the approach was a bit different and more complex), but it looks like [it got lost when the lookup was simplified to use `HasKey`](https://github.com/django/django/commit/bc19dcac44c45fa2071551b5ef8fa6f2288884db).