### PR TITLE
Server sent events

### DIFF
--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import sys
 import tempfile
@@ -11,7 +12,7 @@ from django.core.exceptions import RequestAborted, RequestDataTooBig
 from django.core.handlers import base
 from django.http import (
     FileResponse, HttpRequest, HttpResponse, HttpResponseBadRequest,
-    HttpResponseServerError, QueryDict, parse_cookie,
+    HttpResponseServerError, parse_cookie, QueryDict, ServerSentEventsResponse,
 )
 from django.urls import set_script_prefix
 from django.utils.functional import cached_property
@@ -165,7 +166,7 @@ class ASGIHandler(base.BaseHandler):
         if isinstance(response, FileResponse):
             response.block_size = self.chunk_size
         # Send the response.
-        await self.send_response(response, send)
+        await self.send_response(response, send, receive=receive)
 
     async def read_body(self, receive):
         """Reads a HTTP body from an ASGI connection."""
@@ -214,7 +215,7 @@ class ASGIHandler(base.BaseHandler):
                 content_type='text/plain',
             )
 
-    async def send_response(self, response, send):
+    async def send_response(self, response, send, receive=None):
         """Encode and send a response out over ASGI."""
         # Collect cookies into headers. Have to preserve header case as there
         # are some non-RFC compliant clients that require e.g. Content-Type.
@@ -235,19 +236,51 @@ class ASGIHandler(base.BaseHandler):
             'status': response.status_code,
             'headers': response_headers,
         })
-        # Streaming responses need to be pinned to their iterator.
         if response.streaming:
-            # Access `__iter__` and not `streaming_content` directly in case
-            # it has been overridden in a subclass.
-            for part in response:
-                for chunk, _ in self.chunk_bytes(part):
+            if isinstance(response, ServerSentEventsResponse):
+                if response.retry:
                     await send({
-                        'type': 'http.response.body',
-                        'body': chunk,
-                        # Ignore "more" as there may be more parts; instead,
-                        # use an empty final closing message with False.
-                        'more_body': True,
+                        "type": "http.response.body",
+                        "body": response.retry_message,
+                        "more_body": True,
                     })
+
+                stop_stream = False
+                while not stop_stream:
+                    server_sent_event_future = asyncio.ensure_future(response.receive())
+                    # also listening asgi http.disconnect message to stop
+                    request_response_cycle_future = asyncio.ensure_future(receive())
+                    done, pending = await asyncio.wait({
+                        server_sent_event_future,
+                        request_response_cycle_future,
+                    }, return_when=asyncio.FIRST_COMPLETED)
+                    for future in pending:
+                        future.cancel()
+                    for future in done:
+                        message = future.result()
+                        if message:
+                            if future is request_response_cycle_future and message.get('type') == 'http.disconnect':
+                                stop_stream = True
+                                break
+                            else:
+                                await send({
+                                    'type': 'http.response.body',
+                                    'body': message,
+                                    'more_body': True,
+                                })
+            else:
+                # Streaming responses need to be pinned to their iterator.
+                # Access `__iter__` and not `streaming_content` directly in case
+                # it has been overridden in a subclass.
+                for part in response:
+                    for chunk, _ in self.chunk_bytes(part):
+                        await send({
+                            'type': 'http.response.body',
+                            'body': chunk,
+                            # Ignore "more" as there may be more parts; instead,
+                            # use an empty final closing message with False.
+                            'more_body': True,
+                        })
             # Final closing message.
             await send({'type': 'http.response.body'})
         # Other responses just need chunking.

--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -12,7 +12,7 @@ from django.core.exceptions import RequestAborted, RequestDataTooBig
 from django.core.handlers import base
 from django.http import (
     FileResponse, HttpRequest, HttpResponse, HttpResponseBadRequest,
-    HttpResponseServerError, parse_cookie, QueryDict, ServerSentEventsResponse,
+    HttpResponseServerError, QueryDict, ServerSentEventsResponse, parse_cookie,
 )
 from django.urls import set_script_prefix
 from django.utils.functional import cached_property

--- a/django/http/__init__.py
+++ b/django/http/__init__.py
@@ -7,7 +7,7 @@ from django.http.response import (
     HttpResponseBadRequest, HttpResponseForbidden, HttpResponseGone,
     HttpResponseNotAllowed, HttpResponseNotFound, HttpResponseNotModified,
     HttpResponsePermanentRedirect, HttpResponseRedirect,
-    HttpResponseServerError, JsonResponse, StreamingHttpResponse,
+    HttpResponseServerError, JsonResponse, ServerSentEventsResponse, StreamingHttpResponse,
 )
 
 __all__ = [
@@ -17,5 +17,5 @@ __all__ = [
     'HttpResponsePermanentRedirect', 'HttpResponseNotModified',
     'HttpResponseBadRequest', 'HttpResponseForbidden', 'HttpResponseNotFound',
     'HttpResponseNotAllowed', 'HttpResponseGone', 'HttpResponseServerError',
-    'Http404', 'BadHeaderError', 'JsonResponse', 'FileResponse',
+    'Http404', 'BadHeaderError', 'JsonResponse', 'ServerSentEventsResponse', 'FileResponse',
 ]

--- a/django/http/__init__.py
+++ b/django/http/__init__.py
@@ -7,7 +7,8 @@ from django.http.response import (
     HttpResponseBadRequest, HttpResponseForbidden, HttpResponseGone,
     HttpResponseNotAllowed, HttpResponseNotFound, HttpResponseNotModified,
     HttpResponsePermanentRedirect, HttpResponseRedirect,
-    HttpResponseServerError, JsonResponse, ServerSentEventsResponse, StreamingHttpResponse,
+    HttpResponseServerError, JsonResponse, ServerSentEventsResponse,
+    StreamingHttpResponse,
 )
 
 __all__ = [

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -20,7 +20,9 @@ from django.core.exceptions import DisallowedRedirect
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http.cookie import SimpleCookie
 from django.utils import timezone
-from django.utils.datastructures import (_destruct_iterable_mapping_values, CaseInsensitiveMapping)
+from django.utils.datastructures import (
+    CaseInsensitiveMapping, _destruct_iterable_mapping_values,
+)
 from django.utils.encoding import iri_to_uri
 from django.utils.http import http_date
 from django.utils.regex_helper import _lazy_re_compile

--- a/tests/asgi/tests.py
+++ b/tests/asgi/tests.py
@@ -15,6 +15,7 @@ from django.test import (
     AsyncRequestFactory, SimpleTestCase, modify_settings, override_settings,
 )
 from django.utils.http import http_date
+
 from .urls import message_broker, test_filename
 
 TEST_STATIC_ROOT = Path(__file__).parent / 'project' / 'static'


### PR DESCRIPTION
Added [Server-Sent Events](https://www.w3.org/TR/eventsource/) support to ASGIHandler.

Demo: https://github.com/NiyazNz/django-sse-demo. There are some simple usage examples in [views](https://github.com/NiyazNz/django-sse-demo/blob/master/sse/views.py)

![Chrome dev tools/Network/EventStream](https://user-images.githubusercontent.com/1656940/110205038-595ec580-7e87-11eb-8193-d688070eb206.png)