### PR TITLE
Fixed #33104 -- Fixed wrapping of long words in admin readonly fields.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -84,6 +84,7 @@ form ul.inline li {
     margin-top: 0;
     margin-bottom: 0;
     margin-left: 170px;
+    overflow-wrap: break-word;
 }
 
 .aligned ul label {


### PR DESCRIPTION
Added `overflow-wrap: anywhere` property to readonly fields
this fixes word wrap on long continous text strings like a JIT token

before:
![Screenshot from 2021-09-11 13-26-17](https://user-images.githubusercontent.com/46787056/132940918-72299c5d-eba1-489f-9ee5-074d0163ce7e.png)

after:
![Screenshot from 2021-09-11 13-25-32](https://user-images.githubusercontent.com/46787056/132940914-a8e2e2df-08a9-41df-87d9-80cb6cfc018b.png)

[owerflow-wrap](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)
