### PR TITLE
Refactored and deprecated total_unique_constraints

### DIFF
--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -391,7 +391,7 @@ class ChangeList:
                 *self.lookup_opts.unique_together,
                 *(
                     constraint.fields
-                    for constraint in self.lookup_opts.total_unique_constraints
+                    for constraint in self.lookup_opts.list_unique_constraints
                 ),
             )
             for field_names in constraint_field_names:

--- a/django/contrib/auth/checks.py
+++ b/django/contrib/auth/checks.py
@@ -54,7 +54,7 @@ def check_user_model(app_configs=None, **kwargs):
     # Check that the username field is unique
     if not cls._meta.get_field(cls.USERNAME_FIELD).unique and not any(
         constraint.fields == (cls.USERNAME_FIELD,)
-        for constraint in cls._meta.total_unique_constraints
+        for constraint in cls._meta.list_unique_constraints
     ):
         if (settings.AUTHENTICATION_BACKENDS ==
                 ['django.contrib.auth.backends.ModelBackend']):

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1039,13 +1039,13 @@ class Model(metaclass=ModelBase):
         unique_checks = []
 
         unique_togethers = [(self.__class__, self._meta.unique_together)]
-        constraints = [(self.__class__, self._meta.total_unique_constraints)]
+        constraints = [(self.__class__, self._meta.list_unique_constraints)]
         for parent_class in self._meta.get_parent_list():
             if parent_class._meta.unique_together:
                 unique_togethers.append((parent_class, parent_class._meta.unique_together))
-            if parent_class._meta.total_unique_constraints:
+            if parent_class._meta.list_unique_constraints:
                 constraints.append(
-                    (parent_class, parent_class._meta.total_unique_constraints)
+                    (parent_class, parent_class._meta.list_unique_constraints)
                 )
 
         for model_class, unique_together in unique_togethers:

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -559,7 +559,7 @@ class ForeignObject(RelatedField):
         })
         unique_foreign_fields.update({
             frozenset(uc.fields)
-            for uc in self.remote_field.model._meta.total_unique_constraints
+            for uc in self.remote_field.model._meta.list_unique_constraints
         })
         foreign_fields = {f.name for f in self.foreign_related_fields}
         has_unique_constraint = any(u <= foreign_fields for u in unique_foreign_fields)

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -1,6 +1,7 @@
 import bisect
 import copy
 import inspect
+import warnings
 from collections import defaultdict
 
 from django.apps import apps
@@ -857,10 +858,15 @@ class Options:
         self._get_fields_cache[cache_key] = fields
         return fields
 
-    @cached_property
     def total_unique_constraints(self):
+        msg = "Deprecated, use 'list_unique_constraints' instead"
+        warnings.warn(msg, category=DeprecationWarning)
+        return self.list_unique_constraints
+
+    @cached_property
+    def list_unique_constraints(self):
         """
-        Return a list of total unique constraints. Useful for determining set
+        Return a list of all unique constraints. Useful for determining set
         of fields guaranteed to be unique for all rows.
         """
         return [

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -700,7 +700,7 @@ class QuerySet:
         opts = self.model._meta
         unique_fields = [
             constraint.fields[0]
-            for constraint in opts.total_unique_constraints
+            for constraint in opts.list_unique_constraints
             if len(constraint.fields) == 1
         ]
         if (


### PR DESCRIPTION
`total` implies to me that it will return a number. Instead, I renamed it `list` as it returns a list of the constraints. Could also rename it `all_unique_constraints`, but I found list to be more descriptive.

Also, the tests stalled on my machine, so apologies if tests fail (at least one threw an E--likely because it encountered a warning--though I can't tell which). Will attempt to fix once they finish running here (probably tomorrow).