### PR TITLE
Fixed isolation of test_showmigrations_unmigrated_app().

### DIFF
--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -670,7 +670,15 @@ class MigrateTests(MigrationTestBase):
     def test_showmigrations_plan_app_label_no_migrations(self):
         out = io.StringIO()
         call_command('showmigrations', 'unmigrated_app', format='plan', stdout=out, no_color=True)
-        self.assertEqual('(no migrations)\n', out.getvalue())
+        try:
+            self.assertEqual('(no migrations)\n', out.getvalue())
+        finally:
+            # unmigrated_app.SillyModel has a foreign key to
+            # 'migrations.Tribble', but that model is only defined in a
+            # migration, so the global app registry never sees it and the
+            # reference is left dangling. Remove it to avoid problems in
+            # subsequent tests.
+            apps._pending_operations.pop(('migrations', 'tribble'), None)
 
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations"})
     def test_sqlmigrate_forwards(self):


### PR DESCRIPTION
Follow up to 90916f050c64b817fdf2ea13b5c20986005fd029.
```
./runtests.py migrations.test_commands.MigrateTests.test_showmigrations_plan_app_label_no_migrations migrations.test_commands.MigrateTests.test_migrate_with_system_checks
Testing against Django installed in '/django/django' with up to 8 processes
Found 2 tests.
Creating test database for alias 'default'...
Creating test database for alias 'other'...
System check identified no issues (0 silenced).
.E
======================================================================
ERROR: test_migrate_with_system_checks (migrations.test_commands.MigrateTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/django/test/utils.py", line 430, in inner
    return func(*args, **kwargs)
  File "/django/tests/migrations/test_commands.py", line 78, in test_migrate_with_system_checks
    call_command('migrate', skip_checks=False, no_color=True, stdout=out)
  File "/django/django/core/management/__init__.py", line 181, in call_command
    return command.execute(*args, **defaults)
  File "/django/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/django/django/core/management/base.py", line 89, in wrapped
    res = handle_func(*args, **kwargs)
  File "/django/django/core/management/commands/migrate.py", line 75, in handle
    self.check(databases=[database])
  File "/django/django/core/management/base.py", line 469, in check
    raise SystemCheckError(msg)
django.core.management.base.SystemCheckError: SystemCheckError: System check identified some issues:

ERRORS:
unmigrated_app.SillyModel.silly_tribble: (fields.E307) The field unmigrated_app.SillyModel.silly_tribble was declared with a lazy reference to 'migrations.tribble', but app 'migrations' isn't installed.


----------------------------------------------------------------------
Ran 2 tests in 0.038s

FAILED (errors=1)
Destroying test database for alias 'default'...
Destroying test database for alias 'other'...
```