### PR TITLE
[3.2.x] Fixed #33151-- Bad handling of foreign key field in non-interactive mode of createsuperuser command

### DIFF
--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -137,9 +137,11 @@ class Command(BaseCommand):
                         if not field.many_to_many:
                             fake_user_data[field_name] = input_value
 
-                        # Wrap any foreign keys in fake model instances
-                        if field.many_to_one:
-                            fake_user_data[field_name] = field.remote_field.model(input_value)
+                    # Wrap any foreign keys in fake model instances
+                    if field.many_to_one:
+                        user_data[field_name] = fake_user_data[field_name] = field.remote_field.model(
+                            user_data[field_name]
+                        )
 
                 # Prompt for a password if the model has one.
                 while PASSWORD_FIELD in user_data and user_data[PASSWORD_FIELD] is None:
@@ -185,6 +187,10 @@ class Command(BaseCommand):
                         raise CommandError('You must use --%s with --noinput.' % field_name)
                     field = self.UserModel._meta.get_field(field_name)
                     user_data[field_name] = field.clean(value, None)
+                    if field.many_to_many and isinstance(user_data[field_name], str):
+                        user_data[field_name] = [pk.strip() for pk in user_data[field_name].split(",")]
+                    if field.many_to_one:
+                        user_data[field_name] = field.remote_field.model(field.clean(value, None))
 
             self.UserModel._default_manager.db_manager(database).create_superuser(**user_data)
             if options['verbosity'] >= 1:

--- a/tests/auth_tests/models/with_foreign_key.py
+++ b/tests/auth_tests/models/with_foreign_key.py
@@ -8,7 +8,7 @@ class Email(models.Model):
 
 class CustomUserWithFKManager(BaseUserManager):
     def create_superuser(self, username, email, group, password):
-        user = self.model(username_id=username, email_id=email, group_id=group)
+        user = self.model(username_id=username, email_id=email.id, group_id=group.pk)
         user.set_password(password)
         user.save(using=self._db)
         return user

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -478,6 +478,36 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
             )
 
     @override_settings(AUTH_USER_MODEL='auth_tests.CustomUserWithFK')
+    def test_fields_with_fk_by_env(self):
+        new_io = StringIO()
+        group = Group.objects.create(name='mygroup')
+        email = Email.objects.create(email='mymail@gmail.com')
+        os.environ["DJANGO_SUPERUSER_GROUP"] = str(group.pk)
+        call_command(
+            'createsuperuser',
+            interactive=False,
+            username=email.pk,
+            email=email.email,
+            stdout=new_io,
+        )
+        command_output = new_io.getvalue().strip()
+        self.assertEqual(command_output, 'Superuser created successfully.')
+        u = CustomUserWithFK._default_manager.get(email=email)
+        self.assertEqual(u.username, email)
+        self.assertEqual(u.group, group)
+
+        non_existent_email = 'mymail2@gmail.com'
+        msg = 'email instance with email %r does not exist.' % non_existent_email
+        with self.assertRaisesMessage(CommandError, msg):
+            call_command(
+                'createsuperuser',
+                interactive=False,
+                username=email.pk,
+                email=non_existent_email,
+                stdout=new_io,
+            )
+
+    @override_settings(AUTH_USER_MODEL='auth_tests.CustomUserWithFK')
     def test_fields_with_fk_interactive(self):
         new_io = StringIO()
         group = Group.objects.create(name='mygroup')
@@ -515,6 +545,23 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
             interactive=False,
             username='joe',
             orgs=[org_id_1, org_id_2],
+            stdout=new_io,
+        )
+        command_output = new_io.getvalue().strip()
+        self.assertEqual(command_output, 'Superuser created successfully.')
+        user = CustomUserWithM2M._default_manager.get(username='joe')
+        self.assertEqual(user.orgs.count(), 2)
+
+    @override_settings(AUTH_USER_MODEL='auth_tests.CustomUserWithM2m')
+    def test_fields_with_m2m_by_env(self):
+        new_io = StringIO()
+        org_id_1 = Organization.objects.create(name='Organization 1').pk
+        org_id_2 = Organization.objects.create(name='Organization 2').pk
+        os.environ["DJANGO_SUPERUSER_ORGS"] = "%s,%s" % (org_id_1, org_id_2)
+        call_command(
+            'createsuperuser',
+            interactive=False,
+            username='joe',
             stdout=new_io,
         )
         command_output = new_io.getvalue().strip()


### PR DESCRIPTION
Same as #14910, but for version 3.2.x

Fixes [#33151](https://code.djangoproject.com/ticket/33151)

Better handling of foreign key field in non-interactive mode of createsuperuser command
