### PR TITLE
Fixed #33571 -- Fixed static serving views crash when If-Modified-Since is empty.

### DIFF
--- a/django/views/static.py
+++ b/django/views/static.py
@@ -129,12 +129,14 @@ def was_modified_since(header=None, mtime=0, size=0):
         if header is None:
             raise ValueError
         matches = re.match(r"^([^;]+)(; length=([0-9]+))?$", header, re.IGNORECASE)
+        if matches is None:
+            raise ValueError
         header_mtime = parse_http_date(matches[1])
         header_len = matches[3]
         if header_len and int(header_len) != size:
             raise ValueError
         if int(mtime) > header_mtime:
             raise ValueError
-    except (AttributeError, ValueError, OverflowError):
+    except (ValueError, OverflowError):
         return True
     return False

--- a/tests/view_tests/tests/test_static.py
+++ b/tests/view_tests/tests/test_static.py
@@ -191,3 +191,6 @@ class StaticUtilsTests(unittest.TestCase):
         mtime = 1343416141.107817
         header = http_date(mtime)
         self.assertFalse(was_modified_since(header, mtime))
+
+    def test_was_modified_since_empty_string(self):
+        self.assertTrue(was_modified_since(header="", mtime=1))


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33571

Empty string used to be ignored for If-Modified-Since header, but now raises exception since d6aff369ad3.

`AttributeError` used to catch `None.group(1)`, but `None[1]` raises `TypeError`