### PR TITLE
Fixed #33048 -- Doc'd that DEBUG static files requests don't use middleware chain.

### DIFF
--- a/docs/howto/static-files/index.txt
+++ b/docs/howto/static-files/index.txt
@@ -108,6 +108,10 @@ do this by adding the following snippet to your urls.py::
     folder; it doesn't perform static files discovery like
     :mod:`django.contrib.staticfiles`.
 
+    Finally, static files are served via a wrapper at the WSGI application
+    layer. As a consequence, static files requests do not pass through the
+    normal :doc:`middleware chain </topics/http/middleware>`.
+
 .. _serving-uploaded-files-in-development:
 
 Serving files uploaded by a user during development


### PR DESCRIPTION
ticket-33048

Refactored Django's documentation to explain the role of middleware
chain and how the exclusion of middleware helps the process of serving
the static files automatically.