### PR TITLE
Used first-interaction for GitHub action with welcome message.

### DIFF
--- a/.github/workflows/new_contributor_pr.yml
+++ b/.github/workflows/new_contributor_pr.yml
@@ -13,12 +13,11 @@ jobs:
     name: Hello new contributor
     runs-on: ubuntu-latest
     steps:
-      # Pinned to v2.0
-      - uses: deborah-digges/new-pull-request-comment-action@224c179a9e23f65ec50ff3240b8716369dc415d7
+      - uses: actions/first-interaction@v1
         with:
-          access-token: ${{ secrets.GITHUB_TOKEN }}
-          message: |
-            Hello @{}! Thank you for your contribution 💪
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: |
+            Hello! Thank you for your contribution 💪
 
             As it's your first contribution be sure to check out the [patch review checklist](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/submitting-patches/#patch-review-checklist).
 


### PR DESCRIPTION
`deborah-digges/new-pull-request-comment-action` doesn't work anymore, see logs:

```
Run deborah-digges/new-pull-request-comment-action@224c179a9e23f65ec50ff3240b8716369dc415d7
Request received
New Pull Request..
Commenting
(node:1544) UnhandledPromiseRejectionWarning: HttpError: Resource not accessible by integration
    at /home/runner/work/_actions/deborah-digges/new-pull-request-comment-action/224c179a9e23f65ec50ff3240b8716369dc415d7/node_modules/@octokit/request/dist-node/index.js:66:23
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:1544) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:1544) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```