### PR TITLE
Used CSS flex for admin's submit row.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -254,12 +254,15 @@ fieldset.monospace textarea {
 /* SUBMIT ROW */
 
 .submit-row {
-    padding: 12px 14px 7px;
+    padding: 12px 14px 12px;
     margin: 0 0 20px;
     background: var(--darkened-bg);
     border: 1px solid var(--hairline-color);
     border-radius: 4px;
     overflow: hidden;
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
 }
 
 body.popup .submit-row {
@@ -269,20 +272,18 @@ body.popup .submit-row {
 .submit-row input {
     height: 35px;
     line-height: 15px;
-    margin: 0 5px 5px 0;
+}
+
+.submit-row input, .submit-row a {
+    margin: 0;
 }
 
 .submit-row input.default {
     text-transform: uppercase;
 }
 
-.submit-row p {
-    margin: 0.3em;
-}
-
-.submit-row p.deletelink-box {
-    float: right;
-    margin: 0;
+.submit-row a.deletelink {
+    margin-left: auto;
 }
 
 .submit-row a.deletelink {
@@ -292,7 +293,6 @@ body.popup .submit-row {
     padding: 10px 15px;
     height: 15px;
     line-height: 15px;
-    margin-bottom: 5px;
     color: var(--button-fg);
 }
 
@@ -303,7 +303,6 @@ body.popup .submit-row {
     padding: 10px 15px;
     height: 15px;
     line-height: 15px;
-    margin: 0 5px 5px 0;
     color: var(--button-fg);
 }
 

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -232,7 +232,7 @@ input[type="submit"], button {
     }
 
     .submit-row {
-        padding: 8px 8px 3px 8px;
+        padding: 8px;
     }
 
     .submit-row a.deletelink {
@@ -819,30 +819,23 @@ input[type="submit"], button {
     /* Submit row */
 
     .submit-row {
-        padding: 10px 10px 5px;
+        padding: 10px;
         margin: 0 0 15px;
-        display: flex;
         flex-direction: column;
-    }
-
-    .submit-row > * {
-        width: 100%;
+        gap: 8px;
     }
 
     .submit-row input, .submit-row input.default, .submit-row a {
-        float: none;
-        margin: 0 0 10px;
         text-align: center;
     }
 
     .submit-row a.closelink {
-        float: none;
         padding: 10px 0;
         text-align: center;
     }
 
-    .submit-row p.deletelink-box {
-        order: 4;
+    .submit-row a.deletelink {
+        margin: 0;
     }
 
     /* Messages */

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -114,16 +114,9 @@ thead th.sorted .text {
     float: right;
 }
 
-.submit-row p.deletelink-box {
-    float: left;
-}
-
-.submit-row input.default {
-    margin: 0 0 5px 5px;
-}
-
-.submit-row input {
-    margin: 0 0 5px 5px;
+.submit-row a.deletelink {
+    margin-left: 0;
+    margin-right: auto;
 }
 
 .vDateField, .vTimeField {

--- a/django/contrib/admin/templates/admin/submit_line.html
+++ b/django/contrib/admin/templates/admin/submit_line.html
@@ -8,7 +8,7 @@
 {% if show_close %}<a href="{% url opts|admin_urlname:'changelist' %}" class="closelink">{% translate 'Close' %}</a>{% endif %}
 {% if show_delete_link and original %}
     {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
-    <p class="deletelink-box"><a href="{% add_preserved_filters delete_url %}" class="deletelink">{% translate "Delete" %}</a></p>
+    <a href="{% add_preserved_filters delete_url %}" class="deletelink">{% translate "Delete" %}</a>
 {% endif %}
 {% endblock %}
 </div>

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -1303,7 +1303,10 @@ class TestReadOnlyChangeViewInlinePermissions(TestCase):
             '<a href="/admin/admin_inlines/poll/" class="closelink">Close</a>',
             html=True,
         )
-        delete_link = '<p class="deletelink-box"><a href="/admin/admin_inlines/poll/%s/delete/" class="deletelink">Delete</a></p>'  # noqa
+        delete_link = (
+            '<a href="/admin/admin_inlines/poll/%s/delete/" class="deletelink">Delete'
+            "</a>"
+        )
         self.assertNotContains(response, delete_link % self.poll.id, html=True)
         self.assertNotContains(
             response,


### PR DESCRIPTION
Following up on https://github.com/django/django/pull/15734#issuecomment-1186488751

Unfortunately quite tricky to get the alignment right for the delete link `<a>` with respect to the sibling `<input>`s but I think this is about there.

Before:

<img width="1449" alt="Screenshot 2022-08-17 at 17 21 30" src="https://user-images.githubusercontent.com/3871354/185188273-7d07e769-17eb-4694-af6f-42d9f9797c6a.png">
<img width="517" alt="Screenshot 2022-08-17 at 17 22 07" src="https://user-images.githubusercontent.com/3871354/185188307-1c0f991e-83ec-41d3-b209-706be1a354a3.png">

After:

<img width="1452" alt="Screenshot 2022-08-17 at 17 56 57" src="https://user-images.githubusercontent.com/3871354/185188367-2f421cc8-38c1-434c-9deb-1486487e4f53.png">
<img width="487" alt="Screenshot 2022-08-17 at 18 01 31" src="https://user-images.githubusercontent.com/3871354/185188400-7b2c8be4-9071-483a-8f42-0d175666948c.png">

RTL:

<img width="1420" alt="Screenshot 2022-08-17 at 17 57 48" src="https://user-images.githubusercontent.com/3871354/185188455-7102813d-aa2c-4693-8d8a-518c46348057.png">
