### PR TITLE
Used model's Options.label where applicable.

### DIFF
--- a/django/contrib/contenttypes/admin.py
+++ b/django/contrib/contenttypes/admin.py
@@ -28,9 +28,7 @@ class GenericInlineModelAdminChecks(InlineModelAdminChecks):
         if not gfks:
             return [
                 checks.Error(
-                    "'%s.%s' has no GenericForeignKey." % (
-                        obj.model._meta.app_label, obj.model._meta.object_name
-                    ),
+                    "'%s' has no GenericForeignKey." % obj.model._meta.label,
                     obj=obj.__class__,
                     id='admin.E301'
                 )
@@ -42,8 +40,8 @@ class GenericInlineModelAdminChecks(InlineModelAdminChecks):
             except FieldDoesNotExist:
                 return [
                     checks.Error(
-                        "'ct_field' references '%s', which is not a field on '%s.%s'." % (
-                            obj.ct_field, obj.model._meta.app_label, obj.model._meta.object_name
+                        "'ct_field' references '%s', which is not a field on '%s'." % (
+                            obj.ct_field, obj.model._meta.label,
                         ),
                         obj=obj.__class__,
                         id='admin.E302'
@@ -55,8 +53,8 @@ class GenericInlineModelAdminChecks(InlineModelAdminChecks):
             except FieldDoesNotExist:
                 return [
                     checks.Error(
-                        "'ct_fk_field' references '%s', which is not a field on '%s.%s'." % (
-                            obj.ct_fk_field, obj.model._meta.app_label, obj.model._meta.object_name
+                        "'ct_fk_field' references '%s', which is not a field on '%s'." % (
+                            obj.ct_fk_field, obj.model._meta.label,
                         ),
                         obj=obj.__class__,
                         id='admin.E303'
@@ -71,8 +69,8 @@ class GenericInlineModelAdminChecks(InlineModelAdminChecks):
 
             return [
                 checks.Error(
-                    "'%s.%s' has no GenericForeignKey using content type field '%s' and object ID field '%s'." % (
-                        obj.model._meta.app_label, obj.model._meta.object_name, obj.ct_field, obj.ct_fk_field
+                    "'%s' has no GenericForeignKey using content type field '%s' and object ID field '%s'." % (
+                        obj.model._meta.label, obj.ct_field, obj.ct_fk_field,
                     ),
                     obj=obj.__class__,
                     id='admin.E304'

--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -70,8 +70,7 @@ class GenericForeignKey(FieldCacheMixin):
 
     def __str__(self):
         model = self.model
-        app = model._meta.app_label
-        return '%s.%s.%s' % (app, model._meta.object_name, self.name)
+        return '%s.%s' % (model._meta.label, self.name)
 
     def check(self, **kwargs):
         return [
@@ -343,9 +342,8 @@ class GenericRelation(ForeignObject):
                 return [
                     checks.Error(
                         "The GenericRelation defines a relation with the model "
-                        "'%s.%s', but that model does not have a GenericForeignKey." % (
-                            target._meta.app_label, target._meta.object_name
-                        ),
+                        "'%s', but that model does not have a GenericForeignKey."
+                        % target._meta.label,
                         obj=self,
                         id='contenttypes.E004',
                     )

--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -195,9 +195,8 @@ class Command(BaseCommand):
                                 )
                         # psycopg2 raises ValueError if data contains NUL chars.
                         except (DatabaseError, IntegrityError, ValueError) as e:
-                            e.args = ("Could not load %(app_label)s.%(object_name)s(pk=%(pk)s): %(error_msg)s" % {
-                                'app_label': obj.object._meta.app_label,
-                                'object_name': obj.object._meta.object_name,
+                            e.args = ("Could not load %(object_label)s(pk=%(pk)s): %(error_msg)s" % {
+                                'object_label': obj.object._meta.label,
                                 'pk': obj.object.pk,
                                 'error_msg': e,
                             },)

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -183,8 +183,7 @@ class Field(RegisterLookupMixin):
         if not hasattr(self, 'model'):
             return super().__str__()
         model = self.model
-        app = model._meta.app_label
-        return '%s.%s.%s' % (app, model._meta.object_name, self.name)
+        return '%s.%s' % (model._meta.label, self.name)
 
     def __repr__(self):
         """Display the module, class, and name of the field."""

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -172,14 +172,10 @@ class RelatedField(FieldCacheMixin, Field):
         if (self.remote_field.model not in self.opts.apps.get_models() and
                 not isinstance(self.remote_field.model, str) and
                 self.remote_field.model._meta.swapped):
-            model = "%s.%s" % (
-                self.remote_field.model._meta.app_label,
-                self.remote_field.model._meta.object_name
-            )
             return [
                 checks.Error(
                     "Field defines a relation with the model '%s', which has "
-                    "been swapped out." % model,
+                    "been swapped out." % self.remote_field.model._meta.label,
                     hint="Update the relation to point at 'settings.%s'." % self.remote_field.model._meta.swappable,
                     obj=self,
                     id='fields.E301',
@@ -1479,18 +1475,12 @@ class ManyToManyField(RelatedField):
         if isinstance(self.remote_field.model, str):
             kwargs['to'] = self.remote_field.model
         else:
-            kwargs['to'] = "%s.%s" % (
-                self.remote_field.model._meta.app_label,
-                self.remote_field.model._meta.object_name,
-            )
+            kwargs['to'] = self.remote_field.model._meta.label
         if getattr(self.remote_field, 'through', None) is not None:
             if isinstance(self.remote_field.through, str):
                 kwargs['through'] = self.remote_field.through
             elif not self.remote_field.through._meta.auto_created:
-                kwargs['through'] = "%s.%s" % (
-                    self.remote_field.through._meta.app_label,
-                    self.remote_field.through._meta.object_name,
-                )
+                kwargs['through'] = self.remote_field.through._meta.label
         # If swappable is True, then see if we're actually pointing to the target
         # of a swap.
         swappable_setting = self.swappable_setting

--- a/django/db/models/manager.py
+++ b/django/db/models/manager.py
@@ -185,9 +185,8 @@ class ManagerDescriptor:
 
         if cls._meta.swapped:
             raise AttributeError(
-                "Manager isn't available; '%s.%s' has been swapped for '%s'" % (
-                    cls._meta.app_label,
-                    cls._meta.object_name,
+                "Manager isn't available; '%s' has been swapped for '%s'" % (
+                    cls._meta.label,
                     cls._meta.swapped,
                 )
             )


### PR DESCRIPTION
Follow up to b7a3a6c9ef0a89625881b47594120bca55fa2e49.