### PR TITLE
Fixed #32503 -- Reverted "Fixed #30712 -- Allowed BLOB/TEXT defaults on MySQL 8.0.13+."

### DIFF
--- a/django/contrib/gis/db/backends/mysql/schema.py
+++ b/django/contrib/gis/db/backends/mysql/schema.py
@@ -16,8 +16,8 @@ class MySQLGISSchemaEditor(DatabaseSchemaEditor):
         self.geometry_sql = []
 
     def skip_default(self, field):
-        # Geometry fields are stored as BLOB/TEXT, for which MySQL < 8.0.13 and
-        # MariaDB < 10.2.1 don't support defaults.
+        # Geometry fields are stored as BLOB/TEXT, for which MySQL and MariaDB
+        # < 10.2.1 don't support defaults.
         if isinstance(field, GeometryField) and not self._supports_limited_data_type_defaults:
             return True
         return super().skip_default(field)

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -228,15 +228,14 @@ class BaseDatabaseSchemaEditor:
         include_default = include_default and not self.skip_default(field)
         if include_default:
             default_value = self.effective_default(field)
-            column_default = ' DEFAULT ' + self._column_default_sql(field)
             if default_value is not None:
                 if self.connection.features.requires_literal_defaults:
                     # Some databases can't take defaults as a parameter (oracle)
                     # If this is the case, the individual schema backend should
                     # implement prepare_default
-                    sql += column_default % self.prepare_default(default_value)
+                    sql += " DEFAULT %s" % self.prepare_default(default_value)
                 else:
-                    sql += column_default
+                    sql += " DEFAULT %s"
                     params += [default_value]
         # Oracle treats the empty string ('') as null, so coerce the null
         # option whenever '' is a possible value.
@@ -274,13 +273,6 @@ class BaseDatabaseSchemaEditor:
             'subclasses of BaseDatabaseSchemaEditor for backends which have '
             'requires_literal_defaults must provide a prepare_default() method'
         )
-
-    def _column_default_sql(self, field):
-        """
-        Return the SQL to use in a DEFAULT clause. The resulting string should
-        contain a '%s' placeholder for a default value.
-        """
-        return '%s'
 
     @staticmethod
     def _effective_default(field):
@@ -879,7 +871,7 @@ class BaseDatabaseSchemaEditor:
         argument) a default to new_field's column.
         """
         new_default = self.effective_default(new_field)
-        default = self._column_default_sql(new_field)
+        default = '%s'
         params = [new_default]
 
         if drop:

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -132,8 +132,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     }
 
     # For these data types:
-    # - MySQL < 8.0.13 and MariaDB < 10.2.1 don't accept default values and
-    #   implicitly treat them as nullable
+    # - MySQL and MariaDB < 10.2.1 don't accept default values and implicitly
+    #   treat them as nullable
     # - all versions of MySQL and MariaDB don't support full width database
     #   indexes
     _limited_data_types = (

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -70,22 +70,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     @property
     def _supports_limited_data_type_defaults(self):
-        # MariaDB >= 10.2.1 and MySQL >= 8.0.13 supports defaults for BLOB
-        # and TEXT.
+        # Only MariaDB >= 10.2.1 supports defaults for BLOB and TEXT.
         if self.connection.mysql_is_mariadb:
             return self.connection.mysql_version >= (10, 2, 1)
-        return self.connection.mysql_version >= (8, 0, 13)
-
-    def _column_default_sql(self, field):
-        if (
-            not self.connection.mysql_is_mariadb and
-            self._supports_limited_data_type_defaults and
-            self._is_limited_data_type(field)
-        ):
-            # MySQL supports defaults for BLOB and TEXT columns only if the
-            # default value is written as an expression i.e. in parentheses.
-            return '(%s)'
-        return super()._column_default_sql(field)
+        return False
 
     def add_field(self, model, field):
         super().add_field(model, field)


### PR DESCRIPTION
This reverts commit 6b16c91157512587017e9178d066ed1a683e7795.

[MySQL 8.0.13+](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-13.html#mysqld-8-0-13-data-types) supports defaults on `BLOB`/`TEXT` columns but only when adding a new column. Django doesn't use database defaults so they are only useful to set values for existing rows which is not the case here.

Thanks Matt Westcott for the report.

ticket-32503
ticket-30712

See [comment](https://code.djangoproject.com/ticket/32503#comment:5).