### PR TITLE
Fixed #32469 -- Made assertQuerysetEqual() respect maxDiff when ordered=False.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1062,7 +1062,7 @@ class TransactionTestCase(SimpleTestCase):
         if transform is not None:
             items = map(transform, items)
         if not ordered:
-            return self.assertEqual(Counter(items), Counter(values), msg=msg)
+            return self.assertDictEqual(Counter(items), Counter(values), msg=msg)
         # For example qs.iterator() could be passed as qs, but it does not
         # have 'ordered' attribute.
         if len(values) > 1 and hasattr(qs, 'ordered') and not qs.ordered:

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -325,6 +325,37 @@ class AssertQuerysetEqualTests(TestCase):
             ordered=False
         )
 
+    def test_maxdiff(self):
+        names = ['Joe Smith %s' % i for i in range(20)]
+        Person.objects.bulk_create([Person(name=name) for name in names])
+        names.append('Extra Person')
+
+        with self.assertRaises(AssertionError) as ctx:
+            self.assertQuerysetEqual(
+                Person.objects.filter(name__startswith='Joe'),
+                names,
+                ordered=False,
+                transform=lambda p: p.name,
+            )
+        self.assertIn('Set self.maxDiff to None to see it.', str(ctx.exception))
+
+        original = self.maxDiff
+        self.maxDiff = None
+        try:
+            with self.assertRaises(AssertionError) as ctx:
+                self.assertQuerysetEqual(
+                    Person.objects.filter(name__startswith='Joe'),
+                    names,
+                    ordered=False,
+                    transform=lambda p: p.name,
+                )
+        finally:
+            self.maxDiff = original
+        exception_msg = str(ctx.exception)
+        self.assertNotIn('Set self.maxDiff to None to see it.', exception_msg)
+        for name in names:
+            self.assertIn(name, exception_msg)
+
 
 class AssertQuerysetEqualDeprecationTests(TestCase):
     @classmethod


### PR DESCRIPTION
Fixes ticket-32469. This may interest you @adamchainz given your love of all things testing?