### PR TITLE
Refs #28333 -- Fixed NonQueryWindowTests.test_invalid_filter() on databases that don't support window expressions.

### DIFF
--- a/tests/expressions_window/tests.py
+++ b/tests/expressions_window/tests.py
@@ -1557,6 +1557,20 @@ class WindowFunctionTests(TestCase):
                 )
             )
 
+    def test_invalid_filter(self):
+        msg = (
+            "Heterogeneous disjunctive predicates against window functions are not "
+            "implemented when performing conditional aggregation."
+        )
+        qs = Employee.objects.annotate(
+            window=Window(Rank()),
+            past_dept_cnt=Count("past_departments"),
+        )
+        with self.assertRaisesMessage(NotImplementedError, msg):
+            list(qs.filter(Q(window=1) | Q(department="Accounting")))
+        with self.assertRaisesMessage(NotImplementedError, msg):
+            list(qs.exclude(window=1, department="Accounting"))
+
 
 class WindowUnsupportedTests(TestCase):
     def test_unsupported_backend(self):
@@ -1612,20 +1626,6 @@ class NonQueryWindowTests(SimpleTestCase):
         msg = "Subclasses must implement window_frame_start_end()."
         with self.assertRaisesMessage(NotImplementedError, msg):
             frame.window_frame_start_end(None, None, None)
-
-    def test_invalid_filter(self):
-        msg = (
-            "Heterogeneous disjunctive predicates against window functions are not "
-            "implemented when performing conditional aggregation."
-        )
-        qs = Employee.objects.annotate(
-            window=Window(Rank()),
-            past_dept_cnt=Count("past_departments"),
-        )
-        with self.assertRaisesMessage(NotImplementedError, msg):
-            list(qs.filter(Q(window=1) | Q(department="Accounting")))
-        with self.assertRaisesMessage(NotImplementedError, msg):
-            list(qs.exclude(window=1, department="Accounting"))
 
     def test_invalid_order_by(self):
         msg = (


### PR DESCRIPTION
It crashes e.g. on SQLite 3.19:
```
ERROR: test_invalid_filter (expressions_window.tests.NonQueryWindowTests)
----------------------------------------------------------------------
Traceback (most recent call last):
...
  File "/django/django/db/models/expressions.py", line 1690, in as_sql
    raise NotSupportedError("This backend does not support window expressions.")
django.db.utils.NotSupportedError: This backend does not support window expressions.

```