### PR TITLE
Fixed #33719 -- Fixed test command crash when running in parallel.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -11,7 +11,6 @@ import subprocess
 import sys
 import tempfile
 import warnings
-from functools import partial
 from pathlib import Path
 
 try:
@@ -26,7 +25,7 @@ else:
     from django.core.exceptions import ImproperlyConfigured
     from django.db import connection, connections
     from django.test import TestCase, TransactionTestCase
-    from django.test.runner import _init_worker, get_max_test_processes, parallel_type
+    from django.test.runner import get_max_test_processes, parallel_type
     from django.test.selenium import SeleniumTestCaseBase
     from django.test.utils import NullTimeKeeper, TimeKeeper, get_runner
     from django.utils.deprecation import (
@@ -405,11 +404,8 @@ def django_tests(
             parallel = 1
 
     TestRunner = get_runner(settings)
-    TestRunner.parallel_test_suite.init_worker = partial(
-        _init_worker,
-        process_setup=setup_run_tests,
-        process_setup_args=process_setup_args,
-    )
+    TestRunner.parallel_test_suite.process_setup = setup_run_tests
+    TestRunner.parallel_test_suite.process_setup_args = process_setup_args
     test_runner = TestRunner(
         verbosity=verbosity,
         interactive=interactive,


### PR DESCRIPTION
Thanks Pēteris Caune for the report.

ticket-33719
Regression in 3b3f38b3b09b0f2373e51406ecb8c9c45d36aebc.

``ParallelTestSuite.init_worker`` is a method so we should pass to `self.init_worker.__func__` to the `multiprocessing.Pool()`'s `initializer`.

It was changed in 3b3f38b3b09b0f2373e51406ecb8c9c45d36aebc to allow passing `functools.partial` that is no longer a method. We should avoid changing `init_worker` to a function and pass extra kwargs via the test suite.