### PR TITLE
Corrected "pip install" call in coding style docs.

### DIFF
--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -158,7 +158,7 @@ Imports
 
   .. console::
 
-      $ python -m pip install isort >= 5.1.0
+      $ python -m pip install "isort >= 5.1.0"
       $ isort -rc .
 
   This runs ``isort`` recursively from your current directory, modifying any


### PR DESCRIPTION
As specified in "pip install" documentation:

> "Use quotes around specifiers in the shell when using `>`, `<`, or when using environment markers.

https://pip.pypa.io/en/stable/cli/pip_install/#requirement-specifiers