### PR TITLE
Fixed #29898 -- ModelState for RemoveField and remove_field in spite of model

### DIFF
--- a/django/db/migrations/operations/base.py
+++ b/django/db/migrations/operations/base.py
@@ -1,5 +1,5 @@
 from django.db import router
-
+from contextlib import contextmanager
 
 class Operation:
     """
@@ -138,3 +138,11 @@ class Operation:
             ", ".join(map(repr, self._constructor_args[0])),
             ",".join(" %s=%r" % x for x in self._constructor_args[1].items()),
         )
+
+@contextmanager
+def patch_project_state(schema_editor, project_state):
+    schema_editor.project_state = project_state
+    try:
+        yield
+    finally:
+        del schema_editor.project_state


### PR DESCRIPTION
[ticket-29898](https://code.djangoproject.com/ticket/29898)
Derived from https://github.com/django/django/compare/main...MarkusH:schemaeditor-modelstate
This is the initial commit for `remove_field` and just to get the review from experts.
I would be soon adding all the commits to this branch for all the methods of `schema_editor` to use `ModelState` in spite of the `model` class.
This is the implementation for `BaseDatabaseSchemaEditor` and for other databases like `sqlite3`. I will add a similar type of logic.
Any suggestion, feedback, and help are most welcome and would be highly appreciated.
Regards
Manav Agarwal