### PR TITLE
Fix misleading translation on admin page

### DIFF
--- a/django/contrib/admin/locale/de/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/de/LC_MESSAGES/django.po
@@ -392,7 +392,7 @@ msgid "Welcome,"
 msgstr "Willkommen,"
 
 msgid "View site"
-msgstr "Auf der Website anzeigen"
+msgstr "Hauptseite anzeigen"
 
 msgid "Documentation"
 msgstr "Dokumentation"


### PR DESCRIPTION
In the administrative area, the link to go back to the actual
main website was translated in a misleading way. 
It back-translated to `View *on* Site`, which would need some
contextual stuff, to which the `on` can refer.
The new translation describes better what the link actually *does*