### PR TITLE
Fixed #33250 -- Fixed EmailField's label in PasswordResetForm to match the verbose_name of AbstractUser's EmailField

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1009,6 +1009,7 @@ answer newbie questions, and generally made Django that much better:
     zegor
     Zeynel Özdemir <ozdemir.zynl@gmail.com>
     Zlatko Mašek <zlatko.masek@gmail.com>
+    Zoltán Szatmáry <szatmary.zoltan1222@gmail.com>
     zriv <https://github.com/zriv>
     <Please alphabetize new entries>
 

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -240,7 +240,7 @@ class AuthenticationForm(forms.Form):
 
 class PasswordResetForm(forms.Form):
     email = forms.EmailField(
-        label=_("Email"),
+        label=_('Email address'),
         max_length=254,
         widget=forms.EmailInput(attrs={'autocomplete': 'email'})
     )

--- a/js_tests/admin/inlines.test.js
+++ b/js_tests/admin/inlines.test.js
@@ -178,3 +178,13 @@ QUnit.test('make removeButtons visible again', function(assert) {
     addButton.trigger($.Event( "click", { target: addButton } ));
     assert.equal(this.table.find('.inline-deletelink:visible').length, 2);
 });
+
+QUnit.test('check the dependent prepopulated fields', function(assert) {
+    const $ = django.jQuery;
+    const addButton = this.table.find('.add-row a');
+    addButton.trigger($.Event( "click", { target: addButton } ));
+    const title = this.table.find('#id_article_set-0-title');
+    const slug = this.table.find('#id_article_set-0-slug');
+    title.val('foo bar').change();
+    assert.equal(title.val(), slug.val());
+});

--- a/js_tests/tests.html
+++ b/js_tests/tests.html
@@ -110,6 +110,40 @@
         </div>
       </nav>
     </script>
+    <script type="text/html" id="prepopulated-fields">
+      <div class="inline-related empty-form last-related" id="article_set-empty">
+        <h3><b>Article:</b> <span class="inline_label">#1</span>
+        </h3>
+        <fieldset class="module aligned ">
+          <div class="form-row field-slug">
+            <div>
+              <label class="required" for="id_article_set-__prefix__-slug">Slug:</label> <input type="text"
+                name="article_set-__prefix__-slug" class="vTextField" maxlength="128" id="id_article_set-__prefix__-slug">
+            </div>
+          </div>
+          <div class="form-row field-title">
+            <div>
+              <label class="required" for="id_article_set-__prefix__-title">Title:</label>
+              <input type="text" name="article_set-__prefix__-title" class="vTextField" maxlength="128"
+                id="id_article_set-__prefix__-title">
+            </div>
+          </div>
+          <div class="form-row field-body">
+            <div> <label class="required" for="id_article_set-__prefix__-body">Body:</label> <textarea
+                name="article_set-__prefix__-body" cols="40" rows="10" class="vLargeTextField"
+                id="id_article_set-__prefix__-body"></textarea>
+            </div>
+          </div>
+          <div class="form-row field-link">
+            <div> <label class="required" for="id_article_set-__prefix__-link">Link:</label> <input type="text"
+                name="article_set-__prefix__-link" class="vTextField" maxlength="128" id="id_article_set-__prefix__-link">
+            </div>
+          </div>
+        </fieldset> <input type="hidden" name="article_set-__prefix__-id" id="id_article_set-__prefix__-id">
+        <input type="hidden" name="article_set-__prefix__-blog" id="id_article_set-__prefix__-blog">
+      </div>
+      <div class="add-row"><a href="#">Add another Article</a></div>
+    </script>
 
     <script src="../node_modules/qunit/qunit/qunit.js"></script>
 


### PR DESCRIPTION
It should have be 'Email address', not 'Email'. Even in the *model field* version of EmailField defaults to 'Email address' in its description.