### PR TITLE
Fixed #33471 -- AlterField operation when adding/changing choices is now noop.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1130,6 +1130,7 @@ class BaseDatabaseSchemaEditor:
         # - adding only a db_column and the column name is not changed
         non_database_attrs = [
             'blank',
+            'choices',
             'db_column',
             'editable',
             'error_messages',

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -3538,6 +3538,7 @@ class SchemaTests(TransactionTestCase):
             blank=True,
             editable=False,
             error_messages={'invalid': 'error message'},
+            choices=[('1stChoice', 'First Choice'), ('2ndChoice', 'Second Choice')],
             help_text='help text',
             limit_choices_to={'limit': 'choice'},
             on_delete=PROTECT,


### PR DESCRIPTION
Fixed bug where when user adds "choices" attribute to model field. It does not generate a query anymore. Also added the "choices" field to the testcase "test_alter_field_fk_attributes_noop" in tests\schema\tests.py.