### PR TITLE
Improved wording in running Django’s test suite in contributing tutorial.

### DIFF
--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -199,8 +199,8 @@ work and haven't broken other parts of Django. If you've never run Django's test
 suite before, it's a good idea to run it once beforehand to get familiar with
 its output.
 
-Before running the test suite, install its dependencies by ``cd``-ing into the
-Django ``tests/`` directory and then running:
+Before running the test suite, enter the Django ``tests/`` directory using the
+``cd tests`` command, and install test dependencies by running:
 
 .. console::
 


### PR DESCRIPTION

![editable line](https://user-images.githubusercontent.com/97300899/150296630-a3937090-770d-48f2-91c9-2bbbd46cf535.png)

In line 202 and 203 of contributing.txt file at path "django/docs/intro/" was little confusing as it contains **"cd"-ing**  which looks like a command so I have made it more clear and separated **cd** and made the whole line more clear.