### PR TITLE
Refs #32365 -- Allowed use of non-pytz timezone implementations.

### DIFF
--- a/django/forms/utils.py
+++ b/django/forms/utils.py
@@ -161,6 +161,11 @@ def from_current_timezone(value):
     if settings.USE_TZ and value is not None and timezone.is_naive(value):
         current_timezone = timezone.get_current_timezone()
         try:
+            if (
+                not timezone._is_pytz_zone(current_timezone) and
+                timezone._datetime_ambiguous_or_imaginary(value, current_timezone)
+            ):
+                raise ValueError('Ambiguous or non-existent time.')
             return timezone.make_aware(value, current_timezone)
         except Exception as exc:
             raise ValidationError(

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -20,7 +20,8 @@ from django.utils.dates import (
 )
 from django.utils.regex_helper import _lazy_re_compile
 from django.utils.timezone import (
-    get_default_timezone, is_aware, is_naive, make_aware,
+    _datetime_ambiguous_or_imaginary, get_default_timezone, is_aware, is_naive,
+    make_aware,
 )
 from django.utils.translation import gettext as _
 
@@ -160,15 +161,9 @@ class TimeFormat(Formatter):
         if not self.timezone:
             return ""
 
-        name = None
-        try:
+        if not _datetime_ambiguous_or_imaginary(self.data, self.timezone):
             name = self.timezone.tzname(self.data)
-        except Exception:
-            # pytz raises AmbiguousTimeError during the autumn DST change.
-            # This happens mainly when __init__ receives a naive datetime
-            # and sets self.timezone = get_default_timezone().
-            pass
-        if name is None:
+        else:
             name = self.format('O')
         return str(name)
 
@@ -184,16 +179,13 @@ class TimeFormat(Formatter):
 
         If timezone information is not available, return an empty string.
         """
-        if not self.timezone:
+        if (
+            not self.timezone or
+            _datetime_ambiguous_or_imaginary(self.data, self.timezone)
+        ):
             return ""
 
-        try:
-            offset = self.timezone.utcoffset(self.data)
-        except Exception:
-            # pytz raises AmbiguousTimeError during the autumn DST change.
-            # This happens mainly when __init__ receives a naive datetime
-            # and sets self.timezone = get_default_timezone().
-            return ""
+        offset = self.timezone.utcoffset(self.data)
 
         # `offset` is a datetime.timedelta. For negative values (to the west of
         # UTC) only days can be negative (days=-1) and seconds are always
@@ -232,16 +224,12 @@ class DateFormat(TimeFormat):
 
     def I(self):  # NOQA: E743, E741
         "'1' if Daylight Savings Time, '0' otherwise."
-        try:
-            if self.timezone and self.timezone.dst(self.data):
-                return '1'
-            else:
-                return '0'
-        except Exception:
-            # pytz raises AmbiguousTimeError during the autumn DST change.
-            # This happens mainly when __init__ receives a naive datetime
-            # and sets self.timezone = get_default_timezone().
+        if (
+            not self.timezone or
+            _datetime_ambiguous_or_imaginary(self.data, self.timezone)
+        ):
             return ''
+        return '1' if self.timezone.dst(self.data) else '0'
 
     def j(self):
         "Day of the month without leading zeros; i.e. '1' to '31'"

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -943,21 +943,24 @@ appropriate entities.
     :class:`~datetime.datetime`. If ``timezone`` is set to ``None``, it
     defaults to the :ref:`current time zone <default-current-time-zone>`.
 
-    The ``pytz.AmbiguousTimeError`` exception is raised if you try to make
-    ``value`` aware during a DST transition where the same time occurs twice
-    (when reverting from DST). Setting ``is_dst`` to ``True`` or ``False`` will
-    avoid the exception by choosing if the time is pre-transition or
-    post-transition respectively.
+    When using ``pytz``, the ``pytz.AmbiguousTimeError`` exception is raised if
+    you try to make ``value`` aware during a DST transition where the same time
+    occurs twice (when reverting from DST). Setting ``is_dst`` to ``True`` or
+    ``False`` will avoid the exception by choosing if the time is
+    pre-transition or post-transition respectively.
 
-    The ``pytz.NonExistentTimeError`` exception is raised if you try to make
-    ``value`` aware during a DST transition such that the time never occurred.
-    For example, if the 2:00 hour is skipped during a DST transition, trying to
-    make 2:30 aware in that time zone will raise an exception. To avoid that
-    you can use ``is_dst`` to specify how ``make_aware()`` should interpret
-    such a nonexistent time. If ``is_dst=True`` then the above time would be
-    interpreted as 2:30 DST time (equivalent to 1:30 local time). Conversely,
-    if ``is_dst=False`` the time would be interpreted as 2:30 standard time
-    (equivalent to 3:30 local time).
+    When using ``pytz``, the ``pytz.NonExistentTimeError`` exception is raised
+    if you try to make ``value`` aware during a DST transition such that the
+    time never occurred. For example, if the 2:00 hour is skipped during a DST
+    transition, trying to make 2:30 aware in that time zone will raise an
+    exception. To avoid that you can use ``is_dst`` to specify how
+    ``make_aware()`` should interpret such a nonexistent time. If
+    ``is_dst=True`` then the above time would be interpreted as 2:30 DST time
+    (equivalent to 1:30 local time). Conversely, if ``is_dst=False`` the time
+    would be interpreted as 2:30 standard time (equivalent to 3:30 local time).
+
+    The ``is_dst`` parameter has no effect when using non-``pytz`` timezone
+    implementations.
 
 .. function:: make_naive(value, timezone=None)
 

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -657,6 +657,9 @@ MySQL 5.7 and higher.
 Miscellaneous
 -------------
 
+* Django now supports non-``pytz`` time zones, such as Python 3.9+'s
+  :mod:`zoneinfo` module and its backport.
+
 * The undocumented ``SpatiaLiteOperations.proj4_version()`` method is renamed
   to ``proj_version()``.
 

--- a/docs/topics/i18n/timezones.txt
+++ b/docs/topics/i18n/timezones.txt
@@ -26,8 +26,15 @@ to this problem is to use UTC in the code and use local time only when
 interacting with end users.
 
 Time zone support is disabled by default. To enable it, set :setting:`USE_TZ =
-True <USE_TZ>` in your settings file. Time zone support uses pytz_, which is
-installed when you install Django.
+True <USE_TZ>` in your settings file. By default, time zone support uses pytz_,
+which is installed when you install Django; Django also supports the use of
+other time zone implementations like :mod:`zoneinfo` by passing
+:class:`~datetime.tzinfo` objects directly to functions in
+:mod:`django.utils.timezone`.
+
+.. versionchanged:: 3.2
+
+    Support for non-``pytz`` timezone implementations was added.
 
 .. note::
 
@@ -680,7 +687,8 @@ Usage
 
    pytz_ provides helpers_, including a list of current time zones and a list
    of all available time zones -- some of which are only of historical
-   interest.
+   interest. :mod:`zoneinfo` also provides similar functionality via
+   :func:`zoneinfo.available_timezones`.
 
 .. _pytz: http://pytz.sourceforge.net/
 .. _more examples: http://pytz.sourceforge.net/#example-usage

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,5 +1,6 @@
 asgiref >= 3.2.10
 argon2-cffi >= 16.1.0
+backports.zoneinfo; python_version < '3.9'
 bcrypt
 docutils
 geoip2
@@ -17,4 +18,5 @@ PyYAML
 selenium
 sqlparse >= 0.2.2
 tblib >= 1.5.0
+tzdata
 colorama; sys.platform == 'win32'

--- a/tests/utils_tests/test_timezone.py
+++ b/tests/utils_tests/test_timezone.py
@@ -1,7 +1,16 @@
 import datetime
+import unittest
 from unittest import mock
 
 import pytz
+
+try:
+    import zoneinfo
+except ImportError:
+    try:
+        from backports import zoneinfo
+    except ImportError:
+        zoneinfo = None
 
 from django.test import SimpleTestCase, override_settings
 from django.utils import timezone
@@ -9,6 +18,21 @@ from django.utils import timezone
 CET = pytz.timezone("Europe/Paris")
 EAT = timezone.get_fixed_timezone(180)      # Africa/Nairobi
 ICT = timezone.get_fixed_timezone(420)      # Asia/Bangkok
+UTC = datetime.timezone.utc
+
+HAS_ZONEINFO = zoneinfo is not None
+
+if not HAS_ZONEINFO:
+    PARIS_ZI = None
+    PARIS_IMPLS = (CET,)
+
+    needs_zoneinfo = unittest.skip("Test requires zoneinfo")
+else:
+    PARIS_ZI = zoneinfo.ZoneInfo('Europe/Paris')
+    PARIS_IMPLS = (CET, PARIS_ZI)
+
+    def needs_zoneinfo(f):
+        return f
 
 
 class TimezoneTests(SimpleTestCase):
@@ -142,13 +166,21 @@ class TimezoneTests(SimpleTestCase):
         )
 
     def test_make_aware2(self):
-        self.assertEqual(
-            timezone.make_aware(datetime.datetime(2011, 9, 1, 12, 20, 30), CET),
-            CET.localize(datetime.datetime(2011, 9, 1, 12, 20, 30)))
+        CEST = datetime.timezone(datetime.timedelta(hours=2), 'CEST')
+        for tz in PARIS_IMPLS:
+            with self.subTest(repr(tz)):
+                self.assertEqual(
+                    timezone.make_aware(datetime.datetime(2011, 9, 1, 12, 20, 30), tz),
+                    datetime.datetime(2011, 9, 1, 12, 20, 30, tzinfo=CEST))
+
         with self.assertRaises(ValueError):
             timezone.make_aware(CET.localize(datetime.datetime(2011, 9, 1, 12, 20, 30)), CET)
 
-    def test_make_aware_pytz(self):
+        if HAS_ZONEINFO:
+            with self.assertRaises(ValueError):
+                timezone.make_aware(datetime.datetime(2011, 9, 1, 12, 20, 30, tzinfo=PARIS_ZI), PARIS_ZI)
+
+    def test_make_naive_pytz(self):
         self.assertEqual(
             timezone.make_naive(CET.localize(datetime.datetime(2011, 9, 1, 12, 20, 30)), CET),
             datetime.datetime(2011, 9, 1, 12, 20, 30))
@@ -159,6 +191,18 @@ class TimezoneTests(SimpleTestCase):
             datetime.datetime(2011, 9, 1, 12, 20, 30))
         with self.assertRaisesMessage(ValueError, 'make_naive() cannot be applied to a naive datetime'):
             timezone.make_naive(datetime.datetime(2011, 9, 1, 12, 20, 30), CET)
+
+    @needs_zoneinfo
+    def test_make_naive_zoneinfo(self):
+        self.assertEqual(
+            timezone.make_naive(datetime.datetime(2011, 9, 1, 12, 20, 30, tzinfo=PARIS_ZI), PARIS_ZI),
+            datetime.datetime(2011, 9, 1, 12, 20, 30)
+        )
+
+        self.assertEqual(
+            timezone.make_naive(datetime.datetime(2011, 9, 1, 12, 20, 30, fold=1, tzinfo=PARIS_ZI), PARIS_ZI),
+            datetime.datetime(2011, 9, 1, 12, 20, 30, fold=1)
+        )
 
     def test_make_aware_pytz_ambiguous(self):
         # 2:30 happens twice, once before DST ends and once after
@@ -173,6 +217,21 @@ class TimezoneTests(SimpleTestCase):
         self.assertEqual(std.tzinfo.utcoffset(std), datetime.timedelta(hours=1))
         self.assertEqual(dst.tzinfo.utcoffset(dst), datetime.timedelta(hours=2))
 
+    @needs_zoneinfo
+    def test_make_aware_zoneinfo_ambiguous(self):
+        # 2:30 happens twice, once before DST ends and once after
+        ambiguous = datetime.datetime(2015, 10, 25, 2, 30)
+
+        std = timezone.make_aware(ambiguous.replace(fold=1), timezone=PARIS_ZI)
+        dst = timezone.make_aware(ambiguous, timezone=PARIS_ZI)
+
+        self.assertEqual(
+            std.astimezone(UTC) - dst.astimezone(UTC),
+            datetime.timedelta(hours=1)
+        )
+        self.assertEqual(std.utcoffset(), datetime.timedelta(hours=1))
+        self.assertEqual(dst.utcoffset(), datetime.timedelta(hours=2))
+
     def test_make_aware_pytz_non_existent(self):
         # 2:30 never happened due to DST
         non_existent = datetime.datetime(2015, 3, 29, 2, 30)
@@ -185,6 +244,21 @@ class TimezoneTests(SimpleTestCase):
         self.assertEqual(std - dst, datetime.timedelta(hours=1))
         self.assertEqual(std.tzinfo.utcoffset(std), datetime.timedelta(hours=1))
         self.assertEqual(dst.tzinfo.utcoffset(dst), datetime.timedelta(hours=2))
+
+    @needs_zoneinfo
+    def test_make_aware_zoneinfo_non_existent(self):
+        # 2:30 never happened due to DST
+        non_existent = datetime.datetime(2015, 3, 29, 2, 30)
+
+        std = timezone.make_aware(non_existent, PARIS_ZI)
+        dst = timezone.make_aware(non_existent.replace(fold=1), PARIS_ZI)
+
+        self.assertEqual(
+            std.astimezone(UTC) - dst.astimezone(UTC),
+            datetime.timedelta(hours=1)
+        )
+        self.assertEqual(std.utcoffset(), datetime.timedelta(hours=1))
+        self.assertEqual(dst.utcoffset(), datetime.timedelta(hours=2))
 
     def test_get_default_timezone(self):
         self.assertEqual(timezone.get_default_timezone_name(), 'America/Chicago')


### PR DESCRIPTION
The current plan for switching Django over to use the `zoneinfo` module is a hard switch in Django 4.0, but in the meantime it would be prudent to make it at least _possible_ to use `zoneinfo` with Django. I am not sure if this will be a perfectly smooth experience for the end user, but I've added `zoneinfo`-based tests alongside (nearly) all `pytz`-based tests that I could find, then fixed any resulting errors.

I know the deadline is very tight on this so I did not try to get too fancy with any formatting or the structures here so that we could get the review process started as soon as possible.

If this approach is acceptable, I think I still also need to add a few tests to:

- [x] `tests/admin_widgets`: unnecessary — `pytz` is not used for anything consequential
- [x]  `tests/admin_views`: done
- [x] `tests/db_functions/test_extract_trunc` (truncating with ambiguous and imaginary times — this may need a logic change as well).

CC: @carltongibson @adamchainz