### PR TITLE
Fixed #33939 -- Replaced `lambda` with `functools.partial`

### DIFF
--- a/docs/topics/db/transactions.txt
+++ b/docs/topics/db/transactions.txt
@@ -308,13 +308,11 @@ Pass any function (that takes no arguments) to :func:`on_commit`::
 
     transaction.on_commit(do_something)
 
-You can also bind arguments to your function using `functools.partial`_::
+You can also bind arguments to your function using :func:`functools.partial`::
 
     from functools import partial
 
     transaction.on_commit(partial(some_celery_task.delay, 'arg1'))
-
-.. _`functools.partial`: https://docs.python.org/3/library/functools.html#functools.partial
 
 The function you pass in will be called immediately after a hypothetical
 database write made where ``on_commit()`` is called would be successfully

--- a/docs/topics/db/transactions.txt
+++ b/docs/topics/db/transactions.txt
@@ -308,9 +308,13 @@ Pass any function (that takes no arguments) to :func:`on_commit`::
 
     transaction.on_commit(do_something)
 
-You can also wrap your function in a lambda::
+You can also bind arguments to your function using `functools.partial`_::
 
-    transaction.on_commit(lambda: some_celery_task.delay('arg1'))
+    from functools import partial
+
+    transaction.on_commit(partial(some_celery_task.delay, 'arg1'))
+
+.. _`functools.partial`: https://docs.python.org/3/library/functools.html#functools.partial
 
 The function you pass in will be called immediately after a hypothetical
 database write made where ``on_commit()`` is called would be successfully


### PR DESCRIPTION
Suggest the use of `functools.partial` instead of `lambda` to avoid unexpected argument values.

[#33939](https://code.djangoproject.com/ticket/33939)