### PR TITLE
Fixed ResourceWarning in test_client.tests.ClientTest.test_uploading_named_temp_file().

### DIFF
--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -894,8 +894,11 @@ class ClientTest(TestCase):
         self.assertEqual(response.content, b'temp_file')
 
     def test_uploading_named_temp_file(self):
-        test_file = tempfile.NamedTemporaryFile()
-        response = self.client.post('/upload_view/', data={'named_temp_file': test_file})
+        with tempfile.NamedTemporaryFile() as test_file:
+            response = self.client.post(
+                '/upload_view/',
+                data={'named_temp_file': test_file},
+            )
         self.assertEqual(response.content, b'named_temp_file')
 
 


### PR DESCRIPTION
Noticed in [`sqlite3,windows,Python310`](https://djangoci.com/job/django-windows/database=sqlite3,label=windows,python=Python310/lastCompletedBuild/consoleFull):

```
test_uploading_named_temp_file (test_client.tests.ClientTest) ... Exception ignored in: <_io.FileIO name=3 mode='rb+' closefd=True>
Traceback (most recent call last):
  File "C:\Python310\lib\unittest\case.py", line 549, in _callTestMethod
    method()
ResourceWarning: unclosed file <_io.BufferedRandom name=3>
OK (0.007s)
```