### PR TITLE
Fixed #23895 -- Prevented pickling of ResolverMatch.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -478,6 +478,7 @@ answer newbie questions, and generally made Django that much better:
     Jökull Sólberg Auðunsson <jokullsolberg@gmail.com>
     Jon Dufresne <jon.dufresne@gmail.com>
     Jonas Haag <jonas@lophus.org>
+    Jonathan Davis <jonathandavis47780@gmail.com>
     Jonatas C. D. <jonatas.cd@gmail.com>
     Jonathan Buchanan <jonathan.buchanan@gmail.com>
     Jonathan Daugherty (cygnus) <http://www.cprogrammer.org/>

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -10,6 +10,7 @@ import inspect
 import re
 import string
 from importlib import import_module
+from pickle import PicklingError
 from urllib.parse import quote
 
 from asgiref.local import Local
@@ -70,6 +71,9 @@ class ResolverMatch:
                 self.app_names, self.namespaces, self.route,
             )
         )
+
+    def __reduce_ex__(self, protocol):
+        raise PicklingError(f'Cannot pickle {self.__class__.__qualname__}.')
 
 
 def get_resolver(urlconf=None):

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -1,6 +1,7 @@
 """
 Unit tests for reverse URL lookups.
 """
+import pickle
 import sys
 import threading
 
@@ -1166,6 +1167,12 @@ class ResolverMatchTests(SimpleTestCase):
                     f"url_name='{name}', app_names=[], namespaces=[], "
                     f"route='{name}/')",
                 )
+
+    @override_settings(ROOT_URLCONF='urlpatterns.path_urls')
+    def test_pickling(self):
+        msg = 'Cannot pickle ResolverMatch.'
+        with self.assertRaisesMessage(pickle.PicklingError, msg):
+            pickle.dumps(resolve('/users/'))
 
 
 @override_settings(ROOT_URLCONF='urlpatterns_reverse.erroneous_urls')


### PR DESCRIPTION
Fixes issue [#23895](https://code.djangoproject.com/ticket/23895), where attempting to pickle a `ResolverMatch` for a class-based view causes an exception.