### PR TITLE
Fixed #33004 -- Raise error from save() when private fields(GFKs) gets unsaved object

### DIFF
--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -1,6 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldError
-from django.db import IntegrityError
 from django.db.models import Q
 from django.test import SimpleTestCase, TestCase
 
@@ -252,7 +251,7 @@ class GenericRelationsTests(TestCase):
         t1 = TaggedItem.objects.create(content_object=self.quartz, tag="shiny")
         t2 = TaggedItem.objects.create(content_object=self.quartz, tag="clearish")
         # One save() for each object.
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(4):
             bacon.tags.add(t1, t2, bulk=False)
         self.assertEqual(t1.content_object, bacon)
         self.assertEqual(t2.content_object, bacon)
@@ -469,7 +468,8 @@ class GenericRelationsTests(TestCase):
         exception on model.save().
         """
         quartz = Mineral(name="Quartz", hardness=7)
-        with self.assertRaises(IntegrityError):
+        msg = "save() prohibited to prevent data loss due to unsaved related object 'content_object'."
+        with self.assertRaisesMessage(ValueError, msg):
             TaggedItem.objects.create(tag="shiny", content_object=quartz)
 
     def test_cache_invalidation_for_content_type_id(self):

--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -1,4 +1,3 @@
-from django.db import IntegrityError
 from django.db.models import ProtectedError, Q, Sum
 from django.forms.models import modelform_factory
 from django.test import TestCase, skipIfDBFeature
@@ -118,7 +117,8 @@ class GenericRelationTests(TestCase):
         # Fails with another, ORM-level error
         dev1 = Developer(name='Joe')
         note = Note(note='Deserves promotion', content_object=dev1)
-        with self.assertRaises(IntegrityError):
+        msg = "save() prohibited to prevent data loss due to unsaved related object 'content_object'."
+        with self.assertRaisesMessage(ValueError, msg):
             note.save()
 
     def test_target_model_len_zero(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33004

I thought about adding the validation against private fields in `_prepare_related_fields_for_save` method but it runs many other things besides the validation I wanted to add.

So I made separate function called `_prepare_private_fields_for_save` which basically does similar thing with `_prepare_related_fields_for_save` but unnecessary validations excluded.

I also had to fix `test_add_bulk_false`, which includes a test regrading read query count to database, because my patch requires additional read query when it runs `getattr(self, field.name, None)` to get objects to examine.
