### PR TITLE
Used sets for field names for exclusion.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1214,7 +1214,7 @@ class Model(metaclass=ModelBase):
         but they need to be passed in via the exclude argument.
         """
         if exclude is None:
-            exclude = []
+            exclude = set()
         unique_checks = []
 
         unique_togethers = [(self.__class__, self._meta.unique_together)]
@@ -1401,9 +1401,9 @@ class Model(metaclass=ModelBase):
         """
         errors = {}
         if exclude is None:
-            exclude = []
+            exclude = set()
         else:
-            exclude = list(exclude)
+            exclude = set(exclude)
 
         try:
             self.clean_fields(exclude=exclude)
@@ -1421,7 +1421,7 @@ class Model(metaclass=ModelBase):
         if validate_unique:
             for name in errors:
                 if name != NON_FIELD_ERRORS and name not in exclude:
-                    exclude.append(name)
+                    exclude.add(name)
             try:
                 self.validate_unique(exclude=exclude)
             except ValidationError as e:
@@ -1436,7 +1436,7 @@ class Model(metaclass=ModelBase):
         of all validation errors if any occur.
         """
         if exclude is None:
-            exclude = []
+            exclude = set()
 
         errors = {}
         for f in self._meta.fields:

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -388,7 +388,7 @@ class BaseModelForm(BaseForm):
         For backwards-compatibility, exclude several types of fields from model
         validation. See tickets #12507, #12521, #12553.
         """
-        exclude = []
+        exclude = set()
         # Build up a list of fields that should be excluded from model field
         # validation and unique checks.
         for f in self.instance._meta.fields:
@@ -396,20 +396,20 @@ class BaseModelForm(BaseForm):
             # Exclude fields that aren't on the form. The developer may be
             # adding these values to the model after form validation.
             if field not in self.fields:
-                exclude.append(f.name)
+                exclude.add(f.name)
 
             # Don't perform model validation on fields that were defined
             # manually on the form and excluded via the ModelForm's Meta
             # class. See #12901.
             elif self._meta.fields and field not in self._meta.fields:
-                exclude.append(f.name)
+                exclude.add(f.name)
             elif self._meta.exclude and field in self._meta.exclude:
-                exclude.append(f.name)
+                exclude.add(f.name)
 
             # Exclude fields that failed form validation. There's no need for
             # the model fields to validate them as well.
             elif field in self._errors:
-                exclude.append(f.name)
+                exclude.add(f.name)
 
             # Exclude empty fields that are not required by the form, if the
             # underlying model field is required. This keeps the model field
@@ -425,7 +425,7 @@ class BaseModelForm(BaseForm):
                     and not form_field.required
                     and field_value in form_field.empty_values
                 ):
-                    exclude.append(f.name)
+                    exclude.add(f.name)
         return exclude
 
     def clean(self):
@@ -479,7 +479,7 @@ class BaseModelForm(BaseForm):
         # so this can't be part of _get_validation_exclusions().
         for name, field in self.fields.items():
             if isinstance(field, InlineForeignKeyField):
-                exclude.append(name)
+                exclude.add(name)
 
         try:
             self.instance = construct_instance(


### PR DESCRIPTION
`exclude` is used only for containment checks.