### PR TITLE
Fixed #32649 -- Fixed ModelAdmin.search_fields crash when searching against phrases with unbalanced quotes.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1025,7 +1025,7 @@ class ModelAdmin(BaseModelAdmin):
             orm_lookups = [construct_search(str(search_field))
                            for search_field in search_fields]
             for bit in smart_split(search_term):
-                if bit.startswith(('"', "'")):
+                if bit.startswith(('"', "'")) and bit[0] == bit[-1]:
                     bit = unescape_string_literal(bit)
                 or_queries = [models.Q(**{orm_lookup: bit})
                               for orm_lookup in orm_lookups]

--- a/docs/releases/3.2.1.txt
+++ b/docs/releases/3.2.1.txt
@@ -26,3 +26,7 @@ Bugfixes
 * Fixed a bug in Django 3.2 where a system check would crash on a reverse
   one-to-one relationships in ``CheckConstraint.check`` or
   ``UniqueConstraint.condition`` (:ticket:`32635`).
+
+* Fixed a regression in Django 3.2 that caused a crash of
+  :attr:`.ModelAdmin.search_fields` when searching against phrases with
+  unbalanced quotes (:ticket:`32649`).

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -3541,6 +3541,7 @@ class AdminSearchTest(TestCase):
         cls.per2 = Person.objects.create(name='Grace Hopper', gender=1, alive=False)
         cls.per3 = Person.objects.create(name='Guido van Rossum', gender=1, alive=True)
         Person.objects.create(name='John Doe', gender=1)
+        Person.objects.create(name='John O"Hara', gender=1)
         Person.objects.create(name="John O'Hara", gender=1)
 
         cls.t1 = Recommender.objects.create()
@@ -3616,7 +3617,7 @@ class AdminSearchTest(TestCase):
             response = self.client.get(reverse('admin:admin_views_person_changelist') + '?q=Gui')
         self.assertContains(
             response,
-            """<span class="small quiet">1 result (<a href="?">5 total</a>)</span>""",
+            """<span class="small quiet">1 result (<a href="?">6 total</a>)</span>""",
             html=True
         )
 
@@ -3647,7 +3648,10 @@ class AdminSearchTest(TestCase):
             ("John Doe John", 0),
             ('"John Do"', 1),
             ("'John Do'", 1),
+            ("'John O\'Hara'", 0),
             ("'John O\\'Hara'", 1),
+            ('"John O\"Hara"', 0),
+            ('"John O\\"Hara"', 1),
         ]
         for search, hits in tests:
             with self.subTest(search=search):


### PR DESCRIPTION
Thanks Dlis for the report.

Regression in 26a413507abb38f7eee4cf62f2ee9727fdc7bf8d.

ticket-32649