### PR TITLE
Fixed #33028 -- Used ModelAdmin's opts attribute instead of model._meta.

### DIFF
--- a/django/contrib/auth/admin.py
+++ b/django/contrib/auth/admin.py
@@ -138,7 +138,7 @@ class UserAdmin(admin.ModelAdmin):
             raise PermissionDenied
         if extra_context is None:
             extra_context = {}
-        username_field = self.model._meta.get_field(self.model.USERNAME_FIELD)
+        username_field = self.opts.get_field(self.model.USERNAME_FIELD)
         defaults = {
             "auto_populated_fields": (),
             "username_help_text": username_field.help_text,
@@ -155,7 +155,7 @@ class UserAdmin(admin.ModelAdmin):
             raise Http404(
                 _("%(name)s object with primary key %(key)r does not exist.")
                 % {
-                    "name": self.model._meta.verbose_name,
+                    "name": self.opts.verbose_name,
                     "key": escape(id),
                 }
             )
@@ -197,7 +197,7 @@ class UserAdmin(admin.ModelAdmin):
             "has_delete_permission": False,
             "has_change_permission": True,
             "has_absolute_url": False,
-            "opts": self.model._meta,
+            "opts": self.opts,
             "original": user,
             "save_as": False,
             "show_save": True,

--- a/tests/admin_custom_urls/models.py
+++ b/tests/admin_custom_urls/models.py
@@ -41,7 +41,7 @@ class ActionAdmin(admin.ModelAdmin):
 
             return update_wrapper(wrapper, view)
 
-        info = self.model._meta.app_label, self.model._meta.model_name
+        info = self.opts.app_label, self.opts.model_name
 
         view_name = "%s_%s_add" % info
 


### PR DESCRIPTION
Ticket [ModelAdmin.init has self.opts, but it still nowerewhere else in django.admin.contrib.options not used](https://code.djangoproject.com/ticket/33028)

As the ticket mentions I cleaned up just the `django/contrib/admin/options.py` file and the two classes that inherit from `ModelAdmin` (`ActionAdmin` and `UserAdmin`)

I found other files where `self.model._meta` is used without define a `self.opts`. If you think it's worth it I can do it in a different commit or PR or new ticket!

Thanks!