### PR TITLE
Fixed #33079 -- Fixed get_image_dimensions() on nonexistent images.

### DIFF
--- a/django/core/files/images.py
+++ b/django/core/files/images.py
@@ -44,7 +44,10 @@ def get_image_dimensions(file_or_path, close=False):
         file_pos = file.tell()
         file.seek(0)
     else:
-        file = open(file_or_path, 'rb')
+        try:
+            file = open(file_or_path, 'rb')
+        except OSError:
+            return (None, None)
         close = True
     try:
         # Most of the time Pillow only needs a small chunk to parse the image

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -369,6 +369,10 @@ class GetImageDimensionsTests(unittest.TestCase):
                 size = images.get_image_dimensions(fh)
                 self.assertEqual(size, (None, None))
 
+    def test_missing_file(self):
+        size = images.get_image_dimensions('missing.png')
+        self.assertEqual(size, (None, None))
+
     @unittest.skipUnless(HAS_WEBP, 'WEBP not installed')
     def test_webp(self):
         img_path = os.path.join(os.path.dirname(__file__), 'test.webp')


### PR DESCRIPTION
This is a fix in order to not crash the code which is using get_image_dimensions().

If a non existing file/path passed, the function will return (None, None)

https://code.djangoproject.com/ticket/33079