### PR TITLE
Fixed #33317 -- Added note about unconditional evaluation of {% block %} tags.

### DIFF
--- a/docs/ref/templates/language.txt
+++ b/docs/ref/templates/language.txt
@@ -431,9 +431,10 @@ Here are some tips for working with inheritance:
   In larger templates, this technique helps you see which ``{% block %}``
   tags are being closed.
 
-* When a parent block is overridden in an if condition, the overridden content
-  is output regardless of the truthiness of the condition. For example, this
-  template will still override the content of its parent block::
+* :ttag:`{% block %}<block>` tags are evaluated first. That's why the content
+  of a block is always overridden, regardless of the truthiness of surrounding
+  tags. For example, this template will *always* override the content of the
+  ``title`` block::
 
       {% if change_title %}
           {% block title %}Hello!{% endblock title %}

--- a/docs/ref/templates/language.txt
+++ b/docs/ref/templates/language.txt
@@ -431,6 +431,14 @@ Here are some tips for working with inheritance:
   In larger templates, this technique helps you see which ``{% block %}``
   tags are being closed.
 
+* When a parent block is overridden in an if condition, the overridden content
+  is output regardless of the truthiness of the condition. For example, this
+  template will still override the content of its parent block::
+
+      {% if False %}
+          {% block content %}Foo{% endblock content %}
+      {% endif %}
+
 Finally, note that you can't define multiple :ttag:`block` tags with the same
 name in the same template. This limitation exists because a block tag works in
 "both" directions. That is, a block tag doesn't just provide a hole to fill --

--- a/docs/ref/templates/language.txt
+++ b/docs/ref/templates/language.txt
@@ -435,8 +435,8 @@ Here are some tips for working with inheritance:
   is output regardless of the truthiness of the condition. For example, this
   template will still override the content of its parent block::
 
-      {% if False %}
-          {% block content %}Foo{% endblock content %}
+      {% if change_title %}
+          {% block title %}Hello!{% endblock title %}
       {% endif %}
 
 Finally, note that you can't define multiple :ttag:`block` tags with the same


### PR DESCRIPTION
Add note about not overriding parent blocks within conditionals