### PR TITLE
Refs #24121 -- Added __repr__() to AdminForm, BlockContext, BlockTranslateNode, and IncludeNode.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -44,6 +44,13 @@ class AdminForm:
             readonly_fields = ()
         self.readonly_fields = readonly_fields
 
+    def __repr__(self):
+        return (
+            f'<{self.__class__.__qualname__}: '
+            f'form={self.form.__class__.__qualname__} '
+            f'fieldsets={self.fieldsets!r}>'
+        )
+
     def __iter__(self):
         for name, options in self.fieldsets:
             yield Fieldset(

--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -18,6 +18,9 @@ class BlockContext:
         # Dictionary of FIFO queues.
         self.blocks = defaultdict(list)
 
+    def __repr__(self):
+        return f'<{self.__class__.__qualname__}: blocks={self.blocks!r}>'
+
     def add_blocks(self, blocks):
         for name, block in blocks.items():
             self.blocks[name].insert(0, block)
@@ -158,6 +161,9 @@ class IncludeNode(Node):
         self.extra_context = extra_context or {}
         self.isolated_context = isolated_context
         super().__init__(*args, **kwargs)
+
+    def __repr__(self):
+        return f'<{self.__class__.__qualname__}: template={self.template!r}>'
 
     def render(self, context):
         """

--- a/django/templatetags/i18n.py
+++ b/django/templatetags/i18n.py
@@ -112,6 +112,13 @@ class BlockTranslateNode(Node):
         self.asvar = asvar
         self.tag_name = tag_name
 
+    def __repr__(self):
+        return (
+            f'<{self.__class__.__qualname__}: '
+            f'extra_context={self.extra_context!r} '
+            f'singular={self.singular!r} plural={self.plural!r}>'
+        )
+
     def render_token_list(self, tokens):
         result = []
         vars = []

--- a/tests/admin_views/test_forms.py
+++ b/tests/admin_views/test_forms.py
@@ -1,6 +1,9 @@
 from django.contrib.admin.forms import AdminAuthenticationForm
+from django.contrib.admin.helpers import AdminForm
 from django.contrib.auth.models import User
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
+
+from .admin import ArticleForm
 
 
 # To verify that the login form rejects inactive users, use an authentication
@@ -18,3 +21,21 @@ class AdminAuthenticationFormTests(TestCase):
         }
         form = AdminAuthenticationForm(None, data)
         self.assertEqual(form.non_field_errors(), ['This account is inactive.'])
+
+
+class AdminFormTests(SimpleTestCase):
+    def test_repr(self):
+        fieldsets = (
+            ('My fields', {
+                'classes': ['collapse'],
+                'fields': ('url', 'title', 'content', 'sites'),
+            }),
+        )
+        form = ArticleForm()
+        admin_form = AdminForm(form, fieldsets, {})
+        self.assertEqual(
+            repr(admin_form),
+            "<AdminForm: form=ArticleForm fieldsets=(('My fields', "
+            "{'classes': ['collapse'], "
+            "'fields': ('url', 'title', 'content', 'sites')}),)>",
+        )

--- a/tests/template_tests/syntax_tests/i18n/test_blocktranslate.py
+++ b/tests/template_tests/syntax_tests/i18n/test_blocktranslate.py
@@ -5,6 +5,8 @@ from functools import partial, wraps
 from asgiref.local import Local
 
 from django.template import Context, Template, TemplateSyntaxError
+from django.template.base import Token, TokenType
+from django.templatetags.i18n import BlockTranslateNode
 from django.test import SimpleTestCase, override_settings
 from django.utils import translation
 from django.utils.safestring import mark_safe
@@ -584,3 +586,17 @@ class MiscTests(SimpleTestCase):
 
 class MiscBlockTranslationTests(MiscTests):
     tag_name = 'blocktrans'
+
+
+class BlockTranslateNodeTests(SimpleTestCase):
+    def test_repr(self):
+        block_translate_node = BlockTranslateNode(extra_context={}, singular=[
+            Token(TokenType.TEXT, 'content'),
+            Token(TokenType.VAR, 'variable'),
+        ])
+        self.assertEqual(
+            repr(block_translate_node),
+            '<BlockTranslateNode: extra_context={} '
+            'singular=[<Text token: "content...">, <Var token: "variable...">] '
+            'plural=None>',
+        )

--- a/tests/template_tests/syntax_tests/test_basic.py
+++ b/tests/template_tests/syntax_tests/test_basic.py
@@ -1,5 +1,6 @@
 from django.template.base import TemplateSyntaxError
 from django.template.context import Context
+from django.template.loader_tags import BlockContext, BlockNode
 from django.test import SimpleTestCase
 
 from ..utils import SilentAttrClass, SilentGetItemClass, SomeClass, setup
@@ -333,3 +334,14 @@ class BasicSyntaxTests(SimpleTestCase):
         self.assertEqual(output, '%%')
         output = self.engine.render_to_string('tpl-weird-percent')
         self.assertEqual(output, '% %s')
+
+
+class BlockContextTests(SimpleTestCase):
+    def test_repr(self):
+        block_context = BlockContext()
+        block_context.add_blocks({'content': BlockNode('content', [])})
+        self.assertEqual(
+            repr(block_context),
+            "<BlockContext: blocks=defaultdict(<class 'list'>, "
+            "{'content': [<Block Node: content. Contents: []>]})>",
+        )

--- a/tests/template_tests/syntax_tests/test_include.py
+++ b/tests/template_tests/syntax_tests/test_include.py
@@ -1,6 +1,7 @@
 from django.template import (
     Context, Engine, TemplateDoesNotExist, TemplateSyntaxError, loader,
 )
+from django.template.loader_tags import IncludeNode
 from django.test import SimpleTestCase
 
 from ..utils import setup
@@ -314,3 +315,12 @@ class IncludeTests(SimpleTestCase):
         ], libraries={'custom': 'template_tests.templatetags.custom'})
         output = engine.render_to_string('template', {'vars': range(9)})
         self.assertEqual(output, '012345678')
+
+
+class IncludeNodeTests(SimpleTestCase):
+    def test_repr(self):
+        include_node = IncludeNode('app/template.html')
+        self.assertEqual(
+            repr(include_node),
+            "<IncludeNode: template='app/template.html'>",
+        )


### PR DESCRIPTION
Hello.
I see that `InlineAdminFormSet` inherits from `AdminForm`  so I think we don't need to add to it  `__repr__`
Also, I'm not sure where I should put those tests.  
Thank you for reviewing  