### PR TITLE
Fixed #32374 -- Stopped recording migration application before deferred SQL.

### DIFF
--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -225,8 +225,9 @@ class MigrationExecutor:
                 # Alright, do it normally
                 with self.connection.schema_editor(atomic=migration.atomic) as schema_editor:
                     state = migration.apply(state, schema_editor)
-                    self.record_migration(migration)
-                    migration_recorded = True
+                    if not schema_editor.deferred_sql:
+                        self.record_migration(migration)
+                        migration_recorded = True
         if not migration_recorded:
             self.record_migration(migration)
         # Report progress

--- a/tests/migrations/test_executor.py
+++ b/tests/migrations/test_executor.py
@@ -684,6 +684,33 @@ class ExecutorTests(MigrationTestBase):
         )
         self.assertTableNotExists('record_migration_model')
 
+    def test_migrations_not_applied_on_deferred_sql_failure(self):
+        """Migrations are not recorded if deferred SQL application fails."""
+        class DeferredSQL:
+            def __str__(self):
+                raise DatabaseError('Failed to apply deferred SQL')
+
+        class Migration(migrations.Migration):
+            atomic = False
+
+            def apply(self, project_state, schema_editor, collect_sql=False):
+                schema_editor.deferred_sql.append(DeferredSQL())
+
+        executor = MigrationExecutor(connection)
+        with self.assertRaisesMessage(DatabaseError, 'Failed to apply deferred SQL'):
+            executor.apply_migration(
+                ProjectState(),
+                Migration('0001_initial', 'deferred_sql'),
+            )
+        # The migration isn't recorded as applied since it failed.
+        migration_recorder = MigrationRecorder(connection)
+        self.assertIs(
+            migration_recorder.migration_qs.filter(
+                app='deferred_sql', name='0001_initial',
+            ).exists(),
+            False,
+        )
+
 
 class FakeLoader:
     def __init__(self, graph, applied):

--- a/tests/migrations/test_executor.py
+++ b/tests/migrations/test_executor.py
@@ -1,11 +1,12 @@
 from unittest import mock
 
 from django.apps.registry import apps as global_apps
-from django.db import DatabaseError, connection
+from django.db import DatabaseError, connection, migrations, models
 from django.db.migrations.exceptions import InvalidMigrationPlan
 from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.graph import MigrationGraph
 from django.db.migrations.recorder import MigrationRecorder
+from django.db.migrations.state import ProjectState
 from django.test import (
     SimpleTestCase, modify_settings, override_settings, skipUnlessDBFeature,
 )
@@ -655,18 +656,33 @@ class ExecutorTests(MigrationTestBase):
     # When the feature is False, the operation and the record won't be
     # performed in a transaction and the test will systematically pass.
     @skipUnlessDBFeature('can_rollback_ddl')
-    @override_settings(MIGRATION_MODULES={'migrations': 'migrations.test_migrations'})
     def test_migrations_applied_and_recorded_atomically(self):
         """Migrations are applied and recorded atomically."""
+        class Migration(migrations.Migration):
+            operations = [
+                migrations.CreateModel('model', [
+                    ('id', models.AutoField(primary_key=True)),
+                ]),
+            ]
+
         executor = MigrationExecutor(connection)
         with mock.patch('django.db.migrations.executor.MigrationExecutor.record_migration') as record_migration:
             record_migration.side_effect = RuntimeError('Recording migration failed.')
             with self.assertRaisesMessage(RuntimeError, 'Recording migration failed.'):
+                executor.apply_migration(
+                    ProjectState(),
+                    Migration('0001_initial', 'record_migration'),
+                )
                 executor.migrate([('migrations', '0001_initial')])
         # The migration isn't recorded as applied since it failed.
         migration_recorder = MigrationRecorder(connection)
-        self.assertFalse(migration_recorder.migration_qs.filter(app='migrations', name='0001_initial').exists())
-        self.assertTableNotExists('migrations_author')
+        self.assertIs(
+            migration_recorder.migration_qs.filter(
+                app='record_migration', name='0001_initial',
+            ).exists(),
+            False,
+        )
+        self.assertTableNotExists('record_migration_model')
 
 
 class FakeLoader:


### PR DESCRIPTION
Migrations cannot be recorded in the same transaction as its associated DDL operations when some of it is deferred until the schema editor context exits.

Refs ticket-29721 (#10537)