### PR TITLE
Refs #32682 -- Renamed lookup_needs_distinct() to lookup_spawns_duplicates().

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -17,7 +17,7 @@ from django.contrib.admin.exceptions import DisallowedModelAdminToField
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 from django.contrib.admin.utils import (
     NestedObjects, construct_change_message, flatten_fieldsets,
-    get_deleted_objects, lookup_needs_distinct, model_format_dict,
+    get_deleted_objects, lookup_spawns_duplicates, model_format_dict,
     model_ngettext, quote, unquote,
 )
 from django.contrib.admin.widgets import (
@@ -1031,7 +1031,7 @@ class ModelAdmin(BaseModelAdmin):
                               for orm_lookup in orm_lookups]
                 queryset = queryset.filter(reduce(operator.or_, or_queries))
             may_have_duplicates |= any(
-                lookup_needs_distinct(self.opts, search_spec)
+                lookup_spawns_duplicates(self.opts, search_spec)
                 for search_spec in orm_lookups
             )
         return queryset, may_have_duplicates

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -25,9 +25,9 @@ class FieldIsAForeignKeyColumnName(Exception):
     pass
 
 
-def lookup_needs_distinct(opts, lookup_path):
+def lookup_spawns_duplicates(opts, lookup_path):
     """
-    Return True if 'distinct()' should be used to query the given lookup path.
+    Return True if the given lookup path spawns duplicates.
     """
     lookup_fields = lookup_path.split(LOOKUP_SEP)
     # Go through the fields (following all relations) and look for an m2m.
@@ -45,7 +45,8 @@ def lookup_needs_distinct(opts, lookup_path):
                 path_info = field.get_path_info()
                 opts = path_info[-1].to_opts
                 if any(path.m2m for path in path_info):
-                    # This field is a m2m relation so distinct must be called.
+                    # This field is a m2m relation so duplicates must be
+                    # handled.
                     return True
     return False
 

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -396,6 +396,9 @@ Miscellaneous
   As a side-effect ``makemigrations`` might generate no-op ``AlterField``
   operations for ``ForeignKey`` fields in some cases.
 
+* The undocumented ``django.contrib.admin.utils.lookup_needs_distinct()``
+  function is renamed to ``lookup_spawns_duplicates()``.
+
 .. _deprecated-features-4.0:
 
 Features deprecated in 4.0


### PR DESCRIPTION
Follow up to 187118203197801c6cb72dc8b06b714b23b6dd3d.

See https://github.com/django/django/pull/14313#pullrequestreview-645265035, a deprecation period is not necessary.