### PR TITLE
Refs #33765 -- Added tests for trailing whitespace in JavaScript source map references.

### DIFF
--- a/tests/staticfiles_tests/project/documents/cached/source_map_trailing_whitespace.js
+++ b/tests/staticfiles_tests/project/documents/cached/source_map_trailing_whitespace.js
@@ -1,0 +1,2 @@
+//# sourceMappingURL=source_map.js.map	 
+let a_variable = 1;

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -280,6 +280,20 @@ class TestHashedFiles:
             )
         self.assertPostCondition()
 
+    def test_js_source_map_trailing_whitespace(self):
+        relpath = self.hashed_file_path("cached/source_map_trailing_whitespace.js")
+        self.assertEqual(
+            relpath, "cached/source_map_trailing_whitespace.cd45b8534a87.js"
+        )
+        with storage.staticfiles_storage.open(relpath) as relfile:
+            content = relfile.read()
+            self.assertNotIn(b"//# sourceMappingURL=source_map.js.map\t ", content)
+            self.assertIn(
+                b"//# sourceMappingURL=source_map.js.99914b932bd3.map",
+                content,
+            )
+        self.assertPostCondition()
+
     def test_js_source_map_sensitive(self):
         relpath = self.hashed_file_path("cached/source_map_sensitive.js")
         self.assertEqual(relpath, "cached/source_map_sensitive.5da96fdd3cb3.js")


### PR DESCRIPTION
ticket-33765

I didn't add a release note anywhere since I wasn't sure if this is worth backporting. I propose this wording wherever we add it:

```
:class:`~.storage.ManifestStaticFilesStorage` now correctly ignores trailing whitespace in JavaScript source map references.
```