### PR TITLE
Fixed #33495 -- Improved debug logging message about adapting handlers for middlewares.

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -125,11 +125,11 @@ class BaseHandler:
         if is_async:
             if not method_is_async:
                 if debug:
-                    logger.debug("Synchronous %s adapted.", name)
+                    logger.debug("Synchronous handler adapted for %s.", name)
                 return sync_to_async(method, thread_sensitive=True)
         elif method_is_async:
             if debug:
-                logger.debug("Asynchronous %s adapted.", name)
+                logger.debug("Asynchronous handler adapted for %s.", name)
             return async_to_sync(method)
         return method
 

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -52,9 +52,9 @@ If you want to use these, you will need to deploy Django using
 
     Middleware can be built to support :ref:`both sync and async
     <async-middleware>` contexts. Some of Django's middleware is built like
-    this, but not all. To see what middleware Django has to adapt, you can turn
-    on debug logging for the ``django.request`` logger and look for log
-    messages about *"Synchronous middleware ... adapted"*.
+    this, but not all. To see what middleware Django has to adapt for, you can
+    turn on debug logging for the ``django.request`` logger and look for log
+    messages about *"Asynchronous handler adapted for middleware ..."*.
 
 In both ASGI and WSGI mode, you can still safely use asynchronous support to
 run code concurrently rather than serially. This is especially handy when

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -222,8 +222,8 @@ class MiddlewareNotUsedTests(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             cm.records[0].getMessage(),
-            "Asynchronous middleware middleware_exceptions.tests.MyMiddleware "
-            "adapted.",
+            "Asynchronous handler adapted for middleware "
+            "middleware_exceptions.tests.MyMiddleware.",
         )
         self.assertEqual(
             cm.records[1].getMessage(),
@@ -265,9 +265,8 @@ class MiddlewareSyncAsyncTests(SimpleTestCase):
         self.assertEqual(response.status_code, 402)
         self.assertEqual(
             cm.records[0].getMessage(),
-            "Synchronous middleware "
-            "middleware_exceptions.middleware.async_payment_middleware "
-            "adapted.",
+            "Synchronous handler adapted for middleware "
+            "middleware_exceptions.middleware.async_payment_middleware.",
         )
 
     @override_settings(
@@ -295,8 +294,8 @@ class MiddlewareSyncAsyncTests(SimpleTestCase):
         self.assertEqual(response.status_code, 402)
         self.assertEqual(
             cm.records[0].getMessage(),
-            "Asynchronous middleware "
-            "middleware_exceptions.middleware.PaymentMiddleware adapted.",
+            "Asynchronous handler adapted for middleware "
+            "middleware_exceptions.middleware.PaymentMiddleware.",
         )
 
     @override_settings(


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/33495

> It's the wrapped handler that's adapted to the wrapping middleware. —  Carlton Gibson

The existing log message `"Asynchronous middleware ... adapted"` contradicts https://docs.djangoproject.com/en/4.0/topics/async/#async-views:

> To see what middleware Django has to adapt, you can turn on debug logging for the `django.request` logger and look for log messages about *“Synchronous middleware … adapted”*.

This PR changes it to:

```diff
- To see what middleware Django has to adapt, you can turn
+ To see what middleware Django has to adapt for, you can turn
  on debug logging for the ``django.request`` logger and look for log
- messages about *"Synchronous middleware ... adapted"*.
+ messages about *"Asynchronous handler adapted for middleware ..."*.
```