### PR TITLE
Cleaned up date hierarchy HTML and CSS

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -224,18 +224,16 @@
 /* DATE DRILLDOWN */
 
 .change-list ul.toplinks {
-    display: block;
-    float: left;
-    padding: 0;
+    display: flex;
+    padding: 0 0 5px 0;
     margin: 0;
-    width: 100%;
+    flex-wrap: wrap;
+    gap: 3px 17px;
 }
 
 .change-list ul.toplinks li {
-    padding: 3px 6px;
     font-weight: bold;
     list-style-type: none;
-    display: inline-block;
 }
 
 .change-list ul.toplinks .date-back a {

--- a/django/contrib/admin/templates/admin/date_hierarchy.html
+++ b/django/contrib/admin/templates/admin/date_hierarchy.html
@@ -1,5 +1,4 @@
 {% if show %}
-<div class="xfull">
 <ul class="toplinks">
 {% block date-hierarchy-toplinks %}
 {% block date-hierarchy-back %}
@@ -11,6 +10,5 @@
 {% endfor %}
 {% endblock %}
 {% endblock %}
-</ul><br class="clear">
-</div>
+</ul>
 {% endif %}


### PR DESCRIPTION
Let me know if these PRs are unwelcome or need tickets. I plan to do more of them over the coming weeks / months, so I hope they don't get too annoying, I imagine they take a bit of time to review for only a small gain.

The motivation: I'd like to implement a [more modern design for the admin](https://forum.djangoproject.com/t/an-admin-redesign/11214). It's quite hard at the moment because the admin is a moving target and there's a lot of aging code in there. I'm hoping I can do as much as possible as small isolated cleanups before I really begin in earnest, it seems like it'll make the job easier. Even if not, reducing unnecessary code in the admin and cleaning up the styles seems like a benefit in and of itself.

On this one specifically: I'm not sure why the float was needed. It isn't anymore, even without flexbox. I decided to reimplement with flex anyway though as I feel like it's a bit more explicit what's going on. I'm not exactly sure why but it also results in a "nicer" looking wrap on mobile at least, but maybe it's just luck. I also managed to remove some other code that doesn't seem to be needed anymore. The padding is slightly different than before, wasn't sure how to get it perfect, dev tools didn't seem to want to show the padding. I think the only way to get it perfect would be to use fractions of pixels which seems a bit silly...

Before:
<img width="948" alt="Screenshot 2022-08-21 at 13 11 59" src="https://user-images.githubusercontent.com/3871354/185789891-52107169-a20f-4fde-8c2e-37ac011c6985.png">
<img width="932" alt="Screenshot 2022-08-21 at 13 32 23" src="https://user-images.githubusercontent.com/3871354/185789902-26b977b5-7b49-4bad-8b56-4872c444fd3f.png">
<img width="403" alt="Screenshot 2022-08-21 at 13 12 16" src="https://user-images.githubusercontent.com/3871354/185789907-4f816e93-b5a4-442f-be1b-7dbd5b857ef6.png">

After:
<img width="961" alt="Screenshot 2022-08-21 at 13 45 48" src="https://user-images.githubusercontent.com/3871354/185789911-085af0df-60c2-4df1-bca2-765bf5bd37e8.png">
<img width="954" alt="Screenshot 2022-08-21 at 13 46 07" src="https://user-images.githubusercontent.com/3871354/185789913-9b49c24e-6654-422f-a127-d43e09bb8a7a.png">
<img width="363" alt="Screenshot 2022-08-21 at 13 46 29" src="https://user-images.githubusercontent.com/3871354/185789919-82055771-4cee-4064-813e-081a3d1f05c0.png">

(sorry, I think the desktop widths are a bit different in the before/afters)