### PR TITLE
Fixed #32570 -- Removed unnecessary default_auto_field in app config example.

### DIFF
--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -90,7 +90,6 @@ would provide a proper name for the admin::
     from django.apps import AppConfig
 
     class RockNRollConfig(AppConfig):
-        default_auto_field = 'django.db.models.BigAutoField'
         name = 'rock_n_roll'
         verbose_name = "Rock ’n’ roll"
 


### PR DESCRIPTION
Sucessfully removed "default_auto_field = 'django.db.models.BigAutoField' that was causing confusion.