### PR TITLE
Fixed #32734 -- Added rstrip('/') call to django-admin startapp target.

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -74,7 +74,7 @@ class TemplateCommand(BaseCommand):
                 raise CommandError(e)
         else:
             if app_or_project == 'app':
-                self.validate_name(os.path.basename(target), 'directory')
+                self.validate_name(os.path.basename(target.rstrip(os.sep)), 'directory')
             top_dir = os.path.abspath(os.path.expanduser(target))
             if not os.path.exists(top_dir):
                 raise CommandError("Destination directory '%s' does not "

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2206,6 +2206,17 @@ class StartApp(AdminScriptTestCase):
             "another directory."
         )
 
+    def test_target_name_with_trailing_slash(self):
+        """Directory name with trailing slash is not considred empty (#32734)"""
+        with tempfile.TemporaryDirectory() as prefix:
+            target = os.path.join(prefix, 'directory', '')
+            _, err = self.run_django_admin(['startapp', 'app', target])
+            self.assertNotInOutput(
+                err,
+                "CommandError: '' is not a valid app directory. Please make "
+                "sure the directory is a valid identifier."
+            )
+
     def test_overlaying_app(self):
         # Use a subdirectory so it is outside the PYTHONPATH.
         os.makedirs(os.path.join(self.test_dir, 'apps/app1'))


### PR DESCRIPTION
Added rstrip('/') call to the directory name before validation to
prevent it being considered empty when running `django-admin startapp`
with a directory name with trailing slash.