### PR TITLE
Fixed #33149 -- Made test runner --pdb option work with subTest().

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -107,6 +107,11 @@ class PDBDebugResult(unittest.TextTestResult):
         super().addFailure(test, err)
         self.debug(err)
 
+    def addSubTest(self, test, subtest, err):
+        if err is not None:
+            self.debug(err)
+        super().addSubTest(test, subtest, err)
+
     def debug(self, error):
         self._restoreStdout()
         self.buffer = False


### PR DESCRIPTION
Thanks Lucidot for the report and Mariusz for the intial
suggestion on the ticket.