### PR TITLE
Add a daily build and auto-cancel redundant pipelines

### DIFF
--- a/.github/workflows/cancel_runs.yml
+++ b/.github/workflows/cancel_runs.yml
@@ -1,0 +1,18 @@
+name: Cancel redundant builds
+
+on:
+  # pull_request_target runs in the context of the repository,
+  # and does *not* include any code present in the merge request.
+  # We can perform privileged actions like creating comments and
+  # cancelling runs on pull request events.
+  pull_request_target:
+
+jobs:
+  cancel-runs:
+    runs-on: ubuntu-latest
+    steps:
+      # This is pinned to 0.8.0
+      - uses: styfle/cancel-workflow-action@3d86a7cc43670094ac248017207be0295edbc31d
+        with:
+          workflow_id: 'tests.yml'
+          access_token: ${{ github.token }}

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -1,0 +1,48 @@
+name: Nightly Run
+
+on:
+  schedule:
+    # Run all tests at 2:30am
+    - cron: "30 2 * * *"
+  # Allow triggering this build to test
+  workflow_dispatch:
+
+
+jobs:
+  trigger-runs:
+    runs-on: ubuntu-latest
+    name: Trigger Full Build
+    # Only trigger on the main Django repository
+    if: (github.event_name == 'schedule' && github.repository == 'django/django') || (github.event_name != 'schedule')
+    strategy:
+      matrix:
+        branch:
+          - master
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branch }}
+      # Detect if there are any changes within the last 1 day
+      - id: git_log
+        run: echo "::set-output name=total_lines::$(git log --since '1 day ago' --format=oneline master | wc -l)"
+      # Trigger the 'Tests' workflow. This involves converting the name to a workflow ID, then
+      # invoking createWorkflowDispatch on that ID.
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.NIGHTLY_WORKFLOW_TOKEN}}
+          script: |
+            const {owner, repo} = context.repo;
+            const workflows = await github.actions.listRepoWorkflows({
+              owner,
+              repo,
+            });
+            const workflow_id = workflows.data.workflows.find((workflow) => workflow.name === "Tests").id;
+            await github.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id,
+              ref: "${{ matrix.branch }}",
+            });
+            console.log(`Triggered workflow ID ${workflow_id}`);
+        if: steps.git_log.outputs.total_lines != '0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Tests
 
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
See https://github.com/django/django/pull/13852#issuecomment-770769768

This adds:
* cancelling redundant pipelines in builds (we should add this to the next set of actions we add)
* scheduled master full builds at midnight
* ~~runs the tests on pushes to master~~