### PR TITLE
Fixed #33107 -- Fixed import_string() crash on not fully initialized modules.

### DIFF
--- a/django/utils/module_loading.py
+++ b/django/utils/module_loading.py
@@ -7,7 +7,11 @@ from importlib.util import find_spec as importlib_find
 
 def cached_import(module_path, class_name):
     modules = sys.modules
-    if module_path not in modules:
+    if module_path not in modules or (
+        # Module is not fully initialized.
+        getattr(modules[module_path], '__spec__', None) is not None and
+        getattr(modules[module_path].__spec__, '_initializing', False) is True
+    ):
         import_module(module_path)
     return getattr(modules[module_path], class_name)
 


### PR DESCRIPTION
Regression in ecf87ad513fd8af6e4a6093ed918723a7d88d5ca.

Thanks Collin Anderson for the report.

ticket-33107