### PR TITLE
Repositioned admin object-tools for better responsiveness

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -753,17 +753,18 @@ a.deletelink:focus, a.deletelink:hover {
 /* OBJECT TOOLS */
 
 .object-tools {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     font-size: 10px;
     font-weight: bold;
     padding-left: 0;
-    float: right;
     position: relative;
-    margin-top: -48px;
 }
 
 .object-tools li {
     display: block;
-    float: left;
+    margin-bottom: 15px;
     margin-left: 5px;
     height: 16px;
 }
@@ -960,6 +961,16 @@ table#change-history tbody th {
     text-decoration: none;
     border-bottom-color: var(--primary);
     color: var(--primary);
+}
+
+.content-header {
+    display: flex;
+    justify-content: space-between;
+}
+
+.content-titles h1, .content-titles h2 {
+    white-space: nowrap;
+    margin-right: 10px;
 }
 
 /* SIDEBAR */

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -86,10 +86,14 @@
         <!-- Content -->
         <div id="content" class="{% block coltype %}colM{% endblock %}">
           {% block pretitle %}{% endblock %}
-          {% block content_title %}{% if title %}<h1>{{ title }}</h1>{% endif %}{% endblock %}
-          {% block content_subtitle %}{% if subtitle %}<h2>{{ subtitle }}</h2>{% endif %}{% endblock %}
-          {% block content %}
+          <div class="content-header">
+            <div class="content-titles">
+              {% block content_title %}{% if title %}<h1>{{ title }}</h1>{% endif %}{% endblock %}
+              {% block content_subtitle %}{% if subtitle %}<h2>{{ subtitle }}</h2>{% endif %}{% endblock %}
+            </div>
             {% block object-tools %}{% endblock %}
+          </div>
+          {% block content %}
             {{ content }}
           {% endblock %}
           {% block sidebar %}{% endblock %}

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -37,15 +37,16 @@
 
 {% block coltype %}{% endblock %}
 
+{% block object-tools %}
+  <ul class="object-tools">
+    {% block object-tools-items %}
+      {% change_list_object_tools %}
+    {% endblock %}
+  </ul>
+{% endblock %}
+
 {% block content %}
   <div id="content-main">
-    {% block object-tools %}
-        <ul class="object-tools">
-          {% block object-tools-items %}
-            {% change_list_object_tools %}
-          {% endblock %}
-        </ul>
-    {% endblock %}
     {% if cl.formset and cl.formset.errors %}
         <p class="errornote">
         {% if cl.formset.total_error_count == 1 %}{% translate "Please correct the error below." %}{% else %}{% translate "Please correct the errors below." %}{% endif %}


### PR DESCRIPTION
Moved block object-tools out from content block and added it
to the newly created content-header div. Amended object-tools css
to make object-tools-items wrap on smaller screens without affecting
the content block.

The way it is currently (negative margin and element outside of its parent) seem like an anti-pattern to me 
and it makes it very hard to make responsive when adding more options to `object-tools-items`. 
I have moved the object-tools block outside of the content block and applied flexbox so it can wrap nicely when there are more object-tools-items than can fit on the screen.