### PR TITLE
Fixed #32671 -- Fix CSS var() + relative url() issue in Safari.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -733,6 +733,7 @@ answer newbie questions, and generally made Django that much better:
     pavithran s <pavithran.s@gmail.com>
     Pavlo Kapyshin <i@93z.org>
     permonik@mesias.brnonet.cz
+    Perry Roper <perry@perry.io>
     Petar Marić <http://www.petarmaric.com/>
     Pete Crosier <pete.crosier@gmail.com>
     peter@mymart.com

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -613,24 +613,30 @@ ul.messagelist {
     margin: 0;
 }
 
+/* The background-color property must be defined separately in the 3 following declaration */
+/* blocks to avoid a bug in Safari when loading relative URLs in conjunction with var() */
+/* https://github.com/django/django/pull/14294 */
 ul.messagelist li {
     display: block;
     font-weight: 400;
     font-size: 13px;
     padding: 10px 10px 10px 65px;
     margin: 0 0 10px 0;
-    background: var(--message-success-bg) url(../img/icon-yes.svg) 40px 12px no-repeat;
+    background: url(../img/icon-yes.svg) 40px 12px no-repeat;
+    background-color: var(--message-success-bg);
     background-size: 16px auto;
     color: var(--body-fg);
 }
 
 ul.messagelist li.warning {
-    background: var(--message-warning-bg) url(../img/icon-alert.svg) 40px 14px no-repeat;
+    background: url(../img/icon-alert.svg) 40px 14px no-repeat;
+    background-color: var(--message-warning-bg);
     background-size: 14px auto;
 }
 
 ul.messagelist li.error {
-    background: var(--message-error-bg) url(../img/icon-no.svg) 40px 12px no-repeat;
+    background: url(../img/icon-no.svg) 40px 12px no-repeat;
+    background-color: var(--message-error-bg);
     background-size: 16px auto;
 }
 


### PR DESCRIPTION
There is a bug in Safari where using the var() property alongside a url() that contains a relative path, the relative path will break. The bug also existed in Chrome (​https://bugs.chromium.org/p/chromium/issues/detail?id=618165), which has been fixed. However the Safari bug still exists as of Mac OS 11.2.3.

**Expected Output**

<img width="317" alt="Screen Shot 2021-04-21 at 17 23 26" src="https://user-images.githubusercontent.com/952316/115541550-73365980-a2c9-11eb-954a-11ebfe7f9de2.png">

**Actual Output**

<img width="346" alt="Screen Shot 2021-04-21 at 17 23 17" src="https://user-images.githubusercontent.com/952316/115541520-6b76b500-a2c9-11eb-9437-400a8f9aa73c.png">
<img width="861" alt="Screen Shot 2021-04-21 at 17 24 27" src="https://user-images.githubusercontent.com/952316/115541506-66b20100-a2c9-11eb-8de3-153028c9a30b.png">


As you can see from the console, the URLs end up being **relative to the current page URL**, not the CSS file URL in which they are loaded.

This bug was introduced in ​https://github.com/django/django/commit/0a802233ec1421e5e59a486be69daef9b112fd0d

Related Trac: 
https://code.djangoproject.com/ticket/32671