### PR TITLE
Update the date, time and datetimewidgets to use HTML5 input types

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -490,16 +490,19 @@ class DateTimeBaseInput(TextInput):
 
 
 class DateInput(DateTimeBaseInput):
+    input_type = 'date'
     format_key = 'DATE_INPUT_FORMATS'
     template_name = 'django/forms/widgets/date.html'
 
 
 class DateTimeInput(DateTimeBaseInput):
+    input_type = 'datetime-local'
     format_key = 'DATETIME_INPUT_FORMATS'
     template_name = 'django/forms/widgets/datetime.html'
 
 
 class TimeInput(DateTimeBaseInput):
+    input_type = 'time'
     format_key = 'TIME_INPUT_FORMATS'
     template_name = 'django/forms/widgets/time.html'
 

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -565,7 +565,7 @@ These widgets make use of the HTML elements ``input`` and ``textarea``.
 
     * ``input_type``: ``'text'``
     * ``template_name``: ``'django/forms/widgets/date.html'``
-    * Renders as: ``<input type="text" ...>``
+    * Renders as: ``<input type="date" ...>``
 
     Takes same arguments as :class:`TextInput`, with one more optional argument:
 
@@ -584,7 +584,7 @@ These widgets make use of the HTML elements ``input`` and ``textarea``.
 
     * ``input_type``: ``'text'``
     * ``template_name``: ``'django/forms/widgets/datetime.html'``
-    * Renders as: ``<input type="text" ...>``
+    * Renders as: ``<input type="datetime-local" ...>``
 
     Takes same arguments as :class:`TextInput`, with one more optional argument:
 
@@ -607,7 +607,7 @@ These widgets make use of the HTML elements ``input`` and ``textarea``.
 
     * ``input_type``: ``'text'``
     * ``template_name``: ``'django/forms/widgets/time.html'``
-    * Renders as: ``<input type="text" ...>``
+    * Renders as: ``<input type="time" ...>``
 
     Takes same arguments as :class:`TextInput`, with one more optional argument:
 


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local, https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date, https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time
for the documentation.

Support for the the format (ISO 8601) of this is already present : https://code.djangoproject.com/ticket/11385 / https://github.com/django/django/pull/11893

The main advantage is that no external js/css libraries need to be used for an easy date and time input.