### PR TITLE
Updated link to Microsoft SQL Server backend.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -1126,4 +1126,4 @@ the support channels provided by each 3rd party project.
 .. _CockroachDB: https://pypi.org/project/django-cockroachdb/
 .. _Firebird: https://pypi.org/project/django-firebird/
 .. _Google Cloud Spanner: https://pypi.org/project/django-google-spanner/
-.. _Microsoft SQL Server: https://pypi.org/project/django-mssql-backend/
+.. _Microsoft SQL Server: https://pypi.org/project/mssql-django/


### PR DESCRIPTION
Since this is a trivial documentation change, I have made the change directly against `main`. I have read the contribution guidelines and deemed a URL change basically as trivial as a typo and have therefore not opened a Trac ticket.

Microsoft took on the role of maintaining an adapter package for MS SQL server compatibility. The package on PyPI can be located at https://pypi.org/project/mssql-django/

Microsoft made a [blog post announcing the version 1.0 general release of the adapter package](https://techcommunity.microsoft.com/t5/sql-server-blog/sql-server-3rd-party-backend-for-django-v1-0-released/ba-p/2654239) on their tech community blog on 17-Aug-2021. As at the time of writing, they have released version 1.1.1

Microsoft's package started out as being a copy of the package currently mentioned in the docs. Warren, a Development Manager, at Microsoft first mentioned the support in [this GitHub issue](https://github.com/ESSolutions/django-mssql-backend/issues/91). This means that this package would supersede any cases where `django-mssql-backend` was used before.