### PR TITLE
Fixed #33482 -- Fixed QuerySet filtering againts negated Exists() with empty queryset.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1211,13 +1211,18 @@ class Exists(Subquery):
 
     def as_sql(self, compiler, connection, template=None, **extra_context):
         query = self.query.exists(using=connection.alias)
-        sql, params = super().as_sql(
-            compiler,
-            connection,
-            template=template,
-            query=query,
-            **extra_context,
-        )
+        try:
+            sql, params = super().as_sql(
+                compiler,
+                connection,
+                template=template,
+                query=query,
+                **extra_context,
+            )
+        except EmptyResultSet:
+            if self.negated:
+                return '', ()
+            raise
         if self.negated:
             sql = 'NOT {}'.format(sql)
         return sql, params

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1905,6 +1905,13 @@ class ExistsTests(TestCase):
         )
         self.assertNotIn('ORDER BY', captured_sql)
 
+    def test_negated_empty_exists(self):
+        manager = Manager.objects.create()
+        qs = Manager.objects.filter(
+            ~Exists(Manager.objects.none()) & Q(pk=manager.pk)
+        )
+        self.assertSequenceEqual(qs, [manager])
+
 
 class FieldTransformTests(TestCase):
 


### PR DESCRIPTION
ticket-33482 

Thanks @xi for the report.

---

I haven't confirmed if this is a regression of some sort but I doubt it since no code in 236ebe94bfe24d394d5b49f4405da445550e8aa6 ever supported it.