### PR TITLE
Fix minor doc typo for FilePathField.match glob

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1077,7 +1077,7 @@ directory on the filesystem. Has some special arguments, of which the first is
 The one potential gotcha is that :attr:`~FilePathField.match` applies to the
 base filename, not the full path. So, this example::
 
-    FilePathField(path="/home/images", match="foo.*", recursive=True)
+    FilePathField(path="/home/images", match="foo*", recursive=True)
 
 ...will match ``/home/images/foo.png`` but not ``/home/images/foo/bar.png``
 because the :attr:`~FilePathField.match` applies to the base filename


### PR DESCRIPTION
This fixes a minor typo in the doc of FilePathField.match glob.
The glob 'match="foo.*"' would only match something with a dot
and would never match a directory named "foo" making the
gotcha example moot.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>