### PR TITLE
Refs #33476 -- Mentioned black in docs about pre-commit checks.

### DIFF
--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -26,9 +26,9 @@ On the first commit ``pre-commit`` will install the hooks, these are
 installed in their own environments and will take a short while to
 install on the first run. Subsequent checks will be significantly faster.
 If an error is found an appropriate error message will be displayed.
-If the error was with ``isort`` then the tool will go ahead and fix them for
-you. Review the changes and re-stage for commit if you are happy with
-them.
+If the error was with ``black`` or ``isort`` then the tool will go ahead and
+fix them for you. Review the changes and re-stage for commit if you are happy
+with them.
 
 .. _coding-style-python:
 


### PR DESCRIPTION
I have changed the wording from:
If the error was with ``isort`` then the tool will go ahead and fix them for

to this:
If the error was with ``isort`` or ``black`` then the tool will go ahead and fix them for

keeping in mind the recent adoption of black formatter in the Django codebase.