### PR TITLE
Fixed #33018 -- Corrected function compilation with empty queryset

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -702,7 +702,12 @@ class Func(SQLiteNumericMixin, Expression):
         sql_parts = []
         params = []
         for arg in self.source_expressions:
-            arg_sql, arg_params = compiler.compile(arg)
+            try:
+                arg_sql, arg_params = compiler.compile(arg)
+            except EmptyResultSet:
+                arg_sql, arg_params = getattr(arg, 'empty_aggregate_value', NotImplemented), ()
+                if arg_sql is NotImplemented:
+                    raise
             sql_parts.append(arg_sql)
             params.extend(arg_params)
         data = {**self.extra, **extra_context}

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -144,6 +144,7 @@ class Query(BaseExpression):
 
     alias_prefix = 'T'
     subq_aliases = frozenset([alias_prefix])
+    empty_aggregate_value = 'NULL'
 
     compiler = 'SQLCompiler'
 

--- a/tests/db_functions/comparison/test_coalesce.py
+++ b/tests/db_functions/comparison/test_coalesce.py
@@ -70,3 +70,8 @@ class CoalesceTests(TestCase):
             authors, ['John Smith', 'Rhonda'],
             lambda a: a.name
         )
+
+    def test_empty_query(self):
+        Author.objects.create(name='John Smith')
+        for author in Author.objects.annotate(annotation=Coalesce(Author.objects.none(), 42)):
+            self.assertEqual(author.annotation, 42)


### PR DESCRIPTION
Hi, 

This PR tackles https://code.djangoproject.com/ticket/33018