### PR TITLE
Fixed #33899 -- Fixed migration crash when removing indexed field on SQLite 3.35.5+.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -322,6 +322,7 @@ answer newbie questions, and generally made Django that much better:
     Filip Noetzel <http://filip.noetzel.co.uk/>
     Filip Wasilewski <filip.wasilewski@gmail.com>
     Finn Gruwier Larsen <finn@gruwier.dk>
+    Fiza Ashraf <fizaashraf37@gmail.com>
     Flávio Juvenal da Silva Junior <flavio@vinta.com.br>
     flavio.curella@gmail.com
     Florian Apolloner <florian@apolloner.eu>

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -408,10 +408,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # For explicit "through" M2M fields, do nothing
         elif (
             self.connection.features.can_alter_table_drop_column
-            # Primary keys, unique fields, and foreign keys are not
-            # supported in ALTER TABLE DROP COLUMN.
+            # Primary keys, unique fields, indexed fields, and foreign keys are
+            # not supported in ALTER TABLE DROP COLUMN.
             and not field.primary_key
             and not field.unique
+            and not field.db_index
             and not (field.remote_field and field.db_constraint)
         ):
             super().remove_field(model, field)

--- a/docs/releases/4.1.1.txt
+++ b/docs/releases/4.1.1.txt
@@ -26,3 +26,6 @@ Bugfixes
 * Fixed a regression in Django 4.1 that caused a crash of
   :class:`~django.db.models.expressions.Window` expressions with
   :class:`~django.contrib.postgres.aggregates.ArrayAgg` (:ticket:`33898`).
+
+* Fixed a regression in Django 4.1 that caused a migration crash on SQLite
+  3.35.5+ when removing an indexed field (:ticket:`33899`).

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -813,6 +813,17 @@ class SchemaTests(TransactionTestCase):
                 False,
             )
 
+    def test_remove_indexed_field(self):
+        with connection.schema_editor() as editor:
+            editor.create_model(AuthorCharFieldWithIndex)
+        with connection.schema_editor() as editor:
+            editor.remove_field(
+                AuthorCharFieldWithIndex,
+                AuthorCharFieldWithIndex._meta.get_field("char_field"),
+            )
+        columns = self.column_classes(AuthorCharFieldWithIndex)
+        self.assertNotIn("char_field", columns)
+
     def test_alter(self):
         """
         Tests simple altering of fields


### PR DESCRIPTION
Ticket Reference: https://code.djangoproject.com/ticket/33899#no1

Wrote regression tests for the bug and found first bad commit as below:

`3702819227fd0cdd9b581cd99e11d1561d51cbeb is the first bad commit
commit 3702819227fd0cdd9b581cd99e11d1561d51cbeb
Author: Mariusz Felisiak <felisiak.mariusz@gmail.com>
Date:   Fri Feb 11 22:21:58 2022 +0100

    Refs #32502 -- Avoided table rebuild when removing fields on SQLite 3.35.5+.

    ALTER TABLE ... DROP COLUMN was introduced in SQLite 3.35+ however
    a data corruption issue was fixed in SQLite 3.35.5.

 django/db/backends/sqlite3/features.py |  2 ++
 django/db/backends/sqlite3/schema.py   | 10 ++++++++++
 tests/schema/tests.py                  | 18 ++++++++++++++++++
 3 files changed, 30 insertions(+)
bisect found first bad commit
`

Bug Fix in progress. Once the bug is fixed, the test case should pass.

