### PR TITLE
Fixed #32299 -- Prevented mutating handlers when processing middlewares marking as unused in an async context.

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -51,11 +51,11 @@ class BaseHandler:
                 middleware_is_async = middleware_can_async
             try:
                 # Adapt handler, if needed.
-                handler = self.adapt_method_mode(
+                adapted_handler = self.adapt_method_mode(
                     middleware_is_async, handler, handler_is_async,
                     debug=settings.DEBUG, name='middleware %s' % middleware_path,
                 )
-                mw_instance = middleware(handler)
+                mw_instance = middleware(adapted_handler)
             except MiddlewareNotUsed as exc:
                 if settings.DEBUG:
                     if str(exc):
@@ -63,6 +63,8 @@ class BaseHandler:
                     else:
                         logger.debug('MiddlewareNotUsed: %r', middleware_path)
                 continue
+            else:
+                handler = adapted_handler
 
             if mw_instance is None:
                 raise ImproperlyConfigured(

--- a/docs/releases/3.1.5.txt
+++ b/docs/releases/3.1.5.txt
@@ -12,3 +12,7 @@ Bugfixes
 * Fixed ``__isnull=True`` lookup on key transforms for
   :class:`~django.db.models.JSONField` with Oracle and SQLite
   (:ticket:`32252`).
+
+* Fixed a bug in Django 3.1 that caused a crash when processing middlewares in
+  an async context with a middleware that raises a ``MiddlewareNotUsed``
+  exception (:ticket:`32299`).


### PR DESCRIPTION
ticket-32299

Thanks Hubert Bielenia for the report.