### PR TITLE
Refs #2259 -- Disallowed primary keys in ModelAdmin.list_editable.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -1130,7 +1130,7 @@ class ModelAdminChecks(BaseModelAdminChecks):
                         id="admin.E124",
                     )
                 ]
-            elif not field.editable:
+            elif not field.editable or field.primary_key:
                 return [
                     checks.Error(
                         "The value of '%s' refers to '%s', which is not editable "

--- a/tests/admin_checks/tests.py
+++ b/tests/admin_checks/tests.py
@@ -363,6 +363,23 @@ class SystemChecksTestCase(SimpleTestCase):
         ]
         self.assertEqual(errors, expected)
 
+    def test_pk_not_editable(self):
+        # PKs cannot be edited in the list.
+        class SongAdmin(admin.ModelAdmin):
+            list_display = ["title", "id"]
+            list_editable = ["id"]
+
+        errors = SongAdmin(Song, AdminSite()).check()
+        expected = [
+            checks.Error(
+                "The value of 'list_editable[0]' refers to 'id', which is not editable "
+                "through the admin.",
+                obj=SongAdmin,
+                id="admin.E125",
+            )
+        ]
+        self.assertEqual(errors, expected)
+
     def test_editable(self):
         class SongAdmin(admin.ModelAdmin):
             list_display = ["pk", "title"]


### PR DESCRIPTION
The first fix for Issue ticket-2259

This PR adds a check to not allow the primary key field in `list_editable` of our model admin