### PR TITLE
Doc'd TextField.db_collation as optional.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1343,7 +1343,7 @@ However it is not enforced at the model or database level. Use a
 
 .. attribute:: TextField.db_collation
 
-    The database collation name of the field.
+    Optional. The database collation name of the field.
 
     .. note::
 


### PR DESCRIPTION
Matches CharField.db_collation docs.

Thanks to Paolo Melchiorre for the report.

See https://github.com/django/django/pull/15891#issuecomment-1200119740 @pauloxnet 