### PR TITLE
Refs #27236 -- Moved models with Meta.index_together inside of test methods.

### DIFF
--- a/tests/indexes/models.py
+++ b/tests/indexes/models.py
@@ -43,15 +43,6 @@ class Article(models.Model):
         ]
 
 
-# Model for index_together being used only with single list
-class IndexTogetherSingleList(models.Model):
-    headline = models.CharField(max_length=100)
-    pub_date = models.DateTimeField()
-
-    class Meta:
-        index_together = ["headline", "pub_date"]
-
-
 class IndexedArticle(models.Model):
     headline = models.CharField(max_length=100, db_index=True)
     body = models.TextField(db_index=True)

--- a/tests/indexes/tests.py
+++ b/tests/indexes/tests.py
@@ -3,7 +3,15 @@ from unittest import skipUnless
 
 from django.conf import settings
 from django.db import connection
-from django.db.models import CASCADE, ForeignKey, Index, Q
+from django.db.models import (
+    CASCADE,
+    CharField,
+    DateTimeField,
+    ForeignKey,
+    Index,
+    Model,
+    Q,
+)
 from django.db.models.functions import Lower
 from django.test import (
     TestCase,
@@ -11,15 +19,10 @@ from django.test import (
     skipIfDBFeature,
     skipUnlessDBFeature,
 )
-from django.test.utils import override_settings
+from django.test.utils import isolate_apps, override_settings
 from django.utils import timezone
 
-from .models import (
-    Article,
-    ArticleTranslation,
-    IndexedArticle2,
-    IndexTogetherSingleList,
-)
+from .models import Article, ArticleTranslation, IndexedArticle2
 
 
 class SchemaIndexesTests(TestCase):
@@ -79,8 +82,15 @@ class SchemaIndexesTests(TestCase):
             index_sql[0],
         )
 
+    @isolate_apps("indexes")
     def test_index_together_single_list(self):
-        # Test for using index_together with a single list (#22172)
+        class IndexTogetherSingleList(Model):
+            headline = CharField(max_length=100)
+            pub_date = DateTimeField()
+
+            class Meta:
+                index_together = ["headline", "pub_date"]
+
         index_sql = connection.schema_editor()._model_indexes_sql(
             IndexTogetherSingleList
         )

--- a/tests/schema/models.py
+++ b/tests/schema/models.py
@@ -62,15 +62,6 @@ class AuthorWithUniqueName(models.Model):
         apps = new_apps
 
 
-class AuthorWithIndexedNameAndBirthday(models.Model):
-    name = models.CharField(max_length=255)
-    birthday = models.DateField()
-
-    class Meta:
-        apps = new_apps
-        index_together = [["name", "birthday"]]
-
-
 class AuthorWithUniqueNameAndBirthday(models.Model):
     name = models.CharField(max_length=255)
     birthday = models.DateField()
@@ -178,15 +169,6 @@ class Tag(models.Model):
 
     class Meta:
         apps = new_apps
-
-
-class TagIndexed(models.Model):
-    title = models.CharField(max_length=255)
-    slug = models.SlugField(unique=True)
-
-    class Meta:
-        apps = new_apps
-        index_together = [["slug", "title"]]
 
 
 class TagM2MTest(models.Model):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27236

Completes a part of https://github.com/django/django/pull/15703 by moving some test model classes only used in one test method, into the test method. So that it will be a no-brainer to delete the models once we deprecated `index_together`.