### PR TITLE
Fixed #33848 -- Optimized StateApps.clone().

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -680,10 +680,13 @@ class StateApps(Apps):
         """Return a clone of this registry."""
         clone = StateApps([], {})
         clone.all_models = copy.deepcopy(self.all_models)
-        clone.app_configs = copy.deepcopy(self.app_configs)
-        # Set the pointer to the correct app registry.
-        for app_config in clone.app_configs.values():
+
+        for app_label in self.app_configs:
+            app_config = AppConfigStub(app_label)
             app_config.apps = clone
+            app_config.import_models()
+            clone.app_configs[app_label] = app_config
+
         # No need to actually clone them, they'll never change
         clone.real_models = self.real_models
         return clone


### PR DESCRIPTION
It cleans `config.apps` and `config.models` before `AppConfigStub` deepcopy, to reduce the deepcopy slow call.