### PR TITLE
Fixed #32314 -- Fixed detection when started non-django modules with "python -m" in autoreloader.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -216,14 +216,14 @@ def get_child_arguments():
     executable is reported to not have the .exe extension which can cause bugs
     on reloading.
     """
-    import django.__main__
-    django_main_path = Path(django.__main__.__file__)
+    import __main__
     py_script = Path(sys.argv[0])
 
     args = [sys.executable] + ['-W%s' % o for o in sys.warnoptions]
-    if py_script == django_main_path:
-        # The server was started with `python -m django runserver`.
-        args += ['-m', 'django']
+    # __spec__ is set when the server was started with the `-m` option,
+    # see https://docs.python.org/3/reference/import.html#main-spec
+    if __main__.__spec__ is not None and __main__.__spec__.parent:
+        args += ['-m', __main__.__spec__.parent]
         args += sys.argv[1:]
     elif not py_script.exists():
         # sys.argv[0] may not exist for several reasons on Windows.


### PR DESCRIPTION
[`django.utils.autoreload.get_child_arguments`](https://github.com/django/django/blob/b41d38ae26b1da9519a6cd765bc2f2ce7d355007/django/utils/autoreload.py#L213-L246) detects when Python was launched
like `python -m django`. Previously it could detect only when [`-m`] was passed `django`, and only in Python environments in which [`__file__`] is set on modules. This commit replaces the logic to use [Python's documented way] of determining if [`-m`] was used. Now packages can implement their own [`__main__`] with the [`runserver`] command and `get_child_arguments` correctly detect it, all while avoiding use of [`__file__`].

Note that the tests needed to be updated here for two reasons. The first is to test the new functionality—allowing [`__main__`] from elsewhere than `django/__main__.py`. This is tested in `utils_tests.test_autoreload.TestChildArguments.test_run_as_another_module`. The second reason is that the [`__main__`] module itself needs to be patched in two tests:
* `utils_tests.test_autoreload.TestChildArguments.test_run_as_module`
* `utils_tests.test_autoreload.RestartWithReloaderTests.test_python_m_django`

This is because `get_child_arguments` detects how Python was *actually* started, not just how `sys.argv[0]` claims it was started.

https://code.djangoproject.com/ticket/32314

[`__file__`]: https://docs.python.org/3/reference/import.html#__file__
[`__main__`]: https://docs.python.org/3/library/__main__.html
[Python's documented way]: https://docs.python.org/3/reference/import.html#main-spec
[`-m`]: https://docs.python.org/3/using/cmdline.html#cmdoption-m
[`runserver`]: https://docs.djangoproject.com/en/3.1/ref/django-admin/#runserver