### PR TITLE
Fixed #32789 -- Made feeds emit elements with no content as self-closing tags.

### DIFF
--- a/django/utils/feedgenerator.py
+++ b/django/utils/feedgenerator.py
@@ -187,7 +187,7 @@ class RssFeed(SyndicationFeed):
     content_type = 'application/rss+xml; charset=utf-8'
 
     def write(self, outfile, encoding):
-        handler = SimplerXMLGenerator(outfile, encoding)
+        handler = SimplerXMLGenerator(outfile, encoding, short_empty_elements=True)
         handler.startDocument()
         handler.startElement("rss", self.rss_attributes())
         handler.startElement("channel", self.root_attributes())
@@ -296,7 +296,7 @@ class Atom1Feed(SyndicationFeed):
     ns = "http://www.w3.org/2005/Atom"
 
     def write(self, outfile, encoding):
-        handler = SimplerXMLGenerator(outfile, encoding)
+        handler = SimplerXMLGenerator(outfile, encoding, short_empty_elements=True)
         handler.startDocument()
         handler.startElement('feed', self.root_attributes())
         self.add_root_elements(handler)

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -432,6 +432,10 @@ Miscellaneous
 * The ``object`` argument of undocumented ``ModelAdmin.log_addition()``,
   ``log_change()``, and ``log_deletion()`` methods is renamed to ``obj``.
 
+* :class:`~django.utils.feedgenerator.RssFeed`,
+  :class:`~django.utils.feedgenerator.Atom1Feed`, and their subclasses now
+  emit elements with no content as self-closing tags.
+
 .. _deprecated-features-4.0:
 
 Features deprecated in 4.0


### PR DESCRIPTION
Hello 
this was a problem i encountered at work where the syndication feed doesn't allow self closing tags. for example it produces tags like ``` <enclosure url="http://someurl.com"></enclosure>``` instead of the standard ```<enclosure url="http://someurl.com" />``` i suspect this is caused by the fact that when this code was written self closing tags didn't exist yet. but it has been supported in [XMLGenerator](https://docs.python.org/3/library/xml.sax.utils.html#xml.sax.saxutils.XMLGenerator) since python 3.2 and since it was such a small addition i added them myself.
i appreciate any feedback.
thank you for your time 

ticket-32789