### PR TITLE
Optimized lazy wrappers a bit.

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -88,9 +88,10 @@ class LazySettings(LazyObject):
 
     def __getattr__(self, name):
         """Return the value of a setting and cache it in self.__dict__."""
-        if self._wrapped is empty:
+        if (_wrapped := self._wrapped) is empty:
             self._setup(name)
-        val = getattr(self._wrapped, name)
+            _wrapped = self._wrapped
+        val = getattr(_wrapped, name)
 
         # Special case some settings which require further modification.
         # This is done here for performance reasons so the modified value is cached.

--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -262,9 +262,10 @@ empty = object()
 
 def new_method_proxy(func):
     def inner(self, *args):
-        if self._wrapped is empty:
+        if (_wrapped := self._wrapped) is empty:
             self._setup()
-        return func(self._wrapped, *args)
+            _wrapped = self._wrapped
+        return func(_wrapped, *args)
 
     inner._mask_wrapped = False
     return inner


### PR DESCRIPTION
Avoid calling `__getattribute__()` twice, and avoid calling `itertools.chain` or using a generator.