### PR TITLE
Simplified serializing HTTP response headers.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -153,14 +153,10 @@ class HttpResponseBase:
 
     def serialize_headers(self):
         """HTTP headers as a bytestring."""
-        def to_bytes(val, encoding):
-            return val if isinstance(val, bytes) else val.encode(encoding)
-
-        headers = [
-            (to_bytes(key, 'ascii') + b': ' + to_bytes(value, 'latin-1'))
+        return b'\r\n'.join([
+            key.encode('ascii') + b': ' + value.encode('latin-1')
             for key, value in self.headers.items()
-        ]
-        return b'\r\n'.join(headers)
+        ])
 
     __bytes__ = serialize_headers
 


### PR DESCRIPTION
Since `ResponseHeaders` was introduced, header names and values are stored as strings. Therefore, there is no need to check whether they are bytes.

As a side note, this names and values may be encoded a couple of times during a response process. Firstly, in `ResponseHeaders._convert_to_charset` to validate them. What do you think about storing them as bytes instead of strings in `ResponseHeaders`?