### PR TITLE
Fixed typo in DiscoverRunner --reverse help text.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -498,7 +498,7 @@ class DiscoverRunner:
         )
         parser.add_argument(
             '-r', '--reverse', action='store_true',
-            help='Reverses test cases order.',
+            help='Reverses test case order.',
         )
         parser.add_argument(
             '--debug-mode', action='store_true',


### PR DESCRIPTION
This fixes a typo in the help string for `--reverse`.