### PR TITLE
Fixed #27064 -- Implemented RenameIndex operation

### DIFF
--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -355,6 +355,12 @@ Migrations
   ``RemoveIndex`` and ``AddIndex``, when renaming indexes defined in the
   :attr:`Meta.indexes <django.db.models.Options.indexes>`.
 
+* The migrations autodetector now generates
+  :class:`~django.db.migrations.operations.RenameIndex` operations instead of
+  ``AlterIndexTogether`` and ``AddIndex``, when moving indexes defined in the
+  :attr:`Meta.index_together <django.db.models.Options.index_together>` to the
+  :attr:`Meta.indexes <django.db.models.Options.indexes>`.
+
 Models
 ~~~~~~
 


### PR DESCRIPTION
Hello,

Tackles https://code.djangoproject.com/ticket/27064 by implementing using the RenameIndex operation in the autodetector.

For review, a commit-by-commit approach should be okay:
FYI, the **RenameIndex operation** was added in https://github.com/django/django/pull/15677

**Commit 1**
- Generate a `RenameIndex` operation in the autodetector when nothing changed on an index, apart from the name (see `Index.equal_except_name`

**Commit 2**
Split the `generate_renamed_fields` into two parts, with first a `create_renamed_fields` method.

**Commit 3**
- Again in the autodetector, also generate a `RenameIndex` when an `index_together` has been removed, and an `Index` added that have the same fields.
- Through the `renamed_index_together_values` variable we make sure that no `AlterIndexTogether` is generated

There are probably many things to change/improve, feel free to comment :)