### PR TITLE
Refs #22078 -- Added syndication test for feeds with callable objects.

### DIFF
--- a/tests/syndication_tests/feeds.py
+++ b/tests/syndication_tests/feeds.py
@@ -39,6 +39,14 @@ class TestRss2Feed(views.Feed):
     item_copyright = "Copyright (c) 2007, Sally Smith"
 
 
+class TestRss2FeedWithCallableObject(TestRss2Feed):
+    class TimeToLive:
+        def __call__(self):
+            return 700
+
+    ttl = TimeToLive()
+
+
 class TestRss2FeedWithGuidIsPermaLinkTrue(TestRss2Feed):
     def item_guid_is_permalink(self, item):
         return True

--- a/tests/syndication_tests/tests.py
+++ b/tests/syndication_tests/tests.py
@@ -196,6 +196,12 @@ class SyndicationFeedTest(FeedTestCase):
                 item.getElementsByTagName("guid")[0].attributes.get("isPermaLink")
             )
 
+    def test_rss2_feed_with_callable_object(self):
+        response = self.client.get("/syndication/rss2/with-callable-object/")
+        doc = minidom.parseString(response.content)
+        chan = doc.getElementsByTagName("rss")[0].getElementsByTagName("channel")[0]
+        self.assertChildNodeContent(chan, {"ttl": "700"})
+
     def test_rss2_feed_guid_permalink_false(self):
         """
         Test if the 'isPermaLink' attribute of <guid> element of an item

--- a/tests/syndication_tests/urls.py
+++ b/tests/syndication_tests/urls.py
@@ -4,6 +4,9 @@ from . import feeds
 
 urlpatterns = [
     path("syndication/rss2/", feeds.TestRss2Feed()),
+    path(
+        "syndication/rss2/with-callable-object/", feeds.TestRss2FeedWithCallableObject()
+    ),
     path("syndication/rss2/articles/<int:entry_id>/", feeds.TestGetObjectFeed()),
     path(
         "syndication/rss2/guid_ispermalink_true/",


### PR DESCRIPTION
This PR applies the [felixxm's comment](https://github.com/django/django/pull/15648/files#r877869322) about cover two lines of syndication views code:

**Before:**
![image](https://user-images.githubusercontent.com/16822952/169716396-cac0777e-1549-4a84-9a91-303d91945733.png)

**After:**
![image](https://user-images.githubusercontent.com/16822952/169716405-735837b6-d85a-45c2-93a2-9c8f496d21c6.png)

**To run the new specific test please do:**
`./runtests.py syndication_tests.tests.SyndicationFeedTest.test_rss2_feed_with_callable_object`