### PR TITLE
Fixed #33151 -- Fixed createsuperuser crash for many-to-many required fields in non-interactive mode.

### DIFF
--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -185,6 +185,10 @@ class Command(BaseCommand):
                         raise CommandError('You must use --%s with --noinput.' % field_name)
                     field = self.UserModel._meta.get_field(field_name)
                     user_data[field_name] = field.clean(value, None)
+                    if field.many_to_many and isinstance(user_data[field_name], str):
+                        user_data[field_name] = [
+                            pk.strip() for pk in user_data[field_name].split(',')
+                        ]
 
             self.UserModel._default_manager.db_manager(database).create_superuser(**user_data)
             if options['verbosity'] >= 1:

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -994,6 +994,25 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
         # Environment variables are ignored for non-required fields.
         self.assertEqual(user.first_name, '')
 
+    @override_settings(AUTH_USER_MODEL='auth_tests.CustomUserWithM2m')
+    def test_environment_variable_m2m_non_interactive(self):
+        new_io = StringIO()
+        org_id_1 = Organization.objects.create(name='Organization 1').pk
+        org_id_2 = Organization.objects.create(name='Organization 2').pk
+        with mock.patch.dict(os.environ, {
+            'DJANGO_SUPERUSER_ORGS': f'{org_id_1},{org_id_2}',
+        }):
+            call_command(
+                'createsuperuser',
+                interactive=False,
+                username='joe',
+                stdout=new_io,
+            )
+        command_output = new_io.getvalue().strip()
+        self.assertEqual(command_output, 'Superuser created successfully.')
+        user = CustomUserWithM2M._default_manager.get(username='joe')
+        self.assertEqual(user.orgs.count(), 2)
+
     @mock.patch.dict(os.environ, {
         'DJANGO_SUPERUSER_USERNAME': 'test_superuser',
         'DJANGO_SUPERUSER_EMAIL': 'joe@somewhere.org',


### PR DESCRIPTION
Fixes [#33151](https://code.djangoproject.com/ticket/33151). This bug reproduces in 3.1.x and 3.2.x and most likely in 4.x.

Better handling of foreign key field in non-interactive mode of createsuperuser command

(Supersedes #14913)