### PR TITLE
Fixed #33930 -- Eased customization of delete_confirmation.html template in the admin.

### DIFF
--- a/django/contrib/admin/templates/admin/delete_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_confirmation.html
@@ -21,16 +21,21 @@
 
 {% block content %}
 {% if perms_lacking %}
+  {% block delete_forbidden %}
     <p>{% blocktranslate with escaped_object=object %}Deleting the {{ object_name }} '{{ escaped_object }}' would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:{% endblocktranslate %}</p>
-    <ul>{{ perms_lacking|unordered_list }}</ul>
+    <ul id="deleted-objects">{{ perms_lacking|unordered_list }}</ul>
+  {% endblock %}
 {% elif protected %}
+  {% block delete_protected %}
     <p>{% blocktranslate with escaped_object=object %}Deleting the {{ object_name }} '{{ escaped_object }}' would require deleting the following protected related objects:{% endblocktranslate %}</p>
-    <ul>{{ protected|unordered_list }}</ul>
+    <ul id="deleted-objects">{{ protected|unordered_list }}</ul>
+  {% endblock %}
 {% else %}
+  {% block delete_confirm %}
     <p>{% blocktranslate with escaped_object=object %}Are you sure you want to delete the {{ object_name }} "{{ escaped_object }}"? All of the following related items will be deleted:{% endblocktranslate %}</p>
     {% include "admin/includes/object_delete_summary.html" %}
     <h2>{% translate "Objects" %}</h2>
-    <ul>{{ deleted_objects|unordered_list }}</ul>
+    <ul id="deleted-objects">{{ deleted_objects|unordered_list }}</ul>
     <form method="post">{% csrf_token %}
     <div>
     <input type="hidden" name="post" value="yes">
@@ -40,5 +45,6 @@
     <a href="#" class="button cancel-link">{% translate "No, take me back" %}</a>
     </div>
     </form>
+  {% endblock %}
 {% endif %}
-{% endblock %}
+{% endblock content %}

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -39,6 +39,10 @@ Minor features
   downloading fonts. Additionally, CSS variables are available to more easily
   override the default font families.
 
+* The :source:`admin/delete_confirmation.html
+  <django/contrib/admin/templates/admin/delete_confirmation.html>` template now
+  has some additional blocks and scripting hooks to ease customization.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
By overriding template admin/delete_confirmation.html one can use CSS to hide this list and add a short JavaScript snippet to unhide if necessary.
A CSS selector is required to find this list element.