### PR TITLE
Fixed #33728 -- Reordered submit buttons in admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -506,7 +506,6 @@ a.button {
 }
 
 .button.default, input[type=submit].default, .submit-row input.default {
-    float: right;
     border: none;
     font-weight: 400;
     background: var(--default-button-bg);

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -259,7 +259,6 @@ fieldset.monospace textarea {
     background: var(--darkened-bg);
     border: 1px solid var(--hairline-color);
     border-radius: 4px;
-    text-align: right;
     overflow: hidden;
 }
 
@@ -270,11 +269,10 @@ body.popup .submit-row {
 .submit-row input {
     height: 35px;
     line-height: 15px;
-    margin: 0 0 5px 5px;
+    margin: 0 5px 5px 0;
 }
 
 .submit-row input.default {
-    margin: 0 0 5px 8px;
     text-transform: uppercase;
 }
 
@@ -283,7 +281,7 @@ body.popup .submit-row {
 }
 
 .submit-row p.deletelink-box {
-    float: left;
+    float: right;
     margin: 0;
 }
 

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -239,10 +239,6 @@ input[type="submit"], button {
         padding: 10px 7px;
     }
 
-    .submit-row input.default {
-        margin: 0 0 5px 5px;
-    }
-
     .button, input[type=submit], input[type=button], .submit-row input, a.button {
         padding: 7px;
     }

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -114,16 +114,16 @@ thead th.sorted .text {
     float: right;
 }
 
-.submit-row {
-    text-align: left
-}
-
 .submit-row p.deletelink-box {
-    float: right;
+    float: left;
 }
 
 .submit-row input.default {
-    margin-left: 0;
+    margin: 0 0 5px 5px;
+}
+
+.submit-row input {
+    margin: 0 0 5px 5px;
 }
 
 .vDateField, .vTimeField {
@@ -149,8 +149,8 @@ form ul.inline li {
     padding-left: 7px;
 }
 
-input[type=submit].default, .submit-row input.default {
-    float: left;
+.submit-row {
+    text-align: right;
 }
 
 fieldset .fieldBox {

--- a/django/contrib/admin/templates/admin/submit_line.html
+++ b/django/contrib/admin/templates/admin/submit_line.html
@@ -2,13 +2,13 @@
 <div class="submit-row">
 {% block submit-row %}
 {% if show_save %}<input type="submit" value="{% translate 'Save' %}" class="default" name="_save">{% endif %}
-{% if show_delete_link and original %}
-    {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
-    <p class="deletelink-box"><a href="{% add_preserved_filters delete_url %}" class="deletelink">{% translate "Delete" %}</a></p>
-{% endif %}
 {% if show_save_as_new %}<input type="submit" value="{% translate 'Save as new' %}" name="_saveasnew">{% endif %}
 {% if show_save_and_add_another %}<input type="submit" value="{% translate 'Save and add another' %}" name="_addanother">{% endif %}
 {% if show_save_and_continue %}<input type="submit" value="{% if can_change %}{% translate 'Save and continue editing' %}{% else %}{% translate 'Save and view' %}{% endif %}" name="_continue">{% endif %}
 {% if show_close %}<a href="{% url opts|admin_urlname:'changelist' %}" class="closelink">{% translate 'Close' %}</a>{% endif %}
+{% if show_delete_link and original %}
+    {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
+    <p class="deletelink-box"><a href="{% add_preserved_filters delete_url %}" class="deletelink">{% translate "Delete" %}</a></p>
+{% endif %}
 {% endblock %}
 </div>


### PR DESCRIPTION
This aims to clear up the visual order of the submit row buttons in Django admin forms. I've reordered them for both LTR and RTL languages so that they follow the flow of other form elements.

Before:
![oldLTR](https://user-images.githubusercontent.com/24865043/170485492-f54043b1-d2a0-4b9c-a16e-6d0e0ad41786.PNG)
![oldRTL](https://user-images.githubusercontent.com/24865043/170485513-392f5466-6b25-4d63-a172-61f26fa80acf.PNG)

After:
![newLTR](https://user-images.githubusercontent.com/24865043/170485543-3c5afd58-9c35-4390-8f92-becc4b0ab862.PNG)
![newRTL](https://user-images.githubusercontent.com/24865043/170485551-24fc1ddc-e089-4591-b343-1edd09ffd4c7.PNG)

