### PR TITLE
Fixed #32988 -- Prevented creation of more test databases than TestCases.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -795,6 +795,9 @@ class DiscoverRunner:
             # Since tests are distributed across processes on a per-TestCase
             # basis, there's no need for more processes than TestCases.
             processes = min(self.parallel, len(subsuites))
+            # Update also "parallel" because it's used to determine the number
+            # of test databases.
+            self.parallel = processes
             if processes > 1:
                 suite = self.parallel_test_suite(
                     subsuites,

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -457,6 +457,26 @@ class DiscoverRunnerTests(SimpleTestCase):
         suite = runner.build_suite(['test_runner_apps.tagged'])
         self.assertEqual(suite.processes, len(suite.subsuites))
 
+    def test_number_of_databases_parallel_test_suite(self):
+        """
+        Number of databases doesn't exceed the number of TestCases with
+        parallel tests.
+        """
+        runner = DiscoverRunner(parallel=8, verbosity=0)
+        suite = runner.build_suite(['test_runner_apps.tagged'])
+        self.assertEqual(suite.processes, len(suite.subsuites))
+        self.assertEqual(runner.parallel, suite.processes)
+
+    def test_number_of_databases_no_parallel_test_suite(self):
+        """
+        Number of databases doesn't exceed the number of TestCases with
+        non-parallel tests.
+        """
+        runner = DiscoverRunner(parallel=8, verbosity=0)
+        suite = runner.build_suite(['test_runner_apps.simple.tests.DjangoCase1'])
+        self.assertEqual(runner.parallel, 1)
+        self.assertIsInstance(suite, TestSuite)
+
     def test_buffer_mode_test_pass(self):
         runner = DiscoverRunner(buffer=True, verbosity=0)
         with captured_stdout() as stdout, captured_stderr() as stderr:


### PR DESCRIPTION
`DiscoverRunner.parallel` is used in `setup_databases()` and `teardown_databases()` to control the number of test databases.

Regression in cb6c19749d342c3dc0f97d89ff6887b220cf45b8.

ticket-32988