### PR TITLE
Fixed inspectdb.tests.InspectDBTestCase.test_custom_fields() on SQLite 3.37+.

### DIFF
--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -312,18 +312,17 @@ class InspectDBTestCase(TestCase):
         Introspection of columns with a custom field (#21090)
         """
         out = StringIO()
-        orig_data_types_reverse = connection.introspection.data_types_reverse
-        try:
-            connection.introspection.data_types_reverse = {
+        with mock.patch(
+            'django.db.connection.introspection.data_types_reverse.base_data_types_reverse',
+            {
                 'text': 'myfields.TextField',
                 'bigint': 'BigIntegerField',
-            }
+            },
+        ):
             call_command('inspectdb', 'inspectdb_columntypes', stdout=out)
             output = out.getvalue()
             self.assertIn("text_field = myfields.TextField()", output)
             self.assertIn("big_int_field = models.BigIntegerField()", output)
-        finally:
-            connection.introspection.data_types_reverse = orig_data_types_reverse
 
     def test_introspection_errors(self):
         """


### PR DESCRIPTION
Use `FlexibleFieldLookupDict` which is case-insensitive mapping because SQLite 3.37+ returns some data type names upper-cased e.g. `TEXT`.