### PR TITLE
Configured isort to use its "django" profile.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ['setuptools>=40.8.0', 'wheel']
 build-backend = 'setuptools.build_meta:__legacy__'
+
+[tool.isort]
+profile = "django"

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,11 +57,3 @@ install_script = scripts/rpm-install.sh
 exclude = build,.git,.tox,./tests/.env
 ignore = W504,W601
 max-line-length = 119
-
-[isort]
-combine_as_imports = true
-default_section = THIRDPARTY
-include_trailing_comma = true
-known_first_party = django
-line_length = 79
-multi_line_output = 5


### PR DESCRIPTION
isort 5 added profiles to represent common configurations, including one copying Django’s config ( https://pycqa.github.io/isort/docs/configuration/profiles.html ), so we no longer need to specify the options directly.