### PR TITLE
Refs #30213 -- Removed post-startup check for Watchman availability.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -657,16 +657,7 @@ def start_django(reloader, main_func, *args, **kwargs):
     django_main_thread.start()
 
     while not reloader.should_stop:
-        try:
-            reloader.run(django_main_thread)
-        except WatchmanUnavailable as ex:
-            # It's possible that the watchman service shuts down or otherwise
-            # becomes unavailable. In that case, use the StatReloader.
-            reloader = StatReloader()
-            logger.error("Error connecting to Watchman: %s", ex)
-            logger.info(
-                "Watching for file changes with %s", reloader.__class__.__name__
-            )
+        reloader.run(django_main_thread)
 
 
 def run_with_reloader(main_func, *args, **kwargs):

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -381,16 +381,6 @@ class RunWithReloaderTests(SimpleTestCase):
 
 
 class StartDjangoTests(SimpleTestCase):
-    @mock.patch("django.utils.autoreload.StatReloader")
-    def test_watchman_becomes_unavailable(self, mocked_stat):
-        mocked_stat.should_stop.return_value = True
-        fake_reloader = mock.MagicMock()
-        fake_reloader.should_stop = False
-        fake_reloader.run.side_effect = autoreload.WatchmanUnavailable()
-
-        autoreload.start_django(fake_reloader, lambda: None)
-        self.assertEqual(mocked_stat.call_count, 1)
-
     @mock.patch("django.utils.autoreload.ensure_echo_on")
     def test_echo_on_called(self, mocked_echo):
         fake_reloader = mock.MagicMock()


### PR DESCRIPTION
This is checked at startup in get_reloader(). The runtime check ties
the implementation to Watchman excessively.

Hey @orf 👋 — can I ask for your thoughts here? I was looking at ticket-30213, and this double-check seems a bit excessive… 

* Is it likely Watchman is available at startup but then **becomes** unavailable? (`get_reloader()` already checked it was available... 🤔) 
* Is that worth privileging in relation to other reloader strategies? 
* Can we remove this check? 

Sorry if this is re-treading old ground. 

Thanks! 🎁 