### PR TITLE
Improved performance of DecimalField

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -343,9 +343,8 @@ class DecimalField(IntegerField):
             return None
         if self.localize:
             value = formats.sanitize_separators(value)
-        value = str(value).strip()
         try:
-            value = Decimal(value)
+            value = Decimal(str(value))
         except DecimalException:
             raise ValidationError(self.error_messages['invalid'], code='invalid')
         return value


### PR DESCRIPTION
Decimal() strips the input value therefore duplicate call can be removed. 

Here's a small demo showing that `Decimal` strips whitespace. 

```
In [2]: from decimal import *

In [3]: Decimal(' 2.2 ')
Out[3]: Decimal('2.2')

In [4]: Decimal(' 2.2 \n')
Out[4]: Decimal('2.2')
```

The benchmark I've put together for this one isn't _that_ targetted as it is based upon cleaning an input value. However, I think a 3% improvement on calling `clean()` is still beneficial. Benchmark script is [here](https://gist.github.com/smithdc1/4fb47038a8d34f14764c58e98b213e61).

There are existing tests here that test inputs with spaces (various combinations) are correctly cleaned. 

https://github.com/django/django/blob/e0a46367df8b17905f1c78f5c86f88d21c0f2b4d/tests/forms_tests/field_tests/test_decimalfield.py#L26
