### PR TITLE
Fixed #32738 -- Deprecated `django.utils.datetime_safe` module.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -10,7 +10,7 @@ from itertools import chain
 
 from django.forms.utils import to_current_timezone
 from django.templatetags.static import static
-from django.utils import datetime_safe, formats
+from django.utils import formats
 from django.utils.datastructures import OrderedSet
 from django.utils.dates import MONTHS
 from django.utils.formats import get_format
@@ -1070,13 +1070,13 @@ class SelectDateWidget(Widget):
             return None
         if y is not None and m is not None and d is not None:
             input_format = get_format('DATE_INPUT_FORMATS')[0]
+            input_format = formats.sanitize_strftime_format(input_format)
             try:
                 date_value = datetime.date(int(y), int(m), int(d))
             except ValueError:
                 # Return pseudo-ISO dates with zeros for any unselected values,
                 # e.g. '2017-0-23'.
                 return '%s-%s-%s' % (y or 0, m or 0, d or 0)
-            date_value = datetime_safe.new_date(date_value)
             return date_value.strftime(input_format)
         return data.get(name)
 

--- a/django/utils/datetime_safe.py
+++ b/django/utils/datetime_safe.py
@@ -8,9 +8,17 @@
 # '0010/08/02 was a Monday'
 
 import time
+import warnings
 from datetime import date as real_date, datetime as real_datetime
 
+from django.utils.deprecation import RemovedInDjango50Warning
 from django.utils.regex_helper import _lazy_re_compile
+
+warnings.warn(
+    'The django.utils.datetime_safe module is deprecated.',
+    category=RemovedInDjango50Warning,
+    stacklevel=2,
+)
 
 
 class date(real_date):

--- a/django/utils/datetime_safe.py
+++ b/django/utils/datetime_safe.py
@@ -7,10 +7,8 @@
 # >>> datetime_safe.date(10, 8, 2).strftime("%Y/%m/%d was a %A")
 # '0010/08/02 was a Monday'
 
-import time as ttime
-from datetime import (
-    date as real_date, datetime as real_datetime, time as real_time,
-)
+import time
+from datetime import date as real_date, datetime as real_datetime
 
 from django.utils.regex_helper import _lazy_re_compile
 
@@ -32,10 +30,6 @@ class datetime(real_datetime):
 
     def date(self):
         return date(self.year, self.month, self.day)
-
-
-class time(real_time):
-    pass
 
 
 def new_date(d):
@@ -88,10 +82,10 @@ def strftime(dt, fmt):
     # Move to around the year 2000
     year = year + ((2000 - year) // 28) * 28
     timetuple = dt.timetuple()
-    s1 = ttime.strftime(fmt, (year,) + timetuple[1:])
+    s1 = time.strftime(fmt, (year,) + timetuple[1:])
     sites1 = _findall(s1, str(year))
 
-    s2 = ttime.strftime(fmt, (year + 28,) + timetuple[1:])
+    s2 = time.strftime(fmt, (year + 28,) + timetuple[1:])
     sites2 = _findall(s2, str(year + 28))
 
     sites = []

--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -1,10 +1,12 @@
 import datetime
 import decimal
+import functools
+import re
 import unicodedata
 from importlib import import_module
 
 from django.conf import settings
-from django.utils import dateformat, datetime_safe, numberformat
+from django.utils import dateformat, numberformat
 from django.utils.functional import lazy
 from django.utils.translation import (
     check_for_language, get_language, to_locale,
@@ -221,17 +223,50 @@ def localize_input(value, default=None):
     elif isinstance(value, (decimal.Decimal, float, int)):
         return number_format(value)
     elif isinstance(value, datetime.datetime):
-        value = datetime_safe.new_datetime(value)
         format = default or get_format('DATETIME_INPUT_FORMATS')[0]
+        format = sanitize_strftime_format(format)
         return value.strftime(format)
     elif isinstance(value, datetime.date):
-        value = datetime_safe.new_date(value)
         format = default or get_format('DATE_INPUT_FORMATS')[0]
+        format = sanitize_strftime_format(format)
         return value.strftime(format)
     elif isinstance(value, datetime.time):
         format = default or get_format('TIME_INPUT_FORMATS')[0]
         return value.strftime(format)
     return value
+
+
+@functools.lru_cache()
+def sanitize_strftime_format(fmt):
+    """
+    Ensure that certain specifiers are correctly padded with leading zeros.
+
+    For years < 1000 specifiers %C, %F, %G, and %Y don't work as expected for
+    strftime provided by glibc on Linux as they don't pad the year or century
+    with leading zeros. Support for specifying the padding explicitly is
+    available, however, which can be used to fix this issue.
+
+    FreeBSD, macOS, and Windows do not support explicitly specifying the
+    padding, but return four digit years (with leading zeros) as expected.
+
+    This function checks whether the %Y produces a correctly padded string and,
+    if not, makes the following substitutions:
+
+    - %C → %02C
+    - %F → %010F
+    - %G → %04G
+    - %Y → %04Y
+
+    See https://bugs.python.org/issue13305 for more details.
+    """
+    if datetime.date(1, 1, 1).strftime('%Y') == '0001':
+        return fmt
+    mapping = {'C': 2, 'F': 10, 'G': 4, 'Y': 4}
+    return re.sub(
+        r'((?:^|[^%])(?:%%)*)%([CFGY])',
+        lambda m: r'%s%%0%s%s' % (m[1], mapping[m[2]], m[2]),
+        fmt,
+    )
 
 
 def sanitize_separators(value):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -19,6 +19,8 @@ details on these changes.
 
 * The undocumented ``django.utils.baseconv`` module will be removed.
 
+* The undocumented ``django.utils.datetime_safe`` module will be removed.
+
 .. _deprecation-removed-in-4.1:
 
 4.1

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -437,6 +437,8 @@ Miscellaneous
 
 * The undocumented ``django.utils.baseconv`` module is deprecated.
 
+* The undocumented ``django.utils.datetime_safe`` module is deprecated.
+
 Features removed in 4.0
 =======================
 

--- a/tests/forms_tests/widget_tests/test_selectdatewidget.py
+++ b/tests/forms_tests/widget_tests/test_selectdatewidget.py
@@ -477,7 +477,8 @@ class SelectDateWidgetTest(WidgetTest):
             w.value_from_datadict({'date_year': '1899', 'date_month': '8', 'date_day': '13'}, {}, 'date'),
             '13-08-1899',
         )
-        # And years before 1000 (demonstrating the need for datetime_safe).
+        # And years before 1000 (demonstrating the need for
+        # sanitize_strftime_format).
         w = SelectDateWidget(years=('0001',))
         self.assertEqual(
             w.value_from_datadict({'date_year': '0001', 'date_month': '8', 'date_day': '13'}, {}, 'date'),

--- a/tests/utils_tests/test_datetime_safe.py
+++ b/tests/utils_tests/test_datetime_safe.py
@@ -1,7 +1,10 @@
 from datetime import date as original_date, datetime as original_datetime
 
-from django.test import SimpleTestCase
-from django.utils.datetime_safe import date, datetime
+from django.test import SimpleTestCase, ignore_warnings
+from django.utils.deprecation import RemovedInDjango50Warning
+
+with ignore_warnings(category=RemovedInDjango50Warning):
+    from django.utils.datetime_safe import date, datetime
 
 
 class DatetimeTests(SimpleTestCase):

--- a/tests/utils_tests/test_datetime_safe.py
+++ b/tests/utils_tests/test_datetime_safe.py
@@ -1,10 +1,7 @@
-from datetime import (
-    date as original_date, datetime as original_datetime,
-    time as original_time,
-)
+from datetime import date as original_date, datetime as original_datetime
 
 from django.test import SimpleTestCase
-from django.utils.datetime_safe import date, datetime, time
+from django.utils.datetime_safe import date, datetime
 
 
 class DatetimeTests(SimpleTestCase):
@@ -13,7 +10,6 @@ class DatetimeTests(SimpleTestCase):
         self.percent_y_safe = (1900, 1, 1)  # >= 1900 required on Windows.
         self.just_safe = (1000, 1, 1)
         self.just_unsafe = (999, 12, 31, 23, 59, 59)
-        self.just_time = (11, 30, 59)
         self.really_old = (20, 1, 1)
         self.more_recent = (2006, 1, 1)
 
@@ -30,10 +26,6 @@ class DatetimeTests(SimpleTestCase):
             original_datetime(*self.just_safe).strftime('%Y-%m-%d'), datetime(*self.just_safe).strftime('%Y-%m-%d')
         )
 
-        self.assertEqual(
-            original_time(*self.just_time).strftime('%H:%M:%S'), time(*self.just_time).strftime('%H:%M:%S')
-        )
-
     def test_safe_strftime(self):
         self.assertEqual(date(*self.just_unsafe[:3]).strftime('%Y-%m-%d (weekday %w)'), '0999-12-31 (weekday 2)')
         self.assertEqual(date(*self.just_safe).strftime('%Y-%m-%d (weekday %w)'), '1000-01-01 (weekday 3)')
@@ -44,8 +36,6 @@ class DatetimeTests(SimpleTestCase):
         self.assertEqual(
             datetime(*self.just_safe).strftime('%Y-%m-%d %H:%M:%S (weekday %w)'), '1000-01-01 00:00:00 (weekday 3)'
         )
-
-        self.assertEqual(time(*self.just_time).strftime('%H:%M:%S AM'), '11:30:59 AM')
 
         # %y will error before this date
         self.assertEqual(date(*self.percent_y_safe).strftime('%y'), '00')


### PR DESCRIPTION
ticket-32738