### PR TITLE
Fixed isolation of test_migrate_fake_split_initial.

### DIFF
--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -229,18 +229,20 @@ class MigrateTests(MigrationTestBase):
         """
         Split initial migrations can be faked with --fake-initial.
         """
-        call_command("migrate", "migrations", "0002", verbosity=0)
-        call_command("migrate", "migrations", "zero", fake=True, verbosity=0)
-        out = io.StringIO()
-        with mock.patch('django.core.management.color.supports_color', lambda *args: False):
-            call_command("migrate", "migrations", "0002", fake_initial=True, stdout=out, verbosity=1)
-        value = out.getvalue().lower()
-        self.assertIn("migrations.0001_initial... faked", value)
-        self.assertIn("migrations.0002_second... faked", value)
-        # Fake an apply
-        call_command("migrate", "migrations", fake=True, verbosity=0)
-        # Unmigrate everything
-        call_command("migrate", "migrations", "zero", verbosity=0)
+        try:
+            call_command('migrate', 'migrations', '0002', verbosity=0)
+            call_command('migrate', 'migrations', 'zero', fake=True, verbosity=0)
+            out = io.StringIO()
+            with mock.patch('django.core.management.color.supports_color', lambda *args: False):
+                call_command('migrate', 'migrations', '0002', fake_initial=True, stdout=out, verbosity=1)
+            value = out.getvalue().lower()
+            self.assertIn('migrations.0001_initial... faked', value)
+            self.assertIn('migrations.0002_second... faked', value)
+        finally:
+            # Fake an apply.
+            call_command('migrate', 'migrations', fake=True, verbosity=0)
+            # Unmigrate everything.
+            call_command('migrate', 'migrations', 'zero', verbosity=0)
 
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations_conflict"})
     def test_migrate_conflict_exit(self):


### PR DESCRIPTION
Noticed in [the last build on Oracle](https://djangoci.com/job/django-oracle/database=oracle18,python=python3.7/lastCompletedBuild/testReport/).