### PR TITLE
Updated OWASP Top 10 link in security topic.

### DIFF
--- a/docs/topics/security.txt
+++ b/docs/topics/security.txt
@@ -306,5 +306,5 @@ security protection of the web server, operating system and other components.
   pages also include security principles that apply to any system.
 
 .. _LimitRequestBody: https://httpd.apache.org/docs/2.4/mod/core.html#limitrequestbody
-.. _Top 10 list: https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/
+.. _Top 10 list: https://owasp.org/www-project-top-ten/
 .. _web security: https://infosec.mozilla.org/guidelines/web_security.html

--- a/docs/topics/security.txt
+++ b/docs/topics/security.txt
@@ -306,5 +306,5 @@ security protection of the web server, operating system and other components.
   pages also include security principles that apply to any system.
 
 .. _LimitRequestBody: https://httpd.apache.org/docs/2.4/mod/core.html#limitrequestbody
-.. _Top 10 list: https://owasp.org/www-project-top-ten/
+.. _Top 10 list: https://owasp.org/Top10/
 .. _web security: https://infosec.mozilla.org/guidelines/web_security.html


### PR DESCRIPTION
The latest version of OWASP Top 10 list is 2021, and OWASP has a page for this project. So referring to the project homepage is better than a specific version of it.