### PR TITLE
Fixed #32827 -- Adjusted docs on squashing migrations.

### DIFF
--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -458,7 +458,7 @@ that contains a reference to them. On the plus side, methods and managers from
 these base classes inherit normally, so if you absolutely need access to these
 you can opt to move them into a superclass.
 
-To remove old references, you can :ref:`squash migrations <migration-squashing>`
+To remove old references, you can :ref:`trim migrations <migration-trimming>`
 or, if there aren't many references, copy them into the migration files.
 
 .. _migrations-removing-model-fields:
@@ -505,8 +505,8 @@ to::
 You should keep the field's methods that are required for it to operate in
 database migrations such as ``__init__()``, ``deconstruct()``, and
 ``get_internal_type()``. Keep this stub field for as long as any migrations
-which reference the field exist. For example, after squashing migrations and
-removing the old ones, you should be able to remove the field completely.
+which reference the field exist. For example, after removing migrations by
+trimming or squashing them, you should be able to remove the field completely.
 
 .. _data-migrations:
 
@@ -622,26 +622,116 @@ to be able to write your own, see the :doc:`migration operations reference
 </ref/migration-operations>` and the "how-to" on :doc:`writing migrations
 </howto/writing-migrations>`.
 
-.. _migration-squashing:
+.. _migration-trimming:
 
-Squashing migrations
-====================
+Trimming migrations
+===================
 
 You are encouraged to make migrations freely and not worry about how many you
 have; the migration code is optimized to deal with hundreds at a time without
 much slowdown. However, eventually you will want to move back from having
-several hundred migrations to just a few, and that's where squashing comes in.
+several hundred migrations to just a few. That's where trimming migrations
+comes in.
 
-Squashing is the act of reducing an existing set of many migrations down to
+Trimming is the act of reducing an existing set of many migrations down to
 one (or sometimes a few) migrations which still represent the same changes.
 
-Django does this by taking all of your existing migrations, extracting their
-``Operation``\s and putting them all in sequence, and then running an optimizer
-over them to try and reduce the length of the list - for example, it knows
-that :class:`~django.db.migrations.operations.CreateModel` and
-:class:`~django.db.migrations.operations.DeleteModel` cancel each other out,
-and it knows that :class:`~django.db.migrations.operations.AddField` can be
-rolled into :class:`~django.db.migrations.operations.CreateModel`.
+There are two common approaches to trimming migrations. The first is to use the
+``squashmigrations`` command to create a merged migration file, however this
+approach can be impractical on complex projects. The second approach is to
+coordinate with your team to ensure that all installations of your app are up
+to date, then to have a scheduled time when migrations are removed and
+recreated from scratch.
+
+Which approach is best for your project will depend on the complexity of it
+and the flexibility of your team.
+
+
+.. _manual-migration-trimming:
+
+Trimming migrations manually
+----------------------------
+
+The easiest and most reliable way to trim migrations is to do so manually,
+instead of using the ``squashmigrations`` command. When doing this process, any
+apps that have foreign key interdependencies will need to be trimmed at the same
+time so that old migrations do not depend on deleted migrations. For example,
+if your ``pizza`` app has an ``Ingredients`` model in your ``food`` app, you
+will need to manually trim both the ``food`` and the ``pizza`` apps
+simultaneously. It is often easiest to trim all apps in your project at the
+same time.
+
+Once you have identified the apps you plan to trim, ensure that all of your
+installations of your project are up to date with the same migrations and
+ensure that no new migrations will be created until this process is complete.
+To check that all migrations are in place, run the following on all
+installations of your project::
+
+    $ ./manage.py makemigrations
+
+And::
+
+    $ ./manage.py showmigrations
+
+``makemigrations`` should show "No changes detected" and ``showmigrations``
+should show "[X]" for all migrations, indicating that they have been applied.
+
+After all of your databases are up to date, you need to clear the migration
+history table. Run the following for each of your apps you plan to migrate::
+
+    $ ./manage.py migrate --fake my_app1 my_app2 zero
+
+If you run ``showmigrations`` again, it will now show that none of your
+migrations have been applied.
+
+Next, save any data or SQL migrations that you have. Find these migrations by
+searching for ``RunPython`` and ``RunSQL`` in your migration files, and copy
+anything you find to a temporary file.
+
+Delete all of the migrations in the affected apps with something like::
+
+    $ cd my_app1
+    $ find . -path "migrations/*.py" -not -name "__init__.py" -delete
+
+Create a fresh migration for each app with::
+
+    $ ./manage.py makemigrations
+
+For any app that had data or SQL migrations, recreate empty migration files with
+with::
+
+    $ ./manage.py makemigrations --empty my_app1 my_app2
+
+Using the temporary file you made above, recreate the data and SQL migrations
+that you need by copying over any old ``RunPython`` or ``RunSQL`` commands.
+
+You should now have new migration files representing the state of your
+database and any data migrations that you had prior to starting this process.
+
+Because your database already has these changes applied by your old migrations,
+you do not need to actually migrate it, but these migrations do need to be
+marked as applied. Thus, fake running them with::
+
+    $ ./manage.py migrate --fake
+
+Finally, to verify that everything worked, check that the migration has been
+applied successfully with::
+
+    $ ./manage.py showmigrations
+
+
+.. _migration-squashing:
+
+Squashing migrations
+--------------------
+
+Django squashes migrations by taking all of your existing migrations,
+extracting their ``Operation``\s, putting them all in sequence, and then
+running an optimizer over them to try and reduce the length of the list - for
+example, it knows that :class:`~django.db.migrations.operations.CreateModel`
+and :class:`~django.db.migrations.operations.DeleteModel` cancel each other
+out, and it knows that :class:`~django.db.migrations.operations.AddField` can
+be rolled into :class:`~django.db.migrations.operations.CreateModel`.
 
 Once the operation sequence has been reduced as much as possible - the amount
 possible depends on how closely intertwined your models are and if you have

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -656,10 +656,10 @@ The easiest and most reliable way to trim migrations is to do so manually,
 instead of using the ``squashmigrations`` command. When doing this process, any
 apps that have foreign key interdependencies will need to be trimmed at the same
 time so that old migrations do not depend on deleted migrations. For example,
-if your ``pizza`` app has an ``Ingredients`` model in your ``food`` app, you
-will need to manually trim both the ``food`` and the ``pizza`` apps
-simultaneously. It is often easiest to trim all apps in your project at the
-same time.
+if your ``pizza`` app has a ``ForeignKey`` to an ``Ingredients`` model in your
+``food`` app, you will need to manually trim both the ``food`` and the
+``pizza`` apps simultaneously. It is often easiest to trim all apps in your
+project at the same time.
 
 Once you have identified the apps you plan to trim, ensure that all of your
 installations of your project are up to date with the same migrations and
@@ -679,7 +679,9 @@ should show "[X]" for all migrations, indicating that they have been applied.
 After all of your databases are up to date, you need to clear the migration
 history table. Run the following for each of your apps you plan to migrate::
 
-    $ ./manage.py migrate --fake my_app1 my_app2 zero
+    $ ./manage.py migrate --fake my_app1 zero
+    $ ./manage.py migrate --fake my_app2 zero
+    ...
 
 If you run ``showmigrations`` again, it will now show that none of your
 migrations have been applied.
@@ -688,17 +690,19 @@ Next, save any data or SQL migrations that you have. Find these migrations by
 searching for ``RunPython`` and ``RunSQL`` in your migration files, and copy
 anything you find to a temporary file.
 
-Delete all of the migrations in the affected apps with something like::
+Delete all of the migrations in the affected apps. In a Unix system the
+following will generally work::
 
     $ cd my_app1
     $ find . -path "migrations/*.py" -not -name "__init__.py" -delete
 
-Create a fresh migration for each app with::
+Create migrations for each app. For apps with interdependencies, this may
+create more than one migration::
 
     $ ./manage.py makemigrations
 
-For any app that had data or SQL migrations, recreate empty migration files with
-with::
+For any app that had data or SQL migrations, analyze whether those migrations
+are still needed. For those that are needed, recreate empty migration files::
 
     $ ./manage.py makemigrations --empty my_app1 my_app2
 
@@ -710,12 +714,28 @@ database and any data migrations that you had prior to starting this process.
 
 Because your database already has these changes applied by your old migrations,
 you do not need to actually migrate it, but these migrations do need to be
-marked as applied. Thus, fake running them with::
+marked as applied. Thus, fake running them::
 
     $ ./manage.py migrate --fake
 
-Finally, to verify that everything worked, check that the migration has been
-applied successfully with::
+To verify that everything worked, check that the migration has been
+applied successfully::
+
+    $ ./manage.py showmigrations
+
+This computer is now complete. To deploy this to other computers running the
+code base, begin by clearing the migration history on those computers::
+
+    $ ./manage.py migrate --fake my_app1 zero
+    $ ./manage.py migrate --fake my_app2 zero
+    ...
+
+Then, copy or deploy the new migrations to those computers. Finally, fake the
+new migrations::
+
+    $ ./manage.py migrate --fake
+
+And verify with::
 
     $ ./manage.py showmigrations
 


### PR DESCRIPTION
Pursuant to [the discussion on the Django Dev list][dev], this is a first pass at updating the `squashmigrations` documentation. The goal is to demote the `squashmigrations` approach and to instead prescribe a manual "trimming" process. 

I think this is pretty good, but I'm sure it could benefit from other eyes. A couple notes:

 - I decided to coin a new term for this process called "Trimming migrations". The idea is that squashing is a way of trimming migrations as is manually deleting them. I think the term is pretty accurate (and unused in other contexts), but I'd be open to other ideas. 

 - I tried to cover the use case of trimming all apps at the same time or just trimming a subset of them. I opted not to get into the details too much about migration dependencies.

 - I think there's a lot more manual guidance in here than in most of the Django docs (e.g., run this, run that). Maybe that's fine and it's what the process requires. I couldn't think of a good way around it. I think the manual process here basically says loudly to the reader the honest truth than this is a hacky situation, and that's probably fine. It's not the polish we want in Django, but, frankly, this area of Django isn't polished.

 - I searched around for references in the docs to squashing and didn't find any others that needed updates.

 - In [this post][users], they have a different approach they use for custom `User` models. I don't understand why, so I left it out, they make it seem important. Anybody know what's going on there?

 - I haven't tried this process out yet (I'm just barely finding time to push through this PR), but I think I understand migrations enough that the process is sound. 

I'd welcome any comments or suggestions. This is the biggest documentation PR I've filed in Django. Hopefully it's good! 

[dev]: https://groups.google.com/g/django-developers/c/xpeFRpMTBZw/m/lDq78EedAwAJ
[users]: https://geekchick77.dreamwidth.org/5560.html