### PR TITLE
Removed unnecessary left/right in admin sidebar CSS.

### DIFF
--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -60,13 +60,10 @@
 }
 
 .main.shifted > #nav-sidebar {
-    left: 24px;
     margin-left: 0;
 }
 
 [dir="rtl"] .main.shifted > #nav-sidebar {
-    left: 0;
-    right: 24px;
     margin-right: 0;
 }
 


### PR DESCRIPTION
`left`/`right` are unnecessary are unnecessary and create a visual gap.

| After | Before | 
|:---:|:---:|
| ![image](https://user-images.githubusercontent.com/2865885/113109655-77a9ae00-9206-11eb-87e9-54fc8212cdf2.png) | ![image](https://user-images.githubusercontent.com/2865885/113110081-f56db980-9206-11eb-8896-69ce0da75585.png) |
| ![image](https://user-images.githubusercontent.com/2865885/113112022-091a1f80-9209-11eb-9485-097a686c30d4.png) | ![image](https://user-images.githubusercontent.com/2865885/113111954-f4d62280-9208-11eb-8538-ebfc1a17b9be.png) |

This is a tiny tweak :smile: 
![image](https://user-images.githubusercontent.com/2865885/113111065-12ef5300-9208-11eb-97e2-e6be51a058f1.png)

