### PR TITLE
Fixed #33213 - Updated docs for running coverage tests in parallel

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -353,8 +353,7 @@ Contributors are encouraged to run coverage on the test suite to identify areas
 that need additional tests. The coverage tool installation and use is described
 in :ref:`testing code coverage<topics-testing-code-coverage>`.
 
-Coverage should be run in a single process to obtain accurate statistics. To
-run coverage on the Django test suite using the standard test settings:
+To run coverage on the Django test suite using the standard test settings:
 
 .. console::
 

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -873,8 +873,14 @@ project. You can see a report of this data by typing following command::
 Note that some Django code was executed while running tests, but it is not
 listed here because of the ``source`` flag passed to the previous command.
 
-For more options like annotated HTML listings detailing missed lines, see the
+If you are running tests in parallel using the ``--parallel`` option,
+you need to run ``coverage.py`` with the ``--concurrency=multiprocessing``
+option. You can then combine the results from parallel execution using
+`coverage combine`_.
+For details and more options like annotated HTML listings detailing missed 
+lines, see the
 `coverage.py`_ docs.
 
 .. _coverage.py: https://coverage.readthedocs.io/
 .. _install coverage.py: https://pypi.org/project/coverage/
+.. _coverage combine: https://coverage.readthedocs.io/en/latest/cmd.html#cmd-combine


### PR DESCRIPTION
I updated the documentation to explain how to run tests with `coverage` in parallel and removed a warning not to run the coverage tests for Django in parallel as discussed in [the ticket](https://code.djangoproject.com/ticket/33213#comment:6).
I tried to be brief in order not to reproduce the `coverage` documentation.

Ticket: https://code.djangoproject.com/ticket/33213