### PR TITLE
Fixed wrapping of long messages in the admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -588,6 +588,7 @@ ul.messagelist li {
     background: var(--message-success-bg) url(../img/icon-yes.svg) 40px 12px no-repeat;
     background-size: 16px auto;
     color: var(--body-fg);
+    word-break: break-word;
 }
 
 ul.messagelist li.warning {


### PR DESCRIPTION
Noticed when checking #15333.

Before:
![Screenshot_20220126_082926](https://user-images.githubusercontent.com/2865885/151121846-a5823254-c2cd-426c-a17a-465aa9f34942.png)

After
![Screenshot_20220126_083308](https://user-images.githubusercontent.com/2865885/151121854-aed918b7-891b-459c-abf6-dcaa8862f88f.png)