### PR TITLE
Fixed #32686 -- Removed unnecessary semicolon on collected multiline SQL for RunSQL.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -135,7 +135,7 @@ class BaseDatabaseSchemaEditor:
         # Log the command we're running, then run it
         logger.debug("%s; (params %r)", sql, params, extra={'params': params, 'sql': sql})
         if self.collect_sql:
-            ending = "" if sql.endswith(";") else ";"
+            ending = "" if sql.rstrip().endswith(";") else ";"
             if params is not None:
                 self.collected_sql.append((sql % tuple(map(self.quote_value, params))) + ending)
             else:

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -3007,6 +3007,7 @@ class OperationTests(OperationTestBase):
         project_state = self.set_up_test_model('test_runsql')
         new_state = project_state.clone()
         tests = [
+            'INSERT INTO test_runsql_pony (pink, weight) VALUES (1, 1);\n',
             'INSERT INTO test_runsql_pony (pink, weight) VALUES (1, 1)\n',
         ]
         for sql in tests:

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -3003,6 +3003,20 @@ class OperationTests(OperationTestBase):
             operation.database_forwards("test_runsql", editor, None, None)
             operation.database_backwards("test_runsql", editor, None, None)
 
+    def test_run_sql_add_missing_semicolon_on_collect_sql(self):
+        project_state = self.set_up_test_model('test_runsql')
+        new_state = project_state.clone()
+        tests = [
+            'INSERT INTO test_runsql_pony (pink, weight) VALUES (1, 1)\n',
+        ]
+        for sql in tests:
+            with self.subTest(sql=sql):
+                operation = migrations.RunSQL(sql, migrations.RunPython.noop)
+                with connection.schema_editor(collect_sql=True) as editor:
+                    operation.database_forwards('test_runsql', editor, project_state, new_state)
+                    collected_sql = '\n'.join(editor.collected_sql)
+                    self.assertEqual(collected_sql.count(';'), 1)
+
     def test_run_python(self):
         """
         Tests the RunPython operation


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32686