### PR TITLE
Fixed #32892 -- Optimized django.utils.dateparse.parse_date and django.utils.dateparse.parse_datetime by preferring datetime.fromisoformat for well-formed values.

### DIFF
--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -87,6 +87,9 @@ def parse_time(value):
     Return None if the input isn't well formatted, in particular if it
     contains an offset.
     """
+    if len(value) == 10:
+        return datetime.datetime.fromisoformat(value)
+
     match = time_re.match(value)
     if match:
         kw = match.groupdict()
@@ -104,22 +107,25 @@ def parse_datetime(value):
     Raise ValueError if the input is well formatted but not a valid datetime.
     Return None if the input isn't well formatted.
     """
-    match = datetime_re.match(value)
-    if match:
-        kw = match.groupdict()
-        kw['microsecond'] = kw['microsecond'] and kw['microsecond'].ljust(6, '0')
-        tzinfo = kw.pop('tzinfo')
-        if tzinfo == 'Z':
-            tzinfo = utc
-        elif tzinfo is not None:
-            offset_mins = int(tzinfo[-2:]) if len(tzinfo) > 3 else 0
-            offset = 60 * int(tzinfo[1:3]) + offset_mins
-            if tzinfo[0] == '-':
-                offset = -offset
-            tzinfo = get_fixed_timezone(offset)
-        kw = {k: int(v) for k, v in kw.items() if v is not None}
-        kw['tzinfo'] = tzinfo
-        return datetime.datetime(**kw)
+    try:
+        return datetime.datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        match = datetime_re.match(value)
+        if match:
+            kw = match.groupdict()
+            kw['microsecond'] = kw['microsecond'] and kw['microsecond'].ljust(6, '0')
+            tzinfo = kw.pop('tzinfo')
+            if tzinfo == 'Z':
+                tzinfo = utc
+            elif tzinfo is not None:
+                offset_mins = int(tzinfo[-2:]) if len(tzinfo) > 3 else 0
+                offset = 60 * int(tzinfo[1:3]) + offset_mins
+                if tzinfo[0] == '-':
+                    offset = -offset
+                tzinfo = get_fixed_timezone(offset)
+            kw = {k: int(v) for k, v in kw.items() if v is not None}
+            kw['tzinfo'] = tzinfo
+            return datetime.datetime(**kw)
 
 
 def parse_duration(value):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32892
