### PR TITLE
Refs #22078 -- Added syndication test for feeds with static methods.

### DIFF
--- a/tests/syndication_tests/feeds.py
+++ b/tests/syndication_tests/feeds.py
@@ -47,6 +47,12 @@ class TestRss2FeedWithCallableObject(TestRss2Feed):
     ttl = TimeToLive()
 
 
+class TestRss2FeedWithStaticMethod(TestRss2Feed):
+    @staticmethod
+    def categories():
+        return ("javascript", "vue")
+
+
 class TestRss2FeedWithGuidIsPermaLinkTrue(TestRss2Feed):
     def item_guid_is_permalink(self, item):
         return True

--- a/tests/syndication_tests/tests.py
+++ b/tests/syndication_tests/tests.py
@@ -202,6 +202,12 @@ class SyndicationFeedTest(FeedTestCase):
         chan = doc.getElementsByTagName("rss")[0].getElementsByTagName("channel")[0]
         self.assertChildNodeContent(chan, {"ttl": "700"})
 
+    def test_rss2_feed_with_static_methods(self):
+        response = self.client.get("/syndication/rss2/with-static-methods/")
+        doc = minidom.parseString(response.content)
+        chan = doc.getElementsByTagName("rss")[0].getElementsByTagName("channel")[0]
+        self.assertCategories(chan, ["javascript", "vue"])
+
     def test_rss2_feed_guid_permalink_false(self):
         """
         Test if the 'isPermaLink' attribute of <guid> element of an item

--- a/tests/syndication_tests/urls.py
+++ b/tests/syndication_tests/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path(
         "syndication/rss2/with-callable-object/", feeds.TestRss2FeedWithCallableObject()
     ),
+    path("syndication/rss2/with-static-methods/", feeds.TestRss2FeedWithStaticMethod()),
     path("syndication/rss2/articles/<int:entry_id>/", feeds.TestGetObjectFeed()),
     path(
         "syndication/rss2/guid_ispermalink_true/",


### PR DESCRIPTION
This PR applies the [felixxm's comment](https://github.com/django/django/pull/15648#discussion_r881247655) about add test for feeds with methods decorated by @staticmethod