### PR TITLE
Fixed #32585 -- Fixed Value(output_field=DecimalField()) crash on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -314,6 +314,8 @@ class DatabaseOperations(BaseDatabaseOperations):
         else:
             def converter(value, expression, connection):
                 if value is not None:
+                    if isinstance(value, str):
+                        return create_decimal(float(value))
                     return create_decimal(value)
         return converter
 


### PR DESCRIPTION
Super simple fix, don't know if it is the best way but it works.

Fixes ticket [#32585](https://code.djangoproject.com/ticket/32585)