### PR TITLE
Fixed GEOSTest.test_emptyCollections() on GEOS 3.8.0.

### DIFF
--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -1127,8 +1127,10 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
 
             # Testing __getitem__ (doesn't work on Point or Polygon)
             if isinstance(g, Point):
-                with self.assertRaises(IndexError):
-                    g.x
+                # IndexError is not raised in GEOS 3.8.0.
+                if geos_version_tuple() != (3, 8, 0):
+                    with self.assertRaises(IndexError):
+                        g.x
             elif isinstance(g, Polygon):
                 lr = g.shell
                 self.assertEqual("LINEARRING EMPTY", lr.wkt)


### PR DESCRIPTION
It's a regression in GEOS 3.8.0 fixed in GEOS 3.8.1.

See [logs](https://djangoci.com/job/django-main/2007/database=spatialite,label=focal,python=python3.9/testReport/junit/gis_tests.geos_tests.test_geos/GEOSTest/test_emptyCollections/).