### PR TITLE
Refs #32900 -- Restored '[y/N]' in questioner prompt when merging migrations.

### DIFF
--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -211,7 +211,7 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
         return self._boolean_input(
             "\nMerging will only work if the operations printed above do not conflict\n" +
             "with each other (working on different fields or models)\n" +
-            'Should these migration branches be merged?',
+            'Should these migration branches be merged? [y/N]',
             False,
         )
 


### PR DESCRIPTION
- https://github.com/django/django/pull/14607

`[y/N]` text in `ask_merge()` was removed on PR above.