### PR TITLE
Clarify the role of has_module_permission and has_view_permission for change list view

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1829,7 +1829,8 @@ templates used by the :class:`ModelAdmin` views:
     If obj is ``None``, should return ``True`` or ``False`` to indicate whether
     viewing of objects of this type is permitted in general (e.g., ``False``
     will be interpreted as meaning that the current user is not permitted to
-    view any object of this type).
+    view any object of this type). The object type’s list view is
+    only accessible when ```True``` is returned.
 
     The default implementation returns ``True`` if the user has either the
     "change" or "view" permission.
@@ -1861,7 +1862,7 @@ templates used by the :class:`ModelAdmin` views:
     accessing the module's index page is permitted, ``False`` otherwise.
     Uses :meth:`User.has_module_perms()
     <django.contrib.auth.models.User.has_module_perms>` by default. Overriding
-    it does not restrict access to the view, add, change, or delete views,
+    it does not restrict access to the list, view, add, change, or delete views,
     :meth:`~ModelAdmin.has_view_permission`,
     :meth:`~ModelAdmin.has_add_permission`,
     :meth:`~ModelAdmin.has_change_permission`, and

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1830,7 +1830,7 @@ templates used by the :class:`ModelAdmin` views:
     viewing of objects of this type is permitted in general (e.g., ``False``
     will be interpreted as meaning that the current user is not permitted to
     view any object of this type). The object type’s list view is
-    only accessible when ```True``` is returned.
+    only accessible when ``True`` is returned.
 
     The default implementation returns ``True`` if the user has either the
     "change" or "view" permission.


### PR DESCRIPTION
Clarifies the role of has_module_permission and has_view_permission for change list view.
Thought it would make sense to add a few words, because I expected that `has_module_permission` would check if the change list view should be accessible.