### PR TITLE
Fixed #34007 -- Updated classification of UniqueConstraint validation errors

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1567,6 +1567,11 @@ class Model(AltersData, metaclass=ModelBase):
                     if (
                         getattr(e, "code", None) == "unique"
                         and len(constraint.fields) == 1
+                        and (
+                            constraint.condition is None
+                            or set(constraint.fields)
+                            == constraint.condition.referenced_base_fields
+                        )
                     ):
                         errors.setdefault(constraint.fields[0], []).append(e)
                     else:

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -671,7 +671,7 @@ class UniqueConstraint(BaseConstraint):
                 ):
                     raise ValidationError(
                         self.get_violation_error_message(),
-                        code=self.violation_error_code,
+                        code=self.violation_error_code or "unique",
                     )
             except FieldError:
                 pass

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -669,13 +669,9 @@ class UniqueConstraint(BaseConstraint):
                 if (self.condition & Exists(queryset.filter(self.condition))).check(
                     against, using=using
                 ):
-                    code = (
-                        "unique"
-                        if self.condition.referenced_base_fields == set(self.fields)
-                        else self.violation_error_code
-                    )
                     raise ValidationError(
-                        message=self.get_violation_error_message(), code=code
+                        message=self.get_violation_error_message(),
+                        code=self.violation_error_code or "unique",
                     )
             except FieldError:
                 pass

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -669,9 +669,13 @@ class UniqueConstraint(BaseConstraint):
                 if (self.condition & Exists(queryset.filter(self.condition))).check(
                     against, using=using
                 ):
+                    code = (
+                        "unique"
+                        if self.condition.fields == set(self.fields)
+                        else self.violation_error_code
+                    )
                     raise ValidationError(
-                        self.get_violation_error_message(),
-                        code=self.violation_error_code or "unique",
+                        message=self.get_violation_error_message(), code=code
                     )
             except FieldError:
                 pass

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -671,7 +671,7 @@ class UniqueConstraint(BaseConstraint):
                 ):
                     code = (
                         "unique"
-                        if self.condition.fields == set(self.fields)
+                        if self.condition.referenced_base_fields == set(self.fields)
                         else self.violation_error_code
                     )
                     raise ValidationError(

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -181,17 +181,18 @@ class Q(tree.Node):
         Retrieve all base fields referenced directly or through F expressions excluding
         any fields referenced through joins.
         """
-        # Avoid circular imports
+        # Avoid circular imports.
         from django.db.models import F
 
-        f_references = set(expr.name for expr in self.flatten() if isinstance(expr, F))
-        q_references = set(
+        expressions = list(self.flatten())
+        f_references = {expr.name for expr in expressions if isinstance(expr, F)}
+        q_references = {
             child[0].split(LOOKUP_SEP)[0]
-            for expr in self.flatten()
+            for expr in expressions
             if isinstance(expr, Q)
             for child in expr.children
             if isinstance(child, tuple)
-        )
+        }
         return f_references | q_references
 
 

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -175,6 +175,18 @@ class Q(tree.Node):
     def __hash__(self):
         return hash(self.identity)
 
+    @property
+    def fields(self):
+        def determine_fields(filter_expr):
+            if isinstance(filter_expr, Q):
+                return filter_expr.fields
+            field = filter_expr[0].split(LOOKUP_SEP)[0]
+            return {field}
+
+        return set(
+            field for child in self.children for field in determine_fields(child)
+        )
+
 
 class DeferredAttribute:
     """

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -187,7 +187,7 @@ class Q(tree.Node):
         expressions = list(self.flatten())
         f_references = {expr.name for expr in expressions if isinstance(expr, F)}
         q_references = {
-            child[0].split(LOOKUP_SEP)[0]
+            child[0].split(LOOKUP_SEP, 1)[0]
             for expr in expressions
             if isinstance(expr, Q)
             for child in expr.children

--- a/docs/ref/models/constraints.txt
+++ b/docs/ref/models/constraints.txt
@@ -170,6 +170,12 @@ For example, ``UniqueConstraint(fields=['room', 'date'],
 name='unique_booking')`` ensures each room can only be booked once for each
 date.
 
+If a :class:`~django.core.exceptions.ValidationError` is raised during a
+model's :meth:`validate_constraints() <Model.validate_constraints>` it will be
+classified as a field-error for ``fields`` listing only a single field;
+for ``fields`` listing multiple fields it will be classified as a
+:attr:`non-field-error <django.core.exceptions.NON_FIELD_ERRORS>`.
+
 ``condition``
 -------------
 

--- a/tests/constraints/models.py
+++ b/tests/constraints/models.py
@@ -63,6 +63,20 @@ class UniqueConstraintConditionProduct(models.Model):
         ]
 
 
+class UniqueConstraintSingleFieldConditionProduct(models.Model):
+    name = models.CharField(max_length=255)
+
+    class Meta:
+        required_db_features = {"supports_partial_indexes"}
+        constraints = [
+            models.UniqueConstraint(
+                fields=["name"],
+                name="unique_non_empty_string_name",
+                condition=~models.Q(name=""),
+            ),
+        ]
+
+
 class UniqueConstraintDeferrable(models.Model):
     name = models.CharField(max_length=255)
     shelf = models.CharField(max_length=31)

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -834,8 +834,9 @@ class UniqueConstraintTests(TestCase):
             name=obj1.name, color="blue"
         ).validate_constraints()
         msg = "Constraint “name_without_color_uniq” is violated."
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertRaisesMessage(ValidationError, msg) as cm:
             UniqueConstraintConditionProduct(name=obj2.name).validate_constraints()
+        self.assertEqual(cm.exception.message_dict, {"name": [msg]})
 
     def test_model_validation_constraint_no_code_error(self):
         class ValidateNoCodeErrorConstraint(UniqueConstraint):

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -19,6 +19,7 @@ from .models import (
     UniqueConstraintDeferrable,
     UniqueConstraintInclude,
     UniqueConstraintProduct,
+    UniqueConstraintSingleFieldConditionProduct,
 )
 
 
@@ -836,6 +837,16 @@ class UniqueConstraintTests(TestCase):
         msg = "Constraint “name_without_color_uniq” is violated."
         with self.assertRaisesMessage(ValidationError, msg) as cm:
             UniqueConstraintConditionProduct(name=obj2.name).validate_constraints()
+        self.assertEqual(cm.exception.message_dict, {"__all__": [msg]})
+
+    @skipUnlessDBFeature("supports_partial_indexes")
+    def test_model_validation_with_single_field_in_condition(self):
+        UniqueConstraintSingleFieldConditionProduct.objects.create(name="p1")
+        msg = "Constraint “unique_non_empty_string_name” is violated."
+        with self.assertRaisesMessage(ValidationError, msg) as cm:
+            UniqueConstraintSingleFieldConditionProduct(
+                name="p1"
+            ).validate_constraints()
         self.assertEqual(cm.exception.message_dict, {"name": [msg]})
 
     def test_model_validation_constraint_no_code_error(self):

--- a/tests/queries/test_q.py
+++ b/tests/queries/test_q.py
@@ -263,6 +263,10 @@ class QTests(SimpleTestCase):
                     Q(*items, _connector=connector),
                 )
 
+    def test_fields(self):
+        q = Q(Q(field_1=1) & Q(field_2=1), field_2=1, field_3__lookup=True)
+        self.assertEqual(q.fields, {"field_1", "field_2", "field_3"})
+
 
 class QCheckTests(TestCase):
     def test_basic(self):

--- a/tests/queries/test_q.py
+++ b/tests/queries/test_q.py
@@ -10,6 +10,7 @@ from django.db.models import (
 )
 from django.db.models.expressions import NegatedExpression, RawSQL
 from django.db.models.functions import Lower
+from django.db.models.lookups import Exact, IsNull
 from django.db.models.sql.where import NothingNode
 from django.test import SimpleTestCase, TestCase
 
@@ -263,9 +264,29 @@ class QTests(SimpleTestCase):
                     Q(*items, _connector=connector),
                 )
 
-    def test_fields(self):
-        q = Q(Q(field_1=1) & Q(field_2=1), field_2=1, field_3__lookup=True)
-        self.assertEqual(q.fields, {"field_1", "field_2", "field_3"})
+    def test_referenced_base_fields(self):
+        # Make sure Q.referenced_base_fields retrieves all base fields from both
+        # filters and F expressions
+        q = Q(
+            1,
+            Q(field_1=1) & Q(field_2=1),
+            Exact(F("field_3"), IsNull(F("field_4"), True)),
+            Exact(Q(field_5=F("field_6")), True),
+            field_2=1,
+            field_7__lookup=True,
+        )
+        self.assertEqual(
+            q.referenced_base_fields,
+            {
+                "field_1",
+                "field_2",
+                "field_3",
+                "field_4",
+                "field_5",
+                "field_6",
+                "field_7",
+            },
+        )
 
 
 class QCheckTests(TestCase):

--- a/tests/validation/test_constraints.py
+++ b/tests/validation/test_constraints.py
@@ -83,7 +83,7 @@ class PerformConstraintChecksTest(TestCase):
         self.assertEqual(
             cm.exception.message_dict,
             {
-                "name": [
+                "__all__": [
                     "Constraint “name_without_color_uniq_validation” is violated.",
                 ]
             },

--- a/tests/validation/test_constraints.py
+++ b/tests/validation/test_constraints.py
@@ -83,8 +83,8 @@ class PerformConstraintChecksTest(TestCase):
         self.assertEqual(
             cm.exception.message_dict,
             {
-                "__all__": [
-                    "Constraint “name_without_color_uniq_validation” is violated."
+                "name": [
+                    "Constraint “name_without_color_uniq_validation” is violated.",
                 ]
             },
         )


### PR DESCRIPTION
[Fixes #34007](https://code.djangoproject.com/ticket/34007)

**Notes**:
- I've only updated the one instance that fixes this discrepancy – should we update all `ValidationError` raised from `UniqueConstraint.validate()` to use `code="unique"`?
- I've updated the docs clarifying how unique constraint errors are classified - I can't see any other reference in the docs wrt the terminology "field-error" vs "non-field-error" other than the attr `NON_FIELD_ERRORS` 🤷‍♂️ but I'm sure it will get corrected before merging 😊