### PR TITLE
Fixed #32580 -- Doc'd that HttpRequest.get_host() may raise DisallowedHost.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -855,6 +855,7 @@ answer newbie questions, and generally made Django that much better:
     sloonz <simon.lipp@insa-lyon.fr>
     smurf@smurf.noris.de
     sopel
+    Sreehari K V <sreeharivijayan619@gmail.com>
     Srinivas Reddy Thatiparthy <thatiparthysreenivas@gmail.com>
     Stanislas Guerra <stan@slashdev.me>
     Stanislaus Madueke

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -290,6 +290,10 @@ Methods
 
     Example: ``"127.0.0.1:8000"``
 
+    Raises ``django.core.exceptions.DisallowedHost`` if the host is not in
+    :setting:`ALLOWED_HOSTS` or the domain name is invalid according to
+    :rfc:`1034`/:rfc:`1035 <1035>`.
+
     .. note:: The :meth:`~HttpRequest.get_host()` method fails when the host is
         behind multiple proxies. One solution is to use middleware to rewrite
         the proxy headers, as in the following example::


### PR DESCRIPTION
- Documented HttpRequest.get_host() can raise DisallowedHost exception.
- Add contributor name to AUTHORS.

Ticket [#32580](https://code.djangoproject.com/ticket/32580)