### PR TITLE
Add ModelAdmin.list_grouper_column

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -558,6 +558,7 @@ class ModelAdmin(BaseModelAdmin):
     list_per_page = 100
     list_max_show_all = 200
     list_editable = ()
+    list_grouper_column = None
     search_fields = ()
     search_help_text = None
     date_hierarchy = None
@@ -755,6 +756,7 @@ class ModelAdmin(BaseModelAdmin):
             self,
             sortable_by,
             self.search_help_text,
+            self.list_grouper_column,
         )
 
     def get_object(self, request, object_id, from_field=None):

--- a/django/contrib/admin/templates/admin/change_list_results.html
+++ b/django/contrib/admin/templates/admin/change_list_results.html
@@ -27,6 +27,17 @@
 </thead>
 <tbody>
 {% for result in results %}
+{% if cl.list_grouper_column and list_grouper_index %}
+{% ifchanged result|at:list_grouper_index %}
+<tr class="group_head">
+    <td style="padding-top: 5px; padding-bottom: 5px;" colspan="100%">
+        <div class="dropdown-toggle" style="font-weight: bold;">
+            {{ result|at:list_grouper_index|striptags }}
+        </div>
+    </td>
+</tr>
+{% endifchanged %}
+{% endif %}
 {% if result.form and result.form.non_field_errors %}
     <tr><td colspan="{{ result|length }}">{{ result.form.non_field_errors }}</td></tr>
 {% endif %}

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -297,15 +297,20 @@ def result_list(cl):
     """
     headers = list(result_headers(cl))
     num_sorted_fields = 0
-    for h in headers:
+    list_grouper_column = cl.list_grouper_column and cl.list_grouper_column.lower()
+    list_grouper_index = None
+    for i, h in enumerate(headers):
         if h['sortable'] and h['sorted']:
             num_sorted_fields += 1
+        if h['text'].lower() == list_grouper_column:
+            list_grouper_index = i
     return {
         'cl': cl,
         'result_hidden_fields': list(result_hidden_fields(cl)),
         'result_headers': headers,
         'num_sorted_fields': num_sorted_fields,
         'results': list(results(cl)),
+        'list_grouper_index': list_grouper_index,
     }
 
 

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -50,7 +50,7 @@ class ChangeList:
     def __init__(self, request, model, list_display, list_display_links,
                  list_filter, date_hierarchy, search_fields, list_select_related,
                  list_per_page, list_max_show_all, list_editable, model_admin, sortable_by,
-                 search_help_text):
+                 search_help_text, list_grouper_column):
         self.model = model
         self.opts = model._meta
         self.lookup_opts = self.opts
@@ -70,6 +70,7 @@ class ChangeList:
         self.preserved_filters = model_admin.get_preserved_filters(request)
         self.sortable_by = sortable_by
         self.search_help_text = search_help_text
+        self.list_grouper_column = list_grouper_column
 
         # Get search parameters from the query string.
         _search_form = self.search_form_class(request.GET)

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1047,6 +1047,13 @@ subclass::
     See the default template provided by Django (``admin/filter.html``) for
     a concrete example.
 
+.. attribute:: ModelAdmin.list_grouper_column
+
+    .. versionadded:: 4.0
+
+    Set ``list_grouper_column`` to specify a column name by which
+    to group objects.
+    
 .. attribute:: ModelAdmin.list_max_show_all
 
     Set ``list_max_show_all`` to control how many items can appear on a "Show

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -84,6 +84,9 @@ Minor features
 
 * The new :attr:`.ModelAdmin.search_help_text` attribute allows specifying a
   descriptive text for the search box.
+  
+* The new :attr:`.ModelAdmin.list_grouper_column` attribute allows specifying a
+  column by which objects will be grouped.
 
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -59,6 +59,7 @@ class FilteredChildAdmin(admin.ModelAdmin):
 
 class BandAdmin(admin.ModelAdmin):
     list_filter = ['genres']
+    list_grouper_column = 'genres'
 
 
 class NrOfMembersFilter(admin.SimpleListFilter):

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1351,6 +1351,13 @@ class ChangeListTests(TestCase):
         self.assertEqual(response.context_data['cl'].search_help_text, 'Search help text')
         self.assertContains(response, '<div class="help">Search help text</div>')
 
+    def test_list_grouper_column(self):
+        superuser = self._create_superuser('superuser')
+        m = BandAdmin(Band, custom_site)
+        request = self._mocked_authenticated_request('/band/', superuser)
+        response = m.changelist_view(request)
+        self.assertEqual(response.context_data['cl'].list_grouper_column, 'genres')
+
 
 class GetAdminLogTests(TestCase):
 


### PR DESCRIPTION
Add the ability to group rows which share the same value in the given column.

For ex.:
```
class PersonAdmin(ModelAdmin):
    list_display = ('firstname', 'lastname', 'age')
    ordering = ('lastname', 'firstname')
    list_grouper_column = 'lastname'
```

People will ordered by family name, and a separator row will be inserted between each family, enabling to distinguish families from each other easily.