### PR TITLE
Fixed #33680 -- Corrected example of customizing model loading in docs.

### DIFF
--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -103,7 +103,9 @@ are loaded from the database::
         instance._state.adding = False
         instance._state.db = db
         # customization to store the original field values on the instance
-        instance._loaded_values = dict(zip(field_names, values))
+        instance._loaded_values = dict(
+            zip(field_names, (value for value in values if value is not DEFERRED))
+        )
         return instance
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
The documents example for customising model instance loading does not
match the field names with values. This commit fixes that by setting the
field_names to concrete field names on the class. This way the user can also
see easier if the value was loaded on the instance or it was deferred.