### PR TITLE
Refs #11580 -- Added tests for TextField's __contains lookup on text with more than 4000 chars.

### DIFF
--- a/tests/model_fields/test_textfield.py
+++ b/tests/model_fields/test_textfield.py
@@ -35,6 +35,13 @@ class TextFieldTests(TestCase):
         p.refresh_from_db()
         self.assertEqual(p.body, 'Smile 😀.')
 
+    def test_contains(self):
+        post = Post.objects.create(title='Test', body='A±Ж' * 4000)
+        qs = Post.objects.filter(body__contains='A±Ж')
+        self.assertSequenceEqual(qs, [post])
+        qs = Post.objects.filter(body__contains=1)
+        self.assertSequenceEqual(qs, [])
+
 
 class TestMethods(SimpleTestCase):
     def test_deconstruct(self):


### PR DESCRIPTION
ticket-11580

I couldn't reproduce a crash on Oracle 12c+ and Django 2.0+. Unfortunately, I'm not sure where (Django/Oracle/`cx_Oracle`) and when it was fixed :disappointed: 

@shaib What do you think?