### PR TITLE
ticket_32519

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -317,6 +317,9 @@ class BaseDatabaseFeatures:
     # Does the backend support JSONObject() database function?
     has_json_object_function = True
 
+    # Does the backend support JSONSet() database function?
+    has_json_set_function = True
+
     # Does the backend support column collations?
     supports_collation_on_charfield = True
     supports_collation_on_textfield = True

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -130,6 +130,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     can_introspect_json_field = property(operator.attrgetter("supports_json_field"))
     has_json_object_function = property(operator.attrgetter("supports_json_field"))
+    has_json_set_function = property(operator.attrgetter("supports_json_field"))
 
     @cached_property
     def can_return_columns_from_insert(self):

--- a/django/db/models/functions/__init__.py
+++ b/django/db/models/functions/__init__.py
@@ -1,4 +1,13 @@
-from .comparison import Cast, Coalesce, Collate, Greatest, JSONObject, Least, NullIf
+from .comparison import (
+    Cast,
+    Coalesce,
+    Collate,
+    Greatest,
+    JSONObject,
+    JSONSet,
+    Least,
+    NullIf,
+)
 from .datetime import (
     Extract,
     ExtractDay,
@@ -98,6 +107,7 @@ __all__ = [
     "Collate",
     "Greatest",
     "JSONObject",
+    "JSONSet",
     "Least",
     "NullIf",
     # datetime

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -172,6 +172,84 @@ Usage example::
     >>> author.json_object
     {'name': 'margaret smith', 'alias': 'msmith', 'age': 50}
 
+``JSONSet``
+--------------
+
+.. class:: JSONSet(field="the_json_column_name",
+                   fields: dict = {},
+                   create: bool = True,
+                   op_type: str = "SET"
+                   )
+
+.. versionadded:: 4.1
+
+Takes a ``field`` and ``fields`` dictionary
+
+- sqlite: can have any number of key, value in the ``fields`` dictionary (field,
+  fields)
+- postgresql: only 1 key, value in the ``fields`` dictionary, optionally can
+  set ``create`` to ``False`` (field, fields, create)
+- mariadb: can have any number of key, value in the ``fields`` dictionary (field,
+  fields)
+- oracle: only 1 key, value in the ``fields`` dictionary, optionally pass in
+  ``op_type`` default to "SET" ( field, fields, op_type )
+
+Usage example::
+
+
+    cls.c1 = Flying.objects.create(
+        circus={
+            "id": 1,
+            "name": "Bingo Monty DuClownPort I",
+            "profession": {"active": False, "specialization": ["physical", "bits"]},
+        }
+    )
+    cls.c2 = Flying.objects.create(
+        circus={
+            "id": 2,
+            "name": "Bingo Monty DuClownPort II",
+            "profession": {"active": True, "specialization": ["tumbling"]},
+        }
+    )
+    cls.c3 = Flying.objects.create(
+        circus={
+            "id": 3,
+            "name": "Bingo Monty DuClownPort III",
+            "profession": {"active": False, "specialization": ["fire tumbling"]},
+        }
+    )
+
+    ##########################################################
+
+    objs = Flying.objects.all()
+    name = "Ringo Monty DuClownTown I"
+    key = "$.name"
+    if connection.vendor == "postgresql":
+        key = "{name}"
+        name = '"Ringo Monty DuClownTown I"'
+    ready = JSONSet(field="circus", fields={key: Value(name)})
+    objs.update(circus=ready)
+    assertTrue(
+        all([obj.circus["name"] == name.replace('"', "") for obj in objs])
+    )
+
+    ##########################################################
+
+    objs = Flying.objects.filter(circus__id=1)
+    key = "$.profession.specialization[1]"
+    value = Value("flips")
+    if connection.vendor == "postgresql":
+        key = "{profession,specialization,1}"
+        value = Value('"flips"')
+    ready = JSONSet(field="circus", fields={key: value})
+    objs.update(circus=ready)
+    self.assertEqual(
+        "physical flips",
+        " ".join(objs.first().circus["profession"]["specialization"]),
+    )
+
+
+
 ``Least``
 ---------
 

--- a/tests/db_functions/comparison/test_json_set.py
+++ b/tests/db_functions/comparison/test_json_set.py
@@ -1,0 +1,169 @@
+from django.db import NotSupportedError
+from django.db.models import F, Value, TextField, JSONField, CharField
+from django.db.models.expressions import RawSQL
+from django.db.models.functions import JSONObject, JSONSet, Upper, Concat, Cast, Replace
+from django.test import TestCase
+from django.test.testcases import skipIfDBFeature, skipUnlessDBFeature
+from django.db import connection
+from ..models import Flying
+
+
+class TestDataMixin:
+    @classmethod
+    def setUpTestData(cls):
+        cls.c1 = Flying.objects.create(
+            circus={
+                "id": 1,
+                "name": "Bingo Monty DuClownPort I",
+                "profession": {"active": False, "specialization": ["physical", "bits"]},
+            }
+        )
+        cls.c2 = Flying.objects.create(
+            circus={
+                "id": 2,
+                "name": "Bingo Monty DuClownPort II",
+                "profession": {"active": True, "specialization": ["tumbling"]},
+            }
+        )
+        cls.c3 = Flying.objects.create(
+            circus={
+                "id": 3,
+                "name": "Bingo Monty DuClownPort III",
+                "profession": {"active": False, "specialization": ["fire tumbling"]},
+            }
+        )
+
+
+@skipUnlessDBFeature("has_json_set_function")
+class JSONSetTests(TestDataMixin, TestCase):
+    def test_empty(self):
+        objs = Flying.objects.all()
+
+        with self.assertRaises(AttributeError):
+            objs.update(circus=JSONSet())
+
+        with self.assertRaises(AttributeError):
+            objs.update(circus=JSONSet({}))
+
+    def test_replace_all(self):
+        objs = Flying.objects.all()
+        name = "Ringo Monty DuClownTown I"
+        key = "$.name"
+        if connection.vendor == "postgresql":
+            key = "{name}"
+            name = '"Ringo Monty DuClownTown I"'
+        ready = JSONSet(field="circus", fields={key: Value(name)})
+        objs.update(circus=ready)
+        self.assertTrue(
+            all([obj.circus["name"] == name.replace('"', "") for obj in objs])
+        )
+
+    def test_replace_array_one(self):
+        objs = Flying.objects.filter(circus__id=1)
+        key = "$.profession.specialization[1]"
+        value = Value("flips")
+        if connection.vendor == "postgresql":
+            key = "{profession,specialization,1}"
+            value = Value('"flips"')
+        ready = JSONSet(field="circus", fields={key: value})
+        objs.update(circus=ready)
+        self.assertEqual(
+            "physical flips",
+            " ".join(objs.first().circus["profession"]["specialization"]),
+        )
+
+    def test_replace_array_one_insert(self):
+        objs = Flying.objects.filter(circus__id=2)
+        key = "$.profession.specialization[1]"
+        value = Value("flips")
+        if connection.vendor == "postgresql":
+            key = "{profession,specialization,1}"
+            value = Value('"flips"')
+        ready = JSONSet(field="circus", fields={key: value})
+        objs.update(circus=ready)
+        self.assertEqual(
+            "tumbling flips",
+            " ".join(objs.first().circus["profession"]["specialization"]),
+        )
+
+    def test_filter_and_replace(self):
+        if connection.vendor == "sqlite":
+            objs = Flying.objects.filter(circus__profession__active=False)
+            key = "$.profession.active"
+            ready = JSONSet(field="circus", fields={key: Value(True)})
+            objs.update(circus=ready)
+            self.assertTrue(all([obj.circus["profession"]["active"] for obj in objs]))
+        else:
+            pass
+            # objs = Flying.objects.filter(circus__profession__active=False)
+            # key = "{profession,active}"
+            # ready = JSONSet(field="circus", fields={key: Value(True)})
+            # objs.update(circus=ready)
+            # self.assertTrue(all([obj.circus["profession"]["active"] for obj in objs]))
+
+    def test_filter_and_replace_annotate_all(self):
+        if connection.vendor == "sqlite":
+            objs = Flying.objects.all()
+            upper = JSONSet(
+                field="circus",
+                fields={
+                    "$.name": Upper(F("circus__name")),
+                    "$.profession.specialization[1]": Value("flips"),
+                },
+            )
+            objs.update(circus=upper)
+            items = Flying.objects.annotate(
+                screaming_circus=JSONObject(
+                    name=F("circus__name"),
+                    s=Upper(
+                        Replace(
+                            Concat(
+                                F("circus__profession__specialization__0"),
+                                Value(" "),
+                                F("circus__profession__specialization__1"),
+                            ),
+                            Value('"'),
+                            Value(""),
+                        )
+                    ),
+                )
+            )
+            self.assertSetEqual(
+                {
+                    " ".join(
+                        [item.screaming_circus["name"], item.screaming_circus["s"]]
+                    )
+                    for item in items
+                },
+                {
+                    "BINGO MONTY DUCLOWNPORT I PHYSICAL FLIPS",
+                    "BINGO MONTY DUCLOWNPORT II TUMBLING FLIPS",
+                    "BINGO MONTY DUCLOWNPORT III FIRE TUMBLING FLIPS",
+                },
+            )
+
+    def XXX_test_filter_and_replace_annotate_all_postgreql(self):
+        if connection.vendor == "postgresql":
+            objs = Flying.objects.all()
+            upper = JSONSet(
+                field="circus",
+                fields={
+                    "{name}": Upper(RawSQL("(circus ->> '%s')::varchar")),
+                },
+            )
+            objs.update(circus=upper)
+            flips = JSONSet(
+                field="circus",
+                fields={
+                    "{profession,specialization,1}": Value('"flips"'),
+                },
+            )
+            objs.update(circus=flips)
+
+
+@skipIfDBFeature("has_json_object_function")
+class JSONObjectNotSupportedTests(TestCase):
+    def test_not_supported(self):
+        msg = "JSONSet() is not supported on this database backend."
+        with self.assertRaisesMessage(NotSupportedError, msg):
+            Flying.objects.annotate(crying_circus=JSONSet())

--- a/tests/db_functions/migrations/0002_create_test_models.py
+++ b/tests/db_functions/migrations/0002_create_test_models.py
@@ -89,4 +89,10 @@ class Migration(migrations.Migration):
                 ("f2", models.FloatField(null=True, blank=True)),
             ],
         ),
+        migrations.CreateModel(
+            name="Flying",
+            fields=[
+                ("circus", models.JSONField(null=True, blank=True)),
+            ],
+        ),
     ]

--- a/tests/db_functions/models.py
+++ b/tests/db_functions/models.py
@@ -54,3 +54,10 @@ class IntegerModel(models.Model):
 class FloatModel(models.Model):
     f1 = models.FloatField(null=True, blank=True)
     f2 = models.FloatField(null=True, blank=True)
+
+
+class Flying(models.Model):
+    circus = models.JSONField(blank=True, null=True)
+
+    class Meta:
+        required_db_features = {"supports_json_field"}


### PR DESCRIPTION
Adds a JSONSet Function which can be used in a queryset.update(json_field=JSONSet(field="json_field", fields={"$.hello": Value("world")})

- sqlite supported
- postgresql partially supported
- oracle untested
- mysql/mariadb untested

~~I wasn't able to login via github on the trac website.~~ ( nvm, i had a browser extension turned on )

I'm also wondering where in the code the "__" key and transforms occur, looking into that. Something like this could be wired into json field updates/queries, something akin to `RawSQL` and `Q` and `F`, possibly.

TODO: JSONRemove, less redundant interface on the kwargs

related:

 - https://code.djangoproject.com/ticket/32179
 - https://code.djangoproject.com/ticket/32519
 
 