### PR TITLE
Fixed #34024 -- Fixed crash when aggregating querysets with Q objects annotations.

### DIFF
--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -244,6 +244,10 @@ class WhereNode(tree.Node):
     def contains_over_clause(self):
         return self._contains_over_clause(self)
 
+    @property
+    def is_summary(self):
+        return any(child.is_summary for child in self.children)
+
     @staticmethod
     def _resolve_leaf(expr, query, *args, **kwargs):
         if hasattr(expr, "resolve_expression"):

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -554,6 +554,9 @@ class AggregationTests(TestCase):
             325,
         )
 
+    def test_q_annotation_aggregate(self):
+        self.assertEqual(Book.objects.annotate(has_pk=Q(pk__isnull=False)).count(), 6)
+
     def test_decimal_aggregate_annotation_filter(self):
         """
         Filtering on an aggregate annotation with Decimal values should work.


### PR DESCRIPTION
[Fixes 34024](https://code.djangoproject.com/ticket/34024)

Test added alongside those added with the original PR by Josh.