### PR TITLE
Refs #32365 -- Deprecated django.utils.timezone.utc.

### DIFF
--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -19,7 +19,7 @@ from asgiref.local import Local
 from django.conf import settings
 from django.utils.deprecation import RemovedInDjango50Warning
 
-__all__ = [
+__all__ = [  # noqa for utc RemovedInDjango50Warning.
     "utc",
     "get_fixed_timezone",
     "get_default_timezone",
@@ -41,7 +41,18 @@ __all__ = [
 NOT_PASSED = object()
 
 
-utc = timezone.utc
+def __getattr__(name):
+    if name != "utc":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    warnings.warn(
+        "The django.utils.timezone.utc alias is deprecated. "
+        "Please update your code to use datetime.timezone.utc instead.",
+        RemovedInDjango50Warning,
+        stacklevel=2,
+    )
+
+    return timezone.utc
 
 
 def get_fixed_timezone(offset):
@@ -339,3 +350,11 @@ def _datetime_ambiguous_or_imaginary(dt, tz):
             return False
 
     return tz.utcoffset(dt.replace(fold=not dt.fold)) != tz.utcoffset(dt)
+
+
+# RemovedInDjango50Warning.
+_DIR = dir()
+
+
+def __dir__():
+    return sorted([*_DIR, "utc"])

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -94,6 +94,9 @@ details on these changes.
   ``django.contrib.auth.views.LogoutView`` and
   ``django.contrib.auth.views.logout_then_login()`` will be removed.
 
+* The ``django.utils.timezone.utc`` alias to ``datetime.timezone.utc`` will be
+  removed.
+
 .. _deprecation-removed-in-4.1:
 
 4.1

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -843,6 +843,11 @@ appropriate entities.
 
     :class:`~datetime.tzinfo` instance that represents UTC.
 
+    .. deprecated:: 4.1
+
+        This is an alias to :attr:`datetime.timezone.utc`. Use
+        :attr:`datetime.timezone.utc` directly.
+
 .. function:: get_fixed_timezone(offset)
 
     Returns a :class:`~datetime.tzinfo` instance that represents a time zone

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -541,6 +541,9 @@ Miscellaneous
   :meth:`.RemoteUserBackend.configure_user`. Support  for ``RemoteUserBackend``
   subclasses that do not accept this argument is deprecated.
 
+* The :data:`django.utils.timezone.utc` alias to :attr:`datetime.timezone.utc`
+  is deprecated. Use :attr:`datetime.timezone.utc` directly.
+
 Features removed in 4.1
 =======================
 

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -29,10 +29,11 @@ from django.core.validators import EmailValidator, RegexValidator
 from django.db import migrations, models
 from django.db.migrations.serializer import BaseSerializer
 from django.db.migrations.writer import MigrationWriter, OperationWriter
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, ignore_warnings
 from django.utils.deconstruct import deconstructible
+from django.utils.deprecation import RemovedInDjango50Warning
 from django.utils.functional import SimpleLazyObject
-from django.utils.timezone import get_default_timezone, get_fixed_timezone, utc
+from django.utils.timezone import get_default_timezone, get_fixed_timezone
 from django.utils.translation import gettext_lazy as _
 
 from .models import FoodManager, FoodQuerySet
@@ -532,6 +533,8 @@ class WriterTests(SimpleTestCase):
             datetime.datetime(2014, 1, 1, 1, 1),
             ("datetime.datetime(2014, 1, 1, 1, 1)", {"import datetime"}),
         )
+        with ignore_warnings(category=RemovedInDjango50Warning):
+            from django.utils.timezone import utc
         for tzinfo in (utc, datetime.timezone.utc):
             with self.subTest(tzinfo=tzinfo):
                 self.assertSerializedResultEqual(

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -88,6 +88,19 @@ def get_timezones(key):
     return [constructor(key) for constructor in ZONE_CONSTRUCTORS]
 
 
+class UTCAliasTests(SimpleTestCase):
+    def test_alias_deprecation_warning(self):
+        msg = (
+            "The django.utils.timezone.utc alias is deprecated. "
+            "Please update your code to use datetime.timezone.utc instead."
+        )
+        with self.assertRaisesMessage(RemovedInDjango50Warning, msg):
+            timezone.utc
+
+    def test_timezone_module_dir_includes_utc(self):
+        self.assertIn("utc", dir(timezone))
+
+
 @contextmanager
 def override_database_connection_timezone(timezone):
     try:


### PR DESCRIPTION
Following #15535 and #15537, this is _Step 3_ to deprecate the `timezone.utc` alias. 

In theory we remove in Django 5.0. My only concern is historical migrations. I'd guess removing from the docs, and `__all__` and the `__dir__` implementation, but leaving the `__getattr__`, with a suitable `warning`, so that `utc` can still be imported would let us avoid migration rewrites. … Thoughts? 🤔