### PR TITLE
Fixed #33981 -- removed exception trace from logs on SuspiciousOperation

### DIFF
--- a/django/core/handlers/exception.py
+++ b/django/core/handlers/exception.py
@@ -123,8 +123,7 @@ def response_for_exception(request, exc):
         )
         security_logger.error(
             str(exc),
-            exc_info=exc,
-            extra={"status_code": 400, "request": request},
+            extra={"status_code": 400, "request": request, 'exc_class': exc.__class__},
         )
         if settings.DEBUG:
             response = debug.technical_500_response(

--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -117,7 +117,11 @@ class AdminEmailHandler(logging.Handler):
         if record.exc_info:
             exc_info = record.exc_info
         else:
-            exc_info = (None, record.getMessage(), None)
+            exc_info = (
+                record.exc_class if hasattr(record, 'exc_class') else None, 
+                record.getMessage(),
+                None
+            )
 
         reporter = self.reporter_class(request, is_email=True, *exc_info)
         message = "%s\n\n%s" % (

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -108,8 +108,10 @@ class LoggingAssertionMixin:
             self.assertEqual(record.getMessage(), msg)
             self.assertEqual(record.status_code, status_code)
             if exc_class:
-                self.assertIsNotNone(record.exc_info)
-                self.assertEqual(record.exc_info[0], exc_class)
+                if hasattr(record, 'exc_info') and record.exc_info != None:
+                    self.assertEqual(record.exc_info[0], exc_class)
+                else:
+                    self.assertEqual(record.exc_class, exc_class)
 
 
 @override_settings(DEBUG=True, ROOT_URLCONF="logging_tests.urls")


### PR DESCRIPTION
An exception trace was being injected into the logs for handled
SuspiciousOperation exceptions in order to enable unit test verification
of the exception type. Unit testing of the exception type is worthwhile,
but doing it this way harms user functionality. This fix maintains the
verification of exception types, but without requiring exception traces
in logs. It also enables handled exception types to be specified in
email notifications without the logs needing to contain an exception
trace. All existing functionality and test coverage has been maintained.
Thanks to Carlton Gibson for helpful commentary.