### PR TITLE
Refs #16022 - Use a weak reference for file field memory optimization

### DIFF
--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -238,6 +238,7 @@ class DataModel(models.Model):
 
 class Document(models.Model):
     myfile = models.FileField(upload_to="unused", unique=True)
+    weakfile = models.FileField(upload_to="unused")
 
 
 ###############################################################################


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/16022)

I believe that the tests should all pass. However, I have added a test to my [example project](https://github.com/massover/possible-leak/blob/main/core/tests.py#L72) that fails. I believe this is breaking if the weak ref is lost while trying to use [FileField.save](https://docs.djangoproject.com/en/4.0/ref/models/fields/#django.db.models.fields.files.FieldFile.save). The documented api itself is cyclic which is going to be tricky. 

Let me show the performance difference I observed.

before:

(the drop is a new deployment)

![image](https://user-images.githubusercontent.com/7320967/163205430-12fb8032-d2fb-49af-996f-1acef186fe98.png)

after:

(the drop is a new deployment)

<img width="972" alt="image" src="https://user-images.githubusercontent.com/7320967/163205329-168166d6-f1d1-4b43-bb4b-b1b7b61da033.png">

For my application, the memory utilization and latency saw such huge improvements. The memory utilization is evident in the graphs. The latency improvements come mostly in P99 (requests that are unlucky to catch gc). As @carltongibson notes, it's not a leak per se. It is eventually garbage collected. However, in my application, we were building up so much [gen 2](https://devguide.python.org/garbage_collector/#collecting-the-oldest-generation) garbage that when gc eventually starts, the latency takes a huge hit. With no reference cycle, there is less garbage.

Since this seems like a breaking change as far as I can see, I would hope that some other people can try this out and see if it makes a noticeable difference in their application (as it did for mine). Here is some code that should patch:

```python
def patch_field_file():
    import weakref
    from django.db.models.fields.files import FieldFile

    def __init__(self, instance, field, name):
        super(FieldFile, self).__init__(None, name)
        self.instance = weakref.proxy(instance)
        self.field = field
        self.storage = field.storage
        self._committed = True

    FieldFile.__init__ = __init__
```

The way to verify it would be using your existing memory metrics (!) or using something like [psutil](https://pypi.org/project/psutil/) in code (such as a middleware) and printing it.

```python
class psutilMiddleware:
    def __init__(self, get_response):
        self.get_response = get_response
        self.process = psutil.Process(os.getpid())
        self.memory_start = process.memory_full_info().rss / 1024 ** 2

    def __call__(self, request):
        response = self.get_response(request)
        memory_end = process.memory_full_info().rss / 1024 ** 2
        memory_diff = memory_end - self.memory_start
        print(f"{self.memory_start=}, {memory_end=},  {memory_diff=}")
        return response
```

I get that we all choose python and make tradeoffs on performance in this interpreted garbage collected language. For this improvement, I'm looking for data next, not to imply that because it made a huge impact on my project that it's the way to go. It would be nice if someone else could give their input on a real project! As an example, I believe that something like the following could be affected:

> A User model and api endpoint with an "avatar" file field. If an instance of user has lots of other data on it, I believe that every get request to api/user/:id/ would be creating lots of garbage, which could be increasing request times and worker memory usage non trivially. 

If the api can't break, and we'd like to move forward, here is a suggestion

- descriptor based compatibility flag
- global settings compatibility flag

```python
class FieldFile(File):
    def __init__(self, instance, field, name):
        super().__init__(None, name)
        
        if field.weak:
           self.instance = weakref.proxy(instance)
        elif settings.FILE_FIELD_WEAKREF_COMPAT:
           self.instance =  weakref.proxy(instance)
        else:
           self.instance = instance     
        self.field = field
        self.storage = field.storage
        self._committed = True
        
 # where we can initialize a file field like:
 
 class Example(models.Model):
     f = models.FileField(weak=True)
```





