### PR TITLE
Removed unnecessary tuple call in SQLInsertCompiler.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1441,7 +1441,7 @@ class SQLCompiler:
 
 class SQLInsertCompiler(SQLCompiler):
     returning_fields = None
-    returning_params = tuple()
+    returning_params = ()
 
     def field_as_sql(self, field, val):
         """


### PR DESCRIPTION
Calling `()` is significantly faster than `tuple()`, although I appreciate it won't be much of a factor in the wider context. 

I'll put it out here for consideration. 

```  
In [2]: %timeit tuple()
86.8 ns ± 0.1 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [3]: %timeit ()
19.1 ns ± 0.117 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [4]: %timeit ()
19.2 ns ± 0.129 ns per loop (mean ± std. dev. of 7 runs, 100,000,000 loops each)

In [5]: %timeit tuple()
87.5 ns ± 1.57 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```