### PR TITLE
Fixed #19580 -- Unify reverse foreign key and m2m unsaved model querying

### DIFF
--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -654,6 +654,25 @@ Dropped support for MySQL 5.6
 The end of upstream support for MySQL 5.6 is April 2021. Django 3.2 supports
 MySQL 5.7 and higher.
 
+Unified behaviour of ForeignKey and ManyToManyField
+---------------------------------------------------
+
+The behavior of nullable related ``QuerySet`` has changed.
+
+Before, querying a nullable many-to-many relation was an error. For foreign
+key relations there was no error.
+
+Now it has changed:
+
+* Nullable many-to-many relations now return an empty queryset when the
+  relation field is null (no change for foreign keys).
+
+* For a foreign key relation, trying to add/remove/clear objects when the
+  relation field is null is now an error (no change for m2m).
+
+* For a foreign key relation, trying to use a relation of any kind when the
+  object isn't saved is now an error (no change for m2m).
+
 Miscellaneous
 -------------
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -60,6 +60,7 @@ BCC'ed
 bcrypt
 beatles
 Beaven
+behaviour
 benchmarking
 Benoit
 Berners

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -368,6 +368,75 @@ want. For example::
         )
         # ...
 
+.. versionchanged:: 3.2
+
+    Unified behaviour of ``ForeignKey`` and ``ManyToManyField``.
+
+    The behavior of nullable related ``QuerySet`` has changed.
+
+    Nullable related ``QuerySet`` means a ``QuerySet`` for reverse relation
+    to a field which can be set to null.
+
+    Before, querying a nullable many-to-many relation was an error. For foreign
+    key relations there was no error. To make the nullable relations consistent
+    the following changes were made:
+
+    * Nullable many-to-many relations now return an empty queryset when the
+      relation field is null (no change for foreign keys).
+      For example::
+
+        from django.db import models
+
+        class Car(models.Model):
+          drivers = models.ManyToManyField('Driver')
+
+        class Driver(models.Model):
+          name = models.CharField()
+
+        Car.objects.create().drivers.all()
+
+      returns ``EmptyQuerySet``.
+      Previously it would raise ``ValueError``.
+
+    * For a foreign key relation, trying to add/remove/clear objects when the
+      relation field is null is now an error (no change for m2m).
+      For example, given these related models::
+
+        from django.db import models
+
+        class Poll(models.Model):
+            question = models.CharField(max_length=200, unique=True, null=True)
+
+        class Choice(models.Model):
+            poll = models.ForeignKey(Poll, models.SET_NULL, to_field='question', null=True)
+            choice = models.CharField(max_length=200)
+
+        empty_poll = Poll.objects.create(question=None)
+        choice = Choice.objects.create(choice='B')
+
+      All the below statements now raise a ``ValueError`` ::
+
+        # Previously created a Choice object with ``poll_id=None``
+        empty_poll.choice_set.create()
+        empty_poll.choice_set.get_or_create()
+
+        # Previously the ``choice.poll_id`` remained to None
+        empty_poll.choice_set.add(choice)
+
+        # Previously did nothing
+        empty_poll.choice_set.remove(choice)
+        empty_poll.choice_set.clear()
+
+
+    * For a foreign key relation, trying to use a relation of any kind when the
+      object isn't saved is now an error (no change for m2m).
+      For example invoking::
+
+        Poll(question="How?").choice_set
+
+      now raises a ``ValueError``.
+      Previously it would return a ``RelatedManager``.
+
 .. seealso::
 
     :class:`~django.db.models.ForeignKey` fields accept a number of extra

--- a/tests/m2m_through_regress/tests.py
+++ b/tests/m2m_through_regress/tests.py
@@ -147,8 +147,8 @@ class ToFieldThroughTests(TestCase):
     def test_m2m_relations_unusable_on_null_to_field(self):
         nullcar = Car(make=None)
         msg = (
-            '"<Car: None>" needs to have a value for field "make" before this '
-            'many-to-many relationship can be used.'
+            '"<Car: None>" needs to have a value for field "make" '
+            'before this many-to-many relationship can be used.'
         )
         with self.assertRaisesMessage(ValueError, msg):
             nullcar.drivers.all()

--- a/tests/many_to_many/models.py
+++ b/tests/many_to_many/models.py
@@ -33,7 +33,7 @@ class NoDeletedArticleManager(models.Manager):
 
 
 class Article(models.Model):
-    headline = models.CharField(max_length=100)
+    headline = models.CharField(max_length=100, null=True)
     # Assign a string as name to make sure the intermediary model is
     # correctly created. Refs #20207
     publications = models.ManyToManyField(Publication, name='publications')

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -606,10 +606,9 @@ class ManyToOneTests(TestCase):
         Third.objects.create(name='Third 1')
         Third.objects.create(name='Third 2')
         th = Third(name="testing")
-        # The object isn't saved and thus the relation field is null - we won't even
-        # execute a query in this case.
-        with self.assertNumQueries(0):
-            self.assertEqual(th.child_set.count(), 0)
+        # The object isn't saved and thus the relation cannot be used.
+        with self.assertRaises(ValueError):
+            th.child_set
         th.save()
         # Now the model is saved, so we will need to execute a query.
         with self.assertNumQueries(1):

--- a/tests/many_to_one_null/tests.py
+++ b/tests/many_to_one_null/tests.py
@@ -140,3 +140,38 @@ class ManyToOneNullTests(TestCase):
         self.assertIs(d1.car, None)
         with self.assertNumQueries(0):
             self.assertEqual(list(c1.drivers.all()), [])
+
+    def test_add_remove_on_null_related_field(self):
+        car = Car.objects.create(make=None)
+        driver = Driver.objects.create()
+        msg = (
+            '"<Car: Car object (1)>" needs to have a value for '
+            'field "make" before this relationship can be used.'
+        )
+
+        with self.assertRaisesMessage(ValueError, msg):
+            car.drivers.create()
+
+        with self.assertRaisesMessage(ValueError, msg):
+            car.drivers.add(driver)
+
+        with self.assertRaisesMessage(ValueError, msg):
+            car.drivers.get_or_create()
+
+        with self.assertRaisesMessage(ValueError, msg):
+            car.drivers.remove(driver)
+
+        with self.assertRaisesMessage(ValueError, msg):
+            car.drivers.clear()
+
+        with self.assertNumQueries(0):
+            self.assertEqual(car.drivers.count(), 0)
+
+    def test_unsaved_object_relation(self):
+        c = Car(make="toyota")
+        msg = (
+            '"<Car: Car object (None)>" needs to have a primary'
+            ' key value before this relationship can be used.'
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            c.drivers.all()

--- a/tests/null_queries/tests.py
+++ b/tests/null_queries/tests.py
@@ -42,7 +42,11 @@ class NullQueriesTests(TestCase):
 
         # Related managers use __exact=None implicitly if the object hasn't been saved.
         p2 = Poll(question="How?")
-        self.assertEqual(repr(p2.choice_set.all()), '<QuerySet []>')
+
+        msg = '"<Poll: Q: How? >" needs to have a primary key ' \
+              'value before this relationship can be used.'
+        with self.assertRaisesMessage(ValueError, msg):
+            p2.choice_set.all()
 
     def test_reverse_relations(self):
         """


### PR DESCRIPTION
Rebased the previous PR [#11807](https://github.com/django/django/pull/11807).
I would like to get some clarification on this old ticket, took it under easy-pickings tag.

[#11807](https://github.com/django/django/pull/11807#pullrequestreview-344544165) - this is the last comment from where I started to search next steps to complete the ticket. 
It leads to the undone comments:

1. [#8570](https://github.com/django/django/pull/8570#pullrequestreview-113177526)
Should I move all tests from `m2m_through_regress` to `many_to_many` or some particular tests?


2. [#8570](https://github.com/django/django/pull/8570#pullrequestreview-113506649)
I see prepared changelogs in comment [#11807](https://github.com/django/django/pull/11807#issuecomment-612404721), but don't know where to place them in codebase. Could you explain?

Thanks!

P.S. https://code.djangoproject.com/ticket/19580