### PR TITLE
Fixed #32493 -- Removed redundant never_cache uses from admin views.

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -358,7 +358,6 @@ class AdminSite:
         """
         return JavaScriptCatalog.as_view(packages=['django.contrib.admin'])(request)
 
-    @method_decorator(never_cache)
     def logout(self, request, extra_context=None):
         """
         Log out the user for the given HttpRequest.
@@ -515,7 +514,6 @@ class AdminSite:
 
         return app_list
 
-    @method_decorator(never_cache)
     def index(self, request, extra_context=None):
         """
         Display the main admin index page, which lists all of the installed

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -311,6 +311,11 @@ Miscellaneous
   :setting:`STATIC_URL`, the leading slash is removed from that setting (now
   ``'static/'``) in the default :djadmin:`startproject` template.
 
+* The :class:`~django.contrib.admin.AdminSite` method for the admin ``index``
+  view is no longer decorated with ``never_cache`` when accessed directly,
+  rather than via the recommended ``AdminSite.urls`` property, or
+  ``AdminSite.get_urls()`` method.
+
 .. _deprecated-features-4.0:
 
 Features deprecated in 4.0


### PR DESCRIPTION
Decorating `logout` and `index` with `never_cache `is not needed, since `admin_view` already applies `never_cache`.

https://code.djangoproject.com/ticket/32493#ticket