### PR TITLE
Mark OpClass as public object in indexes module for fix mypy error

### DIFF
--- a/django/contrib/postgres/indexes.py
+++ b/django/contrib/postgres/indexes.py
@@ -4,7 +4,7 @@ from django.utils.functional import cached_property
 
 __all__ = [
     'BloomIndex', 'BrinIndex', 'BTreeIndex', 'GinIndex', 'GistIndex',
-    'HashIndex', 'SpGistIndex',
+    'HashIndex', 'SpGistIndex', 'OpClass',
 ]
 
 


### PR DESCRIPTION
When I try to import OpClass I get the following error from mypy.

`Module 'django.contrib.postgres.indexes' has no attribute 'OpClass'  [attr-defined]`

I try to fix it