### PR TITLE
Refs #33379 -- Fixed minimum supported version of MariaDB.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -52,7 +52,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def minimum_database_version(self):
         if self.connection.mysql_is_mariadb:
-            return (10, 2)
+            return (10, 3)
         else:
             return (5, 7)
 

--- a/tests/backends/mysql/tests.py
+++ b/tests/backends/mysql/tests.py
@@ -107,8 +107,8 @@ class Tests(TestCase):
     @mock.patch.object(connection, "get_database_version")
     def test_check_database_version_supported(self, mocked_get_database_version):
         if connection.mysql_is_mariadb:
-            mocked_get_database_version.return_value = (10, 1)
-            msg = "MariaDB 10.2 or later is required (found 10.1)."
+            mocked_get_database_version.return_value = (10, 2)
+            msg = "MariaDB 10.3 or later is required (found 10.2)."
         else:
             mocked_get_database_version.return_value = (5, 6)
             msg = "MySQL 5.7 or later is required (found 5.6)."


### PR DESCRIPTION
This is a bug in 9ac3ef59f9538cfb520e3607af743532434d1755, so it should be backported to 4.1 before releasing 4.1a1.

MariaDB < 10.3 is not supported by [Django 4.1+](https://docs.djangoproject.com/en/dev/ref/databases/#mariadb-notes-1).