### PR TITLE
Fixed #33224 -- Removed DatabaseFeatures.supports_mixed_date_datetime_comparisons.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -112,9 +112,6 @@ class BaseDatabaseFeatures:
     # deferred
     can_defer_constraint_checks = False
 
-    # date_interval_sql can properly handle mixed Date/DateTime fields and timedeltas
-    supports_mixed_date_datetime_comparisons = True
-
     # Does the backend support tablespaces? Default to False because it isn't
     # in the SQL standard.
     supports_tablespaces = False

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -18,7 +18,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_unspecified_pk = True
     supports_timezones = False
     max_query_params = 999
-    supports_mixed_date_datetime_comparisons = False
     supports_transactions = True
     atomic_transactions = False
     can_rollback_ddl = True
@@ -49,6 +48,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'ci': 'nocase',
         'cs': 'binary',
         'non_default': 'nocase',
+    }
+    django_test_expected_failures = {
+        # The django_format_dtdelta() function doesn't properly handle mixed
+        # Date/DateTime fields and timedeltas.
+        'expressions.tests.FTimeDeltaTests.test_mixed_comparisons1',
     }
 
     @cached_property

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1473,7 +1473,6 @@ class FTimeDeltaTests(TestCase):
             test_set = [e.name for e in Experiment.objects.filter(completed__lte=F('assigned') + days)]
             self.assertEqual(test_set, self.expnames[:i + 1])
 
-    @skipUnlessDBFeature("supports_mixed_date_datetime_comparisons")
     def test_mixed_comparisons1(self):
         for i, delay in enumerate(self.delays):
             test_set = [e.name for e in Experiment.objects.filter(assigned__gt=F('start') - delay)]


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33224