### PR TITLE
Fixed #33449 -- Fixed makemigrations crash on models without Meta.order_with_respect_to but with _order field.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -307,6 +307,7 @@ answer newbie questions, and generally made Django that much better:
     Étienne Beaulé <beauleetienne0@gmail.com>
     Eugene Lazutkin <http://lazutkin.com/blog/>
     Evan Grim <https://github.com/egrim>
+    Fabian Büchler <fabian.buechler@inoqo.com>
     Fabrice Aneche <akh@nobugware.com>
     Farhaan Bukhsh <farhaan.bukhsh@gmail.com>
     favo@exoweb.net

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -685,11 +685,8 @@ class ModelState:
         return self.name.lower()
 
     def get_field(self, field_name):
-        field_name = (
-            self.options['order_with_respect_to']
-            if field_name == '_order'
-            else field_name
-        )
+        if field_name == '_order' and 'order_with_respect_to' in self.options:
+            field_name = self.options['order_with_respect_to']
         return self.fields[field_name]
 
     @classmethod


### PR DESCRIPTION
Regression in aa4acc164d1247c0de515c959f7b09648b57dc42

For models with `_order` fields but not using `Meta.order_with_respect_to`, ModelState.get_field failed to access the `order_with_respect_to` Meta option.

Fixed this by making `ModelState.get_field` more definsive.