### PR TITLE
Removed unreachable SystemExit check.

### DIFF
--- a/django/core/handlers/exception.py
+++ b/django/core/handlers/exception.py
@@ -105,10 +105,6 @@ def response_for_exception(request, exc):
         else:
             response = get_exception_response(request, get_resolver(get_urlconf()), 400, exc)
 
-    elif isinstance(exc, SystemExit):
-        # Allow sys.exit() to actually exit. See tickets #1023 and #4701
-        raise
-
     else:
         signals.got_request_exception.send(sender=None, request=request)
         response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())


### PR DESCRIPTION
This check dates back to Python <2.5, before Python introduced `BaseException` to prevent exactly unwarranted catching of `SystemExit` (and others).

`response_for_exception()` is only called under `except Exception` or `except Http404` so it's now impossible for a `SystemExit` instance to reach the branch.