### PR TITLE
Avoided suggestion of plain-text database password in docs

### DIFF
--- a/docs/topics/http/sessions.txt
+++ b/docs/topics/http/sessions.txt
@@ -417,7 +417,7 @@ This simplistic view logs in a "member" of the site::
 
     def login(request):
         m = Member.objects.get(username=request.POST['username'])
-        if m.password == request.POST['password']:
+        if m.check_password(request.POST['password']):
             request.session['member_id'] = m.id
             return HttpResponse("You're logged in.")
         else:


### PR DESCRIPTION
The example code as written suggests that we are storing `password` directly in the database, instead of hashed etc. Although this is example code for sessions documentation, not auth, and is labelled as "simplistic", people have a habit of copying any code they see. We can avoid the suggestion by using a made up `check_password(password)` method instead of `member.password == password`.
