### PR TITLE
Fixed #33563 -- Fixed contenttype reverse data migration crash with a multiple databases setup.

### DIFF
--- a/django/contrib/contenttypes/migrations/0002_remove_content_type_name.py
+++ b/django/contrib/contenttypes/migrations/0002_remove_content_type_name.py
@@ -2,8 +2,9 @@ from django.db import migrations, models
 
 
 def add_legacy_name(apps, schema_editor):
+    alias = schema_editor.connection.alias
     ContentType = apps.get_model("contenttypes", "ContentType")
-    for ct in ContentType.objects.all():
+    for ct in ContentType.objects.using(alias).all():
         try:
             ct.name = apps.get_model(ct.app_label, ct.model)._meta.object_name
         except LookupError:

--- a/django/contrib/contenttypes/migrations/0002_remove_content_type_name.py
+++ b/django/contrib/contenttypes/migrations/0002_remove_content_type_name.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 def add_legacy_name(apps, schema_editor):
     alias = schema_editor.connection.alias
     ContentType = apps.get_model("contenttypes", "ContentType")
-    for ct in ContentType.objects.using(alias).all():
+    for ct in ContentType.objects.using(alias):
         try:
             ct.name = apps.get_model(ct.app_label, ct.model)._meta.object_name
         except LookupError:

--- a/tests/contenttypes_tests/test_migrations.py
+++ b/tests/contenttypes_tests/test_migrations.py
@@ -1,0 +1,31 @@
+from importlib import import_module
+
+from django.apps import apps
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.test import TransactionTestCase
+
+remove_content_type_name = import_module(
+    "django.contrib.contenttypes.migrations.0002_remove_content_type_name"
+)
+
+
+class MultiDBRemoveContentTypeNameTests(TransactionTestCase):
+    databases = {"default", "other"}
+    available_apps = ["django.contrib.auth", "django.contrib.contenttypes"]
+
+    def test_add_legacy_name_other_database(self):
+        # add_legacy_name() should update ContentType objects in the specified
+        # database. Remove ContentTypes from the default database to distinct
+        # from which database they are fetched.
+        Permission.objects.all().delete()
+        ContentType.objects.all().delete()
+        # ContentType.name in the current version is a property and cannot be
+        # set, so an AttributeError is raised with the other database.
+        with self.assertRaises(AttributeError):
+            with connections["other"].schema_editor() as editor:
+                remove_content_type_name.add_legacy_name(apps, editor)
+        # ContentType were removed from the default database.
+        with connections[DEFAULT_DB_ALIAS].schema_editor() as editor:
+            remove_content_type_name.add_legacy_name(apps, editor)


### PR DESCRIPTION
The ContentType legacy name field population operation would run on the
"default" database regardless of any specified alias

---

Found this while going through our code to ensure that it would smoothly run database restore operations on a given alias. It didn't cause any issues, I only found it by grepping our installed packages for migration operations to see if I should open any fix PRs.