### PR TITLE
Refs #27412 -- Confirmed support for executing Coalesce(subquery).

### DIFF
--- a/tests/db_functions/comparison/test_coalesce.py
+++ b/tests/db_functions/comparison/test_coalesce.py
@@ -64,11 +64,14 @@ class CoalesceTests(TestCase):
 
     def test_empty_queryset(self):
         Author.objects.create(name="John Smith")
+        queryset = Author.objects.values("id")
         tests = [
-            Author.objects.none(),
-            Subquery(Author.objects.none()),
+            (queryset.none(), "QuerySet.none()"),
+            (queryset.filter(id=0), "QuerySet.filter(id=0)"),
+            (Subquery(queryset.none()), "Subquery(QuerySet.none())"),
+            (Subquery(queryset.filter(id=0)), "Subquery(Queryset.filter(id=0)"),
         ]
-        for empty_query in tests:
-            with self.subTest(empty_query.__class__.__name__):
+        for empty_query, description in tests:
+            with self.subTest(description), self.assertNumQueries(1):
                 qs = Author.objects.annotate(annotation=Coalesce(empty_query, 42))
                 self.assertEqual(qs.first().annotation, 42)


### PR DESCRIPTION
This has been supported for subqueries wrapped in Subquery since the expression was introduced and for Queryset directly since Subquery resolves to sql.Query.

Piggy-backed on the existing tests covering Coalesce handling of EmptyResultSet as it seemed like a proper location to combine testing.