### PR TITLE
Refs #20349 -- Avoided loading testing libraries when not needed.

### DIFF
--- a/django/contrib/messages/apps.py
+++ b/django/contrib/messages/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 from django.contrib.messages.storage import base
 from django.contrib.messages.utils import get_level_tags
-from django.test.signals import setting_changed
+from django.core.signals import setting_changed
 from django.utils.translation import gettext_lazy as _
 
 

--- a/django/contrib/postgres/apps.py
+++ b/django/contrib/postgres/apps.py
@@ -3,13 +3,13 @@ from psycopg2.extras import (
 )
 
 from django.apps import AppConfig
+from django.core.signals import setting_changed
 from django.db import connections
 from django.db.backends.signals import connection_created
 from django.db.migrations.writer import MigrationWriter
 from django.db.models import CharField, OrderBy, TextField
 from django.db.models.functions import Collate
 from django.db.models.indexes import IndexExpression
-from django.test.signals import setting_changed
 from django.utils.translation import gettext_lazy as _
 
 from .indexes import OpClass

--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from io import StringIO
-from unittest import expectedFailure, skip
 
 from django.apps import apps
 from django.conf import settings
@@ -303,6 +302,8 @@ class BaseDatabaseCreation:
         Mark tests in Django's test suite which are expected failures on this
         database and test which should be skipped on this database.
         """
+        # Only load unittest if we're actually testing.
+        from unittest import expectedFailure, skip
         for test_name in self.connection.features.django_test_expected_failures:
             test_case_name, _, test_method_name = test_name.rpartition('.')
             test_app = test_name.split('.')[0]

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -31,13 +31,14 @@ from django.core.management import call_command
 from django.core.management.color import no_style
 from django.core.management.sql import emit_post_migrate_signal
 from django.core.servers.basehttp import ThreadedWSGIServer, WSGIRequestHandler
+from django.core.signals import setting_changed
 from django.db import DEFAULT_DB_ALIAS, connection, connections, transaction
 from django.forms.fields import CharField
 from django.http import QueryDict
 from django.http.request import split_domain_port, validate_host
 from django.test.client import AsyncClient, Client
 from django.test.html import HTMLParseError, parse_html
-from django.test.signals import setting_changed, template_rendered
+from django.test.signals import template_rendered
 from django.test.utils import (
     CaptureQueriesContext, ContextList, compare_xml, modify_settings,
     override_settings,

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -19,11 +19,11 @@ from django.apps.registry import Apps
 from django.conf import UserSettingsHolder, settings
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
-from django.core.signals import request_started
+from django.core.signals import request_started, setting_changed
 from django.db import DEFAULT_DB_ALIAS, connections, reset_queries
 from django.db.models.options import Options
 from django.template import Template
-from django.test.signals import setting_changed, template_rendered
+from django.test.signals import template_rendered
 from django.urls import get_script_prefix, set_script_prefix
 from django.utils.deprecation import RemovedInDjango50Warning
 from django.utils.translation import deactivate


### PR DESCRIPTION
This avoids loading django.test, unittest, and xml libraries when not needed.

See https://code.djangoproject.com/ticket/20349

This should give slightly faster startup time and slightly lower memory usage.