### PR TITLE
[3.1.x] Fixed backends.postgresql.tests.Tests.test_nodb_cursor_raises_postgres_authentication_failure().

### DIFF
--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -89,7 +89,7 @@ class Tests(TestCase):
         )
         with self.assertWarnsMessage(RuntimeWarning, msg):
             mocker_connections_all = mock.patch(
-                'django.utils.connection.BaseConnectionHandler.all',
+                'django.db.utils.ConnectionHandler.all',
                 side_effect=mocked_all,
                 autospec=True,
             )


### PR DESCRIPTION
Follow up to 9efe832ee1e5da326e4ee5ed370db963b8fe6624.

I missed this when backporting.