### PR TITLE
Refs #31358 -- Fixed decoding salt in Argon2PasswordHasher.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -354,6 +354,7 @@ class Argon2PasswordHasher(BasePasswordHasher):
             'time_cost': params.time_cost,
             'variety': variety,
             'version': params.version,
+            'params': params,
         }
 
     def verify(self, password, encoded):
@@ -379,10 +380,7 @@ class Argon2PasswordHasher(BasePasswordHasher):
         }
 
     def must_update(self, encoded):
-        algorithm, rest = encoded.split('$', 1)
-        assert algorithm == self.algorithm
-        argon2 = self._load_library()
-        current_params = argon2.extract_parameters('$' + rest)
+        current_params = self.decode(encoded)['params']
         new_params = self.params()
         # Set salt_len to the salt_len of the current parameters because salt
         # is explicitly passed to argon2.

--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -344,7 +344,10 @@ class Argon2PasswordHasher(BasePasswordHasher):
         algorithm, rest = encoded.split('$', 1)
         assert algorithm == self.algorithm
         params = argon2.extract_parameters('$' + rest)
-        variety, *_, salt, hash = rest.split('$')
+        variety, *_, b64salt, hash = rest.split('$')
+        # Add padding.
+        b64salt += '=' * (-len(b64salt) % 4)
+        salt = base64.b64decode(b64salt).decode('latin1')
         return {
             'algorithm': algorithm,
             'hash': hash,

--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -526,6 +526,16 @@ class TestUtilsHashPassArgon2(SimpleTestCase):
         self.assertIs(check_password('secret', encoded), True)
         self.assertIs(check_password('wrong', encoded), False)
 
+    def test_argon2_decode(self):
+        salt = 'abcdefghijk'
+        encoded = make_password('lètmein', salt=salt, hasher='argon2')
+        hasher = get_hasher('argon2')
+        decoded = hasher.decode(encoded)
+        self.assertEqual(decoded['memory_cost'], hasher.memory_cost)
+        self.assertEqual(decoded['parallelism'], hasher.parallelism)
+        self.assertEqual(decoded['salt'], salt)
+        self.assertEqual(decoded['time_cost'], hasher.time_cost)
+
     def test_argon2_upgrade(self):
         self._test_argon2_upgrade('time_cost', 'time cost', 1)
         self._test_argon2_upgrade('memory_cost', 'memory cost', 64)


### PR DESCRIPTION
Argon2 encodes the salt as base64 for representation in the final hash
output. To be able to accurately return the used salt from `decode` we
now b64decode it and decode from latin1 (for the remote possibility that
someone supplied a custom hash consisting solely of bytes -- this would
require a manual construction of the hash though, Django's interface
does not allow for that).

I ran into this while working on #12553 just now.