### PR TITLE
Removed dead link in docs/topics/http/sessions.txt.

### DIFF
--- a/docs/topics/http/sessions.txt
+++ b/docs/topics/http/sessions.txt
@@ -164,10 +164,9 @@ and the :setting:`SECRET_KEY` setting.
 
     **Performance**
 
-    Finally, the size of a cookie can have an impact on the `speed of your site`_.
+    Finally, the size of a cookie can have an impact on the speed of your site.
 
 .. _`replay attacks`: https://en.wikipedia.org/wiki/Replay_attack
-.. _`speed of your site`: https://yuiblog.com/blog/2007/03/01/performance-research-part-3/
 
 Using sessions in views
 =======================


### PR DESCRIPTION
The removed section contains a dead link whose archived content (found here: http://web.archive.org/web/20200229005702/https://yuiblog.com/blog/2007/03/01/performance-research-part-3/ ) suggests keeping cookie sizes small to decrease page load times.

The data was benchmarked using an 800kbps DSL connection. I believe that, in addition to the matter of the dead link, a cookie (which itself cannot exceed 4KB) is no longer worth considering in page load times.