### PR TITLE
Provide ability to abort URL resolution early --- Ticket 22425

### DIFF
--- a/django/urls/__init__.py
+++ b/django/urls/__init__.py
@@ -5,7 +5,7 @@ from .base import (
 )
 from .conf import include, path, re_path
 from .converters import register_converter
-from .exceptions import NoReverseMatch, Resolver404
+from .exceptions import NoReverseMatch, Resolver404, ResolutionAborted
 from .resolvers import (
     LocalePrefixPattern, ResolverMatch, URLPattern, URLResolver,
     get_ns_resolver, get_resolver,
@@ -14,7 +14,7 @@ from .utils import get_callable, get_mod_func
 
 __all__ = [
     'LocalePrefixPattern', 'NoReverseMatch', 'URLPattern',
-    'URLResolver', 'Resolver404', 'ResolverMatch', 'clear_script_prefix',
+    'URLResolver', 'Resolver404', 'ResolverMatch', 'ResolutionAborted', 'clear_script_prefix',
     'clear_url_caches', 'get_callable', 'get_mod_func', 'get_ns_resolver',
     'get_resolver', 'get_script_prefix', 'get_urlconf', 'include',
     'is_valid_path', 'path', 're_path', 'register_converter', 'resolve',

--- a/django/urls/exceptions.py
+++ b/django/urls/exceptions.py
@@ -4,6 +4,9 @@ from django.http import Http404
 class Resolver404(Http404):
     pass
 
+class ResolutionAborted(Resolver404):
+    pass
+
 
 class NoReverseMatch(Exception):
     pass

--- a/tests/urlpatterns_reverse/terminal_urls.py
+++ b/tests/urlpatterns_reverse/terminal_urls.py
@@ -1,0 +1,22 @@
+from django.urls import include, path
+
+from .views import empty_view, terminal_view
+
+
+more_urls = [
+    path('terminal21/', empty_view, name="terminal-21"),
+    path('terminal22/', empty_view, name="terminal-22"),
+]
+
+extra_urls = [
+    path('', terminal_view, name="terminal"),
+    path('terminal1/', empty_view, name="terminal-1"),
+    path('terminal2/', include(more_urls, terminal_prefix=True, terminal_callback="terminal")),
+]
+
+
+urlpatterns = [
+    path('regular_path/', empty_view),
+    path('terminal/', include(extra_urls, terminal_prefix=True)),
+    path('', empty_view, name="empty"),
+]

--- a/tests/urlpatterns_reverse/views.py
+++ b/tests/urlpatterns_reverse/views.py
@@ -14,6 +14,10 @@ def absolute_kwargs_view(request, arg1=1, arg2=2):
     return HttpResponse()
 
 
+def terminal_view(request, *args, **kwargs):
+    return HttpResponse("Fallback")
+
+
 def defaults_view(request, arg1, arg2):
     pass
 


### PR DESCRIPTION
Hello, I've done some initial work for[ this ticket](https://code.djangoproject.com/ticket/22425).
It adds two parameters to the include function: `terminal_prefix` and `terminal_callback`.
If `terminal_prefix` is set to True, only patterns "below" the prefix are tested.
If we have a URL_CONF like:
```
urlpatterns = [
    path('articles/', include(article_urls, terminal_prefix=True)),
    path('blog/', include(article_blogs),
    # Other patterns
]
```
and the user requests a page like `/articles/I-dont-exist/`; if no match is found on article_urls, Django stops here  and directly throws a 404 error without looking further.

If `terminal_callback` is set to a view name and  no match is found under `articles/`, the view defined as fallback will be returned. If we modify the previous URL_CONF as this:

```
urlpatterns = [
    path('home/', views.home, name='home'),
    path('articles/', include(article_urls, terminal_prefix=True, terminal_callback='home')),
    path('blog/', include(article_blogs),
    # Other patterns
]
```
requesting a page like `/articles/I-dont-exist/` will fall back to the home view.

I will be happy to have any feedback and improve it.
