### PR TITLE
Fixed #33062 -- Made MultiPartParser remove non-printable chars from file names.

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -320,6 +320,8 @@ class MultiPartParser:
         file_name = html.unescape(file_name)
         file_name = file_name.rsplit('/')[-1]
         file_name = file_name.rsplit('\\')[-1]
+        # Remove non-printable characters.
+        file_name = ''.join([char for char in file_name if char.isprintable()])
 
         if file_name in {'', '.', '..'}:
             return None


### PR DESCRIPTION
As suggested in this [comment](https://github.com/django/django/pull/14834#issuecomment-913582633) in #14834 This PR fixes [ticket 33062](https://code.djangoproject.com/ticket/33062) by removing all non-printable characters while sanitizing the `file_name` in `MultiPartParser`.