### PR TITLE
Fixed #33546 -- Optimized ResponseHeaders and HttpResponseBase

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -152,11 +152,15 @@ class HttpResponseBase:
     def charset(self):
         if self._charset is not None:
             return self._charset
-        content_type = self.get("Content-Type", "")
-        matched = _charset_from_content_type_re.search(content_type)
-        if matched:
-            # Extract the charset and strip its double quotes
-            return matched["charset"].replace('"', "")
+        # The Content-Type header may not yet be set, because the charset is
+        # being inserted *into* it.
+        if content_type := self.headers.get("Content-Type"):
+            if matched := _charset_from_content_type_re.search(content_type):
+                # Extract the charset and strip its double quotes.
+                # Note that having parsed it from the Content-Type, we don't
+                # store it back into the _charset for later intentionally, to
+                # allow for the Content-Type to be switched again later.
+                return matched["charset"].replace('"', "")
         return settings.DEFAULT_CHARSET
 
     @charset.setter

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -111,15 +111,15 @@ class HttpResponseBase:
     ):
         self.headers = ResponseHeaders(headers)
         self._charset = charset
-        if content_type and "Content-Type" in self.headers:
+        if "Content-Type" not in self.headers:
+            if content_type is None:
+                content_type = f"text/html; charset={self.charset}"
+            self.headers["Content-Type"] = content_type
+        elif content_type:
             raise ValueError(
                 "'headers' must not contain 'Content-Type' when the "
                 "'content_type' parameter is provided."
             )
-        if "Content-Type" not in self.headers:
-            if content_type is None:
-                content_type = "text/html; charset=%s" % self.charset
-            self.headers["Content-Type"] = content_type
         self._resource_closers = []
         # This parameter is set by the handler. It's necessary to preserve the
         # historical behavior of request_finished.

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -43,22 +43,32 @@ class ResponseHeaders(CaseInsensitiveMapping):
         `charset` must be 'ascii' or 'latin-1'. If `mime_encode` is True and
         `value` can't be represented in the given charset, apply MIME-encoding.
         """
-        if not isinstance(value, (bytes, str)):
-            value = str(value)
-        if (isinstance(value, bytes) and (b"\n" in value or b"\r" in value)) or (
-            isinstance(value, str) and ("\n" in value or "\r" in value)
-        ):
-            raise BadHeaderError(
-                "Header values can't contain newlines (got %r)" % value
-            )
         try:
             if isinstance(value, str):
                 # Ensure string is valid in given charset
                 value.encode(charset)
-            else:
+            elif isinstance(value, bytes):
                 # Convert bytestring using given charset
                 value = value.decode(charset)
+            else:
+                value = str(value)
+                # Ensure string is valid in given charset.
+                value.encode(charset)
+            if "\n" in value or "\r" in value:
+                raise BadHeaderError(
+                    f"Header values can't contain newlines (got {value!r})"
+                )
         except UnicodeError as e:
+            # Encoding to a string of the specified charset failed, but we
+            # don't know what type that value was, or if it contains newlines,
+            # which we may need to check for before sending it to be
+            # encoded for multiple character sets.
+            if (isinstance(value, bytes) and (b"\n" in value or b"\r" in value)) or (
+                isinstance(value, str) and ("\n" in value or "\r" in value)
+            ):
+                raise BadHeaderError(
+                    f"Header values can't contain newlines (got {value!r})"
+                ) from e
             if mime_encode:
                 value = Header(value, "utf-8", maxlinelen=sys.maxsize).encode()
             else:

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -33,8 +33,9 @@ class ResponseHeaders(CaseInsensitiveMapping):
         correctly encoded.
         """
         self._store = {}
-        for header, value in self._unpack_items(data):
-            self[header] = value
+        if data:
+            for header, value in self._unpack_items(data):
+                self[header] = value
 
     def _convert_to_charset(self, value, charset, mime_encode=False):
         """
@@ -98,7 +99,7 @@ class HttpResponseBase:
     def __init__(
         self, content_type=None, status=None, reason=None, charset=None, headers=None
     ):
-        self.headers = ResponseHeaders(headers or {})
+        self.headers = ResponseHeaders(headers)
         self._charset = charset
         if content_type and "Content-Type" in self.headers:
             raise ValueError(

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -364,6 +364,27 @@ class HttpResponseTests(SimpleTestCase):
         with self.assertRaises(BadHeaderError):
             r.headers.__setitem__("test\nstr", "test")
 
+    def test_encoded_with_newlines_in_headers(self):
+        """
+        Keys & values which throw a UnicodeError when encoding/decoding should
+        still be checked for newlines and re-raised as a BadHeaderError.
+        These specifically would still throw BadHeaderError after decoding
+        successfully, because the newlines are sandwiched in the middle of the
+        string and email.Header leaves those as they are.
+        """
+        r = HttpResponse()
+        pairs = (
+            ("†\nother", "test"),
+            ("test", "†\nother"),
+            (b"\xe2\x80\xa0\nother", "test"),
+            ("test", b"\xe2\x80\xa0\nother"),
+        )
+        msg = "Header values can't contain newlines"
+        for key, value in pairs:
+            with self.subTest(key=key, value=value):
+                with self.assertRaisesMessage(BadHeaderError, msg):
+                    r[key] = value
+
     def test_dict_behavior(self):
         """
         Test for bug #14020: Make HttpResponse.get work like dict.get


### PR DESCRIPTION
[ticket is 33546](https://code.djangoproject.com/ticket/33546#ticket).

Lets hope CI doesn't disprove me.

Timings, mirrored from ticket, on my local Macbook Air:

|                                                                	| main    	| patched 	|
|----------------------------------------------------------------	|---------	|---------	|
| ResponseHeaders({})                                            	| 745 ns  	| 313 ns  	|
| ResponseHeaders({'TEST': "1"})                                 	| 2.17 µs 	| 1.8 µs  	|
| ResponseHeaders({'TEST': "1", "TEST2": "2"})                   	| 3.51 µs 	| 2.77 µs 	|
| ResponseHeaders({"Content-Type": "application/json"})          	| 2.19 µs 	| 1.93 µs 	|
| HttpResponseBase()                                             	| 7.89 µs 	| 4.18 µs 	|
| HttpResponseBase(headers={"TEST": "1"})                        	| 9.75 µs 	| 6.02 µs 	|
| HttpResponseBase(headers={"TEST": "1", "TEST2": "2"})          	| 11 µs   	| 7.09 µs 	|
| HttpResponseBase(headers={"Content-Type": "application/json"}) 	| 3.71 µs 	| 3.26 µs 	|
| HttpResponseBase(content_type="test")                          	| 4.48 µs 	| 3.03 µs 	|
| HttpResponse()                                                 	| 9.06 µs 	| 5.46 µs 	|
| HttpResponse(headers={"TEST": "1"})                            	| 11.4 µs 	| 7.58 µs 	|
| HttpResponse(headers={"TEST": "1", "TEST2": "2"})              	| 13 µs   	| 8.83 µs 	|
| HttpResponse(headers={"Content-Type": "application/json"})     	| 5.22 µs 	| 4.82 µs 	|
| HttpResponse(content_type="test")                              	| 6.2 µs  	| 4.38 µs 	|

As always, I'd welcome anyone point out flaws,  additional timings to check, or counterpoint datapoints. Also scrutinise my logic, as I've been staring at this for _too long_ ;)