### PR TITLE
Clarified docs about increasing the work factor for bcrypt hasher.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -978,6 +978,7 @@ answer newbie questions, and generally made Django that much better:
     ymasuda@ethercube.com
     Yoong Kang Lim <yoongkang.lim@gmail.com>
     Yusuke Miyazaki <miyazaki.dev@gmail.com>
+    yyyyyyyan <contact@yyyyyyyan.tech>
     Zac Hatfield-Dodds <zac.hatfield.dodds@gmail.com>
     Zachary Voase <zacharyvoase@gmail.com>
     Zach Liu <zachliu@gmail.com>

--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -172,8 +172,9 @@ iterations needs to be increased. We've chosen a reasonable default (and will
 increase it with each release of Django), but you may wish to tune it up or
 down, depending on your security needs and available processing power. To do so,
 you'll subclass the appropriate algorithm and override the ``iterations``
-parameters. For example, to increase the number of iterations used by the
-default PBKDF2 algorithm:
+parameter (use the ``rounds`` parameter when subclassing a bcrypt hasher). For
+example, to increase the number of iterations used by the default PBKDF2
+algorithm:
 
 #. Create a subclass of ``django.contrib.auth.hashers.PBKDF2PasswordHasher``::
 
@@ -200,6 +201,11 @@ default PBKDF2 algorithm:
 
 That's it -- now your Django install will use more iterations when it
 stores passwords using PBKDF2.
+
+.. note::
+
+    bcrypt ``rounds`` is a logarithmic work factor, e.g. 12 rounds means
+    ``2 ** 12`` iterations.
 
 Argon2
 ~~~~~~


### PR DESCRIPTION
The [Password Management docs](https://docs.djangoproject.com/en/dev/topics/auth/passwords/) has a section for increasing the work factor of PBKDF2 and bcrypt. The section instructs the reader to subclass the appropriate algorithm class and override the **iterations** attribute. This attribute, however, is specific to PBKDF2. The bcrypt class uses the **rounds** attribute (the actual iterations number correspond to ``2 ** rounds``). This PR specifies this adding an example of changing the bcrypt rounds attribute.