### PR TITLE
Fixed #23689 -- Made parsing HTTP Accept-Language header case-insensitive.

### DIFF
--- a/django/utils/translation/trans_null.py
+++ b/django/utils/translation/trans_null.py
@@ -61,7 +61,7 @@ def get_language_from_path(request):
 
 
 def get_supported_language_variant(lang_code, strict=False):
-    if lang_code == settings.LANGUAGE_CODE:
+    if lang_code and lang_code.lower() == settings.LANGUAGE_CODE.lower():
         return lang_code
     else:
         raise LookupError(lang_code)

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -478,8 +478,9 @@ def check_for_language(lang_code):
 def get_languages():
     """
     Cache of settings.LANGUAGES in a dictionary for easy lookups by key.
+    Convert keys to lowercase as they should be treated as case-insensitive.
     """
-    return dict(settings.LANGUAGES)
+    return {key.lower(): value for key, value in dict(settings.LANGUAGES).items()}
 
 
 @functools.lru_cache(maxsize=1000)
@@ -510,7 +511,7 @@ def get_supported_language_variant(lang_code, strict=False):
         supported_lang_codes = get_languages()
 
         for code in possible_lang_codes:
-            if code in supported_lang_codes and check_for_language(code):
+            if code.lower() in supported_lang_codes and check_for_language(code):
                 return code
         if not strict:
             # if fr-fr is not supported, try fr-ca.

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1902,9 +1902,10 @@ class MiscTests(SimpleTestCase):
         USE_I18N=True,
         LANGUAGES=[
             ("en", "English"),
+            ("ar-dz", "Algerian Arabic"),
             ("de", "German"),
             ("de-at", "Austrian German"),
-            ("pt-br", "Portuguese (Brazil)"),
+            ("pt-BR", "Portuguese (Brazil)"),
         ],
     )
     def test_get_supported_language_variant_real(self):
@@ -1915,8 +1916,11 @@ class MiscTests(SimpleTestCase):
         self.assertEqual(g("de-at"), "de-at")
         self.assertEqual(g("de-ch"), "de")
         self.assertEqual(g("pt-br"), "pt-br")
+        self.assertEqual(g("pt-BR"), "pt-BR")
         self.assertEqual(g("pt"), "pt-br")
         self.assertEqual(g("pt-pt"), "pt-br")
+        self.assertEqual(g("ar-dz"), "ar-dz")
+        self.assertEqual(g("ar-DZ"), "ar-DZ")
         with self.assertRaises(LookupError):
             g("pt", strict=True)
         with self.assertRaises(LookupError):
@@ -1946,7 +1950,6 @@ class MiscTests(SimpleTestCase):
         LANGUAGES=[
             ("en", "English"),
             ("en-latn-us", "Latin English"),
-            ("en-Latn-US", "BCP 47 case format"),
             ("de", "German"),
             ("de-1996", "German, orthography of 1996"),
             ("de-at", "Austrian German"),
@@ -1970,6 +1973,7 @@ class MiscTests(SimpleTestCase):
             ("/de/", "de"),
             ("/de-1996/", "de-1996"),
             ("/de-at/", "de-at"),
+            ("/de-AT/", "de-AT"),
             ("/de-ch/", "de"),
             ("/de-ch-1901/", "de-ch-1901"),
             ("/de-simple-page-test/", None),


### PR DESCRIPTION
#### Context
```
Chrome:   Accept-Language:  zh-TW,zh;q=0.8,en-US;q=0.6,en;q=0.4
Firefox:  Accept-Language:  zh-tw,zh;q=0.8,en-us;q=0.5,en;q=0.3
```
Django will correctly display Traditional Chinese for Chrome, but won't for Firefox because of lower-cased TW. However in [documentation](https://docs.djangoproject.com/en/4.0/topics/i18n/#term-language-code) it states that Accept-Language header is case-insensitive.

**Note:** 

Running django server with these settings throw an error as mentioned below.
```
LANGUAGES = (
    ('en-us', 'English (US)'),
    ('De', 'Deutsche'),
    ('ar', 'عربى'),
)

LANGUAGE_CODE = 'EN-US'
```
ERROR:
```
ERRORS:
?: (translation.E004) You have provided a value for the LANGUAGE_CODE setting that is not in the LANGUAGES setting.
```
This however will change after these changes are merged. `LANGUAGE_CODE` when searching through `LANGUAGES` will become case-insensitive.


#### Changes
Language code is now parsed in case-insensitive manner. This includes parsing these as case-insensitive:
- Accept-Language header
- LANGUAGE_CODE

Thank you @danielsamuels for [test project.](https://github.com/danielsamuels/django_23689)

#### Ticket
https://code.djangoproject.com/ticket/23689