### PR TITLE
Refs #30231 -- Fixed SeleniumTests.test_inlines_verbose_name with headless mode.

### DIFF
--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -1363,6 +1363,10 @@ class SeleniumTests(AdminSeleniumTestCase):
         verbose_name in the inline form.
         """
         self.admin_login(username='super', password='secret')
+        # Hide sidebar.
+        self.selenium.get(self.live_server_url + reverse('admin:admin_inlines_course_add'))
+        toggle_button = self.selenium.find_element_by_css_selector('#toggle-nav-sidebar')
+        toggle_button.click()
         # Each combination of horizontal/vertical fiter with stacked/tabular
         # inlines.
         tests = [


### PR DESCRIPTION
Admin inlines are not visible on screen sizes just larger than the breakpoint when the sidebar is open.


This fixes the new selenium tests which were introduced in #13436 but fail in `headless` mode. 

@felixxm -- While this fixes the test (I've run locally in `headless` mode anyway)  I'm not sure if it's a suitable patch? 

