### PR TITLE
Fixed #32324 -- Added template block to override the admin site header.

### DIFF
--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -28,6 +28,7 @@
 
     {% if not is_popup %}
     <!-- Header -->
+    {% block header %}
     <div id="header">
         <div id="branding">
         {% block branding %}{% endblock %}
@@ -59,6 +60,7 @@
         {% endblock %}
         {% block nav-global %}{% endblock %}
     </div>
+    {% endblock %}
     <!-- END Header -->
     {% block breadcrumbs %}
     <div class="breadcrumbs">

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -32,7 +32,8 @@ Minor features
 :mod:`django.contrib.admin`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The ``admin/base.html`` template now has a new block ``header`` which
+  contains the admin site header.
 
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Allowing the user to Overwrite the top nav-bar with a single block declaration in an extended admin/base.html.
Scope of Commit: admin/templates/admin/base.html.