### PR TITLE
Removed options parameter from djangoAdminSelect2.

### DIFF
--- a/django/contrib/admin/static/admin/js/autocomplete.js
+++ b/django/contrib/admin/static/admin/js/autocomplete.js
@@ -1,28 +1,22 @@
 'use strict';
 {
     const $ = django.jQuery;
-    const init = function($element, options) {
-        const settings = $.extend({
-            ajax: {
-                data: function(params) {
-                    return {
-                        term: params.term,
-                        page: params.page,
-                        app_label: $element.data('app-label'),
-                        model_name: $element.data('model-name'),
-                        field_name: $element.data('field-name')
-                    };
-                }
-            }
-        }, options);
-        $element.select2(settings);
-    };
 
-    $.fn.djangoAdminSelect2 = function(options) {
-        const settings = $.extend({}, options);
+    $.fn.djangoAdminSelect2 = function() {
         $.each(this, function(i, element) {
-            const $element = $(element);
-            init($element, settings);
+            $(element).select2({
+                ajax: {
+                    data: (params) => {
+                        return {
+                            term: params.term,
+                            page: params.page,
+                            app_label: element.dataset.appLabel,
+                            model_name: element.dataset.modelName,
+                            field_name: element.dataset.fieldName
+                        };
+                    }
+                }
+            });
         });
         return this;
     };


### PR DESCRIPTION
It seems this parameter has never been used internally, so to avoid exposing a large surface area in the admin, remove it. As discussed in this mailing list thread: https://groups.google.com/g/django-developers/c/G-fDkNxhxsE/m/--RtGwmtAQAJ .