### PR TITLE
Fixed #32855: return value of BoundWidget.id_for_label

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -267,7 +267,7 @@ class BoundWidget:
 
     @property
     def id_for_label(self):
-        return 'id_%s_%s' % (self.data['name'], self.data['index'])
+        return self.data['attrs'].get('id')
 
     @property
     def choice_label(self):

--- a/docs/releases/3.2.5.txt
+++ b/docs/releases/3.2.5.txt
@@ -20,3 +20,10 @@ Bugfixes
 * Fixed a regression in Django 3.2 that caused a migration crash on MySQL
   8.0.13+ when adding nullable ``BinaryField``, ``JSONField``, or ``TextField``
   with a default value (:ticket:`32832`).
+
+* Fixed a bug in Django 3.2 and earlier in
+  :meth:`~django.forms.boundfield.BoundWidget.id_for_label`. It returend
+  a wrong ``id``, when used by a ``ChoiceField`` with
+  ``widget=CheckboxSelectMultiple`` and rendered by a form initialized
+  with ``auto_id='...%s...'``.
+  (:ticket:`32855`).

--- a/docs/releases/3.2.5.txt
+++ b/docs/releases/3.2.5.txt
@@ -22,7 +22,7 @@ Bugfixes
   with a default value (:ticket:`32832`).
 
 * Fixed a bug in Django 3.2 and earlier in
-  :meth:`~django.forms.boundfield.BoundWidget.id_for_label`. It returend
+  :meth:`~django.forms.boundfield.BoundWidget.id_for_label`. It returned
   a wrong ``id``, when used by a ``ChoiceField`` with
   ``widget=CheckboxSelectMultiple`` and rendered by a form initialized
   with ``auto_id='...%s...'``.

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -719,7 +719,7 @@ Java</label></li>
         fields = list(BeatleForm(auto_id=False)['name'])
         self.assertEqual(len(fields), 4)
 
-        self.assertEqual(fields[0].id_for_label, 'id_name_0')
+        self.assertEqual(fields[0].id_for_label, None)
         self.assertEqual(fields[0].choice_label, 'John')
         self.assertHTMLEqual(fields[0].tag(), '<option value="john">John</option>')
         self.assertHTMLEqual(str(fields[0]), '<option value="john">John</option>')
@@ -3141,6 +3141,22 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
         form = SomeForm()
         self.assertEqual(form['field'].id_for_label, 'myCustomID')
         self.assertEqual(form['field_none'].id_for_label, 'id_field_none')
+
+    def test_boundfield_id_for_label_override_by_auto_id(self):
+        """
+        If auto_id is provided when initializing the form, the generated ID in subwidgets
+        must reflect that prefix.
+        """
+        class SomeForm(Form):
+            field = MultipleChoiceField(
+                choices=[('a', 'A'), ('b', 'B')],
+                widget=CheckboxSelectMultiple,
+            )
+
+        form = SomeForm(auto_id='prefix_%s')
+        subwidgets = form['field'].subwidgets
+        self.assertEqual(subwidgets[0].id_for_label, 'prefix_field_0')
+        self.assertEqual(subwidgets[1].id_for_label, 'prefix_field_1')
 
     def test_boundfield_widget_type(self):
         class SomeForm(Form):


### PR DESCRIPTION
Fixed a bug in Django 3.2 and earlier in `django.forms.boundfield.BoundWidget.id_for_label`.
It returned a wrong `id`, when used by a `ChoiceField` with `widget=CheckboxSelectMultiple` and rendered by a form initialized  with `auto_id='...%s...'`.