### PR TITLE
Fix for Ticket 23424 (based on fix for Ticket 23356)

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -384,8 +384,8 @@ class Lexer:
             # We could do len(BLOCK_TAG_START) to be more "correct", but we've
             # hard-coded the 2s here for performance. And it's not like
             # the TAG_START values are going to change anytime, anyway.
-            block_content = token_string[2:-2].strip()
             token_start = token_string[0:2]
+            block_content = token_string[2:-2].strip()
             token_type = TAG_START_TOKEN_TYPE_MAP[token_start]
             return Token(token_type, block_content, position, lineno, token_string)
         else:

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -1351,7 +1351,7 @@ def verbatim(parser, token):
     # set the end tag to the entire token contents to allow specific closing
     # tags to be matched
     end_tag = f'end{token.contents}'
-    verbatim_text = parser.parse_verbatim((end_tag,))
+    verbatim_text = parser.parse_verbatim(end_tag)
     parser.delete_first_token()
     return VerbatimNode(verbatim_text)
 

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -19,7 +19,6 @@ from .base import (
     NodeList, TemplateSyntaxError, VariableDoesNotExist, kwarg_re,
     render_value_in_context, token_kwargs,
 )
-from .context import Context
 from .defaultfilters import date
 from .library import Library
 from .smartif import IfParser, Literal
@@ -1349,9 +1348,12 @@ def verbatim(parser, token):
             ...
         {% endverbatim myblock %}
     """
-    nodelist = parser.parse(('endverbatim',))
+    # set the end tag to the entire token contents to allow specific closing
+    # tags to be matched
+    end_tag = f'end{token.contents}'
+    verbatim_text = parser.parse_verbatim((end_tag,))
     parser.delete_first_token()
-    return VerbatimNode(nodelist.render(Context()))
+    return VerbatimNode(verbatim_text)
 
 
 @register.tag

--- a/tests/template_tests/syntax_tests/test_verbatim.py
+++ b/tests/template_tests/syntax_tests/test_verbatim.py
@@ -1,5 +1,3 @@
-from unittest import expectedFailure
-
 from django.template import TemplateSyntaxError
 from django.test import SimpleTestCase
 
@@ -39,21 +37,18 @@ class VerbatimTagTests(SimpleTestCase):
         output = self.engine.render_to_string('verbatim-tag06')
         self.assertEqual(output, 'Don\'t {% endverbatim %} just yet')
 
-    @expectedFailure  # See #23424
     @setup({'verbatim-tag07': '{% verbatim %}{{% endverbatim %}text'
                               '{% verbatim %}}{% endverbatim %}'})
     def test_verbatim_tag07(self):
         output = self.engine.render_to_string('verbatim-tag07')
         self.assertEqual(output, '{text}')
 
-    @expectedFailure  # See #23424
     @setup({'verbatim-tag08': '{% verbatim %}{{{% endverbatim %}text'
                               '{% verbatim %}}}{% endverbatim %}'})
     def test_verbatim_tag08(self):
         output = self.engine.render_to_string('verbatim-tag08', {'field': 'value'})
         self.assertEqual(output, '{{text}}')
 
-    @expectedFailure    # See #23424
     @setup({'verbatim-tag09': '{%verbatim%} {{ {%endverbatim%} computer.{{field}} '
                               '{%verbatim%} }} {%endverbatim%}'})
     def test_verbatim_tag09(self):

--- a/tests/template_tests/syntax_tests/test_verbatim.py
+++ b/tests/template_tests/syntax_tests/test_verbatim.py
@@ -1,3 +1,5 @@
+from unittest import expectedFailure
+
 from django.template import TemplateSyntaxError
 from django.test import SimpleTestCase
 
@@ -36,3 +38,24 @@ class VerbatimTagTests(SimpleTestCase):
     def test_verbatim_tag06(self):
         output = self.engine.render_to_string('verbatim-tag06')
         self.assertEqual(output, 'Don\'t {% endverbatim %} just yet')
+
+    @expectedFailure  # See #23424
+    @setup({'verbatim-tag07': '{% verbatim %}{{% endverbatim %}text'
+                              '{% verbatim %}}{% endverbatim %}'})
+    def test_verbatim_tag07(self):
+        output = self.engine.render_to_string('verbatim-tag07')
+        self.assertEqual(output, '{text}')
+
+    @expectedFailure  # See #23424
+    @setup({'verbatim-tag08': '{% verbatim %}{{{% endverbatim %}text'
+                              '{% verbatim %}}}{% endverbatim %}'})
+    def test_verbatim_tag08(self):
+        output = self.engine.render_to_string('verbatim-tag08', {'field': 'value'})
+        self.assertEqual(output, '{{text}}')
+
+    @expectedFailure    # See #23424
+    @setup({'verbatim-tag09': '{%verbatim%} {{ {%endverbatim%} computer.{{field}} '
+                              '{%verbatim%} }} {%endverbatim%}'})
+    def test_verbatim_tag09(self):
+        output = self.engine.render_to_string('verbatim-tag09', {'field': 'value'})
+        self.assertEqual(output, ' {{  computer.value  }} ')

--- a/tests/template_tests/test_parser.py
+++ b/tests/template_tests/test_parser.py
@@ -32,7 +32,7 @@ class ParserTests(SimpleTestCase):
         lexer = Lexer('{% for i in 1 %}{{ a }}\n{% endfor %}')
         self.assertEqual(
             repr(lexer),
-            '<Lexer template_string="{% for i in 1 %}{{ a...", verbatim=False>',
+            '<Lexer template_string="{% for i in 1 %}{{ a...">',
         )
 
     def test_filter_parsing(self):

--- a/tests/template_tests/test_parser.py
+++ b/tests/template_tests/test_parser.py
@@ -133,3 +133,20 @@ class ParserTests(SimpleTestCase):
                 '1|two_one_opt_arg:"1"',
         ):
             FilterExpression(expr, parser)
+
+    def test_verbatim_parsing(self):
+        str1 = 'Some text1\n{% for u in users %}\n\t{{ user.first_name }}\n{% endfor %}'
+        str2 = '{% endsometag %}'
+        lexer = Lexer(str1 + str2)
+        tokens = lexer.tokenize()
+
+        p = Parser(tokens)
+        verbatim_text = p.parse_verbatim('endsometag')
+
+        self.assertEqual(verbatim_text, str1)
+
+        p = Parser(tokens)
+        verbatim_text_all = p.parse_verbatim('nonexistent')
+        # parsing should continue to end of input as the provided until tag
+        # won't be found
+        self.assertEqual(verbatim_text_all, str1 + str2)


### PR DESCRIPTION
Allows verbatim tag contents to contain tag delimiters eg. `{{`.
This pull request is based off https://github.com/django/django/pull/14686