### PR TITLE
Refs #24121 -- Added __repr__() to OrderedSet.

### DIFF
--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -34,6 +34,10 @@ class OrderedSet:
     def __len__(self):
         return len(self.dict)
 
+    def __repr__(self):
+        data = repr(list(self.dict)) if self.dict else ''
+        return f'{self.__class__.__qualname__}({data})'
+
 
 class MultiValueDictKeyError(KeyError):
     pass

--- a/tests/utils_tests/test_datastructures.py
+++ b/tests/utils_tests/test_datastructures.py
@@ -55,6 +55,10 @@ class OrderedSetTests(SimpleTestCase):
         s.add(2)
         self.assertEqual(len(s), 2)
 
+    def test_repr(self):
+        self.assertEqual(repr(OrderedSet()), 'OrderedSet()')
+        self.assertEqual(repr(OrderedSet([2, 3, 2, 1])), 'OrderedSet([2, 3, 1])')
+
 
 class MultiValueDictTests(SimpleTestCase):
 


### PR DESCRIPTION
While looking at PR #14089, I noticed that there was no `OrderedSet.__repr__()`.

I've attached this to ticket-24121 as, although `OrderedSet` is not listed in the ticket description, the ticket title is pretty generic about improving the `repr()` experience.