### PR TITLE
Refs #32388 -- Raise on duplicates in bulk_update

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -808,7 +808,7 @@ class QuerySet:
         objs = tuple(objs)
         pks = set(obj.pk for obj in objs)
         if len(pks) < len(objs):
-            raise ValueError('bulk_update() cannot update duplicates.')
+            raise ValueError("bulk_update() cannot update duplicates.")
         if None in pks:
             raise ValueError("All bulk_update() objects must have a primary key set.")
         fields = [self.model._meta.get_field(name) for name in fields]

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -806,7 +806,10 @@ class QuerySet:
         if not fields:
             raise ValueError("Field names must be given to bulk_update().")
         objs = tuple(objs)
-        if any(obj.pk is None for obj in objs):
+        pks = set(obj.pk for obj in objs)
+        if len(pks) < len(objs):
+            raise ValueError('bulk_update() cannot update duplicates.')
+        if None in pks:
             raise ValueError("All bulk_update() objects must have a primary key set.")
         fields = [self.model._meta.get_field(name) for name in fields]
         if any(not f.concrete or f.many_to_many for f in fields):

--- a/tests/queries/test_bulk_update.py
+++ b/tests/queries/test_bulk_update.py
@@ -156,7 +156,7 @@ class BulkUpdateTests(TestCase):
         self.assertEqual(rows_updated, 2000)
 
     def test_raise_on_duplicates(self):
-        msg = 'bulk_update() cannot update duplicates.'
+        msg = "bulk_update() cannot update duplicates."
         note = Note.objects.create(note="test-note", misc="test")
         # same batch
         with self.assertRaisesMessage(ValueError, msg):


### PR DESCRIPTION
@felixxm

Implemented a full stop on any duplicates for a single `bulk_update` call, as suggested in https://code.djangoproject.com/ticket/33672. This uses a simple set reduction to compare container lengths before/after the set reduction, which is the fastest way I was able to find (performance note - this runs a tiny bit slower than before, but the difference <<1% of the total runtime, tested up to 10M records).

Still there are some caveats linked to the set reduction:
- pk values must be set serializable, thats the case for standard field types, not sure if there are 3rd types, that break here
- set reduction should be equal to distinction criteria on db side, otherwise it is a false friend (not sufficiently detecting duplicates as seen by the db, or alerting on duplicates, that are not duplicates for the db) - if thats an issue, only an additional db roundtrip with an `pk IN (...)` reduction can assure proper duplicate detection
- this may also apply to combined pks, once django supports those, if the intermediate format cannot reduce correctly
- sets are quite memory hungry - for a short time the set reduction adds ~32MB for 1M pks, ~256MB for 10M pks

I also tried my second suggestion to filter on duplicates for the whole changeset and let only the first one pass, but was not able to find a reasonable fast way to do that. I totally agree with you, that the whole topic is very niche, so simply throwing an exception is imho a good way to delegate the rare issue back to the user.

TODO:
- if accepted, needs some sort of doc changes as well