### PR TITLE
Removed redundant definition of UserModel in ModelBackend.with_perm().

### DIFF
--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -134,7 +134,6 @@ class ModelBackend(BaseBackend):
                 'The `perm` argument must be a string or a permission instance.'
             )
 
-        UserModel = get_user_model()
         if obj is not None:
             return UserModel._default_manager.none()
 


### PR DESCRIPTION
The `UserModel` was already initialized at top and was re-initialized inside `ModelBackends` class' `with_perm()` function

```
from django.contrib.auth import get_user_model
from django.contrib.auth.models import Permission
from django.db.models import Exists, OuterRef, Q

UserModel = get_user_model()

class BaseBackend:
```

Removed the re-initialization

