### PR TITLE
Fixes 32915 -- Don't catch ImportErrors unless it's the settings module that can't be imported

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -246,7 +246,7 @@ class Settings:
         while traceback:
             # Continue stepping through frames as long as we're in the importlib module.
             file = traceback.tb_frame.f_code.co_filename
-            if "importlib" not in file:
+            if not ("importlib" in Path(file).parts or file.startswith('<frozen importlib.')):
                 # The settings module was found before something went wrong.
                 return True
             traceback = traceback.tb_next

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -368,7 +368,9 @@ class ManagementUtility:
         try:
             settings.INSTALLED_APPS
         except ImproperlyConfigured as exc:
-            print(exc)
+            # The following commands can be run even without a valid settings file configured
+            if subcommand not in {'startproject', 'startapp', 'makemessages'}:
+                sys.stderr.write(str(exc) + '\n')
             self.settings_exception = exc
 
         if settings.configured:

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -368,8 +368,7 @@ class ManagementUtility:
         try:
             settings.INSTALLED_APPS
         except ImproperlyConfigured as exc:
-            self.settings_exception = exc
-        except ImportError as exc:
+            print(exc)
             self.settings_exception = exc
 
         if settings.configured:

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1080,12 +1080,12 @@ class ManageSettingsWithSettingsErrors(AdminScriptTestCase):
         self.write_settings(
             'settings.py',
             extra='from django.core.exceptions import ImproperlyConfigured\n'
-                  'raise ImproperlyConfigured()',
+                  'raise ImproperlyConfigured("Improper configuration")',
         )
         args = ['help']
         out, err = self.run_manage(args)
         self.assertOutput(out, 'only Django core commands are listed')
-        self.assertNoOutput(err)
+        self.assertOutput(err, 'Improper configuration\n')
 
 
 class ManageCheck(AdminScriptTestCase):

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -366,6 +366,20 @@ class SettingsTests(SimpleTestCase):
         with self.assertRaisesMessage(RemovedInDjango50Warning, USE_DEPRECATED_PYTZ_DEPRECATED_MSG):
             holder.configure(USE_DEPRECATED_PYTZ=True)
 
+    def test_unable_to_import_settings_module(self):
+        with self.assertRaisesMessage(
+            ImproperlyConfigured, "Settings module fake_settings_module could not be imported"
+        ):
+            Settings('fake_settings_module')
+
+    def test_unable_to_import_a_random_module(self):
+        def mock_import_module(_):
+            raise ModuleNotFoundError("No module named 'fake_module'", name="fake_module")
+
+        with mock.patch("importlib.import_module", mock_import_module):
+            with self.assertRaisesMessage(ImportError, "No module named 'fake_module'"):
+                Settings('fake_settings_module')
+
 
 class TestComplexSettingOverride(SimpleTestCase):
     def setUp(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32915


<img width="842" alt="image" src="https://user-images.githubusercontent.com/10276811/126631366-f126de05-48c6-4f4f-be67-9344650a1c71.png">

