### PR TITLE
Refs #27624 -- Changed Query.explain_info to namedtuple.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -631,10 +631,10 @@ class SQLCompiler:
                     result.append('HAVING %s' % having)
                     params.extend(h_params)
 
-            if self.query.explain_query:
+            if self.query.explain_info:
                 result.insert(0, self.connection.ops.explain_query_prefix(
-                    self.query.explain_format,
-                    **self.query.explain_options
+                    self.query.explain_info.format,
+                    **self.query.explain_info.options
                 ))
 
             if order_by:
@@ -1247,7 +1247,7 @@ class SQLCompiler:
         result = list(self.execute_sql())
         # Some backends return 1 item tuples with strings, and others return
         # tuples with integers and strings. Flatten them out into strings.
-        output_formatter = json.dumps if self.query.explain_format == 'json' else str
+        output_formatter = json.dumps if self.query.explain_info.format == 'json' else str
         for row in result[0]:
             if not isinstance(row, str):
                 yield ' '.join(output_formatter(c) for c in row)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -136,6 +136,9 @@ class RawQuery:
         self.cursor.execute(self.sql, params)
 
 
+ExplainInfo = namedtuple('ExplainInfo', ('format', 'options'))
+
+
 class Query(BaseExpression):
     """A single SQL query."""
 
@@ -227,9 +230,7 @@ class Query(BaseExpression):
 
         self._filtered_relations = {}
 
-        self.explain_query = False
-        self.explain_format = None
-        self.explain_options = {}
+        self.explain_info = None
 
     @property
     def output_field(self):
@@ -545,9 +546,7 @@ class Query(BaseExpression):
 
     def explain(self, using, format=None, **options):
         q = self.clone()
-        q.explain_query = True
-        q.explain_format = format
-        q.explain_options = options
+        q.explain_info = ExplainInfo(format, options)
         compiler = q.get_compiler(using=using)
         return '\n'.join(compiler.explain_query())
 

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -303,9 +303,7 @@ class Query(BaseExpression):
         obj.table_map = self.table_map.copy()
         obj.where = self.where.clone()
         obj.annotations = self.annotations.copy()
-        if self.annotation_select_mask is None:
-            obj.annotation_select_mask = None
-        else:
+        if self.annotation_select_mask is not None:
             obj.annotation_select_mask = self.annotation_select_mask.copy()
         obj.combined_queries = tuple(query.clone() for query in self.combined_queries)
         # _annotation_select_cache cannot be copied, as doing so breaks the
@@ -315,13 +313,9 @@ class Query(BaseExpression):
         # used.
         obj._annotation_select_cache = None
         obj.extra = self.extra.copy()
-        if self.extra_select_mask is None:
-            obj.extra_select_mask = None
-        else:
+        if self.extra_select_mask is not None:
             obj.extra_select_mask = self.extra_select_mask.copy()
-        if self._extra_select_cache is None:
-            obj._extra_select_cache = None
-        else:
+        if self._extra_select_cache is not None:
             obj._extra_select_cache = self._extra_select_cache.copy()
         if self.select_related is not False:
             # Use deepcopy because select_related stores fields in nested


### PR DESCRIPTION
* Turn explain info into one attribute instead of three
* Remove unnecessary `if ... is None` paths, which are already shallow-copied in the `__dict__.copy()` call.

ticket-27624