### PR TITLE
Fixed #32930 -- Fixed URLValidator when port numbers < 10.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -87,7 +87,7 @@ class URLValidator(RegexValidator):
         r'^(?:[a-z0-9.+-]*)://'  # scheme is validated separately
         r'(?:[^\s:@/]+(?::[^\s:@/]*)?@)?'  # user:pass authentication
         r'(?:' + ipv4_re + '|' + ipv6_re + '|' + host_re + ')'
-        r'(?::\d{2,5})?'  # port
+        r'(?::\d{1,5})?'  # port
         r'(?:[/?#][^\s]*)?'  # resource path
         r'\Z', re.IGNORECASE)
     message = _('Enter a valid URL.')
@@ -129,7 +129,7 @@ class URLValidator(RegexValidator):
                 raise
         else:
             # Now verify IPv6 in the netloc part
-            host_match = re.search(r'^\[(.+)\](?::\d{2,5})?$', urlsplit(value).netloc)
+            host_match = re.search(r'^\[(.+)\](?::\d{1,5})?$', urlsplit(value).netloc)
             if host_match:
                 potential_ip = host_match[1]
                 try:

--- a/tests/validators/invalid_urls.txt
+++ b/tests/validators/invalid_urls.txt
@@ -2,6 +2,10 @@ foo
 http://
 http://example
 http://example.
+http://example.com:-1
+http://example.com:-1/
+http://example.com:000000080
+http://example.com:000000080/
 http://.com
 http://invalid-.com
 http://-invalid.com

--- a/tests/validators/invalid_urls.txt
+++ b/tests/validators/invalid_urls.txt
@@ -60,6 +60,7 @@ http://1.2.03.4
 http://1.2.3.04
 http://.www.foo.bar/
 http://.www.foo.bar./
+http://[::1:2::3]:8/
 http://[::1:2::3]:8080/
 http://[]
 http://[]:8080

--- a/tests/validators/valid_urls.txt
+++ b/tests/validators/valid_urls.txt
@@ -2,6 +2,8 @@ http://www.djangoproject.com/
 HTTP://WWW.DJANGOPROJECT.COM/
 http://localhost/
 http://example.com/
+http://example.com:65535
+http://example.com:65535/
 http://example.com./
 http://www.example.com/
 http://www.example.com:8000/test
@@ -27,6 +29,8 @@ http://userid@example.com
 http://userid@example.com/
 http://userid@example.com:8080
 http://userid@example.com:8080/
+http://userid@example.com:65535
+http://userid@example.com:65535/
 http://userid:@example.com
 http://userid:@example.com/
 http://userid:@example.com:8080
@@ -35,6 +39,8 @@ http://userid:password@example.com
 http://userid:password@example.com/
 http://userid:password@example.com:8080
 http://userid:password@example.com:8080/
+http://userid:password@example.com:65535
+http://userid:password@example.com:65535/
 https://userid:paaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaassword@example.com
 https://userid:paaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaassword@example.com:8080
 https://useridddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd:password@example.com

--- a/tests/validators/valid_urls.txt
+++ b/tests/validators/valid_urls.txt
@@ -2,6 +2,8 @@ http://www.djangoproject.com/
 HTTP://WWW.DJANGOPROJECT.COM/
 http://localhost/
 http://example.com/
+http://example.com:0
+http://example.com:0/
 http://example.com:65535
 http://example.com:65535/
 http://example.com./
@@ -37,6 +39,8 @@ http://userid:@example.com:8080
 http://userid:@example.com:8080/
 http://userid:password@example.com
 http://userid:password@example.com/
+http://userid:password@example.com:8
+http://userid:password@example.com:8/
 http://userid:password@example.com:8080
 http://userid:password@example.com:8080/
 http://userid:password@example.com:65535


### PR DESCRIPTION
URL Standards requires port number to be null or a 16-bit unsigned integer