### PR TITLE
Fixed #33532 -- Optimized CaseInsensitiveMapping instantiation for dicts.

### DIFF
--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -327,7 +327,10 @@ class CaseInsensitiveMapping(Mapping):
 
     @staticmethod
     def _unpack_items(data):
-        if isinstance(data, Mapping):
+        # Explicitly test for dict first as the common case for performance,
+        # avoiding abc's __instancecheck__ and _abc_instancecheck for the
+        # general Mapping case.
+        if isinstance(data, (dict, Mapping)):
             yield from data.items()
             return
         for i, elem in enumerate(data):


### PR DESCRIPTION
Ticket is [33532 on Trac](https://code.djangoproject.com/ticket/33532#ticket).

Saves me roughly `0.5µs` across a couple of expectedly common instantiations. Applies mainly to `HttpHeaders` rather than `ResponseHeaders`, as that massages it's data slightly differently and I'd look to target that as a separate patch which I've mostly done pre-black, so will need fixing ;)

Timings from ticket follow.

Before:
```
In [3]: %timeit CaseInsensitiveMapping({'Name': 'Jane'})
1.4 µs ± 7.94 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
In [4]: %timeit HttpHeaders({"HTTP_EXAMPLE": 1})
2.79 µs ± 20.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
In [5]: %timeit HttpHeaders({"CONTENT_LENGTH": 1})
2.56 µs ± 40 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

After:
```
In [3]: %timeit CaseInsensitiveMapping({'Name': 'Jane'})
862 ns ± 9.4 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
In [4]: %timeit HttpHeaders({"HTTP_EXAMPLE": 1})
2.05 µs ± 31 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
In [5]: %timeit HttpHeaders({"CONTENT_LENGTH": 1})
1.98 µs ± 18.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```