### PR TITLE
Fixed #32371 -- Doc'd jquery.init.js dependency for admin widgets.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2218,7 +2218,10 @@ Django admin JavaScript makes use of the `jQuery`_ library.
 To avoid conflicts with user-supplied scripts or libraries, Django's jQuery
 (version 3.5.1) is namespaced as ``django.jQuery``. If you want to use jQuery
 in your own admin JavaScript without including a second copy, you can use the
-``django.jQuery`` object on changelist and add/edit views.
+``django.jQuery`` object on changelist and add/edit views. Also, your own admin
+forms or widgets depending on ``django.jQuery`` must specify
+``js=['admin/js/jquery.init.js', …]`` when :ref:`declaring form media assets
+<assets-as-a-static-definition>`.
 
 The :class:`ModelAdmin` class requires jQuery by default, so there is no need
 to add jQuery to your ``ModelAdmin``’s list of media resources unless you have


### PR DESCRIPTION
Until now this was only documented in the 2.2 release notes. See https://github.com/django/django/commit/418263c4576

I think it's worth it documenting this so people can rely on this.