### PR TITLE
Fixed #33450 -- Made integer primary keys no longer cast to UUID when filtering a GenericRelation on a model with a UUID primary key.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -446,6 +446,7 @@ answer newbie questions, and generally made Django that much better:
     jdetaeye
     Jeff Anderson <jefferya@programmerq.net>
     Jeff Balogh <jbalogh@mozilla.com>
+    Jeffrey Boisvert <info.jeffreyboisvert@gmail.com>
     Jeff Hui <jeffkhui@gmail.com>
     Jeffrey Gelens <jeffrey@gelens.org>
     Jeff Triplett <jeff.triplett@gmail.com>

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -227,7 +227,7 @@ class FieldGetDbPrepValueMixin:
         # For relational fields, use the 'target_field' attribute of the
         # output_field.
         field = getattr(self.lhs.output_field, 'target_field', None)
-        get_db_prep_value = getattr(field, 'get_db_prep_value', None) or self.lhs.output_field.get_db_prep_value
+        get_db_prep_value = getattr(self.lhs.output_field, "get_db_prep_value", None) or field.get_db_prep_value
         return (
             '%s',
             [get_db_prep_value(v, connection, prepared=True) for v in value]

--- a/tests/generic_relations/models.py
+++ b/tests/generic_relations/models.py
@@ -8,6 +8,7 @@ object, be it animal, vegetable, or mineral.
 The canonical example is tags (although this example implementation is *far*
 from complete).
 """
+import uuid
 
 from django.contrib.contenttypes.fields import (
     GenericForeignKey, GenericRelation,
@@ -146,3 +147,18 @@ class AllowsNullGFK(models.Model):
     content_type = models.ForeignKey(ContentType, models.SET_NULL, null=True)
     object_id = models.PositiveIntegerField(null=True)
     content_object = GenericForeignKey()
+
+
+# To test fix for #33450
+class TTag(models.Model):
+    # Note that this models id is a UUID not a BigAutoField like TIntegration
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    object_id = models.PositiveIntegerField()
+    content = GenericForeignKey()
+
+
+class TIntegration(models.Model):
+    # Note that the id here is the default BigAutoField field
+    tags = GenericRelation(TTag, related_query_name='integration')

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -8,7 +8,7 @@ from .models import (
     AllowsNullGFK, Animal, Carrot, Comparison, ConcreteRelatedModel,
     ForConcreteModelModel, ForProxyModelModel, Gecko, ManualPK, Mineral,
     ProxyRelatedModel, Rock, TaggedItem, ValuableRock, ValuableTaggedItem,
-    Vegetable,
+    Vegetable, TIntegration, TTag,
 )
 
 
@@ -571,6 +571,19 @@ class GenericRelationsTests(TestCase):
         qs = Comparison.objects.prefetch_related('first_obj__comparisons')
         for comparison in qs:
             self.assertSequenceEqual(comparison.first_obj.comparisons.all(), [comparison])
+
+    def test_generic_relation_sql_uuid_and_id(self):
+        integration = TIntegration.objects.create()
+        integration.tags.create()
+
+        query_set_without_id = TTag.objects.filter(integration=integration)
+        query_set_with_id = TTag.objects.filter(integration__id=integration.id)
+
+        self.assertEqual(str(query_set_without_id.query), str(query_set_with_id.query))
+
+        # Ensure record is indeed found in both queries
+        self.assertTrue(query_set_without_id.exists())
+        self.assertTrue(query_set_with_id.exists())
 
 
 class ProxyRelatedModelTest(TestCase):


### PR DESCRIPTION
It closes ticket [33450](https://code.djangoproject.com/ticket/33450)

This issue was related to when attempting to filter on a model that had a `GenericRelation` whose primary key was not the usual default primary key type of `BigAutoField` (in the bug report a UUIDField was being used as the primary key instead).

The ticket suggests the casting was the issue however after further investigation it was casting correctly but when it was being applied was incorrect. The ORM was using `TTag`'s primary key type instead of `TIntegration`'s type (which is the default BigAutoField). This still filtered correctly on SQLite but it would still show the query value as `000000000001`. 

All tests pass under SQLite by simply running `runtests.py` in the tests directory. 
