### PR TITLE
Fixed #22828 -- Made model admins return copies of its attributes

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -322,7 +322,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         Hook for specifying fields.
         """
         if self.fields:
-            return self.fields
+            return copy.deepcopy(self.fields)
         # _get_form_for_get_fields() is implemented in subclasses.
         form = self._get_form_for_get_fields(request, obj)
         return [*form.base_fields, *self.get_readonly_fields(request, obj)]
@@ -343,19 +343,19 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         """
         Hook for specifying field ordering.
         """
-        return self.ordering or ()  # otherwise we might try to *None, which is bad ;)
+        return copy.deepcopy(self.ordering) or ()  # otherwise we might try to *None, which is bad ;)
 
     def get_readonly_fields(self, request, obj=None):
         """
         Hook for specifying custom readonly fields.
         """
-        return self.readonly_fields
+        return copy.deepcopy(self.readonly_fields)
 
     def get_prepopulated_fields(self, request, obj=None):
         """
         Hook for specifying custom prepopulated fields.
         """
-        return self.prepopulated_fields
+        return copy.deepcopy(self.prepopulated_fields)
 
     def get_queryset(self, request):
         """
@@ -956,7 +956,7 @@ class ModelAdmin(BaseModelAdmin):
         Return a sequence containing the fields to be displayed on the
         changelist.
         """
-        return self.list_display
+        return copy.deepcopy(self.list_display)
 
     def get_list_display_links(self, request, list_display):
         """
@@ -965,7 +965,7 @@ class ModelAdmin(BaseModelAdmin):
         returned by get_list_display().
         """
         if self.list_display_links or self.list_display_links is None or not list_display:
-            return self.list_display_links
+            return copy.deepcopy(self.list_display_links)
         else:
             # Use only the first item in list_display as link
             return list(list_display)[:1]
@@ -975,7 +975,7 @@ class ModelAdmin(BaseModelAdmin):
         Return a sequence containing the fields to be displayed as filters in
         the right sidebar of the changelist page.
         """
-        return self.list_filter
+        return copy.deepcopy(self.list_filter)
 
     def get_list_select_related(self, request):
         """
@@ -989,7 +989,7 @@ class ModelAdmin(BaseModelAdmin):
         Return a sequence containing the fields to be searched whenever
         somebody submits a search query.
         """
-        return self.search_fields
+        return copy.deepcopy(self.search_fields)
 
     def get_search_results(self, request, queryset, search_term):
         """

--- a/tests/admin_views/test_adminsite.py
+++ b/tests/admin_views/test_adminsite.py
@@ -102,3 +102,77 @@ class SiteActionsTests(SimpleTestCase):
         self.assertEqual(self.site.get_action(action_name), delete_selected)
         self.site.disable_action(action_name)
         self.assertEqual(self.site.get_action(action_name), delete_selected)
+
+
+class ModelAdminTest(SimpleTestCase):
+    class ArticleModelAdmin(admin.ModelAdmin):
+        fields = ['title']
+        ordering = ['title']
+        readonly_fields = ['title']
+        prepopulated_fields = ['title']
+        list_display = ['title']
+        list_display_links = ['title']
+        list_filter = ['title']
+        search_fields = ['title']
+
+    def setUp(self):
+        self.article_model_admin = self.ArticleModelAdmin(
+            Article,
+            site,
+        )
+
+    def test_get_fields_returns_copies_of_its_attributes(self):
+        """ModelAdmin.get_fields() returns copies of its attributes."""
+        fields = self.article_model_admin.fields
+        actual = self.article_model_admin.get_fields(None)
+        self.assertListEqual(actual, fields)
+        self.assertIsNot(actual, fields)
+
+    def test_get_ordering_returns_copies_of_its_attributes(self):
+        """ModelAdmin.get_ordering() returns copies of its attributes."""
+        ordering = self.article_model_admin.ordering
+        actual = self.article_model_admin.get_ordering(None)
+        self.assertListEqual(actual, ordering)
+        self.assertIsNot(actual, ordering)
+
+    def test_get_readonly_fields_returns_copies_of_its_attributes(self):
+        """ModelAdmin.get_readonly_fields() returns copies of its attributes."""
+        readonly_fields = self.article_model_admin.readonly_fields
+        actual = self.article_model_admin.get_readonly_fields(None)
+        self.assertListEqual(actual, readonly_fields)
+        self.assertIsNot(actual, readonly_fields)
+
+    def test_get_prepopulated_fields_returns_copies_of_its_attributes(self):
+        """ModelAdmin.get_prepopulated_fields() returns copies of its attributes."""
+        prepopulated_fields = self.article_model_admin.prepopulated_fields
+        actual = self.article_model_admin.get_prepopulated_fields(None)
+        self.assertListEqual(actual, prepopulated_fields)
+        self.assertIsNot(actual, prepopulated_fields)
+
+    def test_get_list_display_returns_copies_of_its_attributes(self):
+        """ModelAdmin.get_list_display() returns copies of its attributes."""
+        list_display = self.article_model_admin.list_display
+        actual = self.article_model_admin.get_list_display(None)
+        self.assertListEqual(actual, list_display)
+        self.assertIsNot(actual, list_display)
+
+    def test_get_list_display_links_returns_copies_of_its_attributes(self):
+        """ModelAdmin.get_list_display_links() returns copies of its attributes."""
+        list_display_links = self.article_model_admin.list_display_links
+        actual = self.article_model_admin.get_list_display_links(None, [])
+        self.assertListEqual(actual, list_display_links)
+        self.assertIsNot(actual, list_display_links)
+
+    def test_get_list_filter_returns_copies_of_its_attributes(self):
+        """ModelAdmin.get_list_filter() returns copies of its attributes."""
+        list_filter = self.article_model_admin.list_filter
+        actual = self.article_model_admin.get_list_filter(None)
+        self.assertListEqual(actual, list_filter)
+        self.assertIsNot(actual, list_filter)
+
+    def test_get_search_fields_returns_copies_of_its_attributes(self):
+        """ModelAdmin.get_search_fields() returns copies of its attributes."""
+        search_fields = self.article_model_admin.search_fields
+        actual = self.article_model_admin.get_search_fields(None)
+        self.assertListEqual(actual, search_fields)
+        self.assertIsNot(actual, search_fields)


### PR DESCRIPTION
Made Model admins return copies of its attributes by `copy.deepcopy()`.

Ticket: https://code.djangoproject.com/ticket/22828