### PR TITLE
Refs #32292 -- Made dbshell do not use 'postgres' database when service name is set.

### DIFF
--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -13,7 +13,7 @@ class DatabaseClient(BaseDatabaseClient):
 
         host = settings_dict.get('HOST')
         port = settings_dict.get('PORT')
-        dbname = settings_dict.get('NAME') or 'postgres'
+        dbname = settings_dict.get('NAME')
         user = settings_dict.get('USER')
         passwd = settings_dict.get('PASSWORD')
         service = options.get('service')
@@ -22,13 +22,17 @@ class DatabaseClient(BaseDatabaseClient):
         sslcert = options.get('sslcert')
         sslkey = options.get('sslkey')
 
+        if not dbname and not service:
+            # Connect to the default 'postgres' db.
+            dbname = 'postgres'
         if user:
             args += ['-U', user]
         if host:
             args += ['-h', host]
         if port:
             args += ['-p', str(port)]
-        args += [dbname]
+        if dbname:
+            args += [dbname]
         args.extend(parameters)
 
         env = {}

--- a/tests/dbshell/test_postgresql.py
+++ b/tests/dbshell/test_postgresql.py
@@ -70,7 +70,7 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
     def test_service(self):
         self.assertEqual(
             self.settings_to_cmd_args_env({'OPTIONS': {'service': 'django_test'}}),
-            (['psql', 'postgres'], {'PGSERVICE': 'django_test'}),
+            (['psql'], {'PGSERVICE': 'django_test'}),
         )
 
     def test_column(self):


### PR DESCRIPTION
ticket-32292

Regression in dcb3ad3319cad5c270a1856fd5f355e37cf9d474.