### PR TITLE
Avoided counting attributes and methods in docs.

### DIFF
--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -240,13 +240,11 @@ field or an expression returning a numeric data. Both are required.
     Returns the population covariance as a ``float``, or ``default`` if there
     aren't any matching rows.
 
-    Has one optional argument:
-
     .. attribute:: sample
 
-        By default ``CovarPop`` returns the general population covariance.
-        However, if ``sample=True``, the return value will be the sample
-        population covariance.
+        Optional. By default ``CovarPop`` returns the general population
+        covariance. However, if ``sample=True``, the return value will be the
+        sample population covariance.
 
 ``RegrAvgX``
 ------------

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -374,7 +374,7 @@ For each field, we describe the default widget used if you don't specify
       ``min_length`` are provided. Otherwise, all inputs are valid.
     * Error message keys: ``required``, ``max_length``, ``min_length``
 
-    Has four optional arguments for validation:
+    Has the following optional arguments for validation:
 
     .. attribute:: max_length
     .. attribute:: min_length
@@ -550,7 +550,7 @@ For each field, we describe the default widget used if you don't specify
       regular expression.
     * Error message keys: ``required``, ``invalid``
 
-    Has three optional arguments ``max_length``, ``min_length``, and
+    Has the optional arguments ``max_length``, ``min_length``, and
     ``empty_value`` which work just as they do for :class:`CharField`.
 
 ``FileField``
@@ -566,7 +566,7 @@ For each field, we describe the default widget used if you don't specify
     * Error message keys: ``required``, ``invalid``, ``missing``, ``empty``,
       ``max_length``
 
-    Has two optional arguments for validation, ``max_length`` and
+    Has the optional arguments for validation: ``max_length`` and
     ``allow_empty_file``. If provided, these ensure that the file name is at
     most the given length, and that validation will succeed even if the file
     content is empty.
@@ -1009,7 +1009,7 @@ For each field, we describe the default widget used if you don't specify
       given value is a valid URL.
     * Error message keys: ``required``, ``invalid``
 
-    Has three optional arguments ``max_length``, ``min_length``, and
+    Has the optional arguments ``max_length``, ``min_length``, and
     ``empty_value`` which work just as they do for :class:`CharField`.
 
 ``UUIDField``

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -569,12 +569,10 @@ A field to store raw binary data. It can be assigned :class:`bytes`,
 By default, ``BinaryField`` sets :attr:`~Field.editable` to ``False``, in which
 case it can't be included in a :class:`~django.forms.ModelForm`.
 
-``BinaryField`` has one extra optional argument:
-
 .. attribute:: BinaryField.max_length
 
-    The maximum length (in bytes) of the field. The maximum length is enforced
-    in Django's validation using
+    Optional. The maximum length (in bytes) of the field. The maximum length is
+    enforced in Django's validation using
     :class:`~django.core.validators.MaxLengthValidator`.
 
 .. admonition:: Abusing ``BinaryField``
@@ -607,7 +605,7 @@ For large amounts of text, use :class:`~django.db.models.TextField`.
 
 The default form widget for this field is a :class:`~django.forms.TextInput`.
 
-:class:`CharField` has two extra arguments:
+:class:`CharField` has the following extra arguments:
 
 .. attribute:: CharField.max_length
 
@@ -713,7 +711,7 @@ A fixed-precision decimal number, represented in Python by a
 :class:`~decimal.Decimal` instance. It validates the input using
 :class:`~django.core.validators.DecimalValidator`.
 
-Has two **required** arguments:
+Has the following **required** arguments:
 
 .. attribute:: DecimalField.max_digits
 
@@ -781,7 +779,7 @@ A file-upload field.
     The ``primary_key`` argument isn't supported and will raise an error if
     used.
 
-Has two optional arguments:
+Has the following optional arguments:
 
 .. attribute:: FileField.upload_to
 
@@ -1153,8 +1151,8 @@ validates that the uploaded object is a valid image.
 In addition to the special attributes that are available for :class:`FileField`,
 an :class:`ImageField` also has ``height`` and ``width`` attributes.
 
-To facilitate querying on those attributes, :class:`ImageField` has two extra
-optional arguments:
+To facilitate querying on those attributes, :class:`ImageField` has the
+following optional arguments:
 
 .. attribute:: ImageField.height_field
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -147,7 +147,7 @@ Here's the formal declaration of a ``QuerySet``:
     ``QuerySet`` methods return new querysets. These methods are covered in
     detail later in this section.
 
-    The ``QuerySet`` class has two public attributes you can use for
+    The ``QuerySet`` class has the following public attributes you can use for
     introspection:
 
     .. attribute:: ordered
@@ -3599,13 +3599,11 @@ by the aggregate.
     * Return type: ``float`` if input is ``int``, otherwise same as input
       field, or ``output_field`` if supplied
 
-    Has one optional argument:
-
     .. attribute:: distinct
 
-        If ``distinct=True``, ``Avg`` returns the mean value of unique values.
-        This is the SQL equivalent of ``AVG(DISTINCT <field>)``. The default
-        value is ``False``.
+        Optional. If ``distinct=True``, ``Avg`` returns the mean value of
+        unique values. This is the SQL equivalent of ``AVG(DISTINCT <field>)``.
+        The default value is ``False``.
 
 ``Count``
 ~~~~~~~~~
@@ -3618,13 +3616,11 @@ by the aggregate.
     * Default alias: ``<field>__count``
     * Return type: ``int``
 
-    Has one optional argument:
-
     .. attribute:: distinct
 
-        If ``distinct=True``, the count will only include unique instances.
-        This is the SQL equivalent of ``COUNT(DISTINCT <field>)``. The default
-        value is ``False``.
+        Optional. If ``distinct=True``, the count will only include unique
+        instances. This is the SQL equivalent of ``COUNT(DISTINCT <field>)``.
+        The default value is ``False``.
 
     .. note::
 
@@ -3661,12 +3657,11 @@ by the aggregate.
     * Return type: ``float`` if input is ``int``, otherwise same as input
       field, or ``output_field`` if supplied
 
-    Has one optional argument:
-
     .. attribute:: sample
 
-        By default, ``StdDev`` returns the population standard deviation. However,
-        if ``sample=True``, the return value will be the sample standard deviation.
+        Optional. By default, ``StdDev`` returns the population standard
+        deviation. However, if ``sample=True``, the return value will be the
+        sample standard deviation.
 
 ``Sum``
 ~~~~~~~
@@ -3678,13 +3673,11 @@ by the aggregate.
     * Default alias: ``<field>__sum``
     * Return type: same as input field, or ``output_field`` if supplied
 
-    Has one optional argument:
-
     .. attribute:: distinct
 
-        If ``distinct=True``, ``Sum`` returns the sum of unique values. This is
-        the SQL equivalent of ``SUM(DISTINCT <field>)``. The default value is
-        ``False``.
+        Optional. If ``distinct=True``, ``Sum`` returns the sum of unique
+        values. This is the SQL equivalent of ``SUM(DISTINCT <field>)``. The
+        default value is ``False``.
 
 ``Variance``
 ~~~~~~~~~~~~
@@ -3697,12 +3690,11 @@ by the aggregate.
     * Return type: ``float`` if input is ``int``, otherwise same as input
       field, or ``output_field`` if supplied
 
-    Has one optional argument:
-
     .. attribute:: sample
 
-        By default, ``Variance`` returns the population variance. However,
-        if ``sample=True``, the return value will be the sample variance.
+        Optional. By default, ``Variance`` returns the population variance.
+        However, if ``sample=True``, the return value will be the sample
+        variance.
 
 Query-related tools
 ===================

--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -247,7 +247,7 @@ stores passwords using PBKDF2.
 Argon2
 ~~~~~~
 
-Argon2 has three attributes that can be customized:
+Argon2 has the following attributes that can be customized:
 
 #. ``time_cost`` controls the number of iterations within the hash.
 #. ``memory_cost`` controls the size of memory that must be used during the
@@ -277,7 +277,7 @@ follows:
 
 .. versionadded:: 4.0
 
-scrypt_ has four attributes that can be customized:
+scrypt_ has the following attributes that can be customized:
 
 #. ``work_factor`` controls the number of iterations within the hash.
 #. ``block_size``

--- a/docs/topics/db/multi-db.txt
+++ b/docs/topics/db/multi-db.txt
@@ -594,8 +594,8 @@ database other than that specified by your router chain, you'll
 need to write custom :class:`~django.contrib.admin.ModelAdmin` classes
 that will direct the admin to use a specific database for content.
 
-``ModelAdmin`` objects have five methods that require customization for
-multiple-database support::
+``ModelAdmin`` objects have the following methods that require customization
+for multiple-database support::
 
     class MultiDBModelAdmin(admin.ModelAdmin):
         # A handy constant for the name of the alternate database.

--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -769,7 +769,7 @@ This is useful if you want to :ref:`use more than one formset in a view
 Using a formset in views and templates
 ======================================
 
-Formsets have five attributes and five methods associated with rendering.
+Formsets have the following attributes and methods associated with rendering:
 
 .. attribute:: BaseFormSet.renderer
 

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -586,8 +586,8 @@ Expiration policies for these cookies are not followed. If you want a cookie
 to expire, either delete it manually or create a new ``Client`` instance (which
 will effectively delete all cookies).
 
-A test client has two attributes that store persistent state information. You
-can access these properties as part of a test condition.
+A test client has attributes that store persistent state information. You can
+access these properties as part of a test condition.
 
 .. attribute:: Client.cookies
 


### PR DESCRIPTION
We should avoid counting attributes and methods. It's unnecessary, difficult to maintain, creates extra work for documentation translators, and generates typos.

Noticed in #15241.