### PR TITLE
Removed obsolete assertions in BooleanFieldTests.test_return_type().

### DIFF
--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -141,7 +141,6 @@ class NullBooleanModel(models.Model):
 
 class BooleanModel(models.Model):
     bfield = models.BooleanField()
-    string = models.CharField(max_length=10, default="abc")
 
 
 class DateTimeModel(models.Model):

--- a/tests/model_fields/test_booleanfield.py
+++ b/tests/model_fields/test_booleanfield.py
@@ -71,11 +71,6 @@ class BooleanFieldTests(TestCase):
         b4.refresh_from_db()
         self.assertIs(b4.nbfield, False)
 
-        # When an extra clause exists, the boolean conversions are applied with
-        # an offset (#13293).
-        b5 = BooleanModel.objects.extra(select={"string_col": "string"})[0]
-        self.assertNotIsInstance(b5.pk, bool)
-
     def test_select_related(self):
         """
         Boolean fields retrieved via select_related() should return booleans.


### PR DESCRIPTION
Added in e9bbdb39de3047761fa8d03d5241eccd571093ff.

Obsolete since e9103402c0fa873aea58a6a11dba510cd308cb84.

It also crashes on PostgreSQL 15 beta 1, probably because `string` has some special meaning. For example, using:
```
.extra(select={"id_col": "id"})
```
doesn't crash. I couldn't find anything about `string` in  PostgreSQL 15's release notes, but this column name is definitely unfortunate.