### PR TITLE
Refs #32502 -- Avoided table rebuild when removing fields on SQLite 3.35.5+.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -28,6 +28,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_case_insensitive_like = True
     # Is "ALTER TABLE ... RENAME COLUMN" supported?
     can_alter_table_rename_column = Database.sqlite_version_info >= (3, 25, 0)
+    # Is "ALTER TABLE ... DROP COLUMN" supported?
+    can_alter_table_drop_column = Database.sqlite_version_info >= (3, 35, 5)
     supports_parentheses_in_compound = False
     # Deferred constraint checks can be emulated on SQLite < 3.20 but not in a
     # reasonably performant way.

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -789,6 +789,24 @@ class SchemaTests(TransactionTestCase):
         # Introspection treats BLOBs as TextFields
         self.assertEqual(columns["bits"][0], "TextField")
 
+    def test_remove_field(self):
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+            with CaptureQueriesContext(connection) as ctx:
+                editor.remove_field(Author, Author._meta.get_field("name"))
+        columns = self.column_classes(Author)
+        self.assertNotIn("name", columns)
+        if getattr(connection.features, "can_alter_table_drop_column", True):
+            # Table is not rebuilt.
+            self.assertIs(
+                any("CREATE TABLE" in query["sql"] for query in ctx.captured_queries),
+                False,
+            )
+            self.assertIs(
+                any("DROP TABLE" in query["sql"] for query in ctx.captured_queries),
+                False,
+            )
+
     def test_alter(self):
         """
         Tests simple altering of fields


### PR DESCRIPTION
ticket-32502