### PR TITLE
Fixed #30427, Fixed #16176 -- Corrected setting descriptor in Field.contribute_to_class().

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -782,11 +782,7 @@ class Field(RegisterLookupMixin):
         self.model = cls
         cls._meta.add_field(self, private=private_only)
         if self.column:
-            # Don't override classmethods with the descriptor. This means that
-            # if you have a classmethod and a field with the same name, then
-            # such fields can't be deferred (we don't have a check for this).
-            if not getattr(cls, self.attname, None):
-                setattr(cls, self.attname, self.descriptor_class(self))
+            setattr(cls, self.attname, self.descriptor_class(self))
         if self.choices is not None:
             # Don't override a get_FOO_display() method defined explicitly on
             # this class, but don't check methods derived from inheritance, to

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1457,6 +1457,13 @@ different database tables).
 Django will raise a :exc:`~django.core.exceptions.FieldError` if you override
 any model field in any ancestor model.
 
+Note that because of the way fields are resolved during class definition, model
+fields inherited from multiple abstract parent models are resolved in a strict
+depth-first order. This contrasts with standard Python MRO, which is resolved
+breadth-first in cases of diamond shaped inheritance. This difference only
+affects complex model hierarchies, which (as per the advice above) you should
+try to avoid.
+
 Organizing models in a package
 ==============================
 

--- a/tests/check_framework/tests.py
+++ b/tests/check_framework/tests.py
@@ -315,6 +315,12 @@ class CheckFrameworkReservedNamesTests(SimpleTestCase):
                 id='models.E020'
             ),
             Error(
+                "The 'ModelWithFieldCalledCheck.check()' class method is "
+                "currently overridden by %r." % ModelWithFieldCalledCheck.check,
+                obj=ModelWithFieldCalledCheck,
+                id='models.E020'
+            ),
+            Error(
                 "The 'ModelWithRelatedManagerCalledCheck.check()' class method is "
                 "currently overridden by %r." % ModelWithRelatedManagerCalledCheck.check,
                 obj=ModelWithRelatedManagerCalledCheck,

--- a/tests/defer/models.py
+++ b/tests/defer/models.py
@@ -44,3 +44,16 @@ class RefreshPrimaryProxy(Primary):
             if fields.intersection(deferred_fields):
                 fields = fields.union(deferred_fields)
         super().refresh_from_db(using, fields, **kwargs)
+
+
+class ShadowParent(models.Model):
+    """
+    ShadowParent declares a scalar, rather than a field. When this is
+    overridden, the field value, rather than the scalar value must still be
+    used when the field is deferred.
+    """
+    name = 'aphrodite'
+
+
+class ShadowChild(ShadowParent):
+    name = models.CharField(default='adonis', max_length=6)

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 
 from .models import (
     BigChild, Child, ChildProxy, Primary, RefreshPrimaryProxy, Secondary,
+    ShadowChild,
 )
 
 
@@ -164,6 +165,11 @@ class DeferTests(AssertionMixin, TestCase):
         self.assert_delayed(obj, 3)
         self.assertEqual(obj.name, "c1")
         self.assertEqual(obj.value, "foo")
+
+    def test_defer_of_overridden_scalar(self):
+        ShadowChild.objects.create()
+        obj = ShadowChild.objects.defer('name').get()
+        self.assertEqual(obj.name, 'adonis')
 
 
 class BigChildDeferTests(AssertionMixin, TestCase):

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -1212,9 +1212,8 @@ class OtherModelTests(SimpleTestCase):
         class Model(models.Model):
             fk = models.ForeignKey('self', models.CASCADE)
 
-            @property
-            def fk_id(self):
-                pass
+        # Override related field accessor.
+        Model.fk_id = property(lambda self: 'ERROR')
 
         self.assertEqual(Model.check(), [
             Error(

--- a/tests/model_inheritance/test_abstract_inheritance.py
+++ b/tests/model_inheritance/test_abstract_inheritance.py
@@ -59,6 +59,36 @@ class AbstractInheritanceTests(SimpleTestCase):
             ),
         ])
 
+    def test_target_field_may_be_pushed_down(self):
+        """
+        Where the Child model needs to inherit a field from a different base
+        than that given by depth-first resolution, the target field can be
+        **pushed down** by being re-declared.
+        """
+
+        class Root(models.Model):
+            name = models.CharField(max_length=255)
+
+            class Meta:
+                abstract = True
+
+        class ParentA(Root):
+            class Meta:
+                abstract = True
+
+        class ParentB(Root):
+            name = models.IntegerField()
+
+            class Meta:
+                abstract = True
+
+        class Child(ParentA, ParentB):
+            name = models.IntegerField()
+
+        self.assertEqual(Child.check(), [])
+        inherited_field = Child._meta.get_field('name')
+        self.assertTrue(isinstance(inherited_field, models.IntegerField))
+
     def test_multiple_inheritance_cannot_shadow_concrete_inherited_field(self):
         class ConcreteParent(models.Model):
             name = models.CharField(max_length=255)


### PR DESCRIPTION
Replaces #11337. 

Updates, and puts the tests in place that were hanging from the previous PR. It's difficult to follow so I've commented hoping to make them clear (for now and the next poor soul coming back to this 😀)

We had release notes in an earlier version 5fc4884ba104c502e9aac9b72c2dfec1d7df1560 — those were incorrect since the multiple inheritance example **never** worked. See 4bbe8261c402694a1da3efcaafe3332f9c57af15.

The **change** in behaviour proposed is allowing that structure. See the adjustment in the (now named) `test_multiple_inheritance_allows_inherited_field` method. 

Inheritance works ≈as expected **except** for the _depth-first_ resolution in diamond-shaped cases. Calling that out in `docs/topics/db/models.txt` is I think probably worth while. I need to think about exactly where to put that/what to say. Input welcome. 😜