### PR TITLE
Fixed #33958 -- Added imports to examples in "Expressions can reference transforms" section.

### DIFF
--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -710,6 +710,7 @@ To find the earliest year an entry was published, we can issue the query::
 This example finds the value of the highest rated entry and the total number
 of comments on all entries for each year::
 
+    >>> from django.db.models import OuterRef, Subquery, Sum
     >>> Entry.objects.values('pub_date__year').annotate(
     ...     top_rating=Subquery(
     ...         Entry.objects.filter(

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -701,10 +701,12 @@ Django supports using transforms in expressions.
 For example, to find all ``Entry`` objects published in the same year as they
 were last modified::
 
+    >>> from django.db.models import F
     >>> Entry.objects.filter(pub_date__year=F('mod_date__year'))
 
 To find the earliest year an entry was published, we can issue the query::
 
+    >>> from django.db.models import Min
     >>> Entry.objects.aggregate(first_published_year=Min('pub_date__year'))
 
 This example finds the value of the highest rated entry and the total number


### PR DESCRIPTION
Add an import sentence in the documentations example of `topics/db/queries/#expressions-can-reference-transforms`. Example currently looks like this:
<img width="877" alt="Screen Shot 2022-08-28 at 3 21 29 PM" src="https://user-images.githubusercontent.com/25367296/187093097-c5cfc535-6b5b-413e-906e-e30fcea0dd43.png">

And with the change it looks like this
<img width="658" alt="Screen Shot 2022-08-28 at 3 22 04 PM" src="https://user-images.githubusercontent.com/25367296/187093094-4cf0b9a5-d81c-4a78-9ca0-187dddba8e04.png">