### PR TITLE
Fixed #33282 -- Fixed a crash when OR'ing subquery and aggregation lookups.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1181,12 +1181,13 @@ class Subquery(BaseExpression, Combinable):
         return sql, sql_params
 
     def get_group_by_cols(self, alias=None):
+        # If this expression is referenced by an alias for an explicit GROUP BY
+        # through values() a reference to this expression and not the
+        # underlying .query must be returned to ensure external column
+        # references are not grouped against as well.
         if alias:
             return [Ref(alias, self)]
-        external_cols = self.get_external_cols()
-        if any(col.possibly_multivalued for col in external_cols):
-            return [self]
-        return external_cols
+        return self.query.get_group_by_cols()
 
 
 class Exists(Subquery):

--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -48,18 +48,37 @@ def get_normalized_value(value, lhs):
 
 class RelatedIn(In):
     def get_prep_lookup(self):
-        if not isinstance(self.lhs, MultiColSource) and self.rhs_is_direct_value():
-            # If we get here, we are dealing with single-column relations.
-            self.rhs = [get_normalized_value(val, self.lhs)[0] for val in self.rhs]
-            # We need to run the related field's get_prep_value(). Consider case
-            # ForeignKey to IntegerField given value 'abc'. The ForeignKey itself
-            # doesn't have validation for non-integers, so we must run validation
-            # using the target field.
-            if hasattr(self.lhs.output_field, 'path_infos'):
-                # Run the target field's get_prep_value. We can safely assume there is
-                # only one as we don't get to the direct value branch otherwise.
-                target_field = self.lhs.output_field.path_infos[-1].target_fields[-1]
-                self.rhs = [target_field.get_prep_value(v) for v in self.rhs]
+        if not isinstance(self.lhs, MultiColSource):
+            if self.rhs_is_direct_value():
+                # If we get here, we are dealing with single-column relations.
+                self.rhs = [get_normalized_value(val, self.lhs)[0] for val in self.rhs]
+                # We need to run the related field's get_prep_value(). Consider
+                # case ForeignKey to IntegerField given value 'abc'. The
+                # ForeignKey itself doesn't have validation for non-integers,
+                # so we must run validation using the target field.
+                if hasattr(self.lhs.output_field, 'path_infos'):
+                    # Run the target field's get_prep_value. We can safely
+                    # assume there is only one as we don't get to the direct
+                    # value branch otherwise.
+                    target_field = self.lhs.output_field.path_infos[-1].target_fields[-1]
+                    self.rhs = [target_field.get_prep_value(v) for v in self.rhs]
+            elif (
+                not getattr(self.rhs, 'has_select_fields', True) and
+                not getattr(self.lhs.field.target_field, 'primary_key', False)
+            ):
+                self.rhs.clear_select_clause()
+                if (
+                    getattr(self.lhs.output_field, 'primary_key', False) and
+                    self.lhs.output_field.model == self.rhs.model
+                ):
+                    # A case like
+                    # Restaurant.objects.filter(place__in=restaurant_qs), where
+                    # place is a OneToOneField and the primary key of
+                    # Restaurant.
+                    target_field = self.lhs.field.name
+                else:
+                    target_field = self.lhs.field.target_field.name
+                self.rhs.add_fields([target_field], True)
         return super().get_prep_lookup()
 
     def as_sql(self, compiler, connection):
@@ -88,20 +107,7 @@ class RelatedIn(In):
                         [source.name for source in self.lhs.sources], self.rhs),
                     AND)
             return root_constraint.as_sql(compiler, connection)
-        else:
-            if (not getattr(self.rhs, 'has_select_fields', True) and
-                    not getattr(self.lhs.field.target_field, 'primary_key', False)):
-                self.rhs.clear_select_clause()
-                if (getattr(self.lhs.output_field, 'primary_key', False) and
-                        self.lhs.output_field.model == self.rhs.model):
-                    # A case like Restaurant.objects.filter(place__in=restaurant_qs),
-                    # where place is a OneToOneField and the primary key of
-                    # Restaurant.
-                    target_field = self.lhs.field.name
-                else:
-                    target_field = self.lhs.field.target_field.name
-                self.rhs.add_fields([target_field], True)
-            return super().as_sql(compiler, connection)
+        return super().as_sql(compiler, connection)
 
 
 class RelatedLookupMixin:

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1053,6 +1053,14 @@ class Query(BaseExpression):
             if col.alias in self.external_aliases
         ]
 
+    def get_group_by_cols(self, alias=None):
+        if alias:
+            return [Ref(alias, self)]
+        external_cols = self.get_external_cols()
+        if any(col.possibly_multivalued for col in external_cols):
+            return [self]
+        return external_cols
+
     def as_sql(self, compiler, connection):
         # Some backends (e.g. Oracle) raise an error when a subquery contains
         # unnecessary ORDER BY clause.


### PR DESCRIPTION
As a `QuerySet` resolves to `sql.Query` the outer column references grouping logic should be defined on the latter and proxied from `Subquery` for the cases where `get_group_by_cols` is called on unresolved expressions.

Thanks Antonio Terceiro for the report and initial patch.