### PR TITLE
Fixed isolation of test_rename_table_renames_deferred_sql_references().

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -3817,10 +3817,14 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(Book)
             editor.alter_db_table(Author, 'schema_author', 'schema_renamed_author')
             editor.alter_db_table(Author, 'schema_book', 'schema_renamed_book')
-            self.assertGreater(len(editor.deferred_sql), 0)
-            for statement in editor.deferred_sql:
-                self.assertIs(statement.references_table('schema_author'), False)
-                self.assertIs(statement.references_table('schema_book'), False)
+            try:
+                self.assertGreater(len(editor.deferred_sql), 0)
+                for statement in editor.deferred_sql:
+                    self.assertIs(statement.references_table('schema_author'), False)
+                    self.assertIs(statement.references_table('schema_book'), False)
+            finally:
+                editor.alter_db_table(Author, 'schema_renamed_author', 'schema_author')
+                editor.alter_db_table(Author, 'schema_renamed_book', 'schema_book')
 
     def test_rename_column_renames_deferred_sql_references(self):
         with connection.schema_editor() as editor:


### PR DESCRIPTION
```bash
./runtests.py schema.tests.SchemaTests.test_rename_table_renames_deferred_sql_references schema.tests.SchemaTests.test_alter_autofield_pk_to_smallautofield_pk_sequence_owner
Testing against Django installed in '/django/django' with up to 8 processes
Found 2 tests.
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.E
======================================================================
ERROR: test_alter_autofield_pk_to_smallautofield_pk_sequence_owner (schema.tests.SchemaTests)
Converting an implicit PK to SmallAutoField(primary_key=True) should
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "schema_author_pkey1"
DETAIL:  Key (id)=(1) already exists.


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/django/tests/schema/tests.py", line 1361, in test_alter_autofield_pk_to_smallautofield_pk_sequence_owner
    self.assertIsNotNone(Author.objects.create(name='Bar'))
  File "/django/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/django/django/db/models/query.py", line 453, in create
    obj.save(force_insert=True, using=self.db)
  File "/django/django/db/models/base.py", line 730, in save
    self.save_base(using=using, force_insert=force_insert,
  File "/django/django/db/models/base.py", line 767, in save_base
    updated = self._save_table(
  File "/django/django/db/models/base.py", line 872, in _save_table
    results = self._do_insert(cls._base_manager, using, fields, returning_fields, raw)
  File "/django/django/db/models/base.py", line 910, in _do_insert
    return manager._insert(
  File "/django/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/django/django/db/models/query.py", line 1289, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "/django/django/db/models/sql/compiler.py", line 1427, in execute_sql
    cursor.execute(sql, params)
  File "/django/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/django/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/django/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/django/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/django/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.IntegrityError: duplicate key value violates unique constraint "schema_author_pkey1"
DETAIL:  Key (id)=(1) already exists.


----------------------------------------------------------------------
Ran 2 tests in 0.037s

FAILED (errors=1)
Destroying test database for alias 'default'...
```