### PR TITLE
Fix #33936 - Add information to BaseModelForm validation error message

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -2,6 +2,7 @@
 Helper functions for creating Form classes from Django models
 and database field objects.
 """
+import json
 from itertools import chain
 
 from django.core.exceptions import (
@@ -530,10 +531,14 @@ class BaseModelForm(BaseForm):
         """
         if self.errors:
             raise ValueError(
-                "The %s could not be %s because the data didn't validate."
+                "The %s could not be %s because the data didn't validate:\n%s"
                 % (
                     self.instance._meta.object_name,
                     "created" if self.instance._state.adding else "changed",
+                    json.dumps(
+                        self.errors.get_json_data(escape_html=True),
+                        indent=2
+                    )
                 )
             )
         if commit:

--- a/tests/model_forms/test_uuid.py
+++ b/tests/model_forms/test_uuid.py
@@ -1,3 +1,4 @@
+import json
 from django import forms
 from django.core.exceptions import ValidationError
 from django.test import TestCase
@@ -15,7 +16,7 @@ class ModelFormBaseTest(TestCase):
     def test_create_save_error(self):
         form = UUIDPKForm({})
         self.assertFalse(form.is_valid())
-        msg = "The UUIDPK could not be created because the data didn't validate."
+        msg = "The UUIDPK could not be created because the data didn't validate:"
         with self.assertRaisesMessage(ValueError, msg):
             form.save()
 
@@ -23,7 +24,7 @@ class ModelFormBaseTest(TestCase):
         obj = UUIDPK.objects.create(name="foo")
         form = UUIDPKForm({}, instance=obj)
         self.assertFalse(form.is_valid())
-        msg = "The UUIDPK could not be changed because the data didn't validate."
+        msg = "The UUIDPK could not be changed because the data didn't validate:"
         with self.assertRaisesMessage(ValueError, msg):
             form.save()
 

--- a/tests/model_forms/test_uuid.py
+++ b/tests/model_forms/test_uuid.py
@@ -1,4 +1,3 @@
-import json
 from django import forms
 from django.core.exceptions import ValidationError
 from django.test import TestCase

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1,3 +1,4 @@
+import json
 import datetime
 import os
 from decimal import Decimal
@@ -1683,11 +1684,13 @@ class ModelFormBasicTests(TestCase):
             ],
         )
         self.assertEqual(f.cleaned_data, {"url": "foo"})
-        msg = "The Category could not be created because the data didn't validate."
-        with self.assertRaisesMessage(ValueError, msg):
+        msg = "The Category could not be created because the data didn't validate:"
+        msg_data = f"\n{json.dumps(f.errors.get_json_data(escape_html=True), indent=2)}"
+        with self.assertRaisesMessage(ValueError, msg + msg_data):
             f.save()
         f = BaseCategoryForm({"name": "", "slug": "", "url": "foo"})
-        with self.assertRaisesMessage(ValueError, msg):
+        msg_data = f"\n{json.dumps(f.errors.get_json_data(escape_html=True), indent=2)}"
+        with self.assertRaisesMessage(ValueError, msg + msg_data):
             f.save()
 
     def test_multi_fields(self):


### PR DESCRIPTION
This PR adds additional information to the `BaseModelForm.save()` validation error message, including JSON-formatted information about which specific fields failed to validate.

Trac ticket: https://code.djangoproject.com/ticket/33936