### PR TITLE
Used GitHub actions for docs tests.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: Docs
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    name: docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - run: python -m pip install -r docs/requirements.txt
+      - name: Build docs
+        run: |
+          cd docs
+          sphinx-build -b spelling -n -q -W --keep-going -d _build/doctrees -D language=en_US -j auto . _build/spelling

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - run: pip3 install flake8
+      - run: python -m pip install flake8
       - name: flake8
         uses: liskin/gh-problem-matcher-wrap@v1
         with:
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - run: pip3 install isort
+      - run: python -m pip install isort
       - name: isort
         uses: liskin/gh-problem-matcher-wrap@v1
         with:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,8 @@ spelling_lang = 'en_US'
 # Location of word list.
 spelling_word_list_filename = 'spelling_wordlist'
 
+spelling_warning = True
+
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = []
 
@@ -125,7 +127,7 @@ today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', '_theme']
+exclude_patterns = ['_build', '_theme', 'requirements.txt']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 default_role = "default-role-error"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+pyenchant
+sphinx
+sphinxcontrib-spelling


### PR DESCRIPTION
This is almost a copy of the current CI configuration, but will only be used on PRs with docs changes. IMO we can add live preview on `readthedocs` in a separate commit, unless someone can help with setting this up.