### PR TITLE
Avoided isinstance(…, Variable) calls in FilterExpression.resolve().

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -694,9 +694,10 @@ class FilterExpression:
 
         self.filters = filters
         self.var = var_obj
+        self.is_var = isinstance(var_obj, Variable)
 
     def resolve(self, context, ignore_failures=False):
-        if isinstance(self.var, Variable):
+        if self.is_var:
             try:
                 obj = self.var.resolve(context)
             except VariableDoesNotExist:

--- a/django/templatetags/i18n.py
+++ b/django/templatetags/i18n.py
@@ -77,6 +77,7 @@ class TranslateNode(Node):
         self.message_context = message_context
         self.filter_expression = filter_expression
         if isinstance(self.filter_expression.var, str):
+            self.filter_expression.is_var = True
             self.filter_expression.var = Variable("'%s'" %
                                                   self.filter_expression.var)
 


### PR DESCRIPTION
Micro-optimisation proof-of-concept.

By determining the variable type within `__init__()` instead of `resolve()` we can skip an `isinstance()` check at template runtime; templates are executed in production more often than the parse trees themselves, assuming the cached Loader is used. Looks to save roughly **30ns** per invocation, which isn't much to write home about, I grant you.

```
Python 3.9.5 (default, Jun  3 2021, 11:29:17)
IPython 7.29.0 

In [1]: class Variable:
   ...:     x = 1

In [2]: x = Variable()
In [3]: %timeit if isinstance(x, Variable): pass
56.7 ns ± 0.335 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [4]: x = 1
In [5]: %timeit if x: pass
18.9 ns ± 0.352 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [6]: class Old:
   ...:     def __init__(self, var):
   ...:         self.var = var
   ...:     def resolve(self):
   ...:         return True if isinstance(self.var, Variable) else False

In [7]: class New:
   ...:     def __init__(self, var):
   ...:         self.var = var
   ...:         self.is_var = isinstance(self.var, Variable)
   ...:     def resolve(self):
   ...:         return True if self.is_var else False

In [8]: old = Old(Variable())
In [9]: new = New(Variable())

In [10]: %timeit old.resolve()
136 ns ± 0.831 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [11]: %timeit new.resolve()
104 ns ± 0.837 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```

Didn't expect to have to change a separate template tag `TranslateNode` to get the tests to pass locally, so let's see if anything else comes up in CI that would make it more invasive and less worthwhile.

