### PR TITLE
Improve part 5 of the tutorial

### DIFF
--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -152,9 +152,10 @@ whose date lies in the future:
     >>> from django.utils import timezone
     >>> from polls.models import Question
     >>> # create a Question instance with pub_date 30 days in the future
-    >>> future_question = Question(pub_date=timezone.now() + datetime.timedelta(days=30))
+    >>> time = timezone.now() + datetime.timedelta(days=30)
+    >>> question = Question(question_text="Future question.", pub_date=time)
     >>> # was it published recently?
-    >>> future_question.was_published_recently()
+    >>> question.was_published_recently()
     True
 
 Since things in the future are not 'recent', this is clearly wrong.
@@ -190,8 +191,8 @@ Put the following in the ``tests.py`` file in the ``polls`` application:
             is in the future.
             """
             time = timezone.now() + datetime.timedelta(days=30)
-            future_question = Question(pub_date=time)
-            self.assertIs(future_question.was_published_recently(), False)
+            question = Question(question_text="Future question.", pub_date=time)
+            self.assertIs(question.was_published_recently(), False)
 
 Here we have created a :class:`django.test.TestCase` subclass with a method that
 creates a ``Question`` instance with a ``pub_date`` in the future. We then check
@@ -216,7 +217,7 @@ and you'll see something like::
     ----------------------------------------------------------------------
     Traceback (most recent call last):
       File "/path/to/mysite/polls/tests.py", line 16, in test_was_published_recently_with_future_question
-        self.assertIs(future_question.was_published_recently(), False)
+        self.assertIs(question.was_published_recently(), False)
     AssertionError: True is not False
 
     ----------------------------------------------------------------------
@@ -304,18 +305,18 @@ more comprehensively:
         was_published_recently() returns False for questions whose pub_date
         is older than 1 day.
         """
-        time = timezone.now() - datetime.timedelta(days=1, seconds=1)
-        old_question = Question(pub_date=time)
-        self.assertIs(old_question.was_published_recently(), False)
+        time = timezone.now() + datetime.timedelta(days=-1, seconds=-1)
+        question = Question(question_text="Old question.", pub_date=time)
+        self.assertIs(question.was_published_recently(), False)
 
     def test_was_published_recently_with_recent_question(self):
         """
         was_published_recently() returns True for questions whose pub_date
         is within the last day.
         """
-        time = timezone.now() - datetime.timedelta(hours=23, minutes=59, seconds=59)
-        recent_question = Question(pub_date=time)
-        self.assertIs(recent_question.was_published_recently(), True)
+        time = timezone.now() + datetime.timedelta(days=-1, seconds=1)
+        question = Question(question_text="Recent question.", pub_date=time)
+        self.assertIs(question.was_published_recently(), True)
 
 And now we have three tests that confirm that ``Question.was_published_recently()``
 returns sensible values for past, recent, and future questions.
@@ -484,6 +485,7 @@ class:
 
 
     class QuestionIndexViewTests(TestCase):
+
         def test_no_questions(self):
             """
             If no questions exist, an appropriate message is displayed.
@@ -500,6 +502,7 @@ class:
             """
             question = create_question(question_text="Past question.", days=-30)
             response = self.client.get(reverse('polls:index'))
+            self.assertEqual(response.status_code, 200)
             self.assertQuerysetEqual(
                 response.context['latest_question_list'],
                 [question],
@@ -512,6 +515,7 @@ class:
             """
             create_question(question_text="Future question.", days=30)
             response = self.client.get(reverse('polls:index'))
+            self.assertEqual(response.status_code, 200)
             self.assertContains(response, "No polls are available.")
             self.assertQuerysetEqual(response.context['latest_question_list'], [])
 
@@ -523,6 +527,7 @@ class:
             question = create_question(question_text="Past question.", days=-30)
             create_question(question_text="Future question.", days=30)
             response = self.client.get(reverse('polls:index'))
+            self.assertEqual(response.status_code, 200)
             self.assertQuerysetEqual(
                 response.context['latest_question_list'],
                 [question],
@@ -532,12 +537,13 @@ class:
             """
             The questions index page may display multiple questions.
             """
-            question1 = create_question(question_text="Past question 1.", days=-30)
-            question2 = create_question(question_text="Past question 2.", days=-5)
+            question_1 = create_question(question_text="Past question 1.", days=-30)
+            question_2 = create_question(question_text="Past question 2.", days=-5)
             response = self.client.get(reverse('polls:index'))
+            self.assertEqual(response.status_code, 200)
             self.assertQuerysetEqual(
                 response.context['latest_question_list'],
-                [question2, question1],
+                [question_2, question_1],
             )
 
 
@@ -590,13 +596,14 @@ is not:
     :caption: ``polls/tests.py``
 
     class QuestionDetailViewTests(TestCase):
+
         def test_future_question(self):
             """
             The detail view of a question with a pub_date in the future
             returns a 404 not found.
             """
-            future_question = create_question(question_text='Future question.', days=5)
-            url = reverse('polls:detail', args=(future_question.id,))
+            question = create_question(question_text='Future question.', days=5)
+            url = reverse('polls:detail', args=(question.id,))
             response = self.client.get(url)
             self.assertEqual(response.status_code, 404)
 
@@ -605,10 +612,11 @@ is not:
             The detail view of a question with a pub_date in the past
             displays the question's text.
             """
-            past_question = create_question(question_text='Past Question.', days=-5)
-            url = reverse('polls:detail', args=(past_question.id,))
+            question = create_question(question_text='Past question.', days=-5)
+            url = reverse('polls:detail', args=(question.id,))
             response = self.client.get(url)
-            self.assertContains(response, past_question.question_text)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, question.question_text)
 
 Ideas for more tests
 --------------------

--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -491,7 +491,6 @@ class:
             If no questions exist, an appropriate message is displayed.
             """
             response = self.client.get(reverse('polls:index'))
-            self.assertEqual(response.status_code, 200)
             self.assertContains(response, "No polls are available.")
             self.assertQuerysetEqual(response.context['latest_question_list'], [])
 
@@ -515,7 +514,6 @@ class:
             """
             create_question(question_text="Future question.", days=30)
             response = self.client.get(reverse('polls:index'))
-            self.assertEqual(response.status_code, 200)
             self.assertContains(response, "No polls are available.")
             self.assertQuerysetEqual(response.context['latest_question_list'], [])
 
@@ -556,8 +554,10 @@ repetition out of the process of creating questions.
 "No polls are available." and verifies the ``latest_question_list`` is empty.
 Note that the :class:`django.test.TestCase` class provides some additional
 assertion methods. In these examples, we use
-:meth:`~django.test.SimpleTestCase.assertContains()` and
-:meth:`~django.test.TransactionTestCase.assertQuerysetEqual()`.
+:meth:`~django.test.SimpleTestCase.assertContains()` which checks the message
+and the status code, and
+:meth:`~django.test.TransactionTestCase.assertQuerysetEqual()` which checks the
+queryset.
 
 In ``test_past_question``, we create a question and verify that it appears in
 the list.


### PR DESCRIPTION
This PR provides the following changes to the [part 5 of the tutorial](https://docs.djangoproject.com/en/4.0/intro/tutorial05/):

- add missing status code checks;
- remove redundant status code checks since `assertContains` [already performs them](https://docs.djangoproject.com/en/4.0/topics/testing/tools/#django.test.SimpleTestCase.assertContains);
- add missing `question_text` values at `Question` object creation instead of putting the information in variables.