### PR TITLE
use the same absolute_max value in error message

### DIFF
--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -150,7 +150,7 @@ protects against memory exhaustion attacks using forged ``POST`` requests::
     >>> formset.is_valid()
     False
     >>> formset.non_form_errors()
-    ['Please submit at most 1000 forms.']
+    ['Please submit at most 1500 forms.']
 
 When ``absolute_max`` is ``None``, it defaults to ``max_num + 1000``. (If
 ``max_num`` is ``None``, it defaults to ``2000``).


### PR DESCRIPTION
The ArticleFormSet uses `absolute_max=1500`. It would be nice to use the same value in the error example