### PR TITLE
Refs #32483 -- Doc'd caveat about using JSONField key transforms to booleans with QuerySet.values()/values_list() on SQLite.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -695,6 +695,12 @@ You can also refer to fields on related models with reverse relations through
    pronounced if you include multiple such fields in your ``values()`` query,
    in which case all possible combinations will be returned.
 
+.. admonition:: Boolean values for ``JSONField`` on SQLite
+
+    Due to the way the ``JSON_EXTRACT`` SQL function is implemented on SQLite,
+    ``values()`` will return ``1`` and ``0`` instead of ``True`` and ``False``
+    for :class:`~django.db.models.JSONField` key transforms.
+
 ``values_list()``
 ~~~~~~~~~~~~~~~~~
 
@@ -764,6 +770,12 @@ not having any author::
 
     >>> Entry.objects.values_list('authors')
     <QuerySet [('Noam Chomsky',), ('George Orwell',), (None,)]>
+
+.. admonition:: Boolean values for ``JSONField`` on SQLite
+
+    Due to the way the ``JSON_EXTRACT`` SQL function is implemented on SQLite,
+    ``values_list()`` will return ``1`` and ``0`` instead of ``True`` and
+    ``False`` for :class:`~django.db.models.JSONField` key transforms.
 
 ``dates()``
 ~~~~~~~~~~~


### PR DESCRIPTION
ticket-32483

I have [an idea](https://code.djangoproject.com/ticket/32483#comment:5) how to fix this, but it's too tricky for a backport.