### PR TITLE
Fixed #33464 -- Resolved output_field for combined numeric expressions with MOD operator.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -533,6 +533,7 @@ _connector_combinations = [
             Combinable.SUB,
             Combinable.MUL,
             Combinable.DIV,
+            Combinable.MOD,
         )
     },
     # Bitwise operators.

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -2416,7 +2416,13 @@ class CombinedExpressionTests(SimpleTestCase):
             (IntegerField, FloatField, FloatField),
             (FloatField, IntegerField, FloatField),
         ]
-        connectors = [Combinable.ADD, Combinable.SUB, Combinable.MUL, Combinable.DIV]
+        connectors = [
+            Combinable.ADD,
+            Combinable.SUB,
+            Combinable.MUL,
+            Combinable.DIV,
+            Combinable.MOD,
+        ]
         for lhs, rhs, combined in tests:
             for connector in connectors:
                 with self.subTest(


### PR DESCRIPTION
[ticket-33464](https://code.djangoproject.com/ticket/33464)

I'm unsure about the second commit, if it makes sense to define as default `FloatField + DecimalField => DecimalField`.
I'd say that one wants to keep the decimal precision by default, like when doing plain Python arithmetic with a `Decimal`.