### PR TITLE
Fixed isolation of NonAutocommitTests.test_orm_query_after_error_and_rollback().

### DIFF
--- a/tests/transactions/tests.py
+++ b/tests/transactions/tests.py
@@ -477,12 +477,18 @@ class NonAutocommitTests(TransactionTestCase):
 
     available_apps = []
 
+    def setUp(self):
+        transaction.set_autocommit(False)
+
+    def tearDown(self):
+        transaction.rollback()
+        transaction.set_autocommit(True)
+
     def test_orm_query_after_error_and_rollback(self):
         """
         ORM queries are allowed after an error and a rollback in non-autocommit
         mode (#27504).
         """
-        transaction.set_autocommit(False)
         r1 = Reporter.objects.create(first_name='Archibald', last_name='Haddock')
         r2 = Reporter(first_name='Cuthbert', last_name='Calculus', id=r1.id)
         with self.assertRaises(IntegrityError):
@@ -492,12 +498,7 @@ class NonAutocommitTests(TransactionTestCase):
 
     def test_orm_query_without_autocommit(self):
         """#24921 -- ORM queries must be possible after set_autocommit(False)."""
-        transaction.set_autocommit(False)
-        try:
-            Reporter.objects.create(first_name="Tintin")
-        finally:
-            transaction.rollback()
-            transaction.set_autocommit(True)
+        Reporter.objects.create(first_name="Tintin")
 
 
 class DurableTests(TransactionTestCase):


### PR DESCRIPTION
See [logs](https://djangoci.com/view/Main/job/main-random/database=sqlite3,label=bionic,python=python3.9/lastCompletedBuild/consoleFull).

```
./runtests.py backends.sqlite.tests.ThreadSharing transactions.tests.NonAutocommitTests --shuffle=1107509405 --parallel=1
Testing against Django installed in '/django/django'
Using shuffle seed: 1107509405 (given)
Found 3 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
..Exception in thread Thread-1:
Traceback (most recent call last):
  File "/django/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/django/django/db/backends/sqlite3/base.py", line 416, in execute
    return Database.Cursor.execute(self, query, params)
sqlite3.OperationalError: database table is locked

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/django/tests/backends/sqlite/tests.py", line 260, in create_object
    Object.objects.create()
  File "/django/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/django/django/db/models/query.py", line 453, in create
    obj.save(force_insert=True, using=self.db)
  File "/django/django/db/models/base.py", line 730, in save
    self.save_base(using=using, force_insert=force_insert,
  File "/django/django/db/models/base.py", line 767, in save_base
    updated = self._save_table(
  File "/django/django/db/models/base.py", line 872, in _save_table
    results = self._do_insert(cls._base_manager, using, fields, returning_fields, raw)
  File "/django/django/db/models/base.py", line 910, in _do_insert
    return manager._insert(
  File "/django/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/django/django/db/models/query.py", line 1291, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "/django/django/db/models/sql/compiler.py", line 1441, in execute_sql
    cursor.execute(sql, params)
  File "/django/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/django/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/django/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/django/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/django/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/django/django/db/backends/sqlite3/base.py", line 416, in execute
    return Database.Cursor.execute(self, query, params)
django.db.utils.OperationalError: database table is locked
FAIL

======================================================================
FAIL: test_database_sharing_in_threads (backends.sqlite.tests.ThreadSharing)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/tests/backends/sqlite/tests.py", line 265, in test_database_sharing_in_threads
    self.assertEqual(Object.objects.count(), 2)
AssertionError: 1 != 2

----------------------------------------------------------------------
Ran 3 tests in 0.018s

FAILED (failures=1)
Used shuffle seed: 1107509405 (given)
Destroying test database for alias 'default' ('file:memorydb_default?mode=memory&cache=shared')...
```