### PR TITLE
Fixed #33685 -- Added documentation of test service name

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -160,6 +160,10 @@ password from the `password file`_, you must specify them in the
 .. _connection service file: https://www.postgresql.org/docs/current/libpq-pgservice.html
 .. _password file: https://www.postgresql.org/docs/current/libpq-pgpass.html
 
+.. note::
+
+    When running tests the service name ``django_test`` is used.
+
 .. versionchanged:: 4.0
 
     Support for connecting by a service name, and specifying a password file


### PR DESCRIPTION
Add note to document special service name used when running tests

Signed-off-by: Shane Ambler <Develop@Shaneware.Biz>