### PR TITLE
Refs #33697 -- Fixed multipart parsing of headers with double quotes and semicolons.

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -748,7 +748,7 @@ def _parse_header_params(s):
     while s[:1] == b";":
         s = s[1:]
         end = s.find(b";")
-        while end > 0 and s.count(b'"', 0, end) % 2:
+        while end > 0 and (s.count(b'"', 0, end) - s.count(b'\\"', 0, end)) % 2:
             end = s.find(b";", end + 1)
         if end < 0:
             end = len(s)

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -944,3 +944,9 @@ class MultiParserTests(SimpleTestCase):
         for raw_line, expected_title in test_data:
             parsed = parse_header(raw_line)
             self.assertEqual(parsed[1]["title"], expected_title)
+
+    def test_parse_header_with_double_quotes_and_semicolon(self):
+        self.assertEqual(
+            parse_header(b'form-data; name="files"; filename="fo\\"o;bar"'),
+            ("form-data", {"name": b"files", "filename": b'fo"o;bar'}),
+        )


### PR DESCRIPTION
@felixxm Unifying the logic of "http.multipartparser.parse_header" and "utils.http.parse_header_parameters", in order to refactor the two functions on the next step.