### PR TITLE
Fixed #32983 -- Made related_name on symmetric field raise new system check warning.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1258,6 +1258,16 @@ class ManyToManyField(RelatedField):
                 )
             )
 
+        if self.remote_field.symmetrical and self._related_name:
+            warnings.append(
+                checks.Warning(
+                    'related_name has no effect on ManyToManyField '
+                    'with a symmetrical relationship, e.g. to "self".',
+                    obj=self,
+                    id='fields.W345',
+                )
+            )
+
         return warnings
 
     def _check_relationship_model(self, from_model=None, **kwargs):

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -313,6 +313,8 @@ Related fields
   with a ``through`` model.
 * **fields.W344**: The field's intermediary table ``<table name>`` clashes with
   the table name of ``<model>``/``<model>.<field name>``.
+* **fields.W345**: ``related_name`` has no effect on ``ManyToManyField`` with a
+  symmetrical relationship, e.g. to "self".
 
 Models
 ------

--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -438,7 +438,6 @@ class FieldDeconstructionTests(SimpleTestCase):
             m2m = models.ManyToManyField('self')
             m2m_related_name = models.ManyToManyField(
                 'self',
-                related_name='custom_name',
                 related_query_name='custom_query_name',
                 limit_choices_to={'flag': True},
             )
@@ -455,7 +454,6 @@ class FieldDeconstructionTests(SimpleTestCase):
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {
             'to': 'field_deconstruction.MyModel',
-            'related_name': 'custom_name',
             'related_query_name': 'custom_query_name',
             'limit_choices_to': {'flag': True},
         })

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -128,6 +128,20 @@ class RelativeFieldTests(SimpleTestCase):
             ),
         ])
 
+    def test_many_to_many_with_useless_related_name(self):
+        class ModelM2M(models.Model):
+            m2m = models.ManyToManyField('self', related_name='children')
+
+        field = ModelM2M._meta.get_field('m2m')
+        self.assertEqual(ModelM2M.check(), [
+            DjangoWarning(
+                'related_name has no effect on ManyToManyField with '
+                'a symmetrical relationship, e.g. to "self".',
+                obj=field,
+                id='fields.W345',
+            ),
+        ])
+
     def test_ambiguous_relationship_model_from(self):
         class Person(models.Model):
             pass

--- a/tests/model_meta/models.py
+++ b/tests/model_meta/models.py
@@ -23,7 +23,7 @@ class AbstractPerson(models.Model):
 
     # M2M fields
     m2m_abstract = models.ManyToManyField(Relation, related_name='m2m_abstract_rel')
-    friends_abstract = models.ManyToManyField('self', related_name='friends_abstract', symmetrical=True)
+    friends_abstract = models.ManyToManyField('self', symmetrical=True)
     following_abstract = models.ManyToManyField('self', related_name='followers_abstract', symmetrical=False)
 
     # VIRTUAL fields
@@ -60,7 +60,7 @@ class BasePerson(AbstractPerson):
 
     # M2M fields
     m2m_base = models.ManyToManyField(Relation, related_name='m2m_base_rel')
-    friends_base = models.ManyToManyField('self', related_name='friends_base', symmetrical=True)
+    friends_base = models.ManyToManyField('self', symmetrical=True)
     following_base = models.ManyToManyField('self', related_name='followers_base', symmetrical=False)
 
     # VIRTUAL fields
@@ -88,7 +88,7 @@ class Person(BasePerson):
 
     # M2M Fields
     m2m_inherited = models.ManyToManyField(Relation, related_name='m2m_concrete_rel')
-    friends_inherited = models.ManyToManyField('self', related_name='friends_concrete', symmetrical=True)
+    friends_inherited = models.ManyToManyField('self', symmetrical=True)
     following_inherited = models.ManyToManyField('self', related_name='followers_concrete', symmetrical=False)
 
     # VIRTUAL fields


### PR DESCRIPTION
Since ManyToManyFields defined with `symmetrical=True` do not add a
related field to the target model, including a `related_name` argument
will never do what the coder likely expects. This makes including
a related_name with a symmetrical model raise a system check warning.

ticket-32983