### PR TITLE
Fixed #33726 -- Added skip-link to admin for keyboard navigation.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -814,6 +814,20 @@ a.deletelink:focus, a.deletelink:hover {
     max-width: 100%;
 }
 
+.skip-to-content-link {
+    position: absolute;
+    top: -999px;
+    margin: 5px;
+    padding: 5px;
+    background: var(--body-bg);
+    z-index: 1;
+}
+
+.skip-to-content-link:focus {
+    left: 0px;
+    top: 0px;
+}
+
 #content {
     padding: 20px 40px;
 }

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -24,7 +24,7 @@
 
 <body class="{% if is_popup %}popup {% endif %}{% block bodyclass %}{% endblock %}"
   data-admin-utc-offset="{% now "Z" %}">
-
+<a href="#content-start" class="skip-to-content-link">{% translate 'Skip to main content' %}</a>
 <!-- Container -->
 <div id="container">
 
@@ -81,7 +81,7 @@
           {% include "admin/nav_sidebar.html" %}
         {% endblock %}
       {% endif %}
-      <div class="content">
+      <div id="content-start" class="content" tabindex="-1">
         {% block messages %}
           {% if messages %}
             <ul class="messagelist">{% for message in messages %}

--- a/tests/admin_views/test_skip_link_to_content.py
+++ b/tests/admin_views/test_skip_link_to_content.py
@@ -1,0 +1,145 @@
+from django.contrib.admin.tests import AdminSeleniumTestCase
+from django.contrib.auth.models import User
+from django.test import override_settings
+from django.urls import reverse
+
+
+@override_settings(ROOT_URLCONF="admin_views.urls")
+class SeleniumTests(AdminSeleniumTestCase):
+    available_apps = ["admin_views"] + AdminSeleniumTestCase.available_apps
+
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username="super",
+            password="secret",
+            email="super@example.com",
+        )
+
+    def test_use_skip_link_to_content(self):
+        from selenium.webdriver.common.action_chains import ActionChains
+        from selenium.webdriver.common.by import By
+        from selenium.webdriver.common.keys import Keys
+
+        self.admin_login(
+            username="super",
+            password="secret",
+            login_url=reverse("admin:index"),
+        )
+
+        # `Skip link` is not present.
+        skip_link = self.selenium.find_element(By.CLASS_NAME, "skip-to-content-link")
+        self.assertFalse(skip_link.is_displayed())
+
+        # 1st TAB is pressed, `skip link` is shown.
+        body = self.selenium.find_element(By.TAG_NAME, "body")
+        body.send_keys(Keys.TAB)
+        self.assertTrue(skip_link.is_displayed())
+
+        # Press RETURN to skip the navbar links (view site / documentation /
+        # change password / log out) and focus first model in the admin_views list.
+        skip_link.send_keys(Keys.RETURN)
+        self.assertFalse(skip_link.is_displayed())  # `skip link` disappear.
+        keys = [Keys.TAB, Keys.TAB]  # The 1st TAB is the section title.
+        if self.browser == "firefox":
+            # For some reason Firefox doesn't focus the section title ('ADMIN_VIEWS').
+            keys.remove(Keys.TAB)
+        body.send_keys(keys)
+        actors_a_tag = self.selenium.find_element(By.LINK_TEXT, "Actors")
+        self.assertEqual(self.selenium.switch_to.active_element, actors_a_tag)
+
+        # Go to Actors changelist, skip sidebar and focus "Add actor +".
+        with self.wait_page_loaded():
+            actors_a_tag.send_keys(Keys.RETURN)
+        body = self.selenium.find_element(By.TAG_NAME, "body")
+        body.send_keys(Keys.TAB)
+        skip_link = self.selenium.find_element(By.CLASS_NAME, "skip-to-content-link")
+        self.assertTrue(skip_link.is_displayed())
+        ActionChains(self.selenium).send_keys(Keys.RETURN, Keys.TAB).perform()
+        actors_add_url = reverse("admin:admin_views_actor_add")
+        actors_a_tag = self.selenium.find_element(
+            By.CSS_SELECTOR, f"#content [href='{actors_add_url}']"
+        )
+        self.assertEqual(self.selenium.switch_to.active_element, actors_a_tag)
+
+        # Go to the Actor form and the first input will be focused automatically.
+        with self.wait_page_loaded():
+            actors_a_tag.send_keys(Keys.RETURN)
+        first_input = self.selenium.find_element(By.ID, "id_name")
+        self.assertEqual(self.selenium.switch_to.active_element, first_input)
+
+    def test_dont_use_skip_link_to_content(self):
+        from selenium.webdriver.common.by import By
+        from selenium.webdriver.common.keys import Keys
+
+        self.admin_login(
+            username="super",
+            password="secret",
+            login_url=reverse("admin:index"),
+        )
+
+        # `Skip link` is not present.
+        skip_link = self.selenium.find_element(By.CLASS_NAME, "skip-to-content-link")
+        self.assertFalse(skip_link.is_displayed())
+
+        # 1st TAB is pressed, `skip link` is shown.
+        body = self.selenium.find_element(By.TAG_NAME, "body")
+        body.send_keys(Keys.TAB)
+        self.assertTrue(skip_link.is_displayed())
+
+        # The 2nd TAB will focus the page title.
+        body.send_keys(Keys.TAB)
+        django_administration_title = self.selenium.find_element(
+            By.LINK_TEXT, "Django administration"
+        )
+        self.assertFalse(skip_link.is_displayed())  # `skip link` disappear.
+        self.assertEqual(
+            self.selenium.switch_to.active_element, django_administration_title
+        )
+
+    def test_skip_link_is_skipped_when_there_is_searchbar(self):
+        from selenium.webdriver.common.by import By
+
+        self.admin_login(
+            username="super",
+            password="secret",
+            login_url=reverse("admin:index"),
+        )
+
+        group_a_tag = self.selenium.find_element(By.LINK_TEXT, "Groups")
+        with self.wait_page_loaded():
+            group_a_tag.click()
+
+        # `Skip link` is not present.
+        skip_link = self.selenium.find_element(By.CLASS_NAME, "skip-to-content-link")
+        self.assertFalse(skip_link.is_displayed())
+
+        # `Searchbar` has autofocus.
+        searchbar = self.selenium.find_element(By.ID, "searchbar")
+        self.assertEqual(self.selenium.switch_to.active_element, searchbar)
+
+    def test_skip_link_with_RTL_language_doesnt_create_horizontal_scrolling(self):
+        from selenium.webdriver.common.by import By
+        from selenium.webdriver.common.keys import Keys
+
+        with override_settings(LANGUAGE_CODE="ar"):
+            self.admin_login(
+                username="super",
+                password="secret",
+                login_url=reverse("admin:index"),
+            )
+
+            skip_link = self.selenium.find_element(
+                By.CLASS_NAME, "skip-to-content-link"
+            )
+            body = self.selenium.find_element(By.TAG_NAME, "body")
+            body.send_keys(Keys.TAB)
+            self.assertTrue(skip_link.is_displayed())
+
+            is_vertical_scrolleable = self.selenium.execute_script(
+                "return arguments[0].scrollHeight > arguments[0].offsetHeight;", body
+            )
+            is_horizontal_scrolleable = self.selenium.execute_script(
+                "return arguments[0].scrollWeight > arguments[0].offsetWeight;", body
+            )
+            self.assertTrue(is_vertical_scrolleable)
+            self.assertFalse(is_horizontal_scrolleable)


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/33726)

**TO CHECK:**
 - [x] ~~The `skip link` is very simple, same as the screenshot in the ticket, do we want better styles?~~
 - [ ] I'm not big fan of do this, but there is another browser condition (Firefox): https://github.com/django/django/pull/15837/files#diff-12ef717f127caf8dbd84705926228907d362d342d6053ef1135305a0ac75c88bR44
 **like I did previously in** https://github.com/django/django/blob/0dd29209091280ccf34e07c9468746c396b7778e/tests/admin_views/test_prevent_double_submission.py#L62
and looking it again **we could delete** the `elif firefox` ☝️ 
- [x] https://code.djangoproject.com/ticket/33726#comment:3
    - [x] ~~Test keyboard only~~
    - [x] ~~Then keyboard + screenreader~~
    - [x] ~~Test mobile screenreader gestures~~
    - [x] ~~Listen to screenreader output on all devices~~
- [x] ~~Tabulation is OK? https://github.com/django/django/pull/15837#discussion_r921237494~~

**TO RUN TESTS**:

`./runtests.py admin_views.test_skip_link_to_content.SeleniumTests --selenium=BROWSER --parallel=1` with `BROWSER` as `chrome, firefox or safari`

**NOTES**

🗒️ _If you are testing in **Mac** with **Firefox**, please check:_ https://stackoverflow.com/questions/11704828/how-to-allow-keyboard-focus-of-links-in-firefox
🗒️ _If you are testing in **Mac** with **Safari**, please check:_ https://corehelpcenter.bqe.com/hc/en-us/articles/115003481673-Tab-key-is-not-working-on-Mac-Safari#:~:text=You%20can%20resolve%20this%20issue,each%20item%20on%20a%20webpage.