### PR TITLE
Fixed #33160 -- Avoided suppressing query errors in _nodb_cursor() on PostgreSQL.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -304,10 +304,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     @contextmanager
     def _nodb_cursor(self):
+        cursor = None
         try:
             with super()._nodb_cursor() as cursor:
                 yield cursor
         except (Database.DatabaseError, WrappedDatabaseError):
+            if cursor is not None:
+                raise
             warnings.warn(
                 "Normally Django will use a connection to the 'postgres' database "
                 "to avoid running initialization queries against the production "

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -103,6 +103,11 @@ class Tests(TestCase):
                     with connection._nodb_cursor():
                         pass
 
+    def test_nodb_cursor_reraise_exceptions(self):
+        with self.assertRaisesMessage(DatabaseError, 'exception'):
+            with connection._nodb_cursor():
+                raise DatabaseError('exception')
+
     def test_database_name_too_long(self):
         from django.db.backends.postgresql.base import DatabaseWrapper
         settings = connection.settings_dict.copy()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33160