### PR TITLE
Fixed #32389 -- Fixed ResponseHeaders crash when data is not mapping.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -16,7 +16,9 @@ from django.core.exceptions import DisallowedRedirect
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http.cookie import SimpleCookie
 from django.utils import timezone
-from django.utils.datastructures import CaseInsensitiveMapping
+from django.utils.datastructures import (
+    CaseInsensitiveMapping, _destruct_iterable_mapping_values,
+)
 from django.utils.encoding import iri_to_uri
 from django.utils.http import http_date
 from django.utils.regex_helper import _lazy_re_compile
@@ -31,10 +33,7 @@ class ResponseHeaders(CaseInsensitiveMapping):
         correctly encoded.
         """
         if not isinstance(data, Mapping):
-            data = {
-                k: v
-                for k, v in CaseInsensitiveMapping._destruct_iterable_mapping_values(data)
-            }
+            data = {k: v for k, v in _destruct_iterable_mapping_values(data)}
         self._store = {}
         for header, value in data.items():
             self[header] = value

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -835,6 +835,10 @@ class HttpResponseHeadersTestCase(SimpleTestCase):
         # del doesn't raise a KeyError on nonexistent headers.
         del response['X-Foo']
 
+    def test_headers_as_iterable_of_tuple_pairs(self):
+        response = HttpResponse(headers=(('X-Foo', 'bar'),))
+        self.assertEqual(response['X-Foo'], 'bar')
+
     def test_headers_bytestring(self):
         response = HttpResponse()
         response['X-Foo'] = b'bar'


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32389