### PR TITLE
Refs #31617 -- Added an id for helptext in admin forms.

### DIFF
--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -34,7 +34,7 @@
   {{ form.password1.errors }}
   {{ form.password1.label_tag }} {{ form.password1 }}
   {% if form.password1.help_text %}
-  <div class="help">{{ form.password1.help_text|safe }}</div>
+  <div class="help"{% if form.password1.id_for_label %} id="{{ form.password1.id_for_label }}_helptext">{% endif %}{{ form.password1.help_text|safe }}</div>
   {% endif %}
 </div>
 
@@ -42,7 +42,7 @@
   {{ form.password2.errors }}
   {{ form.password2.label_tag }} {{ form.password2 }}
   {% if form.password2.help_text %}
-  <div class="help">{{ form.password2.help_text|safe }}</div>
+  <div class="help"{% if form.password2.id_for_label %} id="{{ form.password2.id_for_label }}_helptext"{% endif %}>{{ form.password2.help_text|safe }}</div>
   {% endif %}
 </div>
 

--- a/django/contrib/admin/templates/admin/includes/fieldset.html
+++ b/django/contrib/admin/templates/admin/includes/fieldset.html
@@ -20,7 +20,9 @@
                         {% endif %}
                     {% endif %}
                     {% if field.field.help_text %}
-                        <div class="help">{{ field.field.help_text|safe }}</div>
+                        <div class="help"{% if field.field.id_for_label %} id="{{ field.field.id_for_label }}_helptext"{% endif %}>
+                          {{ field.field.help_text|safe }}
+                        </div>
                     {% endif %}
                 </div>
             {% endfor %}

--- a/django/contrib/admin/templates/admin/search_form.html
+++ b/django/contrib/admin/templates/admin/search_form.html
@@ -3,7 +3,7 @@
 <div id="toolbar"><form id="changelist-search" method="get">
 <div><!-- DIV needed for valid HTML -->
 <label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search"></label>
-<input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus>
+<input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus{% if cl.search_help_text %} aria-describedby="searchbar_helptext"{% endif %}>
 <input type="submit" value="{% translate 'Search' %}">
 {% if show_result_count %}
     <span class="small quiet">{% blocktranslate count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktranslate %} (<a href="?{% if cl.is_popup %}{{ is_popup_var }}=1{% endif %}">{% if cl.show_full_result_count %}{% blocktranslate with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktranslate %}{% else %}{% translate "Show all" %}{% endif %}</a>)</span>
@@ -14,7 +14,7 @@
 </div>
 {% if cl.search_help_text %}
 <br class="clear">
-<div class="help">{{ cl.search_help_text }}</div>
+<div class="help" id="searchbar_helptext">{{ cl.search_help_text }}</div>
 {% endif %}
 </form></div>
 {% endif %}

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -39,7 +39,7 @@
     {{ form.new_password1.errors }}
     {{ form.new_password1.label_tag }} {{ form.new_password1 }}
     {% if form.new_password1.help_text %}
-    <div class="help">{{ form.new_password1.help_text|safe }}</div>
+    <div class="help"{% if form.new_password1.id_for_label %} id="{{ form.new_password1.id_for_label }}_helptext"{% endif %}>{{ form.new_password1.help_text|safe }}</div>
     {% endif %}
 </div>
 
@@ -47,7 +47,7 @@
 {{ form.new_password2.errors }}
     {{ form.new_password2.label_tag }} {{ form.new_password2 }}
     {% if form.new_password2.help_text %}
-    <div class="help">{{ form.new_password2.help_text|safe }}</div>
+    <div class="help"{% if form.new_password2.id_for_label %} id="{{ form.new_password2.id_for_label }}_helptext"{% endif %}>{{ form.new_password2.help_text|safe }}</div>
     {% endif %}
 </div>
 

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1523,7 +1523,7 @@ class ChangeListTests(TestCase):
         request = self._mocked_authenticated_request("/band/", superuser)
         response = m.changelist_view(request)
         self.assertIsNone(response.context_data["cl"].search_help_text)
-        self.assertNotContains(response, '<div class="help">')
+        self.assertNotContains(response, '<div class="help id="searchbar_helptext">')
         # search_fields with search_help_text.
         m.search_help_text = "Search help text"
         request = self._mocked_authenticated_request("/band/", superuser)
@@ -1531,7 +1531,14 @@ class ChangeListTests(TestCase):
         self.assertEqual(
             response.context_data["cl"].search_help_text, "Search help text"
         )
-        self.assertContains(response, '<div class="help">Search help text</div>')
+        self.assertContains(
+            response, '<div class="help" id="searchbar_helptext">Search help text</div>'
+        )
+        self.assertContains(
+            response,
+            '<input type="text" size="40" name="q" value="" id="searchbar" '
+            'autofocus aria-describedby="searchbar_helptext">',
+        )
 
 
 class GetAdminLogTests(TestCase):

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -263,9 +263,7 @@ class TestInline(TestDataMixin, TestCase):
         stacked and tabular layouts.
         """
         response = self.client.get(reverse("admin:admin_inlines_holder4_add"))
-        self.assertContains(
-            response, '<div class="help">Awesome stacked help text is awesome.</div>', 4
-        )
+        self.assertContains(response, "Awesome stacked help text is awesome.", 4)
         self.assertContains(
             response,
             '<img src="/static/admin/img/icon-unknown.svg" '


### PR DESCRIPTION
Refs Admin Accessibility Ticket https://code.djangoproject.com/ticket/31617

This adds an `id` to the helptext in the admin and should be merged before https://github.com/django/django/pull/15246

If I stack this pr and 15246 then we see the helptext will be associated with the input. 

![image](https://user-images.githubusercontent.com/39445562/147889992-59e68a9b-9275-4e9d-aa90-10d4143344a3.png)


Line 5216 in `tests/admin_views/tests.py` doesn't change because dates are `multiwidgets` and therefore they don't get an `id`. Likely that needs some more thought, but I think that can be addressed separately. Split Date/time widgets need work more generally, likely need a fieldset and a legend etc.
https://github.com/django/django/blob/4400d8568ad5695c46e8de45635a82a27a26b871/django/forms/widgets.py#L852
