### PR TITLE
Refs #10929 -- Allowed NowUTC SQL customization for third-party backends.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -329,6 +329,8 @@ class BaseDatabaseFeatures:
         'non_default': None,  # Non-default.
         'swedish_ci': None  # Swedish case-insensitive.
     }
+    # SQL template override for tests.aggregation.tests.NowUTC
+    test_now_utc_template = None
 
     # A set of dotted paths to tests in Django's test suite that are expected
     # to fail on this database.

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -60,6 +60,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             'swedish_ci': f'{charset}_swedish_ci',
         }
 
+    test_now_utc_template = 'UTC_TIMESTAMP'
+
     @cached_property
     def django_test_skips(self):
         skips = {

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -72,6 +72,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'non_default': 'SWEDISH_CI',
         'swedish_ci': 'SWEDISH_CI',
     }
+    test_now_utc_template = "CURRENT_TIMESTAMP AT TIME ZONE 'UTC'"
 
     django_test_skips = {
         "Oracle doesn't support SHA224.": {

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -62,6 +62,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'non_default': 'sv-x-icu',
         'swedish_ci': 'sv-x-icu',
     }
+    test_now_utc_template = "STATEMENT_TIMESTAMP() AT TIME ZONE 'UTC'"
 
     django_test_skips = {
         'opclasses are PostgreSQL only.': {

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -26,14 +26,10 @@ class NowUTC(Now):
     template = 'CURRENT_TIMESTAMP'
     output_field = DateTimeField()
 
-    def as_mysql(self, compiler, connection, **extra_context):
-        return self.as_sql(compiler, connection, template='UTC_TIMESTAMP', **extra_context)
-
-    def as_oracle(self, compiler, connection, **extra_context):
-        return self.as_sql(compiler, connection, template="CURRENT_TIMESTAMP AT TIME ZONE 'UTC'", **extra_context)
-
-    def as_postgresql(self, compiler, connection, **extra_context):
-        return self.as_sql(compiler, connection, template="STATEMENT_TIMESTAMP() AT TIME ZONE 'UTC'", **extra_context)
+    def as_sql(self, compiler, connection, **extra_context):
+        if connection.features.test_now_utc_template:
+            extra_context['template'] = connection.features.test_now_utc_template
+        return super().as_sql(compiler, connection, **extra_context)
 
 
 class AggregateTestCase(TestCase):


### PR DESCRIPTION
As proposed at https://github.com/django/django/pull/14026#discussion_r677916611.