### PR TITLE
Refs #33173 -- Fixed test_dateparse tests on Python 3.11+.

### DIFF
--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -8,6 +8,7 @@ from django.utils.dateparse import (
     parse_time,
 )
 from django.utils.timezone import get_fixed_timezone
+from django.utils.version import PY311
 
 
 class DateParseTests(unittest.TestCase):
@@ -15,14 +16,18 @@ class DateParseTests(unittest.TestCase):
         # Valid inputs
         self.assertEqual(parse_date("2012-04-23"), date(2012, 4, 23))
         self.assertEqual(parse_date("2012-4-9"), date(2012, 4, 9))
+        if PY311:
+            self.assertEqual(parse_date("20120423"), date(2012, 4, 23))
         # Invalid inputs
-        self.assertIsNone(parse_date("20120423"))
+        self.assertIsNone(parse_date("2012423"))
         with self.assertRaises(ValueError):
             parse_date("2012-04-56")
 
     def test_parse_time(self):
         # Valid inputs
         self.assertEqual(parse_time("09:15:00"), time(9, 15))
+        if PY311:
+            self.assertEqual(parse_time("091500"), time(9, 15))
         self.assertEqual(parse_time("10:10"), time(10, 10))
         self.assertEqual(parse_time("10:20:30.400"), time(10, 20, 30, 400000))
         self.assertEqual(parse_time("10:20:30,400"), time(10, 20, 30, 400000))
@@ -35,7 +40,7 @@ class DateParseTests(unittest.TestCase):
         self.assertIsNone(parse_time("00:05:23+"))
         self.assertIsNone(parse_time("00:05:23+25:00"))
         self.assertIsNone(parse_time("4:18:101"))
-        self.assertIsNone(parse_time("091500"))
+        self.assertIsNone(parse_time("91500"))
         with self.assertRaises(ValueError):
             parse_time("09:15:90")
 


### PR DESCRIPTION
`date`/`datetime`/`time.fromisoformat()` support any valid ISO 8601 format in Python 3.11+, see https://github.com/python/cpython/issues/80010 and https://github.com/python/cpython/commit/1303f8c927227b72d9ee9eae890be4692b4d4592.