### PR TITLE
Fixed #33937 -- Optimized serialization of related m2m fields without natural keys.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -616,6 +616,7 @@ answer newbie questions, and generally made Django that much better:
     Mario Gonzalez <gonzalemario@gmail.com>
     Mariusz Felisiak <felisiak.mariusz@gmail.com>
     Mark Biggers <biggers@utsl.com>
+    Mark Evans <mark@meltdownlabs.com>
     Mark Gensler <mark.gensler@protonmail.com>
     mark@junklight.com
     Mark Lavin <markdlavin@gmail.com>

--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -70,14 +70,20 @@ class Serializer(base.Serializer):
                 def m2m_value(value):
                     return value.natural_key()
 
+                def queryset_iterator(obj, field):
+                    return getattr(obj, field.name).iterator()
+
             else:
 
                 def m2m_value(value):
                     return self._value_from_field(value, value._meta.pk)
 
+                def queryset_iterator(obj, field):
+                    return getattr(obj, field.name).only("pk").iterator()
+
             m2m_iter = getattr(obj, "_prefetched_objects_cache", {}).get(
                 field.name,
-                getattr(obj, field.name).iterator(),
+                queryset_iterator(obj, field),
             )
             self._current[field.name] = [m2m_value(related) for related in m2m_iter]
 

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -146,14 +146,20 @@ class Serializer(base.Serializer):
                         self.xml.endElement("natural")
                     self.xml.endElement("object")
 
+                def queryset_iterator(obj, field):
+                    return getattr(obj, field.name).iterator()
+
             else:
 
                 def handle_m2m(value):
                     self.xml.addQuickElement("object", attrs={"pk": str(value.pk)})
 
+                def queryset_iterator(obj, field):
+                    return getattr(obj, field.name).only("pk").iterator()
+
             m2m_iter = getattr(obj, "_prefetched_objects_cache", {}).get(
                 field.name,
-                getattr(obj, field.name).iterator(),
+                queryset_iterator(obj, field),
             )
             for relobj in m2m_iter:
                 handle_m2m(relobj)


### PR DESCRIPTION
Optimized m2m serialization when using a primary key by only retrieving the primary key from the related model rather than all fields.