### PR TITLE
Fixed #32234 - Fixed inspectdb should inform about composite keys

### DIFF
--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -111,6 +111,9 @@ class Command(BaseCommand):
                             cursor, table_name
                         )
                     )
+                    composite_key = connection.introspection.get_composite_key(
+                        cursor, table_name
+                    )
                     unique_columns = [
                         c["columns"][0]
                         for c in constraints.values()
@@ -126,6 +129,11 @@ class Command(BaseCommand):
 
                 yield ""
                 yield ""
+                if composite_key:
+                    if len(composite_key) > 1:
+                        yield "# Composite key found for table '%s'" % table_name
+                        yield "# but not yet implemented, taking the first one"
+
                 yield "class %s(models.Model):" % table2model(table_name)
                 known_models.append(table2model(table_name))
                 used_column_names = []  # Holds column names used in the table so far

--- a/django/db/backends/base/introspection.py
+++ b/django/db/backends/base/introspection.py
@@ -182,6 +182,20 @@ class BaseDatabaseIntrospection:
                 return constraint["columns"][0]
         return None
 
+    def get_composite_key(self, cursor, table_name):
+        """
+        Return the name of multiple-column primary keys for the given table.
+        """
+
+        cursor.execute(
+            "PRAGMA table_info(%s)" % self.connection.ops.quote_name(table_name)
+        )
+        primary_key_columns = []
+        for _, name, *_, pk in cursor.fetchall():
+            if pk:
+                primary_key_columns.append(name)
+        return primary_key_columns
+
     def get_constraints(self, cursor, table_name):
         """
         Retrieve any constraints or keys (unique, pk, fk, check, index)


### PR DESCRIPTION
Used `PRAGMA` keyword to solve this issue. 
Used this SQLite3 database to reproduce the issue:
`CREATE TABLE test(Cust_Id INTEGER NOT NULL, Order_Id INTEGER NOT NULL,Prod_code INTEGER NOT NULL, Prod_name VARCHAR NOT NULL, PRIMARY KEY(Cust_Id,Prod_code))`