### PR TITLE
Fixed #33163 -- Added example of connection signal handlers in AppConfig.ready() to docs.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -819,6 +819,7 @@ answer newbie questions, and generally made Django that much better:
     Romain Garrigues <romain.garrigues.cs@gmail.com>
     Ronny Haryanto <https://ronny.haryan.to/>
     Ross Poulton <ross@rossp.org>
+    Roxane Bellot <https://github.com/roxanebellot/>
     Rozza <ross.lawley@gmail.com>
     Rudolph Froger <rfroger@estrate.nl>
     Rudy Mutter

--- a/docs/topics/signals.txt
+++ b/docs/topics/signals.txt
@@ -136,9 +136,21 @@ Now, our ``my_callback`` function will be called each time a request finishes.
     In practice, signal handlers are usually defined in a ``signals``
     submodule of the application they relate to. Signal receivers are
     connected in the :meth:`~django.apps.AppConfig.ready` method of your
-    application configuration class. If you're using the :func:`receiver`
-    decorator, import the ``signals`` submodule inside
-    :meth:`~django.apps.AppConfig.ready`.
+    application :ref:`configuration class <configuring-applications-ref>`. If
+    you're using the :func:`receiver` decorator, import the ``signals``
+    submodule inside :meth:`~django.apps.AppConfig.ready`, this will implicitly
+    connect signal handlers::
+
+        from django.apps import AppConfig
+
+        class MyAppConfig(AppConfig):
+            ...
+
+            def ready(self):
+                # Implicitly connect a signal handlers decorated with @receiver.
+                from . import signals
+                # Explicitly connect a signal handler.
+                signals.request_finished.connect(signals.my_callback)
 
 .. note::
 


### PR DESCRIPTION
See [ticket](https://code.djangoproject.com/ticket/33163#ticket) and [forum post](https://forum.djangoproject.com/t/load-signals-automatically/9666)

I tried to keep as much as existing naming and  formulation as I could.

When it is ok with you, I can also do a French translation