### PR TITLE
Changed suggested command for listing tables in sqlite in intro

### DIFF
--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -100,7 +100,7 @@ in your :file:`mysite/settings.py` file and the database migrations shipped
 with the app (we'll cover those later). You'll see a message for each
 migration it applies. If you're interested, run the command-line client for your
 database and type ``\dt`` (PostgreSQL), ``SHOW TABLES;`` (MariaDB, MySQL),
-``.schema`` (SQLite), or ``SELECT TABLE_NAME FROM USER_TABLES;`` (Oracle) to
+``.tables`` (SQLite), or ``SELECT TABLE_NAME FROM USER_TABLES;`` (Oracle) to
 display the tables Django created.
 
 .. admonition:: For the minimalists


### PR DESCRIPTION
- Suggested to use .tables instead of .schema.
- .schema show the CREATE statements while .tables lists table names