### PR TITLE
Fixed GeoIPTest.test04_city() failure with the latest GeoIP2 database.

### DIFF
--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -20,8 +20,8 @@ if HAS_GEOIP2:
     "GeoIP is required along with the GEOIP_PATH setting."
 )
 class GeoIPTest(SimpleTestCase):
-    addr = '75.41.39.1'
-    fqdn = 'tmc.edu'
+    addr = '129.237.192.1'
+    fqdn = 'ku.edu'
 
     def test01_init(self):
         "GeoIP initialization."
@@ -105,7 +105,7 @@ class GeoIPTest(SimpleTestCase):
     @mock.patch('socket.gethostbyname')
     def test04_city(self, gethostbyname):
         "GeoIP city querying methods."
-        gethostbyname.return_value = '75.41.39.1'
+        gethostbyname.return_value = '129.237.192.1'
         g = GeoIP2(country='<foo>')
 
         for query in (self.fqdn, self.addr):
@@ -130,8 +130,8 @@ class GeoIPTest(SimpleTestCase):
             self.assertEqual('NA', d['continent_code'])
             self.assertEqual('North America', d['continent_name'])
             self.assertEqual('US', d['country_code'])
-            self.assertEqual('Dallas', d['city'])
-            self.assertEqual('TX', d['region'])
+            self.assertEqual('Lawrence', d['city'])
+            self.assertEqual('KS', d['region'])
             self.assertEqual('America/Chicago', d['time_zone'])
             self.assertFalse(d['is_in_european_union'])
             geom = g.geos(query)


### PR DESCRIPTION
Stacktrace:
```
Traceback (most recent call last):
  File "/usr/lib/python3.9/unittest/mock.py", line 1337, in patched
    return func(*newargs, **newkeywargs)
  File "/home/jenkins/workspace/pull-requests-bionic/database/spatialite/label/bionic-pr/python/python3.9/tests/gis_tests/test_geoip2.py", line 133, in test04_city
    self.assertEqual('Dallas', d['city'])
AssertionError: 'Dallas' != 'Cottonwood Falls'
- Dallas
+ Cottonwood Falls
```