### PR TITLE
Stopped including type="text/css" attributes for CSS link tags.

### DIFF
--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -2,7 +2,7 @@
 {% load i18n static %}
 {% load admin_urls %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
 {% block bodyclass %}{{ block.super }} {{ opts.app_label }}-{{ opts.model_name }} change-form{% endblock %}
 {% if not is_popup %}
 {% block breadcrumbs %}

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -3,21 +3,21 @@
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr,auto' }}">
 <head>
 <title>{% block title %}{% endblock %}</title>
-<link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
+<link rel="stylesheet" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
 {% block dark-mode-vars %}
-  <link rel="stylesheet" type="text/css" href="{% static "admin/css/dark_mode.css" %}">
+  <link rel="stylesheet" href="{% static "admin/css/dark_mode.css" %}">
 {% endblock %}
 {% if not is_popup and is_nav_sidebar_enabled %}
-  <link rel="stylesheet" type="text/css" href="{% static "admin/css/nav_sidebar.css" %}">
+  <link rel="stylesheet" href="{% static "admin/css/nav_sidebar.css" %}">
   <script src="{% static 'admin/js/nav_sidebar.js' %}" defer></script>
 {% endif %}
 {% block extrastyle %}{% endblock %}
-{% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}">{% endif %}
+{% if LANGUAGE_BIDI %}<link rel="stylesheet" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}">{% endif %}
 {% block extrahead %}{% endblock %}
 {% block responsive %}
     <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0">
-    <link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive.css" %}">
-    {% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive_rtl.css" %}">{% endif %}
+    <link rel="stylesheet" href="{% static "admin/css/responsive.css" %}">
+    {% if LANGUAGE_BIDI %}<link rel="stylesheet" href="{% static "admin/css/responsive_rtl.css" %}">{% endif %}
 {% endblock %}
 {% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE">{% endblock %}
 </head>

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -6,7 +6,7 @@
 {{ media }}
 {% endblock %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
 
 {% block coltype %}colM{% endblock %}
 

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -3,9 +3,9 @@
 
 {% block extrastyle %}
   {{ block.super }}
-  <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+  <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}">
   {% if cl.formset %}
-    <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">
+    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
   {% endif %}
   {% if cl.formset or action_form %}
     <script src="{% url 'admin:jsi18n' %}"></script>

--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/dashboard.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/dashboard.css" %}">{% endblock %}
 
 {% block coltype %}colMS{% endblock %}
 

--- a/django/contrib/admin/templates/admin/login.html
+++ b/django/contrib/admin/templates/admin/login.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/login.css" %}">
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/login.css" %}">
 {{ form.media }}
 {% endblock %}
 

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
 {% block userlinks %}{% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% translate 'Documentation' %}</a> / {% endif %} {% translate 'Change password' %} / <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">

--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>

--- a/django/contrib/admin/templates/registration/password_reset_form.html
+++ b/django/contrib/admin/templates/registration/password_reset_form.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -90,7 +90,7 @@ class Media:
         media = sorted(self._css)
         return chain.from_iterable([
             format_html(
-                '<link href="{}" type="text/css" media="{}" rel="stylesheet">',
+                '<link href="{}" media="{}" rel="stylesheet">',
                 self.absolute_path(path), medium
             ) for path in self._css[medium]
         ] for medium in media)

--- a/django/views/templates/default_urlconf.html
+++ b/django/views/templates/default_urlconf.html
@@ -6,7 +6,7 @@
         <meta charset="utf-8">
         <title>{% translate "The install worked successfully! Congratulations!" %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" type="text/css" href="/static/admin/css/fonts.css">
+        <link rel="stylesheet" href="/static/admin/css/fonts.css">
         <style>
           html {
             line-height: 1.15;

--- a/docs/_theme/djangodocs/layout.html
+++ b/docs/_theme/djangodocs/layout.html
@@ -72,7 +72,7 @@
 </script>
 {% endif %}
 {%- if include_console_assets -%}
-<link rel="stylesheet" href="{{ pathto('_static/console-tabs.css', 1) }}" type="text/css" />
+<link rel="stylesheet" href="{{ pathto('_static/console-tabs.css', 1) }}">
 {%- endif -%}
 {% endblock %}
 

--- a/docs/intro/tutorial06.txt
+++ b/docs/intro/tutorial06.txt
@@ -74,7 +74,7 @@ Next, add the following at the top of ``polls/templates/polls/index.html``:
 
     {% load static %}
 
-    <link rel="stylesheet" type="text/css" href="{% static 'polls/style.css' %}">
+    <link rel="stylesheet" href="{% static 'polls/style.css' %}">
 
 The ``{% static %}`` template tag generates the absolute URL of static files.
 

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -2637,7 +2637,7 @@ It is also able to consume standard context variables, e.g. assuming a
 ``user_stylesheet`` variable is passed to the template::
 
     {% load static %}
-    <link rel="stylesheet" href="{% static user_stylesheet %}" type="text/css" media="screen">
+    <link rel="stylesheet" href="{% static user_stylesheet %}" media="screen">
 
 If you'd like to retrieve a static URL without displaying it, you can use a
 slightly different call::

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -366,6 +366,9 @@ Miscellaneous
   :attr:`~django.contrib.admin.ModelAdmin.inlines` attributes now default to an
   empty tuple rather than an empty list to discourage unintended mutation.
 
+* The ``type="text/css"`` attribute is no longer included in ``<link>`` tags
+  for CSS :doc:`form media </topics/forms/media>`.
+
 .. _deprecated-features-4.1:
 
 Features deprecated in 4.1

--- a/docs/topics/forms/media.txt
+++ b/docs/topics/forms/media.txt
@@ -71,7 +71,7 @@ can be retrieved through this property::
 
     >>> w = CalendarWidget()
     >>> print(w.media)
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" media="all" rel="stylesheet">
     <script src="http://static.example.com/animations.js"></script>
     <script src="http://static.example.com/actions.js"></script>
 
@@ -114,9 +114,14 @@ requirements::
 
 If this last CSS definition were to be rendered, it would become the following HTML::
 
-    <link href="http://static.example.com/pretty.css" type="text/css" media="screen" rel="stylesheet">
-    <link href="http://static.example.com/lo_res.css" type="text/css" media="tv,projector" rel="stylesheet">
-    <link href="http://static.example.com/newspaper.css" type="text/css" media="print" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" media="screen" rel="stylesheet">
+    <link href="http://static.example.com/lo_res.css" media="tv,projector" rel="stylesheet">
+    <link href="http://static.example.com/newspaper.css" media="print" rel="stylesheet">
+
+.. versionchanged:: 4.1
+
+    In older versions, the ``type="text/css"`` attribute is included in CSS
+    links.
 
 ``js``
 ------
@@ -145,8 +150,8 @@ example above::
 
     >>> w = FancyCalendarWidget()
     >>> print(w.media)
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
-    <link href="http://static.example.com/fancy.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/fancy.css" media="all" rel="stylesheet">
     <script src="http://static.example.com/animations.js"></script>
     <script src="http://static.example.com/actions.js"></script>
     <script src="http://static.example.com/whizbang.js"></script>
@@ -165,7 +170,7 @@ an ``extend=False`` declaration to the ``Media`` declaration::
 
     >>> w = FancyCalendarWidget()
     >>> print(w.media)
-    <link href="http://static.example.com/fancy.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/fancy.css" media="all" rel="stylesheet">
     <script src="http://static.example.com/whizbang.js"></script>
 
 If you require even more control over inheritance, define your assets using a
@@ -228,7 +233,7 @@ was ``None``::
 
     >>> w = CalendarWidget()
     >>> print(w.media)
-    <link href="/css/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="/css/pretty.css" media="all" rel="stylesheet">
     <script src="http://uploads.example.com/animations.js"></script>
     <script src="http://othersite.com/actions.js"></script>
 
@@ -236,7 +241,7 @@ But if :setting:`STATIC_URL` is ``'http://static.example.com/'``::
 
     >>> w = CalendarWidget()
     >>> print(w.media)
-    <link href="/css/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="/css/pretty.css" media="all" rel="stylesheet">
     <script src="http://static.example.com/animations.js"></script>
     <script src="http://othersite.com/actions.js"></script>
 
@@ -245,7 +250,7 @@ Or if :mod:`~django.contrib.staticfiles` is configured using the
 
     >>> w = CalendarWidget()
     >>> print(w.media)
-    <link href="/css/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="/css/pretty.css" media="all" rel="stylesheet">
     <script src="https://static.example.com/animations.27e20196a850.js"></script>
     <script src="http://othersite.com/actions.js"></script>
 
@@ -268,12 +273,12 @@ operator to filter out a medium of interest. For example::
 
     >>> w = CalendarWidget()
     >>> print(w.media)
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" media="all" rel="stylesheet">
     <script src="http://static.example.com/animations.js"></script>
     <script src="http://static.example.com/actions.js"></script>
 
     >>> print(w.media['css'])
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" media="all" rel="stylesheet">
 
 When you use the subscript operator, the value that is returned is a
 new ``Media`` object -- but one that only contains the media of interest.
@@ -300,7 +305,7 @@ specified by both::
     >>> w1 = CalendarWidget()
     >>> w2 = OtherWidget()
     >>> print(w1.media + w2.media)
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" media="all" rel="stylesheet">
     <script src="http://static.example.com/animations.js"></script>
     <script src="http://static.example.com/actions.js"></script>
     <script src="http://static.example.com/whizbang.js"></script>
@@ -356,7 +361,7 @@ are part of the form::
 
     >>> f = ContactForm()
     >>> f.media
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" media="all" rel="stylesheet">
     <script src="http://static.example.com/animations.js"></script>
     <script src="http://static.example.com/actions.js"></script>
     <script src="http://static.example.com/whizbang.js"></script>
@@ -375,8 +380,8 @@ CSS for form layout -- add a ``Media`` declaration to the form::
 
     >>> f = ContactForm()
     >>> f.media
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
-    <link href="http://static.example.com/layout.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/layout.css" media="all" rel="stylesheet">
     <script src="http://static.example.com/animations.js"></script>
     <script src="http://static.example.com/actions.js"></script>
     <script src="http://static.example.com/whizbang.js"></script>

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -17,8 +17,8 @@ class FormsMediaTestCase(SimpleTestCase):
         )
         self.assertEqual(
             str(m),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="https://secure.other.com/path/to/js3"></script>"""
@@ -38,8 +38,8 @@ class FormsMediaTestCase(SimpleTestCase):
         m3 = Media(Foo)
         self.assertEqual(
             str(m3),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="https://secure.other.com/path/to/js3"></script>"""
@@ -70,8 +70,8 @@ class FormsMediaTestCase(SimpleTestCase):
         w1 = MyWidget1()
         self.assertEqual(
             str(w1.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="https://secure.other.com/path/to/js3"></script>"""
@@ -80,8 +80,8 @@ class FormsMediaTestCase(SimpleTestCase):
         # Media objects can be interrogated by media type
         self.assertEqual(
             str(w1.media['css']),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">"""
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">"""
         )
 
         self.assertEqual(
@@ -120,9 +120,9 @@ class FormsMediaTestCase(SimpleTestCase):
         w3 = MyWidget3()
         self.assertEqual(
             str(w1.media + w2.media + w3.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
+<link href="/path/to/css3" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="/path/to/js4"></script>
@@ -132,8 +132,8 @@ class FormsMediaTestCase(SimpleTestCase):
         # media addition hasn't affected the original objects
         self.assertEqual(
             str(w1.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="https://secure.other.com/path/to/js3"></script>"""
@@ -148,7 +148,7 @@ class FormsMediaTestCase(SimpleTestCase):
                 js = ('/path/to/js1', '/path/to/js1')
 
         w4 = MyWidget4()
-        self.assertEqual(str(w4.media), """<link href="/path/to/css1" type="text/css" media="all" rel="stylesheet">
+        self.assertEqual(str(w4.media), """<link href="/path/to/css1" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>""")
 
     def test_media_deduplication(self):
@@ -159,7 +159,7 @@ class FormsMediaTestCase(SimpleTestCase):
             css={'all': ('/path/to/css1', '/path/to/css1')},
             js=('/path/to/js1', '/path/to/js1'),
         )
-        self.assertEqual(str(media), """<link href="/path/to/css1" type="text/css" media="all" rel="stylesheet">
+        self.assertEqual(str(media), """<link href="/path/to/css1" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>""")
 
     def test_media_property(self):
@@ -174,7 +174,7 @@ class FormsMediaTestCase(SimpleTestCase):
             media = property(_media)
 
         w4 = MyWidget4()
-        self.assertEqual(str(w4.media), """<link href="/some/path" type="text/css" media="all" rel="stylesheet">
+        self.assertEqual(str(w4.media), """<link href="/some/path" media="all" rel="stylesheet">
 <script src="/some/js"></script>""")
 
         # Media properties can reference the media of their parents
@@ -184,8 +184,8 @@ class FormsMediaTestCase(SimpleTestCase):
             media = property(_media)
 
         w5 = MyWidget5()
-        self.assertEqual(str(w5.media), """<link href="/some/path" type="text/css" media="all" rel="stylesheet">
-<link href="/other/path" type="text/css" media="all" rel="stylesheet">
+        self.assertEqual(str(w5.media), """<link href="/some/path" media="all" rel="stylesheet">
+<link href="/other/path" media="all" rel="stylesheet">
 <script src="/some/js"></script>
 <script src="/other/js"></script>""")
 
@@ -207,9 +207,9 @@ class FormsMediaTestCase(SimpleTestCase):
         w6 = MyWidget6()
         self.assertEqual(
             str(w6.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/other/path" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/other/path" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="/other/js"></script>
 <script src="http://media.other.com/path/to/js2"></script>
@@ -235,8 +235,8 @@ class FormsMediaTestCase(SimpleTestCase):
         w7 = MyWidget7()
         self.assertEqual(
             str(w7.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="https://secure.other.com/path/to/js3"></script>"""
@@ -253,9 +253,9 @@ class FormsMediaTestCase(SimpleTestCase):
         w8 = MyWidget8()
         self.assertEqual(
             str(w8.media),
-            """<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
-<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="/path/to/css3" media="all" rel="stylesheet">
+<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="/path/to/js4"></script>
@@ -287,8 +287,8 @@ class FormsMediaTestCase(SimpleTestCase):
         w9 = MyWidget9()
         self.assertEqual(
             str(w9.media),
-            """<link href="/some/path" type="text/css" media="all" rel="stylesheet">
-<link href="/other/path" type="text/css" media="all" rel="stylesheet">
+            """<link href="/some/path" media="all" rel="stylesheet">
+<link href="/other/path" media="all" rel="stylesheet">
 <script src="/some/js"></script>
 <script src="/other/js"></script>"""
         )
@@ -303,8 +303,8 @@ class FormsMediaTestCase(SimpleTestCase):
                 js = ('/path/to/js1', '/path/to/js4')
 
         w10 = MyWidget10()
-        self.assertEqual(str(w10.media), """<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
-<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
+        self.assertEqual(str(w10.media), """<link href="/path/to/css3" media="all" rel="stylesheet">
+<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="/path/to/js4"></script>""")
 
@@ -328,9 +328,9 @@ class FormsMediaTestCase(SimpleTestCase):
         w11 = MyWidget11()
         self.assertEqual(
             str(w11.media),
-            """<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
-<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="/path/to/css3" media="all" rel="stylesheet">
+<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="/path/to/js4"></script>
@@ -357,9 +357,9 @@ class FormsMediaTestCase(SimpleTestCase):
         w12 = MyWidget12()
         self.assertEqual(
             str(w12.media),
-            """<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
-<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="/path/to/css3" media="all" rel="stylesheet">
+<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="/path/to/js4"></script>"""
         )
@@ -382,10 +382,10 @@ class FormsMediaTestCase(SimpleTestCase):
         multimedia = MultimediaWidget()
         self.assertEqual(
             str(multimedia.media),
-            """<link href="/file4" type="text/css" media="print" rel="stylesheet">
-<link href="/file3" type="text/css" media="screen" rel="stylesheet">
-<link href="/file1" type="text/css" media="screen, print" rel="stylesheet">
-<link href="/file2" type="text/css" media="screen, print" rel="stylesheet">
+            """<link href="/file4" media="print" rel="stylesheet">
+<link href="/file3" media="screen" rel="stylesheet">
+<link href="/file1" media="screen, print" rel="stylesheet">
+<link href="/file2" media="screen, print" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="/path/to/js4"></script>"""
         )
@@ -426,9 +426,9 @@ class FormsMediaTestCase(SimpleTestCase):
         mymulti = MyMultiWidget()
         self.assertEqual(
             str(mymulti.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
+<link href="/path/to/css3" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="/path/to/js4"></script>
@@ -468,9 +468,9 @@ class FormsMediaTestCase(SimpleTestCase):
         f1 = MyForm()
         self.assertEqual(
             str(f1.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
+<link href="/path/to/css3" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="/path/to/js4"></script>
@@ -483,9 +483,9 @@ class FormsMediaTestCase(SimpleTestCase):
         f2 = AnotherForm()
         self.assertEqual(
             str(f1.media + f2.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
+<link href="/path/to/css3" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="/path/to/js4"></script>
@@ -505,10 +505,10 @@ class FormsMediaTestCase(SimpleTestCase):
         f3 = FormWithMedia()
         self.assertEqual(
             str(f3.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/some/form/css" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/some/form/css" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
+<link href="/path/to/css3" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="/some/form/javascript"></script>
 <script src="http://media.other.com/path/to/js2"></script>
@@ -524,10 +524,10 @@ class FormsMediaTestCase(SimpleTestCase):
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="/path/to/js4"></script>
 <script src="https://secure.other.com/path/to/js3"></script>"""
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/some/form/css" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">"""
+            """<link href="http://media.example.com/static/path/to/css1" media="all" rel="stylesheet">
+<link href="/some/form/css" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
+<link href="/path/to/css3" media="all" rel="stylesheet">"""
         )
 
     def test_html_safe(self):

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -2485,8 +2485,8 @@ class OtherModelFormTests(TestCase):
         f = ModelFormWithMedia()
         self.assertHTMLEqual(
             str(f.media),
-            '''<link href="/some/form/css" type="text/css" media="all" rel="stylesheet">
-<script src="/some/form/javascript"></script>'''
+            '<link href="/some/form/css" media="all" rel="stylesheet">'
+            '<script src="/some/form/javascript"></script>'
         )
 
     def test_choices_type(self):

--- a/tests/staticfiles_tests/test_forms.py
+++ b/tests/staticfiles_tests/test_forms.py
@@ -29,8 +29,8 @@ class StaticFilesFormsMediaTestCase(SimpleTestCase):
         )
         self.assertEqual(
             str(m),
-            """<link href="https://example.com/assets/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="https://example.com/assets/path/to/css1" media="all" rel="stylesheet">
+<link href="/path/to/css2" media="all" rel="stylesheet">
 <script src="/path/to/js1"></script>
 <script src="http://media.other.com/path/to/js2"></script>
 <script src="https://secure.other.com/path/to/js3"></script>


### PR DESCRIPTION
Quoting MDN: `The common use of this attribute is to define the type of stylesheet being referenced (such as text/css), but given that CSS is the only stylesheet language used on the web, not only is it possible to omit the type attribute, but is actually now recommended practice.`