### PR TITLE
Fixed #33480 -- Fixed makemigrations crash when renaming field of renamed model.

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -824,7 +824,7 @@ class MigrationAutodetector:
         for app_label, model_name, field_name in sorted(self.new_field_keys - self.old_field_keys):
             old_model_name = self.renamed_models.get((app_label, model_name), model_name)
             old_model_state = self.from_state.models[app_label, old_model_name]
-            new_model_state = self.to_state.models[app_label, old_model_name]
+            new_model_state = self.to_state.models[app_label, model_name]
             field = new_model_state.get_field(field_name)
             # Scan to see if this is actually a rename!
             field_dec = self.deep_deconstruct(field)

--- a/docs/releases/4.0.2.txt
+++ b/docs/releases/4.0.2.txt
@@ -37,3 +37,6 @@ Bugfixes
 * Fixed a bug in Django 4.0 that caused a crash of ``QuerySet.aggregate()``
   after ``annotate()`` on an aggregate function with a
   :ref:`default <aggregate-default>` (:ticket:`33468`).
+
+* Fixed a regression in Django 4.0 that caused a crash of ``makemigrations``
+  when renaming a field of a renamed model (:ticket:`33480`).

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1049,6 +1049,26 @@ class AutodetectorTests(TestCase):
             new_name='renamed_foo',
         )
 
+    def test_rename_field_with_renamed_model(self):
+        changes = self.get_changes(
+            [self.author_name],
+            [
+                ModelState('testapp', 'RenamedAuthor', [
+                    ('id', models.AutoField(primary_key=True)),
+                    ('renamed_name', models.CharField(max_length=200)),
+                ]),
+            ],
+            MigrationQuestioner({'ask_rename_model': True, 'ask_rename': True}),
+        )
+        self.assertNumberMigrations(changes, 'testapp', 1)
+        self.assertOperationTypes(changes, 'testapp', 0, ['RenameModel', 'RenameField'])
+        self.assertOperationAttributes(
+            changes, 'testapp', 0, 0, old_name='Author', new_name='RenamedAuthor',
+        )
+        self.assertOperationAttributes(
+            changes, 'testapp', 0, 1, old_name='name', new_name='renamed_name',
+        )
+
     def test_rename_model(self):
         """Tests autodetection of renamed models."""
         changes = self.get_changes(


### PR DESCRIPTION
Got some typo whet try to rename objects in model.