### PR TITLE
Fixed #13251 -- Made pre/post_delete signals dispatch the origin.

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -116,7 +116,7 @@ def get_deleted_objects(objs, request, admin_site):
         return [], {}, set(), []
     else:
         using = router.db_for_write(obj._meta.model)
-    collector = NestedObjects(using=using)
+    collector = NestedObjects(using=using, origin=objs)
     collector.collect(objs)
     perms_needed = set()
 

--- a/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
+++ b/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
                     ct_info = []
                     for ct in to_remove:
                         ct_info.append('    - Content type for %s.%s' % (ct.app_label, ct.model))
-                        collector = NoFastDeleteCollector(using=using)
+                        collector = NoFastDeleteCollector(using=using, origin=ct)
                         collector.collect([ct])
 
                         for obj_type, objs in collector.data.items():

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -987,7 +987,7 @@ class Model(metaclass=ModelBase):
                 "to None." % (self._meta.object_name, self._meta.pk.attname)
             )
         using = using or router.db_for_write(self.__class__, instance=self)
-        collector = Collector(using=using)
+        collector = Collector(using=using, origin=self)
         collector.collect([self], keep_parents=keep_parents)
         return collector.delete()
 

--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -76,8 +76,10 @@ def get_candidate_relations_to_delete(opts):
 
 
 class Collector:
-    def __init__(self, using):
+    def __init__(self, using, origin=None):
         self.using = using
+        # A Model or QuerySet object.
+        self.origin = origin
         # Initially, {model: {instances}}, later values become lists.
         self.data = defaultdict(set)
         # {model: {(field, value): {instances}}}
@@ -404,7 +406,8 @@ class Collector:
             for model, obj in self.instances_with_model():
                 if not model._meta.auto_created:
                     signals.pre_delete.send(
-                        sender=model, instance=obj, using=self.using
+                        sender=model, instance=obj, using=self.using,
+                        origin=self.origin,
                     )
 
             # fast deletes
@@ -435,7 +438,8 @@ class Collector:
                 if not model._meta.auto_created:
                     for obj in instances:
                         signals.post_delete.send(
-                            sender=model, instance=obj, using=self.using
+                            sender=model, instance=obj, using=self.using,
+                            origin=self.origin,
                         )
 
         # update collected instances

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -753,7 +753,7 @@ class QuerySet:
         del_query.query.select_related = False
         del_query.query.clear_ordering(force=True)
 
-        collector = Collector(using=del_query.db)
+        collector = Collector(using=del_query.db, origin=self)
         collector.collect(del_query)
         deleted, _rows_count = collector.delete()
 

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -195,6 +195,12 @@ Arguments sent with this signal:
 ``using``
     The database alias being used.
 
+``origin``
+    .. versionadded:: 4.1
+
+    The origin of the deletion being the instance of a ``Model`` or
+    ``QuerySet`` class.
+
 ``post_delete``
 ---------------
 
@@ -218,6 +224,12 @@ Arguments sent with this signal:
 
 ``using``
     The database alias being used.
+
+``origin``
+    .. versionadded:: 4.1
+
+    The origin of the deletion being the instance of a ``Model`` or
+    ``QuerySet`` class.
 
 ``m2m_changed``
 ---------------

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -249,7 +249,9 @@ Serialization
 Signals
 ~~~~~~~
 
-* ...
+* The :data:`~django.db.models.signals.pre_delete` and
+  :data:`~django.db.models.signals.post_delete` signals now dispatch the
+  ``origin`` of the deletion.
 
 Templates
 ~~~~~~~~~

--- a/tests/signals/models.py
+++ b/tests/signals/models.py
@@ -30,3 +30,8 @@ class Book(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class Page(models.Model):
+    book = models.ForeignKey(Book, on_delete=models.CASCADE)
+    text = models.TextField()


### PR DESCRIPTION
This is an old ticket! [13251](https://code.djangoproject.com/ticket/13251)

But here I add an approach (if it still needed)