### PR TITLE
Fixed #24529 - Allow double squashing of migrations

### DIFF
--- a/django/core/management/commands/squashmigrations.py
+++ b/django/core/management/commands/squashmigrations.py
@@ -10,7 +10,6 @@ from django.db.migrations.loader import AmbiguityError, MigrationLoader
 from django.db.migrations.migration import SwappableTuple
 from django.db.migrations.optimizer import MigrationOptimizer
 from django.db.migrations.writer import MigrationWriter
-from django.utils.version import get_docs_version
 
 
 class Command(BaseCommand):
@@ -142,12 +141,6 @@ class Command(BaseCommand):
         # as it may be 0002 depending on 0001
         first_migration = True
         for smigration in migrations_to_squash:
-            if smigration.replaces:
-                raise CommandError(
-                    "You cannot squash squashed migrations! Please transition it to a "
-                    "normal migration first: https://docs.djangoproject.com/en/%s/"
-                    "topics/migrations/#squashing-migrations" % get_docs_version()
-                )
             operations.extend(smigration.operations)
             for dependency in smigration.dependencies:
                 if isinstance(dependency, SwappableTuple):
@@ -185,10 +178,7 @@ class Command(BaseCommand):
         # need to feed their replaces into ours
         replaces = []
         for migration in migrations_to_squash:
-            if migration.replaces:
-                replaces.extend(migration.replaces)
-            else:
-                replaces.append((migration.app_label, migration.name))
+            replaces.append((migration.app_label, migration.name))
 
         # Make a new migration with those operations
         subclass = type(

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -251,10 +251,12 @@ Management Commands
 * The new :djadmin:`optimizemigration` command allows optimizing operations for
   a migration.
 
+
 Migrations
 ~~~~~~~~~~
 
-* ...
+* Squashed migrations can now themselves be squashed before being transitioned to
+  normal migrations.
 
 Models
 ~~~~~~

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -703,7 +703,7 @@ migrations it replaces and distribute this change to all running instances
 of your application, making sure that they run ``migrate`` to store the change
 in their database.
 
-You must then transition the squashed migration to a normal migration by:
+You can then transition the squashed migration to a normal migration by:
 
 - Deleting all the migration files it replaces.
 - Updating all migrations that depend on the deleted migrations to depend on
@@ -712,8 +712,11 @@ You must then transition the squashed migration to a normal migration by:
   squashed migration (this is how Django tells that it is a squashed migration).
 
 .. note::
-    Once you've squashed a migration, you should not then re-squash that squashed
-    migration until you have fully transitioned it to a normal migration.
+   You can squash squashed migrations themselves without transitioning to normal
+   migrations, which might be useful for situations where every environment has
+   not yet run the original squashed migration set. But in general it is better
+   to transition squashed migrations to normal migrations to be able to clean up
+   older migration files.
 
 .. admonition:: Pruning references to deleted migrations
 

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -2569,7 +2569,7 @@ class SquashMigrationsTests(MigrationTestBase):
             # we expect to hit a squash replacement cycle check error, but the actual
             # failure is dependent on the order in which the files are read on disk.
             with self.assertRaisesRegex(
-                ValueError,
+                CommandError,
                 r"Cyclical squash replacement found, starting at"
                 r" \('migrations', '2_(squashed|auto)'\)",
             ):

--- a/tests/migrations/test_migration_squash_loop/1_auto.py
+++ b/tests/migrations/test_migration_squash_loop/1_auto.py
@@ -1,0 +1,6 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    operations = [migrations.RunPython(migrations.RunPython.noop)]

--- a/tests/migrations/test_migration_squash_loop/2_auto.py
+++ b/tests/migrations/test_migration_squash_loop/2_auto.py
@@ -1,0 +1,9 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    replaces = [("migrations", "2_squashed")]
+    dependencies = [("migrations", "1_auto")]
+
+    operations = [migrations.RunPython(migrations.RunPython.noop)]

--- a/tests/migrations/test_migration_squash_loop/2_squashed.py
+++ b/tests/migrations/test_migration_squash_loop/2_squashed.py
@@ -1,0 +1,8 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    replaces = [("migrations", "2_auto")]
+    dependencies = [("migrations", "1_auto")]
+    operations = [migrations.RunPython(migrations.RunPython.noop)]


### PR DESCRIPTION
[Related Trac ticket](https://code.djangoproject.com/ticket/24529)

 In order to support multi-level squashing, we need to be a bit smarter  about how we traverse replacements. The solution here introduces some extra checks on squashed migrations (mainly a lookup for whether its replacements need to be squashed first), but the performance hit shouldn't be very large.

This is missing documentation updates and changelog entries, but I would like to get a first look at the implementation strategy here, as well as field any extra testing requests before going further down this path.