### PR TITLE
Fixed `HttpResponse.__repr__` to handle `status_code=None`

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -373,7 +373,7 @@ class HttpResponse(HttpResponseBase):
         self.content = content
 
     def __repr__(self):
-        return "<%(cls)s status_code=%(status_code)d%(content_type)s>" % {
+        return "<%(cls)s status_code=%(status_code)s%(content_type)s>" % {
             "cls": self.__class__.__name__,
             "status_code": self.status_code,
             "content_type": self._content_type_for_repr,


### PR DESCRIPTION
`status_code=None` is used by Strawberry GraphQL [1] for internal
subresponses.  While this use case could be challenged, it appears to be
good to not crash unnecessarily e.g. in a debugger session with:

> *** TypeError: %d format: a real number is required, not NoneType

1: https://github.com/strawberry-graphql/strawberry/blob/816353e2a8a8d5165e9123c4b3f119afccac27ce/strawberry/django/views.py#L36-L37
(via https://github.com/strawberry-graphql/strawberry/pull/773)