### PR TITLE
Fixed #32870 -- Improved error message when URLconf is empty.

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -626,9 +626,10 @@ class URLResolver:
             iter(patterns)
         except TypeError as e:
             msg = (
-                "The included URLconf '{name}' does not appear to have any "
-                "patterns in it. If you see valid patterns in the file then "
-                "the issue is probably caused by a circular import."
+                "The included URLconf '{name}' does not appear to have "
+                "any patterns in it. If you see the 'urlpatterns' variable "
+                "with valid patterns in the file then the issue is probably "
+                "caused by a circular import."
             )
             raise ImproperlyConfigured(msg.format(name=self.urlconf_name)) from e
         return patterns

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -271,8 +271,9 @@ class NoURLPatternsTests(SimpleTestCase):
         with self.assertRaisesMessage(
             ImproperlyConfigured,
             "The included URLconf 'urlpatterns_reverse.no_urls' does not "
-            "appear to have any patterns in it. If you see valid patterns in "
-            "the file then the issue is probably caused by a circular import."
+            "appear to have any patterns in it. If you see the 'urlpatterns' "
+            "variable with valid patterns in the file then the issue is "
+            "probably caused by a circular import."
         ):
             getattr(resolver, 'url_patterns')
 
@@ -1095,8 +1096,9 @@ class NoRootUrlConfTests(SimpleTestCase):
     def test_no_handler_exception(self):
         msg = (
             "The included URLconf 'None' does not appear to have any patterns "
-            "in it. If you see valid patterns in the file then the issue is "
-            "probably caused by a circular import."
+            "in it. If you see the 'urlpatterns' variable with valid patterns "
+            "in the file then the issue is probably caused by a circular "
+            "import."
         )
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             self.client.get('/test/me/')


### PR DESCRIPTION
I found this kind of error when I mispelled `urlspattern` instead of `urlpatterns`inside my `blog/urls.py` file.    
So the console was throwing an error, but this error do not helped me to found the problem. Check it:
```
django.core.exceptions.ImproperlyConfigured: The included URLconf '<module 'blog.urls'
from '.../my_project/blog/urls.py'>' does not
 appear to have any patterns in it. If you see valid patterns in the file then the
 issue is probably caused by a circular import.
```

The problem is not with a circular import, but with the mispelled `urlpatterns` variable itself, so I'm doing this pull request.     
I appreciate any feedback.   
Thanks,
Igor