### PR TITLE
Fixed isolation of test_filename_traversal_upload().

### DIFF
--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -624,7 +624,6 @@ class FileUploadTests(TestCase):
 
     def test_filename_traversal_upload(self):
         os.makedirs(UPLOAD_TO, exist_ok=True)
-        self.addCleanup(shutil.rmtree, MEDIA_ROOT)
         tests = [
             '..&#x2F;test.txt',
             '..&sol;test.txt',


### PR DESCRIPTION
`shutil.rmtree(MEDIA_ROOT)` is already called as a class cleanup:
https://github.com/django/django/blob/aba9c2de669dcc0278c7ffde7981be91801be00b/tests/file_uploads/tests.py#L61
```
./runtests.py file_uploads.tests.FileUploadTests.test_filename_traversal_upload
Testing against Django installed in '/repo/django/django' with up to 8 processes
Found 1 test(s).
...
System check identified no issues (0 silenced).
.E
======================================================================
ERROR: tearDownClass (file_uploads.tests.FileUploadTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.8/shutil.py", line 709, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/usr/lib/python3.8/shutil.py", line 707, in rmtree
    orig_st = os.lstat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/django_ixoyln0t/tmpyam9a1uu'

----------------------------------------------------------------------
Ran 1 test in 0.004s

FAILED (errors=1)
```