### PR TITLE
Fixed #28586 -- Improve handling of missing related/deferred field values

### DIFF
--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -243,3 +243,7 @@ class SynchronousOnlyOperation(Exception):
     """The user tried to call a sync-only function from an async context."""
 
     pass
+
+
+class FetchMissingFieldError(Exception):
+    """The user tried accessing a field that was not loaded from the database."""

--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import signals
+from django.db.models._fetch_missing_fields import fetch_missing_fields
 from django.db.models.aggregates import *  # NOQA
 from django.db.models.aggregates import __all__ as aggregates_all
 from django.db.models.constraints import *  # NOQA
@@ -112,4 +113,5 @@ __all__ += [
     "ManyToOneRel",
     "ManyToManyRel",
     "OneToOneRel",
+    "fetch_missing_fields",
 ]

--- a/django/db/models/_fetch_missing_fields.py
+++ b/django/db/models/_fetch_missing_fields.py
@@ -1,0 +1,72 @@
+from contextlib import contextmanager
+
+from asgiref.local import Local
+
+
+def _validate_new_strategy(strategy):
+    if strategy not in (None, "peers", "never", "on_demand"):
+        raise ValueError(f"{strategy} is not a valid fetch_missing_fields strategy")
+
+    return strategy
+
+
+class _FetchMissingFields:
+    _local = Local()
+    _default_strategies = ("peers", "peers")
+
+    def set_default(self, strategy=None, /, related=None, deferred=None):
+        if strategy and (related or deferred):
+            raise TypeError(
+                "Specify strategy via positional argument OR keyword argument."
+            )
+
+        if strategy == "never":
+            raise ValueError(
+                '"never" cannot be used as default fetch_missing_strategy.'
+            )
+
+        current_related, current_deferred = self._default_strategies
+        self._default_strategies = (
+            _validate_new_strategy(strategy or related) or current_related,
+            _validate_new_strategy(strategy or deferred) or current_deferred,
+        )
+
+    @contextmanager
+    def __call__(self, strategy=None, /, related=None, deferred=None):
+        if strategy and (related or deferred):
+            raise TypeError(
+                "Specify strategy via positional argument OR keyword argument."
+            )
+
+        current_related, current_deferred = self._get_current_strategies()
+        new_strategies = (
+            _validate_new_strategy(related or strategy) or current_related,
+            _validate_new_strategy(deferred or strategy) or current_deferred,
+        )
+
+        if not hasattr(self._local, "stack"):
+            self._local.stack = []
+
+        self._local.stack.append(new_strategies)
+
+        try:
+            yield
+        finally:
+            self._local.stack.pop()
+
+    def get_current_related_strategy(self):
+        return self._get_current_strategies()[0]
+
+    def get_current_deferred_strategy(self):
+        return self._get_current_strategies()[1]
+
+    def _get_current_strategies(self):
+        stack = getattr(self._local, "stack", [])
+
+        if not stack:
+            return self._default_strategies
+
+        return stack[-1]
+
+
+fetch_missing_fields = _FetchMissingFields()

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -454,6 +454,7 @@ class ModelState:
     # on the actual save.
     adding = True
     fields_cache = ModelStateFieldsCacheDescriptor()
+    peers = ()
 
 
 class Model(AltersData, metaclass=ModelBase):

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -65,7 +65,7 @@ and two directions (forward and reverse) for a total of six combinations.
 
 from asgiref.sync import sync_to_async
 
-from django.core.exceptions import FieldError
+from django.core.exceptions import FetchMissingFieldError, FieldError
 from django.db import (
     DEFAULT_DB_ALIAS,
     NotSupportedError,
@@ -73,10 +73,10 @@ from django.db import (
     router,
     transaction,
 )
-from django.db.models import Q, Window, signals
+from django.db.models import Q, Window, fetch_missing_fields, signals
 from django.db.models.functions import RowNumber
 from django.db.models.lookups import GreaterThan, LessThanOrEqual
-from django.db.models.query import QuerySet
+from django.db.models.query import Prefetch, QuerySet, prefetch_related_objects
 from django.db.models.query_utils import DeferredAttribute
 from django.db.models.utils import AltersData, resolve_callables
 from django.utils.functional import cached_property
@@ -233,7 +233,24 @@ class ForwardManyToOneDescriptor:
             else:
                 rel_obj = None
             if rel_obj is None and has_value:
-                rel_obj = self.get_object(instance)
+                if fetch_missing_fields.get_current_related_strategy() == "never":
+                    raise FetchMissingFieldError
+                peers = [
+                    peer
+                    for weakref_peer in instance._state.peers
+                    if (peer := weakref_peer()) is not None and not self.is_cached(peer)
+                ]
+                if len(peers) > 1:
+                    # If the instance was fetched with other instances then
+                    # prefetch the field for all of them
+                    qs = self.get_queryset()
+                    prefetch_related_objects(
+                        peers, Prefetch(self.field.name, queryset=qs)
+                    )
+                    rel_obj = self.field.get_cached_value(instance)
+                else:
+                    rel_obj = self.get_object(instance)
+
                 remote_field = self.field.remote_field
                 # If this is a one-to-one relation, set the reverse accessor
                 # cache on the related object to the current instance to avoid
@@ -476,16 +493,34 @@ class ReverseOneToOneDescriptor:
             if related_pk is None:
                 rel_obj = None
             else:
-                filter_args = self.related.field.get_forward_related_filter(instance)
-                try:
-                    rel_obj = self.get_queryset(instance=instance).get(**filter_args)
-                except self.related.related_model.DoesNotExist:
-                    rel_obj = None
+                peers = [
+                    peer
+                    for weakref_peer in instance._state.peers
+                    if (peer := weakref_peer()) is not None and not self.is_cached(peer)
+                ]
+                if len(peers) > 1:
+                    # If the instance was fetched with other instances then
+                    # prefetch the field for all of them
+                    qs = self.get_queryset()
+                    prefetch_related_objects(
+                        peers, Prefetch(self.related.get_accessor_name(), queryset=qs)
+                    )
+                    rel_obj = self.related.get_cached_value(instance)
                 else:
-                    # Set the forward accessor cache on the related object to
-                    # the current instance to avoid an extra SQL query if it's
-                    # accessed later on.
-                    self.related.field.set_cached_value(rel_obj, instance)
+                    filter_args = self.related.field.get_forward_related_filter(
+                        instance
+                    )
+                    try:
+                        rel_obj = self.get_queryset(instance=instance).get(
+                            **filter_args
+                        )
+                    except self.related.related_model.DoesNotExist:
+                        rel_obj = None
+                    else:
+                        # Set the forward accessor cache on the related object to
+                        # the current instance to avoid an extra SQL query if it's
+                        # accessed later on.
+                        self.related.field.set_cached_value(rel_obj, instance)
             self.related.set_cached_value(instance, rel_obj)
 
         if rel_obj is None:

--- a/tests/fetch_missing_fields/models.py
+++ b/tests/fetch_missing_fields/models.py
@@ -1,0 +1,20 @@
+from django.db import models
+
+
+class Author(models.Model):
+    name = models.TextField()
+
+
+class Book(models.Model):
+    title = models.CharField(max_length=100)
+    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+
+
+class Bio(models.Model):
+    author = models.OneToOneField(
+        Author,
+        models.CASCADE,
+        primary_key=True,
+    )
+
+    text = models.TextField()

--- a/tests/fetch_missing_fields/tests.py
+++ b/tests/fetch_missing_fields/tests.py
@@ -1,0 +1,175 @@
+from django.core.exceptions import FetchMissingFieldError
+from django.db.models import fetch_missing_fields
+from django.test import TestCase
+
+from .models import Author, Bio, Book
+
+
+class FetchMissingFieldsTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author1 = Author.objects.create(name="Charlotte")
+        cls.author2 = Author.objects.create(name="Anne")
+        cls.author3 = Author.objects.create(name="Emily")
+        cls.author4 = Author.objects.create(name="Jane")
+        cls.author_set = {cls.author1, cls.author2, cls.author3, cls.author4}
+
+        cls.book1 = Book.objects.create(title="Poems", author=cls.author1)
+        cls.book2 = Book.objects.create(title="Jane Eyre", author=cls.author2)
+        cls.book3 = Book.objects.create(title="Wuthering Heights", author=cls.author3)
+        cls.book4 = Book.objects.create(
+            title="Sense and Sensibility", author=cls.author4
+        )
+
+    def test_defaults(self):
+        # Check defaults before entering a block
+        self.assertEqual(fetch_missing_fields.get_current_related_strategy(), "peers")
+        self.assertEqual(fetch_missing_fields.get_current_deferred_strategy(), "peers")
+
+        with fetch_missing_fields("never"):
+            self.assertEqual(
+                fetch_missing_fields.get_current_related_strategy(), "never"
+            )
+            self.assertEqual(
+                fetch_missing_fields.get_current_deferred_strategy(), "never"
+            )
+
+        # Ensure modes are reset to defaults when the last context is left
+        self.assertEqual(fetch_missing_fields.get_current_related_strategy(), "peers")
+        self.assertEqual(fetch_missing_fields.get_current_deferred_strategy(), "peers")
+
+    def test_nested_contexts(self):
+        with fetch_missing_fields("never"):
+            self.assertEqual(
+                fetch_missing_fields.get_current_related_strategy(), "never"
+            )
+            with fetch_missing_fields("on_demand"):
+                self.assertEqual(
+                    fetch_missing_fields.get_current_related_strategy(), "on_demand"
+                )
+            self.assertEqual(
+                fetch_missing_fields.get_current_related_strategy(), "never"
+            )
+
+    @fetch_missing_fields(deferred="never")
+    def test_override_single_mode(self):
+        self.assertEqual(fetch_missing_fields.get_current_related_strategy(), "peers")
+        self.assertEqual(fetch_missing_fields.get_current_deferred_strategy(), "never")
+
+    def test_decorator_single_argument(self):
+        @fetch_missing_fields("on_demand")
+        def func():
+            self.assertEqual(
+                fetch_missing_fields.get_current_related_strategy(), "on_demand"
+            )
+
+            self.assertEqual(
+                fetch_missing_fields.get_current_deferred_strategy(), "on_demand"
+            )
+
+        func()
+
+    def test_decorator_kwargs(self):
+        @fetch_missing_fields(related="never", deferred="on_demand")
+        def func():
+            self.assertEqual(
+                fetch_missing_fields.get_current_related_strategy(), "never"
+            )
+
+            self.assertEqual(
+                fetch_missing_fields.get_current_deferred_strategy(), "on_demand"
+            )
+
+        func()
+
+    def test_context_bad_arg(self):
+        with self.assertRaises(ValueError):
+            with fetch_missing_fields("bad_value"):
+                pass
+
+    @fetch_missing_fields("never")
+    def test_fetch_missing_fields_does_not_raise_exception(self):
+        books = list(Book.objects.all())
+        with self.assertRaises(FetchMissingFieldError):
+            books[0].author
+
+    @fetch_missing_fields("peers")
+    def test_auto_chaining(self):
+        Bio.objects.bulk_create(
+            [
+                Bio(author=self.author1, text="bio1"),
+                Bio(author=self.author2, text="bio2"),
+                Bio(author=self.author3, text="bio3"),
+                Bio(author=self.author4, text="bio4"),
+            ]
+        )
+        with self.assertNumQueries(3):
+            bio_texts = {book.author.bio.text for book in Book.objects.all()}
+            self.assertEqual(bio_texts, {"bio1", "bio2", "bio3", "bio4"})
+
+    def test_set_default_disallow_never(self):
+        with self.assertRaises(ValueError):
+            fetch_missing_fields.set_default("never")
+
+    def test_set_default_bad_arg(self):
+        with self.assertRaises(ValueError):
+            fetch_missing_fields.set_default("not_valid")
+
+    def test_set_default_positional_argument(self):
+        fetch_missing_fields.set_default("on_demand")
+        assert fetch_missing_fields.get_current_related_strategy() == "on_demand"
+        assert fetch_missing_fields.get_current_deferred_strategy() == "on_demand"
+
+    def test_set_default_kwarg(self):
+        # Try changing both
+        fetch_missing_fields.set_default(related="on_demand", deferred="never")
+        assert fetch_missing_fields.get_current_related_strategy() == "on_demand"
+        assert fetch_missing_fields.get_current_deferred_strategy() == "never"
+
+        # Change just one, make sure the other stays the same.
+        fetch_missing_fields.set_default(related="peers")
+        assert fetch_missing_fields.get_current_related_strategy() == "peers"
+        assert fetch_missing_fields.get_current_deferred_strategy() == "never"
+
+    def test_one_to_one_forward_peers(self):
+        Bio.objects.bulk_create(
+            [
+                Bio(author=self.author1),
+                Bio(author=self.author2),
+                Bio(author=self.author3),
+                Bio(author=self.author4),
+            ]
+        )
+        with self.assertNumQueries(2):
+            authors = [b.author for b in Bio.objects.all()]
+
+        normal_authors = [b.author for b in Bio.objects.all()]
+        self.assertEqual(authors, normal_authors)
+
+    def test_one_to_one_reverse_peers(self):
+        bios_set = {
+            Bio(author=self.author1),
+            Bio(author=self.author2),
+            Bio(author=self.author3),
+            Bio(author=self.author4),
+        }
+        Bio.objects.bulk_create(bios_set)
+        with self.assertNumQueries(1):
+            authors = list(Author.objects.all())
+
+        with self.assertNumQueries(1):
+            bios = {a.bio for a in authors}
+
+        self.assertEqual(bios, bios_set)
+
+    def test_foreignkey_forward_peers(self):
+        with self.assertNumQueries(1):
+            books = list(Book.objects.all())
+
+        with self.assertNumQueries(1):
+            authors = {book.author for book in books}
+
+        self.assertEqual(authors, self.author_set)
+
+    def tearDown(self):
+        fetch_missing_fields.set_default("peers")

--- a/tests/select_related/tests.py
+++ b/tests/select_related/tests.py
@@ -78,7 +78,7 @@ class SelectRelatedTests(TestCase):
             self.assertEqual(domain.name, "Eukaryota")
 
     def test_list_without_select_related(self):
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(3):
             world = Species.objects.all()
             families = [o.genus.family.name for o in world]
             self.assertEqual(


### PR DESCRIPTION
## Overview
This PR changes how related fields (forward foreign keys, one to one forwards and backwards) are handled when prefetch_related() and select_related() was not used. In that case, the first time such a field is accessed, its and all "peer" objects (instances in the same queryset) will have its related objects of the same type fetched. This avoids the infamous ORM N+1 query problem.

This commit also handles deferred fields (when specified via QuerySet.only() / QuerySet.defer()). By default, Django will fetch all field valeus for all peers. This avoids N+1 queries for deferred fields too.

Consideration has been taken to address potential cases where this behavior leads to worse performance. To track peers, weakrefs is used. In the case retrieving more rows that is needed (which itself is bad!). No more related objects than is needed will be fetched. I.e., running

```py
model = list(HugeTable.objects.all())[0]
model.related_field
```

only one related object will be retrieved.

When dealing with querysets of single objects, a regular `WHERE id = 1234` where clause will be used, not a `IN` clause:

 ```py
SomeModel.objects.first().related_field  # Will not use ... WHERE id IN (1234, ...) to get related_field
```

## Usage
The majority of users will get improved performance where explicit prefetches or incomplete `.only()`/`.defer()` specifications has been made, without making further changes.

However, fine grained control over which strategy is used is provided via`django.db.models.fetch_missing_fields`. Available options is:
  - `peers` - fetch missing fields for all peer instances (the default)
  - `on_demand` - fetch results, one by one.
  - `never` - never fetch missing field value, instead raise `FetchMissingFieldError`.

These strategies can be enabled/disable using a decorator and/or a context manager (with-block) to mark specific pieces:
```py
from django.db.models import fetch_missing_fields

@fetch_missing_fields("never")
def my_view(request):
    qs = MyQuerySet.objects.prefetch_related("something")
    ...

with fetch_missing_fields("on_demand"):
    ...
```

Using the `never` strategy can be useful in performance critical code paths. The exception/stack trace will directly point to the offending field.

For even greater control, different modes can be specified for related and deferred fields:
```py
with fetch_missing_fields(related="peers", deferred="never"): ...
```
This allows having related objects fetches automatically while being strict for deferred fields.

## To be discussed / todo
- [ ] Does sqlite limit the number of IDs that can be given in an `IN` clause, could that lead to problems?
- [ ] Should an additional strategy called `warn` be introduced that is equivalent to `peers` except that it also emits a warning?
- [ ] Should we add `QuerySet.fetch_missing_fields(...)` that always takes precedence over the context/defaults?
- [ ] Docs!
- [ ] Switch to a callable interface instead of string constants, i.e. something like `def func(*, field: Field, instance: Model, peers: list[Model]): ...`
- [ ] Add a way to set the default value mode (without using context managers)

## References
- django-dev discussion "Automatic prefetching in querysets":
  https://groups.google.com/g/django-developers/c/EplZGj-ejvg
- django-dev discussion "Sealing or locking QuerySets -- a suggestion to prevent surprise N+1 queries":
  https://groups.google.com/g/django-developers/c/AR6HwgSYV-M/m/LmHP1OhcEQAJ
- @tolomea s port of django-auto-prefetch to Django: https://github.com/django/django/pull/9064
- django-auto-prefetch: https://pypi.org/project/django-auto-prefetch/
- django-seal: https://pypi.org/project/django-seal/
