### PR TITLE
Prevented SQLCompiler.execute_sql() from closing cursor twice.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1223,15 +1223,11 @@ class SQLCompiler:
             chunk_size,
         )
         if not chunked_fetch or not self.connection.features.can_use_chunked_reads:
-            try:
-                # If we are using non-chunked reads, we return the same data
-                # structure as normally, but ensure it is all read into memory
-                # before going any further. Use chunked_fetch if requested,
-                # unless the database doesn't support it.
-                return list(result)
-            finally:
-                # done with the cursor
-                cursor.close()
+            # If we are using non-chunked reads, we return the same data
+            # structure as normally, but ensure it is all read into memory
+            # before going any further. Use chunked_fetch if requested,
+            # unless the database doesn't support it.
+            return list(result)
         return result
 
     def as_subquery_condition(self, alias, columns, compiler):


### PR DESCRIPTION
A generator is assigned to `result`:

https://github.com/django/django/blob/a56531ab1b772ee4ae94dd805f168761887354c6/django/db/models/sql/compiler.py#L1220-L1224

Inside the `if` block `cursor.close()` is called, but not below it for `return result`.

https://github.com/django/django/blob/a56531ab1b772ee4ae94dd805f168761887354c6/django/db/models/sql/compiler.py#L1225-L1235

Inside `cursor_iter()` there is a call to `cursor.close()` in a `finally` block.

https://github.com/django/django/blob/a56531ab1b772ee4ae94dd805f168761887354c6/django/db/models/sql/compiler.py#L1673-L1682

Thus `return list(result)` will immediately consume the generator and close the cursor.