### PR TITLE
Made GitHub action add welcome message only after opening PR.

### DIFF
--- a/.github/workflows/new_contributor_pr.yml
+++ b/.github/workflows/new_contributor_pr.yml
@@ -2,6 +2,7 @@ name: New contributor message
 
 on:
   pull_request_target:
+    types: [opened]
 
 jobs:
   build:


### PR DESCRIPTION
By default, `pull_request_target` workflow runs when an activity type is `opened`, `synchronize`, or `reopened`. 