### PR TITLE
Fixed #32226 -- Fixed JSON format of QuerySet.explain() on PostgreSQL.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -974,6 +974,7 @@ answer newbie questions, and generally made Django that much better:
     Wilson Miner <wminer@gmail.com>
     Wim Glenn <hey@wimglenn.com>
     wojtek
+    Wu Haotian <whtsky@gmail.com>
     Xavier Francisco <xavier.n.francisco@gmail.com>
     Xia Kai <https://blog.xiaket.org/>
     Yann Fouillat <gagaro42@gmail.com>

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1,4 +1,5 @@
 import collections
+import json
 import re
 from functools import partial
 from itertools import chain
@@ -1250,9 +1251,10 @@ class SQLCompiler:
         result = list(self.execute_sql())
         # Some backends return 1 item tuples with strings, and others return
         # tuples with integers and strings. Flatten them out into strings.
+        output_formatter = json.dumps if self.query.explain_format == 'json' else str
         for row in result[0]:
             if not isinstance(row, str):
-                yield ' '.join(str(c) for c in row)
+                yield ' '.join(output_formatter(c) for c in row)
             else:
                 yield row
 

--- a/tests/queries/test_explain.py
+++ b/tests/queries/test_explain.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 import xml.etree.ElementTree
 
@@ -38,6 +39,13 @@ class ExplainTests(TestCase):
                             except xml.etree.ElementTree.ParseError as e:
                                 self.fail(
                                     f'QuerySet.explain() result is not valid XML: {e}'
+                                )
+                        elif format == 'json':
+                            try:
+                                json.loads(result)
+                            except json.JSONDecodeError as e:
+                                self.fail(
+                                    f'QuerySet.explain() result is not valid JSON: {e}'
                                 )
 
     @skipUnlessDBFeature('validates_explain_options')

--- a/tests/queries/test_explain.py
+++ b/tests/queries/test_explain.py
@@ -1,4 +1,5 @@
 import unittest
+import xml.etree.ElementTree
 
 from django.db import NotSupportedError, connection, transaction
 from django.db.models import Count
@@ -31,6 +32,13 @@ class ExplainTests(TestCase):
                         self.assertTrue(captured_queries[0]['sql'].startswith(connection.ops.explain_prefix))
                         self.assertIsInstance(result, str)
                         self.assertTrue(result)
+                        if format == 'xml':
+                            try:
+                                xml.etree.ElementTree.fromstring(result)
+                            except xml.etree.ElementTree.ParseError as e:
+                                self.fail(
+                                    f'QuerySet.explain() result is not valid XML: {e}'
+                                )
 
     @skipUnlessDBFeature('validates_explain_options')
     def test_unknown_options(self):


### PR DESCRIPTION
Use `json.dumps` to format explain's return when explain format is json.