### PR TITLE
Fixed #31516 -- Improved naming of migrations with multiple operations.

### DIFF
--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -2661,6 +2661,23 @@ class MigrationSuggestNameTests(SimpleTestCase):
         migration = Migration('0002_initial', 'test_app')
         self.assertEqual(migration.suggest_name(), 'delete_person')
 
+    def test_single_operation_long_name(self):
+        class Migration(migrations.Migration):
+            operations = [migrations.CreateModel('A' * 53, fields=[])]
+
+        migration = Migration('some_migration', 'test_app')
+        self.assertEqual(migration.suggest_name(), 'a' * 53)
+
+    def test_two_operations(self):
+        class Migration(migrations.Migration):
+            operations = [
+                migrations.CreateModel('Person', fields=[]),
+                migrations.DeleteModel('Animal'),
+            ]
+
+        migration = Migration('some_migration', 'test_app')
+        self.assertEqual(migration.suggest_name(), 'person_delete_animal')
+
     def test_two_create_models(self):
         class Migration(migrations.Migration):
             operations = [
@@ -2669,7 +2686,7 @@ class MigrationSuggestNameTests(SimpleTestCase):
             ]
 
         migration = Migration('0001_initial', 'test_app')
-        self.assertEqual(migration.suggest_name(), 'animal_person')
+        self.assertEqual(migration.suggest_name(), 'person_animal')
 
     def test_two_create_models_with_initial_true(self):
         class Migration(migrations.Migration):
@@ -2681,6 +2698,32 @@ class MigrationSuggestNameTests(SimpleTestCase):
 
         migration = Migration('0001_initial', 'test_app')
         self.assertEqual(migration.suggest_name(), 'initial')
+
+    def test_many_operations_suffix(self):
+        class Migration(migrations.Migration):
+            operations = [
+                migrations.CreateModel('Person1', fields=[]),
+                migrations.CreateModel('Person2', fields=[]),
+                migrations.CreateModel('Person3', fields=[]),
+                migrations.DeleteModel('Person4'),
+                migrations.DeleteModel('Person5'),
+            ]
+
+        migration = Migration('some_migration', 'test_app')
+        self.assertEqual(
+            migration.suggest_name(),
+            'person1_person2_person3_delete_person4_and_more',
+        )
+
+    def test_operation_with_no_suggested_name(self):
+        class Migration(migrations.Migration):
+            operations = [
+                migrations.CreateModel('Person', fields=[]),
+                migrations.RunSQL('SELECT 1 FROM person;'),
+            ]
+
+        migration = Migration('some_migration', 'test_app')
+        self.assertIs(migration.suggest_name().startswith('auto_'), True)
 
     def test_none_name(self):
         class Migration(migrations.Migration):

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -2633,6 +2633,21 @@ class AutodetectorTests(TestCase):
 
 
 class MigrationSuggestNameTests(SimpleTestCase):
+    def test_no_operations(self):
+        class Migration(migrations.Migration):
+            operations = []
+
+        migration = Migration('some_migration', 'test_app')
+        self.assertIs(migration.suggest_name().startswith('auto_'), True)
+
+    def test_no_operations_initial(self):
+        class Migration(migrations.Migration):
+            initial = True
+            operations = []
+
+        migration = Migration('some_migration', 'test_app')
+        self.assertEqual(migration.suggest_name(), 'initial')
+
     def test_single_operation(self):
         class Migration(migrations.Migration):
             operations = [migrations.CreateModel('Person', fields=[])]


### PR DESCRIPTION
[ticket-31516](https://code.djangoproject.com/ticket/31516)

Supersedes [#12799  ](https://github.com/django/django/pull/12799)