### PR TITLE
Fixed #21544 -- Clarified the effect of setting `USE_L10N` False.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1244,6 +1244,8 @@ Default decimal separator used when formatting decimal numbers.
 
 Note that if :setting:`USE_L10N` is set to ``True``, then the locale-dictated
 format has higher precedence and will be applied instead.
+If :setting:`USE_L10N` is set to ``False``, ``DECIMAL_SEPARATOR`` will be
+observed in form validation, but not in the template filter :tfilter:`floatformat`.
 
 See also :setting:`NUMBER_GROUPING`, :setting:`THOUSAND_SEPARATOR` and
 :setting:`USE_THOUSAND_SEPARATOR`.
@@ -2665,6 +2667,9 @@ used only when :setting:`USE_THOUSAND_SEPARATOR` is ``True`` and
 
 Note that if :setting:`USE_L10N` is set to ``True``, then the locale-dictated
 format has higher precedence and will be applied instead.
+If :setting:`USE_L10N` is set to ``False``, ``THOUSAND_SEPARATOR`` will be
+observed in form validation where :setting:`USE_THOUSAND_SEPARATOR` and
+:setting:`NUMBER_GROUPING` permit, but not in the template filter :tfilter:`floatformat`.
 
 See also :setting:`NUMBER_GROUPING`, :setting:`DECIMAL_SEPARATOR` and
 :setting:`USE_THOUSAND_SEPARATOR`.
@@ -2797,7 +2802,11 @@ A boolean that specifies whether to display numbers using a thousand separator.
 When set to ``True`` and :setting:`USE_L10N` is also ``True``, Django will
 format numbers using the :setting:`NUMBER_GROUPING` and
 :setting:`THOUSAND_SEPARATOR` settings. These settings may also be dictated by
-the locale, which takes precedence.
+the locale, which takes precedence. When :setting:`USE_L10N` is set to
+``False``, ``USE_THOUSAND_SEPARATOR`` will be observed in form validation, but
+not in the template filter :tfilter:`floatformat`. (See the :tfilter:`floatformat`
+documentation for a method to force thousand grouping when :setting:`USE_L10N`
+is ``True`` without regard for ``USE_THOUSAND_SEPARATOR``.)
 
 See also :setting:`DECIMAL_SEPARATOR`, :setting:`NUMBER_GROUPING` and
 :setting:`THOUSAND_SEPARATOR`.

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2775,9 +2775,12 @@ See also :setting:`LANGUAGE_CODE`, :setting:`USE_L10N` and :setting:`USE_TZ`.
 
 Default: ``False``
 
-A boolean that specifies if localized formatting of data will be enabled by
-default or not. If this is set to ``True``, e.g. Django will display numbers and
-dates using the format of the current locale.
+A boolean that specifies whether localized formatting of data will be enabled
+by default. When set to ``True``, Django will display numbers and dates using
+the format of the current locale, or if the locale lacks format information,
+the format dictated by Django's other settings (such as
+:setting:`USE_THOUSAND_SEPARATOR`). Setting ``USE_L10N`` to ``False`` leaves
+it up to each feature whether to observe Django's other format settings.
 
 See also :setting:`LANGUAGE_CODE`, :setting:`USE_I18N` and :setting:`USE_TZ`.
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1244,8 +1244,6 @@ Default decimal separator used when formatting decimal numbers.
 
 Note that if :setting:`USE_L10N` is set to ``True``, then the locale-dictated
 format has higher precedence and will be applied instead.
-If :setting:`USE_L10N` is set to ``False``, ``DECIMAL_SEPARATOR`` will be
-observed in form validation, but not in the template filter :tfilter:`floatformat`.
 
 See also :setting:`NUMBER_GROUPING`, :setting:`THOUSAND_SEPARATOR` and
 :setting:`USE_THOUSAND_SEPARATOR`.
@@ -2667,9 +2665,6 @@ used only when :setting:`USE_THOUSAND_SEPARATOR` is ``True`` and
 
 Note that if :setting:`USE_L10N` is set to ``True``, then the locale-dictated
 format has higher precedence and will be applied instead.
-If :setting:`USE_L10N` is set to ``False``, ``THOUSAND_SEPARATOR`` will be
-observed in form validation where :setting:`USE_THOUSAND_SEPARATOR` and
-:setting:`NUMBER_GROUPING` permit, but not in the template filter :tfilter:`floatformat`.
 
 See also :setting:`NUMBER_GROUPING`, :setting:`DECIMAL_SEPARATOR` and
 :setting:`USE_THOUSAND_SEPARATOR`.
@@ -2802,11 +2797,7 @@ A boolean that specifies whether to display numbers using a thousand separator.
 When set to ``True`` and :setting:`USE_L10N` is also ``True``, Django will
 format numbers using the :setting:`NUMBER_GROUPING` and
 :setting:`THOUSAND_SEPARATOR` settings. These settings may also be dictated by
-the locale, which takes precedence. When :setting:`USE_L10N` is set to
-``False``, ``USE_THOUSAND_SEPARATOR`` will be observed in form validation, but
-not in the template filter :tfilter:`floatformat`. (See the :tfilter:`floatformat`
-documentation for a method to force thousand grouping when :setting:`USE_L10N`
-is ``True`` without regard for ``USE_THOUSAND_SEPARATOR``.)
+the locale, which takes precedence.
 
 See also :setting:`DECIMAL_SEPARATOR`, :setting:`NUMBER_GROUPING` and
 :setting:`THOUSAND_SEPARATOR`.


### PR DESCRIPTION
ticket-21544

<s>If we plan to backport further than 3.2, I can pull out the sentence about forcing grouping into another commit (or drop it).</s> mooted by changes.