### PR TITLE
Refs #28358 -- Fixed infinite recursion in LazyObject.__getattribute__().

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -288,6 +288,9 @@ class LazyObject:
         self._wrapped = empty
 
     def __getattribute__(self, name):
+        if name == "_wrapped":
+            # Avoid recursion when getting wrapped object.
+            return super().__getattribute__(name)
         value = super().__getattribute__(name)
         # If attribute is a proxy method, raise an AttributeError to call
         # __getattr__() and use the wrapped object method.

--- a/tests/utils_tests/test_lazyobject.py
+++ b/tests/utils_tests/test_lazyobject.py
@@ -58,6 +58,14 @@ class LazyObjectTestCase(TestCase):
         obj = self.lazy_wrap(Foo())
         self.assertEqual(obj.foo, "bar")
 
+    def test_getattr_falsey(self):
+        class Thing:
+            def __getattr__(self, key):
+                return []
+
+        obj = self.lazy_wrap(Thing())
+        self.assertEqual(obj.main, [])
+
     def test_setattr(self):
         obj = self.lazy_wrap(Foo())
         obj.foo = "BAR"


### PR DESCRIPTION
…ced by https://github.com/django/django/commit/97d7990abde3fe4b525ae83958fd0b52d6a1d13f

Objects which override the `__getattr__` method to always return something cannot be wrapped by `LazyObject` anymore.

Example: https://github.com/matthiask/django-content-editor/blob/9f9234c11ae61380a46f456ce5308d17bb4f6c1f/content_editor/contents.py#L29-L32 -- I don't care whether the region key exists in this case. It has always been convenient to be able to write `contents.main` and `contents["main"]` depending on the circumstance.

I'm not sure whether this issue should be fixed in Django or in my code. A easy workaround for me would be to change the `__getattr__` behavior when the attribute name starts with an underscore; this may be a good idea anyway, but I wanted to at least raise some awareness :) 

Thanks!