### PR TITLE
Fixed #33486 -- Pluralized admin's delete selected confirmation messages.

### DIFF
--- a/django/contrib/admin/templates/admin/delete_selected_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_selected_confirmation.html
@@ -20,21 +20,33 @@
 
 {% block content %}
 {% if perms_lacking %}
-    <p>{% blocktranslate %}Deleting the selected {{ objects_name }} would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:{% endblocktranslate %}</p>
+    <p>{% blocktranslate count counter=queryset.count trimmed %}
+      Deleting the selected {{ objects_name }} would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:
+      {% plural %}
+      Deleting the selected {{ objects_name }} would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:
+    {% endblocktranslate %}</p>
     <ul>
     {% for obj in perms_lacking %}
         <li>{{ obj }}</li>
     {% endfor %}
     </ul>
 {% elif protected %}
-    <p>{% blocktranslate %}Deleting the selected {{ objects_name }} would require deleting the following protected related objects:{% endblocktranslate %}</p>
+    <p>{% blocktranslate count counter=queryset.count trimmed %}
+      Deleting the selected {{ objects_name }} would require deleting the following protected related objects:
+      {% plural %}
+      Deleting the selected {{ objects_name }} would require deleting the following protected related objects:
+    {% endblocktranslate %}</p>
     <ul>
     {% for obj in protected %}
         <li>{{ obj }}</li>
     {% endfor %}
     </ul>
 {% else %}
-    <p>{% blocktranslate %}Are you sure you want to delete the selected {{ objects_name }}? All of the following objects and their related items will be deleted:{% endblocktranslate %}</p>
+    <p>{% blocktranslate count counter=queryset.count trimmed %}
+      Are you sure you want to delete the selected {{ objects_name }}? All of the following objects and their related items will be deleted:
+      {% plural %}
+      Are you sure you want to delete the selected {{ objects_name }}? All of the following objects and their related items will be deleted:
+    {% endblocktranslate %}</p>
     {% include "admin/includes/object_delete_summary.html" %}
     <h2>{% translate "Objects" %}</h2>
     {% for deletable_object in deletable_objects %}


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33486

Admin's delete selected confirmation messages can contain singular and plural form of a model name as objects_name inside the message.

Despite the fact that for English those messages are the same for singular and plural count, in Polish (and potentially other languages) we inflect adjectives and pronoun basing on the count.

Bringing the pluralization to those three messages will allow to simplify the translations, which now for Polish list all alternative endings (to be done through Transifex).