### PR TITLE
Fixed #19580 -- Unified behavior of reverse foreign key and many-to-many relations for unsaved instances.

### DIFF
--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -375,6 +375,14 @@ this difference. In Django 4.0 and earlier,
 second example query, but this undocumented behavior led to queries with
 excessive joins.
 
+Reverse foreign key changes for unsaved model instances
+-------------------------------------------------------
+
+In order to unify the behavior with many-to-many relations for unsaved model
+instances, a reverse foreign key now raises ``ValueError`` when calling
+:class:`related managers <django.db.models.fields.related.RelatedManager>` for
+unsaved objects.
+
 Miscellaneous
 -------------
 

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -738,14 +738,16 @@ class ManyToOneTests(TestCase):
         self.assertEqual("id", cat.remote_field.get_related_field().name)
 
     def test_relation_unsaved(self):
-        # The <field>_set manager does not join on Null value fields (#17541)
         Third.objects.create(name="Third 1")
         Third.objects.create(name="Third 2")
         th = Third(name="testing")
-        # The object isn't saved and thus the relation field is null - we won't even
-        # execute a query in this case.
-        with self.assertNumQueries(0):
-            self.assertEqual(th.child_set.count(), 0)
+        # The object isn't saved and the relation cannot be used.
+        msg = (
+            "'Third' instance needs to have a primary key value before this "
+            "relationship can be used."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            th.child_set.count()
         th.save()
         # Now the model is saved, so we will need to execute a query.
         with self.assertNumQueries(1):

--- a/tests/many_to_one_null/tests.py
+++ b/tests/many_to_one_null/tests.py
@@ -146,3 +146,36 @@ class ManyToOneNullTests(TestCase):
         self.assertIs(d1.car, None)
         with self.assertNumQueries(0):
             self.assertEqual(list(c1.drivers.all()), [])
+
+    def test_unsaved(self):
+        msg = (
+            "'Car' instance needs to have a primary key value before this relationship "
+            "can be used."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            Car(make="Ford").drivers.all()
+
+    def test_related_null_to_field_related_managers(self):
+        car = Car.objects.create(make=None)
+        driver = Driver.objects.create()
+        msg = (
+            f'"{car!r}" needs to have a value for field "make" before this '
+            f"relationship can be used."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            car.drivers.add(driver)
+        with self.assertRaisesMessage(ValueError, msg):
+            car.drivers.create()
+        with self.assertRaisesMessage(ValueError, msg):
+            car.drivers.get_or_create()
+        with self.assertRaisesMessage(ValueError, msg):
+            car.drivers.update_or_create()
+        with self.assertRaisesMessage(ValueError, msg):
+            car.drivers.remove(driver)
+        with self.assertRaisesMessage(ValueError, msg):
+            car.drivers.clear()
+        with self.assertRaisesMessage(ValueError, msg):
+            car.drivers.set([driver])
+
+        with self.assertNumQueries(0):
+            self.assertEqual(car.drivers.count(), 0)

--- a/tests/null_queries/tests.py
+++ b/tests/null_queries/tests.py
@@ -44,9 +44,14 @@ class NullQueriesTests(TestCase):
         with self.assertRaisesMessage(ValueError, "Cannot use None as a query value"):
             Choice.objects.filter(id__gt=None)
 
-        # Related managers use __exact=None implicitly if the object hasn't been saved.
-        p2 = Poll(question="How?")
-        self.assertEqual(repr(p2.choice_set.all()), "<QuerySet []>")
+    def test_unsaved(self):
+        poll = Poll(question="How?")
+        msg = (
+            "'Poll' instance needs to have a primary key value before this "
+            "relationship can be used."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            poll.choice_set.all()
 
     def test_reverse_relations(self):
         """


### PR DESCRIPTION
The fix changes behaviour of reverse FK to be the same as M2M.