### PR TITLE
Refs #32552 -- Added DiscoverRunner.log() to allow customization.

### DIFF
--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -294,6 +294,9 @@ Tests
 * Django test runner now supports a :option:`--buffer <test --buffer>` option
   with parallel tests.
 
+* The new :meth:`.DiscoverRunner.log` method allows customizing the way
+  messages are logged.
+
 URLs
 ~~~~
 

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -705,6 +705,17 @@ Methods
     Computes and returns a return code based on a test suite, and the result
     from that test suite.
 
+.. method:: DiscoverRunner.log(msg, level=None)
+
+    .. versionadded:: 4.0
+
+    Prints to the console a message with the given integer `logging level`_
+    (e.g. ``logging.DEBUG``, ``logging.INFO``, or ``logging.WARNING``),
+    respecting the current ``verbosity``. For example, an ``INFO`` message will
+    be logged if the ``verbosity`` is at least 1, and ``DEBUG`` will be logged
+    if it is at least 2.
+
+.. _`logging level`: https://docs.python.org/3/library/logging.html#levels
 
 Testing utilities
 -----------------

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import unittest.loader
 from argparse import ArgumentParser
@@ -377,6 +378,43 @@ class DiscoverRunnerTests(SimpleTestCase):
             runner.time_keeper.print_results()
         self.assertTrue(isinstance(runner.time_keeper, TimeKeeper))
         self.assertIn('test', stderr.getvalue())
+
+    def test_log(self):
+        custom_low_level = 5
+        custom_high_level = 45
+        msg = 'logging message'
+        cases = [
+            (0, None, False),
+            (0, custom_low_level, False),
+            (0, logging.DEBUG, False),
+            (0, logging.INFO, False),
+            (0, logging.WARNING, False),
+            (0, custom_high_level, False),
+            (1, None, True),
+            (1, custom_low_level, False),
+            (1, logging.DEBUG, False),
+            (1, logging.INFO, True),
+            (1, logging.WARNING, True),
+            (1, custom_high_level, True),
+            (2, None, True),
+            (2, custom_low_level, True),
+            (2, logging.DEBUG, True),
+            (2, logging.INFO, True),
+            (2, logging.WARNING, True),
+            (2, custom_high_level, True),
+            (3, None, True),
+            (3, custom_low_level, True),
+            (3, logging.DEBUG, True),
+            (3, logging.INFO, True),
+            (3, logging.WARNING, True),
+            (3, custom_high_level, True),
+        ]
+        for verbosity, level, output in cases:
+            with self.subTest(verbosity=verbosity, level=level):
+                with captured_stdout() as stdout:
+                    runner = DiscoverRunner(verbosity=verbosity)
+                    runner.log(msg, level)
+                    self.assertEqual(stdout.getvalue(), f'{msg}\n' if output else '')
 
 
 class DiscoverRunnerGetDatabasesTests(SimpleTestCase):


### PR DESCRIPTION
ticket-32552

Add a method `log(self, message, level)` to DiscoverRunner class which prints the message by comparing the level with self.verbosity. 
Replace the use of print with self.log

