### PR TITLE
Reduced the garbage collection frequency in runtests.py.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -2,6 +2,7 @@
 import argparse
 import atexit
 import copy
+import gc
 import os
 import shutil
 import socket
@@ -52,6 +53,13 @@ warnings.filterwarnings(
     'MemcachedCache is deprecated',
     category=RemovedInDjango41Warning,
 )
+
+# Reduce garbage collection frequency to improve performance. Since CPython
+# uses refcounting, garbage collection only collects objects with cyclic
+# references, which are a minority, so the garbage collection threshold can be
+# larger than the default threshold of 700 allocations + deallocations without
+# much increase in memory usage.
+gc.set_threshold(100_000)
 
 RUNTESTS_DIR = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Don't worry!

This is a technique I've been trying out recently to speed up test suites. It tells the garbage collector to never run and speeds up tests by about 10%.

It's not *that* problematic. Thanks to CPython's refcounting, most objects are freed when they pass out of scope, e.g. at the end of a test method. The garbage collector runs only picks up cyclic references, which are hopefully rare. The potential damage from such cyclic references should also be fairly low during a test run, since the process is by definition short-lived, and most objects created should be small as they are minimal representative examples.

Instagram [disabled garbage collection in production for +10% efficiency](https://instagram-engineering.com/dismissing-python-garbage-collection-at-instagram-4dca40b29172) and [talkpython.com reduced frequency for +10-12% speed](https://twitter.com/mkennedy/status/1339657542591336448).

Here are the benchmarks for running a subset of the django tests with this change:

Before:

```
$ ./runtests.py absolute_url_overrides admin_autodiscover admin_changelist admin_checks admin_custom_urls admin_default_site admin_docs admin_filters admin_inlines admin_ordering admin_registration admin_scripts admin_utils admin_views admin_widgets
...
Ran 1067 tests in 113.626s
...
```

After:

```
$ ./runtests.py absolute_url_overrides admin_autodiscover admin_changelist admin_checks admin_custom_urls admin_default_site admin_docs admin_filters admin_inlines admin_ordering admin_registration admin_scripts admin_utils admin_views admin_widgets
...
Ran 1067 tests in 101.750s
...
```

This mirrors the ~10% gain I've seen on the couple other django projects I've tried this out on.