### PR TITLE
Improved release notes wording for template-based form rendering.

### DIFF
--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -118,10 +118,9 @@ in Django <redis>`.
 Template based form rendering
 -----------------------------
 
-To enhance customization of :class:`Forms <django.forms.Form>`,
-:doc:`Formsets </topics/forms/formsets>`, and
-:class:`~django.forms.ErrorList` they are now rendered using the template
-engine. See the new :meth:`~django.forms.Form.render`,
+:class:`Forms <django.forms.Form>`, :doc:`Formsets </topics/forms/formsets>`,
+and :class:`~django.forms.ErrorList` are now rendered using the template engine
+to enhance customization. See the new :meth:`~django.forms.Form.render`,
 :meth:`~django.forms.Form.get_context`, and
 :attr:`~django.forms.Form.template_name` for ``Form`` and
 :ref:`formset rendering <formset-rendering>` for ``Formset``.


### PR DESCRIPTION
This entry doesn't read very well, specifically the "they" in the middle, so reorder it.