### PR TITLE
Fixed #33960 -- Fixed migrations crash on SQLite < 3.20.

### DIFF
--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -301,7 +301,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                     for column_name, (
                         referenced_column_name,
                         referenced_table_name,
-                    ) in relations:
+                    ) in relations.items():
                         cursor.execute(
                             """
                             SELECT REFERRING.`%s`, REFERRING.`%s` FROM `%s` as REFERRING

--- a/docs/releases/4.1.1.txt
+++ b/docs/releases/4.1.1.txt
@@ -52,3 +52,6 @@ Bugfixes
 
 * Reallowed, following a regression in Django 4.1, creating reverse foreign key
   managers on unsaved instances (:ticket:`33952`).
+
+* Fixed a regression in Django 4.1 that caused a migration crash on SQLite <
+  3.20 (:ticket:`33960`).


### PR DESCRIPTION
Regression in 0b95a96ee10d3e12aef01d449467bcf4641286b4.

Thanks Aristotelis Mikropoulos for the report.

ticket-33960