### PR TITLE
Added TemplatesSetting to list of built-in renderers in FORM_RENDERER docs.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1705,6 +1705,7 @@ renderers are:
 
 * ``'``:class:`django.forms.renderers.DjangoTemplates`\ ``'``
 * ``'``:class:`django.forms.renderers.Jinja2`\ ``'``
+* ``'``:class:`django.forms.renderers.TemplatesSetting`\ ``'``
 
 .. setting:: FORMAT_MODULE_PATH
 


### PR DESCRIPTION
The main docs for `TemplatesSetting`: https://docs.djangoproject.com/en/dev/ref/forms/renderers/#templatessetting