### PR TITLE
Fixed permissions for GitHub action with welcome message.

### DIFF
--- a/.github/workflows/new_contributor_pr.yml
+++ b/.github/workflows/new_contributor_pr.yml
@@ -5,7 +5,7 @@ on:
     types: [opened]
 
 permissions:
-  pull-requests: [read, write]
+  pull-requests: write
 
 jobs:
   build:


### PR DESCRIPTION
Follow up to bc33b047848759e7ae90bf85c94ff6cc5913e1ee.

```
The workflow is not valid. .github/workflows/new_contributor_pr.yml (Line: 8, Col: 18): A sequence was not expected
```

Hopefully that's the final (3rd :exploding_head:) attempt. See [permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) docs.