### PR TITLE
Fixed #28135 -- Made simplify_regex() handle non-capturing groups.

### DIFF
--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -8,7 +8,8 @@ from django.contrib import admin
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.admindocs import utils
 from django.contrib.admindocs.utils import (
-    replace_metacharacters, replace_named_groups, replace_unnamed_groups,
+    remove_non_capturing_groups, replace_metacharacters, replace_named_groups,
+    replace_unnamed_groups,
 )
 from django.core.exceptions import ImproperlyConfigured, ViewDoesNotExist
 from django.db import models
@@ -410,6 +411,7 @@ def simplify_regex(pattern):
     example, turn "^(?P<sport_slug>\w+)/athletes/(?P<athlete_slug>\w+)/$"
     into "/<sport_slug>/athletes/<athlete_slug>/".
     """
+    pattern = remove_non_capturing_groups(pattern)
     pattern = replace_named_groups(pattern)
     pattern = replace_unnamed_groups(pattern)
     pattern = replace_metacharacters(pattern)

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -397,6 +397,13 @@ class AdminDocViewFunctionsTests(SimpleTestCase):
             (r'^(?P<a>(x|y))/b/(?P<c>\w+)', '/<a>/b/<c>'),
             (r'^(?P<a>(x|y))/b/(?P<c>\w+)ab', '/<a>/b/<c>ab'),
             (r'^(?P<a>(x|y)(\(|\)))/b/(?P<c>\w+)ab', '/<a>/b/<c>ab'),
+            # Non-capturing groups.
+            (r'^a(?:\w+)b', '/ab'),
+            (r'^a(?:(x|y))', '/a'),
+            (r'^(?:\w+(?:\w+))a', '/a'),
+            (r'^a(?:\w+)/b(?:\w+)', '/a/b'),
+            (r'(?P<a>\w+)/b/(?:\w+)c(?:\w+)', '/<a>/b/c'),
+            (r'(?P<a>\w+)/b/(\w+)/(?:\w+)c(?:\w+)', '/<a>/b/<var>/c'),
             # Single and repeated metacharacters.
             (r'^a', '/a'),
             (r'^^a', '/a'),


### PR DESCRIPTION
FIX #28135 -- Extend `simply_regex()` to handle regex `non-capturing` groups

Signed-off-by: Ayush Joshi <ayush854032@gmail.com>