### PR TITLE
Refs #31791 -- Improved performance of URLResolver.resolve().

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -581,7 +581,7 @@ class URLResolver:
                             self._join_route(current_route, sub_match.route),
                             tried,
                         )
-                    self._extend_tried(tried, pattern)
+                    tried.append([pattern])
             raise Resolver404({'tried': tried, 'path': new_path})
         raise Resolver404({'path': path})
 


### PR DESCRIPTION
I've been making more progress on benchmarking Django over the last few weeks and I've noticed the `url_resolve()` benchmark slowed down by c.11%. See the red line [here](https://smithdc1.github.io/django-asv/#bench_urls.URLBenchmarks.time_url_resolve?python=3.9&commits=11ebc647), it highlights commit 11ebc6479ffda87376b60c9475d33d8120f86368.

I've put together a smaller [script](https://gist.github.com/smithdc1/8813702bcf2a68cc269adaf59bd86b18) for benchmarking this function and found the new `_extend_tried()` function is the main cause of this. By putting the logic into the main function I'm seeing a c.7% improvement to the current position.

I'm not sure if this needs a new ticket, I've referred to the old one for now. Also, what do you all think about this kind of thing, is this type of change worth having? 

I've marked this as WIP as I need to have a look at the tests a bit more as we don't seem to have test coverage for line 573, the tests seem to pass if the line is deleted completely. :detective: 