### PR TITLE
Refs #26167 -- Added @skipUnlessDBFeature('supports_expression_indexes') to a test.

### DIFF
--- a/tests/indexes/tests.py
+++ b/tests/indexes/tests.py
@@ -555,6 +555,7 @@ class CoveringIndexTests(TransactionTestCase):
                     cursor=cursor, table_name=Article._meta.db_table,
                 ))
 
+    @skipUnlessDBFeature('supports_expression_indexes')
     def test_covering_func_index(self):
         index_name = 'covering_func_headline_idx'
         index = Index(Lower('headline'), name=index_name, include=['pub_date'])


### PR DESCRIPTION
Failure observed on CockroachDB.