### PR TITLE
Refs #24121 -- Added __repr__() to BaseDatabaseWrapper, JoinPromoter, and SQLCompiler.

### DIFF
--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -120,6 +120,12 @@ class BaseDatabaseWrapper:
         self.ops = self.ops_class(self)
         self.validation = self.validation_class(self)
 
+    def __repr__(self):
+        return (
+            f'<{self.__class__.__qualname__} '
+            f'vendor={self.vendor!r} alias={self.alias!r}>'
+        )
+
     def ensure_timezone(self):
         """
         Ensure the connection's timezone is set to `self.timezone_name` and

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -44,6 +44,13 @@ class SQLCompiler:
         self.klass_info = None
         self._meta_ordering = None
 
+    def __repr__(self):
+        return (
+            f'<{self.__class__.__qualname__} '
+            f'model={self.query.model.__qualname__} '
+            f'connection={self.connection!r} using={self.using!r}>'
+        )
+
     def setup_query(self):
         if all(self.query.alias_refcount[a] == 0 for a in self.query.alias_map):
             self.query.get_initial_alias()

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2393,6 +2393,12 @@ class JoinPromoter:
         # inner and/or outer joins.
         self.votes = Counter()
 
+    def __repr__(self):
+        return (
+            f'{self.__class__.__qualname__}(connector={self.connector!r}, '
+            f'num_children={self.num_children!r}, negated={self.negated!r})'
+        )
+
     def add_votes(self, votes):
         """
         Add single vote per item to self.votes. Parameter can be any

--- a/tests/backends/base/test_base.py
+++ b/tests/backends/base/test_base.py
@@ -9,6 +9,13 @@ from ..models import Square
 
 class DatabaseWrapperTests(SimpleTestCase):
 
+    def test_repr(self):
+        conn = connections[DEFAULT_DB_ALIAS]
+        self.assertEqual(
+            repr(conn),
+            f"<DatabaseWrapper vendor={connection.vendor!r} alias='default'>",
+        )
+
     def test_initialization_class_attributes(self):
         """
         The "initialization" class attributes like client_class and

--- a/tests/queries/test_query.py
+++ b/tests/queries/test_query.py
@@ -6,7 +6,7 @@ from django.db.models.expressions import Col, Func
 from django.db.models.fields.related_lookups import RelatedIsNull
 from django.db.models.functions import Lower
 from django.db.models.lookups import Exact, GreaterThan, IsNull, LessThan
-from django.db.models.sql.query import Query
+from django.db.models.sql.query import JoinPromoter, Query
 from django.db.models.sql.where import OR
 from django.test import SimpleTestCase
 from django.test.utils import register_lookup
@@ -150,3 +150,11 @@ class TestQuery(SimpleTestCase):
         msg = 'Cannot filter against a non-conditional expression.'
         with self.assertRaisesMessage(TypeError, msg):
             query.build_where(Func(output_field=CharField()))
+
+
+class JoinPromoterTest(SimpleTestCase):
+    def test_repr(self):
+        self.assertEqual(
+            repr(JoinPromoter('AND', 3, True)),
+            "JoinPromoter(connector='AND', num_children=3, negated=True)",
+        )

--- a/tests/queries/test_sqlcompiler.py
+++ b/tests/queries/test_sqlcompiler.py
@@ -1,0 +1,17 @@
+from django.db import DEFAULT_DB_ALIAS, connection
+from django.db.models.sql import Query
+from django.test import SimpleTestCase
+
+from .models import Item
+
+
+class SQLCompilerTest(SimpleTestCase):
+    def test_repr(self):
+        query = Query(Item)
+        compiler = query.get_compiler(DEFAULT_DB_ALIAS, connection)
+        self.assertEqual(
+            repr(compiler),
+            f"<SQLCompiler model=Item connection="
+            f"<DatabaseWrapper vendor={connection.vendor!r} alias='default'> "
+            f"using='default'>"
+        )


### PR DESCRIPTION
<a class="issue-link js-issue-link" rel="noopener noreferrer nofollow" href="https://code.djangoproject.com/ticket/24121">ticket-24121</a>

I am not particularly sure how to represent `settings_dict` from `BaseDataBaseWrapper.__repr__`.
In this commit, the `__repr__` implementation for `settings_dict` is benchmarked from <a class="issue-link js-issue-link" rel="noopener noreferrer nofollow" href="https://github.com/django/django/commit/179ee13eb37348cd87169a198aec18fedccc8668">179ee13</a> `django/template/base.py` line number 340.
Any advice will be welcomed.