### PR TITLE
Fixed #27704 -- Fixed TypedMultipleChoiceField as base field class for contrib.postgres.ArrayField with choices.

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -219,7 +219,9 @@ class ArrayField(CheckFieldDefaultMixin, Field):
             }
             if self.choices:
                 warnings.warn(
-                    "Choices should be defined in base field.", RemovedInDjango51Warning
+                    "Choices should be defined in base field.",
+                    RemovedInDjango51Warning,
+                    stacklevel=2,
                 )
         return obj.formfield(**{**defaults, **kwargs})
 

--- a/django/contrib/postgres/forms/array.py
+++ b/django/contrib/postgres/forms/array.py
@@ -30,10 +30,6 @@ class SimpleArrayField(forms.CharField):
             self.max_length = max_length
             self.validators.append(ArrayMaxLengthValidator(int(max_length)))
 
-    def clean(self, value):
-        value = super().clean(value)
-        return [self.base_field.clean(val) for val in value]
-
     def prepare_value(self, value):
         if isinstance(value, list):
             return self.delimiter.join(

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1024,7 +1024,7 @@ class Field(RegisterLookupMixin):
                 self.has_default() or "initial" in kwargs
             )
             defaults["choices"] = self.get_choices(include_blank=include_blank)
-            defaults["coerce"] = kwargs.get("coerce", self.to_python)
+            defaults["coerce"] = self.to_python
             if self.null:
                 defaults["empty_value"] = None
             if choices_form_class is not None:

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1024,7 +1024,7 @@ class Field(RegisterLookupMixin):
                 self.has_default() or "initial" in kwargs
             )
             defaults["choices"] = self.get_choices(include_blank=include_blank)
-            defaults["coerce"] = self.to_python
+            defaults["coerce"] = kwargs.get("coerce", self.to_python)
             if self.null:
                 defaults["empty_value"] = None
             if choices_form_class is not None:

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -35,6 +35,10 @@ may be a good choice for the :ref:`range fields <range-fields>` and
     creates a mutable default that is shared between all instances of
     ``ArrayField``.
 
+    If you want to limit the accepted values with a
+    :attr:`~django.db.models.Field.choices` parameter, define the choices in the
+    base_field definition, not in the ``ArrayField`` definition.
+
     .. attribute:: base_field
 
         This is a required argument.

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -3,7 +3,6 @@ import enum
 import json
 import unittest
 import uuid
-import warnings
 
 from django import forms
 from django.core import checks, exceptions, serializers, validators
@@ -1139,12 +1138,9 @@ class TestChoiceFormField(PostgreSQLTestCase):
         model_field = ArrayField(
             models.CharField(max_length=27), choices=(("a1", "A1"), ("b1", "B1"))
         )
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        msg = "Choices should be defined in base field."
+        with self.assertWarnsMessage(RemovedInDjango51Warning, msg):
             model_field.formfield()
-            assert len(w) == 1
-            assert issubclass(w[-1].category, RemovedInDjango51Warning)
-            assert "Choices should be defined in base field." in str(w[-1].message)
 
 
 class TestSplitFormField(PostgreSQLSimpleTestCase):


### PR DESCRIPTION
As per suggestions in @ngnpope's [comment](https://github.com/django/django/pull/7850#issuecomment-738300243) on #7850 made `choices_form_class = TypedMultipleChoiceField` also removed support for `ArrayField.choices` and instead `ArrayField.base_field.choices` shall be used. Removed `ArrayField.clean()` method intoduced in https://github.com/django/django/commit/9dd244394236388c3479ab202a0ec31055f7ec09 because `SimpleArrayField` will no more be used while `ArrayField` has choices and also shifted the test `test_model_field_choices` introduced in https://github.com/django/django/commit/9dd244394236388c3479ab202a0ec31055f7ec09 to `tests.postgres_tests.test_array.TestChoiceFormField`.