### PR TITLE
Fixed #33159 -- Reverted "Fixed #32970 -- Changed WhereNode.clone() to create a shallow copy of children."

### DIFF
--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -148,7 +148,11 @@ class WhereNode(tree.Node):
         clone = self.__class__._new_instance(
             children=None, connector=self.connector, negated=self.negated,
         )
-        clone.children = self.children[:]
+        for child in self.children:
+            if hasattr(child, 'clone'):
+                clone.children.append(child.clone())
+            else:
+                clone.children.append(child)
         return clone
 
     def relabeled_clone(self, change_map):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -1663,6 +1663,12 @@ class Queries5Tests(TestCase):
             'bar %s'
         )
 
+    def test_queryset_reuse(self):
+        # Using querysets doesn't mutate aliases.
+        authors = Author.objects.filter(Q(name='a1') | Q(name='nonexistent'))
+        self.assertEqual(Ranking.objects.filter(author__in=authors).get(), self.rank3)
+        self.assertEqual(authors.count(), 1)
+
 
 class SelectRelatedTests(TestCase):
     def test_tickets_3045_3288(self):


### PR DESCRIPTION
ticket-33159

This reverts commit e441847ecae99dd1ccd0d9ce76dbcff51afa863c.

A shallow copy is not enough because querysets can be reused and evaluated in nested nodes, which shouldn't mutate JOIN aliases.

Thanks Michal Čihař for the report.