### PR TITLE
Refs #32273 -- Completed test coverage for AdminSite.unregister()

### DIFF
--- a/tests/admin_registration/tests.py
+++ b/tests/admin_registration/tests.py
@@ -23,10 +23,14 @@ class TestRegistration(SimpleTestCase):
     def test_bare_registration(self):
         self.site.register(Person)
         self.assertIsInstance(self.site._registry[Person], admin.ModelAdmin)
+        self.site.unregister(Person)
+        self.assertEqual(self.site._registry, {})
 
     def test_registration_with_model_admin(self):
         self.site.register(Person, NameAdmin)
         self.assertIsInstance(self.site._registry[Person], NameAdmin)
+        self.site.unregister(Person)
+        self.assertEqual(self.site._registry, {})
 
     def test_prevent_double_registration(self):
         self.site.register(Person)
@@ -42,6 +46,11 @@ class TestRegistration(SimpleTestCase):
         msg = "The model Person is already registered with 'admin_registration.PersonAdmin'."
         with self.assertRaisesMessage(admin.sites.AlreadyRegistered, msg):
             self.site.register(Person, PersonAdmin)
+
+    def test_unregister_unregistered_model(self):
+        msg = 'The model Person is not registered'
+        with self.assertRaisesMessage(admin.sites.NotRegistered, msg):
+            self.site.unregister(Person)
 
     def test_registration_with_star_star_options(self):
         self.site.register(Person, search_fields=['name'])
@@ -59,6 +68,8 @@ class TestRegistration(SimpleTestCase):
         self.assertEqual(self.site._registry[Person].search_fields, ['name'])
         self.assertIsInstance(self.site._registry[Place], admin.ModelAdmin)
         self.assertEqual(self.site._registry[Place].search_fields, ['name'])
+        self.site.unregister([Person, Place])
+        self.assertEqual(self.site._registry, {})
 
     def test_abstract_model(self):
         """


### PR DESCRIPTION
#13780 added documentation for `AdminSite.unregister()`. This is a complementary PR to add test coverage for the function. 