### PR TITLE
[3.2.x] Bumped django_next_version in docs config.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,7 @@ else:
     release = django_release()
 
 # The "development version" of Django
-django_next_version = '3.2'
+django_next_version = '4.0'
 
 extlinks = {
     'bpo': ('https://bugs.python.org/issue%s', 'bpo-'),


### PR DESCRIPTION
3.2 docs are still showing _Changed in Django Development version_: 
 
![Screenshot 2021-04-10 at 17 09 12](https://user-images.githubusercontent.com/64686/114274603-8e7aac80-9a1f-11eb-9424-af6093fd750c.png)

That's because I didn't update this. 😬

Thanks @claudep for the report! 