### PR TITLE
Fixed #25617 -- Added case-insensitive unique username validation in UserCreationForm

### DIFF
--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -127,6 +127,9 @@ Minor features
 * :class:`~django.contrib.auth.forms.UserCreationForm` now saves many-to-many
   form fields for a custom user model.
 
+* The new :class:`~django.contrib.auth.forms.BaseUserCreationForm` is now the
+  recommended base class for customizing the user creation form.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -483,6 +486,10 @@ Miscellaneous
 
 * The minimum supported version of ``asgiref`` is increased from 3.5.2 to
   3.6.0.
+
+* :class:`~django.contrib.auth.forms.UserCreationForm` now rejects usernames
+  that differ only in case. If you need the previous behavior, use
+  :class:`~django.contrib.auth.forms.BaseUserCreationForm` instead.
 
 .. _deprecated-features-4.2:
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1654,9 +1654,12 @@ provides several built-in forms located in :mod:`django.contrib.auth.forms`:
     A form used in the admin interface to change a user's information and
     permissions.
 
-.. class:: UserCreationForm
+.. class:: BaseUserCreationForm
 
-    A :class:`~django.forms.ModelForm` for creating a new user.
+    .. versionadded:: 4.2
+
+    A :class:`~django.forms.ModelForm` for creating a new user. This is the
+    recommended base class if you need to customize the user creation form.
 
     It has three fields: ``username`` (from the user model), ``password1``,
     and ``password2``. It verifies that ``password1`` and ``password2`` match,
@@ -1665,10 +1668,18 @@ provides several built-in forms located in :mod:`django.contrib.auth.forms`:
     sets the user's password using
     :meth:`~django.contrib.auth.models.User.set_password()`.
 
+.. class:: UserCreationForm
+
+    Inherits from :class:`BaseUserCreationForm`. To help prevent confusion with
+    similar usernames, the form doesn't allow usernames that differ only in
+    case.
+
     .. versionchanged:: 4.2
 
         In older versions, :class:`UserCreationForm` didn't save many-to-many
         form fields for a custom user model.
+
+        In older versions, usernames that differ only in case are allowed.
 
 .. currentmodule:: django.contrib.auth
 


### PR DESCRIPTION
Fixes [#25617](https://code.djangoproject.com/ticket/25617#comment:18)

Renamed original UserCreationForm to BaseUserCreationForm. The new UserCreationForm is a subclass of BaseUserCreationForm with one additional method that checks if a username already exists that differs only in case. Created one additional test ("test_user_already_iexists") for the new behavior and provided different username where necessary to make sure the old tests pass.