### PR TITLE
Fixed #33419 -- Restored marking forms.Field.help_text as HTML safe.

### DIFF
--- a/django/forms/jinja2/django/forms/p.html
+++ b/django/forms/jinja2/django/forms/p.html
@@ -8,7 +8,7 @@
     {% if field.label %}{{ field.label_tag() }}{% endif %}
     {{ field }}
     {% if field.help_text %}
-      <span class="helptext">{{ field.help_text }}</span>
+      <span class="helptext">{{ field.help_text|safe }}</span>
     {% endif %}
     {% if loop.last %}
       {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/django/forms/jinja2/django/forms/table.html
+++ b/django/forms/jinja2/django/forms/table.html
@@ -16,7 +16,7 @@
       {{ field }}
       {% if field.help_text %}
         <br>
-        <span class="helptext">{{ field.help_text }}</span>
+        <span class="helptext">{{ field.help_text|safe }}</span>
       {% endif %}
       {% if loop.last %}
         {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/django/forms/jinja2/django/forms/ul.html
+++ b/django/forms/jinja2/django/forms/ul.html
@@ -12,7 +12,7 @@
     {% if field.label %}{{ field.label_tag() }}{% endif %}
     {{ field }}
     {% if field.help_text %}
-      <span class="helptext">{{ field.help_text }}</span>
+      <span class="helptext">{{ field.help_text|safe }}</span>
     {% endif %}
     {% if loop.last %}
       {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/django/forms/templates/django/forms/p.html
+++ b/django/forms/templates/django/forms/p.html
@@ -8,7 +8,7 @@
     {% if field.label %}{{ field.label_tag }}{% endif %}
     {{ field }}
     {% if field.help_text %}
-      <span class="helptext">{{ field.help_text }}</span>
+      <span class="helptext">{{ field.help_text|safe }}</span>
     {% endif %}
     {% if forloop.last %}
       {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/django/forms/templates/django/forms/table.html
+++ b/django/forms/templates/django/forms/table.html
@@ -16,7 +16,7 @@
       {{ field }}
       {% if field.help_text %}
         <br>
-        <span class="helptext">{{ field.help_text }}</span>
+        <span class="helptext">{{ field.help_text|safe }}</span>
       {% endif %}
       {% if forloop.last %}
         {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/django/forms/templates/django/forms/ul.html
+++ b/django/forms/templates/django/forms/ul.html
@@ -12,7 +12,7 @@
     {% if field.label %}{{ field.label_tag }}{% endif %}
     {{ field }}
     {% if field.help_text %}
-      <span class="helptext">{{ field.help_text }}</span>
+      <span class="helptext">{{ field.help_text|safe }}</span>
     {% endif %}
     {% if forloop.last %}
       {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/docs/releases/4.0.2.txt
+++ b/docs/releases/4.0.2.txt
@@ -11,3 +11,6 @@ Bugfixes
 
 * Fixed a bug in Django 4.0 where ``TestCase.captureOnCommitCallbacks()`` could
   execute callbacks multiple times (:ticket:`33410`).
+
+* Fixed a regression in Django 4.0 where ``help_text`` was HTML-escaped in
+  automatically-generated forms (:ticket:`33419`).

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -2326,6 +2326,41 @@ Password: <input type="password" name="password" required>
 <input type="hidden" name="next" value="/"></li>"""
         )
 
+    def test_help_text_html_safe(self):
+        """help_text should not be escaped."""
+        class UserRegistration(Form):
+            username = CharField(max_length=10, help_text='e.g., user@example.com')
+            password = CharField(
+                widget=PasswordInput,
+                help_text='Help text is <strong>escaped</strong>.',
+            )
+
+        p = UserRegistration(auto_id=False)
+        self.assertHTMLEqual(
+            p.as_ul(),
+            '<li>Username: <input type="text" name="username" maxlength="10" required>'
+            '<span class="helptext">e.g., user@example.com</span></li>'
+            '<li>Password: <input type="password" name="password" required>'
+            '<span class="helptext">Help text is <strong>escaped</strong>.</span></li>'
+        )
+        self.assertHTMLEqual(
+            p.as_p(),
+            '<p>Username: <input type="text" name="username" maxlength="10" required>'
+            '<span class="helptext">e.g., user@example.com</span></p>'
+            '<p>Password: <input type="password" name="password" required>'
+            '<span class="helptext">Help text is <strong>escaped</strong>.</span></p>'
+        )
+        self.assertHTMLEqual(
+            p.as_table(),
+            '<tr><th>Username:</th><td>'
+            '<input type="text" name="username" maxlength="10" required><br>'
+            '<span class="helptext">e.g., user@example.com</span></td></tr>'
+            '<tr><th>Password:</th><td>'
+            '<input type="password" name="password" required><br>'
+            '<span class="helptext">Help text is <strong>escaped</strong>.</span>'
+            '</td></tr>'
+        )
+
     def test_subclassing_forms(self):
         # You can subclass a Form to add fields. The resulting form subclass will have
         # all of the fields of the parent Form, plus whichever fields you define in the


### PR DESCRIPTION
[Ticket 33419](https://code.djangoproject.com/ticket/33419#comment:2)