### PR TITLE
opimize utils.text.capfirst function

### DIFF
--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -12,7 +12,7 @@ from django.utils.translation import gettext as _, gettext_lazy, pgettext
 @keep_lazy_text
 def capfirst(x):
     """Capitalize the first letter of a string."""
-    return x and str(x)[0].upper() + str(x)[1:]
+    return x and str(x).capitalize()
 
 
 # Set up regular expressions


### PR DESCRIPTION
Simple test:
```python
In [2]: x = "abcdefgdhijklmnopqrstuwxxyz"

In [3]: %timeit str(x).capitalize()
358 ns ± 10.2 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [4]: %timeit str(x).capitalize()
349 ns ± 4.84 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [5]: %timeit str(x)[0].upper() + str(x)[1:]
433 ns ± 21.8 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [6]: %timeit str(x)[0].upper() + str(x)[1:]
456 ns ± 48.4 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

It's more import that I think using `str.capitalize()` is probably pythonic.