### PR TITLE
Updated BaseDatabaseFeatures link in testing tools docs.

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1971,8 +1971,10 @@ test if the database doesn't support a specific named feature.
 
 The decorators use a string identifier to describe database features.
 This string corresponds to attributes of the database connection
-features class. See ``django.db.backends.BaseDatabaseFeatures``
-class for a full list of database features that can be used as a basis
+features class. See
+:source:`django.db.backends.base.features.BaseDatabaseFeatures class
+<django/db/backends/base/features.py>`
+for a full list of database features that can be used as a basis
 for skipping tests.
 
 .. function:: skipIfDBFeature(*feature_name_strings)


### PR DESCRIPTION
BaseDatabaseFeatures is in django.db.backends.base.features, not
django.db.backends. While here, added a source link to the referenced
class.