### PR TITLE
Fixed RelatedGeoModelTest.test08_defer_only() on MySQL 8+ with MyISAM storage engine.

### DIFF
--- a/tests/gis_tests/relatedapp/tests.py
+++ b/tests/gis_tests/relatedapp/tests.py
@@ -201,8 +201,8 @@ class RelatedGeoModelTest(TestCase):
 
     def test08_defer_only(self):
         "Testing defer() and only() on Geographic models."
-        qs = Location.objects.all()
-        def_qs = Location.objects.defer("point")
+        qs = Location.objects.all().order_by("pk")
+        def_qs = Location.objects.defer("point").order_by("pk")
         for loc, def_loc in zip(qs, def_qs):
             self.assertEqual(loc.point, def_loc.point)
 


### PR DESCRIPTION
See [logs](https://djangoci.com/job/django-main/database=mysql_gis,label=focal,python=python3.10/2013/testReport/junit/gis_tests.relatedapp.tests/RelatedGeoModelTest/test08_defer_only/).