### PR TITLE
Refs #32018 -- Used --header-link-color for header links in admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -90,7 +90,7 @@ a img {
 }
 
 a.section:link, a.section:visited {
-    color: var(--body-bg);
+    color: var(--header-link-color);
     text-decoration: none;
 }
 

--- a/django/contrib/admin/static/admin/css/login.css
+++ b/django/contrib/admin/static/admin/css/login.css
@@ -16,7 +16,7 @@
 }
 
 .login #header h1 a {
-    color: var(--body-bg);
+    color: var(--header-link-color);
 }
 
 .login #content {

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -28,7 +28,7 @@
 
 .selector-chosen h2 {
     background: var(--primary);
-    color: var(--body-bg);
+    color: var(--header-link-color);
 }
 
 .selector .selector-available h2 {


### PR DESCRIPTION
This seems to be a mistake in https://github.com/django/django/pull/13435 that headers are using the background color. @matthiask could you please check if this makes more sense?