### PR TITLE
Fixed #33198 -- Corrected BinaryField.max_length docs.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -573,8 +573,8 @@ case it can't be included in a :class:`~django.forms.ModelForm`.
 
 .. attribute:: BinaryField.max_length
 
-    The maximum length (in characters) of the field. The maximum length is
-    enforced in Django's validation using
+    The maximum length (in bytes) of the field. The maximum length is enforced
+    in Django's validation using
     :class:`~django.core.validators.MaxLengthValidator`.
 
 .. admonition:: Abusing ``BinaryField``


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33198