### PR TITLE
Fixed #33592 -- Fixed "View on Site" links in custom admin site.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -347,6 +347,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
                     "content_type_id": get_content_type_for_model(obj).pk,
                     "object_id": obj.pk,
                 },
+                current_app=self.admin_site.name,
             )
 
     def get_empty_value_display(self):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -7930,6 +7930,21 @@ class AdminViewOnSiteTests(TestCase):
         model_admin = ModelAdmin(Worker, None)
         self.assertIsNone(model_admin.get_view_on_site_url(Worker()))
 
+    def test_custom_admin_site(self):
+        model_admin = ModelAdmin(City, customadmin.site)
+        content_type_pk = ContentType.objects.get_for_model(City).pk
+        redirect_url = model_admin.get_view_on_site_url(self.c1)
+        self.assertEqual(
+            redirect_url,
+            reverse(
+                f"{customadmin.site.name}:view_on_site",
+                kwargs={
+                    "content_type_id": content_type_pk,
+                    "object_id": self.c1.pk,
+                },
+            ),
+        )
+
 
 @override_settings(ROOT_URLCONF="admin_views.urls")
 class InlineAdminViewOnSiteTest(TestCase):


### PR DESCRIPTION
Adding `current_app` to `reverse` call so it uses the current admin site's `view_on_site` redirect URL. It's the only `reverse` call in the file that is missing the `current_app` keyword argument.

I noticed this with multiple admin sites deployed where users without access to the default site could not use the "view on site" change form links.

I hope this qualifies as trivial. If not, I'll happily open a Trac ticket.