### PR TITLE
Fixed #27147 -- Allowed specifying bounds of tuple inputs for non-discrete range fields.

### DIFF
--- a/django/contrib/postgres/forms/ranges.py
+++ b/django/contrib/postgres/forms/ranges.py
@@ -42,6 +42,9 @@ class BaseRangeField(forms.MultiValueField):
             kwargs['fields'] = [self.base_field(required=False), self.base_field(required=False)]
         kwargs.setdefault('required', False)
         kwargs.setdefault('require_all_fields', False)
+        self.range_kwargs = {}
+        if default_bounds := kwargs.pop('default_bounds', None):
+            self.range_kwargs = {'bounds': default_bounds}
         super().__init__(**kwargs)
 
     def prepare_value(self, value):
@@ -68,7 +71,7 @@ class BaseRangeField(forms.MultiValueField):
                 code='bound_ordering',
             )
         try:
-            range_value = self.range_type(lower, upper)
+            range_value = self.range_type(lower, upper, **self.range_kwargs)
         except TypeError:
             raise exceptions.ValidationError(
                 self.error_messages['invalid'],

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -503,9 +503,9 @@ All of the range fields translate to :ref:`psycopg2 Range objects
 <psycopg2:adapt-range>` in Python, but also accept tuples as input if no bounds
 information is necessary. The default is lower bound included, upper bound
 excluded, that is ``[)`` (see the PostgreSQL documentation for details about
-`different bounds`_).
-
-.. _different bounds: https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-IO
+`different bounds`_). The default bounds can be changed for non-discrete range
+fields (:class:`.DateTimeRangeField` and :class:`.DecimalRangeField`) by using
+the ``default_bounds`` argument.
 
 ``IntegerRangeField``
 ---------------------
@@ -538,22 +538,42 @@ excluded, that is ``[)`` (see the PostgreSQL documentation for details about
 ``DecimalRangeField``
 ---------------------
 
-.. class:: DecimalRangeField(**options)
+.. class:: DecimalRangeField(default_bounds='[)', **options)
 
     Stores a range of floating point values. Based on a
     :class:`~django.db.models.DecimalField`. Represented by a ``numrange`` in
     the database and a :class:`~psycopg2:psycopg2.extras.NumericRange` in
     Python.
 
+    .. attribute:: DecimalRangeField.default_bounds
+
+        .. versionadded:: 4.1
+
+        Optional. The value of ``bounds`` for list and tuple inputs. The
+        default is lower bound included, upper bound excluded, that is ``[)``
+        (see the PostgreSQL documentation for details about
+        `different bounds`_). ``default_bounds`` is not used for
+        :class:`~psycopg2:psycopg2.extras.NumericRange` inputs.
+
 ``DateTimeRangeField``
 ----------------------
 
-.. class:: DateTimeRangeField(**options)
+.. class:: DateTimeRangeField(default_bounds='[)', **options)
 
     Stores a range of timestamps. Based on a
     :class:`~django.db.models.DateTimeField`. Represented by a ``tstzrange`` in
     the database and a :class:`~psycopg2:psycopg2.extras.DateTimeTZRange` in
     Python.
+
+    .. attribute:: DateTimeRangeField.default_bounds
+
+        .. versionadded:: 4.1
+
+        Optional. The value of ``bounds`` for list and tuple inputs. The
+        default is lower bound included, upper bound excluded, that is ``[)``
+        (see the PostgreSQL documentation for details about
+        `different bounds`_). ``default_bounds`` is not used for
+        :class:`~psycopg2:psycopg2.extras.DateTimeTZRange` inputs.
 
 ``DateRangeField``
 ------------------
@@ -884,3 +904,5 @@ used with a custom range functions that expected boundaries, for example to
 define :class:`~django.contrib.postgres.constraints.ExclusionConstraint`. See
 `the PostgreSQL documentation for the full details <https://www.postgresql.org/
 docs/current/rangetypes.html#RANGETYPES-INCLUSIVITY>`_.
+
+.. _different bounds: https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-IO

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -76,6 +76,12 @@ Minor features
   supports covering exclusion constraints using SP-GiST indexes on PostgreSQL
   14+.
 
+* The new ``default_bounds`` attribute of :attr:`DateTimeRangeField
+  <django.contrib.postgres.fields.DateTimeRangeField.default_bounds>` and
+  :attr:`DecimalRangeField
+  <django.contrib.postgres.fields.DecimalRangeField.default_bounds>` allows
+  specifying bounds for list and tuple inputs.
+
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/postgres_tests/fields.py
+++ b/tests/postgres_tests/fields.py
@@ -26,14 +26,23 @@ except ImportError:
             })
             return name, path, args, kwargs
 
+    class DummyContinuousRangeField(models.Field):
+        def __init__(self, *args, default_bounds='[)', **kwargs):
+            super().__init__(**kwargs)
+
+        def deconstruct(self):
+            name, path, args, kwargs = super().deconstruct()
+            kwargs['default_bounds'] = '[)'
+            return name, path, args, kwargs
+
     ArrayField = DummyArrayField
     BigIntegerRangeField = models.Field
     CICharField = models.Field
     CIEmailField = models.Field
     CITextField = models.Field
     DateRangeField = models.Field
-    DateTimeRangeField = models.Field
-    DecimalRangeField = models.Field
+    DateTimeRangeField = DummyContinuousRangeField
+    DecimalRangeField = DummyContinuousRangeField
     HStoreField = models.Field
     IntegerRangeField = models.Field
     SearchVector = models.Expression

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -249,6 +249,7 @@ class Migration(migrations.Migration):
                 ('decimals', DecimalRangeField(null=True, blank=True)),
                 ('timestamps', DateTimeRangeField(null=True, blank=True)),
                 ('timestamps_inner', DateTimeRangeField(null=True, blank=True)),
+                ('timestamps_closed_bounds', DateTimeRangeField(null=True, blank=True, default_bounds='[]')),
                 ('dates', DateRangeField(null=True, blank=True)),
                 ('dates_inner', DateRangeField(null=True, blank=True)),
             ],

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -135,6 +135,9 @@ class RangesModel(PostgreSQLModel):
     decimals = DecimalRangeField(blank=True, null=True)
     timestamps = DateTimeRangeField(blank=True, null=True)
     timestamps_inner = DateTimeRangeField(blank=True, null=True)
+    timestamps_closed_bounds = DateTimeRangeField(
+        blank=True, null=True, default_bounds='[]',
+    )
     dates = DateRangeField(blank=True, null=True)
     dates_inner = DateRangeField(blank=True, null=True)
 

--- a/tests/postgres_tests/test_apps.py
+++ b/tests/postgres_tests/test_apps.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.db.backends.signals import connection_created
 from django.db.migrations.writer import MigrationWriter
 from django.test.utils import modify_settings
@@ -10,7 +12,8 @@ try:
     )
 
     from django.contrib.postgres.fields import (
-        DateRangeField, DateTimeRangeField, IntegerRangeField,
+        DateRangeField, DateTimeRangeField, DecimalRangeField,
+        IntegerRangeField,
     )
 except ImportError:
     pass
@@ -29,6 +32,7 @@ class PostgresConfigTests(PostgreSQLTestCase):
             (DateRange(empty=True), DateRangeField),
             (DateTimeRange(empty=True), DateRangeField),
             (DateTimeTZRange(None, None, '[]'), DateTimeRangeField),
+            (NumericRange(Decimal('1.0'), Decimal('5.0'), '()'), DecimalRangeField),
             (NumericRange(1, 10), IntegerRangeField),
         )
 


### PR DESCRIPTION
This PR fixes [#27147](https://code.djangoproject.com/ticket/27147).

I could think of two UIs to fix the stated problem:

1. We can add a `default_bounds` as an argument to `RangeField` class, and thus all subclasses. The problem of this approach is that we may add some cutler for discrete ranges. For example, IMO it makes no sense to set a `default_bounds` value for a `IntegerRangeField` as it'll always be converted to `[)`, cluttering user's experience. Please, let me know if I'm missing something.
2. We can specialize `RangeField` for continuous ranges. With this approach we're preventing misuse.

I implemented approach 2.

I'm following a conservative approach for `default_bounds`. For example:

```python
from psycopg2.extras import DateTimeTZRange

lower_date = datetime.date(2014, 1, 1)
upper_date = datetime.date(2014, 2, 2)

class DummyRange(models.Model):
        timestamps = DateTimeRangeField(blank=True, null=True, default_bounds='[]')

DummyRange.objects.create(timestamps=DateTimeTZRange(lower_date, upper_date))  # saved with bounds='[)'
DummyRange.objects.create(timestamps=DateTimeTZRange(lower_date, upper_date, '()'))  # saved with bounds='()'
DummyRange.objects.create(timestamps=(lower_date, upper_date))  # saved with bounds='[]' - default_bounds
```
The reasoning behind is that a user knows what's he's doing if he created a `Range` object (Adding a validator sounds like a good idea). I still need to document whichever behavior we choose.

Looking forward for feedback before finishing this feature.