### PR TITLE
Doc'd that users with unusable passwords cannot request a password reset.

### DIFF
--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -182,6 +182,12 @@ Methods
         You may need this if authentication for your application takes place
         against an existing external source such as an LDAP directory.
 
+        .. admonition:: Password reset restriction
+
+            Users having an unusable password will not able to request a
+            password reset email via
+            :class:`~django.contrib.auth.views.PasswordResetView`.
+
     .. method:: has_usable_password()
 
         Returns ``False`` if


### PR DESCRIPTION
Include warning around unusable passwords Users having an unusable passwords will not be able to request password reset emails. This important information is only found in the PasswordResetView docs, and not in the set_unusable_password docs. This patch rectifies this shortcoming and places the information where it is needed.
