### PR TITLE
Fixed changelist filter taking up too much space with long strings

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -137,6 +137,7 @@
     background: var(--darkened-bg);
     border-left: none;
     margin: 0 0 0 30px;
+    word-break: break-word;
 }
 
 #changelist-filter h2 {


### PR DESCRIPTION
Let me know if this needs a ticket.

If you have a long string that can be filtered without breaking characters it really messes up the page (not shown: horizontal scrollbar until you get to the end of the string):

<img width="1198" alt="Screenshot 2022-05-02 at 12 03 00" src="https://user-images.githubusercontent.com/3871354/166220043-86de8b2b-ba6d-4ccc-8fe6-d5c450666d52.png">

With this fix:

<img width="1172" alt="Screenshot 2022-05-02 at 12 20 34" src="https://user-images.githubusercontent.com/3871354/166220069-4bb5bf56-297b-4b64-8a29-e695bf143fed.png">

Could also set `overflow-x: hidden` but didn't want to hide part of the string.