### PR TITLE
Added range filter

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -942,3 +942,7 @@ def pprint(value):
         return pformat(value)
     except Exception as e:
         return "Error in formatting: %s: %s" % (e.__class__.__name__, e)
+
+@register.filter(name='range')
+def _range(dict: int):
+    return range(int)

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -944,5 +944,5 @@ def pprint(value):
         return "Error in formatting: %s: %s" % (e.__class__.__name__, e)
 
 @register.filter(name='range')
-def _range(dict: int):
-    return range(int)
+def _range(value: int):
+    return range(value)


### PR DESCRIPTION
## Added functionality for the pythonic ``range`` function in templates

A simple PR for the added functionality for the ``range`` function (I would say numeric forloop)
In `python` we have
```python
for i in range(5):
    print(i)
```

Here in template they can do:
```django
{% for j in an_integer_no|range %}
    {{j}}
    some html code or a random fnc .........
{% endfor %}
```