### PR TITLE
Fixed #29026 -- Added --scriptable option to makemigrations.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -825,6 +825,13 @@ Generate migration files without Django version and timestamp header.
 Makes ``makemigrations`` exit with a non-zero status when model changes without
 migrations are detected.
 
+.. django-admin-option:: --scriptable
+
+.. versionadded:: 4.1
+
+Diverts log output and input prompts to ``stderr``, writing only paths of
+generated migration files to ``stdout``.
+
 ``migrate``
 -----------
 

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -210,6 +210,10 @@ Management Commands
 * :option:`makemigrations --no-input` now logs default answers and reasons why
   migrations cannot be created.
 
+* The new :option:`makemigrations --scriptable` options diverts log output and
+  input prompts to ``stderr``, writing only paths of generated migration files
+  to ``stdout``.
+
 Migrations
 ~~~~~~~~~~
 

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -1667,6 +1667,47 @@ class MakeMigrationsTests(MigrationTestBase):
         self.assertIn("model_name='sillymodel',", out.getvalue())
         self.assertIn("name='silly_char',", out.getvalue())
 
+    def test_makemigrations_scriptable(self):
+        """
+        With scriptable=True, log output is diverted to stderr, and only the
+        paths of generated migration files are written to stdout.
+        """
+        out = io.StringIO()
+        err = io.StringIO()
+        with self.temporary_migration_module(
+            module='migrations.migrations.test_migrations',
+        ) as migration_dir:
+            call_command(
+                'makemigrations',
+                'migrations',
+                scriptable=True,
+                stdout=out,
+                stderr=err,
+            )
+        initial_file = os.path.join(migration_dir, '0001_initial.py')
+        self.assertEqual(out.getvalue(), f'{initial_file}\n')
+        self.assertIn('    - Create model ModelWithCustomBase\n', err.getvalue())
+
+    @mock.patch('builtins.input', return_value='Y')
+    def test_makemigrations_scriptable_merge(self, mock_input):
+        out = io.StringIO()
+        err = io.StringIO()
+        with self.temporary_migration_module(
+            module='migrations.test_migrations_conflict',
+        ) as migration_dir:
+            call_command(
+                'makemigrations',
+                'migrations',
+                merge=True,
+                name='merge',
+                scriptable=True,
+                stdout=out,
+                stderr=err,
+            )
+        merge_file = os.path.join(migration_dir, '0003_merge.py')
+        self.assertEqual(out.getvalue(), f'{merge_file}\n')
+        self.assertIn(f'Created new merge migration {merge_file}', err.getvalue())
+
     def test_makemigrations_migrations_modules_path_not_exist(self):
         """
         makemigrations creates migrations when specifying a custom location


### PR DESCRIPTION
ticket-29026 desires to separate logging from a simple list of filepaths created in `makemigrations`.

- Today, there is logging to both stdout and stderr (for errors), but no real "program output": the filenames are bolded and indented to flow between other log messages.
- This PR creates a new option `--scriptable` that will 1. divert all current logging to stderr and 2. log only the filepaths of created migration files to stdout, one per line (without leading spaces and styling)
- `--noinput` mode is still necessary to suppress input completely, otherwise interactive prompts go to stderr when `--scriptable` is used

EDIT: moved ticket-29470 solution to #14805

All of this logging can be silenced with `--verbosity 0`: no changes in this respect.