### PR TITLE
Refs #32641 -- Made DiscoverRunner's "Found X tests" message work for finding one test.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -669,7 +669,7 @@ class DiscoverRunner:
         # found or that couldn't be loaded due to syntax errors.
         test_types = (unittest.loader._FailedTest, *self.reorder_by)
         all_tests = list(reorder_tests(all_tests, test_types, self.reverse))
-        self.log('Found %d tests.' % len(all_tests), level=logging.INFO)
+        self.log('Found %d test(s).' % len(all_tests))
         suite = self.test_suite(all_tests)
 
         if self.parallel > 1:

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -306,7 +306,7 @@ class DiscoverRunnerTests(SimpleTestCase):
                 'test_runner_apps.sample.tests_sample.TestDjangoTestCase',
                 'test_runner_apps.simple',
             ])
-            self.assertIn('Found 14 tests.\n', stdout.getvalue())
+            self.assertIn('Found 14 test(s).\n', stdout.getvalue())
 
     def test_pdb_with_parallel(self):
         msg = (


### PR DESCRIPTION
This is a follow-up / clean-up to ticket [#32641](https://code.djangoproject.com/ticket/32641) (and also [#32552](https://code.djangoproject.com/ticket/32552)). See [this comment](https://code.djangoproject.com/ticket/32641#comment:9).