### PR TITLE
Removed reference to non-existent collectstatic --exclude-dirs option.

### DIFF
--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -311,10 +311,10 @@ class TestInteractiveMessages(CollectionTestCase):
                 call_command('collectstatic', interactive=True)
 
 
-class TestCollectionExcludeNoDefaultIgnore(TestDefaults, CollectionTestCase):
+class TestCollectionNoDefaultIgnore(TestDefaults, CollectionTestCase):
     """
-    Test ``--exclude-dirs`` and ``--no-default-ignore`` options of the
-    ``collectstatic`` management command.
+    The ``--no-default-ignore`` option of the ``collectstatic`` management
+    command.
     """
     def run_collectstatic(self):
         super().run_collectstatic(use_default_ignore_patterns=False)


### PR DESCRIPTION
I noticed a reference in a docstring to an option that doesn't exist. It looks like this option was never added, but may have been added as `--ignore`. See this commit: https://github.com/django/django/commit/cfc19f84def07fb950ae8789ed0655eae4f66a92