### PR TITLE
Fixed #32285 -- Raised ImproperlyConfigured when AppConfig.label is not a valid Python identifier.

### DIFF
--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -34,6 +34,10 @@ class AppConfig:
         # This value must be unique across a Django project.
         if not hasattr(self, 'label'):
             self.label = app_name.rpartition(".")[2]
+        if not self.label.isidentifier():
+            raise ImproperlyConfigured(
+                "The app label '%s' is not a valid Python identifier." % self.label
+            )
 
         # Human-readable name for the application e.g. "Admin".
         if not hasattr(self, 'verbose_name'):

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -227,15 +227,14 @@ class ProjectState:
 
 class AppConfigStub(AppConfig):
     """Stub of an AppConfig. Only provides a label and a dict of models."""
-    # Not used, but required by AppConfig.__init__
-    path = ''
-
     def __init__(self, label):
-        self.label = label
+        self.apps = None
+        self.models = {}
         # App-label and app-name are not the same thing, so technically passing
         # in the label here is wrong. In practice, migrations don't care about
         # the app name, but we need something unique, and the label works fine.
-        super().__init__(label, None)
+        self.label = label
+        self.name = label
 
     def import_models(self):
         self.models = self.apps.all_models[self.label]
@@ -332,7 +331,6 @@ class StateApps(Apps):
         if app_label not in self.app_configs:
             self.app_configs[app_label] = AppConfigStub(app_label)
             self.app_configs[app_label].apps = self
-            self.app_configs[app_label].models = {}
         self.app_configs[app_label].models[model._meta.model_name] = model
         self.do_pending_operations(model)
         self.clear_cache()

--- a/tests/apps/tests.py
+++ b/tests/apps/tests.py
@@ -436,6 +436,14 @@ class AppConfigTests(SimpleTestCase):
         ac = AppConfig('label', Stub(__path__=['a']))
         self.assertEqual(repr(ac), '<AppConfig: label>')
 
+    def test_invalid_label(self):
+        class MyAppConfig(AppConfig):
+            label = 'invalid.label'
+
+        msg = "The app label 'invalid.label' is not a valid Python identifier."
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            MyAppConfig('test_app', Stub())
+
     @override_settings(
         INSTALLED_APPS=['apps.apps.ModelPKAppsConfig'],
         DEFAULT_AUTO_FIELD='django.db.models.SmallAutoField',


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32285