### PR TITLE
Fixed #32892 -- Optimized django.utils.dateparse functions by using fromisoformat().

### DIFF
--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -72,10 +72,12 @@ def parse_date(value):
     Raise ValueError if the input is well formatted but not a valid date.
     Return None if the input isn't well formatted.
     """
-    match = date_re.match(value)
-    if match:
-        kw = {k: int(v) for k, v in match.groupdict().items()}
-        return datetime.date(**kw)
+    try:
+        return datetime.date.fromisoformat(value)
+    except ValueError:
+        if match := date_re.match(value):
+            kw = {k: int(v) for k, v in match.groupdict().items()}
+            return datetime.date(**kw)
 
 
 def parse_time(value):
@@ -87,12 +89,18 @@ def parse_time(value):
     Return None if the input isn't well formatted, in particular if it
     contains an offset.
     """
-    match = time_re.match(value)
-    if match:
-        kw = match.groupdict()
-        kw['microsecond'] = kw['microsecond'] and kw['microsecond'].ljust(6, '0')
-        kw = {k: int(v) for k, v in kw.items() if v is not None}
-        return datetime.time(**kw)
+    try:
+        # The fromisoformat() method takes time zone info into account and
+        # returns a time with a tzinfo component, if possible. However, there
+        # are no circumstances where aware datetime.time objects make sense, so
+        # remove the time zone offset.
+        return datetime.time.fromisoformat(value).replace(tzinfo=None)
+    except ValueError:
+        if match := time_re.match(value):
+            kw = match.groupdict()
+            kw['microsecond'] = kw['microsecond'] and kw['microsecond'].ljust(6, '0')
+            kw = {k: int(v) for k, v in kw.items() if v is not None}
+            return datetime.time(**kw)
 
 
 def parse_datetime(value):
@@ -104,22 +112,23 @@ def parse_datetime(value):
     Raise ValueError if the input is well formatted but not a valid datetime.
     Return None if the input isn't well formatted.
     """
-    match = datetime_re.match(value)
-    if match:
-        kw = match.groupdict()
-        kw['microsecond'] = kw['microsecond'] and kw['microsecond'].ljust(6, '0')
-        tzinfo = kw.pop('tzinfo')
-        if tzinfo == 'Z':
-            tzinfo = utc
-        elif tzinfo is not None:
-            offset_mins = int(tzinfo[-2:]) if len(tzinfo) > 3 else 0
-            offset = 60 * int(tzinfo[1:3]) + offset_mins
-            if tzinfo[0] == '-':
-                offset = -offset
-            tzinfo = get_fixed_timezone(offset)
-        kw = {k: int(v) for k, v in kw.items() if v is not None}
-        kw['tzinfo'] = tzinfo
-        return datetime.datetime(**kw)
+    try:
+        return datetime.datetime.fromisoformat(value)
+    except ValueError:
+        if match := datetime_re.match(value):
+            kw = match.groupdict()
+            kw['microsecond'] = kw['microsecond'] and kw['microsecond'].ljust(6, '0')
+            tzinfo = kw.pop('tzinfo')
+            if tzinfo == 'Z':
+                tzinfo = utc
+            elif tzinfo is not None:
+                offset_mins = int(tzinfo[-2:]) if len(tzinfo) > 3 else 0
+                offset = 60 * int(tzinfo[1:3]) + offset_mins
+                if tzinfo[0] == '-':
+                    offset = -offset
+                tzinfo = get_fixed_timezone(offset)
+            kw = {k: int(v) for k, v in kw.items() if v is not None}
+            return datetime.datetime(**kw, tzinfo=tzinfo)
 
 
 def parse_duration(value):

--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -25,6 +25,11 @@ class DateParseTests(unittest.TestCase):
         self.assertEqual(parse_time('10:20:30.400'), time(10, 20, 30, 400000))
         self.assertEqual(parse_time('10:20:30,400'), time(10, 20, 30, 400000))
         self.assertEqual(parse_time('4:8:16'), time(4, 8, 16))
+        # Time zone offset is ignored.
+        self.assertEqual(parse_time('00:05:23+04:00'), time(0, 5, 23))
+        # These should be invalid, see #32904.
+        self.assertEqual(parse_time('00:05:'), time(0, 5))
+        self.assertEqual(parse_time('4:18:101'), time(4, 18, 10))
         # Invalid inputs
         self.assertIsNone(parse_time('091500'))
         with self.assertRaises(ValueError):


### PR DESCRIPTION
[See ticket](https://code.djangoproject.com/ticket/32892)

As of python 3.7, the datetime class includes a `fromisoformat` method which handles the happy path much faster than the regex based method used by` parse_datetime`
This should hold true for `parse_date` and `parse_time` too, but I've not benchmarked those individually (though I can do if requested).

Most of the diff is really just the change in indent level for falling back to the regex format.

Against my local tests, I'm getting the following test failure, which I'm rather hopeful is unrelated. Let's see whether it's repeatable, cos it could be related to the `parse_time` maybe, by the look of the string?

```
FAIL: test_version (admin_scripts.tests.CommandTypes)
version is handled as a special case
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kez/Code/django/tests/admin_scripts/tests.py", line 1447, in test_version
    self.assertOutput(out, get_version())
  File "/Users/kez/Code/django/tests/admin_scripts/tests.py", line 162, in assertOutput
    self.assertIn(msg, stream, "'%s' does not match actual output text '%s'" % (msg, stream))
AssertionError: '4.0.dev20210701110541' not found in '4.0.dev20210701110909\n' : '4.0.dev20210701110541' does not match actual output text '4.0.dev20210701110909
```