### PR TITLE
Fixed #33984 -- Fixed Related managers cache gets stale after saving a fetched model with new PK

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -909,6 +909,10 @@ class Model(metaclass=ModelBase):
         """Save all the parents of cls using values from self."""
         meta = cls._meta
         inserted = False
+
+        if self.pk is None and self._state.adding is True:
+            self._state.related_managers_cache = {}
+
         for parent, field in meta.parents.items():
             # Make sure the link fields are synced between parent and self.
             if (

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -910,8 +910,8 @@ class Model(metaclass=ModelBase):
         meta = cls._meta
         inserted = False
 
-        if self.pk is None and self._state.adding is True:
-            self._state.related_managers_cache = {}
+        if self.pk is None:
+            self._state.related_managers_cache.clear()
 
         for parent, field in meta.parents.items():
             # Make sure the link fields are synced between parent and self.

--- a/tests/m2m_regress/tests.py
+++ b/tests/m2m_regress/tests.py
@@ -82,8 +82,7 @@ class M2MRegressionTests(TestCase):
         entry.save()
         entry.topics.set(old_topics)
         self.assertCountEqual(
-            entry.topics.all(),
-            Entry.objects.get(pk=entry.pk).topics.all()
+            entry.topics.all(), Entry.objects.get(pk=entry.pk).topics.all()
         )
 
     def test_m2m_pk_field_type(self):

--- a/tests/m2m_regress/tests.py
+++ b/tests/m2m_regress/tests.py
@@ -72,8 +72,8 @@ class M2MRegressionTests(TestCase):
         self.assertSequenceEqual(sr_sibling.related.all(), [sr_child.selfrefer_ptr])
 
     def test_m2m_instance_clone(self):
-        t1 = Tag.objects.create(name = "t1")
-        Entry.objects.create(name = "e1")
+        t1 = Tag.objects.create(name="t1")
+        Entry.objects.create(name="e1")
         entry = Entry.objects.all()[0]
         entry.topics.set([t1])
         old_topics = entry.topics.all()

--- a/tests/m2m_regress/tests.py
+++ b/tests/m2m_regress/tests.py
@@ -1,4 +1,3 @@
-from pydoc_data.topics import topics
 from django.core.exceptions import FieldError
 from django.test import TestCase
 

--- a/tests/m2m_regress/tests.py
+++ b/tests/m2m_regress/tests.py
@@ -78,6 +78,7 @@ class M2MRegressionTests(TestCase):
         entry.topics.set([t1])
         old_topics = entry.topics.all()
         entry.pk = None
+        entry._state.adding = True
         entry.save()
         entry.topics.set(old_topics)
         self.assertCountEqual(

--- a/tests/m2m_regress/tests.py
+++ b/tests/m2m_regress/tests.py
@@ -78,7 +78,6 @@ class M2MRegressionTests(TestCase):
         entry.topics.set([t1])
         old_topics = entry.topics.all()
         entry.pk = None
-        entry._state.adding = True
         entry.save()
         entry.topics.set(old_topics)
         self.assertCountEqual(

--- a/tests/m2m_regress/tests.py
+++ b/tests/m2m_regress/tests.py
@@ -1,3 +1,4 @@
+from pydoc_data.topics import topics
 from django.core.exceptions import FieldError
 from django.test import TestCase
 
@@ -70,6 +71,21 @@ class M2MRegressionTests(TestCase):
 
         self.assertSequenceEqual(sr_child.related.all(), [sr_sibling.selfrefer_ptr])
         self.assertSequenceEqual(sr_sibling.related.all(), [sr_child.selfrefer_ptr])
+
+    def test_m2m_instance_clone(self):
+        t1 = Tag.objects.create(name = "t1")
+        Entry.objects.create(name = "e1")
+        entry = Entry.objects.all()[0]
+        entry.topics.set([t1])
+        old_topics = entry.topics.all()
+        entry.pk = None
+        entry._state.adding = True
+        entry.save()
+        entry.topics.set(old_topics)
+        self.assertCountEqual(
+            entry.topics.all(),
+            Entry.objects.get(pk=entry.pk).topics.all()
+        )
 
     def test_m2m_pk_field_type(self):
         # Regression for #11311 - The primary key for models in a m2m relation


### PR DESCRIPTION
[Fixed #33984](https://code.djangoproject.com/ticket/33984)

Fixed Related managers cache gets stale after saving a fetched model with new PK. 

Added a condition for refreshing ```related_managers_cache``` when ```self.pk == None``` and ```self._state.adding == True```  since both the conditions are needed to copy an instance as per documentation of [copying model instances.](https://docs.djangoproject.com/en/4.1/topics/db/queries/#copying-model-instances)