### PR TITLE
Fixed #32665 -- Fixed caches system check crash when STATICFILES_DIRS is a list of 2-tuples.

### DIFF
--- a/django/core/checks/caches.py
+++ b/django/core/checks/caches.py
@@ -27,10 +27,11 @@ def check_cache_location_not_exposed(app_configs, **kwargs):
         if not setting:
             continue
         if name == 'STATICFILES_DIRS':
-            paths = {
-                pathlib.Path(staticfiles_dir).resolve()
-                for staticfiles_dir in setting
-            }
+            paths = set()
+            for staticfiles_dir in setting:
+                if isinstance(staticfiles_dir, (list, tuple)):
+                    _, staticfiles_dir = staticfiles_dir
+                paths.add(pathlib.Path(staticfiles_dir).resolve())
         else:
             paths = {pathlib.Path(setting).resolve()}
         for alias in settings.CACHES:

--- a/docs/releases/3.2.1.txt
+++ b/docs/releases/3.2.1.txt
@@ -47,3 +47,7 @@ Bugfixes
 
 * Fixed a regression in Django 3.2 that stopped the shift-key modifier
   selecting multiple rows in the admin changelist (:ticket:`32647`).
+
+* Fixed a bug in Django 3.2 where a system check would crash on the
+  :setting:`STATICFILES_DIRS` setting with a list of 2-tuples of
+  ``(prefix, path)`` (:ticket:`32665`).

--- a/tests/check_framework/test_caches.py
+++ b/tests/check_framework/test_caches.py
@@ -91,6 +91,35 @@ class CheckCacheLocationTest(SimpleTestCase):
             with self.subTest(setting=setting), self.settings(**settings):
                 self.assertEqual(check_cache_location_not_exposed(None), [])
 
+    def test_staticfiles_dirs_prefix(self):
+        root = pathlib.Path.cwd()
+        tests = [
+            (root, root, 'matches'),
+            (root / 'cache', root, 'is inside'),
+            (root, root / 'other', 'contains'),
+        ]
+        for cache_path, setting_path, msg in tests:
+            settings = self.get_settings(
+                'STATICFILES_DIRS',
+                cache_path,
+                ('prefix', setting_path),
+            )
+            with self.subTest(path=setting_path), self.settings(**settings):
+                msg = self.warning_message % (msg, 'STATICFILES_DIRS')
+                self.assertEqual(check_cache_location_not_exposed(None), [
+                    Warning(msg, id='caches.W002'),
+                ])
+
+    def test_staticfiles_dirs_prefix_not_conflict(self):
+        root = pathlib.Path.cwd()
+        settings = self.get_settings(
+            'STATICFILES_DIRS',
+            root / 'cache',
+            ('prefix', root / 'other'),
+        )
+        with self.settings(**settings):
+            self.assertEqual(check_cache_location_not_exposed(None), [])
+
 
 class CheckCacheAbsolutePath(SimpleTestCase):
     def test_absolute_path(self):


### PR DESCRIPTION
Thanks Jared Lockhart for the report.

Regression in c36075ac1dddfa986340b1a5e15fe48833322372.

ticket-32665