### PR TITLE
Refs #25684 -- Removed double newline from request/response output of runserver.

### DIFF
--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -77,7 +77,7 @@ class WSGIServer(simple_server.WSGIServer):
 
     def handle_error(self, request, client_address):
         if is_broken_pipe_error():
-            logger.info("- Broken pipe from %s\n", client_address)
+            logger.info("- Broken pipe from %s", client_address)
         else:
             super().handle_error(request, client_address)
 
@@ -166,7 +166,7 @@ class WSGIRequestHandler(simple_server.WSGIRequestHandler):
                 extra["status_code"] = 500
                 logger.error(
                     "You're accessing the development server over HTTPS, but "
-                    "it only supports HTTP.\n",
+                    "it only supports HTTP.",
                     extra=extra,
                 )
                 return

--- a/tests/servers/test_basehttp.py
+++ b/tests/servers/test_basehttp.py
@@ -50,7 +50,7 @@ class WSGIRequestHandlerTestCase(SimpleTestCase):
 
         with self.assertLogs("django.server", "ERROR") as cm:
             handler.log_message("GET %s %s", "\x16\x03", "4")
-        self.assertIn(
+        self.assertEqual(
             "You're accessing the development server over HTTPS, "
             "but it only supports HTTP.",
             cm.records[0].getMessage(),
@@ -114,7 +114,7 @@ class WSGIServerTestCase(SimpleTestCase):
         """WSGIServer handles broken pipe errors."""
         request = WSGIRequest(self.request_factory.get("/").environ)
         client_address = ("192.168.2.0", 8080)
-        msg = f"- Broken pipe from {client_address}\n"
+        msg = f"- Broken pipe from {client_address}"
         tests = [
             BrokenPipeError,
             ConnectionAbortedError,


### PR DESCRIPTION
Remove annoying double newline in broken pipe error, which happens all the time on Windows

Before:
![picture1](https://user-images.githubusercontent.com/23004737/153712366-6b7def0b-e45b-4463-97a3-5285d176d20e.png)

After:
![picture2](https://user-images.githubusercontent.com/23004737/153712385-3b8ffc47-6050-4bc7-ba1f-4d1fddaa0632.png)
