### PR TITLE
[3.2.x] Fixed #32548 -- Fixed crash when combining Q() objects with boolean expressions.

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -112,14 +112,10 @@ class Q(tree.Node):
         path = '%s.%s' % (self.__class__.__module__, self.__class__.__name__)
         if path.startswith('django.db.models.query_utils'):
             path = path.replace('django.db.models.query_utils', 'django.db.models')
-        args, kwargs = (), {}
-        if len(self.children) == 1 and not isinstance(self.children[0], Q):
-            child = self.children[0]
-            kwargs = {child[0]: child[1]}
-        else:
-            args = tuple(self.children)
-            if self.connector != self.default:
-                kwargs = {'_connector': self.connector}
+        args = tuple(self.children)
+        kwargs = {}
+        if self.connector != self.default:
+            kwargs['_connector'] = self.connector
         if self.negated:
             kwargs['_negated'] = True
         return path, args, kwargs

--- a/docs/releases/3.2.1.txt
+++ b/docs/releases/3.2.1.txt
@@ -33,3 +33,6 @@ Bugfixes
 
 * Fixed a bug in Django 3.2 where variable lookup errors were logged rendering
   the sitemap template if alternates were not defined (:ticket:`32648`).
+
+* Fixed a regression in Django 3.2 that caused a crash when combining ``Q()``
+  objects which contains boolean expressions (:ticket:`32548`).

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -821,6 +821,10 @@ class BasicExpressionsTests(TestCase):
             Q() & Exists(is_poc),
             Exists(is_poc) | Q(),
             Q() | Exists(is_poc),
+            Q(Exists(is_poc)) & Q(),
+            Q() & Q(Exists(is_poc)),
+            Q(Exists(is_poc)) | Q(),
+            Q() | Q(Exists(is_poc)),
         ]
         for conditions in tests:
             with self.subTest(conditions):


### PR DESCRIPTION
See [comment](https://code.djangoproject.com/ticket/32651#comment:4).

Backport of 00b0786de533dbb3f6208d8d5eaddbf765b4e5b8 from main.

Regression in 466920f6d726eee90d5566e0a9948e92b33a122e.

I will forwardport release notes.