### PR TITLE
Refs #31223 -- Added __class_getitem__() to ForeignKey

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -978,6 +978,9 @@ class ForeignKey(ForeignObject):
         )
         self.db_constraint = db_constraint
 
+    def __class_getitem__(cls, *args, **kwargs):
+        return cls
+
     def check(self, **kwargs):
         return [
             *super().check(**kwargs),

--- a/tests/model_fields/test_foreignkey.py
+++ b/tests/model_fields/test_foreignkey.py
@@ -164,3 +164,6 @@ class ForeignKeyTests(TestCase):
 
             class MyModel(models.Model):
                 child = models.ForeignKey(1, models.CASCADE)
+
+    def test_manager_class_getitem(self):
+        self.assertIs(models.ForeignKey["Foo"], models.ForeignKey)


### PR DESCRIPTION
This is useful especially for models.ForeignKey('self'). I'm not sure if `django-stubs` would use them, but `django-types` would use them:

https://pypi.org/project/django-types/

ticket-31223