### PR TITLE
Fixed #25947, #33330 -- Support printing query using non-default database.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -179,10 +179,10 @@ class QuerySet:
         self.model = model
         self._db = using
         self._hints = hints or {}
-        self._query = query or sql.Query(self.model)
+        self._for_write = False
+        self._query = query or sql.Query(self.model, using=self.db)
         self._result_cache = None
         self._sticky_filter = False
-        self._for_write = False
         self._prefetch_related_lookups = ()
         self._prefetch_done = False
         self._known_related_objects = {}  # {rel_field: {pk: rel_obj}}

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -110,7 +110,7 @@ class QueryTestCase(TestCase):
         book = Book.objects.create(title='Dive Into Python', published=datetime.date(1957, 10, 12))
         with self.settings(DATABASE_ROUTERS=[router]):
             book.refresh_from_db()
-        router.db_for_read.assert_called_once_with(Book, instance=book)
+        router.db_for_read.assert_called_with(Book, instance=book)
 
     def test_basic_queries(self):
         "Queries are constrained to a single database"


### PR DESCRIPTION
This allows writing "print(query_set.query)" when the query can only be
printed by a different database backend.

I also updated a few other places in Query that were using the default DB to reference the DB plumbed into the Query from the QuerySet.

~~A few quotes were also changed from single quote to double quote in the test file, due to running the whole file through the Black code formatter.~~