### PR TITLE
Simplified management command option extraction.

### DIFF
--- a/django/contrib/auth/management/commands/changepassword.py
+++ b/django/contrib/auth/management/commands/changepassword.py
@@ -31,14 +31,12 @@ class Command(BaseCommand):
             help='Specifies the database to use. Default is "default".',
         )
 
-    def handle(self, *args, **options):
-        if options['username']:
-            username = options['username']
-        else:
+    def handle(self, *args, username, database, **options):
+        if not username:
             username = getpass.getuser()
 
         try:
-            u = UserModel._default_manager.using(options['database']).get(**{
+            u = UserModel._default_manager.using(database).get(**{
                 UserModel.USERNAME_FIELD: username
             })
         except UserModel.DoesNotExist:

--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -78,9 +78,8 @@ class Command(BaseCommand):
         self.stdin = options.get('stdin', sys.stdin)  # Used for testing
         return super().execute(*args, **options)
 
-    def handle(self, *args, **options):
+    def handle(self, *args, database, interactive, verbosity, **options):
         username = options[self.UserModel.USERNAME_FIELD]
-        database = options['database']
         user_data = {}
         verbose_field_name = self.username_field.verbose_name
         try:
@@ -91,7 +90,7 @@ class Command(BaseCommand):
             # If not provided, create the user with an unusable password.
             user_data[PASSWORD_FIELD] = None
         try:
-            if options['interactive']:
+            if interactive:
                 # Same as user_data but without many to many fields and with
                 # foreign keys as fake model instances instead of raw IDs.
                 fake_user_data = {}
@@ -193,7 +192,7 @@ class Command(BaseCommand):
                         ]
 
             self.UserModel._default_manager.db_manager(database).create_superuser(**user_data)
-            if options['verbosity'] >= 1:
+            if verbosity >= 1:
                 self.stdout.write("Superuser created successfully.")
         except KeyboardInterrupt:
             self.stderr.write('\nOperation cancelled.')

--- a/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
+++ b/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
@@ -26,18 +26,13 @@ class Command(BaseCommand):
             ),
         )
 
-    def handle(self, **options):
-        db = options['database']
-        include_stale_apps = options['include_stale_apps']
-        interactive = options['interactive']
-        verbosity = options['verbosity']
-
-        if not router.allow_migrate_model(db, ContentType):
+    def handle(self, *, database, include_stale_apps, interactive, verbosity, **options):
+        if not router.allow_migrate_model(database, ContentType):
             return
         ContentType.objects.clear_cache()
 
         apps_content_types = itertools.groupby(
-            ContentType.objects.using(db).order_by('app_label', 'model'),
+            ContentType.objects.using(database).order_by('app_label', 'model'),
             lambda obj: obj.app_label,
         )
         for app_label, content_types in apps_content_types:

--- a/django/contrib/gis/management/commands/ogrinspect.py
+++ b/django/contrib/gis/management/commands/ogrinspect.py
@@ -95,9 +95,7 @@ class Command(BaseCommand):
             help='Generate mapping dictionary for use with `LayerMapping`.',
         )
 
-    def handle(self, *args, **options):
-        data_source, model_name = options.pop('data_source'), options.pop('model_name')
-
+    def handle(self, *args, data_source, model_name, **options):
         # Getting the OGR DataSource from the string parameter.
         try:
             ds = gdal.DataSource(data_source)

--- a/django/contrib/sitemaps/management/commands/ping_google.py
+++ b/django/contrib/sitemaps/management/commands/ping_google.py
@@ -9,8 +9,8 @@ class Command(BaseCommand):
         parser.add_argument('sitemap_url', nargs='?')
         parser.add_argument('--sitemap-uses-http', action='store_true')
 
-    def handle(self, *args, **options):
+    def handle(self, *args, sitemap_url, sitemap_uses_http, **options):
         ping_google(
-            sitemap_url=options['sitemap_url'],
-            sitemap_uses_https=not options['sitemap_uses_http'],
+            sitemap_url=sitemap_url,
+            sitemap_uses_https=not sitemap_uses_http,
         )

--- a/django/contrib/staticfiles/management/commands/collectstatic.py
+++ b/django/contrib/staticfiles/management/commands/collectstatic.py
@@ -68,20 +68,22 @@ class Command(BaseCommand):
             help="Don't ignore the common private glob-style patterns (defaults to 'CVS', '.*' and '*~').",
         )
 
-    def set_options(self, **options):
+    def set_options(
+        self, *, interactive, post_process, ignore_patterns, dry_run, clear,
+        link, use_default_ignore_patterns, verbosity, **options
+    ):
         """
         Set instance variables based on an options dict
         """
-        self.interactive = options['interactive']
-        self.verbosity = options['verbosity']
-        self.symlink = options['link']
-        self.clear = options['clear']
-        self.dry_run = options['dry_run']
-        ignore_patterns = options['ignore_patterns']
-        if options['use_default_ignore_patterns']:
+        self.interactive = interactive
+        self.verbosity = verbosity
+        self.symlink = link
+        self.clear = clear
+        self.dry_run = dry_run
+        if use_default_ignore_patterns:
             ignore_patterns += apps.get_app_config('staticfiles').ignore_patterns
         self.ignore_patterns = list({os.path.normpath(p) for p in ignore_patterns})
-        self.post_process = options['post_process']
+        self.post_process = post_process
 
     def collect(self):
         """

--- a/django/contrib/staticfiles/management/commands/findstatic.py
+++ b/django/contrib/staticfiles/management/commands/findstatic.py
@@ -15,9 +15,8 @@ class Command(LabelCommand):
             help="Only return the first match for each static file.",
         )
 
-    def handle_label(self, path, **options):
-        verbosity = options['verbosity']
-        result = finders.find(path, all=options['all'])
+    def handle_label(self, path, *, all, verbosity, **options):
+        result = finders.find(path, all=all)
         if verbosity >= 2:
             searched_locations = (
                 "\nLooking in the following locations:\n  %s" %

--- a/django/contrib/staticfiles/management/commands/runserver.py
+++ b/django/contrib/staticfiles/management/commands/runserver.py
@@ -19,14 +19,12 @@ class Command(RunserverCommand):
             help='Allows serving static files even if DEBUG is False.',
         )
 
-    def get_handler(self, *args, **options):
+    def get_handler(self, *args, use_static_handler, insecure_serving, **options):
         """
         Return the static files serving handler wrapping the default handler,
         if static files should be served. Otherwise return the default handler.
         """
         handler = super().get_handler(*args, **options)
-        use_static_handler = options['use_static_handler']
-        insecure_serving = options['insecure_serving']
         if use_static_handler and (settings.DEBUG or insecure_serving):
             return StaticFilesHandler(handler)
         return handler

--- a/django/core/management/commands/check.py
+++ b/django/core/management/commands/check.py
@@ -37,9 +37,9 @@ class Command(BaseCommand):
             help='Run database related checks against these aliases.',
         )
 
-    def handle(self, *app_labels, **options):
-        include_deployment_checks = options['deploy']
-        if options['list_tags']:
+    def handle(self, *app_labels, deploy, list_tags, tags, fail_level, databases, **options):
+        include_deployment_checks = deploy
+        if list_tags:
             self.stdout.write('\n'.join(sorted(registry.tags_available(include_deployment_checks))))
             return
 
@@ -48,7 +48,6 @@ class Command(BaseCommand):
         else:
             app_configs = None
 
-        tags = options['tags']
         if tags:
             try:
                 invalid_tag = next(
@@ -65,6 +64,6 @@ class Command(BaseCommand):
             tags=tags,
             display_num_errors=True,
             include_deployment_checks=include_deployment_checks,
-            fail_level=getattr(checks, options['fail_level']),
-            databases=options['databases'],
+            fail_level=getattr(checks, fail_level),
+            databases=databases,
         )

--- a/django/core/management/commands/compilemessages.py
+++ b/django/core/management/commands/compilemessages.py
@@ -56,12 +56,10 @@ class Command(BaseCommand):
                  'Use multiple times to ignore more.',
         )
 
-    def handle(self, **options):
-        locale = options['locale']
-        exclude = options['exclude']
-        ignore_patterns = set(options['ignore_patterns'])
-        self.verbosity = options['verbosity']
-        if options['fuzzy']:
+    def handle(self, *, locale, exclude, fuzzy, ignore_patterns, verbosity, **options):
+        ignore_patterns = set(ignore_patterns)
+        self.verbosity = verbosity
+        if fuzzy:
             self.program_options = self.program_options + ['-f']
 
         if find_command(self.program) is None:

--- a/django/core/management/commands/createcachetable.py
+++ b/django/core/management/commands/createcachetable.py
@@ -28,19 +28,17 @@ class Command(BaseCommand):
             help='Does not create the table, just prints the SQL that would be run.',
         )
 
-    def handle(self, *tablenames, **options):
-        db = options['database']
-        self.verbosity = options['verbosity']
-        dry_run = options['dry_run']
+    def handle(self, *tablenames, database, dry_run, verbosity, **options):
+        self.verbosity = verbosity
         if tablenames:
             # Legacy behavior, tablename specified as argument
             for tablename in tablenames:
-                self.create_table(db, tablename, dry_run)
+                self.create_table(database, tablename, dry_run)
         else:
             for cache_alias in settings.CACHES:
                 cache = caches[cache_alias]
                 if isinstance(cache, BaseDatabaseCache):
-                    self.create_table(db, cache._table, dry_run)
+                    self.create_table(database, cache._table, dry_run)
 
     def create_table(self, database, tablename, dry_run):
         cache = BaseDatabaseCache(tablename, {})

--- a/django/core/management/commands/dbshell.py
+++ b/django/core/management/commands/dbshell.py
@@ -20,10 +20,10 @@ class Command(BaseCommand):
         parameters = parser.add_argument_group('parameters', prefix_chars='--')
         parameters.add_argument('parameters', nargs='*')
 
-    def handle(self, **options):
-        connection = connections[options['database']]
+    def handle(self, *, database, parameters, **options):
+        connection = connections[database]
         try:
-            connection.client.runshell(options['parameters'])
+            connection.client.runshell(parameters)
         except FileNotFoundError:
             # Note that we're assuming the FileNotFoundError relates to the
             # command missing. It could be raised for some other reason, in

--- a/django/core/management/commands/flush.py
+++ b/django/core/management/commands/flush.py
@@ -12,6 +12,8 @@ class Command(BaseCommand):
         'Removes ALL DATA from the database, including data added during '
         'migrations. Does not achieve a "fresh install" state.'
     )
+
+    # Used by Django’s internals:
     stealth_options = ('reset_sequences', 'allow_cascade', 'inhibit_post_migrate')
 
     def add_arguments(self, parser):
@@ -24,15 +26,11 @@ class Command(BaseCommand):
             help='Nominates a database to flush. Defaults to the "default" database.',
         )
 
-    def handle(self, **options):
-        database = options['database']
+    def handle(
+        self, *, interactive, database, verbosity, reset_sequences=True,
+        allow_cascade=False, inhibit_post_migrate=False, **options
+    ):
         connection = connections[database]
-        verbosity = options['verbosity']
-        interactive = options['interactive']
-        # The following are stealth options used by Django's internals.
-        reset_sequences = options.get('reset_sequences', True)
-        allow_cascade = options.get('allow_cascade', False)
-        inhibit_post_migrate = options.get('inhibit_post_migrate', False)
 
         self.style = no_style()
 

--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -66,13 +66,16 @@ class Command(BaseCommand):
             help='Format of serialized data when reading from stdin.',
         )
 
-    def handle(self, *fixture_labels, **options):
-        self.ignore = options['ignore']
-        self.using = options['database']
-        self.app_label = options['app_label']
-        self.verbosity = options['verbosity']
-        self.excluded_models, self.excluded_apps = parse_apps_and_model_labels(options['exclude'])
-        self.format = options['format']
+    def handle(
+        self, *fixture_labels, database, app_label, ignore, exclude, format,
+        verbosity, **options
+    ):
+        self.ignore = ignore
+        self.using = database
+        self.app_label = app_label
+        self.verbosity = verbosity
+        self.excluded_models, self.excluded_apps = parse_apps_and_model_labels(exclude)
+        self.format = format
 
         with transaction.atomic(using=self.using):
             self.loaddata(fixture_labels)

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -281,45 +281,45 @@ class Command(BaseCommand):
             help="Keep .pot file after making messages. Useful when debugging.",
         )
 
-    def handle(self, *args, **options):
-        locale = options['locale']
-        exclude = options['exclude']
-        self.domain = options['domain']
-        self.verbosity = options['verbosity']
-        process_all = options['all']
-        extensions = options['extensions']
-        self.symlinks = options['symlinks']
+    def handle(
+        self, *args, locale, exclude, domain, all, extensions, symlinks,
+        ignore_patterns, use_default_ignore_patterns, no_wrap, no_location,
+        add_location, no_obsolete, keep_pot, verbosity, **options
+    ):
+        self.domain = domain
+        self.verbosity = verbosity
+        process_all = all
+        self.symlinks = symlinks
 
-        ignore_patterns = options['ignore_patterns']
-        if options['use_default_ignore_patterns']:
+        if use_default_ignore_patterns:
             ignore_patterns += ['CVS', '.*', '*~', '*.pyc']
         self.ignore_patterns = list(set(ignore_patterns))
 
         # Avoid messing with mutable class variables
-        if options['no_wrap']:
+        if no_wrap:
             self.msgmerge_options = self.msgmerge_options[:] + ['--no-wrap']
             self.msguniq_options = self.msguniq_options[:] + ['--no-wrap']
             self.msgattrib_options = self.msgattrib_options[:] + ['--no-wrap']
             self.xgettext_options = self.xgettext_options[:] + ['--no-wrap']
-        if options['no_location']:
+        if no_location:
             self.msgmerge_options = self.msgmerge_options[:] + ['--no-location']
             self.msguniq_options = self.msguniq_options[:] + ['--no-location']
             self.msgattrib_options = self.msgattrib_options[:] + ['--no-location']
             self.xgettext_options = self.xgettext_options[:] + ['--no-location']
-        if options['add_location']:
+        if add_location:
             if self.gettext_version < (0, 19):
                 raise CommandError(
                     "The --add-location option requires gettext 0.19 or later. "
                     "You have %s." % '.'.join(str(x) for x in self.gettext_version)
                 )
-            arg_add_location = "--add-location=%s" % options['add_location']
+            arg_add_location = "--add-location=%s" % add_location
             self.msgmerge_options = self.msgmerge_options[:] + [arg_add_location]
             self.msguniq_options = self.msguniq_options[:] + [arg_add_location]
             self.msgattrib_options = self.msgattrib_options[:] + [arg_add_location]
             self.xgettext_options = self.xgettext_options[:] + [arg_add_location]
 
-        self.no_obsolete = options['no_obsolete']
-        self.keep_pot = options['keep_pot']
+        self.no_obsolete = no_obsolete
+        self.keep_pot = keep_pot
 
         if self.domain not in ('django', 'djangojs'):
             raise CommandError("currently makemessages only supports domains "

--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -62,17 +62,19 @@ class Command(BaseCommand):
         self.stdout.write(msg)
 
     @no_translations
-    def handle(self, *app_labels, **options):
-        self.verbosity = options['verbosity']
-        self.interactive = options['interactive']
-        self.dry_run = options['dry_run']
-        self.merge = options['merge']
-        self.empty = options['empty']
-        self.migration_name = options['name']
+    def handle(
+        self, *app_labels, dry_run, merge, empty, interactive, name,
+        include_header, check_changes, verbosity, **options
+    ):
+        self.verbosity = verbosity
+        self.interactive = interactive
+        self.dry_run = dry_run
+        self.merge = merge
+        self.empty = empty
+        self.migration_name = name
         if self.migration_name and not self.migration_name.isidentifier():
             raise CommandError('The migration name must be a valid Python identifier.')
-        self.include_header = options['include_header']
-        check_changes = options['check_changes']
+        self.include_header = include_header
 
         # Make sure the app they asked for exists
         app_labels = set(app_labels)

--- a/django/core/management/commands/sendtestemail.py
+++ b/django/core/management/commands/sendtestemail.py
@@ -23,18 +23,18 @@ class Command(BaseCommand):
             help='Send a test email to the addresses specified in settings.ADMINS.',
         )
 
-    def handle(self, *args, **kwargs):
+    def handle(self, *args, email, managers, admins, **kwargs):
         subject = 'Test email from %s on %s' % (socket.gethostname(), timezone.now())
 
         send_mail(
             subject=subject,
             message="If you\'re reading this, it was successful.",
             from_email=None,
-            recipient_list=kwargs['email'],
+            recipient_list=email,
         )
 
-        if kwargs['managers']:
+        if managers:
             mail_managers(subject, "This email was sent to the site managers.")
 
-        if kwargs['admins']:
+        if admins:
             mail_admins(subject, "This email was sent to the site admins.")

--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -93,10 +93,10 @@ class Command(BaseCommand):
         # Start the interactive interpreter.
         code.interact(local=imported_objects)
 
-    def handle(self, **options):
+    def handle(self, *, interface, command, **options):
         # Execute the command and exit.
-        if options['command']:
-            exec(options['command'], globals())
+        if command:
+            exec(command, globals())
             return
 
         # Execute stdin if it has anything to read and exit.
@@ -105,7 +105,7 @@ class Command(BaseCommand):
             exec(sys.stdin.read(), globals())
             return
 
-        available_shells = [options['interface']] if options['interface'] else self.shells
+        available_shells = [interface] if interface else self.shells
 
         for shell in available_shells:
             try:

--- a/django/core/management/commands/showmigrations.py
+++ b/django/core/management/commands/showmigrations.py
@@ -43,17 +43,16 @@ class Command(BaseCommand):
 
         parser.set_defaults(format='list')
 
-    def handle(self, *args, **options):
-        self.verbosity = options['verbosity']
+    def handle(self, *args, app_label, database, format, verbosity, **options):
+        self.verbosity = verbosity
 
         # Get the database we're operating from
-        db = options['database']
-        connection = connections[db]
+        connection = connections[database]
 
-        if options['format'] == "plan":
-            return self.show_plan(connection, options['app_label'])
+        if format == "plan":
+            return self.show_plan(connection, app_label)
         else:
-            return self.show_list(connection, options['app_label'])
+            return self.show_list(connection, app_label)
 
     def _validate_app_names(self, loader, app_names):
         has_bad_names = False

--- a/django/core/management/commands/sqlflush.py
+++ b/django/core/management/commands/sqlflush.py
@@ -18,8 +18,8 @@ class Command(BaseCommand):
             help='Nominates a database to print the SQL for. Defaults to the "default" database.',
         )
 
-    def handle(self, **options):
-        sql_statements = sql_flush(self.style, connections[options['database']])
-        if not sql_statements and options['verbosity'] >= 1:
+    def handle(self, *, database, verbosity, **options):
+        sql_statements = sql_flush(self.style, connections[database])
+        if not sql_statements and verbosity >= 1:
             self.stderr.write('No tables found.')
         return '\n'.join(sql_statements)

--- a/django/core/management/commands/sqlmigrate.py
+++ b/django/core/management/commands/sqlmigrate.py
@@ -28,16 +28,18 @@ class Command(BaseCommand):
         options['no_color'] = True
         return super().execute(*args, **options)
 
-    def handle(self, *args, **options):
+    def handle(
+        self, *args, app_label, migration_name, database, backwards, verbosity,
+        **options
+    ):
         # Get the database we're operating from
-        connection = connections[options['database']]
+        connection = connections[database]
 
         # Load up a loader to get all the migration data, but don't replace
         # migrations.
         loader = MigrationLoader(connection, replace_migrations=False)
 
         # Resolve command-line arguments into a migration
-        app_label, migration_name = options['app_label'], options['migration_name']
         # Validate app_label
         try:
             apps.get_app_config(app_label)
@@ -61,8 +63,8 @@ class Command(BaseCommand):
 
         # Make a plan that represents just the requested migrations and show SQL
         # for it
-        plan = [(loader.graph.nodes[target], options['backwards'])]
+        plan = [(loader.graph.nodes[target], backwards)]
         sql_statements = loader.collect_sql(plan)
-        if not sql_statements and options['verbosity'] >= 1:
+        if not sql_statements and verbosity >= 1:
             self.stderr.write('No operations found.')
         return '\n'.join(sql_statements)

--- a/django/core/management/commands/sqlsequencereset.py
+++ b/django/core/management/commands/sqlsequencereset.py
@@ -14,12 +14,12 @@ class Command(AppCommand):
             help='Nominates a database to print the SQL for. Defaults to the "default" database.',
         )
 
-    def handle_app_config(self, app_config, **options):
+    def handle_app_config(self, app_config, database, verbosity, **options):
         if app_config.models_module is None:
             return
-        connection = connections[options['database']]
+        connection = connections[database]
         models = app_config.get_models(include_auto_created=True)
         statements = connection.ops.sequence_reset_sql(self.style, models)
-        if not statements and options['verbosity'] >= 1:
+        if not statements and verbosity >= 1:
             self.stderr.write('No sequences found.')
         return '\n'.join(statements)

--- a/django/core/management/commands/squashmigrations.py
+++ b/django/core/management/commands/squashmigrations.py
@@ -44,16 +44,13 @@ class Command(BaseCommand):
             help='Do not add a header comment to the new squashed migration.',
         )
 
-    def handle(self, **options):
+    def handle(
+        self, *, app_label, start_migration_name, migration_name, no_optimize,
+        interactive, squashed_name, include_header, verbosity, **options
+    ):
+        self.verbosity = verbosity
+        self.interactive = interactive
 
-        self.verbosity = options['verbosity']
-        self.interactive = options['interactive']
-        app_label = options['app_label']
-        start_migration_name = options['start_migration_name']
-        migration_name = options['migration_name']
-        no_optimize = options['no_optimize']
-        squashed_name = options['squashed_name']
-        include_header = options['include_header']
         # Validate app_label.
         try:
             apps.get_app_config(app_label)

--- a/django/core/management/commands/testserver.py
+++ b/django/core/management/commands/testserver.py
@@ -26,10 +26,10 @@ class Command(BaseCommand):
             help='Tells Django to use an IPv6 address.',
         )
 
-    def handle(self, *fixture_labels, **options):
-        verbosity = options['verbosity']
-        interactive = options['interactive']
-
+    def handle(
+        self, *fixture_labels, interactive, addrport, use_ipv6, verbosity,
+        **options
+    ):
         # Create a test database.
         db_name = connection.creation.create_test_db(verbosity=verbosity, autoclobber=not interactive, serialize=False)
 
@@ -46,9 +46,9 @@ class Command(BaseCommand):
         use_threading = connection.features.test_db_allows_multiple_connections
         call_command(
             'runserver',
-            addrport=options['addrport'],
+            addrport=addrport,
             shutdown_message=shutdown_message,
             use_reloader=False,
-            use_ipv6=options['use_ipv6'],
+            use_ipv6=use_ipv6,
             use_threading=use_threading
         )

--- a/tests/user_commands/management/commands/dance.py
+++ b/tests/user_commands/management/commands/dance.py
@@ -12,12 +12,11 @@ class Command(BaseCommand):
         parser.add_argument("-x", "--example")
         parser.add_argument("--opt-3", action='store_true', dest='option3')
 
-    def handle(self, *args, **options):
-        example = options["example"]
+    def handle(self, *args, integer, style, example, verbosity, **options):
         if example == "raise":
             raise CommandError(returncode=3)
-        if options['verbosity'] > 0:
-            self.stdout.write("I don't feel like dancing %s." % options["style"])
+        if verbosity > 0:
+            self.stdout.write("I don't feel like dancing %s." % style)
             self.stdout.write(','.join(options))
-        if options['integer'] > 0:
-            self.stdout.write("You passed %d as a positional argument." % options['integer'])
+        if integer > 0:
+            self.stdout.write("You passed %d as a positional argument." % integer)

--- a/tests/user_commands/management/commands/hal.py
+++ b/tests/user_commands/management/commands/hal.py
@@ -8,10 +8,10 @@ class Command(BaseCommand):
         parser.add_argument('args', metavar='app_label', nargs='*', help='Specify the app label(s) to works on.')
         parser.add_argument('--empty', action='store_true', help="Do nothing.")
 
-    def handle(self, *app_labels, **options):
+    def handle(self, *app_labels, empty, **options):
         app_labels = set(app_labels)
 
-        if options['empty']:
+        if empty:
             self.stdout.write()
             self.stdout.write("Dave, I can't do that.")
             return


### PR DESCRIPTION
Similar to #15185 , use improvements to Python function signatures where possible. Much of the `x = options['x']` pattern has been around since Python 2.