### PR TITLE
Refs #33022 -- Fixed test isolation issues in MigrateTests.

### DIFF
--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -951,6 +951,7 @@ class MigrateTests(MigrationTestBase):
         )
         # No changes were actually applied so there is nothing to rollback
 
+    @override_settings(AUTH_USER_MODEL='migrations.Author')
     def test_migrate_partially_applied_squashed_migration(self):
         """
         Migrating to a squashed migration specified by name should succeed


### PR DESCRIPTION
ticket-33022

Thanks to Chris's first efforts, I narrowed the failure to `test_custom_user` followed by `test_migrate_partially_applied_squashed_migration`, which I contributed in 910ecd1b8df.

Try:
`.tests/runtests.py migrations.test_commands.MigrateTests migrations.test_executor.ExecutorTests -k test_custom_user -k test_migrate_partially --shuffle 1022528553`

This diff solves it, but I am not 100% certain of the correct cleanup behavior in `test_custom_user`.