### PR TITLE
Fixed #15130 -- Select correct database when validating models for uniqueness

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1322,7 +1322,9 @@ class Model(metaclass=ModelBase):
             if len(unique_check) != len(lookup_kwargs):
                 continue
 
-            qs = model_class._default_manager.filter(**lookup_kwargs)
+            qs = model_class._default_manager.using(self._state.db).filter(
+                **lookup_kwargs
+            )
 
             # Exclude the current object from the query if we are editing an
             # instance (as opposed to creating a new one)
@@ -1363,7 +1365,9 @@ class Model(metaclass=ModelBase):
                 )
             lookup_kwargs[field] = getattr(self, field)
 
-            qs = model_class._default_manager.filter(**lookup_kwargs)
+            qs = model_class._default_manager.using(self._state.db).filter(
+                **lookup_kwargs
+            )
             # Exclude the current object from the query if we are editing an
             # instance (as opposed to creating a new one)
             if not self._state.adding and self.pk is not None:

--- a/tests/multiple_database/models.py
+++ b/tests/multiple_database/models.py
@@ -47,7 +47,7 @@ class BookManager(models.Manager):
 
 
 class Book(models.Model):
-    title = models.CharField(max_length=100)
+    title = models.CharField(max_length=100, unique_for_date="published")
     published = models.DateField()
     authors = models.ManyToManyField(Person)
     editor = models.ForeignKey(

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -1305,14 +1305,14 @@ class QueryTestCase(TestCase):
 
     def test_unique_validation(self):
         "Model.validate_unique() uses the correct database"
-        mickey = Person.objects.using("default").create(name="Mickey")
-        donald = Person.objects.using("default").create(name="Donald")
+        Person.objects.using("default").create(name="Mickey")
+        Person.objects.using("default").create(name="Donald")
         other_donald = Person.objects.using("other").create(name="Donald")
         self.assertIsNone(other_donald.validate_unique())
 
     def test_unique_for_date(self):
         "unique_for_date uses the correct database"
-        dive1 = Book.objects.using("other").create(
+        Book.objects.using("other").create(
             title="Dive into Python", published=datetime.date(2009, 5, 4)
         )
         dive2 = Book.objects.using("other").create(


### PR DESCRIPTION
This patch ensures that, when looking for duplicates objects
for validation in Model.validate_unique(), the same database is used
as the one used to loaded the object. This applies for both fields marked
'unique=True', and for fields that have a uniqueness date check,
(year, month, day), i.e marked 'unique_for_date="someotherfield"'.

One could argue that the called could decides what database to use.
(this is mentionned in the ticket)
However, before doing that, having good defaults that  allow
simple behaviors to work (in particular in the admin) seems natural.