### PR TITLE
Refs #33173, Refs #30451 -- Fixed ResourceWarning from unclosed body files in ASGI handler on Python 3.11+.

### DIFF
--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -164,12 +164,15 @@ class ASGIHandler(base.BaseHandler):
         except RequestAborted:
             return
         # Request is complete and can be served.
-        set_script_prefix(self.get_script_prefix(scope))
-        await sync_to_async(signals.request_started.send, thread_sensitive=True)(
-            sender=self.__class__, scope=scope
-        )
-        # Get the request and check for basic issues.
-        request, error_response = self.create_request(scope, body_file)
+        try:
+            set_script_prefix(self.get_script_prefix(scope))
+            await sync_to_async(signals.request_started.send, thread_sensitive=True)(
+                sender=self.__class__, scope=scope
+            )
+            # Get the request and check for basic issues.
+            request, error_response = self.create_request(scope, body_file)
+        finally:
+            body_file.close()
         if request is None:
             await self.send_response(error_response, send)
             return
@@ -192,6 +195,7 @@ class ASGIHandler(base.BaseHandler):
         while True:
             message = await receive()
             if message["type"] == "http.disconnect":
+                body_file.close()
                 # Early client disconnect.
                 raise RequestAborted()
             # Add a body chunk from the message, if provided.


### PR DESCRIPTION
```
    Exception ignored in: <function SpooledTemporaryFile.__del__ at 0x7f971e1f1080>
    Traceback (most recent call last):
      File "/usr/local/lib/python3.11/tempfile.py", line 709, in __del__
    ResourceWarning: Unclosed file <tempfile.SpooledTemporaryFile object at 0x7f96fbf0a980>

```