### PR TITLE
Fixed #31714 -- Enable lookup expressions on OuterRef annotations

### DIFF
--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -561,7 +561,7 @@ On PostgreSQL, the SQL looks like:
 Referencing columns from the outer queryset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. class:: OuterRef(field)
+.. class:: OuterRef(field, output_field=None)
 
 Use ``OuterRef`` when a queryset in a ``Subquery`` needs to refer to a field
 from the outer query or its transform. It acts like an :class:`F` expression
@@ -574,6 +574,19 @@ parent. For example, this queryset would need to be within a nested pair of
 ``Subquery`` instances to resolve correctly::
 
     >>> Book.objects.filter(author=OuterRef(OuterRef('pk')))
+
+An ``OuterRef`` cannot be resolved to its ``output_field`` until its queryset
+is annotated to an outer query, therefore we cannot infer which lookups are
+available on the field. Should you wish to filter on a queryset annotation
+from an ``OuterRef`` you must provide an ``output_field`` on instantiation::
+
+    >>> Post.objects.annotate(name_contained_in_other_posts=Exists(
+    >>>     Subquery(
+    >>>         Post.objects.annotate(
+    >>>             outer_name=OuterRef('name', output_field=CharField())
+    >>>         ).filter(outer_name__contains=F('name'))
+    >>>     )
+    >>> ))
 
 Limiting a subquery to a single column
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -836,6 +836,34 @@ class BasicExpressionsTests(TestCase):
         ).get(pk=self.gmbh.pk)
         self.assertEqual(gmbh_salary.max_ceo_salary_raise, 2332)
 
+    def test_lookup_filter_on_annotation_with_outerref(self):
+        annotated_queryset = Company.objects.annotate(
+            salary_raise=OuterRef("num_employees", output_field=IntegerField()),
+        )
+        gmbh_salary = Company.objects.annotate(
+            true_filter=Exists(Subquery(annotated_queryset.filter(salary_raise__gt=1))),
+            false_filter=Exists(
+                Subquery(annotated_queryset.filter(salary_raise__lt=1))
+            ),
+        ).get(pk=self.gmbh.pk)
+        self.assertTrue(gmbh_salary.true_filter)
+        self.assertFalse(gmbh_salary.false_filter)
+
+    def test_invalid_lookup_filter_on_annotation_with_outerref(self):
+        annotated_queryset = Company.objects.annotate(
+            salary_raise=OuterRef("num_employees", output_field=IntegerField()),
+        )
+        with self.assertRaisesMessage(
+            ValueError,
+            "Could not find lookup month for ResolvedOuterRef. Please provide"
+            " appropriate output_field.",
+        ):
+            Company.objects.annotate(
+                invalid_filter=Exists(
+                    Subquery(annotated_queryset.filter(salary_raise__month=1))
+                ),
+            )
+
     def test_annotation_with_nested_outerref(self):
         self.gmbh.point_of_contact = Employee.objects.get(lastname="Meyer")
         self.gmbh.save()


### PR DESCRIPTION
An OuterRef cannot be resolved to its output_field until its queryset is annotated to an outer query, therefore we cannot infer which lookups are available on the field.

This commit adds the ability to provide an output_field on the OuterRef so the available lookups can be inferred.

Apologies the docs example is so contrived - I really struggled to think of an example that would have any value. Perhaps it can be omitted 🤷

https://code.djangoproject.com/ticket/31714