### PR TITLE
Fixed 26721 -- Dumpdata to use ASCII-only json dump to bypass encoding errors.

### DIFF
--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -234,7 +234,7 @@ class Command(BaseCommand):
                     use_natural_foreign_keys=use_natural_foreign_keys,
                     use_natural_primary_keys=use_natural_primary_keys,
                     stream=stream or self.stdout, progress_output=progress_output,
-                    object_count=object_count,
+                    object_count=object_count, ensure_ascii=True,
                 )
             finally:
                 if stream:


### PR DESCRIPTION
It should do the trick, but I don't have Windows to test it.

If you have the issue and a Windows box to test it:

    pip install git+https://github.com/JulienPalard/django@mdk/dumpdata-on-windows