### PR TITLE
Fixed #33437: being able to render form fields individually using form.field.as_p

### DIFF
--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -14,7 +14,7 @@ from django.utils.datastructures import MultiValueDict
 from django.utils.deprecation import RemovedInDjango50Warning
 from django.utils.functional import cached_property
 from django.utils.html import conditional_escape
-from django.utils.safestring import SafeString, mark_safe
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
 from .renderers import get_default_renderer
@@ -91,6 +91,7 @@ class BaseForm(RenderableFormMixin):
         # Instances should always modify self.fields; they should not modify
         # self.base_fields.
         self.fields = copy.deepcopy(self.base_fields)
+
         self._bound_fields_cache = {}
         self.order_fields(self.field_order if field_order is None else field_order)
 
@@ -306,17 +307,7 @@ class BaseForm(RenderableFormMixin):
                     ]
                 hidden_fields.append(bf)
             else:
-                errors_str = str(bf_errors)
-                # RemovedInDjango50Warning.
-                if not isinstance(errors_str, SafeString):
-                    warnings.warn(
-                        f'Returning a plain string from '
-                        f'{self.error_class.__name__} is deprecated. Please '
-                        f'customize via the template system instead.',
-                        RemovedInDjango50Warning,
-                    )
-                    errors_str = mark_safe(errors_str)
-                fields.append((bf, errors_str))
+                fields.append(bf)
         return {
             'form': self,
             'fields': fields,

--- a/django/forms/jinja2/django/forms/fields/default.html
+++ b/django/forms/jinja2/django/forms/fields/default.html
@@ -1,0 +1,1 @@
+{% include "django/forms/fields/table.html" %}

--- a/django/forms/jinja2/django/forms/fields/p.html
+++ b/django/forms/jinja2/django/forms/fields/p.html
@@ -1,0 +1,8 @@
+{{ errors }}
+<p{% set classes = field.css_classes() %}{% if classes %} class="{{ classes }}"{% endif %}>
+  {% if field.label %}{{ field.label_tag() }}{% endif %}
+  {{ field }}
+  {% if field.help_text %}
+    <span class="helptext">{{ field.help_text|safe }}</span>
+  {% endif %}
+</p>

--- a/django/forms/jinja2/django/forms/fields/table.html
+++ b/django/forms/jinja2/django/forms/fields/table.html
@@ -1,0 +1,11 @@
+<tr{% set classes = field.css_classes() %}{% if classes %} class="{{ classes }}"{% endif %}>
+  <th>{% if field.label %}{{ field.label_tag() }}{% endif %}</th>
+  <td>
+    {{ errors }}
+    {{ field }}
+    {% if field.help_text %}
+      <br>
+      <span class="helptext">{{ field.help_text|safe }}</span>
+    {% endif %}
+  </td>
+</tr>

--- a/django/forms/jinja2/django/forms/fields/ul.html
+++ b/django/forms/jinja2/django/forms/fields/ul.html
@@ -1,0 +1,8 @@
+<li{% set classes = field.css_classes() %}{% if classes %} class="{{ classes }}"{% endif %}>
+  {{ errors }}
+  {% if field.label %}{{ field.label_tag() }}{% endif %}
+  {{ field }}
+  {% if field.help_text %}
+    <span class="helptext">{{ field.help_text|safe }}</span>
+  {% endif %}
+</li>

--- a/django/forms/templates/django/forms/fields/default.html
+++ b/django/forms/templates/django/forms/fields/default.html
@@ -1,0 +1,1 @@
+{% include "django/forms/fields/table.html" %}

--- a/django/forms/templates/django/forms/fields/p.html
+++ b/django/forms/templates/django/forms/fields/p.html
@@ -1,0 +1,8 @@
+{{ errors }}
+<p{% with classes=field.css_classes %}{% if classes %} class="{{ classes }}"{% endif %}{% endwith %}>
+  {% if field.label %}{{ field.label_tag }}{% endif %}
+  {{ field }}
+  {% if field.help_text %}
+    <span class="helptext">{{ field.help_text|safe }}</span>
+  {% endif %}
+</p>

--- a/django/forms/templates/django/forms/fields/table.html
+++ b/django/forms/templates/django/forms/fields/table.html
@@ -1,0 +1,11 @@
+<tr{% with classes=field.css_classes %}{% if classes %} class="{{ classes }}"{% endif %}{% endwith %}>
+  <th>{% if field.label %}{{ field.label_tag }}{% endif %}</th>
+  <td>
+    {{ errors }}
+    {{ field }}
+    {% if field.help_text %}
+      <br>
+      <span class="helptext">{{ field.help_text|safe }}</span>
+    {% endif %}
+  </td>
+</tr>

--- a/django/forms/templates/django/forms/fields/ul.html
+++ b/django/forms/templates/django/forms/fields/ul.html
@@ -1,0 +1,8 @@
+<li{% with classes=field.css_classes %}{% if classes %} class="{{ classes }}"{% endif %}{% endwith %}>
+  {{ errors }}
+  {% if field.label %}{{ field.label_tag }}{% endif %}
+  {{ field }}
+  {% if field.help_text %}
+    <span class="helptext">{{ field.help_text|safe }}</span>
+  {% endif %}
+</li>

--- a/django/forms/templates/django/forms/p.html
+++ b/django/forms/templates/django/forms/p.html
@@ -2,18 +2,13 @@
 {% if errors and not fields %}
   <p>{% for field in hidden_fields %}{{ field }}{% endfor %}</p>
 {% endif %}
-{% for field, errors in fields %}
-  {{ errors }}
-  <p{% with classes=field.css_classes %}{% if classes %} class="{{ classes }}"{% endif %}{% endwith %}>
-    {% if field.label %}{{ field.label_tag }}{% endif %}
-    {{ field }}
-    {% if field.help_text %}
-      <span class="helptext">{{ field.help_text|safe }}</span>
-    {% endif %}
-    {% if forloop.last %}
+{% for field in fields %}
+  {{ field.as_p }}
+  {% if forloop.last %}
+    <p hidden>
       {% for field in hidden_fields %}{{ field }}{% endfor %}
-    {% endif %}
-  </p>
+    </p>
+  {% endif %}
 {% endfor %}
 {% if not fields and not errors %}
   {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/django/forms/templates/django/forms/table.html
+++ b/django/forms/templates/django/forms/table.html
@@ -8,21 +8,13 @@
     </td>
   </tr>
 {% endif %}
-{% for field, errors in fields %}
-  <tr{% with classes=field.css_classes %}{% if classes %} class="{{ classes }}"{% endif %}{% endwith %}>
-    <th>{% if field.label %}{{ field.label_tag }}{% endif %}</th>
-    <td>
-      {{ errors }}
-      {{ field }}
-      {% if field.help_text %}
-        <br>
-        <span class="helptext">{{ field.help_text|safe }}</span>
-      {% endif %}
-      {% if forloop.last %}
-        {% for field in hidden_fields %}{{ field }}{% endfor %}
-      {% endif %}
+{% for field in fields %}
+  {{ field.as_table }}
+  {% if forloop.last %}
+    <td hidden>
+      {% for field in hidden_fields %}{{ field }}{% endfor %}
     </td>
-  </tr>
+  {% endif %}
 {% endfor %}
 {% if not fields and not errors %}
   {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/django/forms/templates/django/forms/ul.html
+++ b/django/forms/templates/django/forms/ul.html
@@ -6,18 +6,11 @@
   {% endif %}
   </li>
 {% endif %}
-{% for field, errors in fields %}
-  <li{% with classes=field.css_classes %}{% if classes %} class="{{ classes }}"{% endif %}{% endwith %}>
-    {{ errors }}
-    {% if field.label %}{{ field.label_tag }}{% endif %}
-    {{ field }}
-    {% if field.help_text %}
-      <span class="helptext">{{ field.help_text|safe }}</span>
-    {% endif %}
-    {% if forloop.last %}
-      {% for field in hidden_fields %}{{ field }}{% endfor %}
-    {% endif %}
-  </li>
+{% for field in fields %}
+  {{ field.as_ul }}
+  {% if forloop.last %}
+    <li hidden>{% for field in hidden_fields %}{{ field }}{% endfor %}</li>
+  {% endif %}
 {% endfor %}
 {% if not fields and not errors %}
   {% for field in hidden_fields %}{{ field }}{% endfor %}


### PR DESCRIPTION
This PR adds the feature to render the fields of a form individually using the `{{ form.field.as_p }}` syntax.

This is only a proposition for now. It is meant to be discussed. In particular, I had to change the markup for hidden fields.

I opened [a ticket to follow discussions on this feature request](https://code.djangoproject.com/ticket/33437#ticket).

P.S.: Please also indicate me if it needs further testings. I haven't been able to run them locally. I get:

```
TypeError: cannot pickle 'traceback' object
Exception ignored in: <function Pool.__del__ at 0x7fee1a63c940>
```