### PR TITLE
Fix #33282 - don't use entire queries as columns in GROUP BY

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -431,7 +431,10 @@ class In(FieldGetDbPrepValueIterableMixin, BuiltinLookup):
             if not getattr(self.rhs, 'has_select_fields', True):
                 self.rhs.clear_select_clause()
                 self.rhs.add_fields(['pk'])
-            cols.extend(self.rhs.get_group_by_cols())
+            from django.db.models.sql.query import \
+                Query  # avoid circular import
+            if not isinstance(self.rhs, Query):
+                cols.extend(self.rhs.get_group_by_cols())
         return cols
 
     def get_rhs_op(self, connection, rhs):


### PR DESCRIPTION
When upgrading LAVA (https://lavasoftware.org/) to Django 3.2, I found
some exceptions like this:

  django.db.utils.ProgrammingError: more than one row returned by a
  subquery used as an expression

I bisected those to commit 35431298226165986ad07e91f9d3aca721ff38ec
("Refs #27149 -- Moved subquery expression resolving to Query"). In it,
Query as made a subclass of BaseExpression.
BaseExpression.get_group_by_cols() depends no the value of
`contains_aggregate`, which is set to False by default. However, when
the RHS is a subquery, it does not make sense to add it to GROUP BY.

Unfortunately I could not produce an unit test that could reproduce this
issue, and can only trigger it on the LAVA codebase. This change both
fixes it for me and does not cause any of the existing unit tests to
fail.