### PR TITLE
Fixed typo in docs/ref/forms/renderers.txt.

### DIFF
--- a/docs/ref/forms/renderers.txt
+++ b/docs/ref/forms/renderers.txt
@@ -60,7 +60,7 @@ should return a rendered templates (as a string) or raise
 
         The ``"django/forms/default.html"`` template is deprecated and will be
         removed in Django 5.0. The default will become
-        ``"django/forms/default.html"`` at that time.
+        ``"django/forms/div.html"`` at that time.
 
     .. attribute:: formset_template_name
 


### PR DESCRIPTION
Thanks Josh for the [report](https://forum.djangoproject.com/t/documentation-error-in-4-1-release-notes/15242).