### PR TITLE
Refs #32193 -- Removed python-memcached from test requirements.

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -11,8 +11,6 @@ Pillow >= 6.2.0
 # pylibmc/libmemcached can't be built on Windows.
 pylibmc; sys.platform != 'win32'
 pymemcache >= 3.4.0
-# RemovedInDjango41Warning.
-python-memcached >= 1.59
 pytz
 pywatchman; sys.platform != 'win32'
 PyYAML


### PR DESCRIPTION
`python-memcached` was removed in 05f3a61.