### PR TITLE
Update widgets to support gis_widget_kwargs in admin

### DIFF
--- a/django/contrib/gis/forms/widgets.py
+++ b/django/contrib/gis/forms/widgets.py
@@ -110,9 +110,9 @@ class OSMWidget(OpenLayersWidget):
     default_lat = 47
     default_zoom = 12
 
-    def __init__(self, attrs=None):
+        def __init__(self, **kwargs):
         super().__init__()
         for key in ('default_lon', 'default_lat', 'default_zoom'):
             self.attrs[key] = getattr(self, key)
-        if attrs:
-            self.attrs.update(attrs)
+        if kwargs:
+            self.attrs.update(kwargs)


### PR DESCRIPTION
As per documentation you can define gis_widget_kwargs in GISModelAdmin as
"The keyword arguments that would be passed to the gis_widget. Defaults to an empty dictionary."
https://docs.djangoproject.com/en/4.0/ref/contrib/gis/admin/#django.contrib.gis.admin.GISModelAdmin

But it takes attrs as dict.
Fixed it to take kwargs as new attrs