### PR TITLE
Simplified django.db.utils.load_backend().

### DIFF
--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -1,6 +1,5 @@
 import pkgutil
 from importlib import import_module
-from pathlib import Path
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -113,9 +112,9 @@ def load_backend(backend_name):
     except ImportError as e_user:
         # The database backend wasn't found. Display a helpful error message
         # listing all built-in database backends.
-        backend_dir = str(Path(__file__).parent / 'backends')
+        import django.db.backends
         builtin_backends = [
-            name for _, name, ispkg in pkgutil.iter_modules([backend_dir])
+            name for _, name, ispkg in pkgutil.iter_modules(django.db.backends.__path__)
             if ispkg and name not in {'base', 'dummy', 'postgresql_psycopg2'}
         ]
         if backend_name not in ['django.db.backends.%s' % b for b in builtin_backends]:


### PR DESCRIPTION
`django.db.utils.load_backend(name)` searches `django.db.backends`'s sub-modules to list built-in back ends in its "{name} not found" error message. Previously `load_backend` performed this search by computing the (sole) entry of `django.db.backends.__path__` manually from `django.db.utils.__file__`. Now `django.db.backends.__path__` is used directly.

This change
* avoids duplicating the logic that computes `__path__` in the first place;
* makes `load_backend`'s use of [`pkgutil.iter_modules`] more idiomatic by using a package's `__path__` as the argument;
* avoids importing `pathlib`;
* avoids using `__file__`, which is [not guaranteed to exist];
* does not cost an extra import of `django.db` because it takes place in `django.db.utils` (if `django.db.backends` hasn't been imported yet, that's hardly time consuming as `django/db/backends/__init__.py` is empty).

I have changed no tests or documentation because this patch is purely an internal cleanup/simplification/optimization. I did not file a Trac ticket [because this change is very simple].

[`pkgutil.iter_modules`]: https://docs.python.org/3/library/pkgutil.html#pkgutil.iter_modules
[not guaranteed to exist]: https://docs.python.org/3/reference/import.html#__file__
[because this change is very simple]: https://docs.djangoproject.com/en/3.1/internals/contributing/writing-code/submitting-patches/#typo-fixes-and-trivial-documentation-changes