### PR TITLE
Fixed #32693 -- Quoted and lowercased generated column aliases.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -554,7 +554,10 @@ class SQLCompiler:
                     if alias:
                         s_sql = '%s AS %s' % (s_sql, self.connection.ops.quote_name(alias))
                     elif with_col_aliases:
-                        s_sql = '%s AS %s' % (s_sql, 'Col%d' % col_idx)
+                        s_sql = '%s AS %s' % (
+                            s_sql,
+                            self.connection.ops.quote_name('col%d' % col_idx),
+                        )
                         col_idx += 1
                     params.extend(s_params)
                     out_cols.append(s_sql)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32693
Thanks for the @charettes [suggestions](https://code.djangoproject.com/ticket/32693#comment:1).
@charettes Do you know how to test this patch?