### PR TITLE
Added python_requires/install_requires to setup.cfg example in reusable apps docs.

### DIFF
--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -221,6 +221,9 @@ this. For a small app like polls, this process isn't too difficult.
         [options]
         include_package_data = true
         packages = find:
+        python_requires = >=3.6
+        install_requires =
+            Django >= X.Y  # Replace "X.Y" as appropriate
 
    .. code-block:: python
         :caption: django-polls/setup.py


### PR DESCRIPTION
I hope this helps new users. Unfortunately `install_requires` is still unknown to many new python developers.