### PR TITLE
Fixed #32924 -- Changed BaseForm.get_initial_for_field() to remove microseconds as needed.

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -1,4 +1,3 @@
-import datetime
 import re
 
 from django.core.exceptions import ValidationError
@@ -228,13 +227,7 @@ class BoundField:
 
     @cached_property
     def initial(self):
-        data = self.form.get_initial_for_field(self.field, self.name)
-        # If this is an auto-generated default date, nix the microseconds for
-        # standardized handling. See #22502.
-        if (isinstance(data, (datetime.datetime, datetime.time)) and
-                not self.field.widget.supports_microseconds):
-            data = data.replace(microsecond=0)
-        return data
+        return self.form.get_initial_for_field(self.field, self.name)
 
     def build_widget_attrs(self, attrs, widget=None):
         widget = widget or self.field.widget

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -3,6 +3,7 @@ Form classes
 """
 
 import copy
+import datetime
 
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.forms.fields import Field, FileField
@@ -475,6 +476,11 @@ class BaseForm:
         value = self.initial.get(field_name, field.initial)
         if callable(value):
             value = value()
+        # If this is an auto-generated default date, nix the microseconds
+        # for standardized handling. See #22502.
+        if (isinstance(value, (datetime.datetime, datetime.time)) and
+                not field.widget.supports_microseconds):
+            value = value.replace(microsecond=0)
         return value
 
 

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -2112,12 +2112,18 @@ Password: <input type="password" name="password" required></li>
             ti_without_microsec = DateTimeField(initial=delayed_now, widget=TextInputWithoutMicrosec)
 
         unbound = DateTimeForm()
-        self.assertEqual(unbound['auto_timestamp'].value(), now_no_ms)
-        self.assertEqual(unbound['auto_time_only'].value(), now_no_ms.time())
-        self.assertEqual(unbound['supports_microseconds'].value(), now)
-        self.assertEqual(unbound['hi_default_microsec'].value(), now)
-        self.assertEqual(unbound['hi_without_microsec'].value(), now_no_ms)
-        self.assertEqual(unbound['ti_without_microsec'].value(), now_no_ms)
+        cases = [
+            ('auto_timestamp', now_no_ms),
+            ('auto_time_only', now_no_ms.time()),
+            ('supports_microseconds', now),
+            ('hi_default_microsec', now),
+            ('hi_without_microsec', now_no_ms),
+            ('ti_without_microsec', now_no_ms),
+        ]
+        for field_name, expected in cases:
+            with self.subTest(field_name=field_name):
+                actual = unbound[field_name].value()
+                self.assertEqual(actual, expected)
 
     def get_datetime_form_with_callable_initial(self, disabled, microseconds=0):
         class FakeTime:

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -1990,12 +1990,19 @@ Password: <input type="password" name="password" required></li>
             occupation = CharField(initial=lambda: 'Unknown')
 
         form = PersonForm(initial={'first_name': 'Jane'})
-        self.assertIsNone(form.get_initial_for_field(form.fields['age'], 'age'))
-        self.assertEqual(form.get_initial_for_field(form.fields['last_name'], 'last_name'), 'Doe')
-        # Form.initial overrides Field.initial.
-        self.assertEqual(form.get_initial_for_field(form.fields['first_name'], 'first_name'), 'Jane')
-        # Callables are evaluated.
-        self.assertEqual(form.get_initial_for_field(form.fields['occupation'], 'occupation'), 'Unknown')
+        cases = [
+            ('age', None),
+            ('last_name', 'Doe'),
+            # Form.initial overrides Field.initial.
+            ('first_name', 'Jane'),
+            # Callables are evaluated.
+            ('occupation', 'Unknown'),
+        ]
+        for field_name, expected in cases:
+            with self.subTest(field_name=field_name):
+                field = form.fields[field_name]
+                actual = form.get_initial_for_field(field, field_name)
+                self.assertEqual(actual, expected)
 
     def test_changed_data(self):
         class Person(Form):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32924