### PR TITLE
Fixed #32720 -- Added configuration and docs for Sphinx link checker.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,28 @@ extensions = [
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 2
 
+# Linkcheck settings.
+linkcheck_ignore = [
+    # Special-use addresses and domain names. (RFC 6761/6890)
+    r'^https?://(?:127\.0\.0\.1|\[::1\])(?::\d+)?/',
+    r'^https?://(?:[^/\.]+\.)*example\.(?:com|net|org)(?::\d+)?/',
+    r'^https?://(?:[^/\.]+\.)*(?:example|invalid|localhost|test)(?::\d+)?/',
+    # Pages that are inaccessible because they require authentication.
+    r'^https://github\.com/[^/]+/[^/]+/fork',
+    r'^https://code\.djangoproject\.com/github/login',
+    r'^https://code\.djangoproject\.com/newticket',
+    r'^https://(?:code|www)\.djangoproject\.com/admin/',
+    r'^https://www\.djangoproject\.com/community/add/blogs/',
+    r'^https://www\.google\.com/webmasters/tools/ping',
+    r'^https://search\.google\.com/search-console/welcome',
+    # Fragments used to dynamically switch content or populate fields.
+    r'^https://webchat\.freenode\.net/#',
+    r'^https://github\.com/[^#]+#L\d+-L\d+$',
+    r'^https://help\.apple\.com/itc/podcasts_connect/#/itc',
+    # Anchors on certain pages with missing a[name] attributes.
+    r'^https://tools\.ietf\.org/html/rfc1123\.html#section-',
+]
+
 # Spelling check needs an additional module that is not installed by default.
 # Add it only if spelling check is requested so docs can be generated without it.
 if 'spelling' in sys.argv:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ from os.path import abspath, dirname, join
 #
 # Python's default allowed recursion depth is 1000 but this isn't enough for
 # building docs/ref/settings.txt sometimes.
-# https://groups.google.com/d/topic/sphinx-dev/MtRf64eGtv4/discussion
+# https://groups.google.com/g/sphinx-dev/c/MtRf64eGtv4/discussion
 sys.setrecursionlimit(2000)
 
 # Make sure we get the version of this copy of Django

--- a/docs/faq/general.txt
+++ b/docs/faq/general.txt
@@ -172,7 +172,7 @@ site is one module of Django the framework. Furthermore, although Django has
 special conveniences for building "CMS-y" apps, that doesn't mean it's not just
 as appropriate for building "non-CMS-y" apps (whatever that means!).
 
-.. _Drupal: https://drupal.org/
+.. _Drupal: https://www.drupal.org/
 
 How can I download the Django documentation to read it offline?
 ===============================================================
@@ -197,7 +197,7 @@ software are still a matter of some debate.
 
 For example, `APA style`_,  would dictate something like::
 
-    Django (Version 1.5) [Computer Software]. (2013). Retrieved from https://djangoproject.com.
+    Django (Version 1.5) [Computer Software]. (2013). Retrieved from https://www.djangoproject.com/.
 
 However, the only true guide is what your publisher will accept, so get a copy
 of those guidelines and fill in the gaps as best you can.
@@ -207,11 +207,11 @@ Foundation".
 
 If you need a publishing location, use "Lawrence, Kansas".
 
-If you need a web address, use https://djangoproject.com.
+If you need a web address, use https://www.djangoproject.com/.
 
 If you need a name, just use "Django", without any tagline.
 
 If you need a publication date, use the year of release of the version you're
 referencing (e.g., 2013 for v1.5)
 
-.. _APA style: https://www.apastyle.org
+.. _APA style: https://apastyle.apa.org/

--- a/docs/howto/auth-remote-user.txt
+++ b/docs/howto/auth-remote-user.txt
@@ -12,7 +12,7 @@ Windows Authentication or Apache and `mod_authnz_ldap`_, `CAS`_, `Cosign`_,
 .. _mod_authnz_ldap: https://httpd.apache.org/docs/2.2/mod/mod_authnz_ldap.html
 .. _CAS: https://www.apereo.org/projects/cas
 .. _Cosign: http://weblogin.org
-.. _WebAuth: https://www.stanford.edu/services/webauth/
+.. _WebAuth: https://uit.stanford.edu/service/authentication
 .. _mod_auth_sspi: https://sourceforge.net/projects/mod-auth-sspi
 
 When the Web server takes care of authentication it typically sets the

--- a/docs/howto/custom-template-backend.txt
+++ b/docs/howto/custom-template-backend.txt
@@ -170,4 +170,4 @@ creating an object that specifies the following attributes:
   to load the template, e.g. ``django.template.loaders.filesystem.Loader``.
 
 .. _DEP 182: https://github.com/django/deps/blob/main/final/0182-multiple-template-engines.rst
-.. _Django Debug Toolbar: https://github.com/jazzband/django-debug-toolbar
+.. _Django Debug Toolbar: https://github.com/jazzband/django-debug-toolbar/

--- a/docs/howto/deployment/wsgi/modwsgi.txt
+++ b/docs/howto/deployment/wsgi/modwsgi.txt
@@ -27,7 +27,7 @@ Basic configuration
 Once you've got mod_wsgi installed and activated, edit your Apache server's
 `httpd.conf`_ file and add the following.
 
-.. _httpd.conf: https://wiki.apache.org/httpd/DistrosDefaultLayout
+.. _httpd.conf: https://cwiki.apache.org/confluence/display/httpd/DistrosDefaultLayout
 
 .. code-block:: apache
 

--- a/docs/howto/outputting-pdf.txt
+++ b/docs/howto/outputting-pdf.txt
@@ -15,7 +15,7 @@ printer-friendly NCAA tournament brackets, as PDF files, for people
 participating in a March Madness contest.
 
 .. _ReportLab: https://www.reportlab.com/opensource/
-.. _kusports.com: http://www.kusports.com/
+.. _kusports.com: http://www2.kusports.com/
 
 Install ReportLab
 =================

--- a/docs/howto/windows.txt
+++ b/docs/howto/windows.txt
@@ -22,7 +22,7 @@ Install Python
 Django is a Python web framework, thus requiring Python to be installed on your
 machine. At the time of writing, Python 3.8 is the latest version.
 
-To install Python on your machine go to https://python.org/downloads/. The
+To install Python on your machine go to https://www.python.org/downloads/. The
 website should offer you a download button for the latest Python version.
 Download the executable installer and run it. Check the boxes next to "Install
 launcher for all users (recommended)" then click "Install Now".

--- a/docs/internals/contributing/committing-code.txt
+++ b/docs/internals/contributing/committing-code.txt
@@ -138,7 +138,7 @@ Django's Git repository:
   Credit the contributors in the commit message: "Thanks A for the report and B
   for review." Use git's `Co-Authored-By`_ as appropriate.
 
-  .. _Co-Authored-By: https://help.github.com/articles/creating-a-commit-with-multiple-authors/
+  .. _Co-Authored-By: https://docs.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors
 
 * For commits to a branch, prefix the commit message with the branch name.
   For example: "[1.4.x] Fixed #xxxxx -- Added support for mind reading."

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -142,7 +142,7 @@ Running tests using ``django-docker-box``
 supported databases and python versions. See the `django-docker-box`_ project
 page for installation and usage instructions.
 
-.. _django-docker-box: https://github.com/django/django-docker-box
+.. _django-docker-box: https://github.com/django/django-docker-box/
 
 .. _running-unit-tests-settings:
 
@@ -320,13 +320,13 @@ associated tests will be skipped.
 To run some of the autoreload tests, you'll need to install the Watchman_
 service.
 
-.. _argon2-cffi: https://pypi.org/project/argon2_cffi/
+.. _argon2-cffi: https://pypi.org/project/argon2-cffi/
 .. _asgiref: https://pypi.org/project/asgiref/
 .. _bcrypt: https://pypi.org/project/bcrypt/
 .. _colorama: https://pypi.org/project/colorama/
 .. _docutils: https://pypi.org/project/docutils/
 .. _geoip2: https://pypi.org/project/geoip2/
-.. _jinja2: https://pypi.org/project/jinja2/
+.. _jinja2: https://pypi.org/project/Jinja2/
 .. _numpy: https://pypi.org/project/numpy/
 .. _Pillow: https://pypi.org/project/Pillow/
 .. _PyYAML: https://pyyaml.org/wiki/PyYAML

--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -510,6 +510,28 @@ one of the following:
 * If, and only if, you are sure the word you are using is correct - add it
   to ``docs/spelling_wordlist`` (please keep the list in alphabetical order).
 
+.. _documentation-link-check:
+
+Link check
+==========
+
+Links in documentation can become broken or changed such that they are no
+longer the canonical link. Sphinx provides a builder that can check whether the
+links in the documentation are working. From the ``docs`` directory, run ``make
+linkcheck``. Output is printed to the terminal, but can also be found in
+``_build/linkcheck/output.txt`` and ``_build/linkcheck/output.json``.
+
+Entries that have a status of "working" are fine, those that are "unchecked" or
+"ignored" have been skipped because they either cannot be checked or have
+matched ignore rules in the configuration.
+
+Entries that have a status of "broken" need to be fixed. Those that have a
+status of "redirected" may need to be updated to point to the canonical
+location, e.g. the scheme has changed ``http://`` → ``https://``. In certain
+cases, we do not want to update a "redirected" link, e.g. a rewrite to always
+point to the latest or stable version of documentation, e.g. ``/en/stable/`` →
+``/en/3.2/``.
+
 Translating documentation
 =========================
 

--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -61,7 +61,7 @@ To get started contributing, you'll want to read the :ref:`reStructuredText
 reference <sphinx:rst-index>`.
 
 Your locally-built documentation will be themed differently than the
-documentation at `docs.djangoproject.com <https://docs.djangoproject.com>`_.
+documentation at `docs.djangoproject.com <https://docs.djangoproject.com/>`_.
 This is OK! If your changes look good on your local machine, they'll look good
 on the website.
 

--- a/docs/internals/git.txt
+++ b/docs/internals/git.txt
@@ -50,7 +50,7 @@ website can be found at `github.com/django/djangoproject.com
 <https://github.com/django/djangoproject.com>`_.
 
 .. _Git: https://git-scm.com/
-.. _documentation: https://git-scm.com/documentation
+.. _documentation: https://git-scm.com/doc
 .. _branches: https://github.com/django/django/branches
 .. _tags: https://github.com/django/django/tags
 

--- a/docs/internals/howto-release-django.txt
+++ b/docs/internals/howto-release-django.txt
@@ -103,9 +103,9 @@ any time leading up to the actual release:
 #. Check with the other committers to make sure they don't have any
    uncommitted changes for the release.
 
-#. Proofread the release notes, including looking at the online
-   version to catch any broken links or reST errors, and make sure the
-   release notes contain the correct date.
+#. Proofread the release notes, including looking at the online version to
+   :ref:`catch any broken links <documentation-link-check>` or reST errors, and
+   make sure the release notes contain the correct date.
 
 #. Double-check that the release notes mention deprecation timelines
    for any APIs noted as deprecated, and that they mention any changes

--- a/docs/internals/howto-release-django.txt
+++ b/docs/internals/howto-release-django.txt
@@ -337,7 +337,7 @@ Now you're ready to actually put the release out there. To do this:
    that they install correctly, but it'll catch silly mistakes.
 
 #. Ask a few people on IRC to verify the checksums by visiting the checksums
-   file (e.g. https://www.djangoproject.com/m/pgp/Django-1.5b1.checksum.txt)
+   file (e.g. https://media.djangoproject.com/pgp/Django-1.5b1.checksum.txt)
    and following the instructions in it. For bonus points, they can also unpack
    the downloaded release tarball and verify that its contents appear to be
    correct (proper version numbers, no stray ``.pyc`` or other undesirable
@@ -451,8 +451,8 @@ need to be done by the releaser.
    <https://readthedocs.org/projects/django/>`_. Since the automatically
    generated version names ("stable-A.B.x") differ from the version names
    used in Read the Docs ("A.B.x"), `create a ticket
-   <https://github.com/rtfd/readthedocs.org/issues/5537>`_ requesting the new
-   version.
+   <https://github.com/readthedocs/readthedocs.org/issues/5537>`_ requesting
+   the new version.
 
 #. `Request the new classifier on PyPI
    <https://github.com/pypa/trove-classifiers/issues/29>`_. For example

--- a/docs/internals/mailing-lists.txt
+++ b/docs/internals/mailing-lists.txt
@@ -31,7 +31,7 @@ installation, usage, or debugging of Django.
 * `django-users subscription email address`_
 * `django-users posting email`_
 
-.. _django-users mailing archive: https://groups.google.com/d/forum/django-users
+.. _django-users mailing archive: https://groups.google.com/g/django-users
 .. _django-users subscription email address: mailto:django-users+subscribe@googlegroups.com
 .. _django-users posting email: mailto:django-users@googlegroups.com
 
@@ -48,7 +48,7 @@ the Django Project.
 * `django-core-mentorship subscription email address`_
 * `django-core-mentorship posting email`_
 
-.. _django-core-mentorship mailing archive: https://groups.google.com/d/forum/django-core-mentorship
+.. _django-core-mentorship mailing archive: https://groups.google.com/g/django-core-mentorship
 .. _django-core-mentorship subscription email address: mailto:django-core-mentorship+subscribe@googlegroups.com
 .. _django-core-mentorship posting email: mailto:django-core-mentorship@googlegroups.com
 
@@ -73,7 +73,7 @@ answered there.
 * `django-developers subscription email address`_
 * `django-developers posting email`_
 
-.. _django-developers mailing archive: https://groups.google.com/d/forum/django-developers
+.. _django-developers mailing archive: https://groups.google.com/g/django-developers
 .. _django-developers subscription email address: mailto:django-developers+subscribe@googlegroups.com
 .. _django-developers posting email: mailto:django-developers@googlegroups.com
 
@@ -89,7 +89,7 @@ Django's components.
 * `django-i18n subscription email address`_
 * `django-i18n posting email`_
 
-.. _django-i18n mailing archive: https://groups.google.com/d/forum/django-i18n
+.. _django-i18n mailing archive: https://groups.google.com/g/django-i18n
 .. _django-i18n subscription email address: mailto:django-i18n+subscribe@googlegroups.com
 .. _django-i18n posting email: mailto:django-i18n@googlegroups.com
 
@@ -105,7 +105,7 @@ A (very) low-traffic list for announcing :ref:`upcoming security releases
 * `django-announce subscription email address`_
 * `django-announce posting email`_
 
-.. _django-announce mailing archive: https://groups.google.com/d/forum/django-announce
+.. _django-announce mailing archive: https://groups.google.com/g/django-announce
 .. _django-announce subscription email address: mailto:django-announce+subscribe@googlegroups.com
 .. _django-announce posting email: mailto:django-announce@googlegroups.com
 
@@ -121,6 +121,6 @@ by developers and interested community members.
 * `django-updates subscription email address`_
 * `django-updates posting email`_
 
-.. _django-updates mailing archive: https://groups.google.com/d/forum/django-updates
+.. _django-updates mailing archive: https://groups.google.com/g/django-updates
 .. _django-updates subscription email address: mailto:django-updates+subscribe@googlegroups.com
 .. _django-updates posting email: mailto:django-updates@googlegroups.com

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -343,7 +343,7 @@ This test checks that the ``make_toast()`` returns ``'toast'``.
     * After reading those, if you want something a little meatier to sink
       your teeth into, there's always the Python :mod:`unittest` documentation.
 
-__ https://www.diveinto.org/python3/unit-testing.html
+__ https://diveinto.org/python3/unit-testing.html
 
 Running your new test
 ---------------------

--- a/docs/intro/index.txt
+++ b/docs/intro/index.txt
@@ -34,7 +34,7 @@ place: read this material to quickly get up and running.
     Python quickly, we recommend `Dive Into Python`_. If that's not quite your
     style, there are many other `books about Python`_.
 
-    .. _python: https://python.org/
+    .. _python: https://www.python.org/
     .. _list of Python resources for non-programmers: https://wiki.python.org/moin/BeginnersGuide/NonProgrammers
     .. _Dive Into Python: https://diveinto.org/python3/table-of-contents.html
     .. _books about Python: https://wiki.python.org/moin/PythonBooks

--- a/docs/intro/install.txt
+++ b/docs/intro/install.txt
@@ -14,7 +14,7 @@ Being a Python Web framework, Django requires Python. See
 :ref:`faq-python-version-support` for details. Python includes a lightweight
 database called SQLite_ so you won't need to set up a database just yet.
 
-.. _sqlite: https://sqlite.org/
+.. _sqlite: https://www.sqlite.org/
 
 Get the latest version of Python at https://www.python.org/downloads/ or with
 your operating system's package manager.

--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -212,7 +212,7 @@ Put the following code in that template:
     To make the tutorial shorter, all template examples use incomplete HTML. In
     your own projects you should use `complete HTML documents`__.
 
-__ https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started#Anatomy_of_an_HTML_document
+__ https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started#anatomy_of_an_html_document
 
 Now let's update our ``index`` view in ``polls/views.py`` to use the template:
 

--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -689,7 +689,7 @@ Coverage will help to identify dead code. See
 :doc:`Testing in Django </topics/testing/index>` has comprehensive
 information about testing.
 
-.. _Selenium: http://seleniumhq.org/
+.. _Selenium: https://www.selenium.dev/
 .. _continuous integration: https://en.wikipedia.org/wiki/Continuous_integration
 
 What's next?

--- a/docs/ref/class-based-views/base.txt
+++ b/docs/ref/class-based-views/base.txt
@@ -225,7 +225,7 @@ MRO is an acronym for Method Resolution Order.
         urlpatterns = [
             path('counter/<int:pk>/', ArticleCounterRedirectView.as_view(), name='article-counter'),
             path('details/<int:pk>/', ArticleDetailView.as_view(), name='article-detail'),
-            path('go-to-django/', RedirectView.as_view(url='https://djangoproject.com'), name='go-to-django'),
+            path('go-to-django/', RedirectView.as_view(url='https://www.djangoproject.com/'), name='go-to-django'),
         ]
 
     **Attributes**

--- a/docs/ref/clickjacking.txt
+++ b/docs/ref/clickjacking.txt
@@ -132,5 +132,5 @@ See also
 
 A `complete list`_ of browsers supporting ``X-Frame-Options``.
 
-.. _complete list: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#Browser_compatibility
+.. _complete list: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#browser_compatibility
 .. _other clickjacking prevention techniques: https://en.wikipedia.org/wiki/Clickjacking#Prevention

--- a/docs/ref/contrib/gis/db-api.txt
+++ b/docs/ref/contrib/gis/db-api.txt
@@ -401,7 +401,7 @@ Aggregate                PostGIS  Oracle  SpatiaLite
 =======================  =======  ======  ==========
 
 .. rubric:: Footnotes
-.. [#fnwkt] *See* Open Geospatial Consortium, Inc., `OpenGIS Simple Feature Specification For SQL <http://www.opengis.org/docs/99-049.pdf>`_, Document 99-049 (May 5, 1999), at  Ch. 3.2.5, p. 3-11 (SQL Textual Representation of Geometry).
+.. [#fnwkt] *See* Open Geospatial Consortium, Inc., `OpenGIS Simple Feature Specification For SQL <https://portal.ogc.org/files/?artifact_id=829>`_, Document 99-049 (May 5, 1999), at  Ch. 3.2.5, p. 3-11 (SQL Textual Representation of Geometry).
 .. [#fnewkb] *See* `PostGIS EWKB, EWKT and Canonical Forms <https://postgis.net/docs/using_postgis_dbmanagement.html#EWKB_EWKT>`_, PostGIS documentation at Ch. 4.1.2.
 .. [#fndistsphere15] *See* `PostGIS documentation <https://postgis.net/docs/ST_DistanceSphere.html>`_ on ``ST_DistanceSphere``.
 .. [#] Refer :ref:`mysql-spatial-limitations` section for more details.

--- a/docs/ref/contrib/gis/gdal.txt
+++ b/docs/ref/contrib/gis/gdal.txt
@@ -21,7 +21,7 @@ to raster (image) data.
     Although the module is named ``gdal``, GeoDjango only supports some of the
     capabilities of OGR and GDAL's raster features at this time.
 
-__ https://www.gdal.org/
+__ https://gdal.org/
 __ https://gdal.org/user/vector_data_model.html
 
 Overview
@@ -1644,7 +1644,7 @@ Examples of using the different keys when creating rasters can be found in the
 documentation of the corresponding attributes and methods of the
 :class:`GDALRaster` and :class:`GDALBand` classes.
 
-__ https://geojson.org
+__ https://geojson.org/
 
 The ``ds_input`` dictionary
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/ref/contrib/gis/geoip2.txt
+++ b/docs/ref/contrib/gis/geoip2.txt
@@ -20,7 +20,7 @@ that ``geoip2`` can leverage the C library's faster speed.
 __ https://geoip2.readthedocs.io/
 __ https://pypi.org/project/geoip2/
 __ https://dev.maxmind.com/geoip/geoip2/geolite2/
-__ https://github.com/maxmind/libmaxminddb
+__ https://github.com/maxmind/libmaxminddb/
 
 Example
 =======

--- a/docs/ref/contrib/gis/geoquerysets.txt
+++ b/docs/ref/contrib/gis/geoquerysets.txt
@@ -935,7 +935,7 @@ Example::
     >>> u = Zipcode.objects.filter(poly__within=bbox).aggregate(Union(poly))  # A more sensible approach.
 
 .. rubric:: Footnotes
-.. [#fnde9im] *See* `OpenGIS Simple Feature Specification For SQL <http://www.opengis.org/docs/99-049.pdf>`_, at Ch. 2.1.13.2, p. 2-13 (The Dimensionally Extended Nine-Intersection Model).
+.. [#fnde9im] *See* `OpenGIS Simple Feature Specification For SQL <https://portal.ogc.org/files/?artifact_id=829>`_, at Ch. 2.1.13.2, p. 2-13 (The Dimensionally Extended Nine-Intersection Model).
 .. [#fnsdorelate] *See* `SDO_RELATE documentation <https://docs.oracle.com/en/
    database/oracle/oracle-database/18/spatl/spatial-operators-reference.html#
    GUID-97C17C18-F05E-49B4-BE11-E89B972E2A02>`_, from the Oracle Spatial and

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -19,7 +19,7 @@ maintained by `Refractions Research`__ of Victoria, Canada.
 
 __ https://trac.osgeo.org/geos/
 __ https://sourceforge.net/projects/jts-topo-suite/
-__ https://www.opengeospatial.org/standards/sfs
+__ https://www.ogc.org/standards/sfs
 __ http://www.refractions.net/
 
 Features

--- a/docs/ref/contrib/gis/install/index.txt
+++ b/docs/ref/contrib/gis/install/index.txt
@@ -117,7 +117,7 @@ community!  You can:
   sure to provide a complete description of the problem, versions used,
   and specify the component as "GIS".
 
-__ https://groups.google.com/d/forum/geodjango
+__ https://groups.google.com/g/geodjango
 __ https://code.djangoproject.com/newticket
 
 .. _libsettings:
@@ -333,8 +333,8 @@ of the `Fink`__ package system. `Different packages are available`__ (starting
 with ``django-gis``), depending on which version of Python you want to use.
 
 __ https://schwehr.blogspot.com/
-__ http://www.finkproject.org/
-__ http://pdb.finkproject.org/pdb/browse.php?summary=django-gis
+__ https://www.finkproject.org/
+__ https://pdb.finkproject.org/pdb/browse.php?summary=django-gis
 
 .. _macports:
 

--- a/docs/ref/contrib/gis/install/spatialite.txt
+++ b/docs/ref/contrib/gis/install/spatialite.txt
@@ -18,7 +18,7 @@ For Windows, you may find binaries on the `Gaia-SINS`__ home page.
 In any case, you should always be able to :ref:`install from source
 <spatialite_source>`.
 
-__ https://www.gaia-gis.it/fossil/libspatialite
+__ https://www.gaia-gis.it/fossil/libspatialite/index
 __ https://www.gaia-gis.it/gaia-sins/
 
 .. _spatialite_source:

--- a/docs/ref/contrib/gis/model-api.txt
+++ b/docs/ref/contrib/gis/model-api.txt
@@ -165,7 +165,7 @@ Additional Resources:
 
 __ https://en.wikipedia.org/wiki/Geodesy
 __ https://en.wikipedia.org/wiki/Great_circle
-__ https://www.spatialreference.org/ref/epsg/2796/
+__ https://spatialreference.org/ref/epsg/2796/
 __ https://spatialreference.org/
 __ https://web.archive.org/web/20080302095452/http://welcome.warnercnr.colostate.edu/class_info/nr502/lg3/datums_coordinates/spcs.html
 
@@ -263,9 +263,9 @@ determining `when to use geography data type over geometry data type
 <https://postgis.net/docs/using_postgis_dbmanagement.html#PostGIS_GeographyVSGeometry>`_.
 
 .. rubric:: Footnotes
-.. [#fnogc] OpenGIS Consortium, Inc., `Simple Feature Specification For SQL <https://www.opengeospatial.org/standards/sfs>`_.
+.. [#fnogc] OpenGIS Consortium, Inc., `Simple Feature Specification For SQL <https://www.ogc.org/standards/sfs>`_.
 .. [#fnogcsrid] *See id.* at Ch. 2.3.8, p. 39 (Geometry Values and Spatial Reference Systems).
-.. [#fnsrid] Typically, SRID integer corresponds to an EPSG (`European Petroleum Survey Group <http://www.epsg.org>`_) identifier.  However, it may also be associated with custom projections defined in spatial database's spatial reference systems table.
+.. [#fnsrid] Typically, SRID integer corresponds to an EPSG (`European Petroleum Survey Group <https://epsg.org/>`_) identifier.  However, it may also be associated with custom projections defined in spatial database's spatial reference systems table.
 .. [#fnthematic] Terry A. Slocum, Robert B. McMaster, Fritz C. Kessler, & Hugh H. Howard, *Thematic Cartography and Geographic Visualization* (Prentice Hall, 2nd edition), at Ch. 7.1.3.
 .. [#fndist] This limitation does not apply to PostGIS.
 .. [#fngeography] Please refer to the `PostGIS Geography Type <https://postgis.net/docs/using_postgis_dbmanagement.html#PostGIS_Geography>`_ documentation for more details.

--- a/docs/ref/contrib/gis/sitemaps.txt
+++ b/docs/ref/contrib/gis/sitemaps.txt
@@ -19,4 +19,4 @@ Reference
 --------------
 
 .. rubric:: Footnotes
-.. [#] https://www.opengeospatial.org/standards/kml
+.. [#] https://www.ogc.org/standards/kml

--- a/docs/ref/contrib/gis/tutorial.txt
+++ b/docs/ref/contrib/gis/tutorial.txt
@@ -36,7 +36,7 @@ basic apps`_ project. [#]_
     Proceed through the tutorial sections sequentially for step-by-step
     instructions.
 
-.. _OGC: https://www.opengeospatial.org/
+.. _OGC: https://www.ogc.org/
 .. _world borders: https://thematicmapping.org/downloads/world_borders.php
 .. _GeoDjango basic apps: https://code.google.com/archive/p/geodjango-basic-apps
 
@@ -769,4 +769,4 @@ in your ``admin.py`` file::
 .. [#] This point is the `University of Houston Law Center
        <https://www.law.uh.edu/>`_.
 .. [#] Open Geospatial Consortium, Inc., `OpenGIS Simple Feature Specification
-       For SQL <https://www.opengeospatial.org/standards/sfs>`_.
+       For SQL <https://www.ogc.org/standards/sfs>`_.

--- a/docs/ref/contrib/gis/tutorial.txt
+++ b/docs/ref/contrib/gis/tutorial.txt
@@ -38,7 +38,7 @@ basic apps`_ project. [#]_
 
 .. _OGC: https://www.opengeospatial.org/
 .. _world borders: https://thematicmapping.org/downloads/world_borders.php
-.. _GeoDjango basic apps: https://code.google.com/p/geodjango-basic-apps/
+.. _GeoDjango basic apps: https://code.google.com/archive/p/geodjango-basic-apps
 
 Setting Up
 ==========
@@ -737,7 +737,7 @@ position.
 
 .. _OpenLayers: https://openlayers.org/
 .. _Open Street Map: https://www.openstreetmap.org/
-.. _Vector Map Level 0: https://earth-info.nga.mil/publications/vmap0.html
+.. _Vector Map Level 0: http://web.archive.org/web/20201024202709/https://earth-info.nga.mil/publications/vmap0.html
 .. _OSGeo: https://www.osgeo.org/
 
 .. _osmgeoadmin-intro:

--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -273,7 +273,7 @@ Note:
         links pointing to other language versions using the `hreflang
         attribute`_. The default is ``False``.
 
-        .. _hreflang attribute: https://support.google.com/webmasters/answer/189077
+        .. _hreflang attribute: https://developers.google.com/search/docs/advanced/crawling/localized-versions
 
     .. attribute:: Sitemap.x_default
 
@@ -516,7 +516,7 @@ generate a Google News compatible sitemap:
     {% endspaceless %}
     </urlset>
 
-.. _`Google news sitemaps`: https://support.google.com/news/publisher/answer/74288?hl=en
+.. _`Google news sitemaps`: https://support.google.com/news/publisher-center/answer/9606710
 
 Pinging Google
 ==============
@@ -547,9 +547,9 @@ that: :func:`django.contrib.sitemaps.ping_google()`.
 .. admonition:: Register with Google first!
 
     The :func:`ping_google` command only works if you have registered your
-    site with `Google Webmaster Tools`_.
+    site with `Google Search Console`_.
 
-.. _`Google Webmaster Tools`: https://www.google.com/webmasters/tools/
+.. _`Google Search Console`: https://search.google.com/search-console/welcome
 
 One useful way to call :func:`ping_google` is from a model's ``save()``
 method::

--- a/docs/ref/contrib/sites.txt
+++ b/docs/ref/contrib/sites.txt
@@ -91,7 +91,7 @@ This accomplishes several things quite nicely:
               raise Http404("Article does not exist on this site")
           # ...
 
-.. _ljworld.com: http://www.ljworld.com/
+.. _ljworld.com: https://www2.ljworld.com/
 .. _lawrence.com: http://www.lawrence.com/
 
 Associating content with a single site

--- a/docs/ref/contrib/syndication.txt
+++ b/docs/ref/contrib/syndication.txt
@@ -16,7 +16,7 @@ Django also comes with a lower-level feed-generating API. Use this if
 you want to generate feeds outside of a Web context, or in some other
 lower-level way.
 
-.. _RSS: http://www.whatisrss.com/
+.. _RSS: https://developer.mozilla.org/en-US/docs/Glossary/RSS
 
 The high-level framework
 ========================

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -273,7 +273,7 @@ Another option is to wrap each ``QuerySet`` using server-side cursors in an
 for the duration of the transaction. This way, the server-side cursor will only
 live for the duration of the transaction.
 
-.. _PgBouncer: https://pgbouncer.github.io/
+.. _PgBouncer: https://www.pgbouncer.org/
 
 .. _manually-specified-autoincrement-pk:
 
@@ -387,7 +387,7 @@ MySQL has a couple drivers that implement the Python Database API described in
   library.
 
 .. _mysqlclient: https://pypi.org/project/mysqlclient/
-.. _MySQL Connector/Python: https://dev.mysql.com/downloads/connector/python
+.. _MySQL Connector/Python: https://dev.mysql.com/downloads/connector/python/
 
 These drivers are thread-safe and provide connection pooling.
 
@@ -828,7 +828,7 @@ a row is added, changed, or deleted within the loop, then that row may or may
 not appear, or may appear twice, in subsequent results fetched from the
 iterator. Your code must handle this.
 
-.. _`Isolation in SQLite`: https://sqlite.org/isolation.html
+.. _`Isolation in SQLite`: https://www.sqlite.org/isolation.html
 
 .. _sqlite-json1:
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1787,7 +1787,7 @@ Example usage::
 
     django-admin migrate --pythonpath='/home/djangoprojects/myproject'
 
-.. _import search path: https://www.diveinto.org/python3/your-first-python-program.html#importsearchpath
+.. _import search path: https://diveinto.org/python3/your-first-python-program.html#importsearchpath
 
 .. django-admin-option:: --settings SETTINGS
 

--- a/docs/ref/middleware.txt
+++ b/docs/ref/middleware.txt
@@ -453,7 +453,7 @@ in the :setting:`SECURE_REDIRECT_EXEMPT` setting.
     Django can't seem to tell when a request actually is already secure, you
     may need to set the :setting:`SECURE_PROXY_SSL_HEADER` setting.
 
-.. _nginx: https://nginx.org
+.. _nginx: https://nginx.org/
 
 Session middleware
 ------------------

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1095,9 +1095,9 @@ Without passing ``safe=False``, a :exc:`TypeError` will be raised.
 .. warning::
 
     Before the `5th edition of ECMAScript
-    <https://www.ecma-international.org/ecma-262/5.1/index.html#sec-11.1.4>`_
-    it was possible to poison the JavaScript ``Array`` constructor. For this
-    reason, Django does not allow passing non-dict objects to the
+    <https://262.ecma-international.org/5.1/#sec-11.1.4>`_ it was possible to
+    poison the JavaScript ``Array`` constructor. For this reason, Django does
+    not allow passing non-dict objects to the
     :class:`~django.http.JsonResponse` constructor by default.  However, most
     modern browsers implement ECMAScript 5 which removes this attack vector.
     Therefore it is possible to disable this security precaution.

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1324,8 +1324,9 @@ If ``value`` is ``"String with spaces"``, the output will be
 
 Formats a date according to the given format.
 
-Uses a similar format as PHP's ``date()`` function (https://php.net/date)
-with some differences.
+Uses a similar format to PHP's `date()
+<https://www.php.net/manual/en/function.date.php>`_ function with some
+differences.
 
 .. note::
     These format characters are not used in Django outside of templates. They
@@ -2106,8 +2107,8 @@ individual elements of the sequence.
 Returns a slice of the list.
 
 Uses the same syntax as Python's list slicing. See
-https://www.diveinto.org/python3/native-datatypes.html#slicinglists
-for an introduction.
+https://diveinto.org/python3/native-datatypes.html#slicinglists for an
+introduction.
 
 Example::
 

--- a/docs/releases/0.95.txt
+++ b/docs/releases/0.95.txt
@@ -114,7 +114,7 @@ by Django users and developers from around the world. Friendly people are
 usually available at any hour of the day -- to help, or just to chat.
 
 .. _Django website: https://www.djangoproject.com/
-.. _django-users: https://groups.google.com/group/django-users
+.. _django-users: https://groups.google.com/g/django-users
 
 Thanks for using Django!
 

--- a/docs/releases/0.96.txt
+++ b/docs/releases/0.96.txt
@@ -250,6 +250,4 @@ all their hard work:
 * Everyone who submitted a bug report, patch or ticket comment. We can't
   possibly thank everyone by name -- over 200 developers submitted patches
   that went into 0.96 -- but everyone who's contributed to Django is listed
-  in AUTHORS_.
-
-.. _AUTHORS: https://code.djangoproject.com/browser/django/trunk/AUTHORS
+  in :source:`AUTHORS`.

--- a/docs/releases/1.0-porting-guide.txt
+++ b/docs/releases/1.0-porting-guide.txt
@@ -79,8 +79,8 @@ see `the admin`_ below for more details.
     A contributor to djangosnippets__ has written a script that'll `scan your
     models.py and generate a corresponding admin.py`__.
 
-    __ https://www.djangosnippets.org/
-    __ https://www.djangosnippets.org/snippets/603/
+    __ https://djangosnippets.org/
+    __ https://djangosnippets.org/snippets/603/
 
 Example
 ~~~~~~~

--- a/docs/releases/1.0.txt
+++ b/docs/releases/1.0.txt
@@ -132,7 +132,7 @@ will be merged into the main Django documentation shortly. Huge thanks go to
 Justin Bronn, Jeremy Dunck, Brett Hoerner and Travis Pinney for their efforts in
 creating and completing this feature.
 
-See http://geodjango.org/ for details.
+See :doc:`GeoDjango </ref/contrib/gis/index>` for details.
 
 .. _Geographic Information Systems: https://en.wikipedia.org/wiki/Geographic_information_system
 

--- a/docs/releases/1.1.txt
+++ b/docs/releases/1.1.txt
@@ -347,8 +347,8 @@ For full details, see :ref:`the documentation on defining URL namespaces
 GeoDjango
 ---------
 
-In Django 1.1, GeoDjango_ (i.e. ``django.contrib.gis``) has several new
-features:
+In Django 1.1, :doc:`GeoDjango </ref/contrib/gis/index>` (i.e.
+``django.contrib.gis``) has several new features:
 
 * Support for SpatiaLite_ -- a spatial database for SQLite -- as a spatial
   backend.
@@ -363,7 +363,6 @@ features:
 
 For more details, see the GeoDjango documentation.
 
-.. _geodjango: http://geodjango.org/
 .. _spatialite: https://www.gaia-gis.it/gaia-sins/
 
 Other improvements

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -587,7 +587,7 @@ the timezone based on the system timezone, you can use `tzlocal
 
 This works similar to ``settings.TIME_ZONE = None`` except that it also sets
 ``os.environ['TZ']``. `Let us know
-<https://groups.google.com/d/topic/django-developers/OAV3FChfuPM/discussion>`__
+<https://groups.google.com/g/django-developers/c/OAV3FChfuPM/discussion>`__
 if there's a use case where you find you can't adapt your code to set a
 ``TIME_ZONE``.
 

--- a/docs/releases/1.2.3.txt
+++ b/docs/releases/1.2.3.txt
@@ -7,13 +7,11 @@ released two days after 1.2.2.
 
 This release corrects the following problems:
 
-* The patch_ applied for the security issue covered in Django 1.2.2 caused
-  issues with non-ASCII responses using CSRF tokens.
+* The :commit:`patch <7f84657b6b2243cc787bdb9f296710c8d13ad0bd>` applied for
+  the security issue covered in Django 1.2.2 caused issues with non-ASCII
+  responses using CSRF tokens.
 
 * The patch also caused issues with some forms, most notably the user-editing
   forms in the Django administrative interface.
 
 * The packaging manifest did not contain the full list of required files.
-
-.. _patch: https://code.djangoproject.com/changeset/13699
-

--- a/docs/releases/1.2.5.txt
+++ b/docs/releases/1.2.5.txt
@@ -115,9 +115,9 @@ ModelAdmin.lookup_allowed signature changed
 -------------------------------------------
 
 Django 1.2.4 introduced a method ``lookup_allowed`` on ``ModelAdmin``, to cope
-with a security issue (changeset `[15033]
-<https://code.djangoproject.com/changeset/15033>`_). Although this method was
-never documented, it seems some people have overridden ``lookup_allowed``,
-especially to cope with regressions introduced by that changeset. While the
-method is still undocumented and not marked as stable, it may be helpful to know
-that the signature of this function has changed.
+with a security issue (changeset :commit:`[15033]
+<85207a245bf09fdebe486b4c7bbcb65300f2a693>`). Although this method was never
+documented, it seems some people have overridden ``lookup_allowed``, especially
+to cope with regressions introduced by that changeset. While the method is
+still undocumented and not marked as stable, it may be helpful to know that the
+signature of this function has changed.

--- a/docs/releases/1.2.txt
+++ b/docs/releases/1.2.txt
@@ -370,8 +370,7 @@ The GDAL interface now allows the user to set a
 when iterating over a :class:`~django.contrib.gis.gdal.Layer`.
 
 Finally, :doc:`GeoDjango's documentation </ref/contrib/gis/index>` is now
-included with Django's and is no longer
-hosted separately at `geodjango.org <http://geodjango.org/>`_.
+included with Django's and is no longer hosted separately at ``geodjango.org``.
 
 .. _1.2-js-assisted-inlines:
 

--- a/docs/releases/1.2.txt
+++ b/docs/releases/1.2.txt
@@ -1056,7 +1056,7 @@ this into account.
 For more information, see the full :doc:`syndication framework
 documentation </ref/contrib/syndication>`.
 
-.. _RSS best practices: http://www.rssboard.org/rss-profile
+.. _RSS best practices: https://www.rssboard.org/rss-profile
 
 Technical message IDs
 ---------------------

--- a/docs/releases/1.3.txt
+++ b/docs/releases/1.3.txt
@@ -439,14 +439,13 @@ prohibited words an empty list.
 
 If you want to restore the old behavior, simply put a
 ``PROFANITIES_LIST`` setting in your settings file that includes the
-words that you want to prohibit (see the `commit that implemented this
-change`_ if you want to see the list of words that was historically
-prohibited). However, if avoiding profanities is important to you, you
-would be well advised to seek out a better, less naive approach to the
-problem.
+words that you want to prohibit (see the :commit:`commit that implemented this
+change <edd767d2612d891a906268cf590571f541dd164f>` if you want to see the list
+of words that was historically prohibited). However, if avoiding profanities is
+important to you, you would be well advised to seek out a better, less naive
+approach to the problem.
 
 .. _Scunthorpe problem: https://en.wikipedia.org/wiki/Scunthorpe_problem
-.. _commit that implemented this change: https://code.djangoproject.com/changeset/13996
 
 Localflavor changes
 -------------------
@@ -763,7 +762,8 @@ Changes to the login methods of the admin
 In previous version the admin app defined login methods in multiple locations
 and ignored the almost identical implementation in the already used auth app.
 A side effect of this duplication was the missing adoption of the changes made
-in r12634_ to support a broader set of characters for usernames.
+in :commit:`r12634 <c8015052d935a99a5c8f96434b2d0cd16d8a4e14>` to support a
+broader set of characters for usernames.
 
 This release refactors the admin's login mechanism to use a subclass of the
 :class:`~django.contrib.auth.forms.AuthenticationForm` instead of a manual
@@ -771,8 +771,6 @@ form validation. The previously undocumented method
 ``'django.contrib.admin.sites.AdminSite.display_login_form'`` has been removed
 in favor of a new :attr:`~django.contrib.admin.AdminSite.login_form`
 attribute.
-
-.. _r12634: https://code.djangoproject.com/changeset/12634
 
 ``reset`` and ``sqlreset`` management commands
 ----------------------------------------------

--- a/docs/releases/1.3.txt
+++ b/docs/releases/1.3.txt
@@ -72,7 +72,7 @@ extended.
 See :doc:`the documentation on class-based generic views</topics/class-based-views/index>`
 for more details. There is also a document to help you `convert
 your function-based generic views to class-based
-views <https://docs.djangoproject.com/en/1.4/topics/generic-views-migration/>`_.
+views <https://raw.githubusercontent.com/django/django/ea9dc9f4b03ae034c1dc080730422dda7a9c2e47/docs/topics/generic-views-migration.txt>`_.
 
 Logging
 -------

--- a/docs/releases/1.4.txt
+++ b/docs/releases/1.4.txt
@@ -593,7 +593,7 @@ Django 1.4 also includes several smaller improvements worth noting:
 * The :djadmin:`makemessages` command uses a new and more accurate lexer,
   `JsLex`_, for extracting translatable strings from JavaScript files.
 
-.. _JsLex: https://bitbucket.org/ned/jslex
+.. _JsLex: https://pypi.org/project/jslex/
 
 * The :ttag:`trans` template tag now takes an optional ``as`` argument to
   be able to retrieve a translation string without displaying it but setting

--- a/docs/releases/1.4.txt
+++ b/docs/releases/1.4.txt
@@ -115,7 +115,7 @@ comprehensively. See the
 :class:`documentation<django.test.LiveServerTestCase>` for more details and
 concrete examples.
 
-.. _Selenium: https://selenium.dev/
+.. _Selenium: https://www.selenium.dev/
 
 Updated default project layout and ``manage.py``
 ------------------------------------------------

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -1043,7 +1043,7 @@ occasions, such as:
 This makes the cache effectively work on a per-session basis regardless of the
 ``CACHE_MIDDLEWARE_ANONYMOUS_ONLY`` setting.
 
-__ https://www.google.com/analytics/
+__ https://marketingplatform.google.com/about/analytics/
 
 ``SEND_BROKEN_LINK_EMAILS`` setting
 -----------------------------------

--- a/docs/releases/1.8.8.txt
+++ b/docs/releases/1.8.8.txt
@@ -13,7 +13,7 @@ intentionally after that, but we won't test subsequent releases against Python
 much value in providing security updates for a version of Python that could be
 insecure. To read more about the decision and to let us know if this will be
 problematic for you, please read the `django-developers thread
-<https://groups.google.com/d/topic/django-developers/eMu5UQpUdWs/discussion>`_.
+<https://groups.google.com/g/django-developers/c/eMu5UQpUdWs/discussion>`_.
 
 Bugfixes
 ========

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -934,7 +934,7 @@ relevant documentation pages have been updated or removed.
 
 The new package is available `on GitHub`_ and on PyPI.
 
-.. _on GitHub: https://github.com/django/django-formtools/
+.. _on GitHub: https://github.com/jazzband/django-formtools/
 
 Database connection reloading between tests
 -------------------------------------------

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -99,7 +99,7 @@ Minor features
 
 * The new :attr:`.ModelAdmin.autocomplete_fields` attribute and
   :meth:`.ModelAdmin.get_autocomplete_fields` method allow using a
-  `Select2 <https://select2.org>`_ search widget for ``ForeignKey`` and
+  `Select2 <https://select2.org/>`_ search widget for ``ForeignKey`` and
   ``ManyToManyField``.
 
 :mod:`django.contrib.auth`

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -501,7 +501,8 @@ Django 3.0, we're removing these APIs at this time.
   ``six.python_2_unicode_compatible()``.
 
 * ``django.utils.functional.curry()`` - Use :func:`functools.partial` or
-  :class:`functools.partialmethod`. See :commit:`5b1c389603a353625ae1603`.
+  :class:`functools.partialmethod`. See
+  :commit:`5b1c389603a353625ae1603ba345147356336afb`.
 
 * ``django.utils.safestring.SafeBytes`` - Unused since Django 2.0.
 

--- a/docs/releases/security.txt
+++ b/docs/releases/security.txt
@@ -999,8 +999,8 @@ September 9, 2011 - :cve:`2011-4139`
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 1.2 :commit:`(patch) <c613af4d64>`
-* Django 1.3 :commit:`(patch) <2f7fadc38e>`
+* Django 1.2 :commit:`(patch) <c613af4d6485586c79d692b70a9acac429f3ca9d>`
+* Django 1.3 :commit:`(patch) <2f7fadc38efa58ac0a8f93f936b82332a199f396>`
 
 September 9, 2011 - :cve:`2011-4138`
 ------------------------------------
@@ -1012,8 +1012,8 @@ Information leakage/arbitrary request issuance via ``URLField.verify_exists``.
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 1.2: :commit:`(patch) <7268f8af86>`
-* Django 1.3: :commit:`(patch) <1a76dbefdf>`
+* Django 1.2: :commit:`(patch) <7268f8af86186518821d775c530d5558fd726930>`
+* Django 1.3: :commit:`(patch) <1a76dbefdfc60e2d5954c0ba614c3d054ba9c3f0>`
 
 September 9, 2011 - :cve:`2011-4137`
 ------------------------------------
@@ -1024,8 +1024,8 @@ Denial-of-service via ``URLField.verify_exists``. `Full description
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 1.2 :commit:`(patch) <7268f8af86>`
-* Django 1.3 :commit:`(patch) <1a76dbefdf>`
+* Django 1.2 :commit:`(patch) <7268f8af86186518821d775c530d5558fd726930>`
+* Django 1.3 :commit:`(patch) <1a76dbefdfc60e2d5954c0ba614c3d054ba9c3f0>`
 
 September 9, 2011 - :cve:`2011-4136`
 ------------------------------------
@@ -1036,8 +1036,8 @@ Session manipulation when using memory-cache-backed session. `Full description
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 1.2 :commit:`(patch) <ac7c3a110f>`
-* Django 1.3 :commit:`(patch) <fbe2eead2f>`
+* Django 1.2 :commit:`(patch) <ac7c3a110f906e4dfed3a17451bf7fd9fcb81296>`
+* Django 1.3 :commit:`(patch) <fbe2eead2fa9d808658ca582241bcacb02618840>`
 
 February 8, 2011 - :cve:`2011-0698`
 -----------------------------------
@@ -1048,8 +1048,8 @@ description <https://www.djangoproject.com/weblog/2011/feb/08/security/>`__
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 1.1 :commit:`(patch) <570a32a047>`
-* Django 1.2 :commit:`(patch) <194566480b>`
+* Django 1.1 :commit:`(patch) <570a32a047ea56265646217264b0d3dab1a14dbd>`
+* Django 1.2 :commit:`(patch) <194566480b15cf4e294d3f03ff587019b74044b2>`
 
 February 8, 2011 - :cve:`2011-0697`
 -----------------------------------
@@ -1060,8 +1060,8 @@ XSS via unsanitized names of uploaded files. `Full description
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 1.1 :commit:`(patch) <1966786d2d>`
-* Django 1.2 :commit:`(patch) <1f814a9547>`
+* Django 1.1 :commit:`(patch) <1966786d2dde73e17f39cf340eb33fcb5d73904e>`
+* Django 1.2 :commit:`(patch) <1f814a9547842dcfabdae09573055984af9d3fab>`
 
 February 8, 2011 - :cve:`2011-0696`
 -----------------------------------
@@ -1072,8 +1072,8 @@ CSRF via forged HTTP headers. `Full description
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 1.1 :commit:`(patch) <408c5c873c>`
-* Django 1.2 :commit:`(patch) <818e70344e>`
+* Django 1.1 :commit:`(patch) <408c5c873ce1437c7eee9544ff279ecbad7e150a>`
+* Django 1.2 :commit:`(patch) <818e70344e7193f6ebc73c82ed574e6ce3c91afc>`
 
 December 22, 2010 - :cve:`2010-4535`
 ------------------------------------
@@ -1084,8 +1084,8 @@ Denial-of-service in password-reset mechanism. `Full description
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 1.1 :commit:`(patch) <7f8dd9cbac>`
-* Django 1.2 :commit:`(patch) <d5d8942a16>`
+* Django 1.1 :commit:`(patch) <7f8dd9cbac074389af8d8fd235bf2cb657227b9a>`
+* Django 1.2 :commit:`(patch) <d5d8942a160685c403d381a279e72e09de5489a9>`
 
 December 22, 2010 - :cve:`2010-4534`
 ------------------------------------
@@ -1096,8 +1096,8 @@ Information leakage in administrative interface. `Full description
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 1.1 :commit:`(patch) <17084839fd>`
-* Django 1.2 :commit:`(patch) <85207a245b>`
+* Django 1.1 :commit:`(patch) <17084839fd7e267da5729f2a27753322b9d415a0>`
+* Django 1.2 :commit:`(patch) <85207a245bf09fdebe486b4c7bbcb65300f2a693>`
 
 September 8, 2010 - :cve:`2010-3082`
 ------------------------------------
@@ -1108,7 +1108,7 @@ XSS via trusting unsafe cookie value. `Full description
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 1.2 :commit:`(patch) <7f84657b6b>`
+* Django 1.2 :commit:`(patch) <7f84657b6b2243cc787bdb9f296710c8d13ad0bd>`
 
 October 9, 2009 - :cve:`2009-3965`
 ----------------------------------
@@ -1119,8 +1119,8 @@ description <https://www.djangoproject.com/weblog/2009/oct/09/security/>`__
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 1.0 :commit:`(patch) <594a28a904>`
-* Django 1.1 :commit:`(patch) <e3e992e18b>`
+* Django 1.0 :commit:`(patch) <594a28a9044120bed58671dde8a805c9e0f6c79a>`
+* Django 1.1 :commit:`(patch) <e3e992e18b368fcd56aabafc1b5bf80a6e11b495>`
 
 July 28, 2009 - :cve:`2009-2659`
 --------------------------------
@@ -1131,8 +1131,8 @@ Directory-traversal in development server media handler. `Full description
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 0.96 :commit:`(patch) <da85d76fd6>`
-* Django 1.0 :commit:`(patch) <df7f917b7f>`
+* Django 0.96 :commit:`(patch) <da85d76fd6ca846f3b0ff414e042ddb5e62e2e69>`
+* Django 1.0 :commit:`(patch) <df7f917b7f51ba969faa49d000ffc79572c5dcb4>`
 
 September 2, 2008 - :cve:`2008-3909`
 ------------------------------------
@@ -1157,8 +1157,8 @@ Versions affected
 ~~~~~~~~~~~~~~~~~
 
 * Django 0.91 :commit:`(patch) <6e657e2c404a96e744748209e896d8a69c15fdf2>`
-* Django 0.95 :commit:`(patch) <50ce7fb57d>`
-* Django 0.96 :commit:`(patch) <7791e5c050>`
+* Django 0.95 :commit:`(patch) <50ce7fb57d79e8940ccf6e2781f2f01df029b5c5>`
+* Django 0.96 :commit:`(patch) <7791e5c050cebf86d868c5dab7092185b125fdc9>`
 
 October 26, 2007 - :cve:`2007-5712`
 -----------------------------------
@@ -1189,7 +1189,7 @@ Apparent "caching" of authenticated user. `Full description
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 0.95 :commit:`(patch) <e89f0a6558>`
+* Django 0.95 :commit:`(patch) <e89f0a65581f82a5740bfe989136cea75d09cd67>`
 
 August 16, 2006 - :cve:`2007-0404`
 ----------------------------------
@@ -1202,4 +1202,5 @@ Versions affected
 
 * Django 0.90 :commit:`(patch) <6eefa521be3c658dc0b38f8d62d52e9801e198ab>`
 * Django 0.91 :commit:`(patch) <d31e39173c29537e6a1613278c93634c18a3206e>`
-* Django 0.95 :commit:`(patch) <a132d411c6>` (released January 21 2007)
+* Django 0.95 :commit:`(patch) <a132d411c6986418ee6c0edc331080aa792fee6e>`
+  (released January 21 2007)

--- a/docs/releases/security.txt
+++ b/docs/releases/security.txt
@@ -1156,7 +1156,7 @@ XSS via admin login redirect. `Full description
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 0.91 :commit:`(patch) <50ce7fb57d>`
+* Django 0.91 :commit:`(patch) <6e657e2c404a96e744748209e896d8a69c15fdf2>`
 * Django 0.95 :commit:`(patch) <50ce7fb57d>`
 * Django 0.96 :commit:`(patch) <7791e5c050>`
 
@@ -1200,6 +1200,6 @@ Filename validation issue in translation framework. `Full description
 Versions affected
 ~~~~~~~~~~~~~~~~~
 
-* Django 0.90 :commit:`(patch) <518d406e53>`
-* Django 0.91 :commit:`(patch) <518d406e53>`
+* Django 0.90 :commit:`(patch) <6eefa521be3c658dc0b38f8d62d52e9801e198ab>`
+* Django 0.91 :commit:`(patch) <d31e39173c29537e6a1613278c93634c18a3206e>`
 * Django 0.95 :commit:`(patch) <a132d411c6>` (released January 21 2007)

--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -340,12 +340,12 @@ Include any other hashers that your site uses in this list.
 
 .. _sha1: https://en.wikipedia.org/wiki/SHA1
 .. _pbkdf2: https://en.wikipedia.org/wiki/PBKDF2
-.. _nist: https://dx.doi.org/10.6028/NIST.SP.800-132
+.. _nist: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-132.pdf
 .. _bcrypt: https://en.wikipedia.org/wiki/Bcrypt
 .. _`bcrypt library`: https://pypi.org/project/bcrypt/
-.. _`argon2-cffi library`: https://pypi.org/project/argon2_cffi/
+.. _`argon2-cffi library`: https://pypi.org/project/argon2-cffi/
 .. _argon2: https://en.wikipedia.org/wiki/Argon2
-.. _`Password Hashing Competition`: https://password-hashing.net
+.. _`Password Hashing Competition`: https://www.password-hashing.net/
 
 .. _auth-included-hashers:
 

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -35,9 +35,9 @@ specific views, you can cache only the pieces that are difficult to produce,
 or you can cache your entire site.
 
 Django also works well with "downstream" caches, such as `Squid
-<http://www.squid-cache.org>`_ and browser-based caches. These are the types of
-caches that you don't directly control but to which you can provide hints (via
-HTTP headers) about which parts of your site should be cached, and how.
+<http://www.squid-cache.org/>`_ and browser-based caches. These are the types
+of caches that you don't directly control but to which you can provide hints
+(via HTTP headers) about which parts of your site should be cached, and how.
 
 .. seealso::
     The :ref:`Cache Framework design philosophy <cache-design-philosophy>`

--- a/docs/topics/db/search.txt
+++ b/docs/topics/db/search.txt
@@ -98,7 +98,7 @@ can then look it up in the database. There are a variety of third-party
 libraries which are designed to help with this process.
 
 .. _Elastic: https://www.elastic.co/
-.. _Solr: https://lucene.apache.org/solr/
+.. _Solr: https://solr.apache.org/
 
 PostgreSQL support
 ~~~~~~~~~~~~~~~~~~

--- a/docs/topics/db/transactions.txt
+++ b/docs/topics/db/transactions.txt
@@ -632,7 +632,7 @@ function in autocommit mode: statements will be executed and committed as soon
 as they're called. If your MySQL setup *does* support transactions, Django
 will handle transactions as explained in this document.
 
-.. _information on MySQL transactions: https://dev.mysql.com/doc/refman/en/sql-syntax-transactions.html
+.. _information on MySQL transactions: https://dev.mysql.com/doc/refman/en/sql-transactional-statements.html
 
 Handling exceptions within PostgreSQL transactions
 --------------------------------------------------

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -209,7 +209,7 @@ from the request's POST data, sends that to admin@example.com and redirects to
             # to get proper validation errors.
             return HttpResponse('Make sure all fields are entered and valid.')
 
-.. _Header injection: http://www.nyphp.org/phundamentals/8_Preventing-Email-Header-Injection
+.. _Header injection: http://nyphp.org/phundamentals/8_Preventing-Email-Header-Injection
 
 .. _emailmessage-and-smtpconnection:
 

--- a/docs/topics/external-packages.txt
+++ b/docs/topics/external-packages.txt
@@ -33,6 +33,6 @@ Formtools
 
 ``django-formtools`` is a collection of assorted utilities to work with forms.
 
-* `GitHub <https://github.com/django/django-formtools>`__
+* `GitHub <https://github.com/jazzband/django-formtools/>`__
 * `Documentation <https://django-formtools.readthedocs.io/>`__
 * `PyPI <https://pypi.org/project/django-formtools/>`__

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -422,7 +422,7 @@ form is rendered, the problem may not even be visible on the web page.
 The alternative approach would be to include all fields automatically, or
 remove only some. This fundamental approach is known to be much less secure
 and has led to serious exploits on major websites (e.g. `GitHub
-<https://github.com/blog/1068-public-key-security-vulnerability-and-mitigation>`_).
+<https://github.blog/2012-03-04-public-key-security-vulnerability-and-mitigation/>`_).
 
 There are, however, two shortcuts available for cases where you can guarantee
 these security concerns do not apply to you:

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1555,9 +1555,9 @@ multiple times::
     in general, and doesn't depend on ``gettext``. For more information, read
     its documentation about `working with message catalogs`_.
 
-    .. _Message extracting: http://babel.pocoo.org/en/latest/messages.html#message-extraction
-    .. _Babel: http://babel.pocoo.org/
-    .. _working with message catalogs: http://babel.pocoo.org/en/latest/messages.html
+    .. _Message extracting: https://babel.pocoo.org/en/latest/messages.html#message-extraction
+    .. _Babel: https://babel.pocoo.org/en/latest/
+    .. _working with message catalogs: https://babel.pocoo.org/en/latest/messages.html
 
 .. admonition:: No gettext?
 

--- a/docs/topics/performance.txt
+++ b/docs/topics/performance.txt
@@ -76,7 +76,7 @@ insight into your site's overall performance, including aspects that can't be
 adequately measured from within Django environment. Examples include:
 
 * `Yahoo's Yslow <http://yslow.org/>`_
-* `Google PageSpeed <https://developers.google.com/speed/pagespeed/>`_
+* `Google PageSpeed <https://developers.google.com/speed/>`_
 
 There are also several paid-for services that perform a similar analysis,
 including some that are Django-aware and can integrate with your codebase to
@@ -378,8 +378,8 @@ adequate. However, if the bottlenecks in your Django project seem to lie in the
 template system and you have exhausted other opportunities to remedy this, a
 third-party alternative may be the answer.
 
-`Jinja2 <http://jinja.pocoo.org/docs/>`_ can offer performance improvements,
-particularly when it comes to speed.
+Jinja2_ can offer performance improvements, particularly when it comes to
+speed.
 
 Alternative template systems vary in the extent to which they share Django's
 templating language.
@@ -410,15 +410,15 @@ performance gains for your application to outweigh the potential risks.
 
 With these caveats in mind, you should be aware of:
 
-`PyPy <https://pypy.org/>`_
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`PyPy <https://www.pypy.org/>`_
+~~~~~~~~~~~~~~~~~~~~~~~~~~~----
 
-`PyPy <https://pypy.org/>`_ is an implementation of Python in Python itself
+`PyPy <https://www.pypy.org/>`_ is an implementation of Python in Python itself
 (the 'standard' Python implementation is in C). PyPy can offer substantial
 performance gains, typically for heavyweight applications.
 
 A key aim of the PyPy project is `compatibility
-<https://pypy.org/compat.html>`_ with existing Python APIs and libraries.
+<https://www.pypy.org/compat.html>`_ with existing Python APIs and libraries.
 Django is compatible, but you will need to check the compatibility of other
 libraries you rely on.
 
@@ -428,3 +428,5 @@ C implementations of Python libraries
 Some Python libraries are also implemented in C, and can be much faster. They
 aim to offer the same APIs. Note that compatibility issues and behavior
 differences are not unknown (and not always immediately evident).
+
+.. _Jinja2: https://jinja.palletsprojects.com/

--- a/docs/topics/serialization.txt
+++ b/docs/topics/serialization.txt
@@ -167,7 +167,7 @@ Identifier  Information
 ==========  ==============================================================
 
 .. _json: https://json.org/
-.. _jsonl: http://jsonlines.org/
+.. _jsonl: https://jsonlines.org/
 .. _PyYAML: https://pyyaml.org/
 
 XML
@@ -303,7 +303,7 @@ The JSON serializer uses ``DjangoJSONEncoder`` for encoding. A subclass of
 :class:`~decimal.Decimal`, ``Promise`` (``django.utils.functional.lazy()`` objects), :class:`~uuid.UUID`
    A string representation of the object.
 
-.. _ecma-262: https://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15
+.. _ecma-262: https://262.ecma-international.org/5.1/#sec-15.9.1.15
 
 .. _serialization-formats-jsonl:
 

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -46,7 +46,7 @@ The value of :envvar:`DJANGO_SETTINGS_MODULE` should be in Python path syntax,
 e.g. ``mysite.settings``. Note that the settings module should be on the
 Python `import search path`_.
 
-.. _import search path: https://www.diveinto.org/python3/your-first-python-program.html#importsearchpath
+.. _import search path: https://diveinto.org/python3/your-first-python-program.html#importsearchpath
 
 The ``django-admin`` utility
 ----------------------------

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -988,7 +988,7 @@ case you do not have Firefox installed or wish to use another browser. The
 example above is just a tiny fraction of what the Selenium client can do; check
 out the `full reference`_ for more details.
 
-.. _Selenium: http://seleniumhq.org/
+.. _Selenium: https://www.selenium.dev/
 .. _selenium package: https://pypi.org/project/selenium/
 .. _full reference: https://selenium-python.readthedocs.io/api.html
 .. _Firefox: https://www.mozilla.com/firefox/


### PR DESCRIPTION
ticket-32720

I've used the [linkcheck builder](https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder) in Sphinx to identify a number of broken links that I've fixed, and updated others to use the canonical link so that unnecessary redirects are avoided.

Ideally, the output generated in `docs/_build/linkcheck/output.{json,txt}` would only contain "working" links, but there are some links that are better left redirecting, e.g. for documentation versions such as `https://docs.djangoproject.com/en/stable/` → `https://docs.djangoproject.com/en/3.2/`. There is an open issue for adding a configuration setting to allow certain redirects to be treated as "normal". See https://github.com/sphinx-doc/sphinx/issues/6525#issuecomment-828730361.

Questions:

- [x] Should we add something to `docs/internals/contributing/writing-documentation.txt` about using the linkcheck builder?
- [x] Should we add something to `docs/internals/howto-release-django.txt` about checking before preparing a release?
- [x] ~~If sphinx-doc/sphinx#6525 is resolved, would this check be useful to add to a scheduled action in GitHub?~~
  - *(Opened ticket-32723 to address this at a later date.)*