### PR TITLE
Refs #32873 -- Avoided looking up settings._USE_L10N_INTERNAL twice.

### DIFF
--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -106,14 +106,11 @@ def get_format(format_type, lang=None, use_l10n=None):
     If use_l10n is provided and is not None, it forces the value to
     be localized (or not), overriding the value of settings.USE_L10N.
     """
-    use_l10n = use_l10n or (
-        use_l10n is None
-        and (
-            settings._USE_L10N_INTERNAL
-            if hasattr(settings, "_USE_L10N_INTERNAL")
-            else settings.USE_L10N
-        )
-    )
+    if use_l10n is None:
+        try:
+            use_l10n = settings._USE_L10N_INTERNAL
+        except AttributeError:
+            use_l10n = settings.USE_L10N
     if use_l10n and lang is None:
         lang = get_language()
     cache_key = (format_type, lang)
@@ -181,14 +178,11 @@ def number_format(value, decimal_pos=None, use_l10n=None, force_grouping=False):
     If use_l10n is provided and is not None, it forces the value to
     be localized (or not), overriding the value of settings.USE_L10N.
     """
-    use_l10n = use_l10n or (
-        use_l10n is None
-        and (
-            settings._USE_L10N_INTERNAL
-            if hasattr(settings, "_USE_L10N_INTERNAL")
-            else settings.USE_L10N
-        )
-    )
+    if use_l10n is None:
+        try:
+            use_l10n = settings._USE_L10N_INTERNAL
+        except AttributeError:
+            use_l10n = settings.USE_L10N
     lang = get_language() if use_l10n else None
     return numberformat.format(
         value,


### PR DESCRIPTION
`settings._USE_L10N_INTERNAL` and `settings.USE_L10N` are currently expensive during the transition, so this speeds things up a bit. `settings._USE_L10N_INTERNAL` should generally always be available.