### PR TITLE
Fixed #31486 -- Deprecated passing unsaved objects to related filters.

### DIFF
--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.db.models.lookups import (
     Exact,
     GreaterThan,
@@ -7,6 +9,7 @@ from django.db.models.lookups import (
     LessThan,
     LessThanOrEqual,
 )
+from django.utils.deprecation import RemovedInDjango50Warning
 
 
 class MultiColSource:
@@ -40,6 +43,15 @@ def get_normalized_value(value, lhs):
     from django.db.models import Model
 
     if isinstance(value, Model):
+        if value.pk is None:
+            # When the deprecation ends, replace with:
+            # raise ValueError(
+            #     "Model instances passed to related filters must be saved."
+            # )
+            warnings.warn(
+                "Passing unsaved model instances to related filters is deprecated.",
+                RemovedInDjango50Warning,
+            )
         value_list = []
         sources = lhs.output_field.path_infos[-1].target_fields
         for source in sources:

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -85,6 +85,8 @@ details on these changes.
   objects without providing the ``chunk_size`` argument will no longer be
   allowed.
 
+* Passing unsaved model instances to related filters will no longer be allowed.
+
 .. _deprecation-removed-in-4.1:
 
 4.1

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -484,6 +484,9 @@ Miscellaneous
   versions, no prefetching was done. Providing a value for ``chunk_size``
   signifies that the additional query per chunk needed to prefetch is desired.
 
+* Passing unsaved model instances to related filters is deprecated. In Django
+  5.0, the exception will be raised.
+
 Features removed in 4.1
 =======================
 


### PR DESCRIPTION
In `filter` and `exclude` it is now possible to pass not saved object to relating field. It is considered as passing None. In future version it will be deprecated and will raise error.