### PR TITLE
Doc'd a precise exception type in Paginator.page() docs.

### DIFF
--- a/docs/ref/paginator.txt
+++ b/docs/ref/paginator.txt
@@ -75,7 +75,7 @@ Methods
 
     Returns a :class:`Page` object with the given 1-based index. Raises
     :exc:`PageNotAnInteger` if the ``number`` cannot be converted to an integer
-    by calling ``int()``. Raises :exc:`InvalidPage` if the given page number
+    by calling ``int()``. Raises :exc:`EmptyPage` if the given page number
     doesn't exist.
 
 .. method:: Paginator.get_elided_page_range(number, *, on_each_side=3, on_ends=2)


### PR DESCRIPTION
InvalidPage => EmptyPage