### PR TITLE
Fixed #33340 -- Fixed unquoted column names in queries used by DatabaseCache.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -97,6 +97,7 @@ answer newbie questions, and generally made Django that much better:
     arien <regexbot@gmail.com>
     Armin Ronacher
     Aron Podrigal <aronp@guaranteedplus.com>
+    Arsalan Ghassemi <arsalan.ghassemi@gmail.com>
     Artem Gnilov <boobsd@gmail.com>
     Arthur <avandorp@gmail.com>
     Arthur Jovart <arthur@jovart.com>

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -88,7 +88,8 @@ class BaseDatabaseOperations:
         This is used by the 'db' cache backend to determine where to start
         culling.
         """
-        return "SELECT cache_key FROM %s ORDER BY cache_key LIMIT 1 OFFSET %%s"
+        cache_key = self.quote_name('cache_key')
+        return f'SELECT {cache_key} FROM %s ORDER BY {cache_key} LIMIT 1 OFFSET %%s'
 
     def unification_cast_sql(self, output_field):
         """

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -72,7 +72,12 @@ END;
     }
 
     def cache_key_culling_sql(self):
-        return 'SELECT cache_key FROM %s ORDER BY cache_key OFFSET %%s ROWS FETCH FIRST 1 ROWS ONLY'
+        cache_key = self.quote_name('cache_key')
+        return (
+            f'SELECT {cache_key} '
+            f'FROM %s '
+            f'ORDER BY {cache_key} OFFSET %%s ROWS FETCH FIRST 1 ROWS ONLY'
+        )
 
     def date_extract_sql(self, lookup_type, field_name):
         if lookup_type == 'week_day':

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1113,7 +1113,7 @@ class DBCacheTests(BaseCacheTests, TransactionTestCase):
         with self.assertNumQueries(1):
             cache.delete_many(['a', 'b', 'c'])
 
-    def test_cull_count_queries(self):
+    def test_cull_queries(self):
         old_max_entries = cache._max_entries
         # Force _cull to delete on first cached record.
         cache._max_entries = -1
@@ -1124,6 +1124,13 @@ class DBCacheTests(BaseCacheTests, TransactionTestCase):
                 cache._max_entries = old_max_entries
         num_count_queries = sum('COUNT' in query['sql'] for query in captured_queries)
         self.assertEqual(num_count_queries, 1)
+        # Column names are quoted.
+        for query in captured_queries:
+            sql = query['sql']
+            if 'expires' in sql:
+                self.assertIn(connection.ops.quote_name('expires'), sql)
+            if 'cache_key' in sql:
+                self.assertIn(connection.ops.quote_name('cache_key'), sql)
 
     def test_delete_cursor_rowcount(self):
         """
@@ -1179,6 +1186,15 @@ class DBCacheTests(BaseCacheTests, TransactionTestCase):
             stdout=out,
         )
         self.assertEqual(out.getvalue(), "Cache table 'test cache table' created.\n")
+
+    def test_has_key_query_columns_quoted(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            cache.has_key('key')
+        self.assertEqual(len(captured_queries), 1)
+        sql = captured_queries[0]['sql']
+        # Column names are quoted.
+        self.assertIn(connection.ops.quote_name('expires'), sql)
+        self.assertIn(connection.ops.quote_name('cache_key'), sql)
 
 
 @override_settings(USE_TZ=True)


### PR DESCRIPTION
Hello,

The Trac ticket : https://code.djangoproject.com/ticket/33340