### PR TITLE
Fixed #32445 -- Fixed LiveServerThreadTest.test_closes_connections() for non-in-memory database on SQLite.

### DIFF
--- a/tests/servers/test_liveserverthread.py
+++ b/tests/servers/test_liveserverthread.py
@@ -1,9 +1,14 @@
 from django.db import DEFAULT_DB_ALIAS, connections
-from django.test import LiveServerTestCase, TestCase
+from django.test import LiveServerTestCase, TransactionTestCase
 from django.test.testcases import LiveServerThread
 
 
-class LiveServerThreadTest(TestCase):
+# Use TransactionTestCase instead of TestCase to run outside of a transaction,
+# otherwise closing the connection would implicitly rollback and not set the
+# connection to None.
+class LiveServerThreadTest(TransactionTestCase):
+
+    available_apps = []
 
     def run_live_server_thread(self, connections_override=None):
         thread = LiveServerTestCase._create_server_thread(connections_override)
@@ -16,12 +21,13 @@ class LiveServerThreadTest(TestCase):
         conn = connections[DEFAULT_DB_ALIAS]
         # Pass a connection to the thread to check they are being closed.
         connections_override = {DEFAULT_DB_ALIAS: conn}
-
+        # Open a connection to the database.
+        conn.connect()
         conn.inc_thread_sharing()
         try:
-            self.assertTrue(conn.is_usable())
+            self.assertIsNotNone(conn.connection)
             self.run_live_server_thread(connections_override)
-            self.assertFalse(conn.is_usable())
+            self.assertIsNone(conn.connection)
         finally:
             conn.dec_thread_sharing()
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32445