### PR TITLE
Fixed #22078 -- Fixed crash of Feed with decorated methods.

### DIFF
--- a/tests/syndication_tests/feeds.py
+++ b/tests/syndication_tests/feeds.py
@@ -1,8 +1,27 @@
+from functools import wraps
+
 from django.contrib.syndication import views
 from django.utils import feedgenerator
 from django.utils.timezone import get_fixed_timezone
 
 from .models import Article, Entry
+
+
+def wraps_decorator(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        value = f(*args, **kwargs)
+        return f"{value} -- decorated by @wraps."
+
+    return wrapper
+
+
+def common_decorator(f):
+    def wrapper(*args, **kwargs):
+        value = f(*args, **kwargs)
+        return f"{value} -- common decorated."
+
+    return wrapper
 
 
 class TestRss2Feed(views.Feed):
@@ -47,10 +66,44 @@ class TestRss2FeedWithCallableObject(TestRss2Feed):
     ttl = TimeToLive()
 
 
-class TestRss2FeedWithStaticMethod(TestRss2Feed):
+class TestRss2FeedWithDecoratedMethod(TestRss2Feed):
+    class TimeToLive:
+        @wraps_decorator
+        def __call__(self):
+            return 800
+
+    @staticmethod
+    @wraps_decorator
+    def feed_copyright():
+        return "Copyright (c) 2022, John Doe"
+
+    ttl = TimeToLive()
+
     @staticmethod
     def categories():
         return ("javascript", "vue")
+
+    @wraps_decorator
+    def title(self):
+        return "Overridden title"
+
+    @wraps_decorator
+    def item_title(self, item):
+        return f"Overridden item title: {item.title}"
+
+    @wraps_decorator
+    def description(self, obj):
+        return "Overridden description"
+
+    @wraps_decorator
+    def item_description(self):
+        return "Overridden item description"
+
+
+class TestRss2FeedWithWrongDecoratedMethod(TestRss2Feed):
+    @common_decorator
+    def item_description(self, item):
+        return f"Overridden item description: {item.title}"
 
 
 class TestRss2FeedWithGuidIsPermaLinkTrue(TestRss2Feed):

--- a/tests/syndication_tests/tests.py
+++ b/tests/syndication_tests/tests.py
@@ -202,11 +202,38 @@ class SyndicationFeedTest(FeedTestCase):
         chan = doc.getElementsByTagName("rss")[0].getElementsByTagName("channel")[0]
         self.assertChildNodeContent(chan, {"ttl": "700"})
 
-    def test_rss2_feed_with_static_methods(self):
-        response = self.client.get("/syndication/rss2/with-static-methods/")
+    def test_rss2_feed_with_decorated_methods(self):
+        response = self.client.get("/syndication/rss2/with-decorated-methods/")
         doc = minidom.parseString(response.content)
         chan = doc.getElementsByTagName("rss")[0].getElementsByTagName("channel")[0]
         self.assertCategories(chan, ["javascript", "vue"])
+        self.assertChildNodeContent(
+            chan,
+            {
+                "title": "Overridden title -- decorated by @wraps.",
+                "description": "Overridden description -- decorated by @wraps.",
+                "ttl": "800 -- decorated by @wraps.",
+                "copyright": "Copyright (c) 2022, John Doe -- decorated by @wraps.",
+            },
+        )
+        items = chan.getElementsByTagName("item")
+        self.assertChildNodeContent(
+            items[0],
+            {
+                "title": (
+                    f"Overridden item title: {self.e1.title} -- decorated by @wraps."
+                ),
+                "description": "Overridden item description -- decorated by @wraps.",
+            },
+        )
+
+    def test_rss2_feed_with_wrong_decorated_methods(self):
+        msg = (
+            "Feed method 'item_description' decorated by 'wrapper' needs to use "
+            "@functools.wraps."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            self.client.get("/syndication/rss2/with-wrong-decorated-methods/")
 
     def test_rss2_feed_guid_permalink_false(self):
         """

--- a/tests/syndication_tests/urls.py
+++ b/tests/syndication_tests/urls.py
@@ -7,7 +7,14 @@ urlpatterns = [
     path(
         "syndication/rss2/with-callable-object/", feeds.TestRss2FeedWithCallableObject()
     ),
-    path("syndication/rss2/with-static-methods/", feeds.TestRss2FeedWithStaticMethod()),
+    path(
+        "syndication/rss2/with-decorated-methods/",
+        feeds.TestRss2FeedWithDecoratedMethod(),
+    ),
+    path(
+        "syndication/rss2/with-wrong-decorated-methods/",
+        feeds.TestRss2FeedWithWrongDecoratedMethod(),
+    ),
     path("syndication/rss2/articles/<int:entry_id>/", feeds.TestGetObjectFeed()),
     path(
         "syndication/rss2/guid_ispermalink_true/",


### PR DESCRIPTION
I would like to continue with [coldmin's](https://code.djangoproject.com/ticket/22078#comment:4) work and try to fix this fragile code that [Aymeric Augustin](https://code.djangoproject.com/ticket/22078#comment:1) mentions.

To run the specific tests please do:
`./runtests.py syndication_tests.tests.SyndicationFeedTest.test_feed_with_decorated_methods`
and
`./runtests.py syndication_tests.tests.SyndicationFeedTest.test_feed_with_wrong_decorated_methods`

Thank you!