### PR TITLE
Corrected example of redundant all() in docs.

### DIFF
--- a/docs/topics/db/aggregation.txt
+++ b/docs/topics/db/aggregation.txt
@@ -111,7 +111,7 @@ belong to this ``QuerySet``. This is done by appending an ``aggregate()``
 clause onto the ``QuerySet``::
 
     >>> from django.db.models import Avg
-    >>> Book.objects.aggregate(Avg('price'))
+    >>> Book.objects.all().aggregate(Avg('price'))
     {'price__avg': 34.35}
 
 The ``all()`` is redundant in this example, so this could be simplified to::


### PR DESCRIPTION
Updated the example for redundant all() with aggregate()
Example currently looks like:
![image](https://user-images.githubusercontent.com/59354797/189327375-104d0a5d-5649-48a6-8670-d97ace6dee1f.png)

and with the change it will look like:
![image](https://user-images.githubusercontent.com/59354797/189327951-d74bcd00-e583-43b2-9784-c1d1994920c0.png)
