### PR TITLE
Removed duplicated lines in test_in_lookup_allows_F_expressions_and_expressions_for_datetimes

### DIFF
--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -971,11 +971,6 @@ class IterableLookupInnerExpressionsTests(TestCase):
             experiment=experiment_2,
             result_time=datetime.datetime(2016, 1, 8, 5, 0, 0),
         )
-
-        within_experiment_time = [F('experiment__start'), F('experiment__end')]
-        queryset = Result.objects.filter(result_time__range=within_experiment_time)
-        self.assertSequenceEqual(queryset, [r1])
-
         within_experiment_time = [F('experiment__start'), F('experiment__end')]
         queryset = Result.objects.filter(result_time__range=within_experiment_time)
         self.assertSequenceEqual(queryset, [r1])


### PR DESCRIPTION
Original PR #6216. Maybe it was a bad merge conflict or something?

\\cc @MatthewWilkes in case you remember anything 5 years later. :smile: 