### PR TITLE
Fixed #32369 -- Fixed adding check constraints with pattern lookups and expressions as rhs.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -360,6 +360,8 @@ class BaseDatabaseSchemaEditor:
             not self.connection.features.supports_expression_indexes
         ):
             return None
+        # Index.create_sql returns interpolated SQL which makes params=None a
+        # necessity to avoid escaping attempts on execution.
         self.execute(index.create_sql(model, self), params=None)
 
     def remove_index(self, model, index):
@@ -375,7 +377,9 @@ class BaseDatabaseSchemaEditor:
         """Add a constraint to a model."""
         sql = constraint.create_sql(model, self)
         if sql:
-            self.execute(sql)
+            # Constraint.create_sql returns interpolated SQL which makes
+            # params=None a necessity to avoid escaping attempts on execution.
+            self.execute(sql, params=None)
 
     def remove_constraint(self, model, constraint):
         """Remove a constraint from a model."""


### PR DESCRIPTION
Since `Constraint.create_sql` interpolates its parameters instead of deferring this responsibility to the backend connection it must disable connection level parameters interpolation.