### PR TITLE
Fixed #32733 -- Skipped system check for specifying type of auto-created primary keys on abstract models.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1302,6 +1302,7 @@ class Model(metaclass=ModelBase):
     @classmethod
     def _check_default_pk(cls):
         if (
+            not cls._meta.abstract and
             cls._meta.pk.auto_created and
             # Inherited PKs are checked in parents models.
             not (

--- a/docs/releases/3.2.4.txt
+++ b/docs/releases/3.2.4.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Fixed a bug in Django 3.2 where a final catch-all view in the admin didn't
   respect the server-provided value of ``SCRIPT_NAME`` when redirecting
   unauthenticated users to the login page (:ticket:`32754`).
+
+* Fixed a bug in Django 3.2 where a system check would crash on an abstract
+  model (:ticket:`32733`).

--- a/tests/check_framework/test_model_checks.py
+++ b/tests/check_framework/test_model_checks.py
@@ -434,6 +434,18 @@ class ModelDefaultAutoFieldTests(SimpleTestCase):
             Warning(self.msg, hint=self.hint, obj=Parent, id='models.W042'),
         ])
 
+    def test_auto_created_pk_inherited_abstract_parent(self):
+        class Parent(models.Model):
+            class Meta:
+                abstract = True
+
+        class Child(Parent):
+            pass
+
+        self.assertEqual(checks.run_checks(app_configs=self.apps.get_app_configs()), [
+            Warning(self.msg, hint=self.hint, obj=Child, id='models.W042'),
+        ])
+
     @override_settings(DEFAULT_AUTO_FIELD='django.db.models.BigAutoField')
     def test_default_auto_field_setting(self):
         class Model(models.Model):

--- a/tests/check_framework/test_model_checks.py
+++ b/tests/check_framework/test_model_checks.py
@@ -403,6 +403,14 @@ class ModelDefaultAutoFieldTests(SimpleTestCase):
 
         self.assertEqual(checks.run_checks(app_configs=self.apps.get_app_configs()), [])
 
+    def test_skipped_on_abstract_model(self):
+        class Abstract(models.Model):
+            class Meta:
+                abstract = True
+
+        # Call .check() because abstract models are not registered.
+        self.assertEqual(Abstract.check(), [])
+
     def test_explicit_inherited_parent_link(self):
         class Parent(models.Model):
             id = models.AutoField(primary_key=True)


### PR DESCRIPTION
ticket-32733

System check was introduced in b5e12d4.