### PR TITLE
Fixed #29606 -- Added type check for ALLOWED_HOSTS setting.

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -141,6 +141,7 @@ class Settings:
         mod = importlib.import_module(self.SETTINGS_MODULE)
 
         tuple_settings = (
+            'ALLOWED_HOSTS',
             "INSTALLED_APPS",
             "TEMPLATE_DIRS",
             "LOCALE_PATHS",

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -438,12 +438,13 @@ class IsOverriddenTest(SimpleTestCase):
         self.assertEqual(repr(lazy_settings), expected)
 
 
-class TestListSettings(unittest.TestCase):
+class TestListSettings(SimpleTestCase):
     """
     Make sure settings that should be lists or tuples throw
     ImproperlyConfigured if they are set to a string instead of a list or tuple.
     """
     list_or_tuple_settings = (
+        'ALLOWED_HOSTS',
         "INSTALLED_APPS",
         "TEMPLATE_DIRS",
         "LOCALE_PATHS",
@@ -452,11 +453,12 @@ class TestListSettings(unittest.TestCase):
     def test_tuple_settings(self):
         settings_module = ModuleType('fake_settings_module')
         settings_module.SECRET_KEY = 'foo'
+        msg = 'The %s setting must be a list or a tuple.'
         for setting in self.list_or_tuple_settings:
             setattr(settings_module, setting, ('non_list_or_tuple_value'))
             sys.modules['fake_settings_module'] = settings_module
             try:
-                with self.assertRaises(ImproperlyConfigured):
+                with self.assertRaisesMessage(ImproperlyConfigured, msg % setting):
                     Settings('fake_settings_module')
             finally:
                 del sys.modules['fake_settings_module']


### PR DESCRIPTION
Literally just the same as other people have pushed up but having made changes for feedback that wasn't addressed. https://github.com/django/django/pull/13927

I attempted to contribute to the existing fix but there were permission issues