### PR TITLE
Fixed #33119 -- Doesn't create operation on m2m renamed model case

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1479,7 +1479,7 @@ class ManyToManyField(RelatedField):
         if isinstance(self.remote_field.model, str):
             kwargs['to'] = self.remote_field.model
         else:
-            kwargs['to'] = self.remote_field.model._meta.label
+            kwargs['to'] = self.remote_field.model._meta.label_lower
         if getattr(self.remote_field, 'through', None) is not None:
             if isinstance(self.remote_field.through, str):
                 kwargs['through'] = self.remote_field.through

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1068,6 +1068,39 @@ class AutodetectorTests(TestCase):
         self.assertNumberMigrations(changes, 'testapp', 0)
         self.assertNumberMigrations(changes, 'otherapp', 0)
 
+    def test_m2m_with_renamed_model_case(self):
+        """
+        Model name is case-insensitive. Changing case doesn't lead to any
+        autodetected operations on m2m fields
+        """
+        datacenter_capital_c = ModelState("thirdapp", "DataCenter", [
+            ("id", models.AutoField(primary_key=True)),
+            ("title", models.CharField(max_length=100)),
+        ])
+        datacenter_lowercased_c = ModelState("thirdapp", "Datacenter", [
+            ("id", models.AutoField(primary_key=True)),
+            ("title", models.CharField(max_length=100)),
+        ])
+        package = ModelState("thirdapp", "Package", [
+            ("id", models.AutoField(primary_key=True)),
+            ("name", models.CharField(max_length=100)),
+            ("datacenters", models.ManyToManyField("DataCenter")),
+        ])
+        package_with_renamed_datacenter = ModelState("thirdapp", "Package", [
+            ("id", models.AutoField(primary_key=True)),
+            ("name", models.CharField(max_length=100)),
+            ("datacenters", models.ManyToManyField("Datacenter")),
+        ])
+
+        changes = self.get_changes(
+            [datacenter_capital_c, package],
+            [datacenter_lowercased_c, package_with_renamed_datacenter],
+            questioner=MigrationQuestioner({'ask_rename_model': True})
+        )
+
+        self.assertNumberMigrations(changes, 'testapp', 0)
+        self.assertNumberMigrations(changes, 'otherapp', 0)
+
     def test_rename_m2m_through_model(self):
         """
         Tests autodetection of renamed models that are used in M2M relations as

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1073,20 +1073,20 @@ class AutodetectorTests(TestCase):
         Model name is case-insensitive. Changing case doesn't lead to any
         autodetected operations on m2m fields
         """
-        datacenter_capital_c = ModelState("thirdapp", "DataCenter", [
+        datacenter_capital_c = ModelState("testapp", "DataCenter", [
             ("id", models.AutoField(primary_key=True)),
             ("title", models.CharField(max_length=100)),
         ])
-        datacenter_lowercased_c = ModelState("thirdapp", "Datacenter", [
+        datacenter_lowercased_c = ModelState("testapp", "Datacenter", [
             ("id", models.AutoField(primary_key=True)),
             ("title", models.CharField(max_length=100)),
         ])
-        package = ModelState("thirdapp", "Package", [
+        package = ModelState("testapp", "Package", [
             ("id", models.AutoField(primary_key=True)),
             ("name", models.CharField(max_length=100)),
             ("datacenters", models.ManyToManyField("DataCenter")),
         ])
-        package_with_renamed_datacenter = ModelState("thirdapp", "Package", [
+        package_with_renamed_datacenter = ModelState("testapp", "Package", [
             ("id", models.AutoField(primary_key=True)),
             ("name", models.CharField(max_length=100)),
             ("datacenters", models.ManyToManyField("Datacenter")),


### PR DESCRIPTION
Refactored `ManyToManyField.deconstruct` to set `to` attribute from
the lowered label and prevent the bug when a model changes only casing
of its name