### PR TITLE
Fixed #33613 -- Made createsuperuser detect uniqueness of USERNAME_FIELD when using Meta.constraints.

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -548,7 +548,7 @@ password resets. You must then provide some key implementation details:
         A string describing the name of the field on the user model that is
         used as the unique identifier. This will usually be a username of some
         kind, but it can also be an email address, or any other unique
-        identifier. The field *must* be unique (i.e., have ``unique=True`` set
+        identifier. The field *must* be unique (e.g. have ``unique=True`` set
         in its definition), unless you use a custom authentication backend that
         can support non-unique usernames.
 

--- a/tests/auth_tests/models/__init__.py
+++ b/tests/auth_tests/models/__init__.py
@@ -11,6 +11,7 @@ from .with_foreign_key import CustomUserWithFK, Email
 from .with_integer_username import IntegerUsernameUser
 from .with_last_login_attr import UserWithDisabledLastLoginField
 from .with_many_to_many import CustomUserWithM2M, CustomUserWithM2MThrough, Organization
+from .with_unique_constraint import CustomUserWithUniqueConstraint
 
 __all__ = (
     "CustomEmailField",
@@ -20,6 +21,7 @@ __all__ = (
     "CustomUserWithFK",
     "CustomUserWithM2M",
     "CustomUserWithM2MThrough",
+    "CustomUserWithUniqueConstraint",
     "CustomUserWithoutIsActiveField",
     "Email",
     "ExtensionUser",

--- a/tests/auth_tests/models/with_unique_constraint.py
+++ b/tests/auth_tests/models/with_unique_constraint.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
+from django.db import models
+
+
+class CustomUserWithUniqueConstraintManager(BaseUserManager):
+    def create_superuser(self, username, password):
+        user = self.model(username=username)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+
+class CustomUserWithUniqueConstraint(AbstractBaseUser):
+    username = models.CharField(max_length=150)
+
+    objects = CustomUserWithUniqueConstraintManager()
+    USERNAME_FIELD = "username"
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(fields=["username"], name="unique_custom_username"),
+        ]

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -23,6 +23,7 @@ from .models import (
     CustomUserNonUniqueUsername,
     CustomUserWithFK,
     CustomUserWithM2M,
+    CustomUserWithUniqueConstraint,
     Email,
     Organization,
     UserProxy,
@@ -1049,6 +1050,41 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
         @mock_inputs(
             {"password": return_passwords, "username": return_usernames, "email": ""}
         )
+        def test(self):
+            call_command(
+                "createsuperuser",
+                interactive=True,
+                stdin=MockTTY(),
+                stdout=new_io,
+                stderr=new_io,
+            )
+            self.assertEqual(
+                new_io.getvalue().strip(),
+                "Error: That username is already taken.\n"
+                "Superuser created successfully.",
+            )
+
+        test(self)
+
+    @override_settings(AUTH_USER_MODEL="auth_tests.CustomUserWithUniqueConstraint")
+    def test_existing_username_meta_unique_constraint(self):
+        """
+        Creation fails if the username already exists and a custom user model
+        has UniqueConstraint.
+        """
+        user = CustomUserWithUniqueConstraint.objects.create(username="janet")
+        new_io = StringIO()
+        entered_passwords = ["password", "password"]
+        # Enter the existing username first and then a new one.
+        entered_usernames = [user.username, "joe"]
+
+        def return_passwords():
+            return entered_passwords.pop(0)
+
+        def return_usernames():
+            return entered_usernames.pop(0)
+
+        @mock_inputs({"password": return_passwords, "username": return_usernames})
         def test(self):
             call_command(
                 "createsuperuser",


### PR DESCRIPTION
With a custom User model that uses a `UniqueConstraint` instead of `unique=True` to make usernames unique, using `manage.py createsuperuser` with a duplicate username could cause an IntegrityError:

```
IntegrityError: duplicate key value violates unique constraint "unique_usernames"
DETAIL:  Key (custom_username)=(foo) already exists.
```