### PR TITLE
Fixed #33460 -- Used VALUES clause for insert in bulk on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -337,10 +337,9 @@ class DatabaseOperations(BaseDatabaseOperations):
         return bool(value) if value in (1, 0) else value
 
     def bulk_insert_sql(self, fields, placeholder_rows):
-        return " UNION ALL ".join(
-            "SELECT %s" % ", ".join(row)
-            for row in placeholder_rows
-        )
+        placeholder_rows_sql = (', '.join(row) for row in placeholder_rows)
+        values_sql = ', '.join(f'({sql})' for sql in placeholder_rows_sql)
+        return f'VALUES {values_sql}'
 
     def combine_expression(self, connector, sub_expressions):
         # SQLite doesn't have a ^ operator, so use the user-defined POWER


### PR DESCRIPTION
Edit: [ticket is 33460](https://code.djangoproject.com/ticket/33460)

------

Instead of using the old work-around of `UNION ALL SELECT ...`

[SQLite 3.7.11](http://www.sqlite.org/releaselog/3_7_11.html) introduced the ability to use multiple values directly; SQLite 3.9 is Django's currently documented minimum supported version.

This looks to have a potentially positive effect on `django.db.backends.sqlite3.features.DatabaseFeatures.max_query_params`; prior to this change, increasing that value (e.g due to using `3.32+` to get at higher `SQLITE_MAX_VARIABLE_NUMBER`) would cause test `lookup.tests.LookupTests.test_in_bulk_lots_of_ids` to fail with `django.db.utils.OperationalError: too many terms in compound SELECT` but doesn't have that problem afterwards.

([SQLite 3.8.8](https://www.sqlite.org/releaselog/3_8_8.html) made multiple values not subject to the `SQLITE_LIMIT_COMPOUND_SELECT`)

Queries executed changes from:
```
INSERT INTO "bulk_create_country" ("name", "iso_two_letter", "description") 
SELECT 'Country 0', '', '' UNION ALL SELECT 'Country 1', '', '' UNION ...
```
to:
```
INSERT INTO "bulk_create_country" ("name", "iso_two_letter", "description") 
VALUES ('Country 0', '', ''), ('Country 1', '', ''), ...
```

Let's see what CI says, for a start!