### PR TITLE
Refs #32880 -- Made some titles consistent in how-to documents.

### DIFF
--- a/docs/howto/auth-remote-user.txt
+++ b/docs/howto/auth-remote-user.txt
@@ -1,6 +1,6 @@
-====================================
-Authentication using ``REMOTE_USER``
-====================================
+=========================================
+How to authenticate using ``REMOTE_USER``
+=========================================
 
 This document describes how to make use of external authentication sources
 (where the Web server sets the ``REMOTE_USER`` environment variable) in your

--- a/docs/howto/custom-file-storage.txt
+++ b/docs/howto/custom-file-storage.txt
@@ -1,6 +1,6 @@
-===============================
-Writing a custom storage system
-===============================
+===================================
+How to write a custom storage class
+===================================
 
 .. currentmodule:: django.core.files.storage
 

--- a/docs/howto/custom-lookups.txt
+++ b/docs/howto/custom-lookups.txt
@@ -1,6 +1,6 @@
-==============
-Custom Lookups
-==============
+===========================
+How to write custom lookups
+===========================
 
 .. currentmodule:: django.db.models
 

--- a/docs/howto/custom-management-commands.txt
+++ b/docs/howto/custom-management-commands.txt
@@ -1,6 +1,6 @@
-========================================
-Writing custom ``django-admin`` commands
-========================================
+==============================================
+How to create custom ``django-admin`` commands
+==============================================
 
 .. module:: django.core.management
 

--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -1,6 +1,6 @@
-===========================
-Writing custom model fields
-===========================
+=================================
+How to create custom model fields
+=================================
 
 .. currentmodule:: django.db.models
 

--- a/docs/howto/custom-template-backend.txt
+++ b/docs/howto/custom-template-backend.txt
@@ -1,6 +1,6 @@
-=======================
-Custom template backend
-=======================
+==========================================
+How to implement a custom template backend
+==========================================
 
 Custom backends
 ---------------

--- a/docs/howto/custom-template-tags.txt
+++ b/docs/howto/custom-template-tags.txt
@@ -1,6 +1,6 @@
-================================
-Custom template tags and filters
-================================
+==============================================
+How to create custom template tags and filters
+==============================================
 
 Django's template language comes with a wide variety of :doc:`built-in
 tags and filters </ref/templates/builtins>` designed to address the

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -1,6 +1,6 @@
-===============
-Error reporting
-===============
+=============================
+How to manage error reporting
+=============================
 
 When you're running a public site you should always turn off the
 :setting:`DEBUG` setting. That will make your server run much faster, and will

--- a/docs/howto/initial-data.txt
+++ b/docs/howto/initial-data.txt
@@ -1,6 +1,6 @@
-=================================
-Providing initial data for models
-=================================
+======================================
+How to provide initial data for models
+======================================
 
 It's sometimes useful to pre-populate your database with hard-coded data when
 you're first setting up an app. You can provide initial data with migrations or

--- a/docs/howto/legacy-databases.txt
+++ b/docs/howto/legacy-databases.txt
@@ -1,6 +1,6 @@
-=========================================
-Integrating Django with a legacy database
-=========================================
+==============================================
+How to integrate Django with a legacy database
+==============================================
 
 While Django is best suited for developing new applications, it's quite
 possible to integrate it into legacy databases. Django includes a couple of

--- a/docs/howto/outputting-csv.txt
+++ b/docs/howto/outputting-csv.txt
@@ -1,6 +1,6 @@
-==========================
-Outputting CSV with Django
-==========================
+========================
+How to create CSV output
+========================
 
 This document explains how to output CSV (Comma Separated Values) dynamically
 using Django views. To do this, you can either use the Python CSV library or the

--- a/docs/howto/outputting-pdf.txt
+++ b/docs/howto/outputting-pdf.txt
@@ -1,6 +1,6 @@
-===========================
-Outputting PDFs with Django
-===========================
+=======================
+How to create PDF files
+=======================
 
 This document explains how to output PDF files dynamically using Django views.
 This is made possible by the excellent, open-source ReportLab_ Python PDF

--- a/docs/howto/overriding-templates.txt
+++ b/docs/howto/overriding-templates.txt
@@ -1,6 +1,6 @@
-====================
-Overriding templates
-====================
+=========================
+How to override templates
+=========================
 
 In your project, you might want to override a template in another Django
 application, whether it be a third-party application or a contrib application

--- a/docs/howto/upgrade-version.txt
+++ b/docs/howto/upgrade-version.txt
@@ -1,6 +1,6 @@
-===================================
-Upgrading Django to a newer version
-===================================
+========================================
+How to upgrade Django to a newer version
+========================================
 
 While it can be a complex process at times, upgrading to the latest Django
 version has several benefits:

--- a/docs/howto/writing-migrations.txt
+++ b/docs/howto/writing-migrations.txt
@@ -1,6 +1,6 @@
-===========================
-Writing database migrations
-===========================
+=================================
+How to create database migrations
+=================================
 
 This document explains how to structure and write database migrations for
 different scenarios you might encounter. For introductory material on


### PR DESCRIPTION
Retitled documents for consistency, since some already (correctly) begin
"How to...".
