### PR TITLE
Fixed #33237 -- Fixed detecting source maps in ManifestStaticFilesStorage for multiline files.

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -54,7 +54,7 @@ class HashedFilesMixin:
         )),
         ('*.js', (
             (
-                r'(?P<matched>)^(//# (?-i:sourceMappingURL)=(?P<url>.*))$',
+                r'(?m)(?P<matched>)^(//# (?-i:sourceMappingURL)=(?P<url>.*))$',
                 '//# sourceMappingURL=%(url)s',
             ),
             (

--- a/tests/staticfiles_tests/project/documents/cached/source_map.js
+++ b/tests/staticfiles_tests/project/documents/cached/source_map.js
@@ -1,1 +1,2 @@
 //# sourceMappingURL=source_map.js.map
+let a_variable = 1;

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -260,7 +260,7 @@ class TestHashedFiles:
 
     def test_js_source_map(self):
         relpath = self.hashed_file_path('cached/source_map.js')
-        self.assertEqual(relpath, 'cached/source_map.9371cbb02a26.js')
+        self.assertEqual(relpath, 'cached/source_map.cd45b8534a87.js')
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertNotIn(b'//# sourceMappingURL=source_map.js.map', content)


### PR DESCRIPTION
ticket-33237

Switched regex to multiline mode in order to match per-line, rather than against
the whole file.

Adjusted ordering of asserts in test case to make behavior under test the
(potential) first failure.

Thanks to Joseph Abrahams for the report.

Regression in e32722d1606794f0a85d74811e53a0336a1ce305