### PR TITLE
Refs #28478 -- Removed dead code in DiscoverRunner.get_databases.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -681,25 +681,20 @@ class DiscoverRunner:
     def suite_result(self, suite, result, **kwargs):
         return len(result.failures) + len(result.errors)
 
-    def _get_databases(self, suite):
+    def get_databases(self, suite):
         databases = {}
         for test in suite:
-            if isinstance(test, unittest.TestCase):
-                test_databases = getattr(test, 'databases', None)
-                if test_databases == '__all__':
-                    test_databases = connections
-                if test_databases:
-                    serialized_rollback = getattr(test, 'serialized_rollback', False)
-                    databases.update(
-                        (alias, serialized_rollback or databases.get(alias, False))
-                        for alias in test_databases
-                    )
-            else:
-                databases.update(self._get_databases(test))
-        return databases
-
-    def get_databases(self, suite):
-        databases = self._get_databases(suite)
+            if not isinstance(test, unittest.TestCase):
+                continue
+            test_databases = getattr(test, 'databases', None)
+            if test_databases == '__all__':
+                test_databases = connections
+            if test_databases:
+                serialized_rollback = getattr(test, 'serialized_rollback', False)
+                databases.update(
+                    (alias, serialized_rollback or databases.get(alias, False))
+                    for alias in test_databases
+                )
         if self.verbosity >= 2:
             unused_databases = [alias for alias in connections if alias not in databases]
             if unused_databases:

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -1,4 +1,5 @@
 import os
+import unittest
 from argparse import ArgumentParser
 from contextlib import contextmanager
 from unittest import TestSuite, TextTestRunner, defaultTestLoader, mock
@@ -341,6 +342,10 @@ class DiscoverRunnerTests(SimpleTestCase):
         self.assertIn('test', stderr.getvalue())
 
 
+def get_suite():
+    return unittest.defaultTestLoader.loadTestsFromName('test_runner_apps.databases.tests')
+
+
 class DiscoverRunnerGetDatabasesTests(SimpleTestCase):
     runner = DiscoverRunner(verbosity=2)
     skip_msg = 'Skipping setup of unused database(s): '
@@ -396,3 +401,9 @@ class DiscoverRunnerGetDatabasesTests(SimpleTestCase):
             'test_runner_apps.databases.tests.DefaultDatabaseSerializedTests'
         ])
         self.assertEqual(databases, {'default': True})
+
+    def test_nested_suite(self):
+        databases, _ = self.get_databases([
+            'test_runner.test_discover_runner.get_suite',
+        ])
+        self.assertEqual(databases, {'default': True, 'other': False})


### PR DESCRIPTION
`reorder_suite` flattens out nested `unittest.TestSuite` instances so there's no need to account for this case in get_databases.

This was noticed when trying to adjust an issue with the serialized rollback detection introduced in 3089018e.

Thanks Chris Jerdonek for the heads up.