### PR TITLE
Fixed #32817 -- Added the token source to CsrfViewMiddleware's bad token error messages.

### DIFF
--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -128,33 +128,20 @@ class CsrfViewMiddlewareTestMixin:
         self.assertEqual(403, resp.status_code)
         self.assertEqual(cm.records[0].getMessage(), 'Forbidden (%s): ' % expected)
 
-    def test_csrf_cookie_no_token(self):
+    def test_csrf_cookie_bad_or_missing_token(self):
         """
-        If a CSRF cookie is present but with no token, the middleware rejects
-        the incoming request.
-        """
-        self._check_bad_or_missing_token(None, REASON_CSRF_TOKEN_MISSING)
-
-    def test_csrf_cookie_bad_token_characters(self):
-        """
-        If a CSRF cookie is present but the token has invalid characters, the
+        If a CSRF cookie is present but the token is missing or invalid, the
         middleware rejects the incoming request.
         """
-        self._check_bad_or_missing_token(64 * '*', 'CSRF token has invalid characters.')
-
-    def test_csrf_cookie_bad_token_length(self):
-        """
-        If a CSRF cookie is present but the token has an incorrect length, the
-        middleware rejects the incoming request.
-        """
-        self._check_bad_or_missing_token(16 * 'a', 'CSRF token has incorrect length.')
-
-    def test_csrf_cookie_incorrect_token(self):
-        """
-        If a CSRF cookie is present but the correctly formatted token is
-        incorrect, the middleware rejects the incoming request.
-        """
-        self._check_bad_or_missing_token(64 * 'a', 'CSRF token incorrect.')
+        cases = [
+            (None, REASON_CSRF_TOKEN_MISSING),
+            (64 * '*', 'CSRF token has invalid characters.'),
+            (16 * 'a', 'CSRF token has incorrect length.'),
+            (64 * 'a', 'CSRF token incorrect.'),
+        ]
+        for token, expected in cases:
+            with self.subTest(token=token):
+                self._check_bad_or_missing_token(expected, token)
 
     def test_process_request_csrf_cookie_and_token(self):
         """

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -147,12 +147,24 @@ class CsrfViewMiddlewareTestMixin:
         """
         cases = [
             (None, None, REASON_CSRF_TOKEN_MISSING),
-            (16 * 'a', None, 'CSRF token has incorrect length.'),
-            (64 * '*', None, 'CSRF token has invalid characters.'),
-            (64 * 'a', None, 'CSRF token incorrect.'),
-            (None, 16 * 'a', 'CSRF token has incorrect length.'),
-            (None, 64 * '*', 'CSRF token has invalid characters.'),
-            (None, 64 * 'a', 'CSRF token incorrect.'),
+            (16 * 'a', None, 'CSRF token from POST has incorrect length.'),
+            (64 * '*', None, 'CSRF token from POST has invalid characters.'),
+            (64 * 'a', None, 'CSRF token from POST incorrect.'),
+            (
+                None,
+                16 * 'a',
+                "CSRF token from the 'X-Csrftoken' HTTP header has incorrect length.",
+            ),
+            (
+                None,
+                64 * '*',
+                "CSRF token from the 'X-Csrftoken' HTTP header has invalid characters.",
+            ),
+            (
+                None,
+                64 * 'a',
+                "CSRF token from the 'X-Csrftoken' HTTP header incorrect.",
+            ),
         ]
         for post_token, meta_token, expected in cases:
             with self.subTest(post_token=post_token, meta_token=meta_token):
@@ -168,7 +180,10 @@ class CsrfViewMiddlewareTestMixin:
         If a CSRF cookie is present and an invalid token is passed via a
         custom CSRF_HEADER_NAME, the middleware rejects the incoming request.
         """
-        expected = 'CSRF token has incorrect length.'
+        expected = (
+            "CSRF token from the 'X-Csrftoken-Customized' HTTP header has "
+            "incorrect length."
+        )
         self._check_bad_or_missing_token(
             expected,
             meta_token=16 * 'a',


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32817