### PR TITLE
Fixed comment in CsrfViewMiddleware to say _reject instead of reject.

### DIFF
--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -343,7 +343,7 @@ class CsrfViewMiddleware(MiddlewareMixin):
             # Mechanism to turn off CSRF checks for test suite. It comes after
             # the creation of CSRF cookies, so that everything else continues
             # to work exactly the same (e.g. cookies are sent, etc.), but
-            # before any branches that call reject().
+            # before any branches that call the _reject method.
             return self._accept(request)
 
         # Reject the request if the Origin header doesn't match an allowed


### PR DESCRIPTION
This fixes a method reference in `CsrfViewMiddleware` (`reject()` to `_reject()`) and aligns it with this comment: https://github.com/django/django/blob/854e9b066850b9b4eb1171966e996322b2c16d27/django/middleware/csrf.py#L185