### PR TITLE
Fixed #33247 -- Added configuration for Read The Docs.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+# Configuration for the Read The Docs (RTD) builds of the documentation.
+# Ref: https://docs.readthedocs.io/en/stable/config-file/v2.html
+# Note python.install.requirements is not currently required, as Sphinx is
+# preinstalled and spelling checks not performed by RTD.
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/conf.py
+
+formats:
+  - epub
+  - pdf
+  - htmlzip


### PR DESCRIPTION
Alternated take for the RTD config part of #15039. 

* I think it's worth specifying the path to the configuration file, and the Python version explicitly. (The first for clarity, the second because old branches may not support the rolling latest `"3"`.) 
* As per the comment, I don't think the requirements are necessary (and we don't `pip install  .` django itself currently).

I think we need to merge this and see how it affects RTD (as we don't seem to be wired up for _Build Pull Requests_, despite toggling that…) 