### PR TITLE
Fixed #33051 -- Fixed highlighting the current model in admin's sidebar with non-ASCII model names.

### DIFF
--- a/django/contrib/admin/templates/admin/app_list.html
+++ b/django/contrib/admin/templates/admin/app_list.html
@@ -2,15 +2,15 @@
 
 {% if app_list %}
   {% for app in app_list %}
-    <div class="app-{{ app.app_label }} module{% if app.app_url in request.path %} current-app{% endif %}">
+    <div class="app-{{ app.app_label }} module{% if app.app_url in request.path|urlencode %} current-app{% endif %}">
       <table>
         <caption>
           <a href="{{ app.app_url }}" class="section" title="{% blocktranslate with name=app.name %}Models in the {{ name }} application{% endblocktranslate %}">{{ app.name }}</a>
         </caption>
         {% for model in app.models %}
-          <tr class="model-{{ model.object_name|lower }}{% if model.admin_url in request.path %} current-model{% endif %}">
+          <tr class="model-{{ model.object_name|lower }}{% if model.admin_url in request.path|urlencode %} current-model{% endif %}">
             {% if model.admin_url %}
-              <th scope="row"><a href="{{ model.admin_url }}"{% if model.admin_url in request.path %} aria-current="page"{% endif %}>{{ model.name }}</a></th>
+              <th scope="row"><a href="{{ model.admin_url }}"{% if model.admin_url in request.path|urlencode %} aria-current="page"{% endif %}>{{ model.name }}</a></th>
             {% else %}
               <th scope="row">{{ model.name }}</th>
             {% endif %}

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -1046,3 +1046,7 @@ class ReadOnlyRelatedField(models.Model):
     chapter = models.ForeignKey(Chapter, models.CASCADE)
     language = models.ForeignKey(Language, models.CASCADE)
     user = models.ForeignKey(User, models.CASCADE)
+
+
+class Héllo(models.Model):
+    pass

--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -4,6 +4,8 @@ from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.urls import path, reverse
 
+from .models import Héllo
+
 
 class AdminSiteWithSidebar(admin.AdminSite):
     pass
@@ -17,6 +19,7 @@ site_with_sidebar = AdminSiteWithSidebar(name='test_with_sidebar')
 site_without_sidebar = AdminSiteWithoutSidebar(name='test_without_sidebar')
 
 site_with_sidebar.register(User)
+site_with_sidebar.register(Héllo)
 
 urlpatterns = [
     path('test_sidebar/admin/', site_with_sidebar.urls),
@@ -85,9 +88,23 @@ class AdminSidebarTests(TestCase):
         with self.assertNoLogs('django.template', 'DEBUG'):
             self.client.get(url)
 
+    def test_sidebar_model_name_non_ascii(self):
+        url = reverse('test_with_sidebar:admin_views_héllo_changelist')
+        response = self.client.get(url)
+        self.assertContains(response, '<div class="app-admin_views module current-app">')
+        self.assertContains(response, '<tr class="model-héllo current-model">')
+        self.assertContains(
+            response,
+            '<th scope="row">'
+            '<a href="/test_sidebar/admin/admin_views/h%C3%A9llo/" aria-current="page">'
+            'Héllos</a></th>'
+        )
+
 
 @override_settings(ROOT_URLCONF='admin_views.test_nav_sidebar')
 class SeleniumTests(AdminSeleniumTestCase):
+    available_apps = ['admin_views'] + AdminSeleniumTestCase.available_apps
+
     def setUp(self):
         self.superuser = User.objects.create_superuser(
             username='super',


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33051