### PR TITLE
Refs #33328 -- rewriting 'formset:added'/'formset:removed' triggers in inline.js in pure javascript

### DIFF
--- a/django/contrib/admin/static/admin/js/inlines.js
+++ b/django/contrib/admin/static/admin/js/inlines.js
@@ -130,7 +130,7 @@
             if (options.removed) {
                 options.removed(row);
             }
-            $(document).trigger('formset:removed', [row, options.prefix]);
+            document.querySelector(document).trigger('formset:removed', [row, options.prefix]);
             // Update the TOTAL_FORMS form count.
             const forms = $("." + options.formCssClass);
             $("#id_" + options.prefix + "-TOTAL_FORMS").val(forms.length);

--- a/django/contrib/admin/static/admin/js/inlines.js
+++ b/django/contrib/admin/static/admin/js/inlines.js
@@ -88,7 +88,7 @@
             if (options.added) {
                 options.added(row);
             }
-            $(document).trigger('formset:added', [row, options.prefix]);
+            document.querySelector(document).trigger('formset:added', [row, options.prefix]);
         };
 
         /**


### PR DESCRIPTION
The 'formset:added'/'formset:removed' events trigger in admin inlines.js are currently using jQuery trigger functionality, hence the events can not be catched by pure JS code.

Reference: `https://code.djangoproject.com/ticket/33328`