### PR TITLE
Corrected introduction to range field lookups docs.

### DIFF
--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -711,8 +711,7 @@ The returned ranges share a bound with the passed range.
 Querying using the bounds
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are three transforms available for use in queries. You can extract the
-lower or upper bound, or query based on emptiness.
+Range fields support several extra lookups.
 
 .. fieldlookup:: rangefield.startswith
 


### PR DESCRIPTION
"There are three" has been untrue since 24b9f5082344a127147266dd52d5d2dcd1c9cb44.