### PR TITLE
Fixed #32698 -- Moved HttpRequest.get_raw_uri() to ExceptionReporter._get_raw_insecure_uri().

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -180,17 +180,6 @@ class HttpRequest:
                 raise
         return value
 
-    def get_raw_uri(self):
-        """
-        Return an absolute URI from variables available in this request. Skip
-        allowed hosts protection, so may return insecure URI.
-        """
-        return '{scheme}://{host}{path}'.format(
-            scheme=self.scheme,
-            host=self._get_raw_host(),
-            path=self.get_full_path(),
-        )
-
     def build_absolute_uri(self, location=None):
         """
         Build an absolute URI from the location and the variables available in

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -274,6 +274,17 @@ class ExceptionReporter:
         self.template_does_not_exist = False
         self.postmortem = None
 
+    def _get_raw_insecure_uri(self):
+        """
+        Return an absolute URI from variables available in this request. Skip
+        allowed hosts protection, so may return insecure URI.
+        """
+        return '{scheme}://{host}{path}'.format(
+            scheme=self.request.scheme,
+            host=self.request._get_raw_host(),
+            path=self.request.get_full_path(),
+        )
+
     def get_traceback_data(self):
         """Return a dictionary containing traceback information."""
         if self.exc_type and issubclass(self.exc_type, TemplateDoesNotExist):
@@ -337,6 +348,8 @@ class ExceptionReporter:
             c['request_GET_items'] = self.request.GET.items()
             c['request_FILES_items'] = self.request.FILES.items()
             c['request_COOKIES_items'] = self.request.COOKIES.items()
+            c['request_insecure_uri'] = self._get_raw_insecure_uri()
+
         # Check whether exception info is available
         if self.exc_type:
             c['exception_type'] = self.exc_type.__name__

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -108,7 +108,7 @@
     </tr>
     <tr>
       <th>Request URL:</th>
-      <td>{{ request.get_raw_uri }}</td>
+      <td>{{ request_insecure_uri }}</td>
     </tr>
 {% endif %}
     <tr>
@@ -289,7 +289,7 @@ Environment:
 
 {% if request %}
 Request Method: {{ request.META.REQUEST_METHOD }}
-Request URL: {{ request.get_raw_uri }}
+Request URL: {{ request_insecure_uri }}
 {% endif %}
 Django Version: {{ django_version_info }}
 Python Version: {{ sys_version_info }}

--- a/django/views/templates/technical_500.txt
+++ b/django/views/templates/technical_500.txt
@@ -2,7 +2,7 @@
 {% firstof exception_value 'No exception message supplied' %}
 {% if request %}
 Request Method: {{ request.META.REQUEST_METHOD }}
-Request URL: {{ request.get_raw_uri }}{% endif %}
+Request URL: {{ request_insecure_uri }}{% endif %}
 Django Version: {{ django_version_info }}
 Python Executable: {{ sys_executable }}
 Python Version: {{ sys_version_info }}

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -399,6 +399,9 @@ Miscellaneous
 * The undocumented ``django.contrib.admin.utils.lookup_needs_distinct()``
   function is renamed to ``lookup_spawns_duplicates()``.
 
+* The undocumented ``HttpRequest.get_raw_uri()`` method is removed. The
+  :meth:`.HttpRequest.build_absolute_uri` method may be a suitable alternative.
+
 .. _deprecated-features-4.0:
 
 Features deprecated in 4.0

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -558,18 +558,6 @@ class RequestsTests(SimpleTestCase):
         with self.assertRaises(UnreadablePostError):
             request.FILES
 
-    @override_settings(ALLOWED_HOSTS=['example.com'])
-    def test_get_raw_uri(self):
-        factory = RequestFactory(HTTP_HOST='evil.com')
-        request = factory.get('////absolute-uri')
-        self.assertEqual(request.get_raw_uri(), 'http://evil.com//absolute-uri')
-
-        request = factory.get('/?foo=bar')
-        self.assertEqual(request.get_raw_uri(), 'http://evil.com/?foo=bar')
-
-        request = factory.get('/path/with:colons')
-        self.assertEqual(request.get_raw_uri(), 'http://evil.com/path/with:colons')
-
 
 class HostValidationTests(SimpleTestCase):
     poisoned_hosts = [

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -942,6 +942,20 @@ class ExceptionReporterTests(SimpleTestCase):
             reporter.get_traceback_text()
             m.assert_called_once_with(encoding='utf-8')
 
+    @override_settings(ALLOWED_HOSTS=['example.com'])
+    def test_get_raw_insecure_uri(self):
+        factory = RequestFactory(HTTP_HOST='evil.com')
+        tests = [
+            ('////absolute-uri', 'http://evil.com//absolute-uri'),
+            ('/?foo=bar', 'http://evil.com/?foo=bar'),
+            ('/path/with:colons', 'http://evil.com/path/with:colons'),
+        ]
+        for url, expected in tests:
+            with self.subTest(url=url):
+                request = factory.get(url)
+                reporter = ExceptionReporter(request, None, None, None)
+                self.assertEqual(reporter._get_raw_insecure_uri(), expected)
+
 
 class PlainTextReportTests(SimpleTestCase):
     rf = RequestFactory()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32698