### PR TITLE
Fixed #30086, Refs #32873 -- Made floatformat template filter independent of USE_L10N.

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1732,12 +1732,31 @@ example, when the active locale is ``en`` (English):
 ``34232.00`` ``{{ value|floatformat:"-3g" }}`` ``34,232``
 ============ ================================= =============
 
+Output is always localized (independently of the :ttag:`{% localize off %}
+<localize>` tag) unless the argument passed to ``floatformat`` has the ``u``
+suffix, which will force disabling localization. For example, when the active
+locale is ``pl`` (Polish):
+
+============ ================================= =============
+``value``    Template                          Output
+============ ================================= =============
+``34.23234`` ``{{ value|floatformat:"3" }}``   ``34,232``
+``34.23234`` ``{{ value|floatformat:"3u" }}``  ``34.232``
+============ ================================= =============
+
 Using ``floatformat`` with no argument is equivalent to using ``floatformat``
 with an argument of ``-1``.
 
 .. versionchanged:: 3.2
 
     The ``g`` suffix to force grouping by thousand separators was added.
+
+.. versionchanged:: 4.0
+
+    ``floatformat`` template filter no longer depends on the
+    :setting:`USE_L10N` setting and always returns localized output.
+
+    The ``u`` suffix to force disabling localization was added.
 
 .. templatefilter:: force_escape
 

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -349,7 +349,8 @@ Signals
 Templates
 ~~~~~~~~~
 
-* ...
+* :tfilter:`floatformat` template filter now allows using the ``u`` suffix to
+  force disabling localization.
 
 Tests
 ~~~~~
@@ -567,6 +568,10 @@ Miscellaneous
   need the previous behavior, :ref:`override the widget template
   <overriding-built-in-widget-templates>` with the appropriate template from
   Django 3.2.
+
+* The :tfilter:`floatformat` template filter no longer depends on the
+  :setting:`USE_L10N` setting and always returns localized output. Use the
+  ``u`` suffix to disable localization.
 
 .. _deprecated-features-4.0:
 

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -523,15 +523,15 @@ class FormattingTests(SimpleTestCase):
             self.assertEqual('99999.999', Template('{{ f }}').render(self.ctxt))
             self.assertEqual('Des. 31, 2009', Template('{{ d }}').render(self.ctxt))
             self.assertEqual('Des. 31, 2009, 8:50 p.m.', Template('{{ dt }}').render(self.ctxt))
-            self.assertEqual('66666.67', Template('{{ n|floatformat:2 }}').render(self.ctxt))
-            self.assertEqual('100000.0', Template('{{ f|floatformat }}').render(self.ctxt))
+            self.assertEqual('66666.67', Template('{{ n|floatformat:"2u" }}').render(self.ctxt))
+            self.assertEqual('100000.0', Template('{{ f|floatformat:"u" }}').render(self.ctxt))
             self.assertEqual(
                 '66666.67',
-                Template('{{ n|floatformat:"2g" }}').render(self.ctxt),
+                Template('{{ n|floatformat:"2gu" }}').render(self.ctxt),
             )
             self.assertEqual(
                 '100000.0',
-                Template('{{ f|floatformat:"g" }}').render(self.ctxt),
+                Template('{{ f|floatformat:"ug" }}').render(self.ctxt),
             )
             self.assertEqual('10:15 a.m.', Template('{{ t|time:"TIME_FORMAT" }}').render(self.ctxt))
             self.assertEqual('12/31/2009', Template('{{ d|date:"SHORT_DATE_FORMAT" }}').render(self.ctxt))
@@ -628,12 +628,12 @@ class FormattingTests(SimpleTestCase):
             )
 
             # We shouldn't change the behavior of the floatformat filter re:
-            # thousand separator and grouping when USE_L10N is False even
-            # if the USE_THOUSAND_SEPARATOR, NUMBER_GROUPING and
-            # THOUSAND_SEPARATOR settings are specified
+            # thousand separator and grouping when localization is disabled
+            # even if the USE_THOUSAND_SEPARATOR, NUMBER_GROUPING and
+            # THOUSAND_SEPARATOR settings are specified.
             with self.settings(USE_THOUSAND_SEPARATOR=True, NUMBER_GROUPING=1, THOUSAND_SEPARATOR='!'):
-                self.assertEqual('66666.67', Template('{{ n|floatformat:2 }}').render(self.ctxt))
-                self.assertEqual('100000.0', Template('{{ f|floatformat }}').render(self.ctxt))
+                self.assertEqual('66666.67', Template('{{ n|floatformat:"2u" }}').render(self.ctxt))
+                self.assertEqual('100000.0', Template('{{ f|floatformat:"u" }}').render(self.ctxt))
 
     def test_false_like_locale_formats(self):
         """


### PR DESCRIPTION
ticket-30086