### PR TITLE
Fixed #33407 -- Fixed .radiolist admin CSS.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -37,16 +37,19 @@ label {
 
 /* RADIO BUTTONS */
 
-form ul.radiolist li {
-    list-style-type: none;
+form div.radiolist div {
+    padding-right: 7px;
 }
 
-form ul.radiolist label {
-    float: none;
-    display: inline;
+form div.radiolist.inline div {
+    display: inline-block;
 }
 
-form ul.radiolist input[type="radio"] {
+form div.radiolist label {
+    width: auto;
+}
+
+form div.radiolist input[type="radio"] {
     margin: -2px 4px 0 0;
     padding: 0;
 }
@@ -106,7 +109,7 @@ form .aligned ul {
     padding-left: 10px;
 }
 
-form .aligned ul.radiolist {
+form .aligned div.radiolist {
     display: inline-block;
     margin: 0;
     padding: 0;

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -228,7 +228,7 @@ input[type="submit"], button {
         margin-left: 15px;
     }
 
-    form .aligned ul.radiolist {
+    form .aligned div.radiolist {
         margin-left: 2px;
     }
 
@@ -646,12 +646,13 @@ input[type="submit"], button {
         padding-left: 0;
     }
 
-    form .aligned ul.radiolist {
+    form .aligned div.radiolist {
+        margin-top: 5px;
         margin-right: 15px;
         margin-bottom: -3px;
     }
 
-    form .aligned ul.radiolist:not(.inline) li + li {
+    form .aligned div.radiolist:not(.inline) div + div {
         margin-top: 5px;
     }
 

--- a/docs/releases/4.0.2.txt
+++ b/docs/releases/4.0.2.txt
@@ -25,3 +25,6 @@ Bugfixes
 * Fixed a regression in Django 4.0 that caused a crash of ``makemigrations`` on
   models without ``Meta.order_with_respect_to`` but with a field named
   ``_order`` (:ticket:`33449`).
+
+* Fixed a regression in Django 4.0 that caused incorrect
+  :attr:`.ModelAdmin.radio_fields` layout in the admin (:ticket:`33407`).


### PR DESCRIPTION
Regression in 5942ab5eb165ee2e759174e297148a40dd855920.

Alternate take to #15283. 

This looks like the minimal change to me. Not sure if there aren't more tricky cases. 

Simple model: 

```
class NameChoices(models.TextChoices):
    JOHN = 'John'
    PAUL = "Paul"
    GEORGE = "George"
    RINGO = "Ringo"


class MyModel(models.Model):
    name = models.CharField(max_length=200, choices=NameChoices.choices)
```

And then an admin: 

```
class MyModelAdmin(admin.ModelAdmin):
    radio_fields = {
        'name': admin.HORIZONTAL,
    }
```

Looks _pretty close™_ in big window, with a small margin difference below coming from the parent element in smaller viewport. 

I'll upload a zip of the project to save a cycle. @matthiask — I know you exercise the admin well here, could I ask you to check? 