### PR TITLE
Fixed #18549 -- Fixed heading for inlines with a OneToOneField.

### DIFF
--- a/django/contrib/admin/templates/admin/edit_inline/stacked.html
+++ b/django/contrib/admin/templates/admin/edit_inline/stacked.html
@@ -4,7 +4,11 @@
      data-inline-type="stacked"
      data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
 <fieldset class="module {{ inline_admin_formset.classes }}">
-  <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
+  {% if inline_admin_formset.formset.max_num == 1 %}
+    <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
+  {% else %}
+    <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
+  {% endif %}
 {{ inline_admin_formset.formset.management_form }}
 {{ inline_admin_formset.formset.non_form_errors }}
 

--- a/django/contrib/admin/templates/admin/edit_inline/tabular.html
+++ b/django/contrib/admin/templates/admin/edit_inline/tabular.html
@@ -5,7 +5,11 @@
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
 {{ inline_admin_formset.formset.management_form }}
 <fieldset class="module {{ inline_admin_formset.classes }}">
-   <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
+   {% if inline_admin_formset.formset.max_num == 1 %}
+     <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
+   {% else %}
+     <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
+   {% endif %}
    {{ inline_admin_formset.formset.non_form_errors }}
    <table>
      <thead><tr>

--- a/tests/admin_inlines/admin.py
+++ b/tests/admin_inlines/admin.py
@@ -9,8 +9,8 @@ from .models import (
     Holder, Holder2, Holder3, Holder4, Holder5, Inner, Inner2, Inner3,
     Inner4Stacked, Inner4Tabular, Inner5Stacked, Inner5Tabular, NonAutoPKBook,
     NonAutoPKBookChild, Novel, NovelReadonlyChapter, OutfitItem,
-    ParentModelWithCustomPk, Poll, Profile, ProfileCollection, Question,
-    ReadOnlyInline, ShoppingWeakness, Sighting, SomeChildModel,
+    ParentModelWithCustomPk, Person, Poll, Profile, ProfileCollection,
+    Question, ReadOnlyInline, ShoppingWeakness, Sighting, SomeChildModel,
     SomeParentModel, SottoCapo, Teacher, Title, TitleCollection,
 )
 
@@ -292,6 +292,14 @@ class TeacherAdmin(admin.ModelAdmin):
     inlines = [StudentInline]
 
 
+class AuthorTabularInline(admin.TabularInline):
+    model = Author
+
+
+class FashonistaStackedInline(admin.StackedInline):
+    model = Fashionista
+
+
 site.register(TitleCollection, inlines=[TitleInline])
 # Test bug #12561 and #12778
 # only ModelAdmin media
@@ -318,3 +326,4 @@ site.register([Question, Inner4Stacked, Inner4Tabular])
 site.register(Teacher, TeacherAdmin)
 site.register(Chapter, inlines=[FootNoteNonEditableInlineCustomForm])
 site.register(OutfitItem, inlines=[WeaknessInlineCustomForm])
+site.register(Person, inlines=[AuthorTabularInline, FashonistaStackedInline])

--- a/tests/admin_inlines/models.py
+++ b/tests/admin_inlines/models.py
@@ -44,6 +44,7 @@ class Book(models.Model):
 class Author(models.Model):
     name = models.CharField(max_length=50)
     books = models.ManyToManyField(Book)
+    person = models.OneToOneField('Person', models.CASCADE, null=True)
 
 
 class NonAutoPKBook(models.Model):

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -480,6 +480,11 @@ class TestInline(TestDataMixin, TestCase):
             html=True
         )
 
+    def test_inlines_plural_heading_foreign_key(self):
+        response = self.client.get(reverse('admin:admin_inlines_holder4_add'))
+        self.assertContains(response, '<h2>Inner4 stackeds</h2>', html=True)
+        self.assertContains(response, '<h2>Inner4 tabulars</h2>', html=True)
+
 
 @override_settings(ROOT_URLCONF='admin_inlines.urls')
 class TestInlineMedia(TestDataMixin, TestCase):

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -485,6 +485,11 @@ class TestInline(TestDataMixin, TestCase):
         self.assertContains(response, '<h2>Inner4 stackeds</h2>', html=True)
         self.assertContains(response, '<h2>Inner4 tabulars</h2>', html=True)
 
+    def test_inlines_singular_heading_one_to_one(self):
+        response = self.client.get(reverse('admin:admin_inlines_person_add'))
+        self.assertContains(response, '<h2>Author</h2>', html=True)  # Tabular.
+        self.assertContains(response, '<h2>Fashionista</h2>', html=True)  # Stacked.
+
 
 @override_settings(ROOT_URLCONF='admin_inlines.urls')
 class TestInlineMedia(TestDataMixin, TestCase):


### PR DESCRIPTION
Currently, the admin app uses `verbose_name_plural` for all inlines. It makes more sense to use `verbose_name` for `OneToOneField`s:

https://code.djangoproject.com/ticket/18549