### PR TITLE
Speling mistake change "klass" to "class"

### DIFF
--- a/docs/topics/http/shortcuts.txt
+++ b/docs/topics/http/shortcuts.txt
@@ -151,7 +151,7 @@ will be returned::
 ``get_object_or_404()``
 =======================
 
-.. function:: get_object_or_404(klass, *args, **kwargs)
+.. function:: get_object_or_404(class, *args, **kwargs)
 
    Calls :meth:`~django.db.models.query.QuerySet.get()` on a given model manager,
    but it raises :class:`~django.http.Http404` instead of the model's
@@ -160,7 +160,7 @@ will be returned::
 Required arguments
 ------------------
 
-``klass``
+``class``
     A :class:`~django.db.models.Model` class,
     a :class:`~django.db.models.Manager`,
     or a :class:`~django.db.models.query.QuerySet` instance from which to get
@@ -224,7 +224,7 @@ will be raised if more than one object is found.
 ``get_list_or_404()``
 =====================
 
-.. function:: get_list_or_404(klass, *args, **kwargs)
+.. function:: get_list_or_404(class, *args, **kwargs)
 
    Returns the result of :meth:`~django.db.models.query.QuerySet.filter()` on a
    given model manager cast to a list, raising :class:`~django.http.Http404` if
@@ -233,7 +233,7 @@ will be raised if more than one object is found.
 Required arguments
 ------------------
 
-``klass``
+``class``
     A :class:`~django.db.models.Model`, :class:`~django.db.models.Manager` or
     :class:`~django.db.models.query.QuerySet` instance from which to get the
     list.


### PR DESCRIPTION
get_object_or_404() and get_list_or_404() section change:
this funcation parameter pass keyword spaling is "klass" to change "class".