### PR TITLE
Used Path.read_text() in jinja2.get_exception_info().

### DIFF
--- a/django/template/backends/jinja2.py
+++ b/django/template/backends/jinja2.py
@@ -99,8 +99,7 @@ def get_exception_info(exception):
     if source is None:
         exception_file = Path(exception.filename)
         if exception_file.exists():
-            with open(exception_file, 'r') as fp:
-                source = fp.read()
+            source = exception_file.read_text()
     if source is not None:
         lines = list(enumerate(source.strip().split('\n'), start=1))
         during = lines[lineno - 1][1]


### PR DESCRIPTION
Follow up to 7e3bf2662b5dedeb47856adc18a9378e2d10a599.