### PR TITLE
Fixed #11715 -- Changed default value of ModelAdmin.actions/inlines to empty tuples.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -565,7 +565,7 @@ class ModelAdmin(BaseModelAdmin):
     save_on_top = False
     paginator = Paginator
     preserve_filters = True
-    inlines = []
+    inlines = ()
 
     # Custom templates (designed to be over-ridden in subclasses)
     add_form_template = None
@@ -577,7 +577,7 @@ class ModelAdmin(BaseModelAdmin):
     popup_response_template = None
 
     # Actions
-    actions = []
+    actions = ()
     action_form = helpers.ActionForm
     actions_on_top = True
     actions_on_bottom = False

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -341,6 +341,10 @@ Miscellaneous
   ``request.META['CSRF_COOKIE']`` for storing the unmasked CSRF secret rather
   than a masked version. This is an undocumented, private API.
 
+* The :attr:`.ModelAdmin.actions` and
+  :attr:`~django.contrib.admin.ModelAdmin.inlines` attributes now default to an
+  empty tuple rather than an empty list to discourage unintended mutation.
+
 .. _deprecated-features-4.1:
 
 Features deprecated in 4.1

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -50,6 +50,11 @@ class ModelAdminTests(TestCase):
         ma = ModelAdmin(Band, self.site)
         self.assertEqual(str(ma), 'modeladmin.ModelAdmin')
 
+    def test_default_attributes(self):
+        ma = ModelAdmin(Band, self.site)
+        self.assertEqual(ma.actions, ())
+        self.assertEqual(ma.inlines, ())
+
     # form/fields/fieldsets interaction ##############################
 
     def test_default_fields(self):


### PR DESCRIPTION
ticket-11715

This clarifies the intended pattern of overwriting the default value rather than mutating it (bringing it into alignment with `search_fields` etc.).

Another option is to close the ticket as user error, since in one sense it's expected that mutating the default `inlines` will leak into other subclasses. If there are bugs from that, they're now caught by the system check framework. (See ticket)

Backwards compatibility: if we think the status quo is a legitimate pattern that needs to be temporarily supported, I could look into a deprecation path. But this is a borderline don't-bother cleanup, so waiting for a second opinion.