### PR TITLE
[WIP/RFC] Fixed #33331 -- Fixed handling error with cursor.close() during cleanup

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1209,9 +1209,14 @@ class SQLCompiler:
             cursor = self.connection.cursor()
         try:
             cursor.execute(sql, params)
-        except Exception:
-            # Might fail for server-side cursors (e.g. connection closed)
-            cursor.close()
+        except Exception as exc:
+            errors_occurred = self.connection.errors_occurred
+            try:
+                # Might fail for server-side cursors (e.g. connection closed)
+                cursor.close()
+            except self.connection.Database.Error as close_exc:
+                if not errors_occurred:
+                    raise close_exc from exc
             raise
 
         if result_type == CURSOR:


### PR DESCRIPTION
SQLCompiler.execute_sql: handle expected exception with cursor.close()

Ref: https://blog.ram.rachum.com/post/621791438475296768/improving-python-exception-chaining-with

Basically fixes https://code.djangoproject.com/ticket/16614#comment:31 again.  See the Django ticket for more details.