### PR TITLE
Fixed #32812 -- Restored immutability of named values from QuerySet.values_list().

### DIFF
--- a/django/db/models/utils.py
+++ b/django/db/models/utils.py
@@ -45,4 +45,8 @@ def create_namedtuple_class(*names):
     def __reduce__(self):
         return unpickle_named_row, (names, tuple(self))
 
-    return type('Row', (namedtuple('Row', names),), {'__reduce__': __reduce__})
+    return type(
+        'Row',
+        (namedtuple('Row', names),),
+        {'__reduce__': __reduce__, '__slots__': ()},
+    )

--- a/docs/releases/3.2.5.txt
+++ b/docs/releases/3.2.5.txt
@@ -9,4 +9,6 @@ Django 3.2.5 fixes several bugs in 3.2.4.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 3.2 that caused a crash of
+  ``QuerySet.values_list(…, named=True)`` after ``prefetch_related()``
+  (:ticket:`32812`).

--- a/tests/model_utils/tests.py
+++ b/tests/model_utils/tests.py
@@ -1,0 +1,10 @@
+from django.db.models.utils import create_namedtuple_class
+from django.test import SimpleTestCase
+
+
+class NamedTupleClassTests(SimpleTestCase):
+    def test_immutability(self):
+        row_class = create_namedtuple_class('field1', 'field2')
+        row = row_class('value1', 'value2')
+        with self.assertRaises(AttributeError):
+            row.field3 = 'value3'

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -309,6 +309,13 @@ class PrefetchRelatedTests(TestDataMixin, TestCase):
                     list(Book.objects.prefetch_related(relation))
                     self.assertEqual(add_q_mock.call_count, 1)
 
+    def test_named_values_list(self):
+        qs = Author.objects.prefetch_related('books')
+        self.assertCountEqual(
+            [value.name for value in qs.values_list('name', named=True)],
+            ['Anne', 'Charlotte', 'Emily', 'Jane'],
+        )
+
 
 class RawQuerySetTests(TestDataMixin, TestCase):
     def test_basic(self):


### PR DESCRIPTION
Originally, prefetch_related used with values_list was ignored.
https://github.com/django/django/blob/main/django/db/models/query.py#L1710~L1719

`values_list(named=True)` uses custom namedtuple class created by [create_namedtuple_class function](https://github.com/django/django/blob/main/django/db/models/utils.py). (#13371)
However `__slots__` attribute inherited from superclass has no effect and namedtuple was mutable.
So I added new `__slots__` attribute when the function creates new namedtuple classes.