### PR TITLE
Fixed #33918 __str__ method in Query object wraps strings in quotation marks

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -9,6 +9,7 @@ all about the internals of models in order to get the information it needs.
 import copy
 import difflib
 import functools
+import numbers
 import sys
 from collections import Counter, namedtuple
 from collections.abc import Iterator, Mapping
@@ -283,7 +284,10 @@ class Query(BaseExpression):
         done by the database interface at execution time.
         """
         sql, params = self.sql_with_params()
-        return sql % params
+        return sql % tuple(
+            param if isinstance(param, numbers.Number) else f"'{param}'"
+            for param in params
+        )
 
     def sql_with_params(self):
         """

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -110,6 +110,15 @@ class LastExecutedQueryTest(TestCase):
                     str(qs.query),
                 )
 
+    def test_query_str(self):
+        query_sql = str(Article.objects.filter(headline="", id=1).values("id").query)
+        self.assertEqual(
+            query_sql,
+            'SELECT "backends_article"."id" FROM "backends_article" WHERE'
+            ' ("backends_article"."headline" = \'\' '
+            'AND "backends_article"."id" = 1)',
+        )
+
     @skipUnlessDBFeature("supports_paramstyle_pyformat")
     def test_last_executed_query_dict(self):
         square_opts = Square._meta


### PR DESCRIPTION
When executing `str` on `django.db.models.sql.query.Query` objects, string parameters will be wrapped in single quotation marks.

For example:

```
str(Article.objects.filter(headline="", id=1).values("id").query)
```
returns
```
SELECT "backends_article"."id" FROM "backends_article" WHERE ("backends_article"."headline" = '' AND "backends_article"."id" = 1)
```
