### PR TITLE
Refs #27734 -- Prevented creation of more parallel workers than TestCases.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -404,8 +404,8 @@ class ParallelTestSuite(unittest.TestSuite):
     run_subsuite = _run_subsuite
     runner_class = RemoteTestRunner
 
-    def __init__(self, suite, processes, failfast=False, buffer=False):
-        self.subsuites = partition_suite_by_case(suite)
+    def __init__(self, subsuites, processes, failfast=False, buffer=False):
+        self.subsuites = subsuites
         self.processes = processes
         self.failfast = failfast
         self.buffer = buffer
@@ -685,21 +685,18 @@ class DiscoverRunner:
         suite = self.test_suite(all_tests)
 
         if self.parallel > 1:
-            parallel_suite = self.parallel_test_suite(
-                suite,
-                self.parallel,
-                self.failfast,
-                self.buffer,
-            )
-
+            subsuites = partition_suite_by_case(suite)
             # Since tests are distributed across processes on a per-TestCase
             # basis, there's no need for more processes than TestCases.
-            parallel_units = len(parallel_suite.subsuites)
-            self.parallel = min(self.parallel, parallel_units)
-
-            # If there's only one TestCase, parallelization isn't needed.
-            if self.parallel > 1:
-                suite = parallel_suite
+            processes = min(self.parallel, len(subsuites))
+            # Only use the more complex ParallelTestSuite if we really need it
+            if processes > 1:
+                suite = self.parallel_test_suite(
+                    subsuites,
+                    processes,
+                    self.failfast,
+                    self.buffer,
+                )
 
         return suite
 


### PR DESCRIPTION
Thanks to Mariusz Felisiak for rewriting my original one-liner into this patch ([#32769-2](https://code.djangoproject.com/ticket/32769#comment:2))

I'm happy to amend / change wherever needed, just let me know.

---

The parallel test runner uses multiple workers to distribute the
workload. These workers are assigned a worker ID using a globally
incremented variable, and this worker ID determines what test database
to connect to. When the worker ID surpasses the test database IDs Django
will crash.

Say, you wanted to run 2 testcases on a 4-core CPU in parallel. Before
this patch Django would start out by creating 2 test databases and 4
processes, leading to sporadic crashes.

With this changeset Django starts out with 4 test databases and 2
processes, greatly reducing the likelihood of it going awry.

It won't eliminate the problem completely though because there are other
circumstances in which new workers can be created which can then be
assigned an "illegal" worker ID.