### PR TITLE
Described Article-Reporter relationship in many-to-one topic.

### DIFF
--- a/docs/topics/db/examples/many_to_one.txt
+++ b/docs/topics/db/examples/many_to_one.txt
@@ -2,7 +2,10 @@
 Many-to-one relationships
 =========================
 
-To define a many-to-one relationship, use :class:`~django.db.models.ForeignKey`::
+To define a many-to-one relationship, use :class:`~django.db.models.ForeignKey`.
+
+In this example, a ``Reporter`` can be associated with many ``Article``
+objects, but an ``Article`` can only have one ``Reporter`` object::
 
     from django.db import models
 


### PR DESCRIPTION
When I first read this page, I wasn't sure if an Article could have many Reporters, since in the real world, articles can have multiple authors in the byline. I liked how the many-to-many page described the relationship with a human-friendly description first, so I copied that style here.