### PR TITLE
Fixed #33932 -- Fixed altering AutoFields to OneToOneField on PostgreSQL.

### DIFF
--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -175,7 +175,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 self.sql_drop_indentity
                 % {
                     "table": self.quote_name(table),
-                    "column": self.quote_name(strip_quotes(old_field.column)),
+                    "column": self.quote_name(strip_quotes(new_field.column)),
                 }
             )
             column = strip_quotes(new_field.column)

--- a/docs/releases/4.1.1.txt
+++ b/docs/releases/4.1.1.txt
@@ -39,3 +39,7 @@ Bugfixes
 * Fixed a regression in Django 4.1 that caused an incorrect migration when
   adding ``AutoField``, ``BigAutoField``, or ``SmallAutoField`` on PostgreSQL
   (:ticket:`33919`).
+
+* Fixed a regression in Django 4.1 that caused a migration crash on PostgreSQL
+  when altering ``AutoField``, ``BigAutoField``, or ``SmallAutoField`` to
+  ``OneToOneField`` (:ticket:`33932`).

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1588,6 +1588,32 @@ class SchemaTests(TransactionTestCase):
         # OneToOneField.
         self.assertEqual(counts, {"fks": expected_fks, "uniques": 1, "indexes": 0})
 
+    def test_autofield_to_o2o(self):
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+            editor.create_model(Note)
+
+        # Rename the field.
+        old_field = Author._meta.get_field("id")
+        new_field = AutoField(primary_key=True)
+        new_field.set_attributes_from_name("note_ptr")
+        new_field.model = Author
+
+        with connection.schema_editor() as editor:
+            editor.alter_field(Author, old_field, new_field, strict=True)
+        # Alter AutoField to OneToOneField.
+        new_field_o2o = OneToOneField(Note, CASCADE)
+        new_field_o2o.set_attributes_from_name("note_ptr")
+        new_field_o2o.model = Author
+
+        with connection.schema_editor() as editor:
+            editor.alter_field(Author, new_field, new_field_o2o, strict=True)
+        columns = self.column_classes(Author)
+        field_type, _ = columns["note_ptr_id"]
+        self.assertEqual(
+            field_type, connection.features.introspected_field_types["IntegerField"]
+        )
+
     def test_alter_field_fk_keeps_index(self):
         with connection.schema_editor() as editor:
             editor.create_model(Author)


### PR DESCRIPTION
[Close #33932](https://code.djangoproject.com/ticket/33932)