### PR TITLE
Fixed #32699 -- Fixed comparing to TruncTime() with 0 microseconds on MySQL.

### DIFF
--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -262,7 +262,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         if timezone.is_aware(value):
             raise ValueError("MySQL backend does not support timezone-aware times.")
 
-        return str(value)
+        return value.isoformat(timespec='microseconds')
 
     def max_name_length(self):
         return 64

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -87,6 +87,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'Raises ORA-00600: internal error code.': {
             'model_fields.test_jsonfield.TestQuerying.test_usage_in_subquery',
         },
+        "Comparing to TruncTime() doesn't work on Oracle (#32722).": {
+            'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_trunc_time_no_microseconds',
+            'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_trunc_time_no_microseconds',
+        },
     }
     django_test_expected_failures = {
         # A bug in Django/cx_Oracle with respect to string handling (#23843).

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -923,6 +923,22 @@ class DateFunctionTests(TestCase):
         self.create_model(None, None)
         self.assertIsNone(DTModel.objects.annotate(truncated=TruncTime('start_datetime')).first().truncated)
 
+    def test_trunc_time_no_microseconds(self):
+        start_datetime = datetime(2015, 6, 15, 14, 30, 26)
+        if settings.USE_TZ:
+            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
+        self.create_model(start_datetime, None)
+        self.assertIs(
+            DTModel.objects.filter(start_datetime__time=start_datetime.time()).exists(),
+            True,
+        )
+        self.assertIs(
+            DTModel.objects.annotate(
+                extracted=TruncTime('start_datetime'),
+            ).filter(extracted=start_datetime.time()).exists(),
+            True,
+        )
+
     def test_trunc_day_func(self):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), 'day')


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/32699#ticket