### PR TITLE
Fixed tests on databases that don't support introspecting foreign keys.

### DIFF
--- a/tests/migrations/test_base.py
+++ b/tests/migrations/test_base.py
@@ -125,6 +125,8 @@ class MigrationTestBase(TransactionTestCase):
             )
 
     def assertFKExists(self, table, columns, to, value=True, using="default"):
+        if not connections[using].features.can_introspect_foreign_keys:
+            return
         with connections[using].cursor() as cursor:
             self.assertEqual(
                 value,


### PR DESCRIPTION
This fixes ~30 tests on MySQL with MyISAM storage engine.