### PR TITLE
Fixed #33606 -- Cleansed sessionid cookie in error reports.

### DIFF
--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -281,7 +281,11 @@ following attributes and methods:
 
             import re
 
-            re.compile(r'API|TOKEN|KEY|SECRET|PASS|SIGNATURE', flags=re.IGNORECASE)
+            re.compile(r'API|TOKEN|KEY|SECRET|PASS|SIGNATURE|HTTP_COOKIE', flags=re.IGNORECASE)
+
+        .. versionchanged:: 4.2
+
+            ``HTTP_COOKIE`` was added.
 
     .. method:: is_active(request)
 

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -176,6 +176,9 @@ Forms
 * :func:`~django.forms.models.modelform_factory` now respects the
   ``formfield_callback`` attribute of the ``form``’s ``Meta``.
 
+* Session cookies are now treated as credentials and therefore hidden and
+  replaced with stars (``**********``) in error reports.
+
 Generic Views
 ~~~~~~~~~~~~~
 

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -1696,6 +1696,12 @@ class ExceptionReporterFilterTests(
         )
         self.assertNotIn(b"super_secret", response.content)
 
+    @override_settings(SESSION_COOKIE_NAME="djangosession")
+    def test_cleanse_session_cookie_value(self):
+        self.client.cookies.load({"djangosession": "should not be displayed"})
+        response = self.client.get("/raises500/")
+        self.assertNotContains(response, "should not be displayed", status_code=500)
+
 
 class CustomExceptionReporterFilter(SafeExceptionReporterFilter):
     cleansed_substitute = "XXXXXXXXXXXXXXXXXXXX"


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/33606 

The session ID should be cleansed when reporting errors, just like other credentials.

Related to https://code.djangoproject.com/ticket/29714
Discussion on the mailing list: https://groups.google.com/g/django-developers/c/H5hJxpwYFcw

A quick github search yields multiple occasions where session IDs ended  up in public bug reports. This could potentially be exploited by automatically searching for such requests and hijacking the associated accounts.

Note that in order to be effective we need to cleanse both `request_COOKIES_items` and `request_meta['HTTP_COOKIE']`.