### PR TITLE
fix: `return None or 0` in `Query.get_count`

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -513,7 +513,7 @@ class Query(BaseExpression):
         """
         obj = self.clone()
         obj.add_annotation(Count('*'), alias='__count', is_summary=True)
-        return obj.get_aggregation(using, ['__count'])['__count']
+        return obj.get_aggregation(using, ['__count'])['__count'] or 0
 
     def has_filters(self):
         return self.where


### PR DESCRIPTION
add `or 0` to avoid None value in the return of get_count