### PR TITLE
Corrected multiply defined labels in docs.

### DIFF
--- a/docs/releases/1.2.txt
+++ b/docs/releases/1.2.txt
@@ -16,32 +16,28 @@ Overview
 
 Django 1.2 introduces several large, important new features, including:
 
-* Support for `multiple database connections`_ in a single Django instance.
+* Support for :ref:`multiple database connections
+  <support-for-multiple-databases>` in a single Django instance.
 
 * `Model validation`_ inspired by Django's form validation.
 
-* Vastly `improved protection against Cross-Site Request Forgery`_ (CSRF).
+* Vastly :ref:`improved protection against Cross-Site Request Forgery
+  <improved-csrf-protection>` (CSRF).
 
-* A new `user "messages" framework`_ with support for cookie- and session-based
-  message for both anonymous and authenticated users.
+* A new :ref:`user "messages" framework <messages-framework>` with support for
+  cookie- and session-based message for both anonymous and authenticated users.
 
 * Hooks for `object-level permissions`_, `permissions for anonymous users`_,
-  and `more flexible username requirements`_.
+  and :ref:`more flexible username requirements
+  <relaxed-requirements-for-usernames>`.
 
 * Customization of email sending via `email backends`_.
 
 * New :ref:`"smart" if template tag <new-in-1.2-smart-if>` which supports
   comparison operators.
 
-.. _multiple database connections: `support for multiple databases`_
-.. _improved protection against Cross-Site Request Forgery: `improved CSRF protection`_
-.. _user "messages" framework: `messages framework`_
-.. _more flexible username requirements: `relaxed requirements for usernames`_
-
-These are just the highlights; full details and a complete list of features `may
-be found below`_.
-
-.. _may be found below: `What's new in Django 1.2`_
+These are just the highlights; full details and a complete list of features
+:ref:`may be found below <whats-new-1.2>`.
 
 .. seealso::
 
@@ -80,9 +76,8 @@ backwards-incompatible. The big changes are:
   :func:`~django.contrib.auth.decorators.login_required`, and
   :func:`~django.contrib.auth.decorators.permission_required`, decorators
   from :mod:`django.contrib.auth` only apply to functions and no longer
-  work on methods. There's a simple one-line fix `detailed below`_.
-
-.. _detailed below: `user_passes_test, login_required and permission_required`_
+  work on methods. There's a simple one-line fix :ref:`detailed below
+  <user-passes-test-login-required-permission-required>`.
 
 Again, these are just the big features that will affect the most users. Users
 upgrading from previous versions of Django are heavily encouraged to consult
@@ -118,6 +113,8 @@ announced prior to the release of Django 1.3.
 What's new in Django 1.2
 ========================
 
+.. _support-for-multiple-databases:
+
 Support for multiple databases
 ------------------------------
 
@@ -137,6 +134,8 @@ validation behavior. Note, however, that validation must still be performed
 explicitly. Simply invoking a model instance's ``save()`` method will not
 perform any validation of the instance's data.
 
+.. _improved-csrf-protection:
+
 Improved CSRF protection
 ------------------------
 
@@ -147,6 +146,8 @@ perform some action on your website, using the credentials of a logged-in user
 who visits the malicious site in their browser. A related type of attack, "login
 CSRF," where an attacking site tricks a user's browser into logging into a site
 with someone else's credentials, is also covered.
+
+.. _messages-framework:
 
 Messages framework
 ------------------
@@ -176,6 +177,8 @@ User already did.  This is useful for centralizing permission handling - apps
 can always delegate the question of whether something is allowed or not to
 the authorization/authentication backend. See the :doc:`authentication
 docs </topics/auth/index>` for more details.
+
+.. _relaxed-requirements-for-usernames:
 
 Relaxed requirements for usernames
 ----------------------------------
@@ -557,6 +560,8 @@ independent rendering. When the :ttag:`cycle` tag was not thread safe,
 the state of the :ttag:`cycle` tag would leak between multiple
 renderings of the same :ttag:`include`. Now that the :ttag:`cycle` tag
 is thread safe, this leakage no longer occurs.
+
+.. _user-passes-test-login-required-permission-required:
 
 ``user_passes_test``, ``login_required`` and ``permission_required``
 --------------------------------------------------------------------

--- a/docs/topics/signals.txt
+++ b/docs/topics/signals.txt
@@ -87,14 +87,12 @@ function or method::
 Notice that the function takes a ``sender`` argument, along with wildcard
 keyword arguments (``**kwargs``); all signal handlers must take these arguments.
 
-We'll look at senders `a bit later`_, but right now look at the ``**kwargs``
-argument. All signals send keyword arguments, and may change those keyword
-arguments at any time. In the case of
+We'll look at senders :ref:`a bit later <connecting-to-specific-signals>`, but
+right now look at the ``**kwargs`` argument. All signals send keyword
+arguments, and may change those keyword arguments at any time. In the case of
 :data:`~django.core.signals.request_finished`, it's documented as sending no
 arguments, which means we might be tempted to write our signal handling as
 ``my_callback(sender)``.
-
-.. _a bit later: `connecting to signals sent by specific senders`_
 
 This would be wrong -- in fact, Django will throw an error if you do so. That's
 because at any point arguments could get added to the signal and your receiver

--- a/docs/topics/templates.txt
+++ b/docs/topics/templates.txt
@@ -261,10 +261,10 @@ backend with different options. In that case you should define a unique
 
 :setting:`OPTIONS <TEMPLATES-OPTIONS>` contains backend-specific settings.
 
+.. _template-loading:
+
 Usage
 -----
-
-.. _template-loading:
 
 .. module:: django.template.loader
 


### PR DESCRIPTION
```
Latexmk: Index file 'django.idx' was written
Latexmk: Log file says output to 'django.pdf'
Latexmk: List of undefined refs and citations:
  Label `releases/1.2:improved-csrf-protection' multiply defined
  Label `releases/1.2:messages-framework' multiply defined
  Label `releases/1.2:relaxed-requirements-for-usernames' multiply defined
  Label `releases/1.2:support-for-multiple-databases' multiply defined
  Label `releases/1.2:user-passes-test-login-required-and-permission-required' multiply defined
  Label `releases/1.2:what-s-new-in-django-1-2' multiply defined
  Label `topics/signals:connecting-to-signals-sent-by-specific-senders' multiply defined
  Label `topics/templates:template-loading' multiply defined
Latexmk: Summary of warnings from last run of (pdf)latex:
  Latex found 8 multiply defined reference(s)
```