### PR TITLE
Set the arguement default value for the `send_mail` function of `django.core.mail.__init__.py`.

### DIFF
--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -35,7 +35,7 @@ def get_connection(backend=None, fail_silently=False, **kwds):
     return klass(fail_silently=fail_silently, **kwds)
 
 
-def send_mail(subject, message, recipient_list, from_email=None,
+def send_mail(subject, message, from_email=None, recipient_list=[],
               fail_silently=False, auth_user=None, auth_password=None,
               connection=None, html_message=None):
     """

--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -35,7 +35,7 @@ def get_connection(backend=None, fail_silently=False, **kwds):
     return klass(fail_silently=fail_silently, **kwds)
 
 
-def send_mail(subject, message, from_email, recipient_list,
+def send_mail(subject, message, recipient_list, from_email=None,
               fail_silently=False, auth_user=None, auth_password=None,
               connection=None, html_message=None):
     """


### PR DESCRIPTION
First, I am always using your library well! :)

I set the arguement default value for the `send_mail` function of `django.core.mail.__init__.py`.

The docstring of the send_mail function is shown below.
```
"""
      If from_email is None, use the DEFAULT_FROM_EMAIL setting.  # this line!
    If auth_user is None, use the EMAIL_HOST_USER setting.
    If auth_password is None, use the EMAIL_HOST_PASSWORD setting.
"""
```
The accompanying arguments `auth_user`, `auth_password`, has default value None, but send_mail has no default value.

I think this approach is inefficient because we have to write down unnecessary `from_email` when using it.

```
from django.core.mail import send_mail


send_mail(
	subject="Activate your DoranDoran account.",
	message="Please Activate your account http://localhost:8000",
	from_email=None,
	recipient_list=[user_instance.user.email],
	fail_silently=False,
)
```
like this code...