### PR TITLE
Fixed #33955 -- Fixed AttributeError in admindocs ViewDetailView

### DIFF
--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -253,6 +253,8 @@ _active.local_value = _callback_strs
 
 
 def _is_callback(name, urlresolver=None):
+    if not hasattr(_active, "local_value"):
+        _active.local_value = _callback_strs
     if urlresolver and not urlresolver._populated:
         register_callback(urlresolver, _active.local_value)
     return name in _active.local_value


### PR DESCRIPTION
In Django 4.1, the admindocs `ViewDetailView` raises an `AttributeError`. I'm not clear on why `_active` is missing the `local_value` attribute when `_is_callback` is called, but this simple fix solves the problem.

I've filed https://code.djangoproject.com/ticket/33955