### PR TITLE
Fix MySQL example of CREATE DATABASE to use utf8mb4 character set

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -418,7 +418,7 @@ Creating your database
 
 You can `create your database`_ using the command-line tools and this SQL::
 
-  CREATE DATABASE <dbname> CHARACTER SET utf8;
+  CREATE DATABASE <dbname> CHARACTER SET utf8mb4;
 
 This ensures all tables and columns will use UTF-8 by default.
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/32427#ticket