### PR TITLE
Fixed isolation of RouterTestCase.test_m2m_cross_database_protection().

### DIFF
--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -1344,14 +1344,14 @@ class RouterTestCase(TestCase):
         # If you create an object through a M2M relation, it will be
         # written to the write database, even if the original object
         # was on the read database
-        alice = dive.authors.create(name='Alice')
+        alice = dive.authors.create(name='Alice', pk=3)
         self.assertEqual(alice._state.db, 'default')
 
         # Same goes for get_or_create, regardless of whether getting or creating
         alice, created = dive.authors.get_or_create(name='Alice')
         self.assertEqual(alice._state.db, 'default')
 
-        bob, created = dive.authors.get_or_create(name='Bob')
+        bob, created = dive.authors.get_or_create(name='Bob', defaults={'pk': 4})
         self.assertEqual(bob._state.db, 'default')
 
     def test_o2o_cross_database_protection(self):


### PR DESCRIPTION
Hardcoded pks are necessary for this test case, however we need to set them for all new rows because the sequence will not increment automatically. For example on PostgreSQL:
```
./runtests.py multiple_database.tests.RouterTestCase.test_m2m_cross_database_protection
Testing against Django installed in '/repo/django/django' with up to 8 processes
Found 1 test(s).
...
System check identified no issues (0 silenced).
E
======================================================================
ERROR: test_m2m_cross_database_protection (multiple_database.tests.RouterTestCase)
M2M relations can cross databases if the database share a source
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/repo/django/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "multiple_database_person_pkey"
DETAIL:  Key (id)=(1) already exists.


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/repo/django/tests/multiple_database/tests.py", line 1347, in test_m2m_cross_database_protection
    alice = dive.authors.create(name='Alice')
  File "/repo/django/django/db/models/fields/related_descriptors.py", line 1020, in create
    new_obj = super(ManyRelatedManager, self.db_manager(db)).create(**kwargs)
  File "/repo/django/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/repo/django/django/db/models/query.py", line 453, in create
    obj.save(force_insert=True, using=self.db)
  File "/repo/django/django/db/models/base.py", line 730, in save
    self.save_base(using=using, force_insert=force_insert,
  File "/repo/django/django/db/models/base.py", line 767, in save_base
    updated = self._save_table(
  File "/repo/django/django/db/models/base.py", line 872, in _save_table
    results = self._do_insert(cls._base_manager, using, fields, returning_fields, raw)
  File "/repo/django/django/db/models/base.py", line 910, in _do_insert
    return manager._insert(
  File "/repo/django/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/repo/django/django/db/models/query.py", line 1291, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "/repo/django/django/db/models/sql/compiler.py", line 1439, in execute_sql
    cursor.execute(sql, params)
  File "/repo/django/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/repo/django/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/repo/django/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/repo/django/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/repo/django/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.IntegrityError: duplicate key value violates unique constraint "multiple_database_person_pkey"
DETAIL:  Key (id)=(1) already exists.

----------------------------------------------------------------------
Ran 1 test in 0.031s

FAILED (errors=1)
...
```
It works when the sequence is incremented by other test cases:
```
./runtests.py multiple_database.tests.RouterTestCase.test_foreign_key_cross_database_protection multiple_database.tests.RouterTestCase.test_m2m_cross_database_protection
Testing against Django installed in '/repo/django/django' with up to 8 processes
Found 2 test(s).
...
System check identified no issues (0 silenced).
..
----------------------------------------------------------------------
Ran 2 tests in 0.058s

OK
...
```