### PR TITLE
Fixed #33452 -- Fixed admin change-form layout for submit buttons on mid-sized displays.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -248,7 +248,7 @@ fieldset.monospace textarea {
 /* SUBMIT ROW */
 
 .submit-row {
-    padding: 12px 14px;
+    padding: 12px 14px 7px;
     margin: 0 0 20px;
     background: var(--darkened-bg);
     border: 1px solid var(--hairline-color);
@@ -264,11 +264,11 @@ body.popup .submit-row {
 .submit-row input {
     height: 35px;
     line-height: 15px;
-    margin: 0 0 0 5px;
+    margin: 0 0 5px 5px;
 }
 
 .submit-row input.default {
-    margin: 0 0 0 8px;
+    margin: 0 0 5px 8px;
     text-transform: uppercase;
 }
 
@@ -288,6 +288,7 @@ body.popup .submit-row {
     padding: 10px 15px;
     height: 15px;
     line-height: 15px;
+    margin-bottom: 5px;
     color: var(--button-fg);
 }
 

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -28,7 +28,7 @@ input[type="submit"], button {
     }
 
     #content {
-        padding: 20px 30px 30px;
+        padding: 15px 20px 20px;
     }
 
     div.breadcrumbs {
@@ -230,6 +230,22 @@ input[type="submit"], button {
 
     form .aligned div.radiolist {
         margin-left: 2px;
+    }
+
+    .submit-row {
+        padding: 8px 8px 3px 8px;
+    }
+
+    .submit-row a.deletelink {
+        padding: 10px 7px;
+    }
+
+    .submit-row input.default {
+        margin: 0 0 5px 5px;
+    }
+
+    .button, input[type=submit], input[type=button], .submit-row input, a.button {
+        padding: 7px;
     }
 
     /* Related widget */
@@ -808,7 +824,7 @@ input[type="submit"], button {
     /* Submit row */
 
     .submit-row {
-        padding: 10px 10px 0;
+        padding: 10px 10px 5px;
         margin: 0 0 15px;
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
I had to juggle :juggling_person:  the paddings and margins but I'm happy with the end result.

Alternative to #15367.

ticket-33452

Before < 1024px:
![responsive_before](https://user-images.githubusercontent.com/2865885/151503071-2eefebb3-d9a3-4f88-b78e-4ac519c46338.png)

After < 1024px:
![responsive_after](https://user-images.githubusercontent.com/2865885/151503083-857c7609-e4c2-4af4-bd5b-1a06449dcd46.png)

Before < 800px:
![responsive_before_small](https://user-images.githubusercontent.com/2865885/151503075-1ef185e1-3dce-4d69-8cfc-8dc9ff2dafc7.png)

After < 800px:

![responsive_after_small](https://user-images.githubusercontent.com/2865885/151503088-feab848c-46c2-4c78-bdb8-cdb564f92698.png)