### PR TITLE
Fixed #28889 -- Use JS to prevent double submission of admin forms (disable buttons)

### DIFF
--- a/django/contrib/admin/static/admin/js/change_form.js
+++ b/django/contrib/admin/static/admin/js/change_form.js
@@ -2,32 +2,32 @@
 {
     const inputTags = ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'];
     const modelName = document.getElementById('django-admin-form-add-constants').dataset.modelName;
-    const buttons = document.querySelectorAll('input[type=submit]');
-    const disableSubmitButtons = () => {
+    const disableButtons = (buttons) => {
         buttons.forEach(button => {
-            button.setAttribute('disabled', true);
+            button.setAttribute('disabled', '');
         });
     };
-    const enableSubmitButtons = () => {
+    const enableButtons = (buttons) => {
         buttons.forEach(button => {
             button.removeAttribute('disabled');
         });
     };
 
-    // Enable buttons when browser displays the page
-    // In case the user is navigating forward
-    // and backward through history
-    window.addEventListener('pageshow', () => {
-        enableSubmitButtons();
-    });
-
     if (modelName) {
         const form = document.getElementById(modelName + '_form');
+        const submitButtons = form.querySelectorAll('input[type=submit]');
+
+        // Enable buttons when browser displays the page
+        // In case the user is navigating forward and
+        // backward through history
+        window.addEventListener('pageshow', () => {
+            enableButtons(submitButtons);
+        });
 
         // Disable buttons during submit to avoid multiple submissions
         form.addEventListener('submit', (event) => {
             event.preventDefault();
-            disableSubmitButtons();
+            disableButtons(submitButtons);
             event.target.submit();
         });
 

--- a/django/contrib/admin/static/admin/js/change_form.js
+++ b/django/contrib/admin/static/admin/js/change_form.js
@@ -2,8 +2,19 @@
 {
     const inputTags = ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'];
     const modelName = document.getElementById('django-admin-form-add-constants').dataset.modelName;
+    const submitButtons = document.querySelectorAll('input[type=submit]');
+
     if (modelName) {
         const form = document.getElementById(modelName + '_form');
+
+        form.addEventListener('submit', function(event) {
+            event.preventDefault();
+            submitButtons.forEach(button => {
+                button.setAttribute('disabled', true);
+            });
+            event.target.submit();
+        });
+
         for (const element of form.elements) {
             // HTMLElement.offsetParent returns null when the element is not
             // rendered.

--- a/django/contrib/admin/static/admin/js/change_form.js
+++ b/django/contrib/admin/static/admin/js/change_form.js
@@ -2,16 +2,32 @@
 {
     const inputTags = ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'];
     const modelName = document.getElementById('django-admin-form-add-constants').dataset.modelName;
-    const submitButtons = document.querySelectorAll('input[type=submit]');
+    const buttons = document.querySelectorAll('input[type=submit]');
+    const disableSubmitButtons = () => {
+        buttons.forEach(button => {
+            button.setAttribute('disabled', true);
+        });
+    };
+    const enableSubmitButtons = () => {
+        buttons.forEach(button => {
+            button.removeAttribute('disabled');
+        });
+    };
+
+    // Enable buttons when browser displays the page
+    // In case the user is navigating forward
+    // and backward through history
+    window.addEventListener('pageshow', () => {
+        enableSubmitButtons();
+    });
 
     if (modelName) {
         const form = document.getElementById(modelName + '_form');
 
-        form.addEventListener('submit', function(event) {
+        // Disable buttons during submit to avoid multiple submissions
+        form.addEventListener('submit', (event) => {
             event.preventDefault();
-            submitButtons.forEach(button => {
-                button.setAttribute('disabled', true);
-            });
+            disableSubmitButtons();
             event.target.submit();
         });
 

--- a/tests/admin_views/test_prevent_double_submission.py
+++ b/tests/admin_views/test_prevent_double_submission.py
@@ -1,7 +1,6 @@
 from django.contrib.admin.tests import AdminSeleniumTestCase
 from django.contrib.auth.models import User
 from django.test import override_settings
-from django.test.selenium import SeleniumTestCase
 from django.urls import reverse
 
 from .models import Bookmark
@@ -12,6 +11,7 @@ class SeleniumTests(AdminSeleniumTestCase):
     available_apps = ['admin_views'] + AdminSeleniumTestCase.available_apps
 
     def setUp(self):
+        self.BOOKMARK_ADD_URL = reverse('admin:admin_views_bookmark_add')
         self.superuser = User.objects.create_superuser(
             username='super', password='secret', email='super@example.com',
         )
@@ -19,16 +19,22 @@ class SeleniumTests(AdminSeleniumTestCase):
             username='super', password='secret', login_url=reverse('admin:index'),
         )
 
+    def _fill_form_and_get_save_button(self):
+        from selenium.webdriver.common.by import By
+
+        self.selenium.get(self.live_server_url + self.BOOKMARK_ADD_URL)
+        input_ = self.selenium.find_element(By.ID, 'id_name')
+        input_.send_keys('Bookmark name')
+
+        return self.selenium.find_element(By.CSS_SELECTOR, 'input[name=_save]')
+
     def test_save_buttons_are_disabled_after_click_submit(self):
         from selenium.webdriver.common.by import By
 
-        self.selenium.get(self.live_server_url + reverse('admin:admin_views_bookmark_add'))
-        input_ = self.selenium.find_element(By.ID, 'id_name')
-        input_.send_keys('Bookmark name')
-        save_button = self.selenium.find_element(By.CSS_SELECTOR, 'input[name=_save]')
+        save_button = self._fill_form_and_get_save_button()
         self.selenium.execute_script("arguments[0].click(); window.stop();", save_button)
         submit_buttons = self.selenium.find_elements(By.CSS_SELECTOR, 'input[type=submit]')
-        # All submits buttons are DISABLED
+        # Submits buttons are DISABLED
         for button in submit_buttons:
             self.assertFalse(button.is_enabled())
         self.assertEqual(Bookmark.objects.count(), 0)
@@ -36,73 +42,21 @@ class SeleniumTests(AdminSeleniumTestCase):
     def test_submit_and_go_back(self):
         from selenium.webdriver.common.by import By
 
-        self.selenium.get(self.live_server_url + reverse('admin:admin_views_bookmark_add'))
-        input_ = self.selenium.find_element(By.ID, 'id_name')
-        input_.send_keys('Bookmark name')
-        save_button = self.selenium.find_element(By.CSS_SELECTOR, 'input[name=_save]')
+        save_button = self._fill_form_and_get_save_button()
         save_button.click()
         self.selenium.back()
         submit_buttons = self.selenium.find_elements(By.CSS_SELECTOR, 'input[type=submit]')
-        # All submits buttons are ENABLED
+        # Submits buttons are ENABLED
         for button in submit_buttons:
             self.assertTrue(button.is_enabled())
         self.assertEqual(Bookmark.objects.count(), 1)
 
     def test_double_submit_click_wont_create_multiple_objects(self):
         from selenium.webdriver.common.action_chains import ActionChains
-        from selenium.webdriver.common.by import By
 
-        self.selenium.get(self.live_server_url + reverse('admin:admin_views_bookmark_add'))
-        input_ = self.selenium.find_element(By.ID, 'id_name')
-        input_.send_keys('Bookmark name')
-        save_button = self.selenium.find_element(By.CSS_SELECTOR, 'input[name=_save]')
+        save_button = self._fill_form_and_get_save_button()
 
         with self.wait_page_loaded():
             ActionChains(self.selenium).double_click(save_button).perform()
 
         self.assertEqual(Bookmark.objects.count(), 1)
-
-
-@override_settings(ROOT_URLCONF='admin_views.urls')
-class SeleniumTestsWithJavascriptDisabled(AdminSeleniumTestCase):
-    """
-    If we don't load javascript, we don't prevent multiple requests
-    """
-
-    available_apps = ['admin_views'] + AdminSeleniumTestCase.available_apps
-
-    @classmethod
-    def setUpClass(cls):
-        super(SeleniumTestCase, cls).setUpClass()
-        options = cls.create_options()
-        if cls.browser == 'chrome':
-            options.add_experimental_option('prefs', {'profile.managed_default_content_settings.javascript': 2})
-        elif cls.browser == 'firefox':
-            options.set_preference('javascript.enabled', False)
-        cls.selenium = cls.import_webdriver(cls.browser)(options=options)
-        cls.selenium.implicitly_wait(cls.implicit_wait)
-
-    def setUp(self):
-        self.superuser = User.objects.create_superuser(
-            username='super', password='secret', email='super@example.com',
-        )
-        self.admin_login(
-            username='super', password='secret', login_url=reverse('admin:index'),
-        )
-
-    def test_double_submit_click_will_create_multiple_objects(self):
-        from selenium.webdriver.common.action_chains import ActionChains
-        from selenium.webdriver.common.by import By
-
-        self.selenium.get(self.live_server_url + reverse('admin:admin_views_bookmark_add'))
-        input_ = self.selenium.find_element(By.ID, 'id_name')
-        input_.send_keys('Bookmark name')
-        save_button = self.selenium.find_element(By.CSS_SELECTOR, 'input[name=_save]')
-
-        with self.wait_page_loaded():
-            ActionChains(self.selenium).double_click(save_button).perform()
-
-        if self.browser == 'chrome':
-            self.assertEqual(Bookmark.objects.count(), 2)
-        elif self.browser == 'firefox':  # no duplicated, it works without js!
-            self.assertEqual(Bookmark.objects.count(), 1)

--- a/tests/admin_views/test_prevent_double_submission.py
+++ b/tests/admin_views/test_prevent_double_submission.py
@@ -1,0 +1,85 @@
+from django.contrib.admin.tests import AdminSeleniumTestCase
+from django.contrib.auth.models import User
+from django.test import override_settings
+from django.test.selenium import SeleniumTestCase
+from django.urls import reverse
+
+from .models import Bookmark
+
+
+@override_settings(ROOT_URLCONF='admin_views.urls')
+class SeleniumTests(AdminSeleniumTestCase):
+    available_apps = ['admin_views'] + AdminSeleniumTestCase.available_apps
+
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username='super', password='secret', email='super@example.com',
+        )
+        self.admin_login(
+            username='super', password='secret', login_url=reverse('admin:index'),
+        )
+
+    def test_save_buttons_are_disabled_after_click_submit(self):
+        from selenium.webdriver.common.by import By
+
+        self.selenium.get(self.live_server_url + reverse('admin:admin_views_bookmark_add'))
+        input_ = self.selenium.find_element(By.ID, 'id_name')
+        input_.send_keys('Bookmark name')
+        save_button = self.selenium.find_element(By.CSS_SELECTOR, 'input[name=_save]')
+        self.selenium.execute_script("arguments[0].click(); window.stop();", save_button)
+        save_and_add_another = self.selenium.find_element(By.CSS_SELECTOR, 'input[name="_addanother"]')
+        save_and_continue_editing = self.selenium.find_element(By.CSS_SELECTOR, 'input[name="_continue"]')
+        self.assertFalse(save_button.is_enabled())
+        self.assertFalse(save_and_add_another.is_enabled())
+        self.assertFalse(save_and_continue_editing.is_enabled())
+        self.assertEqual(Bookmark.objects.count(), 0)
+
+    def test_double_submit_click_wont_create_multiple_objects(self):
+        from selenium.webdriver.common.action_chains import ActionChains
+        from selenium.webdriver.common.by import By
+
+        self.selenium.get(self.live_server_url + reverse('admin:admin_views_bookmark_add'))
+        input_ = self.selenium.find_element(By.ID, 'id_name')
+        input_.send_keys('Bookmark name')
+        save_button = self.selenium.find_element(By.CSS_SELECTOR, 'input[name=_save]')
+        ActionChains(self.selenium).double_click(save_button).perform()
+        self.assertEqual(Bookmark.objects.count(), 1)
+
+
+@override_settings(ROOT_URLCONF='admin_views.urls')
+class SeleniumTestsWithJavascriptDisabled(AdminSeleniumTestCase):
+    """
+    Without loading `change_form.js` we don't prevent multiple requests
+    """
+    available_apps = ['admin_views'] + AdminSeleniumTestCase.available_apps
+
+    @classmethod
+    def setUpClass(cls):
+        super(SeleniumTestCase, cls).setUpClass()
+        options = cls.create_options()
+        if cls.browser == "chrome":
+            options.add_experimental_option("prefs", {'profile.managed_default_content_settings.javascript': 2})
+        cls.selenium = cls.import_webdriver(cls.browser)(options=options)
+        cls.selenium.implicitly_wait(cls.implicit_wait)
+
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username='super', password='secret', email='super@example.com',
+        )
+        self.admin_login(
+            username='super', password='secret', login_url=reverse('admin:index'),
+        )
+
+    def test_double_submit_click_will_create_multiple_objects(self):
+        """
+        Objects duplicated caused by faster clicks
+        """
+        from selenium.webdriver.common.action_chains import ActionChains
+        from selenium.webdriver.common.by import By
+
+        self.selenium.get(self.live_server_url + reverse('admin:admin_views_bookmark_add'))
+        input_ = self.selenium.find_element(By.ID, 'id_name')
+        input_.send_keys('Bookmark name')
+        save_button = self.selenium.find_element(By.CSS_SELECTOR, 'input[name=_save]')
+        ActionChains(self.selenium).double_click(save_button).perform()
+        self.assertEqual(Bookmark.objects.count(), 2)


### PR DESCRIPTION
This is the "disable submit buttons" approach for [ticket](https://code.djangoproject.com/ticket/28889)

["You already submitted (alert)" approach](https://github.com/django/django/pull/15217)

We added three tests:
- Buttons are disabled after click save
- Submit and go back
- Double click won't create multiple objects

You can run them doing:
`./runtests.py admin_views.test_prevent_double_submission.SeleniumTests --selenium=chrome`
`./runtests.py admin_views.test_prevent_double_submission.SeleniumTests --selenium=firefox`