### PR TITLE
Refs #32355 -- Restored PY36 and PY37 version constants.

### DIFF
--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -9,6 +9,8 @@ from distutils.version import LooseVersion
 # or later". So that third-party apps can use these values, each constant
 # should remain as long as the oldest supported Django version supports that
 # Python version.
+PY36 = sys.version_info >= (3, 6)
+PY37 = sys.version_info >= (3, 7)
 PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
 


### PR DESCRIPTION
Partially reverts ec0ff406311de88f4e2a135d784363424fe602aa.

PY36 should be removed when Django 2.2 is EOL.
PY37 should be removed when Django 3.2 is EOL.

Thanks to Tim Graham for the report.

Given the comment, I'm half thinking `PY35` should still be there, but it's getting late in the day now... 🤔