### PR TITLE
Fixed #25264 -- Allowed suppressing base command options in --help output.

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -27,6 +27,7 @@ class Command(BaseCommand):
     # Validation is called explicitly each time the server is reloaded.
     requires_system_checks = []
     stealth_options = ('shutdown_message',)
+    suppressed_base_arguments = {'--verbosity', '--traceback'}
 
     default_addr = '127.0.0.1'
     default_addr_ipv6 = '::1'

--- a/docs/howto/custom-management-commands.txt
+++ b/docs/howto/custom-management-commands.txt
@@ -242,6 +242,14 @@ All attributes can be set in your derived class and can be used in
     If you pass the :option:`--no-color` option when running your command, all
     ``self.style()`` calls will return the original string uncolored.
 
+.. attribute:: BaseCommand.suppressed_base_arguments
+
+    .. versionadded:: 4.0
+
+    The default command options to suppress in the help output. This should be
+    a set of option names (e.g. ``'--verbosity'``). The default values for the
+    suppressed options are still passed.
+
 Methods
 -------
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -76,8 +76,8 @@ Displaying debug output
 
 .. program:: None
 
-Use :option:`--verbosity` to specify the amount of notification and debug
-information that ``django-admin`` prints to the console.
+Use :option:`--verbosity`, where it is supported, to specify the amount of
+notification and debug information that ``django-admin`` prints to the console.
 
 Available commands
 ==================
@@ -1796,7 +1796,7 @@ Default options
 .. program:: None
 
 Although some commands may allow their own custom options, every command
-allows for the following options:
+allows for the following options by default:
 
 .. django-admin-option:: --pythonpath PYTHONPATH
 
@@ -1833,6 +1833,8 @@ Displays a full stack trace when a :exc:`~django.core.management.CommandError`
 is raised. By default, ``django-admin`` will show an error message when a
 ``CommandError`` occurs and a full stack trace for any other exception.
 
+This option is ignored by :djadmin:`runserver`.
+
 Example usage::
 
     django-admin migrate --traceback
@@ -1846,6 +1848,8 @@ should print to the console.
 * ``1`` means normal output (default).
 * ``2`` means verbose output.
 * ``3`` means *very* verbose output.
+
+This option is ignored by :djadmin:`runserver`.
 
 Example usage::
 

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -274,6 +274,10 @@ Management Commands
   As a consequence, ``readline`` is no longer loaded if running in *isolated*
   mode.
 
+* The new :attr:`BaseCommand.suppressed_base_arguments
+  <django.core.management.BaseCommand.suppressed_base_arguments>` attribute
+  allows suppressing unsupported default command options in the help output.
+
 Migrations
 ~~~~~~~~~~
 

--- a/tests/admin_scripts/management/commands/suppress_base_options_command.py
+++ b/tests/admin_scripts/management/commands/suppress_base_options_command.py
@@ -1,0 +1,24 @@
+from django.core.management import BaseCommand
+
+
+class Command(BaseCommand):
+
+    help = 'Test suppress base options command.'
+    requires_system_checks = []
+    suppressed_base_arguments = {
+        '-v',
+        '--traceback',
+        '--settings',
+        '--pythonpath',
+        '--no-color',
+        '--force-color',
+        '--version',
+        'file',
+    }
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        self.add_base_argument(parser, 'file', nargs='?', help='input file')
+
+    def handle(self, *labels, **options):
+        print('EXECUTE:SuppressBaseOptionsCommand options=%s' % sorted(options.items()))

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1496,6 +1496,31 @@ class CommandTypes(AdminScriptTestCase):
         self.assertLess(tag_location, version_location)
         self.assertOutput(out, "Checks the entire Django project for potential problems.")
 
+    def test_help_default_options_with_custom_arguments(self):
+        args = ['base_command', '--help']
+        out, err = self.run_manage(args)
+        self.assertNoOutput(err)
+        expected_options = [
+            '-h',
+            '--option_a OPTION_A',
+            '--option_b OPTION_B',
+            '--option_c OPTION_C',
+            '--version',
+            '-v {0,1,2,3}',
+            '--settings SETTINGS',
+            '--pythonpath PYTHONPATH',
+            '--traceback',
+            '--no-color',
+            '--force-color',
+            'args ...',
+        ]
+        for option in expected_options:
+            self.assertOutput(out, f'[{option}]')
+        self.assertOutput(out, '--option_a OPTION_A, -a OPTION_A')
+        self.assertOutput(out, '--option_b OPTION_B, -b OPTION_B')
+        self.assertOutput(out, '--option_c OPTION_C, -c OPTION_C')
+        self.assertOutput(out, '-v {0,1,2,3}, --verbosity {0,1,2,3}')
+
     def test_color_style(self):
         style = color.no_style()
         self.assertEqual(style.ERROR('Hello, world!'), 'Hello, world!')

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1381,6 +1381,15 @@ class ManageRunserverEmptyAllowedHosts(AdminScriptTestCase):
         self.assertOutput(err, 'CommandError: You must set settings.ALLOWED_HOSTS if DEBUG is False.')
 
 
+class ManageRunserverHelpOutput(AdminScriptTestCase):
+    def test_suppressed_options(self):
+        """runserver doesn't support --verbosity and --trackback options."""
+        out, err = self.run_manage(['runserver', '--help'])
+        self.assertNotInOutput(out, '--verbosity')
+        self.assertNotInOutput(out, '--trackback')
+        self.assertOutput(out, '--settings')
+
+
 class ManageTestserver(SimpleTestCase):
 
     @mock.patch.object(TestserverCommand, 'handle', return_value='')
@@ -1845,6 +1854,34 @@ class CommandTypes(AdminScriptTestCase):
             "EXECUTE:LabelCommand label=anotherlabel, options=[('force_color', "
             "False), ('no_color', False), ('pythonpath', None), "
             "('settings', None), ('traceback', False), ('verbosity', 1)]"
+        )
+
+    def test_suppress_base_options_command_help(self):
+        args = ['suppress_base_options_command', '--help']
+        out, err = self.run_manage(args)
+        self.assertNoOutput(err)
+        self.assertOutput(out, 'Test suppress base options command.')
+        self.assertNotInOutput(out, 'input file')
+        self.assertOutput(out, '-h, --help')
+        self.assertNotInOutput(out, '--version')
+        self.assertNotInOutput(out, '--verbosity')
+        self.assertNotInOutput(out, '-v {0,1,2,3}')
+        self.assertNotInOutput(out, '--settings')
+        self.assertNotInOutput(out, '--pythonpath')
+        self.assertNotInOutput(out, '--traceback')
+        self.assertNotInOutput(out, '--no-color')
+        self.assertNotInOutput(out, '--force-color')
+
+    def test_suppress_base_options_command_defaults(self):
+        args = ['suppress_base_options_command']
+        out, err = self.run_manage(args)
+        self.assertNoOutput(err)
+        self.assertOutput(
+            out,
+            "EXECUTE:SuppressBaseOptionsCommand options=[('file', None), "
+            "('force_color', False), ('no_color', False), "
+            "('pythonpath', None), ('settings', None), "
+            "('traceback', False), ('verbosity', 1)]"
         )
 
 


### PR DESCRIPTION
Fixed #25264 - Disabled unnecessary options for runserver command

It is both fix an a feature.
I added new attribute to BaseCommand - disabled_default_arguments, which stores
the list of options, which ad default are always enabled and should be disabled for 
specific command like eg runserver.

This feature allows cleaning the command interface and avoid documentation
mentioning that particular option is unnecessary. When it is not needed it should
not be even allowed, which is more clearer approach imo.

Thanks to @uniglot and @felixxm for suggestions in #14612.