### PR TITLE
[2.2.x] Refs #32856 -- Clarified that psycopg2 < 2.9 is required.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -103,7 +103,7 @@ PostgreSQL notes
 ================
 
 Django supports PostgreSQL 9.4 and higher. `psycopg2`_ 2.5.4 through 2.8.6 is
-required, though the latest release is recommended.
+required, though 2.8.6 is recommended.
 
 .. _psycopg2: https://www.psycopg.org/
 


### PR DESCRIPTION
See https://github.com/django/django/commit/837ffcfa681d0f65f444d881ee3d69aec23770be#commitcomment-59186889.

Follow up to 837ffcfa681d0f65f444d881ee3d69aec23770be.