### PR TITLE
Refs #32074 -- Removed usage of deprecated asyncore and smtpd modules.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -273,6 +273,7 @@ Running all the tests
 If you want to run the full suite of tests, you'll need to install a number of
 dependencies:
 
+*  aiosmtpd_
 *  argon2-cffi_ 19.1.0+
 *  asgiref_ 3.3.2+ (required)
 *  bcrypt_
@@ -322,6 +323,7 @@ associated tests will be skipped.
 To run some of the autoreload tests, you'll need to install the Watchman_
 service.
 
+.. _aiosmtpd: https://pypi.org/project/aiosmtpd/
 .. _argon2-cffi: https://pypi.org/project/argon2-cffi/
 .. _asgiref: https://pypi.org/project/asgiref/
 .. _bcrypt: https://pypi.org/project/bcrypt/

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,3 +1,4 @@
+aiosmtpd
 asgiref >= 3.3.2
 argon2-cffi >= 16.1.0
 backports.zoneinfo; python_version < '3.9'


### PR DESCRIPTION
ticket-32074

`asyncore` and `smtpd` modules were deprecated in Python 3.10.

[`aiosmtpd`](https://aiosmtpd.readthedocs.io/) is the recommended replacement:
```
/django/tests/mail/tests.py:1: DeprecationWarning: The asyncore module is deprecated. The recommended replacement is asyncio
  import asyncore
/django/tests/mail/tests.py:5: DeprecationWarning: The smtpd module is deprecated and unmaintained.  Please see aiosmtpd (https://aiosmtpd.readthedocs.io/) for the recommended replacement.
  import smtpd
/python3.10/smtpd.py:105: DeprecationWarning: The asynchat module is deprecated. The recommended replacement is asyncio
  import asynchat
```