### PR TITLE
Fixed #33098 -- Optimized keep_lazy's internal wrapper for single argument functions.

### DIFF
--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -3,7 +3,14 @@ from unittest import mock
 from django.test import SimpleTestCase
 from django.test.utils import ignore_warnings
 from django.utils.deprecation import RemovedInDjango50Warning
-from django.utils.functional import cached_property, classproperty, lazy
+from django.utils.functional import (
+    cached_property,
+    classproperty,
+    keep_lazy,
+    lazy,
+    lazystr,
+    Promise,
+)
 
 
 class FunctionalTests(SimpleTestCase):
@@ -285,3 +292,252 @@ class FunctionalTests(SimpleTestCase):
 
         self.assertEqual(Foo.foo, 456)
         self.assertEqual(Foo().foo, 456)
+
+
+class KeepLazyExamples:
+    def setUp(self):
+        super().setUp()
+
+        @keep_lazy(str)
+        def keep_lazy_single_argument(value):
+            return "single"
+
+        @keep_lazy(str)
+        def keep_lazy_multiple_arguments(val1, val2, val3):
+            return "multiple"
+
+        @keep_lazy(str)
+        def keep_lazy_posargs(*args):
+            return "posargs"
+
+        @keep_lazy(str)
+        def keep_lazy_kwargs(**kwargs):
+            return "kwargs"
+
+        @keep_lazy(str)
+        def keep_lazy_multiple_arguments_with_kwonly(arg, *, other):
+            return "kwonly"
+
+        @keep_lazy(str)
+        def keep_lazy_multiple_arguments_with_poskwargs(arg, /, other, another):
+            return "poskwargs"
+
+        self.keep_lazy_single_argument = keep_lazy_single_argument
+        self.keep_lazy_multiple_arguments = keep_lazy_multiple_arguments
+        self.keep_lazy_posargs = keep_lazy_posargs
+        self.keep_lazy_kwargs = keep_lazy_kwargs
+        self.keep_lazy_multiple_arguments_with_kwonly = (
+            keep_lazy_multiple_arguments_with_kwonly
+        )
+        self.keep_lazy_multiple_arguments_with_poskwargs = (
+            keep_lazy_multiple_arguments_with_poskwargs
+        )
+
+
+class KeepLazyExceptionTests(KeepLazyExamples, SimpleTestCase):
+    """
+    Wrapping a function with keep_lazy should not cause alterations to the
+    exceptions raised when invalid parameters are given.
+
+    keep_lazy generates multiple functions based on the number of arguments
+    the underlying function being wrapped expects. At function-wrapping time
+    we can't specify the argument names etc, so they're pushed down by passing
+    along all *args and **kwargs, expecting the standard python exceptions
+    to occur.
+    """
+
+    def test_keep_lazy_single_invalid_missing_arguments(self):
+        with self.assertRaisesMessage(
+            TypeError, "missing 1 required positional argument: 'value'"
+        ):
+            self.keep_lazy_single_argument()
+
+    def test_keep_lazy_single_invalid_keyword_argument(self):
+        with self.assertRaisesMessage(
+            TypeError, "got an unexpected keyword argument 'val'"
+        ):
+            self.keep_lazy_single_argument(val="test")
+
+    def test_keep_lazy_single_argument_given_multiple_positional_arguments(self):
+        with self.assertRaisesMessage(
+            TypeError, "takes 1 positional argument but 2 were given"
+        ):
+            self.keep_lazy_single_argument("test", "testing")
+
+    def test_keep_lazy_single_argument_given_multiple_mixed_arguments(self):
+        with self.assertRaisesMessage(
+            TypeError, "got an unexpected keyword argument 'val'"
+        ):
+            self.keep_lazy_single_argument("test", val="testing")
+
+    def test_keep_lazy_single_argument_given_multiple_keyword_arguments(self):
+        with self.assertRaisesMessage(
+            TypeError, "got an unexpected keyword argument 'val'"
+        ):
+            self.keep_lazy_single_argument(value="test", val="testing")
+
+    def test_keep_lazy_multiple_invalid_missing_arguments(self):
+        with self.assertRaisesMessage(
+            TypeError,
+            "missing 3 required positional arguments: 'val1', 'val2', and 'val3'",
+        ):
+            self.keep_lazy_multiple_arguments()
+
+    def test_keep_lazy_multiple_invalid_keyword_argument(self):
+        with self.assertRaisesMessage(
+            TypeError, "got an unexpected keyword argument 'val'"
+        ):
+            self.keep_lazy_multiple_arguments(val="test")
+
+    def test_keep_lazy_multiple_given_too_few_positional_arguments(self):
+        with self.assertRaisesMessage(
+            TypeError, "missing 1 required positional argument: 'val3'"
+        ):
+            self.keep_lazy_multiple_arguments("test", "testing")
+
+    def test_keep_lazy_multiple_given_too_few_keyword_arguments(self):
+        with self.assertRaisesMessage(
+            TypeError, "missing 1 required positional argument: 'val3'"
+        ):
+            self.keep_lazy_multiple_arguments(val1="test", val2="testing")
+
+    def test_keep_lazy_multiple_given_too_many_positional_arguments(self):
+        with self.assertRaisesMessage(
+            TypeError, "takes 3 positional arguments but 4 were given"
+        ):
+            self.keep_lazy_multiple_arguments("test1", "test2", "test3", "test4")
+
+    def test_keep_lazy_multiple_given_too_many_keyword_arguments(self):
+        with self.assertRaisesMessage(
+            TypeError, "got an unexpected keyword argument 'val4'"
+        ):
+            self.keep_lazy_multiple_arguments(
+                val1="test1", val2="test2", val3="test3", val4="test4"
+            )
+
+    def test_keep_lazy_multiple_posarg_given_as_kwarg(self):
+        with self.assertRaisesMessage(
+            TypeError,
+            "got some positional-only arguments passed as keyword arguments: 'arg'",
+        ):
+            self.keep_lazy_multiple_arguments_with_poskwargs(arg=1, other=2, another=3)
+
+    def test_keep_lazy_kwonly_missing(self):
+        with self.assertRaisesMessage(
+            TypeError, "missing 1 required keyword-only argument: 'other'"
+        ):
+            self.keep_lazy_multiple_arguments_with_kwonly(arg=1)
+
+
+class KeepLazyMultipleDispatchTests(KeepLazyExamples, SimpleTestCase):
+    def test_keep_lazy_returns_expected_value(self):
+        self.assertEqual(self.keep_lazy_single_argument(lazystr("s")), "single")
+        self.assertEqual(
+            self.keep_lazy_single_argument.__code__.co_name,
+            "wrapper",
+        )
+
+    def test_keep_lazy_single_positional_argument(self):
+        s = lazystr("s")
+        self.assertIsInstance(self.keep_lazy_single_argument(s), Promise)
+        self.assertEqual(self.keep_lazy_single_argument(s), "single")
+        self.assertEqual(
+            self.keep_lazy_single_argument.__code__.co_name,
+            "wrapper",
+        )
+
+    def test_keep_lazy_single_keyword_argument(self):
+        s = lazystr("s")
+        self.assertIsInstance(self.keep_lazy_single_argument(value=s), Promise)
+        self.assertEqual(self.keep_lazy_single_argument(value=s), "single")
+        self.assertEqual(
+            self.keep_lazy_single_argument.__code__.co_name,
+            "wrapper",
+        )
+
+    def test_keep_lazy_multiple_positional_arguments(self):
+        s = lazystr("s")
+        self.assertIsInstance(self.keep_lazy_multiple_arguments(1, 2, s), Promise)
+        self.assertEqual(self.keep_lazy_multiple_arguments(1, 2, s), "multiple")
+        self.assertEqual(
+            self.keep_lazy_multiple_arguments.__code__.co_name,
+            "wrapper",
+        )
+
+    def test_keep_lazy_multiple_keyword_arguments(self):
+        s = lazystr("s")
+        self.assertIsInstance(
+            self.keep_lazy_multiple_arguments(val1=1, val2=2, val3=s), Promise
+        )
+        self.assertEqual(
+            self.keep_lazy_multiple_arguments(val1=1, val2=2, val3=s), "multiple"
+        )
+        self.assertEqual(
+            self.keep_lazy_multiple_arguments.__code__.co_name,
+            "wrapper",
+        )
+
+    def test_posargs(self):
+        """
+        A function which accepts *args must be dispatched to the multiple argument wrapper
+        """
+        many = lazystr("s")
+        self.assertIsInstance(
+            self.keep_lazy_posargs("this", "may", "take", many, "arguments"), Promise
+        )
+        self.assertEqual(
+            self.keep_lazy_posargs("this", "may", "take", many, "arguments"), "posargs"
+        )
+        self.assertEqual(
+            self.keep_lazy_posargs.__code__.co_name,
+            "wrapper",
+        )
+
+    def test_kwargs(self):
+        """
+        A function which accepts **kwargs must be dispatched to the multiple argument wrapper
+        """
+        many = lazystr("s")
+        self.assertIsInstance(
+            self.keep_lazy_kwargs(this="may", take=many, arguments="too"), Promise
+        )
+        self.assertEqual(
+            self.keep_lazy_kwargs(this="may", take=many, arguments="too"), "kwargs"
+        )
+        self.assertEqual(
+            self.keep_lazy_kwargs.__code__.co_name,
+            "wrapper",
+        )
+
+    def test_kwonly(self):
+        s = lazystr("s")
+        self.keep_lazy_multiple_arguments_with_kwonly(1, other=s)
+        self.assertIsInstance(
+            self.keep_lazy_multiple_arguments_with_kwonly(1, other=s), Promise
+        )
+        self.assertEqual(
+            self.keep_lazy_multiple_arguments_with_kwonly(1, other=s), "kwonly"
+        )
+        self.assertEqual(
+            self.keep_lazy_multiple_arguments_with_kwonly.__code__.co_name,
+            "wrapper",
+        )
+
+    def test_single_complex(self):
+        """
+        A function which accepts arguments plus *args or **kwargs must be
+        dispatched to the multiple argument wrapper
+        """
+        s = lazystr("s")
+        self.assertIsInstance(
+            self.keep_lazy_multiple_arguments_with_poskwargs(1, other=s, another=2),
+            Promise,
+        )
+        self.assertEqual(
+            self.keep_lazy_multiple_arguments_with_poskwargs(1, other=s, another=2),
+            "poskwargs",
+        )
+        self.assertEqual(
+            self.keep_lazy_multiple_arguments_with_poskwargs.__code__.co_name,
+            "wrapper",
+        )

--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -434,7 +434,7 @@ class KeepLazyMultipleDispatchTests(KeepLazyExamples, SimpleTestCase):
         self.assertEqual(self.keep_lazy_single_argument(lazystr("s")), "single")
         self.assertEqual(
             self.keep_lazy_single_argument.__code__.co_name,
-            "wrapper",
+            "keep_lazy_single_argument_wrapper",
         )
 
     def test_keep_lazy_single_positional_argument(self):
@@ -443,7 +443,7 @@ class KeepLazyMultipleDispatchTests(KeepLazyExamples, SimpleTestCase):
         self.assertEqual(self.keep_lazy_single_argument(s), "single")
         self.assertEqual(
             self.keep_lazy_single_argument.__code__.co_name,
-            "wrapper",
+            "keep_lazy_single_argument_wrapper",
         )
 
     def test_keep_lazy_single_keyword_argument(self):
@@ -452,7 +452,7 @@ class KeepLazyMultipleDispatchTests(KeepLazyExamples, SimpleTestCase):
         self.assertEqual(self.keep_lazy_single_argument(value=s), "single")
         self.assertEqual(
             self.keep_lazy_single_argument.__code__.co_name,
-            "wrapper",
+            "keep_lazy_single_argument_wrapper",
         )
 
     def test_keep_lazy_multiple_positional_arguments(self):
@@ -461,7 +461,7 @@ class KeepLazyMultipleDispatchTests(KeepLazyExamples, SimpleTestCase):
         self.assertEqual(self.keep_lazy_multiple_arguments(1, 2, s), "multiple")
         self.assertEqual(
             self.keep_lazy_multiple_arguments.__code__.co_name,
-            "wrapper",
+            "keep_lazy_multiple_argument_wrapper",
         )
 
     def test_keep_lazy_multiple_keyword_arguments(self):
@@ -474,7 +474,7 @@ class KeepLazyMultipleDispatchTests(KeepLazyExamples, SimpleTestCase):
         )
         self.assertEqual(
             self.keep_lazy_multiple_arguments.__code__.co_name,
-            "wrapper",
+            "keep_lazy_multiple_argument_wrapper",
         )
 
     def test_posargs(self):
@@ -490,7 +490,7 @@ class KeepLazyMultipleDispatchTests(KeepLazyExamples, SimpleTestCase):
         )
         self.assertEqual(
             self.keep_lazy_posargs.__code__.co_name,
-            "wrapper",
+            "keep_lazy_multiple_argument_wrapper",
         )
 
     def test_kwargs(self):
@@ -506,7 +506,7 @@ class KeepLazyMultipleDispatchTests(KeepLazyExamples, SimpleTestCase):
         )
         self.assertEqual(
             self.keep_lazy_kwargs.__code__.co_name,
-            "wrapper",
+            "keep_lazy_multiple_argument_wrapper",
         )
 
     def test_kwonly(self):
@@ -520,7 +520,7 @@ class KeepLazyMultipleDispatchTests(KeepLazyExamples, SimpleTestCase):
         )
         self.assertEqual(
             self.keep_lazy_multiple_arguments_with_kwonly.__code__.co_name,
-            "wrapper",
+            "keep_lazy_multiple_argument_wrapper",
         )
 
     def test_single_complex(self):
@@ -539,5 +539,5 @@ class KeepLazyMultipleDispatchTests(KeepLazyExamples, SimpleTestCase):
         )
         self.assertEqual(
             self.keep_lazy_multiple_arguments_with_poskwargs.__code__.co_name,
-            "wrapper",
+            "keep_lazy_multiple_argument_wrapper",
         )


### PR DESCRIPTION
May as well find out if it passes CI, and if the ticket ([33098](https://code.djangoproject.com/ticket/33098)) isn't accepted I'll just close it down.

The check within `keep_lazy_single_argument_wrapper` is slightly more involved than one might think, to support the use-case of functions being called using keyword arguments only, even when there's only 1 argument.

eg: given `escape('1')` and `escape(text='1')` we want both to work _and_ raise a TypeError correctly if the kwarg is given as `test` instead of `text`

We can't know the name of the kwarg at wrapper definition time (I don't think...) without exec() to generate the function, so it consumes *args and **kwargs as the multiple argument wrapper does, expecting there to be only one value to look at.