### PR TITLE
Fixed #32360 -- Added system check for FILE_UPLOAD_TEMP_DIR setting.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -897,6 +897,7 @@ answer newbie questions, and generally made Django that much better:
     Tim Givois <tim.givois.mendez@gmail.com>
     Tim Graham <timograham@gmail.com>
     Tim Heap <tim@timheap.me>
+    Tim McCurrach <tim.mccurrach@gmail.com>
     Tim Saylor <tim.saylor@gmail.com>
     Tobias Kunze <rixx@cutebit.de>
     Tobias McNulty <https://www.caktusgroup.com/blog/>

--- a/django/core/checks/__init__.py
+++ b/django/core/checks/__init__.py
@@ -8,6 +8,7 @@ from .registry import Tags, register, run_checks, tag_exists
 import django.core.checks.async_checks  # NOQA isort:skip
 import django.core.checks.caches  # NOQA isort:skip
 import django.core.checks.database  # NOQA isort:skip
+import django.core.checks.files  # NOQA isort:skip
 import django.core.checks.model_checks  # NOQA isort:skip
 import django.core.checks.security.base  # NOQA isort:skip
 import django.core.checks.security.csrf  # NOQA isort:skip

--- a/django/core/checks/files.py
+++ b/django/core/checks/files.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from django.conf import settings
+
+from . import Error, Tags, register
+
+
+@register(Tags.files)
+def check_setting_file_upload_temp_dir(app_configs, **kwargs):
+    setting = getattr(settings, 'FILE_UPLOAD_TEMP_DIR', None)
+    if setting and not Path(setting).is_dir():
+        return [
+            Error(
+                f"The FILE_UPLOAD_TEMP_DIR setting refers to the nonexistent "
+                f"directory '{setting}'.",
+                id="files.E001",
+            ),
+        ]
+    return []

--- a/django/core/checks/registry.py
+++ b/django/core/checks/registry.py
@@ -13,6 +13,7 @@ class Tags:
     caches = 'caches'
     compatibility = 'compatibility'
     database = 'database'
+    files = 'files'
     models = 'models'
     security = 'security'
     signals = 'signals'

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -82,6 +82,7 @@ Django's system checks are organized using the following tags:
   regular checks do. They are only run by the :djadmin:`migrate` command or if
   you specify configured database aliases using the ``--database`` option when
   calling the :djadmin:`check` command.
+* ``files``: Checks files related configuration.
 * ``models``: Checks of model, field, and manager definitions.
 * ``security``: Checks security related configuration.
 * ``signals``: Checks on signal declarations and handler registrations.
@@ -96,6 +97,10 @@ Some checks may be registered with multiple tags.
 .. versionchanged:: 3.2
 
     The ``sites`` tag was added.
+
+.. versionchanged:: 4.0
+
+    The ``files`` tag was added.
 
 Core system checks
 ==================
@@ -149,6 +154,16 @@ If you're using MySQL or MariaDB, the following checks will be performed:
   ``<alias>``. See also :ref:`mysql-sql-mode`.
 * **mysql.W003**: MySQL/MariaDB may not allow unique ``CharField``\s to have a
   ``max_length`` > 255.
+
+Managing files
+--------------
+
+.. versionadded:: 4.0
+
+The following checks verify your setup for :doc:`/topics/files`:
+
+* **files.E001**: The :setting:`FILE_UPLOAD_TEMP_DIR` setting refers to the
+  nonexistent directory ``<path>``.
 
 Model fields
 ------------

--- a/tests/check_framework/test_files.py
+++ b/tests/check_framework/test_files.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from django.core.checks import Error
+from django.core.checks.files import check_setting_file_upload_temp_dir
+from django.test import SimpleTestCase
+
+
+class FilesCheckTests(SimpleTestCase):
+    def test_file_upload_temp_dir(self):
+        tests = [
+            None,
+            '',
+            Path.cwd(),
+            str(Path.cwd()),
+        ]
+        for setting in tests:
+            with self.subTest(setting), self.settings(FILE_UPLOAD_TEMP_DIR=setting):
+                self.assertEqual(check_setting_file_upload_temp_dir(None), [])
+
+    def test_file_upload_temp_dir_nonexistent(self):
+        for setting in ['nonexistent', Path('nonexistent')]:
+            with self.subTest(setting), self.settings(FILE_UPLOAD_TEMP_DIR=setting):
+                self.assertEqual(
+                    check_setting_file_upload_temp_dir(None),
+                    [
+                        Error(
+                            "The FILE_UPLOAD_TEMP_DIR setting refers to the "
+                            "nonexistent directory 'nonexistent'.",
+                            id='files.E001',
+                        ),
+                    ],
+                )


### PR DESCRIPTION
Added a check that the directory specified by `FILE_UPLOAD_TEMP_DIR` actually exists. It can cause problems otherwise.

See https://code.djangoproject.com/ticket/32360