### PR TITLE
Refs #32074 -- Backported Enum.__repr__() from Python 3.10.

### DIFF
--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -4,6 +4,7 @@ from django.db.models.expressions import ExpressionList, F
 from django.db.models.indexes import IndexExpression
 from django.db.models.query_utils import Q
 from django.db.models.sql.query import Query
+from django.utils.version import PY310
 
 __all__ = ['CheckConstraint', 'Deferrable', 'UniqueConstraint']
 
@@ -84,6 +85,11 @@ class CheckConstraint(BaseConstraint):
 class Deferrable(Enum):
     DEFERRED = 'deferred'
     IMMEDIATE = 'immediate'
+
+    # A similar format is used in Python 3.10+.
+    if not PY310:
+        def __repr__(self):
+            return '%s.%s' % (self.__class__.__qualname__, self._name_)
 
 
 class UniqueConstraint(BaseConstraint):
@@ -218,7 +224,7 @@ class UniqueConstraint(BaseConstraint):
             '' if not self.expressions else ' expressions=%s' % repr(self.expressions),
             ' name=%s' % repr(self.name),
             '' if self.condition is None else ' condition=%s' % self.condition,
-            '' if self.deferrable is None else ' deferrable=%s' % self.deferrable,
+            '' if self.deferrable is None else ' deferrable=%r' % self.deferrable,
             '' if not self.include else ' include=%s' % repr(self.include),
             '' if not self.opclasses else ' opclasses=%s' % repr(self.opclasses),
         )

--- a/django/db/models/enums.py
+++ b/django/db/models/enums.py
@@ -2,6 +2,7 @@ import enum
 from types import DynamicClassAttribute
 
 from django.utils.functional import Promise
+from django.utils.version import PY310
 
 __all__ = ['Choices', 'IntegerChoices', 'TextChoices']
 
@@ -73,6 +74,11 @@ class Choices(enum.Enum, metaclass=ChoicesMeta):
         attributes are rendered as expected in templates and similar contexts.
         """
         return str(self.value)
+
+    # A similar format is used in Python 3.10+.
+    if not PY310:
+        def __repr__(self):
+            return '%s.%s' % (self.__class__.__qualname__, self._name_)
 
 
 class IntegerChoices(int, Choices):

--- a/tests/model_enums/tests.py
+++ b/tests/model_enums/tests.py
@@ -48,7 +48,7 @@ class ChoicesTests(SimpleTestCase):
         self.assertEqual(Suit.values, [1, 2, 3, 4])
         self.assertEqual(Suit.names, ['DIAMOND', 'SPADE', 'HEART', 'CLUB'])
 
-        self.assertEqual(repr(Suit.DIAMOND), '<Suit.DIAMOND: 1>')
+        self.assertEqual(repr(Suit.DIAMOND), 'Suit.DIAMOND')
         self.assertEqual(Suit.DIAMOND.label, 'Diamond')
         self.assertEqual(Suit.DIAMOND.value, 1)
         self.assertEqual(Suit['DIAMOND'], Suit.DIAMOND)
@@ -89,7 +89,7 @@ class ChoicesTests(SimpleTestCase):
         self.assertEqual(YearInSchool.values, ['FR', 'SO', 'JR', 'SR', 'GR'])
         self.assertEqual(YearInSchool.names, ['FRESHMAN', 'SOPHOMORE', 'JUNIOR', 'SENIOR', 'GRADUATE'])
 
-        self.assertEqual(repr(YearInSchool.FRESHMAN), "<YearInSchool.FRESHMAN: 'FR'>")
+        self.assertEqual(repr(YearInSchool.FRESHMAN), 'YearInSchool.FRESHMAN')
         self.assertEqual(YearInSchool.FRESHMAN.label, 'Freshman')
         self.assertEqual(YearInSchool.FRESHMAN.value, 'FR')
         self.assertEqual(YearInSchool['FRESHMAN'], YearInSchool.FRESHMAN)


### PR DESCRIPTION
`Enum.__repr__()` was changed in https://bugs.python.org/issue40066 (see https://github.com/python/cpython/commit/b775106d940e3d77c8af7967545bb9a5b7b162df). The new format is more readable and can be used directly. I think we should use the same in Python < 3.10.

Failures on Python 3.10.0a7 without this patch:
- `model_enums.tests.ChoicesTests.test_integerchoices`
```
Traceback (most recent call last):
  File "C:\Jenkins\workspace\django-windows\database\sqlite3\label\windows\python\Python310\tests\model_enums\tests.py", line 51, in test_integerchoices
    self.assertEqual(repr(Suit.DIAMOND), '<Suit.DIAMOND: 1>')
AssertionError: 'Suit.DIAMOND' != '<Suit.DIAMOND: 1>'
- Suit.DIAMOND
+ <Suit.DIAMOND: 1>
```
- `model_enums.tests.ChoicesTests.test_textchoices`
```
Traceback (most recent call last):
  File "C:\Jenkins\workspace\django-windows\database\sqlite3\label\windows\python\Python310\tests\model_enums\tests.py", line 92, in test_textchoices
    self.assertEqual(repr(YearInSchool.FRESHMAN), "<YearInSchool.FRESHMAN: 'FR'>")
AssertionError: 'YearInSchool.FRESHMAN' != "<YearInSchool.FRESHMAN: 'FR'>"
- YearInSchool.FRESHMAN
+ <YearInSchool.FRESHMAN: 'FR'>
```
- `constraints.tests.UniqueConstraintTests.test_repr_with_deferrable`
````
Traceback (most recent call last):
  File "C:\Jenkins\workspace\django-windows\database\sqlite3\label\windows\python\Python310\tests\constraints\tests.py", line 273, in test_repr_with_deferrable
    self.assertEqual(
AssertionError: "<Uni[28 chars], 'bar') name='unique_fields' deferrable=IMMEDIATE>" != "<Uni[28 chars], 'bar') name='unique_fields' deferrable=Deferrable.IMMEDIATE>"
- <UniqueConstraint: fields=('foo', 'bar') name='unique_fields' deferrable=IMMEDIATE>
+ <UniqueConstraint: fields=('foo', 'bar') name='unique_fields' deferrable=Deferrable.IMMEDIATE>
```
