### PR TITLE
Fixed #25264 -- Removed redundant options of runserver command.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -287,11 +287,6 @@ class BaseCommand:
         )
         parser.add_argument('--version', action='version', version=self.get_version())
         parser.add_argument(
-            '-v', '--verbosity', default=1,
-            type=int, choices=[0, 1, 2, 3],
-            help='Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output',
-        )
-        parser.add_argument(
             '--settings',
             help=(
                 'The Python path to a settings module, e.g. '
@@ -303,7 +298,6 @@ class BaseCommand:
             '--pythonpath',
             help='A directory to add to the Python path, e.g. "/home/djangoprojects/myproject".',
         )
-        parser.add_argument('--traceback', action='store_true', help='Raise on CommandError exceptions')
         parser.add_argument(
             '--no-color', action='store_true',
             help="Don't colorize the command output.",
@@ -312,6 +306,13 @@ class BaseCommand:
             '--force-color', action='store_true',
             help='Force colorization of the command output.',
         )
+        if subcommand != 'runserver':
+            parser.add_argument('--traceback', action='store_true', help='Raise on CommandError exceptions')
+            parser.add_argument(
+                '-v', '--verbosity', default=1,
+                type=int, choices=[0, 1, 2, 3],
+                help='Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output',
+            )
         if self.requires_system_checks:
             parser.add_argument(
                 '--skip-checks', action='store_true',

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1791,7 +1791,8 @@ Default options
 .. program:: None
 
 Although some commands may allow their own custom options, every command
-allows for the following options:
+allows for the following options (except for the :djadmin:`runserver` command,
+because this command do not use :option:`--verbosity` and :option:`--traceback`):
 
 .. django-admin-option:: --pythonpath PYTHONPATH
 
@@ -1827,6 +1828,7 @@ Example usage::
 Displays a full stack trace when a :exc:`~django.core.management.CommandError`
 is raised. By default, ``django-admin`` will show an error message when a
 ``CommandError`` occurs and a full stack trace for any other exception.
+This option is not used with :djadmin:`runserver` command.
 
 Example usage::
 
@@ -1835,7 +1837,7 @@ Example usage::
 .. django-admin-option:: --verbosity {0,1,2,3}, -v {0,1,2,3}
 
 Specifies the amount of notification and debug information that a command
-should print to the console.
+should print to the console. This option is not used with :djadmin:`runserver` command.
 
 * ``0`` means no output.
 * ``1`` means normal output (default).

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1411,12 +1411,10 @@ class ManageTestserver(SimpleTestCase):
                 "has not been deleted. You can explore it on your own."
             ),
             skip_checks=True,
-            traceback=False,
             use_ipv6=False,
             use_reloader=False,
             use_static_handler=True,
             use_threading=connection.features.test_db_allows_multiple_connections,
-            verbosity=1,
         )
 
 
@@ -1495,6 +1493,17 @@ class CommandTypes(AdminScriptTestCase):
         self.assertNotEqual(version_location, -1)
         self.assertLess(tag_location, version_location)
         self.assertOutput(out, "Checks the entire Django project for potential problems.")
+
+    def test_help_ignored_options_by_runserver(self):
+        "runserver does not use --traceback and --verbosity options"
+        args = ['runserver', '--help']
+        out, err = self.run_manage(args)
+        self.assertNoOutput(err)
+        self.assertOutput(out, 'optional')
+        self.assertOutput(out, '--version')
+        self.assertNotInOutput(out, '--verbosity')
+        self.assertNotInOutput(out, '--traceback')
+        self.assertOutput(out, '--no-color')
 
     def test_color_style(self):
         style = color.no_style()


### PR DESCRIPTION
[Ticket #25264](https://code.djangoproject.com/ticket/25264)

This is my first contribution to this project! I would be very thankful if you kindly point out my mistakes if any.

`runserver` command does not use the `--verbosity` option because it already writes out every request it accepts. This command also does not use the `--traceback` option because the server errors are also already caught and the tracebacks are printed out. By this patch, these misleading options are removed.