### PR TITLE
Fixed #32978 - Improved an error message on loaddata/dumpdata when PyYAML is not installed.

### DIFF
--- a/django/core/serializers/__init__.py
+++ b/django/core/serializers/__init__.py
@@ -20,6 +20,7 @@ import importlib
 
 from django.apps import apps
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.base import SerializerDoesNotExist
 
 # Built-in serializers
@@ -69,7 +70,7 @@ def register_serializer(format, serializer_module, serializers=None):
 
     try:
         module = importlib.import_module(serializer_module)
-    except ImportError as exc:
+    except (ImportError, ImproperlyConfigured) as exc:
         bad_serializer = BadSerializer(exc)
 
         module = type('BadSerializerModule', (), {

--- a/django/core/serializers/pyyaml.py
+++ b/django/core/serializers/pyyaml.py
@@ -8,7 +8,14 @@ import collections
 import decimal
 from io import StringIO
 
-import yaml
+try:
+    import yaml
+except ImportError as e:
+    from django.core.exceptions import ImproperlyConfigured
+
+    raise ImproperlyConfigured(
+        'Error loading yaml module. Did you install PyYAML?'
+    ) from e
 
 from django.core.serializers.base import DeserializationError
 from django.core.serializers.python import (


### PR DESCRIPTION
Add tests in test_yaml.py for the new message and exception, while also checking for the underlying ImportError.

This turned out to require a bigger diff than I initially thought it would :/

Comparison:

Old:

```sh
$ ./manage.py dumpdata --format yaml --pks 1 users.User
CommandError: Unable to serialize database: No module named 'yaml'
```

New:

```sh
$ ./manage.py dumpdata --format yaml --pks 1 users.User
CommandError: Unable to serialize database: Error loading yaml module. Did you install PyYAML?
```