### PR TITLE
Removed DatabaseFeatures.validates_explain_options.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -263,10 +263,6 @@ class BaseDatabaseFeatures:
     # What formats does the backend EXPLAIN syntax support?
     supported_explain_formats = set()
 
-    # Does DatabaseOperations.explain_query_prefix() raise ValueError if
-    # unknown kwargs are passed to QuerySet.explain()?
-    validates_explain_options = True
-
     # Does the backend support the default parameter in lead() and lag()?
     supports_default_in_lead_lag = True
 

--- a/tests/queries/test_explain.py
+++ b/tests/queries/test_explain.py
@@ -57,7 +57,6 @@ class ExplainTests(TestCase):
                                     f"QuerySet.explain() result is not valid JSON: {e}"
                                 )
 
-    @skipUnlessDBFeature("validates_explain_options")
     def test_unknown_options(self):
         with self.assertRaisesMessage(ValueError, "Unknown options: TEST, TEST2"):
             Tag.objects.explain(**{"TEST": 1, "TEST2": 1})


### PR DESCRIPTION
Always `True` since 6723a26e59b0b5429a0c5873941e01a2e1bdbb81.