### PR TITLE
Refs #32559 -- Added selenium test for FloatField client-side validation.

### DIFF
--- a/tests/forms_tests/urls.py
+++ b/tests/forms_tests/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from .views import ArticleFormView
+from .views import ArticleFormView, form_view
 
 urlpatterns = [
+    path('form_view/', form_view, name='form_view'),
     path('model_form/<int:pk>/', ArticleFormView.as_view(), name='article_form'),
 ]

--- a/tests/forms_tests/views.py
+++ b/tests/forms_tests/views.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.http import HttpResponse
+from django.template import Context, Template
 from django.views.generic.edit import UpdateView
 
 from .models import Article
@@ -16,3 +18,12 @@ class ArticleFormView(UpdateView):
     model = Article
     success_url = '/'
     form_class = ArticleForm
+
+
+def form_view(request):
+    class Form(forms.Form):
+        number = forms.FloatField()
+
+    template = Template('<html>{{ form }}</html>')
+    context = Context({'form': Form()})
+    return HttpResponse(template.render(context))


### PR DESCRIPTION
`step="any"` is required for non-integer values.
See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#step

Covers behaviour added in 7ec2a21be15af5b2c7513482c3bcfdd1e12782ed.

Fails with this diff: 

```diff
diff --git a/django/forms/fields.py b/django/forms/fields.py
index 65d6a9ec82..6e11b53c66 100644
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -317,8 +317,8 @@ class FloatField(IntegerField):
 
     def widget_attrs(self, widget):
         attrs = super().widget_attrs(widget)
-        if isinstance(widget, NumberInput) and 'step' not in widget.attrs:
-            attrs.setdefault('step', 'any')
+#         if isinstance(widget, NumberInput) and 'step' not in widget.attrs:
+#             attrs.setdefault('step', 'any')
         return attrs
```