### PR TITLE
Fixed #32908 -- Allowed select_for_update(skip_locked) on MariaDB 10.6+.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -185,7 +185,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     @cached_property
     def has_select_for_update_skip_locked(self):
-        return not self.connection.mysql_is_mariadb and self.connection.mysql_version >= (8, 0, 1)
+        if self.connection.mysql_is_mariadb:
+            return self.connection.mysql_version >= (10, 6)
+        return self.connection.mysql_version >= (8, 0, 1)
 
     @cached_property
     def has_select_for_update_nowait(self):

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -686,7 +686,7 @@ a :exc:`~django.db.NotSupportedError` is raised.
 =============== ========= ==========
 Option          MariaDB   MySQL
 =============== ========= ==========
-``SKIP LOCKED``           X (≥8.0.1)
+``SKIP LOCKED`` X (≥10.6) X (≥8.0.1)
 ``NOWAIT``      X (≥10.3) X (≥8.0.1)
 ``OF``                    X (≥8.0.1)
 ``NO KEY``

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1792,11 +1792,11 @@ them::
     >>> Person.objects.select_related('hometown').select_for_update().exclude(hometown=None)
     <QuerySet [<Person: ...)>, ...]>
 
-Currently, the ``postgresql``, ``oracle``, and ``mysql`` database
-backends support ``select_for_update()``. However, MariaDB 10.3+ supports only
-the ``nowait`` argument and MySQL 8.0.1+ supports the ``nowait``,
-``skip_locked``, and ``of`` arguments. The ``no_key`` argument is supported
-only on PostgreSQL.
+The ``postgresql``, ``oracle``, and ``mysql`` database backends support
+``select_for_update()``. However, MariaDB 10.3+ only supports the ``nowait``
+argument, MariaDB 10.6+ also supports the ``skip_locked`` argument, and MySQL
+8.0.1+ supports the ``nowait``, ``skip_locked``, and ``of`` arguments. The
+``no_key`` argument is only supported on PostgreSQL.
 
 Passing ``nowait=True``, ``skip_locked=True``, ``no_key=True``, or ``of`` to
 ``select_for_update()`` using database backends that do not support these
@@ -1835,6 +1835,10 @@ raised if ``select_for_update()`` is used in autocommit mode.
     The ``no_key`` argument was added.
 
     The ``of`` argument was allowed on MySQL 8.0.1+.
+
+.. versionchanged:: 4.0
+
+    The ``skip_locked`` argument was allowed on MariaDB 10.6+.
 
 ``raw()``
 ~~~~~~~~~

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -274,6 +274,9 @@ Models
 * The new :attr:`.Aggregate.empty_aggregate_value` attribute allows specifying
   a value to return when the aggregation is used over an empty result set.
 
+* The ``skip_locked`` argument of :meth:`.QuerySet.select_for_update()` is now
+  allowed on MariaDB 10.6+.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
ticket-32908

See https://mariadb.com/kb/en/select/#skip-locked