### PR TITLE
Refs #32018 -- Corrected color variable for toggle links in admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -226,7 +226,7 @@ fieldset.collapsed h2 {
 }
 
 fieldset .collapse-toggle {
-    color: var(--body-bg);
+    color: var(--header-link-color);
 }
 
 fieldset.collapsed .collapse-toggle {


### PR DESCRIPTION
Follow up to cd3019bc106eed27b2f97776e4dd9ec7cbac29b2. Noticed when checking #14088.

Before:
![image](https://user-images.githubusercontent.com/2865885/110304236-3f41f600-7ff3-11eb-9409-5d0f6f8173d8.png)

After:
![image](https://user-images.githubusercontent.com/2865885/110304097-16216580-7ff3-11eb-8c85-ad546efa4887.png)
