### PR TITLE
Fixed test_relational_post_delete_signals_happen_before_parent_object when run in isolation.

### DIFF
--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -422,9 +422,9 @@ class DeletionTests(TestCase):
             self.assertIs(type(instance), S)
             deletions.append(instance.id)
 
-        r = R.objects.create(pk=1)
-        S.objects.create(pk=1, r=r)
-
+        r = R.objects.create()
+        s = S.objects.create(r=r)
+        s_id = s.pk
         models.signals.post_delete.connect(log_post_delete, sender=S)
 
         try:
@@ -433,7 +433,7 @@ class DeletionTests(TestCase):
             models.signals.post_delete.disconnect(log_post_delete)
 
         self.assertEqual(len(deletions), 1)
-        self.assertEqual(deletions[0], 1)
+        self.assertEqual(deletions[0], s_id)
 
     @skipUnlessDBFeature("can_defer_constraint_checks")
     def test_can_defer_constraint_checks(self):


### PR DESCRIPTION
```
$ ./runtests.py delete.tests.DeletionTests.test_relational_post_delete_signals_happen_before_parent_object
Testing against Django installed in '/django/django' with up to 8 processes
Found 1 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
E
======================================================================
ERROR: test_relational_post_delete_signals_happen_before_parent_object (delete.tests.DeletionTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/django/db/models/query.py", line 928, in get_or_create
    return self.get(**kwargs), False
  File "/django/django/db/models/query.py", line 650, in get
    raise self.model.DoesNotExist(
delete.models.R.DoesNotExist: R matching query does not exist.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/django/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "delete_r_pkey"
DETAIL:  Key (id)=(1) already exists.

```