### PR TITLE
Refs #32508 -- Raised ImproperlyConfigured/TypeError instead of using "assert".

### DIFF
--- a/django/db/backends/postgresql/creation.py
+++ b/django/db/backends/postgresql/creation.py
@@ -2,6 +2,7 @@ import sys
 
 from psycopg2 import errorcodes
 
+from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.base.creation import BaseDatabaseCreation
 from django.db.backends.utils import strip_quotes
 
@@ -21,9 +22,11 @@ class DatabaseCreation(BaseDatabaseCreation):
 
     def sql_table_creation_suffix(self):
         test_settings = self.connection.settings_dict['TEST']
-        assert test_settings['COLLATION'] is None, (
-            "PostgreSQL does not support collation setting at database creation time."
-        )
+        if test_settings.get('COLLATION') is not None:
+            raise ImproperlyConfigured(
+                'PostgreSQL does not support collation setting at database '
+                'creation time.'
+            )
         return self._get_database_create_suffix(
             encoding=test_settings['CHARSET'],
             template=test_settings.get('TEMPLATE'),

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1253,7 +1253,8 @@ class TestCase(TransactionTestCase):
             self.setUpTestData()
             return super()._fixture_setup()
 
-        assert not self.reset_sequences, 'reset_sequences cannot be used on TestCase instances'
+        if self.reset_sequences:
+            raise TypeError('reset_sequences cannot be used on TestCase instances')
         self.atomics = self._enter_atomics()
 
     def _fixture_teardown(self):

--- a/tests/test_utils/test_testcase.py
+++ b/tests/test_utils/test_testcase.py
@@ -43,6 +43,16 @@ class TestTestCase(TestCase):
         with self.assertRaisesMessage(AssertionError, message):
             Car.objects.using('other').get()
 
+    def test_reset_sequences(self):
+        old_reset_sequences = self.reset_sequences
+        self.reset_sequences = True
+        msg = 'reset_sequences cannot be used on TestCase instances'
+        try:
+            with self.assertRaisesMessage(TypeError, msg):
+                self._fixture_setup()
+        finally:
+            self.reset_sequences = old_reset_sequences
+
 
 class NonDeepCopyAble:
     def __deepcopy__(self, memo):


### PR DESCRIPTION
Replace assert with ImproperlyConfigured in django.db.backends.postgresql.creation and replace assert with TypeError in django.test.testcases