### PR TITLE
Fixed #33585 -- Made example git repo URLs use HTTPS protocol.

### DIFF
--- a/docs/internals/contributing/writing-code/working-with-git.txt
+++ b/docs/internals/contributing/writing-code/working-with-git.txt
@@ -58,12 +58,12 @@ Your GitHub repository will be called "origin" in Git.
 You should also set up ``django/django`` as an "upstream" remote (that is, tell
 git that the reference Django repository was the source of your fork of it)::
 
-    git remote add upstream git@github.com:django/django.git
+    git remote add upstream https://github.com/django/django.git
     git fetch upstream
 
 You can add other remotes similarly, for example::
 
-    git remote add akaariai git@github.com:akaariai/django.git
+    git remote add akaariai https://github.com/akaariai/django.git
 
 Working on a ticket
 ===================


### PR DESCRIPTION
The SSH-based checkout requires additional configuration, which is
beneficial to defer for new contributors.

Follow up to 3c6a4fdb6d828a03e368632d88f8261cc30104da. This commit
updates the remaining examples.