### PR TITLE
An implementation of a SuccessDeleteMessageMixin

### DIFF
--- a/django/contrib/messages/views.py
+++ b/django/contrib/messages/views.py
@@ -16,3 +16,21 @@ class SuccessMessageMixin:
 
     def get_success_message(self, cleaned_data):
         return self.success_message % cleaned_data
+
+
+class SuccessDeleteMessageMixin:
+    """
+    Add a success message on a successful DELETE request (and sometimes POST request
+    if this will make trigger delete).
+    """
+    success_message = ''
+
+    def delete(self, *args, **kwargs):
+        response = super().delete(*args, **kwargs)
+        success_message = self.get_success_message()
+        if success_message:
+            messages.success(self.request, success_message)
+        return response
+
+    def get_success_message(self):
+        return self.success_message


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32514

This `Mixin` can be used for `DeleteView`s and similar views where a DELETE request can trigger a success message to inform the user that the deletion has been completed.

We first trigger the underlying logic, such that a 404 exception for example does _not_ trigger a success message.