### PR TITLE
Refs #31369 -- Improved hint message in NullBooleanField's deprecation warning.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2248,7 +2248,7 @@ class NullBooleanField(BooleanField):
             "NullBooleanField is removed except for support in historical "
             "migrations."
         ),
-        "hint": "Use BooleanField(null=True) instead.",
+        "hint": "Use BooleanField(null=True, blank=True) instead.",
         "id": "fields.E903",
     }
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -821,7 +821,7 @@ Miscellaneous
   :class:`~django.db.models.expressions.RawSQL` instead beforehand.
 
 * The ``NullBooleanField`` model field is deprecated in favor of
-  ``BooleanField(null=True)``.
+  ``BooleanField(null=True, blank=True)``.
 
 * ``django.conf.urls.url()`` alias of :func:`django.urls.re_path` is
   deprecated.

--- a/tests/invalid_models_tests/test_deprecated_fields.py
+++ b/tests/invalid_models_tests/test_deprecated_fields.py
@@ -59,7 +59,7 @@ class DeprecatedFieldsTests(SimpleTestCase):
                 checks.Error(
                     "NullBooleanField is removed except for support in historical "
                     "migrations.",
-                    hint="Use BooleanField(null=True) instead.",
+                    hint="Use BooleanField(null=True, blank=True) instead.",
                     obj=NullBooleanFieldModel._meta.get_field("nb"),
                     id="fields.E903",
                 ),


### PR DESCRIPTION
ticket-31369 deprecated the model `NullBooleanField` in Django 3.1 and will now show a warning like this:
>test.TestValue.value_test: (fields.W903) NullBooleanField is deprecated. Support for it (except in historical migrations) will be removed in Django 4.0.
>HINT: Use BooleanField(null=True) instead.

However, the `BooleanField(null=True)` replacement suggested in the hint is not equivalent to `NullBooleanField`. It needs to say `BooleanField(null=True, blank=True)` (with `blank=True` added).

You can see `null=True` and `blank=True` set on the `NullBooleanField` here: https://github.com/django/django/blob/ca9872905559026af82000e46cde6f7dedc897b6/django/db/models/fields/__init__.py#L2000-L2001

Thanks @VinayGValsaraj for finding this issue!