### PR TITLE
Fix incorrect generation fo gin index with OpClass

### DIFF
--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -245,7 +245,7 @@ class IndexExpression(Func):
             for_save,
         )
         if not isinstance(resolve_root_expression, Col):
-            root_expression = Func(root_expression, template='(%(expressions)s)')
+            root_expression = Func(root_expression, template='%(expressions)s')
 
         if wrappers:
             # Order wrappers and set their expressions.


### PR DESCRIPTION
Currently this index definition:
            GinIndex(OpClass(Upper("first_name"), name="gin_trgm_ops"), name="policy_first_name_upper_gin"),
generates:
CREATE INDEX "policy_first_name_upper_gin" ON "main_policy" USING gin ((UPPER("first_name") gin_trgm_ops))

This doesn't work, due to the bonus set of ().

The change I'm proposing above results in the index def above to generate:

CREATE INDEX "policy_last_name_upper_gin" ON "main_policy" USING gin (UPPER("last_name") gin_trgm_ops)

which does the right thing.

I am not super familiar with the code base - so I'm not sure if this would have negative impact on other usecases.