### PR TITLE
Fixed #33822 -- Fixed save() crash on model formsets when not created by modelformset_factory().

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -657,6 +657,7 @@ class BaseModelFormSet(BaseFormSet):
     """
 
     model = None
+    edit_only = False
 
     # Set of fields that must be unique among forms of this set.
     unique_fields = set()

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from django import forms
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
+from django.forms.formsets import formset_factory
 from django.forms.models import (
     BaseModelFormSet,
     _get_foreign_key,
@@ -2065,6 +2066,36 @@ class ModelFormsetTest(TestCase):
         self.assertIs(formset.is_valid(), True)
         formset.save()
         self.assertCountEqual(Author.objects.all(), [charles, walt])
+
+    def test_edit_only_formset_factory_with_basemodelformset(self):
+        charles = Author.objects.create(name="Charles Baudelaire")
+
+        class AuthorForm(forms.ModelForm):
+            class Meta:
+                model = Author
+                fields = "__all__"
+
+        class BaseAuthorFormSet(BaseModelFormSet):
+            def __init__(self, *args, **kwargs):
+                self.model = Author
+                super().__init__(*args, **kwargs)
+
+        AuthorFormSet = formset_factory(AuthorForm, formset=BaseAuthorFormSet)
+        data = {
+            "form-TOTAL_FORMS": "2",
+            "form-INITIAL_FORMS": "1",
+            "form-MAX_NUM_FORMS": "0",
+            "form-0-id": charles.pk,
+            "form-0-name": "Shawn Dong",
+            "form-1-name": "Walt Whitman",
+        }
+        formset = AuthorFormSet(data)
+        self.assertIs(formset.is_valid(), True)
+        formset.save()
+        self.assertEqual(Author.objects.count(), 2)
+        charles.refresh_from_db()
+        self.assertEqual(charles.name, "Shawn Dong")
+        self.assertEqual(Author.objects.count(), 2)
 
 
 class TestModelFormsetOverridesTroughFormMeta(TestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33822