### PR TITLE
Refs #31676 -- Removed Django Core-Mentorship mailing list references in docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -265,7 +265,6 @@ modindex_common_prefix = ["django."]
 # Appended to every page
 rst_epilog = """
 .. |django-users| replace:: :ref:`django-users <django-users-mailing-list>`
-.. |django-core-mentorship| replace:: :ref:`django-core-mentorship <django-core-mentorship-mailing-list>`
 .. |django-developers| replace:: :ref:`django-developers <django-developers-mailing-list>`
 .. |django-announce| replace:: :ref:`django-announce <django-announce-mailing-list>`
 .. |django-updates| replace:: :ref:`django-updates <django-updates-mailing-list>`

--- a/docs/internals/mailing-lists.txt
+++ b/docs/internals/mailing-lists.txt
@@ -35,23 +35,6 @@ installation, usage, or debugging of Django.
 .. _django-users subscription email address: mailto:django-users+subscribe@googlegroups.com
 .. _django-users posting email: mailto:django-users@googlegroups.com
 
-.. _django-core-mentorship-mailing-list:
-
-``django-core-mentorship``
-==========================
-
-The Django Core Mentorship list is intended to provide a welcoming
-introductory environment for community members interested in contributing to
-the Django Project.
-
-* `django-core-mentorship mailing archive`_
-* `django-core-mentorship subscription email address`_
-* `django-core-mentorship posting email`_
-
-.. _django-core-mentorship mailing archive: https://groups.google.com/g/django-core-mentorship
-.. _django-core-mentorship subscription email address: mailto:django-core-mentorship+subscribe@googlegroups.com
-.. _django-core-mentorship posting email: mailto:django-core-mentorship@googlegroups.com
-
 .. _django-developers-mailing-list:
 
 ``django-developers``

--- a/docs/internals/organization.txt
+++ b/docs/internals/organization.txt
@@ -112,9 +112,7 @@ no veto by the technical board.
 
 Core team members are always looking for promising contributors, teaching them
 how the project is managed, and submitting their names to the core team's vote
-when they're ready. If you would like to join the core team, you can contact a
-core team member privately or ask for guidance on the :ref:`Django Core
-Mentorship mailing-list <django-core-mentorship-mailing-list>`.
+when they're ready.
 
 There's no time limit on core team membership. However, in order to provide
 the general public with a reasonable idea of how many people maintain Django,


### PR DESCRIPTION
Django Core-Mentorship mailing list was deleted.