### PR TITLE
Refs #32074 -- Fixed TextChoices/IntegerChoices crash on Python 3.10.

### DIFF
--- a/django/db/models/enums.py
+++ b/django/db/models/enums.py
@@ -8,7 +8,7 @@ __all__ = ['Choices', 'IntegerChoices', 'TextChoices']
 class ChoicesMeta(enum.EnumMeta):
     """A metaclass for creating a enum choices."""
 
-    def __new__(metacls, classname, bases, classdict):
+    def __new__(metacls, classname, bases, classdict, **kwds):
         labels = []
         for key in classdict._member_names:
             value = classdict[key]
@@ -25,7 +25,7 @@ class ChoicesMeta(enum.EnumMeta):
             # Use dict.__setitem__() to suppress defenses against double
             # assignment in enum's classdict.
             dict.__setitem__(classdict, key, value)
-        cls = super().__new__(metacls, classname, bases, classdict)
+        cls = super().__new__(metacls, classname, bases, classdict, **kwds)
         cls._value2label_map_ = dict(zip(cls._value2member_map_, labels))
         # Add a label property to instances of enum which uses the enum member
         # that is passed in as "self" as the value to use when looking up the


### PR DESCRIPTION
`EnumMeta` has a new keyword argument `boundary` in Python 3.10. This is a new mechanism that controls how out-of-range / invalid bits are handled, see the [issue 38250](https://bugs.python.org/issue38250) and https://github.com/python/cpython/commit/7aaeb2a3d682ecba125c33511e4b4796021d2f82:

```
\tests\model_enums\tests.py", line 74, in test_integerchoices_functional_api
    Place = models.IntegerChoices('Place', 'FIRST SECOND THIRD')
  File "C:\Python310\lib\enum.py", line 598, in __call__
    return cls._create_(
  File "C:\Python310\lib\enum.py", line 738, in _create_
    return metacls.__new__(metacls, class_name, bases, classdict, boundary=boundary)
TypeError: ChoicesMeta.__new__() got an unexpected keyword argument 'boundary'

\tests\model_enums\tests.py", line 115, in test_textchoices_functional_api
    Medal = models.TextChoices('Medal', 'GOLD SILVER BRONZE')
  File "C:\Python310\lib\enum.py", line 598, in __call__
    return cls._create_(
  File "C:\Python310\lib\enum.py", line 738, in _create_
    return metacls.__new__(metacls, class_name, bases, classdict, boundary=boundary)
TypeError: ChoicesMeta.__new__() got an unexpected keyword argument 'boundary'
```