### PR TITLE
Fixed #33402 -- Optimized multiple AlterFooTogether operations.

### DIFF
--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1573,21 +1573,13 @@ class AutodetectorTests(TestCase):
         self.assertOperationTypes(changes, 'otherapp', 0, [
             'AlterUniqueTogether',
             'AlterIndexTogether',
-            'AlterUniqueTogether',
-            'AlterIndexTogether',
         ])
         self.assertOperationAttributes(
-            changes, 'otherapp', 0, 0, name='book', unique_together=set(),
-        )
-        self.assertOperationAttributes(
-            changes, 'otherapp', 0, 1, name='book', index_together=set(),
-        )
-        self.assertOperationAttributes(
-            changes, 'otherapp', 0, 2, name='book',
+            changes, 'otherapp', 0, 0, name='book',
             unique_together={('title', 'author')},
         )
         self.assertOperationAttributes(
-            changes, 'otherapp', 0, 3, name='book',
+            changes, 'otherapp', 0, 1, name='book',
             index_together={('title', 'author')},
         )
 
@@ -1639,26 +1631,18 @@ class AutodetectorTests(TestCase):
         self.assertOperationTypes(changes, 'otherapp', 0, [
             'AlterUniqueTogether',
             'AlterIndexTogether',
-            'AlterUniqueTogether',
-            'AlterIndexTogether',
             'RemoveField',
         ])
         self.assertOperationAttributes(
-            changes, 'otherapp', 0, 0, name='book', unique_together=set(),
-        )
-        self.assertOperationAttributes(
-            changes, 'otherapp', 0, 1, name='book', index_together=set(),
-        )
-        self.assertOperationAttributes(
-            changes, 'otherapp', 0, 2, name='book',
+            changes, 'otherapp', 0, 0, name='book',
             unique_together={('author', 'title')},
         )
         self.assertOperationAttributes(
-            changes, 'otherapp', 0, 3, name='book',
+            changes, 'otherapp', 0, 1, name='book',
             index_together={('author', 'title')},
         )
         self.assertOperationAttributes(
-            changes, 'otherapp', 0, 4, model_name='book', name='newfield',
+            changes, 'otherapp', 0, 2, model_name='book', name='newfield',
         )
 
     def test_alter_field_and_foo_together(self):
@@ -1744,21 +1728,13 @@ class AutodetectorTests(TestCase):
             'RenameField',
             'AlterUniqueTogether',
             'AlterIndexTogether',
-            'AlterUniqueTogether',
-            'AlterIndexTogether',
         ])
         self.assertOperationAttributes(
-            changes, 'otherapp', 0, 1, name='book', unique_together=set(),
-        )
-        self.assertOperationAttributes(
-            changes, 'otherapp', 0, 2, name='book', index_together=set(),
-        )
-        self.assertOperationAttributes(
-            changes, 'otherapp', 0, 3, name='book',
+            changes, 'otherapp', 0, 1, name='book',
             unique_together={('title', 'newfield2')},
         )
         self.assertOperationAttributes(
-            changes, 'otherapp', 0, 4, name='book',
+            changes, 'otherapp', 0, 2, name='book',
             index_together={('title', 'newfield2')},
         )
 


### PR DESCRIPTION
Hi,

Tackling https://code.djangoproject.com/ticket/33402 (which stemmed from https://github.com/django/django/pull/14722)

The PR is introducing a method that returns whether an operation interferes with another operation.
In the sense that, an `AlterUniqueTogether` doesn't make it impossible for an `AlterIndexTogether` to be optimized.
However, all other cases, for instance an `AlterField` makes it impossible to optimize `AlterIndexTogether`.
I believe this kind of logic can allow a more fine-grained optimization process to define relationships between operation types.

The naming of the new method can probably be improved.