### PR TITLE
Fixed typo in docs/releases/4.0.txt.

### DIFF
--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -87,7 +87,7 @@ For example::
         last_name = models.CharField(max_length=255)
 
         class Meta:
-            indexes = [
+            constraints = [
                 UniqueConstraint(
                     Lower('first_name'),
                     Lower('last_name').desc(),


### PR DESCRIPTION
The sample code in the Django 4.0 release notes "Functional unique constraints" seems to be wrong.
Isn't `indexes` supposed to be `constraints`?

If it is `indexes`, I get the following error when I actually create the sample app and run the `makemigrations` command (using Django 4.0rc1).

```shell
Traceback (most recent call last):
  File "****/django40_example/manage.py", line 22, in <module>
    main()
  File "****/django40_example/manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "****/django40_example/.venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 425, in execute_from_command_line
    utility.execute()
  File "****/django40_example/.venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 419, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "****/django40_example/.venv/lib/python3.10/site-packages/django/core/management/base.py", line 373, in run_from_argv
    self.execute(*args, **cmd_options)
  File "****/django40_example/.venv/lib/python3.10/site-packages/django/core/management/base.py", line 412, in execute
    self.check()
  File "****/django40_example/.venv/lib/python3.10/site-packages/django/core/management/base.py", line 438, in check
    all_issues = checks.run_checks(
  File "****/django40_example/.venv/lib/python3.10/site-packages/django/core/checks/registry.py", line 77, in run_checks
    new_errors = check(app_configs=app_configs, databases=databases)
  File "****/django40_example/.venv/lib/python3.10/site-packages/django/core/checks/model_checks.py", line 34, in check_all_models
    errors.extend(model.check(**kwargs))
  File "****/django40_example/.venv/lib/python3.10/site-packages/django/db/models/base.py", line 1294, in check
    *cls._check_indexes(databases),
  File "****/django40_example/.venv/lib/python3.10/site-packages/django/db/models/base.py", line 1651, in _check_indexes
    if len(index.name) > index.max_name_length:
AttributeError: 'UniqueConstraint' object has no attribute ‘max_name_length’

```