### PR TITLE
Fixed #32446 -- Deprecated the SERIALIZE test database setting.

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -25,6 +25,7 @@ from django.db.models.options import Options
 from django.template import Template
 from django.test.signals import setting_changed, template_rendered
 from django.urls import get_script_prefix, set_script_prefix
+from django.utils.deprecation import RemovedInDjango50Warning
 from django.utils.translation import deactivate
 
 try:
@@ -156,8 +157,18 @@ def teardown_test_environment():
     del mail.outbox
 
 
-def setup_databases(verbosity, interactive, *, time_keeper=None, keepdb=False, debug_sql=False, parallel=0,
-                    aliases=None, **kwargs):
+def setup_databases(
+    verbosity,
+    interactive,
+    *,
+    time_keeper=None,
+    keepdb=False,
+    debug_sql=False,
+    parallel=0,
+    aliases=None,
+    serialized_aliases=None,
+    **kwargs,
+):
     """Create the test databases."""
     if time_keeper is None:
         time_keeper = NullTimeKeeper()
@@ -176,11 +187,29 @@ def setup_databases(verbosity, interactive, *, time_keeper=None, keepdb=False, d
             if first_alias is None:
                 first_alias = alias
                 with time_keeper.timed("  Creating '%s'" % alias):
+                    # RemovedInDjango50Warning: when the deprecation ends,
+                    # replace with:
+                    # serialize_alias = serialized_aliases is None or alias in serialized_aliases
+                    try:
+                        serialize_alias = connection.settings_dict['TEST']['SERIALIZE']
+                    except KeyError:
+                        serialize_alias = (
+                            serialized_aliases is None or
+                            alias in serialized_aliases
+                        )
+                    else:
+                        warnings.warn(
+                            'The SERIALIZE test database setting is '
+                            'deprecated as it can be inferred from the '
+                            'TestCase/TransactionTestCase.databases that '
+                            'enable the serialized_rollback feature.',
+                            category=RemovedInDjango50Warning,
+                        )
                     connection.creation.create_test_db(
                         verbosity=verbosity,
                         autoclobber=not interactive,
                         keepdb=keepdb,
-                        serialize=connection.settings_dict['TEST'].get('SERIALIZE', True),
+                        serialize=serialize_alias,
                     )
                 if parallel > 1:
                     for index in range(parallel):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -15,6 +15,8 @@ about each item can often be found in the release notes of two versions prior.
 See the :ref:`Django 4.0 release notes <deprecated-features-4.0>` for more
 details on these changes.
 
+* The ``SERIALIZE`` test setting will be removed.
+
 .. _deprecation-removed-in-4.1:
 
 4.1

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -821,6 +821,12 @@ the database state between tests if you don't have transactions). You can set
 this to ``False`` to speed up creation time if you don't have any test classes
 with :ref:`serialized_rollback=True <test-case-serialized-rollback>`.
 
+.. deprecated:: 4.0
+
+   This setting is deprecated as it can be inferred from the
+   :attr:`~django.test.TestCase.databases` with the
+   :ref:`serialized_rollback <test-case-serialized-rollback>` option enabled.
+
 .. setting:: TEST_TEMPLATE
 
 ``TEMPLATE``

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -248,7 +248,11 @@ Templates
 Tests
 ~~~~~
 
-* ...
+* The new ``serialized_aliases`` argument of
+  :func:`django.test.utils.setup_databases` determines which
+  :setting:`DATABASES` aliases test databases should have their state
+  serialized to allow usage of the
+  :ref:`serialized_rollback <test-case-serialized-rollback>` feature.
 
 URLs
 ~~~~
@@ -313,7 +317,9 @@ Features deprecated in 4.0
 Miscellaneous
 -------------
 
-* ...
+* ``SERIALIZE`` test setting is deprecated as it can be inferred from the
+  :attr:`~django.test.TestCase.databases` with the
+  :ref:`serialized_rollback <test-case-serialized-rollback>` option enabled.
 
 Features removed in 4.0
 =======================

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -718,7 +718,7 @@ utility methods in the ``django.test.utils`` module.
     Performs global post-test teardown, such as removing instrumentation from
     the template system and restoring normal email services.
 
-.. function:: setup_databases(verbosity, interactive, *, time_keeper=None, keepdb=False, debug_sql=False, parallel=0, aliases=None, **kwargs)
+.. function:: setup_databases(verbosity, interactive, *, time_keeper=None, keepdb=False, debug_sql=False, parallel=0, aliases=None, serialized_aliases=None, **kwargs)
 
     Creates the test databases.
 
@@ -730,10 +730,19 @@ utility methods in the ``django.test.utils`` module.
     databases should be setup for. If it's not provided, it defaults to all of
     :setting:`DATABASES` aliases.
 
+    The ``serialized_aliases`` argument determines what subset of ``aliases``
+    test databases should have their state serialized to allow usage of the
+    :ref:`serialized_rollback <test-case-serialized-rollback>` feature. If
+    it's not provided, it defaults to ``aliases``.
+
     .. versionchanged:: 3.2
 
         The ``time_keeper`` kwarg was added, and all kwargs were made
         keyword-only.
+
+    .. versionchanged:: 4.0
+
+        The ``serialized_aliases`` kwarg was added.
 
 .. function:: teardown_databases(old_config, parallel=0, keepdb=False)
 

--- a/tests/test_runner_apps/databases/tests.py
+++ b/tests/test_runner_apps/databases/tests.py
@@ -10,6 +10,11 @@ class DefaultDatabaseTests(NoDatabaseTests):
     databases = {'default'}
 
 
+class DefaultDatabaseSerializedTests(NoDatabaseTests):
+    databases = {'default'}
+    serialized_rollback = True
+
+
 class OtherDatabaseTests(NoDatabaseTests):
     databases = {'other'}
 


### PR DESCRIPTION
Whether or not the state of a test database should be serialized can be inferred from the set of databases allowed to be access from discovered `TransactionTestCase` enabling the `serialized_rollback` feature which makes this setting unnecessary.

This should make a significant test suite bootstraping time difference on large projects that didn't explicitly disable test database serialization.

---

This is still missing docs but I figured I'd throw it out there for early feedback.