### PR TITLE
Removed unnecessary WhereNode.is_summary.

### DIFF
--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -182,10 +182,6 @@ class WhereNode(tree.Node):
     def contains_over_clause(self):
         return self._contains_over_clause(self)
 
-    @property
-    def is_summary(self):
-        return any(child.is_summary for child in self.children)
-
     @staticmethod
     def _resolve_leaf(expr, query, *args, **kwargs):
         if hasattr(expr, 'resolve_expression'):


### PR DESCRIPTION
Unnecessary since its introduction in 1df89a60c5b7a28d7fda4c9ba7c07f02fd7de0fa.