### PR TITLE
Document TEST_MIRROR caveat

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -804,7 +804,8 @@ but for all apps.
 Default: ``None``
 
 The alias of the database that this database should mirror during
-testing.
+testing. This depends on transactions, and therefore must be used
+within ``TransactionTestCase`` rather than a plain ``TestCase``.
 
 This setting exists to allow for testing of primary/replica
 (referred to as master/slave by some databases)


### PR DESCRIPTION
Problem: This setting only works in transactions but that isn't documented.

Solution: Add caveat to documentation.

Link: https://code.djangoproject.com/ticket/23718