### PR TITLE
cast _location() return value as string to remove i18n bug

### DIFF
--- a/django/contrib/sitemaps/__init__.py
+++ b/django/contrib/sitemaps/__init__.py
@@ -114,7 +114,7 @@ class Sitemap:
             obj, lang_code = item
             # Activate language from item-tuple or forced one before calling location.
             with translation.override(force_lang_code or lang_code):
-                return self._get("location", item)
+                return str(self._get("location", item))
         return self._get("location", item)
 
     @property


### PR DESCRIPTION
Generating sitemaps for multiple languages does not work - the URL for the default language is simply repeated for every language.

The problem occurs in `django.contrib.sitemaps.__init__.py` when `Sitemap._location()` returns the output of another method `self._get()`. Casting this methods output to a string when returning it results in the expected behavior.

This bug fix was motivated by this [SO question](https://stackoverflow.com/q/73090133/6553466) which contains additional details of my particular use case.

I don't really understand _why_ I need to cast the output of the `_location` method to a string, if anyone can explain why then Id be interested to find out. Something about a lazy reference and a context processor that activates a language in `_location()`, perhaps.