### PR TITLE
Refs #32355 -- Bumped required psycopg2 version to 2.8.4.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -36,8 +36,8 @@ def psycopg2_version():
 
 PSYCOPG2_VERSION = psycopg2_version()
 
-if PSYCOPG2_VERSION < (2, 5, 4):
-    raise ImproperlyConfigured("psycopg2_version 2.5.4 or newer is required; you have %s" % psycopg2.__version__)
+if PSYCOPG2_VERSION < (2, 8, 4):
+    raise ImproperlyConfigured("psycopg2 version 2.8.4 or newer is required; you have %s" % psycopg2.__version__)
 
 
 # Some of these import psycopg2, so import them after checking if it's installed.

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -114,7 +114,7 @@ below for information on how to set up your database correctly.
 PostgreSQL notes
 ================
 
-Django supports PostgreSQL 10 and higher. `psycopg2`_ 2.5.4 or higher is
+Django supports PostgreSQL 10 and higher. `psycopg2`_ 2.8.4 or higher is
 required, though the latest release is recommended.
 
 .. _psycopg2: https://www.psycopg.org/

--- a/docs/releases/4.0.txt
+++ b/docs/releases/4.0.txt
@@ -419,6 +419,9 @@ Dropped support for PostgreSQL 9.6
 Upstream support for PostgreSQL 9.6 ends in November 2021. Django 4.0 supports
 PostgreSQL 10 and higher.
 
+Also, the minimum supported version of ``psycopg2`` is increased from 2.5.4 to
+2.8.4, as ``psycopg2`` 2.8.4 is the first release to support Python 3.8.
+
 Dropped support for Oracle 12.2 and 18c
 ---------------------------------------
 

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -207,9 +207,7 @@ class Tests(TestCase):
         The transaction level can be configured with
         DATABASES ['OPTIONS']['isolation_level'].
         """
-        import psycopg2
         from psycopg2.extensions import (
-            ISOLATION_LEVEL_READ_COMMITTED as read_committed,
             ISOLATION_LEVEL_SERIALIZABLE as serializable,
         )
 
@@ -217,8 +215,7 @@ class Tests(TestCase):
         # and the isolation level isn't reported as 0. This test assumes that
         # PostgreSQL is configured with the default isolation level.
         # Check the level on the psycopg2 connection, not the Django wrapper.
-        default_level = read_committed if psycopg2.__version__ < '2.7' else None
-        self.assertEqual(connection.connection.isolation_level, default_level)
+        self.assertIsNone(connection.connection.isolation_level)
 
         new_connection = connection.copy()
         new_connection.settings_dict['OPTIONS']['isolation_level'] = serializable

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -36,7 +36,6 @@ try:
     from django.contrib.postgres.forms import (
         SimpleArrayField, SplitArrayField, SplitArrayWidget,
     )
-    from django.db.backends.postgresql.base import PSYCOPG2_VERSION
 except ImportError:
     pass
 
@@ -193,8 +192,6 @@ class TestSaveLoad(PostgreSQLTestCase):
         self.assertEqual(field.base_field.model, IntegerArrayModel)
 
     def test_nested_nullable_base_field(self):
-        if PSYCOPG2_VERSION < (2, 7, 5):
-            self.skipTest('See https://github.com/psycopg/psycopg2/issues/325')
         instance = NullableIntegerArrayModel.objects.create(
             field_nested=[[None, None], [None, None]],
         )

--- a/tests/requirements/postgres.txt
+++ b/tests/requirements/postgres.txt
@@ -1,1 +1,1 @@
-psycopg2>=2.5.4
+psycopg2>=2.8.4


### PR DESCRIPTION
[`psycopg2` 2.8.4](https://www.psycopg.org/docs/news.html#what-s-new-in-psycopg-2-8-4) is the first release to support Python 3.8.

I would like to backport this patch to the `4.0.x` branch.