### PR TITLE
Refs #32681 -- Fixed VariableDoesNotExist when rendering some admin template.

### DIFF
--- a/django/contrib/admin/actions.py
+++ b/django/contrib/admin/actions.py
@@ -59,6 +59,7 @@ def delete_selected(modeladmin, request, queryset):
     context = {
         **modeladmin.admin_site.each_context(request),
         'title': title,
+        'subtitle': None,
         'objects_name': str(objects_name),
         'deletable_objects': [deletable_objects],
         'model_count': dict(model_count).items(),

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -400,6 +400,7 @@ class AdminSite:
         context = {
             **self.each_context(request),
             'title': _('Log in'),
+            'subtitle': None,
             'app_path': request.get_full_path(),
             'username': request.user.get_username(),
         }

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -162,6 +162,7 @@ class LogoutView(SuccessURLAllowedHostsMixin, TemplateView):
             'site': current_site,
             'site_name': current_site.name,
             'title': _('Logged out'),
+            'subtitle': None,
             **(self.extra_context or {})
         })
         return context
@@ -204,6 +205,7 @@ class PasswordContextMixin:
         context = super().get_context_data(**kwargs)
         context.update({
             'title': self.title,
+            'subtitle': None,
             **(self.extra_context or {})
         })
         return context

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1122,14 +1122,28 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
     def test_render_views_no_subtitle(self):
         tests = [
             reverse('admin:index'),
+            reverse('admin:password_change'),
             reverse('admin:app_list', args=('admin_views',)),
             reverse('admin:admin_views_article_delete', args=(self.a1.pk,)),
             reverse('admin:admin_views_article_history', args=(self.a1.pk,)),
+            # Login must be after logout.
+            reverse('admin:logout'),
+            reverse('admin:login'),
         ]
         for url in tests:
             with self.subTest(url=url):
                 with self.assertNoLogs('django.template', 'DEBUG'):
                     self.client.get(url)
+
+    def test_render_delete_selected_confirmation_no_subtitle(self):
+        post_data = {
+            'action': 'delete_selected',
+            'selected_across': '0',
+            'index': '0',
+            '_selected_action': self.a1.pk,
+        }
+        with self.assertNoLogs('django.template', 'DEBUG'):
+            self.client.post(reverse('admin:admin_views_article_changelist'), post_data)
 
 
 @override_settings(TEMPLATES=[{


### PR DESCRIPTION
Regression in 84609b3205905097d7d3038d32e6101f012c0619.

Follow up to 4e5bbb6ef2287126badd32842b239f4a8a7394ca.

Thanks Sourav Kumar for the report.

See [comment](https://code.djangoproject.com/ticket/32681?replyto=11#comment:11).