### PR TITLE
Fixed #32632, Fixed #32657 -- Removed flawed support for Subquery deconstruction.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -147,7 +147,6 @@ class Combinable:
         )
 
 
-@deconstructible
 class BaseExpression:
     """Base class for all query expressions."""
 
@@ -389,6 +388,11 @@ class BaseExpression:
             return self.output_field.select_format(compiler, sql, params)
         return sql, params
 
+
+@deconstructible
+class Expression(BaseExpression, Combinable):
+    """An expression that can be combined with other expressions."""
+
     @cached_property
     def identity(self):
         constructor_signature = inspect.signature(self.__init__)
@@ -409,17 +413,12 @@ class BaseExpression:
         return tuple(identity)
 
     def __eq__(self, other):
-        if not isinstance(other, BaseExpression):
+        if not isinstance(other, Expression):
             return NotImplemented
         return other.identity == self.identity
 
     def __hash__(self):
         return hash(self.identity)
-
-
-class Expression(BaseExpression, Combinable):
-    """An expression that can be combined with other expressions."""
-    pass
 
 
 _connector_combinators = {
@@ -1103,7 +1102,7 @@ class Case(Expression):
         return super().get_group_by_cols(alias)
 
 
-class Subquery(Expression):
+class Subquery(BaseExpression, Combinable):
     """
     An explicit subquery. It may contain OuterRef() references to the outer
     query which will be resolved when it is applied to that query.
@@ -1116,16 +1115,6 @@ class Subquery(Expression):
         self.query = getattr(queryset, 'query', queryset)
         self.extra = extra
         super().__init__(output_field)
-
-    def __getstate__(self):
-        state = super().__getstate__()
-        args, kwargs = state['_constructor_args']
-        if args:
-            args = (self.query, *args[1:])
-        else:
-            kwargs['queryset'] = self.query
-        state['_constructor_args'] = args, kwargs
-        return state
 
     def get_source_expressions(self):
         return [self.query]
@@ -1203,6 +1192,7 @@ class Exists(Subquery):
         return sql, params
 
 
+@deconstructible
 class OrderBy(BaseExpression):
     template = '%(expression)s %(ordering)s'
     conditional = False

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -5,6 +5,7 @@ Factored out from django.db.models.query to avoid making the main module very
 large and/or so that they can be used by other modules without getting into
 circular import difficulties.
 """
+import copy
 import functools
 import inspect
 from collections import namedtuple
@@ -43,14 +44,11 @@ class Q(tree.Node):
         if not(isinstance(other, Q) or getattr(other, 'conditional', False) is True):
             raise TypeError(other)
 
-        # If the other Q() is empty, ignore it and just use `self`.
-        if not other:
+        if not self:
+            return other.copy() if hasattr(other, 'copy') else copy.copy(other)
+        elif isinstance(other, Q) and not other:
             _, args, kwargs = self.deconstruct()
             return type(self)(*args, **kwargs)
-        # Or if this Q is empty, ignore it and just use `other`.
-        elif not self:
-            _, args, kwargs = other.deconstruct()
-            return type(other)(*args, **kwargs)
 
         obj = type(self)()
         obj.connector = conn

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -36,7 +36,6 @@ from django.db.models.sql.where import (
     AND, OR, ExtraWhere, NothingNode, WhereNode,
 )
 from django.utils.functional import cached_property
-from django.utils.hashable import make_hashable
 from django.utils.tree import Node
 
 __all__ = ['Query', 'RawQuery']
@@ -249,14 +248,6 @@ class Query(BaseExpression):
     def base_table(self):
         for alias in self.alias_map:
             return alias
-
-    @property
-    def identity(self):
-        identity = (
-            (arg, make_hashable(value))
-            for arg, value in self.__dict__.items()
-        )
-        return (self.__class__, *identity)
 
     def __str__(self):
         """

--- a/docs/releases/3.2.1.txt
+++ b/docs/releases/3.2.1.txt
@@ -68,3 +68,7 @@ Bugfixes
 
 * Fixed a regression in Django 3.2 where the calling process environment would
   not be passed to the ``dbshell`` command on PostgreSQL (:ticket:`32687`).
+
+* Fixed a performance regression in Django 3.2 when building complex filters
+  with subqueries (:ticket:`32632`). As a side-effect the private API to check
+  ``django.db.sql.query.Query`` equality is removed.

--- a/tests/queries/test_q.py
+++ b/tests/queries/test_q.py
@@ -26,6 +26,19 @@ class QTests(SimpleTestCase):
         self.assertEqual(q | Q(), q)
         self.assertEqual(Q() | q, q)
 
+    def test_combine_empty_copy(self):
+        base_q = Q(x=1)
+        tests = [
+            base_q | Q(),
+            Q() | base_q,
+            base_q & Q(),
+            Q() & base_q,
+        ]
+        for i, q in enumerate(tests):
+            with self.subTest(i=i):
+                self.assertEqual(q, base_q)
+                self.assertIsNot(q, base_q)
+
     def test_combine_or_both_empty(self):
         self.assertEqual(Q() | Q(), Q())
 

--- a/tests/queries/test_query.py
+++ b/tests/queries/test_query.py
@@ -150,31 +150,3 @@ class TestQuery(SimpleTestCase):
         msg = 'Cannot filter against a non-conditional expression.'
         with self.assertRaisesMessage(TypeError, msg):
             query.build_where(Func(output_field=CharField()))
-
-    def test_equality(self):
-        self.assertNotEqual(
-            Author.objects.all().query,
-            Author.objects.filter(item__name='foo').query,
-        )
-        self.assertEqual(
-            Author.objects.filter(item__name='foo').query,
-            Author.objects.filter(item__name='foo').query,
-        )
-        self.assertEqual(
-            Author.objects.filter(item__name='foo').query,
-            Author.objects.filter(Q(item__name='foo')).query,
-        )
-
-    def test_hash(self):
-        self.assertNotEqual(
-            hash(Author.objects.all().query),
-            hash(Author.objects.filter(item__name='foo').query)
-        )
-        self.assertEqual(
-            hash(Author.objects.filter(item__name='foo').query),
-            hash(Author.objects.filter(item__name='foo').query),
-        )
-        self.assertEqual(
-            hash(Author.objects.filter(item__name='foo').query),
-            hash(Author.objects.filter(Q(item__name='foo')).query),
-        )


### PR DESCRIPTION
Subquery deconstruction support required implementing complex and expensive
equality rules for sql.Query objects for little benefit as the latter cannot
themselves be made deconstructible due to their reference to model classes.

Making Expression @deconstructible and not BaseExpression allows interested
parties to conform to the "expression" API even if they are not deconstructible
as it's only a requirement for expressions allowed in Model fields and meta
options (e.g. constraints, indexes).