### PR TITLE
Fixed #33124 -- Avoided accessing the database connections when not necessary.

### DIFF
--- a/django/contrib/gis/utils/layermapping.py
+++ b/django/contrib/gis/utils/layermapping.py
@@ -101,7 +101,8 @@ class LayerMapping:
         self.layer = self.ds[layer]
 
         self.using = using if using is not None else router.db_for_write(model)
-        self.spatial_backend = connections[self.using].ops
+        connection = connections[self.using]
+        self.spatial_backend = connection.ops
 
         # Setting the mapping & model attributes.
         self.mapping = mapping
@@ -113,7 +114,7 @@ class LayerMapping:
 
         # Getting the geometry column associated with the model (an
         # exception will be raised if there is no geometry column).
-        if connections[self.using].features.supports_transform:
+        if connection.features.supports_transform:
             self.geo_field = self.geometry_field()
         else:
             transform = False

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -1100,8 +1100,8 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
             # user-defined intermediary models as they could have other fields
             # causing conflicts which must be surfaced.
             can_ignore_conflicts = (
-                connections[db].features.supports_ignore_conflicts and
-                self.through._meta.auto_created is not False
+                self.through._meta.auto_created is not False and
+                connections[db].features.supports_ignore_conflicts
             )
             # Don't send the signal when inserting duplicate data row
             # for symmetrical reverse entries.

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2332,10 +2332,10 @@ class Query(BaseExpression):
         # used. The proper fix would be to defer all decisions where
         # is_nullable() is needed to the compiler stage, but that is not easy
         # to do currently.
-        return (
-            connections[DEFAULT_DB_ALIAS].features.interprets_empty_strings_as_nulls and
-            field.empty_strings_allowed
-        ) or field.null
+        return field.null or (
+            field.empty_strings_allowed and
+            connections[DEFAULT_DB_ALIAS].features.interprets_empty_strings_as_nulls
+        )
 
 
 def get_order_dir(field, default='ASC'):


### PR DESCRIPTION
Ticket is [33124](https://code.djangoproject.com/ticket/33124), following on from [ticket 33025](https://code.djangoproject.com/ticket/33025) which was [PR 14769](https://github.com/django/django/pull/14769).

- Repeated access to `connections[alias]` should be cached into a local variable wherever possible to avoid asking the `Local` for the value twice.
- Asking for `connections[alias]` a single time should be deferred until absolutely necessary (ie: local to the `if` branch, or as the last part of an `if` chained comparison, etc)