### PR TITLE
Fixed #33269 -- Made AnonymousUser/PermissionsMixin.has_perms() raise ValueError on string or non-iterable perm_list.

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -8,6 +8,7 @@ from django.core.mail import send_mail
 from django.db import models
 from django.db.models.manager import EmptyManager
 from django.utils import timezone
+from django.utils.itercompat import is_iterable
 from django.utils.translation import gettext_lazy as _
 
 from .validators import UnicodeUsernameValidator
@@ -304,6 +305,8 @@ class PermissionsMixin(models.Model):
         Return True if the user has each of the specified permissions. If
         object is passed, check if the user has all required perms for it.
         """
+        if not is_iterable(perm_list) or isinstance(perm_list, str):
+            raise ValueError('perm_list must be an iterable of permissions.')
         return all(self.has_perm(perm, obj) for perm in perm_list)
 
     def has_module_perms(self, app_label):
@@ -452,6 +455,8 @@ class AnonymousUser:
         return _user_has_perm(self, perm, obj=obj)
 
     def has_perms(self, perm_list, obj=None):
+        if not is_iterable(perm_list) or isinstance(perm_list, str):
+            raise ValueError('perm_list must be an iterable of permissions.')
         return all(self.has_perm(perm, obj) for perm in perm_list)
 
     def has_module_perms(self, module):

--- a/tests/auth_tests/test_auth_backends.py
+++ b/tests/auth_tests/test_auth_backends.py
@@ -53,6 +53,13 @@ class BaseBackendTest(TestCase):
         self.assertIs(self.user.has_perm('group_perm'), True)
         self.assertIs(self.user.has_perm('other_perm', TestObj()), False)
 
+    def test_has_perms_perm_list_invalid(self):
+        msg = 'perm_list must be an iterable of permissions.'
+        with self.assertRaisesMessage(ValueError, msg):
+            self.user.has_perms('user_perm')
+        with self.assertRaisesMessage(ValueError, msg):
+            self.user.has_perms(object())
+
 
 class CountingMD5PasswordHasher(MD5PasswordHasher):
     """Hasher that counts how many times it computes a hash."""
@@ -475,6 +482,13 @@ class AnonymousUserBackendTest(SimpleTestCase):
     def test_has_perms(self):
         self.assertIs(self.user1.has_perms(['anon'], TestObj()), True)
         self.assertIs(self.user1.has_perms(['anon', 'perm'], TestObj()), False)
+
+    def test_has_perms_perm_list_invalid(self):
+        msg = 'perm_list must be an iterable of permissions.'
+        with self.assertRaisesMessage(ValueError, msg):
+            self.user1.has_perms('perm')
+        with self.assertRaisesMessage(ValueError, msg):
+            self.user1.has_perms(object())
 
     def test_has_module_perms(self):
         self.assertIs(self.user1.has_module_perms("app1"), True)


### PR DESCRIPTION
A colleague made this error recently doing a `user.has_perms("foobar")` instead of the correct `user.has_perms(["foobar"])` or `user.has_perm("foobar")`. The code initially appeared to work fine since in Python, `str` is an iterable that returned individual characters as string when iterated over.

We checked for str in particular rather than enforcing it to be a list, since perm_list may actually be tuple, set, generators, or other iterables.

An alternative way this could be fixed is to just silently behave like `has_perm()` if `perm_list` is actually a string rather than raising an error, but that'll probably enforce a bad habit.