### PR TITLE
Corrected heading level of "Registering and fetching lookups" section in docs.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -516,18 +516,6 @@ underscores to spaces. See :ref:`Verbose field names <verbose-field-names>`.
 A list of validators to run for this field. See the :doc:`validators
 documentation </ref/validators>` for more information.
 
-Registering and fetching lookups
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``Field`` implements the :ref:`lookup registration API <lookup-registration-api>`.
-The API can be used to customize which lookups are available for a field class
-and its instances, and how lookups are fetched from a field.
-
-.. versionchanged:: 4.2
-
-    Support for registering lookups on :class:`~django.db.models.Field`
-    instances was added.
-
 .. _model-field-types:
 
 Field types
@@ -2246,6 +2234,18 @@ Field API reference
 
         This method must be added to fields prior to 1.7 to migrate its data
         using :doc:`/topics/migrations`.
+
+Registering and fetching lookups
+================================
+
+``Field`` implements the :ref:`lookup registration API <lookup-registration-api>`.
+The API can be used to customize which lookups are available for a field class
+and its instances, and how lookups are fetched from a field.
+
+.. versionchanged:: 4.2
+
+    Support for registering lookups on :class:`~django.db.models.Field`
+    instances was added.
 
 .. _model-field-attributes:
 


### PR DESCRIPTION
Currently it's under _"validators"_ :shrug: :

![image](https://user-images.githubusercontent.com/2865885/188124471-00d361ac-30e6-408a-9518-a6989038d464.png)

I moved it below _"Field API reference"_:

![image](https://user-images.githubusercontent.com/2865885/188125007-f9c9936e-f006-43b2-95a4-122db5df6f2c.png)