### PR TITLE
Refs #33446 -- Allowed variable whitespace in CSS source map references

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -57,7 +57,10 @@ class HashedFilesMixin:
                     """@import url("%(url)s")""",
                 ),
                 (
-                    r"(?m)(?P<matched>)^(/\*# (?-i:sourceMappingURL)=(?P<url>.*) \*/)$",
+                    (
+                        r"(?m)(?P<matched>)^(/\*#[ \t]"
+                        r"(?-i:sourceMappingURL)=(?P<url>.*)[ \t]*\*/)$"
+                    ),
                     "/*# sourceMappingURL=%(url)s */",
                 ),
             ),

--- a/tests/staticfiles_tests/project/documents/cached/source_map.css
+++ b/tests/staticfiles_tests/project/documents/cached/source_map.css
@@ -1,2 +1,2 @@
 * {outline: 1px solid red;}
-/*# sourceMappingURL=source_map.css.map */
+/*# sourceMappingURL=source_map.css.map*/

--- a/tests/staticfiles_tests/project/documents/cached/source_map_tabs.css
+++ b/tests/staticfiles_tests/project/documents/cached/source_map_tabs.css
@@ -1,0 +1,2 @@
+* {outline: 1px solid red;}
+/*#	sourceMappingURL=source_map.css.map	*/

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -237,7 +237,19 @@ class TestHashedFiles:
         self.assertEqual(relpath, "cached/source_map.b2fceaf426aa.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
-            self.assertNotIn(b"/*# sourceMappingURL=source_map.css.map */", content)
+            self.assertNotIn(b"/*# sourceMappingURL=source_map.css.map*/", content)
+            self.assertIn(
+                b"/*# sourceMappingURL=source_map.css.99914b932bd3.map */",
+                content,
+            )
+        self.assertPostCondition()
+
+    def test_css_source_map_tabs(self):
+        relpath = self.hashed_file_path("cached/source_map_tabs.css")
+        self.assertEqual(relpath, "cached/source_map_tabs.b2fceaf426aa.css")
+        with storage.staticfiles_storage.open(relpath) as relfile:
+            content = relfile.read()
+            self.assertNotIn(b"/*#\tsourceMappingURL=source_map.css.map\t*/", content)
             self.assertIn(
                 b"/*# sourceMappingURL=source_map.css.99914b932bd3.map */",
                 content,


### PR DESCRIPTION
Follow-up to dc8bb35e39388d41b1f38b6c5d0181224e075f16. Today I have learned that the Webpack default is to output CSS source map comments like `/*# sourceMappingURL=main.css.map*/`, i.e. without trailing space. I regret my past comment: https://github.com/django/django/pull/15329#discussion_r786544249 .

To check what is allowed, I looked at the code inside Chromium that parses these comments: https://github.com/chromium/chromium/blob/56ffc604a38e3759d4c3c488e2da41ac170fca56/third_party/blink/renderer/core/inspector/inspector_style_sheet.cc#L1966 . This way I disovered the initial space may also be a tab, so I’ve allowed that, as well as trailing tabs.