### PR TITLE
Fixs #33808. Specific subquery produces wrong SQL. 

### DIFF
--- a/tests/subquery_parenthesis/models.py
+++ b/tests/subquery_parenthesis/models.py
@@ -1,0 +1,14 @@
+from django.db import models
+
+
+class FirstModel(models.Model):
+    pass
+
+
+class SecondModel(models.Model):
+    related_field2 = models.ManyToManyField(
+        FirstModel, blank=True, related_name="sm_f1",
+    )
+    related_field1 = models.ManyToManyField(
+        FirstModel, blank=True, related_name="sm_f2",
+    )

--- a/tests/subquery_parenthesis/tests.py
+++ b/tests/subquery_parenthesis/tests.py
@@ -1,0 +1,19 @@
+from django.test import TestCase
+from django.db.models import Count, Q, F
+
+from .models import FirstModel
+
+
+class QueryDoesNotFail(TestCase):
+    """This query is broken in Django 3.2
+    https://code.djangoproject.com/ticket/33808
+    """
+
+    def test_broken(self):
+        queryset = FirstModel.objects.annotate(
+            howmany=Count(Q(sm_f1__in=F("sm_f2"))),
+        )
+        try:
+            self.assertEqual(queryset.count(), 0)
+        except Exception:
+            self.fail("This query failed to execute.")


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33808

A very specific subquery produces wrong SQL in Django 3.2. This issue is not present in Django 2.2 or Django 4.0. I bisected and found that the commit 3a505c70e7b228bf1212c067a8f38271ca86ce09 broke this query.

I took the code from tag 4.0 and backported the fix. I produced a test to ensure that this query does not fail to execute.

I *strongly* suggest that this patch is reviewed with high attention, this is a core component and I am not an expert in the field.
