### PR TITLE
Refs #32290 -- Optimized construct_relative_path() by delay computing has_quotes.

### DIFF
--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -235,10 +235,6 @@ def construct_relative_path(current_template_name, relative_name):
     Convert a relative path (starting with './' or '../') to the full template
     name based on the current_template_name.
     """
-    has_quotes = (
-        (relative_name.startswith('"') and relative_name.endswith('"')) or
-        (relative_name.startswith("'") and relative_name.endswith("'"))
-    )
     new_name = relative_name.strip('\'"')
     if not new_name.startswith(('./', '../')):
         # relative_name is a variable or a literal that doesn't contain a
@@ -262,6 +258,10 @@ def construct_relative_path(current_template_name, relative_name):
             "same template in which the tag appears."
             % (relative_name, current_template_name)
         )
+    has_quotes = (
+        relative_name.startswith(('"', "'")) and
+        relative_name[0] == relative_name[-1]
+    )
     return f'"{new_name}"' if has_quotes else new_name
 
 


### PR DESCRIPTION
Small little thing I noted while checking Collin's changes in #15140; `has_quotes` is unused until the very end of `construct_relative_path` (used by `do_extends`, `do_include` and `IncludeNode`), at which point it is known to be a quoted relative path.

For the common case of using "absolute" (relative to the template loader root...) paths, this seems unnecessary, and a small gain can be had by pushing it further down (and removing the `startswith` calls)

Before:
```
In [2]: %timeit construct_relative_path('dir1/two.html', 'dir2/two.html')
445 ns ± 6.97 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [3]: %timeit construct_relative_path('dir1/two.html', '../two.html')
4.1 µs ± 35.9 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

After:
```
In [2]: %timeit construct_relative_path('dir1/two.html', 'dir2/two.html')
263 ns ± 6.16 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [3]: %timeit construct_relative_path('dir1/two.html', '../two.html')
4.09 µs ± 50.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

I did also toy with checking for quotes before doing the `.strip()` call, but it came out as a wash; removing two characters from the start/end of a relatively short string seems thankfully well optimised vs. manually peeking.

-----

I've not created a ticket for this as it's basically moving a variable's declaration, but let me know if you'd like one. Naturally it can also just be dismissed without one if you'd prefer.