### PR TITLE
Fixed #29822 -- Add a Timezone aware datetime widget for admin

### DIFF
--- a/django/contrib/admin/templates/admin/widgets/split_tz_datetime.html
+++ b/django/contrib/admin/templates/admin/widgets/split_tz_datetime.html
@@ -1,0 +1,7 @@
+<p class="datetime">
+  {% with widget=widget.subwidgets.0 %}{% include widget.template_name %}{% endwith %}
+  {% with widget=widget.subwidgets.1 %}{% include widget.template_name %}{% endwith %}
+
+  {{ date_label }} {% with widget=widget.subwidgets.2 %}{% include widget.template_name %}{% endwith %}<br>
+  {{ time_label }} {% with widget=widget.subwidgets.3 %}{% include widget.template_name %}{% endwith %}
+</p>

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -89,6 +89,39 @@ class AdminSplitDateTime(forms.SplitDateTimeWidget):
         return context
 
 
+class AdminTZAwareDateTime(AdminSplitDateTime):
+    """
+    A Timezone aware SplitDateTime Widget.
+    """
+    template_name = 'admin/widgets/split_tz_datetime.html'
+
+    def __init__(self, attrs=None):
+        server_date_time_widgets = [
+            AdminDateWidget(attrs={'type': 'hidden'}),
+            AdminTimeWidget(attrs={'type': 'hidden'})
+        ]
+        local_date_time_widgets = [
+            AdminDateWidget(attrs={'timezone-aware': 'yes'}),
+            AdminTimeWidget(attrs={'timezone-aware': 'yes'})
+        ]
+        widgets = server_date_time_widgets + local_date_time_widgets
+        forms.MultiWidget.__init__(self, widgets, attrs)
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        server_date_id = context['widget']['subwidgets'][0]['attrs']['id']
+        server_time_id = context['widget']['subwidgets'][1]['attrs']['id']
+        # Local Date Widget
+        context['widget']['subwidgets'][2]['attrs']['server-date-id'] = server_date_id
+        # Local Time Widget
+        context['widget']['subwidgets'][3]['attrs']['server-time-id'] = server_time_id
+        return context
+
+    def value_from_datadict(self, data, files, name):
+        # Return just value from server date time widgets
+        return super().value_from_datadict(data, files, name)[:2]
+
+
 class AdminRadioSelect(forms.RadioSelect):
     template_name = 'admin/widgets/radio.html'
 


### PR DESCRIPTION
Ticket :- [https://code.djangoproject.com/ticket/29822](https://code.djangoproject.com/ticket/29822)

Timezone conversion is handled on  frontend using `DateTimeShortcuts.timezoneOffset`.