### PR TITLE
Fixing storing files to models

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import posixpath
 
 from django import forms
@@ -299,7 +300,7 @@ class FileField(Field):
         file = super().pre_save(model_instance, add)
         if file and not file._committed:
             # Commit the file to storage prior to saving the model
-            file.save(file.name, file.file, save=False)
+            file.save(os.path.basename(file.name), file.file, save=False)
         return file
 
     def contribute_to_class(self, cls, name, **kwargs):


### PR DESCRIPTION
Hello everyone!

There's an issue in the latest release of Django (3.2.1), which prevents using a file-like object to assign a file to a model field.

The detailed description of the issue is in a bug report I created here: ticket-32718

Thank you very much for your time, and all the effort you put into making Django such a great framework! :)