### PR TITLE
Made CSRF JavaScript example more reusable.

### DIFF
--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -153,7 +153,7 @@ Finally, you'll need to set the header on your AJAX request. Using the
         {
             headers: {'X-CSRFToken': csrftoken},
             method: 'POST',
-            mode: 'same-origin', // Do not send CSRF token to another domain.
+            mode: 'same-origin' // Do not send CSRF token to another domain.
         }
     );
     fetch(request).then(function(response) {

--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -151,8 +151,8 @@ Finally, you'll need to set the header on your AJAX request. Using the
     const request = new Request(
         /* URL */,
         {
-            headers: {'X-CSRFToken': csrftoken},
             method: 'POST',
+            headers: {'X-CSRFToken': csrftoken},
             mode: 'same-origin' // Do not send CSRF token to another domain.
         }
     );

--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -150,12 +150,13 @@ Finally, you'll need to set the header on your AJAX request. Using the
 
     const request = new Request(
         /* URL */,
-        {headers: {'X-CSRFToken': csrftoken}}
+        {
+            headers: {'X-CSRFToken': csrftoken},
+            method: 'POST',
+            mode: 'same-origin', // Do not send CSRF token to another domain.
+        }
     );
-    fetch(request, {
-        method: 'POST',
-        mode: 'same-origin'  // Do not send CSRF token to another domain.
-    }).then(function(response) {
+    fetch(request).then(function(response) {
         // ...
     });
 


### PR DESCRIPTION
Although this document seems to just be concerned with the CSRF token,  the example caused me confusion about the fetch API. The example code won't work with the changes needed to upload a file. 

Uploading files requires capturing the form and using it to create a FormData object. The Request object needs to be initialized with the following key/value pair: {body: formData}. Here's the problem - the second argument to fetch() is an optional init for the Request object. Using it somehow makes the files not upload. So the example is more usable if the 'headers' and 'mode' keys are given to the Request constructor and the fetch() call omits the second argument.