### PR TITLE
Corrected extract_views_from_urlpatterns()'s docstring.

### DIFF
--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -456,7 +456,8 @@ def extract_views_from_urlpatterns(urlpatterns, base="", namespace=None):
     """
     Return a list of views from a list of urlpatterns.
 
-    Each object in the returned list is a two-tuple: (view_func, regex)
+    Each object in the returned list is a four-tuple:
+    (view_func, regex, namespace, name)
     """
     views = []
     for p in urlpatterns:


### PR DESCRIPTION
Docs clearly did not match the implementation.
Related https://github.com/typeddjango/django-stubs/pull/949