### PR TITLE
Fixed #33455 -- Improved error message when selenium is not installed.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -21,6 +21,7 @@ except ImportError as e:
 else:
     from django.apps import apps
     from django.conf import settings
+    from django.core.exceptions import ImproperlyConfigured
     from django.db import connection, connections
     from django.test import TestCase, TransactionTestCase
     from django.test.runner import get_max_test_processes, parallel_type
@@ -321,6 +322,10 @@ class ActionSelenium(argparse.Action):
     Validate the comma-separated list of requested browsers.
     """
     def __call__(self, parser, namespace, values, option_string=None):
+        try:
+            import selenium  # NOQA
+        except ImportError as e:
+            raise ImproperlyConfigured(f'Error loading selenium module: {e}')
         browsers = values.split(',')
         for browser in browsers:
             try:


### PR DESCRIPTION
Had a couple of ideas in mind on how to check if selenium is installed, went with the idea suggested in the ticket comments (importing selenium).