### PR TITLE
Fixed #32762 -- Fixed locale reset in compilemessages test.

### DIFF
--- a/tests/i18n/test_compilation.py
+++ b/tests/i18n/test_compilation.py
@@ -193,7 +193,7 @@ class CompilationErrorHandling(MessageCompilationTests):
         # po file contains invalid msgstr content (triggers non-ascii error content).
         # Make sure the output of msgfmt is unaffected by the current locale.
         env = os.environ.copy()
-        env.update({'LANG': 'C'})
+        env.update({'LC_ALL': 'C'})
         with mock.patch('django.core.management.utils.run', lambda *args, **kwargs: run(*args, env=env, **kwargs)):
             cmd = MakeMessagesCommand()
             if cmd.gettext_version < (0, 18, 3):


### PR DESCRIPTION
The test in subject originally changed the `LANG` environment variable to `C`
to bypass localization, but this wasn't sufficient in non-English environments.

So the `LC_ALL` variable is modified instead.

(ticket: https://code.djangoproject.com/ticket/32762)