### PR TITLE
#33452 Fix -- Save buttons in admin are too close together on medium screen sizes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -637,6 +637,7 @@ answer newbie questions, and generally made Django that much better:
     Matthew Somerville <matthew-django@dracos.co.uk>
     Matthew Tretter <m@tthewwithanm.com>
     Matthew Wilkes <matt@matthewwilkes.name>
+    Swapnil Shinde <swapnilshinde9382@gmail.com>
     Matthias Kestenholz <mk@406.ch>
     Matthias Pronk <django@masida.nl>
     Matt Hoskins <skaffenuk@googlemail.com>

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -262,7 +262,7 @@ body.popup .submit-row {
 }
 
 .submit-row input {
-    height: 35px;
+    height: 40px;
     line-height: 15px;
     margin: 0 0 0 5px;
 }

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -264,11 +264,11 @@ body.popup .submit-row {
 .submit-row input {
     height: 40px;
     line-height: 15px;
-    margin: 0 0 0 5px;
+    margin: 5px 0 5px 5px;
 }
 
 .submit-row input.default {
-    margin: 0 0 0 8px;
+    margin: 5px 0 5px 8px;
     text-transform: uppercase;
 }
 
@@ -289,6 +289,7 @@ body.popup .submit-row {
     height: 15px;
     line-height: 15px;
     color: var(--button-fg);
+    margin: 5px 0 5px 5px;
 }
 
 .submit-row a.closelink {

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -264,11 +264,11 @@ body.popup .submit-row {
 .submit-row input {
     height: 35px;
     line-height: 15px;
-    margin: 5px 0 5px 5px;
+    margin: 0 0 0 5px;
 }
 
 .submit-row input.default {
-    margin: 5px 0 5px 8px;
+    margin: 0 0 0 8px;
     text-transform: uppercase;
 }
 
@@ -289,7 +289,6 @@ body.popup .submit-row {
     height: 15px;
     line-height: 15px;
     color: var(--button-fg);
-    margin: 5px 0 5px 5px;
 }
 
 .submit-row a.closelink {

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -264,11 +264,11 @@ body.popup .submit-row {
 .submit-row input {
     height: 35px;
     line-height: 15px;
-    margin: 0 0 0 5px;
+    margin: 5px 0 5px 5px;
 }
 
 .submit-row input.default {
-    margin: 0 0 0 8px;
+    margin: 5px 0 5px 8px;
     text-transform: uppercase;
 }
 
@@ -289,6 +289,7 @@ body.popup .submit-row {
     height: 15px;
     line-height: 15px;
     color: var(--button-fg);
+    margin: 5px 0 5px 5px;
 }
 
 .submit-row a.closelink {


### PR DESCRIPTION
tried fitting it in one line. but not enough space to fit all in one line. 
![image](https://user-images.githubusercontent.com/68425016/151356111-083c0eb0-4177-4886-8536-9374000385a3.png)
