### PR TITLE
[WIP] Reverted "Disabled caching in GitHub actions for Windows tests."

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          # cache: 'pip'
-          # cache-dependency-path: 'tests/requirements/py3.txt'
+          cache: 'pip'
+          cache-dependency-path: 'tests/requirements/py3.txt'
       - run: pip install -r tests/requirements/py3.txt -e .
       - name: Run tests
         run: python tests/runtests.py -v2


### PR DESCRIPTION
This reverts commit 11661d3815f273a6968cf09ecc678cf6fa6dcfcd.

Fixed in [setup-python 2.3.2](https://github.com/actions/setup-python/releases/tag/v2.3.2). 