### PR TITLE
Fixed SpGistIndex tests on PostgreSQL 14+.

### DIFF
--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -492,31 +492,31 @@ class SchemaTests(PostgreSQLTestCase):
 
     def test_spgist_index(self):
         # Ensure the table is there and doesn't have an index.
-        self.assertNotIn('field', self.get_constraints(CharFieldModel._meta.db_table))
+        self.assertNotIn('field', self.get_constraints(TextFieldModel._meta.db_table))
         # Add the index.
-        index_name = 'char_field_model_field_spgist'
+        index_name = 'text_field_model_field_spgist'
         index = SpGistIndex(fields=['field'], name=index_name)
         with connection.schema_editor() as editor:
-            editor.add_index(CharFieldModel, index)
-        constraints = self.get_constraints(CharFieldModel._meta.db_table)
+            editor.add_index(TextFieldModel, index)
+        constraints = self.get_constraints(TextFieldModel._meta.db_table)
         # The index was added.
         self.assertEqual(constraints[index_name]['type'], SpGistIndex.suffix)
         # Drop the index.
         with connection.schema_editor() as editor:
-            editor.remove_index(CharFieldModel, index)
-        self.assertNotIn(index_name, self.get_constraints(CharFieldModel._meta.db_table))
+            editor.remove_index(TextFieldModel, index)
+        self.assertNotIn(index_name, self.get_constraints(TextFieldModel._meta.db_table))
 
     def test_spgist_parameters(self):
-        index_name = 'integer_array_spgist_fillfactor'
+        index_name = 'text_field_model_spgist_fillfactor'
         index = SpGistIndex(fields=['field'], name=index_name, fillfactor=80)
         with connection.schema_editor() as editor:
-            editor.add_index(CharFieldModel, index)
-        constraints = self.get_constraints(CharFieldModel._meta.db_table)
+            editor.add_index(TextFieldModel, index)
+        constraints = self.get_constraints(TextFieldModel._meta.db_table)
         self.assertEqual(constraints[index_name]['type'], SpGistIndex.suffix)
         self.assertEqual(constraints[index_name]['options'], ['fillfactor=80'])
         with connection.schema_editor() as editor:
-            editor.remove_index(CharFieldModel, index)
-        self.assertNotIn(index_name, self.get_constraints(CharFieldModel._meta.db_table))
+            editor.remove_index(TextFieldModel, index)
+        self.assertNotIn(index_name, self.get_constraints(TextFieldModel._meta.db_table))
 
     def test_op_class(self):
         index_name = 'test_op_class'


### PR DESCRIPTION
- `postgres_tests.test_indexes.SchemaTests.test_spgist_index`
- `postgres_tests.test_indexes.SchemaTests.test_spgist_parameters`

fail on PostgreSQL 14+ with:

`django.db.utils.DataError: compress method must be defined when leaf type is different from input type`

It's enough to use `TextField` instead of `CharField` (which is not important for these tests).