### PR TITLE
Refs #33333 -- Fixed PickleabilityTestCase.test_annotation_with_callable_default() crash on Oracle.

### DIFF
--- a/tests/queryset_pickle/models.py
+++ b/tests/queryset_pickle/models.py
@@ -46,6 +46,9 @@ class Happening(models.Model):
     number1 = models.IntegerField(blank=True, default=standalone_number)
     number2 = models.IntegerField(blank=True, default=Numbers.get_static_number)
     event = models.OneToOneField(Event, models.CASCADE, null=True)
+
+
+class BinaryFieldModel(models.Model):
     data = models.BinaryField(null=True)
 
 

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -5,7 +5,9 @@ import django
 from django.db import models
 from django.test import TestCase
 
-from .models import Container, Event, Group, Happening, M2MModel, MyEvent
+from .models import (
+    BinaryFieldModel, Container, Event, Group, Happening, M2MModel, MyEvent,
+)
 
 
 class PickleabilityTestCase(TestCase):
@@ -17,8 +19,8 @@ class PickleabilityTestCase(TestCase):
         self.assertEqual(list(pickle.loads(pickle.dumps(qs))), list(qs))
 
     def test_binaryfield(self):
-        Happening.objects.create(data=b'binary data')
-        self.assert_pickles(Happening.objects.all())
+        BinaryFieldModel.objects.create(data=b'binary data')
+        self.assert_pickles(BinaryFieldModel.objects.all())
 
     def test_related_field(self):
         g = Group.objects.create(name="Ponies Who Own Maybachs")


### PR DESCRIPTION
Grouping by LOBs is not allowed on Oracle. This moves a binary field to a separate model.

See [logs](https://djangoci.com/job/django-oracle/lastCompletedBuild/database=oracle19,label=oracle,python=python3.9/testReport/queryset_pickle.tests/PickleabilityTestCase/test_annotation_with_callable_default/).