### PR TITLE
Refs #25265 -- Allowed Query subclasses to build filters.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1760,7 +1760,7 @@ class Query(BaseExpression):
             )
         """
         # Generate the inner query.
-        query = Query(self.model)
+        query = self.__class__(self.model)
         query._filtered_relations = self._filtered_relations
         filter_lhs, filter_rhs = filter_expr
         if isinstance(filter_rhs, OuterRef):


### PR DESCRIPTION
We have created our own engine that adds basic support for PostgreSQL schemas. We needed to subclass the Query class, but exclude statements still contained the original Query class. This small patch fixes it.