### PR TITLE
Improved example of index on SearchVector in full text search docs.

### DIFF
--- a/docs/ref/contrib/postgres/search.txt
+++ b/docs/ref/contrib/postgres/search.txt
@@ -261,7 +261,7 @@ particular model, you can create a functional
 the search vector you wish to use. For example::
 
     GinIndex(
-        SearchVector('first_name', 'last_name', config='english'),
+        SearchVector('body_text', 'headline', config='english'),
         name='search_vector_idx',
     )
 

--- a/docs/ref/contrib/postgres/search.txt
+++ b/docs/ref/contrib/postgres/search.txt
@@ -254,8 +254,6 @@ however, if you're searching more than a few hundred records, you're likely to
 run into performance problems. Full text search is a more intensive process
 than comparing the size of an integer, for example.
 
-.. versionadded:: 3.2
-
 In the event that all the fields you're querying on are contained within one
 particular model, you can create a functional
 :class:`GIN <django.contrib.postgres.indexes.GinIndex>` or

--- a/docs/ref/contrib/postgres/search.txt
+++ b/docs/ref/contrib/postgres/search.txt
@@ -265,10 +265,6 @@ the search vector you wish to use. For example::
         name='search_vector_idx',
     )
 
-In this case, it's important to specify the ``config`` argument in
-``SearchVector`` because otherwise PostgreSQL will consider the function
-mutable and will throw an error.
-
 The PostgreSQL documentation has details on
 `creating indexes for full text search
 <https://www.postgresql.org/docs/current/textsearch-tables.html#TEXTSEARCH-TABLES-INDEX>`_.

--- a/docs/ref/contrib/postgres/search.txt
+++ b/docs/ref/contrib/postgres/search.txt
@@ -254,13 +254,22 @@ however, if you're searching more than a few hundred records, you're likely to
 run into performance problems. Full text search is a more intensive process
 than comparing the size of an integer, for example.
 
+.. versionadded:: 3.2
+
 In the event that all the fields you're querying on are contained within one
 particular model, you can create a functional
 :class:`GIN <django.contrib.postgres.indexes.GinIndex>` or
 :class:`GiST <django.contrib.postgres.indexes.GistIndex>` index which matches
 the search vector you wish to use. For example::
 
-    GinIndex(SearchVector('body_text'), name='body_search_vector_idx')
+    GinIndex(
+        SearchVector('first_name', 'last_name', config='english'),
+        name='search_vector_idx',
+    )
+
+In this case, it's important to specify the ``config`` argument in
+``SearchVector`` because otherwise PostgreSQL will consider the function
+mutable and will throw an error.
 
 The PostgreSQL documentation has details on
 `creating indexes for full text search


### PR DESCRIPTION
I had a tough time using a functional index in SearchVector, and I want to improve documentation about it:
* At first, I just copied the example and was getting a `TypeError` because of unexpected arguments. I was on Django 3.1 and it took me a few minutes to figure out I needed Django 3.2 for that. This is why I included `versionadded`.
* Then, I was able to create a migration, but I got an error for PostgreSQL when applying it: `functions in index expression must be marked IMMUTABLE`. This is because I didn't supply the `config argument`. Added this to the code sample and mentioned it in writing.
* I also added a second field to `SearchVector` to make the example more realistic - pretty much everyone will have 2+ fields there, otherwise they would just use `field__icontains` or `field__search`.

I built the HTML docs using `make html` and made sure it looks alright.

![Screen Shot 2022-08-22 at 00 42 43](https://user-images.githubusercontent.com/4249837/185810055-662b8b3f-9e19-4cb6-bc8a-454a015d93ee.png)