### PR TITLE
Fixed #32934 -- Made Admin sidebar height dynamic based on visible header.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -327,6 +327,7 @@ answer newbie questions, and generally made Django that much better:
     Garry Lawrence
     Garry Polley <garrympolley@gmail.com>
     Garth Kidd <http://www.deadlybloodyserious.com/>
+    Gary Josack
     Gary Wilson <gary.wilson@gmail.com>
     Gasper Koren
     Gasper Zejn <zejn@kiberpipa.org>

--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -1,7 +1,8 @@
 .sticky {
     position: sticky;
     top: 0;
-    max-height: 100vh;
+    /* Subtracts the height of headers */
+    max-height: calc(100vh - 48px - 36px - 1px);
 }
 
 .toggle-nav-sidebar {

--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -1,8 +1,7 @@
 .sticky {
     position: sticky;
     top: 0;
-    /* Subtracts the height of headers */
-    max-height: calc(100vh - 48px - 36px - 1px);
+    max-height: 100vh;
 }
 
 .toggle-nav-sidebar {

--- a/django/contrib/admin/static/admin/js/nav_sidebar.js
+++ b/django/contrib/admin/static/admin/js/nav_sidebar.js
@@ -37,6 +37,34 @@
         });
     }
 
+    function resizeSidebar() {
+        const sidebar = document.querySelector("#nav-sidebar.sticky");
+        if (!sidebar) {
+            return;
+        }
+
+        let headerHeight = 0;
+        const header = document.getElementById('header');
+        const breadcrumbs = document.getElementsByClassName('breadcrumbs');
+
+        if (header) {
+            headerHeight += header.offsetHeight;
+        }
+
+        if (breadcrumbs) {
+            Array.from(breadcrumbs).forEach(function(element) {
+                headerHeight += element.offsetHeight;
+            });
+        }
+
+        const visibleHeader = Math.max(headerHeight - window.pageYOffset, 0);
+        const sidebarHeight = window.innerHeight - visibleHeader - 1;
+        sidebar.style.maxHeight = `${sidebarHeight}px`;
+    }
+    resizeSidebar();
+    document.addEventListener('scroll', resizeSidebar, false);
+    window.addEventListener('resize', resizeSidebar, false);
+
     function initSidebarQuickFilter() {
         const options = [];
         const navSidebar = document.getElementById('nav-sidebar');


### PR DESCRIPTION
The current sticky nav bar on admin anchors past the page. If you have
a long list of apps you have to scroll the whole page and then the nav
to get to the bottom. This subtracts the height of the headers from
the viewport height to get a sticky sidebar that scrolls as you'd expect

### Example of current behavior
You can see there is a scrollbar despite the main content being small. You must scroll the entire page to access the bottom of the nav bar.
![Before](https://user-images.githubusercontent.com/231118/115156636-05c0c980-a03a-11eb-8dfb-b12b6ae010b6.png)

### Example of behavior with this change
![After](https://user-images.githubusercontent.com/231118/115156639-08bbba00-a03a-11eb-8eb1-c5f7cd2a94f2.png)
