### PR TITLE
Refs #32379 -- Added USE_TZ settings to AdminScriptTestCase.write_settings().

### DIFF
--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -64,6 +64,7 @@ class AdminScriptTestCase(SimpleTestCase):
                 'DEFAULT_AUTO_FIELD',
                 'ROOT_URLCONF',
                 'SECRET_KEY',
+                'USE_TZ',
             ]
             for s in exports:
                 if hasattr(settings, s):


### PR DESCRIPTION
Follow up to 8cd55021bcb6c9727c1adccd9623fa4acfc0312b.

Without `USE_TZ` in `settings.py` many `test_runner` and `admin_scripts` tests crash on Python built with `Py_DEBUG`, e.g.
```
======================================================================
FAIL: test_option_name_and_value_separated (test_runner.tests.CustomTestRunnerOptionsSettingsTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "django/tests/test_runner/tests.py", line 312, in test_option_name_and_value_separated
    self.assertNoOutput(err)
  File "django/tests/admin_scripts/tests.py", line 151, in assertNoOutput
    self.assertEqual(len(stream), 0, "Stream should be empty: actually contains '%s'" % stream)
AssertionError: 266 != 0 : Stream should be empty: actually contains 'django/django/conf/__init__.py:163: RemovedInDjango50Warning: The default value of USE_TZ will change from False to True in Django 5.0. Set USE_TZ to False in your project settings if you want to keep the current default behavior.
  warnings.warn(
```

Yes busted, I'm checking our test suite with the Python `main` branch :smile: 