### PR TITLE
Fixed #28358 -- Prevented LazyObject from mimicking nonexistent attributes.

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -157,8 +157,9 @@ class LazySettings(LazyObject):
     def USE_L10N(self):
         stack = traceback.extract_stack()
         # Show a warning if the setting is used outside of Django.
-        # Stack index: -1 this line, -2 the caller.
-        filename, _, _, _ = stack[-2]
+        # Stack index: -1 this line, -2 the LazyObject __getattribute__(),
+        # -3 the caller.
+        filename, _, _, _ = stack[-3]
         if not filename.startswith(os.path.dirname(django.__file__)):
             warnings.warn(
                 USE_L10N_DEPRECATED_MSG,

--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -266,6 +266,7 @@ def new_method_proxy(func):
             self._setup()
         return func(self._wrapped, *args)
 
+    inner._mask_wrapped = False
     return inner
 
 
@@ -285,6 +286,14 @@ class LazyObject:
         # Note: if a subclass overrides __init__(), it will likely need to
         # override __copy__() and __deepcopy__() as well.
         self._wrapped = empty
+
+    def __getattribute__(self, name):
+        value = super().__getattribute__(name)
+        # If attribute is a proxy method, raise an AttributeError to call
+        # __getattr__() and use the wrapped object method.
+        if not getattr(value, "_mask_wrapped", True):
+            raise AttributeError
+        return value
 
     __getattr__ = new_method_proxy(getattr)
 

--- a/tests/utils_tests/test_lazyobject.py
+++ b/tests/utils_tests/test_lazyobject.py
@@ -32,6 +32,28 @@ class LazyObjectTestCase(TestCase):
 
         return AdHocLazyObject()
 
+    def test_getattribute(self):
+        """
+        Proxy methods don't exist on wrapped objects unless they're set.
+        """
+        attrs = [
+            "__getitem__",
+            "__setitem__",
+            "__delitem__",
+            "__iter__",
+            "__len__",
+            "__contains__",
+        ]
+        foo = Foo()
+        obj = self.lazy_wrap(foo)
+        for attr in attrs:
+            with self.subTest(attr):
+                self.assertFalse(hasattr(obj, attr))
+                setattr(foo, attr, attr)
+                obj_with_attr = self.lazy_wrap(foo)
+                self.assertTrue(hasattr(obj_with_attr, attr))
+                self.assertEqual(getattr(obj_with_attr, attr), attr)
+
     def test_getattr(self):
         obj = self.lazy_wrap(Foo())
         self.assertEqual(obj.foo, "bar")


### PR DESCRIPTION
Technically this happens when using `getattr` or similar to a `LazyObject` instance. The instance has the method but the wrapped object might not.

I modified the original PR #8806 to still use `__getattr__`. If an attribute does not exist or if a method is lazy (lazy here meaning it is wrapped with `new_method_proxy`), `__getattribute__` raises an `AttributeError` which triggers `__getattr__`.