### PR TITLE
Add block "end_of_body" for JS includes

### DIFF
--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -100,5 +100,6 @@
     </div>
 </div>
 <!-- END Container -->
+{% block end_of_body %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
It is a common pattern to add JS at the end of the body. See [bootstrap starter template](https://getbootstrap.com/docs/5.0/getting-started/introduction/#starter-template)

The `end_of_body` enables you to add HTML before the closing `</body>` tag.