### PR TITLE
Removed unnecessary lines in test_has_view_or_change_permission_required().

### DIFF
--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -140,8 +140,6 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
         autocomplete view for it.
         """
         request = self.factory.get(self.url, {'term': 'is', **self.opts})
-        self.user.is_staff = True
-        self.user.save()
         request.user = self.user
         with self.assertRaises(PermissionDenied):
             AutocompleteJsonView.as_view(**self.as_view_args)(request)


### PR DESCRIPTION
`AutocompleteJsonViewTests.user` is already a staff member:

https://github.com/django/django/blob/0df5c8187a9fa9828824ec2b1fdf37d1082d7ebe/tests/admin_views/test_autocomplete_view.py#L67-L70

Noticed when checking #14031.