### PR TITLE
Fixed #32676 -- Prevented migrations from rendering related field attributes when not passed during initialization.

### DIFF
--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -387,6 +387,18 @@ custom middleware::
 
 .. _Content-Security-Policy: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
+Migrations autodetector changes
+-------------------------------
+
+The migrations autodetector now uses model states instead of model classes.
+Also, migration operations for ``ForeignKey`` and ``ManyToManyField`` fields no
+longer specify attributes which were not passed to the fields during
+initialization.
+
+As a side-effect, running ``makemigrations`` might generate no-op
+``AlterField`` operations for ``ManyToManyField`` and ``ForeignKey`` fields in
+some cases.
+
 Miscellaneous
 -------------
 
@@ -421,10 +433,6 @@ Miscellaneous
 
 * Tests that fail to load, for example due to syntax errors, now always match
   when using :option:`test --tag`.
-
-* The migrations autodetector now uses model states instead of model classes.
-  As a side-effect ``makemigrations`` might generate no-op ``AlterField``
-  operations for ``ForeignKey`` fields in some cases.
 
 * The undocumented ``django.contrib.admin.utils.lookup_needs_distinct()``
   function is renamed to ``lookup_spawns_duplicates()``.

--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -432,6 +432,34 @@ class FieldDeconstructionTests(SimpleTestCase):
         self.assertEqual(kwargs, {"to": "auth.Permission"})
         self.assertEqual(kwargs['to'].setting_name, "AUTH_USER_MODEL")
 
+    def test_many_to_many_field_related_name(self):
+        class MyModel(models.Model):
+            flag = models.BooleanField(default=True)
+            m2m = models.ManyToManyField('self')
+            m2m_related_name = models.ManyToManyField(
+                'self',
+                related_name='custom_name',
+                related_query_name='custom_query_name',
+                limit_choices_to={'flag': True},
+            )
+
+        name, path, args, kwargs = MyModel.m2m.field.deconstruct()
+        self.assertEqual(path, 'django.db.models.ManyToManyField')
+        self.assertEqual(args, [])
+        # deconstruct() should not include attributes which were not passed to
+        # the field during initialization.
+        self.assertEqual(kwargs, {'to': 'field_deconstruction.MyModel'})
+        # Passed attributes.
+        name, path, args, kwargs = MyModel.m2m_related_name.field.deconstruct()
+        self.assertEqual(path, 'django.db.models.ManyToManyField')
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {
+            'to': 'field_deconstruction.MyModel',
+            'related_name': 'custom_name',
+            'related_query_name': 'custom_query_name',
+            'limit_choices_to': {'flag': True},
+        })
+
     def test_positive_integer_field(self):
         field = models.PositiveIntegerField()
         name, path, args, kwargs = field.deconstruct()

--- a/tests/schema/fields.py
+++ b/tests/schema/fields.py
@@ -34,7 +34,12 @@ class CustomManyToManyField(RelatedField):
         self.db_table = db_table
         if kwargs['rel'].through is not None:
             assert self.db_table is None, "Cannot specify a db_table if an intermediary model is used."
-        super().__init__(**kwargs)
+        super().__init__(
+            related_name=related_name,
+            related_query_name=related_query_name,
+            limit_choices_to=limit_choices_to,
+            **kwargs,
+        )
 
     def contribute_to_class(self, cls, name, **kwargs):
         if self.remote_field.symmetrical and (


### PR DESCRIPTION
Refs https://code.djangoproject.com/ticket/32676