### PR TITLE
Removed obsolete Oracle's test_client_encoding() test.

### DIFF
--- a/tests/backends/oracle/tests.py
+++ b/tests/backends/oracle/tests.py
@@ -37,12 +37,6 @@ class Tests(unittest.TestCase):
             cursor.execute("BEGIN %s := 'X'; END; ", [var])
             self.assertEqual(var.getvalue(), 'X')
 
-    def test_client_encoding(self):
-        """Client encoding is set correctly."""
-        connection.ensure_connection()
-        self.assertEqual(connection.connection.encoding, 'UTF-8')
-        self.assertEqual(connection.connection.nencoding, 'UTF-8')
-
     def test_order_of_nls_parameters(self):
         """
         An 'almost right' datetime works with configured NLS parameters


### PR DESCRIPTION
[encoding](https://cx-oracle.readthedocs.io/en/latest/api_manual/connection.html?#Connection.encoding) and [nencoding](https://cx-oracle.readthedocs.io/en/latest/api_manual/connection.html?#Connection.nencoding) parameters were deprecated in `cx_Oracle` 8.2. Moreover, encoding is handled internally between `cx_Oracle` and Oracle database and there is no need to test it.