### PR TITLE
Fixed #33705 -- Fixed crash when using IsNull() lookup in filters.

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -171,9 +171,10 @@ class Lookup(Expression):
         c.lhs = self.lhs.resolve_expression(
             query, allow_joins, reuse, summarize, for_save
         )
-        c.rhs = self.rhs.resolve_expression(
-            query, allow_joins, reuse, summarize, for_save
-        )
+        if hasattr(self.rhs, "resolve_expression"):
+            c.rhs = self.rhs.resolve_expression(
+                query, allow_joins, reuse, summarize, for_save
+            )
         return c
 
     def select_format(self, compiler, sql, params):

--- a/docs/releases/4.0.5.txt
+++ b/docs/releases/4.0.5.txt
@@ -11,3 +11,6 @@ Bugfixes
 
 * Fixed a bug in Django 4.0 where not all :setting:`OPTIONS <CACHES-OPTIONS>`
   were passed to a Redis client (:ticket:`33681`).
+
+* Fixed a bug in Django 4.0 that caused a crash of ``QuerySet.filter()`` on
+  ``IsNull()`` expressions (:ticket:`33705`).

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -24,6 +24,7 @@ from django.db.models.lookups import (
     Exact,
     GreaterThan,
     GreaterThanOrEqual,
+    IsNull,
     LessThan,
     LessThanOrEqual,
 )
@@ -1284,7 +1285,7 @@ class LookupQueryingTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.s1 = Season.objects.create(year=1942, gt=1942)
-        cls.s2 = Season.objects.create(year=1842, gt=1942)
+        cls.s2 = Season.objects.create(year=1842, gt=1942, nulled_text_field="text")
         cls.s3 = Season.objects.create(year=2042, gt=1942)
 
     def test_annotate(self):
@@ -1365,6 +1366,16 @@ class LookupQueryingTests(TestCase):
     def test_lookup_in_filter(self):
         qs = Season.objects.filter(GreaterThan(F("year"), 1910))
         self.assertCountEqual(qs, [self.s1, self.s3])
+
+    def test_isnull_lookup_in_filter(self):
+        self.assertSequenceEqual(
+            Season.objects.filter(IsNull(F("nulled_text_field"), False)),
+            [self.s2],
+        )
+        self.assertCountEqual(
+            Season.objects.filter(IsNull(F("nulled_text_field"), True)),
+            [self.s1, self.s3],
+        )
 
     def test_filter_lookup_lhs(self):
         qs = Season.objects.annotate(before_20=LessThan(F("year"), 2000)).filter(


### PR DESCRIPTION
Ticket https://code.djangoproject.com/ticket/33705

Made IsNull lookup usable in filters.

Since the right hand side (RHS) value in `IsNull` remains a `bool` type value, we cannot call `resolve_expression` on it, obviously.
Why it doesn't fail when using the `__isnull=` lookup? Because in `db.models.sql.query.Query.build_filter`, `IsNull` verifies `if hasattr(filter_expr, "resolve_expression"):` but `__isnull=` doesn't, so it works differently.

This PR is the simplest approach I could think of to fix the bug. It's a bit general, but should work.
Trying to use a `Value([True|False])` internally in `IsNull` (instead of a plain `bool`) could work, but it's impacting other classes and behaviours down the line, making it a bit difficult to implement in the end.