### PR TITLE
Removed obsolete note in management.get_commands() docstring.

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -65,10 +65,6 @@ def get_commands():
     pairs from this dictionary can then be used in calls to
     load_command_class(app_name, command_name)
 
-    If a specific version of a command must be loaded (e.g., with the
-    startapp command), the instantiated module can be placed in the
-    dictionary in place of the application name.
-
     The dictionary is cached on the first call and reused on subsequent
     calls.
     """


### PR DESCRIPTION
Commit 901c3708fb8a2e51bddd37358f8e536282a8c266 documented that the return dict could directly include command modules instead of name strings, which was true at the time. However, that possibility was removed in commit 38f1fe3b35c212136d959538a309c33bf2d340a9. Other code now relies on this not happening (e.g. the `app = app.rpartition(".")[-1]` added in commit 175e6d77df526dea1ade94661e487072e7c7cd88).