### PR TITLE
Changes to Writer.py file

### DIFF
--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -271,7 +271,7 @@ class MigrationWriter:
 
     @property
     def filename(self):
-        return "%s.py" % self.migration.name
+        return "%s.py" % self.migration.name.replace(".", "_")
 
     @property
     def path(self):


### PR DESCRIPTION
Reason for change: 
- Migration Files generated by makemigrations is not considered as migration file if the name of migration file contains `.` (dot)(excluding the .py extension) 

Description: 
- When adding constraints in django model, the migration file was renamed with 00X_constraint_name.py. If the name of constraint has any `.` then the name of the migration file would be `00X_constraint_.name.py`.
- The generated migration file would be `00X_constraint_.name.py`, which the migrate/showmigrations considers as a nonpython file because of `.name.py` as an extension. So everytime we run makemigrations it would just create a new migrations file. Migrate/ Showmigrations donot find the file as it is not recognized as `.py` file.
- After removing the `.` contained in the file name, `migrate /showmigrations` is then able to find the new migration files. This makes sure that even though there are any `.`(dot) in migration file name, it would get replaced and `migrate/showmigrations` would be able to find the file.  

Or maybe we can do `self.migration.name.replace(".", "_").replace(" ", "_")` for proper naming of migration files at line number 274 of django.db.migrations.writer.py file.

This pull request is also linked to  the ticket: https://code.djangoproject.com/ticket/34050#ticket

Regards,
Bishal Gautam