### PR TITLE
Update widgets.py

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -709,7 +709,7 @@ class NullBooleanSelect(Select):
     """
     def __init__(self, attrs=None):
         choices = (
-            ('unknown', _('Unknown')),
+            ('unknown', _('---------')),
             ('true', _('Yes')),
             ('false', _('No')),
         )


### PR DESCRIPTION
This is my first ever pull request to any project, sorry if it's not quite what it should be.

Match NullBooleanSelect field's "no selection made" label to the form.models.ModelChoiceField's empty_label="---------".
Or "---" since Yes/No <= 3 chars.

Currently it is inconsistent and potentially confusing to users. When using a library like django_filters its slightly convoluted to change without breaking DRY style.

![image](https://user-images.githubusercontent.com/54913241/127411954-7c015e2c-4775-4bc5-9128-c915726b6fb6.png)