### PR TITLE
Fixed #33368 -- Fixed parse_duration() crash on invalid separators for decimal fractions.

### DIFF
--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -42,11 +42,11 @@ standard_duration_re = _lazy_re_compile(
 iso8601_duration_re = _lazy_re_compile(
     r'^(?P<sign>[-+]?)'
     r'P'
-    r'(?:(?P<days>\d+(.\d+)?)D)?'
+    r'(?:(?P<days>\d+([\.,]\d+)?)D)?'
     r'(?:T'
-    r'(?:(?P<hours>\d+(.\d+)?)H)?'
-    r'(?:(?P<minutes>\d+(.\d+)?)M)?'
-    r'(?:(?P<seconds>\d+(.\d+)?)S)?'
+    r'(?:(?P<hours>\d+([\.,]\d+)?)H)?'
+    r'(?:(?P<minutes>\d+([\.,]\d+)?)M)?'
+    r'(?:(?P<seconds>\d+([\.,]\d+)?)S)?'
     r')?'
     r'$'
 )

--- a/tests/forms_tests/field_tests/test_durationfield.py
+++ b/tests/forms_tests/field_tests/test_durationfield.py
@@ -30,6 +30,8 @@ class DurationFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         msg = 'Enter a valid duration.'
         with self.assertRaisesMessage(ValidationError, msg):
             f.clean('not_a_time')
+        with self.assertRaisesMessage(ValidationError, msg):
+            DurationField().clean('P3(3D')
 
     def test_durationfield_clean_not_required(self):
         f = DurationField(required=False)

--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -161,6 +161,11 @@ class DurationParseTests(unittest.TestCase):
             ('-PT0.000005S', timedelta(microseconds=-5)),
             ('-PT0,000005S', timedelta(microseconds=-5)),
             ('-P4DT1H', timedelta(days=-4, hours=-1)),
+            # Invalid separators for decimal fractions.
+            ('P3(3D', None),
+            ('PT3)3H', None),
+            ('PT3|3M', None),
+            ('PT3/3S', None),
         )
         for source, expected in test_values:
             with self.subTest(source=source):


### PR DESCRIPTION
`forms.DurationField().clean()` was raising `ValueError` instead of `ValidationError` when the passed string was invalid.

This behavior was happening because the method `parse_duration` from `django.utils.dateparse` could raise a `ValueError`.

Ticket URL: https://code.djangoproject.com/ticket/33368