### PR TITLE
Added further tests demonstrating usage of functools.partial as a view and the effects thereof

### DIFF
--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -1183,6 +1183,19 @@ class ResolverMatchTests(SimpleTestCase):
         with self.assertRaisesMessage(pickle.PicklingError, msg):
             pickle.dumps(resolve('/users/'))
 
+    @override_settings(ROOT_URLCONF='urlpatterns_reverse.urls')
+    def test_unnamed_partial_viewname(self):
+        tests = (
+            ('/unnamed_partial/', 'functools.partial'),
+            ('/unnamed_partial_nested/', 'functools.partial'),
+            ('/unnamed_partial_wrapped/', 'urlpatterns_reverse.views.empty_view'),
+        )
+        for url, name in tests:
+            with self.subTest(name=name):
+                match = resolve(url)
+                self.assertEqual(match.view_name, name)
+                self.assertEqual(match._func_path, name)
+
 
 @override_settings(ROOT_URLCONF='urlpatterns_reverse.erroneous_urls')
 class ErroneousViewTests(SimpleTestCase):

--- a/tests/urlpatterns_reverse/urls.py
+++ b/tests/urlpatterns_reverse/urls.py
@@ -63,6 +63,11 @@ urlpatterns = [
     path('partial_nested/', empty_view_nested_partial, name='partial_nested'),
     path('partial_wrapped/', empty_view_wrapped, name='partial_wrapped'),
 
+    # Unnamed partials will end up using the dotted path as the view name.
+    path('unnamed_partial/', empty_view_partial),
+    path('unnamed_partial_nested/', empty_view_nested_partial),
+    path('unnamed_partial_wrapped/', empty_view_wrapped),
+
     # This is non-reversible, but we shouldn't blow up when parsing it.
     re_path(r'^(?:foo|bar)(\w+)/$', empty_view, name='disjunction'),
 

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -251,6 +251,40 @@ class DebugViewTests(SimpleTestCase):
             status_code=500,
         )
 
+    def test_partial_technical_500(self):
+        with self.assertLogs('django.request', 'ERROR'):
+            response = self.client.get('/raises500/partial/')
+        self.assertContains(
+            response,
+            '<th>Raised during:</th><td>functools.partial</td>',
+            status_code=500,
+            html=True,
+        )
+        with self.assertLogs('django.request', 'ERROR'):
+            response = self.client.get('/raises500/partial/', HTTP_ACCEPT='text/plain')
+        self.assertContains(
+            response,
+            'Raised during: functools.partial',
+            status_code=500,
+        )
+
+    def test_partial_classbased_technical_500(self):
+        with self.assertLogs('django.request', 'ERROR'):
+            response = self.client.get('/classbased500/partial/')
+        self.assertContains(
+            response,
+            '<th>Raised during:</th><td>functools.partial</td>',
+            status_code=500,
+            html=True,
+        )
+        with self.assertLogs('django.request', 'ERROR'):
+            response = self.client.get('/classbased500/partial/', HTTP_ACCEPT='text/plain')
+        self.assertContains(
+            response,
+            'Raised during: functools.partial',
+            status_code=500,
+        )
+
     def test_non_l10ned_numeric_ids(self):
         """
         Numeric IDs and fancy traceback context blocks line numbers shouldn't be localized.

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -190,11 +190,29 @@ class DebugViewTests(SimpleTestCase):
             html=True,
         )
 
+    def test_partial_technical_404(self):
+        response = self.client.get('/technical404/partial/')
+        self.assertContains(
+            response,
+            '<th>Raised by:</th><td>functools.partial</td>',
+            status_code=404,
+            html=True,
+        )
+
     def test_classbased_technical_404(self):
         response = self.client.get('/classbased404/')
         self.assertContains(
             response,
             '<th>Raised by:</th><td>view_tests.views.Http404View</td>',
+            status_code=404,
+            html=True,
+        )
+
+    def test_partial_classbased_technical_404(self):
+        response = self.client.get('/classbased404/partial/')
+        self.assertContains(
+            response,
+            '<th>Raised by:</th><td>functools.partial</td>',
             status_code=404,
             html=True,
         )

--- a/tests/view_tests/urls.py
+++ b/tests/view_tests/urls.py
@@ -27,11 +27,13 @@ urlpatterns = [
     path('raises403/', views.raises403),
     path('raises404/', views.raises404),
     path('raises500/', views.raises500),
+    path('raises500/partial/', partial(views.raises500)),
     path('custom_reporter_class_view/', views.custom_reporter_class_view),
 
     path('technical404/', views.technical404, name='my404'),
     path('classbased404/', views.Http404View.as_view()),
     path('classbased500/', views.Raises500View.as_view()),
+    path('classbased500/partial/', partial(views.Raises500View.as_view())),
     path('technical404/partial/', partial(views.technical404), name='partial_404'),
     path('classbased404/partial/', partial(views.Http404View.as_view()), name='partial_class_404'),
 

--- a/tests/view_tests/urls.py
+++ b/tests/view_tests/urls.py
@@ -32,6 +32,8 @@ urlpatterns = [
     path('technical404/', views.technical404, name='my404'),
     path('classbased404/', views.Http404View.as_view()),
     path('classbased500/', views.Raises500View.as_view()),
+    path('technical404/partial/', partial(views.technical404), name='partial_404'),
+    path('classbased404/partial/', partial(views.Http404View.as_view()), name='partial_class_404'),
 
     # i18n views
     path('i18n/', include('django.conf.urls.i18n')),


### PR DESCRIPTION
As far as I could tell from glancing around, and a bit of `pdb` jiggery-pokery, these situations weren't explicitly covered. I may be wrong, and I just couldn't find them, though.

The tests _pass_ because this is what is currently happening, but it's debatable that they _should_ pass.

- first commit covers using `path('url/part', partial(myview, x=1))` that is, using a partially applied function without also giving the pattern a nice name. Without using `update_wrapper` the 'proper' (debatable!) name gets swallowed.
- second commit is basically the same thing, but for the displaying of the view name in the technical 404.
- third commit is the same, but for the new `Raised during` being shown on the technical 500 (yay!)

Between `ResolverMatch.__repr__` and `URLPattern.lookup_str` (and the tests of those) it's clear that partials are supported, and perhaps we can improve their output, but at the very least we can document their current output.

This vaguely references tickets [33396](https://code.djangoproject.com/ticket/33396), [22756](https://code.djangoproject.com/ticket/22756), probably [22486](https://code.djangoproject.com/ticket/22486) and sort of [33425](https://code.djangoproject.com/ticket/33425).