### PR TITLE
Fixed #33256 -- Fixed schema test failures when using --keepdb.

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -2317,6 +2317,8 @@ class SchemaTests(TransactionTestCase):
                 # This fails if the unique index name isn't quoted.
                 editor.alter_unique_together(TagUniqueRename, [], (("title", "slug2"),))
         finally:
+            with connection.schema_editor() as editor:
+                editor.delete_model(TagUniqueRename)
             TagUniqueRename._meta.db_table = old_table_name
 
     @isolate_apps("schema")
@@ -2394,6 +2396,7 @@ class SchemaTests(TransactionTestCase):
     def test_remove_field_unique_does_not_remove_meta_constraints(self):
         with connection.schema_editor() as editor:
             editor.create_model(AuthorWithUniqueName)
+        self.local_models = [AuthorWithUniqueName]
         # Add the custom unique constraint
         constraint = UniqueConstraint(fields=["name"], name="author_name_uniq")
         custom_constraint_name = constraint.name
@@ -2526,6 +2529,7 @@ class SchemaTests(TransactionTestCase):
     def test_remove_unique_together_does_not_remove_meta_constraints(self):
         with connection.schema_editor() as editor:
             editor.create_model(AuthorWithUniqueNameAndBirthday)
+        self.local_models = [AuthorWithUniqueNameAndBirthday]
         # Add the custom unique constraint
         constraint = UniqueConstraint(
             fields=["name", "birthday"], name="author_name_birthday_uniq"
@@ -2924,6 +2928,7 @@ class SchemaTests(TransactionTestCase):
     def test_remove_index_together_does_not_remove_meta_indexes(self):
         with connection.schema_editor() as editor:
             editor.create_model(AuthorWithIndexedNameAndBirthday)
+        self.local_models = [AuthorWithIndexedNameAndBirthday]
         # Add the custom index
         index = Index(fields=["name", "birthday"], name="author_name_birthday_idx")
         custom_index_name = index.name
@@ -3062,6 +3067,7 @@ class SchemaTests(TransactionTestCase):
         """
         with connection.schema_editor() as editor:
             editor.create_model(AuthorWithIndexedName)
+        self.local_models = [AuthorWithIndexedName]
         # Ensure the table has its index
         self.assertIn("name", self.get_indexes(AuthorWithIndexedName._meta.db_table))
 
@@ -3650,6 +3656,7 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.create_model(Author)
             editor.create_model(Book)
+        self.isolated_local_models = [Author]
         if connection.vendor == "mysql":
             self.assertForeignKeyExists(
                 Book, "author_id", '"table_author_double_quoted"'
@@ -3660,6 +3667,7 @@ class SchemaTests(TransactionTestCase):
     def test_add_foreign_object(self):
         with connection.schema_editor() as editor:
             editor.create_model(BookForeignObj)
+        self.local_models = [BookForeignObj]
 
         new_field = ForeignObject(
             Author, on_delete=CASCADE, from_fields=["author_id"], to_fields=["id"]
@@ -4338,7 +4346,7 @@ class SchemaTests(TransactionTestCase):
                 apps = new_apps
                 db_table = '"%s"."DJANGO_DOCUMENT_TABLE"' % oracle_user
 
-        self.local_models = [Student, Document]
+        self.isolated_local_models = [Student, Document]
 
         with connection.schema_editor() as editor:
             editor.create_model(Student)


### PR DESCRIPTION
Some tests leave models and for the second run of test,
model already exist error was created.
So models are deleted at the test it self