### PR TITLE
Refs #24020 -- Removed redundant Query.get_loaded_field_names().

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1006,7 +1006,7 @@ class SQLCompiler:
         if not opts:
             opts = self.query.get_meta()
             root_alias = self.query.get_initial_alias()
-        only_load = self.query.get_loaded_field_names()
+        only_load = self.deferred_to_columns()
 
         # Setup for the case when only particular related fields should be
         # included in the related selection.

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1295,7 +1295,7 @@ class SQLCompiler:
         dictionary.
         """
         columns = {}
-        self.query.deferred_to_data(columns, self.query.get_loaded_field_names_cb)
+        self.query.deferred_to_data(columns)
         return columns
 
     def get_converters(self, expressions):

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2341,25 +2341,6 @@ class Query(BaseExpression):
             # Replace any existing "immediate load" field names.
             self.deferred_loading = frozenset(field_names), False
 
-    def get_loaded_field_names(self):
-        """
-        If any fields are marked to be deferred, return a dictionary mapping
-        models to a set of names in those fields that will be loaded. If a
-        model is not in the returned dictionary, none of its fields are
-        deferred.
-
-        If no fields are marked for deferral, return an empty dictionary.
-        """
-        # We cache this because we call this function multiple times
-        # (compiler.fill_related_selections, query.iterator)
-        try:
-            return self._loaded_field_names_cache
-        except AttributeError:
-            collection = {}
-            self.deferred_to_data(collection, self.get_loaded_field_names_cb)
-            self._loaded_field_names_cache = collection
-            return collection
-
     def get_loaded_field_names_cb(self, target, model, fields):
         """Callback used by get_deferred_field_names()."""
         target[model] = {f.attname for f in fields}


### PR DESCRIPTION
`get_loaded_field_names()` is no longer called in multiple places (see 0c7633178fa9410f102e4708cef979b873bccb76) and it's redundant with `SQLCompiler.deferred_to_columns()`.

https://github.com/django/django/blob/c8459708a7e0a2474255b77d0f104a7f16e8b32c/django/db/models/sql/compiler.py#L1291-L1299