### PR TITLE
Test scenario update -- field_deconstruction/tests.py:test_time_field

### DIFF
--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -522,7 +522,7 @@ class FieldDeconstructionTests(SimpleTestCase):
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {'auto_now_add': True})
 
-        # It should be reflected even if both `auto_now` and `auto_now_add` arguments are assigned
+        # It should be reflected even if both `auto_now` and `auto_now_add` arguments are assigned.
         field = models.TimeField(auto_now=True, auto_now_add=True)
         name, path, args, kwargs = field.deconstruct()
         self.assertEqual(args, [])


### PR DESCRIPTION
<h3>Background</h3>

-  It would be better off adding one more test spec what if two optional arguments (`auto_now` & `auto_now_add`) are assigned together as for `FieldDeconstructionTests:test_time_field` from `field_deconstruction/tests.py` 

<h3>Solution</h3>

- One more scenario for assigning both `auto_now` and `auto_now_add` arguments on the `test_time_field` test spec is added on this PR.
