### PR TITLE
Fixed #33095 -- Hide actions if no results

### DIFF
--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -264,8 +264,7 @@ class ChangeList:
         self.result_count = result_count
         self.show_full_result_count = self.model_admin.show_full_result_count
         # Admin actions are shown if there is at least one entry
-        # or if entries are not counted because show_full_result_count is disabled
-        self.show_admin_actions = not self.show_full_result_count or bool(full_result_count)
+        self.show_admin_actions = bool(result_count)
         self.full_result_count = full_result_count
         self.result_list = result_list
         self.can_show_all = can_show_all


### PR DESCRIPTION
The admin actions are only useful if there are results after filtering.