### PR TITLE
Made Field.error_messages a cached property.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -217,12 +217,7 @@ class Field(RegisterLookupMixin):
 
         self._validators = list(validators)  # Store for deconstruction later
 
-        messages = {}
-        for c in reversed(self.__class__.__mro__):
-            messages.update(getattr(c, "default_error_messages", {}))
-        messages.update(error_messages or {})
         self._error_messages = error_messages  # Store for deconstruction later
-        self.error_messages = messages
 
     def __str__(self):
         """
@@ -668,6 +663,14 @@ class Field(RegisterLookupMixin):
         Return the converted value. Subclasses should override this.
         """
         return value
+
+    @cached_property
+    def error_messages(self):
+        messages = {}
+        for c in reversed(self.__class__.__mro__):
+            messages.update(getattr(c, "default_error_messages", {}))
+        messages.update(self._error_messages or {})
+        return messages
 
     @cached_property
     def validators(self):


### PR DESCRIPTION
This speeds up field creation and reduces memory usage.

Refs https://github.com/django/django/pull/15410

Tested speed using this code:

```
import time
from django.db import models
times = []
for x in range(1000):
    start = time.time()
    for x in range(1000):
        models.CharField(max_length=100)
    elapsed = time.time() - start
    times.append(elapsed)
    times.sort()
    print('%.04f min: %.04f, median: %.04f' % (elapsed, times[0], times[len(times) // 2]))
```

baseline:
min: 0.0077, median: 0.0082
with patch:
min: 0.0057, median: 0.0063

So about 23% faster creation. Some fields don't use model validation, like `annotate(output_field=DecimalField())`.