### PR TITLE
Added missing mode="rb" argument to open() call in Client.post() example in docs.

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -244,7 +244,7 @@ Use the ``django.test.Client`` class to make requests.
         wish to upload as a value. For example::
 
             >>> c = Client()
-            >>> with open('wishlist.doc') as fp:
+            >>> with open('wishlist.doc', 'rb') as fp:
             ...     c.post('/customers/wishes/', {'name': 'fred', 'attachment': fp})
 
         (The name ``attachment`` here is not relevant; use whatever name your


### PR DESCRIPTION
The example for how to write a test that involves submitting a file involves uploading a binary file, but doesn't have a file access mode set. Since Python defaults to reading the file as text, this can result in UnicodeDecodeErrors.

This change adds an access_mode of 'rb' to the example thus causing Python to interpret it as a binary file.