### PR TITLE
Fix querysets exclude documentation

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -204,7 +204,7 @@ The lookup parameters (``**kwargs``) should be in the format described in
 underlying SQL statement, and the whole thing is enclosed in a ``NOT()``.
 
 This example excludes all entries whose ``pub_date`` is later than 2005-1-3
-AND whose ``headline`` is "Hello"::
+OR whose ``headline`` is "Hello"::
 
     Entry.objects.exclude(pub_date__gt=datetime.date(2005, 1, 3), headline='Hello')
 
@@ -216,7 +216,7 @@ In SQL terms, that evaluates to:
     WHERE NOT (pub_date > '2005-1-3' AND headline = 'Hello')
 
 This example excludes all entries whose ``pub_date`` is later than 2005-1-3
-OR whose headline is "Hello"::
+AND whose headline is "Hello"::
 
     Entry.objects.exclude(pub_date__gt=datetime.date(2005, 1, 3)).exclude(headline='Hello')
 


### PR DESCRIPTION
This sample:
```
Entry.objects.exclude(pub_date__gt=datetime.date(2005, 1, 3), headline='Hello')
```
Actually excludes using `OR`, not `AND` as it's written in the documentation. Because if we take a look at it's sql query:
```
    SELECT ...
    WHERE NOT (pub_date > '2005-1-3' AND headline = 'Hello')
```
Grouped negation `NOT (pub_date > '2005-1-3' AND headline = 'Hello')`
Can be written like:
```
NOT pub_date > '2005-1-3' OR NOT headline = 'Hello'
```
Ref: https://www.math.toronto.edu/preparing-for-calculus/3_logic/we_3_negation.html
`NOT (A AND B) == NOT A or NOT B`

But this query:
```
    Entry.objects.exclude(pub_date__gt=datetime.date(2005, 1, 3)).exclude(headline='Hello')
```
Check it's SQL:
```
    SELECT ...
    WHERE NOT pub_date > '2005-1-3'
    AND NOT headline = 'Hello'
```
Excludes using `AND`, but documentation says `OR`