### PR TITLE
Fixed #33017 -- Fixed storage engine introspection on MySQL.

### DIFF
--- a/django/db/backends/mysql/introspection.py
+++ b/django/db/backends/mysql/introspection.py
@@ -180,10 +180,11 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Retrieve the storage engine for a given table. Return the default
         storage engine if the table doesn't exist.
         """
-        cursor.execute(
-            "SELECT engine "
-            "FROM information_schema.tables "
-            "WHERE table_name = %s", [table_name])
+        cursor.execute("""
+            SELECT engine
+            FROM information_schema.tables
+            WHERE table_name = %s
+                AND table_schema = DATABASE()""", [table_name])
         result = cursor.fetchone()
         if not result:
             return self.connection.features._mysql_storage_engine

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -108,6 +108,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def _field_should_be_indexed(self, model, field):
         create_index = super()._field_should_be_indexed(model, field)
+        if not create_index:
+            return False
+
         storage = self.connection.introspection.get_storage_engine(
             self.connection.cursor(), model._meta.db_table
         )
@@ -115,11 +118,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # db_constraint=False because the index from that constraint won't be
         # created.
         if (storage == "InnoDB" and
-                create_index and
                 field.get_internal_type() == 'ForeignKey' and
                 field.db_constraint):
             return False
-        return not self._is_limited_data_type(field) and create_index
+        return not self._is_limited_data_type(field)
 
     def _delete_composed_index(self, model, fields, *args):
         """


### PR DESCRIPTION
When querying the `information_schema.tables` for the storage engine, we have to specify `table_schema` in addition to `table_name`, otherwise the query returns a list of results for *all* tables with the specified name from every database in the system. If there are multiple tables with the same name but using different storage engines present in different databases in the MySQL instance, the query could return a wrong result.

We have to limit the query to the current database to make sure we get the correct result.

This also improves performance on MySQL instances with a large number of databases, since querying the `information_schema` table can be very slow.

The `get_storage_engine` function that this patch fixes is invoked when adding columns during migrations to determine whether it should index the column. We have a MySQL instance with over a thousand databases in production and this patch has cut down the time it takes to run a specific set of django migrations from 2 hours to around 15 minutes.

**Trac ticket**: https://code.djangoproject.com/ticket/33017