### PR TITLE
Fixed #28154 -- Prevented infinite loop in FileSystemStorage.save() when a broken symlink with the same name exists.

### DIFF
--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -316,7 +316,7 @@ class FileSystemStorage(Storage):
             pass
 
     def exists(self, name):
-        return os.path.exists(self.path(name))
+        return os.path.lexists(self.path(name))
 
     def listdir(self, path):
         path = self.path(path)


### PR DESCRIPTION
ticket-28154

- The use of `lexists()` was one of the two proposals in the ticket; happy to hear advice on whether this is the best solution.
- The test was adapted from `staticfiles_tests.test_management.TestCollectionLinks.test_clear_broken_symlink()`
- I'm not certain if the last assertion checking the file name is truly needed, but I did wonder if it made the test more readable at a glance (since the line above is where the infinite loop was encountered).
