### PR TITLE
Corrected isort example in coding style docs.

### DIFF
--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -159,7 +159,7 @@ Imports
   .. console::
 
       $ python -m pip install "isort >= 5.1.0"
-      $ isort -rc .
+      $ isort .
 
   This runs ``isort`` recursively from your current directory, modifying any
   files that don't conform to the guidelines. If you need to have imports out


### PR DESCRIPTION
Follow up to e74b3d724e5ddfef96d1d66bd1c58e7aae26fc85.