### PR TITLE
Removed unneeded supports_combined_alters feature flag on Oracle.

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -27,7 +27,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_sequence_reset = False
     can_introspect_materialized_views = True
     atomic_transactions = False
-    supports_combined_alters = False
     nulls_order_largest = True
     requires_literal_defaults = True
     closed_cursor_error_class = InterfaceError


### PR DESCRIPTION
`supports_combined_alters` is False by default:
https://github.com/django/django/blob/ddf321479b0e006bc4efafe57726d54869f38c14/django/db/backends/base/features.py#L168-L169