### PR TITLE
Unified AdminSite imports in docs.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2992,11 +2992,11 @@ to reference your :class:`AdminSite` subclass.
 .. code-block:: python
     :caption: myapp/admin.py
 
-    from django.contrib.admin import AdminSite
+    from django.contrib import admin
 
     from .models import MyModel
 
-    class MyAdminSite(AdminSite):
+    class MyAdminSite(admin.AdminSite):
         site_header = 'Monty Python administration'
 
     admin_site = MyAdminSite(name='myadmin')


### PR DESCRIPTION
While reading the `Django admin site` docs, noticed that all the other code snippets on this page use `from django.contrib import admin`.
Feel free to close the PR if you think it doesn't worth merging.
Thanks!