### PR TITLE
Fixed #32366 -- Updated datetime module usage to recommended approach. 

### DIFF
--- a/django/utils/feedgenerator.py
+++ b/django/utils/feedgenerator.py
@@ -172,8 +172,7 @@ class SyndicationFeed:
                     if latest_date is None or item_date > latest_date:
                         latest_date = item_date
 
-        # datetime.now(tz=utc) is slower, as documented in django.utils.timezone.now
-        return latest_date or datetime.datetime.utcnow().replace(tzinfo=utc)
+        return latest_date or datetime.datetime.now(utc)
 
 
 class Enclosure:

--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -190,8 +190,7 @@ def now():
     Return an aware or naive datetime.datetime, depending on settings.USE_TZ.
     """
     if settings.USE_TZ:
-        # timeit shows that datetime.now(tz=utc) is 24% slower
-        return datetime.utcnow().replace(tzinfo=utc)
+        return datetime.now(utc)
     else:
         return datetime.now()
 


### PR DESCRIPTION
Using .now() is the modern recommended approach.
https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

More depth here:
https://blog.ganssle.io/articles/2019/11/utcnow.html

Extracted from #13877