### PR TITLE
Fixed typo in docs/ref/forms/widgets.txt.

### DIFF
--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -408,7 +408,7 @@ foundation for custom widgets.
     .. method:: get_context(name, value, attrs)
 
         In addition to the ``'widget'`` key described in
-        :meth:`Widget.get_context`, ``MultiValueWidget`` adds a
+        :meth:`Widget.get_context`, ``MultiWidget`` adds a
         ``widget['subwidgets']`` key.
 
         These can be looped over in the widget template:


### PR DESCRIPTION
'MultiValueWidget' is not a Django class.

(Was perhaps conflated with `MultiValueField`.)