### PR TITLE
Fixed DatabaseFeatures.supports_expression_indexes on MySQL with MyISAM.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -336,5 +336,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     def supports_expression_indexes(self):
         return (
             not self.connection.mysql_is_mariadb
+            and self._mysql_storage_engine != "MyISAM"
             and self.connection.mysql_version >= (8, 0, 13)
         )


### PR DESCRIPTION
Functional indexes are not supported with `MyISAM` engine:
```
django.db.utils.OperationalError: (1478, "Table storage engine 'MyISAM' does not support the create option 'Index on virtual generated column'")
```