### PR TITLE
slightly improve the __eq__ method of the Model class

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -609,14 +609,14 @@ class Model(metaclass=ModelBase):
         return "%s object (%s)" % (self.__class__.__name__, self.pk)
 
     def __eq__(self, other):
+        if self is other:
+            return True
         if not isinstance(other, Model):
             return NotImplemented
         if self._meta.concrete_model != other._meta.concrete_model:
             return False
         my_pk = self.pk
-        if my_pk is None:
-            return self is other
-        return my_pk == other.pk
+        return my_pk is not None and my_pk == other.pk
 
     def __hash__(self):
         if self.pk is None:


### PR DESCRIPTION
The `__eq__` method should normally return True if the two references point to the same object. Later in the implementation for `__eq__`, we indeed return `True`, but only after performing checks if this is the same concrete model and if the primary key is `None`.

Since the `a is b` check is very lightweight, it only checks referential equality, it is probably better to move this to the top of the method, we can then also discard that at the bottom of the method.

A small extra improvement might be:

```
return None is not self.pk == other.pk
```

but that likely makes it less readable.