### PR TITLE
Fixed #33631 -- Marked {% blocktranslate asvar %} result as HTML safe.

### DIFF
--- a/django/templatetags/i18n.py
+++ b/django/templatetags/i18n.py
@@ -5,7 +5,7 @@ from django.template import Library, Node, TemplateSyntaxError, Variable
 from django.template.base import TokenType, render_value_in_context
 from django.template.defaulttags import token_kwargs
 from django.utils import translation
-from django.utils.safestring import SafeData, mark_safe
+from django.utils.safestring import SafeData, SafeString, mark_safe
 
 register = Library()
 
@@ -198,7 +198,7 @@ class BlockTranslateNode(Node):
             with translation.override(None):
                 result = self.render(context, nested=True)
         if self.asvar:
-            context[self.asvar] = result
+            context[self.asvar] = SafeString(result)
             return ""
         else:
             return result

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -270,6 +270,9 @@ Miscellaneous
 * The undocumented ``django.http.multipartparser.parse_header()`` function is
   removed. Use ``django.utils.http.parse_header_parameters()`` instead.
 
+* :ttag:`{% blocktranslate asvar … %}<blocktranslate>` result is now marked as
+  safe for (HTML) output purposes.
+
 .. _deprecated-features-4.2:
 
 Features deprecated in 4.2

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -707,6 +707,11 @@ In practice you'll use this to get a string you can use in multiple places in a
 template or so you can use the output as an argument for other template tags or
 filters.
 
+.. versionchanged:: 4.2
+
+    In older versions, ``asvar`` instances weren't marked as safe for (HTML)
+    output purposes.
+
 ``{% blocktranslate %}`` also supports :ref:`contextual
 markers<contextual-markers>` using the ``context`` keyword:
 

--- a/tests/template_tests/syntax_tests/i18n/test_blocktranslate.py
+++ b/tests/template_tests/syntax_tests/i18n/test_blocktranslate.py
@@ -418,6 +418,22 @@ class I18nBlockTransTagTests(SimpleTestCase):
 
     @setup(
         {
+            "i18n_asvar_safestring": (
+                "{% load i18n %}"
+                "{% blocktranslate asvar the_title %}"
+                "{{title}}other text"
+                "{% endblocktranslate %}"
+                "{{ the_title }}"
+            )
+        }
+    )
+    def test_i18n_asvar_safestring(self):
+        context = {"title": "<Main Title>"}
+        output = self.engine.render_to_string("i18n_asvar_safestring", context=context)
+        self.assertEqual(output, "&lt;Main Title&gt;other text")
+
+    @setup(
+        {
             "template": (
                 "{% load i18n %}{% blocktranslate asvar %}Yes{% endblocktranslate %}"
             )


### PR DESCRIPTION
Ticket link 
[https://code.djangoproject.com/ticket/33631](https://code.djangoproject.com/ticket/33631)

Discussion
[https://forum.djangoproject.com/t/blocktranslate-asvar-escapes-without-marking-safe-re-ticket-33631/13146/4](https://forum.djangoproject.com/t/blocktranslate-asvar-escapes-without-marking-safe-re-ticket-33631/13146/4)