### PR TITLE
Fixed bug that causing crash when put tuples as input for param of "default" in range fields (psycopg2)

### DIFF
--- a/django/contrib/postgres/forms/ranges.py
+++ b/django/contrib/postgres/forms/ranges.py
@@ -105,5 +105,7 @@ class RangeWidget(MultiWidget):
 
     def decompress(self, value):
         if value:
+            if isinstance(value, tuple):
+                return value
             return (value.lower, value.upper)
         return (None, None)


### PR DESCRIPTION
All of the range fields translate to psycopg2 Range objects in python, but also accept tuples as input.