### PR TITLE
Refs #31811 -- Corrected DiscoverRunner.setup_databases() signature.

### DIFF
--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -658,7 +658,7 @@ Methods
 
     Returns a ``TestSuite`` instance ready to be run.
 
-.. method:: DiscoverRunner.setup_databases(verbosity, interactive, **kwargs)
+.. method:: DiscoverRunner.setup_databases(**kwargs)
 
     Creates the test databases by calling
     :func:`~django.test.utils.setup_databases`.


### PR DESCRIPTION
Accidentally removed in 61a0ba43cfd4ff66f51a9d73dcd8ed6f6a6d9915.

See [comment](https://github.com/django/django/pull/13224#discussion_r469882795).