### PR TITLE
Refs #32779 -- Changed DatabaseSchemaEditor._unique_sql()/_create_unique_sql() to take fields as second parameter.

### DIFF
--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -187,7 +187,7 @@ class UniqueConstraint(BaseConstraint):
         )
 
     def constraint_sql(self, model, schema_editor):
-        fields = [model._meta.get_field(field_name).column for field_name in self.fields]
+        fields = [model._meta.get_field(field_name) for field_name in self.fields]
         include = [model._meta.get_field(field_name).column for field_name in self.include]
         condition = self._get_condition_sql(model, schema_editor)
         expressions = self._get_index_expressions(model, schema_editor)
@@ -198,7 +198,7 @@ class UniqueConstraint(BaseConstraint):
         )
 
     def create_sql(self, model, schema_editor):
-        fields = [model._meta.get_field(field_name).column for field_name in self.fields]
+        fields = [model._meta.get_field(field_name) for field_name in self.fields]
         include = [model._meta.get_field(field_name).column for field_name in self.include]
         condition = self._get_condition_sql(model, schema_editor)
         expressions = self._get_index_expressions(model, schema_editor)

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -321,6 +321,9 @@ backends.
   ``iso_year`` argument in order to support bounds for ISO-8601 week-numbering
   years.
 
+* The second argument of ``DatabaseSchemaEditor._unique_sql()`` and
+  ``_create_unique_sql()`` methods is now fields instead of columns.
+
 :mod:`django.contrib.gis`
 -------------------------
 

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -3287,7 +3287,7 @@ class SchemaTests(TransactionTestCase):
 
             constraint_name = 'CamelCaseUniqConstraint'
             expected_constraint_name = identifier_converter(constraint_name)
-            editor.execute(editor._create_unique_sql(model, [field.column], constraint_name))
+            editor.execute(editor._create_unique_sql(model, [field], constraint_name))
             self.assertIn(expected_constraint_name, self.get_constraints(model._meta.db_table))
             editor.alter_field(model, get_field(unique=True), field, strict=True)
             self.assertNotIn(expected_constraint_name, self.get_constraints(model._meta.db_table))


### PR DESCRIPTION
Will allow unique indexes to derive tablespaces from fields.

https://github.com/django/django/pull/14448