### PR TITLE
Refs #32881 - Changed contrib.auth.forms to use only one user model

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -667,6 +667,7 @@ answer newbie questions, and generally made Django that much better:
     Mikhail Korobov <kmike84@googlemail.com>
     Mikko Hellsing <mikko@sorl.net>
     Mikołaj Siedlarek <mikolaj.siedlarek@gmail.com>
+    Milan Voršilák <miliworsi@gmail.com>
     milkomeda
     Milton Waddams
     mitakummaa@gmail.com

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -7,7 +7,6 @@ from django.contrib.auth import (
 from django.contrib.auth.hashers import (
     UNUSABLE_PASSWORD_PREFIX, identify_hasher,
 )
-from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ValidationError
@@ -97,7 +96,7 @@ class UserCreationForm(forms.ModelForm):
     )
 
     class Meta:
-        model = User
+        model = UserModel
         fields = ("username",)
         field_classes = {'username': UsernameField}
 
@@ -146,7 +145,7 @@ class UserChangeForm(forms.ModelForm):
     )
 
     class Meta:
-        model = User
+        model = UserModel
         fields = '__all__'
         field_classes = {'username': UsernameField}
 


### PR DESCRIPTION
Inconsistent user models in contrib.auth.forms, ModelForms were used with
contrib.auth.models.User and other forms were used with model obtained with
contrib.auth.get_user_model().