### PR TITLE
Refs #31407 -- Handled potential exception in test cleanup.

### DIFF
--- a/tests/handlers/views.py
+++ b/tests/handlers/views.py
@@ -63,7 +63,11 @@ class CoroutineClearingView:
         return self._unawaited_coroutine
 
     def __del__(self):
-        self._unawaited_coroutine.close()
+        try:
+            self._unawaited_coroutine.close()
+        except AttributeError:
+            # View was never called.
+            pass
 
 
 async_unawaited = CoroutineClearingView()


### PR DESCRIPTION
The test view may not be called when running the tests with
--parallel=2 or greater. Catch the AttributeError for this case.

Seen reviewing #15421 (on macOS)

```
% ./runtests.py --parallel 2 handlers 
Testing against Django installed in '/Users/carlton/Projects/Django/django/django' with up to 2 processes
Found 31 test(s).
Creating test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
System check identified no issues (0 silenced).
...............................
Exception ignored in: <function CoroutineClearingView.__del__ at 0x106dfa7a0>
Traceback (most recent call last):
  File "/Users/carlton/Projects/Django/django/tests/handlers/views.py", line 70, in __del__
AttributeError: 'CoroutineClearingView' object has no attribute '_unawaited_coroutine'

----------------------------------------------------------------------
Ran 31 tests in 0.289s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
```

It comes up because each process gets an instance of `CoroutineClearingView()` but only one of them runs the test to call it, setting the attribute. 

@felixxm reports **not** seeing the error doing the same on Linux. 🤔

//cc @smithdc1 