### PR TITLE
Fixed #33339 -- Made QuerySet.bulk_create() use TO_NCLOB() for TextFields on Oracle.

### DIFF
--- a/django/db/backends/oracle/utils.py
+++ b/django/db/backends/oracle/utils.py
@@ -55,7 +55,7 @@ class Oracle_datetime(datetime.datetime):
 
 class BulkInsertMapper:
     BLOB = 'TO_BLOB(%s)'
-    CLOB = 'TO_CLOB(%s)'
+    NCLOB = 'TO_NCLOB(%s)'
     DATE = 'TO_DATE(%s)'
     INTERVAL = 'CAST(%s as INTERVAL DAY(9) TO SECOND(6))'
     NUMBER = 'TO_NUMBER(%s)'
@@ -78,7 +78,7 @@ class BulkInsertMapper:
         'PositiveSmallIntegerField': NUMBER,
         'SmallAutoField': NUMBER,
         'SmallIntegerField': NUMBER,
-        'TextField': CLOB,
+        'TextField': NCLOB,
         'TimeField': TIMESTAMP,
     }
 


### PR DESCRIPTION
`TextField` is of type `NCLOB` in Oracle, but inserted values were converted with `TO_CLOB`, instead of `TO_NCLOB`.