### PR TITLE
Fixed #32682 -- Made admin changelist use Exists() instead of distinct() for preventing duplicates.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1019,7 +1019,7 @@ class ModelAdmin(BaseModelAdmin):
             # Otherwise, use the field with icontains.
             return "%s__icontains" % field_name
 
-        use_distinct = False
+        may_have_duplicates = False
         search_fields = self.get_search_fields(request)
         if search_fields and search_term:
             orm_lookups = [construct_search(str(search_field))
@@ -1030,9 +1030,11 @@ class ModelAdmin(BaseModelAdmin):
                 or_queries = [models.Q(**{orm_lookup: bit})
                               for orm_lookup in orm_lookups]
                 queryset = queryset.filter(reduce(operator.or_, or_queries))
-            use_distinct |= any(lookup_needs_distinct(self.opts, search_spec) for search_spec in orm_lookups)
-
-        return queryset, use_distinct
+            may_have_duplicates |= any(
+                lookup_needs_distinct(self.opts, search_spec)
+                for search_spec in orm_lookups
+            )
+        return queryset, may_have_duplicates
 
     def get_preserved_filters(self, request):
         """

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1576,14 +1576,16 @@ templates used by the :class:`ModelAdmin` views:
             search_fields = ('name',)
 
             def get_search_results(self, request, queryset, search_term):
-                queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+                queryset, may_have_duplicates = super().get_search_results(
+                    request, queryset, search_term,
+                )
                 try:
                     search_term_as_int = int(search_term)
                 except ValueError:
                     pass
                 else:
                     queryset |= self.model.objects.filter(age=search_term_as_int)
-                return queryset, use_distinct
+                return queryset, may_have_duplicates
 
     This implementation is more efficient than ``search_fields =
     ('name', '=age')`` which results in a string comparison for the numeric

--- a/docs/releases/3.2.1.txt
+++ b/docs/releases/3.2.1.txt
@@ -59,3 +59,9 @@ Bugfixes
 
 * Fixed a bug in Django 3.2 where variable lookup errors were logged when
   rendering some admin templates (:ticket:`32681`).
+
+* Fixed a bug in Django 3.2 where an admin changelist would crash when deleting
+  objects filtered against multi-valued relationships (:ticket:`32682`). The
+  admin changelist now uses ``Exists()`` instead ``QuerySet.distinct()``
+  because calling ``delete()`` after ``distinct()`` is not allowed in Django
+  3.2 to address a data loss possibility.

--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -33,6 +33,7 @@ site.register(Event, EventAdmin)
 class ParentAdmin(admin.ModelAdmin):
     list_filter = ['child__name']
     search_fields = ['child__name']
+    list_select_related = ['child']
 
 
 class ChildAdmin(admin.ModelAdmin):

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -104,6 +104,20 @@ class ChangeListTests(TestCase):
         cl = m.get_changelist_instance(request)
         self.assertEqual(cl.queryset.query.select_related, {'parent': {}})
 
+    def test_select_related_preserved_when_multi_valued_in_search_fields(self):
+        parent = Parent.objects.create(name='Mary')
+        Child.objects.create(parent=parent, name='Danielle')
+        Child.objects.create(parent=parent, name='Daniel')
+
+        m = ParentAdmin(Parent, custom_site)
+        request = self.factory.get('/parent/', data={SEARCH_VAR: 'daniel'})
+        request.user = self.superuser
+
+        cl = m.get_changelist_instance(request)
+        self.assertEqual(cl.queryset.count(), 1)
+        # select_related is preserved.
+        self.assertEqual(cl.queryset.query.select_related, {'child': {}})
+
     def test_select_related_as_tuple(self):
         ia = InvitationAdmin(Invitation, custom_site)
         request = self.factory.get('/invitation/')

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -653,14 +653,16 @@ class PluggableSearchPersonAdmin(admin.ModelAdmin):
     search_fields = ('name',)
 
     def get_search_results(self, request, queryset, search_term):
-        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+        queryset, may_have_duplicates = super().get_search_results(
+            request, queryset, search_term,
+        )
         try:
             search_term_as_int = int(search_term)
         except ValueError:
             pass
         else:
             queryset |= self.model.objects.filter(age=search_term_as_int)
-        return queryset, use_distinct
+        return queryset, may_have_duplicates
 
 
 class AlbumAdmin(admin.ModelAdmin):

--- a/tests/delete_regress/models.py
+++ b/tests/delete_regress/models.py
@@ -24,6 +24,7 @@ class Person(models.Model):
 
 class Book(models.Model):
     pagecount = models.IntegerField()
+    owner = models.ForeignKey('Child', models.CASCADE, null=True)
 
 
 class Toy(models.Model):


### PR DESCRIPTION
ticket-32682

Thanks Zain Patel for the report.