### PR TITLE
Fixed #33164 - Support uppercase in UUID URL converter

### DIFF
--- a/django/urls/converters.py
+++ b/django/urls/converters.py
@@ -23,7 +23,7 @@ class StringConverter:
 
 
 class UUIDConverter:
-    regex = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+    regex = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-f]{4}-[0-9a-fA-F]{12}'
 
     def to_python(self, value):
         return uuid.UUID(value)

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -182,7 +182,7 @@ class ConverterTests(SimpleTestCase):
             ('str', {'abcxyz'}, no_converter),
             ('path', {'allows.ANY*characters'}, no_converter),
             ('slug', {'abcxyz-ABCXYZ_01234567890'}, no_converter),
-            ('uuid', {'39da9369-838e-4750-91a5-f7805cd82839'}, uuid.UUID),
+            ('uuid', {'39da9369-838e-4750-91a5-f7805cd82839', '39DA9369-838E-4750-91A5-F7805CD82839'}, uuid.UUID),
         )
         for url_name, url_suffixes, converter in test_data:
             for url_suffix in url_suffixes:


### PR DESCRIPTION
According to the RFC4122 A Universally Unique IDentifier (UUID) URN Namespace, the formal definition of an UUID string includes hexadecimal digits in uppercase. But the current implementation of the UUID URL converter only supports lowercase digits (from a to f).

