### PR TITLE
Fixed #33681 -- Made Redis client pass CACHES["OPTIONS"] to a connection pool.

### DIFF
--- a/django/core/cache/backends/redis.py
+++ b/django/core/cache/backends/redis.py
@@ -32,9 +32,9 @@ class RedisCacheClient:
         self,
         servers,
         serializer=None,
-        db=None,
         pool_class=None,
         parser_class=None,
+        **options,
     ):
         import redis
 
@@ -58,7 +58,7 @@ class RedisCacheClient:
             parser_class = import_string(parser_class)
         parser_class = parser_class or self._lib.connection.DefaultParser
 
-        self._pool_options = {"parser_class": parser_class, "db": db}
+        self._pool_options = {"parser_class": parser_class, **options}
 
     def _get_connection_pool_index(self, write):
         # Write to the first server. Read from other servers if there are more,

--- a/docs/releases/4.0.5.txt
+++ b/docs/releases/4.0.5.txt
@@ -9,4 +9,5 @@ Django 4.0.5 fixes several bugs in 4.0.4.
 Bugfixes
 ========
 
-* ...
+* Fixed a bug in Django 4.0 where not all :setting:`OPTIONS <CACHES-OPTIONS>`
+  were passed to a Redis client (:ticket:`33681`).

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1817,6 +1817,23 @@ class RedisCacheTests(BaseCacheTests, TestCase):
         self.assertIsInstance(cache._cache._serializer.dumps(True), bytes)
         self.assertIsInstance(cache._cache._serializer.dumps("abc"), bytes)
 
+    @override_settings(
+        CACHES=caches_setting_for_tests(
+            base=RedisCache_params,
+            exclude=redis_excluded_caches,
+            OPTIONS={
+                "db": 5,
+                "socket_timeout": 0.1,
+                "retry_on_timeout": True,
+            },
+        )
+    )
+    def test_redis_pool_options(self):
+        pool = cache._cache._get_connection_pool(write=False)
+        self.assertEqual(pool.connection_kwargs["db"], 5)
+        self.assertEqual(pool.connection_kwargs["socket_timeout"], 0.1)
+        self.assertIs(pool.connection_kwargs["retry_on_timeout"], True)
+
 
 class FileBasedCachePathLibTests(FileBasedCacheTests):
     def mkdtemp(self):


### PR DESCRIPTION
ticket-33681

Thanks Ben Picolo for the report.
