### PR TITLE
Fixed #32549 -- Added check for nested empty Q objects

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -84,14 +84,10 @@ class Q(tree.Node):
         path = '%s.%s' % (self.__class__.__module__, self.__class__.__name__)
         if path.startswith('django.db.models.query_utils'):
             path = path.replace('django.db.models.query_utils', 'django.db.models')
-        args, kwargs = (), {}
-        if len(self.children) == 1 and not isinstance(self.children[0], Q):
-            child = self.children[0]
-            kwargs = {child[0]: child[1]}
-        else:
-            args = tuple(self.children)
-            if self.connector != self.default:
-                kwargs = {'_connector': self.connector}
+        args = tuple(self.children)
+        kwargs = {}
+        if self.connector != self.default:
+            kwargs = {'_connector': self.connector}
         if self.negated:
             kwargs['_negated'] = True
         return path, args, kwargs

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -44,11 +44,11 @@ class Q(tree.Node):
             raise TypeError(other)
 
         # If the other Q() is empty, ignore it and just use `self`.
-        if not other:
+        if isinstance(other, Q) and other.empty():
             _, args, kwargs = self.deconstruct()
             return type(self)(*args, **kwargs)
         # Or if this Q is empty, ignore it and just use `other`.
-        elif not self:
+        elif self.empty():
             _, args, kwargs = other.deconstruct()
             return type(other)(*args, **kwargs)
 
@@ -91,6 +91,12 @@ class Q(tree.Node):
         if self.negated:
             kwargs['_negated'] = True
         return path, args, kwargs
+
+    def empty(self):
+        for child in self.children:
+            if not isinstance(child, Q) or not child.empty():
+                return False
+        return True
 
 
 class DeferredAttribute:

--- a/tests/queries/test_q.py
+++ b/tests/queries/test_q.py
@@ -1,5 +1,7 @@
-from django.db.models import F, Q
+from django.db.models import Exists, F, OuterRef, Q
 from django.test import SimpleTestCase
+
+from .models import Tag
 
 
 class QTests(SimpleTestCase):
@@ -39,17 +41,14 @@ class QTests(SimpleTestCase):
         q = Q(price__gt=F('discounted_price'))
         path, args, kwargs = q.deconstruct()
         self.assertEqual(path, 'django.db.models.Q')
-        self.assertEqual(args, ())
-        self.assertEqual(kwargs, {'price__gt': F('discounted_price')})
+        self.assertEqual(args, (('price__gt', F('discounted_price')),))
+        self.assertEqual(kwargs, {})
 
     def test_deconstruct_negated(self):
         q = ~Q(price__gt=F('discounted_price'))
         path, args, kwargs = q.deconstruct()
-        self.assertEqual(args, ())
-        self.assertEqual(kwargs, {
-            'price__gt': F('discounted_price'),
-            '_negated': True,
-        })
+        self.assertEqual(args, (('price__gt', F('discounted_price')),))
+        self.assertEqual(kwargs, {'_negated': True})
 
     def test_deconstruct_or(self):
         q1 = Q(price__gt=F('discounted_price'))
@@ -86,6 +85,13 @@ class QTests(SimpleTestCase):
         q = Q(Q(price__gt=F('discounted_price')))
         path, args, kwargs = q.deconstruct()
         self.assertEqual(args, (Q(price__gt=F('discounted_price')),))
+        self.assertEqual(kwargs, {})
+
+    def test_deconstruct_boolean_expression(self):
+        tagged = Tag.objects.filter(category=OuterRef('pk'))
+        q = Q(Exists(tagged))
+        path, args, kwargs = q.deconstruct()
+        self.assertEqual(args, (Exists(tagged),))
         self.assertEqual(kwargs, {})
 
     def test_reconstruct(self):

--- a/tests/queries/test_q.py
+++ b/tests/queries/test_q.py
@@ -29,6 +29,19 @@ class QTests(SimpleTestCase):
     def test_combine_or_both_empty(self):
         self.assertEqual(Q() | Q(), Q())
 
+    def test_combine_nested_empty(self):
+        q = Q(x=1)
+        self.assertEqual(q | Q(Q()), q)
+        self.assertEqual(Q(Q()) | q, q)
+        self.assertEqual(q & Q(Q()), q)
+        self.assertEqual(Q(Q()) & q, q)
+
+        q = Q(Q()) | Q(Q())
+        self.assertIs(q.empty(), True)
+
+        q = Q(Q()) & Q(Q())
+        self.assertIs(q.empty(), True)
+
     def test_combine_not_q_object(self):
         obj = object()
         q = Q(x=1)
@@ -93,6 +106,19 @@ class QTests(SimpleTestCase):
         path, args, kwargs = q.deconstruct()
         self.assertEqual(args, (Exists(tagged),))
         self.assertEqual(kwargs, {})
+
+    def test_empty(self):
+        q = Q()
+        self.assertIs(q.empty(), True)
+
+        q = Q(Q(), ~Q(), Q(Q()))
+        self.assertIs(q.empty(), True)
+
+        q = Q(x=1)
+        self.assertIs(q.empty(), False)
+
+        q = Q(Q(), ~Q(), Q(Q(x=1)))
+        self.assertIs(q.empty(), False)
 
     def test_reconstruct(self):
         q = Q(price__gt=F('discounted_price'))


### PR DESCRIPTION
Fixed [ticket-32549](https://code.djangoproject.com/ticket/32549)

Contains pull #14126 to avoid a regression in logical operations between query expressions and empty Q objects.