### PR TITLE
Refs #33173 -- Fixed mail test on Windows with Python 3.11.

### DIFF
--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -15,6 +15,7 @@ PY37 = sys.version_info >= (3, 7)
 PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
 PY310 = sys.version_info >= (3, 10)
+PY311 = sys.version_info >= (3, 11)
 
 
 def get_version(version=None):

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -29,6 +29,7 @@ from django.core.mail.message import BadHeaderError, sanitize_address
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import requires_tz_support
 from django.utils.translation import gettext_lazy
+from django.utils.version import PY311
 
 try:
     from aiosmtpd.controller import Controller
@@ -790,7 +791,7 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
                 filebased.EmailBackend,
             )
 
-        if sys.platform == "win32":
+        if sys.platform == "win32" and not PY311:
             msg = (
                 "_getfullpathname: path should be string, bytes or os.PathLike, not "
                 "object"


### PR DESCRIPTION
While working on the parallel test runner I've been trying it with different Python versions. 

When testing against Python 3.11.0a5 I had one failing test which I've fixed here. 

Likely too early as we don't have c/i against 3.11 yet? But it's here for when you need it. 