### PR TITLE
Refs #32539 - add comments to explain the issue

### DIFF
--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -73,6 +73,8 @@ class SimpleListFilter(ListFilter):
         if self.parameter_name in params:
             value = params.pop(self.parameter_name)
             self.used_parameters[self.parameter_name] = value
+        # step 6: the call from get_filters() gets us to this line which again calls lookups()
+        # which explains the RecurssionError mentioned in the ticket.
         lookup_choices = self.lookups(request, model_admin)
         if lookup_choices is None:
             lookup_choices = ()
@@ -93,6 +95,7 @@ class SimpleListFilter(ListFilter):
         """
         Must be overridden to return a list of tuples (value, verbose value)
         """
+        # step 1: get_changelist_instance() gets called here
         raise NotImplementedError(
             'The SimpleListFilter.lookups() method must be overridden to '
             'return a list of tuples (value, verbose value).'

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -739,6 +739,7 @@ class ModelAdmin(BaseModelAdmin):
             list_display = ['action_checkbox', *list_display]
         sortable_by = self.get_sortable_by(request)
         ChangeList = self.get_changelist(request)
+        # step 2: The call to get_changelist_instance returns a ChangeList object
         return ChangeList(
             request,
             self.model,

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -97,6 +97,7 @@ class ChangeList:
             self.list_editable = ()
         else:
             self.list_editable = list_editable
+        # step 3: returning the ChangeList object calls this __init__() method which calls get_queryset()
         self.queryset = self.get_queryset(request)
         self.get_results(request)
         if self.is_popup:
@@ -129,6 +130,7 @@ class ChangeList:
         return lookup_params
 
     def get_filters(self, request):
+        # step 4: get_queryset() function calls get_filters() (L463)
         lookup_params = self.get_filters_params()
         may_have_duplicates = False
         has_active_filters = False
@@ -142,6 +144,7 @@ class ChangeList:
             lookup_params_count = len(lookup_params)
             if callable(list_filter):
                 # This is simply a custom list filter class.
+                # step 5: this initializes an instance of the filter which in this case is SimpleListFilter
                 spec = list_filter(request, lookup_params, self.model, self.model_admin)
             else:
                 field_path = None


### PR DESCRIPTION
References ticket: https://code.djangoproject.com/ticket/32539
The ticket reports `RecursionError` when `get_changelist_instance` is called inside `lookups()` while defining a custom `SimpleListFilter`.

I have added comments to show why the `RecursionError` occurs. Here is a short summary of it - 
`get_changelist_instance()` returns `ChangeList` object for which `__init__()` function in the `ChangeList` class is called. That function calls `get_queryset()`. `get_queryset()` calls `get_filters()` which initializes the filter (`SimpleListFilter` in this case) whose init method calls `lookups()` function which called `get_changelist_instance()` in the first place.

I also looked up the link mentioned in the ticket that explains why `get_changelist_instance` is called inside `lookups()` in the first place. If I understood correctly, the reason for doing this is that they need to update the lookup filters after the initial filter is chosen. For example if a filter shows type of books and there is another filter that shows count of books at a location. On selecting the type of book, the count of books at that location should be updated to show counts at different locations only for the selected book type. Using `model_admin.get_queryset()` keeps returning the root queryset which has all counts for all types of books at all locations. It is possible to get updated lookups, they have used `change_list.get_queryset`.

I am looking for input to get started on the solution for this ticket.

