### PR TITLE
Refs #32568 -- Optimized escape() by using SafeString instead of mark_safe().

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -24,7 +24,7 @@ def escape(text):
     This may result in double-escaping. If this is a concern, use
     conditional_escape() instead.
     """
-    return mark_safe(html.escape(str(text)))
+    return SafeString(html.escape(str(text)))
 
 
 _js_escapes = {


### PR DESCRIPTION
Spotted while checking #15378. Refs [Ticket 32568](https://code.djangoproject.com/ticket/32568)

In a "simple" template render test `conditional_escape` was taking c.30% of the time. That's due to the `keep_lazy` decorator of `escape`. While I'm not sure there is much we can do there, I noticed that we're calling `mark_safe` on something that looks _very_ "stringy". I therefore think we can return the "SafeString" directly. This has a bigger impact on small strings, but becomes not so important as the string length grows. 

Here's my benchmarks, but they've proved to be a bit off lately so will need review. 

Pre
```
In [2]: %timeit escape("test> Text &*")
6.95 µs ± 18.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [3]: long_text = "test> Text &*" * 500

In [4]: %timeit escape(long_text)
160 µs ± 408 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

Post
```
In [2]: %timeit escape("test> Text &*")
6.06 µs ± 69.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [3]: long_text = "test> Text &*" * 500

In [4]: %timeit escape(long_text)
161 µs ± 2.92 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```