### PR TITLE
Fixed #32833 - inlined ContentType.model_class() in ContentTypeManager.get_for_models()

### DIFF
--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -86,7 +86,7 @@ class ContentTypeManager(models.Manager):
                 model__in=needed_models
             )
             for ct in cts:
-                opts_models = needed_opts.pop(ct.model_class()._meta, [])
+                opts_models = needed_opts.pop(ct._meta.apps.get_model(ct.app_label, ct.model)._meta, [])
                 for model in opts_models:
                     results[model] = ct
                 self._add_to_cache(self.db, ct)

--- a/tests/contenttypes_tests/operations_migrations/0001_initial.py
+++ b/tests/contenttypes_tests/operations_migrations/0001_initial.py
@@ -10,4 +10,16 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True)),
             ],
         ),
+        migrations.CreateModel(
+            'Bar',
+            [
+                ('id', models.AutoField(primary_key=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            'Baz',
+            [
+                ('id', models.AutoField(primary_key=True)),
+            ],
+        ),
     ]

--- a/tests/contenttypes_tests/operations_migrations/0003_get_for_models.py
+++ b/tests/contenttypes_tests/operations_migrations/0003_get_for_models.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def get_for_models(apps, schema_editor):
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    ContentType.objects.get_for_models(
+        apps.all_models['contenttypes_tests']['bar'],
+        apps.all_models['contenttypes_tests']['baz'],
+        apps.all_models['contenttypes_tests']['renamedfoo']
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes_tests', '0002_rename_foo'),
+    ]
+
+    operations = [
+        migrations.RunPython(get_for_models, migrations.RunPython.noop)
+    ]

--- a/tests/contenttypes_tests/test_operations.py
+++ b/tests/contenttypes_tests/test_operations.py
@@ -95,6 +95,9 @@ class ContentTypeManagerOperationsTests(TransactionTestCase):
         'django.contrib.contenttypes',
     ]
 
+    def setUp(self) -> None:
+        call_command('migrate', 'contenttypes_tests', 'zero', database='default', interactive=False, verbosity=0)
+
     def test_get_for_models_creation_on_migration(self):
         ContentType.objects.clear_cache()
         call_command('migrate', 'contenttypes_tests', '0003', database='default', interactive=False, verbosity=0)


### PR DESCRIPTION
On migrations the versioned content type objects does not implement `ContentType.model_class()`, when `ContentTypeManager.get_for_models()` is called and some content type is not in cache a query is made to load them from DB, if at last one is found then `ContentType.model_class()` is called on loaded objects which causes `AttributeError` to be raised.

Followed suggestions given in [ticket discussion](https://code.djangoproject.com/ticket/32833) and inlined `ContentType.model_class()` logic in `ContentTypeManager.get_for_models()`. 