### PR TITLE
Fix typo in swedish translation

### DIFF
--- a/django/conf/locale/sv/LC_MESSAGES/django.po
+++ b/django/conf/locale/sv/LC_MESSAGES/django.po
@@ -1115,7 +1115,7 @@ msgid "0 minutes"
 msgstr "0 minuter"
 
 msgid "Forbidden"
-msgstr "Ottillåtet"
+msgstr "Otillåtet"
 
 msgid "CSRF verification failed. Request aborted."
 msgstr "CSRF-verifikation misslyckades. Förfrågan avbröts."


### PR DESCRIPTION
The Swedish word for "Forbidden" is _"Otillåtet"_, not _"Ottillåtet"_.

(I have attempted to join the Swedish translation team on transifex, and will check more of the translation if/when accepted there, but this one is a simple typo, so I thought I might as well try to submit it as this too.)