### PR TITLE
Use var in for-loop to support ie11 for JavaScript translations

### DIFF
--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -101,7 +101,7 @@ js_catalog_template = r"""
   django.catalog = django.catalog || {};
   {% if catalog_str %}
   const newcatalog = {{ catalog_str }};
-  for (const key in newcatalog) {
+  for (var key in newcatalog) {
     django.catalog[key] = newcatalog[key];
   }
   {% endif %}


### PR DESCRIPTION
According to https://kangax.github.io/compat-table/es6 `const` is not supported in `for-in` loops