### PR TITLE
Fixed #33199 -- Made Signer use keyword-only arguments.

### DIFF
--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -100,7 +100,7 @@ def base64_hmac(salt, value, key, algorithm='sha1'):
 def get_cookie_signer(salt='django.core.signing.get_cookie_signer'):
     Signer = import_string(settings.SIGNING_BACKEND)
     key = force_bytes(settings.SECRET_KEY)  # SECRET_KEY may be str or bytes.
-    return Signer(b'django.http.cookies' + key, salt=salt)
+    return Signer(key=b'django.http.cookies' + key, salt=salt)
 
 
 class JSONSerializer:
@@ -132,7 +132,7 @@ def dumps(obj, key=None, salt='django.core.signing', serializer=JSONSerializer, 
 
     The serializer is expected to return a bytestring.
     """
-    return TimestampSigner(key, salt=salt).sign_object(obj, serializer=serializer, compress=compress)
+    return TimestampSigner(key=key, salt=salt).sign_object(obj, serializer=serializer, compress=compress)
 
 
 def loads(s, key=None, salt='django.core.signing', serializer=JSONSerializer, max_age=None):
@@ -141,11 +141,11 @@ def loads(s, key=None, salt='django.core.signing', serializer=JSONSerializer, ma
 
     The serializer is expected to accept a bytestring.
     """
-    return TimestampSigner(key, salt=salt).unsign_object(s, serializer=serializer, max_age=max_age)
+    return TimestampSigner(key=key, salt=salt).unsign_object(s, serializer=serializer, max_age=max_age)
 
 
 class Signer:
-    def __init__(self, key=None, sep=':', salt=None, algorithm=None):
+    def __init__(self, *, key=None, sep=':', salt=None, algorithm=None):
         self.key = key or settings.SECRET_KEY
         self.sep = sep
         if _SEP_UNSAFE.match(self.sep):

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -253,7 +253,8 @@ Features deprecated in 4.1
 Miscellaneous
 -------------
 
-* ...
+* Keyword arguments to :class:`~django.core.signing.Signer` and
+  :class:`~django.core.signing.TimestampSigner` are now keyword-only.
 
 Features removed in 4.1
 =======================

--- a/docs/topics/signing.txt
+++ b/docs/topics/signing.txt
@@ -88,18 +88,22 @@ By default, the ``Signer`` class uses the :setting:`SECRET_KEY` setting to
 generate signatures. You can use a different secret by passing it to the
 ``Signer`` constructor::
 
-    >>> signer = Signer('my-other-secret')
+    >>> signer = Signer(key='my-other-secret')
     >>> value = signer.sign('My string')
     >>> value
     'My string:EkfQJafvGyiofrdGnuthdxImIJw'
 
-.. class:: Signer(key=None, sep=':', salt=None, algorithm=None)
+.. class:: Signer(*, key=None, sep=':', salt=None, algorithm=None)
 
     Returns a signer which uses ``key`` to generate signatures and ``sep`` to
     separate values. ``sep`` cannot be in the :rfc:`URL safe base64 alphabet
     <4648#section-5>`. This alphabet contains alphanumeric characters, hyphens,
     and underscores. ``algorithm`` must be an algorithm supported by
     :py:mod:`hashlib`, it defaults to ``'sha256'``.
+
+    .. versionchanged:: 4.1
+
+        All kwargs were made keyword-only.
 
 Using the ``salt`` argument
 ---------------------------
@@ -158,7 +162,7 @@ created within a specified period of time::
     >>> signer.unsign(value, max_age=timedelta(seconds=20))
     'hello'
 
-.. class:: TimestampSigner(key=None, sep=':', salt=None, algorithm='sha256')
+.. class:: TimestampSigner(*, key=None, sep=':', salt=None, algorithm='sha256')
 
     .. method:: sign(value)
 
@@ -180,6 +184,10 @@ created within a specified period of time::
         Checks if ``signed_obj`` was signed less than ``max_age`` seconds ago,
         otherwise raises ``SignatureExpired``. The ``max_age`` parameter can
         accept an integer or a :py:class:`datetime.timedelta` object.
+
+    .. versionchanged:: 4.1
+
+        All kwargs were made keyword-only.
 
 .. _signing-complex-data:
 

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -29,7 +29,7 @@ class TestSigner(SimpleTestCase):
             self.assertNotEqual(signer.signature(s), signer2.signature(s))
 
     def test_signature_with_salt(self):
-        "signature(kye=value, salt=...) should work"
+        """signature(value) works with a salted Signer."""
         signer = signing.Signer(key='predictable-secret', salt='extra-salt')
         self.assertEqual(
             signer.signature('hello'),

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -10,8 +10,8 @@ class TestSigner(SimpleTestCase):
 
     def test_signature(self):
         "signature() method should generate a signature"
-        signer = signing.Signer('predictable-secret')
-        signer2 = signing.Signer('predictable-secret2')
+        signer = signing.Signer(key='predictable-secret')
+        signer2 = signing.Signer(key='predictable-secret2')
         for s in (
             b'hello',
             b'3098247:529:087:',
@@ -29,8 +29,8 @@ class TestSigner(SimpleTestCase):
             self.assertNotEqual(signer.signature(s), signer2.signature(s))
 
     def test_signature_with_salt(self):
-        "signature(value, salt=...) should work"
-        signer = signing.Signer('predictable-secret', salt='extra-salt')
+        "signature(kye=value, salt=...) should work"
+        signer = signing.Signer(key='predictable-secret', salt='extra-salt')
         self.assertEqual(
             signer.signature('hello'),
             signing.base64_hmac(
@@ -41,11 +41,11 @@ class TestSigner(SimpleTestCase):
             )
         )
         self.assertNotEqual(
-            signing.Signer('predictable-secret', salt='one').signature('hello'),
-            signing.Signer('predictable-secret', salt='two').signature('hello'))
+            signing.Signer(key='predictable-secret', salt='one').signature('hello'),
+            signing.Signer(key='predictable-secret', salt='two').signature('hello'))
 
     def test_custom_algorithm(self):
-        signer = signing.Signer('predictable-secret', algorithm='sha512')
+        signer = signing.Signer(key='predictable-secret', algorithm='sha512')
         self.assertEqual(
             signer.signature('hello'),
             'Usf3uVQOZ9m6uPfVonKR-EBXjPe7bjMbp3_Fq8MfsptgkkM1ojidN0BxYaT5HAEN1'
@@ -53,14 +53,14 @@ class TestSigner(SimpleTestCase):
         )
 
     def test_invalid_algorithm(self):
-        signer = signing.Signer('predictable-secret', algorithm='whatever')
+        signer = signing.Signer(key='predictable-secret', algorithm='whatever')
         msg = "'whatever' is not an algorithm accepted by the hashlib module."
         with self.assertRaisesMessage(InvalidAlgorithm, msg):
             signer.sign('hello')
 
     def test_sign_unsign(self):
         "sign/unsign should be reversible"
-        signer = signing.Signer('predictable-secret')
+        signer = signing.Signer(key='predictable-secret')
         examples = [
             'q;wjmbk;wkmb',
             '3098247529087',
@@ -75,7 +75,7 @@ class TestSigner(SimpleTestCase):
             self.assertEqual(example, signer.unsign(signed))
 
     def test_sign_unsign_non_string(self):
-        signer = signing.Signer('predictable-secret')
+        signer = signing.Signer(key='predictable-secret')
         values = [
             123,
             1.23,
@@ -91,7 +91,7 @@ class TestSigner(SimpleTestCase):
 
     def test_unsign_detects_tampering(self):
         "unsign should raise an exception if the value has been tampered with"
-        signer = signing.Signer('predictable-secret')
+        signer = signing.Signer(key='predictable-secret')
         value = 'Another string'
         signed_value = signer.sign(value)
         transforms = (
@@ -106,7 +106,7 @@ class TestSigner(SimpleTestCase):
                 signer.unsign(transform(signed_value))
 
     def test_sign_unsign_object(self):
-        signer = signing.Signer('predictable-secret')
+        signer = signing.Signer(key='predictable-secret')
         tests = [
             ['a', 'list'],
             'a string \u2019',
@@ -155,7 +155,7 @@ class TestSigner(SimpleTestCase):
     def test_works_with_non_ascii_keys(self):
         binary_key = b'\xe7'  # Set some binary (non-ASCII key)
 
-        s = signing.Signer(binary_key)
+        s = signing.Signer(key=binary_key)
         self.assertEqual(
             'foo:EE4qGC5MEKyQG5msxYA0sBohAxLC0BJf8uRhemh0BGU',
             s.sign('foo'),
@@ -164,7 +164,7 @@ class TestSigner(SimpleTestCase):
     def test_valid_sep(self):
         separators = ['/', '*sep*', ',']
         for sep in separators:
-            signer = signing.Signer('predictable-secret', sep=sep)
+            signer = signing.Signer(key='predictable-secret', sep=sep)
             self.assertEqual(
                 'foo%sjZQoX_FtSO70jX9HLRGg2A_2s4kdDBxz1QoO_OpEQb0' % sep,
                 signer.sign('foo'),
@@ -184,9 +184,9 @@ class TestTimestampSigner(SimpleTestCase):
     def test_timestamp_signer(self):
         value = 'hello'
         with freeze_time(123456789):
-            signer = signing.TimestampSigner('predictable-key')
+            signer = signing.TimestampSigner(key='predictable-key')
             ts = signer.sign(value)
-            self.assertNotEqual(ts, signing.Signer('predictable-key').sign(value))
+            self.assertNotEqual(ts, signing.Signer(key='predictable-key').sign(value))
             self.assertEqual(signer.unsign(ts), value)
 
         with freeze_time(123456800):


### PR DESCRIPTION
This change simply adds a `*` to the parameters of `django.core.signing.Signer` which forces the naming of all parameters passed to it.

ticket-33199