### PR TITLE
switch to thread-safe pymemcache client

### DIFF
--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -233,7 +233,7 @@ class PyMemcacheCache(BaseMemcachedCache):
     def __init__(self, server, params):
         import pymemcache.serde
         super().__init__(server, params, library=pymemcache, value_not_found_exception=KeyError)
-        self._class = self._lib.HashClient
+        self._class = self._lib.PooledClient
         self._options = {
             'allow_unicode_keys': True,
             'default_noreply': False,


### PR DESCRIPTION
We run Django using gevent, and recently switched from the now-deprecated `django.core.cache.backends.memcached.MemcachedCache` to `PyMemcacheCache` as recommended.  However, gevent is threaded, and `PyMemcacheCache` does not use a thread-safe client - `pymemcache` provides a `PooledClient` for that purpose, but Django currently uses `HashClient`.

This PR switches to the thread-safe client.

Here's a sample of the stack-trace resulting from `HashClient`:

```Traceback (most recent call last):
  File "/opt/repos/locus-web-pipe/.venv/lib/python3.7/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/opt/repos/locus-web-pipe/.venv/lib/python3.7/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
...
  File "src/gevent/_greenlet_primitives.py", line 65, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_gevent_c_greenlet_primitives.pxd", line 35, in gevent._gevent_c_greenlet_primitives._greenlet_switch
gevent._socketcommon.cancel_wait_ex: [Errno 9] File descriptor was closed in another greenlet
 ```