### PR TITLE
Fixed #32807 -- Fixed JSONField crash when redisplaying None values.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1251,6 +1251,8 @@ class JSONField(CharField):
     def bound_data(self, data, initial):
         if self.disabled:
             return initial
+        if data is None:
+            return None
         try:
             return json.loads(data, cls=self.decoder)
         except json.JSONDecodeError:

--- a/tests/forms_tests/field_tests/test_jsonfield.py
+++ b/tests/forms_tests/field_tests/test_jsonfield.py
@@ -97,6 +97,21 @@ class JSONFieldTest(SimpleTestCase):
         form = JSONForm({'json_field': '["bar"]'}, initial={'json_field': ['foo']})
         self.assertIn('[&quot;foo&quot;]</textarea>', form.as_p())
 
+    def test_redisplay_none_input(self):
+        class JSONForm(Form):
+            json_field = JSONField(required=True)
+
+        tests = [
+            {},
+            {'json_field': None},
+        ]
+        for data in tests:
+            with self.subTest(data=data):
+                form = JSONForm(data)
+                self.assertEqual(form['json_field'].value(), 'null')
+                self.assertIn('null</textarea>', form.as_p())
+                self.assertEqual(form.errors['json_field'], ['This field is required.'])
+
     def test_redisplay_wrong_input(self):
         """
         Displaying a bound form (typically due to invalid input). The form


### PR DESCRIPTION
See: https://code.djangoproject.com/ticket/32807

This change prevents an exception from being raised during form rendering when a JSONField is missing from form data, bringing the behaviour of JSONField in line with other fields in this case. Specifically, a blank field is rendered, accompanied by a validation error if the field is required.

Thanks to @AlexHill for the initial patch.

This takes over where https://github.com/django/django/pull/13844 left off.

Ping @felixxm for review.