### PR TITLE
Fixed #32765 -- Removed "for" HTML attribute from ReadOnlyPasswordHashWidget.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -50,6 +50,9 @@ class ReadOnlyPasswordHashWidget(forms.Widget):
         context['summary'] = summary
         return context
 
+    def id_for_label(self, id_):
+        return None
+
 
 class ReadOnlyPasswordHashField(forms.Field):
     widget = ReadOnlyPasswordHashWidget

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -13,6 +13,7 @@ from django.contrib.sites.models import Site
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.core.mail import EmailMultiAlternatives
+from django.forms import forms
 from django.forms.fields import CharField, Field, IntegerField
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.utils import translation
@@ -1024,6 +1025,18 @@ class ReadOnlyPasswordHashTest(SimpleTestCase):
         field = ReadOnlyPasswordHashField()
         self.assertIs(field.disabled, True)
         self.assertFalse(field.has_changed('aaa', 'bbb'))
+
+    def test_label(self):
+        """
+        ReadOnlyPasswordHashWidget doesn't contain a for attribute in the
+        <label> because it doesn't have any labelable elements.
+        """
+        class TestForm(forms.Form):
+            hash_field = ReadOnlyPasswordHashField()
+
+        bound_field = TestForm()['hash_field']
+        self.assertEqual(bound_field.field.widget.id_for_label('id'), None)
+        self.assertEqual(bound_field.label_tag(), '<label>Hash field:</label>')
 
 
 class AdminPasswordChangeFormTest(TestDataMixin, TestCase):


### PR DESCRIPTION
Fixes the 'for' attribute on the label element for ReadOnlyPasswordHashWidget.