### PR TITLE
Refs #33107 -- Optimized cached_import() helper.

### DIFF
--- a/django/utils/module_loading.py
+++ b/django/utils/module_loading.py
@@ -6,14 +6,14 @@ from importlib.util import find_spec as importlib_find
 
 
 def cached_import(module_path, class_name):
-    modules = sys.modules
-    if module_path not in modules or (
-        # Module is not fully initialized.
-        getattr(modules[module_path], '__spec__', None) is not None and
-        getattr(modules[module_path].__spec__, '_initializing', False) is True
+    # Check whether module is loaded and fully initialized.
+    if not (
+        (module := sys.modules.get(module_path)) and
+        (spec := getattr(module, '__spec__', None)) and
+        getattr(spec, '_initializing', False) is False
     ):
-        import_module(module_path)
-    return getattr(modules[module_path], class_name)
+        module = import_module(module_path)
+    return getattr(module, class_name)
 
 
 def import_string(dotted_path):


### PR DESCRIPTION
Follow up on https://github.com/django/django/pull/14858#discussion_r709398928.

```bash
$ sudo pyperf system tune

# Before:

$ pyperf timeit --setup 'from django.utils.module_loading import cached_import' 'cached_import("django.core.cache.backends.memcached", "PyMemcacheCache")'
.....................
Mean +- std dev: 424 ns +- 16 ns

# After:

$ pyperf timeit --setup 'from django.utils.module_loading import cached_import' 'cached_import("django.core.cache.backends.memcached", "PyMemcacheCache")'
.....................
Mean +- std dev: 346 ns +- 14 ns

$ sudo pyperf system reset
```

In the worst case this was accessing `module_path` in `sys.modules` up to four times...