### PR TITLE
Fixed #33061 -- Fixed handling nonexistent keys with negative deltas in incr()/decr() in memcached backends.

### DIFF
--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -105,11 +105,11 @@ class BaseMemcachedCache(BaseCache):
         self._cache.disconnect_all()
 
     def incr(self, key, delta=1, version=None):
-        key = self.make_key(key, version=version)
-        self.validate_key(key)
         # memcached doesn't support a negative delta
         if delta < 0:
-            return self._cache.decr(key, -delta)
+            return self.decr(key, -delta, version=version)
+        key = self.make_key(key, version=version)
+        self.validate_key(key)
         try:
             val = self._cache.incr(key, delta)
 
@@ -122,11 +122,11 @@ class BaseMemcachedCache(BaseCache):
         return val
 
     def decr(self, key, delta=1, version=None):
-        key = self.make_key(key, version=version)
-        self.validate_key(key)
         # memcached doesn't support a negative delta
         if delta < 0:
-            return self._cache.incr(key, -delta)
+            return self.incr(key, -delta, version=version)
+        key = self.make_key(key, version=version)
+        self.validate_key(key)
         try:
             val = self._cache.decr(key, delta)
 

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -382,6 +382,8 @@ class BaseCacheTests:
         self.assertEqual(cache.incr('answer', -10), 42)
         with self.assertRaises(ValueError):
             cache.incr('does_not_exist')
+        with self.assertRaises(ValueError):
+            cache.incr('does_not_exist', -1)
         cache.set('null', None)
         with self.assertRaises(self.incr_decr_type_error):
             cache.incr('null')
@@ -396,6 +398,8 @@ class BaseCacheTests:
         self.assertEqual(cache.decr('answer', -10), 42)
         with self.assertRaises(ValueError):
             cache.decr('does_not_exist')
+        with self.assertRaises(ValueError):
+            cache.incr('does_not_exist', -1)
         cache.set('null', None)
         with self.assertRaises(self.incr_decr_type_error):
             cache.decr('null')

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -139,6 +139,8 @@ class DummyCacheTests(SimpleTestCase):
             cache.incr('answer')
         with self.assertRaises(ValueError):
             cache.incr('does_not_exist')
+        with self.assertRaises(ValueError):
+            cache.incr('does_not_exist', -1)
 
     def test_decr(self):
         "Dummy cache values can't be decremented"
@@ -147,6 +149,8 @@ class DummyCacheTests(SimpleTestCase):
             cache.decr('answer')
         with self.assertRaises(ValueError):
             cache.decr('does_not_exist')
+        with self.assertRaises(ValueError):
+            cache.decr('does_not_exist', -1)
 
     def test_touch(self):
         """Dummy cache can't do touch()."""


### PR DESCRIPTION
This PR makes sure a `ValueError` is raised when a user tries to increment or decrement the value of a key that *does not* exist.  

According to [the ticket (33061)](https://code.djangoproject.com/ticket/33061), this may or may not have been true before, but now should always be true. 

[Here](https://docs.djangoproject.com/en/3.2/topics/cache/#django.core.caches.cache.decr) are the relevant docs stating the intended behavior. Specifically, this sentence was brought up in the ticket discussion as relevant:

> A ValueError will be raised if you attempt to increment or decrement a nonexistent cache key.

The ticket has some more context if anything is unclear 🙂 