### PR TITLE
Fixed documentation of Widget.id_for_label() empty return value.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -301,8 +301,8 @@ class Widget(metaclass=MediaDefiningClass):
 
     def id_for_label(self, id_):
         """
-        Return the HTML ID attribute of this Widget for use by a <label>,
-        given the ID of the field. Return None if no ID is available.
+        Return the HTML ID attribute of this Widget for use by a <label>, given
+        the ID of the field. Return an empty string if no ID is available.
 
         This hook is necessary because some widgets have multiple HTML
         elements and, thus, multiple IDs. In that case, this method should

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -277,7 +277,8 @@ foundation for custom widgets.
     .. method:: id_for_label(id_)
 
         Returns the HTML ID attribute of this widget for use by a ``<label>``,
-        given the ID of the field. Returns ``None`` if an ID isn't available.
+        given the ID of the field. Returns an empty string if an ID isn't
+        available.
 
         This hook is necessary because some widgets have multiple HTML
         elements and, thus, multiple IDs. In that case, this method should


### PR DESCRIPTION
In the documentation, it says the method should return None if no ID is available, but reading the code, we see that child classes return '' (empty string). Moreover, returning None would lead to have html tag like : <input id="None"...> which doesn't seem right.