### PR TITLE
Fixed #33643 -- Fixed inspectdb crash on functional unique constraints on Oracle.

### DIFF
--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -350,7 +350,9 @@ class Command(BaseCommand):
                 columns = params["columns"]
                 if None in columns:
                     has_unsupported_constraint = True
-                columns = [x for x in columns if x is not None]
+                columns = [
+                    x for x in columns if x is not None and x in column_to_field_name
+                ]
                 if len(columns) > 1:
                     unique_together.append(
                         str(tuple(column_to_field_name[c] for c in columns))

--- a/tests/inspectdb/models.py
+++ b/tests/inspectdb/models.py
@@ -1,4 +1,5 @@
 from django.db import connection, models
+from django.db.models.functions import Lower
 
 
 class People(models.Model):
@@ -117,3 +118,16 @@ class UniqueTogether(models.Model):
             ("from_field", "field1"),
             ("non_unique", "non_unique_0"),
         ]
+
+
+class FuncUniqueConstraint(models.Model):
+    name = models.CharField(max_length=255)
+    rank = models.IntegerField()
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                Lower("name"), models.F("rank"), name="index_lower_name"
+            )
+        ]
+        required_db_features = {"supports_expression_indexes"}

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -330,6 +330,13 @@ class InspectDBTestCase(TestCase):
         output = out.getvalue()
         self.assertIn("class InspectdbSpecialTableName(models.Model):", output)
 
+    @skipUnlessDBFeature("supports_expression_indexes")
+    def test_table_with_func_unique_constraint(self):
+        out = StringIO()
+        call_command("inspectdb", "inspectdb_funcuniqueconstraint", stdout=out)
+        output = out.getvalue()
+        self.assertIn("class InspectdbFuncuniqueconstraint(models.Model):", output)
+
     def test_managed_models(self):
         """
         By default the command generates models with `Meta.managed = False`.


### PR DESCRIPTION
Oracle occasionally has indices which index hidden columns, which causes an error when using `inspectdb`. This PR skips those hidden columns. If a particular index only references hidden columns, that index will not be returned.

See: https://code.djangoproject.com/ticket/33643