### PR TITLE
Refs #32567 - LiveServerTestCase fails when URL has special characters on Windows

### DIFF
--- a/django/contrib/staticfiles/handlers.py
+++ b/django/contrib/staticfiles/handlers.py
@@ -1,3 +1,4 @@
+import os
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
@@ -34,8 +35,16 @@ class StaticFilesHandlerMixin:
         Check if the path should be handled. Ignore the path if:
         * the host is provided as part of the base_url
         * the request's path isn't under the media path (or equal)
+        * the path contains a special character (':' or '|')
         """
-        return path.startswith(self.base_url[2]) and not self.base_url[1]
+        valid_path_nt_platform = (
+            os.name == 'nt' and ':' not in path and '|' not in path
+        )
+        return (
+            path.startswith(self.base_url[2])
+            and not self.base_url[1]
+            and valid_path_nt_platform
+        )
 
     def file_path(self, url):
         """

--- a/tests/staticfiles_tests/test_liveserver.py
+++ b/tests/staticfiles_tests/test_liveserver.py
@@ -5,6 +5,7 @@ django.test.LiveServerTestCase.
 """
 
 import os
+from urllib.error import HTTPError
 from urllib.request import urlopen
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
@@ -98,3 +99,17 @@ class StaticLiveServerView(LiveServerBase):
         """
         with self.urlopen('/static/test/file.txt') as f:
             self.assertEqual(f.read().rstrip(b'\r\n'), b'In static directory.')
+
+    # The test is going to access a non-existent static file with a special character.
+    @modify_settings(INSTALLED_APPS={'append': 'staticfiles_tests.apps.test'})
+    def test_staticfiles_special_characters(self):
+        """
+        StaticLiveServerTestCase fails on Windows with special characters
+        (':' or '|')
+        """
+        for filename in ('/static/test/file:abc.txt', '/static/test/file|abc.txt'):
+            with self.subTest(filename=filename):
+                with self.assertRaises(HTTPError) as err:
+                    self.urlopen(filename)
+                err.exception.close()
+                self.assertEqual(err.exception.code, 404, 'Expected 404 response')


### PR DESCRIPTION
Added a test in staticfiles_tests/test_liveserver.py. The test tries to access a URL with a colon (:) or pipe (|) in it. It fails on Windows, but not on Linux. This is likely related to the way Windows handles some characters in file / directory names.

I opened the PR even though I don't have a fix yet as suggested in the bugtracker.