### PR TITLE
Fixed: #33688 - custom template folder name for app directory template loader

### DIFF
--- a/django/template/engine.py
+++ b/django/template/engine.py
@@ -21,6 +21,7 @@ class Engine:
         self,
         dirs=None,
         app_dirs=False,
+        dir_name=None,
         context_processors=None,
         debug=False,
         loaders=None,
@@ -37,7 +38,7 @@ class Engine:
         if loaders is None:
             loaders = ["django.template.loaders.filesystem.Loader"]
             if app_dirs:
-                loaders += ["django.template.loaders.app_directories.Loader"]
+                loaders += [("django.template.loaders.app_directories.Loader", dir_name)]
             loaders = [("django.template.loaders.cached.Loader", loaders)]
         else:
             if app_dirs:

--- a/django/template/loaders/app_directories.py
+++ b/django/template/loaders/app_directories.py
@@ -9,5 +9,17 @@ from .filesystem import Loader as FilesystemLoader
 
 
 class Loader(FilesystemLoader):
+    """ Load templates from folders in the installed apps """
+
+    def __init__(self, engine, dir_name=None):
+        """
+        Loader for Django Templates defined in installed_apps
+        :param engine: The template engine
+        :param dir_name: The directory name in which the templates are located.
+        Default: templates
+        """
+        super().__init__(engine)
+        self.dir_name = dir_name or "templates"
+
     def get_dirs(self):
-        return get_app_template_dirs("templates")
+        return get_app_template_dirs(self.dir_name)

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -397,6 +397,10 @@ Templates
   :setting:`OPTIONS['loaders'] <TEMPLATES-OPTIONS>` isn't specified. You may
   specify ``OPTIONS['loaders']`` to override this, if necessary.
 
+* ``OPTIONS['dir_name']`` defines the name of the folder app directory template
+  loader uses. This can also be defined when defining the loader as its first
+  argument e.g. ``("django.template.loaders.cached.Loader", loaders)``
+
 Tests
 ~~~~~
 

--- a/docs/topics/templates.txt
+++ b/docs/topics/templates.txt
@@ -474,7 +474,7 @@ template engine.
 
 When :setting:`APP_DIRS <TEMPLATES-APP_DIRS>` is ``True``, ``DjangoTemplates``
 engines look for templates in the ``templates`` subdirectory of installed
-applications. This generic name was kept for backwards-compatibility.
+applications. Use ``dir_name`` in the options to set a different name
 
 ``DjangoTemplates`` engines accept the following :setting:`OPTIONS
 <TEMPLATES-OPTIONS>`:
@@ -514,6 +514,9 @@ applications. This generic name was kept for backwards-compatibility.
   :setting:`APP_DIRS <TEMPLATES-APP_DIRS>`.
 
   See :ref:`template-loaders` for details.
+
+* ``'dir_name'``: Defines the name of the template folder used in the
+  subdirectories when ``APP_DIRS`` is set to ``True``.
 
 * ``'string_if_invalid'``: the output, as a string, that the template system
   should use for invalid (e.g. misspelled) variables.

--- a/tests/template_backends/test_django.py
+++ b/tests/template_backends/test_django.py
@@ -190,11 +190,30 @@ class DjangoTemplatesTests(TemplateStringsTests):
                             "django.template.loaders.cached.Loader",
                             [
                                 "django.template.loaders.filesystem.Loader",
-                                "django.template.loaders.app_directories.Loader",
+                                ("django.template.loaders.app_directories.Loader", None)
                             ],
                         )
                     ],
                 )
+
+    def test_dir_name_app_directory_loader(self):
+        engine = DjangoTemplates(
+            {"DIRS": [], "APP_DIRS": True, "NAME": "django",
+             "OPTIONS": {'dir_name': 'custom_template_folder'}}
+        )
+        self.assertEqual(
+            engine.engine.loaders,
+            [
+                (
+                    "django.template.loaders.cached.Loader",
+                    [
+                        "django.template.loaders.filesystem.Loader",
+                        ("django.template.loaders.app_directories.Loader",
+                         "custom_template_folder")
+                    ],
+                )
+            ],
+        )
 
     def test_dirs_pathlib(self):
         engine = DjangoTemplates(

--- a/tests/template_loader/alt_templates/template_loader/custom.html
+++ b/tests/template_loader/alt_templates/template_loader/custom.html
@@ -1,0 +1,1 @@
+Custom page from template

--- a/tests/template_loader/tests.py
+++ b/tests/template_loader/tests.py
@@ -180,3 +180,40 @@ class TemplateLoaderTests(SimpleTestCase):
             ["template_loader/goodbye.html", "template_loader/hello.html"]
         )
         self.assertEqual(content, "Goodbye! (Django templates)\n")
+
+
+class CustomTemplateLoaderTests(SimpleTestCase):
+    @override_settings(
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "OPTIONS": {
+                    "loaders": [
+                        ("django.template.loaders.app_directories.Loader", "alt_templates")
+                    ],
+                },
+            },
+        ]
+    )
+    def test_custom_app_template_name(self):
+        template = select_template(
+            ["template_loader/custom.html"]
+        )
+        self.assertEqual(template.render(), "Custom page from template\n")
+
+    @override_settings(
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "APP_DIRS": True,
+                "OPTIONS": {
+                    "dir_name": "alt_templates",
+                },
+            },
+        ]
+    )
+    def test_dir_name(self):
+        template = select_template(
+            ["template_loader/custom.html"]
+        )
+        self.assertEqual(template.render(), "Custom page from template\n")


### PR DESCRIPTION
Functionality to allow for renaming of the templates folder in your app directories.

It is now possible to customise the template folder name in your app directories. Useful when one has different forms of templates (e.g. mail templates)