### PR TITLE
Refs #28034 -- Corrected docs example in contributing tutorial.

### DIFF
--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -412,6 +412,8 @@ file::
     ``make_toast()``
     ================
 
+    .. function:: make_toast()
+
     .. versionadded:: 2.2
 
     Returns ``'toast'``.


### PR DESCRIPTION
Document Fix -- Fixed code for shortcuts.txt in docs/intro/contributing.txt .

File docs/intro/contributing.txt has an error:
"function:: make_toast()" isn't mentioned in line 414.
Readers who lost this will get a warning "WARNING: py:func reference target not found" when learning make_toast test.

diff in docs/intro/contributing.txt:
412     ``make_toast()``
413     ================
414 
415     .. versionadded:: 2.2
416 
417     Returns ``'toast'``.

494     +``make_toast()``
495     +================
496     +
497     +.. function:: make_toast()
498     +
499     +.. versionadded:: 2.2
500     +
501     +Returns ``'toast'``.