### PR TITLE
Fixed #33816 -- Fixed QuerySet.only() after select_related() crash on proxy models.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -748,6 +748,7 @@ class Query(BaseExpression):
                     cur_model = source.related_model
                 else:
                     cur_model = source.remote_field.model
+                cur_model = cur_model._meta.concrete_model
                 opts = cur_model._meta
                 # Even if we're "just passing through" this model, we must add
                 # both the current model's pk and the related reference field

--- a/tests/proxy_models/tests.py
+++ b/tests/proxy_models/tests.py
@@ -395,6 +395,12 @@ class ProxyModelTests(TestCase):
         p = MyPerson.objects.get(pk=100)
         self.assertEqual(p.name, "Elvis Presley")
 
+    def test_select_related_only(self):
+        user = ProxyTrackerUser.objects.create(name="Joe Doe", status="test")
+        issue = Issue.objects.create(summary="New issue", assignee=user)
+        qs = Issue.objects.select_related("assignee").only("assignee__status")
+        self.assertEqual(qs.get(), issue)
+
     def test_eq(self):
         self.assertEqual(MyPerson(id=100), Person(id=100))
 


### PR DESCRIPTION
QuerySet.only() after select_related() crash on proxy models.