### PR TITLE
OpClass example uses name as positional argument

### DIFF
--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -152,13 +152,13 @@ available from the ``django.contrib.postgres.indexes`` module.
     An ``OpClass()`` expression represents the ``expression`` with a custom
     `operator class`_ that can be used to define functional indexes or unique
     constraints. To use it, you need to add ``'django.contrib.postgres'`` in
-    your :setting:`INSTALLED_APPS`. Set the ``name`` parameter to the name of
-    the `operator class`_.
+    your :setting:`INSTALLED_APPS`. Pass the name of the `operator class`_ as
+    the second argument.
 
     For example::
 
         Index(
-            OpClass(Lower('username'), name='varchar_pattern_ops'),
+            OpClass(Lower('username'), 'varchar_pattern_ops'),
             name='lower_username_idx',
         )
 
@@ -167,7 +167,7 @@ available from the ``django.contrib.postgres.indexes`` module.
     Another example::
 
         UniqueConstraint(
-            OpClass(Upper('description'), name='text_pattern_ops'),
+            OpClass(Upper('description'), 'text_pattern_ops'),
             name='upper_description_unique',
         )
 


### PR DESCRIPTION
Update documentation to match the code in https://github.com/django/django/blob/eba9a9b7f72995206af867600d6685b5405f172a/django/contrib/postgres/indexes.py
OpClass takes the name of the operator class as the second positional argument, not as a keyword argument.