### PR TITLE
Improved docs for Signer to encourage more secure patterns.

### DIFF
--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -3,7 +3,7 @@ Functions for creating and restoring url-safe signed JSON objects.
 
 The format used looks like this:
 
->>> signing.dumps("hello")
+>>> signing.dumps("hello", salt="purpose1")
 'ImhlbGxvIg:1QaUZC:YIye-ze3TTx7gtSv422nZA4sgmk'
 
 There are two components here, separated by a ':'. The first component is a
@@ -13,9 +13,9 @@ component is a base64 encoded hmac/SHA-256 hash of "$first_component:$secret"
 signing.loads(s) checks the signature and returns the deserialized object.
 If the signature fails, a BadSignature exception is raised.
 
->>> signing.loads("ImhlbGxvIg:1QaUZC:YIye-ze3TTx7gtSv422nZA4sgmk")
+>>> signing.loads("ImhlbGxvIg:1QaUZC:YIye-ze3TTx7gtSv422nZA4sgmk", salt="purpose1")
 'hello'
->>> signing.loads("ImhlbGxvIg:1QaUZC:YIye-ze3TTx7gtSv42-modified")
+>>> signing.loads("ImhlbGxvIg:1QaUZC:YIye-ze3TTx7gtSv42-modified", salt="purpose1")
 ...
 BadSignature: Signature "ImhlbGxvIg:1QaUZC:YIye-ze3TTx7gtSv42-modified" does not match
 
@@ -23,7 +23,7 @@ You can optionally compress the JSON prior to base64 encoding it to save
 space, using the compress=True argument. This checks if compression actually
 helps and only applies compression if the result is a shorter string:
 
->>> signing.dumps(list(range(1, 20)), compress=True)
+>>> signing.dumps(list(range(1, 20)), salt="purpose1", compress=True)
 '.eJwFwcERACAIwLCF-rCiILN47r-GyZVJsNgkxaFxoDgxcOHGxMKD_T7vhAml:1QaUaL:BA0thEZrp4FQVXIXuOvYJtLJSrQ'
 
 The fact that the string is compressed is signalled by the prefixed '.' at the

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -375,11 +375,12 @@ Methods
     no longer valid. If you provide the ``default`` argument the exception
     will be suppressed and that default value will be returned instead.
 
-    The optional ``salt`` argument can be used to provide extra protection
-    against brute force attacks on your secret key. If supplied, the
-    ``max_age`` argument will be checked against the signed timestamp
-    attached to the cookie value to ensure the cookie is not older than
-    ``max_age`` seconds.
+    The optional ``salt`` argument must be the same value used for the
+    corresponding :meth:`~HttpResponse.set_signed_cookie` call.
+
+    If supplied, the ``max_age`` argument will be checked against the signed
+    timestamp attached to the cookie value to ensure the cookie is not older
+    than ``max_age`` seconds.
 
     For example::
 
@@ -894,12 +895,16 @@ Methods
 
 .. method:: HttpResponse.set_signed_cookie(key, value, salt='', max_age=None, expires=None, path='/', domain=None, secure=False, httponly=False, samesite=None)
 
-    Like :meth:`~HttpResponse.set_cookie()`, but
-    :doc:`cryptographic signing </topics/signing>` the cookie before setting
-    it. Use in conjunction with :meth:`HttpRequest.get_signed_cookie`.
-    You can use the optional ``salt`` argument for added key strength, but
-    you will need to remember to pass it to the corresponding
-    :meth:`HttpRequest.get_signed_cookie` call.
+    Like :meth:`~HttpResponse.set_cookie()`, but uses :doc:`cryptographic
+    signing </topics/signing>` on the cookie value before setting it. Use in
+    conjunction with :meth:`HttpRequest.get_signed_cookie`.
+
+    The ``key`` is used to generate the signature, to stop attackers re-using a
+    value signed for one key as a valid value for a different key. In addition,
+    it is helpful to use a unique ``salt`` argument for every different purpose
+    you use signed cookies for. See :ref:`understanding-signing-salt` for more
+    details. You will need to remember to pass the same ``salt`` value to the
+    corresponding :meth:`HttpRequest.get_signed_cookie` call.
 
 .. method:: HttpResponse.delete_cookie(key, path='/', domain=None, samesite=None)
 

--- a/docs/topics/signing.txt
+++ b/docs/topics/signing.txt
@@ -49,7 +49,7 @@ Django's signing methods live in the ``django.core.signing`` module.
 To sign a value, first instantiate a ``Signer`` instance::
 
     >>> from django.core.signing import Signer
-    >>> signer = Signer()
+    >>> signer = Signer(salt='purpose.specific.salt')
     >>> value = signer.sign('My string')
     >>> value
     'My string:GdMGD6HNQ_qdgxYP8yBZAdAIV1w'
@@ -115,20 +115,25 @@ generate signatures. You can use a different secret by passing it to the
 
         The ``fallback_keys`` argument was added.
 
-Using the ``salt`` argument
----------------------------
+.. _understanding-signing-salt:
 
-If you do not wish for every occurrence of a particular string to have the same
-signature hash, you can use the optional ``salt`` argument to the ``Signer``
-class. Using a salt will seed the signing hash function with both the salt and
-your :setting:`SECRET_KEY`::
+Understanding and using the ``salt`` argument
+---------------------------------------------
 
-    >>> signer = Signer()
+Every different purpose for which you use signing should either have a
+different secret (which is passed as the first argument to ``Signer`` and is
+equal to :setting:`SECRET_KEY` by default), or use a unique ``salt`` argument
+or both.
+
+Using a salt will seed the signing hash function with both the salt and
+your secret::
+
+    >>> signer = Signer(salt='myproject.purpose1')
     >>> signer.sign('My string')
     'My string:GdMGD6HNQ_qdgxYP8yBZAdAIV1w'
     >>> signer.sign_object({'message': 'Hello!'})
     'eyJtZXNzYWdlIjoiSGVsbG8hIn0:Xdc-mOFDjs22KsQAqfVfi8PQSPdo3ckWJxPWwQOFhR4'
-    >>> signer = Signer(salt='extra')
+    >>> signer = Signer(salt='myproject.purpose2')
     >>> signer.sign('My string')
     'My string:Ee7vGi-ING6n02gkcJ-QLHg6vFw'
     >>> signer.unsign('My string:Ee7vGi-ING6n02gkcJ-QLHg6vFw')
@@ -143,11 +148,66 @@ namespaces.  A signature that comes from one namespace (a particular salt
 value) cannot be used to validate the same plaintext string in a different
 namespace that is using a different salt setting. The result is to prevent an
 attacker from using a signed string generated in one place in the code as input
-to another piece of code that is generating (and verifying) signatures using a
-different salt.
+to another piece of code that is generating (and verifying) signatures for a
+different purpose or in a different context.
 
 Unlike your :setting:`SECRET_KEY`, your salt argument does not need to stay
 secret.
+
+In addition to using salt values, you should think carefully about the value
+you are signing, and how it might be re-used by an attacker.
+
+For example, suppose you are an insurance company, and give a user a quote for
+home insurance of $20/month. You send the user a signed value generated as
+follows, perhaps stored in a cookie:
+
+::
+
+    >>> signer = Signer(salt='acmeinsurance.quotes')
+    >>> signer.sign("20")
+
+
+There are multiple issues with this:
+
+1. It has no time limit or timestamp, so the value can be used forever.
+
+2. We are simply signing the string ``"20"`` which is very ambiguous in
+   meaning. You might also sell car insurance, and an attacker would be able to
+   take this signed value that was intended for home insurance and re-use it to
+   get cheap car insurance. Or they might re-use it for a completely different
+   house, or re-use it in a context where it means a yearly amount, rather than
+   a monthly amount.
+
+3. There is no scoping to the user. The user could take this signed value and
+   share it with a friend, who would also be able to use it on your site.
+
+The answers to these problems are:
+
+- Use :class:`~TimestampSigner`, or build an expiration timestamp into the
+  value that you sign, which you check later.
+
+- Use a more specific salt.
+
+- Instead of signing simple values without context, sign complex objects that
+  express more completely what you want to sign - “we offer the user with email
+  address ``user@example.com`` home insurance for 123 Main St, for the price of
+  20 dollars a month, valid until 2022-05-01”::
+
+    >>> signer = Signer(salt="acmeinsurance.quotes.home_insurance")
+    >>> signer.sign_object({
+    ...    'user_email': 'user@example.com',
+    ...    'address': '123 Main St, 9980-999',
+    ...    'amount': 20,
+    ...    'unit': 'dollars',
+    ...    'period': 'month',
+    ...    'valid_until': '2022-05-01',
+    ... })
+
+- Make sure you use or check each part of the value returned after calling
+  ``unsign``, rather than assuming it matches what you expect.
+
+- Instead of doing this at all, store the values in the database and give
+  the user just a reference.
 
 Verifying timestamped values
 ----------------------------
@@ -158,7 +218,7 @@ created within a specified period of time::
 
     >>> from datetime import timedelta
     >>> from django.core.signing import TimestampSigner
-    >>> signer = TimestampSigner()
+    >>> signer = TimestampSigner(salt='purpose.specific.salt')
     >>> value = signer.sign('hello')
     >>> value
     'hello:1NMg5H:oPVuCqlJWmChm1rA2lyTUtelC-c'
@@ -209,16 +269,16 @@ These use JSON serialization under the hood. JSON ensures that even if your
 arbitrary commands by exploiting the pickle format::
 
     >>> from django.core import signing
-    >>> signer = signing.TimestampSigner()
+    >>> signer = signing.TimestampSigner(salt='myproject.purpose1')
     >>> value = signer.sign_object({'foo': 'bar'})
     >>> value
     'eyJmb28iOiJiYXIifQ:1kx6R3:D4qGKiptAqo5QW9iv4eNLc6xl4RwiFfes6oOcYhkYnc'
     >>> signer.unsign_object(value)
     {'foo': 'bar'}
-    >>> value = signing.dumps({'foo': 'bar'})
+    >>> value = signing.dumps({'foo': 'bar'}, salt='myproject.purpose1')
     >>> value
     'eyJmb28iOiJiYXIifQ:1kx6Rf:LBB39RQmME-SRvilheUe5EmPYRbuDBgQp2tCAi7KGLk'
-    >>> signing.loads(value)
+    >>> signing.loads(value, salt='myproject.purpose1')
     {'foo': 'bar'}
 
 Because of the nature of JSON (there is no native distinction between lists


### PR DESCRIPTION
After seeing a colleague use `Signer`/`TimestampSigner` without the `salt` argument passed, I looked at the docs and found that they do not really encourage its use. This is unfortunate, because it really is required to avoid hacks once you have more than one use of it in your application. The best way to ensure correct usage is to always add the argument.

While I was there, I took the opportunity to explain and encourage better patterns, and updated the `get_signed_cookie` and `set_signed_cookie` docs accordingly.

Passing `salt` to  `set_signed_cookie` is not quite as necessary, because it already uses the `key` value as a salt, but I think it is still helpful. In a large project, it's possible that the same key could be validly used for `set_signed_cookie(key)` but with different purposes - for example they might use a different `path` argument, so the cookies wouldn't clash at the browser level, and therefore they wouldn't notice the clash.