### PR TITLE
Fixed #32646 -- Add request.json() shortcut

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -1,6 +1,7 @@
 import cgi
 import codecs
 import copy
+import json
 from io import BytesIO
 from itertools import chain
 from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlsplit
@@ -353,6 +354,9 @@ class HttpRequest:
         if hasattr(self, '_files'):
             for f in chain.from_iterable(list_[1] for list_ in self._files.lists()):
                 f.close()
+
+    def json(self, **kwargs):
+        return json.loads(self.body, **kwargs)
 
     # File-like and iterator interface.
     #

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -429,6 +429,12 @@ Methods
     <django.views.decorators.vary.vary_on_headers>` so that the responses are
     properly cached.
 
+.. method:: HttpRequest.json(**kwargs)
+
+    Returns JSON decoded request body. Raises ``ValueError`` if decoding fails.
+
+    All ``kwargs`` get passed to Python's json decoder.
+
 .. method:: HttpRequest.read(size=None)
 .. method:: HttpRequest.readline()
 .. method:: HttpRequest.readlines()

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -242,6 +242,9 @@ Requests and Responses
   same browsing context. You can prevent this header from being added by
   setting the :setting:`SECURE_CROSS_ORIGIN_OPENER_POLICY` setting to ``None``.
 
+* New :meth:`HttpRequest.json()` method is a shortcut for decoding json in
+  the request body.
+
 Security
 ~~~~~~~~
 

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -570,6 +570,24 @@ class RequestsTests(SimpleTestCase):
         request = factory.get('/path/with:colons')
         self.assertEqual(request.get_raw_uri(), 'http://evil.com/path/with:colons')
 
+    def test_request_json(self):
+        payload = FakePayload('{"a": 1.5}')
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        self.assertEqual(request.json(), {'a': 1.5})
+        self.assertEqual(request.json(parse_float=str), {'a': '1.5'})
+        payload = FakePayload('a=b')
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        with self.assertRaises(ValueError):
+            request.json()
+
 
 class HostValidationTests(SimpleTestCase):
     poisoned_hosts = [


### PR DESCRIPTION
It would be nice to have a request.json() shortcut.

https://code.djangoproject.com/ticket/32646