### PR TITLE
Fixed #32863 -- Skipped system check for specifying type of auto-created primary keys on models with invalid app_label.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1310,6 +1310,7 @@ class Model(metaclass=ModelBase):
                 cls._meta.pk.remote_field.parent_link
             ) and
             not settings.is_overridden('DEFAULT_AUTO_FIELD') and
+            cls._meta.app_config and
             not cls._meta.app_config._is_default_auto_field_overridden
         ):
             return [

--- a/docs/releases/3.2.5.txt
+++ b/docs/releases/3.2.5.txt
@@ -20,3 +20,6 @@ Bugfixes
 * Fixed a regression in Django 3.2 that caused a migration crash on MySQL
   8.0.13+ when adding nullable ``BinaryField``, ``JSONField``, or ``TextField``
   with a default value (:ticket:`32832`).
+
+* Fixed a bug in Django 3.2 where a system check would crash on a model with an
+  invalid ``app_label`` (:ticket:`32863`).

--- a/tests/check_framework/test_model_checks.py
+++ b/tests/check_framework/test_model_checks.py
@@ -403,6 +403,13 @@ class ModelDefaultAutoFieldTests(SimpleTestCase):
 
         self.assertEqual(checks.run_checks(app_configs=self.apps.get_app_configs()), [])
 
+    def test_skipped_on_model_with_invalid_app_label(self):
+        class Model(models.Model):
+            class Meta:
+                app_label = 'invalid_app_label'
+
+        self.assertEqual(Model.check(), [])
+
     def test_skipped_on_abstract_model(self):
         class Abstract(models.Model):
             class Meta:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32863