### PR TITLE
Fixed #33214 -- Added BaseDatabaseOperations.format_for_duration_arithmetic() stub method.

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -74,6 +74,12 @@ class BaseDatabaseOperations:
         """
         return len(objs)
 
+    def format_for_duration_arithmetic(self, sql):
+        raise NotImplementedError(
+            'subclasses of BaseDatabaseOperations may require a '
+            'format_for_duration_arithmetic() method.'
+        )
+
     def cache_key_culling_sql(self):
         """
         Return an SQL query that retrieves the first cache key greater than the

--- a/tests/backends/base/test_operations.py
+++ b/tests/backends/base/test_operations.py
@@ -85,6 +85,11 @@ class SimpleDatabaseOperationTests(SimpleTestCase):
         now = timezone.now()
         self.assertEqual(self.ops.adapt_timefield_value(now), str(now))
 
+    def test_format_for_duration_arithmetic(self):
+        msg = self.may_require_msg % 'format_for_duration_arithmetic'
+        with self.assertRaisesMessage(NotImplementedError, msg):
+            self.ops.format_for_duration_arithmetic(None)
+
     def test_date_extract_sql(self):
         with self.assertRaisesMessage(NotImplementedError, self.may_require_msg % 'date_extract_sql'):
             self.ops.date_extract_sql(None, None)


### PR DESCRIPTION
[ticket-33214](https://code.djangoproject.com/ticket/33214)