### PR TITLE
Fixed #32774 -- cache_page decorator doesn't work for cross-browser

### DIFF
--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -395,7 +395,7 @@ def learn_cache_key(request, response, cache_timeout=None, key_prefix=None, cach
         headerlist = []
         for header in cc_delim_re.split(response.headers['Vary']):
             header = header.upper().replace('-', '_')
-            if header != 'ACCEPT_LANGUAGE' or not is_accept_language_redundant:
+            if header not in ('ACCEPT', 'ACCEPT_LANGUAGE') or not is_accept_language_redundant:
                 headerlist.append('HTTP_' + header)
         headerlist.sort()
         cache.set(cache_key, headerlist, cache_timeout)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32774

**The root cause:**
- First load using Postman:
  - default header: Accept: */*

- Second load using Firefox:
  - default header: Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'

=> First load's **cache_key** != Second load's **cache_key**