### PR TITLE
Removed unneeded can_use_chunked_reads feature flag on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -10,10 +10,6 @@ from .base import Database
 
 
 class DatabaseFeatures(BaseDatabaseFeatures):
-    # SQLite can read from a cursor since SQLite 3.6.5, subject to the caveat
-    # that statements within a connection aren't isolated from each other. See
-    # https://sqlite.org/isolation.html.
-    can_use_chunked_reads = True
     test_db_allows_multiple_connections = False
     supports_unspecified_pk = True
     supports_timezones = False


### PR DESCRIPTION
Unneeded since c0e3c65b9d1b26cfc38137b7666ef0e108aab77f.

https://github.com/django/django/blob/b8c0b22f2f0f8ce664642332d6d872f300c662b4/django/db/backends/base/features.py#L28