### PR TITLE
Refs #23359 -- Corrected showmigrations help text for the --database option.

### DIFF
--- a/django/core/management/commands/showmigrations.py
+++ b/django/core/management/commands/showmigrations.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--database', default=DEFAULT_DB_ALIAS,
-            help='Nominates a database to synchronize. Defaults to the "default" database.',
+            help='Nominates a database to show migrations for. Defaults to the "default" database.',
         )
 
         formats = parser.add_mutually_exclusive_group()

--- a/django/core/management/commands/showmigrations.py
+++ b/django/core/management/commands/showmigrations.py
@@ -17,7 +17,10 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--database', default=DEFAULT_DB_ALIAS,
-            help='Nominates a database to show migrations for. Defaults to the "default" database.',
+            help=(
+                'Nominates a database to show migrations for. Defaults to the '
+                '"default" database.'
+            ),
         )
 
         formats = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
Just happened to notice this: `python manage.py showmigrations` isn't really synchronizing anything. Or at least I'd understand "synchronize" to mean "apply migrations" (in the sense of the old `python manage.py syncdb`) so felt like it might be good to adjust this wording.

Had a look at some of the other descriptions and they all tend to specifically call out what the command does, so I stuck to that convention:

<img src="https://user-images.githubusercontent.com/7718702/125090569-6145a500-e0c7-11eb-9b7d-4cc323b44238.png" width=500>
