### PR TITLE
Fixed #32702 -- Don't decode escaped URL fragments.

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -218,8 +218,6 @@ def smart_urlquote(url):
     except UnicodeError:  # invalid domain part
         return unquote_quote(url)
 
-    path = unquote_quote(path)
-
     if query:
         # Separately unquoting key/value, so as to not mix querystring separators
         # included in query values. See #22267.
@@ -228,6 +226,7 @@ def smart_urlquote(url):
         # urlencode will take care of quoting
         query = urlencode(query_parts)
 
+    path = unquote_quote(path)
     # Leave fragment unaltered.
 
     return urlunsplit((scheme, netloc, path, query, fragment))

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -218,6 +218,8 @@ def smart_urlquote(url):
     except UnicodeError:  # invalid domain part
         return unquote_quote(url)
 
+    path = unquote_quote(path)
+
     if query:
         # Separately unquoting key/value, so as to not mix querystring separators
         # included in query values. See #22267.
@@ -226,8 +228,7 @@ def smart_urlquote(url):
         # urlencode will take care of quoting
         query = urlencode(query_parts)
 
-    path = unquote_quote(path)
-    fragment = unquote_quote(fragment)
+    # Leave fragment unaltered.
 
     return urlunsplit((scheme, netloc, path, query, fragment))
 

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -255,6 +255,18 @@ class TestUtilsHtml(SimpleTestCase):
                 'Search for <a href="http://google.com/?q=">google.com/?q=</a>!'
             ),
             ('foo@example.com', '<a href="mailto:foo@example.com">foo@example.com</a>'),
+            (
+                'Escaped query string - https://google.com?q=%2Fs+meaning',
+                'Escaped query string - '
+                '<a href="https://google.com?q=%2Fs+meaning">https://google.com?q=%2Fs+meaning</a>'
+            ),
+            (
+                'Escaped fragment - https://example.com/login?u=1#redirect=http%3A%2F%2Fexample.com%2Fadmin',
+                'Escaped fragment - '
+                '<a href="https://example.com/login?u=1#redirect=http%3A%2F%2Fexample.com%2Fadmin">'
+                'https://example.com/login?u=1#redirect=http%3A%2F%2Fexample.com%2Fadmin'
+                '</a>'
+            ),
         )
         for value, output in tests:
             with self.subTest(value=value):


### PR DESCRIPTION
ticket-32702

Currently `urlize()` will unquote then quote the fragment component of URLs.  This transformation can be problematic - for example if it contains a %-encoded URL:

https://example.com/home#next=https%3A%2F%2Fexample2.com

This results in:

```
<a href="https://example.com/home#next=https://example2.com">https://example.com/home#next=https%3A%2F%2Fexample2.com</a>
```

Note how the generated `href` has its fragment decoded.

Because the formatting for the fragment is completely arbitrary and site-dependent, I suggest that the fragment should not be altered at all and simply rendered as-is.


Previous related PRs:
- https://github.com/django/django/pull/2902
- https://github.com/django/django/pull/4253
- https://github.com/django/django/pull/4292

Related Trac:
- https://code.djangoproject.com/ticket/9655