### PR TITLE
Fixed #33252 -- Made cache middleware thread safe.

### DIFF
--- a/django/middleware/cache.py
+++ b/django/middleware/cache.py
@@ -67,7 +67,10 @@ class UpdateCacheMiddleware(MiddlewareMixin):
         self.page_timeout = None
         self.key_prefix = settings.CACHE_MIDDLEWARE_KEY_PREFIX
         self.cache_alias = settings.CACHE_MIDDLEWARE_ALIAS
-        self.cache = caches[self.cache_alias]
+
+    @property
+    def cache(self):
+        return caches[self.cache_alias]
 
     def _should_update_cache(self, request, response):
         return hasattr(request, '_cache_update_cache') and request._cache_update_cache
@@ -126,7 +129,10 @@ class FetchFromCacheMiddleware(MiddlewareMixin):
         super().__init__(get_response)
         self.key_prefix = settings.CACHE_MIDDLEWARE_KEY_PREFIX
         self.cache_alias = settings.CACHE_MIDDLEWARE_ALIAS
-        self.cache = caches[self.cache_alias]
+
+    @property
+    def cache(self):
+        return caches[self.cache_alias]
 
     def process_request(self, request):
         """
@@ -183,7 +189,6 @@ class CacheMiddleware(UpdateCacheMiddleware, FetchFromCacheMiddleware):
             if cache_alias is None:
                 cache_alias = DEFAULT_CACHE_ALIAS
             self.cache_alias = cache_alias
-            self.cache = caches[self.cache_alias]
         except KeyError:
             pass
 

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -994,9 +994,9 @@ class BaseCacheTests:
         self.assertEqual(caches['custom_key'].get('answer2'), 42)
         self.assertEqual(caches['custom_key2'].get('answer2'), 42)
 
+    @override_settings(CACHE_MIDDLEWARE_ALIAS=DEFAULT_CACHE_ALIAS)
     def test_cache_write_unpicklable_object(self):
         fetch_middleware = FetchFromCacheMiddleware(empty_response)
-        fetch_middleware.cache = cache
 
         request = self.factory.get('/cache/test')
         request._cache_update_cache = True
@@ -1011,7 +1011,6 @@ class BaseCacheTests:
             return response
 
         update_middleware = UpdateCacheMiddleware(get_response)
-        update_middleware.cache = cache
         response = update_middleware(request)
 
         get_cache_data = fetch_middleware.process_request(request)

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -2488,6 +2488,21 @@ class CacheMiddlewareTest(SimpleTestCase):
         self.assertIn('Cache-Control', response)
         self.assertIn('Expires', response)
 
+    def test_per_thread(self):
+        """The cache instance is different for each thread."""
+        thread_caches = []
+        middleware = CacheMiddleware(empty_response)
+
+        def runner():
+            thread_caches.append(middleware.cache)
+
+        for _ in range(2):
+            thread = threading.Thread(target=runner)
+            thread.start()
+            thread.join()
+
+        self.assertIsNot(thread_caches[0], thread_caches[1])
+
 
 @override_settings(
     CACHE_MIDDLEWARE_KEY_PREFIX='settingsprefix',


### PR DESCRIPTION
The `caches[key]` response is not thread safe. It must be called inside
the correct thread to return a new object.

https://docs.djangoproject.com/en/3.2/topics/cache/#accessing-the-cache