### PR TITLE
Fixed #33700 -- Skipped extra resolution for successful requests not ending with /

### DIFF
--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -80,7 +80,11 @@ class CommonMiddlewareTest(SimpleTestCase):
         """
         request = self.rf.get("/slash")
         r = CommonMiddleware(get_response_empty).process_request(request)
+        self.assertIsNone(r)
+        response = HttpResponseNotFound()
+        r = CommonMiddleware(get_response_empty).process_response(request, response)
         self.assertEqual(r.status_code, 301)
+        self.assertEqual(r.url, "/slash/")
 
     @override_settings(APPEND_SLASH=True)
     def test_append_slash_redirect_querystring(self):
@@ -164,6 +168,9 @@ class CommonMiddlewareTest(SimpleTestCase):
         # Use 4 slashes because of RequestFactory behavior.
         request = self.rf.get("////evil.com/security")
         r = CommonMiddleware(get_response_404).process_request(request)
+        self.assertIsNone(r)
+        response = HttpResponseNotFound()
+        r = CommonMiddleware(get_response_404).process_response(request, response)
         self.assertEqual(r.status_code, 301)
         self.assertEqual(r.url, "/%2Fevil.com/security/")
         r = CommonMiddleware(get_response_404)(request)
@@ -354,6 +361,9 @@ class CommonMiddlewareTest(SimpleTestCase):
         request = self.rf.get("/slash")
         request.META["QUERY_STRING"] = "drink=café"
         r = CommonMiddleware(get_response_empty).process_request(request)
+        self.assertIsNone(r)
+        response = HttpResponseNotFound()
+        r = CommonMiddleware(get_response_empty).process_response(request, response)
         self.assertEqual(r.status_code, 301)
 
     def test_response_redirect_class(self):


### PR DESCRIPTION
By moving a `should_redirect_with_slash` call out of an `if` block, commit 9390da7fb6e251eaa9a785692f987296cb14523f negated the performance fix of commit 434d309ef6dbecbfd2b322d3a1da78aa5cb05fa8 (https://code.djangoproject.com/ticket/24720). Meanwhile, the logging issue https://code.djangoproject.com/ticket/26293 that it targeted was subsequently fixed more fully by commit 40b69607c751c4afa453edfd41d2ed155e58187e (https://code.djangoproject.com/ticket/26504), so it is no longer needed. This effectively reverts it.

This speeds up successful requests not ending with `/` when `APPEND_SLASH` is enabled (the default, and still useful in projects with a mix of URLs with and without trailing `/`). The amount of speedup varies from about 5% in a typical project to nearly 50% on a benchmark with many routes.

Fixes https://code.djangoproject.com/ticket/33700.