### PR TITLE
Fixed #32549 -- Removed empty Q objects from Q object initialization.

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -84,14 +84,10 @@ class Q(tree.Node):
         path = '%s.%s' % (self.__class__.__module__, self.__class__.__name__)
         if path.startswith('django.db.models.query_utils'):
             path = path.replace('django.db.models.query_utils', 'django.db.models')
-        args, kwargs = (), {}
-        if len(self.children) == 1 and not isinstance(self.children[0], Q):
-            child = self.children[0]
-            kwargs = {child[0]: child[1]}
-        else:
-            args = tuple(self.children)
-            if self.connector != self.default:
-                kwargs = {'_connector': self.connector}
+        args = tuple(self.children)
+        kwargs = {}
+        if self.connector != self.default:
+            kwargs = {'_connector': self.connector}
         if self.negated:
             kwargs['_negated'] = True
         return path, args, kwargs

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -37,6 +37,7 @@ class Q(tree.Node):
     conditional = True
 
     def __init__(self, *args, _connector=None, _negated=False, **kwargs):
+        args = (a for a in args if not isinstance(a, Q) or a)
         super().__init__(children=[*args, *sorted(kwargs.items())], connector=_connector, negated=_negated)
 
     def _combine(self, other, conn):

--- a/tests/queries/test_q.py
+++ b/tests/queries/test_q.py
@@ -39,17 +39,14 @@ class QTests(SimpleTestCase):
         q = Q(price__gt=F('discounted_price'))
         path, args, kwargs = q.deconstruct()
         self.assertEqual(path, 'django.db.models.Q')
-        self.assertEqual(args, ())
-        self.assertEqual(kwargs, {'price__gt': F('discounted_price')})
+        self.assertEqual(args, (('price__gt', F('discounted_price')),))
+        self.assertEqual(kwargs, {})
 
     def test_deconstruct_negated(self):
         q = ~Q(price__gt=F('discounted_price'))
         path, args, kwargs = q.deconstruct()
-        self.assertEqual(args, ())
-        self.assertEqual(kwargs, {
-            'price__gt': F('discounted_price'),
-            '_negated': True,
-        })
+        self.assertEqual(args, (('price__gt', F('discounted_price')),))
+        self.assertEqual(kwargs, {'_negated': True})
 
     def test_deconstruct_or(self):
         q1 = Q(price__gt=F('discounted_price'))
@@ -86,6 +83,12 @@ class QTests(SimpleTestCase):
         q = Q(Q(price__gt=F('discounted_price')))
         path, args, kwargs = q.deconstruct()
         self.assertEqual(args, (Q(price__gt=F('discounted_price')),))
+        self.assertEqual(kwargs, {})
+
+    def test_deconstruct_not_subscriptable(self):
+        q = Q(False)
+        path, args, kwargs = q.deconstruct()
+        self.assertEqual(args, (False,))
         self.assertEqual(kwargs, {})
 
     def test_reconstruct(self):

--- a/tests/queries/test_q.py
+++ b/tests/queries/test_q.py
@@ -85,6 +85,14 @@ class QTests(SimpleTestCase):
         self.assertEqual(args, (Q(price__gt=F('discounted_price')),))
         self.assertEqual(kwargs, {})
 
+    def test_nested_empty(self):
+        q = Q(Q(), ~Q(), Q(Q()))
+        self.assertEqual(q, Q())
+
+    def test_nested_empty_falsy(self):
+        q = Q(Q(), 0, ~Q(), False, Q(Q()), '')
+        self.assertEqual(q, Q(0, False, ''))
+
     def test_deconstruct_not_subscriptable(self):
         q = Q(False)
         path, args, kwargs = q.deconstruct()


### PR DESCRIPTION
Fixes [ticket-32549](https://code.djangoproject.com/ticket/32549)

Contains pull #14126 to prevent a regression in logical operations between query expressions and empty Q objects.