### PR TITLE
Added spelling option to make.bat.

### DIFF
--- a/docs/make.bat
+++ b/docs/make.bat
@@ -34,6 +34,7 @@ if "%1" == "help" (
 	echo.  changes    to make an overview over all changed/added/deprecated items
 	echo.  linkcheck  to check all external links for integrity
 	echo.  doctest    to run all doctests embedded in the documentation if enabled
+	echo.  spelling   to check for typos in documentation
 	goto end
 )
 
@@ -183,6 +184,15 @@ if "%1" == "doctest" (
 	echo.
 	echo.Testing of doctests in the sources finished, look at the ^
 results in %BUILDDIR%/doctest/output.txt.
+	goto end
+)
+
+if "%1" == "spelling" (
+	%SPHINXBUILD% -b spelling %ALLSPHINXOPTS% %BUILDDIR%/spelling
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Check finished. Wrong words can be found in %BUILDDIR%/^
+spelling/output.txt.
 	goto end
 )
 


### PR DESCRIPTION
Spelling is an existing option in Makefile but was missing in make.bat.

There are other capabilities in Makefile that are not available in make.bat, specifically an htmlview option plus certain parameters that can be set from the command line. I started to try to fix these but limited batch file capabilities (and my lack of facility with them) made me decide to leave this for now.