### PR TITLE
Fixed #33396 -- Added view name to technical 500 debug page.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -359,6 +359,7 @@ class ExceptionReporter:
             c['request_FILES_items'] = self.request.FILES.items()
             c['request_COOKIES_items'] = self.request.COOKIES.items()
             c['request_insecure_uri'] = self._get_raw_insecure_uri()
+            c['raising_view_name'] = get_caller(self.request)
 
         # Check whether exception info is available
         if self.exc_type:

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -133,6 +133,12 @@
       <td><span class="fname">{{ lastframe.filename }}</span>, line {{ lastframe.lineno }}, in {{ lastframe.function }}</td>
     </tr>
 {% endif %}
+{% if raising_view_name %}
+    <tr>
+      <th>Raised during:</th>
+      <td>{{ raising_view_name }}</td>
+    </tr>
+{% endif %}
     <tr>
       <th>Python Executable:</th>
       <td>{{ sys_executable }}</td>

--- a/django/views/templates/technical_500.txt
+++ b/django/views/templates/technical_500.txt
@@ -35,6 +35,7 @@ Traceback (most recent call last):
 {% endfor %}
 {% if exception_type %}Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
 {% if exception_value %}Exception Value: {{ exception_value }}{% endif %}{% endif %}{% endif %}
+{% if raising_view_name %}Raised during: {{ raising_view_name }}{% endif %}
 {% if request %}Request information:
 {% if user_str %}USER: {{ user_str }}{% endif %}
 

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -199,6 +199,40 @@ class DebugViewTests(SimpleTestCase):
             html=True,
         )
 
+    def test_technical_500(self):
+        with self.assertLogs('django.request', 'ERROR'):
+            response = self.client.get('/raises500/')
+        self.assertContains(
+            response,
+            '<th>Raised during:</th><td>view_tests.views.raises500</td>',
+            status_code=500,
+            html=True,
+        )
+        with self.assertLogs('django.request', 'ERROR'):
+            response = self.client.get('/raises500/', HTTP_ACCEPT='text/plain')
+        self.assertContains(
+            response,
+            'Raised during: view_tests.views.raises500',
+            status_code=500,
+        )
+
+    def test_classbased_technical_500(self):
+        with self.assertLogs('django.request', 'ERROR'):
+            response = self.client.get('/classbased500/')
+        self.assertContains(
+            response,
+            '<th>Raised during:</th><td>view_tests.views.Raises500View</td>',
+            status_code=500,
+            html=True,
+        )
+        with self.assertLogs('django.request', 'ERROR'):
+            response = self.client.get('/classbased500/', HTTP_ACCEPT='text/plain')
+        self.assertContains(
+            response,
+            'Raised during: view_tests.views.Raises500View',
+            status_code=500,
+        )
+
     def test_non_l10ned_numeric_ids(self):
         """
         Numeric IDs and fancy traceback context blocks line numbers shouldn't be localized.

--- a/tests/view_tests/urls.py
+++ b/tests/view_tests/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
 
     path('technical404/', views.technical404, name='my404'),
     path('classbased404/', views.Http404View.as_view()),
+    path('classbased500/', views.Raises500View.as_view()),
 
     # i18n views
     path('i18n/', include('django.conf.urls.i18n')),

--- a/tests/view_tests/views.py
+++ b/tests/view_tests/views.py
@@ -51,6 +51,14 @@ def raises500(request):
         return technical_500_response(request, *sys.exc_info())
 
 
+class Raises500View(View):
+    def get(self, request):
+        try:
+            raise Exception
+        except Exception:
+            return technical_500_response(request, *sys.exc_info())
+
+
 def raises400(request):
     raise SuspiciousOperation
 


### PR DESCRIPTION
This PR fixes #33396 by explicitly showing the view that ran into an error in the technical 500 page.

Before -
![before-patch](https://user-images.githubusercontent.com/64729027/148398479-29bf5559-f12d-484b-8474-6746ba05270e.jpg)


After -
![after-patch](https://user-images.githubusercontent.com/64729027/148398241-82fdda79-e9bd-4caa-a9d1-a8efae5aaa20.jpg)
