### PR TITLE
Fixed #33995 -- Fixed FormSet.empty_form crash when empty_permitted is passed to form_kwargs.

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -257,14 +257,15 @@ class BaseFormSet(RenderableFormMixin):
 
     @property
     def empty_form(self):
-        form = self.form(
-            auto_id=self.auto_id,
-            prefix=self.add_prefix("__prefix__"),
-            empty_permitted=True,
-            use_required_attribute=False,
+        form_kwargs = {
             **self.get_form_kwargs(None),
-            renderer=self.renderer,
-        )
+            "auto_id": self.auto_id,
+            "prefix": self.add_prefix("__prefix__"),
+            "empty_permitted": True,
+            "use_required_attribute": False,
+            "renderer": self.renderer,
+        }
+        form = self.form(**form_kwargs)
         self.add_fields(form, None)
         return form
 

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -179,6 +179,10 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertTrue(hasattr(formset.empty_form, "custom_kwarg"))
         self.assertEqual(formset.empty_form.custom_kwarg, 1)
 
+    def test_empty_permitted_ignored_empty_form(self):
+        formset = ArticleFormSet(form_kwargs={"empty_permitted": False})
+        self.assertIs(formset.empty_form.empty_permitted, True)
+
     def test_formset_validation(self):
         # FormSet instances can also have an error attribute if validation failed for
         # any of the forms.


### PR DESCRIPTION
[Fixed #33995](https://code.djangoproject.com/ticket/33995)

Rendering empty_form was crashing when ```empty_permitted=True``` or ```empty_permitted=False``` was passed to form_kwargs.