### PR TITLE
Refs #32956 -- Updated words ending in -wards

### DIFF
--- a/django/utils/asyncio.py
+++ b/django/utils/asyncio.py
@@ -21,7 +21,7 @@ def async_unsafe(message):
                     pass
                 else:
                     raise SynchronousOnlyOperation(message)
-            # Pass onwards.
+            # Pass onward.
             return func(*args, **kwargs)
         return inner
     # If the message is actually a function, then be a no-arguments decorator.

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -74,7 +74,7 @@ behavior is from broken web bots too.
     before other middleware that intercepts 404 errors, such as
     :class:`~django.middleware.locale.LocaleMiddleware` or
     :class:`~django.contrib.flatpages.middleware.FlatpageFallbackMiddleware`.
-    Put it towards the top of your :setting:`MIDDLEWARE` setting.
+    Put it toward the top of your :setting:`MIDDLEWARE` setting.
 
 You can tell Django to stop reporting particular 404s by tweaking the
 :setting:`IGNORABLE_404_URLS` setting. It should be a list of compiled

--- a/docs/internals/contributing/bugs-and-features.txt
+++ b/docs/internals/contributing/bugs-and-features.txt
@@ -143,7 +143,7 @@ seriously. After a suitable voting period, if an obvious consensus arises we'll
 follow the votes.
 
 However, consensus is not always possible. If consensus cannot be reached, or
-if the discussion towards a consensus fizzles out without a concrete decision,
+if the discussion toward a consensus fizzles out without a concrete decision,
 the decision may be deferred to the :ref:`technical board <technical-board>`.
 
 Internally, the technical board will use the same voting mechanism. A

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -528,7 +528,7 @@ Several other `MySQLdb connection options`_ may be useful, such as ``ssl``,
 Setting ``sql_mode``
 ~~~~~~~~~~~~~~~~~~~~
 
-From MySQL 5.7 onwards, the default value of the ``sql_mode`` option contains
+From MySQL 5.7 onward, the default value of the ``sql_mode`` option contains
 ``STRICT_TRANS_TABLES``. That option escalates warnings into errors when data
 are truncated upon insertion, so Django highly recommends activating a
 `strict mode`_ for MySQL to prevent data loss (either ``STRICT_TRANS_TABLES``

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1755,7 +1755,7 @@ The possible values for :attr:`~ForeignKey.on_delete` are found in
     a reference to the setting, not to the model directly.
 
     You only want to override this to be ``False`` if you are sure your
-    model should always point towards the swapped-in model - for example,
+    model should always point toward the swapped-in model - for example,
     if it is a profile model designed specifically for your custom user model.
 
     Setting it to ``False`` does not mean you can reference a swappable model
@@ -1969,7 +1969,7 @@ that control how the relationship functions.
     a reference to the setting, not to the model directly.
 
     You only want to override this to be ``False`` if you are sure your
-    model should always point towards the swapped-in model - for example,
+    model should always point toward the swapped-in model - for example,
     if it is a profile model designed specifically for your custom user model.
 
     If in doubt, leave it to its default of ``True``.

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1227,7 +1227,7 @@ Default: ``False``
 If set to ``True``, Django's exception handling of view functions
 (:data:`~django.conf.urls.handler500`, or the debug view if :setting:`DEBUG`
 is ``True``) and logging of 500 responses (:ref:`django-request-logger`) is
-skipped and exceptions propagate upwards.
+skipped and exceptions propagate upward.
 
 This can be useful for some test setups. It shouldn't be used on a live site
 unless you want your web server (instead of Django) to generate "Internal

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -752,7 +752,7 @@ Maximum size of a request body and the number of GET/POST parameters is limited
 Two new settings help mitigate denial-of-service attacks via large requests:
 
 * :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` limits the size that a request body
-  may be. File uploads don't count towards this limit.
+  may be. File uploads don't count toward this limit.
 * :setting:`DATA_UPLOAD_MAX_NUMBER_FIELDS` limits the number of GET/POST
   parameters that are parsed.
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -1658,7 +1658,7 @@ deprecated language codes will be removed in Django 1.9.
 --------------------------------------------
 
 The function ``memoize`` is deprecated and should be replaced by the
-``functools.lru_cache`` decorator (available from Python 3.2 onwards).
+``functools.lru_cache`` decorator (available from Python 3.2 onward).
 
 Django ships a backport of this decorator for older Python versions and it's
 available at ``django.utils.lru_cache.lru_cache``. The deprecated function will

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -336,7 +336,6 @@ OAuth
 OGC
 OGR
 ons
-onwards
 orderable
 Orléans
 orm

--- a/docs/topics/http/middleware.txt
+++ b/docs/topics/http/middleware.txt
@@ -287,7 +287,7 @@ that exception; instead it will get an :class:`~django.http.HttpResponse`
 object with a :attr:`~django.http.HttpResponse.status_code` of 404.
 
 You can set :setting:`DEBUG_PROPAGATE_EXCEPTIONS` to ``True`` to skip this
-conversion and propagate exceptions upwards.
+conversion and propagate exceptions upward.
 
 .. _async-middleware:
 

--- a/docs/topics/performance.txt
+++ b/docs/topics/performance.txt
@@ -166,7 +166,7 @@ produce, or even an entire site.
 
 Implementing caching should not be regarded as an alternative to improving code
 that's performing poorly because it has been written badly. It's one of the
-final steps towards producing well-performing code, not a shortcut.
+final steps toward producing well-performing code, not a shortcut.
 
 :class:`~django.utils.functional.cached_property`
 -------------------------------------------------

--- a/tests/forms_tests/field_tests/test_decimalfield.py
+++ b/tests/forms_tests/field_tests/test_decimalfield.py
@@ -103,7 +103,7 @@ class DecimalFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         f = DecimalField(max_digits=3)
         # Leading whole zeros "collapse" to one digit.
         self.assertEqual(f.clean('0000000.10'), decimal.Decimal("0.1"))
-        # But a leading 0 before the . doesn't count towards max_digits
+        # But a leading 0 before the . doesn't count toward max_digits
         self.assertEqual(f.clean('0000000.100'), decimal.Decimal("0.100"))
         # Only leading whole zeros "collapse" to one digit.
         self.assertEqual(f.clean('000000.02'), decimal.Decimal('0.02'))

--- a/tests/gis_tests/rasterapp/test_rasterfield.py
+++ b/tests/gis_tests/rasterapp/test_rasterfield.py
@@ -329,12 +329,12 @@ class RasterFieldTest(TransactionTestCase):
 
     def test_lookup_with_raster_bbox(self):
         rast = GDALRaster(json.loads(JSON_RASTER))
-        # Shift raster upwards
+        # Shift raster upward
         rast.origin.y = 2
         # The raster in the model is not strictly below
         qs = RasterModel.objects.filter(rast__strictly_below=rast)
         self.assertEqual(qs.count(), 0)
-        # Shift raster further upwards
+        # Shift raster further upward
         rast.origin.y = 6
         # The raster in the model is strictly below
         qs = RasterModel.objects.filter(rast__strictly_below=rast)

--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -89,5 +89,5 @@ class ShellCommandTestCase(SimpleTestCase):
     # in parallel mode. The tests are run in a subprocess and the subprocess's
     # stdin is closed and replaced by /dev/null. Reading from /dev/null always
     # returns EOF and so select always shows that sys.stdin is ready to read.
-    # This causes problems because of the call to select.select() towards the
+    # This causes problems because of the call to select.select() toward the
     # end of shell's handle() method.

--- a/tests/utils_tests/files/strip_tags1.html
+++ b/tests/utils_tests/files/strip_tags1.html
@@ -61,7 +61,7 @@
 
     <div class="divider-vertical"></div>
 
-      <a href="/django/django/notifications" class="notification-indicator tooltipped downwards contextually-unread" title="You have unread notifications in this repository">
+      <a href="/django/django/notifications" class="notification-indicator tooltipped downward contextually-unread" title="You have unread notifications in this repository">
     <span class="mail-status unread"></span>
   </a>
   <div class="divider-vertical"></div>
@@ -69,11 +69,11 @@
 
       <div class="command-bar js-command-bar  ">
             <form accept-charset="UTF-8" action="/search" class="command-bar-form" id="top_search_form" method="get">
-  <a href="/search/advanced" class="advanced-search-icon tooltipped downwards command-bar-search" id="advanced_search" title="Advanced search"><span class="mini-icon mini-icon-advanced-search "></span></a>
+  <a href="/search/advanced" class="advanced-search-icon tooltipped downward command-bar-search" id="advanced_search" title="Advanced search"><span class="mini-icon mini-icon-advanced-search "></span></a>
 
   <input type="text" name="q" id="js-command-bar-field" placeholder="Search or type a command" tabindex="1" data-username="claudep" autocapitalize="off">
 
-  <span class="mini-icon help tooltipped downwards" title="Show command bar help">
+  <span class="mini-icon help tooltipped downward" title="Show command bar help">
     <span class="mini-icon mini-icon-help"></span>
   </span>
 
@@ -99,19 +99,19 @@
         </a>
       </li>
       <li>
-        <a href="/new" id="new_repo" class="tooltipped downwards" title="Create a new repo">
+        <a href="/new" id="new_repo" class="tooltipped downward" title="Create a new repo">
           <span class="mini-icon mini-icon-create"></span>
         </a>
       </li>
       <li>
         <a href="/settings/profile" id="account_settings"
-          class="tooltipped downwards"
+          class="tooltipped downward"
           title="Account settings ">
           <span class="mini-icon mini-icon-account-settings"></span>
         </a>
       </li>
       <li>
-        <a href="/logout" data-method="post" id="logout" class="tooltipped downwards" title="Sign out">
+        <a href="/logout" data-method="post" id="logout" class="tooltipped downward" title="Sign out">
           <span class="mini-icon mini-icon-logout"></span>
         </a>
       </li>
@@ -207,11 +207,11 @@
     </li>
 
     <li class="js-toggler-container js-social-container starring-container on">
-      <a href="/django/django/unstar" class="minibutton js-toggler-target star-button starred upwards" title="Unstar this repo" data-remote="true" data-method="post" rel="nofollow">
+      <a href="/django/django/unstar" class="minibutton js-toggler-target star-button starred upward" title="Unstar this repo" data-remote="true" data-method="post" rel="nofollow">
         <span class="mini-icon mini-icon-remove-star"></span>
         <span class="text">Unstar</span>
       </a>
-      <a href="/django/django/star" class="minibutton js-toggler-target star-button unstarred upwards" title="Star this repo" data-remote="true" data-method="post" rel="nofollow">
+      <a href="/django/django/star" class="minibutton js-toggler-target star-button unstarred upward" title="Star this repo" data-remote="true" data-method="post" rel="nofollow">
         <span class="mini-icon mini-icon-star"></span>
         <span class="text">Star</span>
       </a>
@@ -219,7 +219,7 @@
     </li>
 
         <li>
-          <a href="/django/django/fork_select" class="minibutton js-toggler-target fork-button lighter upwards" title="Fork this repo" rel="facebox nofollow">
+          <a href="/django/django/fork_select" class="minibutton js-toggler-target fork-button lighter upward" title="Fork this repo" rel="facebox nofollow">
             <span class="mini-icon mini-icon-branch-create"></span>
             <span class="text">Fork</span>
           </a>
@@ -701,7 +701,7 @@
   <ol class="content collapse js-transitionable">
     <li>
       <span class="diffstat">
-          <a href="#diff-0" class="tooltipped leftwards" title="1 addition &amp; 1 deletion">
+          <a href="#diff-0" class="tooltipped leftward" title="1 addition &amp; 1 deletion">
             2
             <span class="diffstat-bar"> <i class='plus'>&#xf053;</i><i class='minus'>&#xf053;</i>&#xf053;&#xf053;&#xf053; </span>
           </a>
@@ -710,7 +710,7 @@
     </li>
     <li>
       <span class="diffstat">
-          <a href="#diff-1" class="tooltipped leftwards" title="1 addition &amp; 0 deletions">
+          <a href="#diff-1" class="tooltipped leftward" title="1 addition &amp; 0 deletions">
             1
             <span class="diffstat-bar"> <i class='plus'>&#xf053;</i>&#xf053;&#xf053;&#xf053;&#xf053; </span>
           </a>
@@ -725,7 +725,7 @@
     <div id="diff-0" class="file js-details-container">
       <div class="meta" data-path="django/utils/html.py">
         <div class="info">
-            <span class="diffstat tooltipped rightwards" title="1 addition &amp; 1 deletion">2 <span class="diffstat-bar"><i class='plus'>&#xf053;</i><i class='minus'>&#xf053;</i>&#xf053;&#xf053;&#xf053;</span></span>
+            <span class="diffstat tooltipped rightward" title="1 addition &amp; 1 deletion">2 <span class="diffstat-bar"><i class='plus'>&#xf053;</i><i class='minus'>&#xf053;</i>&#xf053;&#xf053;&#xf053;</span></span>
 
           <span class="js-selectable-text css-truncate css-truncate-target" title="django/utils/html.py">
             django/utils/html.py
@@ -863,7 +863,7 @@
     <div id="diff-1" class="file js-details-container">
       <div class="meta" data-path="tests/regressiontests/utils/html.py">
         <div class="info">
-            <span class="diffstat tooltipped rightwards" title="1 addition &amp; 0 deletions">1 <span class="diffstat-bar"><i class='plus'>&#xf053;</i>&#xf053;&#xf053;&#xf053;&#xf053;</span></span>
+            <span class="diffstat tooltipped rightward" title="1 addition &amp; 0 deletions">1 <span class="diffstat-bar"><i class='plus'>&#xf053;</i>&#xf053;&#xf053;&#xf053;&#xf053;</span></span>
 
           <span class="js-selectable-text css-truncate css-truncate-target" title="tests/regressiontests/utils/html.py">
             tests/regressiontests/utils/html.py
@@ -1024,7 +1024,7 @@
   <div id="write_bucket_525" class="write-content js-write-bucket js-uploadable-container upload-enabled is-default" data-model="asset">
 
 <a href="#fullscreen_comment_body_525" class="enable-fullscreen js-enable-fullscreen tooltipped
-  leftwards " title="Zen Mode">
+  leftward " title="Zen Mode">
   <span class="mini-icon mini-icon-fullscreen"></span>
 </a>
 
@@ -1275,10 +1275,10 @@
     </div>
   </div>
   <div class="fullscreen-sidebar">
-    <a href="#" class="exit-fullscreen js-exit-fullscreen tooltipped leftwards" title="Exit Zen Mode">
+    <a href="#" class="exit-fullscreen js-exit-fullscreen tooltipped leftward" title="Exit Zen Mode">
       <span class="mega-icon mega-icon-normalscreen"></span>
     </a>
-    <a href="#" class="theme-switcher js-theme-switcher tooltipped leftwards"
+    <a href="#" class="theme-switcher js-theme-switcher tooltipped leftward"
       title="Switch themes">
       <span class="mini-icon mini-icon-brightness"></span>
     </a>


### PR DESCRIPTION
AP styleguide: Virtually none of the words ending with -wards end with an s.

Note: I've not attempted forwards and backwards here. That is a much larger change could be a "backward" incompatible change as there's plenty of functions in the migration framework that have forwards and backwards in them. 