### PR TITLE
Refs #32074 -- Used asyncio.get_running_loop() instead of get_event_loop().

### DIFF
--- a/django/utils/asyncio.py
+++ b/django/utils/asyncio.py
@@ -16,12 +16,11 @@ def async_unsafe(message):
             if not os.environ.get('DJANGO_ALLOW_ASYNC_UNSAFE'):
                 # Detect a running event loop in this thread.
                 try:
-                    event_loop = asyncio.get_event_loop()
+                    asyncio.get_running_loop()
                 except RuntimeError:
                     pass
                 else:
-                    if event_loop.is_running():
-                        raise SynchronousOnlyOperation(message)
+                    raise SynchronousOnlyOperation(message)
             # Pass onwards.
             return func(*args, **kwargs)
         return inner


### PR DESCRIPTION
Using `asyncio.get_event_loop()` when there is no running event loop was deprecated in Python 3.10, see https://bugs.python.org/issue39529 and https://github.com/python/cpython/commit/172c0f2752d8708b6dda7b42e6c5a3519420a4e8.