### PR TITLE
Prefer compact coding in json_script

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -67,9 +67,10 @@ def json_script(value, element_id=None, encoder=None):
     """
     from django.core.serializers.json import DjangoJSONEncoder
 
-    json_str = json.dumps(value, cls=encoder or DjangoJSONEncoder).translate(
-        _json_script_escapes
-    )
+    json_str = json.dumps(
+        value, ensure_ascii=False, separators=(',', ':'),
+        cls=encoder or DjangoJSONEncoder
+    ).translate(_json_script_escapes)
     if element_id:
         template = '<script id="{}" type="application/json">{}</script>'
         args = (element_id, mark_safe(json_str))

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1848,7 +1848,7 @@ If ``value`` is the dictionary ``{'hello': 'world'}``, the output will be:
 
 .. code-block:: html
 
-    <script id="hello-data" type="application/json">{"hello": "world"}</script>
+    <script id="hello-data" type="application/json">{"hello":"world"}</script>
 
 The resulting data can be accessed in JavaScript like this:
 
@@ -1861,7 +1861,7 @@ example if ``value`` is ``{'hello': 'world</script>&amp;'}``, the output is:
 
 .. code-block:: html
 
-    <script id="hello-data" type="application/json">{"hello": "world\\u003C/script\\u003E\\u0026amp;"}</script>
+    <script id="hello-data" type="application/json">{"hello":"world\\u003C/script\\u003E\\u0026amp;"}</script>
 
 This is compatible with a strict Content Security Policy that prohibits in-page
 script execution. It also maintains a clean separation between passive data and

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -663,7 +663,7 @@ escaping HTML.
     ``<script>`` tag is given the passed id. For example::
 
         >> json_script({"hello": "world"}, element_id="hello-data")
-        '<script id="hello-data" type="application/json">{"hello": "world"}</script>'
+        '<script id="hello-data" type="application/json">{"hello":"world"}</script>'
 
     The ``encoder``, which defaults to
     :class:`django.core.serializers.json.DjangoJSONEncoder`, will be used to

--- a/tests/template_tests/filter_tests/test_json_script.py
+++ b/tests/template_tests/filter_tests/test_json_script.py
@@ -12,7 +12,7 @@ class JsonScriptTests(SimpleTestCase):
         self.assertEqual(
             output,
             '<script id="test_id" type="application/json">'
-            '{"a": "testing\\r\\njson \'string\\" '
+            '{"a":"testing\\r\\njson \'string\\" '
             '\\u003Cb\\u003Eescaping\\u003C/b\\u003E"}'
             "</script>",
         )
@@ -21,3 +21,10 @@ class JsonScriptTests(SimpleTestCase):
     def test_without_id(self):
         output = self.engine.render_to_string("json-tag02", {"value": {}})
         self.assertEqual(output, '<script type="application/json">{}</script>')
+
+    @setup({"json-tag03": '{{ val|json_script:"el" }}'})
+    def test_non_ascii(self):
+        self.assertHTMLEqual(
+            self.engine.render_to_string("json-tag03", {"val": {"hello": "привет"}}),
+            '<script id="el" type="application/json">{"hello":"привет"}</script>',
+        )

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -192,7 +192,7 @@ class TestUtilsHtml(SimpleTestCase):
             (
                 {"a": "<script>test&ing</script>"},
                 '<script id="test_id" type="application/json">'
-                '{"a": "\\u003Cscript\\u003Etest\\u0026ing\\u003C/script\\u003E"}'
+                '{"a":"\\u003Cscript\\u003Etest\\u0026ing\\u003C/script\\u003E"}'
                 "</script>",
             ),
             # Lazy strings are quoted
@@ -204,7 +204,7 @@ class TestUtilsHtml(SimpleTestCase):
             (
                 {"a": lazystr("<script>test&ing</script>")},
                 '<script id="test_id" type="application/json">'
-                '{"a": "\\u003Cscript\\u003Etest\\u0026ing\\u003C/script\\u003E"}'
+                '{"a":"\\u003Cscript\\u003Etest\\u0026ing\\u003C/script\\u003E"}'
                 "</script>",
             ),
         )
@@ -225,7 +225,7 @@ class TestUtilsHtml(SimpleTestCase):
     def test_json_script_without_id(self):
         self.assertHTMLEqual(
             json_script({"key": "value"}),
-            '<script type="application/json">{"key": "value"}</script>',
+            '<script type="application/json">{"key":"value"}</script>',
         )
 
     def test_smart_urlquote(self):


### PR DESCRIPTION
json.dumps() overrides ensure_ascii=False in DjangoJSONEncoder. Set the
flag again. It is okay because JSON allows the use of Unicode characters
only. Set separators without spaces as well.