### PR TITLE
Refs #33247 -- Pinned Sphinx version for RTD builds.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.10"
+    python: "3.8"
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,6 @@
 # Configuration for the Read The Docs (RTD) builds of the documentation.
 # Ref: https://docs.readthedocs.io/en/stable/config-file/v2.html
-# Note python.install.requirements is not currently required, as Sphinx is
-# preinstalled and spelling checks not performed by RTD.
+# The python.install.requirements pins the version of Sphinx used.
 version: 2
 
 build:
@@ -11,6 +10,10 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt
 
 formats:
   - epub

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 pyenchant
-sphinx
+Sphinx>=3.1.0
 sphinxcontrib-spelling


### PR DESCRIPTION
The default Sphinx version used by RTD is not compatible with Python 3.8+.
Specified a pinned recent version of Sphinx, in line with RTD docs.
https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#pinning-dependencies