### PR TITLE
Refs #32018 -- Used --darkened-bg for <pre> elements.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -239,7 +239,7 @@ code, pre {
 
 pre.literal-block {
     margin: 10px;
-    background: #eee;
+    background: var(--darkened-bg);
     padding: 6px 8px;
 }
 


### PR DESCRIPTION
Noticed when checking #14088.
Before:
![image](https://user-images.githubusercontent.com/2865885/110309075-ce054180-7ff8-11eb-8934-78e84d35ea2f.png)
After:
![image](https://user-images.githubusercontent.com/2865885/110309139-e2e1d500-7ff8-11eb-8b86-3af73f4aa541.png)
