### PR TITLE
Removed unnecessary line in OrderBy.as_sql().

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1232,7 +1232,6 @@ class OrderBy(BaseExpression):
             'ordering': 'DESC' if self.descending else 'ASC',
             **extra_context,
         }
-        template = template or self.template
         params *= template.count('%(expression)s')
         return (template % placeholders).rstrip(), params
 


### PR DESCRIPTION
The first line of `as_sql` (https://github.com/django/django/blob/ed0cc52dc3b0dfebba8a38c12b6157a007309900/django/db/models/expressions.py#L1213) is a duplicate of this line that's being removed, meaning that in this function `template` is already defined in the same manner, making this line a noop.