### PR TITLE
Removed unused InlineAdminForm.ordering_field().

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -526,11 +526,6 @@ class InlineAdminForm(AdminForm):
 
         return AdminField(self.form, DELETION_FIELD_NAME, False)
 
-    def ordering_field(self):
-        from django.forms.formsets import ORDERING_FIELD_NAME
-
-        return AdminField(self.form, ORDERING_FIELD_NAME, False)
-
 
 class InlineFieldset(Fieldset):
     def __init__(self, formset, *args, **kwargs):


### PR DESCRIPTION
Unused since its introduction in a19ed8aea395e8e07164ff7d85bd7dff2f24edca.