### PR TITLE
Refs #30141 -- Removed unused branch in parse_duration().

### DIFF
--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -149,8 +149,6 @@ def parse_duration(value):
         sign = -1 if kw.pop('sign', '+') == '-' else 1
         if kw.get('microseconds'):
             kw['microseconds'] = kw['microseconds'].ljust(6, '0')
-        if kw.get('seconds') and kw.get('microseconds') and kw['seconds'].startswith('-'):
-            kw['microseconds'] = '-' + kw['microseconds']
         kw = {k: float(v.replace(',', '.')) for k, v in kw.items() if v is not None}
         days = datetime.timedelta(kw.pop('days', .0) or .0)
         if match.re == iso8601_duration_re:


### PR DESCRIPTION
`seconds` is a digit and cannot start with `-`.

Unused since 99fc5dc13c12d874ffc1c8f47a6421494e720b31.