### PR TITLE
Fixed ReadOnlyPasswordHashWidget's template for RTL languages.

### DIFF
--- a/django/contrib/auth/templates/auth/widgets/read_only_password_hash.html
+++ b/django/contrib/auth/templates/auth/widgets/read_only_password_hash.html
@@ -1,5 +1,5 @@
 <div{% include 'django/forms/widgets/attrs.html' %}>
 {% for entry in summary %}
-<strong>{{ entry.label }}</strong>{% if entry.value %}: {{ entry.value }}{% endif %}
+<strong>{{ entry.label }}</strong>{% if entry.value %}: <bdi>{{ entry.value }}</bdi>{% endif %}
 {% endfor %}
 </div>

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -1159,14 +1159,13 @@ class ReadOnlyPasswordHashTest(SimpleTestCase):
         )
         self.assertHTMLEqual(
             widget.render("name", value, {"id": "id_password"}),
-            """
-            <div id="id_password">
-                <strong>algorithm</strong>: pbkdf2_sha256
-                <strong>iterations</strong>: 100000
-                <strong>salt</strong>: a6Pucb******
-                <strong>hash</strong>: WmCkn9**************************************
-            </div>
-            """,
+            '<div id="id_password">'
+            "    <strong>algorithm</strong>: <bdi>pbkdf2_sha256</bdi>"
+            "    <strong>iterations</strong>: <bdi>100000</bdi>"
+            "    <strong>salt</strong>: <bdi>a6Pucb******</bdi>"
+            "    <strong>hash</strong>: "
+            "       <bdi>WmCkn9**************************************</bdi>"
+            "</div>",
         )
 
     def test_readonly_field_has_changed(self):

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -1519,9 +1519,9 @@ class ChangelistTests(AuthViewsTestCase):
         # ReadOnlyPasswordHashWidget is used to render the field.
         self.assertContains(
             response,
-            "<strong>algorithm</strong>: %s\n\n"
-            "<strong>salt</strong>: %s********************\n\n"
-            "<strong>hash</strong>: %s**************************\n\n"
+            "<strong>algorithm</strong>: <bdi>%s</bdi>\n\n"
+            "<strong>salt</strong>: <bdi>%s********************</bdi>\n\n"
+            "<strong>hash</strong>: <bdi>%s**************************</bdi>\n\n"
             % (
                 algo,
                 salt[:2],


### PR DESCRIPTION
Following from #15977, this fixes bidirectional support in a part of the user admin:

Before this change,
![image](https://user-images.githubusercontent.com/129187/187791916-75b1f320-48da-4440-923b-e1f0ff0819b8.png)

It may not be obvious to a LTR-only user why this is wrong, so I marked the problems here:
![image](https://user-images.githubusercontent.com/129187/187792757-1dddf382-6060-4271-afe1-1f244428c70e.png)
Note how the 'salt' field, whose name is currently untranslated, is completely broken (the field name is thrown in the middle of the value; marked in red), and how the value of the 'hash' field (cyan) is also turned around.

After this change, it looks like so:
![image](https://user-images.githubusercontent.com/129187/187791185-082c4de5-5baf-483f-960c-95264fc82353.png)
The field name is always to the right of the field value (since this is RTL, this is "before"), and the field value itself is presented properly -- you may compare with the LTR presentation:
![image](https://user-images.githubusercontent.com/129187/187793612-6419a8bd-6627-4bd9-9bc2-73538a9815f4.png)

Note: The use of `dir="auto"` on the `<strong>` tag is for bidi isolation; `<strong dir="auto">...</strong>` is equivalent to `<bdi><strong>...</strong></bdi>`. I thought doing it this way is a little more elegant, but I can see an argument that using `<bdi>` in both cases is more consistent and expresses the intent more clearly.