### PR TITLE
Fixed #34016 -- Fixed QuerySet.values()/values_list() crash on ArrayAgg() and JSONBAgg().

### DIFF
--- a/django/contrib/postgres/aggregates/mixins.py
+++ b/django/contrib/postgres/aggregates/mixins.py
@@ -14,10 +14,13 @@ class OrderableAggMixin:
         return super().resolve_expression(*args, **kwargs)
 
     def get_source_expressions(self):
-        return super().get_source_expressions() + [self.order_by]
+        if self.order_by.source_expressions:
+            return super().get_source_expressions() + [self.order_by]
+        return super().get_source_expressions()
 
     def set_source_expressions(self, exprs):
-        *exprs, self.order_by = exprs
+        if isinstance(exprs[-1], OrderByList):
+            *exprs, self.order_by = exprs
         return super().set_source_expressions(exprs)
 
     def as_sql(self, compiler, connection):

--- a/docs/releases/4.1.2.txt
+++ b/docs/releases/4.1.2.txt
@@ -18,3 +18,7 @@ Bugfixes
 
 * Fixed a bug in Django 4.1 that caused an incorrect validation of
   ``CheckConstraint`` on ``NULL`` values (:ticket:`33996`).
+
+* Fixed a regression in Django 4.1 that caused a
+  ``QuerySet.values()/values_list()`` crash on ``ArrayAgg()`` and
+  ``JSONBAgg()`` (:ticket:`34016`).

--- a/tests/postgres_tests/test_aggregates.py
+++ b/tests/postgres_tests/test_aggregates.py
@@ -686,6 +686,15 @@ class TestGeneralAggregate(PostgreSQLTestCase):
             ],
         )
 
+    def test_values_list(self):
+        tests = [ArrayAgg("integer_field"), JSONBAgg("integer_field")]
+        for aggregation in tests:
+            with self.subTest(aggregation=aggregation):
+                self.assertCountEqual(
+                    AggregateTestModel.objects.values_list(aggregation),
+                    [([0],), ([1],), ([2],), ([0],)],
+                )
+
 
 class TestAggregateDistinct(PostgreSQLTestCase):
     @classmethod


### PR DESCRIPTION
As suggested by Mariusz in https://code.djangoproject.com/ticket/34016#comment:4