### PR TITLE
Updated select_related_descend() comment.

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -223,8 +223,8 @@ def select_related_descend(field, restricted, requested, load_fields, reverse=Fa
     """
     Return True if this field should be used to descend deeper for
     select_related() purposes. Used by both the query construction code
-    (sql.query.fill_related_selections()) and the model instance creation code
-    (query.get_klass_info()).
+    (compiler.get_related_selections()) and the model instance creation code
+    (compiler.klass_info).
 
     Arguments:
      * field - the field to be checked


### PR DESCRIPTION
Outdated since 0c7633178fa9410f102e4708cef979b873bccb76. `fill_related_selections()` and `get_klass_info()` no longer exist.