### PR TITLE
Fixed #32747 -- Prevented initialization of unused caches.

### DIFF
--- a/django/core/cache/__init__.py
+++ b/django/core/cache/__init__.py
@@ -43,6 +43,13 @@ class CacheHandler(BaseConnectionHandler):
             ) from e
         return backend_cls(location, params)
 
+    def all(self, initialized_only=False):
+        return [
+            self[alias] for alias in self
+            # If initialized_only is True, return only initialized caches.
+            if not initialized_only or hasattr(self._connections, alias)
+        ]
+
 
 caches = CacheHandler()
 
@@ -52,7 +59,7 @@ cache = ConnectionProxy(caches, DEFAULT_CACHE_ALIAS)
 def close_caches(**kwargs):
     # Some caches need to do a cleanup at the end of a request cycle. If not
     # implemented in a particular backend cache.close() is a no-op.
-    for cache in caches.all():
+    for cache in caches.all(initialized_only=True):
         cache.close()
 
 

--- a/docs/releases/3.2.4.txt
+++ b/docs/releases/3.2.4.txt
@@ -15,3 +15,6 @@ Bugfixes
 
 * Fixed a bug in Django 3.2 where a system check would crash on an abstract
   model (:ticket:`32733`).
+
+* Prevented unnecessary initialization of unused caches following a regression
+  in Django 3.2 (:ticket:`32747`).


### PR DESCRIPTION
Thanks Alexander Ebral for the report.

Regression in 98e05ccde440cc9b768952cc10bc8285f4924e1f.

ticket-32747