### PR TITLE
Fixed #34046 -- Fixed pinning flake8 and isort versions in tox.ini.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,9 @@ skipsdist = true
 envlist =
     py3
     black
-    flake8 >= 3.7.0
+    flake8
     docs
-    isort >= 5.1.0
+    isort
 
 # Add environment to use the default python3 installation
 [testenv:py3]
@@ -42,7 +42,7 @@ commands = black --check --diff .
 [testenv:flake8]
 basepython = python3
 usedevelop = false
-deps = flake8
+deps = flake8 >= 3.7.0
 changedir = {toxinidir}
 commands = flake8 .
 
@@ -62,7 +62,7 @@ commands =
 [testenv:isort]
 basepython = python3
 usedevelop = false
-deps = isort
+deps = isort >= 5.1.0
 changedir = {toxinidir}
 commands = isort --check-only --diff django tests scripts
 


### PR DESCRIPTION
Now they run the tools expected.

Additionally I set the basepython version to the minimum supported Python version to prevent surprises running the tests when python3 points to an older Python version.

Ticket: https://code.djangoproject.com/ticket/34046