### PR TITLE
Refs #31617 -- Changed dark mode primary-fg to give higher contrast to secondary.

### DIFF
--- a/django/contrib/admin/static/admin/css/dark_mode.css
+++ b/django/contrib/admin/static/admin/css/dark_mode.css
@@ -1,7 +1,7 @@
 @media (prefers-color-scheme: dark) {
     :root {
       --primary: #264b5d;
-      --primary-fg: #eee;
+      --primary-fg: #f7f7f7;
   
       --body-fg: #eeeeee;
       --body-bg: #121212;


### PR DESCRIPTION
[Ticket #31617](https://code.djangoproject.com/ticket/31617)

When logging into to the admin using dark mode the links on the header bar (e.g. change password / logout) fail accessibility tests due to a lack of contrast. The contrast ratio needs to be 4.5 for AA compliance and it is currently 4.29, this patch increases it to 4.64.