### PR TITLE
Fixed #33082 -- Fixed CommandTests.test_subparser_invalid_option on Python 3.9.7+.

### DIFF
--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -17,7 +17,6 @@ from django.test import SimpleTestCase, override_settings
 from django.test.utils import captured_stderr, extend_sys_path, ignore_warnings
 from django.utils import translation
 from django.utils.deprecation import RemovedInDjango41Warning
-from django.utils.version import PY310
 
 from .management.commands import dance
 
@@ -334,9 +333,7 @@ class CommandTests(SimpleTestCase):
         self.assertIn('bar', out.getvalue())
 
     def test_subparser_invalid_option(self):
-        msg = "Error:%s invalid choice: 'test' (choose from 'foo')" % (
-            ' argument {foo}:' if PY310 else ''
-        )
+        msg = "invalid choice: 'test' (choose from 'foo')"
         with self.assertRaisesMessage(CommandError, msg):
             management.call_command('subparser', 'test', 12)
         msg = 'Error: the following arguments are required: subcommand'


### PR DESCRIPTION
Thanks Michał Górny for the report.