### PR TITLE
Refs #21429 -- Added SimpleTestCase.assertNoLogs() on Python < 3.10.

### DIFF
--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -13,6 +13,7 @@ PY36 = sys.version_info >= (3, 6)
 PY37 = sys.version_info >= (3, 7)
 PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
+PY310 = sys.version_info >= (3, 10)
 
 
 def get_version(version=None):

--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -82,9 +82,8 @@ class AdminSidebarTests(TestCase):
     def test_included_app_list_template_context_fully_set(self):
         # All context variables should be set when rendering the sidebar.
         url = reverse('test_with_sidebar:auth_user_changelist')
-        with self.assertRaisesMessage(AssertionError, 'no logs'):
-            with self.assertLogs('django.template', 'DEBUG'):
-                self.client.get(url)
+        with self.assertNoLogs('django.template', 'DEBUG'):
+            self.client.get(url)
 
 
 @override_settings(ROOT_URLCONF='admin_views.test_nav_sidebar')

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -454,10 +454,9 @@ class CsrfViewMiddlewareTestMixin:
         """
         ensure_csrf_cookie() doesn't log warnings (#19436).
         """
-        with self.assertRaisesMessage(AssertionError, 'no logs'):
-            with self.assertLogs('django.request', 'WARNING'):
-                req = self._get_GET_no_csrf_cookie_request()
-                ensure_csrf_cookie_view(req)
+        with self.assertNoLogs('django.request', 'WARNING'):
+            req = self._get_GET_no_csrf_cookie_request()
+            ensure_csrf_cookie_view(req)
 
     def test_post_data_read_failure(self):
         """

--- a/tests/gis_tests/geoadmin/tests.py
+++ b/tests/gis_tests/geoadmin/tests.py
@@ -72,9 +72,8 @@ class GeoAdminTest(SimpleTestCase):
     def test_olwidget_empty_string(self):
         geoadmin = site._registry[City]
         form = geoadmin.get_changelist_form(None)({'point': ''})
-        with self.assertRaisesMessage(AssertionError, 'no logs'):
-            with self.assertLogs('django.contrib.gis', 'ERROR'):
-                output = str(form['point'])
+        with self.assertNoLogs('django.contrib.gis', 'ERROR'):
+            output = str(form['point'])
         self.assertInHTML(
             '<textarea id="id_point" class="vWKTField required" cols="150"'
             ' rows="10" name="point"></textarea>',

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -427,9 +427,8 @@ class GeoLookupTest(TestCase):
 
     def test_wkt_string_in_lookup(self):
         # Valid WKT strings don't emit error logs.
-        with self.assertRaisesMessage(AssertionError, 'no logs'):
-            with self.assertLogs('django.contrib.gis', 'ERROR'):
-                State.objects.filter(poly__intersects='LINESTRING(0 0, 1 1, 5 5)')
+        with self.assertNoLogs('django.contrib.gis', 'ERROR'):
+            State.objects.filter(poly__intersects='LINESTRING(0 0, 1 1, 5 5)')
 
     @skipUnlessDBFeature("supports_relate_lookup")
     def test_relate_lookup(self):

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -177,9 +177,8 @@ class MiddlewareNotUsedTests(SimpleTestCase):
         MIDDLEWARE=['middleware_exceptions.tests.MyMiddleware'],
     )
     def test_do_not_log_when_debug_is_false(self):
-        with self.assertRaisesMessage(AssertionError, 'no logs'):
-            with self.assertLogs('django.request', 'DEBUG'):
-                self.client.get('/middleware_exceptions/view/')
+        with self.assertNoLogs('django.request', 'DEBUG'):
+            self.client.get('/middleware_exceptions/view/')
 
     @override_settings(MIDDLEWARE=[
         'middleware_exceptions.middleware.SyncAndAsyncMiddleware',

--- a/tests/template_tests/test_logging.py
+++ b/tests/template_tests/test_logging.py
@@ -62,6 +62,5 @@ class VariableResolveLoggingTests(SimpleTestCase):
         )
 
     def test_no_log_when_variable_exists(self):
-        with self.assertRaisesMessage(AssertionError, 'no logs'):
-            with self.assertLogs('django.template', self.loglevel):
-                Variable('article.section').resolve({'article': {'section': 'News'}})
+        with self.assertNoLogs('django.template', self.loglevel):
+            Variable('article.section').resolve({'article': {'section': 'News'}})

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import unittest
 import warnings
@@ -26,6 +27,7 @@ from django.test.utils import (
 )
 from django.urls import NoReverseMatch, path, reverse, reverse_lazy
 from django.utils.deprecation import RemovedInDjango41Warning
+from django.utils.log import DEFAULT_LOGGING
 
 from .models import Car, Person, PossessedCar
 from .views import empty_response
@@ -1103,6 +1105,47 @@ class AssertWarnsMessageTests(SimpleTestCase):
             warnings.warn('[.*x+]y?', UserWarning)
         with self.assertWarnsMessage(UserWarning, '[.*x+]y?'):
             func1()
+
+
+# TODO: Remove when dropping support for PY39.
+class AssertNoLogsTest(SimpleTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        logging.config.dictConfig(DEFAULT_LOGGING)
+        cls.addClassCleanup(logging.config.dictConfig, settings.LOGGING)
+
+    def setUp(self):
+        self.logger = logging.getLogger('django')
+
+    @override_settings(DEBUG=True)
+    def test_fails_when_log_emitted(self):
+        msg = "Unexpected logs found: ['INFO:django:FAIL!']"
+        with self.assertRaisesMessage(AssertionError, msg):
+            with self.assertNoLogs('django', 'INFO'):
+                self.logger.info('FAIL!')
+
+    @override_settings(DEBUG=True)
+    def test_text_level(self):
+        with self.assertNoLogs('django', 'INFO'):
+            self.logger.debug('DEBUG logs are ignored.')
+
+    @override_settings(DEBUG=True)
+    def test_int_level(self):
+        with self.assertNoLogs('django', logging.INFO):
+            self.logger.debug('DEBUG logs are ignored.')
+
+    @override_settings(DEBUG=True)
+    def test_default_level(self):
+        with self.assertNoLogs('django'):
+            self.logger.debug('DEBUG logs are ignored.')
+
+    @override_settings(DEBUG=True)
+    def test_does_not_hide_other_failures(self):
+        msg = '1 != 2'
+        with self.assertRaisesMessage(AssertionError, msg):
+            with self.assertNoLogs('django'):
+                self.assertEqual(1, 2)
 
 
 class AssertFieldOutputTests(SimpleTestCase):


### PR DESCRIPTION
Clearer in intent than the existing pattern, tightens the assertion and improves the error message.

Similar to https://github.com/django/django/pull/13853.

I decided against documenting this helper, as it can be considered private API, I intend it to be mostly useful to verify the project’s own logging. I’m happy to add a bit of docs if there’s interest. Or a ticket if it is useful?