### PR TITLE
Improved performance of csrf_input

### DIFF
--- a/django/template/backends/utils.py
+++ b/django/template/backends/utils.py
@@ -1,13 +1,11 @@
 from django.middleware.csrf import get_token
 from django.utils.functional import lazy
-from django.utils.html import format_html
 from django.utils.safestring import SafeString
 
 
 def csrf_input(request):
-    return format_html(
-        '<input type="hidden" name="csrfmiddlewaretoken" value="{}">',
-        get_token(request))
+    token = get_token(request)
+    return SafeString(f'<input type="hidden" name="csrfmiddlewaretoken" value="{token}">')
 
 
 csrf_input_lazy = lazy(csrf_input, SafeString, str)


### PR DESCRIPTION
Hi @kezabelle -- would you be interesting in reviewing this? 

The relevant lines from my (messy) IPython tests follow. I see a c.8% gain here as it avoids a number of function calls. I think this is safe as it's a string that we're in control of and we know that we're going to get sane values back as the token. 
🤞  the full test suite passes. 

``` python

In [8]: r = HttpRequest()

In [10]: def csrf_input_new(request):
    ...:     token = get_token(request)
    ...:     return SafeString(
    ...:         f'<input type="hidden" name="csrfmiddlewaretoken" value="{token}">'
    ...:     )
    ...: 

In [13]: %timeit csrf_input_new(r)
252 µs ± 4.58 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [15]: def csrf_input(request):
    ...:     return format_html(
    ...:         '<input type="hidden" name="csrfmiddlewaretoken" value="{}">',
    ...:         get_token(request),
    ...:     )

In [16]: %timeit csrf_input(r)
272 µs ± 2.88 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

p.s. In my testing `get_token` is takes something in the 250µs-255µs range(!)