### PR TITLE
Refs #18707 -- Corrected django.test.Client signature in docs.

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -109,7 +109,7 @@ Making requests
 
 Use the ``django.test.Client`` class to make requests.
 
-.. class:: Client(enforce_csrf_checks=False, json_encoder=DjangoJSONEncoder, **defaults)
+.. class:: Client(enforce_csrf_checks=False, raise_request_exception=True, json_encoder=DjangoJSONEncoder, **defaults)
 
     It requires no arguments at time of construction. However, you can use
     keyword arguments to specify some default headers. For example, this will
@@ -125,12 +125,12 @@ Use the ``django.test.Client`` class to make requests.
     The ``enforce_csrf_checks`` argument can be used to test CSRF
     protection (see above).
 
-    The ``json_encoder`` argument allows setting a custom JSON encoder for
-    the JSON serialization that's described in :meth:`post`.
-
     The ``raise_request_exception`` argument allows controlling whether or not
     exceptions raised during the request should also be raised in the test.
     Defaults to ``True``.
+
+    The ``json_encoder`` argument allows setting a custom JSON encoder for
+    the JSON serialization that's described in :meth:`post`.
 
     Once you have a ``Client`` instance, you can call any of the following
     methods:


### PR DESCRIPTION
ref: https://github.com/django/django/blob/e9fd2b572410b1236da0d3d0933014138d89f44e/django/test/client.py#L781