### PR TITLE
Fixed #33408 -- Fixed adding nullable unique fields on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -324,10 +324,15 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def add_field(self, model, field):
         """Create a field on a model."""
-        # Fields with default values cannot by handled by ALTER TABLE ADD
-        # COLUMN statement because DROP DEFAULT is not supported in
-        # ALTER TABLE.
-        if not field.null or self.effective_default(field) is not None:
+        if (
+            # Primary keys and unique fields are not supported in ALTER TABLE
+            # ADD COLUMN.
+            field.primary_key or field.unique or
+            # Fields with default values cannot by handled by ALTER TABLE ADD
+            # COLUMN statement because DROP DEFAULT is not supported in
+            # ALTER TABLE.
+            not field.null or self.effective_default(field) is not None
+        ):
             self._remake_table(model, create_field=field)
         else:
             super().add_field(model, field)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -624,6 +624,18 @@ class SchemaTests(TransactionTestCase):
         # Make sure the values were transformed correctly
         self.assertEqual(Author.objects.extra(where=["thing = 1"]).count(), 2)
 
+    def test_add_field_o2o_nullable(self):
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+            editor.create_model(Note)
+        new_field = OneToOneField(Note, CASCADE, null=True)
+        new_field.set_attributes_from_name('note')
+        with connection.schema_editor() as editor:
+            editor.add_field(Author, new_field)
+        columns = self.column_classes(Author)
+        self.assertIn('note_id', columns)
+        self.assertTrue(columns['note_id'][1][6])
+
     def test_add_field_binary(self):
         """
         Tests binary fields get a sane default (#22851)


### PR DESCRIPTION
Regression in 2f73e5406d54cb8945e187eff302a3a3373350be.

Thanks Alan Crosswell for the report.

ticket-33408

According to [SQLite docs](https://www.sqlite.org/lang_altertable.html#alter_table_add_column):
_"The column may not have a PRIMARY KEY or UNIQUE constraint."_