### PR TITLE
Fixed #33300 -- Prevented displaying .hidden elements on small screens.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -300,7 +300,7 @@ p img, h1 img, h2 img, h3 img, h4 img, td img {
 }
 
 .hidden {
-    display: none;
+    display: none!important;
 }
 
 /* TABLES */


### PR DESCRIPTION
Append `!important` to `display:none` for `.hidden` class, to prevent accidentally displaying `.hidden` elements on mobile mode; otherwise `display:none` will be overridden by rules of `display:flex` in responsive.css.