### PR TITLE
Ensured that registered checks accept keyword arguments.

### DIFF
--- a/django/core/checks/registry.py
+++ b/django/core/checks/registry.py
@@ -1,5 +1,6 @@
 from itertools import chain
 
+from django.utils.inspect import func_accepts_kwargs
 from django.utils.itercompat import is_iterable
 
 
@@ -38,13 +39,17 @@ class CheckRegistry:
 
             registry = CheckRegistry()
             @registry.register('mytag', 'anothertag')
-            def my_check(apps, **kwargs):
+            def my_check(app_configs, **kwargs):
                 # ... perform checks and collect `errors` ...
                 return errors
             # or
             registry.register(my_check, 'mytag', 'anothertag')
         """
         def inner(check):
+            if not func_accepts_kwargs(check):
+                raise TypeError(
+                    'Check functions must accept keyword arguments (**kwargs).'
+                )
             check.tags = tags
             checks = self.deployment_checks if kwargs.get('deploy') else self.registered_checks
             checks.add(check)

--- a/django/utils/inspect.py
+++ b/django/utils/inspect.py
@@ -40,6 +40,7 @@ def get_func_full_args(func):
 
 
 def func_accepts_kwargs(func):
+    """Return True if function 'func' accepts keyword arguments **kwargs."""
     return any(
         p for p in _get_signature(func).parameters.values()
         if p.kind == p.VAR_KEYWORD

--- a/tests/check_framework/tests.py
+++ b/tests/check_framework/tests.py
@@ -66,6 +66,14 @@ class SystemCheckFrameworkTests(SimpleTestCase):
         self.assertEqual(errors, errors2)
         self.assertEqual(sorted(errors), [4, 5])
 
+    def test_register_no_kwargs_error(self):
+        registry = CheckRegistry()
+        msg = 'Check functions must accept keyword arguments (**kwargs).'
+        with self.assertRaisesMessage(TypeError, msg):
+            @registry.register
+            def no_kwargs(app_configs, databases):
+                pass
+
 
 class MessageTests(SimpleTestCase):
 


### PR DESCRIPTION
For forwards compatibility, prevent registration of functions that won't allow arguments added in the future.

This *could* go through the deprecation process but in practice we already forced all functions to accept a new argument in Django 3.1 due to the new `databases` argument from #12396.