### PR TITLE
Fixed #33278 -- Improved error for connection/query attempts against disallowed databases in tests.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -139,13 +139,17 @@ class _AssertTemplateNotUsedContext(_AssertTemplateUsedContext):
         return '%s was rendered.' % self.template_name
 
 
+class DatabaseOperationForbidden(AssertionError):
+    pass
+
+
 class _DatabaseFailure:
     def __init__(self, wrapped, message):
         self.wrapped = wrapped
         self.message = message
 
     def __call__(self):
-        raise AssertionError(self.message)
+        raise DatabaseOperationForbidden(self.message)
 
 
 class SimpleTestCase(unittest.TestCase):

--- a/tests/test_utils/test_testcase.py
+++ b/tests/test_utils/test_testcase.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 from django.db import IntegrityError, connections, transaction
 from django.test import TestCase, skipUnlessDBFeature
-from django.test.testcases import TestData
+from django.test.testcases import DatabaseOperationForbidden, TestData
 
 from .models import Car, Person, PossessedCar
 
@@ -28,9 +28,9 @@ class TestTestCase(TestCase):
             "Add 'other' to test_utils.test_testcase.TestTestCase.databases to "
             "ensure proper test isolation and silence this failure."
         )
-        with self.assertRaisesMessage(AssertionError, message):
+        with self.assertRaisesMessage(DatabaseOperationForbidden, message):
             connections['other'].connect()
-        with self.assertRaisesMessage(AssertionError, message):
+        with self.assertRaisesMessage(DatabaseOperationForbidden, message):
             connections['other'].temporary_connection()
 
     def test_disallowed_database_queries(self):
@@ -39,7 +39,7 @@ class TestTestCase(TestCase):
             "Add 'other' to test_utils.test_testcase.TestTestCase.databases to "
             "ensure proper test isolation and silence this failure."
         )
-        with self.assertRaisesMessage(AssertionError, message):
+        with self.assertRaisesMessage(DatabaseOperationForbidden, message):
             Car.objects.using('other').get()
 
     def test_reset_sequences(self):

--- a/tests/test_utils/test_transactiontestcase.py
+++ b/tests/test_utils/test_transactiontestcase.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from django.db import connections
 from django.test import TestCase, TransactionTestCase, override_settings
+from django.test.testcases import DatabaseOperationForbidden
 
 from .models import Car
 
@@ -58,5 +59,5 @@ class DisallowedDatabaseQueriesTests(TransactionTestCase):
             "DisallowedDatabaseQueriesTests.databases to ensure proper test "
             "isolation and silence this failure."
         )
-        with self.assertRaisesMessage(AssertionError, message):
+        with self.assertRaisesMessage(DatabaseOperationForbidden, message):
             Car.objects.using('other').get()

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -21,6 +21,7 @@ from django.test import (
     skipUnlessDBFeature,
 )
 from django.test.html import HTMLParseError, parse_html
+from django.test.testcases import DatabaseOperationForbidden
 from django.test.utils import (
     CaptureQueriesContext, TestContextDecorator, isolate_apps,
     override_settings, setup_test_environment,
@@ -1508,9 +1509,9 @@ class DisallowedDatabaseQueriesTests(SimpleTestCase):
             "test_utils.tests.DisallowedDatabaseQueriesTests.databases to "
             "silence this failure."
         )
-        with self.assertRaisesMessage(AssertionError, expected_message):
+        with self.assertRaisesMessage(DatabaseOperationForbidden, expected_message):
             connection.connect()
-        with self.assertRaisesMessage(AssertionError, expected_message):
+        with self.assertRaisesMessage(DatabaseOperationForbidden, expected_message):
             connection.temporary_connection()
 
     def test_disallowed_database_queries(self):
@@ -1521,7 +1522,7 @@ class DisallowedDatabaseQueriesTests(SimpleTestCase):
             "test_utils.tests.DisallowedDatabaseQueriesTests.databases to "
             "silence this failure."
         )
-        with self.assertRaisesMessage(AssertionError, expected_message):
+        with self.assertRaisesMessage(DatabaseOperationForbidden, expected_message):
             Car.objects.first()
 
     def test_disallowed_database_chunked_cursor_queries(self):
@@ -1532,7 +1533,7 @@ class DisallowedDatabaseQueriesTests(SimpleTestCase):
             "test_utils.tests.DisallowedDatabaseQueriesTests.databases to "
             "silence this failure."
         )
-        with self.assertRaisesMessage(AssertionError, expected_message):
+        with self.assertRaisesMessage(DatabaseOperationForbidden, expected_message):
             next(Car.objects.iterator())
 
 


### PR DESCRIPTION
[Ticket #33278](https://code.djangoproject.com/ticket/33278)
It should be clear at once if a database fails. Currently Database Failures raise AssertionError, and we have to trace the error.
A customized error type should make it a lot easier to use django.