### PR TITLE
Fixed #33508 -- Fixed DatabaseFeatures.supports_index_column_ordering on MariaDB 10.8+.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -316,10 +316,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     @cached_property
     def supports_index_column_ordering(self):
-        return (
-            not self.connection.mysql_is_mariadb
-            and self.connection.mysql_version >= (8, 0, 1)
-        )
+        if self.connection.mysql_is_mariadb:
+            return self.connection.mysql_version >= (10, 8)
+        return self.connection.mysql_version >= (8, 0, 1)
 
     @cached_property
     def supports_expression_indexes(self):


### PR DESCRIPTION
ticket-33508
