### PR TITLE
Fixed #31714 -- Enable lookup expressions on OuterRef annotations

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -599,6 +599,15 @@ class ResolvedOuterRef(F):
     """
     contains_aggregate = False
 
+    def __init__(self, name, output_field=None):
+        """
+        Arguments:
+         * name: the name of the field this expression references
+         * output_field: the output type of the referenced field. Used for coercing lookup expressions
+        """
+        super().__init__(name)
+        self.output_field = output_field
+
     def as_sql(self, *args, **kwargs):
         raise ValueError(
             'This queryset contains a reference to an outer query and may '
@@ -619,14 +628,26 @@ class ResolvedOuterRef(F):
     def get_group_by_cols(self, alias=None):
         return []
 
+    def get_lookup(self, lookup_name):
+        return self.output_field.get_lookup(lookup_name) if self.output_field else None
+
 
 class OuterRef(F):
     contains_aggregate = False
 
+    def __init__(self, name, output_field=None):
+        """
+        Arguments:
+         * name: the name of the field this expression references
+         * output_field: the output type of the referenced field. Used for coercing lookup expressions
+        """
+        super().__init__(name)
+        self.output_field = output_field
+
     def resolve_expression(self, *args, **kwargs):
         if isinstance(self.name, self.__class__):
             return self.name
-        return ResolvedOuterRef(self.name)
+        return ResolvedOuterRef(self.name, output_field=self.output_field)
 
     def relabeled_clone(self, relabels):
         return self

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -556,7 +556,7 @@ On PostgreSQL, the SQL looks like:
 Referencing columns from the outer queryset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. class:: OuterRef(field)
+.. class:: OuterRef(field, output_field=None)
 
 Use ``OuterRef`` when a queryset in a ``Subquery`` needs to refer to a field
 from the outer query or its transform. It acts like an :class:`F` expression
@@ -569,6 +569,19 @@ parent. For example, this queryset would need to be within a nested pair of
 ``Subquery`` instances to resolve correctly::
 
     >>> Book.objects.filter(author=OuterRef(OuterRef('pk')))
+
+An ``OuterRef`` cannot be resolved to its ``output_field`` until its queryset
+is annotated to an outer query, therefore we cannot infer which lookups are
+available on the field. Should you wish to filter on a queryset annotation
+from an ``OuterRef`` you must provide an ``output_field`` on instantiation::
+
+    >>> Post.objects.annotate(name_contained_in_other_posts=Exists(
+    >>>     Subquery(
+    >>>         Post.objects.annotate(
+    >>>             outer_name=OuterRef('name', output_field=CharField())
+    >>>         ).filter(outer_name__contains=F('name'))
+    >>>     )
+    >>> ))
 
 .. versionchanged:: 3.2
 


### PR DESCRIPTION
An OuterRef cannot be resolved to its output_field until its queryset is annotated to an outer query, therefore we cannot infer which lookups are available on the field.

This commit adds the ability to provide an output_field on the OuterRef so the available lookups can be inferred.

Apologies the docs example is so contrived - I really struggled to think of an example that would have any value. Perhaps it can be omitted 🤷 

https://code.djangoproject.com/ticket/31714