### PR TITLE
Fixed isolation of utils_tests.test_autoreload tests.

### DIFF
--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -86,8 +86,11 @@ class TestIterModulesAndFiles(SimpleTestCase):
         filename.write_text("Ceci n'est pas du Python.")
 
         with extend_sys_path(str(filename.parent)):
-            with self.assertRaises(SyntaxError):
-                autoreload.check_errors(import_module)('test_syntax_error')
+            try:
+                with self.assertRaises(SyntaxError):
+                    autoreload.check_errors(import_module)('test_syntax_error')
+            finally:
+                autoreload._exception = None
         self.assertFileFound(filename)
 
     def test_check_errors_catches_all_exceptions(self):
@@ -370,8 +373,11 @@ class TestCheckErrors(SimpleTestCase):
         fake_method = mock.MagicMock(side_effect=RuntimeError())
         wrapped = autoreload.check_errors(fake_method)
         with mock.patch.object(autoreload, '_error_files') as mocked_error_files:
-            with self.assertRaises(RuntimeError):
-                wrapped()
+            try:
+                with self.assertRaises(RuntimeError):
+                    wrapped()
+            finally:
+                autoreload._exception = None
         self.assertEqual(mocked_error_files.append.call_count, 1)
 
 


### PR DESCRIPTION
See [logs](https://djangoci.com/job/master-reverse/95/).

Follow up to e8b4f23115237047c907fca4565020f30ad35a7c.