### PR TITLE
Refs #32956 -- Changed "afterwards" to "afterward" in docs and comments.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -156,7 +156,7 @@ class BaseDatabaseSchemaEditor:
     def table_sql(self, model):
         """Take a model and return its table definition."""
         # Add any unique_togethers (always deferred, as some fields might be
-        # created afterwards, like geometry fields with some backends).
+        # created afterward, like geometry fields with some backends).
         for field_names in model._meta.unique_together:
             fields = [model._meta.get_field(field) for field in field_names]
             self.deferred_sql.append(self._create_unique_sql(model, fields))

--- a/django/db/migrations/graph.py
+++ b/django/db/migrations/graph.py
@@ -100,7 +100,7 @@ class MigrationGraph:
         """
         This may create dummy nodes if they don't yet exist. If
         `skip_validation=True`, validate_consistency() should be called
-        afterwards.
+        afterward.
         """
         if child not in self.nodes:
             error_message = (

--- a/docs/howto/custom-lookups.txt
+++ b/docs/howto/custom-lookups.txt
@@ -132,7 +132,7 @@ We can now run the queries we had before.
     SELECT ... WHERE ABS("experiments"."change") = 27
 
 By using ``Transform`` instead of ``Lookup`` it means we are able to chain
-further lookups afterwards. So
+further lookups afterward. So
 ``Experiment.objects.filter(change__abs__lt=27)`` will generate the following
 SQL:
 

--- a/docs/howto/upgrade-version.txt
+++ b/docs/howto/upgrade-version.txt
@@ -21,7 +21,7 @@ Required Reading
 If it's your first time doing an upgrade, it is useful to read the :doc:`guide
 on the different release processes </internals/release-process>`.
 
-Afterwards, you should familiarize yourself with the changes that were made in
+Afterward, you should familiarize yourself with the changes that were made in
 the new Django version(s):
 
 * Read the :doc:`release notes </releases/index>` for each 'final' release from

--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -80,7 +80,7 @@ The documentation is organized into several categories:
   understands what we're trying to achieve. Don't feel that you need to begin
   with explanations of how things work - what matters is what the reader does,
   not what you explain. It can be helpful to refer back to what you've done and
-  explain afterwards.
+  explain afterward.
 
 * :doc:`Topic guides </topics/index>` aim to explain a concept or subject at a
   fairly high level.

--- a/docs/ref/contrib/gis/install/index.txt
+++ b/docs/ref/contrib/gis/install/index.txt
@@ -292,7 +292,7 @@ Download the framework packages for:
 Install the packages in the order they are listed above, as the GDAL and SQLite
 packages require the packages listed before them.
 
-Afterwards, you can also install the KyngChaos binary packages for `PostgreSQL
+Afterward, you can also install the KyngChaos binary packages for `PostgreSQL
 and PostGIS`__.
 
 After installing the binary packages, you'll want to add the following to

--- a/docs/ref/contrib/gis/tutorial.txt
+++ b/docs/ref/contrib/gis/tutorial.txt
@@ -471,7 +471,7 @@ A few notes about what's going on:
 * The ``transform`` keyword is set to ``False`` because the data in the
   shapefile does not need to be converted -- it's already in WGS84 (SRID=4326).
 
-Afterwards, invoke the Django shell from the ``geodjango`` project directory:
+Afterward, invoke the Django shell from the ``geodjango`` project directory:
 
 .. console::
 

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -182,7 +182,7 @@ the SQL operator ``&&``. For example::
 ``len``
 ~~~~~~~
 
-Returns the length of the array. The lookups available afterwards are those
+Returns the length of the array. The lookups available afterward are those
 available for :class:`~django.db.models.IntegerField`. For example::
 
     >>> Post.objects.create(name='First post', tags=['thoughts', 'django'])

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -295,7 +295,7 @@ cause a conflict. For example::
     IntegrityError: duplicate key value violates unique constraint
     "auth_user_pkey" DETAIL:  Key (id)=(1) already exists.
 
-If you need to specify such values, reset the sequence afterwards to avoid
+If you need to specify such values, reset the sequence afterward to avoid
 reusing a value that's already in the table. The :djadmin:`sqlsequencereset`
 management command generates the SQL statements to do that.
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -559,7 +559,7 @@ Miscellaneous
 
 * Assigning a value to a model's :class:`~django.db.models.ForeignKey` or
   :class:`~django.db.models.OneToOneField` ``'_id'`` attribute now unsets the
-  corresponding field. Accessing the field afterwards will result in a query.
+  corresponding field. Accessing the field afterward will result in a query.
 
 * :func:`~django.utils.cache.patch_vary_headers` now handles an asterisk
   ``'*'`` according to :rfc:`7231#section-7.1.4`, i.e. if a list of header

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -420,7 +420,7 @@ The email backend class has the following methods:
 * ``send_messages(email_messages)`` sends a list of
   :class:`~django.core.mail.EmailMessage` objects. If the connection is
   not open, this call will implicitly open the connection, and close the
-  connection afterwards. If the connection is already open, it will be
+  connection afterward. If the connection is already open, it will be
   left open after mail has been sent.
 
 It can also be used as a context manager, which will automatically call

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -201,7 +201,7 @@ migration will contain a dependency on a migration in ``authors``.
 
 This means that when you run the migrations, the ``authors`` migration runs
 first and creates the table the ``ForeignKey`` references, and then the migration
-that makes the ``ForeignKey`` column runs afterwards and creates the constraint.
+that makes the ``ForeignKey`` column runs afterward and creates the constraint.
 If this didn't happen, the migration would try to create the ``ForeignKey``
 column without the table it's referencing existing and your database would
 throw an error.

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1260,7 +1260,7 @@ Django provides a standard Python context manager (see :pep:`343`) called
                 self.assertRedirects(response, '/other/login/?next=/sekrit/')
 
 This example will override the :setting:`LOGIN_URL` setting for the code
-in the ``with`` block and reset its value to the previous state afterwards.
+in the ``with`` block and reset its value to the previous state afterward.
 
 .. method:: SimpleTestCase.modify_settings()
 

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -310,7 +310,7 @@ class StateTests(SimpleTestCase):
     def test_apps_bulk_update(self):
         """
         StateApps.bulk_update() should update apps.ready to False and reset
-        the value afterwards.
+        the value afterward.
         """
         project_state = ProjectState()
         apps = project_state.apps

--- a/tests/null_fk_ordering/tests.py
+++ b/tests/null_fk_ordering/tests.py
@@ -34,7 +34,7 @@ class NullFkOrderingTests(TestCase):
         Comment.objects.create(post=p2, comment_text='Another second comment')
 
         # We have to test this carefully. Some databases sort NULL values before
-        # everything else, some sort them afterwards. So we extract the ordered list
+        # everything else, some sort them afterward. So we extract the ordered list
         # and check the length. Before the fix, this list was too short (some values
         # were omitted).
         self.assertEqual(len(list(Comment.objects.all())), 4)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -520,7 +520,6 @@ class SchemaTests(TransactionTestCase):
             'column': editor.quote_name(new_field.name),
         }
         self.assertFalse(any(drop_default_sql in query['sql'] for query in ctx.captured_queries))
-        # Ensure the field is right afterwards
         columns = self.column_classes(Author)
         self.assertEqual(columns['age'][0], connection.features.introspected_field_types['IntegerField'])
         self.assertTrue(columns['age'][1][6])
@@ -554,7 +553,6 @@ class SchemaTests(TransactionTestCase):
         new_field.set_attributes_from_name("surname")
         with connection.schema_editor() as editor:
             editor.add_field(Author, new_field)
-        # Ensure the field is right afterwards
         columns = self.column_classes(Author)
         self.assertEqual(columns['surname'][0], connection.features.introspected_field_types['CharField'])
         self.assertEqual(columns['surname'][1][6],
@@ -579,7 +577,6 @@ class SchemaTests(TransactionTestCase):
         new_field.set_attributes_from_name("awesome")
         with connection.schema_editor() as editor:
             editor.add_field(Author, new_field)
-        # Ensure the field is right afterwards
         columns = self.column_classes(Author)
         # BooleanField are stored as TINYINT(1) on MySQL.
         field_type = columns['awesome'][0]
@@ -632,7 +629,6 @@ class SchemaTests(TransactionTestCase):
         new_field.set_attributes_from_name("bits")
         with connection.schema_editor() as editor:
             editor.add_field(Author, new_field)
-        # Ensure the field is right afterwards
         columns = self.column_classes(Author)
         # MySQL annoyingly uses the same backend, so it'll come back as one of
         # these two types.
@@ -672,7 +668,6 @@ class SchemaTests(TransactionTestCase):
         new_field.set_attributes_from_name("name")
         with connection.schema_editor() as editor:
             editor.alter_field(Author, old_field, new_field, strict=True)
-        # Ensure the field is right afterwards
         columns = self.column_classes(Author)
         self.assertEqual(columns['name'][0], "TextField")
         self.assertTrue(columns['name'][1][6])
@@ -681,7 +676,6 @@ class SchemaTests(TransactionTestCase):
         new_field2.set_attributes_from_name("name")
         with connection.schema_editor() as editor:
             editor.alter_field(Author, new_field, new_field2, strict=True)
-        # Ensure the field is right afterwards
         columns = self.column_classes(Author)
         self.assertEqual(columns['name'][0], "TextField")
         self.assertEqual(bool(columns['name'][1][6]), bool(connection.features.interprets_empty_strings_as_nulls))
@@ -907,7 +901,6 @@ class SchemaTests(TransactionTestCase):
         new_field.set_attributes_from_name("height")
         with connection.schema_editor() as editor:
             editor.alter_field(Author, old_field, new_field, strict=True)
-        # Ensure the field is right afterwards
         columns = self.column_classes(Author)
         self.assertFalse(columns['height'][1][6])
         # Verify default value
@@ -1045,7 +1038,6 @@ class SchemaTests(TransactionTestCase):
         new_field.set_attributes_from_name("height")
         with connection.schema_editor() as editor:
             editor.alter_field(AuthorWithDefaultHeight, old_field, new_field, strict=True)
-        # Ensure the field is right afterwards
         columns = self.column_classes(AuthorWithDefaultHeight)
         self.assertFalse(columns['height'][1][6])
 
@@ -1068,7 +1060,6 @@ class SchemaTests(TransactionTestCase):
         new_field.set_attributes_from_name("author")
         with connection.schema_editor() as editor:
             editor.alter_field(Book, old_field, new_field, strict=True)
-        # Ensure the field is right afterwards
         columns = self.column_classes(Book)
         self.assertEqual(columns['author_id'][0], connection.features.introspected_field_types['IntegerField'])
         self.assertForeignKeyExists(Book, 'author_id', 'schema_author')
@@ -1130,7 +1121,6 @@ class SchemaTests(TransactionTestCase):
         new_field.set_attributes_from_name("author")
         with connection.schema_editor() as editor:
             editor.alter_field(BookWithO2O, old_field, new_field, strict=True)
-        # Ensure the field is right afterwards
         columns = self.column_classes(Book)
         self.assertEqual(columns['author_id'][0], connection.features.introspected_field_types['IntegerField'])
         # Ensure the field is not unique anymore
@@ -1162,7 +1152,6 @@ class SchemaTests(TransactionTestCase):
         new_field.set_attributes_from_name("author")
         with connection.schema_editor() as editor:
             editor.alter_field(Book, old_field, new_field, strict=True)
-        # Ensure the field is right afterwards
         columns = self.column_classes(BookWithO2O)
         self.assertEqual(columns['author_id'][0], connection.features.introspected_field_types['IntegerField'])
         # Ensure the field is unique now
@@ -1523,7 +1512,6 @@ class SchemaTests(TransactionTestCase):
         new_field.set_attributes_from_name("display_name")
         with connection.schema_editor() as editor:
             editor.alter_field(Author, old_field, new_field, strict=True)
-        # Ensure the field is right afterwards
         columns = self.column_classes(Author)
         self.assertEqual(columns['display_name'][0], connection.features.introspected_field_types['CharField'])
         self.assertNotIn("name", columns)
@@ -2603,7 +2591,6 @@ class SchemaTests(TransactionTestCase):
         # Alter the table
         with connection.schema_editor(atomic=connection.features.supports_atomic_references_rename) as editor:
             editor.alter_db_table(Author, "schema_author", "schema_otherauthor")
-        # Ensure the table is there afterwards
         Author._meta.db_table = "schema_otherauthor"
         columns = self.column_classes(Author)
         self.assertEqual(columns['name'][0], connection.features.introspected_field_types['CharField'])

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -324,7 +324,7 @@ class CreateDefaultSiteTests(TestCase):
         create_default_site(self.app_config, verbosity=0)
         self.assertEqual(Site.objects.get().pk, 35696)
 
-    @override_settings()  # Restore original ``SITE_ID`` afterwards.
+    @override_settings()  # Restore original ``SITE_ID`` afterward.
     def test_no_site_id(self):
         """
         #24488 - The pk should default to 1 if no ``SITE_ID`` is configured.

--- a/tests/template_tests/filter_tests/test_urlize.py
+++ b/tests/template_tests/filter_tests/test_urlize.py
@@ -313,28 +313,28 @@ class FunctionTests(SimpleTestCase):
         #20364 - Check urlize correctly include quotation marks in links
         """
         self.assertEqual(
-            urlize('before "hi@example.com" afterwards', autoescape=False),
-            'before "<a href="mailto:hi@example.com">hi@example.com</a>" afterwards',
+            urlize('before "hi@example.com" afterward', autoescape=False),
+            'before "<a href="mailto:hi@example.com">hi@example.com</a>" afterward',
         )
         self.assertEqual(
-            urlize('before hi@example.com" afterwards', autoescape=False),
-            'before <a href="mailto:hi@example.com">hi@example.com</a>" afterwards',
+            urlize('before hi@example.com" afterward', autoescape=False),
+            'before <a href="mailto:hi@example.com">hi@example.com</a>" afterward',
         )
         self.assertEqual(
-            urlize('before "hi@example.com afterwards', autoescape=False),
-            'before "<a href="mailto:hi@example.com">hi@example.com</a> afterwards',
+            urlize('before "hi@example.com afterward', autoescape=False),
+            'before "<a href="mailto:hi@example.com">hi@example.com</a> afterward',
         )
         self.assertEqual(
-            urlize('before \'hi@example.com\' afterwards', autoescape=False),
-            'before \'<a href="mailto:hi@example.com">hi@example.com</a>\' afterwards',
+            urlize('before \'hi@example.com\' afterward', autoescape=False),
+            'before \'<a href="mailto:hi@example.com">hi@example.com</a>\' afterward',
         )
         self.assertEqual(
-            urlize('before hi@example.com\' afterwards', autoescape=False),
-            'before <a href="mailto:hi@example.com">hi@example.com</a>\' afterwards',
+            urlize('before hi@example.com\' afterward', autoescape=False),
+            'before <a href="mailto:hi@example.com">hi@example.com</a>\' afterward',
         )
         self.assertEqual(
-            urlize('before \'hi@example.com afterwards', autoescape=False),
-            'before \'<a href="mailto:hi@example.com">hi@example.com</a> afterwards',
+            urlize('before \'hi@example.com afterward', autoescape=False),
+            'before \'<a href="mailto:hi@example.com">hi@example.com</a> afterward',
         )
 
     def test_quote_commas(self):


### PR DESCRIPTION
AP Stylebook has a short entry to advise the preferred spelling for `en-us`.
Afterwards is preferred in British English.