### PR TITLE
Refs #33685 -- Doc'd that using PostgreSQL's service names for testing purposes is not supported.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -165,6 +165,11 @@ password from the `password file`_, you must specify them in the
     Support for connecting by a service name, and specifying a password file
     was added.
 
+.. warning::
+
+    Using a service name for testing purposes is not supported. This
+    :ticket:`may be implemented later <33685>`.
+
 Optimizing PostgreSQL's configuration
 -------------------------------------
 


### PR DESCRIPTION
See [comment](https://code.djangoproject.com/ticket/33685#comment:13).