### PR TITLE
Fixed #32832 -- Fixed adding BLOB/TEXT nullable field with default on MySQL 8.0.13+.

### DIFF
--- a/docs/releases/3.2.5.txt
+++ b/docs/releases/3.2.5.txt
@@ -16,3 +16,7 @@ Bugfixes
 * Fixed a bug in Django 3.2 that caused a migration crash on MySQL 8.0.13+ when
   altering ``BinaryField``, ``JSONField``, or ``TextField`` to non-nullable
   (:ticket:`32503`).
+
+* Fixed a regression in Django 3.2 that caused a migration crash on MySQL
+  8.0.13+ when adding nullable ``BinaryField``, ``JSONField``, or ``TextField``
+  with a default value (:ticket:`32832`).

--- a/docs/releases/3.2.5.txt
+++ b/docs/releases/3.2.5.txt
@@ -12,3 +12,7 @@ Bugfixes
 * Fixed a regression in Django 3.2 that caused a crash of
   ``QuerySet.values_list(…, named=True)`` after ``prefetch_related()``
   (:ticket:`32812`).
+
+* Fixed a bug in Django 3.2 that caused a migration crash on MySQL 8.0.13+ when
+  altering ``BinaryField``, ``JSONField``, or ``TextField`` to non-nullable
+  (:ticket:`32503`).

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -3387,6 +3387,33 @@ class SchemaTests(TransactionTestCase):
             if connection.features.can_introspect_default:
                 self.assertIn(field.default, ['NULL', None])
 
+    def test_add_textfield_default_nullable(self):
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+        # Add new nullable TextField with a default.
+        new_field = TextField(blank=True, null=True, default='text')
+        new_field.set_attributes_from_name('description')
+        with connection.schema_editor() as editor:
+            editor.add_field(Author, new_field)
+        Author.objects.create(name='Anonymous1')
+        with connection.cursor() as cursor:
+            cursor.execute('SELECT description FROM schema_author;')
+            item = cursor.fetchall()[0]
+            self.assertIsNone(item[0])
+            field = next(
+                f
+                for f in connection.introspection.get_table_description(
+                    cursor,
+                    'schema_author',
+                )
+                if f.name == 'description'
+            )
+            # Field is still nullable.
+            self.assertTrue(field.null_ok)
+            # The database default is no longer set.
+            if connection.features.can_introspect_default:
+                self.assertIn(field.default, ['NULL', None])
+
     def test_alter_field_default_dropped(self):
         # Create the table
         with connection.schema_editor() as editor:


### PR DESCRIPTION
ticket-32832, ticket-32503, ticket-32425

| operation  | nullable | support for a default value| 
| ------------- | :---: | :---: |
| add field  |  :white_check_mark:  |   :red_circle:  |
| add field  |  -  |   :green_circle: | 
| alter field  | :white_check_mark:  |   :red_circle: | 
| alter field  | -  |   :red_circle: | 

Alternatively we can revert 6b16c91157512587017e9178d066ed1a683e7795 and 5e04e84d67da8163f365e9f5fcd169e2630e2873.