### PR TITLE
Fixed #32705 -- Prevented database cache backend from checking .rowcount on closed cursor.

### DIFF
--- a/django/core/cache/backends/db.py
+++ b/django/core/cache/backends/db.py
@@ -225,7 +225,7 @@ class DatabaseCache(BaseDatabaseCache):
                 ),
                 keys,
             )
-        return bool(cursor.rowcount)
+            return bool(cursor.rowcount)
 
     def has_key(self, key, version=None):
         key = self.make_key(key, version=version)

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -24,6 +24,7 @@ from django.core.cache import (
 from django.core.cache.backends.base import InvalidCacheBackendError
 from django.core.cache.utils import make_template_fragment_key
 from django.db import close_old_connections, connection, connections
+from django.db.backends.utils import CursorWrapper
 from django.http import (
     HttpRequest, HttpResponse, HttpResponseNotModified, StreamingHttpResponse,
 )
@@ -1115,6 +1116,27 @@ class DBCacheTests(BaseCacheTests, TransactionTestCase):
         cache.set_many({'a': 1, 'b': 2, 'c': 3})
         with self.assertNumQueries(1):
             cache.delete_many(['a', 'b', 'c'])
+
+    def test_delete_cursor_rowcount(self):
+        """
+        The rowcount attribute should not be checked on a closed cursor.
+        """
+        class MockedCursorWrapper(CursorWrapper):
+            is_closed = False
+
+            def close(self):
+                self.cursor.close()
+                self.is_closed = True
+
+            @property
+            def rowcount(self):
+                if self.is_closed:
+                    raise Exception('Cursor is closed.')
+                return self.cursor.rowcount
+
+        cache.set_many({'a': 1, 'b': 2})
+        with mock.patch('django.db.backends.utils.CursorWrapper', MockedCursorWrapper):
+            self.assertIs(cache.delete('a'), True)
 
     def test_zero_cull(self):
         self._perform_cull_test('zero_cull', 50, 18)


### PR DESCRIPTION
The cursor rowcount value was evaluated after the cursor was closed. While the current main backend drivers allow it, it may not always be the case.