### PR TITLE
Ticket 33309 - Distinct fails with uppercase aliases

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -720,7 +720,7 @@ class SQLCompiler:
             targets, alias, _ = self.query.trim_joins(targets, joins, path)
             for target in targets:
                 if name in self.query.annotation_select:
-                    result.append(name)
+                    result.append(self.connection.ops.quote_name(name))
                 else:
                     r, p = self.compile(transform_function(target, alias))
                     result.append(r)

--- a/docs/releases/3.2.10.txt
+++ b/docs/releases/3.2.10.txt
@@ -9,5 +9,4 @@ Django 3.2.10 fixes several bugs in 3.2.9.
 Bugfixes
 ========
 
-* Fixed a bug in Django 3.2 that caused a ProgrammingError when using
-  aliases with uppercases in it on query distinct method (:ticket:`33309`).
+* ...

--- a/docs/releases/3.2.10.txt
+++ b/docs/releases/3.2.10.txt
@@ -9,4 +9,5 @@ Django 3.2.10 fixes several bugs in 3.2.9.
 Bugfixes
 ========
 
-* ...
+* Fixed a bug in Django 3.2 that caused a ProgrammingError when using
+  aliases with uppercases in it on query distinct method (:ticket:`33309`).

--- a/tests/distinct_on_fields/tests.py
+++ b/tests/distinct_on_fields/tests.py
@@ -1,5 +1,5 @@
 from django.db import connection
-from django.db.models import CharField, Max
+from django.db.models import F, CharField, Max
 from django.db.models.functions import Lower
 from django.test import TestCase, skipUnlessDBFeature
 from django.test.utils import register_lookup
@@ -139,3 +139,12 @@ class DistinctOnTests(TestCase):
         """
         staff = Staff.objects.distinct('name').order_by('name', '-organisation').get(name='p1')
         self.assertEqual(staff.organisation, 'o2')
+
+    def test_uppercase_aliases(self):
+        """
+        Distinct on field should allow uppercase letters (regression test).
+        refs #33309
+        """
+
+        qs = Celebrity.objects.annotate(nameAlias=F('name')).distinct('nameAlias').get(pk=1)
+        self.assertEqual(qs, self.celeb1)


### PR DESCRIPTION
Ticket link : https://code.djangoproject.com/ticket/33309

Quotes the name of the fields when performing a distinct on query to fix the ProgrammingError bug.