### PR TITLE
Refs #16117 -- Made @action and @display decorators importable from django.contrib.gis.admin.

### DIFF
--- a/django/contrib/gis/admin/__init__.py
+++ b/django/contrib/gis/admin/__init__.py
@@ -1,12 +1,12 @@
 from django.contrib.admin import (
     HORIZONTAL, VERTICAL, AdminSite, ModelAdmin, StackedInline, TabularInline,
-    autodiscover, register, site,
+    action, autodiscover, display, register, site,
 )
 from django.contrib.gis.admin.options import GeoModelAdmin, OSMGeoAdmin
 from django.contrib.gis.admin.widgets import OpenLayersWidget
 
 __all__ = [
     'HORIZONTAL', 'VERTICAL', 'AdminSite', 'ModelAdmin', 'StackedInline',
-    'TabularInline', 'autodiscover', 'register', 'site',
+    'TabularInline', 'action', 'autodiscover', 'display', 'register', 'site',
     'GeoModelAdmin', 'OSMGeoAdmin', 'OpenLayersWidget',
 ]


### PR DESCRIPTION
I missed this in #13532 for ticket-16117.

It'll be really annoying if `@admin.action` and `@admin.display` don't work when using `from django.contrib.gis import admin`.

Please can this be backported to 3.2?