### PR TITLE
Corrected BaseDatabaseSchemaEditor.execute() signature in docs.

### DIFF
--- a/docs/ref/schema-editor.txt
+++ b/docs/ref/schema-editor.txt
@@ -43,7 +43,7 @@ Methods
 ``execute()``
 -------------
 
-.. method:: BaseDatabaseSchemaEditor.execute(sql, params=[])
+.. method:: BaseDatabaseSchemaEditor.execute(sql, params=())
 
 Executes the SQL statement passed in, with parameters if supplied. This
 is a wrapper around the normal database cursors that allows capture of the SQL


### PR DESCRIPTION
Changed in 9027e6c8a3711034d345535036d1a276d9a8b829.

https://github.com/django/django/blob/3445c50a3affc5ae7b1c2712a139d4a5105aeaf5/django/db/backends/base/schema.py#L130