### PR TITLE
Refs #33476 -- Made management commands use black.

### DIFF
--- a/django/core/management/commands/squashmigrations.py
+++ b/django/core/management/commands/squashmigrations.py
@@ -3,6 +3,7 @@ import os
 from django.apps import apps
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+from django.core.management.utils import run_formatters
 from django.db import DEFAULT_DB_ALIAS, connections, migrations
 from django.db.migrations.loader import AmbiguityError, MigrationLoader
 from django.db.migrations.migration import SwappableTuple
@@ -220,6 +221,7 @@ class Command(BaseCommand):
             )
         with open(writer.path, "w", encoding="utf-8") as fh:
             fh.write(writer.as_string())
+        run_formatters([writer.path])
 
         if self.verbosity > 0:
             self.stdout.write(

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -12,7 +12,7 @@ from urllib.request import build_opener
 import django
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.core.management.utils import handle_extensions
+from django.core.management.utils import handle_extensions, run_formatters
 from django.template import Context, Engine
 from django.utils import archive
 from django.utils.version import get_docs_version
@@ -80,6 +80,7 @@ class TemplateCommand(BaseCommand):
         )
 
     def handle(self, app_or_project, name, target=None, **options):
+        self.written_files = []
         self.app_or_project = app_or_project
         self.a_or_an = "an" if app_or_project == "app" else "a"
         self.paths_to_remove = []
@@ -200,6 +201,7 @@ class TemplateCommand(BaseCommand):
                 else:
                     shutil.copyfile(old_path, new_path)
 
+                self.written_files.append(new_path)
                 if self.verbosity >= 2:
                     self.stdout.write("Creating %s" % new_path)
                 try:
@@ -221,6 +223,8 @@ class TemplateCommand(BaseCommand):
                     os.remove(path_to_remove)
                 else:
                     shutil.rmtree(path_to_remove)
+
+        run_formatters(self.written_files)
 
     def handle_template(self, template, subdir):
         """

--- a/django/core/management/utils.py
+++ b/django/core/management/utils.py
@@ -1,5 +1,7 @@
 import fnmatch
 import os
+import shutil
+import subprocess
 from pathlib import Path
 from subprocess import run
 
@@ -153,3 +155,14 @@ def is_ignored_path(path, ignore_patterns):
         )
 
     return any(ignore(pattern) for pattern in normalize_path_patterns(ignore_patterns))
+
+
+def run_formatters(written_files):
+    """
+    Run the black formatter on the specified files.
+    """
+    if black_path := shutil.which("black"):
+        subprocess.run(
+            [black_path, "--fast", "--", *written_files],
+            capture_output=True,
+        )

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -2050,6 +2050,24 @@ distribution. It enables tab-completion of ``django-admin`` and
 
 See :doc:`/howto/custom-management-commands` for how to add customized actions.
 
+Black formatting
+----------------
+
+.. versionadded:: 4.1
+
+The Python files created by :djadmin:`startproject`, :djadmin:`startapp`,
+:djadmin:`makemigrations`, and :djadmin:`squashmigrations` are formatted using
+the ``black`` command if it is present on your ``PATH``.
+
+If you have ``black`` globally installed, but do not wish it used for the
+current project, you can set the ``PATH`` explicitly::
+
+    PATH=path/to/venv/bin django-admin makemigrations
+
+For commands using ``stdout`` you can pipe the output to ``black`` if needed::
+
+    django-admin inspectdb | black -
+
 ==========================================
 Running management commands from your code
 ==========================================

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -226,6 +226,10 @@ Management Commands
 * The new :option:`migrate --prune` option allows deleting nonexistent
   migrations from the ``django_migrations`` table.
 
+* Python files created by :djadmin:`startproject`, :djadmin:`startapp`,
+  :djadmin:`makemigrations`, and :djadmin:`squashmigrations` are now formatted
+  using the ``black`` command if it is present on your ``PATH``.
+
 Migrations
 ~~~~~~~~~~
 

--- a/tests/admin_scripts/custom_templates/project_template/manage.py-tpl
+++ b/tests/admin_scripts/custom_templates/project_template/manage.py-tpl
@@ -1,6 +1,6 @@
 # The manage.py of the {{ project_name }} test project
 
 # template context:
-project_name = '{{ project_name }}'
-project_directory = '{{ project_directory }}'
-secret_key = '{{ secret_key }}'
+project_name = "{{ project_name }}"
+project_directory = "{{ project_directory }}"
+secret_key = "{{ secret_key }}"

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -41,6 +41,8 @@ custom_templates_dir = os.path.join(os.path.dirname(__file__), "custom_templates
 
 SYSTEM_CHECK_MSG = "System check identified no issues"
 
+HAS_BLACK = shutil.which("black")
+
 
 class AdminScriptTestCase(SimpleTestCase):
     def setUp(self):
@@ -732,7 +734,10 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         with open(os.path.join(app_path, "apps.py")) as f:
             content = f.read()
             self.assertIn("class SettingsTestConfig(AppConfig)", content)
-            self.assertIn("name = 'settings_test'", content)
+            self.assertIn(
+                'name = "settings_test"' if HAS_BLACK else "name = 'settings_test'",
+                content,
+            )
 
     def test_setup_environ_custom_template(self):
         "directory: startapp creates the correct directory with a custom template"
@@ -754,7 +759,7 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         with open(os.path.join(app_path, "apps.py"), encoding="utf8") as f:
             content = f.read()
             self.assertIn("class こんにちはConfig(AppConfig)", content)
-            self.assertIn("name = 'こんにちは'", content)
+            self.assertIn('name = "こんにちは"' if HAS_BLACK else "name = 'こんにちは'", content)
 
     def test_builtin_command(self):
         """
@@ -2614,8 +2619,8 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         test_manage_py = os.path.join(testproject_dir, "manage.py")
         with open(test_manage_py) as fp:
             content = fp.read()
-            self.assertIn("project_name = 'another_project'", content)
-            self.assertIn("project_directory = '%s'" % testproject_dir, content)
+            self.assertIn('project_name = "another_project"', content)
+            self.assertIn('project_directory = "%s"' % testproject_dir, content)
 
     def test_no_escaping_of_project_variables(self):
         "Make sure template context variables are not html escaped"
@@ -2880,11 +2885,15 @@ class StartApp(AdminScriptTestCase):
         with open(os.path.join(app_path, "apps.py")) as f:
             content = f.read()
             self.assertIn("class NewAppConfig(AppConfig)", content)
+            if HAS_BLACK:
+                test_str = 'default_auto_field = "django.db.models.BigAutoField"'
+            else:
+                test_str = "default_auto_field = 'django.db.models.BigAutoField'"
+            self.assertIn(test_str, content)
             self.assertIn(
-                "default_auto_field = 'django.db.models.BigAutoField'",
+                'name = "new_app"' if HAS_BLACK else "name = 'new_app'",
                 content,
             )
-            self.assertIn("name = 'new_app'", content)
 
 
 class DiffSettings(AdminScriptTestCase):

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -3,6 +3,7 @@ asgiref >= 3.4.1
 argon2-cffi >= 16.1.0
 backports.zoneinfo; python_version < '3.9'
 bcrypt
+black
 docutils
 geoip2
 jinja2 >= 2.9.2


### PR DESCRIPTION
Run black on generated files, if it is available on PATH.

* Not sure about tests here… The required edits show black is running, but it's not explicitly covered. We **could** mock `run_formatters` and assert it's called, but I'm not sure of the value of that. 
* I considered a `--no-black` option, but I suspect that's too many knobs. If you don't want `black` why is it on your `PATH`? (More, do we really need an extra option vs saying, _In this case, remove it from your `PATH`_?)

Both of those are 🤷 