### PR TITLE
Fixed typo in docs/internals/contributing/writing-code/coding-style.txt

### DIFF
--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -15,7 +15,7 @@ review. By checking for these issues before code review it allows the reviewer
 to focus on the change itself, and it can also help to reduce the number CI
 runs.
 
-To use the tool, first install ``pre-commit`` and then the git hooks::
+To use the tool, first install ``pre-commit`` and then the git hooks:
 
 .. console::
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/23237214/104104724-75f1dd80-52dc-11eb-8c13-7a9ccf5e4507.png)

After:

![image](https://user-images.githubusercontent.com/23237214/104104735-7f7b4580-52dc-11eb-83b6-79c28180707f.png)
