### PR TITLE
Fixed #31354: Properly reconstruct host header in presence of X-Forwarded-* header.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -126,8 +126,9 @@ class HttpRequest:
 
             if settings.USE_X_FORWARDED_PORT and 'HTTP_X_FORWARDED_PORT' in self.META:
                 if port_in_x_fw_host:
-                    raise ImproperlyConfigured('HTTP_X_FORWARDED_HOST contains a port number '
-                                                'and USE_X_FORWARDED_PORT is set to True')
+                    raise ImproperlyConfigured(
+                        'HTTP_X_FORWARDED_HOST contains a port number and USE_X_FORWARDED_PORT is set to True'
+                    )
                 port = self.META['HTTP_X_FORWARDED_PORT']
 
             self._parsed_host_header = ParsedHostHeader(domain, port)
@@ -631,6 +632,7 @@ def bytes_to_text(s, encoding):
         return str(s, encoding, 'replace')
     else:
         return s
+
 
 def _parse_host_header(host):
     """

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -281,7 +281,7 @@ class ExceptionReporter:
         """
         return '{scheme}://{host}{path}'.format(
             scheme=self.request.scheme,
-            host=self.request._get_raw_host(),
+            host=self.request._get_parsed_host_header().host,
             path=self.request.get_full_path(),
         )
 

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -781,6 +781,7 @@ class CsrfViewMiddlewareTestMixin(CsrfFunctionTestMixin):
     def _test_https_good_referer_matches_cookie_domain(self):
         req = self._get_POST_request_with_token()
         req._is_secure_override = True
+        req.META['HTTP_HOST'] = 'www.example.com'
         req.META['HTTP_REFERER'] = 'https://foo.example.com/'
         req.META['SERVER_PORT'] = '443'
         mw = CsrfViewMiddleware(post_form_view)
@@ -791,7 +792,7 @@ class CsrfViewMiddlewareTestMixin(CsrfFunctionTestMixin):
     def _test_https_good_referer_matches_cookie_domain_with_different_port(self):
         req = self._get_POST_request_with_token()
         req._is_secure_override = True
-        req.META['HTTP_HOST'] = 'www.example.com'
+        req.META['HTTP_HOST'] = 'www.example.com:4443'
         req.META['HTTP_REFERER'] = 'https://foo.example.com:4443/'
         req.META['SERVER_PORT'] = '4443'
         mw = CsrfViewMiddleware(post_form_view)
@@ -1206,7 +1207,12 @@ class CsrfViewMiddlewareTests(CsrfViewMiddlewareTestMixin, SimpleTestCase):
         self.assertMaskedSecretCorrect(csrf_cookie, TEST_SECRET)
         self._check_token_present(resp, csrf_cookie)
 
-    @override_settings(ALLOWED_HOSTS=['www.example.com'], CSRF_COOKIE_DOMAIN='.example.com', USE_X_FORWARDED_PORT=True)
+    @override_settings(
+        ALLOWED_HOSTS=['www.example.com'],
+        CSRF_COOKIE_DOMAIN='.example.com',
+        USE_X_FORWARDED_PORT=True,
+        USE_X_FORWARDED_HOST=True
+    )
     def test_https_good_referer_behind_proxy(self):
         """
         A POST HTTPS request is accepted when USE_X_FORWARDED_PORT=True.

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -115,31 +115,37 @@ class SitesFrameworkTests(TestCase):
         s2 = Site.objects.create(domain='example.com:80', name='example.com:80')
 
         # Host header without port
+        request = HttpRequest()
         request.META = {'HTTP_HOST': 'example.com'}
         site = get_current_site(request)
         self.assertEqual(site, s1)
 
         # Host header with port - match, no fallback without port
+        request = HttpRequest()
         request.META = {'HTTP_HOST': 'example.com:80'}
         site = get_current_site(request)
         self.assertEqual(site, s2)
 
         # Host header with port - no match, fallback without port
+        request = HttpRequest()
         request.META = {'HTTP_HOST': 'example.com:81'}
         site = get_current_site(request)
         self.assertEqual(site, s1)
 
         # Host header with non-matching domain
+        request = HttpRequest()
         request.META = {'HTTP_HOST': 'example.net'}
         with self.assertRaises(ObjectDoesNotExist):
             get_current_site(request)
 
         # Ensure domain for RequestSite always matches host header
         with self.modify_settings(INSTALLED_APPS={'remove': 'django.contrib.sites'}):
+            request = HttpRequest()
             request.META = {'HTTP_HOST': 'example.com'}
             site = get_current_site(request)
             self.assertEqual(site.name, 'example.com')
 
+            request = HttpRequest()
             request.META = {'HTTP_HOST': 'example.com:80'}
             site = get_current_site(request)
             self.assertEqual(site.name, 'example.com:80')


### PR DESCRIPTION
## Follow up to #12844 

When I ran the tests locally, I got the following failures (CSRF); it would be great if someone could assist me.
```
FAIL: test_https_good_referer_matches_cookie_domain (csrf_tests.tests.CsrfViewMiddlewareTests)
A POST HTTPS request with a good referer should be accepted from a
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sreehari/opensource/django/django/django/test/utils.py", line 437, in inner
    return func(*args, **kwargs)
  File "/Users/sreehari/opensource/django/django/tests/csrf_tests/tests.py", line 1228, in test_https_good_referer_matches_cookie_domain
    self._test_https_good_referer_matches_cookie_domain()
  File "/Users/sreehari/opensource/django/django/tests/csrf_tests/tests.py", line 790, in _test_https_good_referer_matches_cookie_domain
    self.assertIsNone(response)
AssertionError: <HttpResponseForbidden status_code=403, "text/html"> is not None

======================================================================
FAIL: test_https_good_referer_matches_cookie_domain (csrf_tests.tests.CsrfViewMiddlewareUseSessionsTests)
A POST HTTPS request with a good referer should be accepted from a
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sreehari/opensource/django/django/django/test/utils.py", line 437, in inner
    return func(*args, **kwargs)
  File "/Users/sreehari/opensource/django/django/tests/csrf_tests/tests.py", line 1359, in test_https_good_referer_matches_cookie_domain
    self._test_https_good_referer_matches_cookie_domain()
  File "/Users/sreehari/opensource/django/django/tests/csrf_tests/tests.py", line 790, in _test_https_good_referer_matches_cookie_domain
    self.assertIsNone(response)
AssertionError: <HttpResponseForbidden status_code=403, "text/html"> is not None

----------------------------------------------------------------------
Ran 15252 tests in 537.241s

FAILED (failures=2, skipped=1193, expected failures=4)
```