### PR TITLE
Fixed #32970 -- Changed WhereNode.clone() to create a shallow copy of children.

### DIFF
--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -146,12 +146,9 @@ class WhereNode(tree.Node):
         value) tuples, or objects supporting .clone().
         """
         clone = self.__class__._new_instance(
-            children=[], connector=self.connector, negated=self.negated)
-        for child in self.children:
-            if hasattr(child, 'clone'):
-                clone.children.append(child.clone())
-            else:
-                clone.children.append(child)
+            children=None, connector=self.connector, negated=self.negated,
+        )
+        clone.children = self.children[:]
         return clone
 
     def relabeled_clone(self, change_map):


### PR DESCRIPTION
~There is no ticket for this, and there may not be one. Please don't actively consider this :)~

~I'm just trying to find out what bits could break if something like this were attempted. All the tests pass locally, but that just means the failures might be in the more exotic ends of the suite. I'll close it down if it errors (highly likely) or open a ticket for further discussion if it doesn't.~

[Ticket is 32970](https://code.djangoproject.com/ticket/32970).

Testing the hypothesis I was mulling over in this comment: https://github.com/django/django/pull/14673#discussion_r673938568

```
Ran 14892 tests in 478.994s
OK (skipped=1193, expected failures=4)
```