### PR TITLE
Refs #28147 -- Fixed loss of assigned parent when saving GenericForeignKey after parent.

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -51,6 +51,7 @@ class GenericForeignKey(FieldCacheMixin):
         self.editable = False
         self.rel = None
         self.column = None
+        self._fk_field_set_none = False
 
     def contribute_to_class(self, cls, name, **kwargs):
         self.name = name
@@ -263,6 +264,7 @@ class GenericForeignKey(FieldCacheMixin):
         setattr(instance, self.ct_field, ct)
         setattr(instance, self.fk_field, fk)
         self.set_cached_value(instance, value)
+        self._fk_field_set_none = fk is None
 
 
 class GenericRel(ForeignObjectRel):

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1123,6 +1123,10 @@ class Model(metaclass=ModelBase):
                         f"{operation_name}() prohibited to prevent data loss due to "
                         f"unsaved related object '{field.name}'."
                     )
+                elif field._fk_field_set_none and getattr(self, field.fk_field) is None:
+                    # Use pk from related object if it has been saved after
+                    # an assignment.
+                    setattr(self, field.fk_field, obj.pk)
 
     def delete(self, using=None, keep_parents=False):
         if self.pk is None:

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -510,6 +510,25 @@ class GenericRelationsTests(TestCase):
         with self.assertRaisesMessage(ValueError, msg):
             tagged_item.save()
 
+    def test_save_generic_foreign_key_after_parent(self):
+        quartz = Mineral(name="Quartz", hardness=7)
+        tag = TaggedItem(tag="shiny", content_object=quartz)
+        quartz.save()
+        # ValueError is not raised as unsaved object since been saved.
+        tag.save()
+        tag.refresh_from_db()
+        self.assertEqual(tag.content_object, quartz)
+
+    def test_assign_gfk_id_none(self):
+        quartz = Mineral.objects.create(name="Quartz", hardness=7)
+        nullable_gfk = AllowsNullGFK.objects.create()
+        nullable_gfk.content_object = quartz
+        nullable_gfk.save()
+        nullable_gfk.object_id = None
+        nullable_gfk.save()
+        self.assertIsNone(nullable_gfk.object_id)
+        self.assertIsNone(nullable_gfk.content_object)
+
     @skipUnlessDBFeature("has_bulk_insert")
     def test_unsaved_generic_foreign_key_parent_bulk_create(self):
         quartz = Mineral(name="Quartz", hardness=7)


### PR DESCRIPTION
Follows on from  "[Fixed #33004 -- Made saving objects with unsaved GenericForeignKey raise ValueError.](https://github.com/django/django/pull/15613)"

Aims to allow saving a `GenericForiegnKey` after the parent (see `test_save_generic_foreign_key_after_parent`), 
**without** removing the ability to save the `fk_field` of the `GenericForeignKey` as None and that nulling out the `GenericForiegnKey` value (see `test_assign_gfk_id_none`).


> We should also check if this doesn't introduce a regression as https://github.com/django/django/commit/519016e5f25d7c0a040015724f9920581551cab0 (fixed in https://github.com/django/django/commit/4122d9d3f1983eea612f236e941d937bd8589a0d).

The only solution I have found so far to prevent the regression is probably quite hacky/flakey.
Look forward to the suggestions people have as to how it can be improved :+1: 