### PR TITLE
Added NPM lock file to git ignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/coverage_html/
 tests/.coverage
 build/
 tests/report/
+package-lock.json

--- a/docs/internals/contributing/writing-code/javascript.txt
+++ b/docs/internals/contributing/writing-code/javascript.txt
@@ -21,8 +21,9 @@ Code style
   conform to the code style of each file.
 
 * Use the `ESLint`_ code linter to check your code for bugs and style errors.
-  ESLint will be run when you run the JavaScript tests. We also recommended
-  installing a ESLint plugin in your text editor.
+  ESLint will be run with :ref:`pre-commit <coding-style-pre-commit>` and when
+  you run the JavaScript tests. We also recommended installing a ESLint plugin
+  in your text editor.
 
 * Where possible, write code that will work even if the page structure is later
   changed with JavaScript. For instance, when binding a click handler, use


### PR DESCRIPTION
We often say to locally exclude files from git, if they're IDE specific for example. The NPM lock file though is something that we'd expect to come up for any user running the `js_tests`. Do we want to globally ignore it as a courtesy? 


Also: `Doc'd that ESLint is also run by pre-commit.` 