### PR TITLE
Fixed #33605 -- Fixed migration crash when altering RegexValidator to pre-compiled regular expression.

### DIFF
--- a/django/db/migrations/utils.py
+++ b/django/db/migrations/utils.py
@@ -15,6 +15,8 @@ class RegexObject:
         self.flags = obj.flags
 
     def __eq__(self, other):
+        if not isinstance(other, RegexObject):
+            return NotImplemented
         return self.pattern == other.pattern and self.flags == other.flags
 
 

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -2410,6 +2410,37 @@ class AutodetectorTests(TestCase):
         self.assertNumberMigrations(changes, "testapp", 1)
         self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
 
+    def test_alter_regex_string_to_compiled_regex(self):
+        regex_string = "^[a-z]+$"
+        from_state = ModelState(
+            "testapp",
+            "model",
+            [
+                (
+                    "id",
+                    models.AutoField(
+                        primary_key=True, validators=[RegexValidator(regex_string)]
+                    ),
+                )
+            ],
+        )
+        to_state = ModelState(
+            "testapp",
+            "model",
+            [
+                (
+                    "id",
+                    models.AutoField(
+                        primary_key=True,
+                        validators=[RegexValidator(re.compile(regex_string))],
+                    ),
+                )
+            ],
+        )
+        changes = self.get_changes([from_state], [to_state])
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["AlterField"])
+
     def test_empty_foo_together(self):
         """
         #23452 - Empty unique/index_together shouldn't generate a migration.


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33605