### PR TITLE
Refs #24522 -- Removed raising RuntimeError from shuffle() method.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -504,10 +504,6 @@ class Shuffler:
     def seed_display(self):
         return f'{self.seed!r} ({self.seed_source})'
 
-    def _hash_item(self, item, key):
-        text = '{}{}'.format(self.seed, key(item))
-        return self._hash_text(text)
-
     def shuffle(self, items, key):
         """
         Return a new list of the items in a shuffled order.
@@ -517,16 +513,13 @@ class Shuffler:
         order of the return value is deterministic. It depends on the seed
         and key function but not on the original order.
         """
-        hashes = {}
-        for item in items:
-            hashed = self._hash_item(item, key)
-            if hashed in hashes:
-                msg = 'item {!r} has same hash {!r} as item {!r}'.format(
-                    item, hashed, hashes[hashed],
-                )
-                raise RuntimeError(msg)
-            hashes[hashed] = item
-        return [hashes[hashed] for hashed in sorted(hashes)]
+        def sort_key(item):
+            key_value = key(item)
+            text = '{}{}'.format(self.seed, key_value)
+            hash_value = self._hash_text(text)
+            return hash_value, key_value
+
+        return list(sorted(items, key=sort_key))
 
 
 class DiscoverRunner:

--- a/tests/test_runner/test_shuffler.py
+++ b/tests/test_runner/test_shuffler.py
@@ -39,30 +39,6 @@ class ShufflerTests(SimpleTestCase):
         shuffler.seed_source = 'test'
         self.assertEqual(shuffler.seed_display, '100 (test)')
 
-    def test_hash_item_seed(self):
-        cases = [
-            (1234, '64ad3fb166ddb41a2ca24f1803b8b722'),
-            # Passing a string gives the same value.
-            ('1234', '64ad3fb166ddb41a2ca24f1803b8b722'),
-            (5678, '4dde450ad339b6ce45a0a2666e35b975'),
-        ]
-        for seed, expected in cases:
-            with self.subTest(seed=seed):
-                shuffler = Shuffler(seed=seed)
-                actual = shuffler._hash_item('abc', lambda x: x)
-                self.assertEqual(actual, expected)
-
-    def test_hash_item_key(self):
-        cases = [
-            (lambda x: x, '64ad3fb166ddb41a2ca24f1803b8b722'),
-            (lambda x: x.upper(), 'ee22e8597bff91742affe4befbf4649a'),
-        ]
-        for key, expected in cases:
-            with self.subTest(key=key):
-                shuffler = Shuffler(seed=1234)
-                actual = shuffler._hash_item('abc', key)
-                self.assertEqual(actual, expected)
-
     def test_shuffle_key(self):
         cases = [
             (lambda x: x, ['a', 'd', 'b', 'c']),
@@ -97,6 +73,5 @@ class ShufflerTests(SimpleTestCase):
 
     def test_shuffle_same_hash(self):
         shuffler = Shuffler(seed=1234)
-        msg = "item 'A' has same hash 'a56ce89262959e151ee2266552f1819c' as item 'a'"
-        with self.assertRaisesMessage(RuntimeError, msg):
-            shuffler.shuffle(['a', 'b', 'A'], lambda x: x.upper())
+        actual = shuffler.shuffle(['a', 'b', 'A'], lambda x: x.upper())
+        self.assertEqual(actual, ['a', 'A', 'b'])


### PR DESCRIPTION
There’s no need to raise an error if two items have the same hash value. Instead, we can secondarily sort by the key values to get a consistent ordering. Since hashes are based upon the seed, two tests that collide with one seed are highly unlikely to collide with another seed, so they get shuffled rather than always run in alphabetical order.