### PR TITLE
Refs #32074 -- Made ExclusionConstraint.__repr__() use Deferrable.__repr__().

### DIFF
--- a/django/contrib/postgres/constraints.py
+++ b/django/contrib/postgres/constraints.py
@@ -161,7 +161,7 @@ class ExclusionConstraint(BaseConstraint):
             repr(self.expressions),
             repr(self.name),
             '' if self.condition is None else ' condition=%s' % self.condition,
-            '' if self.deferrable is None else ' deferrable=%s' % self.deferrable,
+            '' if self.deferrable is None else ' deferrable=%r' % self.deferrable,
             '' if not self.include else ' include=%s' % repr(self.include),
             '' if not self.opclasses else ' opclasses=%s' % repr(self.opclasses),
         )


### PR DESCRIPTION
Follow up to c6859f1a684edec7bb33038b4408046a4db0c16d.

I missed this in the previous patch :facepalm: 