### PR TITLE
Fixed #33561 -- Implemented user synchronization in RemoteUserBackend

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ answer newbie questions, and generally made Django that much better:
     Adiyat Mubarak <adiyatmubarak@gmail.com>
     Adnan Umer <u.adnan@outlook.com>
     Adrian Holovaty <adrian@holovaty.com>
+    Adrian Torres <atorresj@redhat.com>
     Adrien Lemaire <lemaire.adrien@gmail.com>
     Afonso Fernández Nogueira <fonzzo.django@gmail.com>
     AgarFu <heaven@croasanaso.sytes.net>

--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -209,6 +209,7 @@ class RemoteUserBackend(ModelBackend):
                 user = UserModel._default_manager.get_by_natural_key(username)
             except UserModel.DoesNotExist:
                 pass
+        user = self.synchronize_user(request, user)
         return user if self.user_can_authenticate(user) else None
 
     def clean_username(self, username):
@@ -223,6 +224,15 @@ class RemoteUserBackend(ModelBackend):
     def configure_user(self, request, user):
         """
         Configure a user after creation and return the updated user.
+
+        By default, return the user unmodified.
+        """
+        return user
+
+    def synchronize_user(self, request, user):
+        """
+        Synchronize the user's attributes with the remote system's.
+        Return the updated user.
 
         By default, return the user unmodified.
         """

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -660,6 +660,23 @@ The following backends are available in :mod:`django.contrib.auth.backends`:
         if it wasn't provided to :func:`~django.contrib.auth.authenticate`
         (which passes it on to the backend).
 
+    .. method:: synchronize_user(request, user)
+
+        .. versionadded:: 4.1
+
+        Synchronizes existing users with the remote authentication backend.
+        This method is called right after attempting to fetch the user and
+        can be used to synchronize attributes between the remote system and
+        the local Django users. Returns the user object.
+
+        ``request`` is an :class:`~django.http.HttpRequest` and may be ``None``
+        if it wasn't provided to :func:`~django.contrib.auth.authenticate`
+        (which passes it on to the backend).
+
+        ``user`` is an :class:`~django.contrib.auth.models.AbstractUser` and
+        may be ``None``, it's up to implementors to safeguard against this
+        possibility.
+
     .. method:: user_can_authenticate()
 
         Returns whether the user is allowed to authenticate. This method

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -74,6 +74,10 @@ Minor features
 * The default iteration count for the PBKDF2 password hasher is increased from
   320,000 to 390,000.
 
+* The new :meth:`.backends.RemoteUserBackend.synchronize_user` allows for the
+  synchronization of user attributes between a remote system (e.g. LDAP) and
+  the local Django instance on each authentication attempt.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This commit added a new method to the RemoteUserBackend class called
synchronize_user, which is called inside said class' authenticate method
right after fetching the django user (if any).

Implementors should override this method to implement synchronization of
user attributes between the remote system and the Django system, this
method will be called during each authentication attempt and effectively
synchronize the user's attributes.