### PR TITLE
Fixed #32556 -- Fixed assertHTMLEqual() to handle empty string as boolean attributes value.

### DIFF
--- a/django/test/html.py
+++ b/django/test/html.py
@@ -64,9 +64,9 @@ class Element:
             for i in range(len(self.attributes)):
                 attr, value = self.attributes[i]
                 other_attr, other_value = element.attributes[i]
-                if value is None:
+                if not value:
                     value = attr
-                if other_value is None:
+                if not other_value:
                     other_value = other_attr
                 if attr != other_attr or value != other_value:
                     return False

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -714,6 +714,12 @@ class HTMLEqualTests(SimpleTestCase):
             with self.subTest(html1):
                 self.assertHTMLEqual(html1, html2)
 
+    def test_boolean_attribute(self):
+        html1 = '<input attr>'
+        html2 = '<input attr="">'
+        self.assertHTMLEqual(html1, html2)
+        self.assertEqual(parse_html(html1), parse_html(html2))
+
     def test_normalize_refs(self):
         pairs = [
             ('&#39;', '&#x27;'),


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32556