### PR TITLE
Removed unnecessary empty dict creation in ChoiceWidget.create_option().

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -620,8 +620,6 @@ class ChoiceWidget(Widget):
 
     def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
         index = str(index) if subindex is None else "%s_%s" % (index, subindex)
-        if attrs is None:
-            attrs = {}
         option_attrs = self.build_attrs(self.attrs, attrs) if self.option_inherits_attrs else {}
         if selected:
             option_attrs.update(self.checked_attribute)


### PR DESCRIPTION
build_atttrs() already creates an empty dict if extra_attrs is None

We could go further here as we could avoid the function call, see mockup below. But in the benchmark that I'm currently running, I can't see the impact of this as other things are much more material and we start to impact readability here? 
``` python
- option_attrs = self.build_attrs(self.attrs, attrs) if self.option_inherits_attrs else {}
+ option_attrs = {**self.attrs, **(attrs or {})}) if self.option_inherits_attrs else {}
```
When Python 3.9 is the minimum supported version we can use dict unions... 
``` python
option_attrs = self.attrs | (attrs or {}) if self.option_inherits_attrs else {}
```