### PR TITLE
Fixed #32460 -- Allowed "label"/"do_not_call_in_templates" members in model choice enums.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -226,6 +226,11 @@ modifications:
   ``.choices``, ``.labels``, ``.values``, and ``.names`` -- to make it easier
   to access lists of those separate parts of the enumeration. Use ``.choices``
   as a suitable value to pass to :attr:`~Field.choices` in a field definition.
+
+  .. warning::
+
+    These property names cannot be used as member names as they would conflict.
+
 * The use of :func:`enum.unique()` is enforced to ensure that values cannot be
   defined multiple times. This is unlikely to be expected in choices for a
   field.

--- a/tests/model_enums/tests.py
+++ b/tests/model_enums/tests.py
@@ -155,6 +155,10 @@ class ChoicesTests(SimpleTestCase):
         output = template.render(Context({'Suit': Suit}))
         self.assertEqual(output, 'Diamond|1')
 
+    def test_property_names_conflict_with_member_names(self):
+        with self.assertRaises(AttributeError):
+            models.TextChoices('Properties', 'choices labels names values')
+
 
 class Separator(bytes, models.Choices):
     FS = b'\x1c', 'File Separator'

--- a/tests/model_enums/tests.py
+++ b/tests/model_enums/tests.py
@@ -159,6 +159,26 @@ class ChoicesTests(SimpleTestCase):
         with self.assertRaises(AttributeError):
             models.TextChoices('Properties', 'choices labels names values')
 
+    def test_label_member(self):
+        # label can be used as a member.
+        Stationery = models.TextChoices('Stationery', 'label stamp sticker')
+        self.assertEqual(Stationery.label.label, 'Label')
+        self.assertEqual(Stationery.label.value, 'label')
+        self.assertEqual(Stationery.label.name, 'label')
+
+    def test_do_not_call_in_templates_member(self):
+        # do_not_call_in_templates is not implicitly treated as a member.
+        Special = models.IntegerChoices('Special', 'do_not_call_in_templates')
+        self.assertEqual(
+            Special.do_not_call_in_templates.label,
+            'Do Not Call In Templates',
+        )
+        self.assertEqual(Special.do_not_call_in_templates.value, 1)
+        self.assertEqual(
+            Special.do_not_call_in_templates.name,
+            'do_not_call_in_templates',
+        )
+
 
 class Separator(bytes, models.Choices):
     FS = b'\x1c', 'File Separator'


### PR DESCRIPTION
An alternate solution to #14020, fixing ticket-32460. See my [comment](https://code.djangoproject.com/ticket/32460#comment:2).