### PR TITLE
Fixed #5711: serialize doesn't work with extra()

### DIFF
--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -48,6 +48,9 @@ class Serializer(base.Serializer):
     def handle_field(self, obj, field):
         self._current[field.name] = self._value_from_field(obj, field)
 
+    def handle_extra_attr(self, obj, field):
+        self._current[field] = getattr(obj, field)
+
     def handle_fk_field(self, obj, field):
         if self.use_natural_foreign_keys and hasattr(
             field.remote_field.model, "natural_key"

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.serializers import base
 from django.db import DEFAULT_DB_ALIAS, models
+from django.utils.encoding import force_str
 from django.utils.xmlutils import SimplerXMLGenerator, UnserializableContentError
 
 
@@ -97,6 +98,17 @@ class Serializer(base.Serializer):
         else:
             self.xml.addQuickElement("None")
 
+        self.xml.endElement("field")
+
+    def handle_extra_attr(self, obj, field):
+        self.indent(2)
+        self.xml.startElement(
+            "field",
+            {
+                "name": field,
+            },
+        )
+        self.xml.characters(force_str(getattr(obj, field)))
         self.xml.endElement("field")
 
     def handle_fk_field(self, obj, field):

--- a/docs/topics/serialization.txt
+++ b/docs/topics/serialization.txt
@@ -69,6 +69,29 @@ resulting output; it never appears in the ``fields`` part.
     serialized object doesn't specify all the fields that are required by a
     model, the deserializer will not be able to save deserialized instances.
 
+Extra attributes
+~~~~~~~~~~~~~~~~
+
+.. versionadded:: 4.2
+
+If you want to serialize attributes or properties on the model object that
+aren't model fields, you can specify an ``extra`` argument to the serializer::
+
+    from django.core import serializers
+    data = serializers.serialize('xml', SomeModel.objects.all(), extra=('some_property',))
+
+In this example the ``some_property`` attribute of the model will be serialized
+in addition to all the model fields.
+
+The ``fields`` and ``extra`` arguments can be combined to get a subset of the
+model fields as well as the extra non-field attributes specified.
+
+.. note::
+
+    Deserializing a model that was serialized with additional extra attributes
+    will result in an error, as deserialization requires that only the model
+    fields be specified.
+
 Inherited models
 ----------------
 

--- a/tests/serializers/models/base.py
+++ b/tests/serializers/models/base.py
@@ -52,6 +52,10 @@ class Author(models.Model):
     def __str__(self):
         return self.name
 
+    @property
+    def age(self):
+        return 42
+
 
 class Article(models.Model):
     author = models.ForeignKey(Author, models.CASCADE)

--- a/tests/serializers/tests.py
+++ b/tests/serializers/tests.py
@@ -410,6 +410,17 @@ class SerializersTestBase:
         self.assertEqual(self._get_field_values(child_data, "parent_m2m"), [])
         self.assertEqual(self._get_field_values(child_data, "parent_data"), [])
 
+    def test_serialize_extra_non_field_attributes(self):
+        """
+        Tests that non-field attributes can be serialized if passed in
+        explicitly to fields.
+        """
+        a = Author(name="Some Random Person")
+        serial_str = serializers.serialize(self.serializer_name, [a], extra=["age"])
+        age_values = self._get_field_values(serial_str, "age")
+        self.assertEqual(len(age_values), 1)
+        self.assertEqual(int(age_values[0]), 42)
+
 
 class SerializerAPITests(SimpleTestCase):
     def test_stream_class(self):


### PR DESCRIPTION
This is a fixed-up copy of https://github.com/django/django/pull/1176/commits/4471a9f966ebbd564c4ad026c2bc0d99a95a2aa7, part of https://github.com/django/django/pull/1176, that claims to fix https://code.djangoproject.com/ticket/5711.

I don't know if we want this functionality anymore. The original ticket was filed 15 years ago.

However, if we do, here's something that claims to do it.
