### PR TITLE
Fixed #33473 -- Fixed detecting changes by autoreloader in .py files inside template directories.

### DIFF
--- a/django/template/autoreload.py
+++ b/django/template/autoreload.py
@@ -48,6 +48,8 @@ def watch_for_template_changes(sender, **kwargs):
 
 @receiver(file_changed, dispatch_uid='template_loaders_file_changed')
 def template_changed(sender, file_path, **kwargs):
+    if file_path.suffix == '.py':
+        return
     for template_dir in get_template_directories():
         if template_dir in file_path.parents:
             reset_loaders()

--- a/tests/template_tests/test_autoreloader.py
+++ b/tests/template_tests/test_autoreloader.py
@@ -39,6 +39,19 @@ class TemplateReloadTests(SimpleTestCase):
         self.assertIsNone(autoreload.template_changed(None, Path(__file__)))
         mock_reset.assert_not_called()
 
+    @override_settings(
+        TEMPLATES=[
+            {
+                'DIRS': [ROOT],
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            }
+        ]
+    )
+    @mock.patch('django.template.autoreload.reset_loaders')
+    def test_non_template_changed_in_template_directory(self, mock_reset):
+        self.assertIsNone(autoreload.template_changed(None, Path(__file__)))
+        mock_reset.assert_not_called()
+
     def test_watch_for_template_changes(self):
         mock_reloader = mock.MagicMock()
         autoreload.watch_for_template_changes(mock_reloader)


### PR DESCRIPTION
This PR fixes [#33473](https://code.djangoproject.com/ticket/33473) by checking if the changed file is a python file before proceeding in the `template_changed` signal listener.