### PR TITLE
Fixed #33125 -- Avoided redundant unique constraint when converting a non-unique field to primary key on MySQL and PostgreSQL.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1155,8 +1155,10 @@ class BaseDatabaseSchemaEditor:
         return not old_field.primary_key and new_field.primary_key
 
     def _unique_should_be_added(self, old_field, new_field):
-        return (not old_field.unique and new_field.unique) or (
-            old_field.primary_key and not new_field.primary_key and new_field.unique
+        return (
+            not new_field.primary_key and
+            new_field.unique and
+            (not old_field.unique or old_field.primary_key)
         )
 
     def _rename_field_sql(self, table, old_field, new_field, new_type):

--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -174,12 +174,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             return False
         return create_index
 
-    def _unique_should_be_added(self, old_field, new_field):
-        return (
-            super()._unique_should_be_added(old_field, new_field) and
-            not self._field_became_primary_key(old_field, new_field)
-        )
-
     def _is_identity_column(self, table_name, column_name):
         with self.connection.cursor() as cursor:
             cursor.execute("""

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -741,6 +741,13 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.remove_field(Author, Author._meta.get_field('id'))
             editor.alter_field(Author, old_field, new_field, strict=True)
+        # Redundant unique constraint is not added.
+        count = self.get_constraints_count(
+            Author._meta.db_table,
+            Author._meta.get_field('uuid').column,
+            None,
+        )
+        self.assertLessEqual(count['uniques'], 1)
 
     @isolate_apps('schema')
     def test_alter_primary_key_quoted_db_table(self):


### PR DESCRIPTION
Ticket link: https://code.djangoproject.com/ticket/33125

When new_type is primary key, we don't need to add unique key.
This issue also happen on MySQL.
it is redundant UNIQUE constraint like report.

I want to add the logic for checking whether unique key exists or not. but I can't find the interface for checking actual db side unique key.
If you know proper interface for checking this, please add or know me 🙇 

```
CREATE TABLE `blog_pony` (
  `name` varchar(32) NOT NULL,
  `nickname` varchar(32) NOT NULL,
  PRIMARY KEY (`nickname`),
  UNIQUE KEY `blog_pony_nickname_3daa418a_uniq` (`nickname`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
>>> Pony._meta.total_unique_constraints
[]

```
