### PR TITLE
Fixed #31765 -- Made SQLite connections disable legacy ALTER TABLE.

### DIFF
--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -259,6 +259,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         conn.create_aggregate('VAR_POP', 1, list_aggregate(statistics.pvariance))
         conn.create_aggregate('VAR_SAMP', 1, list_aggregate(statistics.variance))
         conn.execute('PRAGMA foreign_keys = ON')
+        # The macOS bundled SQLite defaults legacy_alter_table ON, which
+        # prevents atomic table renames (feature supports_atomic_references_rename)
+        conn.execute('PRAGMA legacy_alter_table = OFF')
         return conn
 
     def init_connection_state(self):

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -1,5 +1,4 @@
 import operator
-import platform
 
 from django.db import transaction
 from django.db.backends.base.features import BaseDatabaseFeatures
@@ -91,10 +90,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     @cached_property
     def supports_atomic_references_rename(self):
-        # SQLite 3.28.0 bundled with MacOS 10.15 does not support renaming
-        # references atomically.
-        if platform.mac_ver()[0].startswith('10.15.') and Database.sqlite_version_info == (3, 28, 0):
-            return False
         return Database.sqlite_version_info >= (3, 26, 0)
 
     @cached_property


### PR DESCRIPTION
Alternative fix for ticket-31765. Works on my macOS 11.6 machine.