### PR TITLE
Fixed typos in comments and docs.

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -915,7 +915,7 @@ class MigrationAutodetector:
     def generate_altered_fields(self):
         """
         Make AlterField operations, or possibly RemovedField/AddField if alter
-        isn's possible.
+        isn't possible.
         """
         for app_label, model_name, field_name in sorted(self.old_field_keys & self.new_field_keys):
             # Did the field change?

--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -160,7 +160,7 @@ def uri_to_iri(uri):
     if uri is None:
         return uri
     uri = force_bytes(uri)
-    # Fast selective unqote: First, split on '%' and then starting with the
+    # Fast selective unquote: First, split on '%' and then starting with the
     # second block, decode the first 2 bytes if they represent a hex code to
     # decode. The rest of the block is the part after '%AB', not containing
     # any '%'. Add that to the output without further processing.

--- a/docs/ref/contrib/gis/install/index.txt
+++ b/docs/ref/contrib/gis/install/index.txt
@@ -484,7 +484,7 @@ Install Django and set up database
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :ref:`install Django <installing-official-release>` on your system. It is
-recommended that you create a :doc:`virtural environment
+recommended that you create a :doc:`virtual environment
 <python:tutorial/venv>` for each project you create.
 
 psycopg2

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -676,7 +676,7 @@ app label and migration name you want to squash up to, and it'll get to work::
   Do you wish to proceed? [yN] y
   Optimizing...
     Optimized from 12 operations to 7 operations.
-  Created new squashed migration /home/andrew/Programs/DjangoTest/test/migrations/0001_squashed_0004_undo_somthing.py
+  Created new squashed migration /home/andrew/Programs/DjangoTest/test/migrations/0001_squashed_0004_undo_something.py
     You should commit this migration but leave the old ones in place;
     the new migration will be used for new installs. Once you are sure
     all instances of the codebase have applied the migrations you squashed,


### PR DESCRIPTION
@felixxm, I separated each one into a separate commit so that the commit message was in the usual style, but feel free to squash it down to a single commit if you think that's preferable. Thanks!