### PR TITLE
Fixed typo in docs/intro/reusable-apps.txt.

### DIFF
--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -242,7 +242,7 @@ this. For a small app like polls, this process isn't too difficult.
 #. Only Python modules and packages are included in the package by default. To
    include additional files, we'll need to create a ``MANIFEST.in`` file. The
    setuptools docs referred to in the previous step discuss this file in more
-   details. To include the templates, the ``README.rst`` and our ``LICENSE``
+   detail. To include the templates, the ``README.rst`` and our ``LICENSE``
    file, create a file ``django-polls/MANIFEST.in`` with the following
    contents:
 


### PR DESCRIPTION
"in more details" should be "in more detail".