### PR TITLE
Fixed #33710 -- Made RenameIndex operation a noop when the old and new name match.

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -960,6 +960,9 @@ class RenameIndex(IndexOperation):
         else:
             from_model_state = from_state.models[app_label, self.model_name_lower]
             old_index = from_model_state.get_index_by_name(self.old_name)
+        # Don't alter when the index name is not changed.
+        if old_index.name == self.new_name:
+            return
 
         to_model_state = to_state.models[app_label, self.model_name_lower]
         new_index = to_model_state.get_index_by_name(self.new_name)

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -2988,6 +2988,11 @@ class OperationTests(OperationTestBase):
         with connection.schema_editor() as editor, self.assertNumQueries(0):
             operation.database_backwards(app_label, editor, new_state, project_state)
         self.assertIndexNameExists(table_name, "new_pony_test_idx")
+        # Reapply, RenameIndex operation is a noop when the old and new name
+        # match.
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, new_state, project_state)
+        self.assertIndexNameExists(table_name, "new_pony_test_idx")
         # Deconstruction.
         definition = operation.deconstruct()
         self.assertEqual(definition[0], "RenameIndex")


### PR DESCRIPTION
Tackles https://code.djangoproject.com/ticket/33710