### PR TITLE
Fixed #32582 -- Removed unnecessary dot in names of cloned test databases on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/creation.py
+++ b/django/db/backends/sqlite3/creation.py
@@ -55,7 +55,7 @@ class DatabaseCreation(BaseDatabaseCreation):
             return orig_settings_dict
         else:
             root, ext = os.path.splitext(orig_settings_dict['NAME'])
-            return {**orig_settings_dict, 'NAME': '{}_{}.{}'.format(root, suffix, ext)}
+            return {**orig_settings_dict, 'NAME': '{}_{}{}'.format(root, suffix, ext)}
 
     def _clone_test_db(self, suffix, verbosity, keepdb=False):
         source_database_name = self.connection.settings_dict['NAME']

--- a/tests/backends/sqlite/test_creation.py
+++ b/tests/backends/sqlite/test_creation.py
@@ -1,7 +1,5 @@
 import copy
-import os
 import unittest
-from random import randint
 
 from django.db import DEFAULT_DB_ALIAS, connection, connections
 from django.test import SimpleTestCase

--- a/tests/backends/sqlite/test_creation.py
+++ b/tests/backends/sqlite/test_creation.py
@@ -17,7 +17,7 @@ class TestDbSignatureTests(SimpleTestCase):
         signature = test_connection.creation_class(test_connection).test_db_signature()
         self.assertEqual(signature, (None, 'custom.sqlite.db'))
 
-    def test_parallel_test_name(self):
+    def test_get_test_db_clone_settings_name(self):
         test_connection = copy.copy(connections[DEFAULT_DB_ALIAS])
         test_connection.settings_dict = copy.deepcopy(connections[DEFAULT_DB_ALIAS].settings_dict)
         test_connection.settings_dict['NAME'] = 'test.sqlite3'

--- a/tests/backends/sqlite/test_creation.py
+++ b/tests/backends/sqlite/test_creation.py
@@ -1,6 +1,6 @@
 import copy
-import unittest
 import os
+import unittest
 from random import randint
 
 

--- a/tests/backends/sqlite/test_creation.py
+++ b/tests/backends/sqlite/test_creation.py
@@ -3,7 +3,6 @@ import os
 import unittest
 from random import randint
 
-
 from django.db import DEFAULT_DB_ALIAS, connection, connections
 from django.test import SimpleTestCase
 

--- a/tests/backends/sqlite/test_creation.py
+++ b/tests/backends/sqlite/test_creation.py
@@ -19,10 +19,17 @@ class TestDbSignatureTests(SimpleTestCase):
 
     def test_get_test_db_clone_settings_name(self):
         test_connection = copy.copy(connections[DEFAULT_DB_ALIAS])
-        test_connection.settings_dict = copy.deepcopy(connections[DEFAULT_DB_ALIAS].settings_dict)
-        test_connection.settings_dict['NAME'] = 'test.sqlite3'
-        test_connection.settings_dict['TEST']['NAME'] = 'test.sqlite3'
-        random_suffix = randint(1, 100)
-        root, ext = os.path.splitext(test_connection.settings_dict['NAME'])
-        settings_dict = test_connection.creation_class(test_connection).get_test_db_clone_settings(random_suffix)
-        self.assertEqual(settings_dict['NAME'], '{}_{}{}'.format(root, random_suffix, ext))
+        test_connection.settings_dict = copy.deepcopy(
+            connections[DEFAULT_DB_ALIAS].settings_dict,
+        )
+        tests = [
+            ('test.sqlite3', 'test_1.sqlite3'),
+            ('test', 'test_1'),
+        ]
+        for test_db_name, expected_clone_name in tests:
+            with self.subTest(test_db_name=test_db_name):
+                test_connection.settings_dict['NAME'] = test_db_name
+                test_connection.settings_dict['TEST']['NAME'] = test_db_name
+                creation_class = test_connection.creation_class(test_connection)
+                clone_settings_dict = creation_class.get_test_db_clone_settings('1')
+                self.assertEqual(clone_settings_dict['NAME'], expected_clone_name)

--- a/tests/backends/sqlite/test_creation.py
+++ b/tests/backends/sqlite/test_creation.py
@@ -1,5 +1,8 @@
 import copy
 import unittest
+import os
+from random import randint
+
 
 from django.db import DEFAULT_DB_ALIAS, connection, connections
 from django.test import SimpleTestCase
@@ -14,3 +17,13 @@ class TestDbSignatureTests(SimpleTestCase):
         test_connection.settings_dict['TEST']['NAME'] = 'custom.sqlite.db'
         signature = test_connection.creation_class(test_connection).test_db_signature()
         self.assertEqual(signature, (None, 'custom.sqlite.db'))
+
+    def test_parallel_test_name(self):
+        test_connection = copy.copy(connections[DEFAULT_DB_ALIAS])
+        test_connection.settings_dict = copy.deepcopy(connections[DEFAULT_DB_ALIAS].settings_dict)
+        test_connection.settings_dict['NAME'] = 'test.sqlite3'
+        test_connection.settings_dict['TEST']['NAME'] = 'test.sqlite3'
+        random_suffix = randint(1, 100)
+        root, ext = os.path.splitext(test_connection.settings_dict['NAME'])
+        settings_dict = test_connection.creation_class(test_connection).get_test_db_clone_settings(random_suffix)
+        self.assertEqual(settings_dict['NAME'], '{}_{}{}'.format(root, random_suffix, ext))


### PR DESCRIPTION
Fixed https://code.djangoproject.com/ticket/32582.

I am not sure in which section of the project I would have to write a test for this patch but if someone guides me then I will definitely write a test for this patch.