### PR TITLE
Fixed #26287 -- Added support for addition operations to SimpleLazyObject.

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -432,6 +432,12 @@ class SimpleLazyObject(LazyObject):
             return result
         return copy.deepcopy(self._wrapped, memo)
 
+    __add__ = new_method_proxy(operator.add)
+
+    @new_method_proxy
+    def __radd__(self, other):
+        return other + self
+
 
 def partition(predicate, values):
     """

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -294,7 +294,7 @@ URLs
 Utilities
 ~~~~~~~~~
 
-* ...
+* ``SimpleLazyObject`` now supports addition operations.
 
 Validators
 ~~~~~~~~~~

--- a/tests/utils_tests/test_lazyobject.py
+++ b/tests/utils_tests/test_lazyobject.py
@@ -317,6 +317,17 @@ class SimpleLazyObjectTestCase(LazyObjectTestCase):
         self.assertIsInstance(obj._wrapped, int)
         self.assertEqual(repr(obj), "<SimpleLazyObject: 42>")
 
+    def test_add(self):
+        obj1 = self.lazy_wrap(1)
+        self.assertEqual(obj1 + 1, 2)
+        obj2 = self.lazy_wrap(2)
+        self.assertEqual(obj2 + obj1, 3)
+        self.assertEqual(obj1 + obj2, 3)
+
+    def test_radd(self):
+        obj1 = self.lazy_wrap(1)
+        self.assertEqual(1 + obj1, 2)
+
     def test_trace(self):
         # See ticket #19456
         old_trace_func = sys.gettrace()


### PR DESCRIPTION
Using the suggestion on the ticket:

```python
__add__ = new_method_proxy(operator.add)
__radd__ = new_method_proxy(lambda a, b: operator.add(b, a))
```

I added some tests to verify that it works.