### PR TITLE
Refs #32219 -- Added admin model inline tests for verbose names.

### DIFF
--- a/tests/admin_inlines/models.py
+++ b/tests/admin_inlines/models.py
@@ -337,3 +337,19 @@ class Profile(models.Model):
     collection = models.ForeignKey(ProfileCollection, models.SET_NULL, blank=True, null=True)
     first_name = models.CharField(max_length=100)
     last_name = models.CharField(max_length=100)
+
+
+class VerboseNameProfile(Profile):
+    class Meta:
+        verbose_name = 'Model with verbose name only'
+
+
+class VerboseNamePluralProfile(Profile):
+    class Meta:
+        verbose_name_plural = 'Model with verbose name plural only'
+
+
+class BothVerboseNameProfile(Profile):
+    class Meta:
+        verbose_name = 'Model with both - name'
+        verbose_name_plural = 'Model with both - plural name'


### PR DESCRIPTION
Add tests for verbose names and verbose plural names of inline models, depending on the values for `verbose_name` and/or `verbose_name_plural` of their parent model.

This precedes https://github.com/django/django/pull/13710, which has these tests as amended to reflect the updated functionality in that PR.