### PR TITLE
Fixed #33338 -- Doc'd and tested that never_cache() decorator set Expires header.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -592,6 +592,7 @@ answer newbie questions, and generally made Django that much better:
     Marc Aymerich Gubern
     Marc Egli <frog32@me.com>
     Marcel Telka <marcel@telka.sk>
+    Marcelo Galigniana <marcelogaligniana@gmail.com>
     Marc Fargas <telenieko@telenieko.com>
     Marc Garcia <marc.garcia@accopensys.com>
     Marcin Wróbel

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -62,9 +62,13 @@ need to distinguish caches by the ``Accept-language`` header.
 
 .. function:: add_never_cache_headers(response)
 
+    Adds an ``Expires`` header to the current date/time.
+
     Adds a ``Cache-Control: max-age=0, no-cache, no-store, must-revalidate,
     private`` header to a response to indicate that a page should never be
     cached.
+
+    Each header is only added if it isn't already set.
 
 .. function:: patch_vary_headers(response, newheaders)
 

--- a/docs/topics/http/decorators.txt
+++ b/docs/topics/http/decorators.txt
@@ -118,9 +118,13 @@ client-side caching.
 
 .. function:: never_cache(view_func)
 
+    This decorator adds an ``Expires`` header to the current date/time.
+
     This decorator adds a ``Cache-Control: max-age=0, no-cache, no-store,
     must-revalidate, private`` header to a response to indicate that a page
     should never be cached.
+
+    Each header is only added if it isn't already set.
 
 .. module:: django.views.decorators.common
 


### PR DESCRIPTION
Full title and issue link: [Document that @never_cache and add_never_cache_headers() set the Expires header.](https://code.djangoproject.com/ticket/33338)

I wrote the documentation based on a link I found in `staticfiles.txt`: https://developer.yahoo.com/performance/rules.html#expires and the docstring in the `http_date` method

Please let me know any changes needed, thank you.