### PR TITLE
Refs #32381 -- Include number of rows matched in bulk_update() return value

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -541,7 +541,7 @@ class QuerySet:
         if any(f.primary_key for f in fields):
             raise ValueError('bulk_update() cannot be used with primary key fields.')
         if not objs:
-            return
+            return 0
         # PK is used twice in the resulting update query, once in the filter
         # and once in the WHEN. Each field will also have one CAST.
         max_batch_size = connections[self.db].ops.bulk_batch_size(['pk', 'pk'] + fields, objs)

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -563,8 +563,8 @@ class QuerySet:
                     case_statement = Cast(case_statement, output_field=field)
                 update_kwargs[field.attname] = case_statement
             updates.append(([obj.pk for obj in batch_objs], update_kwargs))
+        rows = 0
         with transaction.atomic(using=self.db, savepoint=False):
-            rows = 0
             for pks, update_kwargs in updates:
                 rows += self.filter(pk__in=pks).update(**update_kwargs)
         return rows

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -563,11 +563,10 @@ class QuerySet:
                     case_statement = Cast(case_statement, output_field=field)
                 update_kwargs[field.attname] = case_statement
             updates.append(([obj.pk for obj in batch_objs], update_kwargs))
-        rows = 0
         with transaction.atomic(using=self.db, savepoint=False):
             for pks, update_kwargs in updates:
-                rows += self.filter(pk__in=pks).update(**update_kwargs)
-        return rows
+                self.filter(pk__in=pks).update(**update_kwargs)
+        return len(objs)
     bulk_update.alters_data = True
 
     def get_or_create(self, defaults=None, **kwargs):

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -564,8 +564,10 @@ class QuerySet:
                 update_kwargs[field.attname] = case_statement
             updates.append(([obj.pk for obj in batch_objs], update_kwargs))
         with transaction.atomic(using=self.db, savepoint=False):
+            rows = 0
             for pks, update_kwargs in updates:
-                self.filter(pk__in=pks).update(**update_kwargs)
+                rows += self.filter(pk__in=pks).update(**update_kwargs)
+        return rows
     bulk_update.alters_data = True
 
     def get_or_create(self, defaults=None, **kwargs):

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2230,7 +2230,7 @@ Returns ``objs`` as cast to a list, in the same order as provided.
 .. method:: bulk_update(objs, fields, batch_size=None)
 
 This method efficiently updates the given fields on the provided model
-instances, generally with one query. It returns a count of updated objects.
+instances, generally with one query. It returns ``len(objs)``.
 For example::
 
     >>> objs = [
@@ -2262,13 +2262,9 @@ The ``batch_size`` parameter controls how many objects are saved in a single
 query. The default is to update all objects in one batch, except for SQLite
 and Oracle which have restrictions on the number of variables used in a query.
 
-Note that the count of updated objects does not necessarily match the number
-of objects passed to ``bulk_update()`` because there could be duplicates in an
-individual batch.
-
 .. versionchanged:: 4.0
 
-    The return value was changed from ``None`` to a count of updated objects.
+    The return value was changed from ``None`` to ``len(objs)``.
 
 ``count()``
 ~~~~~~~~~~~

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2230,7 +2230,8 @@ Returns ``objs`` as cast to a list, in the same order as provided.
 .. method:: bulk_update(objs, fields, batch_size=None)
 
 This method efficiently updates the given fields on the provided model
-instances, generally with one query::
+instances, generally with one query. It returns a count of updated objects.
+For example::
 
     >>> objs = [
     ...    Entry.objects.create(headline='Entry 1'),
@@ -2239,6 +2240,7 @@ instances, generally with one query::
     >>> objs[0].headline = 'This is entry 1'
     >>> objs[1].headline = 'This is entry 2'
     >>> Entry.objects.bulk_update(objs, ['headline'])
+    2
 
 :meth:`.QuerySet.update` is used to save the changes, so this is more efficient
 than iterating through the list of models and calling ``save()`` on each of
@@ -2259,6 +2261,14 @@ them, but it has a few caveats:
 The ``batch_size`` parameter controls how many objects are saved in a single
 query. The default is to update all objects in one batch, except for SQLite
 and Oracle which have restrictions on the number of variables used in a query.
+
+Note that the count of updated objects does not necessarily match the number
+of objects passed to ``bulk_update()`` because there could be duplicates in an
+individual batch.
+
+.. versionchanged:: 4.0
+
+    The return value was changed from ``None`` to a count of updated objects.
 
 ``count()``
 ~~~~~~~~~~~

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -220,7 +220,7 @@ Models
   whether the queryset contains the given object. This tries to perform the
   query in the simplest and fastest way possible.
 
-* :meth:`.QuerySet.bulk_update` now returns a count of updated objects.
+* :meth:`.QuerySet.bulk_update` now returns the count of passed objects.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -220,6 +220,8 @@ Models
   whether the queryset contains the given object. This tries to perform the
   query in the simplest and fastest way possible.
 
+* :meth:`.QuerySet.bulk_update` now returns a count of updated objects.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/queries/test_bulk_update.py
+++ b/tests/queries/test_bulk_update.py
@@ -125,7 +125,8 @@ class BulkUpdateTests(TestCase):
 
     def test_empty_objects(self):
         with self.assertNumQueries(0):
-            Note.objects.bulk_update([], ['note'])
+            count = Note.objects.bulk_update([], ['note'])
+            self.assertEqual(count, 0)
 
     def test_large_batch(self):
         Note.objects.bulk_create([
@@ -133,7 +134,8 @@ class BulkUpdateTests(TestCase):
             for i in range(0, 2000)
         ])
         notes = list(Note.objects.all())
-        Note.objects.bulk_update(notes, ['note'])
+        count = Note.objects.bulk_update(notes, ['note'])
+        self.assertEqual(count, 2000)
 
     def test_only_concrete_fields_allowed(self):
         obj = Valid.objects.create(valid='test')
@@ -151,7 +153,8 @@ class BulkUpdateTests(TestCase):
     def test_custom_db_columns(self):
         model = CustomDbColumn.objects.create(custom_column=1)
         model.custom_column = 2
-        CustomDbColumn.objects.bulk_update([model], fields=['custom_column'])
+        count = CustomDbColumn.objects.bulk_update([model], fields=['custom_column'])
+        self.assertEqual(count, 1)
         model.refresh_from_db()
         self.assertEqual(model.custom_column, 2)
 
@@ -199,13 +202,6 @@ class BulkUpdateTests(TestCase):
             number.num = F('num') + 1
         Number.objects.bulk_update(numbers, ['num'])
         self.assertCountEqual(Number.objects.filter(num=1), numbers)
-
-    def test_row_count(self):
-        numbers = [Number.objects.create(num=0) for _ in range(10)]
-        for number in numbers:
-            number.num = F('num') + 1
-        rows = Number.objects.bulk_update(numbers, ['num'])
-        self.assertEqual(rows, 10)
 
     def test_booleanfield(self):
         individuals = [Individual.objects.create(alive=False) for _ in range(10)]

--- a/tests/queries/test_bulk_update.py
+++ b/tests/queries/test_bulk_update.py
@@ -200,6 +200,13 @@ class BulkUpdateTests(TestCase):
         Number.objects.bulk_update(numbers, ['num'])
         self.assertCountEqual(Number.objects.filter(num=1), numbers)
 
+    def test_row_count(self):
+        numbers = [Number.objects.create(num=0) for _ in range(10)]
+        for number in numbers:
+            number.num = F('num') + 1
+        rows = Number.objects.bulk_update(numbers, ['num'])
+        self.assertEqual(rows, 10)
+
     def test_booleanfield(self):
         individuals = [Individual.objects.create(alive=False) for _ in range(10)]
         for individual in individuals:


### PR DESCRIPTION
[Ticket #32381 -- Include number of rows matched in bulk_update() return value](https://code.djangoproject.com/ticket/32381)

- [x] Implement the simplest approach (return the sum of its updates)
- [x] Add documentation (`bulk_update`)
- [x] Add documentation (changelogs)
- [x] Discuss/resolve [Tim McCurrach](https://code.djangoproject.com/ticket/32381#comment:8)'s duplicates problem
- [x] Discuss/resolve [Chris Jerdonek](https://code.djangoproject.com/ticket/32381#comment:1)'s future-proofing proposal