### PR TITLE
use the user model with get_user_model

### DIFF
--- a/django/contrib/auth/admin.py
+++ b/django/contrib/auth/admin.py
@@ -6,7 +6,8 @@ from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.forms import (
     AdminPasswordChangeForm, UserChangeForm, UserCreationForm,
 )
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import Group
+from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.db import router, transaction
 from django.http import Http404, HttpResponseRedirect
@@ -21,6 +22,7 @@ from django.views.decorators.debug import sensitive_post_parameters
 csrf_protect_m = method_decorator(csrf_protect)
 sensitive_post_parameters_m = method_decorator(sensitive_post_parameters())
 
+User = get_user_model()
 
 @admin.register(Group)
 class GroupAdmin(admin.ModelAdmin):


### PR DESCRIPTION
If you write a custom user model and inherit from django.contrib.auth.admin.UserAdmin overwriting some fields, then the custom user model will not be displayed on the admin site