### PR TITLE
Improved performance of db.models.options.Options.get_parent_list()

### DIFF
--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -9,7 +9,7 @@ from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db import connections
 from django.db.models import AutoField, Manager, OrderWrt, UniqueConstraint
 from django.db.models.query_utils import PathInfo
-from django.utils.datastructures import ImmutableList, OrderedSet
+from django.utils.datastructures import ImmutableList
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 from django.utils.text import camel_case_to_spaces, format_lazy
@@ -631,11 +631,11 @@ class Options:
         Return all the ancestors of this model as a list ordered by MRO.
         Useful for determining if something is an ancestor, regardless of lineage.
         """
-        result = OrderedSet(self.parents)
+        result = list(self.parents)
         for parent in self.parents:
             for ancestor in parent._meta.get_parent_list():
-                result.add(ancestor)
-        return list(result)
+                result.append(ancestor)
+        return list(dict.fromkeys(result))
 
     def get_ancestor_link(self, ancestor):
         """


### PR DESCRIPTION
A similar change to #13878. My current thinking that each of these needs to review on its own merits, and therefore opened a separate PR. Happy to combine or open tickets, let me know. 

A focused benchmark script is [here](https://gist.github.com/smithdc1/fc8861434840f9a9e65a1a6e358df2e6) and I'm seeing a c.2.3x improvement. 

**Before**
```get_parent_list: Mean +- std dev: 275 us +- 5 us```

**After**
```get_parent_list: Mean +- std dev: 119 us +- 3 us```