### PR TITLE
Fixed #32941 -- Removed get_format_modules()'s unused reverse argument.

### DIFF
--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -86,16 +86,13 @@ def iter_format_modules(lang, format_module_path=None):
                 pass
 
 
-def get_format_modules(lang=None, reverse=False):
+def get_format_modules(lang=None):
     """Return a list of the format modules found."""
     if lang is None:
         lang = get_language()
     if lang not in _format_modules_cache:
         _format_modules_cache[lang] = list(iter_format_modules(lang, settings.FORMAT_MODULE_PATH))
-    modules = _format_modules_cache[lang]
-    if reverse:
-        return list(reversed(modules))
-    return modules
+    return _format_modules_cache[lang]
 
 
 def get_format(format_type, lang=None, use_l10n=None):

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -23,9 +23,9 @@ from django.test import (
 )
 from django.utils import translation
 from django.utils.formats import (
-    date_format, get_format, get_format_modules, iter_format_modules, localize,
-    localize_input, reset_format_cache, sanitize_separators,
-    sanitize_strftime_format, time_format,
+    date_format, get_format, iter_format_modules, localize, localize_input,
+    reset_format_cache, sanitize_separators, sanitize_strftime_format,
+    time_format,
 )
 from django.utils.numberformat import format as nformat
 from django.utils.safestring import SafeString, mark_safe
@@ -1195,13 +1195,6 @@ class FormattingTests(SimpleTestCase):
     def test_get_format_modules_lang(self):
         with translation.override('de', deactivate=True):
             self.assertEqual('.', get_format('DECIMAL_SEPARATOR', lang='en'))
-
-    def test_get_format_modules_stability(self):
-        with self.settings(FORMAT_MODULE_PATH='i18n.other.locale'):
-            with translation.override('de', deactivate=True):
-                old = "%r" % get_format_modules(reverse=True)
-                new = "%r" % get_format_modules(reverse=True)  # second try
-                self.assertEqual(new, old, 'Value returned by get_formats_modules() must be preserved between calls.')
 
     def test_localize_templatetag_and_filter(self):
         """


### PR DESCRIPTION
[Ticket 32941](https://code.djangoproject.com/ticket/32941#ticket). Opened to get the full CI to run and demonstrate it should at least be feasible to remove.