### PR TITLE
Fixed #27471 -- Make admin's list_filter choices collapsable

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -653,6 +653,7 @@ class ModelAdmin(BaseModelAdmin):
             'urlify.js',
             'prepopulate.js',
             'vendor/xregexp/xregexp%s.js' % extra,
+            'filters.js',
         ]
         return forms.Media(js=['admin/js/%s' % url for url in js])
 

--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -198,8 +198,8 @@
     border-bottom: 1px solid var(--hairline-color);
 }
 
-#changelist-filter [id^="expanded_"],
-#changelist-filter [id^="collapsed_"] {
+#changelist-filter [data-expanded],
+#changelist-filter [data-collapsed] {
     display: inline;
 }
 

--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -198,6 +198,11 @@
     border-bottom: 1px solid var(--hairline-color);
 }
 
+#changelist-filter [id^="expanded_"],
+#changelist-filter [id^="collapsed_"] {
+    display: inline;
+}
+
 /* DATE DRILLDOWN */
 
 .change-list ul.toplinks {

--- a/django/contrib/admin/static/admin/js/filters.js
+++ b/django/contrib/admin/static/admin/js/filters.js
@@ -1,0 +1,47 @@
+/**
+ * Expand/collapse change list filters
+ * Filter with choices > CHOICES_EXPANDED_LIMIT are automatically collapsed
+ */
+'use strict';
+{
+    function ready(fn) {
+        if (document.readyState !== 'loading') {
+            fn();
+        } else {
+            document.addEventListener('DOMContentLoaded', fn);
+        }
+    }
+
+    ready(function() {
+        const CHOICES_EXPANDED_LIMIT = 10;
+        const filters = document.querySelectorAll('[data-toggle]');
+        const hide = function(element) {
+            element.classList.add('hidden');
+        };
+        const toggle = function(element) {
+            element.classList.toggle('hidden');
+        };
+
+        filters.forEach(function(filter) {
+            const field = filter.dataset.toggle;
+            const target = `[data-target=${field}]`;
+            const expanded = document.querySelector(`[data-expanded=${field}]`); // - symbol
+            const collapsed = document.querySelector(`[data-collapsed=${field}]`); // + symbol
+            const collapsable = document.querySelector(target); // target to be collapsed
+            const choices = collapsable.querySelectorAll(`li`);
+
+            if (choices.length > CHOICES_EXPANDED_LIMIT) {
+                hide(expanded);
+                hide(collapsable);
+            } else {
+                hide(collapsed);
+            }
+
+            filter.addEventListener('click', function() {
+                toggle(collapsed);
+                toggle(expanded);
+                toggle(collapsable);
+            });
+        });
+    });
+}

--- a/django/contrib/admin/templates/admin/filter.html
+++ b/django/contrib/admin/templates/admin/filter.html
@@ -1,8 +1,42 @@
 {% load i18n %}
-<h3>{% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}</h3>
+
+{% with field=title.split|join:"_" %}
+<a href="#" class="filter_collapse_{{ field }}">
+    <h3>
+        <div id="expanded_{{ field }}">-</div>
+        <div id="collapsed_{{ field }}">+</div>
+        {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
+    </h3>
+</a>
 <ul>
-{% for choice in choices %}
-    <li{% if choice.selected %} class="selected"{% endif %}>
-    <a href="{{ choice.query_string|iriencode }}">{{ choice.display }}</a></li>
-{% endfor %}
+    <div id="collapsable_{{ field }}">
+    {% for choice in choices %}
+        <li{% if choice.selected %} class="selected"{% endif %}>
+        <a href="{{ choice.query_string|iriencode }}">{{ choice.display }}</a></li>
+    {% endfor %}
+    </div>
 </ul>
+
+<script>
+(function($) {
+    $(document).ready(function() {
+        const $expanded = $('#expanded_{{ field }}')
+        const $collapsed = $('#collapsed_{{ field }}')
+        const $collapsable = $('#collapsable_{{ field }}')
+
+        {% if choices|length > 10 %}
+            $expanded.hide();
+            $collapsable.slideToggle();
+        {% else %}
+            $collapsed.hide();
+        {% endif %}
+
+        $('.filter_collapse_{{ field }}').on('click', function () {
+            $collapsed.toggle();
+            $expanded.toggle();
+            $collapsable.slideToggle('slow');
+        });
+    });
+})(django.jQuery);
+</script>
+{% endwith %}

--- a/django/contrib/admin/templates/admin/filter.html
+++ b/django/contrib/admin/templates/admin/filter.html
@@ -1,42 +1,19 @@
 {% load i18n %}
 
 {% with field=title.split|join:"_" %}
-<a href="#" class="filter_collapse_{{ field }}">
+<a href="#" data-toggle="{{ field }}">
     <h3>
-        <div id="expanded_{{ field }}">-</div>
-        <div id="collapsed_{{ field }}">+</div>
+        <div data-expanded="{{ field }}">-</div>
+        <div data-collapsed="{{ field }}">+</div>
         {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
     </h3>
 </a>
 <ul>
-    <div id="collapsable_{{ field }}">
+    <div data-target="{{ field }}">
     {% for choice in choices %}
         <li{% if choice.selected %} class="selected"{% endif %}>
         <a href="{{ choice.query_string|iriencode }}">{{ choice.display }}</a></li>
     {% endfor %}
     </div>
 </ul>
-
-<script>
-(function($) {
-    $(document).ready(function() {
-        const $expanded = $('#expanded_{{ field }}')
-        const $collapsed = $('#collapsed_{{ field }}')
-        const $collapsable = $('#collapsable_{{ field }}')
-
-        {% if choices|length > 10 %}
-            $expanded.hide();
-            $collapsable.slideToggle();
-        {% else %}
-            $collapsed.hide();
-        {% endif %}
-
-        $('.filter_collapse_{{ field }}').on('click', function () {
-            $collapsed.toggle();
-            $expanded.toggle();
-            $collapsable.slideToggle('slow');
-        });
-    });
-})(django.jQuery);
-</script>
 {% endwith %}

--- a/django/contrib/admin/templates/admin/filter.html
+++ b/django/contrib/admin/templates/admin/filter.html
@@ -1,19 +1,15 @@
 {% load i18n %}
 
-{% with field=title.split|join:"_" %}
-<a href="#" data-toggle="{{ field }}">
+<a href="#" data-toggle="{{ lookup_kwarg }}">
     <h3>
-        <div data-expanded="{{ field }}">-</div>
-        <div data-collapsed="{{ field }}">+</div>
+        <div data-expanded="{{ lookup_kwarg }}">-</div>
+        <div data-collapsed="{{ lookup_kwarg }}">+</div>
         {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
     </h3>
 </a>
-<ul>
-    <div data-target="{{ field }}">
+<ul data-target="{{ lookup_kwarg }}">
     {% for choice in choices %}
         <li{% if choice.selected %} class="selected"{% endif %}>
         <a href="{{ choice.query_string|iriencode }}">{{ choice.display }}</a></li>
     {% endfor %}
-    </div>
 </ul>
-{% endwith %}

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -441,6 +441,7 @@ def admin_list_filter(cl, spec):
         'title': spec.title,
         'choices': list(spec.choices(cl)),
         'spec': spec,
+        'lookup_kwarg': spec.lookup_kwarg
     })
 
 

--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
-from django.contrib.auth.admin import UserAdmin
-from django.contrib.auth.models import User
+from django.contrib.auth.admin import GroupAdmin, UserAdmin
+from django.contrib.auth.models import Group, User
 from django.core.paginator import Paginator
 
 from .models import Band, Child, Event, Parent, Swallow
@@ -8,6 +8,7 @@ from .models import Band, Child, Event, Parent, Swallow
 site = admin.AdminSite(name="admin")
 
 site.register(User, UserAdmin)
+site.register(Group, GroupAdmin)
 
 
 class CustomPaginator(Paginator):

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -8,7 +8,7 @@ from django.contrib.admin.tests import AdminSeleniumTestCase
 from django.contrib.admin.views.main import (
     ALL_VAR, IS_POPUP_VAR, ORDER_VAR, PAGE_VAR, SEARCH_VAR, TO_FIELD_VAR,
 )
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group as AdminGroup, User
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.messages.storage.cookie import CookieStorage
 from django.db import connection, models
@@ -1690,22 +1690,9 @@ class SeleniumTests(AdminSeleniumTestCase):
     def test_collapse_filters(self):
         from selenium.webdriver.common.by import By
 
-        from django.contrib.auth.models import Group as AdminGroup
-
         # We create 10 new Groups in addition to the 'All' and 'groups__isnull'
         # to have >10 filters and see if it is collapsed when enter to the list view
-        AdminGroup.objects.bulk_create([
-            Group(name='01'),
-            Group(name='02'),
-            Group(name='03'),
-            Group(name='04'),
-            Group(name='05'),
-            Group(name='06'),
-            Group(name='07'),
-            Group(name='08'),
-            Group(name='09'),
-            Group(name='10')
-        ])
+        AdminGroup.objects.bulk_create(Group(name=str(i)) for i in range(10))
 
         self.admin_login(username='super', password='secret')
         self.selenium.get(self.live_server_url + reverse('admin:auth_user_changelist'))


### PR DESCRIPTION
Ticket https://code.djangoproject.com/ticket/27471

Based on the work made in https://github.com/django/django/pull/7538 I added some improvements: Use of a context variable, added styles in a separate file, a clear functionality using `hide` instead of `toggle` for all the cases and tests added.

**Screenshot**:
![image](https://user-images.githubusercontent.com/16822952/150062704-170a8b54-c2ff-4b90-b9b5-f7f6a8dafd5a.png)

**GIF**:
![django_filters_collapsables](https://user-images.githubusercontent.com/16822952/150206960-a59e06a2-7ef7-4184-b773-985255413136.gif)

I'm not pretty sure where I should write this new functionality at the documentation :thinking: