### PR TITLE
Fixed #32796 -- Changed CsrfViewMiddleware to fail earlier on badly formatted cookie tokens.

### DIFF
--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -863,14 +863,14 @@ class CsrfViewMiddlewareTests(CsrfViewMiddlewareTestMixin, SimpleTestCase):
         If the CSRF cookie has invalid characters in a POST request, the
         middleware rejects the incoming request.
         """
-        self._check_bad_or_missing_cookie(64 * '*', REASON_CSRF_TOKEN_MISSING)
+        self._check_bad_or_missing_cookie(64 * '*', 'CSRF cookie has invalid characters.')
 
     def test_bad_csrf_cookie_length(self):
         """
         If the CSRF cookie has an incorrect length in a POST request, the
         middleware rejects the incoming request.
         """
-        self._check_bad_or_missing_cookie(16 * 'a', REASON_CSRF_TOKEN_MISSING)
+        self._check_bad_or_missing_cookie(16 * 'a', 'CSRF cookie has incorrect length.')
 
     def test_process_view_token_too_long(self):
         """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32796

(This is on top of: https://github.com/django/django/pull/14464 )
