### PR TITLE
Fixed #32673 -- Fixed lookups crash when comparing against lookups on PostgreSQL.

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -87,6 +87,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'Raises ORA-00600: internal error code.': {
             'model_fields.test_jsonfield.TestQuerying.test_usage_in_subquery',
         },
+        "Oracle doesn't allow filters to be compared to another expression in "
+        "the WHERE clause.": {
+            'lookup.tests.LookupTests.test_lookup_rhs',
+        },
     }
     django_test_expected_failures = {
         # A bug in Django/cx_Oracle with respect to string handling (#23843).

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -94,7 +94,13 @@ class Lookup:
             value = self.apply_bilateral_transforms(value)
             value = value.resolve_expression(compiler.query)
         if hasattr(value, 'as_sql'):
-            return compiler.compile(value)
+            sql, params = compiler.compile(value)
+            # Ensure expression is wrapped in parentheses to respect operator
+            # precedence but avoid double wrapping as it can be misinterpreted
+            # on some backends (e.g. subqueries on SQLite).
+            if sql and sql[0] != '(':
+                sql = '(%s)' % sql
+            return sql, params
         else:
             return self.get_db_prep_lookup(value, connection)
 

--- a/tests/lookup/models.py
+++ b/tests/lookup/models.py
@@ -94,6 +94,7 @@ class Product(models.Model):
 
 class Stock(models.Model):
     product = models.ForeignKey(Product, models.CASCADE)
+    short = models.BooleanField(default=False)
     qty_available = models.DecimalField(max_digits=6, decimal_places=2)
 
 


### PR DESCRIPTION
ticket-32673

Regression introduced by 3a505c70e7b228bf1212c067a8f38271ca86ce09.

Nonlitteral right-hand-sides of lookups need to be wrapped in parenthesizes to avoid operator precedence ambiguities.

Thanks Charles Lirsac for the detailed report.

---

@felixxm not sure how we stand with regards to backports here as that's not a regression in 3.2 but it's certainly one from LTS to LTS.