### PR TITLE
Fixed #32704 -- Fixed list of deferred fields when chaining QuerySet.defer() after only().

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2086,7 +2086,12 @@ class Query(BaseExpression):
             self.deferred_loading = existing.union(field_names), True
         else:
             # Remove names from the set of any existing "immediate load" names.
-            self.deferred_loading = existing.difference(field_names), False
+            if new_existing := existing.difference(field_names):
+                self.deferred_loading = new_existing, False
+            else:
+                self.clear_deferred_loading()
+                if new_only := set(field_names).difference(existing):
+                    self.deferred_loading = new_only, True
 
     def add_immediate_loading(self, field_names):
         """

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -52,6 +52,8 @@ class DeferTests(AssertionMixin, TestCase):
         self.assert_delayed(qs.defer('name').only('name').only('value')[0], 2)
         self.assert_delayed(qs.defer("name").only("value")[0], 2)
         self.assert_delayed(qs.only("name").defer("value")[0], 2)
+        self.assert_delayed(qs.only('name').defer('name').defer('value')[0], 1)
+        self.assert_delayed(qs.only('name').defer('name', 'value')[0], 1)
 
     def test_defer_only_clear(self):
         qs = Primary.objects.all()

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -49,8 +49,14 @@ class DeferTests(AssertionMixin, TestCase):
         qs = Primary.objects.all()
         self.assert_delayed(qs.only("name", "value").defer("name")[0], 2)
         self.assert_delayed(qs.defer("name").only("value", "name")[0], 2)
+        self.assert_delayed(qs.defer('name').only('name').only('value')[0], 2)
         self.assert_delayed(qs.defer("name").only("value")[0], 2)
         self.assert_delayed(qs.only("name").defer("value")[0], 2)
+
+    def test_defer_only_clear(self):
+        qs = Primary.objects.all()
+        self.assert_delayed(qs.only('name').defer('name')[0], 0)
+        self.assert_delayed(qs.defer('name').only('name')[0], 0)
 
     def test_defer_on_an_already_deferred_field(self):
         qs = Primary.objects.all()


### PR DESCRIPTION
Hi 👋 

Ticket https://code.djangoproject.com/ticket/32704

Not all added test assertions are entirely relevant to the patch, but it felt like they were missing and are completing the test method.
Heavily inspired by Mariusz' patch https://code.djangoproject.com/attachment/ticket/32704/ticket-32704.diff