### PR TITLE
Made closing in connection handlers more DRY.

### DIFF
--- a/django/core/cache/__init__.py
+++ b/django/core/cache/__init__.py
@@ -60,8 +60,7 @@ cache = ConnectionProxy(caches, DEFAULT_CACHE_ALIAS)
 def close_caches(**kwargs):
     # Some caches need to do a cleanup at the end of a request cycle. If not
     # implemented in a particular backend cache.close() is a no-op.
-    for cache in caches.all(initialized_only=True):
-        cache.close()
+    caches.close_all()
 
 
 signals.request_finished.connect(close_caches)

--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -190,14 +190,6 @@ class ConnectionHandler(BaseConnectionHandler):
         backend = load_backend(db["ENGINE"])
         return backend.DatabaseWrapper(db, alias)
 
-    def close_all(self):
-        for alias in self:
-            try:
-                connection = getattr(self._connections, alias)
-            except AttributeError:
-                continue
-            connection.close()
-
 
 class ConnectionRouter:
     def __init__(self, routers=None):

--- a/django/utils/connection.py
+++ b/django/utils/connection.py
@@ -79,3 +79,7 @@ class BaseConnectionHandler:
             # If initialized_only is True, return only initialized connections.
             if not initialized_only or hasattr(self._connections, alias)
         ]
+
+    def close_all(self):
+        for conn in self.all(initialized_only=True):
+            conn.close()


### PR DESCRIPTION
Following on from #15490 (4f92cf87b013801810226928ddd20097f6e4fccf) we can move `django.db.utils.ConnectionHandler.close_all()` to the parent `django.utils.connection.BaseConnectionHandler` class and make use of `.all(initialized_only=True)`.

Note that, while we update `django.core.cache.close_caches()` to use `.close_all()`, we cannot do the same for "old" database connections and `django.db.close_old_connections()` must remain unchanged.

This a realization of the point made about closing connections in https://github.com/django/django/pull/9272#issuecomment-735441777