### PR TITLE
Refs #33173 -- Fixed test_runner/test_utils tests on Python 3.11+.

### DIFF
--- a/tests/test_runner/test_debug_sql.py
+++ b/tests/test_runner/test_debug_sql.py
@@ -4,6 +4,7 @@ from io import StringIO
 from django.db import connection
 from django.test import TestCase
 from django.test.runner import DiscoverRunner
+from django.utils.version import PY311
 
 from .models import Person
 
@@ -109,14 +110,17 @@ class TestDebugSQL(unittest.TestCase):
         ),
     ]
 
+    # Python 3.11 uses fully qualified test name in the output.
+    method_name = ".runTest" if PY311 else ""
+    test_class_path = "test_runner.test_debug_sql.TestDebugSQL"
     verbose_expected_outputs = [
-        "runTest (test_runner.test_debug_sql.TestDebugSQL.FailingTest) ... FAIL",
-        "runTest (test_runner.test_debug_sql.TestDebugSQL.ErrorTest) ... ERROR",
-        "runTest (test_runner.test_debug_sql.TestDebugSQL.PassingTest) ... ok",
+        f"runTest ({test_class_path}.FailingTest{method_name}) ... FAIL",
+        f"runTest ({test_class_path}.ErrorTest{method_name}) ... ERROR",
+        f"runTest ({test_class_path}.PassingTest{method_name}) ... ok",
         # If there are errors/failures in subtests but not in test itself,
         # the status is not written. That behavior comes from Python.
-        "runTest (test_runner.test_debug_sql.TestDebugSQL.FailingSubTest) ...",
-        "runTest (test_runner.test_debug_sql.TestDebugSQL.ErrorSubTest) ...",
+        f"runTest ({test_class_path}.FailingSubTest{method_name}) ...",
+        f"runTest ({test_class_path}.ErrorSubTest{method_name}) ...",
         (
             """SELECT COUNT(*) AS "__count" """
             """FROM "test_runner_person" WHERE """

--- a/tests/test_runner/test_parallel.py
+++ b/tests/test_runner/test_parallel.py
@@ -4,6 +4,7 @@ import unittest
 
 from django.test import SimpleTestCase
 from django.test.runner import RemoteTestResult
+from django.utils.version import PY311
 
 try:
     import tblib.pickling_support
@@ -125,7 +126,9 @@ class RemoteTestResultTest(SimpleTestCase):
         self.assertEqual(event[0], "addSubTest")
         self.assertEqual(
             str(event[2]),
-            "dummy_test (test_runner.test_parallel.SampleFailingSubtest) (index=0)",
+            "dummy_test (test_runner.test_parallel.SampleFailingSubtest%s) (index=0)"
+            # Python 3.11 uses fully qualified test name in the output.
+            % (".dummy_test" if PY311 else ""),
         )
         self.assertEqual(repr(event[3][1]), "AssertionError('0 != 1')")
 

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -48,6 +48,7 @@ from django.test.utils import (
 from django.urls import NoReverseMatch, path, reverse, reverse_lazy
 from django.utils.deprecation import RemovedInDjango50Warning
 from django.utils.log import DEFAULT_LOGGING
+from django.utils.version import PY311
 
 from .models import Car, Person, PossessedCar
 from .views import empty_response
@@ -100,9 +101,11 @@ class SkippingTestCase(SimpleTestCase):
             SkipTestCase("test_foo").test_foo,
             ValueError,
             "skipUnlessDBFeature cannot be used on test_foo (test_utils.tests."
-            "SkippingTestCase.test_skip_unless_db_feature.<locals>.SkipTestCase) "
+            "SkippingTestCase.test_skip_unless_db_feature.<locals>.SkipTestCase%s) "
             "as SkippingTestCase.test_skip_unless_db_feature.<locals>.SkipTestCase "
-            "doesn't allow queries against the 'default' database.",
+            "doesn't allow queries against the 'default' database."
+            # Python 3.11 uses fully qualified test name in the output.
+            % (".test_foo" if PY311 else ""),
         )
 
     def test_skip_if_db_feature(self):
@@ -145,9 +148,11 @@ class SkippingTestCase(SimpleTestCase):
             SkipTestCase("test_foo").test_foo,
             ValueError,
             "skipIfDBFeature cannot be used on test_foo (test_utils.tests."
-            "SkippingTestCase.test_skip_if_db_feature.<locals>.SkipTestCase) "
+            "SkippingTestCase.test_skip_if_db_feature.<locals>.SkipTestCase%s) "
             "as SkippingTestCase.test_skip_if_db_feature.<locals>.SkipTestCase "
-            "doesn't allow queries against the 'default' database.",
+            "doesn't allow queries against the 'default' database."
+            # Python 3.11 uses fully qualified test name in the output.
+            % (".test_foo" if PY311 else ""),
         )
 
 


### PR DESCRIPTION
Python 3.11 uses fully qualified test name in `unittest` output. See https://github.com/python/cpython/commit/755be9b1505af591b9f2ee424a6525b6c2b65ce9