### PR TITLE
Optimized django.utils.text.capfirst().

### DIFF
--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -12,7 +12,11 @@ from django.utils.translation import gettext as _, gettext_lazy, pgettext
 @keep_lazy_text
 def capfirst(x):
     """Capitalize the first letter of a string."""
-    return x and str(x)[0].upper() + str(x)[1:]
+    if not x:
+        return x
+    if not isinstance(x, str):
+        x = str(x)
+    return x[0].upper() + x[1:]
 
 
 # Set up regular expressions


### PR DESCRIPTION
Alternative to #13905. Unconditionally coercing to `str` type twice is expensive.

```
$ python bench_capfirst.py 
.....................
Capfirst (Old): Mean +- std dev: 372 ns +- 18 ns
.....................
Capfirst (New): Mean +- std dev: 274 ns +- 15 ns
```

<details>
<summary>Benchmark Script (bench_capfirst.py)</summary>

```python
import pyperf


# Original django.utils.text.capfirst() without @keep_lazy_text decorator.
def capfirst_old(x):
    return x and str(x)[0].upper() + str(x)[1:]


def capfirst_new(x):
    if not x:
        return x
    if not isinstance(x, str):
        x = str(x)
    return x[0].upper() + x[1:]


def test(loops, capfirst):
    range_it = range(loops)
    t0 = pyperf.perf_counter()

    for loop in range_it:
        capfirst('abcdefghijklmnopqrstuvwxyz')
        capfirst('ABCDEFGHIJKLMNOPQRSTUVWXYZ')
        capfirst('0123456789')
        capfirst('')
        capfirst(None)
        capfirst(123456789)

    return pyperf.perf_counter() - t0


runner = pyperf.Runner()
runner.bench_time_func('Capfirst (Old)', test, capfirst_old, inner_loops=6)
runner.bench_time_func('Capfirst (New)', test, capfirst_new, inner_loops=6)
```

</details>

----

As an aside, would it make sense for `django.template.defaultfilters.capfirst()` to use `django.utils.text.capfirst()`?
This would enable it to handle non-string values more gracefully.
Also, do we want to avoid doing `str(b'abc')` which results in `"b'abc'"`?