### PR TITLE
chore: remove unused arguments

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -68,7 +68,7 @@ class Q(tree.Node):
         obj.negate()
         return obj
 
-    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
+    def resolve_expression(self, query=None, allow_joins=True, reuse=None):
         # We must promote any new joins to left outer joins so that when Q is
         # used as an expression, rows aren't filtered due to joins.
         clause, joins = query._add_q(


### PR DESCRIPTION
These arguments are not used anyhow in Q.resolve_expression, so why to keep it there?