### PR TITLE
max limit of get query set to 2

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -31,7 +31,7 @@ from django.utils.deprecation import RemovedInDjango50Warning
 from django.utils.functional import cached_property, partition
 
 # The maximum number of results to fetch in a get() query.
-MAX_GET_RESULTS = 21
+MAX_GET_RESULTS = 2
 
 # The maximum number of items to display in a QuerySet.__repr__
 REPR_OUTPUT_SIZE = 20


### PR DESCRIPTION
A limit of more than 2 is not required to get a query. 2 is enough to raise MultipleObjectsReturned, more than that is just increases the query time by scanning for more possibilities.