### PR TITLE
Fixed DatabaseIntrospection.get_relations() docstring.

### DIFF
--- a/django/db/backends/base/introspection.py
+++ b/django/db/backends/base/introspection.py
@@ -146,9 +146,8 @@ class BaseDatabaseIntrospection:
 
     def get_relations(self, cursor, table_name):
         """
-        Return a dictionary of
-        {field_name: (field_name_other_table, other_table)} representing all
-        relationships to the given table.
+        Return a dictionary of {field_name: (field_name_other_table, other_table)}
+        representing all foreign keys in the given table.
         """
         raise NotImplementedError(
             'subclasses of BaseDatabaseIntrospection may require a '

--- a/django/db/backends/mysql/introspection.py
+++ b/django/db/backends/mysql/introspection.py
@@ -151,7 +151,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     def get_relations(self, cursor, table_name):
         """
         Return a dictionary of {field_name: (field_name_other_table, other_table)}
-        representing all relationships to the given table.
+        representing all foreign keys in the given table.
         """
         constraints = self.get_key_columns(cursor, table_name)
         relations = {}

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -184,7 +184,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     def get_relations(self, cursor, table_name):
         """
         Return a dictionary of {field_name: (field_name_other_table, other_table)}
-        representing all relationships to the given table.
+        representing all foreign keys in the given table.
         """
         table_name = table_name.upper()
         cursor.execute("""

--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -119,7 +119,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     def get_relations(self, cursor, table_name):
         """
         Return a dictionary of {field_name: (field_name_other_table, other_table)}
-        representing all relationships to the given table.
+        representing all foreign keys in the given table.
         """
         return {row[0]: (row[2], row[1]) for row in self.get_key_columns(cursor, table_name)}
 

--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -115,7 +115,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     def get_relations(self, cursor, table_name):
         """
         Return a dictionary of {field_name: (field_name_other_table, other_table)}
-        representing all relationships to the given table.
+        representing all foreign keys in the given table.
         """
         # Dictionary of relations to return
         relations = {}


### PR DESCRIPTION
The foreign keys are "in" the given table, not "to" it.