### PR TITLE
Fixed #33750 -- Fixed timezone warning alignment with help texts.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
+++ b/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
@@ -90,10 +90,9 @@
             }
             message = interpolate(message, [timezoneOffset]);
 
-            const warning = document.createElement('span');
-            warning.className = warningClass;
+            const warning = document.createElement('div');
+            warning.classList.add('help', warningClass);
             warning.textContent = message;
-            inp.parentNode.appendChild(document.createElement('br'));
             inp.parentNode.appendChild(warning);
         },
         // Add clock widget to a given field


### PR DESCRIPTION
Previously help_text was wrapped in a paragraph, but the
change to div broke the alignment:

https://code.djangoproject.com/ticket/27207
https://code.djangoproject.com/ticket/33750