### PR TITLE
Fixed #34098 -- Fixed loss of precision for Decimal values in floatformat filter.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -149,7 +149,7 @@ def floatformat(text, arg=-1):
             use_l10n = False
             arg = arg[:-1] or -1
     try:
-        input_val = repr(text)
+        input_val = str(text)
         d = Decimal(input_val)
     except InvalidOperation:
         try:

--- a/tests/template_tests/filter_tests/test_floatformat.py
+++ b/tests/template_tests/filter_tests/test_floatformat.py
@@ -56,6 +56,10 @@ class FunctionTests(SimpleTestCase):
         self.assertEqual(floatformat(0.12345, 2), "0.12")
         self.assertEqual(floatformat(Decimal("555.555"), 2), "555.56")
         self.assertEqual(floatformat(Decimal("09.000")), "9")
+        self.assertEqual(
+            floatformat(Decimal("123456.123456789012345678901"), 21),
+            "123456.123456789012345678901",
+        )
         self.assertEqual(floatformat("foo"), "")
         self.assertEqual(floatformat(13.1031, "bar"), "13.1031")
         self.assertEqual(floatformat(18.125, 2), "18.13")


### PR DESCRIPTION
I discovered that `floatformat` may round up high precision decimal numbers.

The underlying cause is that the first attempt to convert input to a decimal is written in a way that almost never works (`repr` vs `str`).