### PR TITLE
Refs #27795 -- Updated FakePayload() uses to initialize with bytes.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -178,7 +178,7 @@ class AsyncClientHandler(BaseHandler):
         if '_body_file' in scope:
             body_file = scope.pop('_body_file')
         else:
-            body_file = FakePayload('')
+            body_file = FakePayload(b'')
 
         request_started.disconnect(close_old_connections)
         await sync_to_async(request_started.send, thread_sensitive=False)(sender=self.__class__, scope=scope)
@@ -521,7 +521,7 @@ class AsyncRequestFactory(RequestFactory):
         if '_body_file' in request:
             body_file = request.pop('_body_file')
         else:
-            body_file = FakePayload('')
+            body_file = FakePayload(b'')
         return ASGIRequest(self._base_scope(**request), body_file)
 
     def generic(

--- a/tests/handlers/test_exception.py
+++ b/tests/handlers/test_exception.py
@@ -6,7 +6,7 @@ from django.test.client import FakePayload
 class ExceptionHandlerTests(SimpleTestCase):
 
     def get_suspicious_environ(self):
-        payload = FakePayload('a=1&a=2;a=3\r\n')
+        payload = FakePayload(b'a=1&a=2;a=3\r\n')
         return {
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'application/x-www-form-urlencoded',

--- a/tests/requests/test_data_upload_settings.py
+++ b/tests/requests/test_data_upload_settings.py
@@ -11,7 +11,7 @@ TOO_MUCH_DATA_MSG = 'Request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.
 
 class DataUploadMaxMemorySizeFormPostTests(SimpleTestCase):
     def setUp(self):
-        payload = FakePayload('a=1&a=2;a=3\r\n')
+        payload = FakePayload(b'a=1&a=2;a=3\r\n')
         self.request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'application/x-www-form-urlencoded',
@@ -35,13 +35,13 @@ class DataUploadMaxMemorySizeFormPostTests(SimpleTestCase):
 
 class DataUploadMaxMemorySizeMultipartPostTests(SimpleTestCase):
     def setUp(self):
-        payload = FakePayload("\r\n".join([
-            '--boundary',
-            'Content-Disposition: form-data; name="name"',
-            '',
-            'value',
-            '--boundary--'
-            ''
+        payload = FakePayload(b"\r\n".join([
+            b'--boundary',
+            b'Content-Disposition: form-data; name="name"',
+            b'',
+            b'value',
+            b'--boundary--',
+            b'',
         ]))
         self.request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
@@ -64,13 +64,13 @@ class DataUploadMaxMemorySizeMultipartPostTests(SimpleTestCase):
             self.request._load_post_and_files()
 
     def test_file_passes(self):
-        payload = FakePayload("\r\n".join([
-            '--boundary',
-            'Content-Disposition: form-data; name="file1"; filename="test.file"',
-            '',
-            'value',
-            '--boundary--'
-            ''
+        payload = FakePayload(b"\r\n".join([
+            b'--boundary',
+            b'Content-Disposition: form-data; name="file1"; filename="test.file"',
+            b'',
+            b'value',
+            b'--boundary--',
+            b'',
         ]))
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
@@ -133,17 +133,17 @@ class DataUploadMaxNumberOfFieldsGet(SimpleTestCase):
 
 class DataUploadMaxNumberOfFieldsMultipartPost(SimpleTestCase):
     def setUp(self):
-        payload = FakePayload("\r\n".join([
-            '--boundary',
-            'Content-Disposition: form-data; name="name1"',
-            '',
-            'value1',
-            '--boundary',
-            'Content-Disposition: form-data; name="name2"',
-            '',
-            'value2',
-            '--boundary--'
-            ''
+        payload = FakePayload(b"\r\n".join([
+            b'--boundary',
+            b'Content-Disposition: form-data; name="name1"',
+            b'',
+            b'value1',
+            b'--boundary',
+            b'Content-Disposition: form-data; name="name2"',
+            b'',
+            b'value2',
+            b'--boundary--',
+            b'',
         ]))
         self.request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
@@ -168,7 +168,7 @@ class DataUploadMaxNumberOfFieldsMultipartPost(SimpleTestCase):
 
 class DataUploadMaxNumberOfFieldsFormPost(SimpleTestCase):
     def setUp(self):
-        payload = FakePayload("\r\n".join(['a=1&a=2;a=3', '']))
+        payload = FakePayload(b'a=1&a=2;a=3\r\n')
         self.request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'application/x-www-form-urlencoded',

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -238,7 +238,7 @@ class RequestsTests(SimpleTestCase):
         self.assertEqual(stream.read(), b'')
 
     def test_stream(self):
-        payload = FakePayload('name=value')
+        payload = FakePayload(b'name=value')
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'application/x-www-form-urlencoded',
@@ -252,7 +252,7 @@ class RequestsTests(SimpleTestCase):
         Reading from request is allowed after accessing request contents as
         POST or body.
         """
-        payload = FakePayload('name=value')
+        payload = FakePayload(b'name=value')
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'application/x-www-form-urlencoded',
@@ -268,7 +268,7 @@ class RequestsTests(SimpleTestCase):
         Construction of POST or body is not allowed after reading
         from request.
         """
-        payload = FakePayload('name=value')
+        payload = FakePayload(b'name=value')
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'application/x-www-form-urlencoded',
@@ -310,13 +310,14 @@ class RequestsTests(SimpleTestCase):
         # Because multipart is used for large amounts of data i.e. file uploads,
         # we don't want the data held in memory twice, and we don't want to
         # silence the error by setting body = '' either.
-        payload = FakePayload("\r\n".join([
-            '--boundary',
-            'Content-Disposition: form-data; name="name"',
-            '',
-            'value',
-            '--boundary--'
-            '']))
+        payload = FakePayload(b"\r\n".join([
+            b'--boundary',
+            b'Content-Disposition: form-data; name="name"',
+            b'',
+            b'value',
+            b'--boundary--',
+            b'',
+        ]))
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
@@ -360,13 +361,14 @@ class RequestsTests(SimpleTestCase):
         # https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
         # Every request.POST with Content-Length >= 0 is a valid request,
         # this test ensures that we handle Content-Length == 0.
-        payload = FakePayload("\r\n".join([
-            '--boundary',
-            'Content-Disposition: form-data; name="name"',
-            '',
-            'value',
-            '--boundary--'
-            '']))
+        payload = FakePayload(b"\r\n".join([
+            b'--boundary',
+            b'Content-Disposition: form-data; name="name"',
+            b'',
+            b'value',
+            b'--boundary--',
+            b'',
+        ]))
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
@@ -396,7 +398,7 @@ class RequestsTests(SimpleTestCase):
         self.assertEqual(request.body, payload)
 
     def test_read_by_lines(self):
-        payload = FakePayload('name=value')
+        payload = FakePayload(b'name=value')
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'application/x-www-form-urlencoded',
@@ -409,7 +411,7 @@ class RequestsTests(SimpleTestCase):
         """
         POST should be populated even if body is read first
         """
-        payload = FakePayload('name=value')
+        payload = FakePayload(b'name=value')
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'application/x-www-form-urlencoded',
@@ -424,7 +426,7 @@ class RequestsTests(SimpleTestCase):
         POST should be populated even if body is read first, and then
         the stream is read second.
         """
-        payload = FakePayload('name=value')
+        payload = FakePayload(b'name=value')
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'application/x-www-form-urlencoded',
@@ -440,13 +442,14 @@ class RequestsTests(SimpleTestCase):
         POST should be populated even if body is read first, and then
         the stream is read second. Using multipart/form-data instead of urlencoded.
         """
-        payload = FakePayload("\r\n".join([
-            '--boundary',
-            'Content-Disposition: form-data; name="name"',
-            '',
-            'value',
-            '--boundary--'
-            '']))
+        payload = FakePayload(b"\r\n".join([
+            b'--boundary',
+            b'Content-Disposition: form-data; name="name"',
+            b'',
+            b'value',
+            b'--boundary--',
+            b'',
+        ]))
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
@@ -462,12 +465,12 @@ class RequestsTests(SimpleTestCase):
         """
         MultiPartParser.parse() leaves request.POST immutable.
         """
-        payload = FakePayload("\r\n".join([
-            '--boundary',
-            'Content-Disposition: form-data; name="name"',
-            '',
-            'value',
-            '--boundary--',
+        payload = FakePayload(b"\r\n".join([
+            b'--boundary',
+            b'Content-Disposition: form-data; name="name"',
+            b'',
+            b'value',
+            b'--boundary--',
         ]))
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',


### PR DESCRIPTION
Avoids the runtime encoding of Unicode literals to bytes in
FakePayload.write() (via force_bytes()).