### PR TITLE
Removed outdated handling of length parameter to If-Modified-Since header.

### DIFF
--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -430,6 +430,9 @@ Miscellaneous
 * The ``exc_info`` argument of the undocumented
   ``django.utils.log.log_response()`` function is replaced by ``exception``.
 
+* The ``size`` argument of the undocumented
+  ``django.views.static.was_modified_since()`` function is removed.
+
 .. _deprecated-features-4.1:
 
 Features deprecated in 4.1


### PR DESCRIPTION
The length parameter is not described in [RFC-7232](https://httpwg.org/specs/rfc7232.html#header.if-modified-since) and it's against HTTP/1.0 and HTTP/1.1 specifications. It was an old and unofficial extension set by some ancient versions of IE.