### PR TITLE
Refs #33826 -- Fixes an issue on the RedisCache backend delete_many and set_many methods

### DIFF
--- a/django/core/cache/backends/redis.py
+++ b/django/core/cache/backends/redis.py
@@ -218,7 +218,8 @@ class RedisCache(BaseCache):
         for key, value in data.items():
             key = self.make_and_validate_key(key, version=version)
             safe_data[key] = value
-        self._cache.set_many(safe_data, self.get_backend_timeout(timeout))
+        if safe_data:
+            self._cache.set_many(safe_data, self.get_backend_timeout(timeout))
         return []
 
     def delete_many(self, keys, version=None):
@@ -226,7 +227,8 @@ class RedisCache(BaseCache):
         for key in keys:
             key = self.make_and_validate_key(key, version=version)
             safe_keys.append(key)
-        self._cache.delete_many(safe_keys)
+        if safe_keys:
+            self._cache.delete_many(safe_keys)
 
     def clear(self):
         return self._cache.clear()

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1834,6 +1834,18 @@ class RedisCacheTests(BaseCacheTests, TestCase):
         self.assertEqual(pool.connection_kwargs["socket_timeout"], 0.1)
         self.assertIs(pool.connection_kwargs["retry_on_timeout"], True)
 
+    def test_delete_many_no_keys(self):
+        # Behaviour when no keys are passed should not raise
+        # redis.exceptions.ResponseError: wrong number of arguments
+        # for 'del' command
+        self.assertIsNone(cache.delete_many([]))
+
+    def test_set_many_empty_data(self):
+        # Behaviour when an empty dict is passed should not raise
+        # redis.exceptions.ResponseError: Command # 1 (MSET)
+        # of pipeline caused error: wrong number of arguments for 'mset' command
+        self.assertEqual(cache.set_many({}), [])
+
 
 class FileBasedCachePathLibTests(FileBasedCacheTests):
     def mkdtemp(self):


### PR DESCRIPTION
Ref:

- https://code.djangoproject.com/ticket/33826

Changes:

- RedisCache backend changed delete_many and set_many methods to check for keys or data not been empty before performing an actual del or mset on redis