### PR TITLE
Refs #32178 -- Fixed test_mark_expected_failures_and_skips_call teardown.

### DIFF
--- a/tests/backends/base/test_creation.py
+++ b/tests/backends/base/test_creation.py
@@ -120,9 +120,14 @@ class TestDbCreationTests(SimpleTestCase):
         if connection.vendor == 'oracle':
             # Don't close connection on Oracle.
             creation.connection.close = mock.Mock()
-        with mock.patch.object(creation, '_create_test_db'):
-            creation.create_test_db(verbosity=0, autoclobber=True, serialize=False)
-        self.assertIs(mark_expected_failures_and_skips.called, False)
+        old_database_name = test_connection.settings_dict['NAME']
+        try:
+            with mock.patch.object(creation, '_create_test_db'):
+                creation.create_test_db(verbosity=0, autoclobber=True, serialize=False)
+            self.assertIs(mark_expected_failures_and_skips.called, False)
+        finally:
+            with mock.patch.object(creation, '_destroy_test_db'):
+                creation.destroy_test_db(old_database_name, verbosity=0)
 
 
 class TestDeserializeDbFromString(TransactionTestCase):


### PR DESCRIPTION
Test isolation failure observed on CockroachDB.