### PR TITLE
Fixed #32594 -- Doc'd and tested that Signal.disconnect() with lazy references returns None.

### DIFF
--- a/docs/topics/signals.txt
+++ b/docs/topics/signals.txt
@@ -277,7 +277,9 @@ Disconnecting signals
 
 To disconnect a receiver from a signal, call :meth:`Signal.disconnect`. The
 arguments are as described in :meth:`.Signal.connect`. The method returns
-``True`` if a receiver was disconnected and ``False`` if not.
+``True`` if a receiver was disconnected and ``False`` if not. When ``sender``
+is passed as a lazy reference to ``<app label>.<model>``, this method always
+returns ``None``.
 
 The ``receiver`` argument indicates the registered receiver to disconnect. It
 may be ``None`` if ``dispatch_uid`` is used to identify the receiver.

--- a/tests/signals/tests.py
+++ b/tests/signals/tests.py
@@ -351,20 +351,51 @@ class LazyModelRefTests(BaseSignalSetup, SimpleTestCase):
             signals.post_init.disconnect(self.receiver, sender=Created)
 
     @isolate_apps('signals', kwarg_name='apps')
-    def test_disconnect(self, apps):
+    def test_disconnect_registered_model(self, apps):
+        received = []
+
+        def receiver(**kwargs):
+            received.append(kwargs)
+
+        class Created(models.Model):
+            pass
+
+        signals.post_init.connect(receiver, sender='signals.Created', apps=apps)
+        try:
+            self.assertIsNone(
+                signals.post_init.disconnect(receiver, sender='signals.Created', apps=apps)
+            )
+            self.assertIsNone(
+                signals.post_init.disconnect(receiver, sender='signals.Created', apps=apps)
+            )
+            Created()
+            self.assertEqual(received, [])
+        finally:
+            signals.post_init.disconnect(receiver, sender='signals.Created')
+
+    @isolate_apps('signals', kwarg_name='apps')
+    def test_disconnect_unregistered_model(self, apps):
         received = []
 
         def receiver(**kwargs):
             received.append(kwargs)
 
         signals.post_init.connect(receiver, sender='signals.Created', apps=apps)
-        signals.post_init.disconnect(receiver, sender='signals.Created', apps=apps)
+        try:
+            self.assertIsNone(
+                signals.post_init.disconnect(receiver, sender='signals.Created', apps=apps)
+            )
+            self.assertIsNone(
+                signals.post_init.disconnect(receiver, sender='signals.Created', apps=apps)
+            )
 
-        class Created(models.Model):
-            pass
+            class Created(models.Model):
+                pass
 
-        Created()
-        self.assertEqual(received, [])
+            Created()
+            self.assertEqual(received, [])
+        finally:
+            signals.post_init.disconnect(receiver, sender='signals.Created')
 
     def test_register_model_class_senders_immediately(self):
         """


### PR DESCRIPTION
Signal.disconnect() was returning None when sender model string was used.

https://code.djangoproject.com/ticket/32594