### PR TITLE
Refs #33308 -- Adjustments to grouping and compound ordering logic to support psycopg3.

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -97,7 +97,7 @@ class Aggregate(Func):
             return "%s__%s" % (expressions[0].name, self.name.lower())
         raise TypeError("Complex expressions require an alias")
 
-    def get_group_by_cols(self, alias=None):
+    def get_group_by_cols(self):
         return []
 
     def as_sql(self, compiler, connection, **extra_context):

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1470,11 +1470,10 @@ class Subquery(BaseExpression, Combinable):
     def get_external_cols(self):
         return self.query.get_external_cols()
 
-    def as_sql(self, compiler, connection, template=None, query=None, **extra_context):
+    def as_sql(self, compiler, connection, template=None, **extra_context):
         connection.ops.check_expression_support(self)
         template_params = {**self.extra, **extra_context}
-        query = query or self.query
-        subquery_sql, sql_params = query.as_sql(compiler, connection)
+        subquery_sql, sql_params = self.query.as_sql(compiler, connection)
         template_params["subquery"] = subquery_sql[1:-1]
 
         template = template or template_params.get("template", self.template)
@@ -1482,13 +1481,7 @@ class Subquery(BaseExpression, Combinable):
         return sql, sql_params
 
     def get_group_by_cols(self, alias=None):
-        # If this expression is referenced by an alias for an explicit GROUP BY
-        # through values() a reference to this expression and not the
-        # underlying .query must be returned to ensure external column
-        # references are not grouped against as well.
-        if alias:
-            return [Ref(alias, self)]
-        return self.query.get_group_by_cols()
+        return self.query.get_group_by_cols(alias=alias, wrapper=self)
 
 
 class Exists(Subquery):
@@ -1498,28 +1491,18 @@ class Exists(Subquery):
     def __init__(self, queryset, negated=False, **kwargs):
         self.negated = negated
         super().__init__(queryset, **kwargs)
+        self.query = self.query.exists()
 
     def __invert__(self):
         clone = self.copy()
         clone.negated = not self.negated
         return clone
 
-    def get_group_by_cols(self, alias=None):
-        # self.query only gets limited to a single row in the .exists() call
-        # from self.as_sql() so deferring to Query.get_group_by_cols() is
-        # inappropriate.
-        if alias is None:
-            return [self]
-        return super().get_group_by_cols(alias)
-
-    def as_sql(self, compiler, connection, template=None, **extra_context):
-        query = self.query.exists(using=connection.alias)
+    def as_sql(self, compiler, connection, **extra_context):
         try:
             sql, params = super().as_sql(
                 compiler,
                 connection,
-                template=template,
-                query=query,
                 **extra_context,
             )
         except EmptyResultSet:

--- a/django/db/models/functions/math.py
+++ b/django/db/models/functions/math.py
@@ -169,7 +169,7 @@ class Random(NumericOutputFieldMixin, Func):
     def as_sqlite(self, compiler, connection, **extra_context):
         return super().as_sql(compiler, connection, function="RAND", **extra_context)
 
-    def get_group_by_cols(self, alias=None):
+    def get_group_by_cols(self):
         return []
 
 

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -128,7 +128,7 @@ class Lookup(Expression):
     def rhs_is_direct_value(self):
         return not hasattr(self.rhs, "as_sql")
 
-    def get_group_by_cols(self, alias=None):
+    def get_group_by_cols(self):
         cols = []
         for source in self.get_source_expressions():
             cols.extend(source.get_group_by_cols())

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -556,7 +556,7 @@ class Query(BaseExpression):
     def has_filters(self):
         return self.where
 
-    def exists(self, using, limit=True):
+    def exists(self, limit=True):
         q = self.clone()
         if not (q.distinct and q.is_sliced):
             if q.group_by is True:
@@ -568,11 +568,8 @@ class Query(BaseExpression):
                 q.set_group_by(allow_aliases=False)
             q.clear_select_clause()
         if q.combined_queries and q.combinator == "union":
-            limit_combined = connections[
-                using
-            ].features.supports_slicing_ordering_in_compound
             q.combined_queries = tuple(
-                combined_query.exists(using, limit=limit_combined)
+                combined_query.exists(limit=False)
                 for combined_query in q.combined_queries
             )
         q.clear_ordering(force=True)
@@ -1150,12 +1147,16 @@ class Query(BaseExpression):
             if col.alias in self.external_aliases
         ]
 
-    def get_group_by_cols(self, alias=None):
+    def get_group_by_cols(self, alias=None, wrapper=None):
+        # If wrapper is referenced by an alias for an explicit GROUP BY through
+        # values() a reference to this expression and not the self must be
+        # returned to ensure external column references are not grouped against
+        # as well.
         if alias:
-            return [Ref(alias, self)]
+            return [Ref(alias, wrapper or self)]
         external_cols = self.get_external_cols()
         if any(col.possibly_multivalued for col in external_cols):
-            return [self]
+            return [wrapper or self]
         return external_cols
 
     def as_sql(self, compiler, connection):

--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -178,7 +178,7 @@ class WhereNode(tree.Node):
                 sql_string = "(%s)" % sql_string
         return sql_string, result_params
 
-    def get_group_by_cols(self, alias=None):
+    def get_group_by_cols(self):
         cols = []
         for child in self.children:
             cols.extend(child.get_group_by_cols())

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -1036,13 +1036,16 @@ calling the appropriate methods on the wrapped expression.
 
         ``expression`` is the same as ``self``.
 
-    .. method:: get_group_by_cols(alias=None)
+    .. method:: get_group_by_cols()
 
         Responsible for returning the list of columns references by
         this expression. ``get_group_by_cols()`` should be called on any
         nested expressions. ``F()`` objects, in particular, hold a reference
-        to a column. The ``alias`` parameter will be ``None`` unless the
-        expression has been annotated and is used for grouping.
+        to a column.
+
+        .. versionchanged:: 4.2
+
+            The ``alias=None`` keyword argument was removed.
 
     .. method:: asc(nulls_first=None, nulls_last=None)
 

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -329,6 +329,8 @@ Miscellaneous
 * The :option:`makemigrations --check` option no longer creates missing
   migration files.
 
+* The ``alias`` argument for :meth:`.Expression.get_group_by_cols` is removed.
+
 .. _deprecated-features-4.2:
 
 Features deprecated in 4.2

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -1440,9 +1440,7 @@ class AggregateTestCase(TestCase):
             .annotate(cnt=Count("isbn"))
             .filter(cnt__gt=1)
         )
-        query = publishers_having_more_than_one_book_qs.query.exists(
-            using=connection.alias
-        )
+        query = publishers_having_more_than_one_book_qs.query.exists()
         _, _, group_by = query.get_compiler(connection=connection).pre_sql_setup()
         self.assertEqual(len(group_by), 1)
 

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -2525,13 +2525,13 @@ class CombinedExpressionTests(SimpleTestCase):
 class ExpressionWrapperTests(SimpleTestCase):
     def test_empty_group_by(self):
         expr = ExpressionWrapper(Value(3), output_field=IntegerField())
-        self.assertEqual(expr.get_group_by_cols(alias=None), [])
+        self.assertEqual(expr.get_group_by_cols(), [])
 
     def test_non_empty_group_by(self):
         value = Value("f")
         value.output_field = None
         expr = ExpressionWrapper(Lower(value), output_field=IntegerField())
-        group_by_cols = expr.get_group_by_cols(alias=None)
+        group_by_cols = expr.get_group_by_cols()
         self.assertEqual(group_by_cols, [expr.expression])
         self.assertEqual(group_by_cols[0].output_field, expr.output_field)
 


### PR DESCRIPTION
@apollo13 here's a PR demonstrating that it's possible to reference the left outer select clause columns by aliases instead of column index.

Something else that caught my eye is the branch that deals with reference to a non-selected alias

https://github.com/django/django/blob/6f80050496780e2f8a65e2a4374dd6375c9fbfa5/django/db/models/sql/compiler.py#L440-L452

I'm of opinion that we should drop support for that as the implicit column addition can chance the semantic of the query (e.g. `DISTINCT`, `GROUP BY`).

Thoughts?