### PR TITLE
Refs #32260 -- Made admindocs and technical 404 debug page use view_func.view_class.

### DIFF
--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -20,6 +20,9 @@ else:
 
 
 def get_view_name(view_func):
+    if hasattr(view_func, 'view_class'):
+        klass = view_func.view_class
+        return f'{klass.__module__}.{klass.__qualname__}'
     mod_name = view_func.__module__
     view_name = getattr(view_func, '__qualname__', view_func.__class__.__name__)
     return mod_name + '.' + view_name

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -378,7 +378,9 @@ class URLPattern:
         callback = self.callback
         if isinstance(callback, functools.partial):
             callback = callback.func
-        if not hasattr(callback, '__name__'):
+        if hasattr(callback, 'view_class'):
+            callback = callback.view_class
+        elif not hasattr(callback, '__name__'):
             return callback.__module__ + "." + callback.__class__.__name__
         return callback.__module__ + "." + callback.__qualname__
 

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -517,7 +517,9 @@ def technical_404_response(request, exception):
     else:
         obj = resolver_match.func
 
-        if hasattr(obj, '__name__'):
+        if hasattr(obj, 'view_class'):
+            caller = obj.view_class
+        elif hasattr(obj, '__name__'):
             caller = obj.__name__
         elif hasattr(obj, '__class__') and hasattr(obj.__class__, '__name__'):
             caller = obj.__class__.__name__


### PR DESCRIPTION
In reference to the discussion here about changing the `__name__` and `__qualname__` of wrapped views: https://github.com/django/django/pull/14124#discussion_r595871313