### PR TITLE
Refs #33476 -- Refactored problematic code before reformatting by Black.

### DIFF
--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -29,10 +29,11 @@ class BaseUserManager(models.Manager):
             email = email_name + '@' + domain_part.lower()
         return email
 
-    def make_random_password(self, length=10,
-                             allowed_chars='abcdefghjkmnpqrstuvwxyz'
-                                           'ABCDEFGHJKLMNPQRSTUVWXYZ'
-                                           '23456789'):
+    def make_random_password(
+        self,
+        length=10,
+        allowed_chars='abcdefghjkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789',
+    ):
         """
         Generate a random password with the given length and given
         allowed_chars. The default value of allowed_chars does not have "I" or

--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -90,8 +90,9 @@ def get_hashers():
         hasher_cls = import_string(hasher_path)
         hasher = hasher_cls()
         if not getattr(hasher, 'algorithm'):
-            raise ImproperlyConfigured("hasher doesn't specify an "
-                                       "algorithm name: %s" % hasher_path)
+            raise ImproperlyConfigured(
+                "hasher doesn't specify an algorithm name: %s" % hasher_path
+            )
         hashers.append(hasher)
     return hashers
 

--- a/django/contrib/gis/utils/srs.py
+++ b/django/contrib/gis/utils/srs.py
@@ -36,8 +36,9 @@ def add_srs_entry(srs, auth_name='EPSG', auth_srid=None, ref_sys_name=None,
     connection = connections[database]
 
     if not hasattr(connection.ops, 'spatial_version'):
-        raise Exception('The `add_srs_entry` utility only works '
-                        'with spatial backends.')
+        raise Exception(
+            'The `add_srs_entry` utility only works with spatial backends.'
+        )
     if not connection.features.supports_add_srs_entry:
         raise Exception('This utility does not support your database backend.')
     SpatialRefSys = connection.ops.spatial_ref_sys()

--- a/django/contrib/staticfiles/utils.py
+++ b/django/contrib/staticfiles/utils.py
@@ -50,8 +50,9 @@ def check_settings(base_url=None):
             "You're using the staticfiles app "
             "without having set the required STATIC_URL setting.")
     if settings.MEDIA_URL == base_url:
-        raise ImproperlyConfigured("The MEDIA_URL and STATIC_URL "
-                                   "settings must have different values")
+        raise ImproperlyConfigured(
+            "The MEDIA_URL and STATIC_URL settings must have different values"
+        )
     if (settings.DEBUG and settings.MEDIA_URL and settings.STATIC_URL and
             settings.MEDIA_URL.startswith(settings.STATIC_URL)):
         raise ImproperlyConfigured(
@@ -59,5 +60,6 @@ def check_settings(base_url=None):
         )
     if ((settings.MEDIA_ROOT and settings.STATIC_ROOT) and
             (settings.MEDIA_ROOT == settings.STATIC_ROOT)):
-        raise ImproperlyConfigured("The MEDIA_ROOT and STATIC_ROOT "
-                                   "settings must have different values")
+        raise ImproperlyConfigured(
+            "The MEDIA_ROOT and STATIC_ROOT settings must have different values"
+        )

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -552,8 +552,8 @@ class AppCommand(BaseCommand):
         corresponding to an application label given on the command line.
         """
         raise NotImplementedError(
-            "Subclasses of AppCommand must provide"
-            "a handle_app_config() method.")
+            "Subclasses of AppCommand must provide a handle_app_config() method."
+        )
 
 
 class LabelCommand(BaseCommand):

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -15,8 +15,7 @@ try:
     import MySQLdb as Database
 except ImportError as err:
     raise ImproperlyConfigured(
-        'Error loading MySQLdb module.\n'
-        'Did you install mysqlclient?'
+        'Error loading MySQLdb module.\nDid you install mysqlclient?'
     ) from err
 
 from MySQLdb.constants import CLIENT, FIELD_TYPE

--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -233,8 +233,9 @@ class DatabaseOperations(BaseDatabaseOperations):
         # Zero in AUTO_INCREMENT field does not work without the
         # NO_AUTO_VALUE_ON_ZERO SQL mode.
         if value == 0 and not self.connection.features.allows_auto_pk_0:
-            raise ValueError('The database backend does not accept 0 as a '
-                             'value for AutoField.')
+            raise ValueError(
+                'The database backend does not accept 0 as a value for AutoField.'
+            )
         return value
 
     def adapt_datetimefield_value(self, value):

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -377,7 +377,8 @@ END;
     def __foreign_key_constraints(self, table_name, recursive):
         with self.connection.cursor() as cursor:
             if recursive:
-                cursor.execute("""
+                cursor.execute(
+                    """
                     SELECT
                         user_tables.table_name, rcons.constraint_name
                     FROM
@@ -394,9 +395,12 @@ END;
                         user_tables.table_name, rcons.constraint_name
                     HAVING user_tables.table_name != UPPER(%s)
                     ORDER BY MAX(level) DESC
-                """, (table_name, table_name))
+                    """,
+                    (table_name, table_name),
+                )
             else:
-                cursor.execute("""
+                cursor.execute(
+                    """
                     SELECT
                         cons.table_name, cons.constraint_name
                     FROM
@@ -404,7 +408,9 @@ END;
                     WHERE
                         cons.constraint_type = 'R'
                         AND cons.table_name = UPPER(%s)
-                """, (table_name,))
+                    """,
+                    (table_name,),
+                )
             return cursor.fetchall()
 
     @cached_property

--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -179,13 +179,16 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def _is_identity_column(self, table_name, column_name):
         with self.connection.cursor() as cursor:
-            cursor.execute("""
+            cursor.execute(
+                """
                 SELECT
                     CASE WHEN identity_column = 'YES' THEN 1 ELSE 0 END
                 FROM user_tab_cols
                 WHERE table_name = %s AND
                       column_name = %s
-            """, [self.normalize_name(table_name), self.normalize_name(column_name)])
+                """,
+                [self.normalize_name(table_name), self.normalize_name(column_name)],
+            )
             row = cursor.fetchone()
             return row[0] if row else False
 
@@ -197,9 +200,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def _get_default_collation(self, table_name):
         with self.connection.cursor() as cursor:
-            cursor.execute("""
+            cursor.execute(
+                """
                 SELECT default_collation FROM user_tables WHERE table_name = %s
-            """, [self.normalize_name(table_name)])
+                """,
+                [self.normalize_name(table_name)],
+            )
             return cursor.fetchone()[0]
 
     def _alter_column_collation_sql(self, model, new_field, new_type, new_collation):

--- a/django/db/migrations/utils.py
+++ b/django/db/migrations/utils.py
@@ -42,8 +42,7 @@ def resolve_relation(model, app_label=None, model_name=None):
             return app_label, model_name.lower()
         if app_label is None:
             raise TypeError(
-                'app_label must be provided to resolve unscoped model '
-                'relationships.'
+                'app_label must be provided to resolve unscoped model relationships.'
             )
         return app_label, model.lower()
     return model._meta.app_label, model._meta.model_name

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -40,8 +40,7 @@ class CheckConstraint(BaseConstraint):
         self.check = check
         if not getattr(check, 'conditional', False):
             raise TypeError(
-                'CheckConstraint.check must be a Q instance or boolean '
-                'expression.'
+                'CheckConstraint.check must be a Q instance or boolean expression.'
             )
         super().__init__(name)
 

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -101,8 +101,7 @@ class Field(RegisterLookupMixin):
         'invalid_choice': _('Value %(value)r is not a valid choice.'),
         'null': _('This field cannot be null.'),
         'blank': _('This field cannot be blank.'),
-        'unique': _('%(model_name)s with this %(field_label)s '
-                    'already exists.'),
+        'unique': _('%(model_name)s with this %(field_label)s already exists.'),
         # Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
         # Eg: "Title must be unique for pub_date year"
         'unique_for_date': _("%(field_label)s must be unique for "

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -36,8 +36,7 @@ class Index:
             raise ValueError('Index.opclasses must be a list or tuple.')
         if not expressions and not fields:
             raise ValueError(
-                'At least one field or expression is required to define an '
-                'index.'
+                'At least one field or expression is required to define an index.'
             )
         if expressions and fields:
             raise ValueError(

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -530,8 +530,7 @@ class IsNull(BuiltinLookup):
     def as_sql(self, compiler, connection):
         if not isinstance(self.rhs, bool):
             raise ValueError(
-                'The QuerySet value for an isnull lookup must be True or '
-                'False.'
+                'The QuerySet value for an isnull lookup must be True or False.'
             )
         sql, params = compiler.compile(self.lhs)
         if self.rhs:

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -523,8 +523,7 @@ class QuerySet:
                 )
             if not unique_fields and db_features.supports_update_conflicts_with_target:
                 raise ValueError(
-                    'Unique fields that can trigger the upsert must be '
-                    'provided.'
+                    'Unique fields that can trigger the upsert must be provided.'
                 )
             # Updating primary keys and non-concrete fields is forbidden.
             update_fields = [self.model._meta.get_field(name) for name in update_fields]
@@ -930,8 +929,7 @@ class QuerySet:
         self._not_support_combined_queries('contains')
         if self._fields is not None:
             raise TypeError(
-                'Cannot call QuerySet.contains() after .values() or '
-                '.values_list().'
+                'Cannot call QuerySet.contains() after .values() or .values_list().'
             )
         try:
             if obj._meta.concrete_model != self.model._meta.concrete_model:
@@ -1739,8 +1737,7 @@ class Prefetch:
             )
         ):
             raise ValueError(
-                'Prefetch querysets cannot use raw(), values(), and '
-                'values_list().'
+                'Prefetch querysets cannot use raw(), values(), and values_list().'
             )
         if to_attr:
             self.prefetch_to = LOOKUP_SEP.join(lookup.split(LOOKUP_SEP)[:-1] + [to_attr])

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1735,8 +1735,7 @@ class Query(BaseExpression):
                 for alias in self._gen_col_aliases([annotation]):
                     if isinstance(self.alias_map[alias], Join):
                         raise FieldError(
-                            'Joined field references are not permitted in '
-                            'this query'
+                            'Joined field references are not permitted in this query'
                         )
             if summarize:
                 # Summarize currently means we are doing an aggregate() query
@@ -1763,8 +1762,9 @@ class Query(BaseExpression):
             if not allow_joins and len(join_list) > 1:
                 raise FieldError('Joined field references are not permitted in this query')
             if len(targets) > 1:
-                raise FieldError("Referencing multicolumn fields with F() objects "
-                                 "isn't supported")
+                raise FieldError(
+                    "Referencing multicolumn fields with F() objects isn't supported"
+                )
             # Verify that the last lookup in name is a field or a transform:
             # transform_function() raises FieldError if not.
             transform = join_info.transform_function(targets[0], final_alias)

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1218,8 +1218,9 @@ class ModelChoiceField(ChoiceField):
     # This class is a subclass of ChoiceField for purity, but it doesn't
     # actually use any of ChoiceField's implementation.
     default_error_messages = {
-        'invalid_choice': _('Select a valid choice. That choice is not one of'
-                            ' the available choices.'),
+        'invalid_choice': _(
+            'Select a valid choice. That choice is not one of the available choices.'
+        ),
     }
     iterator = ModelChoiceIterator
 
@@ -1338,8 +1339,9 @@ class ModelMultipleChoiceField(ModelChoiceField):
     hidden_widget = MultipleHiddenInput
     default_error_messages = {
         'invalid_list': _('Enter a list of values.'),
-        'invalid_choice': _('Select a valid choice. %(value)s is not one of the'
-                            ' available choices.'),
+        'invalid_choice': _(
+            'Select a valid choice. %(value)s is not one of the available choices.'
+        ),
         'invalid_pk_value': _('“%(pk)s” is not a valid value.')
     }
 

--- a/django/template/backends/base.py
+++ b/django/template/backends/base.py
@@ -38,8 +38,8 @@ class BaseEngine:
         This method is optional.
         """
         raise NotImplementedError(
-            "subclasses of BaseEngine should provide "
-            "a from_string() method")
+            "subclasses of BaseEngine should provide a from_string() method"
+        )
 
     def get_template(self, template_name):
         """
@@ -48,8 +48,8 @@ class BaseEngine:
         Raise TemplateDoesNotExist if no such template exists.
         """
         raise NotImplementedError(
-            "subclasses of BaseEngine must provide "
-            "a get_template() method")
+            "subclasses of BaseEngine must provide a get_template() method"
+        )
 
     # Utility methods: they are provided to minimize code duplication and
     #                  security issues in third-party backends.

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -675,8 +675,9 @@ class FilterExpression:
                     except VariableDoesNotExist:
                         var_obj = None
                 elif var is None:
-                    raise TemplateSyntaxError("Could not find variable at "
-                                              "start of %s." % token)
+                    raise TemplateSyntaxError(
+                        "Could not find variable at start of %s." % token
+                    )
                 else:
                     var_obj = Variable(var)
             else:
@@ -884,9 +885,10 @@ class Variable:
                                 ValueError,  # invalid literal for int()
                                 KeyError,    # current is a dict without `int(bit)` key
                                 TypeError):  # unsubscriptable object
-                            raise VariableDoesNotExist("Failed lookup for key "
-                                                       "[%s] in %r",
-                                                       (bit, current))  # missing attribute
+                            raise VariableDoesNotExist(
+                                "Failed lookup for key [%s] in %r",
+                                (bit, current),
+                            )  # missing attribute
                 if callable(current):
                     if getattr(current, 'do_not_call_in_templates', False):
                         pass

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -793,8 +793,9 @@ def do_for(parser, token):
     """
     bits = token.split_contents()
     if len(bits) < 4:
-        raise TemplateSyntaxError("'for' statements should have at least four"
-                                  " words: %s" % token.contents)
+        raise TemplateSyntaxError(
+            "'for' statements should have at least four words: %s" % token.contents
+        )
 
     is_reversed = bits[-1] == 'reversed'
     in_index = -3 if is_reversed else -2
@@ -806,8 +807,9 @@ def do_for(parser, token):
     loopvars = re.split(r' *, *', ' '.join(bits[1:in_index]))
     for var in loopvars:
         if not var or not invalid_chars.isdisjoint(var):
-            raise TemplateSyntaxError("'for' tag received an invalid argument:"
-                                      " %s" % token.contents)
+            raise TemplateSyntaxError(
+                "'for' tag received an invalid argument: %s" % token.contents
+            )
 
     sequence = parser.compile_filter(bits[in_index + 1])
     nodelist_loop = parser.parse(('empty', 'endfor',))
@@ -1160,8 +1162,9 @@ def regroup(parser, token):
     if bits[2] != 'by':
         raise TemplateSyntaxError("second argument to 'regroup' tag must be 'by'")
     if bits[4] != 'as':
-        raise TemplateSyntaxError("next-to-last argument to 'regroup' tag must"
-                                  " be 'as'")
+        raise TemplateSyntaxError(
+            "next-to-last argument to 'regroup' tag must be 'as'"
+        )
     var_name = bits[5]
     # RegroupNode will take each item in 'target', put it in the context under
     # 'var_name', evaluate 'var_name'.'expression' in the current context, and
@@ -1420,8 +1423,9 @@ def do_with(parser, token):
     remaining_bits = bits[1:]
     extra_context = token_kwargs(remaining_bits, parser, support_legacy=True)
     if not extra_context:
-        raise TemplateSyntaxError("%r expected at least one variable "
-                                  "assignment" % bits[0])
+        raise TemplateSyntaxError(
+            "%r expected at least one variable assignment" % bits[0]
+        )
     if remaining_bits:
         raise TemplateSyntaxError("%r received an invalid token: %r" %
                                   (bits[0], remaining_bits[0]))

--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -315,13 +315,15 @@ def do_include(parser, token):
     while remaining_bits:
         option = remaining_bits.pop(0)
         if option in options:
-            raise TemplateSyntaxError('The %r option was specified more '
-                                      'than once.' % option)
+            raise TemplateSyntaxError(
+                'The %r option was specified more than once.' % option
+            )
         if option == 'with':
             value = token_kwargs(remaining_bits, parser, support_legacy=False)
             if not value:
-                raise TemplateSyntaxError('"with" in %r tag needs at least '
-                                          'one keyword argument.' % bits[0])
+                raise TemplateSyntaxError(
+                    '"with" in %r tag needs at least one keyword argument.' % bits[0]
+                )
         elif option == 'only':
             value = True
         else:

--- a/django/template/response.py
+++ b/django/template/response.py
@@ -49,8 +49,9 @@ class SimpleTemplateResponse(HttpResponse):
         """
         obj_dict = self.__dict__.copy()
         if not self._is_rendered:
-            raise ContentNotRenderedError('The response content must be '
-                                          'rendered before it can be pickled.')
+            raise ContentNotRenderedError(
+                'The response content must be rendered before it can be pickled.'
+            )
         for attr in self.rendering_attrs:
             if attr in obj_dict:
                 del obj_dict[attr]

--- a/django/templatetags/i18n.py
+++ b/django/templatetags/i18n.py
@@ -477,13 +477,15 @@ def do_block_translate(parser, token):
     while remaining_bits:
         option = remaining_bits.pop(0)
         if option in options:
-            raise TemplateSyntaxError('The %r option was specified more '
-                                      'than once.' % option)
+            raise TemplateSyntaxError(
+                'The %r option was specified more than once.' % option
+            )
         if option == 'with':
             value = token_kwargs(remaining_bits, parser, support_legacy=True)
             if not value:
-                raise TemplateSyntaxError('"with" in %r tag needs at least '
-                                          'one keyword argument.' % bits[0])
+                raise TemplateSyntaxError(
+                    '"with" in %r tag needs at least one keyword argument.' % bits[0]
+                )
         elif option == 'count':
             value = token_kwargs(remaining_bits, parser, support_legacy=True)
             if len(value) != 1:

--- a/django/templatetags/tz.py
+++ b/django/templatetags/tz.py
@@ -209,6 +209,7 @@ def get_current_timezone_tag(parser, token):
     # token.split_contents() isn't useful here because this tag doesn't accept variable as arguments
     args = token.contents.split()
     if len(args) != 3 or args[1] != 'as':
-        raise TemplateSyntaxError("'get_current_timezone' requires "
-                                  "'as variable' (got %r)" % args)
+        raise TemplateSyntaxError(
+            "'get_current_timezone' requires 'as variable' (got %r)" % args
+        )
     return GetCurrentTimezoneNode(args[2])

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -894,8 +894,7 @@ class AsyncClient(ClientMixin, AsyncRequestFactory):
         """
         if 'follow' in request:
             raise NotImplementedError(
-                'AsyncClient request methods do not accept the follow '
-                'parameter.'
+                'AsyncClient request methods do not accept the follow parameter.'
             )
         scope = self._base_scope(**request)
         # Curry a data dictionary into an instance of the template renderer

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -987,8 +987,7 @@ class AliasTests(TestCase):
 
     def test_aggregate_alias(self):
         msg = (
-            "Cannot aggregate over the 'other_age' alias. Use annotate() to "
-            "promote it."
+            "Cannot aggregate over the 'other_age' alias. Use annotate() to promote it."
         )
         with self.assertRaisesMessage(FieldError, msg):
             Author.objects.alias(
@@ -1012,10 +1011,7 @@ class AliasTests(TestCase):
 
     def test_values_alias(self):
         qs = Book.objects.alias(rating_alias=F('rating') - 1)
-        msg = (
-            "Cannot select the 'rating_alias' alias. Use annotate() to "
-            "promote it."
-        )
+        msg = "Cannot select the 'rating_alias' alias. Use annotate() to promote it."
         for operation in ['values', 'values_list']:
             with self.subTest(operation=operation):
                 with self.assertRaisesMessage(FieldError, msg):

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -429,8 +429,7 @@ class BulkCreateTests(TestCase):
     )
     def test_update_conflicts_invalid_update_fields(self):
         msg = (
-            'bulk_create() can only be used with concrete fields in '
-            'update_fields.'
+            'bulk_create() can only be used with concrete fields in update_fields.'
         )
         # Reverse one-to-one relationship.
         with self.assertRaisesMessage(ValueError, msg):
@@ -467,8 +466,7 @@ class BulkCreateTests(TestCase):
     )
     def test_update_conflicts_invalid_unique_fields(self):
         msg = (
-            'bulk_create() can only be used with concrete fields in '
-            'unique_fields.'
+            'bulk_create() can only be used with concrete fields in unique_fields.'
         )
         # Reverse one-to-one relationship.
         with self.assertRaisesMessage(ValueError, msg):

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -70,8 +70,7 @@ def empty_response(request):
 
 
 KEY_ERRORS_WITH_MEMCACHED_MSG = (
-    'Cache key contains characters that will cause errors if used with '
-    'memcached: %r'
+    'Cache key contains characters that will cause errors if used with memcached: %r'
 )
 
 

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -409,16 +409,22 @@ class BasicExpressionsTests(TestCase):
 
     def test_order_by_multiline_sql(self):
         raw_order_by = (
-            RawSQL('''
+            RawSQL(
+                """
                 CASE WHEN num_employees > 1000
                      THEN num_chairs
                      ELSE 0 END
-            ''', []).desc(),
-            RawSQL('''
+                """,
+                [],
+            ).desc(),
+            RawSQL(
+                """
                 CASE WHEN num_chairs > 1
                      THEN 1
                      ELSE 0 END
-            ''', []).asc()
+                """,
+                [],
+            ).asc()
         )
         for qs in (
             Company.objects.all(),

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -649,8 +649,7 @@ class FileUploadTests(TestCase):
             'Content-Disposition: form-data; name="file_field"; filename="MiXeD_cAsE.txt"',
             'Content-Type: application/octet-stream',
             '',
-            'file contents\n'
-            '',
+            'file contents\n',
             '--%(boundary)s--\r\n',
         ]
         response = self.client.post(

--- a/tests/forms_tests/widget_tests/test_multiwidget.py
+++ b/tests/forms_tests/widget_tests/test_multiwidget.py
@@ -212,8 +212,7 @@ class MultiWidgetTest(WidgetTest):
     def test_no_whitespace_between_widgets(self):
         widget = MyMultiWidget(widgets=(TextInput, TextInput()))
         self.check_html(widget, 'code', None, html=(
-            '<input type="text" name="code_0">'
-            '<input type="text" name="code_1">'
+            '<input type="text" name="code_0"><input type="text" name="code_1">'
         ), strict=True)
 
     def test_deepcopy(self):

--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -370,8 +370,7 @@ class GISFunctionsTests(FuncTestMixin, TestCase):
     @skipUnlessDBFeature('has_MakeValid_function')
     def test_make_valid_multipolygon(self):
         invalid_geom = fromstr(
-            'POLYGON((0 0, 0 1 , 1 1 , 1 0, 0 0), '
-            '(10 0, 10 1, 11 1, 11 0, 10 0))'
+            'POLYGON((0 0, 0 1 , 1 1 , 1 0, 0 0), (10 0, 10 1, 11 1, 11 0, 10 0))'
         )
         State.objects.create(name='invalid', poly=invalid_geom)
         invalid = State.objects.filter(name='invalid').annotate(

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -1707,8 +1707,7 @@ class ConstraintsTests(TestCase):
 
         self.assertEqual(Model.check(databases=self.databases), [
             Error(
-                "'constraints' refers to the nonexistent field "
-                "'missing_field'.",
+                "'constraints' refers to the nonexistent field 'missing_field'.",
                 obj=Model,
                 id='models.E012',
             ),
@@ -1972,8 +1971,7 @@ class ConstraintsTests(TestCase):
 
         self.assertEqual(Model.check(databases=self.databases), [
             Error(
-                "'constraints' refers to the nonexistent field "
-                "'missing_field'.",
+                "'constraints' refers to the nonexistent field 'missing_field'.",
                 obj=Model,
                 id='models.E012',
             ),
@@ -2075,8 +2073,7 @@ class ConstraintsTests(TestCase):
 
         self.assertEqual(Model.check(databases=self.databases), [
             Error(
-                "'constraints' refers to the nonexistent field "
-                "'missing_field'.",
+                "'constraints' refers to the nonexistent field 'missing_field'.",
                 obj=Model,
                 id='models.E012',
             ),
@@ -2193,8 +2190,7 @@ class ConstraintsTests(TestCase):
 
         self.assertEqual(Model.check(databases=self.databases), [
             Error(
-                "'constraints' refers to the nonexistent field "
-                "'missing_field'.",
+                "'constraints' refers to the nonexistent field 'missing_field'.",
                 obj=Model,
                 id='models.E012',
             ),
@@ -2331,8 +2327,7 @@ class ConstraintsTests(TestCase):
 
         self.assertEqual(Model.check(databases=self.databases), [
             Error(
-                "'constraints' refers to the nonexistent field "
-                "'missing_field'.",
+                "'constraints' refers to the nonexistent field 'missing_field'.",
                 obj=Model,
                 id='models.E012',
             ),
@@ -2348,8 +2343,7 @@ class ConstraintsTests(TestCase):
 
         self.assertEqual(Model.check(databases=self.databases), [
             Error(
-                "'constraints' refers to the nonexistent field "
-                "'missing_field'.",
+                "'constraints' refers to the nonexistent field 'missing_field'.",
                 obj=Model,
                 id='models.E012',
             ),

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -308,9 +308,7 @@ class MigrateTests(MigrationTestBase):
         with mock.patch('django.core.management.color.supports_color', lambda *args: True):
             call_command("showmigrations", format='list', stdout=out, verbosity=0, no_color=False)
         self.assertEqual(
-            '\x1b[1mmigrations\n\x1b[0m'
-            ' [ ] 0001_initial\n'
-            ' [ ] 0002_second\n',
+            '\x1b[1mmigrations\n\x1b[0m [ ] 0001_initial\n [ ] 0002_second\n',
             out.getvalue().lower()
         )
 
@@ -320,9 +318,7 @@ class MigrateTests(MigrationTestBase):
         # Giving the explicit app_label tests for selective `show_list` in the command
         call_command("showmigrations", "migrations", format='list', stdout=out, verbosity=0, no_color=True)
         self.assertEqual(
-            'migrations\n'
-            ' [x] 0001_initial\n'
-            ' [ ] 0002_second\n',
+            'migrations\n [x] 0001_initial\n [ ] 0002_second\n',
             out.getvalue().lower()
         )
         out = io.StringIO()
@@ -343,8 +339,7 @@ class MigrateTests(MigrationTestBase):
         out = io.StringIO()
         call_command('showmigrations', format='list', stdout=out, verbosity=2, no_color=True)
         self.assertEqual(
-            'migrations\n'
-            ' [ ] 0001_squashed_0002 (2 squashed migrations)\n',
+            'migrations\n [ ] 0001_squashed_0002 (2 squashed migrations)\n',
             out.getvalue().lower(),
         )
         out = io.StringIO()
@@ -368,8 +363,7 @@ class MigrateTests(MigrationTestBase):
             out = io.StringIO()
             call_command('showmigrations', format='list', stdout=out, verbosity=2, no_color=True)
             self.assertEqual(
-                'migrations\n'
-                ' [x] 0001_squashed_0002 (2 squashed migrations)\n',
+                'migrations\n [x] 0001_squashed_0002 (2 squashed migrations)\n',
                 out.getvalue().lower(),
             )
         finally:
@@ -447,8 +441,7 @@ class MigrateTests(MigrationTestBase):
             # Show the plan for when there is nothing to apply.
             call_command('migrate', 'migrations', '0003', plan=True, stdout=out, no_color=True)
             self.assertEqual(
-                'Planned operations:\n'
-                '  No planned migration operations.\n',
+                'Planned operations:\n  No planned migration operations.\n',
                 out.getvalue()
             )
             out = io.StringIO()
@@ -609,8 +602,7 @@ class MigrateTests(MigrationTestBase):
         out = io.StringIO()
         call_command('showmigrations', 'mutate_state_b', format='plan', stdout=out)
         self.assertEqual(
-            '[ ]  mutate_state_b.0001_initial\n'
-            '[ ]  mutate_state_b.0002_add_field\n',
+            '[ ]  mutate_state_b.0001_initial\n[ ]  mutate_state_b.0002_add_field\n',
             out.getvalue()
         )
         # Single app with dependencies.
@@ -911,8 +903,7 @@ class MigrateTests(MigrationTestBase):
         call_command("migrate", "migrations", verbosity=0)
         call_command("showmigrations", "migrations", stdout=out, no_color=True)
         self.assertEqual(
-            'migrations\n'
-            ' [x] 0001_squashed_0002 (2 squashed migrations)\n',
+            'migrations\n [x] 0001_squashed_0002 (2 squashed migrations)\n',
             out.getvalue().lower()
         )
         applied_migrations = recorder.applied_migrations()
@@ -944,8 +935,7 @@ class MigrateTests(MigrationTestBase):
         call_command("migrate", "migrations", verbosity=0)
         call_command("showmigrations", "migrations", stdout=out, no_color=True)
         self.assertEqual(
-            'migrations\n'
-            ' [x] 0001_squashed_0002 (2 squashed migrations)\n',
+            'migrations\n [x] 0001_squashed_0002 (2 squashed migrations)\n',
             out.getvalue().lower()
         )
         self.assertIn(
@@ -1115,8 +1105,7 @@ class MigrateTests(MigrationTestBase):
         call_command('migrate', 'migrations', prune=True, stdout=out, no_color=True)
         self.assertEqual(
             out.getvalue(),
-            'Pruning migrations:\n'
-            '  No migrations to prune.\n',
+            'Pruning migrations:\n  No migrations to prune.\n',
         )
         out = io.StringIO()
         call_command(
@@ -2311,8 +2300,7 @@ class AppLabelErrorTests(TestCase):
     """
     nonexistent_app_error = "No installed app with label 'nonexistent_app'."
     did_you_mean_auth_error = (
-        "No installed app with label 'django.contrib.auth'. Did you mean "
-        "'auth'?"
+        "No installed app with label 'django.contrib.auth'. Did you mean 'auth'?"
     )
 
     def test_makemigrations_nonexistent_app_label(self):

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -86,8 +86,7 @@ class OperationWriterTests(SimpleTestCase):
         self.assertEqual(imports, {'import custom_migration_operations.operations'})
         self.assertEqual(
             buff,
-            'custom_migration_operations.operations.TestOperation(\n'
-            '),'
+            'custom_migration_operations.operations.TestOperation(\n),',
         )
 
     def test_args_signature(self):

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -129,8 +129,7 @@ class TestFormField(SimpleTestCase):
 
 class TestSerialization(SimpleTestCase):
     test_data = (
-        '[{"fields": {"value": %s}, '
-        '"model": "model_fields.jsonmodel", "pk": null}]'
+        '[{"fields": {"value": %s}, "model": "model_fields.jsonmodel", "pk": null}]'
     )
     test_values = (
         # (Python value, serialized value),

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -411,8 +411,7 @@ class PrepopulatedFieldsCheckTests(CheckTestCase):
 
         self.assertIsInvalid(
             TestModelAdmin, ValidationTestModel,
-            'The value of \'prepopulated_fields["slug"]\' must be a list '
-            'or tuple.',
+            'The value of \'prepopulated_fields["slug"]\' must be a list or tuple.',
             'admin.E029'
         )
 

--- a/tests/postgres_tests/test_operations.py
+++ b/tests/postgres_tests/test_operations.py
@@ -53,8 +53,7 @@ class AddIndexConcurrentlyTests(OperationTestBase):
         operation = AddIndexConcurrently('Pony', index)
         self.assertEqual(
             operation.describe(),
-            'Concurrently create index pony_pink_idx on field(s) pink of '
-            'model Pony'
+            'Concurrently create index pony_pink_idx on field(s) pink of model Pony',
         )
         operation.state_forwards(self.app_label, new_state)
         self.assertEqual(len(new_state.models[self.app_label, 'pony'].options['indexes']), 1)

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -1352,9 +1352,10 @@ class MultiDbTests(TestCase):
             books = "".join("%s (%s)\n" %
                             (b.title, ", ".join(a.name for a in b.first_time_authors.all()))
                             for b in B.prefetch_related('first_time_authors'))
-        self.assertEqual(books,
-                         "Poems (Charlotte Bronte)\n"
-                         "Sense and Sensibility (Jane Austen)\n")
+        self.assertEqual(
+            books,
+            "Poems (Charlotte Bronte)\nSense and Sensibility (Jane Austen)\n",
+        )
 
     def test_using_is_honored_inheritance(self):
         B = BookWithYear.objects.using('other')
@@ -1391,19 +1392,20 @@ class MultiDbTests(TestCase):
             books = "".join("%s (%s)\n" %
                             (b.title, ", ".join(a.name for a in b.first_time_authors.all()))
                             for b in B.prefetch_related(prefetch))
-        self.assertEqual(books,
-                         "Poems (Charlotte Bronte)\n"
-                         "Sense and Sensibility (Jane Austen)\n")
-
+        self.assertEqual(
+            books,
+            "Poems (Charlotte Bronte)\nSense and Sensibility (Jane Austen)\n",
+        )
         # Explicit using on the same db.
         with self.assertNumQueries(2, using='other'):
             prefetch = Prefetch('first_time_authors', queryset=Author.objects.using('other'))
             books = "".join("%s (%s)\n" %
                             (b.title, ", ".join(a.name for a in b.first_time_authors.all()))
                             for b in B.prefetch_related(prefetch))
-        self.assertEqual(books,
-                         "Poems (Charlotte Bronte)\n"
-                         "Sense and Sensibility (Jane Austen)\n")
+        self.assertEqual(
+            books,
+            "Poems (Charlotte Bronte)\nSense and Sensibility (Jane Austen)\n",
+        )
 
         # Explicit using on a different db.
         with self.assertNumQueries(1, using='default'), self.assertNumQueries(1, using='other'):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -3149,8 +3149,7 @@ class QuerySetExceptionTests(SimpleTestCase):
 
     def test_invalid_order_by(self):
         msg = (
-            "Cannot resolve keyword '*' into field. Choices are: created, id, "
-            "name"
+            "Cannot resolve keyword '*' into field. Choices are: created, id, name"
         )
         with self.assertRaisesMessage(FieldError, msg):
             Article.objects.order_by('*')

--- a/tests/requests/test_data_upload_settings.py
+++ b/tests/requests/test_data_upload_settings.py
@@ -41,7 +41,6 @@ class DataUploadMaxMemorySizeMultipartPostTests(SimpleTestCase):
             '',
             'value',
             '--boundary--'
-            ''
         ]))
         self.request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
@@ -70,7 +69,6 @@ class DataUploadMaxMemorySizeMultipartPostTests(SimpleTestCase):
             '',
             'value',
             '--boundary--'
-            ''
         ]))
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
@@ -143,7 +141,6 @@ class DataUploadMaxNumberOfFieldsMultipartPost(SimpleTestCase):
             '',
             'value2',
             '--boundary--'
-            ''
         ]))
         self.request = WSGIRequest({
             'REQUEST_METHOD': 'POST',

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -316,7 +316,7 @@ class RequestsTests(SimpleTestCase):
             '',
             'value',
             '--boundary--'
-            '']))
+        ]))
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
@@ -341,7 +341,7 @@ class RequestsTests(SimpleTestCase):
             b'',
             b'value',
             b'--boundary--'
-            b''])
+        ])
         payload = FakePayload(payload_data)
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
@@ -366,7 +366,7 @@ class RequestsTests(SimpleTestCase):
             '',
             'value',
             '--boundary--'
-            '']))
+        ]))
         request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -292,8 +292,7 @@ def setup_run_tests(verbosity, start_at, start_after, test_labels=None):
     # Force declaring available_apps in TransactionTestCase for faster tests.
     def no_available_apps(self):
         raise Exception(
-            'Please define available_apps in TransactionTestCase and its '
-            'subclasses.'
+            'Please define available_apps in TransactionTestCase and its subclasses.'
         )
     TransactionTestCase.available_apps = property(no_available_apps)
     TestCase.available_apps = None

--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -11,10 +11,7 @@ from django.test.utils import captured_stdin, captured_stdout
 class ShellCommandTestCase(SimpleTestCase):
     script_globals = 'print("__name__" in globals())'
     script_with_inline_function = (
-        'import django\n'
-        'def f():\n'
-        '    print(django.__version__)\n'
-        'f()'
+        'import django\ndef f():\n    print(django.__version__)\nf()'
     )
 
     def test_command_option(self):

--- a/tests/template_tests/filter_tests/test_urlizetrunc.py
+++ b/tests/template_tests/filter_tests/test_urlizetrunc.py
@@ -60,14 +60,13 @@ class FunctionTests(SimpleTestCase):
 
         self.assertEqual(
             urlizetrunc(uri, 1),
-            '<a href="http://31characteruri.com/test/"'
-            ' rel="nofollow">…</a>',
+            '<a href="http://31characteruri.com/test/" rel="nofollow">…</a>',
         )
 
     def test_overtruncate(self):
         self.assertEqual(
-            urlizetrunc('http://short.com/', 20), '<a href='
-            '"http://short.com/" rel="nofollow">http://short.com/</a>',
+            urlizetrunc('http://short.com/', 20),
+            '<a href="http://short.com/" rel="nofollow">http://short.com/</a>',
         )
 
     def test_query_string(self):

--- a/tests/template_tests/syntax_tests/i18n/test_get_language_info.py
+++ b/tests/template_tests/syntax_tests/i18n/test_get_language_info.py
@@ -36,7 +36,7 @@ class I18nGetLanguageInfoTagTests(SimpleTestCase):
             output = self.engine.render_to_string('i18n38')
         self.assertEqual(output, 'de: German/Deutsch/německy bidi=False')
 
-    @setup({'template': '{% load i18n %}''{% get_language_info %}'})
+    @setup({'template': '{% load i18n %}{% get_language_info %}'})
     def test_no_for_as(self):
         msg = "'get_language_info' requires 'for string as variable' (got [])"
         with self.assertRaisesMessage(TemplateSyntaxError, msg):

--- a/tests/template_tests/test_custom.py
+++ b/tests/template_tests/test_custom.py
@@ -104,8 +104,7 @@ class SimpleTagTests(TagTestCase):
             (
                 "'simple_keyword_only_param' received multiple values for "
                 "keyword argument 'kwarg'",
-                '{% load custom %}{% simple_keyword_only_param kwarg=42 '
-                'kwarg=37 %}',
+                '{% load custom %}{% simple_keyword_only_param kwarg=42 kwarg=37 %}',
             ),
             (
                 "'simple_keyword_only_default' received multiple values for "

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -445,8 +445,7 @@ class DiscoverRunnerTests(SimpleTestCase):
 
     def test_pdb_with_parallel(self):
         msg = (
-            'You cannot use --pdb with parallel tests; pass --parallel=1 to '
-            'use it.'
+            'You cannot use --pdb with parallel tests; pass --parallel=1 to use it.'
         )
         with self.assertRaisesMessage(ValueError, msg):
             DiscoverRunner(pdb=True, parallel=2)

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -437,8 +437,7 @@ class AssertNumQueriesContextManagerTests(TestCase):
 
     def test_failure(self):
         msg = (
-            '1 != 2 : 1 queries executed, 2 expected\nCaptured queries were:\n'
-            '1.'
+            '1 != 2 : 1 queries executed, 2 expected\nCaptured queries were:\n1.'
         )
         with self.assertRaisesMessage(AssertionError, msg):
             with self.assertNumQueries(2):
@@ -927,11 +926,7 @@ class HTMLEqualTests(SimpleTestCase):
             parse_html('</p>')
 
     def test_escaped_html_errors(self):
-        msg = (
-            '<p>\n<foo>\n</p>'
-            ' != '
-            '<p>\n&lt;foo&gt;\n</p>\n'
-        )
+        msg = '<p>\n<foo>\n</p> != <p>\n&lt;foo&gt;\n</p>\n'
         with self.assertRaisesMessage(AssertionError, msg):
             self.assertHTMLEqual('<p><foo></p>', '<p>&lt;foo&gt;</p>')
         with self.assertRaisesMessage(AssertionError, msg):

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -133,8 +133,7 @@ VALID_URLS = [
     'ample.com',
     'http://example.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
     'aaaaa.com',
-    'http://example.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-    'aaaaa',
+    'http://example.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     'http://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaa'
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaa'
     'aaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaa'

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -690,14 +690,12 @@ class ExceptionReporterTests(SimpleTestCase):
             html,
         )
         self.assertIn(
-            '"generated", line 2, in funcName\n'
-            '    &lt;source code not available&gt;',
+            '"generated", line 2, in funcName\n    &lt;source code not available&gt;',
             html,
         )
         text = reporter.get_traceback_text()
         self.assertIn(
-            '"generated", line 2, in funcName\n'
-            '    <source code not available>',
+            '"generated", line 2, in funcName\n    <source code not available>',
             text,
         )
 
@@ -731,14 +729,12 @@ class ExceptionReporterTests(SimpleTestCase):
                 html,
             )
             self.assertIn(
-                '"generated", line 2, in funcName\n'
-                '    &lt;source code not available&gt;',
+                '"generated", line 2, in funcName\n    &lt;source code not available&gt;',
                 html,
             )
             text = reporter.get_traceback_text()
             self.assertIn(
-                '"generated", line 2, in funcName\n'
-                '    <source code not available>',
+                '"generated", line 2, in funcName\n    <source code not available>',
                 text,
             )
 


### PR DESCRIPTION
In these cases `Black` produces unexpected results, e.g.
```python
def make_random_password(
    self,
    length=10,
    allowed_chars='abcdefghjkmnpqrstuvwxyz' 'ABCDEFGHJKLMNPQRSTUVWXYZ' '23456789',
):
```
or
```python
cursor.execute("""
SELECT ...
""",
    [table name],
)
```

As far as I'm aware there is nothing else that could be marked with `fmt: off`, so after merging this PR I'm going to run `Black` on the entire Django code repository and add a single commit to the #15387.