### PR TITLE
Reverted "Fixed forms_tests.tests.test_renderers with Jinja 3.1.0+."

### DIFF
--- a/tests/forms_tests/tests/test_renderers.py
+++ b/tests/forms_tests/tests/test_renderers.py
@@ -1,5 +1,4 @@
 import os
-import posixpath
 import unittest
 
 from django.forms.renderers import (
@@ -9,7 +8,6 @@ from django.forms.renderers import (
     TemplatesSetting,
 )
 from django.test import SimpleTestCase
-from django.utils.version import get_version_tuple
 
 try:
     import jinja2
@@ -51,28 +49,6 @@ class DjangoTemplatesTests(SharedTests, SimpleTestCase):
 class Jinja2Tests(SharedTests, SimpleTestCase):
     renderer = Jinja2
     expected_widget_dir = "jinja2"
-
-    @property
-    def jinja2_version(self):
-        return get_version_tuple(jinja2.__version__)
-
-    def test_installed_apps_template_found(self):
-        """Can find a custom template in INSTALLED_APPS."""
-        renderer = self.renderer()
-        # Found because forms_tests is .
-        tpl = renderer.get_template("forms_tests/custom_widget.html")
-        expected_path = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "..", self.expected_widget_dir)
-        )
-        if self.jinja2_version < (3, 1):
-            expected_path = os.path.join(
-                expected_path, "forms_tests", "custom_widget.html"
-            )
-        else:
-            expected_path = posixpath.join(
-                expected_path, "forms_tests", "custom_widget.html"
-            )
-        self.assertEqual(tpl.origin.name, expected_path)
 
 
 class TemplatesSettingTests(SharedTests, SimpleTestCase):


### PR DESCRIPTION
This reverts commit 1d9d082acf6e152c06833bb9698f88d688b95e40.

See https://github.com/pallets/jinja/issues/1637.