### PR TITLE
Used Ubuntu 20.04 for docs GitHub action.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   docs:
     # OS must be the same as on djangoproject.com.
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: docs
     steps:
       - name: Checkout


### PR DESCRIPTION
`djangoproject.com` is now on Ubuntu 20.04.