### PR TITLE
Corrected docs regarding attributes required for logging in to the admin.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -59,7 +59,7 @@ visiting the URL you hooked it into (``/admin/``, by default).
 
 If you need to create a user to login with, use the :djadmin:`createsuperuser`
 command. By default, logging in to the admin requires that the user has the
-:attr:`~.User.is_superuser` and :attr:`~.User.is_staff` attribute set to
+:attr:`~.User.is_staff` attribute set to
 ``True``.
 
 Finally, determine which of your application's models should be editable in the

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -59,8 +59,7 @@ visiting the URL you hooked it into (``/admin/``, by default).
 
 If you need to create a user to login with, use the :djadmin:`createsuperuser`
 command. By default, logging in to the admin requires that the user has the
-:attr:`~.User.is_staff` attribute set to
-``True``.
+:attr:`~.User.is_staff` attribute set to ``True``.
 
 Finally, determine which of your application's models should be editable in the
 admin interface. For each of those models, register them with the admin as

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -59,7 +59,7 @@ visiting the URL you hooked it into (``/admin/``, by default).
 
 If you need to create a user to login with, use the :djadmin:`createsuperuser`
 command. By default, logging in to the admin requires that the user has the
-:attr:`~.User.is_superuser` or :attr:`~.User.is_staff` attribute set to
+:attr:`~.User.is_superuser` and :attr:`~.User.is_staff` attribute set to
 ``True``.
 
 Finally, determine which of your application's models should be editable in the


### PR DESCRIPTION
The current version of the admin docs note:

> By default, logging in to the admin requires that the user has the is_superuser or is_staff attribute set to True.

But having a user with `is_superuser=True` is not enough: `AdminAuthenticationForm` checks for `is_staff` too:

https://github.com/django/django/blob/9ef4a18dbe71f538a9ef8c39111ae2f0b62eb90b/django/contrib/admin/forms.py#L21-L26