### PR TITLE
Fixed #32814 -- Improved performance of TextNode.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -519,6 +519,7 @@ answer newbie questions, and generally made Django that much better:
     Keith Bussell <kbussell@gmail.com>
     Kenneth Love <kennethlove@gmail.com>
     Kent Hauser <kent@khauser.net>
+    Keryn Knight <keryn@kerynknight.com>
     Kevin Grinberg <kevin@kevingrinberg.com>
     Kevin Kubasik <kevin@kubasik.net>
     Kevin McConnell <kevin.mcconnell@gmail.com>

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -981,6 +981,15 @@ class TextNode(Node):
     def render(self, context):
         return self.s
 
+    def render_annotated(self, context):
+        """
+        Return the given value.
+
+        The default implementation of this method handles exceptions raised
+        during rendering, which is not necessary for text nodes.
+        """
+        return self.s
+
 
 def render_value_in_context(value, context):
     """


### PR DESCRIPTION
Relates to [ticket 32814](https://code.djangoproject.com/ticket/32814).

Most Node subclasses do _something_ when the render method is called, which may require exception catching & the addition of debug information, but TextNode is special in that it just returns the underlying str and doesn't even attempt a cast on it, so the render_annotated method can do exactly the same and skip the intermediate steps.

Let's see if all the tests demonstrate this to be a false understanding :)

(NB: Added myself to `AUTHORS` despite this being a minor change, on the basis of _previous_ contributions [many of which were also minor, to be fair] please feel free to remove if it's without merit but the remainder of the patch is acceptable)