### PR TITLE
Refs #31169 -- Prevented infinite loop in tests on failures.

### DIFF
--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -377,5 +377,4 @@ class BaseDatabaseCreation:
         # connection.settings_dict = settings_dict, new threads would connect
         # to the default database instead of the appropriate clone.
         self.connection.settings_dict.update(settings_dict)
-        self.mark_expected_failures_and_skips()
         self.connection.close()


### PR DESCRIPTION
`mark_expected_failures_and_skips()` should not be called here. It causes infinite loop on failures with MySQL. The MySQL backend checks database features and tries to open a new connection on failures, which causes bumping of worker ID:
```
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 109, in worker
    initializer(*initargs)
  File "/django/django/test/runner.py", line 410, in _init_worker
    connection.creation.setup_worker_connection(_worker_id)
  File "/django/django/db/backends/base/creation.py", line 380, in setup_worker_connection
    self.mark_expected_failures_and_skips()
  File "/django/django/db/backends/base/creation.py", line 343, in mark_expected_failures_and_skips
    for reason, tests in self.connection.features.django_test_skips.items():
  File "/django/django/utils/functional.py", line 57, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/django/django/db/backends/mysql/features.py", line 98, in django_test_skips
    if "ONLY_FULL_GROUP_BY" in self.connection.sql_mode:
  File "/django/django/utils/functional.py", line 57, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/django/django/db/backends/mysql/base.py", line 443, in sql_mode 
    sql_mode = self.mysql_server_data["sql_mode"]
  File "/django/django/utils/functional.py", line 57, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/django/django/db/backends/mysql/base.py", line 399, in mysql_server_data
    with self.temporary_connection() as cursor:
  File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/django/django/db/backends/base/base.py", line 694, in temporary_connection
    with self.cursor() as cursor:
  File "/django/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/django/django/db/backends/base/base.py", line 323, in cursor
    return self._cursor()
  File "/django/django/db/backends/base/base.py", line 299, in _cursor
    self.ensure_connection()
  File "/django/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/django/django/db/backends/base/base.py", line 282, in ensure_connection
    self.connect()
  File "/django/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/django/django/db/backends/base/base.py", line 282, in ensure_connection
    self.connect()
  File "/django/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/django/django/db/backends/base/base.py", line 263, in connect
    self.connection = self.get_new_connection(conn_params)
  File "/django/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/django/django/db/backends/mysql/base.py", line 247, in get_new_connection
    connection = Database.connect(**conn_params)
  File ".virtualenvs/django-test-3.8/lib/python3.8/site-packages/MySQLdb/__init__.py", line 123, in Connect
    return Connection(*args, **kwargs)
  File ".virtualenvs/django-test-3.8/lib/python3.8/site-packages/MySQLdb/connections.py", line 185, in __init__
    super().__init__(*args, **kwargs2)
django.db.utils.OperationalError: (1049, "Unknown database 'test_django_main_1397'")
...

django.db.utils.OperationalError: (1049, "Unknown database 'test_django_main_1398'")
...

django.db.utils.OperationalError: (1049, "Unknown database 'test_django_main_1399'")

...
```