### PR TITLE
Refs #32074 -- Used Enum.repr() format proposed for Python 3.10.

### DIFF
--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -4,7 +4,6 @@ from django.db.models.expressions import ExpressionList, F
 from django.db.models.indexes import IndexExpression
 from django.db.models.query_utils import Q
 from django.db.models.sql.query import Query
-from django.utils.version import PY310
 
 __all__ = ['CheckConstraint', 'Deferrable', 'UniqueConstraint']
 
@@ -86,10 +85,9 @@ class Deferrable(Enum):
     DEFERRED = 'deferred'
     IMMEDIATE = 'immediate'
 
-    # A similar format is used in Python 3.10+.
-    if not PY310:
-        def __repr__(self):
-            return '%s.%s' % (self.__class__.__qualname__, self._name_)
+    # A similar format was proposed for Python 3.10.
+    def __repr__(self):
+        return f'{self.__class__.__qualname__}.{self._name_}'
 
 
 class UniqueConstraint(BaseConstraint):

--- a/django/db/models/enums.py
+++ b/django/db/models/enums.py
@@ -2,7 +2,6 @@ import enum
 from types import DynamicClassAttribute
 
 from django.utils.functional import Promise
-from django.utils.version import PY310
 
 __all__ = ['Choices', 'IntegerChoices', 'TextChoices']
 
@@ -75,10 +74,9 @@ class Choices(enum.Enum, metaclass=ChoicesMeta):
         """
         return str(self.value)
 
-    # A similar format is used in Python 3.10+.
-    if not PY310:
-        def __repr__(self):
-            return '%s.%s' % (self.__class__.__qualname__, self._name_)
+    # A similar format was proposed for Python 3.10.
+    def __repr__(self):
+        return f'{self.__class__.__qualname__}.{self._name_}'
 
 
 class IntegerChoices(int, Choices):


### PR DESCRIPTION
The Python's Steering Council decided to revert changes in the Enum module (see https://bugs.python.org/issue44559) and moved them to Python 3.11.

Follow up to 5d9b065d3f93de056588dfee6f1776294dd8bab2.

It's not clear that the new format will land in Python 3.11 so I didn't want to use `PY311` flag (at least for now). On the other hand, I really like the proposed format and I think we should use it.