### PR TITLE
Removed obsolete version check in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,35 +4,6 @@ from distutils.sysconfig import get_python_lib
 
 from setuptools import setup
 
-CURRENT_PYTHON = sys.version_info[:2]
-REQUIRED_PYTHON = (3, 8)
-
-# This check and everything above must remain compatible with Python 2.7.
-if CURRENT_PYTHON < REQUIRED_PYTHON:
-    sys.stderr.write("""
-==========================
-Unsupported Python version
-==========================
-
-This version of Django requires Python {}.{}, but you're trying to
-install it on Python {}.{}.
-
-This may be because you are using a version of pip that doesn't
-understand the python_requires classifier. Make sure you
-have pip >= 9.0 and setuptools >= 24.2, then try again:
-
-    $ python -m pip install --upgrade pip setuptools
-    $ python -m pip install django
-
-This will install the latest version of Django which works on your
-version of Python. If you can't upgrade your pip (or Python), request
-an older version of Django:
-
-    $ python -m pip install "django<2"
-""".format(*(REQUIRED_PYTHON + CURRENT_PYTHON)))
-    sys.exit(1)
-
-
 # Warn if we are installing over top of an existing installation. This can
 # cause issues where files that were deleted from a more recent Django are
 # still present in site-packages. See #18115.


### PR DESCRIPTION
This was originally added to ensure that Django 2.0+ could not be installed on Python 2.7 or earlier, in particular where the version of `pip` or `setuptools` being used did not support the `python_requires` argument.

Unfortunately, as `REQUIRED_PYTHON` has been bumped, this check no longer satisfies its original purpose and could be misleading, e.g. if `REQUIRED_PYTHON` is 3.8 and `CURRENT_PYTHON` is 3.7 it would request that Django < 2 is installed, but there are later versions of Django that support Python 3.7.

By the time Django 4 is released in December 2021, the `python_requires` argument will have been supported for over five years, and Python 2 will have been EOL for nearly two years, so we can remove this check.

Also see https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires