### PR TITLE
Fixed #33372 - GISModelAdmin.gis_widget_kwargs cannot be used due to signature mismatch

### DIFF
--- a/django/contrib/gis/admin/options.py
+++ b/django/contrib/gis/admin/options.py
@@ -18,7 +18,7 @@ class GeoModelAdminMixin:
             isinstance(db_field, models.GeometryField) and
             (db_field.dim < 3 or self.gis_widget.supports_3d)
         ):
-            kwargs['widget'] = self.gis_widget(**self.gis_widget_kwargs)
+            kwargs['widget'] = self.gis_widget(attrs=self.gis_widget_kwargs)
             return db_field.formfield(**kwargs)
         else:
             return super().formfield_for_dbfield(db_field, request, **kwargs)

--- a/tests/gis_tests/geoadmin/models.py
+++ b/tests/gis_tests/geoadmin/models.py
@@ -21,9 +21,15 @@ class CityAdmin(admin.GISModelAdmin):
         'default_zoom': 12
     }
 
+class CityDefaultAdmin(admin.GISModelAdmin):
+    pass
+
 
 site = admin.AdminSite(name='gis_admin_modeladmin')
 site.register(City, admin.ModelAdmin)
 
 site_gis = admin.AdminSite(name='gis_admin_gismodeladmin')
 site_gis.register(City, CityAdmin)
+
+site_gis_default = admin.AdminSite(name='gis_admin_gismodeladmin')
+site_gis_default.register(City, CityDefaultAdmin)

--- a/tests/gis_tests/geoadmin/models.py
+++ b/tests/gis_tests/geoadmin/models.py
@@ -14,8 +14,16 @@ class City(models.Model):
         return self.name
 
 
+class CityAdmin(admin.GISModelAdmin):
+    gis_widget_kwargs = {
+        'default_lat': 55,
+        'default_lon': 37,
+        'default_zoom': 12
+    }
+
+
 site = admin.AdminSite(name='gis_admin_modeladmin')
 site.register(City, admin.ModelAdmin)
 
 site_gis = admin.AdminSite(name='gis_admin_gismodeladmin')
-site_gis.register(City, admin.GISModelAdmin)
+site_gis.register(City, CityAdmin)

--- a/tests/gis_tests/geoadmin/tests.py
+++ b/tests/gis_tests/geoadmin/tests.py
@@ -1,7 +1,7 @@
 from django.contrib.gis.geos import Point
 from django.test import SimpleTestCase, override_settings
 
-from .models import City, site, site_gis
+from .models import City, CityAdmin, site, site_gis
 
 
 @override_settings(ROOT_URLCONF='django.contrib.gis.tests.geoadmin.urls')
@@ -57,3 +57,11 @@ class GeoAdminTest(SimpleTestCase):
 
 class GISAdminTests(GeoAdminTest):
     admin_site = site_gis  # GISModelAdmin
+
+    def test_widget_initializes_with_attrs(self):
+        geoadmin = self.admin_site._registry[City]
+        form = geoadmin.get_changelist_form(None)()
+        widget = form['point'].field.widget
+        self.assertEqual(widget.attrs['default_lat'], 55)
+        self.assertEqual(widget.attrs['default_lon'], 37)
+        self.assertEqual(widget.attrs['default_zoom'], 12)

--- a/tests/gis_tests/geoadmin/tests.py
+++ b/tests/gis_tests/geoadmin/tests.py
@@ -1,7 +1,7 @@
 from django.contrib.gis.geos import Point
 from django.test import SimpleTestCase, override_settings
 
-from .models import City, CityAdmin, site, site_gis
+from .models import City, CityAdmin, site, site_gis, site_gis_default
 
 
 @override_settings(ROOT_URLCONF='django.contrib.gis.tests.geoadmin.urls')
@@ -57,6 +57,14 @@ class GeoAdminTest(SimpleTestCase):
 
 class GISAdminTests(GeoAdminTest):
     admin_site = site_gis  # GISModelAdmin
+
+    def test_widget_initializes_with_default_attrs(self):
+        geoadmin = site_gis_default._registry[City]
+        form = geoadmin.get_changelist_form(None)()
+        widget = form['point'].field.widget
+        self.assertEqual(widget.attrs['default_lat'], 47)
+        self.assertEqual(widget.attrs['default_lon'], 5)
+        self.assertEqual(widget.attrs['default_zoom'], 12)
 
     def test_widget_initializes_with_attrs(self):
         geoadmin = self.admin_site._registry[City]


### PR DESCRIPTION
The problem is that the gis_widget_kwargs attribute of GeoModelAdminMixin is **-unpacked into gis_widget which is OSMWidget by default.
OSMWidget and BaseGeometryWidget have .__init__(self, attrs=None), not .__init__(self, **kwargs), so this is broken.
https://code.djangoproject.com/ticket/33372