### PR TITLE
Fixed a bug in validation of BooleanField when False passed from an api

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -715,7 +715,7 @@ class BooleanField(Field):
         return super().to_python(value)
 
     def validate(self, value):
-        if not value and self.required:
+        if value is None and self.required:
             raise ValidationError(self.error_messages['required'], code='required')
 
     def has_changed(self, initial, data):


### PR DESCRIPTION
The current implementation of `validate` for BooleanField raises a
ValidationError when the value of the field is false.