### PR TITLE
Fixed #33702 -- Passing a request variable into default 500 and 400 error handlers

### DIFF
--- a/django/views/defaults.py
+++ b/django/views/defaults.py
@@ -96,7 +96,7 @@ def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
         return HttpResponseServerError(
             ERROR_PAGE_TEMPLATE % {"title": "Server Error (500)", "details": ""},
         )
-    return HttpResponseServerError(template.render())
+    return HttpResponseServerError(template.render(request=request))
 
 
 @requires_csrf_token
@@ -118,7 +118,7 @@ def bad_request(request, exception, template_name=ERROR_400_TEMPLATE_NAME):
         )
     # No exception content is passed to the template, to not disclose any
     # sensitive information.
-    return HttpResponseBadRequest(template.render())
+    return HttpResponseBadRequest(template.render(request=request))
 
 
 @requires_csrf_token

--- a/tests/view_tests/templates/error_page_with_request_reference.html
+++ b/tests/view_tests/templates/error_page_with_request_reference.html
@@ -1,0 +1,1 @@
+You're at {{ request.path }} url

--- a/tests/view_tests/tests/test_defaults.py
+++ b/tests/view_tests/tests/test_defaults.py
@@ -138,6 +138,20 @@ class DefaultsTests(TestCase):
             response, "exception: Testing technical 404.", status_code=404
         )
 
+    def test_custom_templates_with_request_reference(self):
+        """
+        Custom error_with_request_reference.html template renders properly
+        with default 400 and 500 handlers.
+        """
+        response = self.client.get("/server_error_with_request/")
+        self.assertContains(
+            response, "You're at /server_error_with_request/ url", status_code=500
+        )
+        response = self.client.get("/bad_request_with_request/")
+        self.assertContains(
+            response, "You're at /bad_request_with_request/ url", status_code=400
+        )
+
     def test_get_absolute_url_attributes(self):
         "A model can set attributes on the get_absolute_url method"
         self.assertTrue(

--- a/tests/view_tests/urls.py
+++ b/tests/view_tests/urls.py
@@ -17,6 +17,14 @@ urlpatterns = [
     # Default views
     path("nonexistent_url/", partial(defaults.page_not_found, exception=None)),
     path("server_error/", defaults.server_error),
+    path(
+        "server_error_with_request/",
+        views.server_error_with_request_reference_in_template,
+    ),
+    path(
+        "bad_request_with_request/",
+        views.bad_request_with_request_reference_in_template,
+    ),
     # a view that raises an exception for the debug view
     path("raises/", views.raises),
     path("raises400/", views.raises400),

--- a/tests/view_tests/views.py
+++ b/tests/view_tests/views.py
@@ -16,6 +16,7 @@ from django.views.debug import (
     technical_500_response,
 )
 from django.views.decorators.debug import sensitive_post_parameters, sensitive_variables
+from django.views.defaults import bad_request, server_error
 
 TEMPLATES_PATH = Path(__file__).resolve().parent / "templates"
 
@@ -56,6 +57,18 @@ class Raises500View(View):
             raise Exception
         except Exception:
             return technical_500_response(request, *sys.exc_info())
+
+
+def server_error_with_request_reference_in_template(request):
+    return server_error(request, template_name="error_page_with_request_reference.html")
+
+
+def bad_request_with_request_reference_in_template(request):
+    return bad_request(
+        request,
+        exception=Exception(),
+        template_name="error_page_with_request_reference.html",
+    )
 
 
 def raises400(request):


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/33702

The problem is that in any custom template rendered by `views.defaults.server_error`, the `request` variable is absent. Here I passed the `request` variable to the default `bad_request` and `server_error` handlers.
This problem does not occur with default 403 and 404 handlers, because the `request` variable is passed into `template.render()`