### PR TITLE
Refs #33725 -- Replaced deprecated find_element_by_css_selector() with find_elements(By.CSS_SELECTOR, …).

### DIFF
--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -148,13 +148,13 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.assertEqual(toggle_button.get_attribute("aria-label"), "Toggle navigation")
         for link in self.selenium.find_elements(By.CSS_SELECTOR, "#nav-sidebar a"):
             self.assertEqual(link.get_attribute("tabIndex"), "0")
-        filter_input = self.selenium.find_element_by_css_selector("#nav-filter")
+        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#nav-filter")
         self.assertEqual(filter_input.get_attribute("tabIndex"), "0")
         toggle_button.click()
         # Hidden sidebar is not reachable via keyboard navigation.
         for link in self.selenium.find_elements(By.CSS_SELECTOR, "#nav-sidebar a"):
             self.assertEqual(link.get_attribute("tabIndex"), "-1")
-        filter_input = self.selenium.find_element_by_css_selector("#nav-filter")
+        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#nav-filter")
         self.assertEqual(filter_input.get_attribute("tabIndex"), "-1")
         main_element = self.selenium.find_element(By.CSS_SELECTOR, "#main")
         self.assertNotIn("shifted", main_element.get_attribute("class").split())
@@ -192,12 +192,12 @@ class SeleniumTests(AdminSeleniumTestCase):
         # Hidden sidebar is not reachable via keyboard navigation.
         for link in self.selenium.find_elements(By.CSS_SELECTOR, "#nav-sidebar a"):
             self.assertEqual(link.get_attribute("tabIndex"), "-1")
-        filter_input = self.selenium.find_element_by_css_selector("#nav-filter")
+        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#nav-filter")
         self.assertEqual(filter_input.get_attribute("tabIndex"), "-1")
         toggle_button.click()
         for link in self.selenium.find_elements(By.CSS_SELECTOR, "#nav-sidebar a"):
             self.assertEqual(link.get_attribute("tabIndex"), "0")
-        filter_input = self.selenium.find_element_by_css_selector("#nav-filter")
+        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#nav-filter")
         self.assertEqual(filter_input.get_attribute("tabIndex"), "0")
         self.assertEqual(
             self.selenium.execute_script(


### PR DESCRIPTION
I missed this in 90dcf271147693a8897f644c4c8943c5b73c02f8 :confused: .