### PR TITLE
Refs #31670 -- Used allowlist_externals in tox.ini (again)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,8 @@ commands = isort --check-only --diff django tests scripts
 usedevelop = false
 deps =
 changedir = {toxinidir}
-whitelist_externals = npm
+allowlist_externals =
+    npm
 commands =
     npm install
     npm test


### PR DESCRIPTION
allowlist_externals is already used once in this file.