### PR TITLE
Improved @display(empty_value) example in ModelAdmin.empty_value_display docs.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -249,7 +249,7 @@ subclass::
         from django.contrib import admin
 
         class AuthorAdmin(admin.ModelAdmin):
-            fields = ('name', 'title', 'view_birth_date')
+            list_display = ('name', 'title', 'view_birth_date')
 
             @admin.display(empty_value='???')
             def view_birth_date(self, obj):


### PR DESCRIPTION
ModelAdmin.empty_value_display example in docs should use `list_display`, see discussion here: <https://code.djangoproject.com/ticket/33398>