### PR TITLE
Fixed #32727 -- Allowed spaces before time zone offset in parse_datetime().

### DIFF
--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -23,7 +23,7 @@ datetime_re = _lazy_re_compile(
     r'(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})'
     r'[T ](?P<hour>\d{1,2}):(?P<minute>\d{1,2})'
     r'(?::(?P<second>\d{1,2})(?:[\.,](?P<microsecond>\d{1,6})\d{0,6})?)?'
-    r'(?P<tzinfo>Z|[+-]\d{2}(?::?\d{2})?)?$'
+    r'\s*(?P<tzinfo>Z|[+-]\d{2}(?::?\d{2})?)?$'
 )
 
 standard_duration_re = _lazy_re_compile(

--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -40,6 +40,9 @@ class DateParseTests(unittest.TestCase):
             ('2012-04-23T10:20:30.400+02', datetime(2012, 4, 23, 10, 20, 30, 400000, get_fixed_timezone(120))),
             ('2012-04-23T10:20:30.400-02', datetime(2012, 4, 23, 10, 20, 30, 400000, get_fixed_timezone(-120))),
             ('2012-04-23T10:20:30,400-02', datetime(2012, 4, 23, 10, 20, 30, 400000, get_fixed_timezone(-120))),
+            ('2012-04-23T10:20:30.400 +0230', datetime(2012, 4, 23, 10, 20, 30, 400000, get_fixed_timezone(150))),
+            ('2012-04-23T10:20:30,400 +00', datetime(2012, 4, 23, 10, 20, 30, 400000, get_fixed_timezone(0))),
+            ('2012-04-23T10:20:30   -02', datetime(2012, 4, 23, 10, 20, 30, 0, get_fixed_timezone(-120))),
         )
         for source, expected in valid_inputs:
             with self.subTest(source=source):


### PR DESCRIPTION
Trac ticket: https://code.djangoproject.com/ticket/32727

According to ISO-8601, there can be any number of whitespace characters between the time strings and timezone strings.

Unfortunately the spec isn't public, but here's the link anyway https://www.iso.org/iso-8601-date-and-time-format.html.


## Examples:

This is a valid ISO-8601 datetime string:

```
2012-04-23T10:20:30.400-02
```
`django.utils.dateparse.parse_datetime` parses this correctly.

This is also a valid ISO-8601 datetime string:
```
2012-04-23T10:20:30.400 -02
```
`django.utils.dateparse.parse_datetime` *does not* parse this correctly and returns `None`.

However, `python-dateutil` parses it correctly.  The difference is that Django uses a (brittle) regex to parse ISO-8601 datetime strings, and python-dateutil does not.

https://github.com/django/django/blob/main/django/utils/dateparse.py#L22
https://github.com/dateutil/dateutil/blob/master/dateutil/parser/isoparser.py

I recommend that Django:

1) Depend on python-dateutil for datetime string parsing

OR

2) Inline python-dateutils' parsing functions

As far as I know there is no regex that can parse the full spec of ISO-8601 datetime strings.


In the meantime, this is a patch to support (valid) whitespace characters between the seconds/millseconds part and the timezone string.