### PR TITLE
Improved wording in password validators docs and docstrings.

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -34,7 +34,7 @@ def get_password_validators(validator_config):
 
 def validate_password(password, user=None, password_validators=None):
     """
-    Validate whether the password meets all validator requirements.
+    Validate that the password meets all validator requirements.
 
     If the password is valid, return ``None``.
     If the password is invalid, raise ValidationError with all error messages.
@@ -90,7 +90,7 @@ password_validators_help_text_html = lazy(_password_validators_help_text_html, s
 
 class MinimumLengthValidator:
     """
-    Validate whether the password is of a minimum length.
+    Validate that the password is of a minimum length.
     """
     def __init__(self, min_length=8):
         self.min_length = min_length
@@ -117,7 +117,7 @@ class MinimumLengthValidator:
 
 class UserAttributeSimilarityValidator:
     """
-    Validate whether the password is sufficiently different from the user's
+    Validate that the password is sufficiently different from the user's
     attributes.
 
     If no specific attributes are provided, look at a sensible list of
@@ -159,7 +159,7 @@ class UserAttributeSimilarityValidator:
 
 class CommonPasswordValidator:
     """
-    Validate whether the password is a common password.
+    Validate that the password is not a common password.
 
     The password is rejected if it occurs in a provided list of passwords,
     which may be gzipped. The list Django ships with contains 20000 common
@@ -195,7 +195,7 @@ class CommonPasswordValidator:
 
 class NumericPasswordValidator:
     """
-    Validate whether the password is alphanumeric.
+    Validate that the password is not entirely numeric.
     """
     def validate(self, password, user=None):
         if password.isdigit():

--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -594,12 +594,12 @@ Django includes four validators:
 
 .. class:: MinimumLengthValidator(min_length=8)
 
-    Validates whether the password meets a minimum length.
+    Validates that the password is of a minimum length.
     The minimum length can be customized with the ``min_length`` parameter.
 
 .. class:: UserAttributeSimilarityValidator(user_attributes=DEFAULT_USER_ATTRIBUTES, max_similarity=0.7)
 
-    Validates whether the password is sufficiently different from certain
+    Validates that the password is sufficiently different from certain
     attributes of the user.
 
     The ``user_attributes`` parameter should be an iterable of names of user
@@ -614,7 +614,7 @@ Django includes four validators:
 
 .. class:: CommonPasswordValidator(password_list_path=DEFAULT_PASSWORD_LIST_PATH)
 
-    Validates whether the password is not a common password. This converts the
+    Validates that the password is not a common password. This converts the
     password to lowercase (to do a case-insensitive comparison) and checks it
     against a list of 20,000 common password created by `Royce Williams
     <https://gist.github.com/roycewilliams/281ce539915a947a23db17137d91aeb7>`_.
@@ -625,7 +625,7 @@ Django includes four validators:
 
 .. class:: NumericPasswordValidator()
 
-    Validates whether the password is not entirely numeric.
+    Validate that the password is not entirely numeric.
 
 Integrating validation
 ----------------------


### PR DESCRIPTION
* Replace “whether” with “that” - “whether“ is somewhat ambiguous as to what counts as valid/invalid.
* Improve descriptions of `MinimumLengthValidator` and `NumericPasswordValidator`.