### PR TITLE
Fixed #33008 -- Fixed prefetch_related() for deleted GenericForeignKeys.

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -213,7 +213,7 @@ class GenericForeignKey(FieldCacheMixin):
             gfk_key,
             True,
             self.name,
-            True,
+            False,
         )
 
     def __get__(self, instance, cls=None):
@@ -229,6 +229,8 @@ class GenericForeignKey(FieldCacheMixin):
         pk_val = getattr(instance, self.fk_field)
 
         rel_obj = self.get_cached_value(instance, default=None)
+        if rel_obj is None and self.is_cached(instance):
+            return rel_obj
         if rel_obj is not None:
             ct_match = ct_id == self.get_content_type(obj=rel_obj, using=instance._state.db).id
             pk_match = rel_obj._meta.pk.to_python(pk_val) == rel_obj.pk

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -1033,6 +1033,24 @@ class GenericRelationTests(TestCase):
         # instance returned by the manager.
         self.assertEqual(list(bookmark.tags.all()), list(bookmark.tags.all().all()))
 
+    def test_deleted_GFK(self):
+        TaggedItem.objects.create(tag='awesome', content_object=self.book1)
+        TaggedItem.objects.create(tag='awesome', content_object=self.book2)
+        ct = ContentType.objects.get_for_model(Book)
+
+        book1_pk = self.book1.pk
+        self.book1.delete()
+
+        with self.assertNumQueries(2):
+            qs = TaggedItem.objects.filter(tag='awesome').prefetch_related('content_object')
+            result = [
+                (tag.object_id, tag.content_type_id, tag.content_object) for tag in qs
+            ]
+            self.assertEqual(result, [
+                (book1_pk, ct.pk, None),
+                (self.book2.pk, ct.pk, self.book2),
+            ])
+
 
 class MultiTableInheritanceTest(TestCase):
 


### PR DESCRIPTION
Patch for [#33008 ](https://code.djangoproject.com/ticket/33008) issue. prefetch_related don't set content_type_id and object_id to None, if GFK object is not found.