### PR TITLE
Javascript modules support for ManifestStaticFilesStorage

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -58,6 +58,12 @@ class HashedFilesMixin:
                 '//# sourceMappingURL=%(url)s',
             ),
         )),
+        ('*.mjs', (
+            (
+                r"""(^|;)\s*(?P<matched>(?P<prefix>import(\s*\*\s*as\s+\w+\s+|\s+\w+\s+|\s*{[\w,\s]*?}\s*)from\s*)['"](?P<url>.*?)['"])""",
+                "%(prefix)s '%(url)s'",
+            ),
+        )),
     )
     keep_intermediate_files = True
 


### PR DESCRIPTION
Modern web developement includes CSS custom properties, [Javascript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), and [web components](https://developer.mozilla.org/en-US/docs/Web/Web_Components).

Unfortunately the manifest storage doesnt support changing the URL of Javascript modules (it only supports JS source maps). Javascript modules solve many of the problems Javascript suffers from as it grew from its infant stags to where it is now. They are important for writing robust Javascript code.

I recommend adding support for them. Unfortunately it is quite a complex regex as there are variations when importing. Ideally one would run it on `.js` and `.mjs` files, but I but it does not seems like an easy modification, so I went with `.mjs` as its more likely to only affect the people who would benefit from it.

It works on the following import styles (taken from <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules>):
```js
import { name, draw, reportArea, reportPerimeter } from './modules/square.js';                         
import randomSquare from './modules/square.js';                                                        
import {default as randomSquare} from './modules/square.js';                                           
import { newFunctionName, anotherNewFunctionName } from './modules/module.js';                         
import { function1 as newFunctionName,                                                                 
        function2 as anotherNewFunctionName } from './modules/module.js';                              
import { name, draw, reportArea, reportPerimeter } from './modules/square.js';                         
import { name, draw, reportArea, reportPerimeter } from './modules/circle.js';                         
import { name, draw, reportArea, reportPerimeter } from './modules/triangle.js';                       
import { name as squareName,                                                                           
        draw as drawSquare,                                                                            
        reportArea as reportSquareArea,                                                                
        reportPerimeter as reportSquarePerimeter } from './modules/square.js';                         
                                                                                                       
import { squareName, drawSquare, reportSquareArea, reportSquarePerimeter } from './modules/square.js'; 
import * as Canvas from './modules/canvas.js';                                                         
import { Square } from './modules/square.js';                                                          
import { Square, Circle, Triangle } from './modules/shapes.js';                                        
import colors from './modules/getColors.js';                                                           
```