### PR TITLE
Update db_index docs

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -324,7 +324,11 @@ scenes.
 
 .. attribute:: Field.db_index
 
-If ``True``, a database index will be created for this field.
+If ``True``, one or more database indexes will be created for this field. When
+used with PostgreSQL, two indexes will be created. One for ``like`` queries,
+and one for exact matches. It is usually preferable to use
+:attr:`Meta.indexes <django.db.models.Options.indexes>`.
+
 
 ``db_tablespace``
 -----------------


### PR DESCRIPTION
I'm diving into my DB and was surprised to learn today that when you use db_index on a field in PostgreSQL, it actually creates two indexes. In my case, these `like` indexes are huge. I have 100GB of them that have never been used according to the analysis I'm doing in https://github.com/freelawproject/courtlistener/issues/1406. That's not good and not what I expected. 

I also discovered while researching this that the preferred way of configuring indexes these days is via the Meta.indexes field, so I made a note about that too.