### PR TITLE
Fixed #32560 -- Fixed test runner with --pdb and --buffer on fail/error.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -101,6 +101,8 @@ class PDBDebugResult(unittest.TextTestResult):
         self.debug(err)
 
     def debug(self, error):
+        self._restoreStdout()
+        self.buffer = False
         exc_type, exc_value, traceback = error
         print("\nOpening PDB: %r" % exc_value)
         pdb.post_mortem(traceback)

--- a/docs/releases/3.1.8.txt
+++ b/docs/releases/3.1.8.txt
@@ -9,4 +9,6 @@ Django 3.1.8 fixes several bugs in 3.1.7.
 Bugfixes
 ========
 
-* ...
+* Fixed a bug in Django 3.1 where the output was hidden on a test error or
+  failure when using :option:`test --pdb` with the
+  :option:`--buffer <test --buffer>` option (:ticket:`32560`).


### PR DESCRIPTION
ticket-32560