### PR TITLE
Fixed #20296 -- Prevented mark_safe() from evaluating lazy objects.

### DIFF
--- a/django/utils/safestring.py
+++ b/django/utils/safestring.py
@@ -7,6 +7,8 @@ be interpreted by the HTML engine (e.g. '<') into the appropriate entities.
 
 from functools import wraps
 
+from django.utils.functional import keep_lazy
+
 
 class SafeData:
     __slots__ = ()
@@ -53,6 +55,7 @@ def _safety_decorator(safety_marker, func):
     return wrapped
 
 
+@keep_lazy(SafeString)
 def mark_safe(s):
     """
     Explicitly mark a string as safe for (HTML) output purposes. The returned

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -312,6 +312,8 @@ Utilities
 
 * ``SimpleLazyObject`` now supports addition operations.
 
+* :func:`~django.utils.safestring.mark_safe` now preserves lazy objects.
+
 Validators
 ~~~~~~~~~~
 


### PR DESCRIPTION
Wrap `mark_safe` with `keep_lazy` to keep it from evaluating lazy objects.