### PR TITLE
Lack input type DateInput/DateTimeInput/TimeInput

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -490,16 +490,19 @@ class DateTimeBaseInput(TextInput):
 
 
 class DateInput(DateTimeBaseInput):
+    input_type = 'date'
     format_key = 'DATE_INPUT_FORMATS'
     template_name = 'django/forms/widgets/date.html'
 
 
 class DateTimeInput(DateTimeBaseInput):
+    input_type = 'datetime'
     format_key = 'DATETIME_INPUT_FORMATS'
     template_name = 'django/forms/widgets/datetime.html'
 
 
 class TimeInput(DateTimeBaseInput):
+    input_type = 'time'
     format_key = 'TIME_INPUT_FORMATS'
     template_name = 'django/forms/widgets/time.html'
 


### PR DESCRIPTION
The input types of DateInput, DateTimeInput, TimeInput are 'text' inheriting from TextInput, so date and/or time is inconvenient to input in web form. They should be 'date', 'datetime', 'time' respectively, then the user can pick or formatting input in web form.