### PR TITLE
Corrected return value of ForeignKey.db_check().

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1035,7 +1035,7 @@ class ForeignKey(ForeignObject):
         })
 
     def db_check(self, connection):
-        return []
+        return None
 
     def db_type(self, connection):
         return self.target_field.rel_db_type(connection=connection)


### PR DESCRIPTION
Field.db_check() should return `None` or a SQL string. Returning `[]` happened to work because it’s falsey.