### PR TITLE
Fixed #33094 -- Disambiguate "Show all"

### DIFF
--- a/tests/admin_views/templates/admin/admin_views/article/search_form.html
+++ b/tests/admin_views/templates/admin/admin_views/article/search_form.html
@@ -6,7 +6,7 @@
 <input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus />
 <input type="submit" value="{% translate 'Search' %}" />
 {% if show_result_count %}
-    <span class="small quiet">{% blocktranslate count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktranslate %} (<a href="?{% if cl.is_popup %}{{ is_popup_var }}=1{% endif %}">{% if cl.show_full_result_count %}{% blocktranslate with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktranslate %}{% else %}{% translate "Show all" %}{% endif %}</a>)</span>
+    <span class="small quiet">{% blocktranslate count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktranslate %} (<a href="?{% if cl.is_popup %}{{ is_popup_var }}=1{% endif %}">{% if cl.show_full_result_count %}{% blocktranslate with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktranslate %}{% else %}{% translate "Clear search" %}{% endif %}</a>)</span>
 {% endif %}
 {% for pair in cl.params.items %}
     {% if pair.0 != search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}"/>{% endif %}


### PR DESCRIPTION
The admin interface used "Show all" with two different meanings.  One
is to disable pagination (a query string of ?all=).  The other is to
disable filters (a query string of ?), when `show_full_result_count` is `False`.

The second case is now described as "Clear search".

Signed-off-by: Richard Laager <rlaager@wiktel.com>