### PR TITLE
Made SerializeMixin check lockfile attr at import time.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1624,12 +1624,15 @@ class SerializeMixin:
     """
     lockfile = None
 
-    @classmethod
-    def setUpClass(cls):
+    def __init_subclass__(cls, /, **kwargs):
+        super().__init_subclass__(**kwargs)
         if cls.lockfile is None:
             raise ValueError(
                 "{}.lockfile isn't set. Set it to a unique value "
                 "in the base class.".format(cls.__name__))
+
+    @classmethod
+    def setUpClass(cls):
         cls._lockfile = open(cls.lockfile)
         locks.lock(cls._lockfile, locks.LOCK_EX)
         super().setUpClass()

--- a/tests/test_utils/test_serializemixin.py
+++ b/tests/test_utils/test_serializemixin.py
@@ -1,0 +1,21 @@
+from django.test import SimpleTestCase
+from django.test.testcases import SerializeMixin
+
+
+class TestSerializeMixin(SimpleTestCase):
+    def test_init_without_lockfile(self):
+        msg = (
+            "ExampleTests.lockfile isn't set. Set it to a unique value in the "
+            "base class."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            class ExampleTests(SerializeMixin, SimpleTestCase):
+                pass
+
+
+class TestSerializeMixinUse(SerializeMixin, SimpleTestCase):
+    lockfile = __file__
+
+    def test_usage(self):
+        # Running this test ensures that the lock/unlock functions have passed.
+        pass


### PR DESCRIPTION
Prevent misconfiguration requiring a whole test run to discover.