### PR TITLE
Fixed #????? -- Optimized django.utils.dateformat.Formatter.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -11,7 +11,7 @@ from pprint import pformat
 from urllib.parse import quote
 
 from django.utils import formats
-from django.utils.dateformat import format, time_format
+from django.utils.dateformat import format
 from django.utils.deprecation import RemovedInDjango51Warning
 from django.utils.encoding import iri_to_uri
 from django.utils.html import avoid_wrapping, conditional_escape, escape, escapejs
@@ -789,7 +789,7 @@ def time(value, arg=None):
         return formats.time_format(value, arg)
     except (AttributeError, TypeError):
         try:
-            return time_format(value, arg)
+            return format(value, arg)
         except (AttributeError, TypeError):
             return ""
 

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -43,6 +43,7 @@ class Formatter:
 
     def __init__(self, obj):
         self.data = obj
+        self.type = "datetime"
 
         if isinstance(obj, datetime):
             # Timezone is only supported when formatting datetime objects, not
@@ -55,11 +56,14 @@ class Formatter:
             if not _datetime_ambiguous_or_imaginary(obj, timezone):
                 self.timezone = timezone
 
+        elif isinstance(obj, date):
+            self.type = "date"
+
     def format(self, formatstr):
         pieces = []
         for i, piece in enumerate(re_formatchars.split(str(formatstr))):
             if i % 2:
-                if type(self.data) is date and piece in self.time_specifiers:
+                if self.type == "date" and piece in self.time_specifiers:
                     raise TypeError(
                         "The format for date objects may not contain "
                         "time-related format specifiers (found '%s')." % piece
@@ -228,7 +232,7 @@ class Formatter:
     def r(self):
         "RFC 5322 formatted date; e.g. 'Thu, 21 Dec 2000 16:01:07 +0200'"
         value = self.data
-        if not isinstance(value, datetime):
+        if self.type == "date":
             # Assume midnight in default timezone if datetime.date provided.
             default_timezone = get_default_timezone()
             value = datetime.combine(value, time.min).replace(tzinfo=default_timezone)
@@ -278,7 +282,7 @@ class Formatter:
     def U(self):
         "Seconds since the Unix epoch (January 1 1970 00:00:00 GMT)"
         value = self.data
-        if not isinstance(value, datetime):
+        if self.type == "date":
             value = datetime.combine(value, time.min)
         return str(int(value.timestamp()))
 

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -57,6 +57,9 @@ class Formatter:
         elif isinstance(obj, date):
             self.type = "date"
 
+        elif isinstance(obj, time):
+            self.type = "time"
+
     def format(self, formatstr):
         escape = 0
         output = ""
@@ -71,9 +74,16 @@ class Formatter:
 
             if escape % 2 or char not in self.all_specifiers:
                 output += char
+            elif self.type == "datetime":
+                output += getattr(self, char)()
             elif self.type == "date" and char in self.time_specifiers:
                 raise TypeError(
                     "The format for date objects may not contain time-related "
+                    f"format specifiers (found {char!r})."
+                )
+            elif self.type == "time" and char in self.date_specifiers:
+                raise TypeError(
+                    "The format for time objects may not contain date-related "
                     f"format specifiers (found {char!r})."
                 )
             else:

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -104,15 +104,16 @@ class TimeFormat(Formatter):
         """
         hour = self.data.hour % 12 or 12
         minute = self.data.minute
-        return f"{hour}:{minute:02d}" if minute else hour
+        return f"{hour}:{minute:02d}" if minute else f"{hour}"
 
     def g(self):
         "Hour, 12-hour format without leading zeros; i.e. '1' to '12'"
-        return self.data.hour % 12 or 12
+        hour = self.data.hour % 12 or 12
+        return f"{hour}"
 
     def G(self):
         "Hour, 24-hour format without leading zeros; i.e. '0' to '23'"
-        return self.data.hour
+        return f"{self.data.hour}"
 
     def h(self):
         "Hour, 12-hour format; i.e. '01' to '12'"
@@ -193,7 +194,7 @@ class TimeFormat(Formatter):
         # UTC) only days can be negative (days=-1) and seconds are always
         # positive. e.g. UTC-1 -> timedelta(days=-1, seconds=82800, microseconds=0)
         # Positive offsets have days=0
-        return offset.days * 86400 + offset.seconds
+        return str(offset.days * 86400 + offset.seconds)
 
 
 class DateFormat(TimeFormat):
@@ -232,7 +233,7 @@ class DateFormat(TimeFormat):
 
     def j(self):
         "Day of the month without leading zeros; i.e. '1' to '31'"
-        return self.data.day
+        return f"{self.data.day}"
 
     def l(self):  # NOQA: E743, E741
         "Day of the week, textual, long; e.g. 'Friday'"
@@ -240,7 +241,7 @@ class DateFormat(TimeFormat):
 
     def L(self):
         "Boolean for whether it is a leap year; i.e. True or False"
-        return calendar.isleap(self.data.year)
+        return str(calendar.isleap(self.data.year))
 
     def m(self):
         "Month; i.e. '01' to '12'"
@@ -252,7 +253,7 @@ class DateFormat(TimeFormat):
 
     def n(self):
         "Month without leading zeros; i.e. '1' to '12'"
-        return self.data.month
+        return f"{self.data.month}"
 
     def N(self):
         "Month abbreviation in Associated Press style. Proprietary extension."
@@ -260,7 +261,7 @@ class DateFormat(TimeFormat):
 
     def o(self):
         "ISO 8601 year number matching the ISO week number (W)"
-        return self.data.isocalendar().year
+        return str(self.data.isocalendar().year)
 
     def r(self):
         "RFC 5322 formatted date; e.g. 'Thu, 21 Dec 2000 16:01:07 +0200'"
@@ -291,22 +292,22 @@ class DateFormat(TimeFormat):
 
     def t(self):
         "Number of days in the given month; i.e. '28' to '31'"
-        return calendar.monthrange(self.data.year, self.data.month)[1]
+        return str(calendar.monthrange(self.data.year, self.data.month)[1])
 
     def U(self):
         "Seconds since the Unix epoch (January 1 1970 00:00:00 GMT)"
         value = self.data
         if not isinstance(value, datetime):
             value = datetime.combine(value, time.min)
-        return int(value.timestamp())
+        return str(int(value.timestamp()))
 
     def w(self):
         "Day of the week, numeric, i.e. '0' (Sunday) to '6' (Saturday)"
-        return (self.data.weekday() + 1) % 7
+        return str((self.data.weekday() + 1) % 7)
 
     def W(self):
         "ISO-8601 week number of year, weeks starting on Monday"
-        return self.data.isocalendar().week
+        return str(self.data.isocalendar().week)
 
     def y(self):
         """Year, 2 digits with leading zeros; e.g. '99'."""
@@ -319,7 +320,7 @@ class DateFormat(TimeFormat):
 
     def z(self):
         """Day of the year, i.e. 1 to 366."""
-        return self.data.timetuple().tm_yday
+        return str(self.data.timetuple().tm_yday)
 
 
 def format(value, format_string):

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -39,6 +39,21 @@ class Formatter:
     date_specifiers = frozenset("bcdDEFIjlLmMnNorStUwWyYz")
     time_specifiers = frozenset("aAefgGhHiOPsTuZ")
     all_specifiers = date_specifiers | time_specifiers
+    timezone = None
+
+    def __init__(self, obj):
+        self.data = obj
+
+        if isinstance(obj, datetime):
+            # Timezone is only supported when formatting datetime objects, not
+            # date objects (timezone information not appropriate), or time
+            # objects (against established django policy).
+            if is_naive(obj):
+                timezone = get_default_timezone()
+            else:
+                timezone = obj.tzinfo
+            if not _datetime_ambiguous_or_imaginary(obj, timezone):
+                self.timezone = timezone
 
     def format(self, formatstr):
         pieces = []
@@ -309,20 +324,7 @@ class Formatter:
 
 
 class TimeFormat(Formatter):
-    def __init__(self, obj):
-        self.data = obj
-        self.timezone = None
-
-        if isinstance(obj, datetime):
-            # Timezone is only supported when formatting datetime objects, not
-            # date objects (timezone information not appropriate), or time
-            # objects (against established django policy).
-            if is_naive(obj):
-                timezone = get_default_timezone()
-            else:
-                timezone = obj.tzinfo
-            if not _datetime_ambiguous_or_imaginary(obj, timezone):
-                self.timezone = timezone
+    pass
 
 
 class DateFormat(TimeFormat):

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -104,7 +104,7 @@ class TimeFormat(Formatter):
         """
         hour = self.data.hour % 12 or 12
         minute = self.data.minute
-        return "%d:%02d" % (hour, minute) if minute else hour
+        return f"{hour}:{minute:02d}" if minute else hour
 
     def g(self):
         "Hour, 12-hour format without leading zeros; i.e. '1' to '12'"
@@ -116,15 +116,16 @@ class TimeFormat(Formatter):
 
     def h(self):
         "Hour, 12-hour format; i.e. '01' to '12'"
-        return "%02d" % (self.data.hour % 12 or 12)
+        hour = self.data.hour % 12 or 12
+        return f"{hour:02d}"
 
     def H(self):
         "Hour, 24-hour format; i.e. '00' to '23'"
-        return "%02d" % self.data.hour
+        return f"{self.data.hour:02d}"
 
     def i(self):
         "Minutes; i.e. '00' to '59'"
-        return "%02d" % self.data.minute
+        return f"{self.data.minute:02d}"
 
     def O(self):  # NOQA: E743, E741
         """
@@ -139,7 +140,9 @@ class TimeFormat(Formatter):
         seconds = offset.days * 86400 + offset.seconds
         sign = "-" if seconds < 0 else "+"
         seconds = abs(seconds)
-        return "%s%02d%02d" % (sign, seconds // 3600, (seconds // 60) % 60)
+        minutes = seconds // 60 % 60
+        hours = seconds // 3600
+        return f"{sign}{hours:02d}{minutes:02d}"
 
     def P(self):
         """
@@ -156,7 +159,7 @@ class TimeFormat(Formatter):
 
     def s(self):
         "Seconds; i.e. '00' to '59'"
-        return "%02d" % self.data.second
+        return f"{self.data.second:02d}"
 
     def T(self):
         """
@@ -171,7 +174,7 @@ class TimeFormat(Formatter):
 
     def u(self):
         "Microseconds; i.e. '000000' to '999999'"
-        return "%06d" % self.data.microsecond
+        return f"{self.data.microsecond:06d}"
 
     def Z(self):
         """
@@ -207,7 +210,7 @@ class DateFormat(TimeFormat):
 
     def d(self):
         "Day of the month, 2 digits with leading zeros; i.e. '01' to '31'"
-        return "%02d" % self.data.day
+        return f"{self.data.day:02d}"
 
     def D(self):
         "Day of the week, textual, 3 letters; e.g. 'Fri'"
@@ -241,7 +244,7 @@ class DateFormat(TimeFormat):
 
     def m(self):
         "Month; i.e. '01' to '12'"
-        return "%02d" % self.data.month
+        return f"{self.data.month:02d}"
 
     def M(self):
         "Month, textual, 3 letters; e.g. 'Jan'"
@@ -307,11 +310,12 @@ class DateFormat(TimeFormat):
 
     def y(self):
         """Year, 2 digits with leading zeros; e.g. '99'."""
-        return "%02d" % (self.data.year % 100)
+        year = self.data.year % 100
+        return f"{year:02d}"
 
     def Y(self):
         """Year, 4 digits with leading zeros; e.g. '1999'."""
-        return "%04d" % self.data.year
+        return f"{self.data.year:04d}"
 
     def z(self):
         """Day of the year, i.e. 1 to 366."""

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -54,23 +54,6 @@ class Formatter:
                 pieces.append(re_escaped.sub(r"\1", piece))
         return "".join(pieces)
 
-
-class TimeFormat(Formatter):
-    def __init__(self, obj):
-        self.data = obj
-        self.timezone = None
-
-        if isinstance(obj, datetime):
-            # Timezone is only supported when formatting datetime objects, not
-            # date objects (timezone information not appropriate), or time
-            # objects (against established django policy).
-            if is_naive(obj):
-                timezone = get_default_timezone()
-            else:
-                timezone = obj.tzinfo
-            if not _datetime_ambiguous_or_imaginary(obj, timezone):
-                self.timezone = timezone
-
     def a(self):
         "'a.m.' or 'p.m.'"
         if self.data.hour > 11:
@@ -82,6 +65,25 @@ class TimeFormat(Formatter):
         if self.data.hour > 11:
             return _("PM")
         return _("AM")
+
+    def b(self):
+        "Month, textual, 3 letters, lowercase; e.g. 'jan'"
+        return MONTHS_3[self.data.month]
+
+    def c(self):
+        """
+        ISO 8601 Format
+        Example : '2008-01-02T10:30:00.000123'
+        """
+        return self.data.isoformat()
+
+    def d(self):
+        "Day of the month, 2 digits with leading zeros; i.e. '01' to '31'"
+        return f"{self.data.day:02d}"
+
+    def D(self):
+        "Day of the week, textual, 3 letters; e.g. 'Fri'"
+        return WEEKDAYS_ABBR[self.data.weekday()]
 
     def e(self):
         """
@@ -99,6 +101,10 @@ class TimeFormat(Formatter):
             pass
         return ""
 
+    def E(self):
+        "Alternative month names as required by some locales. Proprietary extension."
+        return MONTHS_ALT[self.data.month]
+
     def f(self):
         """
         Time, in 12-hour hours and minutes, with minutes left off if they're
@@ -109,6 +115,10 @@ class TimeFormat(Formatter):
         hour = self.data.hour % 12 or 12
         minute = self.data.minute
         return f"{hour}:{minute:02d}" if minute else f"{hour}"
+
+    def F(self):
+        "Month, textual, long; e.g. 'January'"
+        return MONTHS[self.data.month]
 
     def g(self):
         "Hour, 12-hour format without leading zeros; i.e. '1' to '12'"
@@ -131,103 +141,6 @@ class TimeFormat(Formatter):
     def i(self):
         "Minutes; i.e. '00' to '59'"
         return f"{self.data.minute:02d}"
-
-    def O(self):  # NOQA: E743, E741
-        """
-        Difference to Greenwich time in hours; e.g. '+0200', '-0430'.
-
-        If timezone information is not available, return an empty string.
-        """
-        if self.timezone is None:
-            return ""
-
-        offset = self.timezone.utcoffset(self.data)
-        seconds = offset.days * 86400 + offset.seconds
-        sign = "-" if seconds < 0 else "+"
-        seconds = abs(seconds)
-        minutes = seconds // 60 % 60
-        hours = seconds // 3600
-        return f"{sign}{hours:02d}{minutes:02d}"
-
-    def P(self):
-        """
-        Time, in 12-hour hours, minutes and 'a.m.'/'p.m.', with minutes left off
-        if they're zero and the strings 'midnight' and 'noon' if appropriate.
-        Examples: '1 a.m.', '1:30 p.m.', 'midnight', 'noon', '12:30 p.m.'
-        Proprietary extension.
-        """
-        if self.data.minute == 0 and self.data.hour == 0:
-            return _("midnight")
-        if self.data.minute == 0 and self.data.hour == 12:
-            return _("noon")
-        return "%s %s" % (self.f(), self.a())
-
-    def s(self):
-        "Seconds; i.e. '00' to '59'"
-        return f"{self.data.second:02d}"
-
-    def T(self):
-        """
-        Time zone of this machine; e.g. 'EST' or 'MDT'.
-
-        If timezone information is not available, return an empty string.
-        """
-        if self.timezone is None:
-            return ""
-
-        return str(self.timezone.tzname(self.data))
-
-    def u(self):
-        "Microseconds; i.e. '000000' to '999999'"
-        return f"{self.data.microsecond:06d}"
-
-    def Z(self):
-        """
-        Time zone offset in seconds (i.e. '-43200' to '43200'). The offset for
-        timezones west of UTC is always negative, and for those east of UTC is
-        always positive.
-
-        If timezone information is not available, return an empty string.
-        """
-        if self.timezone is None:
-            return ""
-
-        offset = self.timezone.utcoffset(self.data)
-
-        # `offset` is a datetime.timedelta. For negative values (to the west of
-        # UTC) only days can be negative (days=-1) and seconds are always
-        # positive. e.g. UTC-1 -> timedelta(days=-1, seconds=82800, microseconds=0)
-        # Positive offsets have days=0
-        return str(offset.days * 86400 + offset.seconds)
-
-
-class DateFormat(TimeFormat):
-    def b(self):
-        "Month, textual, 3 letters, lowercase; e.g. 'jan'"
-        return MONTHS_3[self.data.month]
-
-    def c(self):
-        """
-        ISO 8601 Format
-        Example : '2008-01-02T10:30:00.000123'
-        """
-        return self.data.isoformat()
-
-    def d(self):
-        "Day of the month, 2 digits with leading zeros; i.e. '01' to '31'"
-        return f"{self.data.day:02d}"
-
-    def D(self):
-        "Day of the week, textual, 3 letters; e.g. 'Fri'"
-        return WEEKDAYS_ABBR[self.data.weekday()]
-
-    def E(self):
-        "Alternative month names as required by some locales. Proprietary extension."
-        return MONTHS_ALT[self.data.month]
-
-    def F(self):
-        "Month, textual, long; e.g. 'January'"
-        return MONTHS[self.data.month]
 
     def I(self):  # NOQA: E743, E741
         "'1' if daylight saving time, '0' otherwise."
@@ -267,6 +180,36 @@ class DateFormat(TimeFormat):
         "ISO 8601 year number matching the ISO week number (W)"
         return str(self.data.isocalendar().year)
 
+    def O(self):  # NOQA: E743, E741
+        """
+        Difference to Greenwich time in hours; e.g. '+0200', '-0430'.
+
+        If timezone information is not available, return an empty string.
+        """
+        if self.timezone is None:
+            return ""
+
+        offset = self.timezone.utcoffset(self.data)
+        seconds = offset.days * 86400 + offset.seconds
+        sign = "-" if seconds < 0 else "+"
+        seconds = abs(seconds)
+        minutes = seconds // 60 % 60
+        hours = seconds // 3600
+        return f"{sign}{hours:02d}{minutes:02d}"
+
+    def P(self):
+        """
+        Time, in 12-hour hours, minutes and 'a.m.'/'p.m.', with minutes left off
+        if they're zero and the strings 'midnight' and 'noon' if appropriate.
+        Examples: '1 a.m.', '1:30 p.m.', 'midnight', 'noon', '12:30 p.m.'
+        Proprietary extension.
+        """
+        if self.data.minute == 0 and self.data.hour == 0:
+            return _("midnight")
+        if self.data.minute == 0 and self.data.hour == 12:
+            return _("noon")
+        return "%s %s" % (self.f(), self.a())
+
     def r(self):
         "RFC 5322 formatted date; e.g. 'Thu, 21 Dec 2000 16:01:07 +0200'"
         value = self.data
@@ -277,6 +220,10 @@ class DateFormat(TimeFormat):
         elif is_naive(value):
             value = make_aware(value, timezone=self.timezone)
         return format_datetime_rfc5322(value)
+
+    def s(self):
+        "Seconds; i.e. '00' to '59'"
+        return f"{self.data.second:02d}"
 
     def S(self):
         """
@@ -297,6 +244,21 @@ class DateFormat(TimeFormat):
     def t(self):
         "Number of days in the given month; i.e. '28' to '31'"
         return str(calendar.monthrange(self.data.year, self.data.month)[1])
+
+    def T(self):
+        """
+        Time zone of this machine; e.g. 'EST' or 'MDT'.
+
+        If timezone information is not available, return an empty string.
+        """
+        if self.timezone is None:
+            return ""
+
+        return str(self.timezone.tzname(self.data))
+
+    def u(self):
+        "Microseconds; i.e. '000000' to '999999'"
+        return f"{self.data.microsecond:06d}"
 
     def U(self):
         "Seconds since the Unix epoch (January 1 1970 00:00:00 GMT)"
@@ -325,6 +287,46 @@ class DateFormat(TimeFormat):
     def z(self):
         """Day of the year, i.e. 1 to 366."""
         return str(self.data.timetuple().tm_yday)
+
+    def Z(self):
+        """
+        Time zone offset in seconds (i.e. '-43200' to '43200'). The offset for
+        timezones west of UTC is always negative, and for those east of UTC is
+        always positive.
+
+        If timezone information is not available, return an empty string.
+        """
+        if self.timezone is None:
+            return ""
+
+        offset = self.timezone.utcoffset(self.data)
+
+        # `offset` is a datetime.timedelta. For negative values (to the west of
+        # UTC) only days can be negative (days=-1) and seconds are always
+        # positive. e.g. UTC-1 -> timedelta(days=-1, seconds=82800, microseconds=0)
+        # Positive offsets have days=0
+        return str(offset.days * 86400 + offset.seconds)
+
+
+class TimeFormat(Formatter):
+    def __init__(self, obj):
+        self.data = obj
+        self.timezone = None
+
+        if isinstance(obj, datetime):
+            # Timezone is only supported when formatting datetime objects, not
+            # date objects (timezone information not appropriate), or time
+            # objects (against established django policy).
+            if is_naive(obj):
+                timezone = get_default_timezone()
+            else:
+                timezone = obj.tzinfo
+            if not _datetime_ambiguous_or_imaginary(obj, timezone):
+                self.timezone = timezone
+
+
+class DateFormat(TimeFormat):
+    pass
 
 
 def format(value, format_string):

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -5,12 +5,13 @@ See https://www.php.net/date for format strings
 Usage:
 >>> from datetime import datetime
 >>> d = datetime.now()
->>> df = DateFormat(d)
->>> print(df.format('jS F Y H:i'))
+>>> f = Formatter(d)
+>>> print(f.format('jS F Y H:i'))
 7th October 2003 11:39
 >>>
 """
 import calendar
+import warnings
 from datetime import date, datetime, time
 from email.utils import format_datetime as format_datetime_rfc5322
 
@@ -22,6 +23,7 @@ from django.utils.dates import (
     WEEKDAYS,
     WEEKDAYS_ABBR,
 )
+from django.utils.deprecation import RemovedInDjango51Warning
 from django.utils.timezone import (
     _datetime_ambiguous_or_imaginary,
     get_default_timezone,
@@ -339,20 +341,34 @@ class Formatter:
 
 
 class TimeFormat(Formatter):
-    pass
+    def __init__(self, obj):
+        warnings.warn(
+            "django.utils.dateformat.TimeFormat is deprecated in favor of "
+            "django.utils.dateformat.Formatter.",
+            RemovedInDjango51Warning,
+        )
+        super().__init__(obj)
 
 
 class DateFormat(TimeFormat):
-    pass
+    def __init__(self, obj):
+        warnings.warn(
+            "django.utils.dateformat.DateFormat is deprecated in favor of "
+            "django.utils.dateformat.Formatter.",
+            RemovedInDjango51Warning,
+        )
+        super().__init__(obj)
 
 
 def format(value, format_string):
-    "Convenience function"
-    df = DateFormat(value)
-    return df.format(format_string)
+    """Convenience function for formatting of dates and times."""
+    return Formatter(value).format(format_string)
 
 
 def time_format(value, format_string):
-    "Convenience function"
-    tf = TimeFormat(value)
-    return tf.format(format_string)
+    warnings.warn(
+        "django.utils.dateformat.time_format() is deprecated in favor of "
+        "django.utils.dateformat.format().",
+        RemovedInDjango51Warning,
+    )
+    return format(value, format_string)

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -36,11 +36,15 @@ re_escaped = _lazy_re_compile(r"\\(.)")
 
 
 class Formatter:
+    date_specifiers = frozenset("bcdDEFIjlLmMnNorStUwWyYz")
+    time_specifiers = frozenset("aAefgGhHiOPsTuZ")
+    all_specifiers = date_specifiers | time_specifiers
+
     def format(self, formatstr):
         pieces = []
         for i, piece in enumerate(re_formatchars.split(str(formatstr))):
             if i % 2:
-                if type(self.data) is date and hasattr(TimeFormat, piece):
+                if type(self.data) is date and piece in self.time_specifiers:
                     raise TypeError(
                         "The format for date objects may not contain "
                         "time-related format specifiers (found '%s')." % piece

--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -164,7 +164,7 @@ def time_format(value, format=None, use_l10n=None):
     If use_l10n is provided and is not None, it forces the value to
     be localized (or not), otherwise it's always localized.
     """
-    return dateformat.time_format(
+    return dateformat.format(
         value, get_format(format or "TIME_FORMAT", use_l10n=use_l10n)
     )
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -35,6 +35,10 @@ details on these changes.
 * The default scheme for ``forms.URLField`` will change from ``"http"`` to
   ``"https"``.
 
+* The undocumented ``django.utils.dateformat.DateFormat`` and
+  ``django.utils.dateformat.TimeFormat`` classes, and the
+  ``django.utils.dateformat.time_format()`` function will be removed.
+
 .. _deprecation-removed-in-5.1:
 
 5.1

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -442,6 +442,11 @@ Miscellaneous
 
 * The default scheme for ``forms.URLField`` will change from ``"http"`` to
   ``"https"`` in Django 6.0.
+* The undocumented ``django.utils.dateformat.DateFormat`` and
+  ``django.utils.dateformat.TimeFormat`` classes, and the
+  ``django.utils.dateformat.time_format()`` function are deprecated in favor of
+  ``django.utils.dateformat.Formatter`` and
+  ``django.utils.dateformat.format()`` respectively.
 
 Features removed in 5.0
 =======================

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -296,3 +296,16 @@ class DateFormatTests(SimpleTestCase):
             with self.subTest(hour=hour):
                 self.assertEqual(dateformat.format(dt, "g"), g_expected)
                 self.assertEqual(dateformat.format(dt, "h"), h_expected)
+
+    def test_multibyte_single_char_format(self):
+        tests = [
+            "😀",
+            "à",
+            "ă",
+            "⌚",
+            "ខ",
+        ]
+        dt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        for format_ in tests:
+            with self.subTest(format=format_):
+                self.assertEqual(dateformat.format(dt, format_), format_)

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -142,9 +142,23 @@ class DateFormatTests(SimpleTestCase):
     def test_dateformat(self):
         my_birthday = datetime(1979, 7, 8, 22, 00)
 
-        self.assertEqual(dateformat.format(my_birthday, r"Y z \C\E\T"), "1979 189 CET")
-
-        self.assertEqual(dateformat.format(my_birthday, r"jS \o\f F"), "8th of July")
+        for format_, expected in [
+            # Simple case for escaping a word.
+            (r"jS \o\f F", "8th of July"),
+            # Simple cases with leading or trailing backslash.
+            # (Not using raw strings here as they cannot end with a backslash.)
+            ("\\jS \\o\\f F", "jth of July"),
+            ("jS \\o\\f F\\", "8th of July\\"),
+            # More pathological cases of nested escaping.
+            (r"Y z \C\E\T", "1979 189 CET"),
+            (r"Y z \\\C\\\E\\\T", r"1979 189 \C\E\T"),
+            (r"Y z \\\\\C\\\\\E\\\\\T", r"1979 189 \\C\\E\\T"),
+            # FIXME: These should work, but the current implementation is broken.
+            # (r"Y z \\C\\E\\T", r"1979 189 \C\July\CET"),
+            # (r"Y z \\\\C\\\\E\\\\T", r"1979 189 \\C\\July\\CET"),
+        ]:
+            with self.subTest(format=format_):
+                self.assertEqual(dateformat.format(my_birthday, format_), expected)
 
     def test_futuredates(self):
         the_future = datetime(2100, 10, 25, 0, 00)

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -8,7 +8,7 @@ from django.utils.timezone import get_default_timezone, get_fixed_timezone, make
 
 
 @override_settings(TIME_ZONE="Europe/Copenhagen")
-class DateFormatTests(SimpleTestCase):
+class FormatterTests(SimpleTestCase):
     def setUp(self):
         self._orig_lang = translation.get_language()
         translation.activate("en-us")
@@ -204,7 +204,7 @@ class DateFormatTests(SimpleTestCase):
 
             for specifier in ["e", "O", "T", "Z"]:
                 with self.subTest(specifier=specifier):
-                    self.assertEqual(dateformat.time_format(noon, specifier), "")
+                    self.assertEqual(dateformat.format(noon, specifier), "")
 
         # Ticket #16924 -- We don't need timezone support to test this
         self.assertEqual(dateformat.format(aware_dt, "O"), "-0330")
@@ -247,7 +247,7 @@ class DateFormatTests(SimpleTestCase):
             ("8:30 p.m.", time(20, 30)),
         ]:
             with self.subTest(time=t):
-                self.assertEqual(dateformat.time_format(t, "P"), expected)
+                self.assertEqual(dateformat.format(t, "P"), expected)
 
     def test_r_format_with_date(self):
         # Assume midnight in default timezone if datetime.date provided.

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, time, timezone, tzinfo
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import TZ_SUPPORT, requires_tz_support
 from django.utils import dateformat, translation
-from django.utils.dateformat import format
+from django.utils.dateformat import Formatter, format
 from django.utils.timezone import get_default_timezone, get_fixed_timezone, make_aware
 
 
@@ -213,7 +213,7 @@ class DateFormatTests(SimpleTestCase):
     def test_invalid_time_format_specifiers(self):
         my_birthday = date(1984, 8, 7)
 
-        for specifier in ["a", "A", "f", "g", "G", "h", "H", "i", "P", "s", "u"]:
+        for specifier in Formatter.time_specifiers:
             with self.subTest(specifier=specifier):
                 msg = (
                     "The format for date objects may not contain time-related "

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -151,11 +151,10 @@ class DateFormatTests(SimpleTestCase):
             ("jS \\o\\f F\\", "8th of July\\"),
             # More pathological cases of nested escaping.
             (r"Y z \C\E\T", "1979 189 CET"),
+            (r"Y z \\C\\E\\T", r"1979 189 \C\July\CET"),
             (r"Y z \\\C\\\E\\\T", r"1979 189 \C\E\T"),
+            (r"Y z \\\\C\\\\E\\\\T", r"1979 189 \\C\\July\\CET"),
             (r"Y z \\\\\C\\\\\E\\\\\T", r"1979 189 \\C\\E\\T"),
-            # FIXME: These should work, but the current implementation is broken.
-            # (r"Y z \\C\\E\\T", r"1979 189 \C\July\CET"),
-            # (r"Y z \\\\C\\\\E\\\\T", r"1979 189 \\C\\July\\CET"),
         ]:
             with self.subTest(format=format_):
                 self.assertEqual(dateformat.format(my_birthday, format_), expected)


### PR DESCRIPTION
@kezabelle I just noticed that you'd posted #15403. It prompted me that there was something that I started a while back.

The main issues with this that I found where:
- Splitting the string using the regex followed by multiple calls to `re.sub()`.
- This is because extra care must be taken for escaped values, but the approach is naive.
  - _(See 46346f8ea08020d503b25472a26b949a5ce980a6 for a similar case of escaped values in a regex that I implemented.)_
- There is some funky handling around `datetime.date` objects not having time-specific formats. I've not fully addressed this yet.

Perhaps you'd like to see how this performs?