### PR TITLE
Fixed #30934 -- Included database alias in django.db.backends log messages.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -251,6 +251,7 @@ answer newbie questions, and generally made Django that much better:
     David Sanders <dsanders11@ucsbalum.com>
     David Schein
     David Tulig <david.tulig@gmail.com>
+    David Winterbottom <david.winterbottom@gmail.com>
     David Wobrock <david.wobrock@gmail.com>
     Davide Ceretti <dav.ceretti@gmail.com>
     Deep L. Sukhwani <deepsukhwani@gmail.com>

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -121,11 +121,12 @@ class CursorDebugWrapper(CursorWrapper):
                 'time': '%.3f' % duration,
             })
             logger.debug(
-                '(%.3f) %s; args=%s',
+                '(%.3f) %s; args=%s; alias=%s',
                 duration,
                 sql,
                 params,
-                extra={'duration': duration, 'sql': sql, 'params': params},
+                self.db.alias,
+                extra={'duration': duration, 'sql': sql, 'params': params, 'alias': self.db.alias},
             )
 
 

--- a/docs/ref/logging.txt
+++ b/docs/ref/logging.txt
@@ -178,6 +178,7 @@ Messages to this logger have the following extra context:
 * ``duration``: The time taken to execute the SQL statement.
 * ``sql``: The SQL statement that was executed.
 * ``params``: The parameters that were used in the SQL call.
+* ``alias``: The alias of the database used in the SQL call.
 
 For performance reasons, SQL logging is only enabled when
 ``settings.DEBUG`` is set to ``True``, regardless of the logging
@@ -187,6 +188,10 @@ This logging does not include framework-level initialization (e.g.
 ``SET TIMEZONE``) or transaction management queries (e.g. ``BEGIN``,
 ``COMMIT``, and ``ROLLBACK``). Turn on query logging in your database if you
 wish to view all database queries.
+
+.. versionchanged:: 4.0
+
+    The database ``alias`` was added to log messages.
 
 .. _django-security-logger:
 

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -226,7 +226,8 @@ Internationalization
 Logging
 ~~~~~~~
 
-* ...
+* The alias of the database used in an SQL call is now passed as extra context
+  along with each message to the :ref:`django-db-logger` logger.
 
 Management Commands
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
ticket-30934.

Resurrects #11994 and finishes it off - it was ever so close!