### PR TITLE
Fixed #32928 -- Confirmed support for GDAL 3.3

### DIFF
--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -21,14 +21,14 @@ if lib_path:
 elif os.name == 'nt':
     # Windows NT shared libraries
     lib_names = [
-        'gdal302', 'gdal301', 'gdal300',
+        'gdal303', 'gdal302', 'gdal301', 'gdal300',
         'gdal204', 'gdal203', 'gdal202', 'gdal201', 'gdal20',
     ]
 elif os.name == 'posix':
     # *NIX library names.
     lib_names = [
         'gdal', 'GDAL',
-        'gdal3.2.0', 'gdal3.1.0', 'gdal3.0.0',
+        'gdal3.3.0', 'gdal3.2.0', 'gdal3.1.0', 'gdal3.0.0',
         'gdal2.4.0', 'gdal2.3.0', 'gdal2.2.0', 'gdal2.1.0', 'gdal2.0.0',
     ]
 else:

--- a/docs/ref/contrib/gis/install/geolibs.txt
+++ b/docs/ref/contrib/gis/install/geolibs.txt
@@ -5,16 +5,16 @@ Installing Geospatial libraries
 GeoDjango uses and/or provides interfaces for the following open source
 geospatial libraries:
 
-========================  ====================================  ================================  =================================
+========================  ====================================  ================================  ======================================
 Program                   Description                           Required                          Supported Versions
-========================  ====================================  ================================  =================================
+========================  ====================================  ================================  ======================================
 :doc:`GEOS <../geos>`     Geometry Engine Open Source           Yes                               3.9, 3.8, 3.7, 3.6
 `PROJ`_                   Cartographic Projections library      Yes (PostgreSQL and SQLite only)  8.x, 7.x, 6.x, 5.x, 4.x
-:doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               3.2, 3.1, 3.0, 2.4, 2.3, 2.2, 2.1
+:doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               3.3, 3.2, 3.1, 3.0, 2.4, 2.3, 2.2, 2.1
 :doc:`GeoIP <../geoip2>`  IP-based geolocation library          No                                2
 `PostGIS`__               Spatial extensions for PostgreSQL     Yes (PostgreSQL only)             3.0, 2.5, 2.4
 `SpatiaLite`__            Spatial extensions for SQLite         Yes (SQLite only)                 5.0, 4.3
-========================  ====================================  ================================  =================================
+========================  ====================================  ================================  ======================================
 
 Note that older or more recent versions of these libraries *may* also work
 totally fine with GeoDjango. Your mileage may vary.
@@ -32,6 +32,7 @@ totally fine with GeoDjango. Your mileage may vary.
     GDAL 3.0.0 2019-05
     GDAL 3.1.0 2020-05-07
     GDAL 3.2.0 2020-11-02
+    GDAL 3.3.0 2021-05-03
     PostGIS 2.4.0 2017-09-30
     PostGIS 2.5.0 2018-09-23
     PostGIS 3.0.0 2019-10-20


### PR DESCRIPTION
I've managed to see the test suite pass with GDAL 3.3. 

I had to patch the [issue with sqlite 3.36](https://code.djangoproject.com/ticket/32935#ticket) for this to work for me, but I think that's unrelated and so we can carry on with this. 
