### PR TITLE
Fixed #33316 -- Added pagination to admin history view.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1927,6 +1927,7 @@ class ModelAdmin(BaseModelAdmin):
     def history_view(self, request, object_id, extra_context=None):
         "The 'history' admin view for this model."
         from django.contrib.admin.models import LogEntry
+        from django.contrib.admin.views.main import PAGE_VAR
 
         # First check if the user can see this history.
         model = self.model
@@ -1945,11 +1946,19 @@ class ModelAdmin(BaseModelAdmin):
             content_type=get_content_type_for_model(model)
         ).select_related().order_by('action_time')
 
+        paginator = self.get_paginator(request, action_list, 100)
+        page_number = request.GET.get(PAGE_VAR, 1)
+        page_obj = paginator.get_page(page_number)
+        page_range = paginator.get_elided_page_range(page_obj.number)
+
         context = {
             **self.admin_site.each_context(request),
             'title': _('Change history: %s') % obj,
             'subtitle': None,
-            'action_list': action_list,
+            'action_list': page_obj,
+            'page_range': page_range,
+            'page_var': PAGE_VAR,
+            'pagination_required': paginator.count > 100,
             'module_name': str(capfirst(opts.verbose_name_plural)),
             'object': obj,
             'opts': opts,

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -1016,3 +1016,49 @@ table#change-history tbody th {
 .popup #header {
     padding: 10px 20px;
 }
+
+/* PAGINATOR */
+
+.paginator {
+    font-size: 13px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    line-height: 22px;
+    margin: 0;
+    border-top: 1px solid var(--hairline-color);
+    width: 100%;
+}
+
+.paginator a:link, .paginator a:visited {
+    padding: 2px 6px;
+    background: var(--button-bg);
+    text-decoration: none;
+    color: var(--button-fg);
+}
+
+.paginator a.showall {
+    border: none;
+    background: none;
+    color: var(--link-fg);
+}
+
+.paginator a.showall:focus, .paginator a.showall:hover {
+    background: none;
+    color: var(--link-hover-color);
+}
+
+.paginator .end {
+    margin-right: 6px;
+}
+
+.paginator .this-page {
+    padding: 2px 6px;
+    font-weight: bold;
+    font-size: 13px;
+    vertical-align: top;
+}
+
+.paginator a:focus, .paginator a:hover {
+    color: white;
+    background: var(--link-hover-color);
+}

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -774,12 +774,19 @@ a.deletelink:focus, a.deletelink:hover {
 
 /* OBJECT HISTORY */
 
-table#change-history {
+#change-history table {
     width: 100%;
 }
 
-table#change-history tbody th {
+#change-history table tbody th {
     width: 16em;
+}
+
+#change-history .paginator {
+    color: var(--body-quiet-color);
+    border-bottom: 1px solid var(--hairline-color);
+    background: var(--body-bg);
+    overflow: hidden;
 }
 
 /* PAGE STRUCTURE */

--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -225,52 +225,6 @@
     color: var(--link-hover-color);
 }
 
-/* PAGINATOR */
-
-.paginator {
-    font-size: 13px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-    line-height: 22px;
-    margin: 0;
-    border-top: 1px solid var(--hairline-color);
-    width: 100%;
-}
-
-.paginator a:link, .paginator a:visited {
-    padding: 2px 6px;
-    background: var(--button-bg);
-    text-decoration: none;
-    color: var(--button-fg);
-}
-
-.paginator a.showall {
-    border: none;
-    background: none;
-    color: var(--link-fg);
-}
-
-.paginator a.showall:focus, .paginator a.showall:hover {
-    background: none;
-    color: var(--link-hover-color);
-}
-
-.paginator .end {
-    margin-right: 6px;
-}
-
-.paginator .this-page {
-    padding: 2px 6px;
-    font-weight: bold;
-    font-size: 13px;
-    vertical-align: top;
-}
-
-.paginator a:focus, .paginator a:hover {
-    color: white;
-    background: var(--link-hover-color);
-}
-
 /* ACTIONS */
 
 .filtered .actions {

--- a/django/contrib/admin/templates/admin/object_history.html
+++ b/django/contrib/admin/templates/admin/object_history.html
@@ -13,10 +13,10 @@
 
 {% block content %}
 <div id="content-main">
-<div class="module">
+<div id="change-history" class="module">
 
 {% if action_list %}
-    <table id="change-history">
+    <table>
         <thead>
         <tr>
             <th scope="col">{% translate 'Date/time' %}</th>
@@ -34,6 +34,20 @@
         {% endfor %}
         </tbody>
     </table>
+    <p class="paginator">
+      {% if pagination_required %}
+        {% for i in page_range %}
+          {% if i == action_list.paginator.ELLIPSIS %}
+            {{ action_list.paginator.ELLIPSIS }}
+          {% elif i == action_list.number %}
+            <span class="this-page">{{ i }}</span>
+          {% else %}
+            <a href="?{{ page_var }}={{ i }}" {% if i == action_list.paginator.num_pages %} class="end" {% endif %}>{{ i }}</a>
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+      {{ action_list.paginator.count }} {% if action_list.paginator.count == 1 %}{% translate "entry" %}{% else %}{% translate "entries" %}{% endif %}
+    </p>
 {% else %}
     <p>{% translate 'This object doesn’t have a change history. It probably wasn’t added via this admin site.' %}</p>
 {% endif %}

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2016,6 +2016,10 @@ Other methods
     Django view for the page that shows the modification history for a given
     model instance.
 
+    .. versionchanged:: 4.1
+
+        Pagination was added.
+
 Unlike the hook-type ``ModelAdmin`` methods detailed in the previous section,
 these five methods are in reality designed to be invoked as Django views from
 the admin application URL dispatching handler to render the pages that deal

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -58,6 +58,9 @@ Minor features
   subclasses can now control the query string value separator when filtering
   for multiple values using the ``__in`` lookup.
 
+* The admin :meth:`history view <django.contrib.admin.ModelAdmin.history_view>`
+  is now paginated.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I added default pagination to the history view, similar used in `change_list.html`

Here there is a GIF showing how it's working **(the example was made with a page size of 2)**:

![history_view_pagination](https://user-images.githubusercontent.com/16822952/144764474-9d20d015-c0e1-4554-8946-0784feb94c83.gif)

In responsive:

![history_view_pagination_responsive](https://user-images.githubusercontent.com/16822952/144764558-e93b4ca7-aaac-4a03-a7d0-2bf6a9573831.png)

Some doubts/questions/clarifications I have:
- I moved the paginator styles from the specific `changelists.css` file to a general one (`base.css`), so it can be used in other views. Is that OK or should I create a specifict stylesheet for the paginator?
- The logic in `object_history.html` is the same implemented by the `paginator_number` template tag. I couldn't re-use it because it expects a `ChangeList` object as param.
- In the `history_view` I defined a default of `100` page size. Also, I used `Paginator`, or should I use `ModelAdmin.get_paginator` method?

Hope was the work expected! Let me know all the necessary changes to be made!

Thank you!