### PR TITLE
Tab completion when executing as `./manage.py`

### DIFF
--- a/extras/django_bash_completion
+++ b/extras/django_bash_completion
@@ -36,7 +36,7 @@ _django_completion()
                    COMP_CWORD=$COMP_CWORD \
                    DJANGO_AUTO_COMPLETE=1 $1 ) )
 }
-complete -F _django_completion -o default manage.py django-admin
+complete -F _django_completion -o default ./manage.py manage.py django-admin
 
 _python_django_completion()
 {


### PR DESCRIPTION
Considering that the `manage.py` file has its executable bit set users will be able to execute the script from the project root directory and they will need to prepend `./` to the script name.