### PR TITLE
Refs #32074 -- Removed usage of Python's deprecated distutils.version package.

### DIFF
--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -3,7 +3,8 @@ import functools
 import os
 import subprocess
 import sys
-from distutils.version import LooseVersion
+
+from django.utils.regex_helper import _lazy_re_compile
 
 # Private, stable API for detecting the Python version. PYXY means "Python X.Y
 # or later". So that third-party apps can use these values, each constant
@@ -95,15 +96,21 @@ def get_git_changeset():
     return timestamp.strftime('%Y%m%d%H%M%S')
 
 
+version_component_re = _lazy_re_compile(r'(\d+|[a-z]+|\.)')
+
+
 def get_version_tuple(version):
     """
     Return a tuple of version numbers (e.g. (1, 2, 3)) from the version
     string (e.g. '1.2.3').
     """
-    loose_version = LooseVersion(version)
     version_numbers = []
-    for item in loose_version.version:
-        if not isinstance(item, int):
-            break
-        version_numbers.append(item)
+    for item in version_component_re.split(version):
+        if item and item != '.':
+            try:
+                component = int(item)
+            except ValueError:
+                break
+            else:
+                version_numbers.append(component)
     return tuple(version_numbers)


### PR DESCRIPTION
The `distutils` package was formally deprecated in Python 3.10 and will be removed in Python 3.12.

See [PEP 632](https://www.python.org/dev/peps/pep-0632/) and [distutils.version.LooseVersion](https://github.com/python/cpython/blob/d00a449d6d421391557393cce695795b4b66c212/Lib/distutils/version.py#L269-L322).