### PR TITLE
Refs #32502 -- Avoided table rebuild when adding fields with no default on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -18,6 +18,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_rollback_ddl = True
     can_create_inline_fk = False
     supports_paramstyle_pyformat = False
+    requires_literal_defaults = True
     can_clone_databases = True
     supports_temporal_subtraction = True
     ignores_table_name_case = True

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -517,6 +517,15 @@ class SchemaTests(TransactionTestCase):
             'column': editor.quote_name(new_field.name),
         }
         self.assertFalse(any(drop_default_sql in query['sql'] for query in ctx.captured_queries))
+        # Table is not rebuilt.
+        self.assertIs(any(
+            'CREATE TABLE' in query['sql']
+            for query in ctx.captured_queries
+        ), False)
+        self.assertIs(any(
+            'DROP TABLE' in query['sql']
+            for query in ctx.captured_queries
+        ), False)
         columns = self.column_classes(Author)
         self.assertEqual(columns['age'][0], connection.features.introspected_field_types['IntegerField'])
         self.assertTrue(columns['age'][1][6])


### PR DESCRIPTION
This covers using `ALTER TABLE ADD COLUMN` statement.

ticket-32502