### PR TITLE
Fixed #34027 -- Fixed migrations crash when altering type of char/text fields referenced by foreign key on PostgreSQL.

### DIFF
--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -2436,6 +2436,45 @@ class OperationTests(OperationTestBase):
             ],
         )
 
+    def test_alter_field_pk_fk_char_to_int(self):
+        app_label = "alter_field_pk_fk_char_to_int"
+        project_state = self.apply_operations(
+            app_label,
+            ProjectState(),
+            operations=[
+                migrations.CreateModel(
+                    name="Parent",
+                    fields=[
+                        ("id", models.CharField(max_length=255, primary_key=True)),
+                    ],
+                ),
+                migrations.CreateModel(
+                    name="Child",
+                    fields=[
+                        ("id", models.BigAutoField(primary_key=True)),
+                        (
+                            "parent",
+                            models.ForeignKey(
+                                f"{app_label}.Parent",
+                                on_delete=models.CASCADE,
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+        )
+        self.apply_operations(
+            app_label,
+            project_state,
+            operations=[
+                migrations.AlterField(
+                    model_name="parent",
+                    name="id",
+                    field=models.BigIntegerField(primary_key=True),
+                ),
+            ],
+        )
+
     def test_rename_field_reloads_state_on_fk_target_changes(self):
         """
         If RenameField doesn't reload state appropriately, the AlterField


### PR DESCRIPTION
PR contains a ~failing~ (now fixed) test in `migrations/test_operations.py`

Note that I couldn't write a `SchemaEditor` test because of the relationships involved.  `SchemaEditor.alter_field()` inspects the target model's pk type to determine the fk type… which would require some magic to do in the scope of those tests.

Hi @felixxm this PR moves some code you added to drop the _like indexes for char fields from PG's `DatabaseSchemaEditor._alter_field()` to `DatabaseSchemaEditor._alter_column_type_sql()` ☺️ This way both the currently altered field and any additional remote fields it finds are updated.