### PR TITLE
Fixed #32443 -- Removed "shifted" CSS class when admin's sidebar is disabled.

### DIFF
--- a/django/contrib/admin/static/admin/js/nav_sidebar.js
+++ b/django/contrib/admin/static/admin/js/nav_sidebar.js
@@ -15,7 +15,6 @@
         }
 
         const main = document.getElementById('main');
-        const navSidebar = document.getElementById('nav-sidebar');
         let navSidebarIsOpen = localStorage.getItem('django.admin.navSidebarIsOpen');
         if (navSidebarIsOpen === null) {
             navSidebarIsOpen = 'true';
@@ -23,7 +22,7 @@
         if (navSidebarIsOpen === 'false') {
             disableNavLinkTabbing();
         }
-        main.classList.toggle('shifted', navSidebar && navSidebarIsOpen === 'true');
+        main.classList.toggle('shifted', navSidebarIsOpen === 'true');
 
         toggleNavSidebar.addEventListener('click', function() {
             if (navSidebarIsOpen === 'true') {

--- a/django/contrib/admin/static/admin/js/nav_sidebar.js
+++ b/django/contrib/admin/static/admin/js/nav_sidebar.js
@@ -15,6 +15,7 @@
         }
 
         const main = document.getElementById('main');
+        const navSidebar = document.getElementById('nav-sidebar');
         let navSidebarIsOpen = localStorage.getItem('django.admin.navSidebarIsOpen');
         if (navSidebarIsOpen === null) {
             navSidebarIsOpen = 'true';
@@ -22,7 +23,7 @@
         if (navSidebarIsOpen === 'false') {
             disableNavLinkTabbing();
         }
-        main.classList.toggle('shifted', navSidebarIsOpen === 'true');
+        main.classList.toggle('shifted', navSidebar && navSidebarIsOpen === 'true');
 
         toggleNavSidebar.addEventListener('click', function() {
             if (navSidebarIsOpen === 'true') {

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -69,7 +69,7 @@
     {% endblock %}
     {% endif %}
 
-    <div class="main shifted" id="main">
+    <div class="main" id="main">
       {% if not is_popup and is_nav_sidebar_enabled %}
         {% block nav-sidebar %}
           {% include "admin/nav_sidebar.html" %}

--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -39,6 +39,7 @@ class AdminSidebarTests(TestCase):
 
     def test_sidebar_not_on_index(self):
         response = self.client.get(reverse('test_with_sidebar:index'))
+        self.assertContains(response, '<div class="main" id="main">')
         self.assertNotContains(response, '<nav class="sticky" id="nav-sidebar">')
 
     def test_sidebar_disabled(self):


### PR DESCRIPTION
Hi

I faced an issue in disabling the nav-sidebar. When I disable the nav-sidebar using `admin.site.enable_nav_sidebar = False`, the `shifted` class is still remaining, because this class is hard-coded in the `main` tag. I remove the hard-coded class and add the `shifted` class whenever we have the `side-navbar` element on the page.