### PR TITLE
Refs #33508 -- Corrected note about MySQL/MariaDB support of index ordering.

### DIFF
--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -80,8 +80,12 @@ define an index with a descending order for a column, add a hyphen before the
 field's name.
 
 For example ``Index(fields=['headline', '-pub_date'])`` would create SQL with
-``(headline, pub_date DESC)``. Index ordering isn't supported on MySQL. In that
-case, a descending index is created as a normal index.
+``(headline, pub_date DESC)``.
+
+.. admonition:: MySQL and MariaDB
+
+    Index ordering isn't supported on MySQL < 8.0.1 and MariaDB < 10.8. In that
+    case, a descending index is created as a normal index.
 
 ``name``
 --------


### PR DESCRIPTION
Refs: https://code.djangoproject.com/ticket/33508