### PR TITLE
Refs #33163 -- Corrected example of connection signal handlers in AppConfig.ready().

### DIFF
--- a/docs/topics/signals.txt
+++ b/docs/topics/signals.txt
@@ -142,6 +142,7 @@ Now, our ``my_callback`` function will be called each time a request finishes.
     connect signal handlers::
 
         from django.apps import AppConfig
+        from django.core.signals import request_finished
 
         class MyAppConfig(AppConfig):
             ...
@@ -150,7 +151,7 @@ Now, our ``my_callback`` function will be called each time a request finishes.
                 # Implicitly connect a signal handlers decorated with @receiver.
                 from . import signals
                 # Explicitly connect a signal handler.
-                signals.request_finished.connect(signals.my_callback)
+                request_finished.connect(signals.my_callback)
 
 .. note::
 


### PR DESCRIPTION
I found this example confusing because we import apps' `signals` and `request_finished` from `django.core.signals` should be used. Before:

![image](https://user-images.githubusercontent.com/2865885/143541575-43704a29-ec25-4a37-886d-58160f894a02.png)
