### PR TITLE
Corrected example in Polygon docstring.

### DIFF
--- a/django/contrib/gis/geos/polygon.py
+++ b/django/contrib/gis/geos/polygon.py
@@ -21,7 +21,7 @@ class Polygon(GEOSGeometry):
         >>> poly = Polygon(shell, (hole1, hole2))
 
         >>> # Example where a tuple parameters are used:
-        >>> poly = Polygon(((0, 0), (0, 10), (10, 10), (0, 10), (0, 0)),
+        >>> poly = Polygon(((0, 0), (0, 10), (10, 10), (10, 0), (0, 0)),
         ...                ((4, 4), (4, 6), (6, 6), (6, 4), (4, 4)))
         """
         if not args:


### PR DESCRIPTION
The current example does not produce a donut, but a geometry with `area` equal to `-4.0`. This commit fixes the broken example.

For reference, the correct example in the docs: https://docs.djangoproject.com/en/4.0/ref/contrib/gis/geos/#polygon