### PR TITLE
Refs #32074 -- Removed usage of deprecated Thread.setDaemon().

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -610,7 +610,7 @@ def start_django(reloader, main_func, *args, **kwargs):
 
     main_func = check_errors(main_func)
     django_main_thread = threading.Thread(target=main_func, args=args, kwargs=kwargs, name='django-main-thread')
-    django_main_thread.setDaemon(True)
+    django_main_thread.daemon = True
     django_main_thread.start()
 
     while not reloader.should_stop:

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -364,7 +364,7 @@ class StartDjangoTests(SimpleTestCase):
             mocked_thread.call_args[1],
             {'target': fake_main_func, 'args': (123,), 'kwargs': {'abc': 123}, 'name': 'django-main-thread'}
         )
-        self.assertSequenceEqual(fake_thread.setDaemon.call_args[0], [True])
+        self.assertIs(fake_thread.daemon, True)
         self.assertTrue(fake_thread.start.called)
 
 


### PR DESCRIPTION
`threading.Thread.setDaemon` has been deprecated since Python 3.10.
Setting the daemon attribute directly is recommended.