### PR TITLE
Fixed #33374 -- Fixed ExpressionWrapper annotations with full queryset.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -994,6 +994,15 @@ class BooleanField(Field):
             defaults = {'form_class': form_class, 'required': False}
         return super().formfield(**{**defaults, **kwargs})
 
+    def select_format(self, compiler, sql, params):
+        sql, params = super().select_format(compiler, sql, params)
+        # Filters that match everything are handled as empty strings in the
+        # WHERE clause, but in SELECT or GROUP BY list they must use a
+        # predicate that's always True.
+        if sql == '':
+            sql = '1'
+        return sql, params
+
 
 class CharField(Field):
     description = _("String (up to %(max_length)s)")


### PR DESCRIPTION
Hi all 👋 ,

Trying to tackle https://code.djangoproject.com/ticket/33374

Not sure this is the most appropriate fix, but I went for a short one.

The issue comes from `django.db.models.sql.where.WhereNode.as_sql` which returns an empty `sql` in the case of a negated empty result set (so a full result set, matching all results).
It is somehow correct to return an empty filter, since no filter will match all results, but when used in a select column that will be aliased, we actually generate an empty column `SELECT AS alias`