### PR TITLE
Fixed #28897 -- Fixed QuerySet.update() on querysets ordered by annotations.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -113,6 +113,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "related fields.": {
                 "update.tests.AdvancedTests."
                 "test_update_ordered_by_inline_m2m_annotation",
+                "update.tests.AdvancedTests.test_update_ordered_by_m2m_annotation",
             },
         }
         if "ONLY_FULL_GROUP_BY" in self.connection.sql_mode:

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -109,6 +109,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "scalar value but it's not implemented (#25287).": {
                 "expressions.tests.FTimeDeltaTests.test_durationfield_multiply_divide",
             },
+            "UPDATE ... ORDER BY syntax on MySQL/MariaDB does not support ordering by"
+            "related fields.": {
+                "update.tests.AdvancedTests."
+                "test_update_ordered_by_inline_m2m_annotation",
+            },
         }
         if "ONLY_FULL_GROUP_BY" in self.connection.sql_mode:
             skips.update(

--- a/tests/update/models.py
+++ b/tests/update/models.py
@@ -41,6 +41,7 @@ class Foo(models.Model):
 class Bar(models.Model):
     foo = models.ForeignKey(Foo, models.CASCADE, to_field="target")
     m2m_foo = models.ManyToManyField(Foo, related_name="m2m_foo")
+    x = models.IntegerField(default=0)
 
 
 class UniqueNumber(models.Model):

--- a/tests/update/tests.py
+++ b/tests/update/tests.py
@@ -225,6 +225,13 @@ class AdvancedTests(TestCase):
                             new_name=annotation,
                         ).update(name=F("new_name"))
 
+    def test_update_ordered_by_inline_m2m_annotation(self):
+        foo = Foo.objects.create(target="test")
+        Bar.objects.create(foo=foo)
+
+        Bar.objects.order_by(Abs("m2m_foo")).update(x=2)
+        self.assertEqual(Bar.objects.get().x, 2)
+
 
 @unittest.skipUnless(
     connection.vendor == "mysql",


### PR DESCRIPTION
Fixes https://code.djangoproject.com/ticket/28897