### PR TITLE
Fixed #20423 -- Doc'd that DTL variable names may not be a number.

### DIFF
--- a/docs/ref/templates/language.txt
+++ b/docs/ref/templates/language.txt
@@ -79,10 +79,10 @@ Variables
 Variables look like this: ``{{ variable }}``. When the template engine
 encounters a variable, it evaluates that variable and replaces it with the
 result. Variable names consist of any combination of alphanumeric characters
-and the underscore (``"_"``) but may not start with an underscore. The dot
-(``"."``) also appears in variable sections, although that has a special
-meaning, as indicated below. Importantly, *you cannot have spaces or
-punctuation characters in variable names.*
+and the underscore (``"_"``) but may not start with an underscore, and may not
+be a number. The dot (``"."``) also appears in variable sections, although that
+has a special meaning, as indicated below. Importantly, *you cannot have spaces
+or punctuation characters in variable names.*
 
 Use a dot (``.``) to access attributes of a variable.
 


### PR DESCRIPTION
Only change to content is to add "or a number." to the sentence "...but may not start with an underscore."

See https://code.djangoproject.com/ticket/20423