### PR TITLE
Fixed #34042 -- Improved accessibility of admin's navigation sidebar.

### DIFF
--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -59,8 +59,13 @@
     content: '\00AB';
 }
 
+.main > #nav-sidebar {
+    visibility: hidden;
+}
+
 .main.shifted > #nav-sidebar {
     margin-left: 0;
+    visibility: visible;
 }
 
 [dir="rtl"] .main.shifted > #nav-sidebar {

--- a/django/contrib/admin/static/admin/js/nav_sidebar.js
+++ b/django/contrib/admin/static/admin/js/nav_sidebar.js
@@ -2,47 +2,24 @@
 {
     const toggleNavSidebar = document.getElementById('toggle-nav-sidebar');
     if (toggleNavSidebar !== null) {
-        const navLinks = document.querySelectorAll('#nav-sidebar a');
-        function disableNavLinkTabbing() {
-            for (const navLink of navLinks) {
-                navLink.tabIndex = -1;
-            }
-        }
-        function enableNavLinkTabbing() {
-            for (const navLink of navLinks) {
-                navLink.tabIndex = 0;
-            }
-        }
-        function disableNavFilterTabbing() {
-            document.getElementById('nav-filter').tabIndex = -1;
-        }
-        function enableNavFilterTabbing() {
-            document.getElementById('nav-filter').tabIndex = 0;
-        }
-
+        const navSidebar = document.getElementById('nav-sidebar');
         const main = document.getElementById('main');
         let navSidebarIsOpen = localStorage.getItem('django.admin.navSidebarIsOpen');
         if (navSidebarIsOpen === null) {
             navSidebarIsOpen = 'true';
         }
-        if (navSidebarIsOpen === 'false') {
-            disableNavLinkTabbing();
-            disableNavFilterTabbing();
-        }
         main.classList.toggle('shifted', navSidebarIsOpen === 'true');
+        navSidebar.setAttribute('aria-expanded', navSidebarIsOpen);
 
         toggleNavSidebar.addEventListener('click', function() {
             if (navSidebarIsOpen === 'true') {
                 navSidebarIsOpen = 'false';
-                disableNavLinkTabbing();
-                disableNavFilterTabbing();
             } else {
                 navSidebarIsOpen = 'true';
-                enableNavLinkTabbing();
-                enableNavFilterTabbing();
             }
             localStorage.setItem('django.admin.navSidebarIsOpen', navSidebarIsOpen);
             main.classList.toggle('shifted');
+            navSidebar.setAttribute('aria-expanded', navSidebarIsOpen);
         });
     }
 

--- a/django/contrib/admin/templates/admin/nav_sidebar.html
+++ b/django/contrib/admin/templates/admin/nav_sidebar.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <button class="sticky toggle-nav-sidebar" id="toggle-nav-sidebar" aria-label="{% translate 'Toggle navigation' %}"></button>
-<nav class="sticky" id="nav-sidebar">
+<nav class="sticky" id="nav-sidebar" aria-label="{% translate 'Sidebar' %}">
   <input type="search" id="nav-filter"
          placeholder="{% translate 'Start typing to filter…' %}"
          aria-label="{% translate 'Filter navigation items' %}">


### PR DESCRIPTION
Improve the experience for screen readers in the django admin with accessibility changes to the sidebar according to https://code.djangoproject.com/ticket/34042

Clarify that the sidebar is closed or open with aria-expanded 'closed' or 'open', aria-label 'Sidebar', and setting the display style to none or block.