### PR TITLE
Improved performance of forms.widgets.Media.merge()

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -11,7 +11,6 @@ from itertools import chain
 from django.forms.utils import to_current_timezone
 from django.templatetags.static import static
 from django.utils import datetime_safe, formats
-from django.utils.datastructures import OrderedSet
 from django.utils.dates import MONTHS
 from django.utils.formats import get_format
 from django.utils.html import format_html, html_safe
@@ -122,18 +121,19 @@ class Media:
         global or in CSS you might want to override a style.
         """
         dependency_graph = defaultdict(set)
-        all_items = OrderedSet()
+        all_items = []
         for list_ in filter(None, lists):
             head = list_[0]
             # The first items depend on nothing but have to be part of the
             # dependency graph to be included in the result.
             dependency_graph.setdefault(head, set())
             for item in list_:
-                all_items.add(item)
+                all_items.append(item)
                 # No self dependencies
                 if head != item:
                     dependency_graph[item].add(head)
                 head = item
+        all_items = list(dict.fromkeys(all_items))
         try:
             return stable_topological_sort(all_items, dependency_graph)
         except CyclicDependencyError:


### PR DESCRIPTION
As highlighted in https://github.com/django/django/pull/13874 `OrderedSet` can be a little "slow". Now that we can rely on dictionaries to be ordered the quickest way to get an ordered list of unique items is `list(dict.fromkeys(iterable))`. 

While `OrderedSet` is not used that much in Django's codebase, one example is in widget `Media`. My [benchmark](https://gist.github.com/smithdc1/f05610c6c28954e88c345d67e793405c) shows this patch is 13% quicker than the current `OrderedSet` approach. 

@felixxm -- Does this change need a ticket? -- I'd like to review the other uses for `OrderedSet` but to review them properly and to write benchmarks will take time. I'm also conscious of the upcoming feature freeze -- so there's an option of considering this as a standalone change, or we could wait for a more comprehensive review.