### PR TITLE
Recommend django<4 on older versions of Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ This will install the latest version of Django which works on your
 version of Python. If you can't upgrade your pip (or Python), request
 an older version of Django:
 
-    $ python -m pip install "django<2"
+    $ python -m pip install "django<4"
 """.format(*(REQUIRED_PYTHON + CURRENT_PYTHON)))
     sys.exit(1)
 


### PR DESCRIPTION
It seems odd to recommend an unsupported version of Django on Python < 3.8