### PR TITLE
Fixed dash-separated deprecation warning in setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ bcrypt = bcrypt
 
 [bdist_rpm]
 doc_files = docs extras AUTHORS INSTALL LICENSE README.rst
-install-script = scripts/rpm-install.sh
+install_script = scripts/rpm-install.sh
 
 [flake8]
 exclude = build,.git,.tox,./tests/.env


### PR DESCRIPTION
I see this warning:
```
/tmp/pip-build-env-0ebxv9_2/overlay/lib/python3.8/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'install-script' will not be supported in future versions. Please use the underscore name 'install_script' instead
```