### PR TITLE
Fixed #33539 -- Fixed spaces in WITH SQL for indexes on PostgreSQL.

### DIFF
--- a/django/contrib/postgres/indexes.py
+++ b/django/contrib/postgres/indexes.py
@@ -29,7 +29,7 @@ class PostgresIndex(Index):
         )
         with_params = self.get_with_params()
         if with_params:
-            statement.parts["extra"] = "WITH (%s) %s" % (
+            statement.parts["extra"] = " WITH (%s)%s" % (
                 ", ".join(with_params),
                 statement.parts["extra"],
             )

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -330,9 +330,14 @@ class SchemaTests(PostgreSQLTestCase):
             name=index_name,
             fastupdate=True,
             gin_pending_list_limit=64,
+            db_tablespace="pg_default",
         )
         with connection.schema_editor() as editor:
             editor.add_index(IntegerArrayModel, index)
+            self.assertIn(
+                ") WITH (gin_pending_list_limit = 64, fastupdate = on) TABLESPACE",
+                str(index.create_sql(IntegerArrayModel, editor)),
+            )
         constraints = self.get_constraints(IntegerArrayModel._meta.db_table)
         self.assertEqual(constraints[index_name]["type"], "gin")
         self.assertEqual(


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33539

Before and after:

`CREATE INDEX "zerver_message_search_tsvector" ON "zerver_message" USING gin ("search_tsvector")WITH (fastupdate = off) ;`

`CREATE INDEX "zerver_message_search_tsvector" ON "zerver_message" USING gin ("search_tsvector") WITH (fastupdate = off);`