### PR TITLE
Fixed #33544 -- Expanded the TEMPLATES section of the Deployment checklist.

### DIFF
--- a/docs/howto/deployment/checklist.txt
+++ b/docs/howto/deployment/checklist.txt
@@ -223,8 +223,10 @@ This helps a lot on virtualized hosts with limited network performance.
 --------------------
 
 Enabling the cached template loader often improves performance drastically, as
-it avoids compiling each template every time it needs to be rendered. See the
-:ref:`template loaders docs <template-loaders>` for more information.
+it avoids compiling each template every time it needs to be rendered. When
+:setting:`DEBUG = False <DEBUG>`, the cached template loader is enabled
+automatically. See :class:`django.template.loaders.cached.Loader` for more
+information.
 
 Error reporting
 ===============


### PR DESCRIPTION
The [TEMPLATES section](https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/#templates) of the Deployment checklist lacked a hint to the default behavior of the cached template loader.
It didn't point out that the cached template loader is enabled only when DEBUG = False.
The newly added sentence clarifies that behavoir and makes the section be in consistence with others (for example [ALLOWED_HOSTS](https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/#allowed-hosts))