### PR TITLE
Fixed #33426 -- Fixed ResolverMatch.__repr_() for class-based views.

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -46,6 +46,8 @@ class ResolverMatch:
         self.namespaces = [x for x in namespaces if x] if namespaces else []
         self.namespace = ':'.join(self.namespaces)
 
+        if hasattr(func, 'view_class'):
+            func = func.view_class
         if not hasattr(func, '__name__'):
             # A class-based view
             self._func_path = func.__class__.__module__ + '.' + func.__class__.__name__

--- a/docs/releases/4.0.2.txt
+++ b/docs/releases/4.0.2.txt
@@ -17,3 +17,6 @@ Bugfixes
 
 * Fixed a regression in Django 4.0 that caused displaying an incorrect name for
   class-based views on the technical 404 debug page (:ticket:`33425`).
+
+* Fixed a regression in Django 4.0 that caused an incorrect ``repr`` of
+  ``ResolverMatch`` for class-based views (:ticket:`33426`).

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -1148,6 +1148,15 @@ class ResolverMatchTests(SimpleTestCase):
             "namespaces=[], route='^no_kwargs/([0-9]+)/([0-9]+)/$')",
         )
 
+    @override_settings(ROOT_URLCONF='urlpatterns_reverse.reverse_lazy_urls')
+    def test_classbased_repr(self):
+        self.assertEqual(
+            repr(resolve('/redirect/')),
+            "ResolverMatch(func=urlpatterns_reverse.views.LazyRedirectView, "
+            "args=(), kwargs={}, url_name=None, app_names=[], "
+            "namespaces=[], route='redirect/')",
+        )
+
     @override_settings(ROOT_URLCONF='urlpatterns_reverse.urls')
     def test_repr_functools_partial(self):
         tests = [


### PR DESCRIPTION
Ticket is [33426](https://code.djangoproject.com/ticket/33426).

I _think_ this is an issue based on my recollection of the ResolverMatch behaviour going back however long, but short of pulling in python 2.7 and going back to the early 1.x series, I can only say it looks like a difference between `3.2.9` and `4.0`

Tests looked to pass locally, so let's see if this works generally.