### PR TITLE
Fixed #32468 -- Corrected usage of never_cache in contrib.admin. 

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -14,6 +14,7 @@ from django.http import (
 )
 from django.template.response import TemplateResponse
 from django.urls import NoReverseMatch, Resolver404, resolve, reverse
+from django.utils.decorators import method_decorator
 from django.utils.functional import LazyObject
 from django.utils.module_loading import import_string
 from django.utils.text import capfirst
@@ -357,7 +358,7 @@ class AdminSite:
         """
         return JavaScriptCatalog.as_view(packages=['django.contrib.admin'])(request)
 
-    @never_cache
+    @method_decorator(never_cache)
     def logout(self, request, extra_context=None):
         """
         Log out the user for the given HttpRequest.
@@ -379,7 +380,7 @@ class AdminSite:
         request.current_app = self.name
         return LogoutView.as_view(**defaults)(request)
 
-    @never_cache
+    @method_decorator(never_cache)
     def login(self, request, extra_context=None):
         """
         Display the login form for the given HttpRequest.
@@ -514,7 +515,7 @@ class AdminSite:
 
         return app_list
 
-    @never_cache
+    @method_decorator(never_cache)
     def index(self, request, extra_context=None):
         """
         Display the main admin index page, which lists all of the installed

--- a/django/views/decorators/cache.py
+++ b/django/views/decorators/cache.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+from django.http import HttpRequest
 from django.middleware.cache import CacheMiddleware
 from django.utils.cache import add_never_cache_headers, patch_cache_control
 from django.utils.decorators import decorator_from_middleware_with_args
@@ -28,6 +29,12 @@ def cache_control(**kwargs):
     def _cache_controller(viewfunc):
         @wraps(viewfunc)
         def _cache_controlled(request, *args, **kw):
+            if not isinstance(request, HttpRequest):
+                raise TypeError(
+                    "cache_control didn't receive an HttpRequest. If you are "
+                    "decorating a classmethod, be sure to use "
+                    "@method_decorator."
+                )
             response = viewfunc(request, *args, **kw)
             patch_cache_control(response, **kwargs)
             return response
@@ -41,6 +48,11 @@ def never_cache(view_func):
     """
     @wraps(view_func)
     def _wrapped_view_func(request, *args, **kwargs):
+        if not isinstance(request, HttpRequest):
+            raise TypeError(
+                "never_cache didn't receive an HttpRequest. If you are "
+                "decorating a classmethod, be sure to use @method_decorator."
+            )
         response = view_func(request, *args, **kwargs)
         add_never_cache_headers(response)
         return response

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -470,7 +470,7 @@ class XFrameOptionsDecoratorsTests(TestCase):
         self.assertIsNone(r.get('X-Frame-Options', None))
 
 
-class NeverCacheDecoratorTest(TestCase):
+class NeverCacheDecoratorTest(SimpleTestCase):
     def test_never_cache_decorator(self):
         @never_cache
         def a_view(request):
@@ -480,3 +480,30 @@ class NeverCacheDecoratorTest(TestCase):
             set(r.headers['Cache-Control'].split(', ')),
             {'max-age=0', 'no-cache', 'no-store', 'must-revalidate', 'private'},
         )
+
+    def test_never_cache_decorator_http_request(self):
+        class MyClass:
+            @never_cache
+            def a_view(self, request):
+                return HttpResponse()
+        msg = (
+            "never_cache didn't receive an HttpRequest. If you are decorating "
+            "a classmethod, be sure to use @method_decorator."
+        )
+        with self.assertRaisesMessage(TypeError, msg):
+            MyClass().a_view(HttpRequest())
+
+
+class CacheControlDecoratorTest(SimpleTestCase):
+    def test_cache_control_decorator_http_request(self):
+        class MyClass:
+            @cache_control(a='b')
+            def a_view(self, request):
+                return HttpResponse()
+
+        msg = (
+            "cache_control didn't receive an HttpRequest. If you are "
+            "decorating a classmethod, be sure to use @method_decorator."
+        )
+        with self.assertRaisesMessage(TypeError, msg):
+            MyClass().a_view(HttpRequest())


### PR DESCRIPTION
…or on login and logout views in admin site.

Fixed [32468](https://code.djangoproject.com/ticket/32468#ticket)