### PR TITLE
Fixed #33309 -- Fixed QuerySet.distinct() crash on mixed case annotation.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -754,7 +754,7 @@ class SQLCompiler:
             targets, alias, _ = self.query.trim_joins(targets, joins, path)
             for target in targets:
                 if name in self.query.annotation_select:
-                    result.append(name)
+                    result.append(self.connection.ops.quote_name(name))
                 else:
                     r, p = self.compile(transform_function(target, alias))
                     result.append(r)

--- a/tests/distinct_on_fields/tests.py
+++ b/tests/distinct_on_fields/tests.py
@@ -1,5 +1,5 @@
 from django.db import connection
-from django.db.models import CharField, Max
+from django.db.models import CharField, F, Max
 from django.db.models.functions import Lower
 from django.test import TestCase, skipUnlessDBFeature
 from django.test.utils import register_lookup
@@ -149,3 +149,9 @@ class DistinctOnTests(TestCase):
         """
         staff = Staff.objects.distinct('name').order_by('name', '-organisation').get(name='p1')
         self.assertEqual(staff.organisation, 'o2')
+
+    def test_distinct_on_mixed_case_annotation(self):
+        qs = Staff.objects.annotate(
+            nAmEAlIaS=F('name'),
+        ).distinct('nAmEAlIaS').order_by('nAmEAlIaS')
+        self.assertSequenceEqual(qs, [self.p1_o1, self.p2_o1, self.p3_o1])


### PR DESCRIPTION
Created after my previous PR (https://github.com/django/django/pull/15118) because I originally checked out from the wrong branch (I thought the patch will be backported to 3.2). @felixxm 

Ticket link : https://code.djangoproject.com/ticket/33309

Quotes the name of the fields when performing a distinct on query to fix the ProgrammingError bug.