### PR TITLE
Add check if TEMPLATES->DIRS settings param is of type list

### DIFF
--- a/django/template/backends/base.py
+++ b/django/template/backends/base.py
@@ -20,12 +20,10 @@ class BaseEngine:
         self.app_dirs = params.pop("APP_DIRS")
 
         dirs = params.pop("DIRS")
-        dirs_type = type(dirs)
-        if dirs_type != list:
+        if type(dirs) != list:
             raise ImproperlyConfigured(
-                f"TEMPLATES->DIRS should be a list but is an {dirs_type} instead!"
+                "Settings parameter TEMPLATES->DIRS is not a list"
             )
-
         self.dirs = list(dirs)
 
         if params:

--- a/django/template/backends/base.py
+++ b/django/template/backends/base.py
@@ -17,8 +17,17 @@ class BaseEngine:
         """
         params = params.copy()
         self.name = params.pop("NAME")
-        self.dirs = list(params.pop("DIRS"))
         self.app_dirs = params.pop("APP_DIRS")
+
+        dirs = params.pop("DIRS")
+        dirs_type = type(dirs)
+        if dirs_type != list:
+            raise ImproperlyConfigured(
+                f"TEMPLATES->DIRS should be a list but is an {dirs_type} instead!"
+            )
+
+        self.dirs = list(dirs)
+
         if params:
             raise ImproperlyConfigured(
                 "Unknown parameters: {}".format(", ".join(params))


### PR DESCRIPTION
I had some strange behavior were Django started watching the whole file system.
After some testing I noticed that if the TEMPLATES/DIRS parameter in the settings.py is a string instead of a list, i.e. "/test/path" it gets split to an list ["/","t","e","s","t"...] and therefore all kind of directories get watched by the autoreloader / file-watcher.

I don't think there is an scenario where someone would want a string here.
I added a simple check that will raise an exception if the parameter is anything else then a string.

Hope this PR is fine, otherwise let me know if something should be adjusted.
