### PR TITLE
Implement manage.py migrate --before <app> <migration>

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -37,6 +37,10 @@ class Command(BaseCommand):
                  'migration. Use the name "zero" to unapply all migrations.',
         )
         parser.add_argument(
+            '--before', action='store_true',
+            help='Migrate backwards to the specified migration and unapply it as well.',
+        )
+        parser.add_argument(
             '--noinput', '--no-input', action='store_false', dest='interactive',
             help='Tells Django to NOT prompt the user for input of any kind.',
         )
@@ -109,6 +113,9 @@ class Command(BaseCommand):
             )
 
         # If they supplied command line arguments, work out what they mean.
+        if options['before'] and not options['migration_name']:
+            raise CommandError("Can't use '--before' without specifying a migration.")
+
         run_syncdb = options['run_syncdb']
         target_app_labels_only = True
         if options['app_label']:
@@ -147,7 +154,7 @@ class Command(BaseCommand):
         else:
             targets = executor.loader.graph.leaf_nodes()
 
-        plan = executor.migration_plan(targets)
+        plan = executor.migration_plan(targets, before=options['before'])
         exit_dry = plan and options['check_unapplied']
 
         if options['plan']:

--- a/tests/migrations/test_executor.py
+++ b/tests/migrations/test_executor.py
@@ -724,10 +724,11 @@ class ExecutorUnitTests(SimpleTestCase):
         r"""
         Minimize rollbacks when target has multiple in-app children.
 
-        a: 1 <---- 3 <--\
-              \ \- 2 <--- 4
-               \       \
-        b:      \- 1 <--- 2
+           a3---a4
+          /    /
+        a1---a2
+          \    \
+           b1---b2
         """
         a1_impl = FakeMigration('a1')
         a1 = ('a', '1')
@@ -766,11 +767,17 @@ class ExecutorUnitTests(SimpleTestCase):
             a4: a4_impl,
         })
 
-        plan = executor.migration_plan({a1})
+        plan_to_a1 = executor.migration_plan({a1})
 
         should_be_rolled_back = [b2_impl, a4_impl, a2_impl, a3_impl]
         exp = [(m, True) for m in should_be_rolled_back]
-        self.assertEqual(plan, exp)
+        self.assertEqual(plan_to_a1, exp)
+
+        plan_to_before_a2 = executor.migration_plan({a2}, before=True)
+
+        should_be_rolled_back = [b2_impl, a4_impl, a2_impl]
+        exp = [(m, True) for m in should_be_rolled_back]
+        self.assertEqual(plan_to_before_a2, exp)
 
     def test_backwards_nothing_to_do(self):
         r"""


### PR DESCRIPTION
Suppose a developer started implementing a feature and wrote some migrations. Then they decide to abandon the feature and to reverse the migrations. The graph of the migrations might look like this:

```
master ...---0050---0051a---0052a
                 \               \
feature           0051b---0052b---0053m---0054b
```

What they need is to reverse migrations 0054b, 0053m, 0052b and 0051b. After this, the DB will be in the 0052a state, the developer can check out the master branch again and continue the work as though the feature branch never existed.

There’s currently no way to invoke `manage.py migrate` to achieve this result, even though it’ would be a perfectly consistent graph. `migrate <app> 0051b` will leave 0051b applied, while `migrate <app> 0050` will reverse the master migrations.

This PR enables `manage.py migrate --before <app> <migration>`. Its precondition is that the migration is applied, and its postcondition is that the migration is not applied, as simple as that. It uses the usual Django mechanisms to determine the set of migrations to be reversed and to ensure consistency.

In the above use case `manage.py migrate --before <app> 0051b` will reverse all the migrations from the feature branch while preserving the ones from the feature branch.

Ticket: https://code.djangoproject.com/ticket/32267