### PR TITLE
Fixed #33854 -- Corrected the order of parameters in dbshell on PostgreSQL.

### DIFF
--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -32,9 +32,9 @@ class DatabaseClient(BaseDatabaseClient):
             args += ["-h", host]
         if port:
             args += ["-p", str(port)]
+        args.extend(parameters)
         if dbname:
             args += [dbname]
-        args.extend(parameters)
 
         env = {}
         if passwd:

--- a/tests/dbshell/test_postgresql.py
+++ b/tests/dbshell/test_postgresql.py
@@ -154,7 +154,7 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
     def test_parameters(self):
         self.assertEqual(
             self.settings_to_cmd_args_env({"NAME": "dbname"}, ["--help"]),
-            (["psql", "dbname", "--help"], None),
+            (["psql", "--help", "dbname"], None),
         )
 
     @skipUnless(connection.vendor == "postgresql", "Requires a PostgreSQL connection")


### PR DESCRIPTION
`psql` doesn't support and positional arguments beyond database name (and optionally username), and all options must come before positional args to be interpreted properly. Those that follow the args are dropped.

This PR ensures the dbshell `parameters` are placed before the database name, and therefore are interpreted by `psql` as expected.