### PR TITLE
Refs #27624 -- Optimized sql.Query creation by moving immutable/singleton attributes to class attributes.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -155,6 +155,66 @@ class Query(BaseExpression):
     base_table_class = BaseTable
     join_class = Join
 
+    default_cols = True
+    default_ordering = True
+    standard_ordering = True
+
+    filter_is_sticky = False
+    subquery = False
+
+    # SQL-related attributes.
+    # Select and related select clauses are expressions to use in the SELECT
+    # clause of the query. The select is used for cases where we want to set up
+    # the select clause to contain other than default fields (values(),
+    # subqueries...). Note that annotations go to annotations dictionary.
+    select = ()
+    # The group_by attribute can have one of the following forms:
+    #  - None: no group by at all in the query
+    #  - A tuple of expressions: group by (at least) those expressions.
+    #    String refs are also allowed for now.
+    #  - True: group by all select fields of the model
+    # See compiler.get_group_by() for details.
+    group_by = None
+    order_by = ()
+    low_mark = 0  # Used for offset/limit.
+    high_mark = None  # Used for offset/limit.
+    distinct = False
+    distinct_fields = ()
+    select_for_update = False
+    select_for_update_nowait = False
+    select_for_update_skip_locked = False
+    select_for_update_of = ()
+    select_for_no_key_update = False
+    select_related = False
+    # Arbitrary limit for select_related to prevents infinite recursion.
+    max_depth = 5
+    # Holds the selects defined by a call to values() or values_list()
+    # excluding annotation_select and extra_select.
+    values_select = ()
+
+    # SQL annotation-related attributes.
+    annotation_select_mask = None
+    _annotation_select_cache = None
+
+    # Set combination attributes.
+    combinator = None
+    combinator_all = False
+    combined_queries = ()
+
+    # These are for extensions. The contents are more or less appended verbatim
+    # to the appropriate clause.
+    extra_select_mask = None
+    _extra_select_cache = None
+
+    extra_tables = ()
+    extra_order_by = ()
+
+    # A tuple that is a set of model field names and either True, if these are
+    # the fields to defer, or False if these are the only fields to load.
+    deferred_loading = (frozenset(), True)
+
+    explain_info = None
+
     def __init__(self, model, alias_cols=True):
         self.model = model
         self.alias_refcount = {}
@@ -172,73 +232,16 @@ class Query(BaseExpression):
         # Map external tables to whether they are aliased.
         self.external_aliases = {}
         self.table_map = {}  # Maps table names to list of aliases.
-        self.default_cols = True
-        self.default_ordering = True
-        self.standard_ordering = True
         self.used_aliases = set()
-        self.filter_is_sticky = False
-        self.subquery = False
 
-        # SQL-related attributes
-        # Select and related select clauses are expressions to use in the
-        # SELECT clause of the query.
-        # The select is used for cases where we want to set up the select
-        # clause to contain other than default fields (values(), subqueries...)
-        # Note that annotations go to annotations dictionary.
-        self.select = ()
         self.where = WhereNode()
-        # The group_by attribute can have one of the following forms:
-        #  - None: no group by at all in the query
-        #  - A tuple of expressions: group by (at least) those expressions.
-        #    String refs are also allowed for now.
-        #  - True: group by all select fields of the model
-        # See compiler.get_group_by() for details.
-        self.group_by = None
-        self.order_by = ()
-        self.low_mark, self.high_mark = 0, None  # Used for offset/limit
-        self.distinct = False
-        self.distinct_fields = ()
-        self.select_for_update = False
-        self.select_for_update_nowait = False
-        self.select_for_update_skip_locked = False
-        self.select_for_update_of = ()
-        self.select_for_no_key_update = False
-
-        self.select_related = False
-        # Arbitrary limit for select_related to prevents infinite recursion.
-        self.max_depth = 5
-
-        # Holds the selects defined by a call to values() or values_list()
-        # excluding annotation_select and extra_select.
-        self.values_select = ()
-
-        # SQL annotation-related attributes
-        self.annotations = {}  # Maps alias -> Annotation Expression
-        self.annotation_select_mask = None
-        self._annotation_select_cache = None
-
-        # Set combination attributes
-        self.combinator = None
-        self.combinator_all = False
-        self.combined_queries = ()
-
+        # Maps alias -> Annotation Expression.
+        self.annotations = {}
         # These are for extensions. The contents are more or less appended
         # verbatim to the appropriate clause.
         self.extra = {}  # Maps col_alias -> (col_sql, params).
-        self.extra_select_mask = None
-        self._extra_select_cache = None
-
-        self.extra_tables = ()
-        self.extra_order_by = ()
-
-        # A tuple that is a set of model field names and either True, if these
-        # are the fields to defer, or False if these are the only fields to
-        # load.
-        self.deferred_loading = (frozenset(), True)
 
         self._filtered_relations = {}
-
-        self.explain_info = None
 
     @property
     def output_field(self):

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -344,11 +344,8 @@ class Query(BaseExpression):
             obj.subq_aliases = self.subq_aliases.copy()
         obj.used_aliases = self.used_aliases.copy()
         obj._filtered_relations = self._filtered_relations.copy()
-        # Clear the cached_property
-        try:
-            del obj.base_table
-        except AttributeError:
-            pass
+        # Clear the cached_property, if it exists.
+        obj.__dict__.pop("base_table", None)
         return obj
 
     def chain(self, klass=None):


### PR DESCRIPTION
So this is much of the same work I think @adamchainz was describing in [comment 5 of the ticket](https://code.djangoproject.com/ticket/27624#comment:5) way back when, but I happened to start investigating it without knowing about the ticket.

This is extracted from a larger set of similar changes/hoists, mostly because sitting down to profile each stage is daunting (and worthless if this ends up being without merit). The diff looks gross in _unified_ mode, but it's mostly just "move any singleton or immutable thing set in `__init__` up to a class variable.

As far as I know, this should all work fine, but let's get the CI to demonstrate that.

### How it works

Being immutable or singletons, none of the values can be modified in place, so assignment has to happen to _replace_ them. Assignment to an instance's class attribute effectively shadows it, pushing the value into the _instance_ `__dict__` instead of the _class_ `__dict__`:

```
class Demo:
    v1 = True
    v2 = {}
a = Demo()
a.v1 = False # new value is pushed into a.__dict__
a.v2['test'] = 1
b = Demo() # b.v2 is {'test': 1}, mutated the class attribute in b.__class__.__dict__
b.v2 = {'test': 2} # a separate dictionary is pushed into b.__dict__
```

By shortening the number of assignments made during `Query.__init__` in favour of class level defaults which are ad-hoc updated to new values, the time to create a `Query` instance can be decreased, which should be beneficial to anything using `prefetch_related` for example, being a hot loop of creating a manager + queryset + query per object.

### Performance

I've attempted to gather some statistics to show the change. I'd be keen for others to run the same tests or additional ones I've not thought of, to verify the correctness and worthiness of the change.

_This is on a local SQLite database with 1000 users (no groups, no assigned permissions)_.

#### Before: (Baseline, main)

```
# imports omitted
In [4]: %timeit Query(None)
2.83 µs ± 41.5 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [5]: %timeit QuerySet(None)
3.91 µs ± 48.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [6]: %timeit tuple(User.objects.prefetch_related('groups', 'user_permissions'))
86.6 ms ± 708 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [7]: x = Query(None)
In [8]: %timeit x.clone()
3.27 µs ± 27.1 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [9]: q = User.objects.filter(pk__in=[1,3,5,7,9]).exclude(pk__in=[3,7]).query
In [10]: %timeit q.clone()
4.43 µs ± 45.1 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [11]: %timeit User.objects.filter(pk__in=[1,3,5,7,9]).exclude(pk__in=[3,7])
122 µs ± 1.66 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

#### After: (HEAD)

```
In [4]: %timeit Query(None)
1.29 µs ± 12.6 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each

In [5]: %timeit QuerySet(None)
2.19 µs ± 39.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [6]: %timeit tuple(User.objects.prefetch_related('groups', 'user_permissions'))
77.4 ms ± 842 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [7]: x = Query(None)
In [8]: %timeit x.clone()
3.01 µs ± 33.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [9]: q = User.objects.filter(pk__in=[1,3,5,7,9]).exclude(pk__in=[3,7]).query
In [10]: %timeit q.clone()
4.29 µs ± 27.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [11]: %timeit User.objects.filter(pk__in=[1,3,5,7,9]).exclude(pk__in=[3,7])
118 µs ± 672 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

#### Difference

| Test                  		| Before  		| After   		|
|-----------------------	|---------	|---------	|
| Query(None)           	| 2.83 µs 		| 1.29 µs 		|
| QuerySet(None)        	| 3.91 µs 		| 2.19 µs 		|
| tuple(User prefetch)  	| 86.6 ms 	| 77.4 ms 	|
| empty Query.clone()   	| 3.27 µs 		| 3.01 µs 		|
| full Query.clone()    	| 4.43 µs 		| 4.29 µs 		|
| User filter + exclude 	| 122 µs  		| 118 µs  		|


As always these numbers should be taken with a grain of salt, and I'd encourage scrutiny. CPU Workload flux probably accounts for some differences, for example.

### Profling

So the runtime appears either improved or the same for the checks I've done, we should see what `cProfile` indicates, too. (Probably) unrelated lines have been chopped for brevity/clarity.

#### Before

```
In [2]: %prun for _ in range(100): tuple(User.objects.prefetch_related('groups', 'user_permissions'))

   25161103 function calls (23957203 primitive calls) in 17.154 seconds
   
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   200700    1.567    0.000    3.108    0.000 query.py:292(clone)    <---- Query.clone
   401000    1.295    0.000    2.004    0.000 query.py:178(__init__) <---- QuerySet
  1607200    1.141    0.000    1.141    0.000 {method 'copy' of 'dict' objects}
   200300    0.625    0.000    0.709    0.000 query.py:151(__init__) <---- Query
   200700    0.411    0.000    4.472    0.000 query.py:1342(_clone)  <---- QuerySet._clone
```

#### After

```
In [2]: %prun for _ in range(100): tuple(User.objects.prefetch_related('groups', 'user_permissions'))

   25161303 function calls (23957403 primitive calls) in 16.256 seconds

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   200700    1.888    0.000    4.792    0.000 query.py:1342(_clone)  <---- QuerySet._clone
  1607200    1.492    0.000    1.492    0.000 {method 'copy' of 'dict' objects}
   200700    0.662    0.000    2.526    0.000 query.py:303(clone)    <---- Query.clone
   401000    0.509    0.000    0.884    0.000 query.py:178(__init__) <---- QuerySet
   200300    0.289    0.000    0.374    0.000 query.py:216(__init__) <---- Query
```

Well, it completed the profiling faster, but I can't fully reconcile why `QuerySet._clone` is now an outlier. Any thoughts or insights into what I'm seeing and whether it's problematic would be appreciated.

### Notes

A second commit is included, because line profiling `Query.clone()` with line_profiler (`%lprun -f Query.clone for _ in range(100): tuple(User.objects.prefetch_related('groups', 'user_permissions'))`) indicated the following line to be relatively expensive (second only to `WhereNode.clone()`):
```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   292                                               def clone(self):
   ...
   334    200700     106016.0      0.5      1.6          try:
   335    200700    1542778.0      7.7     23.7              del obj.base_table
   336    200700     132645.0      0.7      2.0          except AttributeError:
   337    200700     124520.0      0.6      1.9              pass
   338    200700     101358.0      0.5      1.6          return obj
```

After the changes, when `base_table` has not been accessed, it becomes:
```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   303                                               def clone(self):
   ...
   345    200700     125324.0      0.6      2.6          if 'base_table' in obj.__dict__:
   346                                                       obj.__dict__.pop('base_table')
   347    200700     102564.0      0.5      2.1          return obj
```
and if `base_table` has been accessed:
```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   303                                               def clone(self):
   ...
   345       100        126.0      1.3      3.3          if 'base_table' in obj.__dict__:
   346       100        146.0      1.5      3.8              obj.__dict__.pop('base_table')
   347       100        103.0      1.0      2.7          return obj
```
which seems like it should be a win overall. Though it's worth saying that if Python 3.11 implements [zero-cost exceptions](https://bugs.python.org/issue40222) those bits may be worth examining again subsequently.

### Caveats

I think this would possibly make moving to a `__slots__` based class more difficult, _but_ I think that's already somewhat precluded by the `Empty` and `__class__` assignment trick used in `clone` ... or so I vaguely recall. I may be mis-remembering. Regardless, `__slots__` has been unused for all this time so it's probably not immediately on the cards.