### PR TITLE
Fixed #34014 -- Fixed DecimalValidator validating 0 in positive exponent scientific notation.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -486,8 +486,10 @@ class DecimalValidator:
                 self.messages["invalid"], code="invalid", params={"value": value}
             )
         if exponent >= 0:
-            # A positive exponent adds that many trailing zeros.
-            digits = len(digit_tuple) + exponent
+            digits = len(digit_tuple)
+            if digit_tuple != (0,):
+                # A positive exponent adds that many trailing zeros.
+                digits += exponent
             decimals = 0
         else:
             # If the absolute value of the negative exponent is larger than the

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -548,6 +548,7 @@ TEST_DATA = [
         Decimal("70E-6"),
         ValidationError,
     ),
+    (DecimalValidator(max_digits=2, decimal_places=1), Decimal("0E+1"), None),
     # 'Enter a number.' errors
     *[
         (


### PR DESCRIPTION
`DecimalValidator` no longer fails to validate values like e.g. `Decimal('0E+1')`.

https://code.djangoproject.com/ticket/34014