### PR TITLE
Expanded QuerySet.explain() error message if a backends supports no formats.

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -754,6 +754,10 @@ class BaseDatabaseOperations:
                 msg = "%s is not a recognized format." % normalized_format
                 if supported_formats:
                     msg += " Allowed formats: %s" % ", ".join(sorted(supported_formats))
+                else:
+                    msg += (
+                        f" {self.connection.display_name} does not support any formats."
+                    )
                 raise ValueError(msg)
         if options:
             raise ValueError("Unknown options: %s" % ", ".join(sorted(options.keys())))

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -320,7 +320,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             for valid_option in self.explain_options:
                 value = options.pop(valid_option, None)
                 if value is not None:
-                    extra[valid_option.upper()] = value
+                    extra[valid_option] = value
         prefix = super().explain_query_prefix(format, **options)
         if format:
             extra["FORMAT"] = format

--- a/tests/queries/test_explain.py
+++ b/tests/queries/test_explain.py
@@ -74,6 +74,8 @@ class ExplainTests(TestCase):
             msg += " Allowed formats: %s" % ", ".join(
                 sorted(connection.features.supported_explain_formats)
             )
+        else:
+            msg += f" {connection.display_name} does not support any formats."
         with self.assertRaisesMessage(ValueError, msg):
             Tag.objects.explain(format="does not exist")
 


### PR DESCRIPTION
Motivated by the desire to remove [special handling in django-cockroachdb](https://github.com/cockroachdb/django-cockroachdb/blob/058711ea914deba1f58f702c628a6a330c1ce558/django_cockroachdb/operations.py#L48-L49).