### PR TITLE
Fixed #33333 -- Fixed setUpTestData() crash with models.BinaryField on PostgreSQL.

### DIFF
--- a/docs/releases/3.2.10.txt
+++ b/docs/releases/3.2.10.txt
@@ -10,4 +10,6 @@ Django 3.2.10 fixes a security issue with severity "low" and several bugs in
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 3.2 that caused a crash of ``setUpTestData()``
+  with ``BinaryField`` on PostgreSQL, which is ``memoryview``-backed
+  (:ticket:`33333`).

--- a/tests/queryset_pickle/models.py
+++ b/tests/queryset_pickle/models.py
@@ -46,6 +46,7 @@ class Happening(models.Model):
     number1 = models.IntegerField(blank=True, default=standalone_number)
     number2 = models.IntegerField(blank=True, default=Numbers.get_static_number)
     event = models.OneToOneField(Event, models.CASCADE, null=True)
+    data = models.BinaryField(null=True)
 
 
 class Container:

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -16,6 +16,10 @@ class PickleabilityTestCase(TestCase):
     def assert_pickles(self, qs):
         self.assertEqual(list(pickle.loads(pickle.dumps(qs))), list(qs))
 
+    def test_binaryfield(self):
+        Happening.objects.create(data=b'binary data')
+        self.assert_pickles(Happening.objects.all())
+
     def test_related_field(self):
         g = Group.objects.create(name="Ponies Who Own Maybachs")
         self.assert_pickles(Event.objects.filter(group=g.id))

--- a/tests/test_utils/models.py
+++ b/tests/test_utils/models.py
@@ -8,6 +8,7 @@ class Car(models.Model):
 class Person(models.Model):
     name = models.CharField(max_length=100)
     cars = models.ManyToManyField(Car, through='PossessedCar')
+    data = models.BinaryField(null=True)
 
 
 class PossessedCar(models.Model):

--- a/tests/test_utils/test_testcase.py
+++ b/tests/test_utils/test_testcase.py
@@ -74,10 +74,15 @@ class TestDataTests(TestCase):
             belongs_to=cls.jim_douglas,
         )
 
+        cls.person_binary = Person.objects.create(name='Person', data=b'binary data')
+        cls.person_binary_get = Person.objects.get(pk=cls.person_binary.pk)
+
     @assert_no_queries
     def test_class_attribute_equality(self):
         """Class level test data is equal to instance level test data."""
         self.assertEqual(self.jim_douglas, self.__class__.jim_douglas)
+        self.assertEqual(self.person_binary, self.__class__.person_binary)
+        self.assertEqual(self.person_binary_get, self.__class__.person_binary_get)
 
     @assert_no_queries
     def test_class_attribute_identity(self):
@@ -85,6 +90,21 @@ class TestDataTests(TestCase):
         Class level test data is not identical to instance level test data.
         """
         self.assertIsNot(self.jim_douglas, self.__class__.jim_douglas)
+        self.assertIsNot(self.person_binary, self.__class__.person_binary)
+        self.assertIsNot(self.person_binary_get, self.__class__.person_binary_get)
+
+    @assert_no_queries
+    def test_binaryfield_data_type(self):
+        self.assertEqual(bytes(self.person_binary.data), b'binary data')
+        self.assertEqual(bytes(self.person_binary_get.data), b'binary data')
+        self.assertEqual(
+            type(self.person_binary_get.data),
+            type(self.__class__.person_binary_get.data),
+        )
+        self.assertEqual(
+            type(self.person_binary.data),
+            type(self.__class__.person_binary.data),
+        )
 
     @assert_no_queries
     def test_identity_preservation(self):


### PR DESCRIPTION
This makes `models.BinaryField` pickleable on PostgreSQL.

Regression in 3cf80d3fcf7446afdde16a2be515c423f720e54d.

Thanks Adam Zimmerman for the report.

ticket-33333