### PR TITLE
Test Client to send PUT requests to "upload" files

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -429,7 +429,8 @@ class RequestFactory:
             secure=False, **extra):
         """Construct a PUT request."""
         data = self._encode_json(data, content_type)
-        return self.generic('PUT', path, data, content_type,
+        put_data = self._encode_data(data, content_type)
+        return self.generic('PUT', path, put_data, content_type,
                             secure=secure, **extra)
 
     def patch(self, path, data='', content_type='application/octet-stream',


### PR DESCRIPTION
allow put data to test uploading files like we do with post requests. Without this line
if you try to upload a file the the `self.generic()` returns a key errors. Then in the request
the request.FILES/request.data is empty and you cannot access the uploaded file.

Please let me know if there is a specific reason it's setup this way. I just needed to test
an image upload using a PUT request.

Thanks
