### PR TITLE
Refs CVE-2021-31542 -- Adjusted mock AWS storage test for Windows.

### DIFF
--- a/tests/file_storage/test_generate_filename.py
+++ b/tests/file_storage/test_generate_filename.py
@@ -103,7 +103,7 @@ class GenerateFilenameStorageTests(SimpleTestCase):
         folder = 'not/a/folder/'
 
         f = FileField(upload_to=folder, storage=storage)
-        key = 'my-file-key\\with odd characters'
+        key = 'my-file-key$$with odd characters'
         data = ContentFile('test')
         expected_key = AWSS3Storage.prefix + folder + key
 


### PR DESCRIPTION
The validate_file_name() sanitation introduced in
0b79eb36915d178aef5c6a7bbce71b1e76d376d3 correctly rejects the example
file name as containing path elements on Windows. Adjusted test from
914c72be2abb1c6dd860cb9279beaa66409ae1b2 to use alternate 'odd
characters'.

Take 2 on #14346. The `\\' isn't crucial to the test -- or if it is, then this would fall under the change of behaviour from the security fix. 

As such use some other 'odd characters'. 

SO has a list of those S3 allows https://stackoverflow.com/questions/7116450/what-are-valid-s3-key-names-that-can-be-accessed-via-the-s3-rest-api. 