### PR TITLE
Refs #32609 -- Simplified test_labels_set construction in runtests.py's setup().

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -133,11 +133,11 @@ def get_installed():
 
 
 def setup(verbosity, test_labels, start_at, start_after):
-    # Reduce the given test labels to just the app module path.
+    # Reduce each test label to just the top-level module part.
     test_labels_set = set()
     for label in test_labels:
-        bits = label.split('.')[:1]
-        test_labels_set.add('.'.join(bits))
+        test_module = label.split('.')[0]
+        test_labels_set.add(test_module)
 
     # Force declaring available_apps in TransactionTestCase for faster tests.
     def no_available_apps(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32609

This simplifies the construction of `test_labels_set` at the beginning of `runtests.py`'s `setup()` and makes the intent more clear.

The unneeded complexity is left over from before https://github.com/django/django/pull/4106.
