### PR TITLE
Added packaging tools to GitHub actions.

### DIFF
--- a/.github/workflows/schedule_tests.yml
+++ b/.github/workflows/schedule_tests.yml
@@ -28,7 +28,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'tests/requirements/py3.txt'
-      - run: pip install -r tests/requirements/py3.txt -e .
+      - name: Install and upgrade packaging tools
+        run: python -m pip install --upgrade pip setuptools wheel
+      - run: python -m pip install -r tests/requirements/py3.txt -e .
       - name: Run tests
         run: python tests/runtests.py -v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'tests/requirements/py3.txt'
-      - run: pip install -r tests/requirements/py3.txt -e .
+      - name: Install and upgrade packaging tools
+        run: python -m pip install --upgrade pip setuptools wheel
+      - run: python -m pip install -r tests/requirements/py3.txt -e .
       - name: Run tests
         run: python tests/runtests.py -v2
 


### PR DESCRIPTION
To avoid using legacy `setup.py install` and warnings about upgrading `pip`.