### PR TITLE
Fixed #32490 -- Added base36 URL path converter

### DIFF
--- a/django/urls/converters.py
+++ b/django/urls/converters.py
@@ -1,6 +1,8 @@
 import uuid
 from functools import lru_cache
 
+from django.utils.http import base36_to_int, int_to_base36
+
 
 class IntConverter:
     regex = '[0-9]+'
@@ -10,6 +12,18 @@ class IntConverter:
 
     def to_url(self, value):
         return str(value)
+
+
+class Base36Converter:
+    regex = '[0-9a-z]+'
+
+    def to_python(self, value):
+        return base36_to_int(value)
+
+    def to_url(self, value):
+        if isinstance(value, str):
+            return value
+        return int_to_base36(value)
 
 
 class StringConverter:
@@ -42,6 +56,7 @@ class PathConverter(StringConverter):
 
 DEFAULT_CONVERTERS = {
     'int': IntConverter(),
+    'base36': Base36Converter(),
     'path': PathConverter(),
     'slug': SlugConverter(),
     'str': StringConverter(),

--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -121,6 +121,11 @@ The following path converters are available by default:
 
 * ``int`` - Matches zero or any positive integer. Returns an ``int``.
 
+* ``base36`` - Matches zero or any positive integer, formatted as a base 36 string.
+  See :data:`django.utils.http.base36_to_int`. Returns an ``int``.
+
+  .. versionadded:: 4.0
+
 * ``slug`` - Matches any slug string consisting of ASCII letters or numbers,
   plus the hyphen and underscore characters. For example,
   ``building-your-1st-django-site``.
@@ -133,6 +138,7 @@ The following path converters are available by default:
 * ``path`` - Matches any non-empty string, including the path separator,
   ``'/'``. This allows you to match against a complete URL path rather than
   a segment of a URL path as with ``str``.
+
 
 .. _registering-custom-path-converters:
 

--- a/tests/urlpatterns/converter_urls.py
+++ b/tests/urlpatterns/converter_urls.py
@@ -4,5 +4,5 @@ from . import views
 
 urlpatterns = [
     path('{x}/<{x}:{x}>/'.format(x=name), views.empty_view, name=name)
-    for name in ('int', 'path', 'slug', 'str', 'uuid')
+    for name in ('int', 'base36', 'path', 'slug', 'str', 'uuid')
 ]

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 from django.urls import NoReverseMatch, Resolver404, path, resolve, reverse
+from django.utils.http import base36_to_int, int_to_base36
 
 from .converters import DynamicConverter
 from .views import empty_view
@@ -164,33 +165,35 @@ class ConverterTests(SimpleTestCase):
             return x
 
         test_data = (
-            ('int', {'0', '1', '01', 1234567890}, int),
-            ('str', {'abcxyz'}, no_converter),
-            ('path', {'allows.ANY*characters'}, no_converter),
-            ('slug', {'abcxyz-ABCXYZ_01234567890'}, no_converter),
-            ('uuid', {'39da9369-838e-4750-91a5-f7805cd82839'}, uuid.UUID),
+            ('int', {'0', '1', '01', 1234567890}, int, int),
+            ('base36', {'0', '1', '01', '123abc'}, base36_to_int, int_to_base36),
+            ('str', {'abcxyz'}, no_converter, no_converter),
+            ('path', {'allows.ANY*characters'}, no_converter, no_converter),
+            ('slug', {'abcxyz-ABCXYZ_01234567890'}, no_converter, no_converter),
+            ('uuid', {'39da9369-838e-4750-91a5-f7805cd82839'}, uuid.UUID, str),
         )
-        for url_name, url_suffixes, converter in test_data:
+        for url_name, url_suffixes, resolve_converter, reverse_converter in test_data:
             for url_suffix in url_suffixes:
                 url = '/%s/%s/' % (url_name, url_suffix)
                 with self.subTest(url=url):
                     match = resolve(url)
                     self.assertEqual(match.url_name, url_name)
-                    self.assertEqual(match.kwargs, {url_name: converter(url_suffix)})
+                    self.assertEqual(match.kwargs, {url_name: resolve_converter(url_suffix)})
                     # reverse() works with string parameters.
                     string_kwargs = {url_name: url_suffix}
                     self.assertEqual(reverse(url_name, kwargs=string_kwargs), url)
                     # reverse() also works with native types (int, UUID, etc.).
-                    if converter is not no_converter:
+                    if reverse_converter is not no_converter:
                         # The converted value might be different for int (a
                         # leading zero is lost in the conversion).
-                        converted_value = match.kwargs[url_name]
+                        converted_value = reverse_converter(match.kwargs[url_name])
                         converted_url = '/%s/%s/' % (url_name, converted_value)
                         self.assertEqual(reverse(url_name, kwargs={url_name: converted_value}), converted_url)
 
     def test_nonmatching_urls(self):
         test_data = (
             ('int', {'-1', 'letters'}),
+            ('base36', {'-1', '?!_', 'ABC'}),
             ('str', {'', '/'}),
             ('path', {''}),
             ('slug', {'', 'stars*notallowed'}),


### PR DESCRIPTION
Added base36 to the list of default URL path converters, based on
django.utils.http.base36_to_int. It allows shorter URLs for integer
values that are easier to type (easier to keep one's place than in a
longer string of only numbers).