### PR TITLE
 Fixed #32540 -- Optimized DiscoverRunner.build_suite() by calling find_top_level() only if is_discoverable() is true.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -574,28 +574,7 @@ class DiscoverRunner:
             if not os.path.exists(label_as_path):
                 tests = self.test_loader.loadTestsFromName(label)
             elif os.path.isdir(label_as_path) and not self.top_level:
-                # Try to be a bit smarter than unittest about finding the
-                # default top-level for a given directory path, to avoid
-                # breaking relative imports. (Unittest's default is to set
-                # top-level equal to the path, which means relative imports
-                # will result in "Attempted relative import in non-package.").
-
-                # We'd be happy to skip this and require dotted module paths
-                # (which don't cause this problem) instead of file paths (which
-                # do), but in the case of a directory in the cwd, which would
-                # be equally valid if considered as a top-level module or as a
-                # directory path, unittest unfortunately prefers the latter.
-
-                top_level = label_as_path
-                while True:
-                    init_py = os.path.join(top_level, '__init__.py')
-                    if not os.path.exists(init_py):
-                        break
-                    try_next = os.path.dirname(top_level)
-                    if try_next == top_level:
-                        # __init__.py all the way down? give up.
-                        break
-                    top_level = try_next
+                top_level = find_top_level(label_as_path)
                 kwargs['top_level_dir'] = top_level
 
             if not (tests and tests.countTestCases()) and is_discoverable(label):
@@ -762,6 +741,30 @@ def is_discoverable(label):
         return hasattr(mod, '__path__')
 
     return os.path.isdir(os.path.abspath(label))
+
+
+def find_top_level(top_level):
+    # Try to be a bit smarter than unittest about finding the default top-level
+    # for a given directory path, to avoid breaking relative imports.
+    # (Unittest's default is to set top-level equal to the path, which means
+    # relative imports will result in "Attempted relative import in
+    # non-package.").
+
+    # We'd be happy to skip this and require dotted module paths (which don't
+    # cause this problem) instead of file paths (which do), but in the case of
+    # a directory in the cwd, which would be equally valid if considered as a
+    # top-level module or as a directory path, unittest unfortunately prefers
+    # the latter.
+    while True:
+        init_py = os.path.join(top_level, '__init__.py')
+        if not os.path.exists(init_py):
+            break
+        try_next = os.path.dirname(top_level)
+        if try_next == top_level:
+            # __init__.py all the way down? give up.
+            break
+        top_level = try_next
+    return top_level
 
 
 def reorder_tests(tests, classes, reverse=False):

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -565,20 +565,19 @@ class DiscoverRunner:
 
         all_tests = []
         for label in test_labels:
-            kwargs = discover_kwargs.copy()
-            tests = None
-
             label_as_path = os.path.abspath(label)
+            tests = None
 
             # if a module, or "module.ClassName[.method_name]", just run those
             if not os.path.exists(label_as_path):
                 tests = self.test_loader.loadTestsFromName(label)
-            elif os.path.isdir(label_as_path) and not self.top_level:
-                top_level = find_top_level(label_as_path)
-                kwargs['top_level_dir'] = top_level
 
+            # Try discovery if "label" is a package or directory.
             if not (tests and tests.countTestCases()) and is_discoverable(label):
-                # Try discovery if path is a package or directory
+                kwargs = discover_kwargs.copy()
+                if os.path.isdir(label_as_path) and not self.top_level:
+                    kwargs['top_level_dir'] = find_top_level(label_as_path)
+
                 tests = self.test_loader.discover(start_dir=label, **kwargs)
 
                 # Make unittest forget the top-level dir it calculated from this


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32540
