### PR TITLE
Configured Read The Docs to build all formats.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,4 @@ python:
   install:
     - requirements: docs/requirements.txt
 
-formats:
-  - epub
-  - pdf
-  - htmlzip
+formats: all


### PR DESCRIPTION
`all` acts as an alias for all formats ([docs](https://docs.readthedocs.io/en/stable/config-file/v2.html#formats)). Whilst there are only three formats right now, this would auto expand to other formats in the future, which seems desirable?