### PR TITLE
Fixed #33833 -- Corrected .closelink admin CSS.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -303,8 +303,10 @@ body.popup .submit-row {
     padding: 10px 15px;
     height: 15px;
     line-height: 15px;
-    margin: 0 0 0 5px;
+    margin: 0 5px 5px 5px;
     color: var(--button-fg);
+    vertical-align: top;
+    text-decoration: none;
 }
 
 .submit-row a.deletelink:focus,

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -305,20 +305,20 @@ body.popup .submit-row {
     line-height: 15px;
     margin: 0 5px 5px 5px;
     color: var(--button-fg);
-    vertical-align: top;
-    text-decoration: none;
 }
 
 .submit-row a.deletelink:focus,
 .submit-row a.deletelink:hover,
 .submit-row a.deletelink:active {
     background: var(--delete-button-hover-bg);
+    text-decoration: none;
 }
 
 .submit-row a.closelink:focus,
 .submit-row a.closelink:hover,
 .submit-row a.closelink:active {
     background: var(--close-button-hover-bg);
+    text-decoration: none;
 }
 
 /* CUSTOM FORM FIELDS */

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -303,7 +303,7 @@ body.popup .submit-row {
     padding: 10px 15px;
     height: 15px;
     line-height: 15px;
-    margin: 0 5px 5px 5px;
+    margin: 0 5px 5px 0;
     color: var(--button-fg);
 }
 

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -829,14 +829,16 @@ input[type="submit"], button {
         width: 100%;
     }
 
-    .submit-row input, .submit-row input.default, .submit-row a, .submit-row a.closelink {
+    .submit-row input, .submit-row input.default, .submit-row a {
         float: none;
         margin: 0 0 10px;
         text-align: center;
     }
 
     .submit-row a.closelink {
+        float: none;
         padding: 10px 0;
+        text-align: center;
     }
 
     .submit-row p.deletelink-box {


### PR DESCRIPTION
[Ticket 33833](https://code.djangoproject.com/ticket/33833#comment:3)

"Close" button is aligned now and hasn't an underline on focus like near buttons.

## Alignment
`input` and `a` (close button is a link) tags have different alignments by default. I've created a CodePen with commented fix-styles to show it: https://codepen.io/leonidpodriz/pen/RwMpeBB

Also, near inputs have a bottom margin that makes content vertically centered. But `a` hadn't such margin that made such bug.

## Underline
Just added `text-decoration: none`.