### PR TITLE
Refs #33953 -- Fixed test_rename_model_with_db_table_rename_m2m() crash on SQLite < 3.26.

### DIFF
--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1080,12 +1080,12 @@ class OperationTests(OperationTestBase):
                 ),
             ],
         )
-        new_state = project_state.clone()
-        operation = migrations.RenameModel("Pony", "PinkPony")
-        operation.state_forwards(app_label, new_state)
-        with connection.schema_editor() as editor:
-            operation.database_forwards(app_label, editor, project_state, new_state)
-
+        new_state = self.apply_operations(
+            app_label,
+            project_state,
+            operations=[migrations.RenameModel("Pony", "PinkPony")],
+            atomic=connection.features.supports_atomic_references_rename,
+        )
         Pony = new_state.apps.get_model(app_label, "PinkPony")
         Rider = new_state.apps.get_model(app_label, "Rider")
         pony = Pony.objects.create()


### PR DESCRIPTION
It crashes on SQLite < 3.26:
```
ERROR: test_rename_model_with_db_table_rename_m2m (migrations.test_operations.OperationTests)
----------------------------------------------------------------------
Traceback (most recent call last):
...
  File "/django/tests/migrations/test_operations.py", line 1087, in test_rename_model_with_db_table_rename_m2m
    operation.database_forwards(app_label, editor, project_state, new_state)
  File "/django/db/migrations/operations/models.py", line 375, in database_forwards
    schema_editor.alter_db_table(
  File "/django/db/backends/sqlite3/schema.py", line 109, in alter_db_table
    raise NotSupportedError(
django.db.utils.NotSupportedError: Renaming the 'pony' table while in a transaction is not supported on SQLite < 3.26 because it would break referential integrity. Try adding `atomic = False` to the Migration class.

----------------------------------------------------------------------
```