### PR TITLE
Fixed #32485 - Fixed icontains, istartswith and iendswith operators for PostgreSQL performance and result problem.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -107,7 +107,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'exact': '= %s',
         'iexact': '= UPPER(%s)',
         'contains': 'LIKE %s',
-        'icontains': 'LIKE UPPER(%s)',
+        'icontains': 'ILIKE %s',
         'regex': '~ %s',
         'iregex': '~* %s',
         'gt': '> %s',
@@ -116,8 +116,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'lte': '<= %s',
         'startswith': 'LIKE %s',
         'endswith': 'LIKE %s',
-        'istartswith': 'LIKE UPPER(%s)',
-        'iendswith': 'LIKE UPPER(%s)',
+        'istartswith': 'ILIKE %s',
+        'iendswith': 'ILIKE %s',
     }
 
     # The patterns below are used to generate SQL pattern lookup clauses when
@@ -131,11 +131,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     pattern_esc = r"REPLACE(REPLACE(REPLACE({}, E'\\', E'\\\\'), E'%%', E'\\%%'), E'_', E'\\_')"
     pattern_ops = {
         'contains': "LIKE '%%' || {} || '%%'",
-        'icontains': "LIKE '%%' || UPPER({}) || '%%'",
+        'icontains': "ILIKE '%%' || {} || '%%'",
         'startswith': "LIKE {} || '%%'",
-        'istartswith': "LIKE UPPER({}) || '%%'",
+        'istartswith': "ILIKE {} || '%%'",
         'endswith': "LIKE '%%' || {}",
-        'iendswith': "LIKE '%%' || UPPER({})",
+        'iendswith': "ILIKE '%%' || {}",
     }
 
     Database = Database

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -99,8 +99,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             else:
                 lookup = "%s::text"
 
-        # Use UPPER(x) for case-insensitive lookups; it's faster.
-        if lookup_type in ('iexact', 'icontains', 'istartswith', 'iendswith'):
+        if lookup_type == 'iexact':
             lookup = 'UPPER(%s)' % lookup
 
         return lookup


### PR DESCRIPTION
Using "UPPER (column) like" instead of using the "ilike" operator affects PostgreSQL performance and the search results of special characters. We can avoid these problems by using the "illike" operator. I shared examples of these problems on the ticket.