### PR TITLE
Fixed #34000 -- Fixed numberformat.format() crash on empty strings.

### DIFF
--- a/django/utils/numberformat.py
+++ b/django/utils/numberformat.py
@@ -25,7 +25,7 @@ def format(
         module in locale.localeconv() LC_NUMERIC grouping (e.g. (3, 2, 0)).
     * thousand_sep: Thousand separator symbol (for example ",")
     """
-    if number == "":
+    if number is None or number == "":
         return mark_safe(number)
     use_grouping = (
         use_l10n or (use_l10n is None and settings.USE_L10N)

--- a/django/utils/numberformat.py
+++ b/django/utils/numberformat.py
@@ -25,6 +25,8 @@ def format(
         module in locale.localeconv() LC_NUMERIC grouping (e.g. (3, 2, 0)).
     * thousand_sep: Thousand separator symbol (for example ",")
     """
+    if number == "":
+        return mark_safe(number)
     use_grouping = (
         use_l10n or (use_l10n is None and settings.USE_L10N)
     ) and settings.USE_THOUSAND_SEPARATOR

--- a/tests/utils_tests/test_numberformat.py
+++ b/tests/utils_tests/test_numberformat.py
@@ -172,3 +172,6 @@ class TestNumberFormat(SimpleTestCase):
 
         price = EuroDecimal("1.23")
         self.assertEqual(nformat(price, ","), "€ 1,23")
+
+    def test_empty(self):
+        self.assertEqual(nformat("", "."), "")

--- a/tests/utils_tests/test_numberformat.py
+++ b/tests/utils_tests/test_numberformat.py
@@ -175,3 +175,4 @@ class TestNumberFormat(SimpleTestCase):
 
     def test_empty(self):
         self.assertEqual(nformat("", "."), "")
+        self.assertEqual(nformat(None, "."), "None")


### PR DESCRIPTION
When (if str_number[0] == "-") encountered a number field that's a database NULL, e.g. when formatting for the admin list_display,
this caused an IndexError: string index out of range