### PR TITLE
Fixed #32480 -- Corrected docstring and removed redundant comments in django/views/defaults.py.

### DIFF
--- a/django/views/defaults.py
+++ b/django/views/defaults.py
@@ -33,7 +33,7 @@ def get_readable_exception(exception):
     except (AttributeError, IndexError):
         pass
     else:
-        if isinstance(message, str):
+        if message and isinstance(message, str):
             exception_repr = message
     return exception_repr
 

--- a/django/views/defaults.py
+++ b/django/views/defaults.py
@@ -24,20 +24,6 @@ ERROR_PAGE_TEMPLATE = """
 """
 
 
-def get_readable_exception(exception):
-    exception_repr = exception.__class__.__name__
-    # Try to get an "interesting" exception message, if any (and not the ugly
-    # Resolver404 dictionary)
-    try:
-        message = exception.args[0]
-    except (AttributeError, IndexError):
-        pass
-    else:
-        if message and isinstance(message, str):
-            exception_repr = message
-    return exception_repr
-
-
 # These views can be called when CsrfViewMiddleware.process_view() not run,
 # therefore need @requires_csrf_token in case the template needs
 # {% csrf_token %}.
@@ -57,9 +43,19 @@ def page_not_found(request, exception, template_name=ERROR_404_TEMPLATE_NAME):
             The message from the exception which triggered the 404 (if one was
             supplied), or the exception class name
     """
+    exception_repr = exception.__class__.__name__
+    # Try to get an "interesting" exception message, if any (and not the ugly
+    # Resolver404 dictionary)
+    try:
+        message = exception.args[0]
+    except (AttributeError, IndexError):
+        pass
+    else:
+        if isinstance(message, str):
+            exception_repr = message
     context = {
         'request_path': quote(request.path),
-        'exception': get_readable_exception(exception),
+        'exception': exception_repr,
     }
     try:
         template = loader.get_template(template_name)
@@ -150,5 +146,5 @@ def permission_denied(request, exception, template_name=ERROR_403_TEMPLATE_NAME)
             content_type='text/html',
         )
     return HttpResponseForbidden(
-        template.render(request=request, context={'exception': get_readable_exception(exception)})
+        template.render(request=request, context={'exception': str(exception)})
     )

--- a/django/views/defaults.py
+++ b/django/views/defaults.py
@@ -38,7 +38,7 @@ def get_readable_exception(exception):
     return exception_repr
 
 
-# These can be called when CsrfViewMiddleware.process_view has not run,
+# These views can be called when CsrfViewMiddleware.process_view() not run,
 # therefore need @requires_csrf_token in case the template needs
 # {% csrf_token %}.
 
@@ -134,7 +134,7 @@ def permission_denied(request, exception, template_name=ERROR_403_TEMPLATE_NAME)
     Context:
         exception
             The message from the exception which triggered the 403 (if one was
-            supplied), or the exception class name
+            supplied).
 
     If the template does not exist, an Http403 response containing the text
     "403 Forbidden" (as per RFC 7231) will be returned.

--- a/django/views/defaults.py
+++ b/django/views/defaults.py
@@ -133,7 +133,7 @@ def permission_denied(request, exception, template_name=ERROR_403_TEMPLATE_NAME)
     Templates: :template:`403.html`
     Context:
         exception
-            The message from the exception which triggered the 404 (if one was
+            The message from the exception which triggered the 403 (if one was
             supplied), or the exception class name
 
     If the template does not exist, an Http403 response containing the text


### PR DESCRIPTION
1) why having the comment about csrf_token before 404 and 403, but using the decorator for all of them ?
2) why the description for 403 says Context: None but it actually has context exception ?
3) why not get the exception_repr for 403 the same way as for 404 ?

The purpose of my request is more about "Could we please clean the code? It's a little bit confusing".
I mean, if I got it right, there is no particular reason for those things, seems like someone just made some changes and forgot to read the rest of the script to apply those changes there too.
Or if I got it wrong, a comment why it is the way it is would be nice.

Thanks

PS: I'm sorry if my request sounds pedantic, that's just my lack of english, it's really a humble request :)