### PR TITLE
Fixed #32858 -- Fixed ExclusionConstraint crash with index transforms in expressions.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -561,6 +561,7 @@ answer newbie questions, and generally made Django that much better:
     Luan Pablo <luanpab@gmail.com>
     Lucas Connors <https://www.revolutiontech.ca/>
     Luciano Ramalho
+    Lucidiot <lucidiot@brainshit.fr>
     Ludvig Ericson <ludvig.ericson@gmail.com>
     Luis C. Berrocal <luis.berrocal.1942@gmail.com>
     Łukasz Langa <lukasz@langa.pl>

--- a/django/contrib/postgres/constraints.py
+++ b/django/contrib/postgres/constraints.py
@@ -2,6 +2,7 @@ from django.db import NotSupportedError
 from django.db.backends.ddl_references import Statement, Table
 from django.db.models import Deferrable, F, Q
 from django.db.models.constraints import BaseConstraint
+from django.db.models.expressions import Col
 from django.db.models.sql import Query
 
 __all__ = ['ExclusionConstraint']
@@ -73,6 +74,8 @@ class ExclusionConstraint(BaseConstraint):
                 expression = F(expression)
             expression = expression.resolve_expression(query=query)
             sql, params = compiler.compile(expression)
+            if not isinstance(expression, Col):
+                sql = f'({sql})'
             try:
                 opclass = self.opclasses[idx]
                 if opclass:

--- a/django/db/models/functions/comparison.py
+++ b/django/db/models/functions/comparison.py
@@ -42,6 +42,12 @@ class Cast(Func):
             template = "JSON_EXTRACT(%(expressions)s, '$')"
         return self.as_sql(compiler, connection, template=template, **extra_context)
 
+    def as_postgresql(self, compiler, connection, **extra_context):
+        # CAST would be valid too, but the :: shortcut syntax is more readable.
+        # 'expressions' is wrapped in parentheses in case it's a complex
+        # expression.
+        return self.as_sql(compiler, connection, template='(%(expressions)s)::%(db_type)s', **extra_context)
+
     def as_oracle(self, compiler, connection, **extra_context):
         if self.output_field.get_internal_type() == 'JSONField':
             # Oracle doesn't support explicit cast to JSON.

--- a/tests/db_functions/comparison/test_cast.py
+++ b/tests/db_functions/comparison/test_cast.py
@@ -1,9 +1,11 @@
 import datetime
 import decimal
+import unittest
 
 from django.db import connection, models
 from django.db.models.functions import Cast
 from django.test import TestCase, ignore_warnings, skipUnlessDBFeature
+from django.test.utils import CaptureQueriesContext
 
 from ..models import Author, DTModel, Fan, FloatModel
 
@@ -124,6 +126,21 @@ class CastTests(TestCase):
         cast_float = numbers.get().cast_float
         self.assertIsInstance(cast_float, float)
         self.assertEqual(cast_float, 0.125)
+
+    @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL test')
+    def test_expression_wrapped_with_parentheses_on_postgresql(self):
+        """
+        The SQL for the Cast expression is wrapped with parentheses in case
+        it's a complex expression.
+        """
+        with CaptureQueriesContext(connection) as captured_queries:
+            list(Author.objects.annotate(
+                cast_float=Cast(models.Avg('age'), models.FloatField()),
+            ))
+        self.assertIn(
+            '(AVG("db_functions_author"."age"))::double precision',
+            captured_queries[0]['sql'],
+        )
 
     def test_cast_to_text_field(self):
         self.assertEqual(Author.objects.values_list(Cast('age', models.TextField()), flat=True).get(), '1')

--- a/tests/postgres_tests/test_constraints.py
+++ b/tests/postgres_tests/test_constraints.py
@@ -14,7 +14,9 @@ from django.test import modify_settings, skipUnlessDBFeature
 from django.utils import timezone
 
 from . import PostgreSQLTestCase
-from .models import HotelReservation, RangesModel, Room, Scene
+from .models import (
+    HotelReservation, IntegerArrayModel, RangesModel, Room, Scene,
+)
 
 try:
     from psycopg2.extras import DateRange, NumericRange
@@ -668,6 +670,19 @@ class ExclusionConstraintTests(PostgreSQLTestCase):
         self.assertIn(
             constraint_name,
             self.get_constraints(HotelReservation._meta.db_table),
+        )
+
+    def test_index_transform(self):
+        constraint_name = 'first_index_equal'
+        constraint = ExclusionConstraint(
+            name=constraint_name,
+            expressions=[('field__0', RangeOperators.EQUAL)],
+        )
+        with connection.schema_editor() as editor:
+            editor.add_constraint(IntegerArrayModel, constraint)
+        self.assertIn(
+            constraint_name,
+            self.get_constraints(IntegerArrayModel._meta.db_table),
         )
 
     def test_range_adjacent_initially_deferred(self):

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -305,7 +305,7 @@ class SchemaTests(PostgreSQLTestCase):
         self.assertIn(index_name, constraints)
         self.assertIn(constraints[index_name]['type'], GinIndex.suffix)
         self.assertIs(sql.references_column(table, 'field'), True)
-        self.assertIn(' AS tsvector', str(sql))
+        self.assertIn('::tsvector', str(sql))
         with connection.schema_editor() as editor:
             editor.remove_index(TextFieldModel, index)
         self.assertNotIn(index_name, self.get_constraints(table))


### PR DESCRIPTION
Trying to add a PostgreSQL exclusion constraint on a single field of an array (`field__0`, which becomes `"field"[1]` in SQL) caused a syntax error to occur:

```
django.db.utils.ProgrammingError: syntax error at or near "WITH"
LINE 1: ..." ADD CONSTRAINT "foo" EXCLUDE USING GIST ("field"[1] WITH =)
                                                                 ^
```

[The Postgres docs](https://www.postgresql.org/docs/current/sql-altertable.html) imply that column names can be specified as they are, but expressions need to be wrapped in parentheses in exclusion constraints. This adds those parentheses anytime an expression is not just a column.