### PR TITLE
Fixed #32681 -- Fixed VariableDoesNotExist when rendering some admin template.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -982,6 +982,7 @@ answer newbie questions, and generally made Django that much better:
     Zach Liu <zachliu@gmail.com>
     Zach Thompson <zthompson47@gmail.com>
     Zain Memon
+    Zain Patel <zain.patel06@gmail.com>
     Zak Johnson <zakj@nox.cx>
     Žan Anderle <zan.anderle@gmail.com>
     Zbigniew Siciarz <zbigniew@siciarz.net>

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1890,6 +1890,7 @@ class ModelAdmin(BaseModelAdmin):
         context = {
             **self.admin_site.each_context(request),
             'title': title,
+            'subtitle': None,
             'object_name': object_name,
             'object': obj,
             'deleted_objects': deleted_objects,
@@ -1930,6 +1931,7 @@ class ModelAdmin(BaseModelAdmin):
         context = {
             **self.admin_site.each_context(request),
             'title': _('Change history: %s') % obj,
+            'subtitle': None,
             'action_list': action_list,
             'module_name': str(capfirst(opts.verbose_name_plural)),
             'object': obj,

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -524,6 +524,7 @@ class AdminSite:
         context = {
             **self.each_context(request),
             'title': self.index_title,
+            'subtitle': None,
             'app_list': app_list,
             **(extra_context or {}),
         }
@@ -541,6 +542,7 @@ class AdminSite:
         context = {
             **self.each_context(request),
             'title': _('%(app)s administration') % {'app': app_dict['name']},
+            'subtitle': None,
             'app_list': [app_dict],
             'app_label': app_label,
             **(extra_context or {}),

--- a/docs/releases/3.2.1.txt
+++ b/docs/releases/3.2.1.txt
@@ -56,3 +56,6 @@ Bugfixes
   with subqueries that began manifesting in Django 3.2, due to a separate fix
   using ``Exists`` to ``exclude()`` multi-valued relationships
   (:ticket:`32650`).
+
+* Fixed a bug in Django 3.2 where variable lookup errors were logged when
+  rendering some admin templates (:ticket:`32681`).

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1121,6 +1121,18 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         response = self.client.get(reverse('admin:admin_views_city_add'))
         self.assertContains(response, 'overridden_name')
 
+    def test_render_views_no_subtitle(self):
+        tests = [
+            reverse('admin:index'),
+            reverse('admin:app_list', args=('admin_views',)),
+            reverse('admin:admin_views_article_delete', args=(self.a1.pk,)),
+            reverse('admin:admin_views_article_history', args=(self.a1.pk,)),
+        ]
+        for url in tests:
+            with self.subTest(url=url):
+                with self.assertNoLogs('django.template', 'DEBUG'):
+                    self.client.get(url)
+
 
 @override_settings(TEMPLATES=[{
     'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
See ticket description here: https://code.djangoproject.com/ticket/32681

Feel free to close this PR if un-needed :)

Not sure if it's worth adding a test for this - not sure where it'd go. I suspect I could do something like:

```python
self.assertEqual(ctx["subtitle"], None)
```

in `tests/admin_views.py` but not 100% sure that's useful. If it is, please let me know and I can commit that change.