### PR TITLE
FieldFile: expose .mode of underlying file

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -70,6 +70,11 @@ class FieldFile(File):
             return self.file.size
         return self.storage.size(self.name)
 
+    @property
+    def mode(self):
+        self._require_file()
+        return self.file.mode
+
     def open(self, mode='rb'):
         self._require_file()
         if getattr(self, '_file', None) is None:


### PR DESCRIPTION
`.mode` is sometimes seen as part of the implicit interface of "file like objects", despite those not having a properly defined interface to begin with.

An example of a bug flowing from such an assumption is here: https://github.com/pandas-dev/pandas/issues/45488

This PR simply lifts the `.mode` attribute of the underlying file object to the `FieldFile` interface.