### PR TITLE
Slightly more informative message to user

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1937,7 +1937,9 @@ class ModelAdmin(BaseModelAdmin):
                 return SimpleTemplateResponse(
                     "admin/invalid_setup.html",
                     {
-                        "title": _("Database error"),
+                        "title": _(
+                            "Database error/IncorrectLookupParameters in query string"
+                        ),
                     },
                 )
             return HttpResponseRedirect(request.path + "?" + ERROR_FLAG + "=1")


### PR DESCRIPTION
Database Error can be slightly misleading if the problem is erroneous query params specified to be used in the lookup field. 