### PR TITLE
Fixed #32966 -- Fixed TimeField.check() crash for timezone-aware times in default when USE_TZ = True.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1144,6 +1144,42 @@ class DateTimeCheckMixin:
     def _check_fix_default_value(self):
         return []
 
+    # Concrete subclasses use this in their implementations of
+    # _check_fix_default_value().
+    def _check_if_value_fixed(self, value, now=None):
+        """
+        Check if the given value appears to have been provided as a "fixed"
+        time value, and include a warning in the returned list if it does. The
+        value argument must be a date object or aware/naive datetime object. If
+        now is provided, it must be a naive datetime object.
+        """
+        if now is None:
+            now = _get_naive_now()
+        offset = datetime.timedelta(seconds=10)
+        lower = now - offset
+        upper = now + offset
+        if isinstance(value, datetime.datetime):
+            value = _to_naive(value)
+        else:
+            assert isinstance(value, datetime.date)
+            lower = lower.date()
+            upper = upper.date()
+        if lower <= value <= upper:
+            return [
+                checks.Warning(
+                    'Fixed default value provided.',
+                    hint=(
+                        'It seems you set a fixed date / time / datetime '
+                        'value as default for this field. This may not be '
+                        'what you want. If you want to have the current date '
+                        'as default, use `django.utils.timezone.now`'
+                    ),
+                    obj=self,
+                    id='fields.W161',
+                )
+            ]
+        return []
+
 
 class DateField(DateTimeCheckMixin, Field):
     empty_strings_allowed = False
@@ -1175,30 +1211,12 @@ class DateField(DateTimeCheckMixin, Field):
         if isinstance(value, datetime.datetime):
             value = _to_naive(value).date()
         elif isinstance(value, datetime.date):
-            # Nothing to do, as dates don't have tz information
             pass
         else:
             # No explicit date / datetime value -- no checks necessary
             return []
         # At this point, value is a date object.
-        today = _get_naive_now().date()
-        offset = datetime.timedelta(days=1)
-        lower = today - offset
-        upper = today + offset
-        if lower <= value <= upper:
-            return [
-                checks.Warning(
-                    'Fixed default value provided.',
-                    hint='It seems you set a fixed date / time / datetime '
-                         'value as default for this field. This may not be '
-                         'what you want. If you want to have the current date '
-                         'as default, use `django.utils.timezone.now`',
-                    obj=self,
-                    id='fields.W161',
-                )
-            ]
-
-        return []
+        return self._check_if_value_fixed(value)
 
     def deconstruct(self):
         name, path, args, kwargs = super().deconstruct()
@@ -1309,35 +1327,9 @@ class DateTimeField(DateField):
             return []
 
         value = self.default
-        if isinstance(value, datetime.datetime):
-            value = _to_naive(value)
-            now = _get_naive_now()
-            offset = datetime.timedelta(seconds=10)
-            lower = now - offset
-            upper = now + offset
-        elif isinstance(value, datetime.date):
-            now = _get_naive_now()
-            offset = datetime.timedelta(seconds=10)
-            lower = now - offset
-            upper = now + offset
-            lower = lower.date()
-            upper = upper.date()
-        else:
-            # No explicit date / datetime value -- no checks necessary
-            return []
-        if lower <= value <= upper:
-            return [
-                checks.Warning(
-                    'Fixed default value provided.',
-                    hint='It seems you set a fixed date / time / datetime '
-                         'value as default for this field. This may not be '
-                         'what you want. If you want to have the current date '
-                         'as default, use `django.utils.timezone.now`',
-                    obj=self,
-                    id='fields.W161',
-                )
-            ]
-
+        if isinstance(value, (datetime.datetime, datetime.date)):
+            return self._check_if_value_fixed(value)
+        # No explicit date / datetime value -- no checks necessary.
         return []
 
     def get_internal_type(self):
@@ -2203,7 +2195,7 @@ class TimeField(DateTimeCheckMixin, Field):
 
         value = self.default
         if isinstance(value, datetime.datetime):
-            now = _get_naive_now()
+            now = None
         elif isinstance(value, datetime.time):
             now = _get_naive_now()
             # This will not use the right date in the race condition where now
@@ -2213,24 +2205,7 @@ class TimeField(DateTimeCheckMixin, Field):
             # No explicit time / datetime value -- no checks necessary
             return []
         # At this point, value is a datetime object.
-        offset = datetime.timedelta(seconds=10)
-        lower = now - offset
-        upper = now + offset
-        value = _to_naive(value)
-        if lower <= value <= upper:
-            return [
-                checks.Warning(
-                    'Fixed default value provided.',
-                    hint='It seems you set a fixed date / time / datetime '
-                         'value as default for this field. This may not be '
-                         'what you want. If you want to have the current date '
-                         'as default, use `django.utils.timezone.now`',
-                    obj=self,
-                    id='fields.W161',
-                )
-            ]
-
-        return []
+        return self._check_if_value_fixed(value, now=now)
 
     def deconstruct(self):
         name, path, args, kwargs = super().deconstruct()

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1103,6 +1103,16 @@ class CommaSeparatedIntegerField(CharField):
     }
 
 
+def _to_naive(value):
+    if timezone.is_aware(value):
+        value = timezone.make_naive(value, timezone.utc)
+    return value
+
+
+def _get_naive_now():
+    return _to_naive(timezone.now())
+
+
 class DateTimeCheckMixin:
 
     def check(self, **kwargs):
@@ -1161,13 +1171,10 @@ class DateField(DateTimeCheckMixin, Field):
         if not self.has_default():
             return []
 
-        now = timezone.now()
-        if not timezone.is_naive(now):
-            now = timezone.make_naive(now, timezone.utc)
+        now = _get_naive_now()
         value = self.default
         if isinstance(value, datetime.datetime):
-            if not timezone.is_naive(value):
-                value = timezone.make_naive(value, timezone.utc)
+            value = _to_naive(value)
             value = value.date()
         elif isinstance(value, datetime.date):
             # Nothing to do, as dates don't have tz information
@@ -1301,16 +1308,13 @@ class DateTimeField(DateField):
         if not self.has_default():
             return []
 
-        now = timezone.now()
-        if not timezone.is_naive(now):
-            now = timezone.make_naive(now, timezone.utc)
+        now = _get_naive_now()
         value = self.default
         if isinstance(value, datetime.datetime):
             second_offset = datetime.timedelta(seconds=10)
             lower = now - second_offset
             upper = now + second_offset
-            if timezone.is_aware(value):
-                value = timezone.make_naive(value, timezone.utc)
+            value = _to_naive(value)
         elif isinstance(value, datetime.date):
             second_offset = datetime.timedelta(seconds=10)
             lower = now - second_offset
@@ -2197,23 +2201,19 @@ class TimeField(DateTimeCheckMixin, Field):
         if not self.has_default():
             return []
 
-        now = timezone.now()
-        if not timezone.is_naive(now):
-            now = timezone.make_naive(now, timezone.utc)
+        now = _get_naive_now()
         value = self.default
         if isinstance(value, datetime.datetime):
             second_offset = datetime.timedelta(seconds=10)
             lower = now - second_offset
             upper = now + second_offset
-            if timezone.is_aware(value):
-                value = timezone.make_naive(value, timezone.utc)
+            value = _to_naive(value)
         elif isinstance(value, datetime.time):
             second_offset = datetime.timedelta(seconds=10)
             lower = now - second_offset
             upper = now + second_offset
             value = datetime.datetime.combine(now.date(), value)
-            if timezone.is_aware(value):
-                value = timezone.make_naive(value, timezone.utc)
+            value = _to_naive(value)
         else:
             # No explicit time / datetime value -- no checks necessary
             return []

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2213,7 +2213,7 @@ class TimeField(DateTimeCheckMixin, Field):
             upper = now + second_offset
             value = datetime.datetime.combine(now.date(), value)
             if timezone.is_aware(value):
-                value = timezone.make_naive(value, timezone.utc).time()
+                value = timezone.make_naive(value, timezone.utc)
         else:
             # No explicit time / datetime value -- no checks necessary
             return []

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -747,14 +747,16 @@ class TimeFieldTests(SimpleTestCase):
         class Model(models.Model):
             field_dt = models.TimeField(default=now())
             field_t = models.TimeField(default=now().time())
+            # Timezone-aware time object (when USE_TZ=True).
+            field_tz = models.TimeField(default=now().timetz())
             field_now = models.DateField(default=now)
 
-        field_dt = Model._meta.get_field('field_dt')
-        field_t = Model._meta.get_field('field_t')
-        field_now = Model._meta.get_field('field_now')
-        errors = field_dt.check()
-        errors.extend(field_t.check())
-        errors.extend(field_now.check())  # doesn't raise a warning
+        names = ['field_dt', 'field_t', 'field_tz', 'field_now']
+        fields = [Model._meta.get_field(name) for name in names]
+        errors = []
+        for field in fields:
+            errors.extend(field.check())
+
         self.assertEqual(errors, [
             DjangoWarning(
                 'Fixed default value provided.',
@@ -762,7 +764,7 @@ class TimeFieldTests(SimpleTestCase):
                      'value as default for this field. This may not be '
                      'what you want. If you want to have the current date '
                      'as default, use `django.utils.timezone.now`',
-                obj=field_dt,
+                obj=fields[0],
                 id='fields.W161',
             ),
             DjangoWarning(
@@ -771,9 +773,21 @@ class TimeFieldTests(SimpleTestCase):
                      'value as default for this field. This may not be '
                      'what you want. If you want to have the current date '
                      'as default, use `django.utils.timezone.now`',
-                obj=field_t,
+                obj=fields[1],
                 id='fields.W161',
-            )
+            ),
+            DjangoWarning(
+                'Fixed default value provided.',
+                hint=(
+                    'It seems you set a fixed date / time / datetime value as '
+                    'default for this field. This may not be what you want. '
+                    'If you want to have the current date as default, use '
+                    '`django.utils.timezone.now`'
+                ),
+                obj=fields[2],
+                id='fields.W161',
+            ),
+            # field_now doesn't raise a warning.
         ])
 
     @override_settings(USE_TZ=True)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32966