### PR TITLE
Fixed #33287 -- Replaced eval() with json.loads() in the geojson serializer.

### DIFF
--- a/django/contrib/gis/serializers/geojson.py
+++ b/django/contrib/gis/serializers/geojson.py
@@ -1,3 +1,5 @@
+import json
+
 from django.contrib.gis.gdal import CoordTransform, SpatialReference
 from django.core.serializers.base import SerializerDoesNotExist
 from django.core.serializers.json import Serializer as JSONSerializer
@@ -50,7 +52,7 @@ class Serializer(JSONSerializer):
                     srs = SpatialReference(self.srid)
                     self._cts[self._geometry.srid] = CoordTransform(self._geometry.srs, srs)
                 self._geometry.transform(self._cts[self._geometry.srid])
-            data["geometry"] = eval(self._geometry.geojson)
+            data["geometry"] = json.loads(self._geometry.geojson)
         else:
             data["geometry"] = None
         return data


### PR DESCRIPTION
A fix for https://code.djangoproject.com/ticket/33287.

This is a dupe of https://github.com/django/django/pull/15088/, though I filed the Trac ticket.

Some GIS tests seem to be failing with and without this PR. For more details, see https://code.djangoproject.com/ticket/33292.