### PR TITLE
Fixed #33474 -- Added __slots__ to Variable and FilterExpression.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -651,6 +651,9 @@ class FilterExpression:
         >>> fe.var
         <Variable: 'variable'>
     """
+
+    __slots__ = ('token', 'filters', 'var', 'is_var')
+
     def __init__(self, token, parser):
         self.token = token
         matches = filter_re.finditer(token)
@@ -776,6 +779,8 @@ class Variable:
 
     (The example assumes VARIABLE_ATTRIBUTE_SEPARATOR is '.')
     """
+
+    __slots__ = ('var', 'literal', 'lookups', 'translate', 'message_context')
 
     def __init__(self, var):
         self.var = var


### PR DESCRIPTION
[Ticket is 33474](https://code.djangoproject.com/ticket/33474), opening PR to get CI sign-off before it's even considered for accepting.

According to `pympler`, this changes the size of a simple instantiated `Variable` from `592` to `216`, and a `FilterExpression` containing the same `Variable` from `1000` to `368` using `python3.10`. I've not observed any particular difference in runtime performance, though it would be ideal if anyone else could demonstrate there is one, better **or** worse.

Note that in a production environment where the cached template loaders are ordinarily used, this is just going to be reducing the high-water-mark for keeping those around in memory.