### PR TITLE
Refs #27674 --- Deprecated django.contrib.gis.admin.OpenLayersWidget.

### DIFF
--- a/django/contrib/gis/admin/__init__.py
+++ b/django/contrib/gis/admin/__init__.py
@@ -27,8 +27,8 @@ __all__ = [
     "register",
     "site",
     "GISModelAdmin",
-    "OpenLayersWidget",
     # RemovedInDjango50Warning.
     "GeoModelAdmin",
+    "OpenLayersWidget",
     "OSMGeoAdmin",
 ]

--- a/django/contrib/gis/admin/widgets.py
+++ b/django/contrib/gis/admin/widgets.py
@@ -1,9 +1,12 @@
+# RemovedInDjango50Warning.
 import logging
+import warnings
 
 from django.contrib.gis.gdal import GDALException
 from django.contrib.gis.geos import GEOSException, GEOSGeometry
 from django.forms.widgets import Textarea
 from django.utils import translation
+from django.utils.deprecation import RemovedInDjango50Warning
 
 # Creating a template context that contains Django settings
 # values needed by admin map templates.
@@ -15,6 +18,14 @@ class OpenLayersWidget(Textarea):
     """
     Render an OpenLayers map using the WKT of the geometry.
     """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "django.contrib.gis.admin.OpenLayersWidget is deprecated.",
+            RemovedInDjango50Warning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
     def get_context(self, name, value, attrs):
         # Update the template parameters with any attributes passed in.

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -101,6 +101,8 @@ details on these changes.
   ``SimpleTestCase.assertFormError()`` and ``assertFormsetError()`` will no
   longer be allowed.
 
+* The ``django.contrib.gis.admin.OpenLayersWidget`` will be removed.
+
 .. _deprecation-removed-in-4.1:
 
 4.1

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -610,6 +610,8 @@ Miscellaneous
 
   or pass the form/formset object directly instead.
 
+* The undocumented ``django.contrib.gis.admin.OpenLayersWidget`` is deprecated.
+
 Features removed in 4.1
 =======================
 

--- a/tests/gis_tests/geoadmin_deprecated/tests.py
+++ b/tests/gis_tests/geoadmin_deprecated/tests.py
@@ -125,3 +125,8 @@ class DeprecationTests(SimpleTestCase):
             DeprecatedOSMGeoAdmin(City, site)
         with self.assertRaisesMessage(RemovedInDjango50Warning, msg):
             DeprecatedGeoModelAdmin(City, site)
+
+    def test_openlayerswidget_warning(self):
+        msg = "django.contrib.gis.admin.OpenLayersWidget is deprecated."
+        with self.assertRaisesMessage(RemovedInDjango50Warning, msg):
+            admin.OpenLayersWidget()


### PR DESCRIPTION
See [comment](https://code.djangoproject.com/ticket/27674#comment:11).