### PR TITLE
Refs #32355 -- Corrected comments about Python's _NamespacePath.

### DIFF
--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -73,8 +73,7 @@ class AppConfig:
         """Attempt to determine app's filesystem path from its module."""
         # See #21874 for extended discussion of the behavior of this method in
         # various cases.
-        # Convert paths to list because Python's _NamespacePath doesn't support
-        # indexing.
+        # Convert to list because __path__ may not support indexing.
         paths = list(getattr(module, '__path__', []))
         if len(paths) != 1:
             filename = getattr(module, '__file__', None)

--- a/django/utils/module_loading.py
+++ b/django/utils/module_loading.py
@@ -85,7 +85,7 @@ def module_dir(module):
     Raise ValueError otherwise, e.g. for namespace packages that are split
     over several directories.
     """
-    # Convert to list because _NamespacePath does not support indexing.
+    # Convert to list because __path__ may not support indexing.
     paths = list(getattr(module, '__path__', []))
     if len(paths) == 1:
         return paths[0]


### PR DESCRIPTION
`_NamespacePath` supports indexing in Python 3.8+, see https://github.com/python/cpython/commit/ab9b31f94737895f0121f26ba3ad718ebbc24fe1.