### PR TITLE
Fixed 32710 -- Added ? to safe characters in filepath_to_uri

### DIFF
--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -253,7 +253,7 @@ def filepath_to_uri(path):
         return path
     # I know about `os.sep` and `os.altsep` but I want to leave
     # some flexibility for hardcoding separators.
-    return quote(str(path).replace("\\", "/"), safe="/~!*()'")
+    return quote(str(path).replace("\\", "/"), safe="/~!*()'?")
 
 
 def get_system_encoding():


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32710

I see no reason why we shouldn't allow '?' in URIs. This also fixes an issue where the static template tag converts '?' to '%3F'