### PR TITLE
Fixed #33524 -- Allowed overriding empty_label for ForeignKey in ModelAdmin.radio_fields.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -269,7 +269,9 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
                         "class": get_ul_class(self.radio_fields[db_field.name]),
                     }
                 )
-                kwargs["empty_label"] = _("None") if db_field.blank else None
+                kwargs["empty_label"] = (
+                    kwargs.get("empty_label", _("None")) if db_field.blank else None
+                )
 
         if "queryset" not in kwargs:
             queryset = self.get_field_queryset(db, db_field, request)

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -21,6 +21,7 @@ from django.db.models import (
     CharField,
     DateField,
     DateTimeField,
+    ForeignKey,
     ManyToManyField,
     UUIDField,
 )
@@ -140,6 +141,17 @@ class AdminFormfieldForDBFieldTests(SimpleTestCase):
             radio_fields={"main_band": admin.VERTICAL},
         )
         self.assertIsNone(ff.empty_label)
+
+    def test_radio_fields_foreignkey_formfield_overrides_empty_label(self):
+        class MyModelAdmin(admin.ModelAdmin):
+            radio_fields = {"parent": admin.VERTICAL}
+            formfield_overrides = {
+                ForeignKey: {"empty_label": "Custom empty label"},
+            }
+
+        ma = MyModelAdmin(Inventory, admin.site)
+        ff = ma.formfield_for_dbfield(Inventory._meta.get_field("parent"), request=None)
+        self.assertEqual(ff.empty_label, "Custom empty label")
 
     def test_many_to_many(self):
         self.assertFormfield(Band, "members", forms.SelectMultiple)


### PR DESCRIPTION
Fixed [#33524](https://code.djangoproject.com/ticket/33524)