### PR TITLE
Refs #33328 -- Added some advice regarding handling formset:added/removed in 3rd party libraries

### DIFF
--- a/docs/ref/contrib/admin/javascript.txt
+++ b/docs/ref/contrib/admin/javascript.txt
@@ -50,3 +50,29 @@ Two points to keep in mind:
 * ``{{ block.super }}`` is added because Django's
   ``admin_change_form_document_ready`` block contains JavaScript code to handle
   various operations in the change form and we need that to be rendered too.
+
+Supporting versions of Django older than 4.1
+--------------------------------------------
+
+If your event listener still has to support older versions of Django you have
+to use jQuery to register your event listener. jQuery handles JavaScript events
+but the reverse isn't true.
+
+You could check for the presence of ``event.detail.formsetName`` and fall back
+to the old listener signature as follows:
+
+.. code-block:: javascript
+
+    function handleFormsetAdded(row, formsetName) {
+        // Do something
+    }
+
+    $(document).on('formset:added', (event, $row, formsetName) => {
+        if (event.detail.formsetName) {
+            // Django >= 4.1
+            handleFormsetAdded(event.target, event.detail.formsetName)
+        } else {
+            // Django < 4.1, use $row and formsetName
+            handleFormsetAdded($row.get(0), formsetName)
+        }
+    })


### PR DESCRIPTION
Writing code which works with several versions of Django may be somewhat hard at times. 

I tried (and failed) to rewrite the code in django-content-editor to use `addEventListener` instead of jQuery. However, code using `addEventListener` isn't triggered when using `jQuery.trigger(...)` (that's expected, see https://github.com/jquery/jquery/issues/2476)

I therefore propose this addition to the docs. 

Here's the current version which works both with Django 4.0 and 4.1:
https://github.com/matthiask/django-content-editor/blob/e6b4b8b8dd54b922d1b30b625a38b5e3b765d043/content_editor/static/content_editor/content_editor.js#L508-L516