### PR TITLE
Fixed isolation of GenericRelationTests.test_filter_targets_related_pk().

### DIFF
--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -228,9 +228,11 @@ class GenericRelationTests(TestCase):
         self.assertEqual(qs.filter(links__sum__isnull=False).count(), 0)
 
     def test_filter_targets_related_pk(self):
-        HasLinkThing.objects.create()
-        hs2 = HasLinkThing.objects.create()
-        link = Link.objects.create(content_object=hs2)
+        # Use hardcoded PKs to ensure different PKs for "link" and "hs2"
+        # objects.
+        HasLinkThing.objects.create(pk=1)
+        hs2 = HasLinkThing.objects.create(pk=2)
+        link = Link.objects.create(content_object=hs2, pk=1)
         self.assertNotEqual(link.object_id, link.pk)
         self.assertSequenceEqual(HasLinkThing.objects.filter(links=link.pk), [hs2])
 


### PR DESCRIPTION
See [logs](https://djangoci.com/job/main-random/database=mysql,label=bionic,python=python3.9/1/testReport/junit/generic_relations_regress.tests/GenericRelationTests/test_filter_targets_related_pk/):

```console
# ./runtests.py generic_relations_regress.tests.GenericRelationTests --shuffle=5197129667
Testing against Django installed in '/django/django' with up to 8 processes
Using shuffle seed: 5197129667 (given)
Found 24 test(s).
Creating test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
System check identified no issues (0 silenced).
..........F.............
======================================================================
FAIL: test_filter_targets_related_pk (generic_relations_regress.tests.GenericRelationTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/tests/generic_relations_regress/tests.py", line 234, in test_filter_targets_related_pk
    self.assertNotEqual(link.object_id, link.pk)
AssertionError: 7 == 7

----------------------------------------------------------------------
Ran 24 tests in 0.123s

FAILED (failures=1)
Used shuffle seed: 5197129667 (given)
...
```