### PR TITLE
Refs #32226 -- Fixed JSON format of QuerySet.explain() on PostgreSQL when format is uppercased.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1434,9 +1434,8 @@ class SQLCompiler:
         result = list(self.execute_sql())
         # Some backends return 1 item tuples with strings, and others return
         # tuples with integers and strings. Flatten them out into strings.
-        output_formatter = (
-            json.dumps if self.query.explain_info.format == "json" else str
-        )
+        format_ = self.query.explain_info.format
+        output_formatter = json.dumps if format_ and format_.lower() == "json" else str
         for row in result[0]:
             if not isinstance(row, str):
                 yield " ".join(output_formatter(c) for c in row)

--- a/tests/queries/test_explain.py
+++ b/tests/queries/test_explain.py
@@ -41,14 +41,16 @@ class ExplainTests(TestCase):
                         )
                         self.assertIsInstance(result, str)
                         self.assertTrue(result)
-                        if format == "xml":
+                        if not format:
+                            continue
+                        if format.lower() == "xml":
                             try:
                                 xml.etree.ElementTree.fromstring(result)
                             except xml.etree.ElementTree.ParseError as e:
                                 self.fail(
                                     f"QuerySet.explain() result is not valid XML: {e}"
                                 )
-                        elif format == "json":
+                        elif format.lower() == "json":
                             try:
                                 json.loads(result)
                             except json.JSONDecodeError as e:


### PR DESCRIPTION
Follow up to aba9c2de669dcc0278c7ffde7981be91801be00b.

Noticed when polishing #14843.