### PR TITLE
Fixed #31354 -- Include the port from META['HTTP_X_FORWARDED_PORT']

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -104,6 +104,9 @@ class HttpRequest:
         if settings.USE_X_FORWARDED_HOST and (
                 'HTTP_X_FORWARDED_HOST' in self.META):
             host = self.META['HTTP_X_FORWARDED_HOST']
+            server_port = self.get_port()
+            if server_port != ('443' if self.is_secure() else '80'):
+                host = '%s:%s' % (host, server_port)
         elif 'HTTP_HOST' in self.META:
             host = self.META['HTTP_HOST']
         else:

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -841,6 +841,21 @@ class BuildAbsoluteURITests(SimpleTestCase):
             with self.subTest(location=location):
                 self.assertEqual(request.build_absolute_uri(location=location), expected_url)
 
+    @override_settings(
+        USE_X_FORWARDED_PORT=True,
+        USE_X_FORWARDED_HOST=True,
+        ALLOWED_HOSTS=['*'])
+    def test_get_host_with_use_x_forwarded_port_and_http_host(self):
+        request = HttpRequest()
+        request.META = {
+            'HTTP_HOST': 'original.com',
+            'SERVER_PORT': '8000',
+            'HTTP_X_FORWARDED_HOST': 'example.com',
+            'HTTP_X_FORWARDED_PORT': '8080',
+        }
+        self.assertEqual(request.get_host(), 'example.com:8080')
+        self.assertEqual(request.get_port(), '8080')
+
 
 class RequestHeadersTests(SimpleTestCase):
     ENVIRON = {


### PR DESCRIPTION
Include the port from META['HTTP_X_FORWARDED_PORT'] in HttpRequest.get_host()

Include the port from META['HTTP_X_FORWARDED_PORT'] in HttpRequest.get_host() when
HTTP_X_FORWARDED_HOST is present in request.META and the port of the authority is
not 80 for http or 443 for https.