### PR TITLE
Make MultiValueDict more consistent

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -514,9 +514,13 @@ class QueryDict(MultiValueDict):
         value = bytes_to_text(value, self.encoding)
         super().appendlist(key, value)
 
-    def pop(self, key, *args):
+    def pop(self, key, *args, **kwargs):
         self._assert_mutable()
-        return super().pop(key, *args)
+        return super().pop(key, *args, **kwargs)
+
+    def poplist(self, key, *args, **kwargs):
+        self._assert_mutable()
+        return super().poplist(key, *args, **kwargs)
 
     def popitem(self):
         self._assert_mutable()

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -1,6 +1,8 @@
 import copy
 from collections.abc import Mapping
 
+NOT_PASSED = object()
+
 
 class OrderedSet:
     """
@@ -83,6 +85,9 @@ class MultiValueDict(dict):
             list_ = super().__getitem__(key)
         except KeyError:
             raise MultiValueDictKeyError(key)
+        return self._get_last(list_)
+
+    def _get_last(self, list_):
         try:
             return list_[-1]
         except IndexError:
@@ -113,6 +118,31 @@ class MultiValueDict(dict):
         for k, v in data.items():
             self.setlist(k, v)
         self.__dict__.update(obj_dict)
+
+    def pop(self, key, default=NOT_PASSED):
+        """
+        Remove and return the last data value for the passed key. If key doesn't exist
+        or value is an empty list, return `default`.
+        """
+        return self._pop(key, last=True, default=default)
+
+    def poplist(self, key, default=NOT_PASSED):
+        """
+        Remove and return the list of values for the key. If key doesn't exist, return a
+        default value.
+        """
+        return self._pop(key, last=False, default=default)
+
+    def _pop(self, key, last, default=NOT_PASSED):
+        try:
+            val = super(MultiValueDict, self).pop(key)
+            if last:
+                val = self._get_last(val)
+        except KeyError:
+            if default is NOT_PASSED:
+                raise MultiValueDictKeyError(key)
+            val = default
+        return val
 
     def get(self, key, default=None):
         """

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -44,6 +44,8 @@ class QueryDictTests(SimpleTestCase):
             q.popitem()
         with self.assertRaises(AttributeError):
             q.clear()
+        with self.assertRaises(AttributeError):
+            q.poplist("foo")
 
     def test_immutable_get_with_default(self):
         q = QueryDict()
@@ -159,11 +161,15 @@ class QueryDictTests(SimpleTestCase):
         self.assertCountEqual(q.values(), ['another', 'john'])
 
         q.update({'foo': 'hello'})
+        q.setlist("bars", ["hello", "world"])
         self.assertEqual(q['foo'], 'hello')
         self.assertEqual(q.get('foo', 'not available'), 'hello')
         self.assertEqual(q.getlist('foo'), ['bar', 'baz', 'another', 'hello'])
-        self.assertEqual(q.pop('foo'), ['bar', 'baz', 'another', 'hello'])
+        self.assertEqual(q.poplist('foo'), ['bar', 'baz', 'another', 'hello'])
+        breakpoint()
+        self.assertEqual(q.pop('bars'), 'world')
         self.assertEqual(q.pop('foo', 'not there'), 'not there')
+        self.assertEqual(q.pop('bars', 'not there'), 'not there')
         self.assertEqual(q.get('foo', 'not there'), 'not there')
         self.assertEqual(q.setdefault('foo', 'bar'), 'bar')
         self.assertEqual(q['foo'], 'bar')


### PR DESCRIPTION
I was working with query parameters and found that `.pop()` and `.get()` both have different logic. 

I assume that `.pop()` should be the same as `.get()`, but the key should get deleted afterward. 

Here's an example

```python
In [1]: from django.utils.datastructures import MultiValueDict

In [2]: data = MultiValueDict({"name": ["Yaroslav", "Clara"], "age": [22, 32]})

In [3]: data.get("name")
Out[3]: 'Clara'

In [4]: data.pop("name")
Out[4]: ['Yaroslav', 'Clara']
```

As you can see, we've got a single item for `.get()`, and a list for `.pop()`, which is confusing. 

We should have all of that synced. `.get()` with `.getlist()`, and `.pop()` with `.poplist()`.

Here's how it looks like after I've done some changes:

```python
In [4]: data.pop("name")
Out[4]: 'Clara'
...
In [5]: data.poplist("name")
Out[5]: ['Yaroslav', 'Clara']
```
