### PR TITLE
Fixed #24296 -- Made QuerySet.exists() clear selected columns for not sliced distinct querysets.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -562,7 +562,7 @@ class Query(BaseExpression):
 
     def exists(self, using, limit=True):
         q = self.clone()
-        if not q.distinct:
+        if not (q.distinct and q.is_sliced):
             if q.group_by is True:
                 q.add_fields(
                     (f.attname for f in self.model._meta.concrete_fields), False

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2226,6 +2226,14 @@ class ExistsSql(TestCase):
         self.assertNotIn(id, qstr)
         self.assertNotIn(name, qstr)
 
+    def test_sliced_distinct_exists(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            self.assertIs(Article.objects.distinct()[1:3].exists(), False)
+        self.assertEqual(len(captured_queries), 1)
+        captured_sql = captured_queries[0]["sql"]
+        self.assertIn(connection.ops.quote_name("id"), captured_sql)
+        self.assertIn(connection.ops.quote_name("name"), captured_sql)
+
     def test_ticket_18414(self):
         Article.objects.create(name="one", created=datetime.datetime.now())
         Article.objects.create(name="one", created=datetime.datetime.now())

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2226,6 +2226,14 @@ class ExistsSql(TestCase):
         self.assertNotIn(id, qstr)
         self.assertNotIn(name, qstr)
 
+    def test_distinct_exists(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            self.assertIs(Article.objects.distinct().exists(), False)
+        self.assertEqual(len(captured_queries), 1)
+        captured_sql = captured_queries[0]["sql"]
+        self.assertNotIn(connection.ops.quote_name("id"), captured_sql)
+        self.assertNotIn(connection.ops.quote_name("name"), captured_sql)
+
     def test_sliced_distinct_exists(self):
         with CaptureQueriesContext(connection) as captured_queries:
             self.assertIs(Article.objects.distinct()[1:3].exists(), False)


### PR DESCRIPTION
I followed the [Martin Chase suggestion in the ticket 24296](https://code.djangoproject.com/ticket/24296) and clean select fields ONLY if it's a `distinct() + limit + exists()` queryset combination

Also followed the [Tim Graham comment](https://code.djangoproject.com/ticket/24296#comment:1) to add a test inspecting the queryset and check that we are selecting all the fields only in this case