### PR TITLE
Fixed #33425 -- Fixed view name for CBVs on technical 404 debug page.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -545,8 +545,9 @@ def technical_404_response(request, exception):
         obj = resolver_match.func
 
         if hasattr(obj, 'view_class'):
-            caller = obj.view_class
-        elif hasattr(obj, '__name__'):
+            obj = obj.view_class
+
+        if hasattr(obj, '__name__'):
             caller = obj.__name__
         elif hasattr(obj, '__class__') and hasattr(obj.__class__, '__name__'):
             caller = obj.__class__.__name__

--- a/docs/releases/4.0.2.txt
+++ b/docs/releases/4.0.2.txt
@@ -14,3 +14,6 @@ Bugfixes
 
 * Fixed a regression in Django 4.0 where ``help_text`` was HTML-escaped in
   automatically-generated forms (:ticket:`33419`).
+
+* Fixed a regression in Django 4.0 that caused displaying an incorrect name for
+  class-based views on the technical 404 debug page (:ticket:`33425`).

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -177,7 +177,11 @@ class DebugViewTests(SimpleTestCase):
             html=True,
         )
         self.assertContains(response, "Raised by:", status_code=404)
-        self.assertContains(response, "view_tests.views.technical404", status_code=404)
+        self.assertContains(
+            response,
+            '<td>view_tests.views.technical404</td>',
+            status_code=404,
+        )
         self.assertContains(
             response,
             '<p>The current path, <code>technical404/</code>, matched the '
@@ -188,8 +192,12 @@ class DebugViewTests(SimpleTestCase):
 
     def test_classbased_technical_404(self):
         response = self.client.get('/classbased404/')
-        self.assertContains(response, "Raised by:", status_code=404)
-        self.assertContains(response, "view_tests.views.Http404View", status_code=404)
+        self.assertContains(
+            response,
+            '<th>Raised by:</th><td>view_tests.views.Http404View</td>',
+            status_code=404,
+            html=True,
+        )
 
     def test_non_l10ned_numeric_ids(self):
         """


### PR DESCRIPTION
Since the introduction of using `view_class` within the technical 404 page in 0c0b87725bbcffca3bc3a7a2c649995695a5ae3b, it looks like the existing test `test_classbased_technical_404` has been passing erroneously due to not checking strictly enough what is being rendered.

This change introduces 2 commits: 
1. Updates to the test cases to be stricter and more clear about what should be rendered. The test `test_classbased_technical_404` fails both subtests.
2. A patch to fix the output by "unwrapping" the `obj` if there's a `view_class` attribute, and then operating on that, instead of using it as the final value.

This tweak is why I'd not yet got around to trying for a PR on [ticket 33396](https://code.djangoproject.com/ticket/33396). Luckily there's a PR for that as #15286 though this - or something like this, if it's not yet correct - should probably land before that does, so it can take the change into account.