### PR TITLE
Fixed #32813 -- Display development server address after server bind

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ answer newbie questions, and generally made Django that much better:
     Aaron Swartz <http://www.aaronsw.com/>
     Aaron T. Myers <atmyers@gmail.com>
     Abeer Upadhyay <ab.esquarer@gmail.com>
+    Abhijeet Pal
     Abhijeet Viswa <abhijeetviswa@gmail.com>
     Abhinav Patil <https://github.com/ubadub/>
     Abhishek Gautam <abhishekg1128@yahoo.com>

--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -231,19 +231,17 @@ def run(
     addr,
     port,
     wsgi_handler,
+    on_bind,
     ipv6=False,
     threading=False,
     server_cls=WSGIServer,
-    on_bind=None,
 ):
     server_address = (addr, port)
     cls_dict = {}
 
-    if on_bind is not None:
-
-        def server_bind(self):
-            server_cls.server_bind(self)
-            on_bind(self.server_port)
+    def server_bind(self):
+        server_cls.server_bind(self)
+        on_bind(self.server_port)
 
     cls_dict["server_bind"] = server_bind
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1676,6 +1676,16 @@ class ManageRunserver(SimpleTestCase):
         mocked_check.assert_called()
 
 
+class TestManageRunserverOnBindOutput(SimpleTestCase):
+    def test_on_bind_output(self):
+        with captured_stdout() as out:
+            cmd = RunserverCommand()
+            cmd.addr = "127.0.0.1"
+            cmd._raw_ipv6 = False
+            cmd._on_bind("14437")
+        self.assertIn("14437", out.getvalue())
+
+
 class ManageRunserverMigrationWarning(TestCase):
     def setUp(self):
         self.stdout = StringIO()


### PR DESCRIPTION
## Changelog

So far Django displays the server name and port before actual binding;

If a user selects port 0, [wildcard port]:
```
$ ./manage.py runserver 127.0.0.1:0
...
Starting development server at http://127.0.0.1:0/
Quit the server with CONTROL-C.
```
Now if the user opens a browser with this address they will not find the app running here. Because for the wildcard port, the actual physical port is selected by the operating system.  

After this change Django will be able to pick up the correct port:
```
$ ./manage.py runserver 127.0.0.1:0
...
Starting development server at http://127.0.0.1:25837/
Quit the server with CONTROL-C.
```

Ref - https://code.djangoproject.com/ticket/32813

### Backstory

I was looking for tickets for my first contribution to Django and I landed on this task, the original PR https://github.com/django/django/pull/14250 was closed so I picked it up from there. 
