### PR TITLE
update the decorator and get_action_choices to group actions by group fixing #33977

### DIFF
--- a/django/contrib/admin/decorators.py
+++ b/django/contrib/admin/decorators.py
@@ -1,4 +1,4 @@
-def action(function=None, *, permissions=None, description=None):
+def action(function=None, *, permissions=None, description=None, group=None):
     """
     Conveniently add attributes to an action function::
 
@@ -23,6 +23,8 @@ def action(function=None, *, permissions=None, description=None):
             func.allowed_permissions = permissions
         if description is not None:
             func.short_description = description
+        if group is not None:
+            func.action_group = group
         return func
 
     if function is None:

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1,4 +1,5 @@
 import copy
+from collections import defaultdict
 import json
 import re
 from functools import partial, update_wrapper
@@ -1024,11 +1025,13 @@ class ModelAdmin(BaseModelAdmin):
         Return a list of choices for use in a form object.  Each choice is a
         tuple (name, description).
         """
+        choices = defaultdict(list)
+        choices[None].extend(default_choices)
         choices = [] + default_choices
         for func, name, description in self.get_actions(request).values():
             choice = (name, description % model_format_dict(self.opts))
-            choices.append(choice)
-        return choices
+            choices[getattr(func, 'action_group', None)].append(choice)
+        return list(choices.items())
 
     def get_action(self, action):
         """

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1,7 +1,7 @@
 import copy
-from collections import defaultdict
 import json
 import re
+from collections import defaultdict
 from functools import partial, update_wrapper
 from urllib.parse import quote as urlquote
 
@@ -1030,7 +1030,7 @@ class ModelAdmin(BaseModelAdmin):
         choices = [] + default_choices
         for func, name, description in self.get_actions(request).values():
             choice = (name, description % model_format_dict(self.opts))
-            choices[getattr(func, 'action_group', None)].append(choice)
+            choices[getattr(func, "action_group", None)].append(choice)
         return list(choices.items())
 
     def get_action(self, action):

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1027,7 +1027,6 @@ class ModelAdmin(BaseModelAdmin):
         """
         choices = defaultdict(list)
         choices[None].extend(default_choices)
-        choices = [] + default_choices
         for func, name, description in self.get_actions(request).values():
             choice = (name, description % model_format_dict(self.opts))
             choices[getattr(func, "action_group", None)].append(choice)


### PR DESCRIPTION
We can introduce `<optgroup>`s in the Django action selector. This can easily be done by slightly extending the decorator with a group, and rewriting the logic of `get_action_choices` to introduce groups through a `defaultdict`.