### PR TITLE
Fixed #33562 -- Made HttpResponse.set_cookie() support timedelta for the max_age argument.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -244,6 +244,8 @@ class HttpResponseBase:
                 delta = delta + datetime.timedelta(seconds=1)
                 # Just set max_age - the max_age logic will set expires.
                 expires = None
+                if max_age is not None:
+                    raise ValueError("'expires' and 'max_age' can't be used together.")
                 max_age = max(0, delta.days * 86400 + delta.seconds)
             else:
                 self.cookies[key]["expires"] = expires

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -227,6 +227,10 @@ class HttpResponseBase:
         - a naive ``datetime.datetime`` object in UTC,
         - an aware ``datetime.datetime`` object in any time zone.
         If it is a ``datetime.datetime`` object then calculate ``max_age``.
+
+        ``max_age`` can be:
+        - int/float specifying seconds,
+        - ``datetime.timedelta`` object.
         """
         self.cookies[key] = value
         if expires is not None:
@@ -246,6 +250,8 @@ class HttpResponseBase:
         else:
             self.cookies[key]["expires"] = ""
         if max_age is not None:
+            if isinstance(max_age, datetime.timedelta):
+                max_age = max_age.total_seconds()
             self.cookies[key]["max-age"] = int(max_age)
             # IE requires expires, so set it if hasn't been already.
             if not expires:

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -853,9 +853,15 @@ Methods
     Sets a cookie. The parameters are the same as in the
     :class:`~http.cookies.Morsel` cookie object in the Python standard library.
 
-    * ``max_age`` should be an integer number of seconds, or ``None`` (default)
-      if the cookie should last only as long as the client's browser session.
-      If ``expires`` is not specified, it will be calculated.
+    * ``max_age`` should be a :class:`~datetime.timedelta` object, an integer
+      number of seconds, or ``None`` (default) if the cookie should last only
+      as long as the client's browser session. If ``expires`` is not specified,
+      it will be calculated.
+
+      .. versionchanged:: 4.1
+
+        Support for ``timedelta`` objects was added.
+
     * ``expires`` should either be a string in the format
       ``"Wdy, DD-Mon-YY HH:MM:SS GMT"`` or a ``datetime.datetime`` object
       in UTC. If ``expires`` is a ``datetime`` object, the ``max_age``

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -281,7 +281,8 @@ Models
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* :meth:`.HttpResponse.set_cookie` now supports :class:`~datetime.timedelta`
+  objects for the ``max_age`` argument.
 
 Security
 ~~~~~~~~

--- a/tests/responses/test_cookie.py
+++ b/tests/responses/test_cookie.py
@@ -71,6 +71,11 @@ class SetCookieTests(SimpleTestCase):
         response.set_cookie("max_age", max_age=10.6)
         self.assertEqual(response.cookies["max_age"]["max-age"], 10)
 
+    def test_max_age_timedelta(self):
+        response = HttpResponse()
+        response.set_cookie("max_age", max_age=timedelta(hours=1))
+        self.assertEqual(response.cookies["max_age"]["max-age"], 3600)
+
     def test_httponly_cookie(self):
         response = HttpResponse()
         response.set_cookie("example", httponly=True)

--- a/tests/responses/test_cookie.py
+++ b/tests/responses/test_cookie.py
@@ -76,6 +76,14 @@ class SetCookieTests(SimpleTestCase):
         response.set_cookie("max_age", max_age=timedelta(hours=1))
         self.assertEqual(response.cookies["max_age"]["max-age"], 3600)
 
+    def test_max_age_with_expires(self):
+        response = HttpResponse()
+        msg = "'expires' and 'max_age' can't be used together."
+        with self.assertRaisesMessage(ValueError, msg):
+            response.set_cookie(
+                "max_age", expires=datetime(2000, 1, 1), max_age=timedelta(hours=1)
+            )
+
     def test_httponly_cookie(self):
         response = HttpResponse()
         response.set_cookie("example", httponly=True)

--- a/tests/signed_cookies_tests/tests.py
+++ b/tests/signed_cookies_tests/tests.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.core import signing
 from django.http import HttpRequest, HttpResponse
 from django.test import SimpleTestCase, override_settings
@@ -52,8 +54,13 @@ class SignedCookieTest(SimpleTestCase):
         with freeze_time(123456800):
             self.assertEqual(request.get_signed_cookie("c", max_age=12), value)
             self.assertEqual(request.get_signed_cookie("c", max_age=11), value)
+            self.assertEqual(
+                request.get_signed_cookie("c", max_age=timedelta(seconds=11)), value
+            )
             with self.assertRaises(signing.SignatureExpired):
                 request.get_signed_cookie("c", max_age=10)
+            with self.assertRaises(signing.SignatureExpired):
+                request.get_signed_cookie("c", max_age=timedelta(seconds=10))
 
     @override_settings(SECRET_KEY=b"\xe7")
     def test_signed_cookies_with_binary_key(self):

--- a/tests/signed_cookies_tests/tests.py
+++ b/tests/signed_cookies_tests/tests.py
@@ -62,6 +62,13 @@ class SignedCookieTest(SimpleTestCase):
             with self.assertRaises(signing.SignatureExpired):
                 request.get_signed_cookie("c", max_age=timedelta(seconds=10))
 
+    def test_set_signed_cookie_max_age_argument(self):
+        response = HttpResponse()
+        response.set_signed_cookie("c", "value", max_age=100)
+        self.assertEqual(response.cookies["c"]["max-age"], 100)
+        response.set_signed_cookie("d", "value", max_age=timedelta(hours=2))
+        self.assertEqual(response.cookies["d"]["max-age"], 7200)
+
     @override_settings(SECRET_KEY=b"\xe7")
     def test_signed_cookies_with_binary_key(self):
         response = HttpResponse()


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/33562#ticket

The fix is just two lines added to `set_cookie`. I've also added:
* tests for `set_signed_cookie`, which passes arguments through to `set_cookie`
* tests for `get_signed_cookie`, which were passing previously, for symmetry.

In the docs I've put `timedelta` first as the suggested object, because I think that is a better pattern, there is less confusion over units.

The second commit also fixes a very small corner case where we would silently ignore the `max_age` argument.


