### PR TITLE
Refs #32956 -- Corrected spelling of daylight saving time

### DIFF
--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -220,7 +220,7 @@ class DateFormat(TimeFormat):
         return MONTHS[self.data.month]
 
     def I(self):  # NOQA: E743, E741
-        "'1' if Daylight Savings Time, '0' otherwise."
+        "'1' if daylight saving time, '0' otherwise."
         if self._no_timezone_or_datetime_is_ambiguous_or_imaginary:
             return ''
         return '1' if self.timezone.dst(self.data) else '0'

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1401,8 +1401,8 @@ Format character  Description                               Example output
 ``e``             Timezone name. Could be in any format,
                   or might return an empty string,          ``''``, ``'GMT'``, ``'-500'``, ``'US/Eastern'``, etc.
                   depending on the datetime.
-``I``             Daylight Savings Time, whether it's       ``'1'`` or ``'0'``
-                  in effect or not.
+``I``             Daylight saving time, whether it's in     ``'1'`` or ``'0'``
+                  effect or not.
 ``O``             Difference to Greenwich time in hours.    ``'+0200'``
 ``T``             Time zone of this machine.                ``'EST'``, ``'MDT'``
 ``Z``             Time zone offset in seconds. The          ``-43200`` to ``43200``

--- a/docs/topics/i18n/timezones.txt
+++ b/docs/topics/i18n/timezones.txt
@@ -15,8 +15,8 @@ This is handy if your users live in more than one time zone and you want to
 display datetime information according to each user's wall clock.
 
 Even if your website is available in only one time zone, it's still good
-practice to store data in UTC in your database. The main reason is Daylight
-Saving Time (DST). Many countries have a system of DST, where clocks are moved
+practice to store data in UTC in your database. The main reason is daylight
+saving time (DST). Many countries have a system of DST, where clocks are moved
 forward in spring and backward in autumn. If you're working in local time,
 you're likely to encounter errors twice a year, when the transitions happen.
 (The pytz_ documentation discusses `these issues`_ in greater detail.) This
@@ -481,7 +481,7 @@ Setup
 
    Yes. When time zone support is enabled, Django uses a more accurate model
    of local time. This shields you from subtle and unreproducible bugs around
-   Daylight Saving Time (DST) transitions.
+   daylight saving time (DST) transitions.
 
    When you enable time zone support, you'll encounter some errors because
    you're using naive datetimes where Django expects aware datetimes. Such

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -48,7 +48,7 @@ except ImportError:
     HAS_YAML = False
 
 # These tests use the EAT (Eastern Africa Time) and ICT (Indochina Time)
-# who don't have Daylight Saving Time, so we can represent them easily
+# who don't have daylight saving time, so we can represent them easily
 # with fixed offset timezones and use them directly as tzinfo in the
 # constructors.
 


### PR DESCRIPTION
AP Stylebook: Saving not savings, no hyphen and lowercase.

https://twitter.com/APStylebook/status/926582050274074624