### PR TITLE
Fixed #32628 -- Allow extra user-defined AJAX data

### DIFF
--- a/django/contrib/admin/static/admin/js/autocomplete.js
+++ b/django/contrib/admin/static/admin/js/autocomplete.js
@@ -2,16 +2,23 @@
 {
     const $ = django.jQuery;
     const init = function($element, options) {
-        const settings = $.extend({
+        let userData = function(params) {};
+        if (options.ajax && options.ajax.data) {
+            userData = options.ajax.data;
+            delete options.ajax.data;
+        }
+
+        const settings = $.extend(true, {
             ajax: {
                 data: function(params) {
-                    return {
+                    const defaultData = {
                         term: params.term,
                         page: params.page,
                         app_label: $element.data('app-label'),
                         model_name: $element.data('model-name'),
                         field_name: $element.data('field-name')
                     };
+                    return $.extend(defaultData, userData(params));
                 }
             }
         }, options);


### PR DESCRIPTION
[Ticket #32628](https://code.djangoproject.com/ticket/32628)

Opens possibility for developers to pass additional AJAX data when using `djangoAdminSelect2` Javascript function.

Also fixes a bug where other parameters (passed through `options`) nested under the `ajax` key were overwritten to `undefined`.