### PR TITLE
Fixed collation tests on MySQL 8.0.30+.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -66,11 +66,14 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def test_collations(self):
         charset = "utf8"
-        if self.connection.mysql_is_mariadb and self.connection.mysql_version >= (
-            10,
-            6,
+        if (
+            self.connection.mysql_is_mariadb
+            and self.connection.mysql_version >= (10, 6)
+        ) or (
+            not self.connection.mysql_is_mariadb
+            and self.connection.mysql_version >= (8, 0, 30)
         ):
-            # utf8 is an alias for utf8mb3 in MariaDB 10.6+.
+            # utf8 is an alias for utf8mb3 in MariaDB 10.6+ and MySQL 8.0.30+.
             charset = "utf8mb3"
         return {
             "ci": f"{charset}_general_ci",


### PR DESCRIPTION
The `utf8_` collations are renamed to `utf8mb3_*` on MySQL 8.0.30+, see [release notes](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-30.html#mysqld-8-0-30-charset).