### PR TITLE
Fixed #32884 -- Fixed centering of the header on admin login page.

### DIFF
--- a/django/contrib/admin/static/admin/css/login.css
+++ b/django/contrib/admin/static/admin/css/login.css
@@ -13,6 +13,7 @@
 
 .login #header h1 {
     font-size: 18px;
+    margin: 0;
 }
 
 .login #header h1 a {


### PR DESCRIPTION
Ref: [Ticket #32884](https://code.djangoproject.com/ticket/32884).

This is a very small patch to fix the admin login header being very slightly off center, as seen in this screenshot. More information, including discussion of the proposed solution, in the referenced ticket linked above.

![image](https://user-images.githubusercontent.com/2553268/123653239-f8267d80-d7fa-11eb-976d-3da1f57beee8.png)
