### PR TITLE
Fixed #32543 -- Allowed adding help text to the admin search bar.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -559,6 +559,7 @@ class ModelAdmin(BaseModelAdmin):
     list_max_show_all = 200
     list_editable = ()
     search_fields = ()
+    search_help_text = None
     date_hierarchy = None
     save_as = False
     save_as_continue = True
@@ -741,6 +742,7 @@ class ModelAdmin(BaseModelAdmin):
             self.get_list_filter(request),
             self.date_hierarchy,
             self.get_search_fields(request),
+            self.search_help_text,
             self.get_list_select_related(request),
             self.list_per_page,
             self.list_max_show_all,

--- a/django/contrib/admin/templates/admin/search_form.html
+++ b/django/contrib/admin/templates/admin/search_form.html
@@ -11,6 +11,12 @@
 {% for pair in cl.params.items %}
     {% if pair.0 != search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}">{% endif %}
 {% endfor %}
+{% if cl.search_help_text %}
+<br class="clear">
+<small class="quiet" style="margin-left: 23px;">
+    <i>{{ cl.search_help_text }}</i>
+</small>
+{% endif %}
 </div>
 </form></div>
 {% endif %}

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -49,7 +49,7 @@ class ChangeList:
     search_form_class = ChangeListSearchForm
 
     def __init__(self, request, model, list_display, list_display_links,
-                 list_filter, date_hierarchy, search_fields, list_select_related,
+                 list_filter, date_hierarchy, search_fields, search_help_text, list_select_related,
                  list_per_page, list_max_show_all, list_editable, model_admin, sortable_by):
         self.model = model
         self.opts = model._meta
@@ -63,6 +63,7 @@ class ChangeList:
         self.clear_all_filters_qs = None
         self.date_hierarchy = date_hierarchy
         self.search_fields = search_fields
+        self.search_help_text = search_help_text
         self.list_select_related = list_select_related
         self.list_per_page = list_per_page
         self.list_max_show_all = list_max_show_all


### PR DESCRIPTION
The admin `changelist_view` has a search box, but the user does not know which fields will be searched. They can only find out by trial and error.

There is a need for users to know which fields will  be searched.

This patch adds a new `search_help_text` field to `ModelAdmin` that will display a help text below the search  bar.