### PR TITLE
Updated GEOS/GDAL links in docs and comments.

### DIFF
--- a/django/contrib/gis/gdal/datasource.py
+++ b/django/contrib/gis/gdal/datasource.py
@@ -58,7 +58,7 @@ class DataSource(GDALBase):
             self._write = 1
         else:
             self._write = 0
-        # See also https://trac.osgeo.org/gdal/wiki/rfc23_ogr_unicode
+        # See also https://gdal.org/development/rfc/rfc23_ogr_unicode.html
         self.encoding = encoding
 
         Driver.ensure_registered()

--- a/django/contrib/gis/geos/libgeos.py
+++ b/django/contrib/gis/geos/libgeos.py
@@ -57,7 +57,7 @@ def load_geos():
     # Getting the GEOS C library.  The C interface (CDLL) is used for
     # both *NIX and Windows.
     # See the GEOS C API source code for more details on the library function calls:
-    # https://geos.osgeo.org/doxygen/geos__c_8h_source.html
+    # https://libgeos.org/doxygen/geos__c_8h_source.html
     _lgeos = CDLL(lib_path)
     # Here we set up the prototypes for the initGEOS_r and finishGEOS_r
     # routines.  These functions aren't actually called until they are

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -17,7 +17,7 @@ implements the OpenGIS `Simple Features for SQL`__ spatial predicate functions
 and spatial operators. GEOS, now an OSGeo project, was initially developed and
 maintained by `Refractions Research`__ of Victoria, Canada.
 
-__ https://trac.osgeo.org/geos/
+__ https://libgeos.org/
 __ https://sourceforge.net/projects/jts-topo-suite/
 __ https://www.ogc.org/standards/sfs
 __ http://www.refractions.net/

--- a/docs/ref/contrib/gis/install/geolibs.txt
+++ b/docs/ref/contrib/gis/install/geolibs.txt
@@ -213,8 +213,8 @@ Configure, make and install::
 If you have any problems, please see the troubleshooting section below for
 suggestions and solutions.
 
-__ https://trac.osgeo.org/gdal/
-__ https://trac.osgeo.org/gdal/wiki/GdalOgrInPython
+__ https://gdal.org/
+__ https://gdal.org/api/python.html
 
 .. _gdaltrouble:
 


### PR DESCRIPTION
The official GEOS web site is now ​https://libgeos.org