### PR TITLE
Refs #33476 -- Fixed some black formatting edge cases.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: 22.1.0
     hooks:
     - id: black
+      exclude: \.py-tpl$
   - repo: https://github.com/PyCQA/isort
     rev: 5.9.3
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ build-backend = 'setuptools.build_meta:__legacy__'
 
 [tool.black]
 target-version = ['py38']
-extend-exclude = 'tests/test_runner_apps/tagged/tests_syntax_error.py'
+force-exclude = 'tests/test_runner_apps/tagged/tests_syntax_error.py'


### PR DESCRIPTION
When trying to run `pre-commmit run --all-files` I get the following output:

```
❯ pre-commit run --all-files
black....................................................................Failed
- hook id: black
- exit code: 123
- files were modified by this hook

error: cannot format tests/test_runner_apps/tagged/tests_syntax_error.py: Cannot parse: 11:1: 1syntax_error  # NOQA
reformatted django/conf/project_template/manage.py-tpl

Oh no! 💥 💔 💥
1 file reformatted, 2737 files left unchanged, 1 file failed to reformat.

isort....................................................................Passed
flake8...................................................................Passed
eslint...................................................................Passed
```

It turns out that `extend-exclude` isn't enough and we need `force-exclude`, see [here](https://github.com/psf/black/issues/438).

It addition, somehow it is picking up one `.py-tpl` file, but not the others. ISTM that we should format all of these up-front rather than solely relying on them being reformatted later as per #15412.
