### PR TITLE
Handle None being passed to JSONField.bound_data()

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1250,6 +1250,8 @@ class JSONField(CharField):
     def bound_data(self, data, initial):
         if self.disabled:
             return initial
+        if data is None:
+            return InvalidJSONInput()
         try:
             return json.loads(data, cls=self.decoder)
         except json.JSONDecodeError:

--- a/tests/forms_tests/field_tests/test_jsonfield.py
+++ b/tests/forms_tests/field_tests/test_jsonfield.py
@@ -5,6 +5,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.forms import (
     CharField, Form, JSONField, Textarea, TextInput, ValidationError,
 )
+from django.forms.fields import InvalidJSONInput
 from django.test import SimpleTestCase
 
 
@@ -114,3 +115,10 @@ class JSONFieldTest(SimpleTestCase):
         form = JSONForm({'name': 'xy', 'json_field': '{"foo"}'})
         self.assertEqual(form.errors['json_field'], ['Enter a valid JSON.'])
         self.assertIn('{&quot;foo&quot;}</textarea>', form.as_p())
+
+    def test_bound_data_none(self):
+        class JSONForm(Form):
+            json_field = JSONField(required=True)
+        form = JSONForm({'name': 'xyz'})
+        self.assertEqual(form["json_field"].value(), InvalidJSONInput())
+        self.assertEqual(form.errors['json_field'], ['This field is required.'])


### PR DESCRIPTION
This change prevents an exception from being raised during form rendering when a JSONField is missing from form data, bringing the behaviour of JSONField in line with other fields in this case. Specifically, a blank field is rendered, accompanied by a validation error if the field is required.