### PR TITLE
Fixed #33773 -- Made Index with multiple fields respect DEFAULT_INDEX_TABLESPACE.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -2,6 +2,7 @@ import logging
 import operator
 from datetime import datetime
 
+from django.conf import settings
 from django.db.backends.ddl_references import (
     Columns,
     Expressions,
@@ -1306,6 +1307,8 @@ class BaseDatabaseSchemaEditor:
         if db_tablespace is None:
             if len(fields) == 1 and fields[0].db_tablespace:
                 db_tablespace = fields[0].db_tablespace
+            elif settings.DEFAULT_INDEX_TABLESPACE:
+                db_tablespace = settings.DEFAULT_INDEX_TABLESPACE
             elif model._meta.db_tablespace:
                 db_tablespace = model._meta.db_tablespace
         if db_tablespace is not None:

--- a/tests/model_indexes/tests.py
+++ b/tests/model_indexes/tests.py
@@ -3,7 +3,7 @@ from unittest import mock
 from django.conf import settings
 from django.db import connection, models
 from django.db.models.functions import Lower, Upper
-from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
+from django.test import SimpleTestCase, TestCase, override_settings, skipUnlessDBFeature
 from django.test.utils import isolate_apps
 
 from .models import Book, ChildModel1, ChildModel2
@@ -305,6 +305,7 @@ class SimpleIndexesTests(SimpleTestCase):
         )
 
 
+@override_settings(DEFAULT_TABLESPACE=None)
 class IndexesTests(TestCase):
     @skipUnlessDBFeature("supports_tablespaces")
     def test_db_tablespace(self):


### PR DESCRIPTION
Added check for the setting in schema's _get_index_tablespace_sql
before it falls back to the model's db_tablespace.
Thanks to Simon Charette for locating where issue lay.