### PR TITLE
Clarified URL patterns in tutorial 3.

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -121,8 +121,8 @@ like so::
 
 The ``question_id=34`` part comes from ``<int:question_id>``. Using angle
 brackets "captures" part of the URL and sends it as a keyword argument to the
-view function. The ``question_id>`` part of the string defines the name that
-will be used to identify the matched pattern, and the ``<int`` part is a
+view function. The ``question_id`` part of the string defines the name that
+will be used to identify the matched pattern, and the ``int`` part is a
 converter that determines what patterns should match this part of the URL path.
 The ``:`` separates those parts.
 

--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -121,9 +121,10 @@ like so::
 
 The ``question_id=34`` part comes from ``<int:question_id>``. Using angle
 brackets "captures" part of the URL and sends it as a keyword argument to the
-view function. The ``:question_id>`` part of the string defines the name that
-will be used to identify the matched pattern, and the ``<int:`` part is a
+view function. The ``question_id>`` part of the string defines the name that
+will be used to identify the matched pattern, and the ``<int`` part is a
 converter that determines what patterns should match this part of the URL path.
+The ``:`` separates those parts.
 
 Write views that actually do something
 ======================================

--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -124,7 +124,7 @@ brackets "captures" part of the URL and sends it as a keyword argument to the
 view function. The ``question_id`` part of the string defines the name that
 will be used to identify the matched pattern, and the ``int`` part is a
 converter that determines what patterns should match this part of the URL path.
-The ``:`` separates those parts.
+The colon (``:``) separates the converter and pattern name.
 
 Write views that actually do something
 ======================================


### PR DESCRIPTION
The ":" colon char was in both the parts, which could lead to ambiguous understanding of the text (e.g. "<int::question_id>" instead of "<int:question_id>"). I fixed that and added the descriptor of the ":" colon, since it wasn't made notice of anymore.