### PR TITLE
#34044 -- Add the admin app filter on index pages in addition to the navbar

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -393,6 +393,7 @@ answer newbie questions, and generally made Django that much better:
     Hiroki Kiyohara <hirokiky@gmail.com>
     Honza Král <honza.kral@gmail.com>
     Horst Gutmann <zerok@zerokspot.com>
+    Hugo Herter <git@hugoherter.com>
     Hugo Osvaldo Barrera <hugo@barrera.io>
     HyukJin Jang <wkdgurwls00@naver.com>
     Hyun Mi Ae

--- a/django/contrib/admin/static/admin/css/app_filter.css
+++ b/django/contrib/admin/static/admin/css/app_filter.css
@@ -1,0 +1,22 @@
+
+#app-filter {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 2px 5px;
+    margin: 5px 0;
+    border: 1px solid var(--border-color);
+    background-color: var(--darkened-bg);
+    color: var(--body-fg);
+
+    flex: 1;
+    min-width: 150px;
+    max-height: 2em;
+}
+
+#app-filter:focus {
+    border-color: var(--body-quiet-color);
+}
+
+#app-filter.no-results {
+    background: var(--message-error-bg);
+}

--- a/django/contrib/admin/static/admin/css/app_filter.css
+++ b/django/contrib/admin/static/admin/css/app_filter.css
@@ -20,3 +20,34 @@
 #app-filter.no-results {
     background: var(--message-error-bg);
 }
+
+/* Styles only relevant to index pages */
+
+.filterable-apps-table caption {
+    /* The captions were resized when using a filter.
+     This ensures that they keep their original width. */
+    width: calc(100% - 16px);
+}
+
+.admin-index-title {
+    display: flex;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+}
+
+@media (max-width: 767px) {
+    .admin-index-title {
+        margin-bottom: 10px;
+    }
+}
+
+.admin-index-title h1 {
+    flex: 2;
+    margin-bottom: 0;
+    padding-right: 1em;
+}
+
+.admin-index-title #app-filter {
+    display: inline-block;
+}
+

--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -116,24 +116,6 @@
     }
 }
 
-#nav-filter {
-    width: 100%;
-    box-sizing: border-box;
-    padding: 2px 5px;
-    margin: 5px 0;
-    border: 1px solid var(--border-color);
-    background-color: var(--darkened-bg);
-    color: var(--body-fg);
-}
-
-#nav-filter:focus {
-    border-color: var(--body-quiet-color);
-}
-
-#nav-filter.no-results {
-    background: var(--message-error-bg);
-}
-
 #nav-sidebar table {
     width: 100%;
 }

--- a/django/contrib/admin/static/admin/js/app_filter.js
+++ b/django/contrib/admin/static/admin/js/app_filter.js
@@ -1,0 +1,59 @@
+'use strict';
+{
+    function initAppFilter() {
+        if (!document.getElementById('app-filter')) {
+            return;
+        }
+
+        const options = [];
+        const filterableElements = document.getElementsByClassName('filterable-apps-table');
+        for (const filterableElement of filterableElements) {
+            filterableElement.querySelectorAll('th[scope=row] a').forEach((container) => {
+                options.push({title: container.innerHTML, node: container});
+            });
+        }
+
+        function checkValue(event) {
+            let filterValue = event.target.value;
+            if (filterValue) {
+                filterValue = filterValue.toLowerCase();
+            }
+            if (event.key === 'Escape') {
+                filterValue = '';
+                event.target.value = ''; // clear input
+            }
+            let matches = false;
+            for (const o of options) {
+                let displayValue = '';
+                if (filterValue) {
+                    if (o.title.toLowerCase().indexOf(filterValue) === -1) {
+                        displayValue = 'none';
+                    } else {
+                        matches = true;
+                    }
+                }
+                // show/hide parent <TR>
+                o.node.parentNode.parentNode.style.display = displayValue;
+            }
+            if (!filterValue || matches) {
+                event.target.classList.remove('no-results');
+            } else {
+                event.target.classList.add('no-results');
+            }
+            sessionStorage.setItem('django.admin.navSidebarFilterValue', filterValue);
+        }
+
+        const nav = document.getElementById('app-filter');
+        nav.addEventListener('change', checkValue, false);
+        nav.addEventListener('input', checkValue, false);
+        nav.addEventListener('keyup', checkValue, false);
+
+        const storedValue = sessionStorage.getItem('django.admin.navSidebarFilterValue');
+        if (storedValue) {
+            nav.value = storedValue;
+            checkValue({target: nav, key: ''});
+        }
+    }
+    window.initAppFilter = initAppFilter;
+    initAppFilter();
+}

--- a/django/contrib/admin/static/admin/js/nav_sidebar.js
+++ b/django/contrib/admin/static/admin/js/nav_sidebar.js
@@ -13,11 +13,11 @@
                 navLink.tabIndex = 0;
             }
         }
-        function disableNavFilterTabbing() {
-            document.getElementById('nav-filter').tabIndex = -1;
+        function disableAppFilterTabbing() {
+            document.getElementById('app-filter').tabIndex = -1;
         }
-        function enableNavFilterTabbing() {
-            document.getElementById('nav-filter').tabIndex = 0;
+        function enableAppFilterTabbing() {
+            document.getElementById('app-filter').tabIndex = 0;
         }
 
         const main = document.getElementById('main');
@@ -27,7 +27,7 @@
         }
         if (navSidebarIsOpen === 'false') {
             disableNavLinkTabbing();
-            disableNavFilterTabbing();
+            disableAppFilterTabbing();
         }
         main.classList.toggle('shifted', navSidebarIsOpen === 'true');
 
@@ -35,68 +35,14 @@
             if (navSidebarIsOpen === 'true') {
                 navSidebarIsOpen = 'false';
                 disableNavLinkTabbing();
-                disableNavFilterTabbing();
+                disableAppFilterTabbing();
             } else {
                 navSidebarIsOpen = 'true';
                 enableNavLinkTabbing();
-                enableNavFilterTabbing();
+                enableAppFilterTabbing();
             }
             localStorage.setItem('django.admin.navSidebarIsOpen', navSidebarIsOpen);
             main.classList.toggle('shifted');
         });
     }
-
-    function initSidebarQuickFilter() {
-        const options = [];
-        const navSidebar = document.getElementById('nav-sidebar');
-        if (!navSidebar) {
-            return;
-        }
-        navSidebar.querySelectorAll('th[scope=row] a').forEach((container) => {
-            options.push({title: container.innerHTML, node: container});
-        });
-
-        function checkValue(event) {
-            let filterValue = event.target.value;
-            if (filterValue) {
-                filterValue = filterValue.toLowerCase();
-            }
-            if (event.key === 'Escape') {
-                filterValue = '';
-                event.target.value = ''; // clear input
-            }
-            let matches = false;
-            for (const o of options) {
-                let displayValue = '';
-                if (filterValue) {
-                    if (o.title.toLowerCase().indexOf(filterValue) === -1) {
-                        displayValue = 'none';
-                    } else {
-                        matches = true;
-                    }
-                }
-                // show/hide parent <TR>
-                o.node.parentNode.parentNode.style.display = displayValue;
-            }
-            if (!filterValue || matches) {
-                event.target.classList.remove('no-results');
-            } else {
-                event.target.classList.add('no-results');
-            }
-            sessionStorage.setItem('django.admin.navSidebarFilterValue', filterValue);
-        }
-
-        const nav = document.getElementById('nav-filter');
-        nav.addEventListener('change', checkValue, false);
-        nav.addEventListener('input', checkValue, false);
-        nav.addEventListener('keyup', checkValue, false);
-
-        const storedValue = sessionStorage.getItem('django.admin.navSidebarFilterValue');
-        if (storedValue) {
-            nav.value = storedValue;
-            checkValue({target: nav, key: ''});
-        }
-    }
-    window.initSidebarQuickFilter = initSidebarQuickFilter;
-    initSidebarQuickFilter();
 }

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -10,7 +10,9 @@
 {% endblock %}
 {% if not is_popup and is_nav_sidebar_enabled %}
   <link rel="stylesheet" href="{% static "admin/css/nav_sidebar.css" %}">
+  <link rel="stylesheet" href="{% static "admin/css/app_filter.css" %}">
   <script src="{% static 'admin/js/nav_sidebar.js' %}" defer></script>
+  <script src="{% static 'admin/js/app_filter.js' %}" defer></script>
 {% endif %}
 {% if LANGUAGE_BIDI %}<link rel="stylesheet" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}">{% endif %}
 {% block responsive %}

--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -11,8 +11,17 @@
 
 {% block nav-sidebar %}{% endblock %}
 
+{% block content_title %}
+  <div class="admin-index-title">
+    {% if title %}<h1>{{ title }}</h1>{% endif %}
+    <input type="search" id="app-filter"
+           placeholder="{% translate 'Start typing to filter…' %}"
+           aria-label="{% translate 'Filter navigation items' %}">
+  </div>
+{% endblock %}
+
 {% block content %}
-<div id="content-main">
+<div id="content-main" class="filterable-apps-table">
   {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
 </div>
 {% endblock %}

--- a/django/contrib/admin/templates/admin/nav_sidebar.html
+++ b/django/contrib/admin/templates/admin/nav_sidebar.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <button class="sticky toggle-nav-sidebar" id="toggle-nav-sidebar" aria-label="{% translate 'Toggle navigation' %}"></button>
-<nav class="sticky" id="nav-sidebar">
-  <input type="search" id="nav-filter"
+<nav class="sticky filterable-apps-table" id="nav-sidebar">
+  <input type="search" id="app-filter"
          placeholder="{% translate 'Start typing to filter…' %}"
          aria-label="{% translate 'Filter navigation items' %}">
   {% include 'admin/app_list.html' with app_list=available_apps show_changelinks=False %}

--- a/js_tests/admin/navigation.test.js
+++ b/js_tests/admin/navigation.test.js
@@ -6,19 +6,19 @@ QUnit.module('admin.sidebar: filter', {
         const $ = django.jQuery;
         $('#qunit-fixture').append($('#nav-sidebar-filter').text());
         this.navSidebar = $('#nav-sidebar');
-        this.navFilter = $('#nav-filter');
-        initSidebarQuickFilter();
+        this.appFilter = $('#app-filter');
+        initAppFilter();
     }
 });
 
 QUnit.test('filter by a model name', function(assert) {
     assert.equal(this.navSidebar.find('th[scope=row] a').length, 2);
 
-    this.navFilter.val('us'); // Matches 'users'.
-    this.navFilter[0].dispatchEvent(new Event('change'));
+    this.appFilter.val('us'); // Matches 'users'.
+    this.appFilter[0].dispatchEvent(new Event('change'));
     assert.equal(this.navSidebar.find('tr[class^="model-"]:visible').length, 1);
 
-    this.navFilter.val('nonexistent');
-    this.navFilter[0].dispatchEvent(new Event('change'));
+    this.appFilter.val('nonexistent');
+    this.appFilter[0].dispatchEvent(new Event('change'));
     assert.equal(this.navSidebar.find('tr[class^="model-"]:visible').length, 0);
 });

--- a/js_tests/tests.html
+++ b/js_tests/tests.html
@@ -84,8 +84,8 @@
         </div>
     </script>
     <script type="text/html" id="nav-sidebar-filter">
-      <nav class="sticky" id="nav-sidebar">
-        <input type="search" id="nav-filter"
+      <nav class="sticky filterable-apps-table" id="nav-sidebar">
+        <input type="search" id="app-filter"
                placeholder="Start typing to filter..."
                aria-label="Filter navigation items">
         <div class="app-auth module current-app">
@@ -122,6 +122,7 @@
     <script src='./admin/core.test.js'></script>
 
     <script src='../django/contrib/admin/static/admin/js/nav_sidebar.js' data-cover></script>
+    <script src='../django/contrib/admin/static/admin/js/app_filter.js' data-cover></script>
     <script src='./admin/navigation.test.js'></script>
 
     <script src='../django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js' data-cover></script>

--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -43,21 +43,29 @@ class AdminSidebarTests(TestCase):
     def test_sidebar_not_on_index(self):
         response = self.client.get(reverse("test_with_sidebar:index"))
         self.assertContains(response, '<div class="main" id="main">')
-        self.assertNotContains(response, '<nav class="sticky" id="nav-sidebar">')
+        self.assertNotContains(
+            response, '<nav class="sticky filterable-apps-table" id="nav-sidebar">'
+        )
 
     def test_sidebar_disabled(self):
         response = self.client.get(reverse("test_without_sidebar:index"))
-        self.assertNotContains(response, '<nav class="sticky" id="nav-sidebar">')
+        self.assertNotContains(
+            response, '<nav class="sticky filterable-apps-table" id="nav-sidebar">'
+        )
 
     def test_sidebar_unauthenticated(self):
         self.client.logout()
         response = self.client.get(reverse("test_with_sidebar:login"))
-        self.assertNotContains(response, '<nav class="sticky" id="nav-sidebar">')
+        self.assertNotContains(
+            response, '<nav class="sticky filterable-apps-table" id="nav-sidebar">'
+        )
 
     def test_sidebar_aria_current_page(self):
         url = reverse("test_with_sidebar:auth_user_changelist")
         response = self.client.get(url)
-        self.assertContains(response, '<nav class="sticky" id="nav-sidebar">')
+        self.assertContains(
+            response, '<nav class="sticky ' 'filterable-apps-table" id="nav-sidebar">'
+        )
         self.assertContains(
             response, '<a href="%s" aria-current="page">Users</a>' % url
         )
@@ -80,7 +88,9 @@ class AdminSidebarTests(TestCase):
     def test_sidebar_aria_current_page_missing_without_request_context_processor(self):
         url = reverse("test_with_sidebar:auth_user_changelist")
         response = self.client.get(url)
-        self.assertContains(response, '<nav class="sticky" id="nav-sidebar">')
+        self.assertContains(
+            response, '<nav class="sticky filterable-apps-table" id="nav-sidebar">'
+        )
         # Does not include aria-current attribute.
         self.assertContains(response, '<a href="%s">Users</a>' % url)
         self.assertNotContains(response, "aria-current")
@@ -148,13 +158,13 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.assertEqual(toggle_button.get_attribute("aria-label"), "Toggle navigation")
         for link in self.selenium.find_elements(By.CSS_SELECTOR, "#nav-sidebar a"):
             self.assertEqual(link.get_attribute("tabIndex"), "0")
-        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#nav-filter")
+        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#app-filter")
         self.assertEqual(filter_input.get_attribute("tabIndex"), "0")
         toggle_button.click()
         # Hidden sidebar is not reachable via keyboard navigation.
         for link in self.selenium.find_elements(By.CSS_SELECTOR, "#nav-sidebar a"):
             self.assertEqual(link.get_attribute("tabIndex"), "-1")
-        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#nav-filter")
+        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#app-filter")
         self.assertEqual(filter_input.get_attribute("tabIndex"), "-1")
         main_element = self.selenium.find_element(By.CSS_SELECTOR, "#main")
         self.assertNotIn("shifted", main_element.get_attribute("class").split())
@@ -192,12 +202,12 @@ class SeleniumTests(AdminSeleniumTestCase):
         # Hidden sidebar is not reachable via keyboard navigation.
         for link in self.selenium.find_elements(By.CSS_SELECTOR, "#nav-sidebar a"):
             self.assertEqual(link.get_attribute("tabIndex"), "-1")
-        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#nav-filter")
+        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#app-filter")
         self.assertEqual(filter_input.get_attribute("tabIndex"), "-1")
         toggle_button.click()
         for link in self.selenium.find_elements(By.CSS_SELECTOR, "#nav-sidebar a"):
             self.assertEqual(link.get_attribute("tabIndex"), "0")
-        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#nav-filter")
+        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#app-filter")
         self.assertEqual(filter_input.get_attribute("tabIndex"), "0")
         self.assertEqual(
             self.selenium.execute_script(
@@ -221,6 +231,6 @@ class SeleniumTests(AdminSeleniumTestCase):
             "return sessionStorage.getItem('django.admin.navSidebarFilterValue')"
         )
         self.assertIsNone(self.selenium.execute_script(filter_value_script))
-        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#nav-filter")
+        filter_input = self.selenium.find_element(By.CSS_SELECTOR, "#app-filter")
         filter_input.send_keys("users")
         self.assertEqual(self.selenium.execute_script(filter_value_script), "users")


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/34044

This Pull Request contains two commits:
- The first refactors the admin quick search to make it independent from the navbar itself
- The second enables the quick search on index pages as well, in order to fix ticket 34044

## Screenshots

![image](https://user-images.githubusercontent.com/404665/192107026-72401fd1-ef88-4ed7-98b0-30b783864173.png)
![image](https://user-images.githubusercontent.com/404665/192107039-fb34eed4-1527-4979-a1f4-fa290db593e8.png)
![image](https://user-images.githubusercontent.com/404665/192107057-6a1c5c4a-b258-44be-825a-5c0d85fae81f.png)
![image](https://user-images.githubusercontent.com/404665/192107071-ffdbf22e-436b-4a27-aa27-596b0034fbad.png)
![image](https://user-images.githubusercontent.com/404665/192107079-228a4219-c4e6-4260-abac-e476ea2b8097.png)
![image](https://user-images.githubusercontent.com/404665/192107084-aade334b-770f-4135-94f9-de818c2ef61a.png)
![image](https://user-images.githubusercontent.com/404665/192107090-1fafdf26-4606-47c8-96b2-f55aee3c9fb7.png)


