### PR TITLE
provide a dedicated LazyObject.__class__ method

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -337,7 +337,13 @@ class LazyObject:
 
     # Need to pretend to be the wrapped class, for the sake of objects that
     # care about this (especially in equality tests)
-    __class__ = property(new_method_proxy(operator.attrgetter("__class__")))
+    
+    def __class__(self):
+        if self._wrapped is empty:
+            return type(self)
+        
+        return type(self._wrapped)
+    
     __eq__ = new_method_proxy(operator.eq)
     __lt__ = new_method_proxy(operator.lt)
     __gt__ = new_method_proxy(operator.gt)


### PR DESCRIPTION
fixes https://code.djangoproject.com/ticket/32894#ticket

this will fall back to returning the LazyObjects' type when it is uninitialized.
Alternatively this could be a try/except block trying to initialize, but i think thats not improving anything.