### PR TITLE
Removed unused Node.__iter__().

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -978,9 +978,6 @@ class Node:
                     )
             raise
 
-    def __iter__(self):
-        yield self
-
     def get_nodes_by_type(self, nodetype):
         """
         Return a list of all nodes (within this node and its nodelist)


### PR DESCRIPTION
As far as I can tell from executing the test suite locally, this is either unused or untested. Let's find out if the full CI suggests otherwise.