### PR TITLE
More info about exception.

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -81,7 +81,7 @@ class Apps:
                 # Prevent reentrant calls to avoid running AppConfig.ready()
                 # methods twice.
                 self.app_configs = {}
-                #collect exceptons
+                #collect exceptions 
             self.loading = True
 
             # Phase 1: initialize app configs and import app modules.

--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -80,7 +80,8 @@ class Apps:
             if self.loading:
                 # Prevent reentrant calls to avoid running AppConfig.ready()
                 # methods twice.
-                raise RuntimeError("populate() isn't reentrant")
+                self.app_configs = {}
+                #collect exceptons
             self.loading = True
 
             # Phase 1: initialize app configs and import app modules.


### PR DESCRIPTION
Instead of "RuntimeError: populate() isn't reentrant " django will show more info about the cause of  error or exception.

```
Scenarios: (i) Improper imports.
                  (ii)Dependency requirement not satisfied.

```


