### PR TITLE
Refs #31811 -- Restored **kwargs to django.test.utils.setup_databases().

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -157,7 +157,7 @@ def teardown_test_environment():
 
 
 def setup_databases(verbosity, interactive, *, time_keeper=None, keepdb=False, debug_sql=False, parallel=0,
-                    aliases=None):
+                    aliases=None, **kwargs):
     """Create the test databases."""
     if time_keeper is None:
         time_keeper = NullTimeKeeper()


### PR DESCRIPTION
Accidentally removed in 61a0ba43cfd4ff66f51a9d73dcd8ed6f6a6d9915.