### PR TITLE
Fix UserCreationForm model from User to UserModel

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -104,7 +104,7 @@ class UserCreationForm(forms.ModelForm):
     )
 
     class Meta:
-        model = User
+        model = UserModel
         fields = ("username",)
         field_classes = {"username": UsernameField}
 


### PR DESCRIPTION
Hi coders,

The old `model = User` line, don't work if I specified `AUTH_USER_MODEL` in the project settings, therefore it should get the User model from the `get_user_model` function instead, so if I changed the User model it could grab it and work exactly as it should work.

If there is any advice, edit or good practice thing to do kindly let me know.