### PR TITLE
Fixed #33133 -- Fixed handling NullBooleanField in historical migrations.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1999,9 +1999,6 @@ class NullBooleanField(BooleanField):
         del kwargs['blank']
         return name, path, args, kwargs
 
-    def get_internal_type(self):
-        return "NullBooleanField"
-
 
 class PositiveIntegerRelDbTypeMixin:
     def __init_subclass__(cls, **kwargs):


### PR DESCRIPTION
See ticket-33133 and https://github.com/jieter/django-tables2/pull/822.