### PR TITLE
Improved migrate help text for the --check option.

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -81,7 +81,10 @@ class Command(BaseCommand):
             "--check",
             action="store_true",
             dest="check_unapplied",
-            help="Exits with a non-zero status if unapplied migrations exist.",
+            help=(
+                "Exits with a non-zero status if unapplied migrations exist. Does not "
+                "apply migrations."
+            ),
         )
         parser.add_argument(
             "--prune",

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -82,8 +82,8 @@ class Command(BaseCommand):
             action="store_true",
             dest="check_unapplied",
             help=(
-                "Exits with a non-zero status if unapplied migrations exist. Does not "
-                "apply migrations."
+                "Exits with a non-zero status if unapplied migrations exist and does "
+                "not actually apply migrations."
             ),
         )
         parser.add_argument(


### PR DESCRIPTION
This very small tweak helps clarify a small difference between the `--check` flags available to `makemigrations` and `migrate`:

 - `makemigrations --check` will make the migrations unless you also add `--dry-run`.
 - `migrate --check` will *not* migrate things and doesn't have a `--dry-run` argument.

I had some existential fear about this difference today when I was using `migrate --check` as part of an automated deployment pipeline. I assumed, wrongly, that it'd need some kind of `--dry-run` parameter to prevent it from running migrations (something that's devastating in our big-data environment) and resorted to creating a test to prove myself wrong. 

With this change, nobody else will have any doubt in the future.