### PR TITLE
Improved F() deconstruction.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -560,7 +560,7 @@ class TemporalSubtraction(CombinedExpression):
         return connection.ops.subtract_temporals(self.lhs.output_field.get_internal_type(), lhs, rhs)
 
 
-@deconstructible
+@deconstructible(path='django.db.models.F')
 class F(Combinable):
     """An object capable of resolving references to existing query objects."""
 

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -981,7 +981,7 @@ class FTests(SimpleTestCase):
     def test_deconstruct(self):
         f = F('name')
         path, args, kwargs = f.deconstruct()
-        self.assertEqual(path, 'django.db.models.expressions.F')
+        self.assertEqual(path, 'django.db.models.F')
         self.assertEqual(args, (f.name,))
         self.assertEqual(kwargs, {})
 


### PR DESCRIPTION
This improves migration readability by replacing `django.db.models.expressions.F()` with `models.F()`.