### PR TITLE
Refs #31259 -- Changed the background color of messages in dark mode

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -76,6 +76,11 @@
     --hairline-color: #272727;
     --border-color: #353535;
 
+    --error-fg: #e35f5f;
+    --message-success-bg: #006b1b;
+    --message-warning-bg: #583305;
+    --message-error-bg: #570808;
+
     --darkened-bg: #212121;
     --selected-bg: #1b1b1b;
     --selected-row: #00363a;

--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -91,7 +91,7 @@
 
 #nav-sidebar .current-app .section:link,
 #nav-sidebar .current-app .section:visited {
-    color: var(--selected-row);
+    color: var(--header-color);
     font-weight: bold;
 }
 


### PR DESCRIPTION
I played around with the current `master` version and the dark mode by @mimi89999 and noticed that messages seem to be quite unreadable (I really hope I didn't fuck up again and run with outdated and/or locally overwritten CSS):

![image](https://user-images.githubusercontent.com/2627/104566482-f05c8d80-564d-11eb-865b-68fae482c1a2.png)

This pull request changes background colors. I have very bad taste (tm) when it comes to choosing colors, so help would be appreciated very much here. Edits are enabled. 