### PR TITLE
Refs #31356 -- Changed IRC links to the Libera.Chat webchat.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ ticket here: https://code.djangoproject.com/newticket
 To get more help:
 
 * Join the ``#django`` channel on ``irc.libera.chat``. Lots of helpful people
-  hang out there.
+  hang out there. See https://web.libera.chat if you're new to IRC.
 
 * Join the django-users mailing list, or read the archives, at
   https://groups.google.com/group/django-users.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,7 @@ linkcheck_ignore = [
     r'^https://www\.google\.com/webmasters/tools/ping',
     r'^https://search\.google\.com/search-console/welcome',
     # Fragments used to dynamically switch content or populate fields.
+    r'^https://web\.libera\.chat/#',
     r'^https://github\.com/[^#]+#L\d+-L\d+$',
     r'^https://help\.apple\.com/itc/podcasts_connect/#/itc',
     # Anchors on certain pages with missing a[name] attributes.

--- a/docs/faq/help.txt
+++ b/docs/faq/help.txt
@@ -27,7 +27,7 @@ Then, please post it in one of the following channels:
   documentation`_ for different ways to connect.
 
 .. _`"Using Django"`: https://forum.djangoproject.com/c/users
-.. _#django IRC channel: irc://irc.libera.chat/django
+.. _#django IRC channel: https://web.libera.chat/#django
 .. _Libera.Chat documentation: https://libera.chat/guides/connect
 
 In all these channels please abide by the `Django Code of Conduct`_. In

--- a/docs/internals/contributing/bugs-and-features.txt
+++ b/docs/internals/contributing/bugs-and-features.txt
@@ -164,4 +164,4 @@ Votes on technical matters should be announced and held in public on the
 
 .. _searching: https://code.djangoproject.com/search
 .. _custom queries: https://code.djangoproject.com/query
-.. _#django: irc://irc.libera.chat/django
+.. _#django: https://web.libera.chat/#django

--- a/docs/internals/contributing/index.txt
+++ b/docs/internals/contributing/index.txt
@@ -81,7 +81,7 @@ Django community and others to maintain a great ecosystem to work in:
 We're looking forward to working with you. Welcome aboard! ⛵️
 
 .. _posting guidelines: https://code.djangoproject.com/wiki/UsingTheMailingList
-.. _#django IRC channel: irc://irc.libera.chat/django
+.. _#django IRC channel: https://web.libera.chat/#django
 .. _community page: https://www.djangoproject.com/community/
 .. _Django forum: https://forum.djangoproject.com/
 .. _register it here: https://www.djangoproject.com/community/add/blogs/

--- a/docs/internals/contributing/writing-code/index.txt
+++ b/docs/internals/contributing/writing-code/index.txt
@@ -39,5 +39,5 @@ best chances to be included in Django core:
 
 .. _ticket tracker: https://code.djangoproject.com/
 .. _easy pickings: https://code.djangoproject.com/query?status=!closed&easy=1
-.. _#django-dev IRC channel: irc://irc.libera.chat/django-dev
+.. _#django-dev IRC channel: https://web.libera.chat/#django-dev
 .. _Django forum: https://forum.djangoproject.com/

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -45,7 +45,7 @@ so that it can be of use to the widest audience.
     chat with other Django users who might be able to help.
 
 __ https://diveinto.org/python3/table-of-contents.html
-__ irc://irc.libera.chat/django-dev
+__ https://web.libera.chat/#django-dev
 
 What does this tutorial cover?
 ------------------------------

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -127,7 +127,7 @@ particular Django setup, try the |django-users| mailing list or the `#django
 IRC channel`_ instead.
 
 .. _ticket system: https://code.djangoproject.com/
-.. _#django IRC channel: irc://irc.libera.chat/django
+.. _#django IRC channel: https://web.libera.chat/#django
 
 In plain text
 -------------


### PR DESCRIPTION
The Libera.Chat webchat is now up: https://web.libera.chat

Follow up to 66491f08fe86629fa25977bb3dddda06959f65e7.

ticket-31356