### PR TITLE
Improved Model.__init__() properties loop.

### DIFF
--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -78,12 +78,22 @@ class ModelInstanceCreationTests(TestCase):
             Article(None, 'Seventh article', datetime(2021, 3, 1), pub_date=None)
 
     def test_cannot_create_instance_with_invalid_kwargs(self):
-        with self.assertRaisesMessage(TypeError, "Article() got an unexpected keyword argument 'foo'"):
+        msg = "Article() got unexpected keyword arguments: 'foo'"
+        with self.assertRaisesMessage(TypeError, msg):
             Article(
                 id=None,
                 headline='Some headline',
                 pub_date=datetime(2005, 7, 31),
                 foo='bar',
+            )
+        msg = "Article() got unexpected keyword arguments: 'foo', 'bar'"
+        with self.assertRaisesMessage(TypeError, msg):
+            Article(
+                id=None,
+                headline='Some headline',
+                pub_date=datetime(2005, 7, 31),
+                foo='bar',
+                bar='baz',
             )
 
     def test_can_leave_off_value_for_autofield_and_it_gets_value_on_save(self):

--- a/tests/properties/tests.py
+++ b/tests/properties/tests.py
@@ -18,7 +18,7 @@ class PropertyTests(TestCase):
             setattr(self.a, 'full_name', 'Paul McCartney')
 
         # And cannot be used to initialize the class.
-        with self.assertRaisesMessage(TypeError, "Person() got an unexpected keyword argument 'full_name'"):
+        with self.assertRaises(AttributeError):
             Person(full_name='Paul McCartney')
 
         # But "full_name_2" has, and it can be used to initialize the class.


### PR DESCRIPTION
* Loop with `.items()` rather than copy the keys into a tuple. This avoids refetching the values (twice).
* Accumulate unrecognized arguments raise an exception with all of them.