### PR TITLE
Refs 32637 -- Made technical 404 debug page display exception message when URL is resolved.

### DIFF
--- a/django/views/templates/technical_404.html
+++ b/django/views/templates/technical_404.html
@@ -26,7 +26,7 @@
 <body>
   <div id="summary">
     <h1>Page not found <span>(404)</span></h1>
-    {% if reason %}<pre class="exception_value">{{ reason }}</pre>{% endif %}
+    {% if reason and resolved %}<pre class="exception_value">{{ reason }}</pre>{% endif %}
     <table class="meta">
       <tr>
         <th>Request Method:</th>

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -122,6 +122,11 @@ class DebugViewTests(SimpleTestCase):
 
     def test_404(self):
         response = self.client.get('/raises404/')
+        self.assertNotContains(
+            response,
+            '<pre class="exception_value">',
+            status_code=404,
+        )
         self.assertContains(
             response,
             '<p>The current path, <code>not-in-urls</code>, didn’t match any '
@@ -133,6 +138,11 @@ class DebugViewTests(SimpleTestCase):
     def test_404_not_in_urls(self):
         response = self.client.get('/not-in-urls')
         self.assertNotContains(response, "Raised by:", status_code=404)
+        self.assertNotContains(
+            response,
+            '<pre class="exception_value">',
+            status_code=404,
+        )
         self.assertContains(response, "Django tried these URL patterns", status_code=404)
         self.assertContains(
             response,


### PR DESCRIPTION
Follow up to 3b8527e32b665df91622649550813bb1ec9a9251.

We shouldn't display an exception message when URL is not resolved.

Before:
![tried1](https://user-images.githubusercontent.com/2865885/116034127-0e7d5500-a663-11eb-8376-6bcf5663d1e1.png)
After:
![tried2](https://user-images.githubusercontent.com/2865885/116034129-0fae8200-a663-11eb-8718-1b6276629a3b.png)
