### PR TITLE
fix #33295: datatype of msg handled in self.stdout.write management function

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -148,7 +148,7 @@ class OutputWrapper(TextIOBase):
 
     def write(self, msg='', style_func=None, ending=None):
         ending = self.ending if ending is None else ending
-        if ending and not msg.endswith(ending):
+        if isinstance(msg, str) and ending and not msg.endswith(ending):
             msg += ending
         style_func = style_func or self.style_func
         self._out.write(style_func(msg))


### PR DESCRIPTION
Ticket link: https://code.djangoproject.com/ticket/33295