### PR TITLE
Coalesce needed when aggregating within a Subquery

### DIFF
--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -691,6 +691,7 @@ there is an ``OuterRef``, this will not be possible to resolve).
 
 The example above assumes that there is at least one comment on a post.  To 
 correctly handle the case where there are no comments on a post, use :class:`~django.db.models.functions.Coalesce`:
+
     >>> Post.objects.filter(length__gt=Coalesce(Subquery(total_comments), 0))
 
 Raw SQL expressions

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -689,6 +689,10 @@ This is the only way to perform an aggregation within a ``Subquery``, as
 using :meth:`~.QuerySet.aggregate` attempts to evaluate the queryset (and if
 there is an ``OuterRef``, this will not be possible to resolve).
 
+The example above assumes that there is at least one comment on a post.  To 
+correctly handle the case where there are no comments on a post, use :class:`~django.db.models.functions.Coalesce`:
+    >>> Post.objects.filter(length__gt=Coalesce(Subquery(total_comments), 0))
+
 Raw SQL expressions
 -------------------
 


### PR DESCRIPTION
Clarify the need to use Coalesce when aggregating within a Subquery to cover the case when there are no related records.  Provide an example.