### PR TITLE
Moved ManagementForm's fields to class attributes.

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -30,15 +30,13 @@ class ManagementForm(Form):
     new forms via JavaScript, you should increment the count field of this form
     as well.
     """
-    def __init__(self, *args, **kwargs):
-        self.base_fields[TOTAL_FORM_COUNT] = IntegerField(widget=HiddenInput)
-        self.base_fields[INITIAL_FORM_COUNT] = IntegerField(widget=HiddenInput)
-        # MIN_NUM_FORM_COUNT and MAX_NUM_FORM_COUNT are output with the rest of
-        # the management form, but only for the convenience of client-side
-        # code. The POST value of them returned from the client is not checked.
-        self.base_fields[MIN_NUM_FORM_COUNT] = IntegerField(required=False, widget=HiddenInput)
-        self.base_fields[MAX_NUM_FORM_COUNT] = IntegerField(required=False, widget=HiddenInput)
-        super().__init__(*args, **kwargs)
+    TOTAL_FORMS = IntegerField(widget=HiddenInput)
+    INITIAL_FORMS = IntegerField(widget=HiddenInput)
+    # MIN_NUM_FORM_COUNT and MAX_NUM_FORM_COUNT are output with the rest of the
+    # management form, but only for the convenience of client-side code. The
+    # POST value of them returned from the client is not checked.
+    MIN_NUM_FORMS = IntegerField(required=False, widget=HiddenInput)
+    MAX_NUM_FORMS = IntegerField(required=False, widget=HiddenInput)
 
     def clean(self):
         cleaned_data = super().clean()

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -7,7 +7,10 @@ from django.forms import (
     BaseForm, CharField, DateField, FileField, Form, IntegerField,
     SplitDateTimeField, formsets,
 )
-from django.forms.formsets import BaseFormSet, all_valid, formset_factory
+from django.forms.formsets import (
+    INITIAL_FORM_COUNT, MAX_NUM_FORM_COUNT, MIN_NUM_FORM_COUNT,
+    TOTAL_FORM_COUNT, BaseFormSet, ManagementForm, all_valid, formset_factory,
+)
 from django.forms.utils import ErrorList
 from django.forms.widgets import HiddenInput
 from django.test import SimpleTestCase
@@ -996,6 +999,18 @@ class FormsFormsetTestCase(SimpleTestCase):
 <td><input type="text" name="form-0-name" value="Gin Tonic" id="id_form-0-name"></td></tr>
 <tr><th><label for="id_form-1-name">Name:</label></th>
 <td><input type="text" name="form-1-name" id="id_form-1-name"></td></tr>"""
+        )
+
+    def test_management_form_field_names(self):
+        """The management form class has field names matching the constants."""
+        self.assertCountEqual(
+            ManagementForm.base_fields,
+            [
+                TOTAL_FORM_COUNT,
+                INITIAL_FORM_COUNT,
+                MIN_NUM_FORM_COUNT,
+                MAX_NUM_FORM_COUNT,
+            ],
         )
 
     def test_management_form_prefix(self):


### PR DESCRIPTION
This helps introspection, and it follows the comment in `BaseForm.__init__` not to avoid changing `base_fields`.

Thanks to Silvio Gutierrez and Baptiste Mispelon for investigating.

Following this forum discussion: https://forum.djangoproject.com/t/why-are-fields-in-managementform-dynamically-populated/10901

It seems the main reason `base_fields` was used was to ensure the field names align with the constants. I’ve done that by instead adding a test that they do.