### PR TITLE
Fixed #32517 -- Made OrderedSet reversible.

### DIFF
--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -25,6 +25,9 @@ class OrderedSet:
     def __iter__(self):
         return iter(self.dict)
 
+    def __reversed__(self):
+        return reversed(self.dict)
+
     def __contains__(self, item):
         return item in self.dict
 

--- a/tests/utils_tests/test_datastructures.py
+++ b/tests/utils_tests/test_datastructures.py
@@ -1,7 +1,7 @@
 """
 Tests for stuff in django.utils.datastructures.
 """
-
+import collections.abc
 import copy
 import pickle
 
@@ -33,6 +33,11 @@ class OrderedSetTests(SimpleTestCase):
         s.add(1)
         s.discard(2)
         self.assertEqual(len(s), 1)
+
+    def test_reversed(self):
+        s = reversed(OrderedSet([1, 2, 3]))
+        self.assertIsInstance(s, collections.abc.Iterator)
+        self.assertEqual(list(s), [3, 2, 1])
 
     def test_contains(self):
         s = OrderedSet()


### PR DESCRIPTION
[#32517 Allow calling reversed() on an OrderedSet](https://code.djangoproject.com/ticket/32517) by @cjerdonek 