### PR TITLE
Fixed #20205 -- Failed model validation for empty strings in fields where empty_strings_allowed = False and blank = True.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1256,7 +1256,8 @@ class Model(metaclass=ModelBase):
             # Skip validation for empty fields with blank=True. The developer
             # is responsible for making sure they have a valid value.
             raw_value = getattr(self, f.attname)
-            if f.blank and raw_value in f.empty_values:
+            if f.blank and raw_value in f.empty_values and (
+                    f.empty_strings_allowed or raw_value != ''):
                 continue
             try:
                 setattr(self, f.attname, f.clean(raw_value, self))

--- a/tests/model_forms/models.py
+++ b/tests/model_forms/models.py
@@ -480,3 +480,7 @@ class NullableUniqueCharFieldModel(models.Model):
     email = models.EmailField(blank=True, null=True)
     slug = models.SlugField(blank=True, null=True)
     url = models.URLField(blank=True, null=True)
+
+
+class NullablePositiveIntegerField(models.Model):
+    maybe_number = models.PositiveIntegerField(blank=True, null=True)

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -24,10 +24,10 @@ from .models import (
     CustomFieldForExclusionModel, DateTimePost, DerivedBook, DerivedPost,
     Document, ExplicitPK, FilePathModel, FlexibleDatePost, Homepage,
     ImprovedArticle, ImprovedArticleWithParentLink, Inventory,
-    NullableUniqueCharFieldModel, Person, Photo, Post, Price, Product,
-    Publication, PublicationDefaults, StrictAssignmentAll,
-    StrictAssignmentFieldSpecific, Student, StumpJoke, TextFile, Triple,
-    Writer, WriterProfile, test_images,
+    NullablePositiveIntegerField, NullableUniqueCharFieldModel, Person, Photo,
+    Post, Price, Product, Publication, PublicationDefaults,
+    StrictAssignmentAll, StrictAssignmentFieldSpecific, Student, StumpJoke,
+    TextFile, Triple, Writer, WriterProfile, test_images,
 )
 
 if test_images:
@@ -326,6 +326,11 @@ class ModelFormBaseTest(TestCase):
         self.assertEqual(form.instance.email, empty_value)
         self.assertEqual(form.instance.slug, empty_value)
         self.assertEqual(form.instance.url, empty_value)
+
+    def test_empty_string_positive_integer_field(self):
+        instance = NullablePositiveIntegerField(maybe_number='')
+        with self.assertRaises(ValidationError):
+            instance.full_clean()
 
     def test_missing_fields_attribute(self):
         message = (


### PR DESCRIPTION
ticket-20205

It seems curious that under the status quo, where `empty_strings_allowed` is `False`, that we would skip model validation even at the moment we are holding an empty string (as opposed to `None` or any of the other values in `empty_values`).

However, we could also close this patch and treat as a duplicate of ticket-22224 and add either Simon's friendly guardrail for folks without a solution for `MyModel.clean()` or just `wontfix`.

Happy to hear advice or to be nudged toward the mailing list.