### PR TITLE
Add mod to combinable connectors

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -430,7 +430,7 @@ _connector_combinators = {
         (fields.IntegerField, fields.FloatField, fields.FloatField),
         (fields.FloatField, fields.IntegerField, fields.FloatField),
     ]
-    for connector in (Combinable.ADD, Combinable.SUB, Combinable.MUL, Combinable.DIV)
+    for connector in (Combinable.ADD, Combinable.SUB, Combinable.MUL, Combinable.DIV, Combinable.MOD)
 }
 
 


### PR DESCRIPTION
As reproted in [33464](https://code.djangoproject.com/ticket/33464), the query expression throws an expression if you do a MOD on decimal field with Int (like 3.2 % 2), instead of outputting the result as a Decimal value. 

Adding the MOD to the `_connector_combinators` to resolve it. 