### PR TITLE
Fixed #33491 -- Fixed change-list selected row-highlight on cancelled delete.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -258,7 +258,10 @@
     vertical-align: baseline;
 }
 
-#changelist table tbody tr.selected {
+/* Once the :has() pseudo-class is supported by all browsers, the tr.selected
+   selector and the JS adding the class can be removed. */
+#changelist table tbody tr.selected,
+#changelist table tbody tr:has(input[type=checkbox]:checked) {
     background-color: var(--selected-row);
 }
 


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/33491)

First, thank you Mariusz for **Cc**me in this ticket!

~~In this PR I apply your suggestion of~~
> ~~we should enforce clearing checkboxes, instead of highlighting rows on Chrome. This would make this behavior browser-agnostic.~~

To run the test please do: `./runtests.py admin_views.tests.SeleniumTests.test_checkboxes_state_after_submit_and_go_back --selenium=<browser> --parallel=1` with `browser` as `chrome`, `firefox` or `safari`


