### PR TITLE
Fixed #33012 -- Added Redis cache backend.

### DIFF
--- a/django/core/cache/backends/redis.py
+++ b/django/core/cache/backends/redis.py
@@ -1,0 +1,224 @@
+"""Redis cache backend."""
+
+import random
+import re
+
+from django.core.cache.backends.base import DEFAULT_TIMEOUT, BaseCache
+from django.core.serializers.base import PickleSerializer
+from django.utils.functional import cached_property
+from django.utils.module_loading import import_string
+
+
+class RedisSerializer(PickleSerializer):
+    def dumps(self, obj):
+        if isinstance(obj, int):
+            return obj
+        return super().dumps(obj)
+
+    def loads(self, data):
+        try:
+            return int(data)
+        except ValueError:
+            return super().loads(data)
+
+
+class RedisCacheClient:
+    def __init__(
+        self,
+        servers,
+        serializer=None,
+        db=None,
+        pool_class=None,
+        parser_class=None,
+    ):
+        import redis
+
+        self._lib = redis
+        self._servers = servers
+        self._pools = {}
+
+        self._client = self._lib.Redis
+
+        if isinstance(pool_class, str):
+            pool_class = import_string(pool_class)
+        self._pool_class = pool_class or self._lib.ConnectionPool
+
+        if isinstance(serializer, str):
+            serializer = import_string(serializer)
+        if callable(serializer):
+            serializer = serializer()
+        self._serializer = serializer or RedisSerializer()
+
+        if isinstance(parser_class, str):
+            parser_class = import_string(parser_class)
+        parser_class = parser_class or self._lib.connection.DefaultParser
+
+        self._pool_options = {'parser_class': parser_class, 'db': db}
+
+    def _get_connection_pool_index(self, write):
+        # Write to the first server. Read from other servers if there are more,
+        # otherwise read from the first server.
+        if write or len(self._servers) == 1:
+            return 0
+        return random.randint(1, len(self._servers) - 1)
+
+    def _get_connection_pool(self, write):
+        index = self._get_connection_pool_index(write)
+        if index not in self._pools:
+            self._pools[index] = self._pool_class.from_url(
+                self._servers[index], **self._pool_options,
+            )
+        return self._pools[index]
+
+    def get_client(self, key=None, *, write=False):
+        # key is used so that the method signature remains the same and custom
+        # cache client can be implemented which might require the key to select
+        # the server, e.g. sharding.
+        pool = self._get_connection_pool(write)
+        return self._client(connection_pool=pool)
+
+    def add(self, key, value, timeout):
+        client = self.get_client(key, write=True)
+        value = self._serializer.dumps(value)
+
+        if timeout == 0:
+            if ret := bool(client.set(key, value, nx=True)):
+                client.delete(key)
+            return ret
+        else:
+            return bool(client.set(key, value, ex=timeout, nx=True))
+
+    def get(self, key, default):
+        client = self.get_client(key)
+        value = client.get(key)
+        return default if value is None else self._serializer.loads(value)
+
+    def set(self, key, value, timeout):
+        client = self.get_client(key, write=True)
+        value = self._serializer.dumps(value)
+        if timeout == 0:
+            client.delete(key)
+        else:
+            client.set(key, value, ex=timeout)
+
+    def touch(self, key, timeout):
+        client = self.get_client(key, write=True)
+        if timeout is None:
+            return bool(client.persist(key))
+        else:
+            return bool(client.expire(key, timeout))
+
+    def delete(self, key):
+        client = self.get_client(key, write=True)
+        return bool(client.delete(key))
+
+    def get_many(self, keys):
+        client = self.get_client(None)
+        ret = client.mget(keys)
+        return {
+            k: self._serializer.loads(v) for k, v in zip(keys, ret) if v is not None
+        }
+
+    def has_key(self, key):
+        client = self.get_client(key)
+        return bool(client.exists(key))
+
+    def incr(self, key, delta):
+        client = self.get_client(key)
+        if not client.exists(key):
+            raise ValueError("Key '%s' not found." % key)
+        return client.incr(key, delta)
+
+    def set_many(self, data, timeout):
+        client = self.get_client(None, write=True)
+        pipeline = client.pipeline()
+        pipeline.mset({k: self._serializer.dumps(v) for k, v in data.items()})
+
+        if timeout is not None:
+            # Setting timeout for each key as redis does not support timeout
+            # with mset().
+            for key in data:
+                pipeline.expire(key, timeout)
+        pipeline.execute()
+
+    def delete_many(self, keys):
+        client = self.get_client(None, write=True)
+        client.delete(*keys)
+
+    def clear(self):
+        client = self.get_client(None, write=True)
+        return bool(client.flushdb())
+
+
+class RedisCache(BaseCache):
+    def __init__(self, server, params):
+        super().__init__(params)
+        if isinstance(server, str):
+            self._servers = re.split('[;,]', server)
+        else:
+            self._servers = server
+
+        self._class = RedisCacheClient
+        self._options = params.get('OPTIONS', {})
+
+    @cached_property
+    def _cache(self):
+        return self._class(self._servers, **self._options)
+
+    def get_backend_timeout(self, timeout=DEFAULT_TIMEOUT):
+        if timeout == DEFAULT_TIMEOUT:
+            timeout = self.default_timeout
+        # The key will be made persistent if None used as a timeout.
+        # Non-positive values will cause the key to be deleted.
+        return None if timeout is None else max(0, int(timeout))
+
+    def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        return self._cache.add(key, value, self.get_backend_timeout(timeout))
+
+    def get(self, key, default=None, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        return self._cache.get(key, default)
+
+    def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        self._cache.set(key, value, self.get_backend_timeout(timeout))
+
+    def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        return self._cache.touch(key, self.get_backend_timeout(timeout))
+
+    def delete(self, key, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        return self._cache.delete(key)
+
+    def get_many(self, keys, version=None):
+        key_map = {self.make_and_validate_key(key, version=version): key for key in keys}
+        ret = self._cache.get_many(key_map.keys())
+        return {key_map[k]: v for k, v in ret.items()}
+
+    def has_key(self, key, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        return self._cache.has_key(key)
+
+    def incr(self, key, delta=1, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        return self._cache.incr(key, delta)
+
+    def set_many(self, data, timeout=DEFAULT_TIMEOUT, version=None):
+        safe_data = {}
+        for key, value in data.items():
+            key = self.make_and_validate_key(key, version=version)
+            safe_data[key] = value
+        self._cache.set_many(safe_data, self.get_backend_timeout(timeout))
+        return []
+
+    def delete_many(self, keys, version=None):
+        safe_keys = []
+        for key in keys:
+            key = self.make_and_validate_key(key, version=version)
+            safe_keys.append(key)
+        self._cache.delete_many(safe_keys)
+
+    def clear(self):
+        return self._cache.clear()

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -285,6 +285,7 @@ dependencies:
 *  PyYAML_
 *  pytz_ (required)
 *  pywatchman_
+*  redis_
 *  setuptools_
 *  memcached_, plus a :ref:`supported Python binding <memcached>`
 *  gettext_ (:ref:`gettext_on_windows`)
@@ -308,8 +309,9 @@ encounter.
 You can also install the database adapter(s) of your choice using
 ``oracle.txt``, ``mysql.txt``, or ``postgres.txt``.
 
-If you want to test the memcached cache backend, you'll also need to define
-a :setting:`CACHES` setting that points at your memcached instance.
+If you want to test the memcached or Redis cache backends, you'll also need to
+define a :setting:`CACHES` setting that points at your memcached or Redis
+instance respectively.
 
 To run the GeoDjango tests, you will need to :doc:`set up a spatial database
 and install the Geospatial libraries</ref/contrib/gis/install/index>`.
@@ -332,6 +334,7 @@ service.
 .. _PyYAML: https://pyyaml.org/wiki/PyYAML
 .. _pytz: https://pypi.org/project/pytz/
 .. _pywatchman: https://pypi.org/project/pywatchman/
+.. _redis: https://pypi.org/project/redis/
 .. _setuptools: https://pypi.org/project/setuptools/
 .. _memcached: https://memcached.org/
 .. _gettext: https://www.gnu.org/software/gettext/manual/gettext.html

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -153,6 +153,7 @@ The cache backend to use. The built-in cache backends are:
 * ``'django.core.cache.backends.locmem.LocMemCache'``
 * ``'django.core.cache.backends.memcached.PyMemcacheCache'``
 * ``'django.core.cache.backends.memcached.PyLibMCCache'``
+* ``'django.core.cache.backends.redis.RedisCache'``
 
 You can use a cache backend that doesn't ship with Django by setting
 :setting:`BACKEND <CACHES-BACKEND>` to a fully-qualified path of a cache
@@ -161,6 +162,10 @@ backend class (i.e. ``mypackage.backends.whatever.WhateverCache``).
 .. versionchanged:: 3.2
 
     The ``PyMemcacheCache`` backend was added.
+
+.. versionchanged:: 4.0
+
+    The ``RedisCache`` backend was added.
 
 .. setting:: CACHES-KEY_FUNCTION
 

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -65,6 +65,16 @@ The new :ref:`scrypt password hasher <scrypt-usage>` is more secure and
 recommended over PBKDF2. However, it's not the default as it requires OpenSSL
 1.1+ and more memory.
 
+Redis cache backend
+-------------------
+
+The new ``django.core.cache.backends.redis.RedisCache`` cache backend provides
+built-in support for caching with Redis. `redis-py`_ 3.0.0 or higher is
+required. For more details, see the :ref:`documentation on caching with Redis
+in Django <redis>`.
+
+.. _`redis-py`: https://pypi.org/project/redis/
+
 Minor features
 --------------
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -423,6 +423,7 @@ recomputation
 recursed
 redeclare
 redirections
+redis
 redisplay
 redisplayed
 redisplaying

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -62,7 +62,6 @@ settings file. Here's an explanation of all available values for
 Memcached
 ---------
 
-The fastest, most efficient type of cache supported natively by Django,
 Memcached__ is an entirely memory-based cache server, originally developed
 to handle high loads at LiveJournal.com and subsequently open-sourced by
 Danga Interactive. It is used by sites such as Facebook and Wikipedia to
@@ -168,6 +167,71 @@ particularly temporary.
     The ``MemcachedCache`` backend is deprecated as ``python-memcached`` has
     some problems and seems to be unmaintained. Use ``PyMemcacheCache`` or
     ``PyLibMCCache`` instead.
+
+.. _redis:
+
+Redis
+-----
+
+.. versionadded:: 4.0
+
+Redis__ is an in-memory database that can be used for caching. To begin you'll
+need a Redis server running either locally or on a remote machine.
+
+__ https://redis.io/
+
+After setting up the Redis server, you'll need to install Python bindings for
+Redis. `redis-py`_ is the binding supported natively by Django. Installing the
+additional `hiredis-py`_ package is also recommended.
+
+.. _`redis-py`: https://pypi.org/project/redis/
+.. _`hiredis-py`: https://pypi.org/project/hiredis/
+
+To use Redis as your cache backend with Django:
+
+* Set :setting:`BACKEND <CACHES-BACKEND>` to
+  ``django.core.cache.backends.redis.RedisCache``.
+
+* Set :setting:`LOCATION <CACHES-LOCATION>` to the URL pointing to your Redis
+  instance, using the appropriate scheme. See the ``redis-py`` docs for
+  `details on the available schemes
+  <https://redis-py.readthedocs.io/en/stable/#redis.ConnectionPool.from_url>`_.
+
+For example, if Redis is running on localhost (127.0.0.1) port 6379::
+
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+            'LOCATION': 'redis://127.0.0.1:6379',
+        }
+    }
+
+Often Redis servers are protected with authentication. In order to supply a
+username and password, add them in the ``LOCATION`` along with the URL::
+
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+            'LOCATION': 'redis://username:password@127.0.0.1:6379',
+        }
+    }
+
+If you have multiple Redis servers set up in the replication mode, you can
+specify the servers either as a semicolon or comma delimited string, or as a
+list. While using multiple servers, write operations are performed on the first
+server (leader). Read operations are performed on the other servers (replicas)
+chosen at random::
+
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+            'LOCATION': [
+                'redis://127.0.0.1:6379', # leader
+                'redis://127.0.0.1:6378', # read-replica 1
+                'redis://127.0.0.1:6377', # read-replica 2
+            ],
+        }
+    }
 
 .. _database-caching:
 
@@ -422,9 +486,9 @@ behavior. These arguments are provided as additional keys in the
     On some backends (``database`` in particular) this makes culling *much*
     faster at the expense of more cache misses.
 
-  Memcached backends pass the contents of :setting:`OPTIONS <CACHES-OPTIONS>`
-  as keyword arguments to the client constructors, allowing for more advanced
-  control of client behavior. For example usage, see below.
+  The Memcached and Redis backends pass the contents of :setting:`OPTIONS
+  <CACHES-OPTIONS>` as keyword arguments to the client constructors, allowing
+  for more advanced control of client behavior. For example usage, see below.
 
 * :setting:`KEY_PREFIX <CACHES-KEY_PREFIX>`: A string that will be
   automatically included (prepended by default) to all cache keys
@@ -495,6 +559,27 @@ flag on the connection's socket::
             }
         }
     }
+
+Here's an example configuration for a ``redis`` based backend that selects
+database ``10`` (by default Redis ships with 16 logical databases), specifies a
+`parser class`_ (``redis.connection.HiredisParser`` will be used by default if
+the ``hiredis-py`` package is installed), and sets a custom `connection pool
+class`_ (``redis.ConnectionPool`` is used by default)::
+
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+            'LOCATION': 'redis://127.0.0.1:6379',
+            'OPTIONS': {
+                'db': '10',
+                'parser_class': 'redis.connection.PythonParser',
+                'pool_class': 'redis.BlockingConnectionPool',
+            }
+        }
+    }
+
+.. _`parser class`: https://github.com/andymccurdy/redis-py#parsers
+.. _`connection pool class`: https://github.com/andymccurdy/redis-py#connection-pools
 
 .. _the-per-site-cache:
 

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -15,6 +15,7 @@ python-memcached >= 1.59
 pytz
 pywatchman; sys.platform != 'win32'
 PyYAML
+redis >= 3.0.0
 selenium
 sqlparse >= 0.2.2
 tblib >= 1.5.0


### PR DESCRIPTION
ticket-33012

This PR is in accordance with this [GSoC project](https://summerofcode.withgoogle.com/projects/#6292871491092480)
The detailed proposal can be found [here](https://docs.google.com/document/d/1_gIa_17uCNlwJTmqiMLkiVtRgTOD2MvHpy4NNFvKBWc/edit?usp=sharing)

This PR aims at adding support for Redis to be used as a caching backend with Django. As redis is the most popular caching backend, adding it to django.core.cache module would be a great addition for developers who previously had to rely on the use of third party packages.

Major Tasks : 
- [x] Create RedisCache as a subclass of the BaseCache class and implement methods
- [x] Create PickleSerializer to serialize data before storing it into redis
- [x] Extend existing tests for new class
- [x] Add Documentation and Release Notes
- [x] Add additional tests for RedisCache and RedisCacheClient
- [x] Moving `PickleSerializer` from `django.contrib.sessions.serializers` to `django.core.serializers.base`. See [comment](https://github.com/django/django/pull/14437/#discussion_r699197718) #14827

Remaining Tasks :
- [x] Waiting for #14802
- [ ] Documenting extra arguments. See [comment](https://github.com/django/django/pull/14437/#discussion_r699194492)

Future Tasks : 
- [ ] Add support for providing `username` and `password` in `OPTIONS`. This will be possible in the upcoming version of redis-py
- [ ] Milli second support (To be discussed)
