### PR TITLE
Refs #29026 -- Allowed customizing InteractiveMigrationQuestioner's prompt destination.

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -144,7 +144,11 @@ class Command(BaseCommand):
             return self.handle_merge(loader, conflicts)
 
         if self.interactive:
-            questioner = InteractiveMigrationQuestioner(specified_apps=app_labels, dry_run=self.dry_run)
+            questioner = InteractiveMigrationQuestioner(
+                specified_apps=app_labels,
+                dry_run=self.dry_run,
+                prompt_output=self.stdout,
+            )
         else:
             questioner = NonInteractiveMigrationQuestioner(
                 specified_apps=app_labels,
@@ -250,7 +254,7 @@ class Command(BaseCommand):
         if it's safe; otherwise, advises on how to fix it.
         """
         if self.interactive:
-            questioner = InteractiveMigrationQuestioner()
+            questioner = InteractiveMigrationQuestioner(prompt_output=self.stdout)
         else:
             questioner = MigrationQuestioner(defaults={'ask_merge': True})
 

--- a/tests/migrations/test_questioner.py
+++ b/tests/migrations/test_questioner.py
@@ -1,12 +1,14 @@
 import datetime
+from io import StringIO
 from unittest import mock
 
+from django.core.management.base import OutputWrapper
 from django.db.migrations.questioner import (
     InteractiveMigrationQuestioner, MigrationQuestioner,
 )
 from django.db.models import NOT_PROVIDED
 from django.test import SimpleTestCase
-from django.test.utils import captured_stdout, override_settings
+from django.test.utils import override_settings
 
 
 class QuestionerTests(SimpleTestCase):
@@ -24,65 +26,60 @@ class QuestionerTests(SimpleTestCase):
 
     @mock.patch('builtins.input', return_value='2')
     def test_ask_not_null_alteration_not_provided(self, mock):
-        questioner = InteractiveMigrationQuestioner()
-        with captured_stdout():
-            question = questioner.ask_not_null_alteration('field_name', 'model_name')
+        questioner = InteractiveMigrationQuestioner(prompt_output=OutputWrapper(StringIO()))
+        question = questioner.ask_not_null_alteration('field_name', 'model_name')
         self.assertEqual(question, NOT_PROVIDED)
 
 
 class QuestionerHelperMethodsTests(SimpleTestCase):
-    questioner = InteractiveMigrationQuestioner()
+    def setUp(self):
+        self.prompt = OutputWrapper(StringIO())
+        self.questioner = InteractiveMigrationQuestioner(prompt_output=self.prompt)
 
     @mock.patch('builtins.input', return_value='datetime.timedelta(days=1)')
     def test_questioner_default_timedelta(self, mock_input):
-        questioner = InteractiveMigrationQuestioner()
-        with captured_stdout():
-            value = questioner._ask_default()
+        value = self.questioner._ask_default()
         self.assertEqual(value, datetime.timedelta(days=1))
 
     @mock.patch('builtins.input', return_value='')
     def test_questioner_default_no_user_entry(self, mock_input):
-        with captured_stdout():
-            value = self.questioner._ask_default(default='datetime.timedelta(days=1)')
+        value = self.questioner._ask_default(default='datetime.timedelta(days=1)')
         self.assertEqual(value, datetime.timedelta(days=1))
 
     @mock.patch('builtins.input', side_effect=['', 'exit'])
     def test_questioner_no_default_no_user_entry(self, mock_input):
-        with captured_stdout() as stdout, self.assertRaises(SystemExit):
+        with self.assertRaises(SystemExit):
             self.questioner._ask_default()
         self.assertIn(
             "Please enter some code, or 'exit' (without quotes) to exit.",
-            stdout.getvalue(),
+            self.prompt.getvalue(),
         )
 
     @mock.patch('builtins.input', side_effect=['bad code', 'exit'])
     def test_questioner_no_default_bad_user_entry_code(self, mock_input):
-        with captured_stdout() as stdout, self.assertRaises(SystemExit):
+        with self.assertRaises(SystemExit):
             self.questioner._ask_default()
-        self.assertIn('Invalid input: ', stdout.getvalue())
+        self.assertIn('Invalid input: ', self.prompt.getvalue())
 
     @mock.patch('builtins.input', side_effect=['', 'n'])
     def test_questioner_no_default_no_user_entry_boolean(self, mock_input):
-        with captured_stdout():
-            value = self.questioner._boolean_input('Proceed?')
+        value = self.questioner._boolean_input('Proceed?')
         self.assertIs(value, False)
 
     @mock.patch('builtins.input', return_value='')
     def test_questioner_default_no_user_entry_boolean(self, mock_input):
-        with captured_stdout():
-            value = self.questioner._boolean_input('Proceed?', default=True)
+        value = self.questioner._boolean_input('Proceed?', default=True)
         self.assertIs(value, True)
 
     @mock.patch('builtins.input', side_effect=[10, 'garbage', 1])
     def test_questioner_bad_user_choice(self, mock_input):
         question = 'Make a choice:'
-        with captured_stdout() as stdout:
-            value = self.questioner._choice_input(question, choices='abc')
+        value = self.questioner._choice_input(question, choices='abc')
         expected_msg = (
             f'{question}\n'
             f' 1) a\n'
             f' 2) b\n'
             f' 3) c\n'
         )
-        self.assertIn(expected_msg, stdout.getvalue())
+        self.assertIn(expected_msg, self.prompt.getvalue())
         self.assertEqual(value, 1)


### PR DESCRIPTION
ticket-29026

Previously, the interactive migrations questioner did not obey the value of `stdout` provided to the command, and prompts went to either sys.stdout or sys.stderr depending on whether the prompt was part of a call to `input()`. Now, it obeys the command's choice for stdout, and moreover, is configurable by the argument `prompt_output`.

Extracted from #14751.