### PR TITLE
Fixed #33886 -- Reallowed using GeoIP2() when GEOS is not installed.

### DIFF
--- a/django/contrib/gis/geoip2/base.py
+++ b/django/contrib/gis/geoip2/base.py
@@ -3,7 +3,6 @@ import socket
 import geoip2.database
 
 from django.conf import settings
-from django.contrib.gis.geos import Point
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_ipv46_address
 from django.utils._os import to_path
@@ -219,6 +218,9 @@ class GeoIP2:
         "Return a GEOS Point object for the given query."
         ll = self.lon_lat(query)
         if ll:
+            # Allows importing and using GeoIP2() when GEOS is not installed.
+            from django.contrib.gis.geos import Point
+
             return Point(ll, srid=4326)
         else:
             return None

--- a/docs/releases/4.1.1.txt
+++ b/docs/releases/4.1.1.txt
@@ -9,4 +9,5 @@ Django 4.1.1 fixes several bugs in 4.1.
 Bugfixes
 ========
 
-* ...
+* Reallowed, following a regression in Django 4.1, using ``GeoIP2()`` when GEOS
+  is not installed (:ticket:`33886`).


### PR DESCRIPTION
This reverts commit 31bef51d8ea5e3bf650de1495ae1f0566670b8f3 to allow using the GeoIP module without GDAL installed.

Refs https://code.djangoproject.com/ticket/33886

Refs https://github.com/django/django/pull/15146