### PR TITLE
Refs #24522 -- Fixed code comment about seeds in Shuffler.__init__().

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -492,7 +492,7 @@ class Shuffler:
 
     def __init__(self, seed=None):
         if seed is None:
-            # Limit seeds to 9 digits for simpler output.
+            # Limit seeds to 10 digits for simpler output.
             seed = random.randint(0, 10**10 - 1)
             seed_source = 'generated'
         else:


### PR DESCRIPTION
Refs: https://code.djangoproject.com/ticket/24522

(I noticed this when looking at the initial comment for https://github.com/django/django/pull/14616.)