### PR TITLE
Fix typo in example code: article -> articles

### DIFF
--- a/docs/ref/class-based-views/base.txt
+++ b/docs/ref/class-based-views/base.txt
@@ -239,7 +239,7 @@ MRO is an acronym for Method Resolution Order.
         from django.urls import path
         from django.views.generic.base import RedirectView
 
-        from article.views import ArticleCounterRedirectView, ArticleDetailView
+        from articles.views import ArticleCounterRedirectView, ArticleDetailView
 
         urlpatterns = [
             path('counter/<int:pk>/', ArticleCounterRedirectView.as_view(), name='article-counter'),

--- a/docs/ref/class-based-views/generic-display.txt
+++ b/docs/ref/class-based-views/generic-display.txt
@@ -57,7 +57,7 @@ many projects they are typically the most commonly used views.
 
         from django.urls import path
 
-        from article.views import ArticleDetailView
+        from articles.views import ArticleDetailView
 
         urlpatterns = [
             path('<slug:slug>/', ArticleDetailView.as_view(), name='article-detail'),
@@ -147,7 +147,7 @@ many projects they are typically the most commonly used views.
 
         from django.urls import path
 
-        from article.views import ArticleListView
+        from articles.views import ArticleListView
 
         urlpatterns = [
             path('', ArticleListView.as_view(), name='article-list'),

--- a/docs/ref/class-based-views/generic-display.txt
+++ b/docs/ref/class-based-views/generic-display.txt
@@ -37,7 +37,7 @@ many projects they are typically the most commonly used views.
     #. :meth:`~django.views.generic.detail.BaseDetailView.get`
     #. :meth:`~django.views.generic.base.TemplateResponseMixin.render_to_response()`
 
-    **Example myapp/views.py**::
+    **Example views.py**::
 
         from django.utils import timezone
         from django.views.generic.detail import DetailView
@@ -53,7 +53,7 @@ many projects they are typically the most commonly used views.
                 context['now'] = timezone.now()
                 return context
 
-    **Example myapp/urls.py**::
+    **Example urls.py**::
 
         from django.urls import path
 
@@ -63,7 +63,7 @@ many projects they are typically the most commonly used views.
             path('<slug:slug>/', ArticleDetailView.as_view(), name='article-detail'),
         ]
 
-    **Example myapp/article_detail.html**:
+    **Example article_detail.html**:
 
     .. code-block:: html+django
 
@@ -143,7 +143,7 @@ many projects they are typically the most commonly used views.
                 context['now'] = timezone.now()
                 return context
 
-    **Example myapp/urls.py**::
+    **Example urls.py**::
 
         from django.urls import path
 
@@ -153,7 +153,7 @@ many projects they are typically the most commonly used views.
             path('', ArticleListView.as_view(), name='article-list'),
         ]
 
-    **Example myapp/article_list.html**:
+    **Example article_list.html**:
 
     .. code-block:: html+django
 


### PR DESCRIPTION
In the example code there is the use of "from article.xyz" and "from article**s**.uvw" . I think this is a typo and `articles` should be consistently used.