### PR TITLE
Fixed #32946 -- Changed internal usage of dynamic Q() objects construction to use non-kwargs initialization. 

### DIFF
--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -451,11 +451,12 @@ class EmptyFieldListFilter(FieldListFilter):
         if self.lookup_val not in ('0', '1'):
             raise IncorrectLookupParameters
 
-        lookup_condition = models.Q()
+        lookup_conditions = []
         if self.field.empty_strings_allowed:
-            lookup_condition |= models.Q(**{self.field_path: ''})
+            lookup_conditions.append((self.field_path, ''))
         if self.field.null:
-            lookup_condition |= models.Q(**{'%s__isnull' % self.field_path: True})
+            lookup_conditions.append((f'{self.field_path}__isnull', True))
+        lookup_condition = models.Q(*lookup_conditions, _connector=models.Q.OR)
         if self.lookup_val == '1':
             return queryset.filter(lookup_condition)
         return queryset.exclude(lookup_condition)

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -971,8 +971,8 @@ class Model(metaclass=ModelBase):
         op = 'gt' if is_next else 'lt'
         order = '' if is_next else '-'
         param = getattr(self, field.attname)
-        q = Q(**{'%s__%s' % (field.name, op): param})
-        q = q | Q(**{field.name: param, 'pk__%s' % op: self.pk})
+        q = Q((field.name, param), (f'pk__{op}', self.pk), _connector=Q.AND)
+        q = Q(q, (f'{field.name}__{op}', param), _connector=Q.OR)
         qs = self.__class__._default_manager.using(self._state.db).filter(**kwargs).filter(q).order_by(
             '%s%s' % (order, field.name), '%spk' % order
         )

--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -1,6 +1,5 @@
-import operator
 from collections import Counter, defaultdict
-from functools import partial, reduce
+from functools import partial
 from itertools import chain
 from operator import attrgetter
 
@@ -347,10 +346,13 @@ class Collector:
         """
         Get a QuerySet of the related model to objs via related fields.
         """
-        predicate = reduce(operator.or_, (
-            query_utils.Q(**{'%s__in' % related_field.name: objs})
-            for related_field in related_fields
-        ))
+        predicate = query_utils.Q(
+            *(
+                (f'{related_field.name}__in', objs)
+                for related_field in related_fields
+            ),
+            _connector=query_utils.Q.OR,
+        )
         return related_model._base_manager.using(self.using).filter(predicate)
 
     def instances_with_model(self):

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -359,12 +359,12 @@ class RelatedField(FieldCacheMixin, Field):
         select all instances of self.related_field.model related through
         this field to obj. obj is an instance of self.model.
         """
-        base_filter = {
-            rh_field.attname: getattr(obj, lh_field.attname)
+        base_filter = (
+            (rh_field.attname, getattr(obj, lh_field.attname))
             for lh_field, rh_field in self.related_fields
-        }
+        )
         descriptor_filter = self.get_extra_descriptor_filter(obj)
-        base_q = Q(**base_filter)
+        base_q = Q(*base_filter)
         if isinstance(descriptor_filter, dict):
             return base_q & Q(**descriptor_filter)
         elif descriptor_filter:

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -866,18 +866,17 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
         do_not_call_in_templates = True
 
         def _build_remove_filters(self, removed_vals):
-            filters = Q(**{self.source_field_name: self.related_val})
+            filters = Q((self.source_field_name, self.related_val))
             # No need to add a subquery condition if removed_vals is a QuerySet without
             # filters.
             removed_vals_filters = (not isinstance(removed_vals, QuerySet) or
                                     removed_vals._has_filters())
             if removed_vals_filters:
-                filters &= Q(**{'%s__in' % self.target_field_name: removed_vals})
+                filters &= Q((f'{self.target_field_name}__in', removed_vals))
             if self.symmetrical:
-                symmetrical_filters = Q(**{self.target_field_name: self.related_val})
+                symmetrical_filters = Q((self.target_field_name, self.related_val))
                 if removed_vals_filters:
-                    symmetrical_filters &= Q(
-                        **{'%s__in' % self.source_field_name: removed_vals})
+                    symmetrical_filters &= Q((f'{self.source_field_name}__in', removed_vals))
                 filters |= symmetrical_filters
             return filters
 

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -516,6 +516,10 @@ Miscellaneous
   ``ForeignObject`` and ``ForeignObjectRel`` are removed. If needed, initialize
   ``django.db.models.sql.where.WhereNode`` instead.
 
+* The ``filter_clause`` argument of the undocumented ``Query.add_filter()``
+  method is replaced by two positional arguments ``filter_lhs`` and
+  ``filter_rhs``.
+
 .. _deprecated-features-4.0:
 
 Features deprecated in 4.0


### PR DESCRIPTION
[Ticket is 32946](https://code.djangoproject.com/ticket/32946).
Changes a bunch of internal usages of `Q()` to prefer `Q(('a', 1))` instead of `Q(a=1)` for consistency (eg: internally `split_exclude` already does the same thing) and for performance of dynamic generation of them (eg: for creating a long list of `x = 1 OR y = 2 OR z = 3` without many intermediate `Q` objects being combined)

I've avoided (hopefully) touching internal usages that might be considered semi-user-facing, such as `ModelBackend.with_perm`, the migration `0011_update_proxy_permissions.py`, `When(...)`, descriptor filter when it's a dict, `limit_choices_to` when it's a dict ... etc. 
For those where it _could_ be changed (eg: `ModelBackend.with_perm`) I'll happily do so if requested.

Along the way I've removed the `add_filter` method. It can come back if desired, but it had been simplified over the years to the point of being a needless wrapper IMHO. YMMV.

```
Ran 14892 tests in 508.389s
OK (skipped=1193, expected failures=4)
```