### PR TITLE
Fixed #32645 -- Fixed QuerySet.update() crash when ordered by joined fields on MySQL/MariaDB.

### DIFF
--- a/django/db/backends/mysql/compiler.py
+++ b/django/db/backends/mysql/compiler.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import FieldError
+from django.db.models.expressions import Col
 from django.db.models.sql import compiler
 
 
@@ -45,8 +46,16 @@ class SQLUpdateCompiler(compiler.SQLUpdateCompiler, SQLCompiler):
         if self.query.order_by:
             order_by_sql = []
             order_by_params = []
+            db_table = self.query.get_meta().db_table
             try:
-                for _, (sql, params, _) in self.get_order_by():
+                for resolved, (sql, params, _) in self.get_order_by():
+                    if (
+                        isinstance(resolved.expression, Col) and
+                        resolved.expression.alias != db_table
+                    ):
+                        # Ignore ordering if it contains joined fields, because
+                        # they cannot be used in the ORDER BY clause.
+                        raise FieldError
                     order_by_sql.append(sql)
                     order_by_params.extend(params)
                 update_query += ' ORDER BY ' + ', '.join(order_by_sql)

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2646,7 +2646,8 @@ unique field in the order that is specified without conflicts. For example::
 
 .. note::
 
-    If the ``order_by()`` clause contains annotations, it will be ignored.
+    ``order_by()`` clause will be ignored if it contains annotations, inherited
+    fields, or lookups spanning relations.
 
 ``delete()``
 ~~~~~~~~~~~~

--- a/docs/releases/3.2.1.txt
+++ b/docs/releases/3.2.1.txt
@@ -36,3 +36,7 @@ Bugfixes
 
 * Fixed a regression in Django 3.2 that caused a crash when combining ``Q()``
   objects which contains boolean expressions (:ticket:`32548`).
+
+* Fixed a regression in Django 3.2 that caused a crash of ``QuerySet.update()``
+  on a queryset ordered by inherited or joined fields on MySQL and MariaDB
+  (:ticket:`32645`).

--- a/tests/update/models.py
+++ b/tests/update/models.py
@@ -45,3 +45,7 @@ class Bar(models.Model):
 
 class UniqueNumber(models.Model):
     number = models.IntegerField(unique=True)
+
+
+class UniqueNumberChild(UniqueNumber):
+    pass


### PR DESCRIPTION
Thanks Matt Westcott for the report.

Regression in 779e615e362108862f1681f965ee9e4f1d0ae6d2.

ticket-32645