### PR TITLE
Added backward compatibility test for ConnectionHandler.databases property.

### DIFF
--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -183,6 +183,9 @@ class ConnectionHandler(BaseConnectionHandler):
 
     @property
     def databases(self):
+        # Maintained for backward compatibility as some 3rd party packages have
+        # made use of this private API in the past. It is no longer used within
+        # Django itself.
         return self.settings
 
     def create_connection(self, alias):

--- a/tests/db_utils/tests.py
+++ b/tests/db_utils/tests.py
@@ -40,6 +40,14 @@ class ConnectionHandlerTests(SimpleTestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             conns["other"].ensure_connection()
 
+    def test_databases_property(self):
+        # The "databases" property is maintained for backwards compatibility
+        # with 3rd party packages. It should be an alias of the "settings"
+        # property.
+        conn = ConnectionHandler({})
+        self.assertNotEqual(conn.settings, {})
+        self.assertEqual(conn.settings, conn.databases)
+
     def test_nonexistent_alias(self):
         msg = "The connection 'nonexistent' doesn't exist."
         conns = ConnectionHandler(


### PR DESCRIPTION
The `ConnectionHandler.databases` property is no longer used within Django, but it is maintained for backward compatibility with external packages that have used this private API in the past. Let's add a test to ensure that this is not accidentally removed in the future without deprecation.

See the following comments:

- https://github.com/django/django/pull/9272#discussion_r538074131
- https://github.com/django/django/pull/15490#issuecomment-1064995358