### PR TITLE
Fixed #33146 -- Wrong command in ASGI deployment guide

### DIFF
--- a/docs/howto/deployment/asgi/uvicorn.txt
+++ b/docs/howto/deployment/asgi/uvicorn.txt
@@ -24,7 +24,7 @@ called (separated by a colon).
 
 For a typical Django project, invoking Uvicorn would look like::
 
-    gunicorn myproject.asgi:application -k uvicorn.workers.UvicornWorker
+    uvicorn myproject.asgi:application -k uvicorn.workers.UvicornWorker
 
 This will start one process listening on ``127.0.0.1:8000``. It requires that
 your project be on the Python path; to ensure that run this command from the


### PR DESCRIPTION
The command to start the ASGI server in the uvicorn deployment guide was
wrong.