### PR TITLE
Refs CVE-2021-31542 -- Skipped mock AWS storage test on Windows.

### DIFF
--- a/tests/file_storage/test_generate_filename.py
+++ b/tests/file_storage/test_generate_filename.py
@@ -1,4 +1,6 @@
 import os
+import sys
+from unittest import skipIf
 
 from django.core.exceptions import SuspiciousFileOperation
 from django.core.files.base import ContentFile
@@ -93,6 +95,7 @@ class GenerateFilenameStorageTests(SimpleTestCase):
             os.path.normpath('some/folder/test_with_space.txt')
         )
 
+    @skipIf(sys.platform == 'win32', 'Path components in filename are not supported after 0b79eb3.')
     def test_filefield_awss3_storage(self):
         """
         Simulate a FileField with an S3 storage which uses keys rather than


### PR DESCRIPTION
The validate_file_name() sanitation introduced in
0b79eb36915d178aef5c6a7bbce71b1e76d376d3 correctly rejects the example file
name as containing path elements on Windows. This breaks the test introduced in
914c72be2abb1c6dd860cb9279beaa66409ae1b2 to allow path components for storages
that may allow them.

Test is skipped pending a discussed storage refactoring to support this
use-case.