### PR TITLE
:memo: Fix templates dir in tutorial 07

### DIFF
--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -315,7 +315,7 @@ Open your settings file (:file:`mysite/settings.py`, remember) and add a
     TEMPLATES = [
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': [BASE_DIR / 'templates'],
+            'DIRS': [f"{BASE_DIR}/templates"],
             'APP_DIRS': True,
             'OPTIONS': {
                 'context_processors': [


### PR DESCRIPTION
Current tutorial contains a syntax error: 
```python
'DIRS': [BASE_DIR / 'templates'],
```