### PR TITLE
Raise exception used to raise even after False

### DIFF
--- a/django/contrib/auth/mixins.py
+++ b/django/contrib/auth/mixins.py
@@ -44,7 +44,7 @@ class AccessMixin:
         return self.redirect_field_name
 
     def handle_no_permission(self):
-        if self.raise_exception or self.request.user.is_authenticated:
+        if self.raise_exception:
             raise PermissionDenied(self.get_permission_denied_message())
 
         path = self.request.build_absolute_uri()


### PR DESCRIPTION
Raise exception used to raise exceptions in traceback  even when it was set to False. It shouldn't check if the user is authenticated or not for raising exception.