### PR TITLE
Fixed #32574 -- Confirmed support for PROJ 8.x.

### DIFF
--- a/docs/ref/contrib/gis/install/geolibs.txt
+++ b/docs/ref/contrib/gis/install/geolibs.txt
@@ -9,7 +9,7 @@ geospatial libraries:
 Program                   Description                           Required                          Supported Versions
 ========================  ====================================  ================================  =================================
 :doc:`GEOS <../geos>`     Geometry Engine Open Source           Yes                               3.9, 3.8, 3.7, 3.6
-`PROJ`_                   Cartographic Projections library      Yes (PostgreSQL and SQLite only)  7.x. 6.x, 5.x, 4.x
+`PROJ`_                   Cartographic Projections library      Yes (PostgreSQL and SQLite only)  8.x, 7.x, 6.x, 5.x, 4.x
 :doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               3.2, 3.1, 3.0, 2.4, 2.3, 2.2, 2.1
 :doc:`GeoIP <../geoip2>`  IP-based geolocation library          No                                2
 `PostGIS`__               Spatial extensions for PostgreSQL     Yes (PostgreSQL only)             3.0, 2.5, 2.4


### PR DESCRIPTION
While I've targeted 4.0 for this change, I was wondering if we should backport this to 3.2 as we did with GDAL and GEOS? (see https://github.com/django/django/commit/e3cfba0029516aafe40f963378e234df2c0d33bb)

I'm seeing the tests pass with:

```
proj==8.0.0
spatialite==5.0.1
gdal==3.2.2
geos==3.9.1
```