### PR TITLE
Clarified database connections lifetime outside HTTP requests.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -31,7 +31,7 @@ Persistent connections
 ----------------------
 
 Persistent connections avoid the overhead of reestablishing a connection to
-the database in each request. They're controlled by the
+the database in each HTTP request. They're controlled by the
 :setting:`CONN_MAX_AGE` parameter which defines the maximum lifetime of a
 connection. It can be set independently for each database.
 
@@ -96,6 +96,10 @@ parameters such as the connection's isolation level or time zone, you should
 either restore Django's defaults at the end of each request, force an
 appropriate value at the beginning of each request, or disable persistent
 connections.
+
+If a connection is created in a long-running process, outside of Django’s
+request-response cycle, the connection will remain open until explicitly
+closed, or timeout occurs.
 
 Encoding
 --------


### PR DESCRIPTION
At first glance, I thought this section (and the whole page) referred to requests to the database, hinting that Django would have recreated connections to the database after each query.

In reality, Django manages that only in the context of `HttpRequest` calls. Hence, this commit clarifies this behavior in the documentation.

/cc @schinckel 