### PR TITLE
Fixed #33178 -- Made createsuperuser validate required fields passed in options in interactive mode.

### DIFF
--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -124,6 +124,8 @@ class Command(BaseCommand):
                 for field_name in self.UserModel.REQUIRED_FIELDS:
                     field = self.UserModel._meta.get_field(field_name)
                     user_data[field_name] = options[field_name]
+                    if user_data[field_name] is not None:
+                        user_data[field_name] = field.clean(user_data[field_name], None)
                     while user_data[field_name] is None:
                         message = self._get_input_message(field)
                         input_value = self.get_input_data(field, message)

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -568,6 +568,29 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
                     verbosity=0,
                 )
 
+    @override_settings(AUTH_USER_MODEL='auth_tests.CustomUserWithFK')
+    def test_validate_fk_via_option_interactive(self):
+        email = Email.objects.create(email='mymail@gmail.com')
+        Group.objects.all().delete()
+        nonexistent_group_id = 1
+        msg = f'group instance with id {nonexistent_group_id} does not exist.'
+
+        @mock_inputs({
+            'password': 'nopasswd',
+            'Username (Email.id): ': email.pk,
+            'Email (Email.email): ': email.email,
+        })
+        def test(self):
+            with self.assertRaisesMessage(CommandError, msg):
+                call_command(
+                    'createsuperuser',
+                    group=nonexistent_group_id,
+                    stdin=MockTTY(),
+                    verbosity=0,
+                )
+
+        test(self)
+
     @override_settings(AUTH_USER_MODEL='auth_tests.CustomUserWithM2m')
     def test_fields_with_m2m(self):
         new_io = StringIO()


### PR DESCRIPTION
Fixes [#33178](https://code.djangoproject.com/ticket/33178): `creratesuperuser` does not validate `REQUIRED_FIELDS` fields value in interactive mode when passed by command-line