### PR TITLE
Fixed #32385 -- Removed unused and duplicated loading of tags in admin templates.

### DIFF
--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -18,7 +18,6 @@
 {% endblock %}
 {% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE">{% endblock %}
 </head>
-{% load i18n %}
 
 <body class="{% if is_popup %}popup {% endif %}{% block bodyclass %}{% endblock %}"
   data-admin-utc-offset="{% now "Z" %}">

--- a/django/contrib/admin/templates/admin/change_list_results.html
+++ b/django/contrib/admin/templates/admin/change_list_results.html
@@ -1,4 +1,4 @@
-{% load i18n static %}
+{% load i18n %}
 {% if result_hidden_fields %}
 <div class="hiddenfields">{# DIV for HTML validation #}
 {% for item in result_hidden_fields %}{{ item }}{% endfor %}

--- a/django/contrib/admin/templates/admin/edit_inline/stacked.html
+++ b/django/contrib/admin/templates/admin/edit_inline/stacked.html
@@ -1,4 +1,4 @@
-{% load i18n admin_urls static %}
+{% load i18n admin_urls %}
 <div class="js-inline-admin-formset inline-group"
      id="{{ inline_admin_formset.formset.prefix }}-group"
      data-inline-type="stacked"

--- a/django/contrib/admin/templates/admin/prepopulated_fields_js.html
+++ b/django/contrib/admin/templates/admin/prepopulated_fields_js.html
@@ -1,4 +1,4 @@
-{% load l10n static %}
+{% load static %}
 <script id="django-admin-prepopulated-fields-constants"
         src="{% static "admin/js/prepopulate_init.js" %}"
         data-prepopulated-fields="{{ prepopulated_fields_json }}">


### PR DESCRIPTION
 - `i18n` template tags are currently loaded twice in the `admin/base.html`.
 - `l10n` is unused in `prepopulated_fields_js.html` since d638cdc42acec608c1967f44af6be32a477c239f,
 - `static` is unused in `change_list_results.html` since f2ed107b079b050950e2fc5f2b689ca553ae12f5,
 - `static` is unused in `stacked.html` since d61ebc8fed212366340b1ed6f5d7722613801459.

https://code.djangoproject.com/ticket/32385