### PR TITLE
Fixed #29538 -- Fixed crash of ordering when parent model's Meta.ordering contains expressions.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -390,6 +390,18 @@ class BaseExpression:
     def copy(self):
         return copy.copy(self)
 
+    def prefix_references(self, prefix):
+        clone = self.copy()
+        clone.set_source_expressions(
+            [
+                F(f"{prefix}__{expr.name}")
+                if isinstance(expr, F)
+                else expr.prefix_references(prefix)
+                for expr in self.get_source_expressions()
+            ]
+        )
+        return clone
+
     def get_group_by_cols(self, alias=None):
         if not self.contains_aggregate:
             return [self]

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -907,6 +907,8 @@ class SQLCompiler:
 
             results = []
             for item in opts.ordering:
+                if hasattr(item, "prefix_references"):
+                    item = item.prefix_references(name)
                 if hasattr(item, "resolve_expression") and not isinstance(
                     item, OrderBy
                 ):

--- a/tests/ordering/models.py
+++ b/tests/ordering/models.py
@@ -62,3 +62,17 @@ class Reference(models.Model):
 
     class Meta:
         ordering = ("article",)
+
+
+class OrderedByExpression(models.Model):
+    name = models.CharField(max_length=30)
+
+    class Meta:
+        ordering = (models.functions.Lower("name"),)
+
+
+class OrderedByExpressionChild(models.Model):
+    parent = models.ForeignKey(OrderedByExpression, models.CASCADE)
+
+    def __str__(self) -> str:
+        return self.parent.name

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -14,7 +14,15 @@ from django.db.models import (
 from django.db.models.functions import Upper
 from django.test import TestCase
 
-from .models import Article, Author, ChildArticle, OrderedByFArticle, Reference
+from .models import (
+    Article,
+    Author,
+    ChildArticle,
+    OrderedByExpressionChild,
+    OrderedByExpression,
+    OrderedByFArticle,
+    Reference,
+)
 
 
 class OrderingTests(TestCase):
@@ -517,6 +525,20 @@ class OrderingTests(TestCase):
             articles,
             ["Article 1", "Article 4", "Article 3", "Article 2"],
             attrgetter("headline"),
+        )
+
+    def test_order_by_fk_with_expression_in_ordering(self):
+        p3 = OrderedByExpression.objects.create(name="oBJ 3")
+        p2 = OrderedByExpression.objects.create(name="OBJ 2")
+        p1 = OrderedByExpression.objects.create(name="obj 1")
+
+        c3 = OrderedByExpressionChild.objects.create(parent=p3)
+        c2 = OrderedByExpressionChild.objects.create(parent=p2)
+        c1 = OrderedByExpressionChild.objects.create(parent=p1)
+
+        self.assertQuerysetEqual(
+            list(OrderedByExpressionChild.objects.order_by("parent")),
+            [c1, c2, c3],
         )
 
     def test_order_by_ptr_field_with_default_ordering_by_expression(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/30557 & https://code.djangoproject.com/ticket/33678