### PR TITLE
Fixed #33351 -- Made path()/re_path() raise TypeError when kwargs argument is not a dict.

### DIFF
--- a/django/urls/conf.py
+++ b/django/urls/conf.py
@@ -57,6 +57,10 @@ def include(arg, namespace=None):
 def _path(route, view, kwargs=None, name=None, Pattern=None):
     from django.views import View
 
+    if kwargs is not None and not isinstance(kwargs, dict):
+        raise TypeError(
+            f'kwargs argument must be a dict, but got {kwargs.__class__.__name__}.'
+        )
     if isinstance(view, (list, tuple)):
         # For include(...) processing.
         pattern = Pattern(route, is_endpoint=False)

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -4,7 +4,9 @@ import uuid
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-from django.urls import NoReverseMatch, Resolver404, path, resolve, reverse
+from django.urls import (
+    NoReverseMatch, Resolver404, path, re_path, resolve, reverse,
+)
 from django.views import View
 
 from .converters import DynamicConverter
@@ -136,6 +138,13 @@ class SimplifiedURLTests(SimpleTestCase):
     def test_path_inclusion_is_reversible(self):
         url = reverse('inner-extra', kwargs={'extra': 'something'})
         self.assertEqual(url, '/included_urls/extra/something/')
+
+    def test_invalid_kwargs(self):
+        msg = 'kwargs argument must be a dict, but got str.'
+        with self.assertRaisesMessage(TypeError, msg):
+            path('hello/', empty_view, 'name')
+        with self.assertRaisesMessage(TypeError, msg):
+            re_path('^hello/$', empty_view, 'name')
 
     def test_invalid_converter(self):
         msg = "URL route 'foo/<nonexistent:var>/' uses invalid converter 'nonexistent'."


### PR DESCRIPTION
Added conditional to _path function to raise TypeError when kwargs is not None and not a dict.

Reason: Prevent a commonly made mistake when defining urlpatterns.

Ticket URL: https://code.djangoproject.com/ticket/33351

