### PR TITLE
Refs #33355 -- Fixed Trunc() with years < 1000 on SQLite.

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -77,6 +77,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             'db_functions.text.test_sha224.SHA224Tests.test_basic',
             'db_functions.text.test_sha224.SHA224Tests.test_transform',
         },
+        "Oracle doesn't correctly calculate ISO 8601 week numbering before "
+        "1583 (the Gregorian calendar was introduced in 1582).": {
+            'db_functions.datetime.test_extract_trunc.DateFunctionTests.test_trunc_week_before_1000',
+            'db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_trunc_week_before_1000',
+        },
         "Oracle doesn't support bitwise XOR.": {
             'expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_xor',
             'expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_xor_null',

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -451,17 +451,17 @@ def _sqlite_date_trunc(lookup_type, dt, tzname, conn_tzname):
     if dt is None:
         return None
     if lookup_type == 'year':
-        return "%i-01-01" % dt.year
+        return '%04i-01-01' % dt.year
     elif lookup_type == 'quarter':
         month_in_quarter = dt.month - (dt.month - 1) % 3
-        return '%i-%02i-01' % (dt.year, month_in_quarter)
+        return '%04i-%02i-01' % (dt.year, month_in_quarter)
     elif lookup_type == 'month':
-        return "%i-%02i-01" % (dt.year, dt.month)
+        return '%04i-%02i-01' % (dt.year, dt.month)
     elif lookup_type == 'week':
         dt = dt - datetime.timedelta(days=dt.weekday())
-        return "%i-%02i-%02i" % (dt.year, dt.month, dt.day)
+        return '%04i-%02i-%02i' % (dt.year, dt.month, dt.day)
     elif lookup_type == 'day':
-        return "%i-%02i-%02i" % (dt.year, dt.month, dt.day)
+        return '%04i-%02i-%02i' % (dt.year, dt.month, dt.day)
 
 
 def _sqlite_time_trunc(lookup_type, dt, tzname, conn_tzname):
@@ -520,23 +520,23 @@ def _sqlite_datetime_trunc(lookup_type, dt, tzname, conn_tzname):
     if dt is None:
         return None
     if lookup_type == 'year':
-        return "%i-01-01 00:00:00" % dt.year
+        return '%04i-01-01 00:00:00' % dt.year
     elif lookup_type == 'quarter':
         month_in_quarter = dt.month - (dt.month - 1) % 3
-        return '%i-%02i-01 00:00:00' % (dt.year, month_in_quarter)
+        return '%04i-%02i-01 00:00:00' % (dt.year, month_in_quarter)
     elif lookup_type == 'month':
-        return "%i-%02i-01 00:00:00" % (dt.year, dt.month)
+        return '%04i-%02i-01 00:00:00' % (dt.year, dt.month)
     elif lookup_type == 'week':
         dt = dt - datetime.timedelta(days=dt.weekday())
-        return "%i-%02i-%02i 00:00:00" % (dt.year, dt.month, dt.day)
+        return '%04i-%02i-%02i 00:00:00' % (dt.year, dt.month, dt.day)
     elif lookup_type == 'day':
-        return "%i-%02i-%02i 00:00:00" % (dt.year, dt.month, dt.day)
+        return '%04i-%02i-%02i 00:00:00' % (dt.year, dt.month, dt.day)
     elif lookup_type == 'hour':
-        return "%i-%02i-%02i %02i:00:00" % (dt.year, dt.month, dt.day, dt.hour)
+        return '%04i-%02i-%02i %02i:00:00' % (dt.year, dt.month, dt.day, dt.hour)
     elif lookup_type == 'minute':
-        return "%i-%02i-%02i %02i:%02i:00" % (dt.year, dt.month, dt.day, dt.hour, dt.minute)
+        return '%04i-%02i-%02i %02i:%02i:00' % (dt.year, dt.month, dt.day, dt.hour, dt.minute)
     elif lookup_type == 'second':
-        return "%i-%02i-%02i %02i:%02i:%02i" % (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
+        return '%04i-%02i-%02i %02i:%02i:%02i' % (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
 
 
 def _sqlite_time_extract(lookup_type, dt):

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -653,7 +653,7 @@ class DateFunctionTests(TestCase):
         self.assertEqual(DTModel.objects.filter(start_datetime__second=ExtractSecond('start_datetime')).count(), 2)
 
     def test_trunc_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
+        start_datetime = datetime(999, 6, 15, 14, 30, 50, 321)
         end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
@@ -730,9 +730,7 @@ class DateFunctionTests(TestCase):
         qs = DTModel.objects.filter(start_datetime__date=Trunc('start_datetime', 'day', output_field=DateField()))
         self.assertEqual(qs.count(), 2)
 
-    def test_trunc_week(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+    def _test_trunc_week(self, start_datetime, end_datetime):
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -758,6 +756,18 @@ class DateFunctionTests(TestCase):
                 (end_datetime, truncate_to(end_datetime.date(), 'week')),
             ],
             lambda m: (m.start_datetime, m.truncated),
+        )
+
+    def test_trunc_week(self):
+        self._test_trunc_week(
+            start_datetime=datetime(2015, 6, 15, 14, 30, 50, 321),
+            end_datetime=datetime(2016, 6, 15, 14, 10, 50, 123),
+        )
+
+    def test_trunc_week_before_1000(self):
+        self._test_trunc_week(
+            start_datetime=datetime(999, 6, 15, 14, 30, 50, 321),
+            end_datetime=datetime(2016, 6, 15, 14, 10, 50, 123),
         )
 
     def test_trunc_invalid_arguments(self):


### PR DESCRIPTION
Thanks to Nick Pope for spotting the bug in Code Review of https://github.com/django/django/pull/15173 .