### PR TITLE
Refs #32105 -- Moved ExceptionReporter template paths to properties.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -245,8 +245,14 @@ class SafeExceptionReporterFilter:
 
 class ExceptionReporter:
     """Organize and coordinate reporting on exceptions."""
-    html_template_path = CURRENT_DIR / 'templates' / 'technical_500.html'
-    text_template_path = CURRENT_DIR / 'templates' / 'technical_500.txt'
+
+    @property
+    def html_template_path(self):
+        return CURRENT_DIR / 'templates' / 'technical_500.html'
+
+    @property
+    def text_template_path(self):
+        return CURRENT_DIR / 'templates' / 'technical_500.txt'
 
     def __init__(self, request, exc_type, exc_value, tb, is_email=False):
         self.request = request

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -323,17 +323,18 @@ Your custom reporter class needs to inherit from
 
         .. versionadded:: 3.2
 
-        A :class:`pathlib.Path` representing the absolute filesystem path to a
-        template for rendering the HTML representation of the exception.
-        Defaults to the Django provided template.
+        Property that returns a :class:`pathlib.Path` representing the absolute
+        filesystem path to a template for rendering the HTML representation of
+        the exception. Defaults to the Django provided template.
 
     .. attribute:: text_template_path
 
         .. versionadded:: 3.2
 
-        A :class:`pathlib.Path` representing the absolute filesystem path to a
-        template for rendering the plain-text representation of the exception.
-        Defaults to the Django provided template.
+        Property that returns a :class:`pathlib.Path` representing the absolute
+        filesystem path to a template for rendering the plain-text
+        representation of the exception. Defaults to the Django provided
+        template.
 
     .. method:: get_traceback_data()
 

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -299,10 +299,10 @@ Decorators
 Error Reporting
 ~~~~~~~~~~~~~~~
 
-* Custom :class:`~django.views.debug.ExceptionReporter` subclasses can now set
-  the :attr:`~django.views.debug.ExceptionReporter.html_template_path` and
-  :attr:`~django.views.debug.ExceptionReporter.text_template_path` class
-  attributes to override the templates used to render exception reports.
+* Custom :class:`~django.views.debug.ExceptionReporter` subclasses can now
+  define the :attr:`~django.views.debug.ExceptionReporter.html_template_path`
+  and :attr:`~django.views.debug.ExceptionReporter.text_template_path`
+  properties to override the templates used to render exception reports.
 
 File Uploads
 ~~~~~~~~~~~~


### PR DESCRIPTION
Replaced `ExceptionRerporter`'s `{text,html}_template_path` class attributes with `@property`s per @carltongibson's request at https://github.com/django/django/pull/13841#pullrequestreview-624007046 to simplify future changes to the implementation. Per https://github.com/django/django/pull/13841#issuecomment-810054032 there's no need to change any documentation: Django documents instance attributes and properties the same way.

There's no Trac ticket for this, but I can make one if it's necessary.