### PR TITLE
Fixed unescape_string_literal() crash on empty strings.

### DIFF
--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -375,7 +375,7 @@ def unescape_string_literal(s):
         >>> unescape_string_literal("'\'ab\' c'")
         "'ab' c"
     """
-    if s[0] not in "\"'" or s[-1] != s[0]:
+    if not s or s[0] not in "\"'" or s[-1] != s[0]:
         raise ValueError("Not a string literal: %r" % s)
     quote = s[0]
     return s[1:-1].replace(r'\%s' % quote, quote).replace(r'\\', '\\')

--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -226,7 +226,7 @@ class TestUtilsText(SimpleTestCase):
                 self.assertEqual(text.unescape_string_literal(lazystr(value)), output)
 
     def test_unescape_string_literal_invalid_value(self):
-        items = ['abc', "'abc\""]
+        items = ['', 'abc', "'abc\""]
         for item in items:
             msg = f'Not a string literal: {item!r}'
             with self.assertRaisesMessage(ValueError, msg):

--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -225,6 +225,13 @@ class TestUtilsText(SimpleTestCase):
                 self.assertEqual(text.unescape_string_literal(value), output)
                 self.assertEqual(text.unescape_string_literal(lazystr(value)), output)
 
+    def test_unescape_string_literal_invalid_value(self):
+        items = ['abc', "'abc\""]
+        for item in items:
+            msg = f'Not a string literal: {item!r}'
+            with self.assertRaisesMessage(ValueError, msg):
+                text.unescape_string_literal(item)
+
     def test_get_valid_filename(self):
         filename = "^&'@{}[],$=!-#()%+~_123.txt"
         self.assertEqual(text.get_valid_filename(filename), "-_123.txt")


### PR DESCRIPTION
Found while fuzzing Django :)