### PR TITLE
Fixed #6106 -- makemessages overrides the *.po files even if they are already up to date

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -208,7 +208,7 @@ class Command(BaseCommand):
 
     requires_system_checks = []
 
-    msgmerge_options = ['-q', '--previous']
+    msgmerge_options = ['-q', '--backup=none', '--previous', '--update']
     msguniq_options = ['--to-code=utf-8']
     msgattrib_options = ['--no-obsolete']
     xgettext_options = ['--from-code=UTF-8', '--add-comments=Translators']
@@ -615,13 +615,15 @@ class Command(BaseCommand):
 
         if os.path.exists(pofile):
             args = ['msgmerge'] + self.msgmerge_options + [pofile, potfile]
-            msgs, errors, status = popen_wrapper(args)
+            _, errors, status = popen_wrapper(args)
             if errors:
                 if status != STATUS_OK:
                     raise CommandError(
                         "errors happened while running msgmerge\n%s" % errors)
                 elif self.verbosity > 0:
                     self.stdout.write(errors)
+            with open(pofile, encoding='utf-8') as fp:
+                msgs = fp.read()
         else:
             with open(potfile, encoding='utf-8') as fp:
                 msgs = fp.read()

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -804,3 +804,29 @@ class NoSettingsExtractionTests(AdminScriptTestCase):
         out, err = self.run_django_admin(['makemessages', '-l', 'en', '-v', '0'])
         self.assertNoOutput(err)
         self.assertNoOutput(out)
+
+
+class UnchangedPoExtractionTests(ExtractorTests):
+
+    work_subdir = 'unchanged'
+
+    def setUp(self):
+        super().setUp()
+        with open(self.PO_FILE) as fp:
+            self.original_po_contents = fp.read()
+
+    def test_po_remains_unchanged(self):
+        """
+        PO files are unchanged unless there are new changes.
+        """
+        _, po_contents = self._run_makemessages()
+        self.assertEqual(po_contents, self.original_po_contents)
+
+    def test_po_changes_with_new_strings(self):
+        """
+        PO file is properly updated when new changes are detected.
+        """
+        os.rename('new_file.py.tmp', 'new_file.py')
+        _, po_contents = self._run_makemessages()
+        self.assertNotEqual(po_contents, self.original_po_contents)
+        self.assertMsgId('This is a hitherto undiscovered translatable string.', po_contents)

--- a/tests/i18n/unchanged/__init__.py
+++ b/tests/i18n/unchanged/__init__.py
@@ -1,0 +1,8 @@
+# This package is used to test whether makemessages leaves files untouched
+# when there are no updates to the file. This should include not touching the
+# POT-Creation-Date.
+
+from django.utils.translation import gettext as _
+
+dummy1 = _("This is a translatable string.")
+dummy2 = _("This is another translatable string.")

--- a/tests/i18n/unchanged/locale/de/LC_MESSAGES/django.po
+++ b/tests/i18n/unchanged/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-04-25 15:39-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: __init__.py:7
+msgid "This is a translatable string."
+msgstr "And this has been translated."
+
+#: __init__.py:8
+msgid "This is another translatable string."
+msgstr "And this also has been translated."

--- a/tests/i18n/unchanged/new_file.py.tmp
+++ b/tests/i18n/unchanged/new_file.py.tmp
@@ -1,0 +1,3 @@
+from django.utils.translation import gettext as _
+
+dummy3 = _("This is a hitherto undiscovered translatable string.")


### PR DESCRIPTION
ticket-6106

Added `--update` option to msgmerge_options so that *.po files are not re-created if they
are not required to be. Also added `--backup=none` inorder to remove unwanted backup files