### PR TITLE
Fixed #33657 -- Allowed customizing formatter class of argument parsers.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -286,10 +286,10 @@ class BaseCommand:
         Create and return the ``ArgumentParser`` which will be used to
         parse the arguments to this command.
         """
+        kwargs.setdefault("formatter_class", DjangoHelpFormatter)
         parser = CommandParser(
             prog="%s %s" % (os.path.basename(prog_name), subcommand),
             description=self.help or None,
-            formatter_class=DjangoHelpFormatter,
             missing_args_message=getattr(self, "missing_args_message", None),
             called_from_command_line=getattr(self, "_called_from_command_line", None),
             **kwargs,

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -1,4 +1,5 @@
 import os
+from argparse import ArgumentDefaultsHelpFormatter
 from io import StringIO
 from unittest import mock
 
@@ -408,8 +409,14 @@ class CommandTests(SimpleTestCase):
     def test_create_parser_kwargs(self):
         """BaseCommand.create_parser() passes kwargs to CommandParser."""
         epilog = "some epilog text"
-        parser = BaseCommand().create_parser("prog_name", "subcommand", epilog=epilog)
+        parser = BaseCommand().create_parser(
+            "prog_name",
+            "subcommand",
+            epilog=epilog,
+            formatter_class=ArgumentDefaultsHelpFormatter,
+        )
         self.assertEqual(parser.epilog, epilog)
+        self.assertEqual(parser.formatter_class, ArgumentDefaultsHelpFormatter)
 
     def test_outputwrapper_flush(self):
         out = StringIO()


### PR DESCRIPTION
[Ticket #33657](https://code.djangoproject.com/ticket/33657)

Made the changes recommended in [Comment 2](https://code.djangoproject.com/ticket/33657#comment:2l)