### PR TITLE
Updated note about ListView pagination example in CBV docs.

### DIFF
--- a/docs/ref/class-based-views/generic-display.txt
+++ b/docs/ref/class-based-views/generic-display.txt
@@ -167,8 +167,7 @@ many projects they are typically the most commonly used views.
         </ul>
 
     If you're using pagination, you can adapt the :ref:`example template from
-    the pagination docs <using-paginator-in-view>`. Change instances of
-    ``contacts`` in that example template to ``page_obj``.
+    the pagination docs <paginating-a-list-view>`.
 
 .. class:: django.views.generic.list.BaseListView
 

--- a/docs/topics/pagination.txt
+++ b/docs/topics/pagination.txt
@@ -78,6 +78,8 @@ accessing the items for each page::
     objects such as Django's ``QuerySet`` to use a more efficient ``count()``
     method when available.
 
+.. _paginating-a-list-view:
+
 Paginating a ``ListView``
 =========================
 


### PR DESCRIPTION
The removed line was introduced in #9821, but #12230 changed the code in the example from `contacts` to `page_obj`