### PR TITLE
Fixed #32716 -- Fixed ManifestStaticFilesStorage crash when max_post_process_passes is 0.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,6 +99,7 @@ answer newbie questions, and generally made Django that much better:
     Arthur Koziel <http://arthurkoziel.com>
     Arthur Rio <arthur.rio44@gmail.com>
     Arvis Bickovskis <viestards.lists@gmail.com>
+    Arya Khaligh <bartararya@gmail.com>
     Aryeh Leib Taurog <http://www.aryehleib.com/>
     A S Alam <aalam@users.sf.net>
     Asif Saif Uddin <auvipy@gmail.com>

--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -260,6 +260,7 @@ class HashedFilesMixin:
                 processed_adjustable_paths[name] = (name, hashed_name, processed)
 
         paths = {path: paths[path] for path in adjustable_paths}
+        substitutions = False
 
         for i in range(self.max_post_process_passes):
             substitutions = False

--- a/tests/staticfiles_tests/storage.py
+++ b/tests/staticfiles_tests/storage.py
@@ -97,3 +97,7 @@ class ExtraPatternsStorage(ManifestStaticFilesStorage):
 class NoneHashStorage(ManifestStaticFilesStorage):
     def file_hash(self, name, content=None):
         return None
+
+
+class NoPostProcessReplacedPathStorage(ManifestStaticFilesStorage):
+    max_post_process_passes = 0

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -463,6 +463,18 @@ class TestCollectionNoneHashStorage(CollectionTestCase):
         self.assertEqual(relpath, 'cached/styles.css')
 
 
+@override_settings(
+    STATICFILES_STORAGE='staticfiles_tests.storage.NoPostProcessReplacedPathStorage'
+)
+class TestCollectionNoPostProcessReplacedPaths(CollectionTestCase):
+    run_collectstatic_in_setUp = False
+
+    def test_collectstatistic_no_post_process_replaced_paths(self):
+        stdout = StringIO()
+        self.run_collectstatic(verbosity=1, stdout=stdout)
+        self.assertIn('post-processed', stdout.getvalue())
+
+
 @override_settings(STATICFILES_STORAGE='staticfiles_tests.storage.SimpleStorage')
 class TestCollectionSimpleStorage(CollectionTestCase):
     hashed_file_path = hashed_file_path


### PR DESCRIPTION
I fixed [32716](https://code.djangoproject.com/ticket/32716) bug reported in Trac. 

Fixing the error makes sense because setting max_post_process_passes=0 enables the user to turn off changing references by Django when using ManifestStaticFilesStorage. This also makes sense for ticket [21080](https://code.djangoproject.com/ticket/21080#comment:19). 