### PR TITLE
Refs #28333 -- Explicitly ordered outer qualify query on window filtering.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -683,7 +683,7 @@ class SQLCompiler:
             for ordering in order_by:
                 ordering_sql, ordering_params = self.compile(ordering)
                 ordering_sqls.append(ordering_sql)
-                ordering_params.extend(ordering_params)
+                params.extend(ordering_params)
             result.extend(["ORDER BY", ", ".join(ordering_sqls)])
         return result, params
 


### PR DESCRIPTION
While most backends will propagate derived table ordering as long as the outer query doesn't perform additional processing the SQL specs doesn't explicitly state the ordering must be maintained.