### PR TITLE
Fixed #32840 -- Optimized Field.get_col().

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -392,13 +392,13 @@ class Field(RegisterLookupMixin):
         return []
 
     def get_col(self, alias, output_field=None):
-        if output_field is None:
-            output_field = self
-        if alias != self.model._meta.db_table or output_field != self:
-            from django.db.models.expressions import Col
-            return Col(alias, self, output_field)
-        else:
+        if (
+            alias == self.model._meta.db_table and
+            (output_field is None or output_field == self)
+        ):
             return self.cached_col
+        from django.db.models.expressions import Col
+        return Col(alias, self, output_field)
 
     @cached_property
     def cached_col(self):


### PR DESCRIPTION
This generally obviates 1 isinstance test + 2 getattr calls per column in the normal case of something like `tuple(User.objects.all())`

If an output_field is given, it *may* still compare as equal to self (intentionally or through coincidental attributes) so may not be ignored completely.

As per [the ticket](https://code.djangoproject.com/ticket/32840) the gains are truly minimal (at least over the short term, the longer the process runs, it'll naturally account for more worth). For this profiling to demonstrate anything, I've run the above query in a loop 1000 times:

before:
```
5464644 function calls (5455125 primitive calls)
ncalls          tottime  percall  cumtime  percall filename:lineno(function)
240591          0.027    0.000    0.027    0.000 {built-in method builtins.isinstance}
175400/174145   0.029    0.000    0.044    0.000 {built-in method builtins.getattr}
11000           0.008    0.000    0.018    0.000 django/db/models/fields/__init__.py:394(get_col)
```

after:
```
5420646 function calls (5411127 primitive calls)
ncalls          tottime  percall  cumtime  percall filename:lineno(function)
229591          0.025    0.000    0.026    0.000 {built-in method builtins.isinstance}
153400/152145   0.027    0.000    0.042    0.000 {built-in method builtins.getattr}
11000           0.004    0.000    0.004    0.000 django/db/models/fields/__init__.py:394(get_col)
```

Note that on the ticket, @carltongibson proposed a solution which would remove the `if output_field is None:  output_field = self` entirely, to the same effect. The reason I've _not_ opted for that is not a criticism of it, but for keeping intent as clear as possible -- the version which was suggested relies on the mental parsing of the `x or y` twice (which always causes me to double take) and leaves open an accidental regression in the future should someone justify an implementation of `Field.__bool__` which is equally/more costly as `Field.__eq__`
