### PR TITLE
Fixed #32466 -- Corrected autocomplete to_field resolution for complex cases.

### DIFF
--- a/django/contrib/admin/views/autocomplete.py
+++ b/django/contrib/admin/views/autocomplete.py
@@ -90,7 +90,8 @@ class AutocompleteJsonView(BaseListView):
                 type(model_admin).__qualname__
             )
 
-        to_field_name = getattr(source_field.remote_field, 'field_name', model_admin.model._meta.pk.name)
+        to_field_name = getattr(source_field.remote_field, 'field_name', remote_model._meta.pk.attname)
+        to_field_name = remote_model._meta.get_field(to_field_name).attname
         if not model_admin.to_field_allowed(request, to_field_name):
             raise PermissionDenied
 

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -428,7 +428,9 @@ class AutocompleteMixin:
         }
         if not self.is_required and not self.allow_multiple_selected:
             default[1].append(self.create_option(name, '', '', False, 0))
-        to_field_name = getattr(self.field.remote_field, 'field_name', self.field.model._meta.pk.name)
+        remote_model_opts = self.field.remote_field.model._meta
+        to_field_name = getattr(self.field.remote_field, 'field_name', remote_model_opts.pk.attname)
+        to_field_name = remote_model_opts.get_field(to_field_name).attname
         choices = (
             (getattr(obj, to_field_name), self.choices.field.label_from_instance(obj))
             for obj in self.choices.queryset.using(self.db).filter(**{'%s__in' % to_field_name: selected_choices})

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -338,6 +338,24 @@ class Child(models.Model):
             raise ValidationError('invalid')
 
 
+class PKChild(models.Model):
+    """
+    Used to check autocomplete to_field resolution when ForeignKey is PK.
+    """
+    parent = models.ForeignKey(Parent, models.CASCADE, primary_key=True)
+    name = models.CharField(max_length=128)
+
+    class Meta:
+        ordering = ['parent']
+
+    def __str__(self):
+        return self.name
+
+
+class Toy(models.Model):
+    child = models.ForeignKey(PKChild, models.CASCADE)
+
+
 class EmptyModel(models.Model):
     def __str__(self):
         return "Primary key = %s" % self.id
@@ -615,10 +633,24 @@ class Song(models.Model):
 class Employee(Person):
     code = models.CharField(max_length=20)
 
+    class Meta:
+        ordering = ['name']
+
 
 class WorkHour(models.Model):
     datum = models.DateField()
     employee = models.ForeignKey(Employee, models.CASCADE)
+
+
+class Manager(Employee):
+    """
+    A multi-layer MTI child.
+    """
+    pass
+
+
+class Bonus(models.Model):
+    recipient = models.ForeignKey(Manager, on_delete=models.CASCADE)
 
 
 class Question(models.Model):

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -622,6 +622,7 @@ class WorkHour(models.Model):
 
 
 class Question(models.Model):
+    big_id = models.BigAutoField(primary_key=True)
     question = models.CharField(max_length=20)
     posted = models.DateField(default=datetime.date.today)
     expires = models.DateTimeField(null=True, blank=True)

--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -94,6 +94,30 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
             'pagination': {'more': False},
         })
 
+    def test_custom_to_field_permission_denied(self):
+        Question.objects.create(question='Is this a question?')
+        request = self.factory.get(self.url, {'term': 'is', **self.opts, 'field_name': 'question_with_to_field'})
+        request.user = self.user
+        with self.assertRaises(PermissionDenied):
+            AutocompleteJsonView.as_view(**self.as_view_args)(request)
+
+    def test_custom_to_field_custom_pk(self):
+        q = Question.objects.create(question='Is this a question?')
+        opts = {
+            'app_label': Question._meta.app_label,
+            'model_name': Question._meta.model_name,
+            'field_name': 'related_questions',
+        }
+        request = self.factory.get(self.url, {'term': 'is', **opts})
+        request.user = self.superuser
+        response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(data, {
+            'results': [{'id': str(q.big_id), 'text': q.question}],
+            'pagination': {'more': False},
+        })
+
     def test_field_does_not_exist(self):
         request = self.factory.get(self.url, {'term': 'is', **self.opts, 'field_name': 'does_not_exist'})
         request.user = self.superuser

--- a/tests/admin_widgets/models.py
+++ b/tests/admin_widgets/models.py
@@ -18,7 +18,11 @@ class Member(models.Model):
         return self.name
 
 
-class Band(models.Model):
+class Artist(models.Model):
+    pass
+
+
+class Band(Artist):
     uuid = models.UUIDField(unique=True, default=uuid.uuid4)
     name = models.CharField(max_length=100)
     style = models.CharField(max_length=20)
@@ -45,6 +49,25 @@ class Album(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class ReleaseEvent(models.Model):
+    """
+    Used to check that autocomplete widget correctly resolves attname for FK as
+    PK example.
+    """
+    album = models.ForeignKey(Album, models.CASCADE, primary_key=True)
+    name = models.CharField(max_length=100)
+
+    class Meta:
+        ordering = ['name']
+
+    def __str__(self):
+        return self.name
+
+
+class VideoStream(models.Model):
+    release_event = models.ForeignKey(ReleaseEvent, models.CASCADE)
 
 
 class HiddenInventoryManager(models.Manager):

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -24,7 +24,7 @@ from django.utils import translation
 from .models import (
     Advisor, Album, Band, Bee, Car, Company, Event, Honeycomb, Individual,
     Inventory, Member, MyFileField, Profile, School, Student,
-    UnsafeLimitChoicesTo,
+    UnsafeLimitChoicesTo, VideoStream,
 )
 from .widgetadmin import site as widget_admin_site
 
@@ -624,7 +624,17 @@ class ForeignKeyRawIdWidgetTest(TestCase):
         self.assertHTMLEqual(
             w.render('test', None),
             '<input type="text" name="test" class="vForeignKeyRawIdAdminField">\n'
-            '<a href="/admin_widgets/band/?name=%22%26%3E%3Cescapeme&amp;_to_field=id" '
+            '<a href="/admin_widgets/band/?name=%22%26%3E%3Cescapeme&amp;_to_field=artist_ptr" '
+            'class="related-lookup" id="lookup_id_test" title="Lookup"></a>'
+        )
+
+    def test_render_fk_as_pk_model(self):
+        rel = VideoStream._meta.get_field('release_event').remote_field
+        w = widgets.ForeignKeyRawIdWidget(rel, widget_admin_site)
+        self.assertHTMLEqual(
+            w.render('test', None),
+            '<input type="text" name="test" class="vForeignKeyRawIdAdminField">\n'
+            '<a href="/admin_widgets/releaseevent/?_to_field=album" '
             'class="related-lookup" id="lookup_id_test" title="Lookup"></a>'
         )
 

--- a/tests/admin_widgets/widgetadmin.py
+++ b/tests/admin_widgets/widgetadmin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 
 from .models import (
     Advisor, Album, Band, Bee, Car, CarTire, Event, Inventory, Member, Profile,
-    School, User,
+    ReleaseEvent, School, User, VideoStream,
 )
 
 
@@ -47,6 +47,8 @@ site.register(Member)
 site.register(Band)
 site.register(Event, EventAdmin)
 site.register(Album, AlbumAdmin)
+site.register(ReleaseEvent, search_fields=['name'])
+site.register(VideoStream, autocomplete_fields=['release_event'])
 
 site.register(Inventory)
 


### PR DESCRIPTION
The `to_field_name` validation and query setup applies to foreign
keys only, not to m2m relationships. The correct fallback in those
cases would be `'pk'`. The ORM will correclty map the this value
to the corresponding actual PK field name.

See also ticket-32466