### PR TITLE
Fixed #33358 -- Fixed handling timedelta < 1 day in schema operations on Oracle.

### DIFF
--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -6,6 +6,7 @@ from django.db import DatabaseError
 from django.db.backends.base.schema import (
     BaseDatabaseSchemaEditor, _related_non_m2m_objects,
 )
+from django.utils.duration import duration_iso_string
 
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
@@ -27,6 +28,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     def quote_value(self, value):
         if isinstance(value, (datetime.date, datetime.time, datetime.datetime)):
             return "'%s'" % value
+        elif isinstance(value, datetime.timedelta):
+            return "'%s'" % duration_iso_string(value)
         elif isinstance(value, str):
             return "'%s'" % value.replace("\'", "\'\'").replace('%', '%%')
         elif isinstance(value, (bytes, bytearray, memoryview)):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33358

Adding duration field with default <24h raises an error in oracle, this fixes it.