### PR TITLE
Fixed #32501 -- Added support for returning fields from INSERT statements on SQLite 3.35+.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -117,3 +117,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     can_introspect_json_field = property(operator.attrgetter('supports_json_field'))
     has_json_object_function = property(operator.attrgetter('supports_json_field'))
+
+    @cached_property
+    def can_return_columns_from_insert(self):
+        return Database.sqlite_version_info >= (3, 35)
+
+    can_return_rows_from_bulk_insert = property(operator.attrgetter('can_return_columns_from_insert'))

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2171,7 +2171,8 @@ This has a number of caveats though:
 * It does not work with child models in a multi-table inheritance scenario.
 * If the model's primary key is an :class:`~django.db.models.AutoField`, the
   primary key attribute can only be retrieved on certain databases (currently
-  PostgreSQL and MariaDB 10.5+). On other databases, it will not be set.
+  PostgreSQL, MariaDB 10.5+, and SQLite 3.35+). On other databases, it will not
+  be set.
 * It does not work with many-to-many relationships.
 * It casts ``objs`` to a list, which fully evaluates ``objs`` if it's a
   generator. The cast allows inspecting all objects so that any objects with a
@@ -2209,6 +2210,10 @@ normally supports it).
 
 .. _MySQL documentation: https://dev.mysql.com/doc/refman/en/sql-mode.html#ignore-strict-comparison
 .. _MariaDB documentation: https://mariadb.com/kb/en/ignore/
+
+.. versionchanged:: 4.0
+
+    Support for the fetching primary key attributes on SQLite 3.35+ was added.
 
 ``bulk_update()``
 ~~~~~~~~~~~~~~~~~

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -230,6 +230,9 @@ Models
   :class:`Round() <django.db.models.functions.Round>` database function allows
   specifying the number of decimal places after rounding.
 
+* :meth:`.QuerySet.bulk_create` now sets the primary key on objects when using
+  SQLite 3.35+.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
patch for ticket [#32501](https://code.djangoproject.com/ticket/32501).