### PR TITLE
Fixed #10929 -- Added default argument to aggregates.

### DIFF
--- a/django/contrib/postgres/aggregates/general.py
+++ b/django/contrib/postgres/aggregates/general.py
@@ -18,7 +18,7 @@ class ArrayAgg(OrderableAggMixin, Aggregate):
         return ArrayField(self.source_expressions[0].output_field)
 
     def convert_value(self, value, expression, connection):
-        if not value:
+        if value is None and self.default is None:
             return []
         return value
 
@@ -48,7 +48,7 @@ class JSONBAgg(OrderableAggMixin, Aggregate):
     output_field = JSONField()
 
     def convert_value(self, value, expression, connection):
-        if not value:
+        if value is None and self.default is None:
             return '[]'
         return value
 
@@ -63,6 +63,6 @@ class StringAgg(OrderableAggMixin, Aggregate):
         super().__init__(expression, delimiter_expr, **extra)
 
     def convert_value(self, value, expression, connection):
-        if not value:
+        if value is None and self.default is None:
             return ''
         return value

--- a/django/contrib/postgres/aggregates/general.py
+++ b/django/contrib/postgres/aggregates/general.py
@@ -1,5 +1,8 @@
+import warnings
+
 from django.contrib.postgres.fields import ArrayField
 from django.db.models import Aggregate, BooleanField, JSONField, Value
+from django.utils.deprecation import RemovedInDjango50Warning
 
 from .mixins import OrderableAggMixin
 
@@ -8,19 +11,43 @@ __all__ = [
 ]
 
 
-class ArrayAgg(OrderableAggMixin, Aggregate):
+# RemovedInDjango50Warning
+NOT_PROVIDED = object()
+
+
+class DeprecatedConvertValueMixin:
+    def __init__(self, *expressions, default=NOT_PROVIDED, **extra):
+        if default is NOT_PROVIDED:
+            default = None
+            self._default_provided = False
+        else:
+            self._default_provided = True
+        super().__init__(*expressions, default=default, **extra)
+
+    def convert_value(self, value, expression, connection):
+        if value is None and not self._default_provided:
+            warnings.warn(self.deprecation_msg, category=RemovedInDjango50Warning)
+            return self.deprecation_value
+        return value
+
+
+class ArrayAgg(DeprecatedConvertValueMixin, OrderableAggMixin, Aggregate):
     function = 'ARRAY_AGG'
     template = '%(function)s(%(distinct)s%(expressions)s %(ordering)s)'
     allow_distinct = True
 
+    # RemovedInDjango50Warning
+    deprecation_value = property(lambda self: [])
+    deprecation_msg = (
+        'In Django 5.0, ArrayAgg() will return None instead of an empty list '
+        'if there are no rows. Pass default=None to opt into the new behavior '
+        'and silence this warning or default=Value([]) to keep the previous '
+        'behavior.'
+    )
+
     @property
     def output_field(self):
         return ArrayField(self.source_expressions[0].output_field)
-
-    def convert_value(self, value, expression, connection):
-        if value is None and self.default is None:
-            return []
-        return value
 
 
 class BitAnd(Aggregate):
@@ -41,28 +68,36 @@ class BoolOr(Aggregate):
     output_field = BooleanField()
 
 
-class JSONBAgg(OrderableAggMixin, Aggregate):
+class JSONBAgg(DeprecatedConvertValueMixin, OrderableAggMixin, Aggregate):
     function = 'JSONB_AGG'
     template = '%(function)s(%(distinct)s%(expressions)s %(ordering)s)'
     allow_distinct = True
     output_field = JSONField()
 
-    def convert_value(self, value, expression, connection):
-        if value is None and self.default is None:
-            return '[]'
-        return value
+    # RemovedInDjango50Warning
+    deprecation_value = '[]'
+    deprecation_msg = (
+        "In Django 5.0, JSONBAgg() will return None instead of an empty list "
+        "if there are no rows. Pass default=None to opt into the new behavior "
+        "and silence this warning or default=Value('[]') to keep the previous "
+        "behavior."
+    )
 
 
-class StringAgg(OrderableAggMixin, Aggregate):
+class StringAgg(DeprecatedConvertValueMixin, OrderableAggMixin, Aggregate):
     function = 'STRING_AGG'
     template = '%(function)s(%(distinct)s%(expressions)s %(ordering)s)'
     allow_distinct = True
 
+    # RemovedInDjango50Warning
+    deprecation_value = ''
+    deprecation_msg = (
+        "In Django 5.0, StringAgg() will return None instead of an empty "
+        "string if there are no rows. Pass default=None to opt into the new "
+        "behavior and silence this warning or default=Value('') to keep the "
+        "previous behavior."
+    )
+
     def __init__(self, expression, delimiter, **extra):
         delimiter_expr = Value(str(delimiter))
         super().__init__(expression, delimiter_expr, **extra)
-
-    def convert_value(self, value, expression, connection):
-        if value is None and self.default is None:
-            return ''
-        return value

--- a/django/contrib/postgres/aggregates/statistics.py
+++ b/django/contrib/postgres/aggregates/statistics.py
@@ -9,10 +9,10 @@ __all__ = [
 class StatAggregate(Aggregate):
     output_field = FloatField()
 
-    def __init__(self, y, x, output_field=None, filter=None):
+    def __init__(self, y, x, output_field=None, filter=None, default=None):
         if not x or not y:
             raise ValueError('Both y and x must be provided.')
-        super().__init__(y, x, output_field=output_field, filter=filter)
+        super().__init__(y, x, output_field=output_field, filter=filter, default=default)
 
 
 class Corr(StatAggregate):
@@ -20,9 +20,9 @@ class Corr(StatAggregate):
 
 
 class CovarPop(StatAggregate):
-    def __init__(self, y, x, sample=False, filter=None):
+    def __init__(self, y, x, sample=False, filter=None, default=None):
         self.function = 'COVAR_SAMP' if sample else 'COVAR_POP'
-        super().__init__(y, x, filter=filter)
+        super().__init__(y, x, filter=filter, default=default)
 
 
 class RegrAvgX(StatAggregate):

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -88,6 +88,17 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                     'annotations.tests.NonAggregateAnnotationTestCase.test_annotation_aggregate_with_m2o',
                 },
             })
+        if not self.connection.mysql_is_mariadb and self.connection.mysql_version < (8,):
+            skips.update({
+                'Casting to datetime/time is not supported by MySQL < 8.0. (#30224)': {
+                    'aggregation.tests.AggregateTestCase.test_aggregation_default_using_time_from_python',
+                    'aggregation.tests.AggregateTestCase.test_aggregation_default_using_datetime_from_python',
+                },
+                'MySQL < 8.0 returns string type instead of datetime/time. (#30224)': {
+                    'aggregation.tests.AggregateTestCase.test_aggregation_default_using_time_from_database',
+                    'aggregation.tests.AggregateTestCase.test_aggregation_default_using_datetime_from_database',
+                },
+            })
         if (
             self.connection.mysql_is_mariadb and
             (10, 4, 3) < self.connection.mysql_version < (10, 5, 2)

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -30,6 +30,10 @@ details on these changes.
 * The ``extra_tests`` argument for ``DiscoverRunner.build_suite()`` and
   ``DiscoverRunner.run_tests()`` will be removed.
 
+* The ``django.contrib.postgres.aggregates.ArrayAgg``, ``JSONBAgg``, and
+  ``StringAgg`` aggregates will return ``None`` when there are no rows instead
+  of ``[]``, ``[]``, and ``''`` respectively.
+
 .. _deprecation-removed-in-4.1:
 
 4.1

--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -52,6 +52,13 @@ General-purpose aggregation functions
             from django.db.models import F
             F('some_field').desc()
 
+    .. deprecated:: 4.0
+
+        If there are no rows and ``default`` is not provided, ``ArrayAgg``
+        returns an empty list instead of ``None``. This behavior is deprecated
+        and will be removed in Django 5.0. If you need it, explicitly set
+        ``default`` to ``Value([])``.
+
 ``BitAnd``
 ----------
 
@@ -138,6 +145,13 @@ General-purpose aggregation functions
 
         Examples are the same as for :attr:`ArrayAgg.ordering`.
 
+    .. deprecated:: 4.0
+
+        If there are no rows and ``default`` is not provided, ``JSONBAgg``
+        returns an empty list instead of ``None``. This behavior is deprecated
+        and will be removed in Django 5.0. If you need it, explicitly set
+        ``default`` to ``Value('[]')``.
+
 ``StringAgg``
 -------------
 
@@ -163,6 +177,13 @@ General-purpose aggregation functions
         elements in the result string.
 
         Examples are the same as for :attr:`ArrayAgg.ordering`.
+
+    .. deprecated:: 4.0
+
+        If there are no rows and ``default`` is not provided, ``StringAgg``
+        returns an empty string instead of ``None``. This behavior is
+        deprecated and will be removed in Django 5.0. If you need it,
+        explicitly set ``default`` to ``Value('')``.
 
 Aggregate functions for statistics
 ==================================

--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -19,8 +19,8 @@ module. They are described in more detail in the `PostgreSQL docs
 
 .. admonition:: Common aggregate options
 
-    All aggregates have the :ref:`filter <aggregate-filter>` keyword
-    argument.
+    All aggregates have the :ref:`filter <aggregate-filter>` keyword argument
+    and most also have the :ref:`default <aggregate-default>` keyword argument.
 
 General-purpose aggregation functions
 =====================================
@@ -28,9 +28,10 @@ General-purpose aggregation functions
 ``ArrayAgg``
 ------------
 
-.. class:: ArrayAgg(expression, distinct=False, filter=None, ordering=(), **extra)
+.. class:: ArrayAgg(expression, distinct=False, filter=None, default=None, ordering=(), **extra)
 
-    Returns a list of values, including nulls, concatenated into an array.
+    Returns a list of values, including nulls, concatenated into an array, or
+    ``default`` if there are no values.
 
     .. attribute:: distinct
 
@@ -54,26 +55,26 @@ General-purpose aggregation functions
 ``BitAnd``
 ----------
 
-.. class:: BitAnd(expression, filter=None, **extra)
+.. class:: BitAnd(expression, filter=None, default=None, **extra)
 
     Returns an ``int`` of the bitwise ``AND`` of all non-null input values, or
-    ``None`` if all values are null.
+    ``default`` if all values are null.
 
 ``BitOr``
 ---------
 
-.. class:: BitOr(expression, filter=None, **extra)
+.. class:: BitOr(expression, filter=None, default=None, **extra)
 
     Returns an ``int`` of the bitwise ``OR`` of all non-null input values, or
-    ``None`` if all values are null.
+    ``default`` if all values are null.
 
 ``BoolAnd``
 -----------
 
-.. class:: BoolAnd(expression, filter=None, **extra)
+.. class:: BoolAnd(expression, filter=None, default=None, **extra)
 
-    Returns ``True``, if all input values are true, ``None`` if all values are
-    null or if there are no values, otherwise ``False`` .
+    Returns ``True``, if all input values are true, ``default`` if all values
+    are null or if there are no values, otherwise ``False``.
 
     Usage example::
 
@@ -92,9 +93,9 @@ General-purpose aggregation functions
 ``BoolOr``
 ----------
 
-.. class:: BoolOr(expression, filter=None, **extra)
+.. class:: BoolOr(expression, filter=None, default=None, **extra)
 
-    Returns ``True`` if at least one input value is true, ``None`` if all
+    Returns ``True`` if at least one input value is true, ``default`` if all
     values are null or if there are no values, otherwise ``False``.
 
     Usage example::
@@ -114,9 +115,10 @@ General-purpose aggregation functions
 ``JSONBAgg``
 ------------
 
-.. class:: JSONBAgg(expressions, distinct=False, filter=None, ordering=(), **extra)
+.. class:: JSONBAgg(expressions, distinct=False, filter=None, default=None, ordering=(), **extra)
 
-    Returns the input values as a ``JSON`` array.
+    Returns the input values as a ``JSON`` array, or ``default`` if there are
+    no values.
 
     .. attribute:: distinct
 
@@ -139,10 +141,10 @@ General-purpose aggregation functions
 ``StringAgg``
 -------------
 
-.. class:: StringAgg(expression, delimiter, distinct=False, filter=None, ordering=())
+.. class:: StringAgg(expression, delimiter, distinct=False, filter=None, default=None, ordering=())
 
     Returns the input values concatenated into a string, separated by
-    the ``delimiter`` string.
+    the ``delimiter`` string, or ``default`` if there are no values.
 
     .. attribute:: delimiter
 
@@ -174,17 +176,17 @@ field or an expression returning a numeric data. Both are required.
 ``Corr``
 --------
 
-.. class:: Corr(y, x, filter=None)
+.. class:: Corr(y, x, filter=None, default=None)
 
-    Returns the correlation coefficient as a ``float``, or ``None`` if there
+    Returns the correlation coefficient as a ``float``, or ``default`` if there
     aren't any matching rows.
 
 ``CovarPop``
 ------------
 
-.. class:: CovarPop(y, x, sample=False, filter=None)
+.. class:: CovarPop(y, x, sample=False, filter=None, default=None)
 
-    Returns the population covariance as a ``float``, or ``None`` if there
+    Returns the population covariance as a ``float``, or ``default`` if there
     aren't any matching rows.
 
     Has one optional argument:
@@ -198,18 +200,18 @@ field or an expression returning a numeric data. Both are required.
 ``RegrAvgX``
 ------------
 
-.. class:: RegrAvgX(y, x, filter=None)
+.. class:: RegrAvgX(y, x, filter=None, default=None)
 
     Returns the average of the independent variable (``sum(x)/N``) as a
-    ``float``, or ``None`` if there aren't any matching rows.
+    ``float``, or ``default`` if there aren't any matching rows.
 
 ``RegrAvgY``
 ------------
 
-.. class:: RegrAvgY(y, x, filter=None)
+.. class:: RegrAvgY(y, x, filter=None, default=None)
 
     Returns the average of the dependent variable (``sum(y)/N``) as a
-    ``float``, or ``None`` if there aren't any matching rows.
+    ``float``, or ``default`` if there aren't any matching rows.
 
 ``RegrCount``
 -------------
@@ -219,56 +221,60 @@ field or an expression returning a numeric data. Both are required.
     Returns an ``int`` of the number of input rows in which both expressions
     are not null.
 
+    .. note::
+
+        The ``default`` argument is not supported.
+
 ``RegrIntercept``
 -----------------
 
-.. class:: RegrIntercept(y, x, filter=None)
+.. class:: RegrIntercept(y, x, filter=None, default=None)
 
     Returns the y-intercept of the least-squares-fit linear equation determined
-    by the ``(x, y)`` pairs as a ``float``, or ``None`` if there aren't any
+    by the ``(x, y)`` pairs as a ``float``, or ``default`` if there aren't any
     matching rows.
 
 ``RegrR2``
 ----------
 
-.. class:: RegrR2(y, x, filter=None)
+.. class:: RegrR2(y, x, filter=None, default=None)
 
     Returns the square of the correlation coefficient as a ``float``, or
-    ``None`` if there aren't any matching rows.
+    ``default`` if there aren't any matching rows.
 
 ``RegrSlope``
 -------------
 
-.. class:: RegrSlope(y, x, filter=None)
+.. class:: RegrSlope(y, x, filter=None, default=None)
 
     Returns the slope of the least-squares-fit linear equation determined
-    by the ``(x, y)`` pairs as a ``float``, or ``None`` if there aren't any
+    by the ``(x, y)`` pairs as a ``float``, or ``default`` if there aren't any
     matching rows.
 
 ``RegrSXX``
 -----------
 
-.. class:: RegrSXX(y, x, filter=None)
+.. class:: RegrSXX(y, x, filter=None, default=None)
 
     Returns ``sum(x^2) - sum(x)^2/N`` ("sum of squares" of the independent
-    variable) as a ``float``, or ``None`` if there aren't any matching rows.
+    variable) as a ``float``, or ``default`` if there aren't any matching rows.
 
 ``RegrSXY``
 -----------
 
-.. class:: RegrSXY(y, x, filter=None)
+.. class:: RegrSXY(y, x, filter=None, default=None)
 
     Returns ``sum(x*y) - sum(x) * sum(y)/N`` ("sum of products" of independent
-    times dependent variable) as a ``float``, or ``None`` if there aren't any
-    matching rows.
+    times dependent variable) as a ``float``, or ``default`` if there aren't
+    any matching rows.
 
 ``RegrSYY``
 -----------
 
-.. class:: RegrSYY(y, x, filter=None)
+.. class:: RegrSYY(y, x, filter=None, default=None)
 
     Returns ``sum(y^2) - sum(y)^2/N`` ("sum of squares" of the dependent
-    variable)  as a ``float``, or ``None`` if there aren't any matching rows.
+    variable) as a ``float``, or ``default`` if there aren't any matching rows.
 
 Usage examples
 ==============

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -59,7 +59,7 @@ will result in a database error.
 Usage examples::
 
     >>> # Get a screen name from least to most public
-    >>> from django.db.models import Sum, Value as V
+    >>> from django.db.models import Sum
     >>> from django.db.models.functions import Coalesce
     >>> Author.objects.create(name='Margaret Smith', goes_by='Maggie')
     >>> author = Author.objects.annotate(
@@ -68,13 +68,18 @@ Usage examples::
     Maggie
 
     >>> # Prevent an aggregate Sum() from returning None
+    >>> # The aggregate default argument uses Coalesce() under the hood.
     >>> aggregated = Author.objects.aggregate(
-    ...    combined_age=Coalesce(Sum('age'), V(0)),
-    ...    combined_age_default=Sum('age'))
+    ...    combined_age=Sum('age'),
+    ...    combined_age_default=Sum('age', default=0),
+    ...    combined_age_coalesce=Coalesce(Sum('age'), 0),
+    ... )
     >>> print(aggregated['combined_age'])
-    0
-    >>> print(aggregated['combined_age_default'])
     None
+    >>> print(aggregated['combined_age_default'])
+    0
+    >>> print(aggregated['combined_age_coalesce'])
+    0
 
 .. warning::
 

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -393,7 +393,7 @@ some complex computations::
 
 The ``Aggregate`` API is as follows:
 
-.. class:: Aggregate(*expressions, output_field=None, distinct=False, filter=None, **extra)
+.. class:: Aggregate(*expressions, output_field=None, distinct=False, filter=None, default=None, **extra)
 
     .. attribute:: template
 
@@ -452,12 +452,21 @@ The ``filter`` argument takes a :class:`Q object <django.db.models.Q>` that's
 used to filter the rows that are aggregated. See :ref:`conditional-aggregation`
 and :ref:`filtering-on-annotations` for example usage.
 
+The ``default`` argument takes a value that will be passed along with the
+aggregate to :class:`~django.db.models.functions.Coalesce`. This is useful for
+specifying a value to be returned other than ``None`` when the queryset (or
+grouping) contains no entries.
+
 The ``**extra`` kwargs are ``key=value`` pairs that can be interpolated
 into the ``template`` attribute.
 
 .. versionchanged:: 3.2
 
     Support for transforms of the field was added.
+
+.. versionchanged:: 4.0
+
+    The ``default`` argument was added.
 
 Creating your own Aggregate Functions
 -------------------------------------

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -3540,8 +3540,10 @@ documentation to learn how to create your aggregates.
 
     Aggregation functions return ``None`` when used with an empty
     ``QuerySet``. For example, the ``Sum`` aggregation function returns ``None``
-    instead of ``0`` if the ``QuerySet`` contains no entries. An exception is
-    ``Count``, which does return ``0`` if the ``QuerySet`` is empty.
+    instead of ``0`` if the ``QuerySet`` contains no entries. To return another
+    value instead, pass a value to the ``default`` argument. An exception is
+    ``Count``, which does return ``0`` if the ``QuerySet`` is empty. ``Count``
+    does not support the ``default`` argument.
 
 All aggregates have the following parameters in common:
 
@@ -3578,6 +3580,16 @@ rows that are aggregated.
 See :ref:`conditional-aggregation` and :ref:`filtering-on-annotations` for
 example usage.
 
+.. _aggregate-default:
+
+``default``
+~~~~~~~~~~~
+
+.. versionadded:: 4.0
+
+An optional argument that allows specifying a value to use as a default value
+when the queryset (or grouping) contains no entries.
+
 ``**extra``
 ~~~~~~~~~~~
 
@@ -3587,7 +3599,7 @@ by the aggregate.
 ``Avg``
 ~~~~~~~
 
-.. class:: Avg(expression, output_field=None, distinct=False, filter=None, **extra)
+.. class:: Avg(expression, output_field=None, distinct=False, filter=None, default=None, **extra)
 
     Returns the mean value of the given expression, which must be numeric
     unless you specify a different ``output_field``.
@@ -3623,10 +3635,14 @@ by the aggregate.
         This is the SQL equivalent of ``COUNT(DISTINCT <field>)``. The default
         value is ``False``.
 
+    .. note::
+
+        The ``default`` argument is not supported.
+
 ``Max``
 ~~~~~~~
 
-.. class:: Max(expression, output_field=None, filter=None, **extra)
+.. class:: Max(expression, output_field=None, filter=None, default=None, **extra)
 
     Returns the maximum value of the given expression.
 
@@ -3636,7 +3652,7 @@ by the aggregate.
 ``Min``
 ~~~~~~~
 
-.. class:: Min(expression, output_field=None, filter=None, **extra)
+.. class:: Min(expression, output_field=None, filter=None, default=None, **extra)
 
     Returns the minimum value of the given expression.
 
@@ -3646,7 +3662,7 @@ by the aggregate.
 ``StdDev``
 ~~~~~~~~~~
 
-.. class:: StdDev(expression, output_field=None, sample=False, filter=None, **extra)
+.. class:: StdDev(expression, output_field=None, sample=False, filter=None, default=None, **extra)
 
     Returns the standard deviation of the data in the provided expression.
 
@@ -3664,7 +3680,7 @@ by the aggregate.
 ``Sum``
 ~~~~~~~
 
-.. class:: Sum(expression, output_field=None, distinct=False, filter=None, **extra)
+.. class:: Sum(expression, output_field=None, distinct=False, filter=None, default=None, **extra)
 
     Computes the sum of all values of the given expression.
 
@@ -3682,7 +3698,7 @@ by the aggregate.
 ``Variance``
 ~~~~~~~~~~~~
 
-.. class:: Variance(expression, output_field=None, sample=False, filter=None, **extra)
+.. class:: Variance(expression, output_field=None, sample=False, filter=None, default=None, **extra)
 
     Returns the variance of the data in the provided expression.
 

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -288,6 +288,10 @@ Models
 * :class:`~django.db.models.Lookup` expressions may now be used in ``QuerySet``
   annotations, aggregations, and directly in filters.
 
+* The new :ref:`default <aggregate-default>` argument for built-in aggregates
+  allows specifying a value to be returned when the queryset (or grouping)
+  contains no entries, rather than ``None``.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -540,6 +540,13 @@ Miscellaneous
 * The ``extra_tests`` argument for :meth:`.DiscoverRunner.build_suite` and
   :meth:`.DiscoverRunner.run_tests` is deprecated.
 
+* The :class:`~django.contrib.postgres.aggregates.ArrayAgg`,
+  :class:`~django.contrib.postgres.aggregates.JSONBAgg`, and
+  :class:`~django.contrib.postgres.aggregates.StringAgg` aggregates will return
+  ``None`` when there are no rows instead of ``[]``, ``[]``, and ``''``
+  respectively in Django 5.0. If you need the previous behavior, explicitly set
+  ``default`` to ``Value([])``, ``Value('[]')``, or ``Value('')``.
+
 Features removed in 4.0
 =======================
 

--- a/tests/postgres_tests/test_aggregates.py
+++ b/tests/postgres_tests/test_aggregates.py
@@ -72,6 +72,34 @@ class TestGeneralAggregate(PostgreSQLTestCase):
                     )
                     self.assertEqual(values, {'aggregation': expected_result})
 
+    def test_default_argument(self):
+        AggregateTestModel.objects.all().delete()
+        tests = [
+            (ArrayAgg('char_field', default=['<empty>']), ['<empty>']),
+            (ArrayAgg('integer_field', default=[0]), [0]),
+            (ArrayAgg('boolean_field', default=[False]), [False]),
+            (BitAnd('integer_field', default=0), 0),
+            (BitOr('integer_field', default=0), 0),
+            (BoolAnd('boolean_field', default=False), False),
+            (BoolOr('boolean_field', default=False), False),
+            (JSONBAgg('integer_field', default=Value('["<empty>"]')), ['<empty>']),
+            (StringAgg('char_field', delimiter=';', default=Value('<empty>')), '<empty>'),
+        ]
+        for aggregation, expected_result in tests:
+            with self.subTest(aggregation=aggregation):
+                # Empty result with non-execution optimization.
+                with self.assertNumQueries(0):
+                    values = AggregateTestModel.objects.none().aggregate(
+                        aggregation=aggregation,
+                    )
+                    self.assertEqual(values, {'aggregation': expected_result})
+                # Empty result when query must be executed.
+                with self.assertNumQueries(1):
+                    values = AggregateTestModel.objects.aggregate(
+                        aggregation=aggregation,
+                    )
+                    self.assertEqual(values, {'aggregation': expected_result})
+
     def test_array_agg_charfield(self):
         values = AggregateTestModel.objects.aggregate(arrayagg=ArrayAgg('char_field'))
         self.assertEqual(values, {'arrayagg': ['Foo1', 'Foo2', 'Foo4', 'Foo3']})
@@ -515,6 +543,37 @@ class TestStatisticsAggregate(PostgreSQLTestCase):
                     )
                     self.assertEqual(values, {'aggregation': expected_result})
 
+    def test_default_argument(self):
+        StatTestModel.objects.all().delete()
+        tests = [
+            (Corr(y='int2', x='int1', default=0), 0),
+            (CovarPop(y='int2', x='int1', default=0), 0),
+            (CovarPop(y='int2', x='int1', sample=True, default=0), 0),
+            (RegrAvgX(y='int2', x='int1', default=0), 0),
+            (RegrAvgY(y='int2', x='int1', default=0), 0),
+            # RegrCount() doesn't support the default argument.
+            (RegrIntercept(y='int2', x='int1', default=0), 0),
+            (RegrR2(y='int2', x='int1', default=0), 0),
+            (RegrSlope(y='int2', x='int1', default=0), 0),
+            (RegrSXX(y='int2', x='int1', default=0), 0),
+            (RegrSXY(y='int2', x='int1', default=0), 0),
+            (RegrSYY(y='int2', x='int1', default=0), 0),
+        ]
+        for aggregation, expected_result in tests:
+            with self.subTest(aggregation=aggregation):
+                # Empty result with non-execution optimization.
+                with self.assertNumQueries(0):
+                    values = StatTestModel.objects.none().aggregate(
+                        aggregation=aggregation,
+                    )
+                    self.assertEqual(values, {'aggregation': expected_result})
+                # Empty result when query must be executed.
+                with self.assertNumQueries(1):
+                    values = StatTestModel.objects.aggregate(
+                        aggregation=aggregation,
+                    )
+                    self.assertEqual(values, {'aggregation': expected_result})
+
     def test_corr_general(self):
         values = StatTestModel.objects.aggregate(corr=Corr(y='int2', x='int1'))
         self.assertEqual(values, {'corr': -1.0})
@@ -538,6 +597,11 @@ class TestStatisticsAggregate(PostgreSQLTestCase):
     def test_regr_count_general(self):
         values = StatTestModel.objects.aggregate(regrcount=RegrCount(y='int2', x='int1'))
         self.assertEqual(values, {'regrcount': 3})
+
+    def test_regr_count_default(self):
+        msg = 'RegrCount does not allow default.'
+        with self.assertRaisesMessage(TypeError, msg):
+            RegrCount(y='int2', x='int1', default=0)
 
     def test_regr_intercept_general(self):
         values = StatTestModel.objects.aggregate(regrintercept=RegrIntercept(y='int2', x='int1'))


### PR DESCRIPTION
Supersedes #13645 for ticket-10929.

This supports a ``default`` argument using ``Coalesce`` for all aggregate classes other than ``Count``.

~~This could probably do with a few more tests against some other types, e.g. date/time.~~