### PR TITLE
Corrected AppConfig.get_models() signature in docs.

### DIFF
--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -242,7 +242,7 @@ Read-only attributes
 Methods
 -------
 
-.. method:: AppConfig.get_models()
+.. method:: AppConfig.get_models(include_auto_created=False, include_swapped=False)
 
     Returns an iterable of :class:`~django.db.models.Model` classes for this
     application.


### PR DESCRIPTION
Hi there,

Just a little PR to clarify the `AppConfig.get_models()` signature, here's a link to the method for reference: https://github.com/django/django/blob/6ffe48b8e43140e79180ec6dc02577437e761819/django/apps/config.py#L241