### PR TITLE
Fix typo (Annoys me every time I run the command)

### DIFF
--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -157,7 +157,7 @@ class Command(BaseCommand):
                         validate_password(password2, self.UserModel(**fake_user_data))
                     except exceptions.ValidationError as err:
                         self.stderr.write('\n'.join(err.messages))
-                        response = input('Bypass password validation and create user anyway? [y/N]: ')
+                        response = input('Bypass password validation and create user anyway? [y/n]: ')
                         if response.lower() != 'y':
                             continue
                     user_data[PASSWORD_FIELD] = password


### PR DESCRIPTION
Fix the typo of `y/N` to `y/n`
This annoys me every time I run `python manage.py createsuperuser` with a password like `admin` for testing.

Sorry if I broke [CONTRIBUTING guidelines](https://github.com/django/django/blob/316cc34d046ad86e100227772294f906fae1c2e5/CONTRIBUTING.rst) with this PR, but it isn't very clear.