### PR TITLE
Fixed #29127 -- Prevented DiscoverRunner from hiding tagged test with syntax errors.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -852,6 +852,10 @@ def partition_suite_by_case(suite):
 
 
 def test_match_tags(test, tags, exclude_tags):
+    if isinstance(test, unittest.loader._FailedTest):
+        # Tests that couldn't load always match to prevent tests from falsely
+        # passing due e.g. to syntax errors.
+        return True
     test_tags = set(getattr(test, 'tags', []))
     test_fn_name = getattr(test, '_testMethodName', str(test))
     if hasattr(test, test_fn_name):

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1497,6 +1497,12 @@ don't.
 Runs only tests :ref:`marked with the specified tags <topics-tagging-tests>`.
 May be specified multiple times and combined with :option:`test --exclude-tag`.
 
+Tests that fail to load are always considered matching.
+
+.. versionchanged:: 4.0
+
+    In older versions, tests that failed to load did not match tags.
+
 .. option:: --exclude-tag EXCLUDE_TAGS
 
 Excludes tests :ref:`marked with the specified tags <topics-tagging-tests>`.

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -373,6 +373,9 @@ Miscellaneous
   non-boolean attribute without a value equal to an attribute with the same
   name and value.
 
+* Tests that fail to load, for example due to syntax errors, now always match
+  when using :option:`test --tag`.
+
 .. _deprecated-features-4.0:
 
 Features deprecated in 4.0

--- a/tests/test_runner_apps/tagged/tests_syntax_error.py
+++ b/tests/test_runner_apps/tagged/tests_syntax_error.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+from django.test import tag
+
+
+@tag('syntax_error')
+class SyntaxErrorTestCase(TestCase):
+    pass
+
+
+1syntax_error  # NOQA


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29127