### PR TITLE
Refs #31617 -- Removed redundant title text in filter.html

### DIFF
--- a/django/contrib/admin/templates/admin/filter.html
+++ b/django/contrib/admin/templates/admin/filter.html
@@ -3,6 +3,6 @@
 <ul>
 {% for choice in choices %}
     <li{% if choice.selected %} class="selected"{% endif %}>
-    <a href="{{ choice.query_string|iriencode }}" title="{{ choice.display }}">{{ choice.display }}</a></li>
+    <a href="{{ choice.query_string|iriencode }}">{{ choice.display }}</a></li>
 {% endfor %}
 </ul>

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -753,11 +753,11 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         )
         self.assertContains(response, '<div id="changelist-filter">')
         self.assertContains(
-            response, '<a href="?surface__exact=x" title="Horizontal">Horizontal</a>',
+            response, '<a href="?surface__exact=x">Horizontal</a>',
             msg_prefix=fail_msg, html=True
         )
         self.assertContains(
-            response, '<a href="?surface__exact=y" title="Vertical">Vertical</a>',
+            response, '<a href="?surface__exact=y">Vertical</a>',
             msg_prefix=fail_msg, html=True
         )
 


### PR DESCRIPTION
Title text should provide advisory information and should not be the same or very similar to the element text.