### PR TITLE
Refs #32355 -- Removed unnecessary list() calls before reversed() on dictviews.

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -68,7 +68,7 @@ def get_commands():
     if not settings.configured:
         return commands
 
-    for app_config in reversed(list(apps.get_app_configs())):
+    for app_config in reversed(apps.get_app_configs()):
         path = os.path.join(app_config.path, 'management')
         commands.update({name: app_config.name for name in find_commands(path)})
 

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -191,7 +191,7 @@ class DjangoTranslation(gettext_module.GNUTranslations):
     def _add_installed_apps_translations(self):
         """Merge translations from each installed app."""
         try:
-            app_configs = reversed(list(apps.get_app_configs()))
+            app_configs = reversed(apps.get_app_configs())
         except AppRegistryNotReady:
             raise AppRegistryNotReady(
                 "The translation infrastructure cannot be initialized before the "


### PR DESCRIPTION
Dict and dictviews are iterable in reversed insertion order using `reversed()` in Python 3.8+, see https://github.com/python/cpython/commit/6531bf6309c8fda1954060a0fb5ea930b1efb656.