### PR TITLE
Fixed #6106 -- Prevented makemessages from changing .po files when up to date.

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -4,6 +4,7 @@ import re
 import sys
 from functools import total_ordering
 from itertools import dropwhile
+from pathlib import Path
 
 import django
 from django.conf import settings
@@ -208,7 +209,7 @@ class Command(BaseCommand):
 
     requires_system_checks = []
 
-    msgmerge_options = ['-q', '--previous']
+    msgmerge_options = ['-q', '--backup=none', '--previous', '--update']
     msguniq_options = ['--to-code=utf-8']
     msgattrib_options = ['--no-obsolete']
     xgettext_options = ['--from-code=UTF-8', '--add-comments=Translators']
@@ -615,13 +616,14 @@ class Command(BaseCommand):
 
         if os.path.exists(pofile):
             args = ['msgmerge'] + self.msgmerge_options + [pofile, potfile]
-            msgs, errors, status = popen_wrapper(args)
+            _, errors, status = popen_wrapper(args)
             if errors:
                 if status != STATUS_OK:
                     raise CommandError(
                         "errors happened while running msgmerge\n%s" % errors)
                 elif self.verbosity > 0:
                     self.stdout.write(errors)
+            msgs = Path(pofile).read_text(encoding='utf-8')
         else:
             with open(potfile, encoding='utf-8') as fp:
                 msgs = fp.read()

--- a/tests/i18n/unchanged/__init__.py
+++ b/tests/i18n/unchanged/__init__.py
@@ -1,0 +1,4 @@
+from django.utils.translation import gettext as _
+
+string1 = _('This is a translatable string.')
+string2 = _('This is another translatable string.')

--- a/tests/i18n/unchanged/locale/de/LC_MESSAGES/django.po.tmp
+++ b/tests/i18n/unchanged/locale/de/LC_MESSAGES/django.po.tmp
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-04-25 15:39-0500\n"
+"PO-Revision-Date: 2014-05-25 15:39-0500\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: __init__.py:3
+msgid "This is a translatable string."
+msgstr "And this has been translated."
+
+#: __init__.py:4
+msgid "This is another translatable string."
+msgstr "And this also has been translated."

--- a/tests/i18n/unchanged/models.py.tmp
+++ b/tests/i18n/unchanged/models.py.tmp
@@ -1,0 +1,3 @@
+from django.utils.translation import gettext as _
+
+string3 = _('This is a hitherto undiscovered translatable string.')


### PR DESCRIPTION
Adds `--update` option to msgmerge_options so that *.po files are not
re-created unless there are actual changes, as well as `--backup=none`
inorder to remove unwanted backup files.

Co-authored-by: Daniyal Abbasi <abbasi.daniyal98@gmail.com>