### PR TITLE
Fixed #32798 -- Fixed ASGIHandler to run response iterators in sync context

### DIFF
--- a/tests/asgi/urls.py
+++ b/tests/asgi/urls.py
@@ -1,5 +1,6 @@
-from django.http import FileResponse, HttpResponse
+from django.http import FileResponse, HttpResponse, StreamingHttpResponse
 from django.urls import path
+from django.utils.asyncio import async_unsafe
 
 
 def hello(request):
@@ -14,6 +15,24 @@ def hello_meta(request):
     )
 
 
+def streaming_view(request):
+    @async_unsafe
+    def async_unsafe_function():
+        return True
+
+    def generate():
+        # Response iterators should be run in a sync context so functions that
+        # are sync unsafe like database calls can be used.
+        async_unsafe_function()
+
+        yield "Hello World!"
+
+    return StreamingHttpResponse(
+        generate(),
+        content_type="text/plain"
+    )
+
+
 test_filename = __file__
 
 
@@ -21,4 +40,5 @@ urlpatterns = [
     path('', hello),
     path('file/', lambda x: FileResponse(open(test_filename, 'rb'))),
     path('meta/', hello_meta),
+    path('streaming/', streaming_view),
 ]


### PR DESCRIPTION
I did some quick performance tests to make sure this isn't significantly slower. I set up a view with a streaming response yielding 100 items. timeit reports "3.04 msec per loop," compared to "3.64 msec per loop" on the main branch, so pretty much the same. The alternative implementations I tried are much slower (using `async_to_sync(Queue.put)()` instead of `Queue.put_nowait()` is 21 msec per loop; not using a queue is 15.5 msec per loop).