### PR TITLE
Refs #27488 -- Corrected detection of IsValid() support on SpatiaLite.

### DIFF
--- a/django/contrib/gis/db/backends/spatialite/operations.py
+++ b/django/contrib/gis/db/backends/spatialite/operations.py
@@ -82,7 +82,7 @@ class SpatiaLiteOperations(BaseSpatialOperations, DatabaseOperations):
     def unsupported_functions(self):
         unsupported = {'BoundingCircle', 'GeometryDistance', 'MemSize'}
         if not self.lwgeom_version():
-            unsupported |= {'Azimuth', 'GeoHash', 'IsValid', 'MakeValid'}
+            unsupported |= {'Azimuth', 'GeoHash', 'MakeValid'}
         return unsupported
 
     @cached_property

--- a/docs/ref/contrib/gis/db-api.txt
+++ b/docs/ref/contrib/gis/db-api.txt
@@ -326,7 +326,7 @@ Lookup Type                        PostGIS    Oracle   MariaDB   MySQL [#]_   Sp
 :lookup:`equals`                   X          X        X         X            X          C
 :lookup:`exact <same_as>`          X          X        X         X            X          B
 :lookup:`intersects`               X          X        X         X            X          B
-:lookup:`isvalid`                  X          X                  X (≥ 5.7.5)  X (LWGEOM)
+:lookup:`isvalid`                  X          X                  X (≥ 5.7.5)  X
 :lookup:`overlaps`                 X          X        X         X            X          B
 :lookup:`relate`                   X          X        X                      X          C
 :lookup:`same_as`                  X          X        X         X            X          B
@@ -371,7 +371,7 @@ Function                              PostGIS  Oracle         MariaDB      MySQL
 :class:`ForcePolygonCW`               X                                                X
 :class:`GeoHash`                      X                                    X (≥ 5.7.5) X (LWGEOM)
 :class:`Intersection`                 X        X              X            X           X
-:class:`IsValid`                      X        X                           X (≥ 5.7.5) X (LWGEOM)
+:class:`IsValid`                      X        X                           X (≥ 5.7.5) X
 :class:`Length`                       X        X              X            X           X
 :class:`LineLocatePoint`              X                                                X
 :class:`MakeValid`                    X                                                X (LWGEOM)

--- a/docs/ref/contrib/gis/functions.txt
+++ b/docs/ref/contrib/gis/functions.txt
@@ -374,7 +374,7 @@ intersection between them.
 
 *Availability*: `MySQL
 <https://dev.mysql.com/doc/refman/en/spatial-convenience-functions.html#function_st-isvalid>`__ (≥ 5.7.5),
-`PostGIS <https://postgis.net/docs/ST_IsValid.html>`__, Oracle, SpatiaLite (LWGEOM)
+`PostGIS <https://postgis.net/docs/ST_IsValid.html>`__, Oracle, SpatiaLite
 
 Accepts a geographic field or expression and tests if the value is well formed.
 Returns ``True`` if its value is a valid geometry and ``False`` otherwise.


### PR DESCRIPTION
`LWGEOM` is not required for `IsValid()`, see [4.3](http://www.gaia-gis.it/gaia-sins/spatialite-sql-4.3.0.html#p4) and [5.0](http://www.gaia-gis.it/gaia-sins/spatialite-sql-5.0.0.html#p4) docs.

Noticed when reviewing #14213.