### PR TITLE
Refs #32338 -- Added Boundfield.legend_tag().

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -145,7 +145,7 @@ class BoundField:
             initial_value = self.initial
         return field.has_changed(initial_value, self.data)
 
-    def label_tag(self, contents=None, attrs=None, label_suffix=None):
+    def label_tag(self, contents=None, attrs=None, label_suffix=None, tag=None):
         """
         Wrap the given contents in a <label>, if the field has an ID attribute.
         contents should be mark_safe'd to avoid HTML escaping. If contents
@@ -181,8 +181,21 @@ class BoundField:
             'label': contents,
             'attrs': attrs,
             'use_tag': bool(id_),
+            'tag': tag or 'label',
         }
         return self.form.render(self.form.template_name_label, context)
+
+    def legend_tag(self, contents=None, attrs=None, label_suffix=None):
+        """
+        Wrap the given contents in a <legend>, if the field has an ID
+        attribute. Contents should be mark_safe'd to avoid HTML escaping. If
+        contents aren't given, use the field's HTML-escaped label.
+
+        If attrs are given, use them as HTML attributes on the <legend> tag.
+
+        label_suffix overrides the form's label_suffix.
+        """
+        return self.label_tag(contents, attrs, label_suffix, tag='legend')
 
     def css_classes(self, extra_classes=None):
         """

--- a/django/forms/jinja2/django/forms/label.html
+++ b/django/forms/jinja2/django/forms/label.html
@@ -1,1 +1,1 @@
-{% if use_tag %}<label{% if attrs %}{% include 'django/forms/attrs.html' %}{% endif %}>{{ label }}</label>{% else %}{{ label }}{% endif %}
+{% if use_tag %}<{{ tag }}{% if attrs %}{% include 'django/forms/attrs.html' %}{% endif %}>{{ label }}</{{ tag }}>{% else %}{{ label }}{% endif %}

--- a/django/forms/templates/django/forms/label.html
+++ b/django/forms/templates/django/forms/label.html
@@ -1,1 +1,1 @@
-{% if use_tag %}<label{% include 'django/forms/attrs.html' %}>{{ label }}</label>{% else %}{{ label }}{% endif %}
+{% if use_tag %}<{{ tag }}{% include 'django/forms/attrs.html' %}>{{ label }}</{{ tag }}>{% else %}{{ label }}{% endif %}

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -542,9 +542,9 @@ default template, see also :ref:`overriding-built-in-form-templates`.
 .. attribute:: Form.template_name_label
 
 The template used to render a field's ``<label>``, used when calling
-:meth:`BoundField.label_tag`. Can be changed per form by overriding this
-attribute or more generally by overriding the default template, see also
-:ref:`overriding-built-in-form-templates`.
+:meth:`BoundField.label_tag`/:meth:`~BoundField.legend_tag`. Can be changed per
+form by overriding this attribute or more generally by overriding the default
+template, see also :ref:`overriding-built-in-form-templates`.
 
 ``as_p()``
 ----------
@@ -672,8 +672,12 @@ classes, as needed. The HTML will look something like::
     <tr><th><label for="id_cc_myself">Cc myself:<label> ...
     >>> f['subject'].label_tag()
     <label class="required" for="id_subject">Subject:</label>
+    >>> f['subject'].legend_tag()
+    <legend class="required" for="id_subject">Subject:</legend>
     >>> f['subject'].label_tag(attrs={'class': 'foo'})
     <label for="id_subject" class="foo required">Subject:</label>
+    >>> f['subject'].legend_tag(attrs={'class': 'foo'})
+    <legend for="id_subject" class="foo required">Subject:</legend>
 
 .. _ref-forms-api-configuring-label:
 
@@ -797,7 +801,8 @@ Fields can also define their own :attr:`~django.forms.Field.label_suffix`.
 This will take precedence over :attr:`Form.label_suffix
 <django.forms.Form.label_suffix>`. The suffix can also be overridden at runtime
 using the ``label_suffix`` parameter to
-:meth:`~django.forms.BoundField.label_tag`.
+:meth:`~django.forms.BoundField.label_tag`/
+:meth:`~django.forms.BoundField.legend_tag`.
 
 .. attribute:: Form.use_required_attribute
 
@@ -1092,7 +1097,8 @@ Attributes of ``BoundField``
 
     Use this property to render the ID of this field. For example, if you are
     manually constructing a ``<label>`` in your template (despite the fact that
-    :meth:`~BoundField.label_tag` will do this for you):
+    :meth:`~BoundField.label_tag`/:meth:`~BoundField.legend_tag` will do this
+    for you):
 
     .. code-block:: html+django
 
@@ -1142,7 +1148,7 @@ Attributes of ``BoundField``
 .. attribute:: BoundField.label
 
     The :attr:`~django.forms.Field.label` of the field. This is used in
-    :meth:`~BoundField.label_tag`.
+    :meth:`~BoundField.label_tag`/:meth:`~BoundField.legend_tag`.
 
 .. attribute:: BoundField.name
 
@@ -1208,7 +1214,7 @@ Methods of ``BoundField``
         >>> f['message'].css_classes('foo bar')
         'foo bar required'
 
-.. method:: BoundField.label_tag(contents=None, attrs=None, label_suffix=None)
+.. method:: BoundField.label_tag(contents=None, attrs=None, label_suffix=None, tag=None)
 
     Renders a label tag for the form field using the template specified by
     :attr:`.Form.template_name_label`.
@@ -1225,7 +1231,8 @@ Methods of ``BoundField``
       field's widget ``attrs`` or :attr:`BoundField.auto_id`. Additional
       attributes can be provided by the ``attrs`` argument.
     * ``use_tag``: A boolean which is ``True`` if the label has an ``id``.
-      If ``False`` the default template omits the ``<label>`` tag.
+      If ``False`` the default template omits the ``tag``.
+    * ``tag``: An optional string to customize the tag, defaults to ``label``.
 
     .. tip::
 
@@ -1248,6 +1255,19 @@ Methods of ``BoundField``
     .. versionchanged:: 4.0
 
         The label is now rendered using the template engine.
+
+    .. versionchanged:: 4.1
+
+        The ``tag`` argument was added.
+
+.. method:: BoundField.legend_tag(contents=None, attrs=None, label_suffix=None)
+
+    .. versionadded:: 4.1
+
+    Calls :meth:`.label_tag` with ``tag='legend'`` to render the label with
+    ``<legend>`` tags. This is useful when rendering radio and multiple
+    checkbox widgets where ``<legend>`` may be more appropriate than a
+    ``<label>``.
 
 .. method:: BoundField.value()
 

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -177,7 +177,9 @@ File Uploads
 Forms
 ~~~~~
 
-* ...
+* The new :meth:`~django.forms.BoundField.legend_tag` allows rendering field
+  labels in ``<legend>`` tags via the new ``tag`` argument of
+  :meth:`~django.forms.BoundField.label_tag`.
 
 Generic Views
 ~~~~~~~~~~~~~

--- a/tests/forms_tests/templates/forms_tests/legend_test.html
+++ b/tests/forms_tests/templates/forms_tests/legend_test.html
@@ -1,0 +1,7 @@
+{% for field in form %}
+  {% if field.widget_type == 'radioselect' %}
+    {{ field.legend_tag }}
+  {% else %}
+    {{ field.label_tag }}
+  {% endif %}
+{% endfor %}

--- a/tests/forms_tests/tests/test_i18n.py
+++ b/tests/forms_tests/tests/test_i18n.py
@@ -44,7 +44,15 @@ class FormsI18nTests(SimpleTestCase):
 
         f = SomeForm()
         self.assertHTMLEqual(f['field_1'].label_tag(), '<label for="id_field_1">field_1:</label>')
+        self.assertHTMLEqual(
+            f['field_1'].legend_tag(),
+            '<legend for="id_field_1">field_1:</legend>',
+        )
         self.assertHTMLEqual(f['field_2'].label_tag(), '<label for="field_2_id">field_2:</label>')
+        self.assertHTMLEqual(
+            f['field_2'].legend_tag(),
+            '<legend for="field_2_id">field_2:</legend>',
+        )
 
     def test_non_ascii_choices(self):
         class SomeForm(Form):

--- a/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
+++ b/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
@@ -185,3 +185,4 @@ class CheckboxSelectMultipleTest(WidgetTest):
         bound_field = TestForm()['f']
         self.assertEqual(bound_field.field.widget.id_for_label('id'), '')
         self.assertEqual(bound_field.label_tag(), '<label>F:</label>')
+        self.assertEqual(bound_field.legend_tag(), '<legend>F:</legend>')

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -830,6 +830,18 @@ class TestFieldOverridesByFormMeta(SimpleTestCase):
             str(form['slug'].label_tag()),
             '<label for="id_slug">Slug:</label>',
         )
+        self.assertHTMLEqual(
+            form['name'].legend_tag(),
+            '<legend for="id_name">Title:</legend>',
+        )
+        self.assertHTMLEqual(
+            form['url'].legend_tag(),
+            '<legend for="id_url">The URL:</legend>',
+        )
+        self.assertHTMLEqual(
+            form['slug'].legend_tag(),
+            '<legend for="id_slug">Slug:</legend>',
+        )
 
     def test_help_text_overrides(self):
         form = FieldOverridesByFormMetaForm()

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -1801,6 +1801,10 @@ class TestModelFormsetOverridesTroughFormMeta(TestCase):
         })
         form = BookFormSet.form()
         self.assertHTMLEqual(form['title'].label_tag(), '<label for="id_title">Name:</label>')
+        self.assertHTMLEqual(
+            form['title'].legend_tag(),
+            '<legend for="id_title">Name:</legend>',
+        )
 
     def test_inlineformset_factory_labels_overrides(self):
         BookFormSet = inlineformset_factory(Author, Book, fields="__all__", labels={
@@ -1808,6 +1812,10 @@ class TestModelFormsetOverridesTroughFormMeta(TestCase):
         })
         form = BookFormSet.form()
         self.assertHTMLEqual(form['title'].label_tag(), '<label for="id_title">Name:</label>')
+        self.assertHTMLEqual(
+            form['title'].legend_tag(),
+            '<legend for="id_title">Name:</legend>',
+        )
 
     def test_modelformset_factory_help_text_overrides(self):
         BookFormSet = modelformset_factory(Book, fields="__all__", help_texts={


### PR DESCRIPTION
[Ticket #32338](https://code.djangoproject.com/ticket/32338)

The solution for this ticket requires a way of rendering the `<label>` tag as `<legend>` . e.g.

`<legend>Radio choice required:</legend>`

I thought about adding a new `legend.html` template but thought adding customisation to the existing template would be a more generalised solution to the problem. As shown in the new test I've added the way I envisage this being used is to check for the widget type and then render it as a legend if it's a radio/multiple checkbox. 