### PR TITLE
Fixed #33096 -- Fixed <form> nesting in technical 500 template.

### DIFF
--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -276,8 +276,8 @@
       {% endfor %}
     </ul>
   </div>
-  <form action="https://dpaste.com/" name="pasteform" id="pasteform" method="post">
 {% if not is_email %}
+  <form action="https://dpaste.com/" name="pasteform" id="pasteform" method="post">
   <div id="pastebinTraceback" class="pastebin">
     <input type="hidden" name="language" value="PythonConsole">
     <input type="hidden" name="title"
@@ -327,8 +327,8 @@ Exception Value: {{ exception_value|force_escape }}
   <input type="submit" value="Share this traceback on a public website">
   </div>
 </form>
-</div>
 {% endif %}
+</div>
 {% endif %}
 
 <div id="requestinfo">

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -422,6 +422,22 @@ class AdminEmailHandlerTest(SimpleTestCase):
         msg = mail.outbox[0]
         self.assertEqual(msg.body, 'message\n\ncustom traceback text')
 
+    @override_settings(ADMINS=[('admin', 'admin@example.com')])
+    def test_emit_no_form_tag(self):
+        """HTML email doesn't contain forms."""
+        handler = AdminEmailHandler(include_html=True)
+        record = self.logger.makeRecord(
+            'name', logging.ERROR, 'function', 'lno', 'message', None, None,
+        )
+        handler.emit(record)
+        self.assertEqual(len(mail.outbox), 1)
+        msg = mail.outbox[0]
+        self.assertEqual(msg.subject, '[Django] ERROR: message')
+        self.assertEqual(len(msg.alternatives), 1)
+        body_html = str(msg.alternatives[0][0])
+        self.assertIn('<div id="traceback">', body_html)
+        self.assertNotIn('<form', body_html)
+
 
 class SettingsConfigTest(AdminScriptTestCase):
     """


### PR DESCRIPTION
This fixes the template nesting, such that the form is completely inside the if block.
This is not just a cosmetic change, as the gmail antivirus blocks the email when the stray form tag is there:
```
host gmail-smtp-in.l.google.com[142.250.110.26] said:
    This message was blocked because its content presents a potential
    security issue. Please visit
    https://support.google.com/mail/?p=BlockedMessage to review our
    message content and attachment content guidelines.
```
After this patch, gmail no longer blocks the emails.