### PR TITLE
Fixed #29049 -- Added slicing notation to F expressions.

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -304,7 +304,6 @@ class IndexTransformFactory:
 
 
 class SliceTransform(Transform):
-
     def __init__(self, start, end, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.start = start
@@ -312,11 +311,11 @@ class SliceTransform(Transform):
 
     def as_sql(self, compiler, connection):
         lhs, params = compiler.compile(self.lhs)
-        # self.start is set to 1 if slice start is not provided
+        # self.start is set to 1 if slice start is not provided.
         if self.end:
-            return '%s[%%s:%%s]' % lhs, params + [self.start, self.end]
+            return f'{lhs}[%s:%s]', params + [self.start, self.end]
         else:
-            return '%s[%%s:]' % lhs, params + [self.start]
+            return f'{lhs}[%s:]', params + [self.start]
 
 
 class SliceTransformFactory:

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -679,7 +679,10 @@ class SliceableF(F):
             if subscript.stop and subscript.start and subscript.stop < subscript.start:
                 raise ValueError('Slice stop must be greater than slice start.')
             self.start = 1 if subscript.start is None else subscript.start + 1
-            self.length = None if subscript.stop is None else subscript.stop - (subscript.start or 0)
+            if subscript.stop is None:
+                self.length = None
+            else:
+                self.length = subscript.stop - (subscript.start or 0)
         else:
             raise TypeError('Argument to slice must be either int or slice instance.')
 
@@ -692,7 +695,7 @@ class SliceableF(F):
         for_save=False,
     ):
         resolved = query.resolve_ref(self.name, allow_joins, reuse, summarize)
-        return resolved.target.slice_expression(resolved, self.start, self.length)
+        return resolved.output_field.slice_expression(resolved, self.start, self.length)
 
 
 class Func(SQLiteNumericMixin, Expression):

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -163,17 +163,17 @@ the field value of each one, and saving each one back to the database::
 * getting the database, rather than Python, to do work
 * reducing the number of queries some operations require
 
-.. _string-expressions-using-f:
+.. _slicing-using-f:
 
-Using string-expressions in ``F()``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Slicing ``F()`` expressions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 4.1
 
-For fields that are string-expressions (or
-:class:`~django.contrib.postgres.fields.ArrayField`), you can use standard
-index or slicing notation. The indices are 0-based and the ``step`` argument to
-``slice`` is not supported. For example::
+For string-based fields, text-based fields, and
+:class:`~django.contrib.postgres.fields.ArrayField`, you can you can use
+Python's array-slicing syntax. The indices are 0-based and the ``step``
+argument to ``slice`` is not supported. For example::
 
     >>> # Replacing a name with a substring of itself.
     >>> writer = Writers.objects.get(name='Priyansh')

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -163,6 +163,26 @@ the field value of each one, and saving each one back to the database::
 * getting the database, rather than Python, to do work
 * reducing the number of queries some operations require
 
+.. _string-expressions-using-f:
+
+Using string-expressions in ``F()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 4.1
+
+For fields that are string-expressions (or
+:class:`~django.contrib.postgres.fields.ArrayField`), you can use standard
+index or slicing notation. The indices are 0-based and the ``step`` argument to
+``slice`` is not supported. For example::
+
+    >>> # Replacing a name with a substring of itself.
+    >>> writer = Writers.objects.get(name='Priyansh')
+    >>> writer.name = F('name')[1:5]
+    >>> writer.save()
+    >>> writer.refresh_from_db()
+    >>> writer.name
+    'riya'
+
 .. _avoiding-race-conditions-using-f:
 
 Avoiding race conditions using ``F()``

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -185,7 +185,10 @@ Migrations
 Models
 ~~~~~~
 
-* ...
+* :class:`F expressions <django.db.models.F>` now support
+  :ref:`slicing notation <string-expressions-using-f>` for ``CharField``,
+  ``EmailField``, ``SlugField``, ``URLField``, ``TextField``, and
+  ``django.contrib.postgres.fields.ArrayField``.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -185,9 +185,10 @@ Migrations
 Models
 ~~~~~~
 
-* :class:`F expressions <django.db.models.F>` now support
-  :ref:`slicing notation <string-expressions-using-f>` for ``CharField``,
-  ``EmailField``, ``SlugField``, ``URLField``, ``TextField``, and
+* :class:`F() <django.db.models.F>` and
+  :class:`OuterRef() <django.db.models.OuterRef>` expressions now support
+  :ref:`slicing <slicing-using-f>` for ``CharField``, ``EmailField``,
+  ``SlugField``, ``URLField``, ``TextField``, and
   ``django.contrib.postgres.fields.ArrayField``.
 
 Requests and Responses

--- a/tests/expressions/models.py
+++ b/tests/expressions/models.py
@@ -102,3 +102,7 @@ class UUIDPK(models.Model):
 class UUID(models.Model):
     uuid = models.UUIDField(null=True)
     uuid_fk = models.ForeignKey(UUIDPK, models.CASCADE, null=True)
+
+
+class Text(models.Model):
+    name = models.TextField()

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -179,30 +179,35 @@ class BasicExpressionsTests(TestCase):
         self._test_slicing_of_f_expressions(Text)
 
     def test_slicing_of_f_expressions_with_annotate(self):
-        companies = Company.objects.annotate(first_three=F('name')[:3])
-        self.assertCountEqual(
-            companies.values_list('first_three', flat=True),
-            ['Exa', 'Foo', 'Tes'],
+        qs = Company.objects.annotate(
+            first_three=F('name')[:3],
+            after_three=F('name')[3:],
+            random_four=F('name')[2:5],
+            first_letter_slice=F('name')[:1],
+            first_letter_index=F('name')[0],
         )
-        companies = Company.objects.annotate(after_three=F('name')[3:])
-        self.assertCountEqual(
-            companies.values_list('after_three', flat=True),
-            ['mple Inc.', 'bar Ltd.', 't GmbH'],
+        tests = [
+            ('first_three', ['Exa', 'Foo', 'Tes']),
+            ('after_three', ['mple Inc.', 'bar Ltd.', 't GmbH']),
+            ('random_four', ['amp', 'oba', 'st ']),
+            ('first_letter_slice', ['E', 'F', 'T']),
+            ('first_letter_index', ['E', 'F', 'T']),
+        ]
+        for annotation, expected in tests:
+            with self.subTest(annotation):
+                self.assertCountEqual(qs.values_list(annotation, flat=True), expected)
+
+    def test_slicing_of_f_expression_with_annotated_expression(self):
+        qs = Company.objects.annotate(
+            new_name=Case(
+                When(based_in_eu=True, then=Concat(Value('EU:'), F('name'))),
+                default=F('name'),
+            ),
+            first_two=F('new_name')[:3],
         )
-        companies = Company.objects.annotate(random_four=F('name')[2:5])
         self.assertCountEqual(
-            companies.values_list('random_four', flat=True),
-            ['amp', 'oba', 'st '],
-        )
-        companies = Company.objects.annotate(first_letter=F('name')[:1])
-        self.assertCountEqual(
-            companies.values_list('first_letter', flat=True),
-            ['E', 'F', 'T'],
-        )
-        companies = Company.objects.annotate(first_letter=F('name')[0])
-        self.assertCountEqual(
-            companies.values_list('first_letter', flat=True),
-            ['E', 'F', 'T'],
+            qs.values_list('first_two', flat=True),
+            ['Exa', 'EU:', 'Tes'],
         )
 
     def test_slicing_of_f_expressions_with_negative_index(self):
@@ -213,17 +218,17 @@ class BasicExpressionsTests(TestCase):
                 F('name')[i]
 
     def test_slicing_of_f_expressions_with_slice_stop_less_than_slice_start(self):
-        msg = 'Slice stop must be greater than slice start'
+        msg = 'Slice stop must be greater than slice start.'
         with self.assertRaisesMessage(ValueError, msg):
             F('name')[4:2]
 
     def test_slicing_of_f_expressions_with_invalid_type(self):
-        msg = "Argument to slice must be either int or slice instance."
+        msg = 'Argument to slice must be either int or slice instance.'
         with self.assertRaisesMessage(TypeError, msg):
             F('name')['error']
 
     def test_slicing_of_f_expressions_with_step(self):
-        msg = "Step argument is not supported."
+        msg = 'Step argument is not supported.'
         with self.assertRaisesMessage(ValueError, msg):
             F('name')[::4]
 
@@ -231,6 +236,16 @@ class BasicExpressionsTests(TestCase):
         msg = 'This field does not support slicing.'
         with self.assertRaisesMessage(NotSupportedError, msg):
             Company.objects.update(num_chairs=F('num_chairs')[:4])
+
+    def test_slicing_of_outerref(self):
+        qs = Company.objects.filter(Exists(
+            Company.objects.annotate(
+                seventh_letter=F('name')[7],
+            ).filter(
+                seventh_letter=OuterRef('name')[2],
+            )
+        ))
+        self.assertSequenceEqual(qs, [self.gmbh])
 
     def test_arithmetic(self):
         # We can perform arithmetic operations in expressions

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -9,7 +9,7 @@ from django.core import checks, exceptions, serializers, validators
 from django.core.exceptions import FieldError
 from django.core.management import call_command
 from django.db import IntegrityError, connection, models
-from django.db.models.expressions import Exists, OuterRef, RawSQL, Value
+from django.db.models.expressions import Exists, F, OuterRef, RawSQL, Value
 from django.db.models.functions import Cast, JSONObject, Upper
 from django.test import TransactionTestCase, modify_settings, override_settings
 from django.test.utils import isolate_apps
@@ -511,6 +511,30 @@ class TestQuerying(PostgreSQLTestCase):
             qs.values_list('first_two', flat=True),
             [None, [1], [2], [2, 3], [20, 30]],
         )
+
+    def test_slicing_notation_in_f_expressions(self):
+        tests = [
+            (F('field')[:2], [1, 2]),
+            (F('field')[2:], [3, 4]),
+            (F('field')[1:3], [2, 3]),
+        ]
+        for expression, expected in tests:
+            with self.subTest(expression=expression, expected=expected):
+                instance = IntegerArrayModel.objects.create(field=[1, 2, 3, 4])
+                instance.field = expression
+                instance.save()
+                instance.refresh_from_db()
+                self.assertSequenceEqual(instance.field, expected)
+
+    def test_slicing_notation_in_f_expressions_with_annotate(self):
+        instance = IntegerArrayModel(field=[1, 2, 3])
+        instance.save()
+        annotated_model = IntegerArrayModel.objects.annotate(first_two=F('field')[:2])
+        self.assertSequenceEqual(annotated_model[0].first_two, [1, 2])
+        annotated_model = IntegerArrayModel.objects.annotate(after_two=F('field')[2:])
+        self.assertSequenceEqual(annotated_model[0].after_two, [3])
+        annotated_model = IntegerArrayModel.objects.annotate(random_two=F('field')[1:3])
+        self.assertEqual(annotated_model[0].random_two, [2, 3])
 
     def test_usage_in_subquery(self):
         self.assertSequenceEqual(


### PR DESCRIPTION
Ticket: [29049](https://code.djangoproject.com/ticket/29049). 
Previous PR: #11208

F expressions on string-based fields and arrays can now use standard
python slicing-notation. Added a new class SliceableF that handles
identification of sliceable fields. Step-argument is not supported.

