### PR TITLE
Add support for multiple values for `x-forwarded-proto` header

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -261,7 +261,8 @@ class HttpRequest:
                 )
             header_value = self.META.get(header)
             if header_value is not None:
-                return "https" if header_value == secure_value else "http"
+                header_values = [val.strip() for val in header_value.split(",")]
+                return "https" if secure_value in header_values else "http"
         return self._get_scheme()
 
     def is_secure(self):

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -425,6 +425,18 @@ class SecureProxySslHeaderTest(SimpleTestCase):
         self.assertIs(req.is_secure(), True)
 
     @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"))
+    def test_set_with_xheader_right_multiple(self):
+        req = HttpRequest()
+        req.META["HTTP_X_FORWARDED_PROTO"] = "https, http"
+        self.assertIs(req.is_secure(), True)
+
+    @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"))
+    def test_set_with_xheader_http_only_multiple(self):
+        req = HttpRequest()
+        req.META["HTTP_X_FORWARDED_PROTO"] = "http, http"
+        self.assertIs(req.is_secure(), False)
+
+    @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"))
     def test_xheader_preferred_to_underlying_request(self):
         class ProxyRequest(HttpRequest):
             def _get_scheme(self):


### PR DESCRIPTION
This pull request adds support for multiple, comma-separated, values for the `x-forwarded-proto` header. 

When Django is deployed behind more than one proxy, the proxy behavior is sometimes to list the protocol as a comma-separated list. However, currently, Django expects only one value for the `x-forwarded-proto` header, instead of parsing it as a list of values and setting the protocol accordingly. 