### PR TITLE
Fixed #32675 -- Doc'd that autodector changes might cause generation of no-op migrations.

### DIFF
--- a/django/contrib/admin/migrations/0001_initial.py
+++ b/django/contrib/admin/migrations/0001_initial.py
@@ -21,7 +21,6 @@ class Migration(migrations.Migration):
                 ('action_flag', models.PositiveSmallIntegerField(verbose_name='action flag')),
                 ('change_message', models.TextField(verbose_name='change message', blank=True)),
                 ('content_type', models.ForeignKey(
-                    to_field='id',
                     on_delete=models.SET_NULL,
                     blank=True, null=True,
                     to='contenttypes.ContentType',

--- a/django/contrib/auth/migrations/0001_initial.py
+++ b/django/contrib/auth/migrations/0001_initial.py
@@ -19,7 +19,6 @@ class Migration(migrations.Migration):
                 ('content_type', models.ForeignKey(
                     to='contenttypes.ContentType',
                     on_delete=models.CASCADE,
-                    to_field='id',
                     verbose_name='content type',
                 )),
                 ('codename', models.CharField(max_length=100, verbose_name='codename')),

--- a/django/contrib/redirects/migrations/0001_initial.py
+++ b/django/contrib/redirects/migrations/0001_initial.py
@@ -14,7 +14,6 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('site', models.ForeignKey(
                     to='sites.Site',
-                    to_field='id',
                     on_delete=models.CASCADE,
                     verbose_name='site',
                 )),

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -392,6 +392,10 @@ Miscellaneous
 * Tests that fail to load, for example due to syntax errors, now always match
   when using :option:`test --tag`.
 
+* The migrations autodetector now uses model states instead of model classes.
+  As a side-effect ``makemigrations`` might generate no-op ``AlterField``
+  operations for ``ForeignKey`` fields in some cases.
+
 .. _deprecated-features-4.0:
 
 Features deprecated in 4.0


### PR DESCRIPTION
Refs https://code.djangoproject.com/ticket/32675