### PR TITLE
Refs #4027 -- Added Model._state.adding to docs about copying model instances.

### DIFF
--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -1233,12 +1233,15 @@ Copying model instances
 
 Although there is no built-in method for copying model instances, it is
 possible to easily create new instance with all fields' values copied. In the
-simplest case, you can set ``pk`` to ``None``. Using our blog example::
+simplest case, you can set ``pk`` to ``None`` and
+:attr:`_state.adding <django.db.models.Model._state>` to ``True``. Using our
+blog example::
 
     blog = Blog(name='My blog', tagline='Blogging is easy')
     blog.save() # blog.pk == 1
 
     blog.pk = None
+    blog._state.adding = True
     blog.save() # blog.pk == 2
 
 Things get more complicated if you use inheritance. Consider a subclass of
@@ -1251,10 +1254,11 @@ Things get more complicated if you use inheritance. Consider a subclass of
     django_blog.save() # django_blog.pk == 3
 
 Due to how inheritance works, you have to set both ``pk`` and ``id`` to
-``None``::
+``None``, and ``_state.adding`` to ``True``::
 
     django_blog.pk = None
     django_blog.id = None
+    django_blog._state.adding = True
     django_blog.save() # django_blog.pk == 4
 
 This process doesn't copy relations that aren't part of the model's database
@@ -1265,6 +1269,7 @@ entry::
     entry = Entry.objects.all()[0] # some previous entry
     old_authors = entry.authors.all()
     entry.pk = None
+    entry._state.adding = True
     entry.save()
     entry.authors.set(old_authors)
 
@@ -1274,6 +1279,7 @@ For example, assuming ``entry`` is already duplicated as above::
 
     detail = EntryDetail.objects.all()[0]
     detail.pk = None
+    detail._state.adding = True
     detail.entry = entry
     detail.save()
 


### PR DESCRIPTION
When creating a new object from an existing object, the description currently overlooks that the `object._state.adding` should be set to `True`. This may not matter in many cases, which can explain why this is left out here, but it does matter when using models with natural keys combined with third party packages as `object.pk` will not be a faly value in these cases.

It is currently an issue in https://github.com/django-treebeard/django-treebeard/issues/210 . I have contacted the original author of this section and his response can be found here: https://github.com/django/django/commit/a97ecfdea80080da7e522d8dd8a4792a777694f9#commitcomment-47314995