### PR TITLE
Fixed #32943 -- Added support for covering indexes and exclusion constraints for SP-GiST on PostgreSQL 14+.

### DIFF
--- a/django/contrib/postgres/constraints.py
+++ b/django/contrib/postgres/constraints.py
@@ -45,10 +45,6 @@ class ExclusionConstraint(BaseConstraint):
             raise ValueError(
                 'ExclusionConstraint.include must be a list or tuple.'
             )
-        if include and index_type and index_type.lower() != 'gist':
-            raise ValueError(
-                'Covering exclusion constraints only support GiST indexes.'
-            )
         if not isinstance(opclasses, (list, tuple)):
             raise ValueError(
                 'ExclusionConstraint.opclasses must be a list or tuple.'
@@ -124,9 +120,23 @@ class ExclusionConstraint(BaseConstraint):
         )
 
     def check_supported(self, schema_editor):
-        if self.include and not schema_editor.connection.features.supports_covering_gist_indexes:
+        if (
+            self.include and
+            self.index_type.lower() == 'gist' and
+            not schema_editor.connection.features.supports_covering_gist_indexes
+        ):
             raise NotSupportedError(
-                'Covering exclusion constraints require PostgreSQL 12+.'
+                'Covering exclusion constraints using a GiST index require '
+                'PostgreSQL 12+.'
+            )
+        if (
+            self.include and
+            self.index_type.lower() == 'spgist' and
+            not schema_editor.connection.features.supports_covering_spgist_indexes
+        ):
+            raise NotSupportedError(
+                'Covering exclusion constraints using an SP-GiST index '
+                'require PostgreSQL 14+.'
             )
 
     def deconstruct(self):

--- a/django/contrib/postgres/indexes.py
+++ b/django/contrib/postgres/indexes.py
@@ -220,6 +220,13 @@ class SpGistIndex(PostgresIndex):
             with_params.append('fillfactor = %d' % self.fillfactor)
         return with_params
 
+    def check_supported(self, schema_editor):
+        if (
+            self.include and
+            not schema_editor.connection.features.supports_covering_spgist_indexes
+        ):
+            raise NotSupportedError('Covering SP-GiST indexes require PostgreSQL 14+.')
+
 
 class OpClass(Func):
     template = '%(expressions)s %(name)s'

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -99,4 +99,5 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_websearch_to_tsquery = property(operator.attrgetter('is_postgresql_11'))
     supports_covering_indexes = property(operator.attrgetter('is_postgresql_11'))
     supports_covering_gist_indexes = property(operator.attrgetter('is_postgresql_12'))
+    supports_covering_spgist_indexes = property(operator.attrgetter('is_postgresql_14'))
     supports_non_deterministic_collations = property(operator.attrgetter('is_postgresql_12'))

--- a/docs/ref/contrib/postgres/constraints.txt
+++ b/docs/ref/contrib/postgres/constraints.txt
@@ -115,7 +115,13 @@ used for queries that select only included fields
 (:attr:`~ExclusionConstraint.include`) and filter only by indexed fields
 (:attr:`~ExclusionConstraint.expressions`).
 
-``include`` is supported only for GiST indexes on PostgreSQL 12+.
+``include`` is supported for GiST indexes on PostgreSQL 12+ and SP-GiST
+indexes on PostgreSQL 14+.
+
+.. versionchanged:: 4.1
+
+    Support for covering exclusion constraints using SP-GiST indexes on
+    PostgreSQL 14+ was added.
 
 ``opclasses``
 -------------

--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -138,6 +138,10 @@ available from the ``django.contrib.postgres.indexes`` module.
     Provide an integer value from 10 to 100 to the fillfactor_ parameter to
     tune how packed the index pages will be. PostgreSQL's default is 90.
 
+    .. versionchanged:: 4.1
+
+        Support for covering SP-GiST indexes on PostgreSQL 14+ was added.
+
     .. _fillfactor: https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
 
 ``OpClass()`` expressions

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -210,8 +210,14 @@ See the PostgreSQL documentation for more details about `covering indexes`_.
 
 .. admonition:: Restrictions on PostgreSQL
 
-    PostgreSQL 11+ only supports covering B-Tree indexes, and PostgreSQL 12+
-    also supports covering :class:`GiST indexes
-    <django.contrib.postgres.indexes.GistIndex>`.
+    PostgreSQL 11+ only supports covering B-Tree indexes, PostgreSQL 12+ also
+    supports covering :class:`GiST indexes
+    <django.contrib.postgres.indexes.GistIndex>`, and PostgreSQL 14+ also
+    supports covering :class:`SP-GiST indexes
+    <django.contrib.postgres.indexes.SpGistIndex>`.
+
+.. versionchanged:: 4.1
+
+    Support for covering SP-GiST indexes with PostgreSQL 14+ was added.
 
 .. _covering indexes: https://www.postgresql.org/docs/current/indexes-index-only-scans.html

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -68,6 +68,9 @@ Minor features
   aggregate function returns an ``int`` of the bitwise ``XOR`` of all non-null
   input values.
 
+* :class:`~django.contrib.postgres.indexes.SpGistIndex` now supports covering
+  indexes on PostgreSQL 14+.
+
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -71,6 +71,10 @@ Minor features
 * :class:`~django.contrib.postgres.indexes.SpGistIndex` now supports covering
   indexes on PostgreSQL 14+.
 
+* :class:`~django.contrib.postgres.constraints.ExclusionConstraint` now
+  supports covering exclusion constraints using SP-GiST indexes on PostgreSQL
+  14+.
+
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -196,6 +196,7 @@ geospatial
 Gettext
 GiB
 gis
+GiST
 Googol
 Greenhill
 gunicorn

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -142,7 +142,7 @@ class Migration(migrations.Migration):
             name='Scene',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('scene', models.CharField(max_length=255)),
+                ('scene', models.TextField()),
                 ('setting', models.CharField(max_length=255)),
             ],
             options=None,

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -101,7 +101,7 @@ class BigAutoFieldModel(models.Model):
 # Scene/Character/Line models are used to test full text search. They're
 # populated with content from Monty Python and the Holy Grail.
 class Scene(models.Model):
-    scene = models.CharField(max_length=255)
+    scene = models.TextField()
     setting = models.CharField(max_length=255)
 
 


### PR DESCRIPTION
ticket-32943

Currently PostgreSQL 14 is still in beta, so marking as a draft.

Pinging @hannseman who may be interested in this having added the support for covering indexes and exclusion constraints.