### PR TITLE
Fixed page numbers in Paginator.get_elided_page_range() example in docs.

### DIFF
--- a/docs/ref/paginator.txt
+++ b/docs/ref/paginator.txt
@@ -95,7 +95,7 @@ Methods
     For example, with the default values for ``on_each_side`` and ``on_ends``,
     if the current page is 10 and there are 50 pages, the page range will be
     ``[1, 2, '…', 7, 8, 9, 10, 11, 12, 13, '…', 49, 50]``. This will result in
-    pages 4, 5, and 6 to the left of and 8, 9, and 10 to the right of the
+    pages 7, 8, and 9 to the left of and 11, 12, and 13 to the right of the
     current page as well as pages 1 and 2 at the start and 49 and 50 at the
     end.
 


### PR DESCRIPTION
It's late at night already for me so I hope I'm not confusing something: it seems that the page numbers mentioned in the example for `get_elided_page_range()` are not correct. 