### PR TITLE
Fixed typo in docs/ref/contrib/admin/index.txt.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2572,7 +2572,7 @@ on whichever model contains the actual reference to the
 :class:`~django.db.models.ManyToManyField`. Depending on your ``ModelAdmin``
 definition, each many-to-many field in your model will be represented by a
 standard HTML ``<select multiple>``, a horizontal or vertical filter, or a
-``raw_id_admin`` widget. However, it is also possible to replace these
+``raw_id_fields`` widget. However, it is also possible to replace these
 widgets with inlines.
 
 Suppose we have the following models::


### PR DESCRIPTION
There is no `raw_id_admin`, seems to be referring to `raw_id_fields`.