### PR TITLE
Fixed #32470 -- Fixed ResolverMatch instance on test clients when request.urlconf is set.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -725,7 +725,10 @@ class Client(ClientMixin, RequestFactory):
         response.context = data.get('context')
         response.json = partial(self._parse_json, response)
         # Attach the ResolverMatch instance to the response.
-        response.resolver_match = SimpleLazyObject(lambda: resolve(request['PATH_INFO']))
+        urlconf = getattr(response.wsgi_request, 'urlconf', None)
+        response.resolver_match = SimpleLazyObject(
+            lambda: resolve(request['PATH_INFO'], urlconf=urlconf),
+        )
         # Flatten a single context. Not really necessary anymore thanks to the
         # __getattr__ flattening in ContextList, but has some edge case
         # backwards compatibility implications.
@@ -914,7 +917,10 @@ class AsyncClient(ClientMixin, AsyncRequestFactory):
         response.context = data.get('context')
         response.json = partial(self._parse_json, response)
         # Attach the ResolverMatch instance to the response.
-        response.resolver_match = SimpleLazyObject(lambda: resolve(request['path']))
+        urlconf = getattr(response.asgi_request, 'urlconf', None)
+        response.resolver_match = SimpleLazyObject(
+            lambda: resolve(request['path'], urlconf=urlconf),
+        )
         # Flatten a single context. Not really necessary anymore thanks to the
         # __getattr__ flattening in ContextList, but has some edge case
         # backwards compatibility implications.

--- a/tests/test_client/urls_middleware_urlconf.py
+++ b/tests/test_client/urls_middleware_urlconf.py
@@ -1,0 +1,11 @@
+from django.http import HttpResponse
+from django.urls import path
+
+
+def empty_response(request):
+    return HttpResponse()
+
+
+urlpatterns = [
+    path('middleware_urlconf_view/', empty_response, name='middleware_urlconf_view'),
+]


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32470#ticket

When `request.urlconf` is set by middleware, and points to a module other than the `ROOT_URLCONF`, the test client request will either:
a) Raise a `Resolver404` if the path resolved is not part of the `ROOT_URLCONF` (even though the client has performed a successful request); or
b) Resolve the path from `ROOT_URLCONF` module instead of the one set on the `request.urlconf` attribute.

This occurs because the resolution of `response.resolver_match` only considers the request path.

This patch passes the URLConf used on the request to `resolve()` 
