### PR TITLE
Refs #26167 -- Corrected OpClass() example in docs.

### DIFF
--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -190,7 +190,10 @@ available from the ``django.contrib.postgres.indexes`` module.
 
     For example::
 
-        Index(OpClass(Lower('username'), name='varchar_pattern_ops'))
+        Index(
+            OpClass(Lower('username'), name='varchar_pattern_ops'),
+            name='lower_username_idx',
+        )
 
     creates an index on ``Lower('username')`` using ``varchar_pattern_ops``.
 


### PR DESCRIPTION
The `name` argument is required on `Index` with expressions. I didn't create a ticket since this was such a small fix but maybe it's needed since it'll need a backport for 3.2?