### PR TITLE
Fix issue with stale time zone files in Oracle Instantclient

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -245,7 +245,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         cursor.execute(
             "ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS'"
             " NLS_TIMESTAMP_FORMAT = 'YYYY-MM-DD HH24:MI:SS.FF'" +
-            (" TIME_ZONE = 'UTC'" if settings.USE_TZ else '')
+            (" TIME_ZONE = '+00:00'" if settings.USE_TZ else '')
         )
         cursor.close()
         if 'operators' not in self.__dict__:


### PR DESCRIPTION
Use numeric timezone offset instead of "UTC"

This prevents "ORA-01805: possible error in date/time operation" error after upgrade
to newer database server while not updating time zone files in Oracle Instantclient