### PR TITLE
Refs #27694 -- Doc'd lookups that can be chained with HStoreField key transforms.

### DIFF
--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -358,6 +358,13 @@ You can chain other lookups after key lookups::
 If the key you wish to query by clashes with the name of another lookup, you
 need to use the :lookup:`hstorefield.contains` lookup instead.
 
+.. note::
+
+    Key transforms can also be chained with: :lookup:`contains`,
+    :lookup:`icontains`, :lookup:`endswith`, :lookup:`iendswith`,
+    :lookup:`iexact`, :lookup:`regex`, :lookup:`iregex`, :lookup:`startswith`,
+    and :lookup:`istartswith` lookups.
+
 .. warning::
 
     Since any string could be a key in a hstore value, any lookup other than

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -78,6 +78,10 @@ class TestQuerying(PostgreSQLTestCase):
             HStoreModel(field={'c': 'd'}),
             HStoreModel(field={}),
             HStoreModel(field=None),
+            HStoreModel(field={'cat': 'TigrOu', 'breed': 'birman'}),
+            HStoreModel(field={'cat': 'minou', 'breed': 'ragdoll'}),
+            HStoreModel(field={'cat': 'kitty', 'breed': 'Persian'}),
+            HStoreModel(field={'cat': 'Kit Kat', 'breed': 'persian'}),
         ])
 
     def test_exact(self):
@@ -141,7 +145,7 @@ class TestQuerying(PostgreSQLTestCase):
         qs = HStoreModel.objects.annotate(a=F('field__a'))
         self.assertCountEqual(
             qs.values_list('a', flat=True),
-            ['b', 'b', None, None, None],
+            ['b', 'b', None, None, None, None, None, None, None],
         )
 
     def test_keys(self):
@@ -156,10 +160,58 @@ class TestQuerying(PostgreSQLTestCase):
             self.objs[:1]
         )
 
-    def test_field_chaining(self):
+    def test_field_chaining_contains(self):
         self.assertSequenceEqual(
             HStoreModel.objects.filter(field__a__contains='b'),
             self.objs[:2]
+        )
+
+    def test_field_chaining_icontains(self):
+        self.assertSequenceEqual(
+            HStoreModel.objects.filter(field__cat__icontains='INo'),
+            [self.objs[6]],
+        )
+
+    def test_field_chaining_startswith(self):
+        self.assertSequenceEqual(
+            HStoreModel.objects.filter(field__cat__startswith='kit'),
+            [self.objs[7]],
+        )
+
+    def test_field_chaining_istartswith(self):
+        self.assertSequenceEqual(
+            HStoreModel.objects.filter(field__cat__istartswith='kit'),
+            self.objs[7:],
+        )
+
+    def test_field_chaining_endswith(self):
+        self.assertSequenceEqual(
+            HStoreModel.objects.filter(field__cat__endswith='ou'),
+            [self.objs[6]],
+        )
+
+    def test_field_chaining_iendswith(self):
+        self.assertSequenceEqual(
+            HStoreModel.objects.filter(field__cat__iendswith='ou'),
+            self.objs[5:7],
+        )
+
+    def test_field_chaining_iexact(self):
+        self.assertSequenceEqual(
+            HStoreModel.objects.filter(field__breed__iexact='persian'),
+            self.objs[7:],
+        )
+
+    def test_field_chaining_regex(self):
+        self.assertSequenceEqual(
+            HStoreModel.objects.filter(field__cat__regex=r'ou$'),
+            [self.objs[6]],
+        )
+
+    def test_field_chaining_iregex(self):
+        self.assertSequenceEqual(
+            HStoreModel.objects.filter(field__cat__iregex=r'oU$'),
+            self.objs[5:7],
         )
 
     def test_order_by_field(self):
@@ -190,7 +242,7 @@ class TestQuerying(PostgreSQLTestCase):
         obj = HStoreModel.objects.create(field={'a': None})
         self.assertSequenceEqual(
             HStoreModel.objects.filter(field__a__isnull=True),
-            self.objs[2:5] + [obj]
+            self.objs[2:9] + [obj],
         )
         self.assertSequenceEqual(
             HStoreModel.objects.filter(field__a__isnull=False),


### PR DESCRIPTION
- Add note for supported lookups
- Add tests for supported lookups 

linked to [ticket-27694](https://code.djangoproject.com/ticket/27694)