### PR TITLE
Fixed #32820 --- Improved form accessibility on errors.

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -247,6 +247,8 @@ class BoundField:
                 attrs['required'] = True
         if self.field.disabled:
             attrs['disabled'] = True
+        if self.errors:
+            attrs['aria-invalid'] = "true"
         return attrs
 
     @property


### PR DESCRIPTION
[Relevant ticket](https://code.djangoproject.com/ticket/32820).

By adding `aria-invalid="true"`, the accessibility of the form is improved. As per the
description of the ticket, the attribute allows a screen reader to
identify the error on the field.