### PR TITLE
Fixed DataUploadMaxNumberOfFieldsFormPost.test_number_exceeded().

### DIFF
--- a/tests/requests/test_data_upload_settings.py
+++ b/tests/requests/test_data_upload_settings.py
@@ -168,7 +168,7 @@ class DataUploadMaxNumberOfFieldsMultipartPost(SimpleTestCase):
 
 class DataUploadMaxNumberOfFieldsFormPost(SimpleTestCase):
     def setUp(self):
-        payload = FakePayload("\r\n".join(['a=1&a=2;a=3', '']))
+        payload = FakePayload("\r\n".join(['a=1&a=2&a=3', '']))
         self.request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
Follow up to 0ad9fa02e07b853003b3c2244d1015620705f020.