### PR TITLE
Fixed #32990 -- Simplified and optimized tag regex.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -356,6 +356,7 @@ answer newbie questions, and generally made Django that much better:
     Graham Carlyle <graham.carlyle@maplecroft.net>
     Grant Jenks <contact@grantjenks.com>
     Greg Chapple <gregchapple1@gmail.com>
+    Greg Twohig
     Gregor Allensworth <greg.allensworth@gmail.com>
     Gregor Müllegger <gregor@muellegger.de>
     Grigory Fateyev <greg@dial.com.ru>

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -85,12 +85,10 @@ SINGLE_BRACE_END = '}'
 # (e.g. strings)
 UNKNOWN_SOURCE = '<unknown source>'
 
-# match a variable or block tag and capture the entire tag, including start/end
-# delimiters
-tag_re = (_lazy_re_compile('(%s.*?%s|%s.*?%s|%s.*?%s)' %
-          (re.escape(BLOCK_TAG_START), re.escape(BLOCK_TAG_END),
-           re.escape(VARIABLE_TAG_START), re.escape(VARIABLE_TAG_END),
-           re.escape(COMMENT_TAG_START), re.escape(COMMENT_TAG_END))))
+# Match BLOCK_TAG_*, VARIABLE_TAG_*, and COMMENT_TAG_* tags and capture the
+# entire tag, including start/end delimiters. Using re.compile() is faster
+# than instantiating SimpleLazyObject with _lazy_re_compile().
+tag_re = re.compile(r'({%.*?%}|{{.*?}}|{#.*?#})')
 
 logger = logging.getLogger('django.template')
 


### PR DESCRIPTION
Refactors the lazy_re_compiled tag_re which used six re.escape calls into a quickly compiled regex without redundant escape characters. Adds tests for the Lexer to ensure correct behavior.

The simple expansion of the strings with escape sequences yields `'(\\{%.*?%\\}|\\{\\{.*?\\}\\}|\\{\\#.*?\\#\\})'` which is full of redundant escape characters.

It turns out there is more overhead in just instantiating the `SimpleLazyObject` with `_lazy_re_compile` than there is in compiling the regex immediately.
```
$ python -m timeit -s 'from django.utils.regex_helper import _lazy_re_compile' "_lazy_re_compile('(\\{%.*?%\\}|\\{\\{.*?\\}\\}|\\{\\#.*?\\#\\})')"
500000 loops, best of 5: 620 nsec per loop
$ python -m timeit -s 'import re' "re.compile(r'({%.*?%}|{{.*?}}|{#.*?#})')"
1000000 loops, best of 5: 277 nsec per loop
```

Rather than adding a test to ensure the same pattern is used (which would not pass as the pattern has been trimmed of redundant escape characters) I added tests of the Lexers that use this regex to ensure they are sensibly parsing tags from a template string.