### PR TITLE
Fixed #33796 -- Fixed ordered combined queryset crash when used in subquery on PostgreSQL and MySQL.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -175,6 +175,25 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                     },
                 }
             )
+        if (
+            self.connection.mysql_is_mariadb and self.connection.mysql_version < (10, 4)
+        ) or (
+            not self.connection.mysql_is_mariadb
+            and self.connection.mysql_version < (8,)
+        ):
+            skips.update(
+                {
+                    "Parenthesized combined queries are not supported on MySQL < 8 and "
+                    "MariaDB < 10.4": {
+                        "queries.test_qs_combinators.QuerySetSetOperationTests."
+                        "test_union_in_subquery",
+                        "queries.test_qs_combinators.QuerySetSetOperationTests."
+                        "test_union_in_subquery_related_outerref",
+                        "queries.test_qs_combinators.QuerySetSetOperationTests."
+                        "test_union_in_with_ordering",
+                    }
+                }
+            )
         if not self.supports_explain_analyze:
             skips.update(
                 {

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -175,16 +175,12 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                     },
                 }
             )
-        if (
-            self.connection.mysql_is_mariadb and self.connection.mysql_version < (10, 4)
-        ) or (
-            not self.connection.mysql_is_mariadb
-            and self.connection.mysql_version < (8,)
+        if not self.connection.mysql_is_mariadb and self.connection.mysql_version < (
+            8,
         ):
             skips.update(
                 {
-                    "Parenthesized combined queries are not supported on MySQL < 8 and "
-                    "MariaDB < 10.4": {
+                    "Parenthesized combined queries are not supported on MySQL < 8.": {
                         "queries.test_qs_combinators.QuerySetSetOperationTests."
                         "test_union_in_subquery",
                         "queries.test_qs_combinators.QuerySetSetOperationTests."

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -116,6 +116,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "migrations.test_operations.OperationTests."
             "test_alter_field_pk_fk_db_collation",
         },
+        "Oracle raises an error when a subquery contains unnecessary ORDER BY "
+        "clause (#32786).": {
+            "queries.test_qs_combinators.QuerySetSetOperationTests."
+            "test_union_in_with_ordering",
+        },
     }
     django_test_expected_failures = {
         # A bug in Django/cx_Oracle with respect to string handling (#23843).

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -116,11 +116,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "migrations.test_operations.OperationTests."
             "test_alter_field_pk_fk_db_collation",
         },
-        "Oracle raises an error when a subquery contains unnecessary ORDER BY "
-        "clause (#32786).": {
-            "queries.test_qs_combinators.QuerySetSetOperationTests."
-            "test_union_in_with_ordering",
-        },
     }
     django_test_expected_failures = {
         # A bug in Django/cx_Oracle with respect to string handling (#23843).

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -548,6 +548,11 @@ class SQLCompiler:
                         or not features.supports_slicing_ordering_in_compound
                     ):
                         part_sql = "({})".format(part_sql)
+                elif (
+                    self.query.subquery
+                    and features.supports_slicing_ordering_in_compound
+                ):
+                    part_sql = "({})".format(part_sql)
                 parts += ((part_sql, part_args),)
             except EmptyResultSet:
                 # Omit the empty queryset with UNION and with DIFFERENCE if the

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1178,6 +1178,8 @@ class Query(BaseExpression):
             and not connection.features.ignores_unnecessary_order_by_in_subqueries
         ):
             self.clear_ordering(force=False)
+            for query in self.combined_queries:
+                query.clear_ordering(force=False)
         sql, params = self.get_compiler(connection=connection).as_sql()
         if self.subquery:
             sql = "(%s)" % sql


### PR DESCRIPTION
Thanks Shai Berger for the report.
    
Regression in 30a01441347d5a2146af2944b29778fa0834d4be.

ticket-33796

Only the first commit is intended for backporting.