### PR TITLE
fix a typo in the italian translation

### DIFF
--- a/django/conf/locale/it/LC_MESSAGES/django.po
+++ b/django/conf/locale/it/LC_MESSAGES/django.po
@@ -1221,7 +1221,7 @@ msgstr ""
 "riattivalo almeno per questo sito, o per connessioni \"same-origin\""
 
 msgid "More information is available with DEBUG=True."
-msgstr "Maggiorni informazioni sono disponibili con DEBUG=True"
+msgstr "Maggiori informazioni sono disponibili con DEBUG=True"
 
 msgid "No year specified"
 msgstr "Anno non specificato"


### PR DESCRIPTION
Not much to say... "Maggiori" means "More", "Maggiorni" is not an italian word. 