### PR TITLE
Fixed #32768 -- Added Vary header when redirecting to prefixed i18n pattern.

### DIFF
--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -53,7 +53,12 @@ class LocaleMiddleware(MiddlewareMixin):
                     '%s%s/' % (script_prefix, language),
                     1
                 )
-                return self.response_redirect_class(language_url)
+                # Redirect to the language-specific URL as detected by
+                # get_language_from_request(). HTTP caches may cache this
+                # redirect, so add the Vary header.
+                redirect = self.response_redirect_class(language_url)
+                patch_vary_headers(redirect, ('Accept-Language', 'Cookie'))
+                return redirect
 
         if not (i18n_patterns_used and language_from_path):
             patch_vary_headers(response, ('Accept-Language',))

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -254,9 +254,13 @@ class URLVaryAcceptLanguageTests(URLTestCaseBase):
         self.assertEqual(response.get('Vary'), 'Accept-Language')
 
     def test_en_redirect(self):
+        """
+        The redirect to a prefixed URL depends on 'Accept-Language' and
+        'Cookie', but once prefixed no header is set.
+        """
         response = self.client.get('/account/register/', HTTP_ACCEPT_LANGUAGE='en')
         self.assertRedirects(response, '/en/account/register/')
-        self.assertFalse(response.get('Vary'))
+        self.assertEqual(response.get('Vary'), 'Accept-Language, Cookie')
 
         response = self.client.get(response.headers['location'])
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Fixed #32768 -- An incorrect language is sometimes displayed -
redirects adding a language code to a path can be inappropriate cached by
HTTP caches

If LocaleMiddleware uses the headers Accept-Language and/or Cookie to
determine where to redirect to, then it should add a Vary header to the
redirect so that caches know what to do when caching the redirect
itself.