### PR TITLE
Refs #23919 -- Removed unneeded AttributeError catching in collectstatic's link_file().

### DIFF
--- a/django/contrib/staticfiles/management/commands/collectstatic.py
+++ b/django/contrib/staticfiles/management/commands/collectstatic.py
@@ -314,10 +314,6 @@ class Command(BaseCommand):
                 if os.path.lexists(full_path):
                     os.unlink(full_path)
                 os.symlink(source_path, full_path)
-            except AttributeError:
-                import platform
-                raise CommandError("Symlinking is not supported by Python %s." %
-                                   platform.python_version())
             except NotImplementedError:
                 import platform
                 raise CommandError("Symlinking is not supported in this "


### PR DESCRIPTION
Related change made in django/utils/_os.py in 6478e07.