### PR TITLE
Fixed isolation of i18n.tests.FormattingTests.test_get_custom_format().

### DIFF
--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1254,6 +1254,7 @@ class FormattingTests(SimpleTestCase):
         self.assertEqual(get_format('DEBUG'), 'DEBUG')
 
     def test_get_custom_format(self):
+        reset_format_cache()
         with self.settings(FORMAT_MODULE_PATH='i18n.other.locale'):
             with translation.override('fr', deactivate=True):
                 self.assertEqual('d/m/Y CUSTOM', get_format('CUSTOM_DAY_FORMAT'))


### PR DESCRIPTION
```bash
./runtests.py i18n.tests.FormattingTests.test_all_format_strings i18n.tests.FormattingTests.test_get_custom_format
Testing against Django installed in '/django/django' with up to 8 processes
Found 2 tests.
System check identified no issues (0 silenced).
.F
======================================================================
FAIL: test_get_custom_format (i18n.tests.FormattingTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/tests/i18n/tests.py", line 1259, in test_get_custom_format
    self.assertEqual('d/m/Y CUSTOM', get_format('CUSTOM_DAY_FORMAT'))
AssertionError: 'd/m/Y CUSTOM' != 'CUSTOM_DAY_FORMAT'
- d/m/Y CUSTOM
+ CUSTOM_DAY_FORMAT


----------------------------------------------------------------------
Ran 2 tests in 0.221s

FAILED (failures=1)
```