### PR TITLE
Fixed #32797 -- Use source strings for plural translation in admin utils.

### DIFF
--- a/django/contrib/admin/locale/en/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/en/LC_MESSAGES/django.po
@@ -155,9 +155,11 @@ msgstr ""
 msgid "change message"
 msgstr ""
 
-#: contrib/admin/models.py:66
+#: contrib/admin/models.py:66 contrib/admin/models.py:68
 msgid "log entry"
-msgstr ""
+msgid_plural "log entries"
+msgstr[0] ""
+msgstr[1] ""
 
 #: contrib/admin/models.py:67
 msgid "log entries"

--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -7,7 +7,7 @@ from django.db import models
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 from django.utils.text import get_text_list
-from django.utils.translation import gettext, gettext_lazy as _
+from django.utils.translation import gettext, gettext_lazy as _, ngettext_noop
 
 ADDITION = 1
 CHANGE = 2
@@ -65,6 +65,7 @@ class LogEntry(models.Model):
     class Meta:
         verbose_name = _('log entry')
         verbose_name_plural = _('log entries')
+        ngettext_noop('log entry', 'log entries')
         db_table = 'django_admin_log'
         ordering = ['-action_time']
 

--- a/django/contrib/auth/locale/en/LC_MESSAGES/django.po
+++ b/django/contrib/auth/locale/en/LC_MESSAGES/django.po
@@ -182,17 +182,21 @@ msgstr ""
 msgid "codename"
 msgstr ""
 
-#: contrib/auth/models.py:67
+#: contrib/auth/models.py:69 contrib/auth/models.py:71
 msgid "permission"
-msgstr ""
+msgid_plural "permissions"
+msgstr[0] ""
+msgstr[1] ""
 
 #: contrib/auth/models.py:68 contrib/auth/models.py:111
 msgid "permissions"
 msgstr ""
 
-#: contrib/auth/models.py:118
+#: contrib/auth/models.py:120 contrib/auth/models.py:122
 msgid "group"
-msgstr ""
+msgid_plural "groups"
+msgstr[0] ""
+msgstr[1] ""
 
 #: contrib/auth/models.py:119 contrib/auth/models.py:242
 msgid "groups"
@@ -268,9 +272,11 @@ msgstr ""
 msgid "date joined"
 msgstr ""
 
-#: contrib/auth/models.py:360
+#: contrib/auth/models.py:367 contrib/auth/models.py:369
 msgid "user"
-msgstr ""
+msgid_plural "users"
+msgstr[0] ""
+msgstr[1] ""
 
 #: contrib/auth/models.py:361
 msgid "users"

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -8,7 +8,7 @@ from django.core.mail import send_mail
 from django.db import models
 from django.db.models.manager import EmptyManager
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, ngettext_noop
 
 from .validators import UnicodeUsernameValidator
 
@@ -68,6 +68,7 @@ class Permission(models.Model):
     class Meta:
         verbose_name = _('permission')
         verbose_name_plural = _('permissions')
+        ngettext_noop('permission', 'permissions')
         unique_together = [['content_type', 'codename']]
         ordering = ['content_type__app_label', 'content_type__model', 'codename']
 
@@ -118,6 +119,7 @@ class Group(models.Model):
     class Meta:
         verbose_name = _('group')
         verbose_name_plural = _('groups')
+        ngettext_noop('group', 'groups')
 
     def __str__(self):
         return self.name
@@ -364,6 +366,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
     class Meta:
         verbose_name = _('user')
         verbose_name_plural = _('users')
+        ngettext_noop('user', 'users')
         abstract = True
 
     def clean(self):

--- a/django/contrib/contenttypes/locale/en/LC_MESSAGES/django.po
+++ b/django/contrib/contenttypes/locale/en/LC_MESSAGES/django.po
@@ -21,9 +21,11 @@ msgstr ""
 msgid "python model class name"
 msgstr ""
 
-#: contrib/contenttypes/models.py:139
+#: contrib/contenttypes/models.py:139 contrib/contenttypes/models.py:141
 msgid "content type"
-msgstr ""
+msgid_plural "content types"
+msgstr[0] ""
+msgstr[1] ""
 
 #: contrib/contenttypes/models.py:140
 msgid "content types"

--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from django.apps import apps
 from django.db import models
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, ngettext_noop
 
 
 class ContentTypeManager(models.Manager):
@@ -138,6 +138,7 @@ class ContentType(models.Model):
     class Meta:
         verbose_name = _('content type')
         verbose_name_plural = _('content types')
+        ngettext_noop('content type', 'content types')
         db_table = 'django_content_type'
         unique_together = [['app_label', 'model']]
 

--- a/django/contrib/flatpages/locale/en/LC_MESSAGES/django.po
+++ b/django/contrib/flatpages/locale/en/LC_MESSAGES/django.po
@@ -87,9 +87,11 @@ msgstr ""
 msgid "sites"
 msgstr ""
 
-#: contrib/flatpages/models.py:31
+#: contrib/flatpages/models.py:31 contrib/flatpages/models.py:33
 msgid "flat page"
-msgstr ""
+msgid_plural "flat pages"
+msgstr[0] ""
+msgstr[1] ""
 
 #: contrib/flatpages/models.py:32
 msgid "flat pages"

--- a/django/contrib/flatpages/models.py
+++ b/django/contrib/flatpages/models.py
@@ -2,7 +2,7 @@ from django.contrib.sites.models import Site
 from django.db import models
 from django.urls import NoReverseMatch, get_script_prefix, reverse
 from django.utils.encoding import iri_to_uri
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, ngettext_noop
 
 
 class FlatPage(models.Model):
@@ -30,6 +30,7 @@ class FlatPage(models.Model):
         db_table = 'django_flatpage'
         verbose_name = _('flat page')
         verbose_name_plural = _('flat pages')
+        ngettext_noop('flat page', 'flat pages')
         ordering = ['url']
 
     def __str__(self):

--- a/django/contrib/redirects/locale/en/LC_MESSAGES/django.po
+++ b/django/contrib/redirects/locale/en/LC_MESSAGES/django.po
@@ -41,9 +41,11 @@ msgid ""
 "scheme such as “https://”."
 msgstr ""
 
-#: contrib/redirects/models.py:25
+#: contrib/redirects/models.py:25 contrib/redirects/models.py:27
 msgid "redirect"
-msgstr ""
+msgid_plural "redirects"
+msgstr[0] ""
+msgstr[1] ""
 
 #: contrib/redirects/models.py:26
 msgid "redirects"

--- a/django/contrib/redirects/models.py
+++ b/django/contrib/redirects/models.py
@@ -1,6 +1,6 @@
 from django.contrib.sites.models import Site
 from django.db import models
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, ngettext_noop
 
 
 class Redirect(models.Model):
@@ -24,6 +24,7 @@ class Redirect(models.Model):
     class Meta:
         verbose_name = _('redirect')
         verbose_name_plural = _('redirects')
+        ngettext_noop('redirect', 'redirects')
         db_table = 'django_redirect'
         unique_together = [['site', 'old_path']]
         ordering = ['old_path']

--- a/django/contrib/sessions/base_session.py
+++ b/django/contrib/sessions/base_session.py
@@ -3,7 +3,7 @@ This module allows importing AbstractBaseSession even
 when django.contrib.sessions is not in INSTALLED_APPS.
 """
 from django.db import models
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, ngettext_noop
 
 
 class BaseSessionManager(models.Manager):
@@ -34,6 +34,7 @@ class AbstractBaseSession(models.Model):
         abstract = True
         verbose_name = _('session')
         verbose_name_plural = _('sessions')
+        ngettext_noop('session', 'sessions')
 
     def __str__(self):
         return self.session_key

--- a/django/contrib/sessions/locale/en/LC_MESSAGES/django.po
+++ b/django/contrib/sessions/locale/en/LC_MESSAGES/django.po
@@ -29,9 +29,11 @@ msgstr ""
 msgid "expire date"
 msgstr ""
 
-#: contrib/sessions/models.py:52
+#: contrib/sessions/base_session.py:35 contrib/sessions/base_session.py:37
 msgid "session"
-msgstr ""
+msgid_plural "sessions"
+msgstr[0] ""
+msgstr[1] ""
 
 #: contrib/sessions/models.py:53
 msgid "sessions"

--- a/django/contrib/sites/locale/en/LC_MESSAGES/django.po
+++ b/django/contrib/sites/locale/en/LC_MESSAGES/django.po
@@ -29,9 +29,11 @@ msgstr ""
 msgid "display name"
 msgstr ""
 
-#: contrib/sites/models.py:88
+#: contrib/sites/models.py:92 contrib/sites/models.py:94
 msgid "site"
-msgstr ""
+msgid_plural "sites"
+msgstr[0] ""
+msgstr[1] ""
 
 #: contrib/sites/models.py:89
 msgid "sites"

--- a/django/contrib/sites/models.py
+++ b/django/contrib/sites/models.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
 from django.db.models.signals import pre_delete, pre_save
 from django.http.request import split_domain_port
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, ngettext_noop
 
 SITE_CACHE = {}
 
@@ -91,6 +91,7 @@ class Site(models.Model):
         db_table = 'django_site'
         verbose_name = _('site')
         verbose_name_plural = _('sites')
+        ngettext_noop('site', 'sites')
         ordering = ['domain']
 
     def __str__(self):

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -550,6 +550,7 @@ class Command(BaseCommand):
                 '--keyword=gettext_noop',
                 '--keyword=gettext_lazy',
                 '--keyword=ngettext_lazy:1,2',
+                '--keyword=ngettext_noop:1,2',
                 '--keyword=pgettext:1c,2',
                 '--keyword=npgettext:1c,2,3',
                 '--keyword=pgettext_lazy:1c,2',

--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -14,7 +14,7 @@ __all__ = [
     'get_language_info', 'get_language_bidi',
     'check_for_language', 'to_language', 'to_locale', 'templatize',
     'gettext', 'gettext_lazy', 'gettext_noop', 'is_lazy_gettext',
-    'ngettext', 'ngettext_lazy',
+    'ngettext', 'ngettext_lazy', 'ngettext_noop',
     'pgettext', 'pgettext_lazy',
     'npgettext', 'npgettext_lazy',
 ]
@@ -72,6 +72,10 @@ def gettext_noop(message):
 
 def gettext(message):
     return _trans.gettext(message)
+
+
+def ngettext_noop(singular, plural):
+    return _trans.ngettext_noop(singular, plural)
 
 
 def ngettext(singular, plural, number):

--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -5,7 +5,7 @@ from contextlib import ContextDecorator
 from decimal import ROUND_UP, Decimal
 
 from django.utils.autoreload import autoreload_started, file_changed
-from django.utils.functional import lazy
+from django.utils.functional import lazy, Promise
 from django.utils.regex_helper import _lazy_re_compile
 
 __all__ = [
@@ -13,7 +13,7 @@ __all__ = [
     'get_language', 'get_language_from_request',
     'get_language_info', 'get_language_bidi',
     'check_for_language', 'to_language', 'to_locale', 'templatize',
-    'gettext', 'gettext_lazy', 'gettext_noop',
+    'gettext', 'gettext_lazy', 'gettext_noop', 'is_lazy_gettext',
     'ngettext', 'ngettext_lazy',
     'pgettext', 'pgettext_lazy',
     'npgettext', 'npgettext_lazy',
@@ -88,6 +88,10 @@ def npgettext(context, singular, plural, number):
 
 gettext_lazy = lazy(gettext, str)
 pgettext_lazy = lazy(pgettext, str)
+
+
+def is_lazy_gettext(obj):
+    return isinstance(obj, Promise) and obj.__reduce__()[1][0] == gettext
 
 
 def lazy_number(func, resultclass, number=None, **kwargs):

--- a/django/utils/translation/trans_null.py
+++ b/django/utils/translation/trans_null.py
@@ -21,6 +21,10 @@ def ngettext(singular, plural, number):
 ngettext_lazy = ngettext
 
 
+def ngettext_noop(singular, plural):
+    return plural
+
+
 def pgettext(context, message):
     return gettext(message)
 

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -388,6 +388,13 @@ def gettext_noop(message):
     return message
 
 
+def ngettext_noop(singular, plural):
+    """
+    Mark strings for plural translation but don't translate them now.
+    """
+    return plural
+
+
 def do_ntranslate(singular, plural, number, translation_function):
     global _default
 

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -179,6 +179,9 @@ language because they are exchanged over systems or users -- such as strings
 in a database -- but should be translated at the last possible point in time,
 such as when the string is presented to the user.
 
+Use the :func:`django.utils.translation.ngettext_noop()` function to specify
+pluralized messages without translating them.
+
 Pluralization
 -------------
 

--- a/tests/admin_utils/models.py
+++ b/tests/admin_utils/models.py
@@ -85,3 +85,9 @@ class VehicleMixin(Vehicle):
 
 class Car(VehicleMixin):
     pass
+
+
+class Foo(models.Model):
+    class Meta:
+        verbose_name = _('foo')
+        verbose_name_plural = _('foos')

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from decimal import Decimal
+from unittest.mock import patch
 
 from django import forms
 from django.conf import settings
@@ -8,7 +9,7 @@ from django.contrib.admin import helpers
 from django.contrib.admin.utils import (
     NestedObjects, display_for_field, display_for_value, flatten,
     flatten_fieldsets, help_text_for_field, label_for_field, lookup_field,
-    quote,
+    quote, model_ngettext,
 )
 from django.db import DEFAULT_DB_ALIAS, models
 from django.test import SimpleTestCase, TestCase, override_settings
@@ -16,7 +17,7 @@ from django.utils.formats import localize
 from django.utils.safestring import mark_safe
 
 from .models import (
-    Article, Car, Count, Event, EventGuide, Location, Site, Vehicle,
+    Article, Car, Count, Event, EventGuide, Location, Site, Vehicle, Foo,
 )
 
 
@@ -410,3 +411,9 @@ class UtilsTests(SimpleTestCase):
 
     def test_quote(self):
         self.assertEqual(quote('something\nor\nother'), 'something_0Aor_0Aother')
+
+    @patch('django.contrib.admin.utils.ngettext')
+    def test_model_ngettext(self, ngettext):
+        model_ngettext(Foo(), None)
+        self.assertIsInstance(ngettext.call_args.args[0], str, type(ngettext.call_args.args[0]))
+        self.assertIsInstance(ngettext.call_args.args[1], str, type(ngettext.call_args.args[1]))

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -33,7 +33,7 @@ from django.utils.translation import (
     activate, check_for_language, deactivate, get_language, get_language_bidi,
     get_language_from_request, get_language_info, gettext, gettext_lazy,
     ngettext, ngettext_lazy, npgettext, npgettext_lazy, pgettext,
-    round_away_from_one, to_language, to_locale, trans_null, trans_real,
+    round_away_from_one, to_language, to_locale, trans_null, trans_real, is_lazy_gettext,
 )
 from django.utils.translation.reloader import (
     translation_file_changed, watch_for_translation_changes,
@@ -347,6 +347,11 @@ class TranslationTests(SimpleTestCase):
         self.assertIs(trans_null.get_language_bidi(), False)
         with override_settings(LANGUAGE_CODE='he'):
             self.assertIs(get_language_bidi(), True)
+
+    def test_is_lazy_gettext(self):
+        self.assertTrue(is_lazy_gettext(gettext_lazy('foo')))
+        self.assertFalse(is_lazy_gettext('bar'))
+        self.assertFalse(is_lazy_gettext(ngettext_lazy('boo', 'far')))
 
 
 class TranslationLoadingTests(SimpleTestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32797