### PR TITLE
Fixed #32734 -- Fixed validation of startapp's directory with trailing slash.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -798,6 +798,7 @@ answer newbie questions, and generally made Django that much better:
     Rob Nguyen <tienrobertnguyenn@gmail.com>
     Robin Munn <http://www.geekforgod.com/>
     Rodrigo Pinheiro Marques de Araújo <fenrrir@gmail.com>
+    Rohith P R <https://rohithpr.com>
     Romain Garrigues <romain.garrigues.cs@gmail.com>
     Ronny Haryanto <https://ronny.haryan.to/>
     Ross Poulton <ross@rossp.org>

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -73,9 +73,9 @@ class TemplateCommand(BaseCommand):
             except OSError as e:
                 raise CommandError(e)
         else:
-            if app_or_project == 'app':
-                self.validate_name(os.path.basename(target), 'directory')
             top_dir = os.path.abspath(os.path.expanduser(target))
+            if app_or_project == 'app':
+                self.validate_name(os.path.basename(top_dir), 'directory')
             if not os.path.exists(top_dir):
                 raise CommandError("Destination directory '%s' does not "
                                    "exist, please create it first." % top_dir)

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2206,6 +2206,13 @@ class StartApp(AdminScriptTestCase):
             "another directory."
         )
 
+    def test_trailing_slash_in_target_app_directory_name(self):
+        app_dir = os.path.join(self.test_dir, 'apps', 'app1')
+        os.makedirs(app_dir)
+        _, err = self.run_django_admin(['startapp', 'app', os.path.join('apps', 'app1', '')])
+        self.assertNoOutput(err)
+        self.assertIs(os.path.exists(os.path.join(app_dir, 'apps.py')), True)
+
     def test_overlaying_app(self):
         # Use a subdirectory so it is outside the PYTHONPATH.
         os.makedirs(os.path.join(self.test_dir, 'apps/app1'))


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32734

Added a test that fails on master:
<img width="1212" alt="Screenshot 2021-05-11 at 4 02 31 PM" src="https://user-images.githubusercontent.com/10276811/117803058-d2a5da80-b273-11eb-871e-5fa9bd3285dd.png">

The test passes after the fix is applied:
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/10276811/117803122-e3eee700-b273-11eb-81f7-ed1bfdc30793.png">

Running start app with a trailing slash in the target dirname works:
<img width="663" alt="image" src="https://user-images.githubusercontent.com/10276811/117814599-20294400-b282-11eb-923b-43b83ae28088.png">
