### PR TITLE
Fixed #32420 -- Fixed detecting primary key values in deserialization when PK is also a FK.

### DIFF
--- a/django/core/serializers/base.py
+++ b/django/core/serializers/base.py
@@ -257,7 +257,7 @@ def build_instance(Model, data, db):
     natural keys, try to retrieve it from the database.
     """
     default_manager = Model._meta.default_manager
-    pk = data.get(Model._meta.pk.name)
+    pk = data.get(Model._meta.pk.attname)
     if (pk is None and hasattr(default_manager, 'get_by_natural_key') and
             hasattr(Model, 'natural_key')):
         natural_key = Model(**data).natural_key()

--- a/tests/serializers/models/natural.py
+++ b/tests/serializers/models/natural.py
@@ -53,3 +53,17 @@ class NaturalPKWithDefault(models.Model):
 
     def natural_key(self):
         return (self.name,)
+
+
+class FKAsPKNoNaturalKeyManager(models.Manager):
+    def get_by_natural_key(self, *args, **kwargs):
+        return super().get_by_natural_key(*args, **kwargs)
+
+
+class FKAsPKNoNaturalKey(models.Model):
+    pk_fk = models.ForeignKey(NaturalKeyAnchor, on_delete=models.CASCADE, primary_key=True)
+
+    objects = FKAsPKNoNaturalKeyManager()
+
+    def natural_key(self):
+        raise NotImplementedError('This method was not expected to be called.')


### PR DESCRIPTION
Implements directly info provided here, incl. the test exposing the issue: https://code.djangoproject.com/ticket/32420