### PR TITLE
Fixed #33781 -- Restored alignment for admin split-field timezone war…

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -123,6 +123,12 @@ form .aligned div.help {
     padding-left: 10px;
 }
 
+form .aligned p.datetime div.help.timezonewarning {
+    margin-left: 0;
+    padding-left: 0;
+    font-weight: normal;
+}
+
 form .aligned label + p.help,
 form .aligned label + div.help {
     margin-left: 0;


### PR DESCRIPTION
…nings.

Regression in f3e2bb0833105f43efc0cc6f19c8465bc1b1a785.
Refs ticket-33750 and ticket-27207.

A slightly more specific selector to remove the unwanted margin/padding, and restore the font-weight. 

Before f3e2bb0833105f43efc0cc6f19c8465bc1b1a785:

![before](https://user-images.githubusercontent.com/64686/177733947-647f3ae8-fc8d-4785-b2fe-d9ab03834519.png)

With this adjustment: 

<img width="425" alt="Screenshot 2022-07-07 at 10 56 15" src="https://user-images.githubusercontent.com/64686/177734042-4d731250-39f5-40d8-9470-a402eddabb12.png">


