### PR TITLE
Fixed #33655 -- Removed unnecessary constant from GROUP BY clause for QuerySet.exists().

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -27,6 +27,7 @@ from django.db.models.expressions import (
     OuterRef,
     Ref,
     ResolvedOuterRef,
+    Value,
 )
 from django.db.models.fields import Field
 from django.db.models.fields.related_lookups import MultiColSource
@@ -582,8 +583,7 @@ class Query(BaseExpression):
         q.clear_ordering(force=True)
         if limit:
             q.set_limits(high=1)
-        q.add_extra({"a": 1}, None, None, None, None, None)
-        q.set_extra_mask(["a"])
+        q.add_annotation(Value(1), "a")
         return q
 
     def has_results(self, using):

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -1434,6 +1434,18 @@ class AggregateTestCase(TestCase):
         )
         self.assertTrue(publisher_qs.exists())
 
+    def test_aggregation_filter_exists(self):
+        publishers_having_more_than_one_book_qs = (
+            Book.objects.values("publisher")
+            .annotate(cnt=Count("isbn"))
+            .filter(cnt__gt=1)
+        )
+        query = publishers_having_more_than_one_book_qs.query.exists(
+            using=connection.alias
+        )
+        _, _, group_by = query.get_compiler(connection=connection).pre_sql_setup()
+        self.assertEqual(len(group_by), 1)
+
     def test_aggregation_exists_annotation(self):
         published_books = Book.objects.filter(publisher=OuterRef("pk"))
         publisher_qs = Publisher.objects.annotate(


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/33655

Use `Value` instead of `extra` for `QuerySet.exists()` as per @charettes's suggestion.

I've added a single new test focused on the disappearance of `, (1)` that we want to avoid in the GROUP BY clause.
The test fails before the fix and passes after.
With test default settings (sqlite), the test's query goes from:
```
SELECT (1) AS "a" FROM "aggregation_book" GROUP BY "aggregation_book"."publisher_id", (1) HAVING COUNT("aggregation_book"."isbn") > 1 LIMIT 1
```
to:
```
SELECT 1 AS "a" FROM "aggregation_book" GROUP BY "aggregation_book"."publisher_id" HAVING COUNT("aggregation_book"."isbn") > 1 LIMIT 1
```