### PR TITLE
Fixes #27574 -- Support distance geodetic MySQL

### DIFF
--- a/django/contrib/gis/db/backends/mysql/features.py
+++ b/django/contrib/gis/db/backends/mysql/features.py
@@ -8,7 +8,6 @@ from django.utils.functional import cached_property
 class DatabaseFeatures(BaseSpatialFeatures, MySQLDatabaseFeatures):
     has_spatialrefsys_table = False
     supports_add_srs_entry = False
-    supports_distance_geodetic = False
     supports_length_geodetic = False
     supports_area_geodetic = False
     supports_transform = False

--- a/django/contrib/gis/db/backends/mysql/operations.py
+++ b/django/contrib/gis/db/backends/mysql/operations.py
@@ -83,11 +83,14 @@ class MySQLOperations(BaseSpatialOperations, DatabaseOperations):
         value = value[0]
         if isinstance(value, Distance):
             if f.geodetic(self.connection):
-                raise ValueError(
-                    'Only numeric values of degree units are allowed on '
-                    'geodetic distance queries.'
-                )
-            dist_param = getattr(value, Distance.unit_attname(f.units_name(self.connection)))
+                if lookup_type == 'dwithin':
+                    raise ValueError(
+                        'Only numeric values of degree units are allowed on '
+                        'geographic DWithin queries.'
+                    )
+                dist_param = value.m
+            else:
+                dist_param = getattr(value, Distance.unit_attname(f.units_name(self.connection)))
         else:
             dist_param = value
         return [dist_param]

--- a/django/contrib/gis/db/models/functions.py
+++ b/django/contrib/gis/db/models/functions.py
@@ -257,11 +257,14 @@ class DistanceResultMixin:
 class Distance(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
     geom_param_pos = (0, 1)
     spheroid = None
+    radius = None
 
-    def __init__(self, expr1, expr2, spheroid=None, **extra):
+    def __init__(self, expr1, expr2, spheroid=None, radius=None, **extra):
         expressions = [expr1, expr2]
         if spheroid is not None:
             self.spheroid = self._handle_param(spheroid, 'spheroid', bool)
+        if radius is not None:
+            self.radius = self._handle_param(radius, 'radius', int)
         super().__init__(*expressions, **extra)
 
     def as_postgresql(self, compiler, connection, **extra_context):
@@ -295,6 +298,15 @@ class Distance(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
             extra_context['template'] = 'COALESCE(%(function)s(%(expressions)s, %(spheroid)s), 0)'
             extra_context['spheroid'] = int(bool(self.spheroid))
         return super().as_sql(compiler, connection, **extra_context)
+
+    def as_mysql(self, compiler, connection, **extra_context):
+        clone = self.copy()
+        function = None
+        if self.geo_field.geodetic(connection):
+            function = connection.ops.spatial_function_name('Distance_Sphere')
+            if self.radius:
+                clone.source_expressions.append(Value(self.radius))
+        return super(Distance, clone).as_sql(compiler, connection, function=function, **extra_context)
 
 
 class Envelope(GeomOutputGeoFunc):

--- a/docs/ref/contrib/gis/functions.txt
+++ b/docs/ref/contrib/gis/functions.txt
@@ -257,7 +257,7 @@ geometry B.
 ``Distance``
 ============
 
-.. class:: Distance(expr1, expr2, spheroid=None, **extra)
+.. class:: Distance(expr1, expr2, spheroid=None, radius=None, **extra)
 
 *Availability*: MariaDB, `MySQL
 <https://dev.mysql.com/doc/refman/en/spatial-relation-functions-object-shapes.html#function_st-distance>`__,
@@ -276,7 +276,10 @@ When distances are calculated with geodetic (angular) coordinates, as is the
 case with the default WGS84 (4326) SRID, you can set the ``spheroid`` keyword
 argument to decide if the calculation should be based on a simple sphere (less
 accurate, less resource-intensive) or on a spheroid (more accurate, more
-resource-intensive).
+resource-intensive). On MySQL, the spheroid keyword does not supported, but
+you can specify the radius of the sphere to use in the calculation with the
+``radius`` keyword argument (See `ST_Distance_Sphere
+<https://dev.mysql.com/doc/refman/en/spatial-convenience-functions.html#function_st-distance-sphere>`__).
 
 In the following example, the distance from the city of Hobart to every other
 :class:`~django.contrib.gis.db.models.PointField` in the ``AustraliaCity``

--- a/tests/gis_tests/distapp/tests.py
+++ b/tests/gis_tests/distapp/tests.py
@@ -236,13 +236,6 @@ class DistanceTest(TestCase):
             {'relative_distance': 100, 'count': 4},
         ])
 
-    def test_mysql_geodetic_distance_error(self):
-        if not connection.ops.mysql:
-            self.skipTest('This is a MySQL-specific test.')
-        msg = 'Only numeric values of degree units are allowed on geodetic distance queries.'
-        with self.assertRaisesMessage(ValueError, msg):
-            AustraliaCity.objects.filter(point__distance_lte=(Point(0, 0), D(m=100))).exists()
-
     @skipUnlessDBFeature('supports_dwithin_lookup')
     def test_dwithin_subquery(self):
         """dwithin lookup in a subquery using OuterRef as a parameter."""


### PR DESCRIPTION
Supports geodetic distance calculation on MySQL 5.7+.

https://dev.mysql.com/doc/refman/5.7/en/spatial-convenience-functions.html#function_st-distance-sphere