### PR TITLE
[3.2.x] Fixed test_request_lifecycle_signals_dispatched_with_thread_sensitive with asgiref 3.5.1+.

### DIFF
--- a/tests/asgi/tests.py
+++ b/tests/asgi/tests.py
@@ -235,11 +235,8 @@ class ASGITest(SimpleTestCase):
         # Give response.close() time to finish.
         await communicator.wait()
 
-        # At this point, AsyncToSync does not have a current executor. Thus
-        # SyncToAsync falls-back to .single_thread_executor.
-        target_thread = next(iter(SyncToAsync.single_thread_executor._threads))
+        # AsyncToSync should have executed the signals in the same thread.
         request_started_thread, request_finished_thread = signal_handler.threads
-        self.assertEqual(request_started_thread, target_thread)
-        self.assertEqual(request_finished_thread, target_thread)
+        self.assertEqual(request_started_thread, request_finished_thread)
         request_started.disconnect(signal_handler)
         request_finished.disconnect(signal_handler)


### PR DESCRIPTION
See [comment](https://code.djangoproject.com/ticket/33795#comment:2) and [logs](https://djangoci.com/view/Main/job/django-3.2/83/).