### PR TITLE
Fixed isolation of admin_views.tests.ValidXHTMLTests.

### DIFF
--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5787,7 +5787,6 @@ class AdminDocsTest(TestCase):
             ],
         },
     }],
-    USE_I18N=False,
 )
 class ValidXHTMLTests(TestCase):
 
@@ -5799,9 +5798,10 @@ class ValidXHTMLTests(TestCase):
         self.client.force_login(self.superuser)
 
     def test_lang_name_present(self):
-        response = self.client.get(reverse('admin:app_list', args=('admin_views',)))
-        self.assertNotContains(response, ' lang=""')
-        self.assertNotContains(response, ' xml:lang=""')
+        with translation.override(None):
+            response = self.client.get(reverse('admin:app_list', args=('admin_views',)))
+            self.assertNotContains(response, ' lang=""')
+            self.assertNotContains(response, ' xml:lang=""')
 
 
 @override_settings(ROOT_URLCONF='admin_views.urls', USE_THOUSAND_SEPARATOR=True)


### PR DESCRIPTION
```
./runtests.py admin_views.tests.ValidXHTMLTests i18n.tests.CountrySpecificLanguageTests.test_check_for_language i18n.tests.FormattingTests.test_sanitize_separators --parallel=1

Testing against Django installed in '/home/felixx/repo/django/django'
Found 3 test(s).
Creating test database for alias 'default'...
System check identified no issues (1 silenced).
.FE
======================================================================
ERROR: test_sanitize_separators (i18n.tests.FormattingTests)
Tests django.utils.formats.sanitize_separators.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/repo/django/tests/i18n/tests.py", line 1142, in test_sanitize_separators
    self.assertEqual(sanitize_separators('12\xa0345'), '12\xa0345')
  File "/repo/django/django/utils/formats.py", line 282, in sanitize_separators
    decimal_separator = get_format('DECIMAL_SEPARATOR')
  File "/repo/django/django/utils/formats.py", line 125, in get_format
    for module in get_format_modules(lang):
  File "/repo/django/django/utils/formats.py", line 94, in get_format_modules
    _format_modules_cache[lang] = list(iter_format_modules(lang, settings.FORMAT_MODULE_PATH))
  File "/repo/django/django/utils/formats.py", line 77, in iter_format_modules
    locale = to_locale(lang)
  File "/repo/django/django/utils/translation/__init__.py", line 204, in to_locale
    lang, _, country = language.lower().partition('-')
AttributeError: 'NoneType' object has no attribute 'lower'

======================================================================
FAIL: test_check_for_language (i18n.tests.CountrySpecificLanguageTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/repo/django/tests/i18n/tests.py", line 1854, in test_check_for_language
    self.assertFalse(check_for_language('en_US'))
AssertionError: True is not false

----------------------------------------------------------------------
Ran 3 tests in 0.386s

FAILED (failures=1, errors=1)
Destroying test database for alias 'default'...
```