### PR TITLE
Fixed #33260 -- Fixed crash when chaining QuerySet.exists() after select_for_update(of=()).

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1077,6 +1077,8 @@ class SQLCompiler:
                     (path, klass_info)
                     for klass_info in klass_info.get('related_klass_infos', [])
                 )
+        if not self.klass_info:
+            return []
         result = []
         invalid_names = []
         for name in self.query.select_for_update_of:

--- a/tests/select_for_update/tests.py
+++ b/tests/select_for_update/tests.py
@@ -244,6 +244,14 @@ class SelectForUpdateTests(TransactionTestCase):
             values = list(Person.objects.select_related('born').select_for_update(of=('self',)).values('born__name'))
         self.assertEqual(values, [{'born__name': self.city1.name}])
 
+    @skipUnlessDBFeature(
+        'has_select_for_update_of', 'supports_select_for_update_with_limit',
+    )
+    def test_for_update_of_with_exists(self):
+        with transaction.atomic():
+            qs = Person.objects.select_for_update(of=('self', 'born'))
+            self.assertIs(qs.exists(), True)
+
     @skipUnlessDBFeature('has_select_for_update_nowait')
     def test_nowait_raises_error_on_block(self):
         """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33260