### PR TITLE
Fixed #32866 -- Fixed trimming trailing punctuation from escaped string in urlize().

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -283,8 +283,9 @@ def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
             middle_unescaped = html.unescape(middle)
             stripped = middle_unescaped.rstrip(TRAILING_PUNCTUATION_CHARS)
             if middle_unescaped != stripped:
-                trail = middle[len(stripped):] + trail
-                middle = middle[:len(stripped) - len(middle_unescaped)]
+                punctuation_count = len(middle_unescaped) - len(stripped)
+                trail = middle[-punctuation_count:] + trail
+                middle = middle[:-punctuation_count]
                 trimmed_something = True
         return lead, middle, trail
 

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -251,6 +251,10 @@ class TestUtilsHtml(SimpleTestCase):
                 'Search for <a href="http://google.com/?q=">google.com/?q=</a>! and see.'
             ),
             (
+                'Search for google.com/?q=1&lt! and see.',
+                'Search for <a href="http://google.com/?q=1%3C">google.com/?q=1&lt</a>! and see.'
+            ),
+            (
                 lazystr('Search for google.com/?q=!'),
                 'Search for <a href="http://google.com/?q=">google.com/?q=</a>!'
             ),


### PR DESCRIPTION
…g punctuation.