### PR TITLE
Added Home-page and History back option to standard 404 template.

### DIFF
--- a/django/views/defaults.py
+++ b/django/views/defaults.py
@@ -72,7 +72,7 @@ def page_not_found(request, exception, template_name=ERROR_404_TEMPLATE_NAME):
             ERROR_PAGE_TEMPLATE
             % {
                 "title": "Not Found",
-                "details": "The requested resource was not found on this server.",
+                "details": "The requested resource was not found on this server.  <br> Go to <a href='/' style='color: black;'>Home page</a> Or <a onclick='history.back()' style='cursor: pointer; text-decoration: underline;'> Go Back</a>",
             },
         )
         body = template.render(Context(context))


### PR DESCRIPTION
The Django Standard Not Found (404) page which appears when Debug = False says only that The resource was not found on the server. It doesn't give the option to the user to visit the homepage of the website or to revert back in the history like most standard websites do.

In this commit, I have added the option to go to the Home-page of the website or to revert back in history so that users find it easy to navigate in the website.


![homepage](https://user-images.githubusercontent.com/90550606/160235079-b6027402-dcd3-4fd4-9fd4-59cae813f26a.PNG)
