### PR TITLE
Fixed #33633 -- Skipped some test_utils tests on databases that don't support transactions.

### DIFF
--- a/tests/test_utils/test_testcase.py
+++ b/tests/test_utils/test_testcase.py
@@ -41,6 +41,7 @@ class TestTestCase(TestCase):
         with self.assertRaisesMessage(DatabaseOperationForbidden, message):
             Car.objects.using("other").get()
 
+    @skipUnlessDBFeature("supports_transactions")
     def test_reset_sequences(self):
         old_reset_sequences = self.reset_sequences
         self.reset_sequences = True
@@ -61,6 +62,10 @@ def assert_no_queries(test):
     return inner
 
 
+# On databases with no transaction support (for instance, MySQL with the MyISAM
+# engine), setUpTestData() is called before each test, so there is no need to
+# clone class level test data.
+@skipUnlessDBFeature("supports_transactions")
 class TestDataTests(TestCase):
     # setUpTestData re-assignment are also wrapped in TestData.
     jim_douglas = None

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -2126,6 +2126,7 @@ class OverrideSettingsTests(SimpleTestCase):
             self.assertIn(expected_location, finder.locations)
 
 
+@skipUnlessDBFeature("supports_transactions")
 class TestBadSetUpTestData(TestCase):
     """
     An exception in setUpTestData() shouldn't leak a transaction which would
@@ -2160,6 +2161,7 @@ class TestBadSetUpTestData(TestCase):
         self.assertFalse(self._in_atomic_block)
 
 
+@skipUnlessDBFeature("supports_transactions")
 class CaptureOnCommitCallbacksTests(TestCase):
     databases = {"default", "other"}
     callback_called = False


### PR DESCRIPTION
The testing framework has some different behaviors for backends not supporting transactions. Mostly in `TestCase._fixture_setup` and `TestCase.setUpClass`. Skip them.