### PR TITLE
Fixed #33627 -- Improved nonexistent pk in ModelMultipleChoiceFieldTests.test_model_multiple_choice_field().

### DIFF
--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -2098,7 +2098,8 @@ class ModelMultipleChoiceFieldTests(TestCase):
             [self.c1, self.c2],
         )
         with self.assertRaises(ValidationError):
-            f.clean(["100"])
+            max_pk = max(Category.objects.values_list("pk", flat=True))
+            f.clean([f"{max_pk + 1}"])
         with self.assertRaises(ValidationError):
             f.clean("hello")
         with self.assertRaises(ValidationError):

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -2098,8 +2098,7 @@ class ModelMultipleChoiceFieldTests(TestCase):
             [self.c1, self.c2],
         )
         with self.assertRaises(ValidationError):
-            max_pk = max(Category.objects.values_list("pk", flat=True))
-            f.clean([f"{max_pk + 1}"])
+            f.clean(["0"])
         with self.assertRaises(ValidationError):
             f.clean("hello")
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
This test used the "magic constant" 100 as a primary key that was expected to be absent.
However in some situations this primary key did exist.
As a result an expected ValidationError was not raised.

Fixed by constructing and using a non-existent primary key.

--- 

This PR is our first contribution. We are very open to suggestions and improvements.

This PR was a group effort by Ordina Pythoneers, they would like to thank Ordina for the time to do this. 

@wangremy
@marielleboot
@lennartschepers
@athleas
@PieterGcode
@SanderBeekhuis