### PR TITLE
Fixed #32269 -- Fixed parse_duration() for negative days in ISO 8601 format.

### DIFF
--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -144,4 +144,6 @@ def parse_duration(value):
             kw['microseconds'] = '-' + kw['microseconds']
         kw = {k: float(v.replace(',', '.')) for k, v in kw.items() if v is not None}
         days = datetime.timedelta(kw.pop('days', .0) or .0)
+        if match.re == iso8601_duration_re:
+            days *= sign
         return days + sign * datetime.timedelta(**kw)

--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -70,6 +70,7 @@ class DurationParseTests(unittest.TestCase):
     def test_parse_postgresql_format(self):
         test_values = (
             ('1 day', timedelta(1)),
+            ('-1 day', timedelta(-1)),
             ('1 day 0:00:01', timedelta(days=1, seconds=1)),
             ('1 day -0:00:01', timedelta(days=1, seconds=-1)),
             ('-1 day -0:00:01', timedelta(days=-1, seconds=-1)),
@@ -137,10 +138,15 @@ class DurationParseTests(unittest.TestCase):
             ('P0.5D', timedelta(hours=12)),
             ('P0,5D', timedelta(hours=12)),
             ('PT5H', timedelta(hours=5)),
+            ('-PT5H', timedelta(hours=-5)),
             ('PT5M', timedelta(minutes=5)),
+            ('-PT5M', timedelta(minutes=-5)),
             ('PT5S', timedelta(seconds=5)),
+            ('-PT5S', timedelta(seconds=-5)),
             ('PT0.000005S', timedelta(microseconds=5)),
             ('PT0,000005S', timedelta(microseconds=5)),
+            ('-PT0.000005S', timedelta(microseconds=-5)),
+            ('-PT0,000005S', timedelta(microseconds=-5)),
         )
         for source, expected in test_values:
             with self.subTest(source=source):

--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -135,8 +135,11 @@ class DurationParseTests(unittest.TestCase):
             ('P4M', None),
             ('P4W', None),
             ('P4D', timedelta(days=4)),
+            ('-P1D', timedelta(days=-1)),
             ('P0.5D', timedelta(hours=12)),
             ('P0,5D', timedelta(hours=12)),
+            ('-P0.5D', timedelta(hours=-12)),
+            ('-P0,5D', timedelta(hours=-12)),
             ('PT5H', timedelta(hours=5)),
             ('-PT5H', timedelta(hours=-5)),
             ('PT5M', timedelta(minutes=5)),
@@ -147,6 +150,7 @@ class DurationParseTests(unittest.TestCase):
             ('PT0,000005S', timedelta(microseconds=5)),
             ('-PT0.000005S', timedelta(microseconds=-5)),
             ('-PT0,000005S', timedelta(microseconds=-5)),
+            ('-P4DT1H', timedelta(days=-4, hours=-1)),
         )
         for source, expected in test_values:
             with self.subTest(source=source):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32269