### PR TITLE
Refs #32956 -- Corrected usage of "insure" and "assure".

### DIFF
--- a/django/contrib/gis/db/models/proxy.py
+++ b/django/contrib/gis/db/models/proxy.py
@@ -58,7 +58,7 @@ class SpatialProxy(DeferredAttribute):
         gtype = self.field.geom_type
 
         if gtype == 'RASTER' and (value is None or isinstance(value, (str, dict, self._klass))):
-            # For raster fields, assure input is None or a string, dict, or
+            # For raster fields, ensure input is None or a string, dict, or
             # raster instance.
             pass
         elif isinstance(value, self._klass):

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -33,10 +33,7 @@ class RemoteUserTest(TestCase):
         self.patched_settings.disable()
 
     def test_no_remote_user(self):
-        """
-        Tests requests where no remote user is specified and insures that no
-        users get created.
-        """
+        """Users are not created when remote user is not specified."""
         num_users = User.objects.count()
 
         response = self.client.get('/remote_user/')

--- a/tests/raw_query/tests.py
+++ b/tests/raw_query/tests.py
@@ -228,9 +228,7 @@ class RawQueryTests(TestCase):
         self.assertSuccessfulRawQuery(Reviewer, query, reviewers)
 
     def test_extra_conversions(self):
-        """
-        Test to insure that extra translations are ignored.
-        """
+        """Extra translations are ignored."""
         query = "SELECT * FROM raw_query_author"
         translations = {'something': 'else'}
         authors = Author.objects.all()


### PR DESCRIPTION
I think we usually want to "ensure" (things happen) rather than to insure or to assure. "Ensure" appears many hundreds of times, I had a quick scan but I didn't check all of them closely.

The test names look like they don't meet the expected style so I rewrote them. I'm not particularly confident in writing these descriptions so feedback is very welcome.