### PR TITLE
Fixed #33406 -- Avoided creation of MaxLengthValidator(None) when resolving Value.output_field for strings.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1010,7 +1010,8 @@ class CharField(Field):
     def __init__(self, *args, db_collation=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.db_collation = db_collation
-        self.validators.append(validators.MaxLengthValidator(self.max_length))
+        if self.max_length is not None:
+            self.validators.append(validators.MaxLengthValidator(self.max_length))
 
     def check(self, **kwargs):
         databases = kwargs.get('databases') or []

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1859,6 +1859,7 @@ class ValueTests(TestCase):
         and this demonstrates that they don't throw an exception.
         """
         value_types = [
+            'str',
             True,
             42,
             3.14,

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1852,6 +1852,29 @@ class ValueTests(TestCase):
         with self.assertRaisesMessage(FieldError, msg):
             Value(object()).output_field
 
+    def test_output_field_does_not_create_broken_validators(self):
+        """
+        The output field for a given Value doesn't get cleaned & validated,
+        however validators may still be instantiated for a given field type
+        and this demonstrates that they don't throw an exception.
+        """
+        value_types = [
+            True,
+            42,
+            3.14,
+            datetime.date(2019, 5, 15),
+            datetime.datetime(2019, 5, 15),
+            datetime.time(3, 16),
+            datetime.timedelta(1),
+            Decimal('3.14'),
+            b'',
+            uuid.uuid4(),
+        ]
+        for value in value_types:
+            with self.subTest(type=type(value)):
+                field = Value(value)._resolve_output_field()
+                field.clean(value, model_instance=None)
+
 
 class ExistsTests(TestCase):
     def test_optimizations(self):


### PR DESCRIPTION
[Ticket is 33406 - 'Micro-optimisation for Value._resolve_output_field (by modifying CharField.\_\_init\_\_)'](https://code.djangoproject.com/ticket/33406)

This brings the behaviour in line with `Field` subclasses which append to the validators within `__init__`, like `BinaryField`, and prevents the creation of a validator which incorrectly throws a `TypeError`, if it were used.

Locally this benchmarks as saving roughly `2µs` per invocation; see ticket for full examples.

Lets see if the tests pass, given I've had to pull and rebase and haven't tested beyond the default sqlite runtests.