### PR TITLE
Fixed Query.clone()'s docstring.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -319,7 +319,7 @@ class Query(BaseExpression):
     def clone(self):
         """
         Return a copy of the current Query. A lightweight alternative to
-        to deepcopy().
+        deepcopy().
         """
         obj = Empty()
         obj.__class__ = self.__class__


### PR DESCRIPTION
It seems like a comment misspell