### PR TITLE
Fixed #32450 -- Fixed crash when ANDing/ORing an empty Q() with not pickleable Q().

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -5,7 +5,6 @@ Factored out from django.db.models.query to avoid making the main module very
 large and/or so that they can be used by other modules without getting into
 circular import difficulties.
 """
-import copy
 import functools
 import inspect
 from collections import namedtuple
@@ -46,10 +45,12 @@ class Q(tree.Node):
 
         # If the other Q() is empty, ignore it and just use `self`.
         if not other:
-            return copy.deepcopy(self)
+            _, args, kwargs = self.deconstruct()
+            return type(self)(*args, **kwargs)
         # Or if this Q is empty, ignore it and just use `other`.
         elif not self:
-            return copy.deepcopy(other)
+            _, args, kwargs = other.deconstruct()
+            return type(other)(*args, **kwargs)
 
         obj = type(self)()
         obj.connector = conn

--- a/tests/queries/test_q.py
+++ b/tests/queries/test_q.py
@@ -8,11 +8,19 @@ class QTests(SimpleTestCase):
         self.assertEqual(q & Q(), q)
         self.assertEqual(Q() & q, q)
 
+        q = Q(x__in={}.keys())
+        self.assertEqual(q & Q(), q)
+        self.assertEqual(Q() & q, q)
+
     def test_combine_and_both_empty(self):
         self.assertEqual(Q() & Q(), Q())
 
     def test_combine_or_empty(self):
         q = Q(x=1)
+        self.assertEqual(q | Q(), q)
+        self.assertEqual(Q() | q, q)
+
+        q = Q(x__in={}.keys())
         self.assertEqual(q | Q(), q)
         self.assertEqual(Q() | q, q)
 


### PR DESCRIPTION
[ticket-32450](https://code.djangoproject.com/ticket/32450)