### PR TITLE
Refs #33671 -- Fixed migrations crash when adding collation to a primary key on Oracle.

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -4608,6 +4608,31 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(Author, new_field, old_field, strict=True)
         self.assertIsNone(self.get_column_collation(Author._meta.db_table, "name"))
 
+    @skipUnlessDBFeature("supports_collation_on_charfield")
+    def test_alter_primary_key_db_collation(self):
+        collation = connection.features.test_collations.get("non_default")
+        if not collation:
+            self.skipTest("Language collations are not supported.")
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Thing)
+
+        old_field = Thing._meta.get_field("when")
+        new_field = CharField(max_length=1, db_collation=collation, primary_key=True)
+        new_field.set_attributes_from_name("when")
+        new_field.model = Thing
+        with connection.schema_editor() as editor:
+            editor.alter_field(Thing, old_field, new_field, strict=True)
+        self.assertEqual(self.get_primary_key(Thing._meta.db_table), "when")
+        self.assertEqual(
+            self.get_column_collation(Thing._meta.db_table, "when"),
+            collation,
+        )
+        with connection.schema_editor() as editor:
+            editor.alter_field(Thing, new_field, old_field, strict=True)
+        self.assertEqual(self.get_primary_key(Thing._meta.db_table), "when")
+        self.assertIsNone(self.get_column_collation(Thing._meta.db_table, "when"))
+
     @skipUnlessDBFeature(
         "supports_collation_on_charfield", "supports_collation_on_textfield"
     )


### PR DESCRIPTION
Oracle doesn't support adding/altering collations when a column is indexed. This fixes an issue for primary keys, the remaining part for related foreign keys will be fixed in #15629.