### PR TITLE
Fixed #32350 -- Fixed showmigrations crash for applied squashed migrations.

### DIFF
--- a/django/core/management/commands/showmigrations.py
+++ b/django/core/management/commands/showmigrations.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
                         # Mark it as applied/unapplied
                         if applied_migration:
                             output = ' [X] %s' % title
-                            if self.verbosity >= 2:
+                            if self.verbosity >= 2 and hasattr(applied_migration, 'applied'):
                                 output += ' (applied at %s)' % applied_migration.applied.strftime('%Y-%m-%d %H:%M:%S')
                             self.stdout.write(output)
                         else:

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -335,6 +335,44 @@ class MigrateTests(MigrationTestBase):
         # Cleanup by unmigrating everything
         call_command("migrate", "migrations", "zero", verbosity=0)
 
+    @override_settings(MIGRATION_MODULES={'migrations': 'migrations.test_migrations_squashed'})
+    def test_showmigrations_list_squashed(self):
+        out = io.StringIO()
+        call_command('showmigrations', format='list', stdout=out, verbosity=2, no_color=True)
+        self.assertEqual(
+            'migrations\n'
+            ' [ ] 0001_squashed_0002 (2 squashed migrations)\n',
+            out.getvalue().lower(),
+        )
+        out = io.StringIO()
+        call_command(
+            'migrate',
+            'migrations',
+            '0001_squashed_0002',
+            stdout=out,
+            verbosity=2,
+            no_color=True,
+        )
+        try:
+            self.assertIn(
+                'operations to perform:\n'
+                '  target specific migration: 0001_squashed_0002, from migrations\n'
+                'running pre-migrate handlers for application migrations\n'
+                'running migrations:\n'
+                '  applying migrations.0001_squashed_0002... ok (',
+                out.getvalue().lower(),
+            )
+            out = io.StringIO()
+            call_command('showmigrations', format='list', stdout=out, verbosity=2, no_color=True)
+            self.assertEqual(
+                'migrations\n'
+                ' [x] 0001_squashed_0002 (2 squashed migrations)\n',
+                out.getvalue().lower(),
+            )
+        finally:
+            # Unmigrate everything.
+            call_command('migrate', 'migrations', 'zero', verbosity=0)
+
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations_run_before"})
     def test_showmigrations_plan(self):
         """


### PR DESCRIPTION
[https://code.djangoproject.com/ticket/32350#ticket](https://code.djangoproject.com/ticket/32350#ticket)

Some migrations don't have an applied timestamp, this pull requests ensures a check takes place before attempting to show it.