### PR TITLE
Update multipartparser.py

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -272,7 +272,7 @@ class MultiPartParser:
                                 stripped_chunk = b"".join(chunk.split())
 
                                 remaining = len(stripped_chunk) % 4
-                                while remaining != 0:
+                                while remaining > 0:
                                     over_chunk = field_stream.read(4 - remaining)
                                     if not over_chunk:
                                         break


### PR DESCRIPTION
having != instead of > could lead to an infinite loop, and maybe rounding remaining would also help