### PR TITLE
Fixed #33449 -- Fixed makemigrations crash on models without Meta.order_with_respect_to but with _order field.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -307,6 +307,7 @@ answer newbie questions, and generally made Django that much better:
     Étienne Beaulé <beauleetienne0@gmail.com>
     Eugene Lazutkin <http://lazutkin.com/blog/>
     Evan Grim <https://github.com/egrim>
+    Fabian Büchler <fabian.buechler@inoqo.com>
     Fabrice Aneche <akh@nobugware.com>
     Farhaan Bukhsh <farhaan.bukhsh@gmail.com>
     favo@exoweb.net

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -685,11 +685,8 @@ class ModelState:
         return self.name.lower()
 
     def get_field(self, field_name):
-        field_name = (
-            self.options['order_with_respect_to']
-            if field_name == '_order'
-            else field_name
-        )
+        if field_name == '_order':
+            field_name = self.options.get('order_with_respect_to', field_name)
         return self.fields[field_name]
 
     @classmethod

--- a/docs/releases/4.0.2.txt
+++ b/docs/releases/4.0.2.txt
@@ -20,3 +20,7 @@ Bugfixes
 
 * Fixed a regression in Django 4.0 that caused an incorrect ``repr`` of
   ``ResolverMatch`` for class-based views (:ticket:`33426`).
+
+* Fixed a regression in Django 4.0 that caused a crash of ``makemigrations`` on
+  models without ``Meta.order_with_respect_to`` but with a field named
+  ``_order`` (:ticket:`33449`).

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -959,6 +959,44 @@ class StateTests(SimpleTestCase):
             ["id", "author"],
         )
 
+    def test_modelstate_get_field_order_wrt(self):
+        new_apps = Apps()
+
+        class Author(models.Model):
+            name = models.TextField()
+
+            class Meta:
+                app_label = 'migrations'
+                apps = new_apps
+
+        class Book(models.Model):
+            author = models.ForeignKey(Author, models.CASCADE)
+
+            class Meta:
+                app_label = 'migrations'
+                apps = new_apps
+                order_with_respect_to = 'author'
+
+        model_state = ModelState.from_model(Book)
+        order_wrt_field = model_state.get_field('_order')
+        self.assertIsInstance(order_wrt_field, models.ForeignKey)
+        self.assertEqual(order_wrt_field.related_model, 'migrations.author')
+
+    def test_modelstate_get_field_no_order_wrt_order_field(self):
+        new_apps = Apps()
+
+        class HistoricalRecord(models.Model):
+            _order = models.PositiveSmallIntegerField()
+
+            class Meta:
+                app_label = 'migrations'
+                apps = new_apps
+
+        model_state = ModelState.from_model(HistoricalRecord)
+        order_field = model_state.get_field('_order')
+        self.assertIsNone(order_field.related_model)
+        self.assertIsInstance(order_field, models.PositiveSmallIntegerField)
+
     def test_manager_refer_correct_model_version(self):
         """
         #24147 - Managers refer to the correct version of a


### PR DESCRIPTION
Regression in aa4acc164d1247c0de515c959f7b09648b57dc42.