### PR TITLE
Fixed #33300 -- Ensured hidden elements are not displayed on small screens.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -266,7 +266,7 @@ p img, h1 img, h2 img, h3 img, h4 img, td img {
 }
 
 .hidden {
-    display: none;
+    display: none !important;
 }
 
 /* TABLES */

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5146,6 +5146,25 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.wait_until(lambda d: len(d.window_handles) == 1, 1)
         self.selenium.switch_to.window(self.selenium.window_handles[-1])
 
+    def test_hidden_fields_small_window(self):
+        from selenium.webdriver.common.by import By
+
+        self.admin_login(
+            username='super',
+            password='secret',
+            login_url=reverse('admin:index'),
+        )
+        self.selenium.get(self.live_server_url + reverse('admin:admin_views_story_add'))
+        field_title = self.selenium.find_element(By.CLASS_NAME, 'field-title')
+        current_size = self.selenium.get_window_size()
+        try:
+            self.selenium.set_window_size(1024, 768)
+            self.assertIs(field_title.is_displayed(), False)
+            self.selenium.set_window_size(767, 575)
+            self.assertIs(field_title.is_displayed(), False)
+        finally:
+            self.selenium.set_window_size(current_size['width'], current_size['height'])
+
 
 @override_settings(ROOT_URLCONF='admin_views.urls')
 class ReadonlyTest(AdminFieldExtractionMixin, TestCase):


### PR DESCRIPTION
Ticket - [https://code.djangoproject.com/ticket/33300](https://code.djangoproject.com/ticket/33300)

Added test to this patch [PR](https://github.com/django/django/pull/14775)