### PR TITLE
Refs #33365, Refs #30530 -- Doc'd re_path() behavior change in Django 2.2.25, 3.1.14, and 3.2.10.

### DIFF
--- a/docs/ref/urls.txt
+++ b/docs/ref/urls.txt
@@ -72,8 +72,17 @@ groups from the regular expression are passed to the view -- as named arguments
 if the groups are named, and as positional arguments otherwise. The values are
 passed as strings, without any type conversion.
 
+When a ``route`` ends with ``$`` the whole requested URL, matching against
+:attr:`~django.http.HttpRequest.path_info`, must match the regular expression
+pattern (:py:func:`re.fullmatch` is used).
+
 The ``view``, ``kwargs`` and ``name`` arguments are the same as for
 :func:`~django.urls.path()`.
+
+.. versionchanged:: 2.2.25
+
+    In older versions, a full-match wasn't required for a ``route`` which ends
+    with ``$``.
 
 ``include()``
 =============


### PR DESCRIPTION
Follow up to d4dcd5b9dd9e462fec8220e33e3e6c822b7e88a6.

@paketep Does is work for you?