### PR TITLE
Use single quote for str literals

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -290,7 +290,7 @@ for a given poll. Here's the view:
         try:
             question = Question.objects.get(pk=question_id)
         except Question.DoesNotExist:
-            raise Http404("Question does not exist")
+            raise Http404('Question does not exist')
         return render(request, 'polls/detail.html', {'question': question})
 
 The new concept here: The view raises the :exc:`~django.http.Http404` exception

--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -490,7 +490,7 @@ class:
             """
             response = self.client.get(reverse('polls:index'))
             self.assertEqual(response.status_code, 200)
-            self.assertContains(response, "No polls are available.")
+            self.assertContains(response, 'No polls are available.')
             self.assertQuerysetEqual(response.context['latest_question_list'], [])
 
         def test_past_question(self):
@@ -498,7 +498,7 @@ class:
             Questions with a pub_date in the past are displayed on the
             index page.
             """
-            question = create_question(question_text="Past question.", days=-30)
+            question = create_question(question_text='Past question.', days=-30)
             response = self.client.get(reverse('polls:index'))
             self.assertQuerysetEqual(
                 response.context['latest_question_list'],
@@ -510,9 +510,9 @@ class:
             Questions with a pub_date in the future aren't displayed on
             the index page.
             """
-            create_question(question_text="Future question.", days=30)
+            create_question(question_text='Future question.', days=30)
             response = self.client.get(reverse('polls:index'))
-            self.assertContains(response, "No polls are available.")
+            self.assertContains(response, 'No polls are available.')
             self.assertQuerysetEqual(response.context['latest_question_list'], [])
 
         def test_future_question_and_past_question(self):
@@ -520,8 +520,8 @@ class:
             Even if both past and future questions exist, only past questions
             are displayed.
             """
-            question = create_question(question_text="Past question.", days=-30)
-            create_question(question_text="Future question.", days=30)
+            question = create_question(question_text='Past question.', days=-30)
+            create_question(question_text='Future question.', days=30)
             response = self.client.get(reverse('polls:index'))
             self.assertQuerysetEqual(
                 response.context['latest_question_list'],
@@ -532,8 +532,8 @@ class:
             """
             The questions index page may display multiple questions.
             """
-            question1 = create_question(question_text="Past question 1.", days=-30)
-            question2 = create_question(question_text="Past question 2.", days=-5)
+            question1 = create_question(question_text='Past question 1.', days=-30)
+            question2 = create_question(question_text='Past question 2.', days=-5)
             response = self.client.get(reverse('polls:index'))
             self.assertQuerysetEqual(
                 response.context['latest_question_list'],


### PR DESCRIPTION
This is a very simple simple pull request. It changes the double to single quote to prefer Python str declarations and also to have consistent statement in the tutorial pages.