### PR TITLE
Fixed #32437 -- Fixed cleaning up ALLOWED_HOSTS in LiveServerTestCase on setUpClass() failure.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1573,11 +1573,12 @@ class LiveServerTestCase(TransactionTestCase):
             for conn in cls.server_thread.connections_override.values():
                 conn.dec_thread_sharing()
 
+            cls._live_server_modified_settings.disable()
+            super().tearDownClass()
+
     @classmethod
     def tearDownClass(cls):
         cls._tearDownClassInternal()
-        cls._live_server_modified_settings.disable()
-        super().tearDownClass()
 
 
 class SerializeMixin:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32437