### PR TITLE
Fixed #32392 -- Fixed ExclusionConstraint crash with Cast() in expressions.

### DIFF
--- a/django/db/models/functions/comparison.py
+++ b/django/db/models/functions/comparison.py
@@ -42,12 +42,6 @@ class Cast(Func):
             template = "JSON_EXTRACT(%(expressions)s, '$')"
         return self.as_sql(compiler, connection, template=template, **extra_context)
 
-    def as_postgresql(self, compiler, connection, **extra_context):
-        # CAST would be valid too, but the :: shortcut syntax is more readable.
-        # 'expressions' is wrapped in parentheses in case it's a complex
-        # expression.
-        return self.as_sql(compiler, connection, template='(%(expressions)s)::%(db_type)s', **extra_context)
-
     def as_oracle(self, compiler, connection, **extra_context):
         if self.output_field.get_internal_type() == 'JSONField':
             # Oracle doesn't support explicit cast to JSON.

--- a/tests/db_functions/comparison/test_cast.py
+++ b/tests/db_functions/comparison/test_cast.py
@@ -1,12 +1,9 @@
 import datetime
 import decimal
-import unittest
 
 from django.db import connection, models
 from django.db.models.functions import Cast
-from django.test import (
-    TestCase, ignore_warnings, override_settings, skipUnlessDBFeature,
-)
+from django.test import TestCase, ignore_warnings, skipUnlessDBFeature
 
 from ..models import Author, DTModel, Fan, FloatModel
 
@@ -127,16 +124,6 @@ class CastTests(TestCase):
         cast_float = numbers.get().cast_float
         self.assertIsInstance(cast_float, float)
         self.assertEqual(cast_float, 0.125)
-
-    @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL test')
-    @override_settings(DEBUG=True)
-    def test_expression_wrapped_with_parentheses_on_postgresql(self):
-        """
-        The SQL for the Cast expression is wrapped with parentheses in case
-        it's a complex expression.
-        """
-        list(Author.objects.annotate(cast_float=Cast(models.Avg('age'), models.FloatField())))
-        self.assertIn('(AVG("db_functions_author"."age"))::double precision', connection.queries[-1]['sql'])
 
     def test_cast_to_text_field(self):
         self.assertEqual(Author.objects.values_list(Cast('age', models.TextField()), flat=True).get(), '1')

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -305,7 +305,7 @@ class SchemaTests(PostgreSQLTestCase):
         self.assertIn(index_name, constraints)
         self.assertIn(constraints[index_name]['type'], GinIndex.suffix)
         self.assertIs(sql.references_column(table, 'field'), True)
-        self.assertIn('::tsvector', str(sql))
+        self.assertIn(' AS tsvector', str(sql))
         with connection.schema_editor() as editor:
             editor.remove_index(TextFieldModel, index)
         self.assertNotIn(index_name, self.get_constraints(table))


### PR DESCRIPTION
Fix for ticket #32392: ExclusionConstraint() crashes with Cast().