### PR TITLE
Refs #33247 -- Used XeLaTeX for PDF docs build.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -272,34 +272,22 @@ rst_epilog = """
 
 # -- Options for LaTeX output --------------------------------------------------
 
-# Use lualatex for Unicode support.
-latex_engine = 'lualatex'
-# Set fonts and fallbacks for CJK and Emojis.
+# Use XeLaTeX for Unicode support.
+latex_engine = 'xelatex'
+latex_use_xindy = False
+# Set font for CJK and fallbacks for unicode characters.
 latex_elements = {
+    'fontpkg': r"""
+        \setmainfont{Symbola}
+    """,
     'preamble': r"""
-        \directlua{
-            luaotfload.add_fallback("seriffallbacks", {
-                "Noto Serif CJK SC:style=Regular;",
-                "Symbola:Style=Regular;"
-            })
-        }
-        \setmainfont{FreeSerif}[RawFeature={fallback=seriffallbacks}]
-
-        \directlua{
-            luaotfload.add_fallback("sansfallbacks", {
-                "Noto Sans CJK SC:style=Regular;",
-                "Symbola:Style=Regular;"
-            })
-        }
-        \setsansfont{FreeSans}[RawFeature={fallback=sansfallbacks}]
-
-        \directlua{
-            luaotfload.add_fallback("monofallbacks", {
-                "Noto Sans Mono CJK SC:style=Regular;",
-                "Symbola:Style=Regular;"
-            })
-        }
-        \setmonofont{FreeMono}[RawFeature={fallback=monofallbacks}]
+        \usepackage{newunicodechar}
+        \usepackage[UTF8]{ctex}
+        \newunicodechar{π}{\ensuremath{\pi}}
+        \newunicodechar{≤}{\ensuremath{\le}}
+        \newunicodechar{≥}{\ensuremath{\ge}}
+        \newunicodechar{♥}{\ensuremath{\heartsuit}}
+        \newunicodechar{…}{\ensuremath{\ldots}}
     """,
 }
 


### PR DESCRIPTION
`LuaTeX` builds don't work on [Read the Docs](https://readthedocs.org/projects/django/builds/) and it looks that `XeLaTeX` is the [recommended](https://docs.readthedocs.io/en/stable/guides/pdf-non-ascii-languages.html#sphinx-pdfs-with-unicode) engine on RTD. 

I attached the built docs: [django.pdf](https://github.com/django/django/files/7522423/django.pdf)

- π on page 1109 - `Azimuth()` docs,
- ♥ and ✓ on page 1919,
- 你好 on page 1942 - `slugify()` docs,
- emojis on page 2507,
