### PR TITLE
Fixed #32772 -- Made database cache count size once per set.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -641,6 +641,7 @@ answer newbie questions, and generally made Django that much better:
     Michael S. Brown <michael@msbrown.net>
     Michael Hall <mhall1@ualberta.ca>
     Michael Josephson <http://www.sdjournal.com/>
+    Michael Lissner <mike@free.law>
     Michael Manfre <mmanfre@gmail.com>
     michael.mcewan@gmail.com
     Michael Placentra II <someone@michaelplacentra2.net>


### PR DESCRIPTION
This is a small change following up the discussion in:

https://code.djangoproject.com/ticket/32772

To reiterate what's there, I've found that COUNT queries are pretty slow when you have a large DB cache. When I looked at this code recently, I discovered that it calls COUNT twice unnecessarily, when once is enough if you track the number of expired rows. 

I think this should fix it and I look forward to a review! 