### PR TITLE
Fixed #29063 -- Fixed migrate crash when specifying a name of partially applied squashed migrations.

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -140,7 +140,16 @@ class Command(BaseCommand):
                 except KeyError:
                     raise CommandError("Cannot find a migration matching '%s' from app '%s'." % (
                         migration_name, app_label))
-                targets = [(app_label, migration.name)]
+                target = (app_label, migration.name)
+                # Partially applied squashed migrations are not included in the
+                # graph, use the last replacement instead.
+                if (
+                    target not in executor.loader.graph.nodes and
+                    target in executor.loader.replacements
+                ):
+                    incomplete_migration = executor.loader.replacements[target]
+                    target = incomplete_migration.replaces[-1]
+                targets = [target]
             target_app_labels_only = False
         elif options['app_label']:
             targets = [key for key in executor.loader.graph.leaf_nodes() if key[0] == app_label]

--- a/django/core/management/commands/sqlmigrate.py
+++ b/django/core/management/commands/sqlmigrate.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         # Get the database we're operating from
         connection = connections[options['database']]
 
-        # Load up an loader to get all the migration data, but don't replace
+        # Load up a loader to get all the migration data, but don't replace
         # migrations.
         loader = MigrationLoader(connection, replace_migrations=False)
 

--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -149,7 +149,10 @@ class MigrationLoader:
                 "There is more than one migration for '%s' with the prefix '%s'" % (app_label, name_prefix)
             )
         elif not results:
-            raise KeyError("There no migrations for '%s' with the prefix '%s'" % (app_label, name_prefix))
+            raise KeyError(
+                f"There is no migration for '{app_label}' with the prefix "
+                f"'{name_prefix}'"
+            )
         else:
             return self.disk_migrations[results[0]]
 

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -951,6 +951,34 @@ class MigrateTests(MigrationTestBase):
         )
         # No changes were actually applied so there is nothing to rollback
 
+    def test_migrate_partially_applied_squashed_migration(self):
+        """
+        Migrating to a squashed migration specified by name should succeed
+        even if it is partially applied.
+        """
+        with self.temporary_migration_module(module='migrations.test_migrations'):
+            recorder = MigrationRecorder(connection)
+            try:
+                call_command('migrate', 'migrations', '0001_initial', verbosity=0)
+                call_command(
+                    'squashmigrations',
+                    'migrations',
+                    '0002',
+                    interactive=False,
+                    verbosity=0,
+                )
+                call_command(
+                    'migrate',
+                    'migrations',
+                    '0001_squashed_0002_second',
+                    verbosity=0,
+                )
+                applied_migrations = recorder.applied_migrations()
+                self.assertIn(('migrations', '0002_second'), applied_migrations)
+            finally:
+                # Unmigrate everything.
+                call_command('migrate', 'migrations', 'zero', verbosity=0)
+
     @override_settings(MIGRATION_MODULES={'migrations': 'migrations.test_migrations'})
     def test_migrate_inconsistent_history(self):
         """

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -182,7 +182,7 @@ class LoaderTests(TestCase):
         msg = "There is more than one migration for 'migrations' with the prefix '0'"
         with self.assertRaisesMessage(AmbiguityError, msg):
             migration_loader.get_migration_by_prefix("migrations", "0")
-        msg = "There no migrations for 'migrations' with the prefix 'blarg'"
+        msg = "There is no migration for 'migrations' with the prefix 'blarg'"
         with self.assertRaisesMessage(KeyError, msg):
             migration_loader.get_migration_by_prefix("migrations", "blarg")
 
@@ -299,7 +299,7 @@ class LoaderTests(TestCase):
         loader.build_graph()
         self.assertEqual(num_nodes(), 3)
 
-        # Starting at 5 to 7 we are passed the squashed migrations
+        # Starting at 5 to 7 we are past the squashed migrations.
         self.record_applied(recorder, 'migrations', '5_auto')
         loader.build_graph()
         self.assertEqual(num_nodes(), 2)

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -179,9 +179,11 @@ class LoaderTests(TestCase):
             migration_loader.get_migration_by_prefix("migrations", "0001").name,
             "0001_initial",
         )
-        with self.assertRaises(AmbiguityError):
+        msg = "There is more than one migration for 'migrations' with the prefix '0'"
+        with self.assertRaisesMessage(AmbiguityError, msg):
             migration_loader.get_migration_by_prefix("migrations", "0")
-        with self.assertRaises(KeyError):
+        msg = "There no migrations for 'migrations' with the prefix 'blarg'"
+        with self.assertRaisesMessage(KeyError, msg):
             migration_loader.get_migration_by_prefix("migrations", "blarg")
 
     def test_load_import_error(self):


### PR DESCRIPTION
ticket-29063

Supersedes #14643, which was merely an attempt to spruce up the `NodeNotFoundError` to be more informative.

The original ticket does not say with specificity how to reproduce the issue. Mariusz demonstrated on #14643 that several related scenarios already have sufficient messaging. The scenario in this regression test--attempting to migrate to an incompletely applied squashed migration, and moreover, specifying it by name--is one we can fix at the source.

Given that, I think we can close the ticket with this change. (While an understandable suggestion, I don't think we need to be raising warnings, as the original report mused.)