### PR TITLE
Added back initialization of `AppConfigStub.models_module` attribute that got missing after `super().__init__()` call was removed

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -521,6 +521,7 @@ class AppConfigStub(AppConfig):
     """Stub of an AppConfig. Only provides a label and a dict of models."""
     def __init__(self, label):
         self.apps = None
+        self.models_module = None
         self.models = {}
         # App-label and app-name are not the same thing, so technically passing
         # in the label here is wrong. In practice, migrations don't care about


### PR DESCRIPTION
In, https://github.com/django/django/commit/110001d0bbbabe2a5b57b14a59bd0e4b71bf2712, the call of `super.__init__` was removed, however the attribute `super.models_module` that [is initialized to `None` in the `AppConfig` class](https://github.com/django/django/blob/main/django/apps/config.py#L52) was omitted, apparently for no reason. I believe that's a bug, as it makes any code that assumes presence of this attribute on `AppConfigStub` to fail. 