### PR TITLE
Used more specific unittest assertions in tests.

### DIFF
--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -241,7 +241,7 @@ class NonAggregateAnnotationTestCase(TestCase):
             ),
             rating_count=Count('rating'),
         ).first()
-        self.assertEqual(book.isnull_pubdate, False)
+        self.assertIs(book.isnull_pubdate, False)
         self.assertEqual(book.rating_count, 1)
 
     @skipUnlessDBFeature('supports_boolean_expr_in_select_clause')

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -1035,7 +1035,7 @@ class ReadOnlyPasswordHashTest(SimpleTestCase):
             hash_field = ReadOnlyPasswordHashField()
 
         bound_field = TestForm()['hash_field']
-        self.assertEqual(bound_field.field.widget.id_for_label('id'), None)
+        self.assertIsNone(bound_field.field.widget.id_for_label('id'))
         self.assertEqual(bound_field.label_tag(), '<label>Hash field:</label>')
 
 

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -501,7 +501,7 @@ class BackendTestCase(TransactionTestCase):
         params, kwargs = mocked_logger.debug.call_args
         self.assertIn('; alias=%s', params[0])
         self.assertEqual(params[2], sql)
-        self.assertEqual(params[3], None)
+        self.assertIsNone(params[3])
         self.assertEqual(params[4], connection.alias)
         self.assertEqual(
             list(kwargs['extra']),

--- a/tests/model_inheritance/test_abstract_inheritance.py
+++ b/tests/model_inheritance/test_abstract_inheritance.py
@@ -57,7 +57,7 @@ class AbstractInheritanceTests(SimpleTestCase):
 
         self.assertEqual(Child.check(), [])
         inherited_field = Child._meta.get_field('name')
-        self.assertTrue(isinstance(inherited_field, models.CharField))
+        self.assertIsInstance(inherited_field, models.CharField)
         self.assertEqual(inherited_field.max_length, 255)
 
     def test_diamond_shaped_multiple_inheritance_is_depth_first(self):
@@ -93,7 +93,7 @@ class AbstractInheritanceTests(SimpleTestCase):
 
         self.assertEqual(Child.check(), [])
         inherited_field = Child._meta.get_field('name')
-        self.assertTrue(isinstance(inherited_field, models.CharField))
+        self.assertIsInstance(inherited_field, models.CharField)
         self.assertEqual(inherited_field.max_length, 255)
 
     def test_target_field_may_be_pushed_down(self):
@@ -124,7 +124,7 @@ class AbstractInheritanceTests(SimpleTestCase):
 
         self.assertEqual(Child.check(), [])
         inherited_field = Child._meta.get_field('name')
-        self.assertTrue(isinstance(inherited_field, models.IntegerField))
+        self.assertIsInstance(inherited_field, models.IntegerField)
 
     def test_multiple_inheritance_cannot_shadow_concrete_inherited_field(self):
         class ConcreteParent(models.Model):

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -405,7 +405,7 @@ class DiscoverRunnerTests(SimpleTestCase):
             with runner.time_keeper.timed('test'):
                 pass
             runner.time_keeper.print_results()
-        self.assertTrue(isinstance(runner.time_keeper, NullTimeKeeper))
+        self.assertIsInstance(runner.time_keeper, NullTimeKeeper)
         self.assertNotIn('test', stderr.getvalue())
 
     def test_timings_captured(self):
@@ -414,7 +414,7 @@ class DiscoverRunnerTests(SimpleTestCase):
             with runner.time_keeper.timed('test'):
                 pass
             runner.time_keeper.print_results()
-        self.assertTrue(isinstance(runner.time_keeper, TimeKeeper))
+        self.assertIsInstance(runner.time_keeper, TimeKeeper)
         self.assertIn('test', stderr.getvalue())
 
     def test_log(self):


### PR DESCRIPTION
I ran flake8 with the [flake8-assertive](https://pypi.org/project/flake8-assertive/) under the tests-folder, and found a few archaic asserts. Maybe 23919 should be referenced.

```
❯ flake8 . | grep A50
./annotations/tests.py:244:9: A502 prefer assertFalse() instead of comparing to False
./test_runner/test_discover_runner.py:346:9: A501 prefer assertIsInstance() for 'isinstance()' expressions
./test_runner/test_discover_runner.py:355:9: A501 prefer assertIsInstance() for 'isinstance()' expressions
```