### PR TITLE
Fixed #30398 -- Added CONN_HEALTH_CHECKS database setting.

### DIFF
--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -172,6 +172,7 @@ class ConnectionHandler(BaseConnectionHandler):
         if conn['ENGINE'] == 'django.db.backends.' or not conn['ENGINE']:
             conn['ENGINE'] = 'django.db.backends.dummy'
         conn.setdefault('CONN_MAX_AGE', 0)
+        conn.setdefault('CONN_HEALTH_CHECKS', False)
         conn.setdefault('OPTIONS', {})
         conn.setdefault('TIME_ZONE', None)
         for setting in ['NAME', 'USER', 'PASSWORD', 'HOST', 'PORT']:

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -62,8 +62,19 @@ At the end of each request, Django closes the connection if it has reached its
 maximum age or if it is in an unrecoverable error state. If any database
 errors have occurred while processing the requests, Django checks whether the
 connection still works, and closes it if it doesn't. Thus, database errors
-affect at most one request; if the connection becomes unusable, the next
-request gets a fresh connection.
+affect at most one request per each application's worker thread; if the
+connection becomes unusable, the next request gets a fresh connection.
+
+Setting :setting:`CONN_HEALTH_CHECKS` to ``True`` can be used to improve the
+robustness of connection reuse and prevent errors when a connection has been
+closed by the database server which is now ready to accept and serve new
+connections, e.g. after database server restart. The health check is performed
+only once per request and only if the database is being accessed during the
+handling of the request.
+
+.. versionchanged:: 4.1
+
+    The :setting:`CONN_HEALTH_CHECKS` setting was added.
 
 Caveats
 ~~~~~~~

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -628,7 +628,25 @@ Default: ``0``
 
 The lifetime of a database connection, as an integer of seconds. Use ``0`` to
 close database connections at the end of each request — Django's historical
-behavior — and ``None`` for unlimited persistent connections.
+behavior — and ``None`` for unlimited :ref:`persistent database connections
+<persistent-database-connections>`.
+
+.. setting:: CONN_HEALTH_CHECKS
+
+``CONN_HEALTH_CHECKS``
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 4.1
+
+Default: ``False``
+
+If set to ``True``, existing :ref:`persistent database connections
+<persistent-database-connections>` will be health checked before they are
+reused in each request performing database access. If the health check fails,
+the connection will be re-established without failing the request when the
+connection is no longer usable but the database server is ready to accept and
+serve new connections (e.g. after database server restart closing existing
+connections).
 
 .. setting:: OPTIONS
 

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -208,6 +208,11 @@ Models
   :class:`~django.db.models.expressions.Window` expression now accepts string
   references to fields and transforms.
 
+* The new :setting:`CONN_HEALTH_CHECKS` setting allows enabling health checks
+  for :ref:`persistent database connections <persistent-database-connections>`
+  in order to reduce the number of failed requests, e.g. after database server
+  restart.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Introduce `CONN_HEALTH_CHECKS` DB setting which can be used to enable database connection health checks for Django's persistent DB connections.

If it's set to `False` (default), the behavior is the same as without this change.

If it's set to `True`, then health checks are enabled. They work as follows (assuming an already existing "persistent" DB connection):

- Before each connection reuse, perform a connection test (eg. `SELECT 1` query in case of PostgreSQL).

- This only happens once per request, regardless of how many DB transactions will be performed during the handling of the request.

- This only happens for "requests" that do use the database.

- If the check fails, close the connection and create a new one.

Fixes [30398](https://code.djangoproject.com/ticket/30398). Some prior discussion also exists in #11311 and #11335.