### PR TITLE
Fixed #24179 -- Added filtering to selected side of vertical/horizontal filters.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -346,6 +346,7 @@ answer newbie questions, and generally made Django that much better:
     Gary Wilson <gary.wilson@gmail.com>
     Gasper Koren
     Gasper Zejn <zejn@kiberpipa.org>
+    Gav O'Connor <https://github.com/Scalamoosh>
     Gavin Wahl <gavinwahl@gmail.com>
     Ge Hanbin <xiaomiba0904@gmail.com>
     geber@datacollect.com

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -20,13 +20,24 @@
     flex-direction: column;
 }
 
-.selector-chosen select {
-    border-top: none;
-}
-
 .selector-available h2, .selector-chosen h2 {
     border: 1px solid var(--border-color);
     border-radius: 4px 4px 0 0;
+}
+
+.selector-chosen .list-footer-display {
+    border: 1px solid var(--border-color);
+    border-top: none;
+    border-radius: 0 0 4px 4px;
+    margin: 0 0 10px;
+    padding: 8px;
+    text-align: center;
+    background: var(--primary);
+    color: var(--header-link-color);
+    cursor: pointer;
+}
+.selector-chosen .list-footer-display__clear {
+    color: var(--breadcrumbs-fg);
 }
 
 .selector-chosen h2 {
@@ -60,7 +71,8 @@
     line-height: 1;
 }
 
-.selector .selector-available input {
+.selector .selector-available input,
+.selector .selector-chosen input {
     width: 320px;
     margin-left: 8px;
 }
@@ -85,6 +97,15 @@
     padding: 0 10px;
     margin: 0 0 10px;
     border-radius: 0 0 4px 4px;
+}
+.selector .selector-chosen--with-filtered select {
+    margin: 0;
+    border-radius: 0;
+    height: 14em;
+}
+
+.selector .selector-chosen:not(.selector-chosen--with-filtered) .list-footer-display {
+    display: none;
 }
 
 .selector-add, .selector-remove {

--- a/django/contrib/admin/static/admin/js/SelectBox.js
+++ b/django/contrib/admin/static/admin/js/SelectBox.js
@@ -41,6 +41,10 @@
             }
             SelectBox.redisplay(id);
         },
+        get_hidden_node_count(id) {
+            const cache = SelectBox.cache[id] || [];
+            return cache.filter(node => node.displayed === 0).length;
+        },
         delete_from_cache: function(id, value) {
             let delete_index = null;
             const cache = SelectBox.cache[id];

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -43,6 +43,11 @@ Minor features
   <django/contrib/admin/templates/admin/delete_confirmation.html>` template now
   has some additional blocks and scripting hooks to ease customization.
 
+* The chosen options of
+  :attr:`~django.contrib.admin.ModelAdmin.filter_horizontal` and
+  :attr:`~django.contrib.admin.ModelAdmin.filter_vertical` widgets are now
+  filterable.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/js_tests/admin/SelectFilter2.test.js
+++ b/js_tests/admin/SelectFilter2.test.js
@@ -16,3 +16,69 @@ QUnit.test('init', function(assert) {
     assert.equal($('.selector-remove').text(), "Remove");
     assert.equal($('.selector-clearall').text(), "Remove all");
 });
+
+QUnit.test('filtering available options', function(assert) {
+    const $ = django.jQuery;
+    $('<form><select multiple id="select"></select></form>').appendTo('#qunit-fixture');
+    $('<option value="1" title="Red">Red</option>').appendTo('#select');
+    $('<option value="2" title="Blue">Blue</option>').appendTo('#select');
+    $('<option value="3" title="Green">Green</option>').appendTo('#select');
+    SelectFilter.init('select', 'items', 0);
+    assert.equal($('#select_from option').length, 3);
+    assert.equal($('#select_to option').length, 0);
+    const done = assert.async();
+    const search_term = 'r';
+    const event = new KeyboardEvent('keyup', {'key': search_term});
+    $('#select_input').val(search_term);
+    SelectFilter.filter_key_up(event, 'select');
+    setTimeout(() => {
+        assert.equal($('#select_from option').length, 2);
+        assert.equal($('#select_to option').length, 0);
+        assert.equal($('#select_from option')[0].value, '1');
+        assert.equal($('#select_from option')[1].value, '3');
+        done();
+    });
+});
+
+QUnit.test('filtering available options to nothing', function(assert) {
+    const $ = django.jQuery;
+    $('<form><select multiple id="select"></select></form>').appendTo('#qunit-fixture');
+    $('<option value="1" title="Red">Red</option>').appendTo('#select');
+    $('<option value="2" title="Blue">Blue</option>').appendTo('#select');
+    $('<option value="3" title="Green">Green</option>').appendTo('#select');
+    SelectFilter.init('select', 'items', 0);
+    assert.equal($('#select_from option').length, 3);
+    assert.equal($('#select_to option').length, 0);
+    const done = assert.async();
+    const search_term = 'x';
+    const event = new KeyboardEvent('keyup', {'key': search_term});
+    $('#select_input').val(search_term);
+    SelectFilter.filter_key_up(event, 'select');
+    setTimeout(() => {
+        assert.equal($('#select_from option').length, 0);
+        assert.equal($('#select_to option').length, 0);
+        done();
+    });
+});
+
+QUnit.test('selecting option', function(assert) {
+    const $ = django.jQuery;
+    $('<form><select multiple id="select"></select></form>').appendTo('#qunit-fixture');
+    $('<option value="1" title="Red">Red</option>').appendTo('#select');
+    $('<option value="2" title="Blue">Blue</option>').appendTo('#select');
+    $('<option value="3" title="Green">Green</option>').appendTo('#select');
+    SelectFilter.init('select', 'items', 0);
+    assert.equal($('#select_from option').length, 3);
+    assert.equal($('#select_to option').length, 0);
+    // move to the right
+    const done = assert.async();
+    $('#select_from')[0].selectedIndex = 0;
+    const event = new KeyboardEvent('keydown', {'keyCode': 39, 'charCode': 39});
+    SelectFilter.filter_key_down(event, 'select');
+    setTimeout(() => {
+        assert.equal($('#select_from option').length, 2);
+        assert.equal($('#select_to option').length, 1);
+        assert.equal($('#select_to option')[0].value, '1');
+        done();
+    });
+});

--- a/js_tests/admin/SelectFilter2.test.js
+++ b/js_tests/admin/SelectFilter2.test.js
@@ -30,12 +30,35 @@ QUnit.test('filtering available options', function(assert) {
     const search_term = 'r';
     const event = new KeyboardEvent('keyup', {'key': search_term});
     $('#select_input').val(search_term);
-    SelectFilter.filter_key_up(event, 'select');
+    SelectFilter.filter_key_up(event, 'select', '_from');
     setTimeout(() => {
         assert.equal($('#select_from option').length, 2);
         assert.equal($('#select_to option').length, 0);
         assert.equal($('#select_from option')[0].value, '1');
         assert.equal($('#select_from option')[1].value, '3');
+        done();
+    });
+});
+
+QUnit.test('filtering selected options', function(assert) {
+    const $ = django.jQuery;
+    $('<form><select multiple id="select"></select></form>').appendTo('#qunit-fixture');
+    $('<option selected value="1" title="Red">Red</option>').appendTo('#select');
+    $('<option selected value="2" title="Blue">Blue</option>').appendTo('#select');
+    $('<option selected value="3" title="Green">Green</option>').appendTo('#select');
+    SelectFilter.init('select', 'items', 0);
+    assert.equal($('#select_from option').length, 0);
+    assert.equal($('#select_to option').length, 3);
+    const done = assert.async();
+    const search_term = 'r';
+    const event = new KeyboardEvent('keyup', {'key': search_term});
+    $('#select_selected_input').val(search_term);
+    SelectFilter.filter_key_up(event, 'select', '_to', '_selected_input');
+    setTimeout(() => {
+        assert.equal($('#select_from option').length, 0);
+        assert.equal($('#select_to option').length, 2);
+        assert.equal($('#select_to option')[0].value, '1');
+        assert.equal($('#select_to option')[1].value, '3');
         done();
     });
 });
@@ -53,7 +76,28 @@ QUnit.test('filtering available options to nothing', function(assert) {
     const search_term = 'x';
     const event = new KeyboardEvent('keyup', {'key': search_term});
     $('#select_input').val(search_term);
-    SelectFilter.filter_key_up(event, 'select');
+    SelectFilter.filter_key_up(event, 'select', '_from');
+    setTimeout(() => {
+        assert.equal($('#select_from option').length, 0);
+        assert.equal($('#select_to option').length, 0);
+        done();
+    });
+});
+
+QUnit.test('filtering selected options to nothing', function(assert) {
+    const $ = django.jQuery;
+    $('<form><select multiple id="select"></select></form>').appendTo('#qunit-fixture');
+    $('<option selected value="1" title="Red">Red</option>').appendTo('#select');
+    $('<option selected value="2" title="Blue">Blue</option>').appendTo('#select');
+    $('<option selected value="3" title="Green">Green</option>').appendTo('#select');
+    SelectFilter.init('select', 'items', 0);
+    assert.equal($('#select_from option').length, 0);
+    assert.equal($('#select_to option').length, 3);
+    const done = assert.async();
+    const search_term = 'x';
+    const event = new KeyboardEvent('keyup', {'key': search_term});
+    $('#select_selected_input').val(search_term);
+    SelectFilter.filter_key_up(event, 'select', '_to', '_selected_input');
     setTimeout(() => {
         assert.equal($('#select_from option').length, 0);
         assert.equal($('#select_to option').length, 0);
@@ -74,11 +118,33 @@ QUnit.test('selecting option', function(assert) {
     const done = assert.async();
     $('#select_from')[0].selectedIndex = 0;
     const event = new KeyboardEvent('keydown', {'keyCode': 39, 'charCode': 39});
-    SelectFilter.filter_key_down(event, 'select');
+    SelectFilter.filter_key_down(event, 'select', '_from', '_to');
     setTimeout(() => {
         assert.equal($('#select_from option').length, 2);
         assert.equal($('#select_to option').length, 1);
         assert.equal($('#select_to option')[0].value, '1');
         done();
+    });
+});
+
+QUnit.test('deselecting option', function(assert) {
+    const $ = django.jQuery;
+    $('<form><select multiple id="select"></select></form>').appendTo('#qunit-fixture');
+    $('<option selected value="1" title="Red">Red</option>').appendTo('#select');
+    $('<option value="2" title="Blue">Blue</option>').appendTo('#select');
+    $('<option value="3" title="Green">Green</option>').appendTo('#select');
+    SelectFilter.init('select', 'items', 0);
+    assert.equal($('#select_from option').length, 2);
+    assert.equal($('#select_to option').length, 1);
+    assert.equal($('#select_to option')[0].value, '1');
+    // move back to the left
+    const done_left = assert.async();
+    $('#select_to')[0].selectedIndex = 0;
+    const event_left = new KeyboardEvent('keydown', {'keyCode': 37, 'charCode': 37});
+    SelectFilter.filter_key_down(event_left, 'select', '_to', '_from');
+    setTimeout(() => {
+        assert.equal($('#select_from option').length, 3);
+        assert.equal($('#select_to option').length, 0);
+        done_left();
     });
 });


### PR DESCRIPTION
Add functionality to the SelectFilter widget to allow searching on the "Selected" side.

The fix is purely for displaying the results, and the value passed to the server/saved to the DB are not affected by what is visible due to search terms. This is to keep it in-line with the "Available" side of the widget.

- Allow selected to be filtered
- Allow filter to be cleared
- Warn the user when they have hidden options

Implements [Ticket #24179 - FilteredSelectMultiple widget - add filter field to the right column.](https://code.djangoproject.com/ticket/24179)

![filter_horizontal](https://user-images.githubusercontent.com/585291/186424157-efdba0de-6fd2-44c5-bb27-f031a193b48b.gif)

