### PR TITLE
Fixed #32635 -- Fixed system check crash for reverse o2o relations in CheckConstraint.check and UniqueConstraint.condition.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -2105,6 +2105,8 @@ class Model(metaclass=ModelBase):
                 # JOIN must happen at the first lookup.
                 first_lookup = lookups[0]
                 if (
+                    hasattr(field, 'get_transform') and
+                    hasattr(field, 'get_lookup') and
                     field.get_transform(first_lookup) is None and
                     field.get_lookup(first_lookup) is None
                 ):

--- a/docs/releases/3.2.1.txt
+++ b/docs/releases/3.2.1.txt
@@ -22,3 +22,7 @@ Bugfixes
 
 * Restored, following a regression in Django 3.2, displaying an exception
   message on the technical 404 debug page (:ticket:`32637`).
+
+* Fixed a bug in Django 3.2 where a system check would crash on a reverse
+  one-to-one relationships in ``CheckConstraint.check`` or
+  ``UniqueConstraint.condition`` (:ticket:`32635`).

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -1695,6 +1695,27 @@ class ConstraintsTests(TestCase):
         ])
 
     @skipUnlessDBFeature('supports_table_check_constraints')
+    def test_check_constraint_pointing_to_reverse_o2o(self):
+        class Model(models.Model):
+            parent = models.OneToOneField('self', models.CASCADE)
+
+            class Meta:
+                constraints = [
+                    models.CheckConstraint(
+                        name='name',
+                        check=models.Q(model__isnull=True),
+                    ),
+                ]
+
+        self.assertEqual(Model.check(databases=self.databases), [
+            Error(
+                "'constraints' refers to the nonexistent field 'model'.",
+                obj=Model,
+                id='models.E012',
+            ),
+        ])
+
+    @skipUnlessDBFeature('supports_table_check_constraints')
     def test_check_constraint_pointing_to_m2m_field(self):
         class Model(models.Model):
             m2m = models.ManyToManyField('self')
@@ -1941,6 +1962,28 @@ class ConstraintsTests(TestCase):
                 obj=Model,
                 id='models.E041',
             )
+        ] if connection.features.supports_partial_indexes else [])
+
+    def test_unique_constraint_pointing_to_reverse_o2o(self):
+        class Model(models.Model):
+            parent = models.OneToOneField('self', models.CASCADE)
+
+            class Meta:
+                required_db_features = {'supports_partial_indexes'}
+                constraints = [
+                    models.UniqueConstraint(
+                        fields=['parent'],
+                        name='name',
+                        condition=models.Q(model__isnull=True),
+                    ),
+                ]
+
+        self.assertEqual(Model.check(databases=self.databases), [
+            Error(
+                "'constraints' refers to the nonexistent field 'model'.",
+                obj=Model,
+                id='models.E012',
+            ),
         ] if connection.features.supports_partial_indexes else [])
 
     def test_deferrable_unique_constraint(self):

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -1778,6 +1778,7 @@ class ConstraintsTests(TestCase):
             field2 = models.PositiveSmallIntegerField()
             field3 = models.PositiveSmallIntegerField()
             parent = models.ForeignKey('self', models.CASCADE)
+            previous = models.OneToOneField('self', models.CASCADE, related_name='next')
 
             class Meta:
                 constraints = [
@@ -1792,9 +1793,18 @@ class ConstraintsTests(TestCase):
                     models.CheckConstraint(
                         name='name3', check=models.Q(parent__field3=models.F('field1'))
                     ),
+                    models.CheckConstraint(
+                        name='name4', check=models.Q(name=Lower('previous__name')),
+                    ),
                 ]
 
-        joined_fields = ['parent__field1', 'parent__field2', 'parent__field3', 'parent__name']
+        joined_fields = [
+            'parent__field1',
+            'parent__field2',
+            'parent__field3',
+            'parent__name',
+            'previous__name',
+        ]
         errors = Model.check(databases=self.databases)
         expected_errors = [
             Error(


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32635