### PR TITLE
Fixed #33073 -- Fixed queryset crash with aggregation and empty queryset annotation.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1692,7 +1692,7 @@ class Query(BaseExpression):
                 yield expr
             elif include_external and callable(getattr(expr, 'get_external_cols', None)):
                 yield from expr.get_external_cols()
-            else:
+            elif hasattr(expr, 'get_source_expressions'):
                 yield from cls._gen_cols(
                     expr.get_source_expressions(),
                     include_external=include_external,

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -1603,3 +1603,17 @@ class AggregateTestCase(TestCase):
             value=Sum('price', filter=Q(rating__lt=3.0), default=Avg('pages') / 10.0),
         )
         self.assertAlmostEqual(result['value'], Decimal('61.72'), places=2)
+
+    def test_exists_none_with_aggregate(self):
+        qs = Book.objects.all().annotate(
+            count=Count('id'),
+            exists=Exists(Author.objects.none()),
+        )
+        self.assertEqual(len(qs), 6)
+
+    def test_exists_extra_where_with_aggregate(self):
+        qs = Book.objects.all().annotate(
+            count=Count('id'),
+            exists=Exists(Author.objects.extra(where=['1=0'])),
+        )
+        self.assertEqual(len(qs), 6)


### PR DESCRIPTION
Hi,

Tentatively fixing https://code.djangoproject.com/ticket/33073