### PR TITLE
Fixed #33917: Move app_config initialization inside if block

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -123,10 +123,10 @@ class ModelBase(type):
 
         app_label = None
 
-        # Look for an application configuration to attach the model to.
-        app_config = apps.get_containing_app_config(module)
-
         if getattr(meta, "app_label", None) is None:
+            # Look for an application configuration to attach the model to.
+            app_config = apps.get_containing_app_config(module)
+
             if app_config is None:
                 if not abstract:
                     raise RuntimeError(


### PR DESCRIPTION
Optimize `ModelBase.__new__` by moving variable `app_config` inside the if block where it is used. `app_config` is not used outside this if block.