### PR TITLE
Fixed passwords mismatch message.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -78,7 +78,7 @@ class UserCreationForm(forms.ModelForm):
     password.
     """
     error_messages = {
-        'password_mismatch': _('The two password fields didn’t match.'),
+        'password_mismatch': _("The two password fields didn't match."),
     }
     password1 = forms.CharField(
         label=_("Password"),
@@ -319,7 +319,7 @@ class SetPasswordForm(forms.Form):
     password
     """
     error_messages = {
-        'password_mismatch': _('The two password fields didn’t match.'),
+        'password_mismatch': _("The two password fields didn't match."),
     }
     new_password1 = forms.CharField(
         label=_("New password"),
@@ -392,7 +392,7 @@ class AdminPasswordChangeForm(forms.Form):
     A form used to change the password of a user in the admin interface.
     """
     error_messages = {
-        'password_mismatch': _('The two password fields didn’t match.'),
+        'password_mismatch': _("The two password fields didn't match."),
     }
     required_css_class = 'required'
     password1 = forms.CharField(

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5368,7 +5368,7 @@ class UserAdminTest(TestCase):
         })
         self.assertEqual(response.status_code, 200)
         self.assertFormError(response, 'adminform', 'password', [])
-        self.assertFormError(response, 'adminform', 'password2', ['The two password fields didn’t match.'])
+        self.assertFormError(response, 'adminform', 'password2', ["The two password fields didn't match."])
 
     def test_user_fk_add_popup(self):
         """User addition through a FK popup should return the appropriate JavaScript response."""


### PR DESCRIPTION
Error in message 'The two password fields didn’t match.' incorrect quotes. Because of it translating doesn't work.
To fix it were replaced ’ to '.