### PR TITLE
Fixed #33461 -- Escaped template errors in the technical 500 debug page.

### DIFF
--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -190,7 +190,7 @@
 <div id="template">
    <h2>Error during template rendering</h2>
    <p>In template <code>{{ template_info.name }}</code>, error at line <strong>{{ template_info.line }}</strong></p>
-   <h3>{{ template_info.message }}</h3>
+   <h3>{{ template_info.message|force_escape }}</h3>
    <table class="source{% if template_info.top %} cut-top{% endif %}
       {% if template_info.bottom != template_info.total %} cut-bottom{% endif %}">
    {% for source_line in template_info.source_lines %}
@@ -316,7 +316,7 @@ Using engine {{ entry.backend.name }}:
 {% endif %}{% endif %}{% if template_info %}
 Template error:
 In template {{ template_info.name }}, error at line {{ template_info.line }}
-   {{ template_info.message }}
+   {{ template_info.message|force_escape }}
 {% for source_line in template_info.source_lines %}{% if source_line.0 == template_info.line %}   {{ source_line.0 }} : {{ template_info.before }} {{ template_info.during }} {{ template_info.after }}{% else %}   {{ source_line.0 }} : {{ source_line.1 }}{% endif %}{% endfor %}{% endif %}
 
 Traceback (most recent call last):{% for frame in frames %}

--- a/tests/view_tests/urls.py
+++ b/tests/view_tests/urls.py
@@ -59,6 +59,11 @@ urlpatterns += i18n_patterns(
 )
 
 urlpatterns += [
+    path(
+        'safestring_exception/',
+        views.safestring_in_template_exception,
+        name='safestring_exception',
+    ),
     path('template_exception/', views.template_exception, name='template_exception'),
     path(
         'raises_template_does_not_exist/<path:path>',

--- a/tests/view_tests/views.py
+++ b/tests/view_tests/views.py
@@ -9,7 +9,7 @@ from django.core.exceptions import (
 )
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import render
-from django.template import TemplateDoesNotExist
+from django.template import Context, Template, TemplateDoesNotExist
 from django.urls import get_resolver
 from django.views import View
 from django.views.debug import (
@@ -87,6 +87,18 @@ class Http404View(View):
 
 def template_exception(request):
     return render(request, 'debug/template_exception.html')
+
+
+def safestring_in_template_exception(request):
+    """
+    Trigger an exception in the template machinery which causes a SafeString
+    to be inserted as args[0] of the Exception.
+    """
+    template = Template('{% extends "<script>alert(1);</script>" %}')
+    try:
+        template.render(Context())
+    except Exception:
+        return technical_500_response(request, *sys.exc_info())
 
 
 def jsi18n(request):


### PR DESCRIPTION
[Ticket is 33461](https://code.djangoproject.com/ticket/33461).

I've used the reproducer from my original submission to the security address, but slightly adapted to force **2** alerts to appear, when the patch isn't in place. This has required using `html=False` in the `assertNotContains` to avoid getting `django.test.html.HTMLParseError: ('Unexpected end tag textarea ...`

I've opted to ~just apply `escape` in the place where it's officially rendered, rather than~ use the `force_escape` filter ~and risk potentially missing something (like the breaking out of the textarea!) - though it was suggested that maybe `force_escape` was enough to tackle the issue, so I'm OK with changing it if that's preferred.~

-------
(Edit: oh get in the bin, flake8 and isort)
(Edit 2: oh, I forgot I was only running the single test case I added, rather than the whole suite. Oops! Guess I'll have opportunity to go and fix linters anyway, sigh ;))
(Edit 3: hey this time I ran the actual suite, and moved from `escape` to `force_escape` to restore the expected Plain Text output. Given I've had over a week to think on this, you'd think I'd have perhaps got this right first time. Dear reader, you'd be wrong, I am _so_ fallible)
(Edit 4: **sigh**, windows failures, and I've got no idea why!)