### PR TITLE
Fixed #32643 -- Fixed decoding of messages in the pre-Django 3.2 format.

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -1,3 +1,4 @@
+import binascii
 import json
 
 from django.conf import settings
@@ -166,7 +167,7 @@ class CookieStorage(BaseStorage):
         #     pass
         except signing.BadSignature:
             decoded = None
-        except json.JSONDecodeError:
+        except (binascii.Error, json.JSONDecodeError):
             decoded = self.signer.unsign(data)
 
         if decoded:

--- a/docs/releases/3.2.1.txt
+++ b/docs/releases/3.2.1.txt
@@ -40,3 +40,7 @@ Bugfixes
 * Fixed a regression in Django 3.2 that caused a crash of ``QuerySet.update()``
   on a queryset ordered by inherited or joined fields on MySQL and MariaDB
   (:ticket:`32645`).
+
+* Fixed a regression in Django 3.2 that caused a crash when decoding a cookie
+  value, used by ``django.contrib.messages.storage.cookie.CookieStorage``, in
+  the pre-Django 3.2 format (:ticket:`32643`).


### PR DESCRIPTION
As discussed… I am not sure about release notes, I guess we do only need them for the cherry pick back to 3.2 and not main? 