### PR TITLE
Fixed #32893 -- Fixed serialization of models.Model class in migrations.

### DIFF
--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -273,7 +273,7 @@ class TupleSerializer(BaseSequenceSerializer):
 class TypeSerializer(BaseSerializer):
     def serialize(self):
         special_cases = [
-            (models.Model, "models.Model", []),
+            (models.Model, "models.Model", ['from django.db import models']),
             (type(None), 'type(None)', []),
         ]
         for case, string, imports in special_cases:

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -658,6 +658,13 @@ class WriterTests(SimpleTestCase):
     def test_serialize_type_none(self):
         self.assertSerializedEqual(type(None))
 
+    def test_serialize_type_model(self):
+        self.assertSerializedEqual(models.Model)
+        self.assertSerializedResultEqual(
+            MigrationWriter.serialize(models.Model),
+            ("('models.Model', {'from django.db import models'})", set()),
+        )
+
     def test_simple_migration(self):
         """
         Tests serializing a simple migration.


### PR DESCRIPTION
…when serializing models.Model

- it returned an empty set earlier.

Thanks Jaap Joris Vens for the report.

[ticket-32893](https://code.djangoproject.com/ticket/32893)