### PR TITLE
Fix 'SyntaxError: invalid for/in left-hand side' in old FF, for examp…

### DIFF
--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -101,7 +101,8 @@ js_catalog_template = r"""
   django.catalog = django.catalog || {};
   {% if catalog_str %}
   const newcatalog = {{ catalog_str }};
-  for (const key in newcatalog) {
+  var key;
+  for (key in newcatalog) {
     django.catalog[key] = newcatalog[key];
   }
   {% endif %}


### PR DESCRIPTION
JS like 'for (const key in newcatalog)' fails on relatively old browsers, like Firefox 44 (five years old).

![image](https://user-images.githubusercontent.com/1609739/131539259-8b4aadf5-ff06-4578-8f17-e7f590844f7e.png)


I replaced it for compatible expression.

All tests passed.