### PR TITLE
Fixed #33945 -- use the right database in Model.get_{previous|next}_in_order()

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -2458,9 +2458,7 @@ class Model(metaclass=ModelBase):
 def method_set_order(self, ordered_obj, id_list, using=None):
     order_wrt = ordered_obj._meta.order_with_respect_to
     filter_args = order_wrt.get_forward_related_filter(self)
-    ordered_obj.objects.db_manager(using or self._state.db).filter(
-        **filter_args
-    ).bulk_update(
+    ordered_obj.objects.db_manager(using).filter(**filter_args).bulk_update(
         [ordered_obj(pk=pk, _order=order) for order, pk in enumerate(id_list)],
         ["_order"],
     )

--- a/tests/multiple_database/models.py
+++ b/tests/multiple_database/models.py
@@ -70,7 +70,7 @@ class Pet(models.Model):
     owner = models.ForeignKey(Person, models.CASCADE)
 
     class Meta:
-        ordering = ("name",)
+        order_with_respect_to = "owner"
 
 
 class UserProfile(models.Model):

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -1302,6 +1302,19 @@ class QueryTestCase(TestCase):
             title="Dive into Water", published=datetime.date(2009, 5, 4), extra_arg=True
         )
 
+    def test_order_with_respect_to(self):
+        """
+        Model.set_XXX_order() and Model.get_{previous|next}_in_order() use
+        the correct database.
+        """
+        human = Person.objects.using("other").create(name="Human")
+        dog = Pet.objects.using("other").create(name="Dog", owner=human)
+        cat = Pet.objects.using("other").create(name="Cat", owner=human)
+        duck = Pet.objects.using("other").create(name="Duck", owner=human)
+        human.set_pet_order([duck.pk, dog.pk, cat.pk], "other")
+        self.assertEqual(dog.get_next_in_order(), cat)
+        self.assertEqual(dog.get_previous_in_order(), duck)
+
 
 class ConnectionRouterTestCase(SimpleTestCase):
     @override_settings(


### PR DESCRIPTION

This is the last one of all the cases where the internal _default_manager
doesn't use the correct DB. I went through the code and there shouldn't
be any of them anymore