### PR TITLE
Fixed typos in assertQuerysetEqual() docs and 1.6 release notes.

### DIFF
--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -165,7 +165,7 @@ Minor features
 * The :meth:`~django.test.TransactionTestCase.assertQuerysetEqual` now checks
   for undefined order and raises :exc:`ValueError` if undefined
   order is spotted. The order is seen as undefined if the given ``QuerySet``
-  isn't ordered and there are more than one ordered values to compare against.
+  isn't ordered and there is more than one ordered value to compare against.
 
 * Added :meth:`~django.db.models.query.QuerySet.earliest` for symmetry with
   :meth:`~django.db.models.query.QuerySet.latest`.

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1690,7 +1690,7 @@ your test suite.
     provide an implicit ordering, you can set the ``ordered`` parameter to
     ``False``, which turns the comparison into a ``collections.Counter`` comparison.
     If the order is undefined (if the given ``qs`` isn't ordered and the
-    comparison is against more than one ordered values), a ``ValueError`` is
+    comparison is against more than one ordered value), a ``ValueError`` is
     raised.
 
     Output in case of error can be customized with the ``msg`` argument.


### PR DESCRIPTION
"One" agrees with "value" in "more than one ordered value."

I get that "more" is fouling things up, but it's "there is more than one way to skin a cat/apple", not "ways."

***

Same issue in the exception message itself, but I figure that wouldn't be backported, so I'll wait for guidance.

```diff --git a/django/test/testcases.py b/django/test/testcases.py
index eacf852118..2aa9c8ef46 100644
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1067,7 +1067,7 @@ class TransactionTestCase(SimpleTestCase):
         # have 'ordered' attribute.
         if len(values) > 1 and hasattr(qs, 'ordered') and not qs.ordered:
             raise ValueError("Trying to compare non-ordered queryset "
-                             "against more than one ordered values")
+                             "against more than one ordered value")
         return self.assertEqual(list(items), values, msg=msg)
 
     def assertNumQueries(self, num, func=None, *args, using=DEFAULT_DB_ALIAS, **kwargs):
diff --git a/tests/test_utils/tests.py b/tests/test_utils/tests.py
index 9465ace804..166f93a629 100644
--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -289,7 +289,7 @@ class AssertQuerysetEqualTests(TestCase):
     def test_undefined_order(self):
         # Using an unordered queryset with more than one ordered value
         # is an error.
-        msg = 'Trying to compare non-ordered queryset against more than one ordered values'
+        msg = 'Trying to compare non-ordered queryset against more than one ordered value'
         with self.assertRaisesMessage(ValueError, msg):
             self.assertQuerysetEqual(
                 Person.objects.all(),
```