### PR TITLE
Fixed #32667 -- Added link to labeling checks in BaseCommand.requires_system_checks docs.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ answer newbie questions, and generally made Django that much better:
     Abhijeet Viswa <abhijeetviswa@gmail.com>
     Abhinav Patil <https://github.com/ubadub/>
     Abhishek Gautam <abhishekg1128@yahoo.com>
+    Abhyudai <https://github.com/abhiabhi94>
     Adam Allred <adam.w.allred@gmail.com>
     Adam Bogdał <adam@bogdal.pl>
     Adam Donaghy

--- a/docs/howto/custom-management-commands.txt
+++ b/docs/howto/custom-management-commands.txt
@@ -218,9 +218,10 @@ All attributes can be set in your derived class and can be used in
 .. attribute:: BaseCommand.requires_system_checks
 
     A list or tuple of tags, e.g. ``[Tags.staticfiles, Tags.models]``. System
-    checks registered in the chosen tags will be checked for errors prior to
-    executing the command. The value ``'__all__'`` can be used to specify
-    that all system checks should be performed. Default value is ``'__all__'``.
+    checks :ref:`registered in the chosen tags <registering-labeling-checks>`
+    will be checked for errors prior to executing the command. The value
+    ``'__all__'`` can be used to specify that all system checks should be
+    performed. Default value is ``'__all__'``.
 
     .. versionchanged:: 3.2
 

--- a/docs/topics/checks.txt
+++ b/docs/topics/checks.txt
@@ -77,6 +77,8 @@ implied by the class name.
 * :class:`Error`
 * :class:`Critical`
 
+.. _registering-labeling-checks:
+
 Registering and labeling checks
 -------------------------------
 


### PR DESCRIPTION
Added reference in the custom manangement commands documentation.

Co-authored-by: Mariusz Felisiak <felisiak.mariusz@gmail.com>