### PR TITLE
Fixed #32899 -- Added note about avoiding non-dict objects in JsonResponse docs.

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1092,6 +1092,10 @@ parameter to ``False``::
 
 Without passing ``safe=False``, a :exc:`TypeError` will be raised.
 
+Note that an API based on ``dict`` objects is more extensible, flexible, and
+makes it easier to maintain forwards compatibility. Therefore, you should avoid
+using non-dict objects in JSON-encoded response.
+
 .. warning::
 
     Before the `5th edition of ECMAScript


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32899