### PR TITLE
Fixed #32365 -- Made zoneinfo the default timezone implementation.

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -19,6 +19,13 @@ from django.utils.functional import LazyObject, empty
 
 ENVIRONMENT_VARIABLE = "DJANGO_SETTINGS_MODULE"
 
+# RemovedInDjango50Warning
+USE_DEPRECATED_PYTZ_DEPRECATED_MSG = (
+    "The USE_DEPRECATED_PYTZ setting, and support for pytz timezones is "
+    "deprecated in favor of the stdlib zoneinfo module. Please update your "
+    "code to use zoneinfo and remove the USE_DEPRECATED_PYTZ setting."
+)
+
 
 class SettingsReference(str):
     """
@@ -167,6 +174,9 @@ class Settings:
                 category=RemovedInDjango50Warning,
             )
 
+        if self.is_overridden('USE_DEPRECATED_PYTZ'):
+            warnings.warn(USE_DEPRECATED_PYTZ_DEPRECATED_MSG, RemovedInDjango50Warning)
+
         if hasattr(time, 'tzset') and self.TIME_ZONE:
             # When we can, attempt to validate the timezone. If we can't find
             # this file, no check happens and it's harmless.
@@ -211,6 +221,9 @@ class UserSettingsHolder:
     def __setattr__(self, name, value):
         self._deleted.discard(name)
         super().__setattr__(name, value)
+
+        if name == 'USE_DEPRECATED_PYTZ':
+            warnings.warn(USE_DEPRECATED_PYTZ_DEPRECATED_MSG, RemovedInDjango50Warning)
 
     def __delattr__(self, name):
         self._deleted.add(name)

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -43,6 +43,11 @@ TIME_ZONE = 'America/Chicago'
 # If you set this to True, Django will use timezone-aware datetimes.
 USE_TZ = False
 
+# RemovedInDjango50Warning
+# Set True to continue using pytz tzinfo objects during the Django 4.x release
+# cycle.
+USE_DEPRECATED_PYTZ = False
+
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -43,9 +43,9 @@ TIME_ZONE = 'America/Chicago'
 # If you set this to True, Django will use timezone-aware datetimes.
 USE_TZ = False
 
-# RemovedInDjango50Warning
-# Set True to continue using pytz tzinfo objects during the Django 4.x release
-# cycle.
+# RemovedInDjango50Warning: It's a transitional setting helpful in migrating
+# from pytz tzinfo to ZoneInfo(). Set True to continue using pytz tzinfo
+# objects during the Django 4.x release cycle.
 USE_DEPRECATED_PYTZ = False
 
 # Language code for this installation. All choices can be found here:

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.conf import settings
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 from django.contrib.admin.utils import (
     display_for_field, display_for_value, get_fields_from_path,
@@ -328,7 +329,7 @@ def date_hierarchy(cl):
         field = get_fields_from_path(cl.model, field_name)[-1]
         if isinstance(field, models.DateTimeField):
             dates_or_datetimes = 'datetimes'
-            qs_kwargs = {'is_dst': True}
+            qs_kwargs = {'is_dst': True} if settings.USE_DEPRECATED_PYTZ else {}
         else:
             dates_or_datetimes = 'dates'
             qs_kwargs = {}

--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -6,7 +6,10 @@ import warnings
 from collections import deque
 from contextlib import contextmanager
 
-import pytz
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -21,6 +24,14 @@ from django.utils.asyncio import async_unsafe
 from django.utils.functional import cached_property
 
 NO_DB_ALIAS = '__no_db__'
+
+
+# RemovedInDjango50Warning
+def timezone_constructor(tzname):
+    if settings.USE_DEPRECATED_PYTZ:
+        import pytz
+        return pytz.timezone(tzname)
+    return zoneinfo.ZoneInfo(tzname)
 
 
 class BaseDatabaseWrapper:
@@ -135,7 +146,7 @@ class BaseDatabaseWrapper:
         elif self.settings_dict['TIME_ZONE'] is None:
             return timezone.utc
         else:
-            return pytz.timezone(self.settings_dict['TIME_ZONE'])
+            return timezone_constructor(self.settings_dict['TIME_ZONE'])
 
     @cached_property
     def timezone_name(self):

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -14,12 +14,12 @@ import warnings
 from itertools import chain
 from sqlite3 import dbapi2 as Database
 
-import pytz
-
 from django.core.exceptions import ImproperlyConfigured
 from django.db import IntegrityError
 from django.db.backends import utils as backend_utils
-from django.db.backends.base.base import BaseDatabaseWrapper
+from django.db.backends.base.base import (
+    BaseDatabaseWrapper, timezone_constructor,
+)
 from django.utils import timezone
 from django.utils.asyncio import async_unsafe
 from django.utils.dateparse import parse_datetime, parse_time
@@ -431,7 +431,7 @@ def _sqlite_datetime_parse(dt, tzname=None, conn_tzname=None):
     except (TypeError, ValueError):
         return None
     if conn_tzname:
-        dt = dt.replace(tzinfo=pytz.timezone(conn_tzname))
+        dt = dt.replace(tzinfo=timezone_constructor(conn_tzname))
     if tzname is not None and tzname != conn_tzname:
         sign_index = tzname.find('+') + tzname.find('-') + 1
         if sign_index > -1:
@@ -441,7 +441,7 @@ def _sqlite_datetime_parse(dt, tzname=None, conn_tzname=None):
                 hours, minutes = offset.split(':')
                 offset_delta = datetime.timedelta(hours=int(hours), minutes=int(minutes))
                 dt += offset_delta if sign == '+' else -offset_delta
-        dt = timezone.localtime(dt, pytz.timezone(tzname))
+        dt = timezone.localtime(dt, timezone_constructor(tzname))
     return dt
 
 

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -67,7 +67,14 @@ class DatetimeDatetimeSerializer(BaseSerializer):
         imports = ["import datetime"]
         if self.value.tzinfo is not None:
             imports.append("from django.utils.timezone import utc")
-        return repr(self.value).replace('<UTC>', 'utc'), set(imports)
+        # Serialize, replacing tzinfo implementation details:
+        serialized = (
+            repr(self.value)
+            .replace('backports.', '')  # zoneinfo for PY38
+            .replace("zoneinfo.ZoneInfo(key='UTC')", 'utc')
+            .replace('<UTC>', 'utc')  # pytz
+        )
+        return serialized, set(imports)
 
 
 class DecimalSerializer(BaseSerializer):

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -188,7 +188,7 @@ class TruncBase(TimezoneMixin, Transform):
     kind = None
     tzinfo = None
 
-    def __init__(self, expression, output_field=None, tzinfo=None, is_dst=None, **extra):
+    def __init__(self, expression, output_field=None, tzinfo=None, is_dst=timezone.IS_DST_PASSED, **extra):
         self.tzinfo = tzinfo
         self.is_dst = is_dst
         super().__init__(expression, output_field=output_field, **extra)
@@ -264,7 +264,7 @@ class TruncBase(TimezoneMixin, Transform):
 
 class Trunc(TruncBase):
 
-    def __init__(self, expression, kind, output_field=None, tzinfo=None, is_dst=None, **extra):
+    def __init__(self, expression, kind, output_field=None, tzinfo=None, is_dst=timezone.IS_DST_PASSED, **extra):
         self.kind = kind
         super().__init__(
             expression, output_field=output_field, tzinfo=tzinfo,

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -916,7 +916,7 @@ class QuerySet:
             'datefield', flat=True
         ).distinct().filter(plain_field__isnull=False).order_by(('-' if order == 'DESC' else '') + 'datefield')
 
-    def datetimes(self, field_name, kind, order='ASC', tzinfo=None, is_dst=None):
+    def datetimes(self, field_name, kind, order='ASC', tzinfo=None, is_dst=timezone.IS_DST_PASSED):
         """
         Return a list of datetime objects representing all available
         datetimes for the given field_name, scoped to 'kind'.

--- a/django/templatetags/tz.py
+++ b/django/templatetags/tz.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 register = Library()
 
 
+# RemovedInDjango50Warning
 class UnknownTimezoneException(BaseException):
     pass
 
@@ -23,11 +24,11 @@ def timezone_constructor(tzname):
         try:
             return pytz.timezone(tzname)
         except pytz.UnknownTimeZoneError:
-            raise UnknownTimezoneException()
+            raise UnknownTimezoneException
     try:
         return zoneinfo.ZoneInfo(tzname)
     except zoneinfo.ZoneInfoNotFoundError:
-        raise UnknownTimezoneException()
+        raise UnknownTimezoneException
 
 
 # HACK: datetime instances cannot be assigned new attributes. Define a subclass

--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -3,6 +3,7 @@ Timezone-related classes and functions.
 """
 
 import functools
+import warnings
 
 try:
     import zoneinfo
@@ -15,6 +16,7 @@ from datetime import datetime, timedelta, timezone, tzinfo
 from asgiref.local import Local
 
 from django.conf import settings
+from django.utils.deprecation import RemovedInDjango50Warning
 
 __all__ = [  # noqa: F822 RemovedInDjango50Warning
     'utc', 'get_fixed_timezone',
@@ -24,6 +26,9 @@ __all__ = [  # noqa: F822 RemovedInDjango50Warning
     'localtime', 'now',
     'is_aware', 'is_naive', 'make_aware', 'make_naive',
 ]
+
+# RemovedInDjango50Warning
+IS_DST_PASSED = object()
 
 
 # RemovedInDjango50Warning
@@ -248,8 +253,16 @@ def is_naive(value):
     return value.utcoffset() is None
 
 
-def make_aware(value, timezone=None, is_dst=None):
+def make_aware(value, timezone=None, is_dst=IS_DST_PASSED):
     """Make a naive datetime.datetime in a given time zone aware."""
+    if is_dst is IS_DST_PASSED:
+        is_dst = None
+    else:
+        warnings.warn(
+            'The is_dst argument to make_aware() is deprecated as it has no '
+            'effect with zoneinfo time zones.',
+            RemovedInDjango50Warning
+        )
     if timezone is None:
         timezone = get_current_timezone()
     if _is_pytz_zone(timezone):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -34,6 +34,14 @@ details on these changes.
   ``StringAgg`` aggregates will return ``None`` when there are no rows instead
   of ``[]``, ``[]``, and ``''`` respectively.
 
+* The transitional ``USE_DEPRECATED_PYTZ`` setting, and support for ``pytz``
+  timezones is deprecated in favor of the standard library ``zoneinfo``
+  module.
+
+* As part of the migration to use ``zoneinfo`` time zone, the ``is_dst``
+  argument to ``django.utils.timezone.make_aware``, and various functions that
+  proxy to it, is deprecated.
+
 .. _deprecation-removed-in-4.1:
 
 4.1

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -524,6 +524,10 @@ The ``is_dst`` parameter indicates whether or not ``pytz`` should interpret
 nonexistent and ambiguous datetimes in daylight saving time. By default (when
 ``is_dst=None``), ``pytz`` raises an exception for such datetimes.
 
+.. versionchanged:: 4.0
+
+    The ``is_dst`` parameter is deprecated and will be removed in Django 5.0.
+
 Given the datetime ``2015-06-15 14:30:50.000321+00:00``, the built-in ``kind``\s
 return:
 
@@ -606,6 +610,10 @@ Usage example::
 .. class:: TruncQuarter(expression, output_field=None, tzinfo=None, is_dst=None, **extra)
 
     .. attribute:: kind = 'quarter'
+
+.. versionchanged:: 4.0
+
+    The ``is_dst`` parameter is deprecated and will be removed in Django 5.0.
 
 These are logically equivalent to ``Trunc('date_field', kind)``. They truncate
 all parts of the date up to ``kind`` which allows grouping or filtering dates
@@ -691,6 +699,10 @@ truncate function. It's also registered as a transform on ``DateTimeField`` as
 
     .. attribute:: kind = 'second'
 
+.. versionchanged:: 4.0
+
+    The ``is_dst`` parameter is deprecated and will be removed in Django 5.0.
+
 These are logically equivalent to ``Trunc('datetime_field', kind)``. They
 truncate all parts of the date up to ``kind`` and allow grouping or filtering
 datetimes with less precision. ``expression`` must have an ``output_field`` of
@@ -739,6 +751,10 @@ Usage example::
     :noindex:
 
     .. attribute:: kind = 'second'
+
+.. versionchanged:: 4.0
+
+    The ``is_dst`` parameter is deprecated and will be removed in Django 5.0.
 
 These are logically equivalent to ``Trunc('time_field', kind)``. They truncate
 all parts of the time up to ``kind`` which allows grouping or filtering times

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -242,7 +242,8 @@ Takes an ``expression`` representing a ``DateField``, ``DateTimeField``,
 of the date referenced by ``lookup_name`` as an ``IntegerField``.
 Django usually uses the databases' extract function, so you may use any
 ``lookup_name`` that your database supports. A ``tzinfo`` subclass, usually
-provided by ``pytz``, can be passed to extract a value in a specific timezone.
+provided by :mod:`zoneinfo`, can be passed to extract a value in a specific
+timezone.
 
 Given the datetime ``2015-06-15 23:30:01.000321+00:00``, the built-in
 ``lookup_name``\s return:
@@ -450,8 +451,8 @@ to that timezone before the value is extracted. The example below converts to
 the Melbourne timezone (UTC +10:00), which changes the day, weekday, and hour
 values that are returned::
 
-    >>> import pytz
-    >>> melb = pytz.timezone('Australia/Melbourne')  # UTC+10:00
+    >>> import zoneinfo
+    >>> melb = zoneinfo.ZoneInfo('Australia/Melbourne')  # UTC+10:00
     >>> with timezone.override(melb):
     ...    Experiment.objects.annotate(
     ...        day=ExtractDay('start_datetime'),
@@ -466,8 +467,8 @@ values that are returned::
 Explicitly passing the timezone to the ``Extract`` function behaves in the same
 way, and takes priority over an active timezone::
 
-    >>> import pytz
-    >>> melb = pytz.timezone('Australia/Melbourne')
+    >>> import zoneinfo
+    >>> melb = zoneinfo.ZoneInfo('Australia/Melbourne')
     >>> Experiment.objects.annotate(
     ...     day=ExtractDay('start_datetime', tzinfo=melb),
     ...     weekday=ExtractWeekDay('start_datetime', tzinfo=melb),
@@ -517,8 +518,8 @@ part, and an ``output_field`` that's either ``DateTimeField()``,
 ``TimeField()``, or ``DateField()``. It returns a datetime, date, or time
 depending on ``output_field``, with fields up to ``kind`` set to their minimum
 value. If ``output_field`` is omitted, it will default to the ``output_field``
-of ``expression``. A ``tzinfo`` subclass, usually provided by ``pytz``, can be
-passed to truncate a value in a specific timezone.
+of ``expression``. A ``tzinfo`` subclass, usually provided by :mod:`zoneinfo`,
+can be passed to truncate a value in a specific timezone.
 
 The ``is_dst`` parameter indicates whether or not ``pytz`` should interpret
 nonexistent and ambiguous datetimes in daylight saving time. By default (when
@@ -642,8 +643,8 @@ that deal with date-parts can be used with ``DateField``::
     2014-01-01 1
     2015-01-01 2
 
-    >>> import pytz
-    >>> melb = pytz.timezone('Australia/Melbourne')
+    >>> import zoneinfo
+    >>> melb = zoneinfo.ZoneInfo('Australia/Melbourne')
     >>> experiments_per_month = Experiment.objects.annotate(
     ...    month=TruncMonth('start_datetime', tzinfo=melb)).values('month').annotate(
     ...    experiments=Count('id'))
@@ -716,10 +717,10 @@ Usage example::
     ...     TruncDate, TruncDay, TruncHour, TruncMinute, TruncSecond,
     ... )
     >>> from django.utils import timezone
-    >>> import pytz
+    >>> import zoneinfo
     >>> start1 = datetime(2014, 6, 15, 14, 30, 50, 321, tzinfo=timezone.utc)
     >>> Experiment.objects.create(start_datetime=start1, start_date=start1.date())
-    >>> melb = pytz.timezone('Australia/Melbourne')
+    >>> melb = zoneinfo.ZoneInfo('Australia/Melbourne')
     >>> Experiment.objects.annotate(
     ...     date=TruncDate('start_datetime'),
     ...     day=TruncDay('start_datetime', tzinfo=melb),
@@ -728,10 +729,10 @@ Usage example::
     ...     second=TruncSecond('start_datetime'),
     ... ).values('date', 'day', 'hour', 'minute', 'second').get()
     {'date': datetime.date(2014, 6, 15),
-     'day': datetime.datetime(2014, 6, 16, 0, 0, tzinfo=<DstTzInfo 'Australia/Melbourne' AEST+10:00:00 STD>),
-     'hour': datetime.datetime(2014, 6, 16, 0, 0, tzinfo=<DstTzInfo 'Australia/Melbourne' AEST+10:00:00 STD>),
-     'minute': 'minute': datetime.datetime(2014, 6, 15, 14, 30, tzinfo=<UTC>),
-     'second': datetime.datetime(2014, 6, 15, 14, 30, 50, tzinfo=<UTC>)
+     'day': datetime.datetime(2014, 6, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo('Australia/Melbourne')),
+     'hour': datetime.datetime(2014, 6, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo('Australia/Melbourne')),
+     'minute': 'minute': datetime.datetime(2014, 6, 15, 14, 30, tzinfo=zoneinfo.ZoneInfo('UTC')),
+     'second': datetime.datetime(2014, 6, 15, 14, 30, 50, tzinfo=zoneinfo.ZoneInfo('UTC'))
     }
 
 ``TimeField`` truncation
@@ -783,8 +784,8 @@ that deal with time-parts can be used with ``TimeField``::
     14:00:00 2
     17:00:00 1
 
-    >>> import pytz
-    >>> melb = pytz.timezone('Australia/Melbourne')
+    >>> import zoneinfo
+    >>> melb = zoneinfo.ZoneInfo('Australia/Melbourne')
     >>> experiments_per_hour = Experiment.objects.annotate(
     ...    hour=TruncHour('start_datetime', tzinfo=melb),
     ... ).values('hour').annotate(experiments=Count('id'))

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -847,13 +847,11 @@ ambiguous datetimes in daylight saving time. By default (when ``is_dst=None``),
     As a consequence, your database must be able to interpret the value of
     ``tzinfo.tzname(None)``. This translates into the following requirements:
 
-    - SQLite: no requirements. Conversions are performed in Python with pytz_
-      (installed when you install Django).
+    - SQLite: no requirements. Conversions are performed in Python.
     - PostgreSQL: no requirements (see `Time Zones`_).
     - Oracle: no requirements (see `Choosing a Time Zone File`_).
     - MySQL: load the time zone tables with `mysql_tzinfo_to_sql`_.
 
-    .. _pytz: http://pytz.sourceforge.net/
     .. _Time Zones: https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-TIMEZONES
     .. _Choosing a Time Zone File: https://docs.oracle.com/en/database/oracle/
        oracle-database/18/nlspg/datetime-data-types-and-time-zone-support.html

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -834,6 +834,11 @@ object. If it's ``None``, Django uses the :ref:`current time zone
 ambiguous datetimes in daylight saving time. By default (when ``is_dst=None``),
 ``pytz`` raises an exception for such datetimes.
 
+.. versionchanged:: 4.0
+
+    The ``is_dst`` parameter is deprecated and will be removed in Django
+    5.0.
+
 .. _database-time-zone-definitions:
 
 .. note::

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -672,8 +672,8 @@ When :setting:`USE_TZ` is ``False``, it is an error to set this option.
     otherwise, you should leave this option unset. It's best to store datetimes
     in UTC because it avoids ambiguous or nonexistent datetimes during daylight
     saving time changes. Also, receiving datetimes in UTC keeps datetime
-    arithmetic simple — there's no need for the ``normalize()`` method provided
-    by pytz.
+    arithmetic simple — there's no need to consider potential offset changes
+    over a DST transition.
 
   * If you're connecting to a third-party database that stores datetimes in a
     local time rather than UTC, then you must set this option to the
@@ -690,8 +690,8 @@ When :setting:`USE_TZ` is ``False``, it is an error to set this option.
   as ``date_trunc``, because their results depend on the time zone.
 
   However, this has a downside: receiving all datetimes in local time makes
-  datetime arithmetic more tricky — you must call the ``normalize()`` method
-  provided by pytz after each operation.
+  datetime arithmetic more tricky — you must account for possible offset
+  changes over DST transitions.
 
   Consider converting to local time explicitly with ``AT TIME ZONE`` in raw SQL
   queries instead of setting the ``TIME_ZONE`` option.
@@ -2749,6 +2749,23 @@ the correct environment.
     match the system time zone.
 
 .. _list of time zones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+
+.. setting:: USE_DEPRECATED_PYTZ
+
+``USE_DEPRECATED_PYTZ``
+-----------------------
+
+.. versionadded:: 4.0
+
+Default: ``False``
+
+A boolean that specifies whether to use ``pytz``, rather than :mod:`zoneinfo`,
+as the default time zone implementation.
+
+.. note::
+
+    This is a transitional setting to aid the migration to ``zoneinfo``. It
+    will be removed in Django 5.0, and will trigger a warning if enabled.
 
 .. setting:: USE_I18N
 

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -960,6 +960,11 @@ appropriate entities.
     The ``is_dst`` parameter has no effect when using non-``pytz`` timezone
     implementations.
 
+    .. versionchanged:: 4.0
+
+        The ``is_dst`` parameter is deprecated and will be removed in Django
+        5.0.
+
 .. function:: make_naive(value, timezone=None)
 
     Returns a naive :class:`~datetime.datetime` that represents in

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -28,6 +28,30 @@ The Django 3.2.x series is the last to support Python 3.6 and 3.7.
 What's new in Django 4.0
 ========================
 
+``zoneinfo`` is now the default timezone implementation
+-------------------------------------------------------
+
+These notes are WIP.
+
+* The ``zoneinfo`` module is included in the Python stdlib from Python 3.9. It
+  is now the default timezone implementation used by Django.
+  ``timezone.get_default_timezone()`` and related functions return ``ZoneInfo``
+  objects by default.
+
+* ``backports.zoneinfo`` is available for Python 3.8.
+
+  ``tzdata`` is an additional requirement on Windows.
+
+* ``USE_DEPRECATED_PYTZ`` is provided to continue using ``pytz`` during
+  the 4.x release cycle. This setting will be removed in Django 5.0.
+
+  You may need to use this if ...timezone arithmetic over offset changes...
+
+  Note: The ``timezone.utc`` alias requires settings to be configured in order
+  to use ``USE_DEPRECATED_PYTZ``.  If you access ``timezone.utc`` before the
+  settings are configured it will be a ``ZoneInfo`` instance.
+
+
 Functional unique constraints
 -----------------------------
 

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -28,29 +28,46 @@ The Django 3.2.x series is the last to support Python 3.6 and 3.7.
 What's new in Django 4.0
 ========================
 
-``zoneinfo`` is now the default timezone implementation
--------------------------------------------------------
+``zoneinfo`` default timezone implementation
+--------------------------------------------
 
-These notes are WIP.
+The Python standard library's :mod:`zoneinfo` is now the default timezone
+implementation in Django.
 
-* The ``zoneinfo`` module is included in the Python stdlib from Python 3.9. It
-  is now the default timezone implementation used by Django.
-  ``timezone.get_default_timezone()`` and related functions return ``ZoneInfo``
-  objects by default.
+This is the next step in the migration from using ``pytz`` to using
+:mod:`zoneinfo`. Django 3.2 allowed the use of non-``pytz`` time zones. Django
+4.0 makes ``zoneinfo`` the default implementation. Support for ``pytz`` is now
+deprecated and will be removed in Django 5.0.
 
-* ``backports.zoneinfo`` is available for Python 3.8.
+:mod:`zoneinfo` is part of the Python standard library from Python 3.9. The
+``backports.zoneinfo`` package is automatically installed alongside Django if
+you are using Python 3.8.
 
-  ``tzdata`` is an additional requirement on Windows.
+To the extent that you are always operating on aware datetimes with UTC, then
+the move to ``zoneinfo`` should be largely transparent.
 
-* ``USE_DEPRECATED_PYTZ`` is provided to continue using ``pytz`` during
-  the 4.x release cycle. This setting will be removed in Django 5.0.
+If though you are you are working with non-UTC time zones, you will need to
+audit your code, since ``pytz`` and ``zoneinfo`` are not entirely equivalent:
 
-  You may need to use this if ...timezone arithmetic over offset changes...
+* The transitional :setting:`USE_DEPRECATED_PYTZ` setting is provided to
+  continue using ``pytz`` during the 4.x release cycle. This setting will be
+  removed in Django 5.0.
 
-  Note: The ``timezone.utc`` alias requires settings to be configured in order
-  to use ``USE_DEPRECATED_PYTZ``.  If you access ``timezone.utc`` before the
-  settings are configured it will be a ``ZoneInfo`` instance.
+* Usages of :func:`django.utils.timezone.activate`,
+  :func:`django.utils.timezone.override`, or the :setting:`DATABASE-TIME_ZONE`
+  setting, as well as calls to the ``pytz`` ``normalize()`` or ``localize()``
+  functions are candidate locations for review.
 
+* The ``is_dst`` argument to :func:`django.utils.timezone.make_aware`, and
+  functions that proxy to it, is also deprecated, since it has no effect for
+  ``zoneinfo`` time zones.
+
+The Python Core Team maintain a `pytz_deprecation_shim`_ package to assist the
+migration to ``zoneinfo``. Use of this package plus the
+:setting:`USE_DEPRECATED_PYTZ` transitional setting is recommended if you need
+a gradual update path.
+
+.. _pytz_deprecation_shim: https://pytz-deprecation-shim.readthedocs.io/en/latest/index.html
 
 Functional unique constraints
 -----------------------------

--- a/docs/topics/i18n/timezones.txt
+++ b/docs/topics/i18n/timezones.txt
@@ -19,10 +19,9 @@ practice to store data in UTC in your database. The main reason is daylight
 saving time (DST). Many countries have a system of DST, where clocks are moved
 forward in spring and backward in autumn. If you're working in local time,
 you're likely to encounter errors twice a year, when the transitions happen.
-(The pytz_ documentation discusses `these issues`_ in greater detail.) This
-probably doesn't matter for your blog, but it's a problem if you over-bill or
-under-bill your customers by one hour, twice a year, every year. The solution
-to this problem is to use UTC in the code and use local time only when
+This probably doesn't matter for your blog, but it's a problem if you over-bill
+or under-bill your customers by one hour, twice a year, every year. The
+solution to this problem is to use UTC in the code and use local time only when
 interacting with end users.
 
 Time zone support is disabled by default. To enable it, set :setting:`USE_TZ =
@@ -32,14 +31,19 @@ True <USE_TZ>` in your settings file.
 
     In Django 5.0, time zone support will be enabled by default.
 
-By default, time zone support uses pytz_, which is installed when you install
-Django; Django also supports the use of other time zone implementations like
-:mod:`zoneinfo` by passing :class:`~datetime.tzinfo` objects directly to
-functions in :mod:`django.utils.timezone`.
+Time zone support uses :mod:`zoneinfo`, which is part of the Python standard
+library from Python 3.9. A backport is installed when you install Django if you
+are using Python 3.8.
 
 .. versionchanged:: 3.2
 
     Support for non-``pytz`` timezone implementations was added.
+
+.. versionchanged:: 4.0
+
+    :mod:`zoneinfo` was made the default timezone implementation. You may
+    continue to use `pytz`_ during the 4.x release cycle via the
+    :setting:`USE_DEPRECATED_PYTZ` setting.
 
 .. note::
 
@@ -94,8 +98,8 @@ should be aware too. In this mode, the example above becomes::
     Dealing with aware datetime objects isn't always intuitive. For instance,
     the ``tzinfo`` argument of the standard datetime constructor doesn't work
     reliably for time zones with DST. Using UTC is generally safe; if you're
-    using other time zones, you should review the `pytz`_ documentation
-    carefully.
+    using other time zones, you should review the :mod:`zoneinfo`
+    documentation carefully.
 
 .. note::
 
@@ -119,8 +123,8 @@ receives one, it attempts to make it aware by interpreting it in the
 :ref:`default time zone <default-current-time-zone>` and raises a warning.
 
 Unfortunately, during DST transitions, some datetimes don't exist or are
-ambiguous. In such situations, pytz_ raises an exception. That's why you should
-always create aware datetime objects when time zone support is enabled.
+ambiguous. That's why you should always create aware datetime objects when time
+zone support is enabled.
 
 In practice, this is rarely an issue. Django gives you aware datetime objects
 in the models and forms, and most often, new datetime objects are created from
@@ -169,16 +173,16 @@ selection logic that makes sense for you.
 
 Most websites that care about time zones ask users in which time zone they live
 and store this information in the user's profile. For anonymous users, they use
-the time zone of their primary audience or UTC. pytz_ provides helpers_, like a
-list of time zones per country, that you can use to pre-select the most likely
-choices.
+the time zone of their primary audience or UTC.
+:func:`zoneinfo.available_timezones` provides a set of available timezones that
+you can use to pre-select the most likely choices.
 
 Here's an example that stores the current timezone in the session. (It skips
 error handling entirely for the sake of simplicity.)
 
 Add the following middleware to :setting:`MIDDLEWARE`::
 
-    import pytz
+    import zoneinfo
 
     from django.utils import timezone
 
@@ -189,7 +193,7 @@ Add the following middleware to :setting:`MIDDLEWARE`::
         def __call__(self, request):
             tzname = request.session.get('django_timezone')
             if tzname:
-                timezone.activate(pytz.timezone(tzname))
+                timezone.activate(zoneinfo.ZoneInfo(tzname))
             else:
                 timezone.deactivate()
             return self.get_response(request)
@@ -198,12 +202,15 @@ Create a view that can set the current timezone::
 
     from django.shortcuts import redirect, render
 
+    # Prepare a list of common timezone choices you wish to offer.
+    common_timezones = [...]
+
     def set_timezone(request):
         if request.method == 'POST':
             request.session['django_timezone'] = request.POST['timezone']
             return redirect('/')
         else:
-            return render(request, 'template.html', {'timezones': pytz.common_timezones})
+            return render(request, 'template.html', {'timezones': common_timezones})
 
 Include a form in ``template.html`` that will ``POST`` to this view:
 
@@ -231,9 +238,8 @@ When you enable time zone support, Django interprets datetimes entered in
 forms in the :ref:`current time zone <default-current-time-zone>` and returns
 aware datetime objects in ``cleaned_data``.
 
-If the current time zone raises an exception for datetimes that don't exist or
-are ambiguous because they fall in a DST transition (the timezones provided by
-pytz_ do this), such datetimes will be reported as invalid values.
+Converted datetimes that don't exist or are ambiguous because they fall in a
+DST transition will be reported as invalid values.
 
 .. _time-zones-in-templates:
 
@@ -589,20 +595,20 @@ Troubleshooting
    None of this is true in a time zone aware environment::
 
        >>> import datetime
-       >>> import pytz
-       >>> paris_tz = pytz.timezone("Europe/Paris")
-       >>> new_york_tz = pytz.timezone("America/New_York")
-       >>> paris = paris_tz.localize(datetime.datetime(2012, 3, 3, 1, 30))
-       # This is the correct way to convert between time zones with pytz.
-       >>> new_york = new_york_tz.normalize(paris.astimezone(new_york_tz))
+       >>> import zoneinfo
+       >>> paris_tz = zoneinfo.ZoneInfo("Europe/Paris")
+       >>> new_york_tz = zoneinfo.ZoneInfo("America/New_York")
+       >>> paris = datetime.datetime(2012, 3, 3, 1, 30, tzinfo=paris_tz)
+       # This is the correct way to convert between time zones.
+       >>> new_york = paris.astimezone(new_york_tz)
        >>> paris == new_york, paris.date() == new_york.date()
        (True, False)
        >>> paris - new_york, paris.date() - new_york.date()
        (datetime.timedelta(0), datetime.timedelta(1))
        >>> paris
-       datetime.datetime(2012, 3, 3, 1, 30, tzinfo=<DstTzInfo 'Europe/Paris' CET+1:00:00 STD>)
+       datetime.datetime(2012, 3, 3, 1, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris'))
        >>> new_york
-       datetime.datetime(2012, 3, 2, 19, 30, tzinfo=<DstTzInfo 'America/New_York' EST-1 day, 19:00:00 STD>)
+       datetime.datetime(2012, 3, 2, 19, 30, tzinfo=zoneinfo.ZoneInfo(key='America/New_York'))
 
    As this example shows, the same datetime has a different date, depending on
    the time zone in which it is represented. But the real problem is more
@@ -627,14 +633,13 @@ Troubleshooting
    will be the current timezone::
 
        >>> from django.utils import timezone
-       >>> timezone.activate(pytz.timezone("Asia/Singapore"))
+       >>> timezone.activate(zoneinfo.ZoneInfo("Asia/Singapore"))
        # For this example, we set the time zone to Singapore, but here's how
        # you would obtain the current time zone in the general case.
        >>> current_tz = timezone.get_current_timezone()
-       # Again, this is the correct way to convert between time zones with pytz.
-       >>> local = current_tz.normalize(paris.astimezone(current_tz))
+       >>> local = paris.astimezone(current_tz)
        >>> local
-       datetime.datetime(2012, 3, 3, 8, 30, tzinfo=<DstTzInfo 'Asia/Singapore' SGT+8:00:00 STD>)
+       datetime.datetime(2012, 3, 3, 8, 30, tzinfo=zoneinfo.ZoneInfo(key='Asia/Singapore'))
        >>> local.date()
        datetime.date(2012, 3, 3)
 
@@ -651,18 +656,14 @@ Usage
    ``"Europe/Helsinki"`` **time zone. How do I turn that into an aware
    datetime?**
 
-   This is exactly what pytz_ is for.
+   Here you need to create the required ``ZoneInfo`` instance and attach it to
+   the naïve datetime::
 
+       >>> import zoneinfo
        >>> from django.utils.dateparse import parse_datetime
        >>> naive = parse_datetime("2012-02-21 10:28:45")
-       >>> import pytz
-       >>> pytz.timezone("Europe/Helsinki").localize(naive, is_dst=None)
-       datetime.datetime(2012, 2, 21, 10, 28, 45, tzinfo=<DstTzInfo 'Europe/Helsinki' EET+2:00:00 STD>)
-
-   Note that ``localize`` is a pytz extension to the :class:`~datetime.tzinfo`
-   API. Also, you may want to catch ``pytz.InvalidTimeError``. The
-   documentation of pytz contains `more examples`_. You should review it
-   before attempting to manipulate aware datetimes.
+       >>> naive.replace(tzinfo=zoneinfo.ZoneInfo("Europe/Helsinki"))
+       datetime.datetime(2012, 2, 21, 10, 28, 45, tzinfo=zoneinfo.ZoneInfo(key='Europe/Helsinki'))
 
 #. **How can I obtain the local time in the current time zone?**
 
@@ -683,19 +684,14 @@ Usage
 
        >>> from django.utils import timezone
        >>> timezone.localtime(timezone.now())
-       datetime.datetime(2012, 3, 3, 20, 10, 53, 873365, tzinfo=<DstTzInfo 'Europe/Paris' CET+1:00:00 STD>)
+       datetime.datetime(2012, 3, 3, 20, 10, 53, 873365, tzinfo=zoneinfo.ZoneInfo(key='Europe/Paris'))
 
    In this example, the current time zone is ``"Europe/Paris"``.
 
 #. **How can I see all available time zones?**
 
-   pytz_ provides helpers_, including a list of current time zones and a list
-   of all available time zones -- some of which are only of historical
-   interest. :mod:`zoneinfo` also provides similar functionality via
-   :func:`zoneinfo.available_timezones`.
+   :func:`zoneinfo.available_timezones` provides the set of all valid keys for
+   IANA time zones available to your system. See the docs for usage
+   considerations.
 
 .. _pytz: http://pytz.sourceforge.net/
-.. _more examples: http://pytz.sourceforge.net/#example-usage
-.. _these issues: http://pytz.sourceforge.net/#problems-with-localtime
-.. _helpers: http://pytz.sourceforge.net/#helpers
-.. _tz database: https://en.wikipedia.org/wiki/Tz_database

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,8 +38,9 @@ include_package_data = true
 zip_safe = false
 install_requires =
     asgiref >= 3.3.2
-    pytz
+    backports.zoneinfo; python_version<"3.9"
     sqlparse >= 0.2.2
+    tzdata; sys_platform == 'win32'
 
 [options.entry_points]
 console_scripts =

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5,15 +5,15 @@ import unittest
 from unittest import mock
 from urllib.parse import parse_qsl, urljoin, urlparse
 
-import pytz
-
 try:
     import zoneinfo
 except ImportError:
-    try:
-        from backports import zoneinfo
-    except ImportError:
-        zoneinfo = None
+    from backports import zoneinfo
+
+try:
+    import pytz
+except ImportError:
+    pytz = None
 
 from django.contrib import admin
 from django.contrib.admin import AdminSite, ModelAdmin
@@ -73,10 +73,10 @@ MULTIPART_ENCTYPE = 'enctype="multipart/form-data"'
 
 def make_aware_datetimes(dt, iana_key):
     """Makes one aware datetime for each supported time zone provider."""
-    yield pytz.timezone(iana_key).localize(dt, is_dst=None)
+    yield dt.replace(tzinfo=zoneinfo.ZoneInfo(iana_key))
 
-    if zoneinfo is not None:
-        yield dt.replace(tzinfo=zoneinfo.ZoneInfo(iana_key))
+    if pytz is not None:
+        yield pytz.timezone(iana_key).localize(dt, is_dst=None)
 
 
 class AdminFieldExtractionMixin:

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -4,7 +4,10 @@ import re
 from datetime import datetime, timedelta
 from importlib import import_module
 
-import pytz
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
 
 from django import forms
 from django.conf import settings
@@ -967,8 +970,8 @@ class DateTimePickerShortcutsSeleniumTests(AdminWidgetSeleniumTestCase):
         error_margin = timedelta(seconds=10)
 
         # If we are neighbouring a DST, we add an hour of error margin.
-        tz = pytz.timezone('America/Chicago')
-        utc_now = datetime.now(pytz.utc)
+        tz = zoneinfo.ZoneInfo('America/Chicago')
+        utc_now = datetime.now(zoneinfo.ZoneInfo('UTC'))
         tz_yesterday = (utc_now - timedelta(days=1)).astimezone(tz).tzname()
         tz_tomorrow = (utc_now + timedelta(days=1)).astimezone(tz).tzname()
         if tz_yesterday != tz_tomorrow:

--- a/tests/datetimes/tests.py
+++ b/tests/datetimes/tests.py
@@ -1,6 +1,10 @@
 import datetime
+import unittest
 
-import pytz
+try:
+    import pytz
+except ImportError:
+    pytz = None
 
 from django.test import TestCase, override_settings
 from django.utils import timezone
@@ -91,7 +95,8 @@ class DateTimesTests(TestCase):
         qs = Article.objects.datetimes('pub_date', 'second')
         self.assertEqual(qs[0], now)
 
-    @override_settings(USE_TZ=True, TIME_ZONE='UTC')
+    @unittest.skipUnless(pytz is not None, "Test needs pytz")
+    @override_settings(USE_TZ=True, TIME_ZONE='UTC', USE_DEPRECATED_PYTZ=True)
     def test_datetimes_ambiguous_and_invalid_times(self):
         sao = pytz.timezone('America/Sao_Paulo')
         utc = pytz.UTC

--- a/tests/datetimes/tests.py
+++ b/tests/datetimes/tests.py
@@ -6,8 +6,9 @@ try:
 except ImportError:
     pytz = None
 
-from django.test import TestCase, override_settings
+from django.test import TestCase, ignore_warnings, override_settings
 from django.utils import timezone
+from django.utils.deprecation import RemovedInDjango50Warning
 
 from .models import Article, Category, Comment
 
@@ -96,6 +97,7 @@ class DateTimesTests(TestCase):
         self.assertEqual(qs[0], now)
 
     @unittest.skipUnless(pytz is not None, "Test needs pytz")
+    @ignore_warnings(category=RemovedInDjango50Warning)
     @override_settings(USE_TZ=True, TIME_ZONE='UTC', USE_DEPRECATED_PYTZ=True)
     def test_datetimes_ambiguous_and_invalid_times(self):
         sao = pytz.timezone('America/Sao_Paulo')

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -24,9 +24,11 @@ from django.db.models.functions import (
     TruncYear,
 )
 from django.test import (
-    TestCase, override_settings, skipIfDBFeature, skipUnlessDBFeature,
+    TestCase, ignore_warnings, override_settings, skipIfDBFeature,
+    skipUnlessDBFeature,
 )
 from django.utils import timezone
+from django.utils.deprecation import RemovedInDjango50Warning
 
 from ..models import Author, DTModel, Fan
 
@@ -106,8 +108,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 10)
         end_datetime = datetime(2016, 6, 15, 14, 10)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
 
@@ -143,8 +145,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 10)
         end_datetime = datetime(2016, 6, 15, 14, 10)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
 
@@ -166,8 +168,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 10)
         end_datetime = datetime(2016, 6, 15, 14, 10)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
 
@@ -189,8 +191,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
 
@@ -288,8 +290,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -327,8 +329,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -347,8 +349,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -367,14 +369,14 @@ class DateFunctionTests(TestCase):
     def test_extract_iso_year_func_boundaries(self):
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            end_datetime = timezone.make_aware(end_datetime)
         week_52_day_2014 = datetime(2014, 12, 27, 13, 0)  # Sunday
         week_1_day_2014_2015 = datetime(2014, 12, 31, 13, 0)  # Wednesday
         week_53_day_2015 = datetime(2015, 12, 31, 13, 0)  # Thursday
         if settings.USE_TZ:
-            week_1_day_2014_2015 = timezone.make_aware(week_1_day_2014_2015, is_dst=False)
-            week_52_day_2014 = timezone.make_aware(week_52_day_2014, is_dst=False)
-            week_53_day_2015 = timezone.make_aware(week_53_day_2015, is_dst=False)
+            week_1_day_2014_2015 = timezone.make_aware(week_1_day_2014_2015)
+            week_52_day_2014 = timezone.make_aware(week_52_day_2014)
+            week_53_day_2015 = timezone.make_aware(week_53_day_2015)
         days = [week_52_day_2014, week_1_day_2014_2015, week_53_day_2015]
         obj_1_iso_2014 = self.create_model(week_52_day_2014, end_datetime)
         obj_1_iso_2015 = self.create_model(week_1_day_2014_2015, end_datetime)
@@ -405,8 +407,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -425,8 +427,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -445,8 +447,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -466,8 +468,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 8, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -485,13 +487,13 @@ class DateFunctionTests(TestCase):
     def test_extract_quarter_func_boundaries(self):
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            end_datetime = timezone.make_aware(end_datetime)
 
         last_quarter_2014 = datetime(2014, 12, 31, 13, 0)
         first_quarter_2015 = datetime(2015, 1, 1, 13, 0)
         if settings.USE_TZ:
-            last_quarter_2014 = timezone.make_aware(last_quarter_2014, is_dst=False)
-            first_quarter_2015 = timezone.make_aware(first_quarter_2015, is_dst=False)
+            last_quarter_2014 = timezone.make_aware(last_quarter_2014)
+            first_quarter_2015 = timezone.make_aware(first_quarter_2015)
         dates = [last_quarter_2014, first_quarter_2015]
         self.create_model(last_quarter_2014, end_datetime)
         self.create_model(first_quarter_2015, end_datetime)
@@ -506,15 +508,15 @@ class DateFunctionTests(TestCase):
     def test_extract_week_func_boundaries(self):
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            end_datetime = timezone.make_aware(end_datetime)
 
         week_52_day_2014 = datetime(2014, 12, 27, 13, 0)  # Sunday
         week_1_day_2014_2015 = datetime(2014, 12, 31, 13, 0)  # Wednesday
         week_53_day_2015 = datetime(2015, 12, 31, 13, 0)  # Thursday
         if settings.USE_TZ:
-            week_1_day_2014_2015 = timezone.make_aware(week_1_day_2014_2015, is_dst=False)
-            week_52_day_2014 = timezone.make_aware(week_52_day_2014, is_dst=False)
-            week_53_day_2015 = timezone.make_aware(week_53_day_2015, is_dst=False)
+            week_1_day_2014_2015 = timezone.make_aware(week_1_day_2014_2015)
+            week_52_day_2014 = timezone.make_aware(week_52_day_2014)
+            week_53_day_2015 = timezone.make_aware(week_53_day_2015)
 
         days = [week_52_day_2014, week_1_day_2014_2015, week_53_day_2015]
         self.create_model(week_53_day_2015, end_datetime)
@@ -533,8 +535,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -559,8 +561,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -594,8 +596,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -614,8 +616,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -634,8 +636,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -654,8 +656,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
 
@@ -760,8 +762,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), 'year')
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -794,10 +796,10 @@ class DateFunctionTests(TestCase):
         last_quarter_2015 = truncate_to(datetime(2015, 12, 31, 14, 10, 50, 123), 'quarter')
         first_quarter_2016 = truncate_to(datetime(2016, 1, 1, 14, 10, 50, 123), 'quarter')
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
-            last_quarter_2015 = timezone.make_aware(last_quarter_2015, is_dst=False)
-            first_quarter_2016 = timezone.make_aware(first_quarter_2016, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
+            last_quarter_2015 = timezone.make_aware(last_quarter_2015)
+            first_quarter_2016 = timezone.make_aware(first_quarter_2016)
         self.create_model(start_datetime=start_datetime, end_datetime=end_datetime)
         self.create_model(start_datetime=end_datetime, end_datetime=start_datetime)
         self.create_model(start_datetime=last_quarter_2015, end_datetime=end_datetime)
@@ -833,8 +835,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), 'month')
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -865,8 +867,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), 'week')
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -889,8 +891,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -917,8 +919,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -945,8 +947,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 26)  # 0 microseconds.
         end_datetime = datetime(2015, 6, 15, 14, 30, 26, 321)
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.assertIs(
             DTModel.objects.filter(
@@ -970,8 +972,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), 'day')
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -994,8 +996,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), 'hour')
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -1026,8 +1028,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), 'minute')
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -1058,8 +1060,8 @@ class DateFunctionTests(TestCase):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), 'second')
         if settings.USE_TZ:
-            start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-            end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+            start_datetime = timezone.make_aware(start_datetime)
+            end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
         self.assertQuerysetEqual(
@@ -1093,9 +1095,9 @@ class DateFunctionTests(TestCase):
         fan_since_2 = datetime(2015, 2, 3, 15, 0, 0)
         fan_since_3 = datetime(2017, 2, 3, 15, 0, 0)
         if settings.USE_TZ:
-            fan_since_1 = timezone.make_aware(fan_since_1, is_dst=False)
-            fan_since_2 = timezone.make_aware(fan_since_2, is_dst=False)
-            fan_since_3 = timezone.make_aware(fan_since_3, is_dst=False)
+            fan_since_1 = timezone.make_aware(fan_since_1)
+            fan_since_2 = timezone.make_aware(fan_since_2)
+            fan_since_3 = timezone.make_aware(fan_since_3)
         Fan.objects.create(author=author_1, name='Tom', fan_since=fan_since_1)
         Fan.objects.create(author=author_1, name='Emma', fan_since=fan_since_2)
         Fan.objects.create(author=author_2, name='Isabella', fan_since=fan_since_3)
@@ -1121,9 +1123,9 @@ class DateFunctionTests(TestCase):
         datetime_2 = datetime(2001, 3, 5)
         datetime_3 = datetime(2002, 1, 3)
         if settings.USE_TZ:
-            datetime_1 = timezone.make_aware(datetime_1, is_dst=False)
-            datetime_2 = timezone.make_aware(datetime_2, is_dst=False)
-            datetime_3 = timezone.make_aware(datetime_3, is_dst=False)
+            datetime_1 = timezone.make_aware(datetime_1)
+            datetime_2 = timezone.make_aware(datetime_2)
+            datetime_3 = timezone.make_aware(datetime_3)
         obj_1 = self.create_model(datetime_1, datetime_3)
         obj_2 = self.create_model(datetime_2, datetime_1)
         obj_3 = self.create_model(datetime_3, datetime_2)
@@ -1152,8 +1154,8 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
     def test_extract_func_with_timezone(self):
         start_datetime = datetime(2015, 6, 15, 23, 30, 1, 321)
         end_datetime = datetime(2015, 6, 16, 13, 11, 27, 123)
-        start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-        end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+        start_datetime = timezone.make_aware(start_datetime)
+        end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         delta_tzinfo_pos = datetime_timezone(timedelta(hours=5))
         delta_tzinfo_neg = datetime_timezone(timedelta(hours=-5, minutes=17))
@@ -1211,8 +1213,8 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
     def test_extract_func_explicit_timezone_priority(self):
         start_datetime = datetime(2015, 6, 15, 23, 30, 1, 321)
         end_datetime = datetime(2015, 6, 16, 13, 11, 27, 123)
-        start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-        end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+        start_datetime = timezone.make_aware(start_datetime)
+        end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
 
         for melb in self.get_timezones('Australia/Melbourne'):
@@ -1241,8 +1243,8 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
     def test_trunc_timezone_applied_before_truncation(self):
         start_datetime = datetime(2016, 1, 1, 1, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
-        start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-        end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+        start_datetime = timezone.make_aware(start_datetime)
+        end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
 
         for melb, pacific in zip(
@@ -1272,6 +1274,7 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
                 self.assertEqual(model.pacific_time, pacific_start_datetime.time())
 
     @needs_pytx
+    @ignore_warnings(category=RemovedInDjango50Warning)
     def test_trunc_ambiguous_and_invalid_times(self):
         sao = pytz.timezone('America/Sao_Paulo')
         utc = timezone.utc
@@ -1303,8 +1306,8 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
         """
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
-        start_datetime = timezone.make_aware(start_datetime, is_dst=False)
-        end_datetime = timezone.make_aware(end_datetime, is_dst=False)
+        start_datetime = timezone.make_aware(start_datetime)
+        end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
 

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -32,7 +32,7 @@ from ..models import Author, DTModel, Fan
 
 HAS_PYTZ = pytz is not None
 if not HAS_PYTZ:
-    needs_pytx = unittest.skip("Test requires pytz")
+    needs_pytx = unittest.skip('Test requires pytz')
 else:
     def needs_pytx(f):
         return f

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -4,7 +4,10 @@ import unittest
 from types import ModuleType, SimpleNamespace
 from unittest import mock
 
-from django.conf import ENVIRONMENT_VARIABLE, LazySettings, Settings, settings
+from django.conf import (
+    ENVIRONMENT_VARIABLE, USE_DEPRECATED_PYTZ_DEPRECATED_MSG, LazySettings,
+    Settings, settings,
+)
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 from django.test import (
@@ -347,6 +350,21 @@ class SettingsTests(SimpleTestCase):
                 Settings('fake_settings_module')
         finally:
             del sys.modules['fake_settings_module']
+
+    def test_use_deprecated_pytz_deprecation(self):
+        settings_module = ModuleType('fake_settings_module')
+        settings_module.USE_DEPRECATED_PYTZ = True
+        settings_module.USE_TZ = True
+        sys.modules['fake_settings_module'] = settings_module
+        try:
+            with self.assertRaisesMessage(RemovedInDjango50Warning, USE_DEPRECATED_PYTZ_DEPRECATED_MSG):
+                Settings('fake_settings_module')
+        finally:
+            del sys.modules['fake_settings_module']
+
+        holder = LazySettings()
+        with self.assertRaisesMessage(RemovedInDjango50Warning, USE_DEPRECATED_PYTZ_DEPRECATED_MSG):
+            holder.configure(USE_DEPRECATED_PYTZ=True)
 
 
 class TestComplexSettingOverride(SimpleTestCase):

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -362,6 +362,21 @@ class NewDatabaseTests(TestCase):
                 self.assertEqual(Event.objects.filter(dt__in=(prev, dt, next)).count(), 1)
                 self.assertEqual(Event.objects.filter(dt__range=(prev, next)).count(), 1)
 
+    def test_connection_timezone(self):
+        tests = [
+            (False, None, zoneinfo.ZoneInfo),
+            (False, 'Africa/Nairobi', zoneinfo.ZoneInfo),
+            (True, None, pytz.BaseTzInfo),
+            (True, 'Africa/Nairobi', pytz.BaseTzInfo),
+        ]
+        for use_pytz, connection_tz, expected_type in tests:
+            with self.subTest(use_pytz=use_pytz, connection_tz=connection_tz):
+                connection.timezone.clear_cache()
+                with override_settings(USE_DEPRECATED_PYTZ=use_pytz), \
+                     override_database_connection_timezone(connection_tz):
+                    self.assertIsInstance(connection.timezone, expected_type)
+                connection.timezone.clear_cache()
+
     def test_query_convert_timezones(self):
         # Connection timezone is equal to the current timezone, datetime
         # shouldn't be converted.

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -24,12 +24,13 @@ from django.template import (
     Context, RequestContext, Template, TemplateSyntaxError, context_processors,
 )
 from django.test import (
-    SimpleTestCase, TestCase, TransactionTestCase, override_settings,
-    skipIfDBFeature, skipUnlessDBFeature,
+    SimpleTestCase, TestCase, TransactionTestCase, ignore_warnings,
+    override_settings, skipIfDBFeature, skipUnlessDBFeature,
 )
 from django.test.utils import requires_tz_support
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.deprecation import RemovedInDjango50Warning
 from django.utils.timezone import timedelta
 
 from .forms import (
@@ -362,6 +363,7 @@ class NewDatabaseTests(TestCase):
                 self.assertEqual(Event.objects.filter(dt__in=(prev, dt, next)).count(), 1)
                 self.assertEqual(Event.objects.filter(dt__range=(prev, next)).count(), 1)
 
+    @ignore_warnings(category=RemovedInDjango50Warning)
     def test_connection_timezone(self):
         tests = [
             (False, None, zoneinfo.ZoneInfo),
@@ -1004,6 +1006,7 @@ class TemplateTests(SimpleTestCase):
         })
         self.assertEqual(tpl.render(ctx), "2011-09-01T12:20:30+02:00")
 
+    @ignore_warnings(category=RemovedInDjango50Warning)
     def test_timezone_templatetag_invalid_argument(self):
         with self.assertRaises(TemplateSyntaxError):
             Template("{% load tz %}{% timezone %}{% endtimezone %}").render()

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -14,7 +14,10 @@ from pathlib import Path
 from subprocess import CompletedProcess
 from unittest import mock, skip, skipIf
 
-import pytz
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
 
 import django.__main__
 from django.apps.registry import Apps
@@ -243,7 +246,7 @@ class TestChildArguments(SimpleTestCase):
 class TestUtilities(SimpleTestCase):
     def test_is_django_module(self):
         for module, expected in (
-            (pytz, False),
+            (zoneinfo, False),
             (sys, False),
             (autoreload, True)
         ):
@@ -252,7 +255,7 @@ class TestUtilities(SimpleTestCase):
 
     def test_is_django_path(self):
         for module, expected in (
-            (pytz.__file__, False),
+            (zoneinfo.__file__, False),
             (contextlib.__file__, False),
             (autoreload.__file__, True)
         ):

--- a/tests/utils_tests/test_timezone.py
+++ b/tests/utils_tests/test_timezone.py
@@ -222,6 +222,7 @@ class TimezoneTests(SimpleTestCase):
         )
 
     @needs_pytx
+    @ignore_warnings(category=RemovedInDjango50Warning)
     def test_make_aware_pytz_ambiguous(self):
         # 2:30 happens twice, once before DST ends and once after
         ambiguous = datetime.datetime(2015, 10, 25, 2, 30)
@@ -250,6 +251,7 @@ class TimezoneTests(SimpleTestCase):
         self.assertEqual(dst.utcoffset(), datetime.timedelta(hours=2))
 
     @needs_pytx
+    @ignore_warnings(category=RemovedInDjango50Warning)
     def test_make_aware_pytz_non_existent(self):
         # 2:30 never happened due to DST
         non_existent = datetime.datetime(2015, 3, 29, 2, 30)

--- a/tests/utils_tests/test_timezone.py
+++ b/tests/utils_tests/test_timezone.py
@@ -45,7 +45,6 @@ class TimezoneTests(SimpleTestCase):
         # RemovedInDjango50Warning
         timezone.get_default_timezone.cache_clear()
 
-    # TODO: Add similar tests for BaseDatabaseWrapper.timezone()
     def test_default_timezone_is_zoneinfo(self):
         self.assertIsInstance(timezone.get_default_timezone(), zoneinfo.ZoneInfo)
 

--- a/tests/utils_tests/test_timezone.py
+++ b/tests/utils_tests/test_timezone.py
@@ -26,9 +26,9 @@ if not HAS_PYTZ:
     CET = None
     PARIS_IMPLS = (PARIS_ZI,)
 
-    needs_pytx = unittest.skip("Test requires pytz")
+    needs_pytx = unittest.skip('Test requires pytz')
 else:
-    CET = pytz.timezone("Europe/Paris")
+    CET = pytz.timezone('Europe/Paris')
     PARIS_IMPLS = (PARIS_ZI, CET)
 
     def needs_pytx(f):
@@ -54,18 +54,6 @@ class TimezoneTests(SimpleTestCase):
     @override_settings(USE_DEPRECATED_PYTZ=True)
     def test_setting_allows_fallback_to_pytz(self):
         self.assertIsInstance(timezone.get_default_timezone(), pytz.BaseTzInfo)
-
-    @needs_pytx
-    @override_settings(USE_DEPRECATED_PYTZ=True)
-    def test_setting_allows_fallback_to_pytz_warning(self):
-        msg = (
-            "The USE_DEPRECATED_PYTZ setting, and support for pytz "
-            "timezones is deprecated in favor of the stdlib zoneinfo module."
-            " Please update your code to use zoneinfo and remove the "
-            "USE_DEPRECATED_PYTZ setting."
-        )
-        with self.assertRaisesMessage(RemovedInDjango50Warning, msg):
-            timezone.get_default_timezone()
 
     def test_now(self):
         with override_settings(USE_TZ=True):


### PR DESCRIPTION
Time to get moving on the migration to zoneinfo by default in Django 4.0

This PR is currently just a sketch to gather initial feedback and form the TODO list. 
First pass is very minimal. I've added a few TODO-like comments.

Some useful links: 

* https://github.com/django/django/pull/13073 @pganssle's Original PoC PR
* https://github.com/django/django/pull/13877 3.2 Allowed use of non-pytz timezone implementations. 
* https://groups.google.com/g/django-developers/c/PtIyadoC-fI/m/NxkYPSxnCAAJ Mailing list thread
* TRAC ticket-32365

On the thread, @aaugustin's [proposal to move straight to `zoneinfo` with a fallback setting](https://groups.google.com/g/django-developers/c/PtIyadoC-fI/m/X-LibUB9BQAJ). 

Swapping to `zonefinfo` and introducing the fallback setting has (locally) just a single failure in `migrations.test_writer.WriterTests.test_serialize_datetime` — looks like it will flex on whether we're using `backports.zoneinfo` or `zoneinfo`, but OK. 

There are **various** docs changes to make, but my main questions are around: 

* The exact migration advice. I've added bullet points to the release notes here. 
* Changes to setup.cfg to `install_requires`. 
* And then (hence) to what extent we tighten the `HAS_ZONEINFO` requirement for 4.0 (vs 5.0). 

@aaugustin @pganssle can I ask for initial input/comments along those lines? 
Thanks. 


----

My plan is to noodle[0] on this over the next couple of weeks. I'd add the obvious missing bits and begin on the docs. 

[0]: Technical term™


----

TODOs: 

- [ ] Settle whether we can use `datetime.timezone.utc`, rather than `ZoneInfo`. Discussion from https://github.com/django/django/pull/14669#issuecomment-896095164
- [x] Add tests for BaseDatabaseWrapper.timezone()
- [x] Make `pytz` imports conditional https://github.com/django/django/pull/14669#discussion_r673688483
- [x] Adjust `install_requires` https://github.com/django/django/pull/14669#pullrequestreview-713100093 — Test clean installs
- [ ] Adjust docs. ✍️ 