### PR TITLE
Refs #32987 -- Added templates check for multiple libraries with the same import name.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -220,6 +220,7 @@ answer newbie questions, and generally made Django that much better:
     Daniel Alves Barbosa de Oliveira Vaz <danielvaz@gmail.com>
     Daniel Duan <DaNmarner@gmail.com>
     Daniele Procida <daniele@vurt.org>
+    Daniel Fairhead <danthedeckie@gmail.com>
     Daniel Greenfeld
     dAniel hAhler
     Daniel Jilg <daniel@breakthesystem.org>

--- a/django/core/checks/templates.py
+++ b/django/core/checks/templates.py
@@ -1,6 +1,10 @@
 import copy
+from collections import defaultdict
+from importlib import import_module
 
+from django.apps import apps
 from django.conf import settings
+from django.template.backends.django import get_package_libraries
 
 from . import Error, Tags, register
 
@@ -12,6 +16,10 @@ E001 = Error(
 E002 = Error(
     "'string_if_invalid' in TEMPLATES OPTIONS must be a string but got: {} ({}).",
     id="templates.E002",
+)
+E003 = Error(
+    "You have multiple libraries named: '{}'. Rename one of: {}.",
+    id="templates.E003",
 )
 
 
@@ -32,4 +40,33 @@ def check_string_if_invalid_is_string(app_configs, **kwargs):
             error = copy.copy(E002)
             error.msg = error.msg.format(string_if_invalid, type(string_if_invalid).__name__)
             errors.append(error)
+    return errors
+
+
+@register(Tags.templates)
+def check_for_mulitple_libraries_with_the_same_name(app_configs, **kwargs):
+    errors = []
+
+    libraries = defaultdict(list)
+    candidates = ['django.templatetags']
+    candidates.extend(f'{app.name}.templatetags' for app in apps.get_app_configs())
+
+    for candidate in candidates:
+        try:
+            pkg = import_module(candidate)
+        except ModuleNotFoundError:
+            # No templatetags package defined. This is safe to ignore.
+            continue
+
+        if hasattr(pkg, '__path__'):
+            for name in get_package_libraries(pkg):
+                import_name = name[len(candidate) + 1:]
+                libraries[import_name].append(name)
+
+    for library_name, items in libraries.items():
+        if len(items) > 1:
+            error = copy.copy(E003)
+            error.msg = error.msg.format(library_name, ', '.join(f"'{item}'" for item in items))
+            errors.append(error)
+
     return errors

--- a/django/core/checks/templates.py
+++ b/django/core/checks/templates.py
@@ -1,10 +1,8 @@
 import copy
 from collections import defaultdict
-from importlib import import_module
 
-from django.apps import apps
 from django.conf import settings
-from django.template.backends.django import get_package_libraries
+from django.template.backends.django import get_template_tag_module_names
 
 from . import Error, Tags, register
 
@@ -47,26 +45,16 @@ def check_string_if_invalid_is_string(app_configs, **kwargs):
 def check_for_mulitple_libraries_with_the_same_name(app_configs, **kwargs):
     errors = []
 
+    # TODO - also include checks for custom libraries defined in OPTIONS
+
     libraries = defaultdict(list)
-    candidates = ['django.templatetags']
-    candidates.extend(f'{app.name}.templatetags' for app in apps.get_app_configs())
-
-    for candidate in candidates:
-        try:
-            pkg = import_module(candidate)
-        except ModuleNotFoundError:
-            # No templatetags package defined. This is safe to ignore.
-            continue
-
-        if hasattr(pkg, '__path__'):
-            for name in get_package_libraries(pkg):
-                import_name = name[len(candidate) + 1:]
-                libraries[import_name].append(name)
+    for module_name, full_name in get_template_tag_module_names():
+        libraries[module_name].append(full_name)
 
     for library_name, items in libraries.items():
         if len(items) > 1:
             error = copy.copy(E003)
-            error.msg = error.msg.format(library_name, ', '.join(f"'{item}'" for item in items))
+            error.msg = error.msg.format(library_name, ', '.join(repr(item) for item in items))
             errors.append(error)
 
     return errors

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -542,6 +542,9 @@ configured:
 * **templates.E002**: ``string_if_invalid`` in :setting:`TEMPLATES`
   :setting:`OPTIONS <TEMPLATES-OPTIONS>` must be a string but got: ``{value}``
   (``{type}``).
+* **templates.E003**: Multiple installed apps have ``templatetags`` modules with the
+  same file name, so ``{% load <name> %}`` will not be able to determine which
+  one to load.  You should rename one of them.
 
 Translation
 -----------

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -527,6 +527,7 @@ tablespace
 tablespaces
 Tajik
 teardown
+templatetags
 templating
 testcase
 textarea


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32987

This is an additional templates check that notifies the user if they have multiple modules with the same name.

Eg:

- `core/templatetags/basic_tags.py`
- `news/templatetags/basic_tags.py`

Where the user might import them in a template:

```django
{% load basic_tags %}
```

And the template importer will otherwise silently drop one of them (based on import order), and they will get `TemplateSyntaxError` at runtime when they try to use any of the functions / filters / tags in the library that is dropped.