### PR TITLE
Fixed #32532 -- Made DiscoverRunner raise RuntimeError when a test label is a file path.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -600,6 +600,13 @@ class DiscoverRunner:
             if not is_package:
                 return tests
         elif not os.path.isdir(label_as_path):
+            if os.path.exists(label_as_path):
+                assert tests is None
+                raise RuntimeError(
+                    f'One of the test labels is a path to a file: {label!r}, '
+                    f'which is not supported. Use a dotted module name '
+                    f'instead.'
+                )
             return tests
 
         kwargs = discover_kwargs.copy()

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -47,6 +47,16 @@ class DiscoverRunnerTests(SimpleTestCase):
         ns = parser.parse_args(["--debug-mode"])
         self.assertTrue(ns.debug_mode)
 
+    def test_load_tests_for_label_file_path(self):
+        with change_cwd('.'):
+            msg = (
+                "One of the test labels is a path to a file: "
+                "'test_discover_runner.py', which is not supported. Use a "
+                "dotted module name instead."
+            )
+            with self.assertRaisesMessage(RuntimeError, msg):
+                DiscoverRunner().load_tests_for_label('test_discover_runner.py', {})
+
     def test_dotted_test_module(self):
         count = DiscoverRunner().build_suite(
             ['test_runner_apps.sample.tests_sample'],


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32532

Here is an example with this patch:

```
$ ./runtests.py test_runner/test_discover_runner.py
Testing against Django installed in ...
Traceback (most recent call last):
  ...
RuntimeError: One of the test labels is a path to a file: 'test_runner/test_discover_runner.py'
Test labels that are paths but not importable as names can only be directories.
```