### PR TITLE
Refs #32353, Refs #32352 -- Fixed GIS tests with PROJ 7.X.

### DIFF
--- a/tests/gis_tests/gdal_tests/test_geom.py
+++ b/tests/gis_tests/gdal_tests/test_geom.py
@@ -350,7 +350,9 @@ class OGRGeomTest(SimpleTestCase, TestDataMixin):
         self.assertEqual(k1, orig)
         self.assertNotEqual(k1, k2)
 
-        prec = 3
+        # Different PROJ versions use different transformations, all are
+        # correct as having a 1 meter accuracy.
+        prec = -1
         for p in (t1, t2, t3, k2):
             self.assertAlmostEqual(trans.x, p.x, prec)
             self.assertAlmostEqual(trans.y, p.y, prec)
@@ -360,7 +362,9 @@ class OGRGeomTest(SimpleTestCase, TestDataMixin):
         ls_orig = OGRGeometry('LINESTRING(-104.609 38.255)', 4326)
         ls_trans = OGRGeometry('LINESTRING(992385.4472045 481455.4944650)', 2774)
 
-        prec = 3
+        # Different PROJ versions use different transformations, all are
+        # correct as having a 1 meter accuracy.
+        prec = -1
         ls_orig.transform(ls_trans.srs)
         # Making sure the coordinate dimension is still 2D.
         self.assertEqual(2, ls_orig.coord_dim)

--- a/tests/gis_tests/geoapp/test_serializers.py
+++ b/tests/gis_tests/geoapp/test_serializers.py
@@ -77,10 +77,11 @@ class GeoJSONSerializerTests(TestCase):
     def test_srid_option(self):
         geojson = serializers.serialize('geojson', City.objects.all().order_by('name'), srid=2847)
         geodata = json.loads(geojson)
-        self.assertEqual(
-            [int(c) for c in geodata['features'][0]['geometry']['coordinates']],
-            [1564802, 5613214]
-        )
+        coordinates = geodata['features'][0]['geometry']['coordinates']
+        # Different PROJ versions use different transformations, all are
+        # correct as having a 1 meter accuracy.
+        self.assertAlmostEqual(coordinates[0], 1564802, -1)
+        self.assertAlmostEqual(coordinates[1], 5613214, -1)
 
     def test_deserialization_exception(self):
         """

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -1140,7 +1140,9 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         self.assertEqual(k1, orig)
         self.assertNotEqual(k1, k2)
 
-        prec = 3
+        # Different PROJ versions use different transformations, all are
+        # correct as having a 1 meter accuracy.
+        prec = -1
         for p in (t1, t2, t3, k2):
             self.assertAlmostEqual(trans.x, p.x, prec)
             self.assertAlmostEqual(trans.y, p.y, prec)

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -28,7 +28,9 @@ class GeometryFieldTest(SimpleTestCase):
         # Making the field in a different SRID from that of the geometry, and
         # asserting it transforms.
         fld = forms.GeometryField(srid=32140)
-        tol = 0.0001
+        # Different PROJ versions use different transformations, all are
+        # correct as having a 1 meter accuracy.
+        tol = 1
         xform_geom = GEOSGeometry('POINT (951640.547328465 4219369.26171664)', srid=32140)
         # The cleaned geometry is transformed to 32140 (the widget map_srid is 3857).
         cleaned_geom = fld.clean('SRID=3857;POINT (-10615777.40976205 3473169.895707852)')


### PR DESCRIPTION
Different PROJ versions use different transformations, all are correct as having a 1 meter accuracy.

These are differences in PROJ versions that cannot and should not be handled in Django itself.

Thanks Jani Tiainen and David Smith for reports.

See https://github.com/OSGeo/gdal/issues/3377 and https://github.com/django/django/pull/14133#issuecomment-802309020.

---

Checked with GDAL 3.1.0, 3.1.1, and 3.1.4.