### PR TITLE
Auto add applabel to installed_apps settings

### DIFF
--- a/django/core/management/commands/startapp.py
+++ b/django/core/management/commands/startapp.py
@@ -11,4 +11,15 @@ class Command(TemplateCommand):
     def handle(self, **options):
         app_name = options.pop("name")
         target = options.pop("directory")
+        import re
+        import os
+        settings_file = os.environ['DJANGO_SETTINGS_MODULE'].replace(".", "/") + ".py"
+        with open(settings_file, 'r+') as f:
+            s = f.read()
+            app_list = re.search(r"INSTALLED_APPS.*?]", s, re.DOTALL)[0]
+            app_new_list = app_list.replace('\n]', '') + '\n    "' + app_name + '",\n]'
+            f.truncate(0)
+            f.seek(0)
+            settings_content = s.replace(app_list, app_new_list)
+            f.write(settings_content)
         super().handle("app", app_name, target, **options)


### PR DESCRIPTION
### Automatically add the application name to the `INSTALLED_APPS` list in the settings module when the `startapp` command is run 

When we run the `startapp` command, we want to automatically add it to the `settings.py`, which will append to the `INSTALLED_APPS` list.

Further, I want to add an argument to the `startapp` command that will allow the flexible option for automatically including the app name in the settings file like `--auto` or similar options. By default, it won't add it, just when we parse the `--auto` parameter, it will append it to the list replacing it with regex.

Below is what my end goal looks like with the feature

```
django-admin startapp --auto my_app
``` 
 **In the current PR, it just adds it by default, since I am not sure how to add an argument/option to the app's command.**

This is just an idea for further polishing of the feature.
How is the idea, please I am open to suggestions to make it thoroughly usable