### PR TITLE
Fixed #33881 -- Added support for database collations to ArrayField(Char/TextFields).

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -25,6 +25,7 @@ class ArrayField(CheckFieldDefaultMixin, Field):
 
     def __init__(self, base_field, size=None, **kwargs):
         self.base_field = base_field
+        self.db_collation = getattr(self.base_field, "db_collation", None)
         self.size = size
         if self.size:
             self.default_validators = [
@@ -96,6 +97,11 @@ class ArrayField(CheckFieldDefaultMixin, Field):
     def cast_db_type(self, connection):
         size = self.size or ""
         return "%s[%s]" % (self.base_field.cast_db_type(connection), size)
+
+    def db_parameters(self, connection):
+        db_params = super().db_parameters(connection)
+        db_params["collation"] = self.db_collation
+        return db_params
 
     def get_placeholder(self, value, compiler, connection):
         return "%s::{}".format(self.db_type(connection))

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -950,7 +950,7 @@ class BaseDatabaseSchemaEditor:
         if old_collation != new_collation:
             # Collation change handles also a type change.
             fragment = self._alter_column_collation_sql(
-                model, new_field, new_type, new_collation
+                model, new_field, new_type, new_collation, old_field
             )
             actions.append(fragment)
         # Type change?
@@ -1079,6 +1079,7 @@ class BaseDatabaseSchemaEditor:
                     new_rel.field,
                     rel_type,
                     rel_collation,
+                    old_rel.field,
                 )
                 other_actions = []
             else:
@@ -1226,7 +1227,9 @@ class BaseDatabaseSchemaEditor:
             [],
         )
 
-    def _alter_column_collation_sql(self, model, new_field, new_type, new_collation):
+    def _alter_column_collation_sql(
+        self, model, new_field, new_type, new_collation, old_field
+    ):
         return (
             self.sql_alter_column_collate
             % {

--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -242,9 +242,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             )
             return cursor.fetchone()[0]
 
-    def _alter_column_collation_sql(self, model, new_field, new_type, new_collation):
+    def _alter_column_collation_sql(
+        self, model, new_field, new_type, new_collation, old_field
+    ):
         if new_collation is None:
             new_collation = self._get_default_collation(model._meta.db_table)
         return super()._alter_column_collation_sql(
-            model, new_field, new_type, new_collation
+            model, new_field, new_type, new_collation, old_field
         )


### PR DESCRIPTION
ticket-33881

With this patch ~~(:thinking: `USING` is missing)~~:
```sql
ALTER TABLE "test_33872_postgrescifieldsmodel" ALTER COLUMN "array_ci_text" TYPE text[] COLLATE "sv-x-icu" USING "array_ci_text"::text[];
```
Without this patch:
```sql
ALTER TABLE "test_33872_postgrescifieldsmodel" ALTER COLUMN "array_ci_text" TYPE text[] USING "array_ci_text"::text[];
```