### PR TITLE
Update libgdal.py

### DIFF
--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -12,6 +12,8 @@ logger = logging.getLogger('django.contrib.gis')
 # Custom library path set?
 try:
     from django.conf import settings
+    if not settings.configured:
+        settings.configure()
     lib_path = settings.GDAL_LIBRARY_PATH
 except (AttributeError, ImportError, ImproperlyConfigured, OSError):
     lib_path = None


### PR DESCRIPTION
resolved: 
Putting the GDAL_LIBRARY_PATH in the global_settings.py file did not work. So the GDAL library couldn't get found by the package. 
This was because the settings class did not get configured after importing. 
Adding these two lines fixed the problem.