### PR TITLE
Fixed #32934 -- Set admin sidebar height to be dynamic based on visible header

### DIFF
--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -40,6 +40,7 @@
     border-right: 1px solid var(--hairline-color);
     background-color: var(--body-bg);
     overflow: auto;
+    height: calc(100vh - 87px);
 }
 
 [dir="rtl"] #nav-sidebar {

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -61,6 +61,12 @@ input[type="submit"], button {
         line-height: 1.4;
     }
 
+    /* Sticky nav */
+
+    #nav-sidebar {
+        height: calc(100vh - 119px);
+    }
+
     /* Dashboard */
 
     .dashboard #content {


### PR DESCRIPTION
A pure CSS solution for ticket #32934 addressed in PR #14281 instead of the javascript approach in the previous PR. 

This solution uses `calc()` to responsively set the height of the navigation sidebar to be `100vh` minus whatever the height of the header is, so that it does not extend past the fold, making scrolling through it a little easier. It uses a media query at 1024px.

One edge case is when the title of the header has been replaced with some very long text, which increases the height of the header even further. In that case, we just revert back to the current behavior and the navbar extends past the fold. This edge case is expected to be very rare, since the amount of text required in the header is long.

This achieves the previous PR's expected result -
Before:
![115156636-05c0c980-a03a-11eb-8dfb-b12b6ae010b6](https://user-images.githubusercontent.com/64729027/147313225-c25f2577-209e-4fac-863f-f7bd45d2a67c.png)


After:
![115156639-08bbba00-a03a-11eb-8eb1-c5f7cd2a94f2](https://user-images.githubusercontent.com/64729027/147313263-f50af0d2-d2d8-43f7-9409-c0dd91f8748b.png)
