### PR TITLE
Fixed #32640 -- Made ModelBase.add_to_class() more careful

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -332,6 +332,13 @@ class ModelBase(type):
         else:
             setattr(cls, name, value)
 
+    def create_auto_pk(cls, pk_class):
+        pk_field = pk_class(verbose_name='ID', primary_key=True, auto_created=True)
+        try:
+            cls.add_to_class('id', pk_field)
+        except Exception:
+            raise FieldError(f"Adding a generated Primary Key field to model {cls.__name__} failed.")
+
     def _prepare(cls):
         """Create some methods once self._meta has been populated."""
         opts = cls._meta

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -322,6 +322,11 @@ class ModelBase(type):
         return new_class
 
     def add_to_class(cls, name, value):
+        if name in cls.__dict__:  # not hasattr() to avoid parent attrs
+            raise AttributeError(
+                f"Class {cls.__name__} has an attribute '{name}' which would be "
+                f"overridden. Check definitions."
+            )
         if _has_contribute_to_class(value):
             value.contribute_to_class(cls, name)
         else:

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -283,8 +283,7 @@ class Options:
                 self.setup_pk(field)
             else:
                 pk_class = self._get_default_pk_class()
-                auto = pk_class(verbose_name='ID', primary_key=True, auto_created=True)
-                model.add_to_class('id', auto)
+                model.create_auto_pk(pk_class)
 
     def add_manager(self, manager):
         self.local_managers.append(manager)

--- a/tests/managers_regress/tests.py
+++ b/tests/managers_regress/tests.py
@@ -156,6 +156,18 @@ class ManagersRegressionTests(TestCase):
         relation = related.test_fk.create()
         self.assertEqual(related.test_fk.get(), relation)
 
+    @isolate_apps('managers_regress')
+    def test_generated_manager_does_not_override(self):
+        # Make sure a generated manager does not override an attribute
+        # defined explicitly on the class
+        msg = (
+            "Class Bogus has an attribute 'objects' which would be "
+            "overridden. Check definitions."
+        )
+        with self.assertRaisesMessage(AttributeError, msg):
+            class Bogus(models.Model):
+                objects = "not a manager"
+
 
 @isolate_apps('managers_regress')
 class TestManagerInheritance(SimpleTestCase):


### PR DESCRIPTION
~This currently breaks two tests~ -- with it, in two cases of invalid models, where earlier `Model.check()` would return errors, now the attempt to even create the model raises an exception.

Do we treat this as a regression or an improvement?
