### PR TITLE
Refs #32819 -- Added aria-describedby for help_text.

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -278,6 +278,13 @@ class BoundField:
                 attrs["required"] = True
         if self.field.disabled:
             attrs["disabled"] = True
+        id_for_label = self.id_for_label
+        if (
+            self.field.help_text
+            and id_for_label
+            and "aria-describedby" not in widget.attrs
+        ):
+            attrs["aria-describedby"] = "%s_helptext" % id_for_label
         return attrs
 
     @property

--- a/django/forms/jinja2/django/forms/p.html
+++ b/django/forms/jinja2/django/forms/p.html
@@ -8,7 +8,7 @@
     {% if field.label %}{{ field.label_tag() }}{% endif %}
     {{ field }}
     {% if field.help_text %}
-      <span class="helptext">{{ field.help_text|safe }}</span>
+      <span class="helptext"{% if field.id_for_label %} id="{{ field.id_for_label}}_helptext"{% endif %}>{{ field.help_text|safe }}</span>
     {% endif %}
     {% if loop.last %}
       {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/django/forms/jinja2/django/forms/table.html
+++ b/django/forms/jinja2/django/forms/table.html
@@ -16,7 +16,7 @@
       {{ field }}
       {% if field.help_text %}
         <br>
-        <span class="helptext">{{ field.help_text|safe }}</span>
+        <span class="helptext"{% if field.id_for_label %} id="{{ field.id_for_label}}_helptext"{% endif %}>{{ field.help_text|safe }}</span>
       {% endif %}
       {% if loop.last %}
         {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/django/forms/jinja2/django/forms/ul.html
+++ b/django/forms/jinja2/django/forms/ul.html
@@ -12,7 +12,7 @@
     {% if field.label %}{{ field.label_tag() }}{% endif %}
     {{ field }}
     {% if field.help_text %}
-      <span class="helptext">{{ field.help_text|safe }}</span>
+      <span class="helptext"{% if field.id_for_label %} id="{{ field.id_for_label}}_helptext"{% endif %}>{{ field.help_text|safe }}</span>
     {% endif %}
     {% if loop.last %}
       {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/django/forms/templates/django/forms/p.html
+++ b/django/forms/templates/django/forms/p.html
@@ -8,7 +8,7 @@
     {% if field.label %}{{ field.label_tag }}{% endif %}
     {{ field }}
     {% if field.help_text %}
-      <span class="helptext">{{ field.help_text|safe }}</span>
+      <span class="helptext"{% if field.id_for_label %} id="{{ field.id_for_label}}_helptext"{% endif %}>{{ field.help_text|safe }}</span>
     {% endif %}
     {% if forloop.last %}
       {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/django/forms/templates/django/forms/table.html
+++ b/django/forms/templates/django/forms/table.html
@@ -16,7 +16,7 @@
       {{ field }}
       {% if field.help_text %}
         <br>
-        <span class="helptext">{{ field.help_text|safe }}</span>
+        <span class="helptext"{% if field.id_for_label %} id="{{ field.id_for_label}}_helptext"{% endif %}>{{ field.help_text|safe }}</span>
       {% endif %}
       {% if forloop.last %}
         {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/django/forms/templates/django/forms/ul.html
+++ b/django/forms/templates/django/forms/ul.html
@@ -12,7 +12,7 @@
     {% if field.label %}{{ field.label_tag }}{% endif %}
     {{ field }}
     {% if field.help_text %}
-      <span class="helptext">{{ field.help_text|safe }}</span>
+      <span class="helptext"{% if field.id_for_label %} id="{{ field.id_for_label}}_helptext"{% endif %}>{{ field.help_text|safe }}</span>
     {% endif %}
     {% if forloop.last %}
       {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -258,6 +258,36 @@ fields. We've specified ``auto_id=False`` to simplify the output::
     <p>Sender: <input type="email" name="sender" required> A valid email address, please.</p>
     <p>Cc myself: <input type="checkbox" name="cc_myself"></p>
 
+When a field has help text and :attr:`~django.forms.BoundField.id_for_label`
+returns a value the help text will be associated with the input using
+``aria-describedby``::
+
+    >>> from django import forms
+    >>> class UserForm(forms.Form):
+    ...     username = forms.CharField(max_length=10, help_text='e.g., user@example.com')
+    >>> f = UserForm()
+    >>> print(f.as_p())
+    <p><label for="id_username">Username:</label>
+    <input type="text" name="username" maxlength="10" required aria-describedby="id_username_helptext" id="id_username">
+    <span class="helptext" id="id_username_helptext">e.g., user@example.com</span></p>
+
+``aria-describedby`` can be customized by adding it to the ``attrs`` of
+the field's widget. In this scenario you'll need to also customize the form
+template to make the same customization to the ``id`` of the help text.
+
+    >>> class UserForm(forms.Form):
+    ...     username = forms.CharField(
+    ...         max_length=10, help_text='e.g., user@example.com',
+    ...         widget=forms.TextInput(attrs={'aria-describedby': 'custom-description'}),
+    ...     )
+    >>> f = UserForm()
+    >>> print(f['username'])
+    <input type="text" name="username" aria-describedby="custom-description" maxlength="10" id="id_username" required>
+
+.. versionchanged:: 4.1
+
+    ``aria-describedby`` was added to associate ``help_text`` with its input.
+
 ``error_messages``
 ------------------
 

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -183,8 +183,9 @@ Django will then include the extra attributes in the rendered output:
     <tr><th>Url:</th><td><input type="url" name="url" required></td></tr>
     <tr><th>Comment:</th><td><input type="text" name="comment" size="40" required></td></tr>
 
-You can also set the HTML ``id`` using :attr:`~Widget.attrs`. See
-:attr:`BoundField.id_for_label` for an example.
+You can also set the HTML ``id`` and ``aria-describedby`` using
+:attr:`~Widget.attrs`. See :attr:`BoundField.id_for_label` and
+:attr:`~django.forms.Field.help_text` for examples.
 
 .. _styling-widget-classes:
 

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -221,6 +221,9 @@ Forms
   attributes help to identify widgets where its inputs should be grouped in a
   ``<fieldset>`` with a ``<legend>``.
 
+* To improve accessibility :attr:`~django.forms.Field.help_text` is now
+  associated to its input using ``aria-describedby``.
+
 Generic Views
 ~~~~~~~~~~~~~
 

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -452,7 +452,7 @@ class TestInline(TestDataMixin, TestCase):
         self.assertContains(
             response,
             '<input id="id_-1-0-name" type="text" class="vTextField" name="-1-0-name" '
-            'maxlength="100">',
+            'maxlength="100" aria-describedby="id_-1-0-name_helptext" >',
             html=True,
         )
         self.assertContains(

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -2877,6 +2877,108 @@ Password: <input type="password" name="password" required>
             "</td></tr>",
         )
 
+        def test_help_text_aria_describedby(self):
+            """
+            aira-describedby is added to the widget and refers to the id of
+            the help_text.
+            """
+
+            class UserRegistration(Form):
+                username = CharField(max_length=10, help_text="e.g., user@example.com")
+                password = CharField(
+                    widget=PasswordInput, help_text="Wählen Sie mit Bedacht."
+                )
+
+            p = UserRegistration()
+            self.assertHTMLEqual(
+                p.as_ul(),
+                '<li><label for="id_username">Username:</label>'
+                '<input type="text" name="username" maxlength="10" required '
+                'aria-describedby="id_username_helptext" id="id_username">'
+                '<span class="helptext" id="id_username_helptext">'
+                'e.g., user@example.com</span></li><li><label for="id_password">'
+                'Password:</label><input type="password" name="password" '
+                'required aria-describedby="id_password_helptext" id="id_password">'
+                '<span class="helptext" id="id_password_helptext">'
+                "Wählen Sie mit Bedacht.</span></li>",
+            )
+            self.assertHTMLEqual(
+                p.as_p(),
+                '<p><label for="id_username">Username:</label>'
+                '<input type="text" name="username" maxlength="10" required '
+                'aria-describedby="id_username_helptext" id="id_username">'
+                '<span class="helptext" id="id_username_helptext">'
+                'e.g., user@example.com</span></p><p><label for="id_password">'
+                'Password:</label><input type="password" name="password" '
+                'required aria-describedby="id_password_helptext" id="id_password">'
+                '<span class="helptext" id="id_password_helptext">'
+                "Wählen Sie mit Bedacht.</span></p>",
+            )
+            self.assertHTMLEqual(
+                p.as_table(),
+                '<tr><th><label for="id_username">Username:</label></th><td>'
+                '<input type="text" name="username" maxlength="10" required '
+                'aria-describedby="id_username_helptext" id="id_username"><br>'
+                '<span class="helptext" id="id_username_helptext">'
+                "e.g., user@example.com</span></td></tr><tr><th><label "
+                'for="id_password">Password:</label></th><td><input type="password" '
+                'name="password" required aria-describedby="id_password_helptext" '
+                'id="id_password"><br><span class="helptext" id="id_password_helptext">'
+                "Wählen Sie mit Bedacht.</span></td></tr>",
+            )
+
+    def test_custom_describedby(self):
+        """aria-describedby provided to the widget overrides the default"""
+
+        class UserRegistration(Form):
+            username = CharField(
+                max_length=10,
+                help_text="e.g., user@example.com",
+                widget=TextInput(attrs={"aria-describedby": "custom-description"}),
+            )
+            password = CharField(
+                widget=PasswordInput, help_text="Wählen Sie mit Bedacht."
+            )
+
+        p = UserRegistration()
+        self.assertHTMLEqual(
+            p.as_ul(),
+            '<li><label for="id_username">Username:</label><input type="text" '
+            'name="username" maxlength="10" required '
+            'aria-describedby="custom-description" '
+            'id="id_username"><span class="helptext" id="id_username_helptext">'
+            'e.g., user@example.com</span></li><li><label for="id_password">Password:'
+            '</label><input type="password" name="password" required '
+            'aria-describedby="id_password_helptext" id="id_password">'
+            '<span class="helptext" id="id_password_helptext">'
+            "Wählen Sie mit Bedacht.</span></li>",
+        )
+        self.assertHTMLEqual(
+            p.as_p(),
+            '<p><label for="id_username">Username:</label><input type="text" '
+            'name="username" maxlength="10" required '
+            'aria-describedby="custom-description" '
+            'id="id_username"><span class="helptext" id="id_username_helptext">'
+            'e.g., user@example.com</span></p><p><label for="id_password">Password:'
+            '</label><input type="password" name="password" required '
+            'aria-describedby="id_password_helptext" id="id_password">'
+            '<span class="helptext" id="id_password_helptext">'
+            "Wählen Sie mit Bedacht.</span></p>",
+        )
+        self.assertHTMLEqual(
+            p.as_table(),
+            '<tr><th><label for="id_username">Username:</label></th><td>'
+            '<input type="text" name="username" maxlength="10" required '
+            'aria-describedby="custom-description" id="id_username"><br>'
+            '<span class="helptext" id="id_username_helptext">'
+            "e.g., user@example.com</span></td></tr><tr><th>"
+            '<label for="id_password">Password:</label></th><td>'
+            '<input type="password" name="password" required '
+            'aria-describedby="id_password_helptext" id="id_password"><br>'
+            '<span class="helptext" id="id_password_helptext">'
+            "Wählen Sie mit Bedacht.</span></td></tr>",
+        )
+
     def test_subclassing_forms(self):
         # You can subclass a Form to add fields. The resulting form subclass will have
         # all of the fields of the parent Form, plus whichever fields you define in the
@@ -4567,7 +4669,10 @@ class TemplateTests(SimpleTestCase):
         # Form gives each field an "id" attribute.
         t = Template(
             "<form>"
-            "<p>{{ form.username.label_tag }} {{ form.username }}</p>"
+            "<p>{{ form.username.label_tag }} {{ form.username }}"
+            '<span {% if form.username.id_for_label %}id="'
+            '{{ form.username.id_for_label }}_helptext"{% endif %}>'
+            "{{ form.username.help_text}}</span></p>"
             "<p>{{ form.password1.label_tag }} {{ form.password1 }}</p>"
             "<p>{{ form.password2.label_tag }} {{ form.password2 }}</p>"
             '<input type="submit" required>'
@@ -4577,7 +4682,8 @@ class TemplateTests(SimpleTestCase):
             t.render(Context({"form": f})),
             "<form>"
             "<p>Username: "
-            '<input type="text" name="username" maxlength="10" required></p>'
+            '<input type="text" name="username" maxlength="10" required>'
+            "<span>Good luck picking a username that doesn't already exist.</span></p>"
             '<p>Password1: <input type="password" name="password1" required></p>'
             '<p>Password2: <input type="password" name="password2" required></p>'
             '<input type="submit" required>'
@@ -4589,7 +4695,9 @@ class TemplateTests(SimpleTestCase):
             "<form>"
             '<p><label for="id_username">Username:</label>'
             '<input id="id_username" type="text" name="username" maxlength="10" '
-            "required></p>"
+            'aria-describedby="id_username_helptext" required>'
+            '<span id="id_username_helptext">'
+            "Good luck picking a username that doesn't already exist.</span></p>"
             '<p><label for="id_password1">Password1:</label>'
             '<input type="password" name="password1" id="id_password1" required></p>'
             '<p><label for="id_password2">Password2:</label>'
@@ -4626,7 +4734,7 @@ class TemplateTests(SimpleTestCase):
             "<form>"
             '<p><legend for="id_username">Username:</legend>'
             '<input id="id_username" type="text" name="username" maxlength="10" '
-            "required></p>"
+            'aria-describedby="id_username_helptext" required></p>'
             '<p><legend for="id_password1">Password1:</legend>'
             '<input type="password" name="password1" id="id_password1" required></p>'
             '<p><legend for="id_password2">Password2:</legend>'

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -940,7 +940,8 @@ class TestFieldOverridesByFormMeta(SimpleTestCase):
         )
         self.assertHTMLEqual(
             str(form["slug"]),
-            '<input id="id_slug" type="text" name="slug" maxlength="20" required>',
+            '<input id="id_slug" type="text" name="slug" maxlength="20" required '
+            'aria-describedby="id_slug_helptext">',
         )
 
     def test_label_overrides(self):


### PR DESCRIPTION
[Ticket 32819](https://code.djangoproject.com/ticket/32819)

This adds `aria-describedby` functionality for `help_text`. We'll still need to think about errors but that seems a much more complex based on prior work. Would it be ok to approach this ticket in stages?

