### PR TITLE
Fixed #32243 -- Added docs examples for manually saving Files.

### DIFF
--- a/docs/topics/files.txt
+++ b/docs/topics/files.txt
@@ -33,6 +33,7 @@ store a photo::
         name = models.CharField(max_length=255)
         price = models.DecimalField(max_digits=5, decimal_places=2)
         photo = models.ImageField(upload_to='cars')
+        specs = models.FileFile(upload_to='specs')
 
 Any ``Car`` instance will have a ``photo`` attribute that you can use to get at
 the details of the attached photo::
@@ -72,6 +73,16 @@ location (:setting:`MEDIA_ROOT` if you are using the default
     '/media/cars/chevy_ii.jpg'
     >>> car.photo.path == new_path
     True
+
+To save an existing file on disk to a :class:`~django.db.models.FileField`::
+
+    >>> from pathlib import Path
+    >>> from django.core.files import File
+    >>> path = Path('/some/external/specs.pdf')
+    >>> car = Car.objects.get(name='57 Chevy')
+    >>> with path.open(mode='rb') as f:
+    ...     car.specs = File(f, name=path.name)
+    ...     car.save()
 
 .. note::
 

--- a/docs/topics/http/file-uploads.txt
+++ b/docs/topics/http/file-uploads.txt
@@ -126,6 +126,19 @@ model::
             form = UploadFileForm()
         return render(request, 'upload.html', {'form': form})
 
+If you are constructing an object manually outside of a request, you can assign
+a :class:`~django.core.files.File` like object to the
+:class:`~django.db.models.FileField`::
+
+    from django.core.management.base import BaseCommand
+    from django.core.files.base import ContentFile
+
+    class MyCommand(BaseCommand):
+        def handle(self, *args, **options):
+            content_file = ContentFile(b'Hello world!', name='hello-world.txt')
+            instance = ModelWithFileField(file_field=content_file)
+            instance.save()
+
 Uploading multiple files
 ------------------------
 


### PR DESCRIPTION
[Ticket #32243](https://code.djangoproject.com/ticket/32243#comment:7)

After suggesting a solution on the [forums](https://forum.djangoproject.com/t/cant-upload-image-though-manage-py-shell/11231/3), I thought that the documentation could use an example as well. As far as I could find, there wasn't an example for how to upload a file outside of a request context. I know I have done this in tests, celery tasks, and management commands.