### PR TITLE
Fixed #34012 -- Made QuerySet.order_by() apply transforms on related fields for models with Meta.ordering.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1001,12 +1001,14 @@ class SQLCompiler:
 
         # If we get to this point and the field is a relation to another model,
         # append the default ordering for that model unless it is the pk
-        # shortcut or the attribute name of the field that is specified.
+        # shortcut or the attribute name of the field that is specified or
+        # there are transforms to process.
         if (
             field.is_relation
             and opts.ordering
             and getattr(field, "attname", None) != pieces[-1]
             and name != "pk"
+            and not getattr(transform_function, "has_transforms", False)
         ):
             # Firstly, avoid infinite loops.
             already_seen = already_seen or set()

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1819,6 +1819,7 @@ class Query(BaseExpression):
             final_transformer = functools.partial(
                 transform, name=name, previous=final_transformer
             )
+            final_transformer.has_transforms = True
         # Then, add the path to the query's joins. Note that we can't trim
         # joins at this stage - we will need the information about join type
         # of the trimmed joins.

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from operator import attrgetter
 
+from django.core.exceptions import FieldError
 from django.db.models import (
     CharField,
     Count,
@@ -90,6 +91,18 @@ class OrderingTests(TestCase):
             ],
             attrgetter("headline"),
         )
+
+    def test_default_ordering_override_unknown_field(self):
+        """
+        Attempts to override default ordering on related models with an unknown
+        field should result in an error.
+        """
+        msg = (
+            "Cannot resolve keyword 'unknown_field' into field. Choices are: "
+            "article, author, editor, editor_id, id, name"
+        )
+        with self.assertRaisesMessage(FieldError, msg):
+            list(Article.objects.order_by("author__unknown_field"))
 
     def test_order_by_override(self):
         """

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -68,6 +68,9 @@ class Annotation(models.Model):
 class DateTimePK(models.Model):
     date = models.DateTimeField(primary_key=True, default=datetime.datetime.now)
 
+    class Meta:
+        ordering = ["date"]
+
 
 class ExtraInfo(models.Model):
     info = models.CharField(max_length=100)


### PR DESCRIPTION
Hi Carlton/Mariusz,

I had a look through the ordering code and it seems safe to assume that anything of the form `order_by(related__something)` must assume "something" is a field and not a transform. If we look at `find_ordering_name()` [it ignores any transforms after a relation field and starts looking at the `Meta.ordering` of that relation](https://github.com/django/django/blob/3ba7f2e9069c54db6d6d9d2fd1945b2dbc935d9c/django/db/models/sql/compiler.py#L1002-L1010) after calling `_setup_joins()`.

The only thing I'm unsure of is whether this could impact any code not dealing with ordering.

Note: Btw is someone able to confirm transforms on `order_by()` is still a thing? I just tried it and it doesn't appear to work using a simple `order_by('char_field__length')` 🤔