### PR TITLE
Fixed #33236 -- Fixed assertHTMLEqual() error message for escaped HTML.

### DIFF
--- a/django/test/html.py
+++ b/django/test/html.py
@@ -1,5 +1,5 @@
 """Compare two HTML documents."""
-
+import html
 from html.parser import HTMLParser
 
 from django.utils.regex_helper import _lazy_re_compile
@@ -150,7 +150,10 @@ class Element:
                 output += ' %s' % key
         if self.children:
             output += '>\n'
-            output += ''.join(str(c) for c in self.children)
+            output += ''.join([
+                html.escape(c) if isinstance(c, str) else str(c)
+                for c in self.children
+            ])
             output += '\n</%s>' % self.name
         else:
             output += '>'
@@ -165,7 +168,10 @@ class RootElement(Element):
         super().__init__(None, ())
 
     def __str__(self):
-        return ''.join(str(c) for c in self.children)
+        return ''.join([
+            html.escape(c) if isinstance(c, str) else str(c)
+            for c in self.children
+        ])
 
 
 class HTMLParseError(Exception):

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -868,6 +868,11 @@ class HTMLEqualTests(SimpleTestCase):
         dom2 = parse_html('<a><b/><b/></a><b/><b/>')
         self.assertEqual(dom2.count(dom1), 2)
 
+    def test_root_element_escaped_html(self):
+        html = '&lt;br&gt;'
+        parsed = parse_html(html)
+        self.assertEqual(str(parsed), html)
+
     def test_parsing_errors(self):
         with self.assertRaises(AssertionError):
             self.assertHTMLEqual('<p>', '')
@@ -881,6 +886,17 @@ class HTMLEqualTests(SimpleTestCase):
             self.assertHTMLEqual('< div></ div>', '<div></div>')
         with self.assertRaises(HTMLParseError):
             parse_html('</p>')
+
+    def test_escaped_html_errors(self):
+        msg = (
+            '<p>\n<foo>\n</p>'
+            ' != '
+            '<p>\n&lt;foo&gt;\n</p>\n'
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.assertHTMLEqual('<p><foo></p>', '<p>&lt;foo&gt;</p>')
+        with self.assertRaisesMessage(AssertionError, msg):
+            self.assertHTMLEqual('<p><foo></p>', '<p>&#60;foo&#62;</p>')
 
     def test_contains_html(self):
         response = HttpResponse('''<body>


### PR DESCRIPTION
**Ticket Link:** https://code.djangoproject.com/ticket/33236

The diff shown in the error message of assertHTMLEqual seems to be converting escaped HTML text to unescaped text.

This makes it hard to write tests when testing XSS vulnerabilities in our tags and filters. Though the assertions work correct, the error messages don't show the correct differences.

**Steps to reproduce**

```python
from django.test import TestCase

class UtilsTestCase(TestCase):
def test_assersion(self):
	escaped = "<p>&lt;foo&gt;</p>"
	raw = "<p><foo></p>"
	self.assertHTMLEqual(escaped, raw)
```

**Expected Output**

```
AssertionError: <p>
&lt;foo&gt;
</p> != <p>
<foo>
</p>
  <p>
- &lt;foo&gt;
+ <foo>
  </p>
```

**Actual Output**

```
AssertionError: <p>
<foo>
</p> != <p>
<foo>
</p>
  <p>
  <foo>
  </p>
```

## Fix

The message in assertHTMLEqual shows incorrect output because it shows the escaped HTML entities as unescaped.

The bug is probably caused because the `__str__` method in the `Element` class treats all its children the same. The children are either a tree or string. In the case of a string, the Python's HTMLParser `unescape`s the contents. For their string representation, we probably need to `escape` them back.

I have added a patch for this in this pull request.