### PR TITLE
Refs #26872 -- Fixed wrapping of long choices in ModelAdmin.list_filter.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -173,8 +173,7 @@
 #changelist-filter a {
     display: block;
     color: var(--body-quiet-color);
-    text-overflow: ellipsis;
-    overflow-x: hidden;
+    word-break: break-word;
 }
 
 #changelist-filter li.selected {


### PR DESCRIPTION
Regression in 269a76714616fd7ad166a14113f3354bab8d9b65.
Noticed when checking #15247.

`title` was added in 2f587737d7acffbd67cb8f427c5fbc5c42ae60c8 to help with displaying long choices:

![3 1 filter](https://user-images.githubusercontent.com/2865885/147561114-96ade201-eca6-434c-9d27-1acf17f06259.png)

however `text-overflow: ellipsis; overflow-x: hidden;` doesn't work anymore because we use CSS flex properties for `changelist` filter since 269a76714616fd7ad166a14113f3354bab8d9b65:
![3 2 filter](https://user-images.githubusercontent.com/2865885/147561240-a3548312-d020-4d5f-a319-7f13b9f1622c.png)

I fixed this regression by wrapping long words in choices:
![with_fix](https://user-images.githubusercontent.com/2865885/147561313-137299a5-db1e-4e6c-9d05-5532089f66ae.png)

