### PR TITLE
Fixed #32664 -- Made PasswordResetTokenGenerator.secret validation lazy.

### DIFF
--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -12,11 +12,18 @@ class PasswordResetTokenGenerator:
     """
     key_salt = "django.contrib.auth.tokens.PasswordResetTokenGenerator"
     algorithm = None
-    secret = None
+    _secret = None
 
     def __init__(self):
-        self.secret = self.secret or settings.SECRET_KEY
         self.algorithm = self.algorithm or 'sha256'
+
+    def _get_secret(self):
+        return self._secret or settings.SECRET_KEY
+
+    def _set_secret(self, secret):
+        self._secret = secret
+
+    secret = property(_get_secret, _set_secret)
 
     def make_token(self, user):
         """

--- a/tests/auth_tests/test_tokens.py
+++ b/tests/auth_tests/test_tokens.py
@@ -111,3 +111,23 @@ class TokenGeneratorTest(TestCase):
         # Tokens created with a different secret don't validate.
         self.assertIs(p0.check_token(user, tk1), False)
         self.assertIs(p1.check_token(user, tk0), False)
+
+    def test_token_with_different_secret_subclass(self):
+        class CustomPasswordResetTokenGenerator(PasswordResetTokenGenerator):
+            secret = 'test-secret'
+
+        user = User.objects.create_user('tokentestuser', 'test2@example.com', 'testpw')
+        custom_password_generator = CustomPasswordResetTokenGenerator()
+        tk_custom = custom_password_generator.make_token(user)
+        self.assertIs(custom_password_generator.check_token(user, tk_custom), True)
+
+        default_password_generator = PasswordResetTokenGenerator()
+        self.assertNotEqual(
+            custom_password_generator.secret,
+            default_password_generator.secret,
+        )
+        self.assertEqual(default_password_generator.secret, settings.SECRET_KEY)
+        # Tokens created with a different secret don't validate.
+        tk_default = default_password_generator.make_token(user)
+        self.assertIs(custom_password_generator.check_token(user, tk_default), False)
+        self.assertIs(default_password_generator.check_token(user, tk_custom), False)

--- a/tests/auth_tests/test_tokens.py
+++ b/tests/auth_tests/test_tokens.py
@@ -3,7 +3,9 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from .models import CustomEmailField
 
@@ -131,3 +133,10 @@ class TokenGeneratorTest(TestCase):
         tk_default = default_password_generator.make_token(user)
         self.assertIs(custom_password_generator.check_token(user, tk_default), False)
         self.assertIs(default_password_generator.check_token(user, tk_custom), False)
+
+    @override_settings(SECRET_KEY='')
+    def test_secret_lazy_validation(self):
+        default_token_generator = PasswordResetTokenGenerator()
+        msg = 'The SECRET_KEY setting must not be empty.'
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            default_token_generator.secret


### PR DESCRIPTION
Django apps initialization to run management command triggers the admin
autodiscovery. The auth admin imports from django.contrib.auth.forms,
which imports the django.contrib.auth.tokens, instantiating a
PasswordResetTokenGenerator that requires a SECRET_KEY.

For several management commands, the token generator is unused. It
should only complain about a missing SECRET_KEY when it is used.