### PR TITLE
Refs #33173 -- Used locale.getlocale() instead of getdefaultlocale().

### DIFF
--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -249,12 +249,12 @@ def filepath_to_uri(path):
 
 def get_system_encoding():
     """
-    The encoding of the default system locale. Fallback to 'ascii' if the
+    The encoding for the character type functions. Fallback to 'ascii' if the
     #encoding is unsupported by Python or could not be determined. See tickets
     #10335 and #5846.
     """
     try:
-        encoding = locale.getdefaultlocale()[1] or "ascii"
+        encoding = locale.getlocale()[1] or "ascii"
         codecs.lookup(encoding)
     except Exception:
         encoding = "ascii"

--- a/tests/utils_tests/test_encoding.py
+++ b/tests/utils_tests/test_encoding.py
@@ -106,7 +106,7 @@ class TestEncodingUtils(SimpleTestCase):
         self.assertEqual(smart_str("foo"), "foo")
 
     def test_get_default_encoding(self):
-        with mock.patch("locale.getdefaultlocale", side_effect=Exception):
+        with mock.patch("locale.getlocale", side_effect=Exception):
             self.assertEqual(get_system_encoding(), "ascii")
 
     def test_repercent_broken_unicode_recursion_error(self):


### PR DESCRIPTION
`locale.getdefaultlocale()` was deprecated in Python 3.11, see https://bugs.python.org/issue46659 and https://github.com/python/cpython/commit/b899126094731bc49fecb61f2c1b7557d74ca839.