### PR TITLE
Fixed #32904 -- Made parse_time() more strict.

### DIFF
--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -16,7 +16,7 @@ date_re = _lazy_re_compile(
 
 time_re = _lazy_re_compile(
     r'(?P<hour>\d{1,2}):(?P<minute>\d{1,2})'
-    r'(?::(?P<second>\d{1,2})(?:[\.,](?P<microsecond>\d{1,6})\d{0,6})?)?'
+    r'(?::(?P<second>\d{1,2})(?:[\.,](?P<microsecond>\d{1,6})\d{0,6})?)?$'
 )
 
 datetime_re = _lazy_re_compile(

--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -27,10 +27,12 @@ class DateParseTests(unittest.TestCase):
         self.assertEqual(parse_time('4:8:16'), time(4, 8, 16))
         # Time zone offset is ignored.
         self.assertEqual(parse_time('00:05:23+04:00'), time(0, 5, 23))
-        # These should be invalid, see #32904.
-        self.assertEqual(parse_time('00:05:'), time(0, 5))
-        self.assertEqual(parse_time('4:18:101'), time(4, 18, 10))
         # Invalid inputs
+        self.assertIsNone(parse_time('00:05:'))
+        self.assertIsNone(parse_time('00:05:23,'))
+        self.assertIsNone(parse_time('00:05:23+'))
+        self.assertIsNone(parse_time('00:05:23+25:00'))
+        self.assertIsNone(parse_time('4:18:101'))
         self.assertIsNone(parse_time('091500'))
         with self.assertRaises(ValueError):
             parse_time('09:15:90')


### PR DESCRIPTION
Thanks Keryn Knight for the report.