### PR TITLE
Refs #33247 -- Fixed rendering of Unicode chars and emojis in PDF docs build.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -272,13 +272,35 @@ rst_epilog = """
 
 # -- Options for LaTeX output --------------------------------------------------
 
+# Use lualatex for Unicode support.
+latex_engine = 'lualatex'
+# Set fonts and fallbacks for CJK and Emojis.
 latex_elements = {
-    'preamble': (
-        '\\DeclareUnicodeCharacter{2264}{\\ensuremath{\\le}}'
-        '\\DeclareUnicodeCharacter{2265}{\\ensuremath{\\ge}}'
-        '\\DeclareUnicodeCharacter{2665}{[unicode-heart]}'
-        '\\DeclareUnicodeCharacter{2713}{[unicode-checkmark]}'
-    ),
+    'preamble': r"""
+        \directlua{
+            luaotfload.add_fallback("seriffallbacks", {
+                "Noto Serif CJK SC:style=Regular;",
+                "Symbola:Style=Regular;"
+            })
+        }
+        \setmainfont{FreeSerif}[RawFeature={fallback=seriffallbacks}]
+
+        \directlua{
+            luaotfload.add_fallback("sansfallbacks", {
+                "Noto Sans CJK SC:style=Regular;",
+                "Symbola:Style=Regular;"
+            })
+        }
+        \setsansfont{FreeSans}[RawFeature={fallback=sansfallbacks}]
+
+        \directlua{
+            luaotfload.add_fallback("monofallbacks", {
+                "Noto Sans Mono CJK SC:style=Regular;",
+                "Symbola:Style=Regular;"
+            })
+        }
+        \setmonofont{FreeMono}[RawFeature={fallback=monofallbacks}]
+    """,
 }
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
Readthedocs [recently added support for Ubuntu 20.04][rtd-blog], along with
a way to specify that you just want to use the latest stable version of
Python. Opting in to that should fix the PDF builds that are currently
failing due to the RTD python being too old.

[rtd-blog]: https://blog.readthedocs.com/new-build-specification/

Additionally, the current doc build setup triggers a few Unicode bugs. If
you look at the current PDF docs, there are blanks or question marks in a
few places:

  - The documentation for `class Azimuth` is missing some Pi symbols

  - Search for “if you want to allow Unicode characters …” (the irony!) and
    there are missing CJK characters in the code block

  - The “Join the Django community ❤️” heading lacks heart

To fix that, this PR switches to lualatex and sets up some fallback fonts.

Readthedocs doesn’t do PDF builds on pull requests so a few different PRs
might need to be merged in to get this fully working.