### PR TITLE
Fixed #33212 -- Match Set-Cookie parsing RFC when parsing Cookie header.

### DIFF
--- a/django/http/cookie.py
+++ b/django/http/cookie.py
@@ -9,15 +9,34 @@ def parse_cookie(cookie):
     Return a dictionary parsed from a `Cookie:` header string.
     """
     cookiedict = {}
-    for chunk in cookie.split(';'):
-        if '=' in chunk:
-            key, val = chunk.split('=', 1)
-        else:
-            # Assume an empty name per
-            # https://bugzilla.mozilla.org/show_bug.cgi?id=169091
-            key, val = '', chunk
-        key, val = key.strip(), val.strip()
-        if key or val:
-            # unquote using Python's algorithm.
-            cookiedict[key] = cookies._unquote(val)
+    # Parse Cookie header similar to multiple Set-Cookie headers, using algorithm from RFC6265 section 5.2.
+    # "The algorithm below is more permissive... use this algorithm so as to interoperate"
+    for set_cookie_string in cookie.split(';'):
+        # 1. The name-value-pair string consists of the characters up to, but not including, the first %x3B (";")
+        name_value_pair = set_cookie_string  # We're already splitting on semicolon above.
+        # 2. If the name-value-pair string lacks a %x3D ("=") character, ignore the set-cookie-string entirely.
+        if '=' not in name_value_pair:
+            continue
+        # 3. The (possibly empty) name string consists of the characters up
+        #    to, but not including, the first %x3D ("=") character, and the
+        #    (possibly empty) value string consists of the characters after
+        #    the first %x3D ("=") character.
+        name, value = name_value_pair.split('=', 1)
+        # 4. Remove any leading or trailing WSP characters from the name
+        #    string and the value string.
+        # RFC5234 Appendix B.1 says WSP means SP or HTAB
+        name, value = name.strip(' \t'), value.strip(' \t')
+        # 5. If the name string is empty, ignore the set-cookie-string
+        #    entirely.
+        if not name:
+            continue
+        # 6. The cookie-name is the name string, and the cookie-value is the
+        #    value string.
+
+        # The RFC allows for multiple cookies with the same name.
+        # Most implementations use the first value, so match that.
+        if name in cookiedict:
+            continue
+        # For backward-compatibility, unquote value using Python's algorithm.
+        cookiedict[name] = cookies._unquote(value)
     return cookiedict

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -247,7 +247,9 @@ Upstream support for MariaDB 10.2 ends in May 2022. Django 4.1 supports MariaDB
 Miscellaneous
 -------------
 
-* ...
+* If multiple cookies are sent with the same name, Django now uses the first
+  value rather than the last value in ``request.COOKIES``. The ``Cookie``
+  header parsing code is slightly stricter.
 
 .. _deprecated-features-4.1:
 

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -761,7 +761,7 @@ class CookieTests(unittest.TestCase):
         # treats all semicolons as delimiters, even within quotes.
         self.assertEqual(
             parse_cookie('keebler="E=mc2; L=\\"Loves\\"; fudge=\\012;"'),
-            {'keebler': '"E=mc2', 'L': '\\"Loves\\"', 'fudge': '\\012', '': '"'}
+            {'keebler': '"E=mc2', 'L': '\\"Loves\\"', 'fudge': '\\012'}
         )
         # Illegal cookies that have an '=' char in an unquoted value.
         self.assertEqual(parse_cookie('keebler=E=mc2'), {'keebler': 'E=mc2'})
@@ -773,20 +773,19 @@ class CookieTests(unittest.TestCase):
     def test_cookie_edgecases(self):
         # Cookies that RFC6265 allows.
         self.assertEqual(parse_cookie('a=b; Domain=example.com'), {'a': 'b', 'Domain': 'example.com'})
-        # parse_cookie() has historically kept only the last cookie with the
-        # same name.
-        self.assertEqual(parse_cookie('a=b; h=i; a=c'), {'a': 'c', 'h': 'i'})
+        # Use only the first value if multiple cookies have the same name. #33212
+        self.assertEqual(parse_cookie('a=b; h=i; a=c'), {'a': 'b', 'h': 'i'})
 
     def test_invalid_cookies(self):
         """
         Cookie strings that go against RFC6265 but browsers will send if set
         via document.cookie.
         """
-        # Chunks without an equals sign appear as unnamed values per
-        # https://bugzilla.mozilla.org/show_bug.cgi?id=169091
-        self.assertIn('django_language', parse_cookie('abc=def; unnamed; django_language=en'))
+        # IE, Firefox, and Blink, but not WebKit allow un-named cookies, but
+        # RFC6265 specifically says to ignore name-value-pair without an equal sign.
+        self.assertEqual(parse_cookie('abc=def; unnamed; django_language=en'), {'abc': 'def', 'django_language': 'en'})
         # Even a double quote may be an unnamed value.
-        self.assertEqual(parse_cookie('a=b; "; c=d'), {'a': 'b', '': '"', 'c': 'd'})
+        self.assertEqual(parse_cookie('a=b; "; c=d'), {'a': 'b', 'c': 'd'})
         # Spaces in names and values, and an equals sign in values.
         self.assertEqual(parse_cookie('a b c=d e = f; gh=i'), {'a b c': 'd e = f', 'gh': 'i'})
         # More characters the spec forbids.
@@ -795,8 +794,8 @@ class CookieTests(unittest.TestCase):
         self.assertEqual(parse_cookie('saint=André Bessette'), {'saint': 'André Bessette'})
         # Browsers don't send extra whitespace or semicolons in Cookie headers,
         # but parse_cookie() should parse whitespace the same way
-        # document.cookie parses whitespace.
-        self.assertEqual(parse_cookie('  =  b  ;  ;  =  ;   c  =  ;  '), {'': 'b', 'c': ''})
+        # document.cookie and Set-Cookie parses whitespace.
+        self.assertEqual(parse_cookie('  \t  \t = \t  b \t ;  ; \t = \t ; \t  c  =  ; \t '), {'c': ''})
 
     def test_samesite(self):
         c = SimpleCookie('name=value; samesite=lax; httponly')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33212