### PR TITLE
Fixed #33004 -- Made saving objects with unsaved GenericForeignKey raise ValueError.

### DIFF
--- a/tests/generic_relations_regress/models.py
+++ b/tests/generic_relations_regress/models.py
@@ -104,11 +104,6 @@ class Company(models.Model):
     links = GenericRelation(Link)
 
 
-# For testing #13085 fix, we also use Note model defined above
-class Developer(models.Model):
-    name = models.CharField(max_length=15)
-
-
 class Team(models.Model):
     name = models.CharField(max_length=15)
 

--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -1,4 +1,3 @@
-from django.db import IntegrityError
 from django.db.models import ProtectedError, Q, Sum
 from django.forms.models import modelform_factory
 from django.test import TestCase, skipIfDBFeature
@@ -15,7 +14,6 @@ from .models import (
     Contact,
     Content,
     D,
-    Developer,
     Guild,
     HasLinkThing,
     Link,
@@ -139,14 +137,6 @@ class GenericRelationTests(TestCase):
         self.assertEqual(len(places), 2)
         self.assertEqual(count_places(p1), 1)
         self.assertEqual(count_places(p2), 1)
-
-    def test_target_model_is_unsaved(self):
-        """Test related to #13085"""
-        # Fails with another, ORM-level error
-        dev1 = Developer(name="Joe")
-        note = Note(note="Deserves promotion", content_object=dev1)
-        with self.assertRaises(IntegrityError):
-            note.save()
 
     def test_target_model_len_zero(self):
         """


### PR DESCRIPTION
Tracker ticket: https://code.djangoproject.com/ticket/33004
GFK fields would raise an IntegrityError on save/bulk_create when they have an unsaved related model
Changed to a ValueError to allign with the behaviour of OneToOneField and ForeignKey fields.

Thank you @jonnythebard  for the initial patch: https://github.com/django/django/pull/14807 :muscle: 

Tried to address the review comments