### PR TITLE
Removed unused map_options JS variable.

### DIFF
--- a/django/contrib/gis/templates/gis/openlayers.html
+++ b/django/contrib/gis/templates/gis/openlayers.html
@@ -13,7 +13,6 @@
     {% if display_raw %}<p>{% translate "Debugging window (serialized value)" %}</p>{% endif %}
     <textarea id="{{ id }}" class="vSerializedField required" cols="150" rows="10" name="{{ name }}">{{ serialized }}</textarea>
     <script>
-        {% block map_options %}var map_options = {};{% endblock %}
         {% block base_layer %}
             var base_layer = new ol.layer.Tile({
                 source: new ol.source.XYZ({
@@ -30,7 +29,6 @@
             geom_name: '{{ geom_type }}',
             id: '{{ id }}',
             map_id: '{{ id }}_map',
-            map_options: map_options,
             map_srid: {{ map_srid|unlocalize }},
             name: '{{ name }}'
         };


### PR DESCRIPTION
map_options is not referenced at all in OLMapWidget.js.