### PR TITLE
Update package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ description = A high-level Python web framework that encourages rapid developmen
 long_description = file: README.rst
 license = BSD-3-Clause
 classifiers =
-    Development Status :: 2 - Pre-Alpha
+    Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
     Intended Audience :: Developers


### PR DESCRIPTION
I know it's common to shy away from "production ready" tags these days, but I think Django _might_ be ready to drop its `pre-alpha` status 😌

From what I can tell this was set several years back and just hasn't been touched.