### PR TITLE
Fixed #32089 -- Fixed prefetch_related_objects() when some objects are already fetched.

### DIFF
--- a/tests/prefetch_related/test_prefetch_related_objects.py
+++ b/tests/prefetch_related/test_prefetch_related_objects.py
@@ -97,6 +97,16 @@ class PrefetchRelatedObjectsTests(TestCase):
         with self.assertNumQueries(0):
             self.assertCountEqual(book1.authors.all(), [self.author1, self.author2, self.author3])
 
+    def test_prefetch_object_twice(self):
+        book1 = Book.objects.get(id=self.book1.id)
+        book2 = Book.objects.get(id=self.book2.id)
+        with self.assertNumQueries(1):
+            prefetch_related_objects([book1], Prefetch('authors'))
+        with self.assertNumQueries(1):
+            prefetch_related_objects([book1, book2], Prefetch('authors'))
+        with self.assertNumQueries(0):
+            self.assertCountEqual(book2.authors.all(), [self.author1])
+
     def test_prefetch_object_to_attr(self):
         book1 = Book.objects.get(id=self.book1.id)
         with self.assertNumQueries(1):
@@ -104,6 +114,22 @@ class PrefetchRelatedObjectsTests(TestCase):
 
         with self.assertNumQueries(0):
             self.assertCountEqual(book1.the_authors, [self.author1, self.author2, self.author3])
+
+    def test_prefetch_object_to_attr_twice(self):
+        book1 = Book.objects.get(id=self.book1.id)
+        book2 = Book.objects.get(id=self.book2.id)
+        with self.assertNumQueries(1):
+            prefetch_related_objects(
+                [book1],
+                Prefetch('authors', to_attr='the_authors'),
+            )
+        with self.assertNumQueries(1):
+            prefetch_related_objects(
+                [book1, book2],
+                Prefetch('authors', to_attr='the_authors'),
+            )
+        with self.assertNumQueries(0):
+            self.assertCountEqual(book2.the_authors, [self.author1])
 
     def test_prefetch_queryset(self):
         book1 = Book.objects.get(id=self.book1.id)


### PR DESCRIPTION
Previously, `prefetch_related_objects()` didn't set `to_attr` on all model instances if the first instance already had its `to_attr` set by a previous call to `prefetch_related_objects()`. I fixed this by making `prefetch_related_objects()` check each model instance to determine if it was previously prefetched, and prefetch it if it wasn't.

This check results in a slight performance overhead, but since the information about which models are already prefetched is passed as a very small function that is then only called once per model instance, the overhead in terms of both runtime and memory should be minimal. There is no overhead in terms of the number of SQL queries.

The patch passed all tests against SQLite, and I added a regression test exposing the bug.

If I understand correctly, the same bug can't appear in `prefetch_related()` or `select_related()` because the objects they are called on are guaranteed to be completely homogeneous; correct me if I am wrong.

Thanks Dennis Kliban for the report & Adam Johnson for the partial fix.

[Trac link](https://code.djangoproject.com/ticket/32089)