### PR TITLE
Removed unnecessary semicolons in docs about performing raw SQL.

### DIFF
--- a/docs/topics/db/sql.txt
+++ b/docs/topics/db/sql.txt
@@ -315,15 +315,15 @@ immutable and accessible by field names or indices, which might be useful::
 
 Here is an example of the difference between the three::
 
-    >>> cursor.execute("SELECT id, parent_id FROM test LIMIT 2");
+    >>> cursor.execute("SELECT id, parent_id FROM test LIMIT 2")
     >>> cursor.fetchall()
     ((54360982, None), (54360880, None))
 
-    >>> cursor.execute("SELECT id, parent_id FROM test LIMIT 2");
+    >>> cursor.execute("SELECT id, parent_id FROM test LIMIT 2")
     >>> dictfetchall(cursor)
     [{'parent_id': None, 'id': 54360982}, {'parent_id': None, 'id': 54360880}]
 
-    >>> cursor.execute("SELECT id, parent_id FROM test LIMIT 2");
+    >>> cursor.execute("SELECT id, parent_id FROM test LIMIT 2")
     >>> results = namedtuplefetchall(cursor)
     >>> results
     [Result(id=54360982, parent_id=None), Result(id=54360880, parent_id=None)]


### PR DESCRIPTION
Remove the trailing `;` given these are not required or typically used in python code - but also given the example involves SQL code, there's a (hopefully small! but possibly still real) possibility of confusion for new users that perhaps the `;` is ending the SQL statement somehow, though of course it isn't being outside the quotes & brackets.

I realise this is a very small change so wasn't sure:
 - whether a CLA was required (https://www.djangoproject.com/foundation/cla/faq/ suggests perhaps not given how trivial this is)
 - whether to add myself to `AUTHORS` (feels a bit cheeky, I'm quite happy to wait until I submit something more substantial!)

Hopefully this patch is acceptable without an accompanying ticket per the start of https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/submitting-patches/
This is my first contribution to Django so please let me know if I've done something wrong & I'll not be offended!