### PR TITLE
Fixed #33653 -- Fixed template crash when calling methods for built-in types without required arguments.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -913,15 +913,18 @@ class Variable:
                         try:  # method call (assuming no args required)
                             current = current()
                         except TypeError:
-                            signature = inspect.signature(current)
                             try:
-                                signature.bind()
-                            except TypeError:  # arguments *were* required
-                                current = (
-                                    context.template.engine.string_if_invalid
-                                )  # invalid method call
+                                signature = inspect.signature(current)
+                            except ValueError:  # No signature found.
+                                current = context.template.engine.string_if_invalid
                             else:
-                                raise
+                                try:
+                                    signature.bind()
+                                except TypeError:  # Arguments *were* required.
+                                    # Invalid method call.
+                                    current = context.template.engine.string_if_invalid
+                                else:
+                                    raise
         except Exception as e:
             template_name = getattr(context, "template_name", None) or "unknown"
             logger.debug(

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -183,6 +183,14 @@ class TemplateTestMixin:
         for node in template.nodelist:
             self.assertEqual(node.origin, template.origin)
 
+    def test_render_built_in_type_method(self):
+        """
+        Templates should not crash when rendering methods for built-in types
+        without required arguments.
+        """
+        template = self._engine().from_string("{{ description.count }}")
+        self.assertEqual(template.render(Context({"description": "test"})), "")
+
 
 class TemplateTests(TemplateTestMixin, SimpleTestCase):
     debug_engine = False


### PR DESCRIPTION
return empty content for methods on built-in types. e.g.
we should render {{ some_str.count }} as an empty string, instead of crashing the page