### PR TITLE
Fixed #32949 -- Restored invalid number handling in DecimalField.validate().

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -349,6 +349,17 @@ class DecimalField(IntegerField):
             raise ValidationError(self.error_messages['invalid'], code='invalid')
         return value
 
+    def validate(self, value):
+        super().validate(value)
+        if value in self.empty_values:
+            return
+        if not value.is_finite():
+            raise ValidationError(
+                self.error_messages['invalid'],
+                code='invalid',
+                params={'value': value},
+            )
+
     def widget_attrs(self, widget):
         attrs = super().widget_attrs(widget)
         if isinstance(widget, NumberInput) and 'step' not in widget.attrs:

--- a/docs/releases/3.2.6.txt
+++ b/docs/releases/3.2.6.txt
@@ -9,4 +9,6 @@ Django 3.2.6 fixes several bugs in 3.2.5.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 3.2 that caused a crash validating ``"NaN"``
+  input with a ``forms.DecimalField`` that had a specified ``max_value``
+  (:ticket:`32949`).

--- a/tests/forms_tests/field_tests/test_decimalfield.py
+++ b/tests/forms_tests/field_tests/test_decimalfield.py
@@ -49,7 +49,7 @@ class DecimalFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         self.assertIsNone(f.min_value)
 
     def test_enter_a_number_error(self):
-        f = DecimalField(max_digits=4, decimal_places=2)
+        f = DecimalField(max_value=1, max_digits=4, decimal_places=2)
         values = (
             '-NaN', 'NaN', '+NaN',
             '-sNaN', 'sNaN', '+sNaN',


### PR DESCRIPTION
This PR fixes error:

I have a form like this:

```python
class OrderForm(forms.ModelForm):
    sum = DecimalField(max_value=12)

    class Meta:
        model = Order
        fields = ['sum']

# model
class Order(models.Model):
    sum = models.DecimalField(
        'Sum',
        max_digits=18,
        decimal_places=2,
        default=0
    )
```

If I pass "NaN" value to this form it will fail with `decimal.InvalidOperation` error.

It was fixed in https://github.com/django/django/commit/c886f3dee33adc9f94332b4133a37960e985e273, but became broken in https://github.com/django/django/commit/1dce629c038b88a26d02ddc9d5e7f047933581ee