### PR TITLE
Refs #20287 -- BaseContext (and it's subclasses) lack emulation of dictionary items()

### DIFF
--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -174,7 +174,7 @@ class IncludeNode(Node):
                 template_name = (template_name,)
             else:
                 template_name = tuple(template_name)
-            cache = context.render_context.dicts[0].setdefault(self, {})
+            cache = context.render_context.dicts[-1].setdefault(self, {})
             template = cache.get(template_name)
             if template is None:
                 template = context.template.engine.select_template(template_name)

--- a/tests/template_tests/test_context.py
+++ b/tests/template_tests/test_context.py
@@ -60,29 +60,27 @@ class ContextTests(SimpleTestCase):
         c = Context({'a': 1})
         c.push(Context({'b': 2}))
         c.push(Context({'c': 3, 'd': {'z': '26'}}))
-        self.assertEqual(
-            c.dicts,
-            [
-                {'False': False, 'None': None, 'True': True},
-                {'a': 1},
-                {'b': 2},
-                {'c': 3, 'd': {'z': '26'}},
-            ]
-        )
+        expected = [
+            {'False': False, 'None': None, 'True': True},
+            {'a': 1},
+            {'b': 2},
+            {'c': 3, 'd': {'z': '26'}},
+        ]
+        expected.reverse()
+        self.assertEqual(c.dicts, expected)
 
     def test_update_proper_layering(self):
         c = Context({'a': 1})
         c.update(Context({'b': 2}))
         c.update(Context({'c': 3, 'd': {'z': '26'}}))
-        self.assertEqual(
-            c.dicts,
-            [
-                {'False': False, 'None': None, 'True': True},
-                {'a': 1},
-                {'b': 2},
-                {'c': 3, 'd': {'z': '26'}},
-            ]
-        )
+        expected = [
+            {'False': False, 'None': None, 'True': True},
+            {'a': 1},
+            {'b': 2},
+            {'c': 3, 'd': {'z': '26'}},
+        ]
+        expected.reverse()
+        self.assertEqual(c.dicts, expected)
 
     def test_setdefault(self):
         c = Context()
@@ -212,7 +210,7 @@ class ContextTests(SimpleTestCase):
         c.push({'b': 2})
         c.set_upward('a', 2)
         self.assertEqual(len(c.dicts), 3)
-        self.assertEqual(c.dicts[-1]['a'], 2)
+        self.assertEqual(c.dicts[0]['a'], 2)
 
 
 class RequestContextTests(SimpleTestCase):


### PR DESCRIPTION
Here's a proposal to close [ticket #20287](https://code.djangoproject.com/ticket/20287) as 'wontfix'

The ticket has two elements:

**BaseContext to inherit from ChainMap**

This is where most of the discussion is on the ticket. This patch is my mock-up of what this could look like (I've learned so much about contexts and templates looking at this, it's been very rewarding!). There is some background info in the original [Python issue](https://bugs.python.org/issue11297) that introduced this feature. Having spent some time with this I don't think it's a good idea to do this due to:

- `Context` was introduced 15 years ago in    https://github.com/django/django/commit/f69cf70ed813a8cd7e1f963a14ae39103e8d5265. I don't think we want to start changing the API here. 

- The  push/pop functions in `ChainMap` return a new class rather than modify in place. Therefore we'd be fighting against the underlying class behavior. It would take quite a lot of work to replicate the current ability of `push()`  being used as a context manager. 

- A quick benchmark shows creating a new class is slower than pushing/popping from a list. 

**Being able to iterate over items**

The reason cited for this need is that one of the layers in a `Context` could be a `Context`. There is another accepted ticket to stop this behavior with [key comments](https://code.djangoproject.com/ticket/18105#comment:1) being  "passing a Context to another Context init is a mistake". Therefore it doesn't make sense to me to make changes that accommodate this scenario. 