### PR TITLE
django.db.model.utils.make_model_tuple() assumes apps can't be nested

### DIFF
--- a/django/db/models/utils.py
+++ b/django/db/models/utils.py
@@ -12,7 +12,7 @@ def make_model_tuple(model):
         if isinstance(model, tuple):
             model_tuple = model
         elif isinstance(model, str):
-            app_label, model_name = model.split(".")
+            app_label, model_name = model.rsplit(".", 1)
             model_tuple = app_label, model_name.lower()
         else:
             model_tuple = model._meta.app_label, model._meta.model_name


### PR DESCRIPTION
Hey there,

Using Django 4 after using Django 1 (yes, I know :( ) for a really long time and not used to this AppsConfig and app_label stuff.

Anyway, I was following Two Scoops and cookiecutter suggested layouts where they recommend you take the config/ out of the project/  and then put apps into the project/ .

This worked well until I needed to customize the User model and set my own AUTH_USER_MODEL. I then ran into the following error when starting up:

```
Feb 28 05:48:13 webapidev uwsgi[358012]: Traceback (most recent call last):
Feb 28 05:48:13 webapidev uwsgi[358012]:   File "/var/www/django/projectenv/lib/python3.8/site-packages/django/db/models/utils.py", line 15, in make_model_tuple
Feb 28 05:48:13 webapidev uwsgi[358012]:     app_label, model_name = model.split(".")
Feb 28 05:48:13 webapidev uwsgi[358012]: ValueError: too many values to unpack (expected 2)

... (skipping the nested tracebacks) ...

Feb 28 05:48:13 webapidev uwsgi[358012]: ValueError: Invalid model reference 'project.users.User'. String model references must be of the form 'app_label.ModelName'.
```

I figured this fix was trivial enough to pass off to y'all in a PR and didn't bother making an issue or anything.

My apologies if I missed the proper channels to do this or something.

I really enjoy using Django and have for years. Thanks for making such a great product!

Ryan