### PR TITLE
Added Google Cloud Spanner to list of third-party DB backends.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -1104,6 +1104,7 @@ by 3rd parties that allow you to use other databases with Django:
 
 * `CockroachDB`_
 * `Firebird`_
+* `Google Cloud Spanner`_
 * `Microsoft SQL Server`_
 
 The Django versions and ORM features supported by these unofficial backends
@@ -1113,4 +1114,5 @@ the support channels provided by each 3rd party project.
 
 .. _CockroachDB: https://pypi.org/project/django-cockroachdb/
 .. _Firebird: https://pypi.org/project/django-firebird/
+.. _Google Cloud Spanner: https://pypi.org/project/django-google-spanner/
 .. _Microsoft SQL Server: https://pypi.org/project/django-mssql-backend/


### PR DESCRIPTION
Google Cloud Spanner [Django library](https://pypi.org/project/django-google-spanner/) has been now added to GA

It support Django 3.2 and 2.2 as per the [blog post](https://cloud.google.com/blog/topics/developers-practitioners/django-orm-support-cloud-spanner-now-generally-available)