### PR TITLE
lift up values to last context to speed up access

### DIFF
--- a/django/template/context.py
+++ b/django/template/context.py
@@ -79,7 +79,9 @@ class BaseContext:
         "Get a variable's value, starting at the current context and going upward"
         for d in reversed(self.dicts):
             if key in d:
-                return d[key]
+                value = d[key]
+                self.dicts[-1][key] = value
+                return value
         raise KeyError(key)
 
     def __delitem__(self, key):


### PR DESCRIPTION
```python3
from django.template.context import *
from timeit import timeit

class UpContext(Context):
    def __getitem__(self, key):
        val = super().__getitem__(key)
        self.dicts[-1][key] = val
        return val

c = Context({'Q': 34})
c1 = UpContext({'Q': 34})

for i in range(10):
    c.push(d=i)
    c1.push(d=i)

def f():
    c['Q']

def f1():
    c1['Q']

>>> timeit(f)
1.316134085005615
>>> timeit(f1)
1.2122753569856286
```


