### PR TITLE
Fixed #33667 -- Used --header-branding-color for branding headers in admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -895,10 +895,10 @@ a.deletelink:focus, a.deletelink:hover {
     margin: 0 20px 0 0;
     font-weight: 300;
     font-size: 1.5rem;
-    color: var(--accent);
+    color: var(--header-branding-color);
 }
 
-#branding h1, #branding h1 a:link, #branding h1 a:visited {
+#branding h1 a:link, #branding h1 a:visited {
     color: var(--accent);
 }
 


### PR DESCRIPTION
Fixes [#33667](https://code.djangoproject.com/ticket/33667)