### PR TITLE
Added missing "event" argument to addEventListener() call in actions.js.

### DIFF
--- a/django/contrib/admin/static/admin/js/actions.js
+++ b/django/contrib/admin/static/admin/js/actions.js
@@ -125,7 +125,7 @@
             });
         });
 
-        document.querySelector('#changelist-form button[name=index]').addEventListener('click', function() {
+        document.querySelector('#changelist-form button[name=index]').addEventListener('click', function(event) {
             if (list_editable_changed) {
                 const confirmed = confirm(gettext("You have unsaved changes on individual editable fields. If you run an action, your unsaved changes will be lost."));
                 if (!confirmed) {


### PR DESCRIPTION
Very small change. Noticed that ```event.preventDefault();``` was being called but the event listener function didn't have an ```event``` argument.