### PR TITLE
Refs #21429 -- Added SimpleTestCase.assertLogRecords.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -755,6 +755,10 @@ class SimpleTestCase(unittest.TestCase):
             else:
                 self.fail(f'Unexpected logs found: {cm.output!r}')
 
+    def assertLogRecords(self, logs, expected):
+        records = [(log.levelname, log.msg, log.args) for log in logs.records]
+        self.assertEqual(records, expected)
+
     def assertFieldOutput(self, fieldclass, valid, invalid, field_args=None,
                           field_kwargs=None, empty_value=''):
         """

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -101,7 +101,9 @@ class CsrfViewMiddlewareTestMixin:
         with self.assertLogs('django.security.csrf', 'WARNING') as cm:
             resp = mw.process_view(req, post_form_view, (), {})
         self.assertEqual(403, resp.status_code)
-        self.assertEqual(cm.records[0].getMessage(), 'Forbidden (%s): ' % REASON_NO_CSRF_COOKIE)
+        self.assertLogRecords(
+            cm, [('WARNING', 'Forbidden (%s): %s', (REASON_NO_CSRF_COOKIE, ''))],
+        )
 
     def test_process_request_csrf_cookie_no_token(self):
         """
@@ -114,7 +116,9 @@ class CsrfViewMiddlewareTestMixin:
         with self.assertLogs('django.security.csrf', 'WARNING') as cm:
             resp = mw.process_view(req, post_form_view, (), {})
         self.assertEqual(403, resp.status_code)
-        self.assertEqual(cm.records[0].getMessage(), 'Forbidden (%s): ' % REASON_BAD_TOKEN)
+        self.assertLogRecords(
+            cm, [('WARNING', 'Forbidden (%s): %s', (REASON_BAD_TOKEN, ''))],
+        )
 
     def test_process_request_csrf_cookie_and_token(self):
         """
@@ -170,14 +174,18 @@ class CsrfViewMiddlewareTestMixin:
         with self.assertLogs('django.security.csrf', 'WARNING') as cm:
             resp = mw.process_view(req, post_form_view, (), {})
         self.assertEqual(403, resp.status_code)
-        self.assertEqual(cm.records[0].getMessage(), 'Forbidden (%s): ' % REASON_NO_CSRF_COOKIE)
+        self.assertLogRecords(
+            cm, [('WARNING', 'Forbidden (%s): %s', (REASON_NO_CSRF_COOKIE, ''))],
+        )
 
         req = TestingHttpRequest()
         req.method = 'DELETE'
         with self.assertLogs('django.security.csrf', 'WARNING') as cm:
             resp = mw.process_view(req, post_form_view, (), {})
         self.assertEqual(403, resp.status_code)
-        self.assertEqual(cm.records[0].getMessage(), 'Forbidden (%s): ' % REASON_NO_CSRF_COOKIE)
+        self.assertLogRecords(
+            cm, [('WARNING', 'Forbidden (%s): %s', (REASON_NO_CSRF_COOKIE, ''))],
+        )
 
     def test_put_and_delete_allowed(self):
         """
@@ -508,7 +516,9 @@ class CsrfViewMiddlewareTestMixin:
         with self.assertLogs('django.security.csrf', 'WARNING') as cm:
             resp = mw.process_view(req, post_form_view, (), {})
         self.assertEqual(resp.status_code, 403)
-        self.assertEqual(cm.records[0].getMessage(), 'Forbidden (%s): ' % REASON_BAD_TOKEN)
+        self.assertLogRecords(
+            cm, [('WARNING', 'Forbidden (%s): %s', (REASON_BAD_TOKEN, ''))],
+        )
 
 
 class CsrfViewMiddlewareTests(CsrfViewMiddlewareTestMixin, SimpleTestCase):

--- a/tests/schema/test_logging.py
+++ b/tests/schema/test_logging.py
@@ -12,7 +12,4 @@ class SchemaLoggerTests(TestCase):
             editor.execute(sql, params)
         self.assertEqual(cm.records[0].sql, sql)
         self.assertEqual(cm.records[0].params, params)
-        self.assertEqual(
-            cm.records[0].getMessage(),
-            'SELECT * FROM foo WHERE id in (%s, %s); (params [42, 1337])',
-        )
+        self.assertLogRecords(cm, [('DEBUG', '%s; (params %r)', (sql, params))])

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -325,7 +325,7 @@ class SessionTestsMixin:
                 with self.assertLogs('django.security.SuspiciousSession', 'WARNING') as cm:
                     self.assertEqual(self.session.decode(encoded), {})
                 # The failed decode is logged.
-                self.assertIn('Session data corrupted', cm.output[0])
+                self.assertLogRecords(cm, [('WARNING', 'Session data corrupted', ())])
 
     def test_decode_serializer_exception(self):
         signer = TimestampSigner(salt=self.session.key_salt)

--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -26,7 +26,7 @@ class ShellCommandTestCase(SimpleTestCase):
                     'getLogger("test").info(django.__version__)'
                 ),
             )
-        self.assertEqual(cm.records[0].getMessage(), __version__)
+        self.assertLogRecords(cm, [('INFO', __version__, ())])
 
     def test_command_option_globals(self):
         with captured_stdout() as stdout:

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -91,9 +91,8 @@ class DebugViewTests(SimpleTestCase):
         with self.assertLogs('django.request', 'WARNING') as cm:
             response = self.client.get('/raises400_bad_request/')
         self.assertContains(response, '<div class="context" id="', status_code=400)
-        self.assertEqual(
-            cm.records[0].getMessage(),
-            'Malformed request syntax: /raises400_bad_request/',
+        self.assertLogRecords(
+            cm, [('WARNING', '%s: %s', ('Malformed request syntax', '/raises400_bad_request/'))],
         )
 
     # Ensure no 403.html template exists to test the default case.
@@ -349,9 +348,8 @@ class NonDjangoTemplatesDebugViewTests(SimpleTestCase):
         with self.assertLogs('django.request', 'WARNING') as cm:
             response = self.client.get('/raises400_bad_request/')
         self.assertContains(response, '<div class="context" id="', status_code=400)
-        self.assertEqual(
-            cm.records[0].getMessage(),
-            'Malformed request syntax: /raises400_bad_request/',
+        self.assertLogRecords(
+            cm, [('WARNING', '%s: %s', ('Malformed request syntax', '/raises400_bad_request/'))],
         )
 
     def test_403(self):


### PR DESCRIPTION
Tighten assertions as the helper verifies:

- the number of messages logged, where the test suite mostly verified
  the first message.
- variable data is logged separately.
- logging level, as assertLogs catches all messages above a given level.

Will be used to verify log messages in #21429.