### PR TITLE
Fixed #33982 -- Fixed migrations crash when adding model with ExclusionConstraint.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -269,7 +269,9 @@ class BaseDatabaseSchemaEditor:
         sql = self.sql_create_table % {
             "table": self.quote_name(model._meta.db_table),
             "definition": ", ".join(
-                constraint for constraint in (*column_sqls, *constraints) if constraint
+                str(constraint)
+                for constraint in (*column_sqls, *constraints)
+                if constraint
             ),
         }
         if model._meta.db_tablespace:

--- a/docs/releases/4.1.2.txt
+++ b/docs/releases/4.1.2.txt
@@ -9,4 +9,5 @@ Django 4.1.2 fixes several bugs in 4.1.1.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 4.1 that caused a migration crash on PostgreSQL
+  when adding a model with ``ExclusionConstraint`` (:ticket:`33982`).


### PR DESCRIPTION
Previously, we were getting a crash when attempting to perform a string join with a constraint's (`ExclusionConstraint`) SQL that was actually a `Statement` object instead of a string.

This change ensures that any `Statement` objects are converted into a string before passing to join.

https://code.djangoproject.com/ticket/33982