### PR TITLE
Comma separator

### DIFF
--- a/docs/faq/contributing.txt
+++ b/docs/faq/contributing.txt
@@ -68,7 +68,7 @@ issue over and over. This sort of behavior will not gain you any additional
 attention -- certainly not the attention that you need in order to get your
 issue addressed.
 
-But I've reminded you several times and you keep ignoring my patch!
+But I've reminded you several times, and you keep ignoring my patch!
 ===================================================================
 
 Seriously - we're not ignoring you. If your patch stands no chance of


### PR DESCRIPTION
Compound sentence: two built-in sentences with a noun and a verb must be separated by a comma.