### PR TITLE
Refs #34041 -- Added navigation landmark to breadcrumbs in admin.

### DIFF
--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -69,11 +69,15 @@
     </div>
     {% endblock %}
     <!-- END Header -->
-    {% block breadcrumbs %}
-    <div class="breadcrumbs">
-    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-    {% if title %} &rsaquo; {{ title }}{% endif %}
-    </div>
+    {% block nav-breadcrumbs %}
+      <nav aria-label="{% translate 'Breadcrumbs' %}">
+        {% block breadcrumbs %}
+          <div class="breadcrumbs">
+            <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+            {% if title %} &rsaquo; {{ title }}{% endif %}
+          </div>
+        {% endblock %}
+      </nav>
     {% endblock %}
     {% endif %}
 

--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -7,7 +7,7 @@
 
 {% block bodyclass %}{{ block.super }} dashboard{% endblock %}
 
-{% block breadcrumbs %}{% endblock %}
+{% block nav-breadcrumbs %}{% endblock %}
 
 {% block nav-sidebar %}{% endblock %}
 

--- a/django/contrib/admin/templates/admin/login.html
+++ b/django/contrib/admin/templates/admin/login.html
@@ -15,7 +15,7 @@
 
 {% block content_title %}{% endblock %}
 
-{% block breadcrumbs %}{% endblock %}
+{% block nav-breadcrumbs %}{% endblock %}
 
 {% block content %}
 {% if form.errors and not form.non_field_errors %}

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -48,6 +48,9 @@ Minor features
   :attr:`~django.contrib.admin.ModelAdmin.filter_vertical` widgets are now
   filterable.
 
+* The ``admin/base.html`` template now has a new block ``nav-breadcrumbs``
+  which contains the navigation landmark and the ``breadcrumbs`` block.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/admin_views/test_breadcrumbs.py
+++ b/tests/admin_views/test_breadcrumbs.py
@@ -1,0 +1,25 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+
+@override_settings(ROOT_URLCONF="admin_views.urls")
+class AdminBreadcrumbsTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="super",
+            password="secret",
+            email="super@example.com",
+        )
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+
+    def test_breadcrumbs_absent(self):
+        response = self.client.get(reverse("admin:index"))
+        self.assertNotContains(response, '<nav aria-label="Breadcrumbs">')
+
+    def test_breadcrumbs_present(self):
+        response = self.client.get(reverse("admin:auth_user_add"))
+        self.assertContains(response, '<nav aria-label="Breadcrumbs">')


### PR DESCRIPTION
This addresses the first item in [#34041](https://code.djangoproject.com/ticket/34041). Addressing the other items will require a larger refactoring. 

We introduced another block so that we can hide the breadcrumbs without having an empty nav on the page.

Pair-programmed with the great @thibaudcolas 