### PR TITLE
Fixed #32265, Refs #32355 -- Removed unnecessary ServerHandler.handle_error().

### DIFF
--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -117,11 +117,6 @@ class ServerHandler(simple_server.ServerHandler):
         self.get_stdin()._read_limited()
         super().close()
 
-    def handle_error(self):
-        # Ignore broken pipe errors, otherwise pass on
-        if not is_broken_pipe_error():
-            super().handle_error()
-
 
 class WSGIRequestHandler(simple_server.WSGIRequestHandler):
     protocol_version = 'HTTP/1.1'


### PR DESCRIPTION
`ConnectionAbortedError`, `BrokenPipeError`, `ConnectionResetError` raised from `SocketServer.BaseServer.finish_request()` are already suppressed by `wsgiref.handlers.BaseHandler.run()` in Python 3.7+, see https://github.com/python/cpython/commit/47ffc1a9f6fab1c17cdcc325d4af066317369ed7.

ticket-32265