### PR TITLE
Refs #32956 -- Lowercased "internet" and "email" where appropriate.

### DIFF
--- a/docs/howto/deployment/checklist.txt
+++ b/docs/howto/deployment/checklist.txt
@@ -2,7 +2,7 @@
 Deployment checklist
 ====================
 
-The Internet is a hostile environment. Before deploying your Django project,
+The internet is a hostile environment. Before deploying your Django project,
 you should take some time to review your settings, with security, performance,
 and operations in mind.
 

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -123,7 +123,7 @@ Filtering error reports
     Filtering sensitive data is a hard problem, and it's nearly impossible to
     guarantee that sensitive data won't leak into an error report. Therefore,
     error reports should only be available to trusted team members and you
-    should avoid transmitting error reports unencrypted over the Internet
+    should avoid transmitting error reports unencrypted over the internet
     (such as through email).
 
 Filtering sensitive information

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -1097,7 +1097,7 @@ details on these changes.
 * The ``django.contrib.gis.db.backend`` module will be removed in favor
   of the specific backends.
 
-* ``SMTPConnection`` will be removed in favor of a generic Email backend API.
+* ``SMTPConnection`` will be removed in favor of a generic email backend API.
 
 * The many to many SQL generation functions on the database backends
   will be removed.


### PR DESCRIPTION
The change for "web" is large and I need to spend more time working on and reviewing that piece of work

However, changes for some other words are much smaller. 

- Email: The writing docs already recomneds the spelling of "email" (no hypen)
- Internet: Potentially a little more divisisive but the AP Stylebook recomends the lowercased spelling of this word. 

FYI -- I've purchased a copy of the stylebook, so let me know if you need more evidence than just my say so 👍 