### PR TITLE
Test client redirect to a URL without a trailing slash fix

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -834,7 +834,7 @@ class Client(ClientMixin, RequestFactory):
                 extra['SERVER_PORT'] = str(url.port)
 
             # Prepend the request path to handle relative path redirects
-            path = url.path
+            path = url.path or '/'
             if not path.startswith('/'):
                 path = urljoin(response.request['PATH_INFO'], path)
 

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -273,6 +273,16 @@ class ClientTest(TestCase):
         # location returned 301 when retrieved
         self.assertRedirects(response, '/permanent_redirect_view/', target_status_code=301)
 
+    def test_redirect_without_trailing_slash(self):
+        "Get a URL that redirects to a non relative URL without the trailing slash"
+        response = self.client.get('/external_redirect_view/', follow=True)
+        self.assertRedirects(response, 'https://testserver')
+
+    def test_redirect_without_trailing_slash_with_query(self):
+        "Get a URL that redirects to a non relative URL without the trailing slash with query params"
+        response = self.client.get('/external_redirect_view/?foo=bar', follow=True)
+        self.assertRedirects(response, 'https://testserver?foo=bar')
+
     def test_follow_redirect(self):
         "A URL that redirects can be followed to termination."
         response = self.client.get('/double_redirect_view/', follow=True)

--- a/tests/test_client/urls.py
+++ b/tests/test_client/urls.py
@@ -5,6 +5,7 @@ from django.views.generic import RedirectView
 from . import views
 
 urlpatterns = [
+    path('', views.index_view, name='index'),
     path('upload_view/', views.upload_view, name='upload_view'),
     path('get_view/', views.get_view, name='get_view'),
     path('post_view/', views.post_view),
@@ -29,6 +30,7 @@ urlpatterns = [
     path('http_redirect_view/', RedirectView.as_view(url='/secure_view/')),
     path('https_redirect_view/', RedirectView.as_view(url='https://testserver/secure_view/')),
     path('double_redirect_view/', views.double_redirect_view),
+    path('external_redirect_view/', views.external_redirect_view),
     path('bad_view/', views.bad_view),
     path('form_view/', views.form_view),
     path('form_view_with_template/', views.form_view_with_template),

--- a/tests/test_client/views.py
+++ b/tests/test_client/views.py
@@ -131,6 +131,14 @@ def redirect_view(request):
     return HttpResponseRedirect('/get_view/' + query)
 
 
+def external_redirect_view(request):
+    if request.GET:
+        query = '?' + urlencode(request.GET, True)
+    else:
+        query = ''
+    return HttpResponseRedirect('https://testserver' + query)
+
+
 def method_saving_307_redirect_query_string_view(request):
     return HttpResponseRedirect('/post_view/?hello=world', status=307)
 
@@ -393,3 +401,7 @@ class TwoArgException(Exception):
 
 def two_arg_exception(request):
     raise TwoArgException('one', 'two')
+
+
+def index_view(request):
+    return HttpResponse('Hello world')


### PR DESCRIPTION
Currently, when you redirect with the test client to an external URL without a trailing slash, the test client will redirect to the view you redirected from.

For example, if I test a view at `/my-view/` that redirects to `https://example.com`, the test client will instead redirect to `/my-view/`. This fixes that issue.