### PR TITLE
Fixed #32095 -- Made QuerySet.update_or_create() save only fields passed in defaults or with custom pre_save().

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -799,15 +799,7 @@ class Model(metaclass=ModelBase):
                 return
 
             update_fields = frozenset(update_fields)
-            field_names = set()
-
-            for field in self._meta.concrete_fields:
-                if not field.primary_key:
-                    field_names.add(field.name)
-
-                    if field.name != field.attname:
-                        field_names.add(field.attname)
-
+            field_names = self._meta._non_pk_concrete_field_names
             non_model_fields = update_fields.difference(field_names)
 
             if non_model_fields:

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -89,6 +89,7 @@ class Options:
         "many_to_many",
         "concrete_fields",
         "local_concrete_fields",
+        "_non_pk_concrete_field_names",
         "_forward_fields_map",
         "managers",
         "managers_map",
@@ -980,6 +981,19 @@ class Options:
             attr = inspect.getattr_static(self.model, name)
             if isinstance(attr, property):
                 names.append(name)
+        return frozenset(names)
+
+    @cached_property
+    def _non_pk_concrete_field_names(self):
+        """
+        Return a set of the non-pk concrete field names defined on the model.
+        """
+        names = []
+        for field in self.concrete_fields:
+            if not field.primary_key:
+                names.append(field.name)
+                if field.name != field.attname:
+                    names.append(field.attname)
         return frozenset(names)
 
     @cached_property

--- a/tests/get_or_create/models.py
+++ b/tests/get_or_create/models.py
@@ -63,3 +63,4 @@ class Book(models.Model):
         related_name="books",
         db_column="publisher_id_column",
     )
+    updated = models.DateTimeField(auto_now=True)


### PR DESCRIPTION
Extended from @apollo13 patch: https://github.com/django/django/pull/13526
Tried to address the PR comments which were to add handling for the auto_now fields and a test for the mti case.

