### PR TITLE
Changed django.utils.log.log_response() to take exception instance.

### DIFF
--- a/django/core/handlers/exception.py
+++ b/django/core/handlers/exception.py
@@ -64,7 +64,7 @@ def response_for_exception(request, exc):
             'Forbidden (Permission denied): %s', request.path,
             response=response,
             request=request,
-            exc_info=sys.exc_info(),
+            exception=exc,
         )
 
     elif isinstance(exc, MultiPartParserError):
@@ -73,7 +73,7 @@ def response_for_exception(request, exc):
             'Bad request (Unable to parse request body): %s', request.path,
             response=response,
             request=request,
-            exc_info=sys.exc_info(),
+            exception=exc,
         )
 
     elif isinstance(exc, BadRequest):
@@ -85,7 +85,7 @@ def response_for_exception(request, exc):
             '%s: %s', str(exc), request.path,
             response=response,
             request=request,
-            exc_info=sys.exc_info(),
+            exception=exc,
         )
     elif isinstance(exc, SuspiciousOperation):
         if isinstance(exc, (RequestDataTooBig, TooManyFieldsSent)):
@@ -113,7 +113,7 @@ def response_for_exception(request, exc):
             '%s: %s', response.reason_phrase, request.path,
             response=response,
             request=request,
-            exc_info=sys.exc_info(),
+            exception=exc,
         )
 
     # Force a TemplateResponse to be rendered.

--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -199,7 +199,7 @@ class ServerFormatter(logging.Formatter):
         return self._fmt.find('{server_time}') >= 0
 
 
-def log_response(message, *args, response=None, request=None, logger=request_logger, level=None, exc_info=None):
+def log_response(message, *args, response=None, request=None, logger=request_logger, level=None, exception=None):
     """
     Log errors based on HttpResponse status.
 
@@ -209,8 +209,8 @@ def log_response(message, *args, response=None, request=None, logger=request_log
     """
     # Check if the response has already been logged. Multiple requests to log
     # the same response can be received in some cases, e.g., when the
-    # response is the result of an exception and is logged at the time the
-    # exception is caught so that the exc_info can be recorded.
+    # response is the result of an exception and is logged when the exception
+    # is caught, to record the exception.
     if getattr(response, '_has_been_logged', False):
         return
 
@@ -228,6 +228,6 @@ def log_response(message, *args, response=None, request=None, logger=request_log
             'status_code': response.status_code,
             'request': request,
         },
-        exc_info=exc_info,
+        exc_info=exception,
     )
     response._has_been_logged = True

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -400,6 +400,9 @@ Miscellaneous
   :meth:`~.SimpleTestCase.assertFormsetError` is deprecated. Use ``errors=[]``
   instead.
 
+* The ``exc_info`` argument of the undocumented
+  ``django.utils.log.log_response()`` function is replaced by ``exception``.
+
 Features removed in 4.1
 =======================
 


### PR DESCRIPTION
Following this discussion: https://github.com/django/django/pull/13910/files#r771297073

There’s little point retrieving a fresh reference to the exception in the legacy tuple format, when it’s all available via the exception instance we already have.