### PR TITLE
Refactored redirects handling in auth views.

### DIFF
--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -85,7 +85,10 @@ class LoginView(RedirectURLMixin, FormView):
 
     def get_default_redirect_url(self):
         """Return the default redirect URL."""
-        return resolve_url(self.next_page or settings.LOGIN_REDIRECT_URL)
+        if self.next_page:
+            return resolve_url(self.next_page)
+        else:
+            return resolve_url(settings.LOGIN_REDIRECT_URL)
 
     def get_form_class(self):
         return self.authentication_form or self.form_class
@@ -151,13 +154,17 @@ class LogoutView(RedirectURLMixin, TemplateView):
     # RemovedInDjango50Warning.
     get = post
 
-    def get_success_url(self):
-        if self.next_page is not None:
-            next_page = resolve_url(self.next_page)
+    def get_default_redirect_url(self):
+        """Return the default redirect URL, or None if no URL is configured."""
+        if self.next_page:
+            return resolve_url(self.next_page)
         elif settings.LOGOUT_REDIRECT_URL:
-            next_page = resolve_url(settings.LOGOUT_REDIRECT_URL)
+            return resolve_url(settings.LOGOUT_REDIRECT_URL)
         else:
-            next_page = self.next_page
+            return None
+
+    def get_success_url(self):
+        next_page = self.get_default_redirect_url()
 
         if (
             self.redirect_field_name in self.request.POST

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -142,16 +142,16 @@ class LogoutView(RedirectURLMixin, TemplateView):
     def post(self, request, *args, **kwargs):
         """Logout may be done via POST."""
         auth_logout(request)
-        next_page = self.get_next_page()
-        if next_page:
+        redirect_to = self.get_success_url()
+        if redirect_to:
             # Redirect to this page until the session has been cleared.
-            return HttpResponseRedirect(next_page)
+            return HttpResponseRedirect(redirect_to)
         return super().get(request, *args, **kwargs)
 
     # RemovedInDjango50Warning.
     get = post
 
-    def get_next_page(self):
+    def get_success_url(self):
         if self.next_page is not None:
             next_page = resolve_url(self.next_page)
         elif settings.LOGOUT_REDIRECT_URL:

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -495,6 +495,9 @@ Miscellaneous
   enabled in development. You may specify ``OPTIONS['loaders']`` to override
   this, if necessary.
 
+* The undocumented ``django.contrib.auth.views.SuccessURLAllowedHostsMixin``
+  mixin is replaced by ``RedirectURLMixin``.
+
 .. _deprecated-features-4.1:
 
 Features deprecated in 4.1

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -18,6 +18,7 @@ from django.contrib.auth.models import Permission, User
 from django.contrib.auth.views import (
     INTERNAL_RESET_SESSION_TOKEN,
     LoginView,
+    RedirectURLMixin,
     logout_then_login,
     redirect_to_login,
 )
@@ -38,6 +39,20 @@ from django.utils.http import urlsafe_base64_encode
 from .client import PasswordResetConfirmClient
 from .models import CustomUser, UUIDUser
 from .settings import AUTH_TEMPLATES
+
+
+class RedirectURLMixinTests(TestCase):
+    @override_settings(ROOT_URLCONF="auth_tests.urls")
+    def test_get_default_redirect_url_next_page(self):
+        class RedirectURLView(RedirectURLMixin):
+            next_page = "/custom/"
+
+        self.assertEqual(RedirectURLView().get_default_redirect_url(), "/custom/")
+
+    def test_get_default_redirect_url_no_next_page(self):
+        msg = "No URL to redirect to. Provide a next_page."
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            RedirectURLMixin().get_default_redirect_url()
 
 
 @override_settings(

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -984,6 +984,8 @@ class LogoutThenLoginTests(AuthViewsTestCase):
         csrf_token = get_token(req)
         req.COOKIES[settings.CSRF_COOKIE_NAME] = csrf_token
         req.POST = {"csrfmiddlewaretoken": csrf_token}
+        req.META["SERVER_NAME"] = "testserver"
+        req.META["SERVER_PORT"] = 80
         req.session = self.client.session
         response = logout_then_login(req)
         self.confirm_logged_out()
@@ -996,6 +998,8 @@ class LogoutThenLoginTests(AuthViewsTestCase):
         csrf_token = get_token(req)
         req.COOKIES[settings.CSRF_COOKIE_NAME] = csrf_token
         req.POST = {"csrfmiddlewaretoken": csrf_token}
+        req.META["SERVER_NAME"] = "testserver"
+        req.META["SERVER_PORT"] = 80
         req.session = self.client.session
         response = logout_then_login(req, login_url="/custom/")
         self.confirm_logged_out()
@@ -1007,6 +1011,8 @@ class LogoutThenLoginTests(AuthViewsTestCase):
         self.login()
         req = HttpRequest()
         req.method = "GET"
+        req.META["SERVER_NAME"] = "testserver"
+        req.META["SERVER_PORT"] = 80
         req.session = self.client.session
         response = logout_then_login(req)
         # RemovedInDjango50Warning: When the deprecation ends, replace with
@@ -1345,7 +1351,8 @@ class LogoutTest(AuthViewsTestCase):
     def test_logout_redirect_url_named_setting(self):
         self.login()
         response = self.client.post("/logout/")
-        self.assertRedirects(response, "/logout/", fetch_redirect_response=False)
+        self.assertContains(response, "Logged out")
+        self.confirm_logged_out()
 
 
 def get_perm(Model, perm):


### PR DESCRIPTION
There's a lot of security-sensitive code around handling redirects in LoginView and LogoutView, in django.contrib.auth.views.

The actual behavior is very similar in both classes but the implementation is quite different, making it hard to follow what's going on.

I refactored to align the implementation in both classes and move the common parts to a mixin (which existed already).

This PR builds upon #15607. It is split in atomic commits to show the refactoring steps. I recommend you review it commit-by-commit.