### PR TITLE
[2.2.x] Refs #32856 -- Doc'd that psycopg2 < 2.9 is required.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -102,10 +102,10 @@ below for information on how to set up your database correctly.
 PostgreSQL notes
 ================
 
-Django supports PostgreSQL 9.4 and higher. `psycopg2`_ 2.5.4 or higher is
+Django supports PostgreSQL 9.4 and higher. `psycopg2`_ 2.5.4 through 2.8.6 is
 required, though the latest release is recommended.
 
-.. _psycopg2: http://initd.org/psycopg/
+.. _psycopg2: https://www.psycopg.org/
 
 PostgreSQL connection settings
 -------------------------------

--- a/tests/requirements/postgres.txt
+++ b/tests/requirements/postgres.txt
@@ -1,1 +1,1 @@
-psycopg2-binary>=2.5.4
+psycopg2-binary>=2.5.4, < 2.9


### PR DESCRIPTION
ticket-32856