### PR TITLE
Fixed #27827 -- Used "raise from" when raising InvalidTemplateLibrary exceptions in get_package_libraries().

### DIFF
--- a/django/template/backends/django.py
+++ b/django/template/backends/django.py
@@ -123,7 +123,7 @@ def get_package_libraries(pkg):
             raise InvalidTemplateLibrary(
                 "Invalid template library specified. ImportError raised when "
                 "trying to load '%s': %s" % (entry[1], e)
-            )
+            ) from e
 
         if hasattr(module, 'register'):
             yield entry[1]

--- a/tests/template_backends/test_django.py
+++ b/tests/template_backends/test_django.py
@@ -104,13 +104,14 @@ class DjangoTemplatesTests(TemplateStringsTests):
             InvalidTemplateLibrary,
             "ImportError raised when trying to load "
             "'template_backends.apps.importerror.templatetags.broken_tags'"
-        ):
+        ) as cm:
             DjangoTemplates({
                 'DIRS': [],
                 'APP_DIRS': False,
                 'NAME': 'django',
                 'OPTIONS': {},
             })
+        self.assertIsInstance(cm.exception.__cause__, ImportError)
 
     def test_builtins_discovery(self):
         engine = DjangoTemplates({


### PR DESCRIPTION
ticket-27827