### PR TITLE
Renamed "object" argument of ModelAdmin.log_addition(), log_change(), and log_deletion() methods.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -801,7 +801,7 @@ class ModelAdmin(BaseModelAdmin):
     def get_paginator(self, request, queryset, per_page, orphans=0, allow_empty_first_page=True):
         return self.paginator(queryset, per_page, orphans, allow_empty_first_page)
 
-    def log_addition(self, request, object, message):
+    def log_addition(self, request, obj, message):
         """
         Log that an object has been successfully added.
 
@@ -810,14 +810,14 @@ class ModelAdmin(BaseModelAdmin):
         from django.contrib.admin.models import ADDITION, LogEntry
         return LogEntry.objects.log_action(
             user_id=request.user.pk,
-            content_type_id=get_content_type_for_model(object).pk,
-            object_id=object.pk,
-            object_repr=str(object),
+            content_type_id=get_content_type_for_model(obj).pk,
+            object_id=obj.pk,
+            object_repr=str(obj),
             action_flag=ADDITION,
             change_message=message,
         )
 
-    def log_change(self, request, object, message):
+    def log_change(self, request, obj, message):
         """
         Log that an object has been successfully changed.
 
@@ -826,14 +826,14 @@ class ModelAdmin(BaseModelAdmin):
         from django.contrib.admin.models import CHANGE, LogEntry
         return LogEntry.objects.log_action(
             user_id=request.user.pk,
-            content_type_id=get_content_type_for_model(object).pk,
-            object_id=object.pk,
-            object_repr=str(object),
+            content_type_id=get_content_type_for_model(obj).pk,
+            object_id=obj.pk,
+            object_repr=str(obj),
             action_flag=CHANGE,
             change_message=message,
         )
 
-    def log_deletion(self, request, object, object_repr):
+    def log_deletion(self, request, obj, object_repr):
         """
         Log that an object will be deleted. Note that this method must be
         called before the deletion.
@@ -843,8 +843,8 @@ class ModelAdmin(BaseModelAdmin):
         from django.contrib.admin.models import DELETION, LogEntry
         return LogEntry.objects.log_action(
             user_id=request.user.pk,
-            content_type_id=get_content_type_for_model(object).pk,
-            object_id=object.pk,
+            content_type_id=get_content_type_for_model(obj).pk,
+            object_id=obj.pk,
             object_repr=object_repr,
             action_flag=DELETION,
         )

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -426,6 +426,9 @@ Miscellaneous
 * The undocumented ``HttpRequest.get_raw_uri()`` method is removed. The
   :meth:`.HttpRequest.build_absolute_uri` method may be a suitable alternative.
 
+* The ``object`` argument of undocumented ``ModelAdmin.log_addition()``,
+  ``log_change()``, and ``log_deletion()`` methods is renamed to ``obj``.
+
 .. _deprecated-features-4.0:
 
 Features deprecated in 4.0

--- a/tests/auth_tests/urls_custom_user_admin.py
+++ b/tests/auth_tests/urls_custom_user_admin.py
@@ -7,12 +7,12 @@ site = admin.AdminSite(name='custom_user_admin')
 
 
 class CustomUserAdmin(UserAdmin):
-    def log_change(self, request, object, message):
+    def log_change(self, request, obj, message):
         # LogEntry.user column doesn't get altered to expect a UUID, so set an
         # integer manually to avoid causing an error.
         original_pk = request.user.pk
         request.user.pk = 1
-        super().log_change(request, object, message)
+        super().log_change(request, obj, message)
         request.user.pk = original_pk
 
 


### PR DESCRIPTION
Wasn't sure if this change needed a ticket since it's trivial, I can open one if desired.

`obj` is used instead of `object` throughout `django.contrib.admin` since `object` shadows the built-in. This change just makes it consistent in the one place it wasn't.