### PR TITLE
Fixed #32800 -- Changed CsrfViewMiddleware not to mask the CSRF secret.

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -34,6 +34,11 @@ USE_L10N_DEPRECATED_MSG = (
     'display numbers and dates using the format of the current locale.'
 )
 
+CSRF_COOKIE_MASKED_DEPRECATED_MSG = (
+    'The CSRF_COOKIE_MASKED transitional setting is deprecated. Support for '
+    'it will be removed in Django 5.0.'
+)
+
 
 class SettingsReference(str):
     """
@@ -206,6 +211,9 @@ class Settings:
         if self.is_overridden('USE_DEPRECATED_PYTZ'):
             warnings.warn(USE_DEPRECATED_PYTZ_DEPRECATED_MSG, RemovedInDjango50Warning)
 
+        if self.is_overridden('CSRF_COOKIE_MASKED'):
+            warnings.warn(CSRF_COOKIE_MASKED_DEPRECATED_MSG, RemovedInDjango50Warning)
+
         if hasattr(time, 'tzset') and self.TIME_ZONE:
             # When we can, attempt to validate the timezone. If we can't find
             # this file, no check happens and it's harmless.
@@ -254,6 +262,8 @@ class UserSettingsHolder:
         self._deleted.discard(name)
         if name == 'USE_L10N':
             warnings.warn(USE_L10N_DEPRECATED_MSG, RemovedInDjango50Warning)
+        if name == 'CSRF_COOKIE_MASKED':
+            warnings.warn(CSRF_COOKIE_MASKED_DEPRECATED_MSG, RemovedInDjango50Warning)
         super().__setattr__(name, value)
         if name == 'USE_DEPRECATED_PYTZ':
             warnings.warn(USE_DEPRECATED_PYTZ_DEPRECATED_MSG, RemovedInDjango50Warning)

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -557,6 +557,10 @@ CSRF_HEADER_NAME = 'HTTP_X_CSRFTOKEN'
 CSRF_TRUSTED_ORIGINS = []
 CSRF_USE_SESSIONS = False
 
+# Whether to mask CSRF cookie value. It's a transitional setting helpful in
+# migrating multiple instance of the same project to Django 4.1+.
+CSRF_COOKIE_MASKED = False
+
 ############
 # MESSAGES #
 ############

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -128,7 +128,7 @@ class InvalidTokenFormat(Exception):
         self.reason = reason
 
 
-def _sanitize_token(token):
+def _check_token_format(token):
     """
     Raise an InvalidTokenFormat error if the token has an invalid length or
     characters that aren't allowed. The token argument can be a CSRF cookie
@@ -239,7 +239,7 @@ class CsrfViewMiddleware(MiddlewareMixin):
                 csrf_secret = None
             else:
                 # This can raise InvalidTokenFormat.
-                _sanitize_token(csrf_secret)
+                _check_token_format(csrf_secret)
         if csrf_secret is None:
             return None
         # Django versions before 4.0 masked the secret before storing.
@@ -386,7 +386,7 @@ class CsrfViewMiddleware(MiddlewareMixin):
             token_source = 'POST'
 
         try:
-            _sanitize_token(request_csrf_token)
+            _check_token_format(request_csrf_token)
         except InvalidTokenFormat as exc:
             reason = self._bad_token_message(exc.reason, token_source)
             raise RejectRequest(reason)

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -67,6 +67,8 @@ details on these changes.
 
 * The ``SitemapIndexItem.__str__()`` method will be removed.
 
+* The ``CSRF_COOKIE_MASKED`` transitional setting will be removed.
+
 .. _deprecation-removed-in-4.1:
 
 4.1

--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -110,11 +110,12 @@ The above code could be simplified by using the `JavaScript Cookie library
 
 .. note::
 
-    The CSRF token is also present in the DOM, but only if explicitly included
-    using :ttag:`csrf_token` in a template. The cookie contains the canonical
-    token; the ``CsrfViewMiddleware`` will prefer the cookie to the token in
-    the DOM. Regardless, you're guaranteed to have the cookie if the token is
-    present in the DOM, so you should use the cookie!
+    The CSRF token is also present in the DOM in a masked form, but only if
+    explicitly included using :ttag:`csrf_token` in a template. The cookie
+    contains the canonical, unmasked token. The
+    :class:`~django.middleware.csrf.CsrfViewMiddleware` will accept either.
+    However, in order to protect against `BREACH`_ attacks, it's recommended to
+    use a masked token.
 
 .. warning::
 
@@ -231,25 +232,21 @@ How it works
 
 The CSRF protection is based on the following things:
 
-#. A CSRF cookie that is based on a random secret value, which other sites
-   will not have access to.
+#. A CSRF cookie that is a random secret value, which other sites will not have
+   access to.
 
-   This cookie is set by ``CsrfViewMiddleware``. It is sent with every
-   response that has called ``django.middleware.csrf.get_token()`` (the
-   function used internally to retrieve the CSRF token), if it wasn't already
-   set on the request.
+   ``CsrfViewMiddleware`` sends this cookie with the response whenever
+   ``django.middleware.csrf.get_token()`` is called. It can also send it in
+   other cases. For security reasons, the value of the secret is changed each
+   time a user logs in.
 
-   In order to protect against `BREACH`_ attacks, the token is not simply the
-   secret; a random mask is prepended to the secret and used to scramble it.
+#. A hidden form field with the name 'csrfmiddlewaretoken', present in all
+   outgoing POST forms.
 
-   For security reasons, the value of the secret is changed each time a
-   user logs in.
-
-#. A hidden form field with the name 'csrfmiddlewaretoken' present in all
-   outgoing POST forms. The value of this field is, again, the value of the
-   secret, with a mask which is both added to it and used to scramble it. The
-   mask is regenerated on every call to ``get_token()`` so that the form field
-   value is changed in every such response.
+   In order to protect against `BREACH`_ attacks, the value of this field is
+   not simply the secret. It is scrambled differently with each response using
+   a mask. The mask is generated randomly on every call to ``get_token()``, so
+   the form field value is different each time.
 
    This part is done by the template tag.
 
@@ -293,6 +290,10 @@ The CSRF protection is based on the following things:
 .. versionadded:: 4.0
 
     ``Origin`` checking was added, as described above.
+
+.. versionchanged:: 4.1
+
+    In older versions, the CSRF cookie value was masked.
 
 This ensures that only forms that have originated from trusted domains can be
 used to POST data back.

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -347,6 +347,22 @@ form input <acquiring-csrf-token-from-html>` instead of :ref:`from the cookie
 
 See :setting:`SESSION_COOKIE_HTTPONLY` for details on ``HttpOnly``.
 
+.. setting:: CSRF_COOKIE_MASKED
+
+``CSRF_COOKIE_MASKED``
+----------------------
+
+.. versionadded:: 4.1
+
+Default: ``False``
+
+Whether to mask the CSRF cookie. See
+:ref:`release notes <csrf-cookie-masked-usage>` for usage details.
+
+.. deprecated:: 4.1
+
+    This transitional setting is deprecated and will be removed in Django 5.0.
+
 .. setting:: CSRF_COOKIE_NAME
 
 ``CSRF_COOKIE_NAME``

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -26,6 +26,25 @@ officially support the latest release of each series.
 What's new in Django 4.1
 ========================
 
+.. _csrf-cookie-masked-usage:
+
+``CSRF_COOKIE_MASKED`` setting
+------------------------------
+
+The new :setting:`CSRF_COOKIE_MASKED` transitional setting allows specifying
+whether to mask the CSRF cookie.
+
+:class:`~django.middleware.csrf.CsrfViewMiddleware` no longer masks the CSRF
+cookie like it does the CSRF token in the DOM. If you are upgrading multiple
+instances of the same project to Django 4.1, you should set
+:setting:`CSRF_COOKIE_MASKED` to ``True`` during the transition, in
+order to allow compatibility with the older versions of Django. Once the
+transition to 4.1 is complete you can stop overriding
+:setting:`CSRF_COOKIE_MASKED`.
+
+This setting is deprecated as of this release and will be removed in Django
+5.0.
+
 Minor features
 --------------
 
@@ -270,6 +289,13 @@ Miscellaneous
 * The Django test runner now returns a non-zero error code for unexpected
   successes from tests marked with :py:func:`unittest.expectedFailure`.
 
+* :class:`~django.middleware.csrf.CsrfViewMiddleware` no longer masks the CSRF
+  cookie like it does the CSRF token in the DOM.
+
+* :class:`~django.middleware.csrf.CsrfViewMiddleware` now uses
+  ``request.META['CSRF_COOKIE']`` for storing the unmasked CSRF secret rather
+  than a masked version. This is an undocumented, private API.
+
 .. _deprecated-features-4.1:
 
 Features deprecated in 4.1
@@ -282,6 +308,8 @@ Miscellaneous
   Custom sitemap index templates should be updated for the adjusted
   :ref:`context variables <sitemap-index-context-variables>`, expecting a list
   of objects with ``location`` and optional ``lastmod`` attributes.
+
+* ``CSRF_COOKIE_MASKED`` transitional setting is deprecated.
 
 Features removed in 4.1
 =======================

--- a/tests/csrf_tests/test_context_processor.py
+++ b/tests/csrf_tests/test_context_processor.py
@@ -9,7 +9,7 @@ class TestContextProcessor(CsrfFunctionTestMixin, SimpleTestCase):
 
     def test_force_token_to_string(self):
         request = HttpRequest()
-        test_token = '1bcdefghij2bcdefghij3bcdefghij4bcdefghij5bcdefghij6bcdefghijABCD'
-        request.META['CSRF_COOKIE'] = test_token
+        test_secret = 32 * 'a'
+        request.META['CSRF_COOKIE'] = test_secret
         token = csrf(request).get('csrf_token')
-        self.assertMaskedSecretCorrect(token, 'lcccccccX2kcccccccY2jcccccccssIC')
+        self.assertMaskedSecretCorrect(token, test_secret)

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -8,7 +8,7 @@ from django.middleware.csrf import (
     CSRF_ALLOWED_CHARS, CSRF_SECRET_LENGTH, CSRF_SESSION_KEY,
     CSRF_TOKEN_LENGTH, REASON_BAD_ORIGIN, REASON_CSRF_TOKEN_MISSING,
     REASON_NO_CSRF_COOKIE, CsrfViewMiddleware, InvalidTokenFormat,
-    RejectRequest, _does_token_match, _mask_cipher_secret, _sanitize_token,
+    RejectRequest, _check_token_format, _does_token_match, _mask_cipher_secret,
     _unmask_cipher_token, get_token, rotate_token,
 )
 from django.test import SimpleTestCase, override_settings
@@ -106,7 +106,7 @@ class CsrfFunctionTests(CsrfFunctionTestMixin, SimpleTestCase):
         self.assertNotEqual(cookie, TEST_SECRET)
         self.assertIs(request.META['CSRF_COOKIE_NEEDS_UPDATE'], True)
 
-    def test_sanitize_token_valid(self):
+    def test_check_token_format_valid(self):
         cases = [
             # A token of length CSRF_SECRET_LENGTH.
             TEST_SECRET,
@@ -116,10 +116,10 @@ class CsrfFunctionTests(CsrfFunctionTestMixin, SimpleTestCase):
         ]
         for token in cases:
             with self.subTest(token=token):
-                actual = _sanitize_token(token)
+                actual = _check_token_format(token)
                 self.assertIsNone(actual)
 
-    def test_sanitize_token_invalid(self):
+    def test_check_token_format_invalid(self):
         cases = [
             (64 * '*', 'has invalid characters'),
             (16 * 'a', 'has incorrect length'),
@@ -127,7 +127,7 @@ class CsrfFunctionTests(CsrfFunctionTestMixin, SimpleTestCase):
         for token, expected_message in cases:
             with self.subTest(token=token):
                 with self.assertRaisesMessage(InvalidTokenFormat, expected_message):
-                    _sanitize_token(token)
+                    _check_token_format(token)
 
     def test_does_token_match(self):
         cases = [

--- a/tests/deprecation/test_csrf_cookie_masked.py
+++ b/tests/deprecation/test_csrf_cookie_masked.py
@@ -1,0 +1,30 @@
+import sys
+from types import ModuleType
+
+from django.conf import CSRF_COOKIE_MASKED_DEPRECATED_MSG, Settings, settings
+from django.test import SimpleTestCase
+from django.utils.deprecation import RemovedInDjango50Warning
+
+
+class CsrfCookieMaskedDeprecationTests(SimpleTestCase):
+    msg = CSRF_COOKIE_MASKED_DEPRECATED_MSG
+
+    def test_override_settings_warning(self):
+        with self.assertRaisesMessage(RemovedInDjango50Warning, self.msg):
+            with self.settings(CSRF_COOKIE_MASKED=True):
+                pass
+
+    def test_settings_init_warning(self):
+        settings_module = ModuleType('fake_settings_module')
+        settings_module.USE_TZ = False
+        settings_module.CSRF_COOKIE_MASKED = True
+        sys.modules['fake_settings_module'] = settings_module
+        try:
+            with self.assertRaisesMessage(RemovedInDjango50Warning, self.msg):
+                Settings('fake_settings_module')
+        finally:
+            del sys.modules['fake_settings_module']
+
+    def test_access(self):
+        # Warning is not raised on access.
+        self.assertEqual(settings.CSRF_COOKIE_MASKED, False)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32800