### PR TITLE
Changes to Sitemap for static views section

### DIFF
--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -371,7 +371,7 @@ the ``location`` method of the sitemap. For example::
     from django.contrib import sitemaps
     from django.urls import reverse
 
-    class StaticViewSitemap(sitemaps.Sitemap):
+    class StaticViewSitemap(Sitemap):
         priority = 0.5
         changefreq = 'daily'
 
@@ -388,7 +388,7 @@ the ``location`` method of the sitemap. For example::
     from .sitemaps import StaticViewSitemap
     from . import views
 
-    sitemaps = {
+    sitemap = {
         'static': StaticViewSitemap,
     }
 


### PR DESCRIPTION
Changes to Sitemap for static views section of sitemaps.txt docs.

These are minor changes notices while working with Django.

1. class StaticViewSitemap(Sitemap):

Current:
class StaticViewSitemap(sitemaps.Sitemap):

Proposed:
class StaticViewSitemap(Sitemap):
Since in the import from django.contrib.sitemaps import Sitemap sitemaps is already imported so its not required in class.

Same section # urls.py:

Current:

sitemaps = {
    'static': StaticViewSitemap,
}

Proposed:
sitemap = {
    'static': StaticViewSitemap,
}

Since in the import is sitemap
from django.contrib.sitemaps.views import sitemap

we should write sitemap in urls.py not sitemaps.