### PR TITLE
Fixed #34022 -- support logout of non-staff users as well.

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -267,7 +267,7 @@ class AdminSite:
         urlpatterns = [
             path("", wrap(self.index), name="index"),
             path("login/", self.login, name="login"),
-            path("logout/", wrap(self.logout), name="logout"),
+            path("logout/", self.logout, name="logout"),
             path(
                 "password_change/",
                 wrap(self.password_change, cacheable=True),


### PR DESCRIPTION
I'd appreciate a pointer to where the existing test suite should be amended to capture the existing behaviour and then a fixed one. I see `test_login_page_notice_for_non_staff_users` in `tests/admin_views/tests.py` but there's also `tests/auth_tests/test_views.py` where it might potentially belong.