### PR TITLE
Remark "urlconf matches are against quoted URLs"

### DIFF
--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -287,6 +287,12 @@ The URLconf doesn't look at the request method. In other words, all request
 methods -- ``POST``, ``GET``, ``HEAD``, etc. -- will be routed to the same
 function for the same URL.
 
+Also note that if the URL contains characters that require quoting,
+the URLconf talks about the quoted (encoded) form, e.g. 
+``Orleàns/`` will arrive as ``Orle%C3%A0ns/``.
+Use the latter for immediate matching.
+Use :func:`urllib.parse.unquote` to obtain the original value.
+
 Specifying defaults for view arguments
 ======================================
 


### PR DESCRIPTION
It is not obvious where Django magic has already provided transparency
of the various encoding/decoding steps and where is has not.
Here it has not, which is worth mentioning.