### PR TITLE
Corrected directive for signals in django.contrib.auth docs.

### DIFF
--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -419,7 +419,7 @@ Login and logout signals
 The auth framework uses the following :doc:`signals </topics/signals>` that
 can be used for notification when a user logs in or out.
 
-.. function:: user_logged_in
+.. data:: user_logged_in
 
     Sent when a user logs in successfully.
 
@@ -434,7 +434,7 @@ can be used for notification when a user logs in or out.
     ``user``
         The user instance that just logged in.
 
-.. function:: user_logged_out
+.. data:: user_logged_out
 
     Sent when the logout method is called.
 
@@ -449,7 +449,7 @@ can be used for notification when a user logs in or out.
         The user instance that just logged out or ``None`` if the
         user was not authenticated.
 
-.. function:: user_login_failed
+.. data:: user_login_failed
 
     Sent when the user failed to login successfully
 

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -654,7 +654,7 @@ Here's what each of the built-in processors does:
 ``django.contrib.auth.context_processors.auth``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: auth
+.. function:: auth(request)
 
 If this processor is enabled, every ``RequestContext`` will contain these
 variables:
@@ -672,7 +672,7 @@ variables:
 ``django.template.context_processors.debug``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: debug
+.. function:: debug(request)
 
 If this processor is enabled, every ``RequestContext`` will contain these two
 variables -- but only if your :setting:`DEBUG` setting is set to ``True`` and
@@ -689,7 +689,7 @@ the request's IP address (``request.META['REMOTE_ADDR']``) is in the
 ``django.template.context_processors.i18n``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: i18n
+.. function:: i18n(request)
 
 If this processor is enabled, every ``RequestContext`` will contain these
 variables:
@@ -713,7 +713,7 @@ If this processor is enabled, every ``RequestContext`` will contain a variable
 ``django.template.context_processors.static``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: static
+.. function:: static(request)
 
 If this processor is enabled, every ``RequestContext`` will contain a variable
 ``STATIC_URL``, providing the value of the :setting:`STATIC_URL` setting.
@@ -734,7 +734,7 @@ If this processor is enabled, every ``RequestContext`` will contain a variable
 ``django.template.context_processors.tz``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: tz
+.. function:: tz(request)
 
 If this processor is enabled, every ``RequestContext`` will contain a variable
 ``TIME_ZONE``, providing the name of the currently active time zone.

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -647,7 +647,7 @@ __ `Controlling cache: Using other headers`_
 The per-view cache
 ==================
 
-.. function:: django.views.decorators.cache.cache_page
+.. function:: django.views.decorators.cache.cache_page(timeout, *, cache=None, key_prefix=None)
 
 A more granular way to use the caching framework is by caching the output of
 individual views. ``django.views.decorators.cache`` defines a ``cache_page``

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -515,7 +515,7 @@ And then later::
 Localized names of languages
 ----------------------------
 
-.. function:: get_language_info
+.. function:: get_language_info(lang_code)
 
 The ``get_language_info()`` function provides detailed information about
 languages::

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1290,7 +1290,7 @@ For each action, you can supply either a list of values or a string. When the
 value already exists in the list, ``append`` and ``prepend`` have no effect;
 neither does ``remove`` when the value doesn't exist.
 
-.. function:: override_settings
+.. function:: override_settings(**kwargs)
 
 In case you want to override a setting for a test method, Django provides the
 :func:`~django.test.override_settings` decorator (see :pep:`318`). It's used
@@ -1316,7 +1316,7 @@ The decorator can also be applied to :class:`~django.test.TestCase` classes::
             response = self.client.get('/sekrit/')
             self.assertRedirects(response, '/other/login/?next=/sekrit/')
 
-.. function:: modify_settings
+.. function:: modify_settings(*args, **kwargs)
 
 Likewise, Django provides the :func:`~django.test.modify_settings`
 decorator::


### PR DESCRIPTION
Signals should use `data` directive, these are not functions. For example:

https://github.com/django/django/blob/3d7ac6420c0ff23305bc50c69c419c4ed5d2a838/docs/ref/signals.txt#L148