### PR TITLE
Added YugabyteDB to list of third-party DB backends.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -1118,6 +1118,7 @@ by 3rd parties that allow you to use other databases with Django:
 * `Google Cloud Spanner`_
 * `Microsoft SQL Server`_
 * `TiDB`_
+* `YugabyteDB`_
 
 The Django versions and ORM features supported by these unofficial backends
 vary considerably. Queries regarding the specific capabilities of these
@@ -1129,3 +1130,4 @@ the support channels provided by each 3rd party project.
 .. _Google Cloud Spanner: https://pypi.org/project/django-google-spanner/
 .. _Microsoft SQL Server: https://pypi.org/project/mssql-django/
 .. _TiDB: https://pypi.org/project/django-tidb/
+.. _YugabyteDB: https://pypi.org/project/django-yugabytedb/


### PR DESCRIPTION
YugabyteDB is a Postgres compatible database and has a backend for Django overriding features supported differently in YugbayteDB as compared to Postgres.

We would love to get listed on the list of third party backends on the databases page. 

Please let us know in case any changes are required to help us get listed here.

Thanks!