### PR TITLE
Fixed #33656 -- Fixed MultiWidget crash when compressed value is a tuple.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -884,9 +884,9 @@ class MultiWidget(Widget):
         if self.is_localized:
             for widget in self.widgets:
                 widget.is_localized = self.is_localized
-        # value is a list of values, each corresponding to a widget
+        # value is a list/tuple of values, each corresponding to a widget
         # in self.widgets.
-        if not isinstance(value, list):
+        if not isinstance(value, (list, tuple)):
             value = self.decompress(value)
 
         final_attrs = context["widget"]["attrs"]

--- a/tests/forms_tests/widget_tests/test_multiwidget.py
+++ b/tests/forms_tests/widget_tests/test_multiwidget.py
@@ -133,6 +133,15 @@ class MultiWidgetTest(WidgetTest):
         self.check_html(
             widget,
             "name",
+            ("john", "lennon"),
+            html=(
+                '<input type="text" class="big" value="john" name="name_0">'
+                '<input type="text" class="small" value="lennon" name="name_1">'
+            ),
+        )
+        self.check_html(
+            widget,
+            "name",
             "john__lennon",
             html=(
                 '<input type="text" class="big" value="john" name="name_0">'

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -1094,3 +1094,15 @@ class TestWidget(PostgreSQLSimpleTestCase):
             '<input type="text" name="datetimerange_0" value="2006-01-10 07:30:00">'
             '<input type="text" name="datetimerange_1" value="2006-02-12 09:50:00">',
         )
+
+    def test_range_widget_render_tuple_value(self):
+        field = pg_forms.ranges.DateTimeRangeField()
+        dt_range_tuple = (
+            datetime.datetime(2022, 4, 22, 10, 24),
+            datetime.datetime(2022, 5, 12, 9, 25),
+        )
+        self.assertHTMLEqual(
+            field.widget.render("datetimerange", dt_range_tuple),
+            '<input type="text" name="datetimerange_0" value="2022-04-22 10:24:00">'
+            '<input type="text" name="datetimerange_1" value="2022-05-12 09:25:00">',
+        )


### PR DESCRIPTION
Fixed bug that causing crash when putting tuples as input for param of "default" in XXRangeFields for postgres