### PR TITLE
Removed stale Windows asyncio test skips.

### DIFF
--- a/tests/asgi/tests.py
+++ b/tests/asgi/tests.py
@@ -2,7 +2,6 @@ import asyncio
 import sys
 import threading
 from pathlib import Path
-from unittest import skipIf
 
 from asgiref.testing import ApplicationCommunicator
 
@@ -23,10 +22,6 @@ from .urls import sync_waiter, test_filename
 TEST_STATIC_ROOT = Path(__file__).parent / "project" / "static"
 
 
-@skipIf(
-    sys.platform == "win32" and (3, 8, 0) < sys.version_info < (3, 8, 1),
-    "https://bugs.python.org/issue38563",
-)
 @override_settings(ROOT_URLCONF="asgi.urls")
 class ASGITest(SimpleTestCase):
     async_request_factory = AsyncRequestFactory()

--- a/tests/async/tests.py
+++ b/tests/async/tests.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
-import sys
-from unittest import mock, skipIf
+from unittest import mock
 
 from asgiref.sync import async_to_sync
 
@@ -15,10 +14,6 @@ from django.views.generic.base import View
 from .models import SimpleModel
 
 
-@skipIf(
-    sys.platform == "win32" and (3, 8, 0) < sys.version_info < (3, 8, 1),
-    "https://bugs.python.org/issue38563",
-)
 class CacheTest(SimpleTestCase):
     def test_caches_local(self):
         @async_to_sync
@@ -30,10 +25,6 @@ class CacheTest(SimpleTestCase):
         self.assertIs(cache_1, cache_2)
 
 
-@skipIf(
-    sys.platform == "win32" and (3, 8, 0) < sys.version_info < (3, 8, 1),
-    "https://bugs.python.org/issue38563",
-)
 class DatabaseConnectionTest(SimpleTestCase):
     """A database connection cannot be used in an async context."""
 
@@ -42,10 +33,6 @@ class DatabaseConnectionTest(SimpleTestCase):
             list(SimpleModel.objects.all())
 
 
-@skipIf(
-    sys.platform == "win32" and (3, 8, 0) < sys.version_info < (3, 8, 1),
-    "https://bugs.python.org/issue38563",
-)
 class AsyncUnsafeTest(SimpleTestCase):
     """
     async_unsafe decorator should work correctly and returns the correct


### PR DESCRIPTION
Underlying issue was fixed in Python 3.8.1, now many versions ago.
https://bugs.python.org/issue38563