### PR TITLE
Refs #26430 -- Removed unused branch in sql.Query.get_count().

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -513,10 +513,7 @@ class Query(BaseExpression):
         """
         obj = self.clone()
         obj.add_annotation(Count('*'), alias='__count', is_summary=True)
-        number = obj.get_aggregation(using, ['__count'])['__count']
-        if number is None:
-            number = 0
-        return number
+        return obj.get_aggregation(using, ['__count'])['__count']
 
     def has_filters(self):
         return self.where


### PR DESCRIPTION
Now that sql.Query.get_aggregation properly deals with empty result sets summary Count annotations cannot result in None.