### PR TITLE
Corrected file reference

### DIFF
--- a/django/contrib/admin/templates/admin/base_site.html
+++ b/django/contrib/admin/templates/admin/base_site.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/base_site.html" %}
 
 {% block title %}{% if subtitle %}{{ subtitle }} | {% endif %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
 


### PR DESCRIPTION
Following the tutorials on https://docs.djangoproject.com/en/4.0/intro/tutorial07/ I realized, that when I copy the template from django\contrib\admin\templates\admin to customize (e.g. the "Django administration" placeholder), this template points to "admin/base.html" instead of "admin/base_site.html".