### PR TITLE
Fixed malformed attribute directives in docs.

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1228,7 +1228,7 @@ implementation details see :ref:`using-the-views`.
 
     **Attributes:**
 
-    .. attribute: template_name
+    .. attribute:: template_name
 
         The full name of a template to use for displaying the password change
         form. Defaults to :file:`registration/password_change_form.html` if not

--- a/docs/topics/class-based-views/generic-display.txt
+++ b/docs/topics/class-based-views/generic-display.txt
@@ -68,8 +68,6 @@ of built-in generic views to help generate list and detail views of objects.
 Let's start by looking at some examples of showing a list of objects or an
 individual object.
 
-.. comment: link here to the other topic pages (form handling, date based, mixins)
-
 We'll be using these models::
 
     # models.py

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -250,7 +250,7 @@ If you set :envvar:`DJANGO_SETTINGS_MODULE`, access settings values somehow,
 that settings have already been configured. There is a property for this
 purpose:
 
-.. attribute: django.conf.settings.configured
+.. attribute:: django.conf.settings.configured
 
 For example::
 


### PR DESCRIPTION
I think the two attribute changes are fairly straight forward.

While looking for other cases I found the comment one, not sure what this was intended for but it's been there for about a decade and doesn't show in the docs. Therefore I thought we could remove it? 

I've put as two separate commits so the second one can be dropped/squashed as needed.