### PR TITLE
Refs #32743 -- Fixed recreation of foreign key constraints when altering type of referenced primary key with MTI.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -483,6 +483,7 @@ answer newbie questions, and generally made Django that much better:
     Jonathan Daugherty (cygnus) <http://www.cprogrammer.org/>
     Jonathan Feignberg <jdf@pobox.com>
     Jonathan Slenders
+    Jordan Bae <qoentlr37@gmail.com>
     Jordan Dimov <s3x3y1@gmail.com>
     Jordi J. Tablada <jordi.joan@gmail.com>
     Jorge Bastida <me@jorgebastida.com>

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -849,8 +849,8 @@ class BaseDatabaseSchemaEditor:
             self.execute(self._create_fk_sql(model, new_field, "_fk_%(to_table)s_%(to_column)s"))
         # Rebuild FKs that pointed to us if we previously had to drop them
         if drop_foreign_keys:
-            for rel in new_field.model._meta.related_objects:
-                if _is_relevant_relation(rel, new_field) and rel.field.db_constraint:
+            for _, rel in rels_to_update:
+                if rel.field.db_constraint:
                     self.execute(self._create_fk_sql(rel.related_model, rel.field, "_fk"))
         # Does it have check constraints we need to add?
         if old_db_params['check'] != new_db_params['check'] and new_db_params['check']:

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1551,10 +1551,32 @@ class OperationTests(OperationTestBase):
         with connection.schema_editor() as editor:
             operation.database_forwards(app_label, editor, project_state, new_state)
         assertIdTypeEqualsMTIFkType()
+        if connection.features.supports_foreign_keys:
+            self.assertFKExists(
+                f'{app_label}_shetlandpony',
+                ['pony_ptr_id'],
+                (f'{app_label}_pony', 'id'),
+            )
+            self.assertFKExists(
+                f'{app_label}_shetlandrider',
+                ['pony_id'],
+                (f'{app_label}_shetlandpony', 'pony_ptr_id'),
+            )
         # Reversal.
         with connection.schema_editor() as editor:
             operation.database_backwards(app_label, editor, new_state, project_state)
         assertIdTypeEqualsMTIFkType()
+        if connection.features.supports_foreign_keys:
+            self.assertFKExists(
+                f'{app_label}_shetlandpony',
+                ['pony_ptr_id'],
+                (f'{app_label}_pony', 'id'),
+            )
+            self.assertFKExists(
+                f'{app_label}_shetlandrider',
+                ['pony_id'],
+                (f'{app_label}_shetlandpony', 'pony_ptr_id'),
+            )
 
     @skipUnlessDBFeature('supports_foreign_keys')
     def test_alter_field_reloads_state_on_fk_with_to_field_target_type_change(self):


### PR DESCRIPTION
Hi, about this ticket https://code.djangoproject.com/ticket/32743, David made fix and it was merged. https://github.com/django/django/pull/14691

I think we missed remaking foreign key about MTI.
I added small fix.

my expectation is  django migrate makes below SQL.
```
ALTER TABLE `blog_child` DROP FOREIGN KEY `blog_child_parent_ptr_id_7d90b142_fk_blog_parent_id`
ALTER TABLE `blog_mainmodel` DROP FOREIGN KEY `blog_mainmodel_child_id_3ddf4948_fk_blog_child_parent_ptr_id`
ALTER TABLE `blog_parent` MODIFY `id` bigint AUTO_INCREMENT NOT NULL
ALTER TABLE `blog_child` MODIFY `parent_ptr_id` bigint NOT NULL
ALTER TABLE `blog_mainmodel` MODIFY `child_id` bigint NOT NULL
ALTER TABLE `blog_child` ADD CONSTRAINT `blog_child_parent_ptr_id_7d90b142_fk` FOREIGN KEY (`parent_ptr_id`) REFERENCES `blog_parent` (`id`)
ALTER TABLE `blog_mainmodel` ADD CONSTRAINT `blog_mainmodel_child_id_3ddf4948_fk_blog_child_parent_ptr_id` FOREIGN KEY (`child_id`) REFERENCES `blog_child` (`parent_ptr_id`);
```

current code makes below SQL.
```
ALTER TABLE `blog_child` DROP FOREIGN KEY `blog_child_parent_ptr_id_7d90b142_fk_blog_parent_id`
ALTER TABLE `blog_mainmodel` DROP FOREIGN KEY `blog_mainmodel_child_id_3ddf4948_fk_blog_child_parent_ptr_id`
ALTER TABLE `blog_parent` MODIFY `id` bigint AUTO_INCREMENT NOT NULL
ALTER TABLE `blog_child` MODIFY `parent_ptr_id` bigint NOT NULL
ALTER TABLE `blog_mainmodel` MODIFY `child_id` bigint NOT NULL
ALTER TABLE `blog_child` ADD CONSTRAINT `blog_child_parent_ptr_id_7d90b142_fk` FOREIGN KEY (`parent_ptr_id`) REFERENCES `blog_parent` (`id`)
```

I added a list that saves dropped foreign keys and then remakes using that list.
If you think we need some fix or something, please know me.