### PR TITLE
fix utils/baseconv.py -> self.sign

### DIFF
--- a/django/utils/baseconv.py
+++ b/django/utils/baseconv.py
@@ -58,7 +58,7 @@ class BaseConverter:
         return "<%s: base%s (%s)>" % (self.__class__.__name__, len(self.digits), self.digits)
 
     def encode(self, i):
-        neg, value = self.convert(i, self.decimal_digits, self.digits, '-')
+        neg, value = self.convert(i, self.decimal_digits, self.digits, self.sign)
         if neg:
             return self.sign + value
         return value


### PR DESCRIPTION
In [1]: from django.utils import baseconv                                                                                                                                                     

In [2]: base11 = baseconv.BaseConverter('0123456789-', sign='$')                                                                                                                              

In [3]: base11.encode('$1234')                                                                                 

ValueError: substring not found