### PR TITLE
Fixed #33350 -- Fix how view decorators check for `request`

### DIFF
--- a/django/utils/decorators.py
+++ b/django/utils/decorators.py
@@ -152,6 +152,16 @@ def make_middleware_decorator(middleware_class):
     return _make_decorator
 
 
+def require_method_decorator(request, name):
+    # check properties instead of an `isinstance` check to allow for objects
+    # like Django REST framework's `Request`
+    if not hasattr(request, 'path') and not hasattr(request, 'method'):
+        raise TypeError(
+            name + " didn't receive a request as its first argument. If you "
+            "are decorating a classmethod, make sure to use @method_decorator."
+        )
+
+
 def sync_and_async_middleware(func):
     """
     Mark a middleware factory as returning a hybrid middleware supporting both

--- a/django/views/decorators/clickjacking.py
+++ b/django/views/decorators/clickjacking.py
@@ -11,12 +11,13 @@ def xframe_options_deny(view_func):
     def some_view(request):
         ...
     """
+    @wraps(view_func)
     def wrapped_view(*args, **kwargs):
         resp = view_func(*args, **kwargs)
         if resp.get('X-Frame-Options') is None:
             resp['X-Frame-Options'] = 'DENY'
         return resp
-    return wraps(view_func)(wrapped_view)
+    return wrapped_view
 
 
 def xframe_options_sameorigin(view_func):
@@ -29,12 +30,13 @@ def xframe_options_sameorigin(view_func):
     def some_view(request):
         ...
     """
+    @wraps(view_func)
     def wrapped_view(*args, **kwargs):
         resp = view_func(*args, **kwargs)
         if resp.get('X-Frame-Options') is None:
             resp['X-Frame-Options'] = 'SAMEORIGIN'
         return resp
-    return wraps(view_func)(wrapped_view)
+    return wrapped_view
 
 
 def xframe_options_exempt(view_func):
@@ -46,8 +48,9 @@ def xframe_options_exempt(view_func):
     def some_view(request):
         ...
     """
+    @wraps(view_func)
     def wrapped_view(*args, **kwargs):
         resp = view_func(*args, **kwargs)
         resp.xframe_options_exempt = True
         return resp
-    return wraps(view_func)(wrapped_view)
+    return wrapped_view

--- a/django/views/decorators/common.py
+++ b/django/views/decorators/common.py
@@ -8,7 +8,8 @@ def no_append_slash(view_func):
     """
     # view_func.should_append_slash = False would also work, but decorators are
     # nicer if they don't have side effects, so return a new function.
+    @wraps(view_func)
     def wrapped_view(*args, **kwargs):
         return view_func(*args, **kwargs)
     wrapped_view.should_append_slash = False
-    return wraps(view_func)(wrapped_view)
+    return wrapped_view

--- a/django/views/decorators/csrf.py
+++ b/django/views/decorators/csrf.py
@@ -50,7 +50,8 @@ def csrf_exempt(view_func):
     """Mark a view function as being exempt from the CSRF view protection."""
     # view_func.csrf_exempt = True would also work, but decorators are nicer
     # if they don't have side effects, so return a new function.
+    @wraps(view_func)
     def wrapped_view(*args, **kwargs):
         return view_func(*args, **kwargs)
     wrapped_view.csrf_exempt = True
-    return wraps(view_func)(wrapped_view)
+    return wrapped_view

--- a/django/views/decorators/vary.py
+++ b/django/views/decorators/vary.py
@@ -14,17 +14,17 @@ def vary_on_headers(*headers):
 
     Note that the header names are not case-sensitive.
     """
-    def decorator(func):
-        @wraps(func)
-        def inner_func(*args, **kwargs):
-            response = func(*args, **kwargs)
+    def decorator(view_func):
+        @wraps(view_func)
+        def wrapped_view(*args, **kwargs):
+            response = view_func(*args, **kwargs)
             patch_vary_headers(response, headers)
             return response
-        return inner_func
+        return wrapped_view
     return decorator
 
 
-def vary_on_cookie(func):
+def vary_on_cookie(view_func):
     """
     A view decorator that adds "Cookie" to the Vary header of a response. This
     indicates that a page's contents depends on cookies. Usage:
@@ -33,9 +33,9 @@ def vary_on_cookie(func):
         def index(request):
             ...
     """
-    @wraps(func)
-    def inner_func(*args, **kwargs):
-        response = func(*args, **kwargs)
+    @wraps(view_func)
+    def wrapped_view(*args, **kwargs):
+        response = view_func(*args, **kwargs)
         patch_vary_headers(response, ('Cookie',))
         return response
-    return inner_func
+    return wrapped_view

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -503,30 +503,3 @@ class NeverCacheDecoratorTest(SimpleTestCase):
             set(r.headers['Cache-Control'].split(', ')),
             {'max-age=0', 'no-cache', 'no-store', 'must-revalidate', 'private'},
         )
-
-    def test_never_cache_decorator_http_request(self):
-        class MyClass:
-            @never_cache
-            def a_view(self, request):
-                return HttpResponse()
-        msg = (
-            "never_cache didn't receive an HttpRequest. If you are decorating "
-            "a classmethod, be sure to use @method_decorator."
-        )
-        with self.assertRaisesMessage(TypeError, msg):
-            MyClass().a_view(HttpRequest())
-
-
-class CacheControlDecoratorTest(SimpleTestCase):
-    def test_cache_control_decorator_http_request(self):
-        class MyClass:
-            @cache_control(a='b')
-            def a_view(self, request):
-                return HttpResponse()
-
-        msg = (
-            "cache_control didn't receive an HttpRequest. If you are "
-            "decorating a classmethod, be sure to use @method_decorator."
-        )
-        with self.assertRaisesMessage(TypeError, msg):
-            MyClass().a_view(HttpRequest())


### PR DESCRIPTION
This change removes the strict `isinstance` check added in some of the
view decorators and replaces it with a check for `path` and `method`. In
addition this change normalizes how all the decorators are defined to
give them consistent function names and using the modern decorator
syntax.