### PR TITLE
refs #32255 changed has_perm signature to forward **kwargs

### DIFF
--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -24,7 +24,7 @@ class BaseBackend:
             *self.get_group_permissions(user_obj, obj=obj),
         }
 
-    def has_perm(self, user_obj, perm, obj=None):
+    def has_perm(self, user_obj, perm, obj=None, **kwargs):
         return perm in self.get_all_permissions(user_obj, obj=obj)
 
 
@@ -104,8 +104,8 @@ class ModelBackend(BaseBackend):
             user_obj._perm_cache = super().get_all_permissions(user_obj)
         return user_obj._perm_cache
 
-    def has_perm(self, user_obj, perm, obj=None):
-        return user_obj.is_active and super().has_perm(user_obj, perm, obj=obj)
+    def has_perm(self, user_obj, perm, obj=None, **kwargs):
+        return user_obj.is_active and super().has_perm(user_obj, perm, obj=obj, **kwargs)
 
     def has_module_perms(self, user_obj, app_label):
         """

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -199,7 +199,7 @@ def _user_get_permissions(user, obj, from_name):
     return permissions
 
 
-def _user_has_perm(user, perm, obj):
+def _user_has_perm(user, perm, obj, **kwargs):
     """
     A backend can raise `PermissionDenied` to short-circuit permission checking.
     """
@@ -207,7 +207,7 @@ def _user_has_perm(user, perm, obj):
         if not hasattr(backend, 'has_perm'):
             continue
         try:
-            if backend.has_perm(user, perm, obj):
+            if backend.has_perm(user, perm, obj, **kwargs):
                 return True
         except PermissionDenied:
             return False
@@ -284,7 +284,7 @@ class PermissionsMixin(models.Model):
     def get_all_permissions(self, obj=None):
         return _user_get_permissions(self, obj, 'all')
 
-    def has_perm(self, perm, obj=None):
+    def has_perm(self, perm, obj=None, **kwargs):
         """
         Return True if the user has the specified permission. Query all
         available auth backends, but return immediately if any backend returns
@@ -297,14 +297,14 @@ class PermissionsMixin(models.Model):
             return True
 
         # Otherwise we need to check the backends.
-        return _user_has_perm(self, perm, obj)
+        return _user_has_perm(self, perm, obj, **kwargs)
 
-    def has_perms(self, perm_list, obj=None):
+    def has_perms(self, perm_list, obj=None, **kwargs):
         """
         Return True if the user has each of the specified permissions. If
         object is passed, check if the user has all required perms for it.
         """
-        return all(self.has_perm(perm, obj) for perm in perm_list)
+        return all(self.has_perm(perm, obj, **kwargs) for perm in perm_list)
 
     def has_module_perms(self, app_label):
         """
@@ -448,11 +448,11 @@ class AnonymousUser:
     def get_all_permissions(self, obj=None):
         return _user_get_permissions(self, obj, 'all')
 
-    def has_perm(self, perm, obj=None):
-        return _user_has_perm(self, perm, obj=obj)
+    def has_perm(self, perm, obj=None, **kwargs):
+        return _user_has_perm(self, perm, obj=obj, **kwargs)
 
-    def has_perms(self, perm_list, obj=None):
-        return all(self.has_perm(perm, obj) for perm in perm_list)
+    def has_perms(self, perm_list, obj=None, **kwargs):
+        return all(self.has_perm(perm, obj, **kwargs) for perm in perm_list)
 
     def has_module_perms(self, module):
         return _user_has_module_perms(self, module)


### PR DESCRIPTION
It refers to: https://code.djangoproject.com/ticket/32255

I changed the has_perm and has_perms signature. All tests runs fine. 

It is somehow a breaking change in the meaning that all auth backends should change and also accept a **kwargs from now on.
I'm open to suggestions to avoid this.