### PR TITLE
Refs CVE-2021-31542 -- Skipped mock AWS storage test on Windows.

### DIFF
--- a/tests/file_storage/test_generate_filename.py
+++ b/tests/file_storage/test_generate_filename.py
@@ -1,4 +1,6 @@
 import os
+import sys
+from unittest import skipIf
 
 from django.core.exceptions import SuspiciousFileOperation
 from django.core.files.base import ContentFile
@@ -93,11 +95,15 @@ class GenerateFilenameStorageTests(SimpleTestCase):
             os.path.normpath('some/folder/test_with_space.txt')
         )
 
+    @skipIf(sys.platform == 'win32', "Example filename uses illegal Windows path characters.")
     def test_filefield_awss3_storage(self):
         """
         Simulate a FileField with an S3 storage which uses keys rather than
         folders and names. FileField and Storage shouldn't have any os.path()
         calls that break the key.
+
+        Skipped on Windows because (correctly) \\ will not pass
+        validate_file_name() sanitization there.
         """
         storage = AWSS3Storage()
         folder = 'not/a/folder/'


### PR DESCRIPTION
The validate_file_name() sanitation introduced in
0b79eb36915d178aef5c6a7bbce71b1e76d376d3 correctly rejects the example
file name as containing path elements on Windows. The resultant failure
is not relevant to the test as introduced in
914c72be2abb1c6dd860cb9279beaa66409ae1b2.