### PR TITLE
Fixed #33025 -- Avoided accessing the database connections in Query.build_lookup() when not necessary.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1192,8 +1192,11 @@ class Query(BaseExpression):
         # stage because join promotion can't be done in the compiler. Using
         # DEFAULT_DB_ALIAS isn't nice but it's the best that can be done here.
         # A similar thing is done in is_nullable(), too.
-        if (connections[DEFAULT_DB_ALIAS].features.interprets_empty_strings_as_nulls and
-                lookup_name == 'exact' and lookup.rhs == ''):
+        if (
+            lookup_name == 'exact' and
+            lookup.rhs == '' and
+            connections[DEFAULT_DB_ALIAS].features.interprets_empty_strings_as_nulls
+        ):
             return lhs.get_lookup('isnull')(lhs, True)
 
         return lookup


### PR DESCRIPTION
[Ticket is 33025](https://code.djangoproject.com/ticket/33025), spawned out of prior ticket [33015](https://code.djangoproject.com/ticket/33015).

Of the built-in backends, only Oracle treats empty strings and nulls as equal, so avoid testing the default connection backend for `interprets_empty_strings_as_nulls` if it can be established from the lookup that it wouldn't affect the lookup instance returned.
This improves performance a small amount for most lookups being built, because accessing the connections requires touching the thread critical `Local` which is an expensive operation.