### PR TITLE
Optimized handling case-insensitive mappings.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -5,7 +5,6 @@ import os
 import re
 import sys
 import time
-from collections.abc import Mapping
 from email.header import Header
 from http.client import responses
 from urllib.parse import quote, urlparse
@@ -16,9 +15,7 @@ from django.core.exceptions import DisallowedRedirect
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http.cookie import SimpleCookie
 from django.utils import timezone
-from django.utils.datastructures import (
-    CaseInsensitiveMapping, _destruct_iterable_mapping_values,
-)
+from django.utils.datastructures import CaseInsensitiveMapping
 from django.utils.encoding import iri_to_uri
 from django.utils.http import http_date
 from django.utils.regex_helper import _lazy_re_compile
@@ -32,10 +29,8 @@ class ResponseHeaders(CaseInsensitiveMapping):
         Populate the initial data using __setitem__ to ensure values are
         correctly encoded.
         """
-        if not isinstance(data, Mapping):
-            data = {k: v for k, v in _destruct_iterable_mapping_values(data)}
         self._store = {}
-        for header, value in data.items():
+        for header, value in self._unpack_items(data):
             self[header] = value
 
     def _convert_to_charset(self, value, charset, mime_encode=False):


### PR DESCRIPTION
Elements yielded by `_destruct_iterable_mapping_values` are always unpacked. Since unpacking can be done with any iterable, there is no need to convert elements to tuples if they are iterables.

Also, such elements can be used directly in for loops, creating a dictionary of them is excessive.