### PR TITLE
Made HashedFilesMixin ignore URLs without a path.

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -202,6 +202,10 @@ class HashedFilesMixin:
             # Strip off the fragment so a path-like fragment won't interfere.
             url_path, fragment = urldefrag(url)
 
+            # Ignore URLs without a path
+            if not url_path:
+                return matched
+
             if url_path.startswith("/"):
                 # Otherwise the condition above would have returned prematurely.
                 assert url_path.startswith(settings.STATIC_URL)

--- a/tests/staticfiles_tests/project/documents/cached/css/ignored.css
+++ b/tests/staticfiles_tests/project/documents/cached/css/ignored.css
@@ -5,5 +5,6 @@ body {
     background: url("data:foobar");
     background: url("chrome:foobar");
     background: url("//foobar");
+    background: url();
 }
 

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -65,7 +65,7 @@ class TestHashedFiles:
 
     def test_path_ignored_completely(self):
         relpath = self.hashed_file_path("cached/css/ignored.css")
-        self.assertEqual(relpath, "cached/css/ignored.554da52152af.css")
+        self.assertEqual(relpath, "cached/css/ignored.55e7c226dda1.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertIn(b"#foobar", content)
@@ -74,6 +74,7 @@ class TestHashedFiles:
             self.assertIn(b"data:foobar", content)
             self.assertIn(b"chrome:foobar", content)
             self.assertIn(b"//foobar", content)
+            self.assertIn(b"url()", content)
         self.assertPostCondition()
 
     def test_path_with_querystring(self):


### PR DESCRIPTION
I ran into this with patternfly, which sets up URLs like this:
--pf-c-background-image--Filter: url("#image_overlay");

When using this together with whitenoise &
WHITENOISE_KEEP_ONLY_HASHED_FILES, whitenoise tries to remove the
STATIC_ROOT. This is arguably a bug in whitenoise, but there is no point
in doing post processing for files without an url_path.

I have no idea how to test this :/ @felixxm any ideas?