### PR TITLE
Fixed #33589 -- Made admin calendar widget escape all char occurrences in date input formats.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
+++ b/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
@@ -389,11 +389,7 @@
         handleCalendarCallback: function(num) {
             let format = get_format('DATE_INPUT_FORMATS')[0];
             // the format needs to be escaped a little
-            format = format.replace('\\', '\\\\')
-                .replace('\r', '\\r')
-                .replace('\n', '\\n')
-                .replace('\t', '\\t')
-                .replace("'", "\\'");
+            format = DateTimeShortcuts.escapeFormat(format);
             return function(y, m, d) {
                 DateTimeShortcuts.calendarInputs[num].value = new Date(y, m - 1, d).strftime(format);
                 DateTimeShortcuts.calendarInputs[num].focus();
@@ -406,6 +402,14 @@
             DateTimeShortcuts.calendarInputs[num].value = d.strftime(get_format('DATE_INPUT_FORMATS')[0]);
             DateTimeShortcuts.calendarInputs[num].focus();
             DateTimeShortcuts.dismissCalendar(num);
+        },
+        escapeFormat: function(format) {
+            format = format.replace(/\\/g, "\\\\")
+                .replace(/\r/g, "\\r")
+                .replace(/\n/g, "\\n")
+                .replace(/\t/g, "\\t")
+                .replace(/'/g, "\\'");
+            return format;
         }
     };
 

--- a/js_tests/admin/DateTimeShortcuts.test.js
+++ b/js_tests/admin/DateTimeShortcuts.test.js
@@ -40,3 +40,9 @@ QUnit.test('time zone offset warning', function(assert) {
     $('body').attr('data-admin-utc-offset', savedOffset);
     assert.equal($('.timezonewarning').text(), 'Note: You are 1 hour behind server time.');
 });
+
+QUnit.test('calendar escape format', function(assert) {
+    let dateInputFormat = "'%d \r\t\\\n %B \n\\\r\t %Y'";
+    dateInputFormat = DateTimeShortcuts.escapeFormat(dateInputFormat);
+    assert.equal(dateInputFormat, "\\'%d \\r\\t\\\\\\n %B \\n\\\\\\r\\t %Y\\'");
+});


### PR DESCRIPTION
Now the replacement of the string of characters is for all occurrences and not just the first occurrence.