### PR TITLE
Fixed #32578 -- Fixed crash in CsrfViewMiddleware when a request with Origin header has an invalid host.

### DIFF
--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -226,12 +226,17 @@ class CsrfViewMiddleware(MiddlewareMixin):
 
     def _origin_verified(self, request):
         request_origin = request.META['HTTP_ORIGIN']
-        good_origin = '%s://%s' % (
-            'https' if request.is_secure() else 'http',
-            request.get_host(),
-        )
-        if request_origin == good_origin:
-            return True
+        try:
+            good_host = request.get_host()
+        except DisallowedHost:
+            pass
+        else:
+            good_origin = '%s://%s' % (
+                'https' if request.is_secure() else 'http',
+                good_host,
+            )
+            if request_origin == good_origin:
+                return True
         if request_origin in self.allowed_origins_exact:
             return True
         try:

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -319,6 +319,15 @@ class CsrfViewMiddlewareTestMixin:
         response = mw.process_view(req, token_view, (), {})
         self.assertEqual(response.status_code, 403)
 
+    def test_origin_malformed_host(self):
+        req = self._get_POST_no_csrf_cookie_request()
+        req._is_secure_override = True
+        req.META['HTTP_HOST'] = '@malformed'
+        req.META['HTTP_ORIGIN'] = 'https://www.evil.org'
+        mw = CsrfViewMiddleware(token_view)
+        response = mw.process_view(req, token_view, (), {})
+        self.assertEqual(response.status_code, 403)
+
     @override_settings(DEBUG=True)
     def test_https_malformed_referer(self):
         """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32578
