### PR TITLE
Improved performance of django.forms.ChoiceWidget.optgroups()

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -606,8 +606,8 @@ class ChoiceWidget(Widget):
 
             for subvalue, sublabel in choices:
                 selected = (
-                    str(subvalue) in value and
-                    (not has_selected or self.allow_multiple_selected)
+                    (not has_selected or self.allow_multiple_selected) and
+                    str(subvalue) in value
                 )
                 has_selected |= selected
                 subgroup.append(self.create_option(


### PR DESCRIPTION
I was looking at SelectDateWidget as I thought I spotted an ideal candidate for a list comprehension. When I looked into it I found that the slowest part of this benchmark is creating all of the options, so I investigated this instead.

I found two items that could help here. The first is re-ordering the select logic, the `str` and `in` are more expensive than an attribute lookup. 

The second change is to "cache" the `create_option` function (I'm not sure what the correct way of describing this is). I'm less sure about this change, but it _does_ have a sizeable impact so I've suggested it. 

The only other thing I considered here was also "caching" `self.allow_multiple_selected` as it _should_ be quicker to store that as a local variable. However, I can't detect the impact of this change, so it's not proposed here. 

Finally, this list is _quite_ long and so performance gains are larger as there are more loops. I tested with a shorter, simpler widget and I couldn't detect any impact of this change. Therefore I think it benefits larger option lists and doesn't detriment smaller ones.

Start
`SelectDateWidget: Mean +- std dev: 4.50 ms +- 0.14 ms`

re-order logic (4%)
`SelectDateWidget: Mean +- std dev: 4.31 ms +- 0.19 ms`

_cache_ create_option (a further 4%; 8% total)
`SelectDateWidget: Mean +- std dev: 4.13 ms +- 0.11 ms`


<details>
<summary>bench_selectdatewidget.py</summary>
<p>

``` python
from django.conf.global_settings import INSTALLED_APPS
import django
from django.conf import settings
from django.forms.widgets import SelectDateWidget
import pyperf

settings.configure(INSTALLED_APPS= ('__main__',))
django.setup()


def test(loops):
    range_it = range(loops)
    widget = SelectDateWidget(years=(2020,))
    t0 = pyperf.perf_counter()

    # repeat to reduce impact of for loop
    for loop in range_it:
        widget.get_context('widget', "2020-10-10", {})
        widget.get_context('widget', "2020-10-10", {})
        widget.get_context('widget', "2020-10-10", {})
        widget.get_context('widget', "2020-10-10", {})
        widget.get_context('widget', "2020-10-10", {})
        widget.get_context('widget', "2020-10-10", {})
        widget.get_context('widget', "2020-10-10", {})
        widget.get_context('widget', "2020-10-10", {})
        widget.get_context('widget', "2020-10-10", {})
        widget.get_context('widget', "2020-10-10", {})

    return pyperf.perf_counter() - t0

runner = pyperf.Runner()
runner.bench_time_func('SelectDateWidget', test)

```

</p>
</details>  