### PR TITLE
Fixed #32391 -- Used CSS flex properties for changelist filter.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -128,8 +128,8 @@
 /* FILTER COLUMN */
 
 #changelist-filter {
+    flex: 0 0 240px;
     order: 1;
-    width: 240px;
     background: var(--darkened-bg);
     border-left: none;
     margin: 0 0 0 30px;

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -157,7 +157,7 @@ input[type="submit"], button {
     }
 
     #changelist-filter {
-        width: 200px;
+        flex-basis: 200px;
     }
 
     .change-list .filtered .results,

--- a/docs/releases/3.1.6.txt
+++ b/docs/releases/3.1.6.txt
@@ -9,4 +9,5 @@ Django 3.1.6 fixes several bugs in 3.1.5.
 Bugfixes
 ========
 
-* ...
+* Fixed an admin layout issue in Django 3.1 where changelist filter controls 
+  would become squashed (:ticket:`32391`).


### PR DESCRIPTION
Hi there,

I've found a CSS bug in the Django admin. When the left-side container becomes too wide, the filters become squashed. That's because the flex-grow/shrink/basis values aren't set for the filter.

![Screen Shot 2021-01-27 at 19 27 51](https://user-images.githubusercontent.com/6533742/106121441-a228ad80-6168-11eb-99b2-c65a28657b06.jpg)


​https://github.com/django/django/blob/master/django/contrib/admin/static/admin/css/changelists.css#L10 

I suggest replacing the width value with `flex-basis` and set `flex-grow/shrink` props to 0.
Here is a ticket https://code.djangoproject.com/ticket/32391#ticket



Thanks,
Denis
