### PR TITLE
Added note about zero timeout in cache settings docs.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -232,7 +232,8 @@ consult your backend module's own documentation.
 Default: ``300``
 
 The number of seconds before a cache entry is considered stale. If the value of
-this settings is ``None``, cache entries will not expire.
+this setting is ``None``, cache entries will not expire. A value of ``0``
+causes keys to immediately expire (effectively "don't cache").
 
 .. setting:: CACHES-VERSION
 


### PR DESCRIPTION
This is just tacking on the additional sentence from [here](https://docs.djangoproject.com/en/3.2/topics/cache/#cache-arguments) to keep these more aligned. Also fixed a small typo.