### PR TITLE
Refs #27624 -- Optimized Query.clone() for non-combined queries.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -306,7 +306,10 @@ class Query(BaseExpression):
         obj.annotations = self.annotations.copy()
         if self.annotation_select_mask is not None:
             obj.annotation_select_mask = self.annotation_select_mask.copy()
-        obj.combined_queries = tuple(query.clone() for query in self.combined_queries)
+        if self.combined_queries:
+            obj.combined_queries = tuple([
+                query.clone() for query in self.combined_queries
+            ])
         # _annotation_select_cache cannot be copied, as doing so breaks the
         # (necessary) state in which both annotations and
         # _annotation_select_cache point to the same underlying objects.


### PR DESCRIPTION
Relates to [ticket 27624](https://code.djangoproject.com/ticket/27624), and tangentially/indirectly also [ticket 31767](https://code.djangoproject.com/ticket/31767).

I can re-target it as a new ticket if desired, but it fits into the immutability changes in 27624 (if no new ticket is required, I'll naturally pop a comment on the ticket about this).

This follows on the heels of @adamchainz changes in PR #14857. Extracted from a bunch of changes I'd been toying with ... only some of which are fruitful. I've re-run all the timings afresh in isolation as a result, see below.

This technically is just clawing back performance, WRT to [ticket 27624](https://code.djangoproject.com/ticket/27624), because I think that ticket predates the introduction of `union`/`intersection` etc.

Line profiling `Query.clone` shows that making a new `.combined_queries` is amongst the more expensive operations done, second only to cloning the `Where` (which I'm tracking separately in [ticket 32970](https://code.djangoproject.com/ticket/32970)/[PR 14709](https://github.com/django/django/pull/14709)):
```
In [1]: from django.contrib.auth.models import User
In [2]: from django.db.models.sql.query import Query
In [3]: x = User.objects.filter(email="example@example.com").query
In [4]: %load_ext line_profiler
In [5]: %lprun -f Query.clone x.clone()
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   291                                               def clone(self):
...
   305         1         23.0     23.0     29.1          obj.where = self.where.clone()
...
   309         1          6.0      6.0      7.6          obj.combined_queries = tuple(query.clone() for query in self.combined_queries)
```
This is because the cost of creating a generator expression and subsequently calling `tuple` (which has to be looked up in case of re-binding):
```
309     >>  120 LOAD_GLOBAL             12 (tuple)
            122 LOAD_CONST               2 (<code object <genexpr> at 0x10d892240, file "django/db/models/sql/query.py", line 309>)
            124 LOAD_CONST               3 ('Query.clone.<locals>.<genexpr>')
            126 MAKE_FUNCTION            0
            128 LOAD_FAST                0 (self)
            130 LOAD_ATTR               13 (combined_queries)
            132 GET_ITER
            134 CALL_FUNCTION            1
            136 CALL_FUNCTION            1
            138 LOAD_FAST                1 (obj)
            140 STORE_ATTR              13 (combined_queries)
Disassembly of <code object <genexpr> at 0x10d892240, file "django/db/models/sql/query.py", line 309>:
309           0 LOAD_FAST                0 (.0)
        >>    2 FOR_ITER                14 (to 18)
              4 STORE_FAST               1 (query)
              6 LOAD_FAST                1 (query)
              8 LOAD_METHOD              0 (clone)
             10 CALL_METHOD              0
             12 YIELD_VALUE
             14 POP_TOP
             16 JUMP_ABSOLUTE            2
        >>   18 LOAD_CONST               0 (None)
             20 RETURN_VALUE
```
However, because the initial value for `combined_queries` is `()` (thus immutable, hence the relation to [ticket 27624](https://code.djangoproject.com/ticket/27624)) we can avoid that cost by doing a quicker truthy check on the attribute and letting the empty tuple be copied until it's value changes which will cause a new tuple() to be created; this changes the line profiling (for non combined queries) to:
```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   291                                               def clone(self):
...
   309         1          1.0      1.0      1.2          if self.combined_queries:
   310                                                       obj.combined_queries = tuple(query.clone() for query in self.combined_queries)
```
and the runtime changes from:
```
In [1]: from django.contrib.auth.models import User
In [2]: full = User.objects.filter(email="example@example.com").filter(username="example").query
In [3]: empty = User.objects.all().query
In [4]: %timeit -n 1_000_000 empty.clone()
3.62 µs ± 82 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
In [5]: %timeit -n 1_000_000 full.clone()
3.99 µs ± 87.7 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```
to:
```
In [4]: %timeit -n 1_000_000 empty.clone()
3.23 µs ± 69.6 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
In [5]: %timeit -n 1_000_000 full.clone()
3.44 µs ± 75.1 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

Naturally, some of that change is going to be simple flux in workload on my laptop. I've run it multiple times (swapping the order so I do the `after` and then the `before` to account for ramp up, etc), and the lowest I've seen is `2.89µs` on the after, and `4.3µs` on the before (sigh!), but in each scenario the change has been demonstrably quicker, mostly by between `100-300ns` which seems in line with the line-profiler output.