### PR TITLE
Use format string in migrations docs

### DIFF
--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -566,7 +566,7 @@ the historical model and iterate over the rows::
         # version than this migration expects. We use the historical version.
         Person = apps.get_model('yourappname', 'Person')
         for person in Person.objects.all():
-            person.name = '%s %s' % (person.first_name, person.last_name)
+            person.name = f'{person.first_name} {person.last_name}'
             person.save()
 
     class Migration(migrations.Migration):


### PR DESCRIPTION
Using a format string (`f''`) makes the docs a little easier to read and encourages use of idiomatic Python practices.