### PR TITLE
Fixed wrapping of long values in technical 500 debug page.

### DIFF
--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -27,7 +27,7 @@
     table.vars { margin:5px 0 2px 40px; }
     table.vars td, table.req td { font-family:monospace; }
     table td.code { width:100%; }
-    table td.code pre { overflow:hidden; }
+    table td.code pre { overflow:hidden; word-break: break-word; }
     table.source th { color:#666; }
     table.source td { font-family:monospace; white-space:pre; border-bottom:1px solid #eee; }
     ul.traceback { list-style-type:none; color: #222; }


### PR DESCRIPTION
As coincidence would have it (given #15251 proposes the same fix elsewhere), I've just opened up a project and noted I had a looooong horizontal scrollbar  (4.0 and 3.2 both exhibit it) because of some env var shenanigans (thanks, [direnv](https://direnv.net/) :)). Here's a quick proposed fix for that.

Unlike that PR, I don't have a ticket to reference.

Before:
<img width="1424" alt="Screenshot 2021-12-28 at 20 44 16" src="https://user-images.githubusercontent.com/118377/147607310-5c9341b9-ea18-4575-89e2-434c5944a6d5.png">


After:
<img width="1435" alt="Screenshot 2021-12-28 at 20 45 12" src="https://user-images.githubusercontent.com/118377/147607328-40814662-2f5a-4d7d-87dc-fc9796b11c52.png">

