### PR TITLE
Fixed #33367 -- Fixed URLValidator crash in some edge cases.

### DIFF
--- a/tests/forms_tests/field_tests/test_urlfield.py
+++ b/tests/forms_tests/field_tests/test_urlfield.py
@@ -100,6 +100,10 @@ class URLFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
             # even on domains that don't fail the domain label length check in
             # the regex.
             'http://%s' % ("X" * 200,),
+            # urlsplit() raises ValueError.
+            '////]@N.AN',
+            # Empty hostname.
+            '#@A.bO',
         ]
         msg = "'Enter a valid URL.'"
         for value in tests:


### PR DESCRIPTION
`forms.URLField().clean()` was raising `ValueError` instead of `ValidationError` when the passed string was an invalid IPv6 URL. 

This behavior was happening because the method `urlsplit` from `urllib.parse` could raise a `ValueError`.

Ticket URL: https://code.djangoproject.com/ticket/33367