### PR TITLE
Enabled build-system isolation via pip.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ['setuptools>=40.8.0', 'wheel']
+build-backend = 'setuptools.build_meta:__legacy__'


### PR DESCRIPTION
This is described in https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support and enables build system isolation via PEP-517. In practice this means that pip will use an environment where it downloads setuptools and wheel first and as such will not conflict with whatever is active in the current python env. This is a good thing (tm) :D This now allows for installation in virtualenvs that do not have setuptools/wheel but only pip.

The new behavior (compare against master) of a pip install can be observed due to the following output:
```
  Building wheel for Django (PEP 517) ... done
```
if the loglevel is increased further one sees that pip now downloads setuptools & wheel.