### PR TITLE
Fixed #32403 -- Fixed re-raising DatabaseErrors when using only 'postgres' database.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -332,6 +332,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                             yield cursor
                     finally:
                         conn.close()
+                    break
+            else:
+                raise
 
     @cached_property
     def pg_version(self):

--- a/docs/releases/3.1.7.txt
+++ b/docs/releases/3.1.7.txt
@@ -9,4 +9,6 @@ Django 3.1.7 fixes several bugs in 3.1.6.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 3.1 that caused ``RuntimeError`` instead of
+  connection errors when using only the ``'postgres'`` database
+  (:ticket:`32403`).


### PR DESCRIPTION
ticket-32403

Thanks Kazantcev Andrey for the report.

Regression in f48f671223a20b161ca819cf7d6298e43b8ba5fe.