### PR TITLE
Refs #11293 -- Added test for filtering aggregates with negated & operator.

### DIFF
--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -1682,13 +1682,25 @@ class AggregationTests(TestCase):
             qs, ["Adrian Holovaty", "Peter Norvig"], lambda b: b.name
         )
 
-    def test_ticket_11293(self):
+    def test_filter_aggregates_or_connector(self):
         q1 = Q(price__gt=50)
         q2 = Q(authors__count__gt=1)
         query = Book.objects.annotate(Count("authors")).filter(q1 | q2).order_by("pk")
         self.assertQuerysetEqual(
             query,
             [self.b1.pk, self.b4.pk, self.b5.pk, self.b6.pk],
+            attrgetter("pk"),
+        )
+
+    def test_filter_aggregates_negated_and_connector(self):
+        q1 = Q(price__gt=50)
+        q2 = Q(authors__count__gt=1)
+        query = (
+            Book.objects.annotate(Count("authors")).filter(~(q1 & q2)).order_by("pk")
+        )
+        self.assertQuerysetEqual(
+            query,
+            [self.b1.pk, self.b2.pk, self.b3.pk, self.b4.pk, self.b6.pk],
             attrgetter("pk"),
         )
 


### PR DESCRIPTION
This is a regression test for ticket-11293 and negated `AND` operator (currently not covered). It crashes with:
```diff
diff --git a/django/db/models/sql/where.py b/django/db/models/sql/where.py
index 532780fd98..430911cabe 100644
--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -41,9 +41,7 @@ class WhereNode(tree.Node):
         in_negated = negated ^ self.negated
         # If the effective connector is OR and this node contains an aggregate,
         # then we need to push the whole branch to HAVING clause.
-        may_need_split = (in_negated and self.connector == AND) or (
-            not in_negated and self.connector == OR
-        )
+        may_need_split = not in_negated and self.connector == OR
         if may_need_split and self.contains_aggregate:
             return None, self
         where_parts = []
```

Noticed when polishing #14480, see https://github.com/django/django/pull/14480#discussion_r715398397.