### PR TITLE
Refs #31026 -- Changed @jinja2_tests imports to be relative.

### DIFF
--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -23,7 +23,8 @@ from django.test import SimpleTestCase
 from django.test.utils import override_settings
 from django.utils.datastructures import MultiValueDict
 from django.utils.safestring import mark_safe
-from tests.forms_tests.tests import jinja2_tests
+
+from . import jinja2_tests
 
 
 class FrameworkForm(Form):

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -14,7 +14,8 @@ from django.forms.formsets import (
 from django.forms.utils import ErrorList
 from django.forms.widgets import HiddenInput
 from django.test import SimpleTestCase
-from tests.forms_tests.tests import jinja2_tests
+
+from . import jinja2_tests
 
 
 class Choice(Form):

--- a/tests/forms_tests/tests/test_i18n.py
+++ b/tests/forms_tests/tests/test_i18n.py
@@ -4,7 +4,8 @@ from django.forms import (
 from django.test import SimpleTestCase
 from django.utils import translation
 from django.utils.translation import gettext_lazy
-from tests.forms_tests.tests import jinja2_tests
+
+from . import jinja2_tests
 
 
 class FormsI18nTests(SimpleTestCase):

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -5,12 +5,12 @@ from django.db import models
 from django.forms import CharField, FileField, Form, ModelForm
 from django.forms.models import ModelFormMetaclass
 from django.test import SimpleTestCase, TestCase
-from tests.forms_tests.tests import jinja2_tests
 
 from ..models import (
     BoundaryModel, ChoiceFieldModel, ChoiceModel, ChoiceOptionModel, Defaults,
     FileModel, OptionalMultiChoiceModel,
 )
+from . import jinja2_tests
 
 
 class ChoiceFieldForm(ModelForm):


### PR DESCRIPTION
When invoking tests like this:
```
% python3 runtests.py forms_tests
```

I was seeing five failures akin to:
```
======================================================================
ERROR: forms_tests.tests.tests (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: forms_tests.tests.tests
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/Users/account/django/tests/forms_tests/tests/tests.py", line 8, in <module>
    from tests.forms_tests.tests import jinja2_tests
ModuleNotFoundError: No module named 'tests.forms_tests'


----------------------------------------------------------------------
Ran 474 tests in 0.522s

FAILED (errors=5, skipped=1)
```
***

Of course, forgive me if this is just an issue with my local setup being nonstandard somehow, but I noticed there aren't other imports in the test suite beginning `from tests...`. If there's something I need to do differently, I'm willing to update the contributor docs.