### PR TITLE
Skipped SchemaTests.test_alter_field_type_and_db_collation on databases that don't support collation on TextField.

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -4565,7 +4565,9 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(Author, new_field, old_field, strict=True)
         self.assertIsNone(self.get_column_collation(Author._meta.db_table, "name"))
 
-    @skipUnlessDBFeature("supports_collation_on_charfield")
+    @skipUnlessDBFeature(
+        "supports_collation_on_charfield", "supports_collation_on_textfield"
+    )
     def test_alter_field_type_and_db_collation(self):
         collation = connection.features.test_collations.get("non_default")
         if not collation:


### PR DESCRIPTION
We alter `TextField` to `CharField` and back to `TextField` with collation. Some databases support collations on `CharFields` but don't support collations on `TextField`, we have to take this into account.