### PR TITLE
Refs #24638 -- Added support for SQL comments in queries.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1702,7 +1702,7 @@ class QuerySet:
         return clone
 
     def comment(self, message):
-        """Adds a comment to be inserted into the query."""
+        """Add a comment to the query."""
         clone = self._clone()
         if "/*" in message or "*/" in message:
             raise ValueError(

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1701,6 +1701,17 @@ class QuerySet:
         clone._db = alias
         return clone
 
+    def comment(self, message):
+        """Adds a comment to be inserted into the query."""
+        clone = self._clone()
+        if "/*" in message or "*/" in message:
+            raise ValueError(
+                "Cannot pass strings containing /* or */ to comment(). "
+                "Escape or strip these delimiters before calling comment()."
+            )
+        clone.query.comments = (*clone.query.comments, message)
+        return clone
+
     ###################################
     # PUBLIC INTROSPECTION ATTRIBUTES #
     ###################################

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -629,9 +629,7 @@ class SQLCompiler:
                     params += distinct_params
 
                 if self.query.comments:
-                    result.append(
-                        " ".join(f"/*{comment}*/" for comment in self.query.comments)
-                    )
+                    result += (f"/* {comment} */" for comment in self.query.comments)
 
                 out_cols = []
                 col_idx = 1
@@ -1802,8 +1800,8 @@ class SQLUpdateCompiler(SQLCompiler):
         table = self.query.base_table
         result = ["UPDATE"]
         if self.query.comments:
-            result.append(" ".join(f"/*{comment}*/" for comment in self.query.comments))
-        result.extend(["%s SET" % qn(table), ", ".join(values)])
+            result += (f"/* {comment} */" for comment in self.query.comments)
+        result += (qn(table), "SET", ", ".join(values))
         where, params = self.compile(self.query.where)
         if where:
             result.append("WHERE %s" % where)

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -629,7 +629,7 @@ class SQLCompiler:
                     params += distinct_params
 
                 if self.query.comments:
-                    result += (f"/* {comment} */" for comment in self.query.comments)
+                    result += (self.comments_sql(),)
 
                 out_cols = []
                 col_idx = 1
@@ -1450,6 +1450,9 @@ class SQLCompiler:
             else:
                 yield row
 
+    def comments_sql(self):
+        return " ".join([f"/* {comment} */" for comment in self.query.comments])
+
 
 class SQLInsertCompiler(SQLCompiler):
     returning_fields = None
@@ -1800,7 +1803,7 @@ class SQLUpdateCompiler(SQLCompiler):
         table = self.query.base_table
         result = ["UPDATE"]
         if self.query.comments:
-            result += (f"/* {comment} */" for comment in self.query.comments)
+            result += (self.comments_sql(),)
         result += (qn(table), "SET", ", ".join(values))
         where, params = self.compile(self.query.where)
         if where:

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -628,6 +628,11 @@ class SQLCompiler:
                     result += distinct_result
                     params += distinct_params
 
+                if self.query.comments:
+                    result.append(
+                        " ".join(f"/*{comment}*/" for comment in self.query.comments)
+                    )
+
                 out_cols = []
                 col_idx = 1
                 for _, (s_sql, s_params), alias in self.select + extra_select:
@@ -1795,10 +1800,10 @@ class SQLUpdateCompiler(SQLCompiler):
             else:
                 values.append("%s = NULL" % qn(name))
         table = self.query.base_table
-        result = [
-            "UPDATE %s SET" % qn(table),
-            ", ".join(values),
-        ]
+        result = ["UPDATE"]
+        if self.query.comments:
+            result.append(" ".join(f"/*{comment}*/" for comment in self.query.comments))
+        result.extend(["%s SET" % qn(table), ", ".join(values)])
         where, params = self.compile(self.query.where)
         if where:
             result.append("WHERE %s" % where)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -226,6 +226,7 @@ class Query(BaseExpression):
     deferred_loading = (frozenset(), True)
 
     explain_info = None
+    comments = ()
 
     def __init__(self, model, alias_cols=True):
         self.model = model

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1901,21 +1901,11 @@ Adds an SQL comment to be inserted into the resultant SQL statement, after
 
 ...translates (roughly) into the following SQL::
 
-    SELECT /*blog/views.py:50*/ blog_entry.* FROM blog_entry
+    SELECT /* blog/views.py:50 */ blog_entry.* FROM blog_entry
 
 This is useful for adding information to the SQL statement which when logged
 can be used to correlate slow and problematic queries to the generating source
 code.
-
-It can also be used to pass optimizer hints to supporting database engines.
-For example, on MySQL you can force the join order by setting the
-``STRAIGHT_JOIN`` hint with ``comment()`` like so::
-
-    Entry.objects.select_related('blog').comment("! STRAIGHT_JOIN").all()
-
-This results in the specially interpreted 'non-comment' comment::
-
-    SELECT /*! STRAIGHT_JOIN */ blog_entry.*, blog_blog.* FROM ...
 
 .. note::
 
@@ -1934,7 +1924,7 @@ entries, for example::
 
 ...translates into::
 
-    UPDATE blog_entry.* /*blog/views.py:75*/ /*python=3.11*/ SET "headline" = 'This is new'
+    UPDATE blog_entry.* /* blog/views.py:75 */ /* python=3.11 */ SET "headline" = 'This is new'
 
 Operators that return new ``QuerySet``\s
 ----------------------------------------

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1899,21 +1899,13 @@ Adds an SQL comment to be inserted into the resultant SQL statement, after
 
     Entry.objects.comment("blog/views.py:50").all()
 
-...translates (roughly) into the following SQL::
+… translates (roughly) into the following SQL::
 
     SELECT /* blog/views.py:50 */ blog_entry.* FROM blog_entry
 
 This is useful for adding information to the SQL statement which when logged
 can be used to correlate slow and problematic queries to the generating source
 code.
-
-.. note::
-
-    The SQL block comment delimiters, ``/*`` and ``*/`` are added automatically.
-    To protect against SQL injection attacks and invalid queries any
-    combination of ``/*`` and ``*/`` present in the comment will raise an
-    exception. Strip or escape these delimiters from the comment to
-    circumvent this.
 
 Comments can be chained and will be added to the SQL statement as separate
 entries, for example::
@@ -1922,7 +1914,7 @@ entries, for example::
         headline="This is new"
     )
 
-...translates into::
+… translates into::
 
     UPDATE blog_entry.* /* blog/views.py:75 */ /* python=3.11 */ SET "headline" = 'This is new'
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1887,6 +1887,55 @@ See the :doc:`/topics/db/sql` for more information.
   filtering. As such, it should generally be called from the ``Manager`` or
   from a fresh ``QuerySet`` instance.
 
+``comment()``
+~~~~~~~~~~~~~
+
+.. versionadded:: 4.2
+
+.. method:: comment(message)
+
+Adds an SQL comment to be inserted into the resultant SQL statement, after
+``SELECT``/``UPDATE``, and if applicable, ``DISTINCT``.. For example::
+
+    Entry.objects.comment("blog/views.py:50").all()
+
+...translates (roughly) into the following SQL::
+
+    SELECT /*blog/views.py:50*/ blog_entry.* FROM blog_entry
+
+This is useful for adding information to the SQL statement which when logged
+can be used to correlate slow and problematic queries to the generating source
+code.
+
+It can also be used to pass optimizer hints to supporting database engines.
+For example, on MySQL you can force the join order by setting the
+``STRAIGHT_JOIN`` hint with ``comment()`` like so::
+
+    Entry.objects.select_related('blog').comment("! STRAIGHT_JOIN").all()
+
+This results in the specially interpreted 'non-comment' comment::
+
+    SELECT /*! STRAIGHT_JOIN */ blog_entry.*, blog_blog.* FROM ...
+
+.. note::
+
+    The SQL block comment delimiters, ``/*`` and ``*/`` are added automatically.
+    To protect against SQL injection attacks and invalid queries any
+    combination of ``/*`` and ``*/`` present in the comment will raise an
+    exception. Strip or escape these delimiters from the comment to
+    circumvent this.
+
+Comments can be chained and will be added to the SQL statement as separate
+entries, for example::
+
+    Entry.objects.comment("blog/views.py:50").comment("python=3.11").update(
+        headline="This is new"
+    )
+
+...translates into::
+
+    UPDATE blog_entry.* /*blog/views.py:75*/ /*python=3.11*/ SET "headline" = 'This is new'
+
 Operators that return new ``QuerySet``\s
 ----------------------------------------
 

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -163,7 +163,9 @@ Migrations
 Models
 ~~~~~~
 
-* ...
+* The new :meth:`.QuerySet.comment` method allows for injecting comments into
+  the generated SQL statements. This can be useful for traceability and adding
+  optimizer hints for supporting backends.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -164,8 +164,8 @@ Models
 ~~~~~~
 
 * The new :meth:`.QuerySet.comment` method allows for injecting comments into
-  the generated SQL statements. This can be useful for traceability and adding
-  optimizer hints for supporting backends.
+  the generated SQL statements. This can be useful for correlating troublesome
+  queries to the application code.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -720,6 +720,7 @@ class ManagerTest(SimpleTestCase):
         "alatest",
         "aupdate",
         "aupdate_or_create",
+        "comment",
     ]
 
     def test_manager_methods(self):

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -702,6 +702,7 @@ class ManagerTest(SimpleTestCase):
         "union",
         "intersection",
         "difference",
+        "comment",
         "aaggregate",
         "abulk_create",
         "abulk_update",
@@ -720,7 +721,6 @@ class ManagerTest(SimpleTestCase):
         "alatest",
         "aupdate",
         "aupdate_or_create",
-        "comment",
     ]
 
     def test_manager_methods(self):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -4556,8 +4556,8 @@ class TestComment(TestCase):
         with CaptureQueriesContext(connection) as captured_queries:
             list(NamedCategory.objects.comment("! STRAIGHT_JOIN"))
             list(NamedCategory.objects.comment("").comment("some comment"))
-        self.assertIn("SELECT /*! STRAIGHT_JOIN*/ ", captured_queries[0]["sql"])
-        self.assertIn("SELECT /**/ /*some comment*/ ", captured_queries[1]["sql"])
+        self.assertIn("SELECT /* ! STRAIGHT_JOIN */ ", captured_queries[0]["sql"])
+        self.assertIn("SELECT /*  */ /* some comment */ ", captured_queries[1]["sql"])
 
     def test_select_subquery(self):
         with CaptureQueriesContext(connection) as captured_queries:
@@ -4571,8 +4571,8 @@ class TestComment(TestCase):
                 ).comment("a comment")
             )
         sql = captured_queries[0]["sql"]
-        self.assertIn("(SELECT /*a subquery comment*/ ", sql)
-        self.assertIn("SELECT /*a comment*/ ", sql)
+        self.assertIn("(SELECT /* a subquery comment */ ", sql)
+        self.assertIn("SELECT /* a comment */ ", sql)
 
     def test_select_aggregate(self):
         with CaptureQueriesContext(connection) as captured_queries:
@@ -4580,12 +4580,12 @@ class TestComment(TestCase):
                 tag_per_parent=Count("pk")
             ).aggregate(Max("tag_per_parent")),
         sql = captured_queries[0]["sql"]
-        self.assertIn("(SELECT /*a subquery comment*/ ", sql)
+        self.assertIn("(SELECT /* a subquery comment */ ", sql)
 
     def test_update(self):
         with CaptureQueriesContext(connection) as captured_queries:
             NamedCategory.objects.comment("this is an update").update(name="monty")
-        self.assertIn("UPDATE /*this is an update*/ ", captured_queries[0]["sql"])
+        self.assertIn("UPDATE /* this is an update */ ", captured_queries[0]["sql"])
 
     def test_stops_delimiters_in_message(self):
         for message in ["foo=/a/b/c*/", "/*foo=/a/b/c", "**//SELECT nothing;//**"]:

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -4549,3 +4549,49 @@ class Ticket23622Tests(TestCase):
             set(Ticket23605A.objects.filter(qy).values_list("pk", flat=True)),
         )
         self.assertSequenceEqual(Ticket23605A.objects.filter(qx), [a2])
+
+
+class TestComment(TestCase):
+    def test_select(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            list(NamedCategory.objects.comment("! STRAIGHT_JOIN"))
+            list(NamedCategory.objects.comment("").comment("some comment"))
+        self.assertIn("SELECT /*! STRAIGHT_JOIN*/ ", captured_queries[0]["sql"])
+        self.assertIn("SELECT /**/ /*some comment*/ ", captured_queries[1]["sql"])
+
+    def test_select_subquery(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            list(
+                NamedCategory.objects.annotate(
+                    foo=(
+                        Tag.objects.filter(category=OuterRef("id"))
+                        .comment("a subquery comment")
+                        .values("name")[:1]
+                    )
+                ).comment("a comment")
+            )
+        sql = captured_queries[0]["sql"]
+        self.assertIn("(SELECT /*a subquery comment*/ ", sql)
+        self.assertIn("SELECT /*a comment*/ ", sql)
+
+    def test_select_aggregate(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            Tag.objects.comment("a subquery comment").values("parent").annotate(
+                tag_per_parent=Count("pk")
+            ).aggregate(Max("tag_per_parent")),
+        sql = captured_queries[0]["sql"]
+        self.assertIn("(SELECT /*a subquery comment*/ ", sql)
+
+    def test_update(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            NamedCategory.objects.comment("this is an update").update(name="monty")
+        self.assertIn("UPDATE /*this is an update*/ ", captured_queries[0]["sql"])
+
+    def test_stops_delimiters_in_message(self):
+        for message in ["foo=/a/b/c*/", "/*foo=/a/b/c", "**//SELECT nothing;//**"]:
+            with self.assertRaisesMessage(
+                ValueError,
+                "Cannot pass strings containing /* or */ to comment(). "
+                "Escape or strip these delimiters before calling comment().",
+            ):
+                NamedCategory.objects.comment(message)

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -4588,10 +4588,11 @@ class TestComment(TestCase):
         self.assertIn("UPDATE /* this is an update */ ", captured_queries[0]["sql"])
 
     def test_stops_delimiters_in_message(self):
-        for message in ["foo=/a/b/c*/", "/*foo=/a/b/c", "**//SELECT nothing;//**"]:
-            with self.assertRaisesMessage(
-                ValueError,
+        for comment in ["foo=/a/b/c*/", "/*foo=/a/b/c", "**//SELECT nothing;//**"]:
+            msg = (
                 "Cannot pass strings containing /* or */ to comment(). "
-                "Escape or strip these delimiters before calling comment().",
-            ):
-                NamedCategory.objects.comment(message)
+                "Escape or strip these delimiters before calling comment()."
+            )
+
+            with self.subTest(comment), self.assertRaisesMessage(ValueError, msg):
+                NamedCategory.objects.comment(comment)


### PR DESCRIPTION
[Ticket 24638](https://code.djangoproject.com/ticket/24638#ticket)

This PR tries to bring back life into this ticket which last stalled in https://github.com/django/django/pull/4495. I think it would be a useful addition to Django for adding traceability into stuff like logged slow queries.

I stuck with using the C-style block comment delimiters (`/**/`) instead of the double-dash (`--`) as the later require a line break to mark the end of the comment and that felt off since to my knowledge we previously haven't output any line breaks in queries. The downside of using the block comments it that they are harder to sanitize but recursively stripping the delimiters using a regex should be sufficient.  

Except for sanitation of the input this PR changes so that the comments ends up at the end of the statement, it also allows chaining of comments. This aligns the behaviour with how [Ruby on Rails does it](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-annotate). The [sqlcommenter specification](https://google.github.io/sqlcommenter/spec/) used for distributed tracing also expects comments at the end of the statement. 

Adding the comment at the end of the statement stops this method from being used to add optimizer hints on supporting databases but I think that should be treated as a separate ticket.
