### PR TITLE
Fix the tutorial07 settings.py example error

### DIFF
--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -315,7 +315,7 @@ Open your settings file (:file:`mysite/settings.py`, remember) and add a
     TEMPLATES = [
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': [BASE_DIR / 'templates'],
+            'DIRS': [os.path.join(BASE_DIR, 'templates')],
             'APP_DIRS': True,
             'OPTIONS': {
                 'context_processors': [


### PR DESCRIPTION
Document tutorial07 settings.py example will cause an error.

`'DIRS': [BASE_DIR / 'templates'],` will result in `TypeError: unsupported operand type(s) for /: 'str' and 'str'`

It should use `'DIRS': [os.path.join(BASE_DIR, 'templates')],` instead.