### PR TITLE
Fixed #32637 -- Restored exception message on technical 404 debug page.

### DIFF
--- a/django/views/templates/technical_404.html
+++ b/django/views/templates/technical_404.html
@@ -20,11 +20,13 @@
     #info ol li { font-family: monospace; }
     #summary { background: #ffc; }
     #explanation { background:#eee; border-bottom: 0px none; }
+    pre.exception_value { font-family: sans-serif; color: #575757; font-size: 1.5em; margin: 10px 0 10px 0; }
   </style>
 </head>
 <body>
   <div id="summary">
     <h1>Page not found <span>(404)</span></h1>
+    {% if reason %}<pre class="exception_value">{{ reason }}</pre>{% endif %}
     <table class="meta">
       <tr>
         <th>Request Method:</th>
@@ -66,8 +68,6 @@
         {% endif %}
         {% if resolved %}matched the last one.{% else %}didn’t match any of these.{% endif %}
       </p>
-    {% else %}
-      <p>{{ reason }}</p>
     {% endif %}
   </div>
 

--- a/docs/releases/3.2.1.txt
+++ b/docs/releases/3.2.1.txt
@@ -19,3 +19,6 @@ Bugfixes
   ``QuerySet.values()/values_list()`` after ``QuerySet.union()``,
   ``intersection()``, and ``difference()`` when it was ordered by an
   unannotated field (:ticket:`32627`).
+
+* Restored, following a regression in Django 3.2, displaying an exception
+  message on the technical 404 debug page (:ticket:`32637`).

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -160,6 +160,12 @@ class DebugViewTests(SimpleTestCase):
 
     def test_technical_404(self):
         response = self.client.get('/technical404/')
+        self.assertContains(
+            response,
+            '<pre class="exception_value">Testing technical 404.</pre>',
+            status_code=404,
+            html=True,
+        )
         self.assertContains(response, "Raised by:", status_code=404)
         self.assertContains(response, "view_tests.views.technical404", status_code=404)
         self.assertContains(


### PR DESCRIPTION
ticket-32637

I added a message to the header for consistency with the technical 500 page and because it doesn't look good in the previous place.

Proposed changes:
![image](https://user-images.githubusercontent.com/2865885/114497625-d9184680-9c22-11eb-927e-e2305a7785f7.png)
a message in the previous place:
![image](https://user-images.githubusercontent.com/2865885/114497738-154ba700-9c23-11eb-89ac-f7b5b657473e.png)