### PR TITLE
Refs #33990 -- Renamed TransactionTestCase.assertQuerysetEqual() to assertQuerySetEqual().

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1322,7 +1322,16 @@ class TransactionTestCase(SimpleTestCase):
                 inhibit_post_migrate=inhibit_post_migrate,
             )
 
-    def assertQuerysetEqual(self, qs, values, transform=None, ordered=True, msg=None):
+    # RemovedInDjango51Warning.
+    def assertQuerysetEqual(self, *args, **kw):
+        warnings.warn(
+            "assertQuerysetEqual() is deprecated in favor of assertQuerySetEqual().",
+            category=RemovedInDjango51Warning,
+            stacklevel=2,
+        )
+        return self.assertQuerySetEqual(*args, **kw)
+
+    def assertQuerySetEqual(self, qs, values, transform=None, ordered=True, msg=None):
         values = list(values)
         items = qs
         if transform is not None:

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -37,6 +37,8 @@ details on these changes.
 
 * The ``SimpleTestCase.assertFormsetError()`` method will be removed.
 
+* The ``TransactionTestCase.assertQuerysetEqual()`` method will be removed.
+
 .. _deprecation-removed-in-5.0:
 
 5.0

--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -491,7 +491,7 @@ class:
             response = self.client.get(reverse('polls:index'))
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, "No polls are available.")
-            self.assertQuerysetEqual(response.context['latest_question_list'], [])
+            self.assertQuerySetEqual(response.context['latest_question_list'], [])
 
         def test_past_question(self):
             """
@@ -500,7 +500,7 @@ class:
             """
             question = create_question(question_text="Past question.", days=-30)
             response = self.client.get(reverse('polls:index'))
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 response.context['latest_question_list'],
                 [question],
             )
@@ -513,7 +513,7 @@ class:
             create_question(question_text="Future question.", days=30)
             response = self.client.get(reverse('polls:index'))
             self.assertContains(response, "No polls are available.")
-            self.assertQuerysetEqual(response.context['latest_question_list'], [])
+            self.assertQuerySetEqual(response.context['latest_question_list'], [])
 
         def test_future_question_and_past_question(self):
             """
@@ -523,7 +523,7 @@ class:
             question = create_question(question_text="Past question.", days=-30)
             create_question(question_text="Future question.", days=30)
             response = self.client.get(reverse('polls:index'))
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 response.context['latest_question_list'],
                 [question],
             )
@@ -535,7 +535,7 @@ class:
             question1 = create_question(question_text="Past question 1.", days=-30)
             question2 = create_question(question_text="Past question 2.", days=-5)
             response = self.client.get(reverse('polls:index'))
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 response.context['latest_question_list'],
                 [question2, question1],
             )
@@ -551,7 +551,7 @@ repetition out of the process of creating questions.
 Note that the :class:`django.test.TestCase` class provides some additional
 assertion methods. In these examples, we use
 :meth:`~django.test.SimpleTestCase.assertContains()` and
-:meth:`~django.test.TransactionTestCase.assertQuerysetEqual()`.
+:meth:`~django.test.TransactionTestCase.assertQuerySetEqual()`.
 
 In ``test_past_question``, we create a question and verify that it appears in
 the list.

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -162,7 +162,7 @@ Minor features
 * The ``HttpOnly`` flag can be set on the CSRF cookie with
   :setting:`CSRF_COOKIE_HTTPONLY`.
 
-* The :meth:`~django.test.TransactionTestCase.assertQuerysetEqual` now checks
+* The ``assertQuerysetEqual()`` now checks
   for undefined order and raises :exc:`ValueError` if undefined
   order is spotted. The order is seen as undefined if the given ``QuerySet``
   isn't ordered and there is more than one ordered value to compare against.

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -539,7 +539,8 @@ Tests
   <django.db.transaction.on_commit>` in a list. This allows you to test such
   callbacks without using the slower :class:`.TransactionTestCase`.
 
-* :meth:`.TransactionTestCase.assertQuerysetEqual` now supports direct
+* :meth:`TransactionTestCase.assertQuerysetEqual()
+  <django.test.TransactionTestCase.assertQuerySetEqual>` now supports direct
   comparison against another queryset rather than being restricted to
   comparison against a list of string representations of objects when using the
   default value for the ``transform`` argument.

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -422,3 +422,6 @@ Miscellaneous
 
 * ``SimpleTestCase.assertFormsetError()`` is deprecated in favor of
   ``assertFormSetError()``.
+
+* ``TransactionTestCase.assertQuerysetEqual()`` is deprecated in favor of
+  ``assertQuerySetEqual()``.

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -787,7 +787,7 @@ add some database-specific features:
 * Database :attr:`~TransactionTestCase.fixtures`.
 * Test :ref:`skipping based on database backend features <skipping-tests>`.
 * The remaining specialized :meth:`assert*
-  <TransactionTestCase.assertQuerysetEqual>` methods.
+  <TransactionTestCase.assertQuerySetEqual>` methods.
 
 Django's :class:`TestCase` class is a more commonly used subclass of
 ``TransactionTestCase`` that makes use of database transaction facilities
@@ -1777,7 +1777,7 @@ your test suite.
 
     Output in case of error can be customized with the ``msg`` argument.
 
-.. method:: TransactionTestCase.assertQuerysetEqual(qs, values, transform=None, ordered=True, msg=None)
+.. method:: TransactionTestCase.assertQuerySetEqual(qs, values, transform=None, ordered=True, msg=None)
 
     Asserts that a queryset ``qs`` matches a particular iterable of values
     ``values``.
@@ -1793,6 +1793,11 @@ your test suite.
     raised.
 
     Output in case of error can be customized with the ``msg`` argument.
+
+    .. deprecated:: 4.2
+
+        The ``assertQuerysetEqual()`` assertion method is deprecated. Use
+        ``assertQuerySetEqual()`` instead.
 
 .. method:: TransactionTestCase.assertNumQueries(num, func, *args, **kwargs)
 

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -240,7 +240,7 @@ class AggregateTestCase(TestCase):
         self.assertEqual(vals, {"min_year": 1991})
 
     def test_annotate_basic(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Book.objects.annotate().order_by("pk"),
             [
                 "The Definitive Guide to Django: Web Development Done Right",
@@ -276,7 +276,7 @@ class AggregateTestCase(TestCase):
                 "The Definitive Guide to Django: Web Development Done Right",
             )
         ]
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.order_by("pk"), rows, lambda r: (r.id, r.isbn, r.page_sum, r.name)
         )
 
@@ -297,7 +297,7 @@ class AggregateTestCase(TestCase):
                 "The Definitive Guide to Django: Web Development Done Right",
             )
         ]
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.order_by("pk"),
             rows,
             lambda r: (r.id, r.isbn, r.page_sum, r.contact.name, r.name),
@@ -309,7 +309,7 @@ class AggregateTestCase(TestCase):
             .annotate(Avg("authors__age"))
             .order_by("name")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             books,
             [
                 ("Artificial Intelligence: A Modern Approach", 51.5),
@@ -321,7 +321,7 @@ class AggregateTestCase(TestCase):
         )
 
         books = Book.objects.annotate(num_authors=Count("authors")).order_by("name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             books,
             [
                 ("Artificial Intelligence: A Modern Approach", 2),
@@ -344,7 +344,7 @@ class AggregateTestCase(TestCase):
             .annotate(Avg("book__rating"))
             .order_by("name")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors,
             [
                 ("Adrian Holovaty", 4.5),
@@ -358,7 +358,7 @@ class AggregateTestCase(TestCase):
         )
 
         authors = Author.objects.annotate(num_books=Count("book")).order_by("name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors,
             [
                 ("Adrian Holovaty", 1),
@@ -376,7 +376,7 @@ class AggregateTestCase(TestCase):
 
     def test_reverse_fkey_annotate(self):
         books = Book.objects.annotate(Sum("publisher__num_awards")).order_by("name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             books,
             [
                 ("Artificial Intelligence: A Modern Approach", 7),
@@ -394,7 +394,7 @@ class AggregateTestCase(TestCase):
         )
 
         publishers = Publisher.objects.annotate(Sum("book__price")).order_by("name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             publishers,
             [
                 ("Apress", Decimal("59.69")),
@@ -515,7 +515,7 @@ class AggregateTestCase(TestCase):
         )
 
         authors = Author.objects.annotate(Avg("friends__age")).order_by("name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors,
             [
                 ("Adrian Holovaty", 32.0),
@@ -709,7 +709,7 @@ class AggregateTestCase(TestCase):
             .filter(num_books__gt=1)
             .order_by("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             publishers,
             ["Apress", "Prentice Hall", "Expensive Publisher"],
             lambda p: p.name,
@@ -718,7 +718,7 @@ class AggregateTestCase(TestCase):
         publishers = Publisher.objects.filter(book__price__lt=Decimal("40.0")).order_by(
             "pk"
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             publishers,
             [
                 "Apress",
@@ -735,7 +735,7 @@ class AggregateTestCase(TestCase):
             .filter(num_books__gt=1, book__price__lt=Decimal("40.0"))
             .order_by("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             publishers,
             ["Apress", "Prentice Hall", "Expensive Publisher"],
             lambda p: p.name,
@@ -747,14 +747,14 @@ class AggregateTestCase(TestCase):
             .filter(num_books__gt=1)
             .order_by("pk")
         )
-        self.assertQuerysetEqual(publishers, ["Apress"], lambda p: p.name)
+        self.assertQuerySetEqual(publishers, ["Apress"], lambda p: p.name)
 
         publishers = (
             Publisher.objects.annotate(num_books=Count("book"))
             .filter(num_books__range=[1, 3])
             .order_by("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             publishers,
             [
                 "Apress",
@@ -771,7 +771,7 @@ class AggregateTestCase(TestCase):
             .filter(num_books__range=[1, 2])
             .order_by("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             publishers,
             ["Apress", "Sams", "Prentice Hall", "Morgan Kaufmann"],
             lambda p: p.name,
@@ -782,7 +782,7 @@ class AggregateTestCase(TestCase):
             .filter(num_books__in=[1, 3])
             .order_by("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             publishers,
             ["Sams", "Morgan Kaufmann", "Expensive Publisher"],
             lambda p: p.name,
@@ -802,7 +802,7 @@ class AggregateTestCase(TestCase):
             .filter(num_authors__exact=2)
             .order_by("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             books,
             [
                 "The Definitive Guide to Django: Web Development Done Right",
@@ -816,14 +816,14 @@ class AggregateTestCase(TestCase):
             .filter(num_friends=0)
             .order_by("pk")
         )
-        self.assertQuerysetEqual(authors, ["Brad Dayley"], lambda a: a.name)
+        self.assertQuerySetEqual(authors, ["Brad Dayley"], lambda a: a.name)
 
         publishers = (
             Publisher.objects.annotate(num_books=Count("book__id"))
             .filter(num_books__gt=1)
             .order_by("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             publishers, ["Apress", "Prentice Hall"], lambda p: p.name
         )
 
@@ -832,12 +832,12 @@ class AggregateTestCase(TestCase):
             .annotate(num_books=Count("book__id"))
             .filter(num_books__gt=1)
         )
-        self.assertQuerysetEqual(publishers, ["Apress"], lambda p: p.name)
+        self.assertQuerySetEqual(publishers, ["Apress"], lambda p: p.name)
 
         books = Book.objects.annotate(num_authors=Count("authors__id")).filter(
             authors__name__contains="Norvig", num_authors__gt=1
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             books, ["Artificial Intelligence: A Modern Approach"], lambda b: b.name
         )
 
@@ -1002,7 +1002,7 @@ class AggregateTestCase(TestCase):
         # Try to generate query tree
         str(excluded_books.query)
 
-        self.assertQuerysetEqual(excluded_books, all_books, lambda x: x.pk)
+        self.assertQuerySetEqual(excluded_books, all_books, lambda x: x.pk)
 
         # Check internal state
         self.assertIsNone(annotated_books.query.alias_map["aggregation_book"].join_type)
@@ -1086,7 +1086,7 @@ class AggregateTestCase(TestCase):
             combined_ages=Sum("age") + Sum("friends__age")
         ).order_by("name")
         for qs in (authors, authors2):
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 qs,
                 [
                     ("Adrian Holovaty", 132),
@@ -1381,7 +1381,7 @@ class AggregateTestCase(TestCase):
             .filter(price_or_median__gte=F("num_awards"))
             .order_by("num_awards")
         )
-        self.assertQuerysetEqual(qs, [1, 3, 7, 9], lambda v: v.num_awards)
+        self.assertQuerySetEqual(qs, [1, 3, 7, 9], lambda v: v.num_awards)
 
         qs2 = (
             Publisher.objects.annotate(
@@ -1392,7 +1392,7 @@ class AggregateTestCase(TestCase):
             .filter(rating_or_num_awards__gt=F("num_awards"))
             .order_by("num_awards")
         )
-        self.assertQuerysetEqual(qs2, [1, 3], lambda v: v.num_awards)
+        self.assertQuerySetEqual(qs2, [1, 3], lambda v: v.num_awards)
 
     def test_arguments_must_be_expressions(self):
         msg = "QuerySet.aggregate() received non-expression(s): %s."
@@ -1692,7 +1692,7 @@ class AggregateTestCase(TestCase):
     def test_aggregation_random_ordering(self):
         """Random() is not included in the GROUP BY when used for ordering."""
         authors = Author.objects.annotate(contact_count=Count("book")).order_by("?")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors,
             [
                 ("Adrian Holovaty", 1),

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -828,7 +828,7 @@ class AggregationTests(TestCase):
         # Regression for #10113 - Fields mentioned in order_by() must be
         # included in the GROUP BY. This only becomes a problem when the
         # order_by introduces a new join.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Book.objects.annotate(num_authors=Count("authors")).order_by(
                 "publisher__name", "name"
             ),
@@ -851,7 +851,7 @@ class AggregationTests(TestCase):
             .annotate(Avg("authors__age"))
             .order_by("name")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 (
@@ -914,7 +914,7 @@ class AggregationTests(TestCase):
             .filter(n_authors__gt=2)
             .order_by("n_authors")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Book.objects.filter(id__in=ids),
             [
                 "Python Web Development with Django",
@@ -1023,7 +1023,7 @@ class AggregationTests(TestCase):
         # the original query can still be used
         books = Book.objects.all()
         books.aggregate(Avg("authors__age"))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             books.all(),
             [
                 "Artificial Intelligence: A Modern Approach",
@@ -1059,7 +1059,7 @@ class AggregationTests(TestCase):
             .order_by("sheets")
             .values("sheets")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs, [150, 175, 224, 264, 473, 566], lambda b: int(b["sheets"])
         )
 
@@ -1084,7 +1084,7 @@ class AggregationTests(TestCase):
         self.assertEqual(sorted(p.name for p in publishers), ["Apress", "Sams"])
 
         books = Book.objects.filter(publisher__in=publishers)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             books,
             [
                 "Practical Django Projects",
@@ -1190,7 +1190,7 @@ class AggregationTests(TestCase):
             .filter(pages__lt=F("n_authors") * 200)
             .values_list("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Book.objects.filter(pk__in=qs),
             ["Python Web Development with Django"],
             attrgetter("name"),
@@ -1239,7 +1239,7 @@ class AggregationTests(TestCase):
             .filter(Q(n_authors=2) | Q(name="Python Web Development with Django"))
             .order_by("name")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 "Artificial Intelligence: A Modern Approach",
@@ -1258,7 +1258,7 @@ class AggregationTests(TestCase):
                 )
             )
         ).order_by("name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 "The Definitive Guide to Django: Web Development Done Right",
@@ -1273,7 +1273,7 @@ class AggregationTests(TestCase):
             .filter(Q(rating_sum__gt=5.5) | Q(rating_sum__isnull=True))
             .order_by("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 "Apress",
@@ -1290,7 +1290,7 @@ class AggregationTests(TestCase):
             .filter(Q(rating_sum__gt=F("book_count")) | Q(rating_sum=None))
             .order_by("num_awards")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 "Jonno's House of Books",
@@ -1308,7 +1308,7 @@ class AggregationTests(TestCase):
             .annotate(authorCount=Count("authors"))
             .order_by("authorCount")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Python Web Development with Django", 3),
@@ -1387,14 +1387,14 @@ class AggregationTests(TestCase):
             .filter(book_cnt=2)
             .order_by("name")
         )
-        self.assertQuerysetEqual(qs, ["Peter Norvig"], lambda b: b.name)
+        self.assertQuerySetEqual(qs, ["Peter Norvig"], lambda b: b.name)
         # Neither in this case
         qs = (
             Author.objects.annotate(book_count=Count("book"))
             .filter(book_count=2)
             .order_by("name")
         )
-        self.assertQuerysetEqual(qs, ["Peter Norvig"], lambda b: b.name)
+        self.assertQuerySetEqual(qs, ["Peter Norvig"], lambda b: b.name)
         # This case used to fail because the ORM couldn't resolve the
         # automatically generated annotation name `book__count`
         qs = (
@@ -1402,7 +1402,7 @@ class AggregationTests(TestCase):
             .filter(book__count=2)
             .order_by("name")
         )
-        self.assertQuerysetEqual(qs, ["Peter Norvig"], lambda b: b.name)
+        self.assertQuerySetEqual(qs, ["Peter Norvig"], lambda b: b.name)
         # Referencing the auto-generated name in an aggregate() also works.
         self.assertEqual(
             Author.objects.annotate(Count("book")).aggregate(Max("book__count")),
@@ -1570,7 +1570,7 @@ class AggregationTests(TestCase):
                 self.assertEqual(len(grouping), 2)
                 self.assertIn("id", grouping[0][0])
                 self.assertIn("id", grouping[1][0])
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     qs.order_by("name"),
                     [
                         ("Artificial Intelligence: A Modern Approach", 2),
@@ -1659,7 +1659,7 @@ class AggregationTests(TestCase):
             .exclude(Q(book_cnt=2), Q(book_cnt=2))
             .order_by("name")
         )
-        self.assertQuerysetEqual(qs, expected_results, lambda b: b.name)
+        self.assertQuerySetEqual(qs, expected_results, lambda b: b.name)
         expected_results = Author.objects.exclude(
             pk__in=Author.objects.annotate(book_cnt=Count("book")).filter(book_cnt=2)
         ).order_by("name")
@@ -1669,7 +1669,7 @@ class AggregationTests(TestCase):
             .exclude(Q(book_cnt=2) | Q(book_cnt=2))
             .order_by("name")
         )
-        self.assertQuerysetEqual(qs, expected_results, lambda b: b.name)
+        self.assertQuerySetEqual(qs, expected_results, lambda b: b.name)
 
     def test_name_filters(self):
         qs = (
@@ -1677,7 +1677,7 @@ class AggregationTests(TestCase):
             .filter(Q(book__count__exact=2) | Q(name="Adrian Holovaty"))
             .order_by("name")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs, ["Adrian Holovaty", "Peter Norvig"], lambda b: b.name
         )
 
@@ -1690,7 +1690,7 @@ class AggregationTests(TestCase):
             .filter(Q(name="Peter Norvig") | Q(age=F("book__count") + 33))
             .order_by("name")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs, ["Adrian Holovaty", "Peter Norvig"], lambda b: b.name
         )
 
@@ -1698,7 +1698,7 @@ class AggregationTests(TestCase):
         q1 = Q(price__gt=50)
         q2 = Q(authors__count__gt=1)
         query = Book.objects.annotate(Count("authors")).filter(q1 | q2).order_by("pk")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             query,
             [self.b1.pk, self.b4.pk, self.b5.pk, self.b6.pk],
             attrgetter("pk"),
@@ -1710,7 +1710,7 @@ class AggregationTests(TestCase):
         query = (
             Book.objects.annotate(Count("authors")).filter(~(q1 & q2)).order_by("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             query,
             [self.b1.pk, self.b2.pk, self.b3.pk, self.b4.pk, self.b6.pk],
             attrgetter("pk"),
@@ -1720,7 +1720,7 @@ class AggregationTests(TestCase):
         q1 = Q(price__gt=50)
         q2 = Q(authors__count__gt=1)
         query = Book.objects.annotate(Count("authors")).filter(q1 ^ q2).order_by("pk")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             query,
             [self.b1.pk, self.b4.pk, self.b6.pk],
             attrgetter("pk"),
@@ -1732,7 +1732,7 @@ class AggregationTests(TestCase):
         query = (
             Book.objects.annotate(Count("authors")).filter(~(q1 ^ q2)).order_by("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             query,
             [self.b2.pk, self.b3.pk, self.b5.pk],
             attrgetter("pk"),
@@ -1756,7 +1756,7 @@ class AggregationTests(TestCase):
         qs = Book.objects.annotate(account=Count("authors")).filter(
             account=F("publisher__num_awards")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs, ["Sams Teach Yourself Django in 24 Hours"], lambda b: b.name
         )
 
@@ -1873,7 +1873,7 @@ class SelfReferentialFKTests(TestCase):
         t1 = SelfRefFK.objects.create(name="t1")
         SelfRefFK.objects.create(name="t2", parent=t1)
         SelfRefFK.objects.create(name="t3", parent=t1)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             SelfRefFK.objects.annotate(num_children=Count("children")).order_by("name"),
             [("t1", 2), ("t2", 0), ("t3", 0)],
             lambda x: (x.name, x.num_children),

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -517,7 +517,7 @@ class NonAggregateAnnotationTestCase(TestCase):
             .order_by("store_name")
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             books,
             ["Amazon.com", "Books.com", "Mamma and Pappa's Books"],
             lambda b: b.store_name,
@@ -609,7 +609,7 @@ class NonAggregateAnnotationTestCase(TestCase):
             .filter(chain="Westfield")
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Angus & Robinson", "Westfield", True, "155860191"),
@@ -629,7 +629,7 @@ class NonAggregateAnnotationTestCase(TestCase):
 
     def test_order_by_annotation(self):
         authors = Author.objects.annotate(other_age=F("age")).order_by("other_age")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors,
             [
                 25,
@@ -651,7 +651,7 @@ class NonAggregateAnnotationTestCase(TestCase):
             .annotate(age_count=Count("age"))
             .order_by("age_count", "age")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors,
             [
                 (25, 1),
@@ -735,7 +735,7 @@ class NonAggregateAnnotationTestCase(TestCase):
             (2, "Buffy", False, 42, "Summers", 18, Decimal(40000.00), store.name, 17),
         ]
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.order_by("id"),
             rows,
             lambda e: (
@@ -786,7 +786,7 @@ class NonAggregateAnnotationTestCase(TestCase):
         ]
 
         # and we respect deferred columns!
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.defer("age").order_by("id"),
             rows,
             lambda e: (
@@ -835,7 +835,7 @@ class NonAggregateAnnotationTestCase(TestCase):
             )
         ).order_by("name")
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Apple", "APPL"),
@@ -891,7 +891,7 @@ class NonAggregateAnnotationTestCase(TestCase):
         # LOWER function supported by:
         # oracle, postgres, mysql, sqlite, sqlserver
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Apple", "APPL".lower()),
@@ -1333,7 +1333,7 @@ class AliasTests(TestCase):
     def test_order_by_alias(self):
         qs = Author.objects.alias(other_age=F("age")).order_by("other_age")
         self.assertIs(hasattr(qs.first(), "other_age"), False)
-        self.assertQuerysetEqual(qs, [34, 34, 35, 46, 57], lambda a: a.age)
+        self.assertQuerySetEqual(qs, [34, 34, 35, 46, 57], lambda a: a.age)
 
     def test_order_by_alias_aggregate(self):
         qs = (
@@ -1342,7 +1342,7 @@ class AliasTests(TestCase):
             .order_by("age_count", "age")
         )
         self.assertIs(hasattr(qs.first(), "age_count"), False)
-        self.assertQuerysetEqual(qs, [35, 46, 57, 34], lambda a: a["age"])
+        self.assertQuerySetEqual(qs, [35, 46, 57, 34], lambda a: a["age"])
 
     def test_dates_alias(self):
         qs = Book.objects.alias(

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -199,7 +199,7 @@ class ModelTest(TestCase):
         some_pub_date = datetime(2014, 5, 16, 12, 1)
         for headline in headlines:
             Article(headline=headline, pub_date=some_pub_date).save()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.order_by("headline"),
             sorted(headlines),
             transform=lambda a: a.headline,

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -49,7 +49,7 @@ class BulkCreateTests(TestCase):
     def test_simple(self):
         created = Country.objects.bulk_create(self.data)
         self.assertEqual(created, self.data)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Country.objects.order_by("-name"),
             [
                 "United States of America",
@@ -119,7 +119,7 @@ class BulkCreateTests(TestCase):
                 Country(name="Tortall", iso_two_letter="TA"),
             ]
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             ProxyCountry.objects.all(),
             {"Qwghlm", "Tortall"},
             attrgetter("name"),
@@ -131,7 +131,7 @@ class BulkCreateTests(TestCase):
                 ProxyProxyCountry(name="Netherlands", iso_two_letter="NT"),
             ]
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             ProxyProxyCountry.objects.all(),
             {
                 "Qwghlm",
@@ -146,7 +146,7 @@ class BulkCreateTests(TestCase):
         State.objects.bulk_create(
             [State(two_letter_code=s) for s in ["IL", "NY", "CA", "ME"]]
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             State.objects.order_by("two_letter_code"),
             [
                 "CA",
@@ -163,7 +163,7 @@ class BulkCreateTests(TestCase):
             State.objects.bulk_create(
                 [State(two_letter_code=s) for s in ["IL", "NY", "CA", "ME"]]
             )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             State.objects.order_by("two_letter_code"),
             [
                 "CA",

--- a/tests/custom_columns/tests.py
+++ b/tests/custom_columns/tests.py
@@ -50,7 +50,7 @@ class CustomColumnsTests(TestCase):
         self.assertSequenceEqual(self.article.authors.all(), [self.a2, self.a1])
 
     def test_get_all_articles_for_an_author(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.a1.article_set.all(),
             [
                 "Django lets you build web apps easily",

--- a/tests/custom_lookups/tests.py
+++ b/tests/custom_lookups/tests.py
@@ -373,7 +373,7 @@ class BilateralTransformTests(TestCase):
                     Author(name="Ray"),
                 ]
             )
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 Author.objects.filter(name__upper__in=["foo", "bar", "doe"]).order_by(
                     "name"
                 ),

--- a/tests/custom_managers/tests.py
+++ b/tests/custom_managers/tests.py
@@ -44,7 +44,7 @@ class CustomManagerTests(TestCase):
         """
         Test a custom Manager method.
         """
-        self.assertQuerysetEqual(Person.objects.get_fun_people(), ["Bugs Bunny"], str)
+        self.assertQuerySetEqual(Person.objects.get_fun_people(), ["Bugs Bunny"], str)
 
     def test_queryset_copied_to_default(self):
         """
@@ -83,7 +83,7 @@ class CustomManagerTests(TestCase):
             with self.subTest(manager_name=manager_name):
                 manager = getattr(Person, manager_name)
                 queryset = manager.filter()
-                self.assertQuerysetEqual(queryset, ["Bugs Bunny"], str)
+                self.assertQuerySetEqual(queryset, ["Bugs Bunny"], str)
                 self.assertIs(queryset._filter_CustomQuerySet, True)
 
                 # Specialized querysets inherit from our custom queryset.
@@ -116,7 +116,7 @@ class CustomManagerTests(TestCase):
         Queryset method doesn't override the custom manager method.
         """
         queryset = Person.custom_queryset_custom_manager.filter()
-        self.assertQuerysetEqual(queryset, ["Bugs Bunny"], str)
+        self.assertQuerySetEqual(queryset, ["Bugs Bunny"], str)
         self.assertIs(queryset._filter_CustomManager, True)
 
     def test_related_manager(self):
@@ -139,7 +139,7 @@ class CustomManagerTests(TestCase):
         """
         Custom managers respond to usual filtering methods
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Book.published_objects.all(),
             [
                 "How to program",
@@ -161,7 +161,7 @@ class CustomManagerTests(TestCase):
             first_name="Droopy", last_name="Dog", fun=False, favorite_book=self.b1
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_books.order_by("first_name").all(),
             [
                 "Bugs",
@@ -170,7 +170,7 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.fun_people_favorite_books.all(),
             [
                 "Bugs",
@@ -178,7 +178,7 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_books(manager="boring_people").all(),
             [
                 "Droopy",
@@ -186,7 +186,7 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_books(manager="fun_people").all(),
             [
                 "Bugs",
@@ -209,7 +209,7 @@ class CustomManagerTests(TestCase):
             first_name="Droopy", last_name="Dog", fun=False, favorite_thing=self.b1
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_things.all(),
             [
                 "Bugs",
@@ -218,7 +218,7 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.fun_people_favorite_things.all(),
             [
                 "Bugs",
@@ -226,7 +226,7 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_things(manager="boring_people").all(),
             [
                 "Droopy",
@@ -234,7 +234,7 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_things(manager="fun_people").all(),
             [
                 "Bugs",
@@ -255,7 +255,7 @@ class CustomManagerTests(TestCase):
         )
         self.b1.fun_authors.add(droopy)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.authors.order_by("first_name").all(),
             [
                 "Bugs",
@@ -264,7 +264,7 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.fun_authors.order_by("first_name").all(),
             [
                 "Bugs",
@@ -272,7 +272,7 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.authors(manager="boring_people").all(),
             [
                 "Droopy",
@@ -280,7 +280,7 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.authors(manager="fun_people").all(),
             [
                 "Bugs",
@@ -298,7 +298,7 @@ class CustomManagerTests(TestCase):
         )
 
         self.b1.fun_people_favorite_books.remove(droopy, bulk=bulk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             FunPerson._base_manager.filter(favorite_book=self.b1),
             [
                 "Bugs",
@@ -309,7 +309,7 @@ class CustomManagerTests(TestCase):
         )
 
         self.b1.fun_people_favorite_books.remove(bugs, bulk=bulk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             FunPerson._base_manager.filter(favorite_book=self.b1),
             [
                 "Droopy",
@@ -321,7 +321,7 @@ class CustomManagerTests(TestCase):
         bugs.save()
 
         self.b1.fun_people_favorite_books.clear(bulk=bulk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             FunPerson._base_manager.filter(favorite_book=self.b1),
             [
                 "Droopy",
@@ -343,7 +343,7 @@ class CustomManagerTests(TestCase):
 
         # The fun manager DOESN'T remove boring people.
         self.b1.favorite_books(manager="fun_people").remove(droopy, bulk=bulk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_books(manager="boring_people").all(),
             [
                 "Droopy",
@@ -353,7 +353,7 @@ class CustomManagerTests(TestCase):
         )
         # The boring manager DOES remove boring people.
         self.b1.favorite_books(manager="boring_people").remove(droopy, bulk=bulk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_books(manager="boring_people").all(),
             [],
             lambda c: c.first_name,
@@ -364,7 +364,7 @@ class CustomManagerTests(TestCase):
 
         # The fun manager ONLY clears fun people.
         self.b1.favorite_books(manager="fun_people").clear(bulk=bulk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_books(manager="boring_people").all(),
             [
                 "Droopy",
@@ -372,7 +372,7 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_books(manager="fun_people").all(),
             [],
             lambda c: c.first_name,
@@ -391,7 +391,7 @@ class CustomManagerTests(TestCase):
         )
 
         self.b1.fun_people_favorite_things.remove(droopy, bulk=bulk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             FunPerson._base_manager.order_by("first_name").filter(
                 favorite_thing_id=self.b1.pk
             ),
@@ -404,7 +404,7 @@ class CustomManagerTests(TestCase):
         )
 
         self.b1.fun_people_favorite_things.remove(bugs, bulk=bulk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             FunPerson._base_manager.order_by("first_name").filter(
                 favorite_thing_id=self.b1.pk
             ),
@@ -418,7 +418,7 @@ class CustomManagerTests(TestCase):
         bugs.save()
 
         self.b1.fun_people_favorite_things.clear(bulk=bulk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             FunPerson._base_manager.order_by("first_name").filter(
                 favorite_thing_id=self.b1.pk
             ),
@@ -442,7 +442,7 @@ class CustomManagerTests(TestCase):
 
         # The fun manager DOESN'T remove boring people.
         self.b1.favorite_things(manager="fun_people").remove(droopy, bulk=bulk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_things(manager="boring_people").all(),
             [
                 "Droopy",
@@ -453,7 +453,7 @@ class CustomManagerTests(TestCase):
 
         # The boring manager DOES remove boring people.
         self.b1.favorite_things(manager="boring_people").remove(droopy, bulk=bulk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_things(manager="boring_people").all(),
             [],
             lambda c: c.first_name,
@@ -464,7 +464,7 @@ class CustomManagerTests(TestCase):
 
         # The fun manager ONLY clears fun people.
         self.b1.favorite_things(manager="fun_people").clear(bulk=bulk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_things(manager="boring_people").all(),
             [
                 "Droopy",
@@ -472,7 +472,7 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.favorite_things(manager="fun_people").all(),
             [],
             lambda c: c.first_name,
@@ -491,7 +491,7 @@ class CustomManagerTests(TestCase):
         self.b1.fun_authors.add(droopy)
 
         self.b1.fun_authors.remove(droopy)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.fun_authors.through._default_manager.all(),
             [
                 "Bugs",
@@ -502,7 +502,7 @@ class CustomManagerTests(TestCase):
         )
 
         self.b1.fun_authors.remove(bugs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.fun_authors.through._default_manager.all(),
             [
                 "Droopy",
@@ -513,7 +513,7 @@ class CustomManagerTests(TestCase):
         self.b1.fun_authors.add(bugs)
 
         self.b1.fun_authors.clear()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.fun_authors.through._default_manager.all(),
             [
                 "Droopy",
@@ -530,7 +530,7 @@ class CustomManagerTests(TestCase):
 
         # The fun manager DOESN'T remove boring people.
         self.b1.authors(manager="fun_people").remove(droopy)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.authors(manager="boring_people").all(),
             [
                 "Droopy",
@@ -541,7 +541,7 @@ class CustomManagerTests(TestCase):
 
         # The boring manager DOES remove boring people.
         self.b1.authors(manager="boring_people").remove(droopy)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.authors(manager="boring_people").all(),
             [],
             lambda c: c.first_name,
@@ -551,7 +551,7 @@ class CustomManagerTests(TestCase):
 
         # The fun manager ONLY clears fun people.
         self.b1.authors(manager="fun_people").clear()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.authors(manager="boring_people").all(),
             [
                 "Droopy",
@@ -559,7 +559,7 @@ class CustomManagerTests(TestCase):
             lambda c: c.first_name,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.b1.authors(manager="fun_people").all(),
             [],
             lambda c: c.first_name,
@@ -628,7 +628,7 @@ class CustomManagerTests(TestCase):
         It will be inherited by the abstract model's children.
         """
         PersonFromAbstract.abstract_persons.create(objects="Test")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             PersonFromAbstract.abstract_persons.all(),
             ["Test"],
             lambda c: c.objects,
@@ -642,7 +642,7 @@ class TestCars(TestCase):
         Car.cars.create(name="Corvette", mileage=21, top_speed=180)
         Car.cars.create(name="Neon", mileage=31, top_speed=100)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Car._default_manager.order_by("name"),
             [
                 "Corvette",
@@ -650,7 +650,7 @@ class TestCars(TestCase):
             ],
             lambda c: c.name,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Car.cars.order_by("name"),
             [
                 "Corvette",
@@ -659,7 +659,7 @@ class TestCars(TestCase):
             lambda c: c.name,
         )
         # alternate manager
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Car.fast_cars.all(),
             [
                 "Corvette",
@@ -667,7 +667,7 @@ class TestCars(TestCase):
             lambda c: c.name,
         )
         # explicit default manager
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             FastCarAsDefault.cars.order_by("name"),
             [
                 "Corvette",
@@ -675,7 +675,7 @@ class TestCars(TestCase):
             ],
             lambda c: c.name,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             FastCarAsDefault._default_manager.all(),
             [
                 "Corvette",
@@ -683,7 +683,7 @@ class TestCars(TestCase):
             lambda c: c.name,
         )
         # explicit base manager
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             FastCarAsBase.cars.order_by("name"),
             [
                 "Corvette",
@@ -691,7 +691,7 @@ class TestCars(TestCase):
             ],
             lambda c: c.name,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             FastCarAsBase._base_manager.all(),
             [
                 "Corvette",
@@ -779,4 +779,4 @@ class CustomManagersRegressTestCase(TestCase):
         """
         qs_custom = Person.custom_init_queryset_manager.all()
         qs_default = Person.objects.all()
-        self.assertQuerysetEqual(qs_custom, qs_default)
+        self.assertQuerySetEqual(qs_custom, qs_default)

--- a/tests/custom_methods/tests.py
+++ b/tests/custom_methods/tests.py
@@ -15,14 +15,14 @@ class MethodsTests(TestCase):
         )
 
         self.assertFalse(a.was_published_today())
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             a.articles_from_same_day_1(),
             [
                 "Beatles reunite",
             ],
             lambda a: a.headline,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             a.articles_from_same_day_2(),
             [
                 "Beatles reunite",
@@ -30,14 +30,14 @@ class MethodsTests(TestCase):
             lambda a: a.headline,
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             b.articles_from_same_day_1(),
             [
                 "Parrot programs in Python",
             ],
             lambda a: a.headline,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             b.articles_from_same_day_2(),
             [
                 "Parrot programs in Python",

--- a/tests/custom_pk/tests.py
+++ b/tests/custom_pk/tests.py
@@ -33,10 +33,10 @@ class BasicCustomPKTests(TestCase):
         )
         self.assertSequenceEqual(Employee.objects.all(), [self.fran, self.dan])
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Business.objects.filter(name="Sears"), ["Sears"], lambda b: b.name
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Business.objects.filter(pk="Sears"),
             [
                 "Sears",
@@ -52,7 +52,7 @@ class BasicCustomPKTests(TestCase):
             self.business.employees.all(),
             [self.fran, self.dan],
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.fran.business_set.all(),
             [
                 "Sears",
@@ -73,14 +73,14 @@ class BasicCustomPKTests(TestCase):
             [self.fran, self.dan],
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Business.objects.filter(employees__employee_code=123),
             [
                 "Sears",
             ],
             lambda b: b.name,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Business.objects.filter(employees__pk=123),
             [
                 "Sears",
@@ -88,7 +88,7 @@ class BasicCustomPKTests(TestCase):
             lambda b: b.name,
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Business.objects.filter(employees__first_name__startswith="Fran"),
             [
                 "Sears",

--- a/tests/db_functions/comparison/test_coalesce.py
+++ b/tests/db_functions/comparison/test_coalesce.py
@@ -15,7 +15,7 @@ class CoalesceTests(TestCase):
         Author.objects.create(name="John Smith", alias="smithj")
         Author.objects.create(name="Rhonda")
         authors = Author.objects.annotate(display_name=Coalesce("alias", "name"))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), ["smithj", "Rhonda"], lambda a: a.display_name
         )
 
@@ -39,7 +39,7 @@ class CoalesceTests(TestCase):
         article = Article.objects.annotate(
             headline=Coalesce("summary", "text", output_field=TextField()),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             article.order_by("title"), [lorem_ipsum], lambda a: a.headline
         )
         # mixed Text and Char wrapped
@@ -48,7 +48,7 @@ class CoalesceTests(TestCase):
                 Lower("summary"), Lower("text"), output_field=TextField()
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             article.order_by("title"), [lorem_ipsum.lower()], lambda a: a.headline
         )
 
@@ -56,11 +56,11 @@ class CoalesceTests(TestCase):
         Author.objects.create(name="John Smith", alias="smithj")
         Author.objects.create(name="Rhonda")
         authors = Author.objects.order_by(Coalesce("alias", "name"))
-        self.assertQuerysetEqual(authors, ["Rhonda", "John Smith"], lambda a: a.name)
+        self.assertQuerySetEqual(authors, ["Rhonda", "John Smith"], lambda a: a.name)
         authors = Author.objects.order_by(Coalesce("alias", "name").asc())
-        self.assertQuerysetEqual(authors, ["Rhonda", "John Smith"], lambda a: a.name)
+        self.assertQuerySetEqual(authors, ["Rhonda", "John Smith"], lambda a: a.name)
         authors = Author.objects.order_by(Coalesce("alias", "name").desc())
-        self.assertQuerysetEqual(authors, ["John Smith", "Rhonda"], lambda a: a.name)
+        self.assertQuerySetEqual(authors, ["John Smith", "Rhonda"], lambda a: a.name)
 
     def test_empty_queryset(self):
         Author.objects.create(name="John Smith")

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -277,21 +277,21 @@ class DateFunctionTests(TestCase):
         ):
             list(DTModel.objects.annotate(extracted=Extract("start_date", "second")))
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=Extract("start_datetime", "year")
             ).order_by("start_datetime"),
             [(start_datetime, start_datetime.year), (end_datetime, end_datetime.year)],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=Extract("start_datetime", "quarter")
             ).order_by("start_datetime"),
             [(start_datetime, 2), (end_datetime, 2)],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=Extract("start_datetime", "month")
             ).order_by("start_datetime"),
@@ -301,21 +301,21 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=Extract("start_datetime", "day")
             ).order_by("start_datetime"),
             [(start_datetime, start_datetime.day), (end_datetime, end_datetime.day)],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=Extract("start_datetime", "week")
             ).order_by("start_datetime"),
             [(start_datetime, 25), (end_datetime, 24)],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=Extract("start_datetime", "week_day")
             ).order_by("start_datetime"),
@@ -325,7 +325,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=Extract("start_datetime", "iso_week_day"),
             ).order_by("start_datetime"),
@@ -335,14 +335,14 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=Extract("start_datetime", "hour")
             ).order_by("start_datetime"),
             [(start_datetime, start_datetime.hour), (end_datetime, end_datetime.hour)],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=Extract("start_datetime", "minute")
             ).order_by("start_datetime"),
@@ -352,7 +352,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=Extract("start_datetime", "second")
             ).order_by("start_datetime"),
@@ -417,7 +417,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=Extract("duration", "second")).order_by(
                 "start_datetime"
             ),
@@ -465,14 +465,14 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractYear("start_datetime")).order_by(
                 "start_datetime"
             ),
             [(start_datetime, start_datetime.year), (end_datetime, end_datetime.year)],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractYear("start_date")).order_by(
                 "start_datetime"
             ),
@@ -494,14 +494,14 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=ExtractIsoYear("start_datetime")
             ).order_by("start_datetime"),
             [(start_datetime, start_datetime.year), (end_datetime, end_datetime.year)],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractIsoYear("start_date")).order_by(
                 "start_datetime"
             ),
@@ -538,7 +538,7 @@ class DateFunctionTests(TestCase):
             )
             .order_by("start_datetime")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 (week_52_day_2014, 2014),
@@ -569,7 +569,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractMonth("start_datetime")).order_by(
                 "start_datetime"
             ),
@@ -579,7 +579,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractMonth("start_date")).order_by(
                 "start_datetime"
             ),
@@ -604,14 +604,14 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractDay("start_datetime")).order_by(
                 "start_datetime"
             ),
             [(start_datetime, start_datetime.day), (end_datetime, end_datetime.day)],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractDay("start_date")).order_by(
                 "start_datetime"
             ),
@@ -633,14 +633,14 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractWeek("start_datetime")).order_by(
                 "start_datetime"
             ),
             [(start_datetime, 25), (end_datetime, 24)],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractWeek("start_date")).order_by(
                 "start_datetime"
             ),
@@ -663,14 +663,14 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=ExtractQuarter("start_datetime")
             ).order_by("start_datetime"),
             [(start_datetime, 2), (end_datetime, 3)],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractQuarter("start_date")).order_by(
                 "start_datetime"
             ),
@@ -704,7 +704,7 @@ class DateFunctionTests(TestCase):
             )
             .order_by("start_datetime")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 (last_quarter_2014, 4),
@@ -737,7 +737,7 @@ class DateFunctionTests(TestCase):
             )
             .order_by("start_datetime")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 (week_52_day_2014, 52),
@@ -755,7 +755,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=ExtractWeekDay("start_datetime")
             ).order_by("start_datetime"),
@@ -765,7 +765,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractWeekDay("start_date")).order_by(
                 "start_datetime"
             ),
@@ -790,7 +790,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=ExtractIsoWeekDay("start_datetime"),
             ).order_by("start_datetime"),
@@ -800,7 +800,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=ExtractIsoWeekDay("start_date"),
             ).order_by("start_datetime"),
@@ -825,14 +825,14 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractHour("start_datetime")).order_by(
                 "start_datetime"
             ),
             [(start_datetime, start_datetime.hour), (end_datetime, end_datetime.hour)],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractHour("start_time")).order_by(
                 "start_datetime"
             ),
@@ -854,7 +854,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=ExtractMinute("start_datetime")
             ).order_by("start_datetime"),
@@ -864,7 +864,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractMinute("start_time")).order_by(
                 "start_datetime"
             ),
@@ -889,7 +889,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 extracted=ExtractSecond("start_datetime")
             ).order_by("start_datetime"),
@@ -899,7 +899,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=ExtractSecond("start_time")).order_by(
                 "start_datetime"
             ),
@@ -963,7 +963,7 @@ class DateFunctionTests(TestCase):
         self.create_model(end_datetime, start_datetime)
 
         def test_datetime_kind(kind):
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 DTModel.objects.annotate(
                     truncated=Trunc(
                         "start_datetime", kind, output_field=DateTimeField()
@@ -977,7 +977,7 @@ class DateFunctionTests(TestCase):
             )
 
         def test_date_kind(kind):
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 DTModel.objects.annotate(
                     truncated=Trunc("start_date", kind, output_field=DateField())
                 ).order_by("start_datetime"),
@@ -989,7 +989,7 @@ class DateFunctionTests(TestCase):
             )
 
         def test_time_kind(kind):
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 DTModel.objects.annotate(
                     truncated=Trunc("start_time", kind, output_field=TimeField())
                 ).order_by("start_datetime"),
@@ -1001,7 +1001,7 @@ class DateFunctionTests(TestCase):
             )
 
         def test_datetime_to_time_kind(kind):
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 DTModel.objects.annotate(
                     truncated=Trunc("start_datetime", kind, output_field=TimeField()),
                 ).order_by("start_datetime"),
@@ -1044,7 +1044,7 @@ class DateFunctionTests(TestCase):
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 truncated=Trunc("start_datetime", "week", output_field=DateTimeField())
             ).order_by("start_datetime"),
@@ -1054,7 +1054,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.truncated),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(
                 truncated=Trunc("start_date", "week", output_field=DateField())
             ).order_by("start_datetime"),
@@ -1137,7 +1137,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncYear("start_datetime")).order_by(
                 "start_datetime"
             ),
@@ -1147,7 +1147,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncYear("start_date")).order_by(
                 "start_datetime"
             ),
@@ -1194,7 +1194,7 @@ class DateFunctionTests(TestCase):
         self.create_model(start_datetime=end_datetime, end_datetime=start_datetime)
         self.create_model(start_datetime=last_quarter_2015, end_datetime=end_datetime)
         self.create_model(start_datetime=first_quarter_2016, end_datetime=end_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncQuarter("start_date")).order_by(
                 "start_datetime"
             ),
@@ -1206,7 +1206,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncQuarter("start_datetime")).order_by(
                 "start_datetime"
             ),
@@ -1241,7 +1241,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncMonth("start_datetime")).order_by(
                 "start_datetime"
             ),
@@ -1251,7 +1251,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncMonth("start_date")).order_by(
                 "start_datetime"
             ),
@@ -1288,7 +1288,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncWeek("start_datetime")).order_by(
                 "start_datetime"
             ),
@@ -1325,7 +1325,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncDate("start_datetime")).order_by(
                 "start_datetime"
             ),
@@ -1372,7 +1372,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncTime("start_datetime")).order_by(
                 "start_datetime"
             ),
@@ -1446,7 +1446,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncDay("start_datetime")).order_by(
                 "start_datetime"
             ),
@@ -1482,7 +1482,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncHour("start_datetime")).order_by(
                 "start_datetime"
             ),
@@ -1492,7 +1492,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncHour("start_time")).order_by(
                 "start_datetime"
             ),
@@ -1529,7 +1529,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncMinute("start_datetime")).order_by(
                 "start_datetime"
             ),
@@ -1539,7 +1539,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncMinute("start_time")).order_by(
                 "start_datetime"
             ),
@@ -1578,7 +1578,7 @@ class DateFunctionTests(TestCase):
             end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncSecond("start_datetime")).order_by(
                 "start_datetime"
             ),
@@ -1588,7 +1588,7 @@ class DateFunctionTests(TestCase):
             ],
             lambda m: (m.start_datetime, m.extracted),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DTModel.objects.annotate(extracted=TruncSecond("start_time")).order_by(
                 "start_datetime"
             ),
@@ -1909,7 +1909,7 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
             with self.subTest(repr(melb)):
 
                 def test_datetime_kind(kind):
-                    self.assertQuerysetEqual(
+                    self.assertQuerySetEqual(
                         DTModel.objects.annotate(
                             truncated=Trunc(
                                 "start_datetime",
@@ -1934,7 +1934,7 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
                     )
 
                 def test_datetime_to_date_kind(kind):
-                    self.assertQuerysetEqual(
+                    self.assertQuerySetEqual(
                         DTModel.objects.annotate(
                             truncated=Trunc(
                                 "start_datetime",
@@ -1959,7 +1959,7 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
                     )
 
                 def test_datetime_to_time_kind(kind):
-                    self.assertQuerysetEqual(
+                    self.assertQuerySetEqual(
                         DTModel.objects.annotate(
                             truncated=Trunc(
                                 "start_datetime",

--- a/tests/db_functions/datetime/test_now.py
+++ b/tests/db_functions/datetime/test_now.py
@@ -39,12 +39,12 @@ class NowTests(TestCase):
         a2.save()
         a2.refresh_from_db()
         self.assertIsInstance(a2.published, datetime)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(published__lte=Now()),
             ["How to Django"],
             lambda a: a.title,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(published__gt=Now()),
             ["How to Time Travel"],
             lambda a: a.title,

--- a/tests/db_functions/tests.py
+++ b/tests/db_functions/tests.py
@@ -17,7 +17,7 @@ class FunctionTests(TestCase):
         Author.objects.create(name="Rhonda Simpson", alias="ronny")
 
         authors = Author.objects.order_by(Length(Coalesce("alias", "name")))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors,
             [
                 "Rhonda Simpson",
@@ -27,7 +27,7 @@ class FunctionTests(TestCase):
         )
 
         authors = Author.objects.order_by(Length(Coalesce("alias", "name")).desc())
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors,
             [
                 "John Smith",
@@ -41,7 +41,7 @@ class FunctionTests(TestCase):
             Author.objects.create(name="John Smith", alias="smithj")
             Author.objects.create(name="Rhonda")
             authors = Author.objects.filter(name__upper__exact="john smith")
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 authors.order_by("name"),
                 [
                     "John Smith",
@@ -54,7 +54,7 @@ class FunctionTests(TestCase):
             Author.objects.create(name="John Smith", alias="smithj")
             Author.objects.create(name="Rhonda")
             authors = Author.objects.filter(name__upper__in=["john smith", "rhonda"])
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 authors.order_by("name"),
                 [
                     "John Smith",
@@ -66,12 +66,12 @@ class FunctionTests(TestCase):
     def test_function_as_filter(self):
         Author.objects.create(name="John Smith", alias="SMITHJ")
         Author.objects.create(name="Rhonda")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.filter(alias=Upper(V("smithj"))),
             ["John Smith"],
             lambda x: x.name,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.exclude(alias=Upper(V("smithj"))),
             ["Rhonda"],
             lambda x: x.name,

--- a/tests/db_functions/text/test_concat.py
+++ b/tests/db_functions/text/test_concat.py
@@ -21,7 +21,7 @@ class ConcatTests(TestCase):
         Author.objects.create(name="Margaret", goes_by="Maggie")
         Author.objects.create(name="Rhonda", alias="adnohR")
         authors = Author.objects.annotate(joined=Concat("alias", "goes_by"))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"),
             [
                 "",
@@ -46,7 +46,7 @@ class ConcatTests(TestCase):
         authors = Author.objects.annotate(
             joined=Concat("name", V(" ("), "goes_by", V(")"), output_field=CharField()),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"),
             [
                 "Jayden ()",

--- a/tests/db_functions/text/test_left.py
+++ b/tests/db_functions/text/test_left.py
@@ -13,12 +13,12 @@ class LeftTests(TestCase):
 
     def test_basic(self):
         authors = Author.objects.annotate(name_part=Left("name", 5))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), ["John ", "Rhond"], lambda a: a.name_part
         )
         # If alias is null, set it to the first 2 lower characters of the name.
         Author.objects.filter(alias__isnull=True).update(alias=Lower(Left("name", 2)))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), ["smithj", "rh"], lambda a: a.alias
         )
 
@@ -30,6 +30,6 @@ class LeftTests(TestCase):
         authors = Author.objects.annotate(
             name_part=Left("name", Value(3, output_field=IntegerField()))
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), ["Joh", "Rho"], lambda a: a.name_part
         )

--- a/tests/db_functions/text/test_length.py
+++ b/tests/db_functions/text/test_length.py
@@ -14,7 +14,7 @@ class LengthTests(TestCase):
             name_length=Length("name"),
             alias_length=Length("alias"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"),
             [(10, 6), (6, None)],
             lambda a: (a.name_length, a.alias_length),
@@ -26,7 +26,7 @@ class LengthTests(TestCase):
         Author.objects.create(name="John Smith", alias="smithj1")
         Author.objects.create(name="Rhonda", alias="ronny")
         authors = Author.objects.order_by(Length("name"), Length("alias"))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors,
             [
                 ("Rhonda", "ronny"),
@@ -41,6 +41,6 @@ class LengthTests(TestCase):
             Author.objects.create(name="John Smith", alias="smithj")
             Author.objects.create(name="Rhonda")
             authors = Author.objects.filter(name__length__gt=7)
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 authors.order_by("name"), ["John Smith"], lambda a: a.name
             )

--- a/tests/db_functions/text/test_lower.py
+++ b/tests/db_functions/text/test_lower.py
@@ -11,11 +11,11 @@ class LowerTests(TestCase):
         Author.objects.create(name="John Smith", alias="smithj")
         Author.objects.create(name="Rhonda")
         authors = Author.objects.annotate(lower_name=Lower("name"))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), ["john smith", "rhonda"], lambda a: a.lower_name
         )
         Author.objects.update(name=Lower("name"))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"),
             [
                 ("john smith", "john smith"),
@@ -35,6 +35,6 @@ class LowerTests(TestCase):
             Author.objects.create(name="John Smith", alias="smithj")
             Author.objects.create(name="Rhonda")
             authors = Author.objects.filter(name__lower__exact="john smith")
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 authors.order_by("name"), ["John Smith"], lambda a: a.name
             )

--- a/tests/db_functions/text/test_pad.py
+++ b/tests/db_functions/text/test_pad.py
@@ -35,7 +35,7 @@ class PadTests(TestCase):
         for function, padded_name in tests:
             with self.subTest(function=function):
                 authors = Author.objects.annotate(padded_name=function)
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     authors, [padded_name], lambda a: a.padded_name, ordered=False
                 )
 
@@ -51,7 +51,7 @@ class PadTests(TestCase):
         Author.objects.create(name="Rhonda", alias="john_smith")
         Author.objects.create(name="♥♣♠", alias="bytes")
         authors = Author.objects.annotate(filled=LPad("name", Length("alias")))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("alias"),
             ["  ♥♣♠", "    Rhonda"],
             lambda a: a.filled,

--- a/tests/db_functions/text/test_repeat.py
+++ b/tests/db_functions/text/test_repeat.py
@@ -24,7 +24,7 @@ class RepeatTests(TestCase):
         for function, repeated_text in tests:
             with self.subTest(function=function):
                 authors = Author.objects.annotate(repeated_text=function)
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     authors, [repeated_text], lambda a: a.repeated_text, ordered=False
                 )
 

--- a/tests/db_functions/text/test_replace.py
+++ b/tests/db_functions/text/test_replace.py
@@ -15,7 +15,7 @@ class ReplaceTests(TestCase):
         qs = Author.objects.annotate(
             without_middlename=Replace(F("name"), Value("R. R. "), Value("")),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("George R. R. Martin", "George Martin"),
@@ -29,7 +29,7 @@ class ReplaceTests(TestCase):
         qs = Author.objects.annotate(
             same_name=Replace(F("name"), Value("r. r."), Value(""))
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("George R. R. Martin", "George R. R. Martin"),
@@ -45,7 +45,7 @@ class ReplaceTests(TestCase):
                 Concat(Value("Author: "), F("name")), Value("Author: "), Value("")
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("George R. R. Martin", "George R. R. Martin"),
@@ -59,7 +59,7 @@ class ReplaceTests(TestCase):
         Author.objects.update(
             name=Replace(F("name"), Value("R. R. "), Value("")),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.all(),
             [
                 ("George Martin"),
@@ -72,7 +72,7 @@ class ReplaceTests(TestCase):
     def test_replace_with_default_arg(self):
         # The default replacement is an empty string.
         qs = Author.objects.annotate(same_name=Replace(F("name"), Value("R. R. ")))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("George R. R. Martin", "George Martin"),

--- a/tests/db_functions/text/test_reverse.py
+++ b/tests/db_functions/text/test_reverse.py
@@ -25,7 +25,7 @@ class ReverseTests(TestCase):
 
     def test_basic(self):
         authors = Author.objects.annotate(backward=Reverse("name"))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors,
             [
                 ("John Smith", "htimS nhoJ"),

--- a/tests/db_functions/text/test_right.py
+++ b/tests/db_functions/text/test_right.py
@@ -13,12 +13,12 @@ class RightTests(TestCase):
 
     def test_basic(self):
         authors = Author.objects.annotate(name_part=Right("name", 5))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), ["Smith", "honda"], lambda a: a.name_part
         )
         # If alias is null, set it to the first 2 lower characters of the name.
         Author.objects.filter(alias__isnull=True).update(alias=Lower(Right("name", 2)))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), ["smithj", "da"], lambda a: a.alias
         )
 
@@ -30,6 +30,6 @@ class RightTests(TestCase):
         authors = Author.objects.annotate(
             name_part=Right("name", Value(3, output_field=IntegerField()))
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), ["ith", "nda"], lambda a: a.name_part
         )

--- a/tests/db_functions/text/test_strindex.py
+++ b/tests/db_functions/text/test_strindex.py
@@ -12,7 +12,7 @@ class StrIndexTests(TestCase):
         Author.objects.create(name="J. R. R. Tolkien")
         Author.objects.create(name="Terry Pratchett")
         authors = Author.objects.annotate(fullstop=StrIndex("name", Value("R.")))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), [9, 4, 0], lambda a: a.fullstop
         )
 
@@ -28,7 +28,7 @@ class StrIndexTests(TestCase):
             written=timezone.now(),
         )
         articles = Article.objects.annotate(title_pos=StrIndex("text", "title"))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             articles.order_by("title"), [15, 0], lambda a: a.title_pos
         )
 
@@ -36,7 +36,7 @@ class StrIndexTests(TestCase):
         Author.objects.create(name="Terry Pratchett")
         Author.objects.create(name="J. R. R. Tolkien")
         Author.objects.create(name="George. R. R. Martin")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.order_by(StrIndex("name", Value("R.")).asc()),
             [
                 "Terry Pratchett",
@@ -45,7 +45,7 @@ class StrIndexTests(TestCase):
             ],
             lambda a: a.name,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.order_by(StrIndex("name", Value("R.")).desc()),
             [
                 "George. R. R. Martin",
@@ -60,12 +60,12 @@ class StrIndexTests(TestCase):
         Author.objects.create(name="皇帝")
         Author.objects.create(name="皇帝 ツリー")
         authors = Author.objects.annotate(sb=StrIndex("name", Value("リ")))
-        self.assertQuerysetEqual(authors.order_by("name"), [2, 0, 5], lambda a: a.sb)
+        self.assertQuerySetEqual(authors.order_by("name"), [2, 0, 5], lambda a: a.sb)
 
     def test_filtering(self):
         Author.objects.create(name="George. R. R. Martin")
         Author.objects.create(name="Terry Pratchett")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.annotate(middle_name=StrIndex("name", Value("R."))).filter(
                 middle_name__gt=0
             ),

--- a/tests/db_functions/text/test_substr.py
+++ b/tests/db_functions/text/test_substr.py
@@ -10,18 +10,18 @@ class SubstrTests(TestCase):
         Author.objects.create(name="John Smith", alias="smithj")
         Author.objects.create(name="Rhonda")
         authors = Author.objects.annotate(name_part=Substr("name", 5, 3))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), [" Sm", "da"], lambda a: a.name_part
         )
         authors = Author.objects.annotate(name_part=Substr("name", 2))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), ["ohn Smith", "honda"], lambda a: a.name_part
         )
         # If alias is null, set to first 5 lower characters of the name.
         Author.objects.filter(alias__isnull=True).update(
             alias=Lower(Substr("name", 1, 5)),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), ["smithj", "rhond"], lambda a: a.alias
         )
 
@@ -43,6 +43,6 @@ class SubstrTests(TestCase):
         Author.objects.create(name="Rhonda")
         substr = Substr(Upper("name"), StrIndex("name", V("h")), 5)
         authors = Author.objects.annotate(name_part=substr)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"), ["HN SM", "HONDA"], lambda a: a.name_part
         )

--- a/tests/db_functions/text/test_trim.py
+++ b/tests/db_functions/text/test_trim.py
@@ -15,7 +15,7 @@ class TrimTests(TestCase):
             rtrim=RTrim("name"),
             trim=Trim("name"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("alias"),
             [
                 ("John ", "  John", "John"),
@@ -38,4 +38,4 @@ class TrimTests(TestCase):
                     authors = Author.objects.filter(
                         **{"name__%s" % transform.lookup_name: trimmed_name}
                     )
-                    self.assertQuerysetEqual(authors, [" John  "], lambda a: a.name)
+                    self.assertQuerySetEqual(authors, [" John  "], lambda a: a.name)

--- a/tests/db_functions/text/test_upper.py
+++ b/tests/db_functions/text/test_upper.py
@@ -11,7 +11,7 @@ class UpperTests(TestCase):
         Author.objects.create(name="John Smith", alias="smithj")
         Author.objects.create(name="Rhonda")
         authors = Author.objects.annotate(upper_name=Upper("name"))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"),
             [
                 "JOHN SMITH",
@@ -20,7 +20,7 @@ class UpperTests(TestCase):
             lambda a: a.upper_name,
         )
         Author.objects.update(name=Upper("name"))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             authors.order_by("name"),
             [
                 ("JOHN SMITH", "JOHN SMITH"),
@@ -34,7 +34,7 @@ class UpperTests(TestCase):
             Author.objects.create(name="John Smith", alias="smithj")
             Author.objects.create(name="Rhonda")
             authors = Author.objects.filter(name__upper__exact="JOHN SMITH")
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 authors.order_by("name"),
                 [
                     "John Smith",

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -144,7 +144,7 @@ class DeferTests(AssertionMixin, TestCase):
         obj = Primary.objects.defer("value").get(name="p2")
         obj.name = "a new name"
         obj.save()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Primary.objects.all(),
             [
                 "p1",

--- a/tests/defer_regress/tests.py
+++ b/tests/defer_regress/tests.py
@@ -70,7 +70,7 @@ class DeferRegressionTest(TestCase):
         obj = Leaf.objects.only("name", "child").select_related()[0]
         self.assertEqual(obj.child.name, "c1")
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Leaf.objects.select_related().only("child__name", "second_child__name"),
             [
                 "l1",

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -248,7 +248,7 @@ class BasicExpressionsTests(TestCase):
     def test_update_with_fk(self):
         # ForeignKey can become updated with the value of another ForeignKey.
         self.assertEqual(Company.objects.update(point_of_contact=F("ceo")), 3)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Company.objects.all(),
             ["Joe Smith", "Frank Meyer", "Max Mustermann"],
             lambda c: str(c.point_of_contact),
@@ -259,7 +259,7 @@ class BasicExpressionsTests(TestCase):
         Number.objects.create(integer=1, float=1.0)
         Number.objects.create(integer=2)
         Number.objects.filter(float__isnull=False).update(float=Value(None))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Number.objects.all(), [None, None], lambda n: n.float, ordered=False
         )
 
@@ -272,7 +272,7 @@ class BasicExpressionsTests(TestCase):
         )
         c.save()
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Company.objects.filter(ceo__firstname=F("point_of_contact__firstname")),
             ["Foobar Ltd.", "Test GmbH"],
             lambda c: c.name,
@@ -1027,7 +1027,7 @@ class IterableLookupInnerExpressionsTests(TestCase):
         queryset = SimulationRun.objects.exclude(
             midpoint__range=[F("start__time"), F("end__time")]
         )
-        self.assertQuerysetEqual(queryset, [], ordered=False)
+        self.assertQuerySetEqual(queryset, [], ordered=False)
         for alias in queryset.query.alias_map.values():
             if isinstance(alias, Join):
                 self.assertEqual(alias.join_type, constants.LOUTER)
@@ -1079,7 +1079,7 @@ class IterableLookupInnerExpressionsTests(TestCase):
         the test simple.
         """
         queryset = Company.objects.filter(name__in=[F("num_chairs") + "1)) OR ((1==1"])
-        self.assertQuerysetEqual(queryset, [], ordered=False)
+        self.assertQuerySetEqual(queryset, [], ordered=False)
 
     def test_in_lookup_allows_F_expressions_and_expressions_for_datetimes(self):
         start = datetime.datetime(2016, 2, 3, 15, 0, 0)
@@ -1285,7 +1285,7 @@ class ExpressionsNumericTests(TestCase):
         We can fill a value in all objects with an other value of the
         same object.
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Number.objects.all(),
             [(-1, -1), (42, 42), (1337, 1337)],
             lambda n: (n.integer, round(n.float)),
@@ -1299,7 +1299,7 @@ class ExpressionsNumericTests(TestCase):
         self.assertEqual(
             Number.objects.filter(integer__gt=0).update(integer=F("integer") + 1), 2
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Number.objects.all(),
             [(-1, -1), (43, 42), (1338, 1337)],
             lambda n: (n.integer, round(n.float)),
@@ -1314,7 +1314,7 @@ class ExpressionsNumericTests(TestCase):
         self.assertEqual(
             Number.objects.filter(integer__gt=0).update(integer=F("integer") + 1), 2
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Number.objects.exclude(float=F("integer")),
             [(43, 42), (1338, 1337)],
             lambda n: (n.integer, round(n.float)),
@@ -2025,7 +2025,7 @@ class FTimeDeltaTests(TestCase):
             )
             .order_by("name")
         )
-        self.assertQuerysetEqual(over_estimate, ["e3", "e4", "e5"], lambda e: e.name)
+        self.assertQuerySetEqual(over_estimate, ["e3", "e4", "e5"], lambda e: e.name)
 
     def test_duration_with_datetime_microseconds(self):
         delta = datetime.timedelta(microseconds=8999999999999999)
@@ -2042,7 +2042,7 @@ class FTimeDeltaTests(TestCase):
         more_than_4_days = Experiment.objects.filter(
             assigned__lt=F("completed") - Value(datetime.timedelta(days=4))
         )
-        self.assertQuerysetEqual(more_than_4_days, ["e3", "e4", "e5"], lambda e: e.name)
+        self.assertQuerySetEqual(more_than_4_days, ["e3", "e4", "e5"], lambda e: e.name)
 
     def test_negative_timedelta_update(self):
         # subtract 30 seconds, 30 minutes, 2 hours and 2 days

--- a/tests/expressions_case/tests.py
+++ b/tests/expressions_case/tests.py
@@ -80,7 +80,7 @@ class CaseExpressionTests(TestCase):
         ]
 
     def test_annotate(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 test=Case(
                     When(integer=1, then=Value("one")),
@@ -101,7 +101,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_without_default(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 test=Case(
                     When(integer=1, then=1),
@@ -113,7 +113,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_with_expression_as_value(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 f_test=Case(
                     When(integer=1, then=F("integer") + 1),
@@ -126,7 +126,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_with_expression_as_condition(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 f_test=Case(
                     When(integer2=F("integer"), then=Value("equal")),
@@ -146,7 +146,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_with_join_in_value(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 join_test=Case(
                     When(integer=1, then=F("o2o_rel__integer") + 1),
@@ -160,7 +160,7 @@ class CaseExpressionTests(TestCase):
 
     def test_annotate_with_in_clause(self):
         fk_rels = FKCaseTestModel.objects.filter(integer__in=[5])
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.only("pk", "integer")
             .annotate(
                 in_test=Sum(
@@ -176,7 +176,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_with_join_in_condition(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 join_test=Case(
                     When(integer2=F("o2o_rel__integer"), then=Value("equal")),
@@ -197,7 +197,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_with_join_in_predicate(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 join_test=Case(
                     When(o2o_rel__integer=1, then=Value("one")),
@@ -219,7 +219,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_with_annotation_in_value(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 f_plus_1=F("integer") + 1,
                 f_plus_3=F("integer") + 3,
@@ -237,7 +237,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_with_annotation_in_condition(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 f_plus_1=F("integer") + 1,
             )
@@ -261,7 +261,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_with_annotation_in_predicate(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 f_minus_2=F("integer") - 2,
             )
@@ -287,7 +287,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_with_aggregation_in_value(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.values(*self.group_by_fields)
             .annotate(
                 min=Min("fk_rel__integer"),
@@ -313,7 +313,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_with_aggregation_in_condition(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.values(*self.group_by_fields)
             .annotate(
                 min=Min("fk_rel__integer"),
@@ -339,7 +339,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_with_aggregation_in_predicate(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.values(*self.group_by_fields)
             .annotate(
                 max=Max("fk_rel__integer"),
@@ -365,7 +365,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_annotate_exclude(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 test=Case(
                     When(integer=1, then=Value("one")),
@@ -426,7 +426,7 @@ class CaseExpressionTests(TestCase):
         self.assertTrue(all(obj.selected == "selected" for obj in objects))
 
     def test_combined_expression(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 test=Case(
                     When(integer=1, then=2),
@@ -440,7 +440,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_in_subquery(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(
                 pk__in=CaseTestModel.objects.annotate(
                     test=Case(
@@ -469,7 +469,7 @@ class CaseExpressionTests(TestCase):
             When(pk=0, then=Value("0")),
             default=Value("1"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(somecase=SOME_CASE).order_by("pk"),
             CaseTestModel.objects.annotate(somecase=SOME_CASE)
             .order_by("pk")
@@ -532,7 +532,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(
                 integer2=Case(
                     When(integer=2, then=3),
@@ -545,7 +545,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter_without_default(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(
                 integer2=Case(
                     When(integer=2, then=3),
@@ -557,7 +557,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter_with_expression_as_value(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(
                 integer2=Case(
                     When(integer=2, then=F("integer") + 1),
@@ -570,7 +570,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter_with_expression_as_condition(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(
                 string=Case(
                     When(integer2=F("integer"), then=Value("2")),
@@ -582,7 +582,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter_with_join_in_value(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(
                 integer2=Case(
                     When(integer=2, then=F("o2o_rel__integer") + 1),
@@ -595,7 +595,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter_with_join_in_condition(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(
                 integer=Case(
                     When(integer2=F("o2o_rel__integer") + 1, then=2),
@@ -607,7 +607,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter_with_join_in_predicate(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(
                 integer2=Case(
                     When(o2o_rel__integer=1, then=1),
@@ -620,7 +620,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter_with_annotation_in_value(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 f=F("integer"),
                 f_plus_1=F("integer") + 1,
@@ -637,7 +637,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter_with_annotation_in_condition(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 f_plus_1=F("integer") + 1,
             )
@@ -653,7 +653,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter_with_annotation_in_predicate(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 f_plus_1=F("integer") + 1,
             )
@@ -670,7 +670,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter_with_aggregation_in_value(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.values(*self.group_by_fields)
             .annotate(
                 min=Min("fk_rel__integer"),
@@ -688,7 +688,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter_with_aggregation_in_condition(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.values(*self.group_by_fields)
             .annotate(
                 min=Min("fk_rel__integer"),
@@ -706,7 +706,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_filter_with_aggregation_in_predicate(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.values(*self.group_by_fields)
             .annotate(
                 max=Max("fk_rel__integer"),
@@ -730,7 +730,7 @@ class CaseExpressionTests(TestCase):
                 default=Value("other"),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, "one"),
@@ -751,7 +751,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=2),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [(1, 1), (2, 2), (3, None), (2, 2), (3, None), (3, None), (4, None)],
             transform=attrgetter("integer", "integer2"),
@@ -765,7 +765,7 @@ class CaseExpressionTests(TestCase):
                 default="integer",
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [("1", 2), ("2", 5), ("3", 3), ("2", 5), ("3", 3), ("3", 3), ("4", 4)],
             transform=attrgetter("string", "integer"),
@@ -778,7 +778,7 @@ class CaseExpressionTests(TestCase):
                 When(integer2=F("integer") + 1, then=Value("+1")),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, "equal"),
@@ -823,7 +823,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=2),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [(1, 1), (2, 2), (3, None), (2, 2), (3, None), (3, None), (4, None)],
             transform=attrgetter("integer", "big_integer"),
@@ -837,7 +837,7 @@ class CaseExpressionTests(TestCase):
                 default=b"",
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, b"one"),
@@ -859,7 +859,7 @@ class CaseExpressionTests(TestCase):
                 default=False,
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, True),
@@ -880,7 +880,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=date(2015, 1, 2)),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, date(2015, 1, 1)),
@@ -901,7 +901,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=datetime(2015, 1, 2)),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, datetime(2015, 1, 1)),
@@ -924,7 +924,7 @@ class CaseExpressionTests(TestCase):
                 ),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, Decimal("1.1")),
@@ -945,7 +945,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=timedelta(2)),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, timedelta(1)),
@@ -967,7 +967,7 @@ class CaseExpressionTests(TestCase):
                 default=Value(""),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, "1@example.com"),
@@ -988,7 +988,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=Value("~/2")),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [(1, "~/1"), (2, "~/2"), (3, ""), (2, "~/2"), (3, ""), (3, ""), (4, "")],
             transform=lambda o: (o.integer, str(o.file)),
@@ -1002,7 +1002,7 @@ class CaseExpressionTests(TestCase):
                 default=Value(""),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [(1, "~/1"), (2, "~/2"), (3, ""), (2, "~/2"), (3, ""), (3, ""), (4, "")],
             transform=attrgetter("integer", "file_path"),
@@ -1015,7 +1015,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=2.2),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [(1, 1.1), (2, 2.2), (3, None), (2, 2.2), (3, None), (3, None), (4, None)],
             transform=attrgetter("integer", "float"),
@@ -1029,7 +1029,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=Value("~/2")),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [(1, "~/1"), (2, "~/2"), (3, ""), (2, "~/2"), (3, ""), (3, ""), (4, "")],
             transform=lambda o: (o.integer, str(o.image)),
@@ -1043,7 +1043,7 @@ class CaseExpressionTests(TestCase):
                 output_field=GenericIPAddressField(),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, "1.1.1.1"),
@@ -1064,7 +1064,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=False),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, True),
@@ -1085,7 +1085,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=2),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [(1, 1), (2, 2), (3, None), (2, 2), (3, None), (3, None), (4, None)],
             transform=attrgetter("integer", "positive_big_integer"),
@@ -1098,7 +1098,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=2),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [(1, 1), (2, 2), (3, None), (2, 2), (3, None), (3, None), (4, None)],
             transform=attrgetter("integer", "positive_integer"),
@@ -1111,7 +1111,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=2),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [(1, 1), (2, 2), (3, None), (2, 2), (3, None), (3, None), (4, None)],
             transform=attrgetter("integer", "positive_small_integer"),
@@ -1125,7 +1125,7 @@ class CaseExpressionTests(TestCase):
                 default=Value(""),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [(1, "1"), (2, "2"), (3, ""), (2, "2"), (3, ""), (3, ""), (4, "")],
             transform=attrgetter("integer", "slug"),
@@ -1138,7 +1138,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=2),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [(1, 1), (2, 2), (3, None), (2, 2), (3, None), (3, None), (4, None)],
             transform=attrgetter("integer", "small_integer"),
@@ -1151,7 +1151,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=Value("2")),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(string__in=["1", "2"]).order_by("pk"),
             [(1, "1"), (2, "2"), (2, "2")],
             transform=attrgetter("integer", "string"),
@@ -1165,7 +1165,7 @@ class CaseExpressionTests(TestCase):
                 default=Value(""),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [(1, "1"), (2, "2"), (3, ""), (2, "2"), (3, ""), (3, ""), (4, "")],
             transform=attrgetter("integer", "text"),
@@ -1178,7 +1178,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=time(2)),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, time(1)),
@@ -1200,7 +1200,7 @@ class CaseExpressionTests(TestCase):
                 default=Value(""),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, "http://1.example.com/"),
@@ -1221,7 +1221,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=UUID("22222222222222222222222222222222")),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, UUID("11111111111111111111111111111111")),
@@ -1244,7 +1244,7 @@ class CaseExpressionTests(TestCase):
                 When(integer=2, then=obj2.pk),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.order_by("pk"),
             [
                 (1, obj1.pk),
@@ -1259,7 +1259,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_lookup_in_condition(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 test=Case(
                     When(integer__lt=2, then=Value("less than 2")),
@@ -1280,7 +1280,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_lookup_different_fields(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 test=Case(
                     When(integer=2, integer2=3, then=Value("when")),
@@ -1300,7 +1300,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_combined_q_object(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.annotate(
                 test=Case(
                     When(Q(integer=2) | Q(integer2=3), then=Value("when")),
@@ -1320,7 +1320,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_order_by_conditional_implicit(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(integer__lte=2)
             .annotate(
                 test=Case(
@@ -1335,7 +1335,7 @@ class CaseExpressionTests(TestCase):
         )
 
     def test_order_by_conditional_explicit(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(integer__lte=2)
             .annotate(
                 test=Case(
@@ -1357,7 +1357,7 @@ class CaseExpressionTests(TestCase):
         #    would remove o from the results. So, in effect we are testing that
         #    we are promoting the fk_rel join to a left outer join here.
         # 2. The default value of 3 is generated for the case expression.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(pk=o.pk).annotate(
                 foo=Case(
                     When(fk_rel__pk=1, then=2),
@@ -1368,7 +1368,7 @@ class CaseExpressionTests(TestCase):
             lambda x: (x, x.foo),
         )
         # Now 2 should be generated, as the fk_rel is null.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(pk=o.pk).annotate(
                 foo=Case(
                     When(fk_rel__isnull=True, then=2),
@@ -1387,7 +1387,7 @@ class CaseExpressionTests(TestCase):
         #    would remove o from the results. So, in effect we are testing that
         #    we are promoting the fk_rel join to a left outer join here.
         # 2. The default value of 3 is generated for the case expression.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(pk=o.pk).annotate(
                 foo=Case(
                     When(fk_rel__pk=1, then=2),
@@ -1402,7 +1402,7 @@ class CaseExpressionTests(TestCase):
             lambda x: (x, x.foo, x.bar),
         )
         # Now 2 should be generated, as the fk_rel is null.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             CaseTestModel.objects.filter(pk=o.pk).annotate(
                 foo=Case(
                     When(fk_rel__isnull=True, then=2),
@@ -1434,7 +1434,7 @@ class CaseExpressionTests(TestCase):
         # The integer=4 case has one integer, thus the result is 1, and
         # integer=10 doesn't have any and this too generates 1 (instead of 0)
         # as ~Q() also matches nulls.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [(1, 2), (2, 2), (2, 2), (3, 2), (3, 2), (3, 2), (4, 1), (10, 1)],
             lambda x: x[1:],
@@ -1459,7 +1459,7 @@ class CaseExpressionTests(TestCase):
             .order_by("integer")
         )
         self.assertEqual(str(qs.query).count(" JOIN "), 1)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 (1, 2, 2),
@@ -1485,7 +1485,7 @@ class CaseExpressionTests(TestCase):
         ]
         for case, value in tests:
             with self.subTest(case=case):
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     CaseTestModel.objects.values("string")
                     .annotate(
                         case=case,
@@ -1522,7 +1522,7 @@ class CaseDocumentationExamples(TestCase):
         )
 
     def test_simple_example(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Client.objects.annotate(
                 discount=Case(
                     When(account_type=Client.GOLD, then=Value("5%")),
@@ -1537,7 +1537,7 @@ class CaseDocumentationExamples(TestCase):
     def test_lookup_example(self):
         a_month_ago = date.today() - timedelta(days=30)
         a_year_ago = date.today() - timedelta(days=365)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Client.objects.annotate(
                 discount=Case(
                     When(registered_on__lte=a_year_ago, then=Value("10%")),
@@ -1559,7 +1559,7 @@ class CaseDocumentationExamples(TestCase):
                 default=Value(Client.REGULAR),
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Client.objects.order_by("pk"),
             [("Jane Doe", "G"), ("James Smith", "R"), ("Jack Black", "P")],
             transform=attrgetter("name", "account_type"),
@@ -1614,7 +1614,7 @@ class CaseDocumentationExamples(TestCase):
     def test_filter_example(self):
         a_month_ago = date.today() - timedelta(days=30)
         a_year_ago = date.today() - timedelta(days=365)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Client.objects.filter(
                 registered_on__lte=Case(
                     When(account_type=Client.GOLD, then=a_month_ago),

--- a/tests/expressions_window/tests.py
+++ b/tests/expressions_window/tests.py
@@ -103,7 +103,7 @@ class WindowFunctionTests(TestCase):
                 qs = Employee.objects.annotate(
                     rank=Window(expression=DenseRank(), order_by=order_by),
                 )
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     qs,
                     [
                         ("Jones", 45000, "Accounting", datetime.date(2005, 11, 1), 1),
@@ -137,7 +137,7 @@ class WindowFunctionTests(TestCase):
                 order_by=[F("hire_date").asc()],
             )
         ).order_by("department", "department_sum")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Jones", "Accounting", 45000, 45000),
@@ -173,7 +173,7 @@ class WindowFunctionTests(TestCase):
                 order_by=F("hire_date__year").asc(),
             )
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Jones", 45000, "Accounting", datetime.date(2005, 11, 1), 1),
@@ -212,7 +212,7 @@ class WindowFunctionTests(TestCase):
                 order_by=F("pk").asc(),
             )
         ).order_by("pk")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Jones", "Accounting", 1),
@@ -242,7 +242,7 @@ class WindowFunctionTests(TestCase):
                 expression=RowNumber(),
             )
         ).order_by("pk")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Jones", "Accounting", 1),
@@ -269,7 +269,7 @@ class WindowFunctionTests(TestCase):
                 partition_by="department",
             )
         ).order_by("department", "-salary", "name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Adams", 50000, "Accounting", 44250.00),
@@ -306,7 +306,7 @@ class WindowFunctionTests(TestCase):
                 order_by=[F("salary").asc(), F("name").asc()],
             )
         ).order_by("department", F("salary").asc(), F("name").asc())
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Williams", 37000, "Accounting", None),
@@ -333,7 +333,7 @@ class WindowFunctionTests(TestCase):
                 order_by=[F("bonus").asc(), F("name").asc()],
             )
         ).order_by("department", F("bonus").asc(), F("name").asc())
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Williams", 92.5, "Accounting", None),
@@ -360,7 +360,7 @@ class WindowFunctionTests(TestCase):
                 order_by=F("hire_date").asc(),
             )
         ).order_by("department", "hire_date")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Jones", 45000, "Accounting", datetime.date(2005, 11, 1), 45000),
@@ -393,7 +393,7 @@ class WindowFunctionTests(TestCase):
                 order_by=F("hire_date").asc(),
             )
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 (
@@ -531,7 +531,7 @@ class WindowFunctionTests(TestCase):
                 order_by=[F("salary").asc(), F("name").asc()],
             )
         ).order_by("department", "salary", "name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Williams", "Accounting", 37000, 37000),
@@ -562,7 +562,7 @@ class WindowFunctionTests(TestCase):
                 partition_by=ExtractYear("hire_date"),
             )
         ).order_by(ExtractYear("hire_date"), "salary")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Jones", "Accounting", 45000, 2005, 100000),
@@ -599,7 +599,7 @@ class WindowFunctionTests(TestCase):
             )
         ).order_by("salary", "name")
         # Round result of cume_dist because Oracle uses greater precision.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Moore", "IT", 34000, 0.0833333333),
@@ -631,7 +631,7 @@ class WindowFunctionTests(TestCase):
                 partition_by=F("department"),
             )
         ).order_by("department", "hire_date", "name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Jones", "Accounting", datetime.date(2005, 11, 1), 45000, None),
@@ -670,7 +670,7 @@ class WindowFunctionTests(TestCase):
                 partition_by="department",
             )
         ).order_by("department", F("hire_date").asc(), F("name").desc())
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Jones", 45000, "Accounting", datetime.date(2005, 11, 1), 45000),
@@ -707,7 +707,7 @@ class WindowFunctionTests(TestCase):
                 order_by=F("hire_date").asc(),
             )
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Jones", 45000, "Accounting", datetime.date(2005, 11, 1), 37000),
@@ -758,7 +758,7 @@ class WindowFunctionTests(TestCase):
                 order_by="-salary",
             )
         ).order_by("ntile", "-salary", "name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Miller", "Management", 100000, 1),
@@ -789,7 +789,7 @@ class WindowFunctionTests(TestCase):
             )
         ).order_by("percent_rank")
         # Round to account for precision differences among databases.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Moore", "IT", 34000, 0.0),
@@ -838,7 +838,7 @@ class WindowFunctionTests(TestCase):
                 partition_by=[F("department"), F("hire_date__year")],
             )
         ).order_by("department", "hire_date", "name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Jones", 45000, "Accounting", datetime.date(2005, 11, 1), 45000),
@@ -876,7 +876,7 @@ class WindowFunctionTests(TestCase):
                 order_by=[F("hire_date").asc(), F("name").asc()],
             )
         ).order_by("department", "sum")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Jones", 45000, "Accounting", datetime.date(2005, 11, 1), 45000),
@@ -921,25 +921,25 @@ class WindowFunctionTests(TestCase):
             ),
         ).order_by("department", "name")
         # Direct window reference.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.filter(department_salary_rank=1),
             ["Adams", "Wilkinson", "Miller", "Johnson", "Smith"],
             lambda employee: employee.name,
         )
         # Through a combined expression containing a window.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.filter(department_avg_age_diff__gt=0),
             ["Jenson", "Jones", "Williams", "Miller", "Smith"],
             lambda employee: employee.name,
         )
         # Intersection of multiple windows.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.filter(department_salary_rank=1, department_avg_age_diff__gt=0),
             ["Miller"],
             lambda employee: employee.name,
         )
         # Union of multiple windows.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.filter(Q(department_salary_rank=1) | Q(department_avg_age_diff__gt=0)),
             [
                 "Adams",
@@ -1021,7 +1021,7 @@ class WindowFunctionTests(TestCase):
                 Window(Avg("age"), partition_by="department") - F("age")
             ),
         ).order_by("department", "name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.filter(department_avg_age_diff__gt=0),
             ["Jenson", "Jones", "Williams", "Miller", "Smith"],
             lambda employee: employee.name,
@@ -1038,7 +1038,7 @@ class WindowFunctionTests(TestCase):
             .filter(department_avg_age_diff__gt=0)
             .order_by("department", "name")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             ["Jenson", "Jones", "Williams", "Miller", "Smith"],
             lambda employee: employee.name,
@@ -1056,19 +1056,19 @@ class WindowFunctionTests(TestCase):
             ),
         ).order_by("department", "name")
         # Direct window reference.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.exclude(department_salary_rank__gt=1),
             ["Adams", "Wilkinson", "Miller", "Johnson", "Smith"],
             lambda employee: employee.name,
         )
         # Through a combined expression containing a window.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.exclude(department_avg_age_diff__lte=0),
             ["Jenson", "Jones", "Williams", "Miller", "Smith"],
             lambda employee: employee.name,
         )
         # Union of multiple windows.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.exclude(
                 Q(department_salary_rank__gt=1) | Q(department_avg_age_diff__lte=0)
             ),
@@ -1076,7 +1076,7 @@ class WindowFunctionTests(TestCase):
             lambda employee: employee.name,
         )
         # Intersection of multiple windows.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.exclude(department_salary_rank__gt=1, department_avg_age_diff__lte=0),
             [
                 "Adams",
@@ -1144,7 +1144,7 @@ class WindowFunctionTests(TestCase):
         A query filtering against a window function have its limit applied
         after window filtering takes place.
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Employee.objects.annotate(
                 department_salary_rank=Window(
                     Rank(), partition_by="department", order_by="-salary"
@@ -1179,7 +1179,7 @@ class WindowFunctionTests(TestCase):
             )
         )
         self.assertIn("RANGE BETWEEN 2 PRECEDING AND 2 FOLLOWING", str(qs.query))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Williams", 37000, "Accounting", datetime.date(2009, 6, 1), 37000),
@@ -1218,7 +1218,7 @@ class WindowFunctionTests(TestCase):
         self.assertIn(
             "RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING", str(qs.query)
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Jones", "Accounting", 45000, datetime.date(2005, 11, 1), 165000),
@@ -1260,7 +1260,7 @@ class WindowFunctionTests(TestCase):
                 .values("hire_date")[:1],
             ),
         ).order_by("department", "name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Adams", "Accounting", datetime.date(2005, 11, 1)),
@@ -1297,7 +1297,7 @@ class WindowFunctionTests(TestCase):
             )
         ).order_by("sum", "hire_date")
         self.assertIn("ROWS BETWEEN UNBOUNDED PRECEDING AND 3 FOLLOWING", str(qs.query))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Miller", 100000, "Management", datetime.date(2005, 6, 1), 280000),
@@ -1430,7 +1430,7 @@ class WindowFunctionTests(TestCase):
                         order_by=[order_by],
                     )
                 ).order_by("value__department", "department_sum")
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     qs,
                     [
                         ("Brown", "HR", 50000, 50000),

--- a/tests/extra_regress/tests.py
+++ b/tests/extra_regress/tests.py
@@ -44,7 +44,7 @@ class ExtraRegressTests(TestCase):
             ]
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [("Second Revision", "First Revision")],
             transform=lambda r: (r.title, r.base.title),
@@ -52,7 +52,7 @@ class ExtraRegressTests(TestCase):
 
         # Queryset to search for string in title:
         qs2 = RevisionableModel.objects.filter(title__contains="Revision")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs2,
             [
                 ("First Revision", "First Revision"),
@@ -63,7 +63,7 @@ class ExtraRegressTests(TestCase):
         )
 
         # Following queryset should return the most recent revision:
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs & qs2,
             [("Second Revision", "First Revision")],
             transform=lambda r: (r.title, r.base.title),
@@ -139,7 +139,7 @@ class ExtraRegressTests(TestCase):
         but then removes the reference because of an optimization. The table
         should still be present because of the extra() call.
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             (
                 Order.objects.extra(
                     where=["username=%s"], params=["fred"], tables=["auth_user"]

--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -70,7 +70,7 @@ class FilteredRelationTests(TestCase):
             .order_by("pk", "book_join__pk")
         )
         with self.assertNumQueries(1):
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 qs,
                 [
                     (self.author1, self.book1, self.editor_a, self.author1),
@@ -90,7 +90,7 @@ class FilteredRelationTests(TestCase):
             .select_related("author_join", "editor_join")
             .order_by("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 (self.book1, self.author1, self.editor_a),
@@ -120,7 +120,7 @@ class FilteredRelationTests(TestCase):
             .order_by("pk")
         )
         with self.assertNumQueries(1):
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 qs,
                 [
                     (self.book1, self.author1),
@@ -143,7 +143,7 @@ class FilteredRelationTests(TestCase):
                 .order_by("pk")
             )
             with self.assertNumQueries(1):
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     qs,
                     [
                         (self.book1, self.author1),
@@ -408,7 +408,7 @@ class FilteredRelationTests(TestCase):
     def test_defer(self):
         # One query for the list and one query for the deferred title.
         with self.assertNumQueries(2):
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 Author.objects.annotate(
                     book_alice=FilteredRelation(
                         "book", condition=Q(book__title__iexact="poem by alice")
@@ -458,7 +458,7 @@ class FilteredRelationTests(TestCase):
             .order_by("pk", "book_editor_worked_with__pk")
         )
         with self.assertNumQueries(1):
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 qs,
                 [
                     (self.author1, self.editor_a),
@@ -567,7 +567,7 @@ class FilteredRelationTests(TestCase):
             )
             .order_by("author", "book_title", "preferred_by_author_pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 ("Alice", "The book by Alice", None),
@@ -594,7 +594,7 @@ class FilteredRelationTests(TestCase):
             .order_by("pk", "author_favorite_book_editor__pk")
         )
         with self.assertNumQueries(1):
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 qs,
                 [
                     (self.book1, self.editor_b),

--- a/tests/fixtures/tests.py
+++ b/tests/fixtures/tests.py
@@ -274,7 +274,7 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
 
         # Load fixture 6, JSON file with dynamic ContentType fields. Testing ManyToOne.
         management.call_command("loaddata", "fixture6.json", verbosity=0)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Tag.objects.all(),
             [
                 '<Tag: <Article: Copyright is fine the way it is> tagged "copyright">',
@@ -286,7 +286,7 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
 
         # Load fixture 7, XML file with dynamic ContentType fields. Testing ManyToOne.
         management.call_command("loaddata", "fixture7.xml", verbosity=0)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Tag.objects.all(),
             [
                 '<Tag: <Article: Copyright is fine the way it is> tagged "copyright">',
@@ -300,7 +300,7 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
 
         # Load fixture 8, JSON file with dynamic Permission fields. Testing ManyToMany.
         management.call_command("loaddata", "fixture8.json", verbosity=0)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Visa.objects.all(),
             [
                 "<Visa: Django Reinhardt Can add user, Can change user, Can delete "
@@ -314,7 +314,7 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
 
         # Load fixture 9, XML file with dynamic Permission fields. Testing ManyToMany.
         management.call_command("loaddata", "fixture9.xml", verbosity=0)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Visa.objects.all(),
             [
                 "<Visa: Django Reinhardt Can add user, Can change user, Can delete "
@@ -934,7 +934,7 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
             management.call_command(
                 "loaddata", "db_fixture_1", verbosity=0, app_label="someotherapp"
             )
-        self.assertQuerysetEqual(Article.objects.all(), [])
+        self.assertQuerySetEqual(Article.objects.all(), [])
         management.call_command(
             "loaddata", "db_fixture_1", verbosity=0, app_label="fixtures"
         )
@@ -985,7 +985,7 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
             management.call_command(
                 "loaddata", "db_fixture_3", verbosity=0, database="default"
             )
-        self.assertQuerysetEqual(Article.objects.all(), [])
+        self.assertQuerySetEqual(Article.objects.all(), [])
 
     def test_output_formats(self):
         # Load back in fixture 1, we need the articles from it
@@ -993,7 +993,7 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
 
         # Try to load fixture 6 using format discovery
         management.call_command("loaddata", "fixture6", verbosity=0)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Tag.objects.all(),
             [
                 '<Tag: <Article: Time to reform copyright> tagged "copyright">',

--- a/tests/fixtures_model_package/tests.py
+++ b/tests/fixtures_model_package/tests.py
@@ -10,7 +10,7 @@ class SampleTestCase(TestCase):
 
     def test_class_fixtures(self):
         "Test cases can load fixture objects into models defined in packages"
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.all(),
             [
                 "Django conquers world!",
@@ -26,7 +26,7 @@ class FixtureTestCase(TestCase):
         "Fixtures can load data into models defined in packages"
         # Load fixture 1. Single JSON file, with two objects
         management.call_command("loaddata", "model_package_fixture1.json", verbosity=0)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.all(),
             [
                 "Time to reform copyright",
@@ -38,7 +38,7 @@ class FixtureTestCase(TestCase):
         # Load fixture 2. JSON file imported by default. Overwrites some
         # existing objects
         management.call_command("loaddata", "model_package_fixture2.json", verbosity=0)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.all(),
             [
                 "Django conquers world!",
@@ -54,7 +54,7 @@ class FixtureTestCase(TestCase):
         ):
             management.call_command("loaddata", "unknown.json", verbosity=0)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.all(),
             [
                 "Django conquers world!",

--- a/tests/fixtures_regress/tests.py
+++ b/tests/fixtures_regress/tests.py
@@ -599,7 +599,7 @@ class TestFixtures(TestCase):
     @override_settings(FIXTURE_DIRS=[Path(_cur_dir) / "fixtures_1"])
     def test_fixtures_dir_pathlib(self):
         management.call_command("loaddata", "inner/absolute.json", verbosity=0)
-        self.assertQuerysetEqual(Absolute.objects.all(), [1], transform=lambda o: o.pk)
+        self.assertQuerySetEqual(Absolute.objects.all(), [1], transform=lambda o: o.pk)
 
 
 class NaturalKeyFixtureTests(TestCase):
@@ -792,7 +792,7 @@ class NaturalKeyFixtureTests(TestCase):
             verbosity=0,
         )
         books = Book.objects.all()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             books,
             [
                 "<Book: Cryptonomicon by Neal Stephenson (available at Amazon, "

--- a/tests/foreign_object/test_agnostic_order_trimjoin.py
+++ b/tests/foreign_object/test_agnostic_order_trimjoin.py
@@ -13,14 +13,14 @@ class TestLookupQuery(TestCase):
         cls.contact1 = Contact.objects.create(company_code=1, customer_code=20)
 
     def test_deep_mixed_forward(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Address.objects.filter(customer__contacts=self.contact1),
             [self.address.id],
             attrgetter("id"),
         )
 
     def test_deep_mixed_backward(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Contact.objects.filter(customer__address=self.address),
             [self.contact1.id],
             attrgetter("id"),

--- a/tests/foreign_object/tests.py
+++ b/tests/foreign_object/tests.py
@@ -113,7 +113,7 @@ class MultiColumnFKTests(TestCase):
             group_id=self.cia.id,
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Membership.objects.filter(person__name__contains="o"),
             [self.bob.id],
             attrgetter("person_id"),
@@ -146,7 +146,7 @@ class MultiColumnFKTests(TestCase):
             date_joined=timemark + timedelta,
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Person.objects.filter(membership__date_joined__gte=timemark),
             ["Jim"],
             attrgetter("name"),
@@ -171,14 +171,14 @@ class MultiColumnFKTests(TestCase):
             group_id=self.cia.id,
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Membership.objects.filter(person__in=[self.george, self.jim]),
             [
                 self.jim.id,
             ],
             attrgetter("person_id"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Membership.objects.filter(person__in=Person.objects.filter(name="Jim")),
             [
                 self.jim.id,
@@ -281,7 +281,7 @@ class MultiColumnFKTests(TestCase):
 
     def test_m2m_through_forward_returns_valid_members(self):
         # We start out by making sure that the Group 'CIA' has no members.
-        self.assertQuerysetEqual(self.cia.members.all(), [])
+        self.assertQuerySetEqual(self.cia.members.all(), [])
 
         Membership.objects.create(
             membership_country=self.usa, person=self.bob, group=self.cia
@@ -292,13 +292,13 @@ class MultiColumnFKTests(TestCase):
 
         # Bob and Jim should be members of the CIA.
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.cia.members.all(), ["Bob", "Jim"], attrgetter("name")
         )
 
     def test_m2m_through_reverse_returns_valid_members(self):
         # We start out by making sure that Bob is in no groups.
-        self.assertQuerysetEqual(self.bob.groups.all(), [])
+        self.assertQuerySetEqual(self.bob.groups.all(), [])
 
         Membership.objects.create(
             membership_country=self.usa, person=self.bob, group=self.cia
@@ -308,13 +308,13 @@ class MultiColumnFKTests(TestCase):
         )
 
         # Bob should be in the CIA and a Republican
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.bob.groups.all(), ["CIA", "Republican"], attrgetter("name")
         )
 
     def test_m2m_through_forward_ignores_invalid_members(self):
         # We start out by making sure that the Group 'CIA' has no members.
-        self.assertQuerysetEqual(self.cia.members.all(), [])
+        self.assertQuerySetEqual(self.cia.members.all(), [])
 
         # Something adds jane to group CIA but Jane is in Soviet Union which
         # isn't CIA's country.
@@ -323,11 +323,11 @@ class MultiColumnFKTests(TestCase):
         )
 
         # There should still be no members in CIA
-        self.assertQuerysetEqual(self.cia.members.all(), [])
+        self.assertQuerySetEqual(self.cia.members.all(), [])
 
     def test_m2m_through_reverse_ignores_invalid_members(self):
         # We start out by making sure that Jane has no groups.
-        self.assertQuerysetEqual(self.jane.groups.all(), [])
+        self.assertQuerySetEqual(self.jane.groups.all(), [])
 
         # Something adds jane to group CIA but Jane is in Soviet Union which
         # isn't CIA's country.
@@ -336,10 +336,10 @@ class MultiColumnFKTests(TestCase):
         )
 
         # Jane should still not be in any groups
-        self.assertQuerysetEqual(self.jane.groups.all(), [])
+        self.assertQuerySetEqual(self.jane.groups.all(), [])
 
     def test_m2m_through_on_self_works(self):
-        self.assertQuerysetEqual(self.jane.friends.all(), [])
+        self.assertQuerySetEqual(self.jane.friends.all(), [])
 
         Friendship.objects.create(
             from_friend_country=self.jane.person_country,
@@ -348,12 +348,12 @@ class MultiColumnFKTests(TestCase):
             to_friend=self.george,
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.jane.friends.all(), ["George"], attrgetter("name")
         )
 
     def test_m2m_through_on_self_ignores_mismatch_columns(self):
-        self.assertQuerysetEqual(self.jane.friends.all(), [])
+        self.assertQuerySetEqual(self.jane.friends.all(), [])
 
         # Note that we use ids instead of instances. This is because instances
         # on ForeignObject properties will set all related field off of the
@@ -365,7 +365,7 @@ class MultiColumnFKTests(TestCase):
             from_friend_country_id=self.george.person_country_id,
         )
 
-        self.assertQuerysetEqual(self.jane.friends.all(), [])
+        self.assertQuerySetEqual(self.jane.friends.all(), [])
 
     def test_prefetch_related_m2m_forward_works(self):
         Membership.objects.create(

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -122,7 +122,7 @@ class GenericRelationsTests(TestCase):
         qs = TaggedItem.objects.filter(
             Q(animal__isnull=False) | Q(manualpk__id=1)
         ).order_by("tag")
-        self.assertQuerysetEqual(qs, ["hairy", "mpk", "yellow"], lambda x: x.tag)
+        self.assertQuerySetEqual(qs, ["hairy", "mpk", "yellow"], lambda x: x.tag)
 
     def test_exclude_generic_relations(self):
         """
@@ -199,7 +199,7 @@ class GenericRelationsTests(TestCase):
         If you delete an object with an explicit Generic relation, the related
         objects are deleted when the source object is deleted.
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             TaggedItem.objects.all(),
             [
                 ("fatty", Vegetable, self.bacon.pk),
@@ -211,7 +211,7 @@ class GenericRelationsTests(TestCase):
         )
         self.lion.delete()
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             TaggedItem.objects.all(),
             [
                 ("fatty", Vegetable, self.bacon.pk),
@@ -228,7 +228,7 @@ class GenericRelationsTests(TestCase):
         TaggedItem.objects.create(content_object=self.quartz, tag="clearish")
         quartz_pk = self.quartz.pk
         self.quartz.delete()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             TaggedItem.objects.all(),
             [
                 ("clearish", Mineral, quartz_pk),
@@ -252,7 +252,7 @@ class GenericRelationsTests(TestCase):
         tag.delete()
 
         self.assertSequenceEqual(self.lion.tags.all(), [self.yellow])
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             TaggedItem.objects.all(),
             [
                 ("fatty", Vegetable, self.bacon.pk),

--- a/tests/generic_views/test_edit.py
+++ b/tests/generic_views/test_edit.py
@@ -113,7 +113,7 @@ class CreateViewTests(TestCase):
         )
         self.assertEqual(res.status_code, 302)
         self.assertRedirects(res, "/list/authors/")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.values_list("name", flat=True), ["Randall Munroe"]
         )
 
@@ -131,7 +131,7 @@ class CreateViewTests(TestCase):
         self.assertEqual(res.status_code, 302)
         artist = Artist.objects.get(name="Rene Magritte")
         self.assertRedirects(res, "/detail/artist/%d/" % artist.pk)
-        self.assertQuerysetEqual(Artist.objects.all(), [artist])
+        self.assertQuerySetEqual(Artist.objects.all(), [artist])
 
     def test_create_with_redirect(self):
         res = self.client.post(
@@ -140,7 +140,7 @@ class CreateViewTests(TestCase):
         )
         self.assertEqual(res.status_code, 302)
         self.assertRedirects(res, "/edit/authors/create/")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.values_list("name", flat=True), ["Randall Munroe"]
         )
 
@@ -149,7 +149,7 @@ class CreateViewTests(TestCase):
             "/edit/authors/create/interpolate_redirect/",
             {"name": "Randall Munroe", "slug": "randall-munroe"},
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.values_list("name", flat=True), ["Randall Munroe"]
         )
         self.assertEqual(res.status_code, 302)
@@ -179,7 +179,7 @@ class CreateViewTests(TestCase):
         self.assertEqual(res.status_code, 302)
         obj = Author.objects.get(slug="randall-munroe")
         self.assertRedirects(res, reverse("author_detail", kwargs={"pk": obj.pk}))
-        self.assertQuerysetEqual(Author.objects.all(), [obj])
+        self.assertQuerySetEqual(Author.objects.all(), [obj])
 
     def test_create_without_redirect(self):
         msg = (
@@ -266,7 +266,7 @@ class UpdateViewTests(TestCase):
         )
         self.assertEqual(res.status_code, 302)
         self.assertRedirects(res, "/list/authors/")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.values_list("name", flat=True), ["Randall Munroe (xkcd)"]
         )
 
@@ -278,7 +278,7 @@ class UpdateViewTests(TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertTemplateUsed(res, "generic_views/author_form.html")
         self.assertEqual(len(res.context["form"].errors), 1)
-        self.assertQuerysetEqual(Author.objects.all(), [self.author])
+        self.assertQuerySetEqual(Author.objects.all(), [self.author])
         self.assertEqual(res.context["view"].get_form_called_count, 1)
 
     def test_update_with_object_url(self):
@@ -288,7 +288,7 @@ class UpdateViewTests(TestCase):
         )
         self.assertEqual(res.status_code, 302)
         self.assertRedirects(res, "/detail/artist/%d/" % a.pk)
-        self.assertQuerysetEqual(Artist.objects.all(), [a])
+        self.assertQuerySetEqual(Artist.objects.all(), [a])
 
     def test_update_with_redirect(self):
         res = self.client.post(
@@ -297,7 +297,7 @@ class UpdateViewTests(TestCase):
         )
         self.assertEqual(res.status_code, 302)
         self.assertRedirects(res, "/edit/authors/create/")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.values_list("name", flat=True),
             ["Randall Munroe (author of xkcd)"],
         )
@@ -307,7 +307,7 @@ class UpdateViewTests(TestCase):
             "/edit/author/%d/update/interpolate_redirect/" % self.author.pk,
             {"name": "Randall Munroe (author of xkcd)", "slug": "randall-munroe"},
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.values_list("name", flat=True),
             ["Randall Munroe (author of xkcd)"],
         )
@@ -338,7 +338,7 @@ class UpdateViewTests(TestCase):
         )
         self.assertEqual(res.status_code, 302)
         self.assertRedirects(res, "/detail/author/%d/" % self.author.pk)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.values_list("name", flat=True),
             ["Randall Munroe (author of xkcd)"],
         )
@@ -370,7 +370,7 @@ class UpdateViewTests(TestCase):
         )
         self.assertEqual(res.status_code, 302)
         self.assertRedirects(res, "/list/authors/")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Author.objects.values_list("name", flat=True), ["Randall Munroe (xkcd)"]
         )
 
@@ -395,20 +395,20 @@ class DeleteViewTests(TestCase):
         res = self.client.post("/edit/author/%d/delete/" % self.author.pk)
         self.assertEqual(res.status_code, 302)
         self.assertRedirects(res, "/list/authors/")
-        self.assertQuerysetEqual(Author.objects.all(), [])
+        self.assertQuerySetEqual(Author.objects.all(), [])
 
     def test_delete_by_delete(self):
         # Deletion with browser compatible DELETE method
         res = self.client.delete("/edit/author/%d/delete/" % self.author.pk)
         self.assertEqual(res.status_code, 302)
         self.assertRedirects(res, "/list/authors/")
-        self.assertQuerysetEqual(Author.objects.all(), [])
+        self.assertQuerySetEqual(Author.objects.all(), [])
 
     def test_delete_with_redirect(self):
         res = self.client.post("/edit/author/%d/delete/redirect/" % self.author.pk)
         self.assertEqual(res.status_code, 302)
         self.assertRedirects(res, "/edit/authors/create/")
-        self.assertQuerysetEqual(Author.objects.all(), [])
+        self.assertQuerySetEqual(Author.objects.all(), [])
 
     def test_delete_with_interpolated_redirect(self):
         res = self.client.post(
@@ -416,7 +416,7 @@ class DeleteViewTests(TestCase):
         )
         self.assertEqual(res.status_code, 302)
         self.assertRedirects(res, "/edit/authors/create/?deleted=%d" % self.author.pk)
-        self.assertQuerysetEqual(Author.objects.all(), [])
+        self.assertQuerySetEqual(Author.objects.all(), [])
         # Also test with escaped chars in URL
         a = Author.objects.create(
             **{"name": "Randall Munroe", "slug": "randall-munroe"}
@@ -438,7 +438,7 @@ class DeleteViewTests(TestCase):
         res = self.client.post("/edit/author/%d/delete/special/" % self.author.pk)
         self.assertEqual(res.status_code, 302)
         self.assertRedirects(res, "/list/authors/")
-        self.assertQuerysetEqual(Author.objects.all(), [])
+        self.assertQuerySetEqual(Author.objects.all(), [])
 
     def test_delete_without_redirect(self):
         msg = "No URL to redirect to. Provide a success_url."

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -404,12 +404,12 @@ class GeoLookupTest(TestCase):
     @skipUnlessGISLookup("strictly_above", "strictly_below")
     def test_strictly_above_below_lookups(self):
         dallas = City.objects.get(name="Dallas")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             City.objects.filter(point__strictly_above=dallas.point).order_by("name"),
             ["Chicago", "Lawrence", "Oklahoma City", "Pueblo", "Victoria"],
             lambda b: b.name,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             City.objects.filter(point__strictly_below=dallas.point).order_by("name"),
             ["Houston", "Wellington"],
             lambda b: b.name,

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -130,7 +130,7 @@ class LookupTests(TestCase):
         # returns results using database-level iteration.
         self.assertIsInstance(Article.objects.iterator(), collections.abc.Iterator)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.iterator(),
             [
                 "Article 5",
@@ -144,7 +144,7 @@ class LookupTests(TestCase):
             transform=attrgetter("headline"),
         )
         # iterator() can be used on any QuerySet.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__endswith="4").iterator(),
             ["Article 4"],
             transform=attrgetter("headline"),
@@ -818,52 +818,52 @@ class LookupTests(TestCase):
             ]
         )
         # zero-or-more
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__regex=r"fo*"),
             Article.objects.filter(headline__in=["f", "fo", "foo", "fooo"]),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__iregex=r"fo*"),
             Article.objects.filter(headline__in=["f", "fo", "foo", "fooo", "hey-Foo"]),
         )
         # one-or-more
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__regex=r"fo+"),
             Article.objects.filter(headline__in=["fo", "foo", "fooo"]),
         )
         # wildcard
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__regex=r"fooo?"),
             Article.objects.filter(headline__in=["foo", "fooo"]),
         )
         # leading anchor
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__regex=r"^b"),
             Article.objects.filter(headline__in=["bar", "baxZ", "baz"]),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__iregex=r"^a"),
             Article.objects.filter(headline="AbBa"),
         )
         # trailing anchor
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__regex=r"z$"),
             Article.objects.filter(headline="baz"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__iregex=r"z$"),
             Article.objects.filter(headline__in=["baxZ", "baz"]),
         )
         # character sets
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__regex=r"ba[rz]"),
             Article.objects.filter(headline__in=["bar", "baz"]),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__regex=r"ba.[RxZ]"),
             Article.objects.filter(headline="baxZ"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__iregex=r"ba[RxZ]"),
             Article.objects.filter(headline__in=["bar", "baxZ", "baz"]),
         )
@@ -882,7 +882,7 @@ class LookupTests(TestCase):
         )
 
         # alternation
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__regex=r"oo(f|b)"),
             Article.objects.filter(
                 headline__in=[
@@ -893,7 +893,7 @@ class LookupTests(TestCase):
                 ]
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__iregex=r"oo(f|b)"),
             Article.objects.filter(
                 headline__in=[
@@ -905,13 +905,13 @@ class LookupTests(TestCase):
                 ]
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__regex=r"^foo(f|b)"),
             Article.objects.filter(headline__in=["foobar", "foobarbaz", "foobaz"]),
         )
 
         # greedy matching
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__regex=r"b.*az"),
             Article.objects.filter(
                 headline__in=[
@@ -923,7 +923,7 @@ class LookupTests(TestCase):
                 ]
             ),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__iregex=r"b.*ar"),
             Article.objects.filter(
                 headline__in=[
@@ -951,7 +951,7 @@ class LookupTests(TestCase):
                 Article(pub_date=now, headline="bazbaRFOO"),
             ]
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__regex=r"b(.).*b\1").values_list(
                 "headline", flat=True
             ),
@@ -963,14 +963,14 @@ class LookupTests(TestCase):
         A regex lookup does not fail on null/None values
         """
         Season.objects.create(year=2012, gt=None)
-        self.assertQuerysetEqual(Season.objects.filter(gt__regex=r"^$"), [])
+        self.assertQuerySetEqual(Season.objects.filter(gt__regex=r"^$"), [])
 
     def test_regex_non_string(self):
         """
         A regex lookup does not fail on non-string fields
         """
         s = Season.objects.create(year=2013, gt=444)
-        self.assertQuerysetEqual(Season.objects.filter(gt__regex=r"^444$"), [s])
+        self.assertQuerySetEqual(Season.objects.filter(gt__regex=r"^444$"), [s])
 
     def test_regex_non_ascii(self):
         """

--- a/tests/m2m_and_m2o/tests.py
+++ b/tests/m2m_and_m2o/tests.py
@@ -28,7 +28,7 @@ class RelatedObjectTests(TestCase):
         i3.save()
         i3.cc.add(r)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Issue.objects.filter(client=r.id),
             [
                 1,
@@ -36,15 +36,15 @@ class RelatedObjectTests(TestCase):
             ],
             lambda i: i.num,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Issue.objects.filter(client=g.id),
             [
                 3,
             ],
             lambda i: i.num,
         )
-        self.assertQuerysetEqual(Issue.objects.filter(cc__id__exact=g.id), [])
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(Issue.objects.filter(cc__id__exact=g.id), [])
+        self.assertQuerySetEqual(
             Issue.objects.filter(cc__id__exact=r.id),
             [
                 2,
@@ -55,7 +55,7 @@ class RelatedObjectTests(TestCase):
 
         # These queries combine results from the m2m and the m2o relationships.
         # They're three ways of saying the same thing.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Issue.objects.filter(Q(cc__id__exact=r.id) | Q(client=r.id)),
             [
                 1,
@@ -64,7 +64,7 @@ class RelatedObjectTests(TestCase):
             ],
             lambda i: i.num,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Issue.objects.filter(cc__id__exact=r.id)
             | Issue.objects.filter(client=r.id),
             [
@@ -74,7 +74,7 @@ class RelatedObjectTests(TestCase):
             ],
             lambda i: i.num,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Issue.objects.filter(Q(client=r.id) | Q(cc__id__exact=r.id)),
             [
                 1,

--- a/tests/m2m_intermediary/tests.py
+++ b/tests/m2m_intermediary/tests.py
@@ -17,7 +17,7 @@ class M2MIntermediaryTests(TestCase):
         w1 = Writer.objects.create(reporter=r1, article=a, position="Main writer")
         w2 = Writer.objects.create(reporter=r2, article=a, position="Contributor")
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             a.writer_set.select_related().order_by("-position"),
             [
                 ("John Smith", "Main writer"),
@@ -31,7 +31,7 @@ class M2MIntermediaryTests(TestCase):
         self.assertEqual(w1.article, a)
         self.assertEqual(w2.article, a)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             r1.writer_set.all(),
             [("John Smith", "Main writer")],
             lambda w: (str(w.reporter), w.position),

--- a/tests/m2m_multiple/tests.py
+++ b/tests/m2m_multiple/tests.py
@@ -24,7 +24,7 @@ class M2MMultipleTests(TestCase):
         a2.primary_categories.add(c1, c2)
         a2.secondary_categories.add(c4)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             a1.primary_categories.all(),
             [
                 "Crime",
@@ -32,7 +32,7 @@ class M2MMultipleTests(TestCase):
             ],
             lambda c: c.name,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             a2.primary_categories.all(),
             [
                 "News",
@@ -40,22 +40,22 @@ class M2MMultipleTests(TestCase):
             ],
             lambda c: c.name,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             a1.secondary_categories.all(),
             [
                 "Life",
             ],
             lambda c: c.name,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             c1.primary_article_set.all(),
             [
                 "Parrot runs",
             ],
             lambda a: a.headline,
         )
-        self.assertQuerysetEqual(c1.secondary_article_set.all(), [])
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(c1.secondary_article_set.all(), [])
+        self.assertQuerySetEqual(
             c2.primary_article_set.all(),
             [
                 "Parrot steals",
@@ -63,17 +63,17 @@ class M2MMultipleTests(TestCase):
             ],
             lambda a: a.headline,
         )
-        self.assertQuerysetEqual(c2.secondary_article_set.all(), [])
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(c2.secondary_article_set.all(), [])
+        self.assertQuerySetEqual(
             c3.primary_article_set.all(),
             [
                 "Parrot steals",
             ],
             lambda a: a.headline,
         )
-        self.assertQuerysetEqual(c3.secondary_article_set.all(), [])
-        self.assertQuerysetEqual(c4.primary_article_set.all(), [])
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(c3.secondary_article_set.all(), [])
+        self.assertQuerySetEqual(c4.primary_article_set.all(), [])
+        self.assertQuerySetEqual(
             c4.secondary_article_set.all(),
             [
                 "Parrot steals",

--- a/tests/m2m_through/tests.py
+++ b/tests/m2m_through/tests.py
@@ -44,7 +44,7 @@ class M2mThroughTests(TestCase):
         Membership.objects.create(person=self.jane, group=self.rock)
 
         expected = ["Jane", "Jim"]
-        self.assertQuerysetEqual(self.rock.members.all(), expected, attrgetter("name"))
+        self.assertQuerySetEqual(self.rock.members.all(), expected, attrgetter("name"))
 
     def test_get_on_intermediate_model(self):
         Membership.objects.create(person=self.jane, group=self.rock)
@@ -204,14 +204,14 @@ class M2mThroughTests(TestCase):
 
         self.rock.members.clear()
 
-        self.assertQuerysetEqual(self.rock.members.all(), [])
+        self.assertQuerySetEqual(self.rock.members.all(), [])
 
     def test_retrieve_reverse_intermediate_items(self):
         Membership.objects.create(person=self.jim, group=self.rock)
         Membership.objects.create(person=self.jim, group=self.roll)
 
         expected = ["Rock", "Roll"]
-        self.assertQuerysetEqual(self.jim.group_set.all(), expected, attrgetter("name"))
+        self.assertQuerySetEqual(self.jim.group_set.all(), expected, attrgetter("name"))
 
     def test_add_on_reverse_m2m_with_intermediate_model(self):
         self.bob.group_set.add(self.rock)
@@ -237,7 +237,7 @@ class M2mThroughTests(TestCase):
 
         self.jim.group_set.clear()
 
-        self.assertQuerysetEqual(self.jim.group_set.all(), [])
+        self.assertQuerySetEqual(self.jim.group_set.all(), [])
 
     def test_query_model_by_attribute_name_of_related_model(self):
         Membership.objects.create(person=self.jim, group=self.rock)
@@ -246,7 +246,7 @@ class M2mThroughTests(TestCase):
         Membership.objects.create(person=self.jim, group=self.roll)
         Membership.objects.create(person=self.jane, group=self.roll)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Group.objects.filter(members__name="Bob"), ["Roll"], attrgetter("name")
         )
 
@@ -284,7 +284,7 @@ class M2mThroughTests(TestCase):
         Membership.objects.create(person=self.bob, group=self.roll)
 
         qs = Group.objects.filter(membership__invite_reason="She was just awesome.")
-        self.assertQuerysetEqual(qs, ["Roll"], attrgetter("name"))
+        self.assertQuerySetEqual(qs, ["Roll"], attrgetter("name"))
 
     def test_query_second_model_by_intermediate_model_attribute(self):
         Membership.objects.create(
@@ -296,7 +296,7 @@ class M2mThroughTests(TestCase):
         Membership.objects.create(person=self.bob, group=self.roll)
 
         qs = Person.objects.filter(membership__invite_reason="She was just awesome.")
-        self.assertQuerysetEqual(qs, ["Jane"], attrgetter("name"))
+        self.assertQuerySetEqual(qs, ["Jane"], attrgetter("name"))
 
     def test_query_model_by_related_model_name(self):
         Membership.objects.create(person=self.jim, group=self.rock)
@@ -305,7 +305,7 @@ class M2mThroughTests(TestCase):
         Membership.objects.create(person=self.jim, group=self.roll)
         Membership.objects.create(person=self.jane, group=self.roll)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Person.objects.filter(group__name="Rock"),
             ["Jane", "Jim"],
             attrgetter("name"),
@@ -315,7 +315,7 @@ class M2mThroughTests(TestCase):
         CustomMembership.objects.create(person=self.bob, group=self.rock)
         CustomMembership.objects.create(person=self.jim, group=self.rock)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Person.objects.filter(custom__name="Rock"),
             ["Bob", "Jim"],
             attrgetter("name"),
@@ -335,19 +335,19 @@ class M2mThroughTests(TestCase):
         )
 
         qs = Person.objects.filter(membership__date_joined__gt=datetime(2004, 1, 1))
-        self.assertQuerysetEqual(qs, ["Jane", "Jim", "Jim"], attrgetter("name"))
+        self.assertQuerySetEqual(qs, ["Jane", "Jim", "Jim"], attrgetter("name"))
 
     def test_custom_related_name_forward_empty_qs(self):
-        self.assertQuerysetEqual(self.rock.custom_members.all(), [])
+        self.assertQuerySetEqual(self.rock.custom_members.all(), [])
 
     def test_custom_related_name_reverse_empty_qs(self):
-        self.assertQuerysetEqual(self.bob.custom.all(), [])
+        self.assertQuerySetEqual(self.bob.custom.all(), [])
 
     def test_custom_related_name_forward_non_empty_qs(self):
         CustomMembership.objects.create(person=self.bob, group=self.rock)
         CustomMembership.objects.create(person=self.jim, group=self.rock)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.rock.custom_members.all(), ["Bob", "Jim"], attrgetter("name")
         )
 
@@ -355,7 +355,7 @@ class M2mThroughTests(TestCase):
         CustomMembership.objects.create(person=self.bob, group=self.rock)
         CustomMembership.objects.create(person=self.jim, group=self.rock)
 
-        self.assertQuerysetEqual(self.bob.custom.all(), ["Rock"], attrgetter("name"))
+        self.assertQuerySetEqual(self.bob.custom.all(), ["Rock"], attrgetter("name"))
 
     def test_custom_related_name_doesnt_conflict_with_fky_related_name(self):
         c = CustomMembership.objects.create(person=self.bob, group=self.rock)
@@ -369,7 +369,7 @@ class M2mThroughTests(TestCase):
         event = Event.objects.create(title="Rockwhale 2014")
         Invitation.objects.create(event=event, inviter=self.bob, invitee=self.jim)
         Invitation.objects.create(event=event, inviter=self.bob, invitee=self.jane)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             event.invitees.all(), ["Jane", "Jim"], attrgetter("name")
         )
 
@@ -377,7 +377,7 @@ class M2mThroughTests(TestCase):
 class M2mThroughReferentialTests(TestCase):
     def test_self_referential_empty_qs(self):
         tony = PersonSelfRefM2M.objects.create(name="Tony")
-        self.assertQuerysetEqual(tony.friends.all(), [])
+        self.assertQuerySetEqual(tony.friends.all(), [])
 
     def test_self_referential_non_symmetrical_first_side(self):
         tony = PersonSelfRefM2M.objects.create(name="Tony")
@@ -386,7 +386,7 @@ class M2mThroughReferentialTests(TestCase):
             first=tony, second=chris, date_friended=datetime.now()
         )
 
-        self.assertQuerysetEqual(tony.friends.all(), ["Chris"], attrgetter("name"))
+        self.assertQuerySetEqual(tony.friends.all(), ["Chris"], attrgetter("name"))
 
     def test_self_referential_non_symmetrical_second_side(self):
         tony = PersonSelfRefM2M.objects.create(name="Tony")
@@ -395,7 +395,7 @@ class M2mThroughReferentialTests(TestCase):
             first=tony, second=chris, date_friended=datetime.now()
         )
 
-        self.assertQuerysetEqual(chris.friends.all(), [])
+        self.assertQuerySetEqual(chris.friends.all(), [])
 
     def test_self_referential_non_symmetrical_clear_first_side(self):
         tony = PersonSelfRefM2M.objects.create(name="Tony")
@@ -406,10 +406,10 @@ class M2mThroughReferentialTests(TestCase):
 
         chris.friends.clear()
 
-        self.assertQuerysetEqual(chris.friends.all(), [])
+        self.assertQuerySetEqual(chris.friends.all(), [])
 
         # Since this isn't a symmetrical relation, Tony's friend link still exists.
-        self.assertQuerysetEqual(tony.friends.all(), ["Chris"], attrgetter("name"))
+        self.assertQuerySetEqual(tony.friends.all(), ["Chris"], attrgetter("name"))
 
     def test_self_referential_non_symmetrical_both(self):
         tony = PersonSelfRefM2M.objects.create(name="Tony")
@@ -421,9 +421,9 @@ class M2mThroughReferentialTests(TestCase):
             first=chris, second=tony, date_friended=datetime.now()
         )
 
-        self.assertQuerysetEqual(tony.friends.all(), ["Chris"], attrgetter("name"))
+        self.assertQuerySetEqual(tony.friends.all(), ["Chris"], attrgetter("name"))
 
-        self.assertQuerysetEqual(chris.friends.all(), ["Tony"], attrgetter("name"))
+        self.assertQuerySetEqual(chris.friends.all(), ["Tony"], attrgetter("name"))
 
     def test_through_fields_self_referential(self):
         john = Employee.objects.create(name="john")
@@ -435,7 +435,7 @@ class M2mThroughReferentialTests(TestCase):
         Relationship.objects.create(source=john, target=mary, another=None)
         Relationship.objects.create(source=john, target=harry, another=peter)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             john.subordinates.all(), ["peter", "mary", "harry"], attrgetter("name")
         )
 

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -290,7 +290,7 @@ class ManyToOneTests(TestCase):
         )
         # ... and should work fine with the string that comes out of
         # forms.Form.cleaned_data.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             (
                 Article.objects.filter(reporter__first_name__exact="John").extra(
                     where=["many_to_one_reporter.last_name='%s'" % "Smith"]

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -373,7 +373,7 @@ class TestQuerying(TestCase):
             self.assertSequenceEqual(qs, [self.objs[4]])
         none_val = "" if connection.features.interprets_empty_strings_as_nulls else None
         qs = NullableJSONModel.objects.filter(value__isnull=False)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs.filter(value__isnull=False)
             .annotate(key=KT("value__d__1__f"))
             .values("key")
@@ -392,7 +392,7 @@ class TestQuerying(TestCase):
             .annotate(count=Count("value__d__0"))
             .order_by("count")
         )
-        self.assertQuerysetEqual(qs, [0, 1], operator.itemgetter("count"))
+        self.assertQuerySetEqual(qs, [0, 1], operator.itemgetter("count"))
 
     def test_order_grouping_custom_decoder(self):
         NullableJSONModel.objects.create(value_custom={"a": "b"})

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -1661,7 +1661,7 @@ class ModelFormsetTest(TestCase):
 
         PlayerInlineFormSet = inlineformset_factory(Team, Player, fields="__all__")
         formset = PlayerInlineFormSet()
-        self.assertQuerysetEqual(formset.get_queryset(), [])
+        self.assertQuerySetEqual(formset.get_queryset(), [])
 
         formset = PlayerInlineFormSet(instance=team)
         players = formset.get_queryset()

--- a/tests/model_formsets_regress/tests.py
+++ b/tests/model_formsets_regress/tests.py
@@ -259,7 +259,7 @@ class InlineFormsetTests(TestCase):
 
         self.assertTrue(formset.is_valid())
         formset.save()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             dalnet.host_set.order_by("hostname"),
             Host.objects.filter(
                 hostname__in=[

--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -316,7 +316,7 @@ class ModelInheritanceDataTests(TestCase):
         )
 
     def test_filter_inherited_model(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             ItalianRestaurant.objects.filter(address="1234 W. Ash"),
             [
                 "Ristorante Miron",
@@ -327,7 +327,7 @@ class ModelInheritanceDataTests(TestCase):
     def test_update_inherited_model(self):
         self.italian_restaurant.address = "1234 W. Elm"
         self.italian_restaurant.save()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             ItalianRestaurant.objects.filter(address="1234 W. Elm"),
             [
                 "Ristorante Miron",
@@ -337,14 +337,14 @@ class ModelInheritanceDataTests(TestCase):
 
     def test_parent_fields_available_for_filtering_in_child_model(self):
         # Parent fields can be used directly in filters on the child model.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Restaurant.objects.filter(name="Demon Dogs"),
             [
                 "Demon Dogs",
             ],
             attrgetter("name"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             ItalianRestaurant.objects.filter(address="1234 W. Ash"),
             [
                 "Ristorante Miron",
@@ -405,12 +405,12 @@ class ModelInheritanceDataTests(TestCase):
             p.restaurant
 
         self.assertEqual(p.supplier, s1)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.italian_restaurant.provider.order_by("-name"),
             ["Luigi's Pasta", "Joe's Chickens"],
             attrgetter("name"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Restaurant.objects.filter(provider__name__contains="Chickens"),
             [
                 "Ristorante Miron",
@@ -418,7 +418,7 @@ class ModelInheritanceDataTests(TestCase):
             ],
             attrgetter("name"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             ItalianRestaurant.objects.filter(provider__name__contains="Chickens"),
             [
                 "Ristorante Miron",
@@ -515,14 +515,14 @@ class ModelInheritanceDataTests(TestCase):
             name="Central market",
             address="610 some street",
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Place.objects.filter(supplier__isnull=False),
             [
                 "Central market",
             ],
             attrgetter("name"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Place.objects.filter(supplier__isnull=True).order_by("name"),
             [
                 "Demon Dogs",
@@ -537,7 +537,7 @@ class ModelInheritanceDataTests(TestCase):
             name="Central market",
             address="610 some street",
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Place.objects.exclude(supplier__isnull=False).order_by("name"),
             [
                 "Demon Dogs",
@@ -545,7 +545,7 @@ class ModelInheritanceDataTests(TestCase):
             ],
             attrgetter("name"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Place.objects.exclude(supplier__isnull=True),
             [
                 "Central market",

--- a/tests/model_inheritance_regress/tests.py
+++ b/tests/model_inheritance_regress/tests.py
@@ -429,10 +429,10 @@ class ModelInheritanceTest(TestCase):
 
     def test_inherited_nullable_exclude(self):
         obj = SelfRefChild.objects.create(child_data=37, parent_data=42)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             SelfRefParent.objects.exclude(self_data=72), [obj.pk], attrgetter("pk")
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             SelfRefChild.objects.exclude(self_data=72), [obj.pk], attrgetter("pk")
         )
 
@@ -524,7 +524,7 @@ class ModelInheritanceTest(TestCase):
         Supplier.objects.create(name="John", restaurant=r1)
         Supplier.objects.create(name="Jane", restaurant=r2)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Supplier.objects.order_by("name").select_related(),
             [
                 "Jane",

--- a/tests/model_regress/tests.py
+++ b/tests/model_regress/tests.py
@@ -93,13 +93,13 @@ class ModelTests(TestCase):
         Party.objects.create(when=datetime.datetime(1998, 12, 31))
         Party.objects.create(when=datetime.datetime(1999, 1, 1))
         Party.objects.create(when=datetime.datetime(1, 3, 3))
-        self.assertQuerysetEqual(Party.objects.filter(when__month=2), [])
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(Party.objects.filter(when__month=2), [])
+        self.assertQuerySetEqual(
             Party.objects.filter(when__month=1),
             [datetime.date(1999, 1, 1)],
             attrgetter("when"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Party.objects.filter(when__month=12),
             [
                 datetime.date(1999, 12, 31),
@@ -108,7 +108,7 @@ class ModelTests(TestCase):
             attrgetter("when"),
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Party.objects.filter(when__year=1998),
             [
                 datetime.date(1998, 12, 31),
@@ -116,7 +116,7 @@ class ModelTests(TestCase):
             attrgetter("when"),
         )
         # Regression test for #8510
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Party.objects.filter(when__day="31"),
             [
                 datetime.date(1999, 12, 31),
@@ -125,7 +125,7 @@ class ModelTests(TestCase):
             attrgetter("when"),
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Party.objects.filter(when__month="12"),
             [
                 datetime.date(1999, 12, 31),
@@ -134,7 +134,7 @@ class ModelTests(TestCase):
             attrgetter("when"),
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Party.objects.filter(when__year="1998"),
             [
                 datetime.date(1998, 12, 31),
@@ -143,14 +143,14 @@ class ModelTests(TestCase):
         )
 
         # Regression test for #18969
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Party.objects.filter(when__year=1),
             [
                 datetime.date(1, 3, 3),
             ],
             attrgetter("when"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Party.objects.filter(when__year="1"),
             [
                 datetime.date(1, 3, 3),
@@ -165,7 +165,7 @@ class ModelTests(TestCase):
         Party.objects.create()
         p = Party.objects.filter(when__month=1)[0]
         self.assertEqual(p.when, datetime.date(1999, 1, 1))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Party.objects.filter(pk=p.pk).dates("when", "month"),
             [1],
             attrgetter("month"),

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -1230,10 +1230,10 @@ class QueryTestCase(TestCase):
         val = Book.objects.db_manager("other").raw(
             "SELECT id FROM multiple_database_book"
         )
-        self.assertQuerysetEqual(val, [dive.pk], attrgetter("pk"))
+        self.assertQuerySetEqual(val, [dive.pk], attrgetter("pk"))
 
         val = Book.objects.raw("SELECT id FROM multiple_database_book").using("other")
-        self.assertQuerysetEqual(val, [dive.pk], attrgetter("pk"))
+        self.assertQuerySetEqual(val, [dive.pk], attrgetter("pk"))
 
     def test_select_related(self):
         """

--- a/tests/null_fk/tests.py
+++ b/tests/null_fk/tests.py
@@ -21,7 +21,7 @@ class NullFkTests(TestCase):
         self.assertEqual(c.post, p)
         self.assertIsNone(Comment.objects.select_related().get(id=c2.id).post)
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Comment.objects.select_related("post__forum__system_info").all(),
             [
                 (c1.id, "My first comment", "<Post: First Post>"),
@@ -35,7 +35,7 @@ class NullFkTests(TestCase):
             Comment.objects.select_related("post").filter(post__isnull=True)[0].post
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Comment.objects.select_related("post__forum__system_info__system_details"),
             [
                 (c1.id, "My first comment", "<Post: First Post>"),

--- a/tests/or_lookups/tests.py
+++ b/tests/or_lookups/tests.py
@@ -21,7 +21,7 @@ class OrLookupsTests(TestCase):
         ).pk
 
     def test_filter_or(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             (
                 Article.objects.filter(headline__startswith="Hello")
                 | Article.objects.filter(headline__startswith="Goodbye")
@@ -30,21 +30,21 @@ class OrLookupsTests(TestCase):
             attrgetter("headline"),
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__contains="Hello")
             | Article.objects.filter(headline__contains="bye"),
             ["Hello", "Goodbye", "Hello and goodbye"],
             attrgetter("headline"),
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline__iexact="Hello")
             | Article.objects.filter(headline__contains="ood"),
             ["Hello", "Goodbye", "Hello and goodbye"],
             attrgetter("headline"),
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(
                 Q(headline__startswith="Hello") | Q(headline__startswith="Goodbye")
             ),
@@ -56,12 +56,12 @@ class OrLookupsTests(TestCase):
         # You can shorten this syntax with code like the following,  which is
         # especially useful if building the query in stages:
         articles = Article.objects.all()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             articles.filter(headline__startswith="Hello")
             & articles.filter(headline__startswith="Goodbye"),
             [],
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             articles.filter(headline__startswith="Hello")
             & articles.filter(headline__contains="bye"),
             ["Hello and goodbye"],
@@ -69,32 +69,32 @@ class OrLookupsTests(TestCase):
         )
 
     def test_pk_q(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(Q(pk=self.a1) | Q(pk=self.a2)),
             ["Hello", "Goodbye"],
             attrgetter("headline"),
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(Q(pk=self.a1) | Q(pk=self.a2) | Q(pk=self.a3)),
             ["Hello", "Goodbye", "Hello and goodbye"],
             attrgetter("headline"),
         )
 
     def test_pk_in(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(pk__in=[self.a1, self.a2, self.a3]),
             ["Hello", "Goodbye", "Hello and goodbye"],
             attrgetter("headline"),
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(pk__in=(self.a1, self.a2, self.a3)),
             ["Hello", "Goodbye", "Hello and goodbye"],
             attrgetter("headline"),
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(pk__in=[self.a1, self.a2, self.a3, 40000]),
             ["Hello", "Goodbye", "Hello and goodbye"],
             attrgetter("headline"),
@@ -108,20 +108,20 @@ class OrLookupsTests(TestCase):
 
     def test_q_negated(self):
         # Q objects can be negated
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(Q(pk=self.a1) | ~Q(pk=self.a2)),
             ["Hello", "Hello and goodbye"],
             attrgetter("headline"),
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(~Q(pk=self.a1) & ~Q(pk=self.a2)),
             ["Hello and goodbye"],
             attrgetter("headline"),
         )
         # This allows for more complex queries than filter() and exclude()
         # alone would allow
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(Q(pk=self.a1) & (~Q(pk=self.a2) | Q(pk=self.a3))),
             ["Hello"],
             attrgetter("headline"),
@@ -131,13 +131,13 @@ class OrLookupsTests(TestCase):
         # The 'complex_filter' method supports framework features such as
         # 'limit_choices_to' which normally take a single dictionary of lookup
         # arguments but need to support arbitrary queries via Q objects too.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.complex_filter({"pk": self.a1}),
             ["Hello"],
             attrgetter("headline"),
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.complex_filter(Q(pk=self.a1) | Q(pk=self.a2)),
             ["Hello", "Goodbye"],
             attrgetter("headline"),
@@ -145,9 +145,9 @@ class OrLookupsTests(TestCase):
 
     def test_empty_in(self):
         # Passing "in" an empty list returns no results ...
-        self.assertQuerysetEqual(Article.objects.filter(pk__in=[]), [])
+        self.assertQuerySetEqual(Article.objects.filter(pk__in=[]), [])
         # ... but can return results if we OR it with another query.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(Q(pk__in=[]) | Q(headline__icontains="goodbye")),
             ["Goodbye", "Hello and goodbye"],
             attrgetter("headline"),
@@ -155,7 +155,7 @@ class OrLookupsTests(TestCase):
 
     def test_q_and(self):
         # Q arg objects are ANDed
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(
                 Q(headline__startswith="Hello"), Q(headline__contains="bye")
             ),
@@ -163,7 +163,7 @@ class OrLookupsTests(TestCase):
             attrgetter("headline"),
         )
         # Q arg AND order is irrelevant
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(
                 Q(headline__contains="bye"), headline__startswith="Hello"
             ),
@@ -171,7 +171,7 @@ class OrLookupsTests(TestCase):
             attrgetter("headline"),
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(
                 Q(headline__startswith="Hello") & Q(headline__startswith="Goodbye")
             ),
@@ -179,7 +179,7 @@ class OrLookupsTests(TestCase):
         )
 
     def test_q_exclude(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.exclude(Q(headline__startswith="Hello")),
             ["Goodbye"],
             attrgetter("headline"),

--- a/tests/order_with_respect_to/base_tests.py
+++ b/tests/order_with_respect_to/base_tests.py
@@ -25,7 +25,7 @@ class BaseOrderWithRespectToTests:
 
     def test_default_to_insertion_order(self):
         # Answers will always be ordered in the order they were inserted.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.q1.answer_set.all(),
             [
                 "John",
@@ -82,7 +82,7 @@ class BaseOrderWithRespectToTests:
         # Change the ordering to the swapped version -
         # this changes the ordering of the queryset.
         a.question.set_answer_order(id_list)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.q1.answer_set.all(),
             ["John", "Paul", "George", "Number five", "Ringo"],
             attrgetter("text"),

--- a/tests/order_with_respect_to/tests.py
+++ b/tests/order_with_respect_to/tests.py
@@ -44,6 +44,6 @@ class TestOrderWithRespectToOneToOnePK(TestCase):
         c1 = d.component_set.create()
         c2 = d.component_set.create()
         d.set_component_order([c1.id, c2.id])
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             d.component_set.all(), [c1.id, c2.id], attrgetter("pk")
         )

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -52,7 +52,7 @@ class OrderingTests(TestCase):
         By default, Article.objects.all() orders by pub_date descending, then
         headline ascending.
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.all(),
             [
                 "Article 4",
@@ -71,7 +71,7 @@ class OrderingTests(TestCase):
         Override ordering with order_by, which is in the same format as the
         ordering attribute in models.
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.order_by("headline"),
             [
                 "Article 1",
@@ -81,7 +81,7 @@ class OrderingTests(TestCase):
             ],
             attrgetter("headline"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.order_by("pub_date", "-headline"),
             [
                 "Article 1",
@@ -109,7 +109,7 @@ class OrderingTests(TestCase):
         Only the last order_by has any effect (since they each override any
         previous ordering).
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.order_by("id"),
             [
                 "Article 1",
@@ -119,7 +119,7 @@ class OrderingTests(TestCase):
             ],
             attrgetter("headline"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.order_by("id").order_by("-headline"),
             [
                 "Article 4",
@@ -137,7 +137,7 @@ class OrderingTests(TestCase):
                 F("author").desc(nulls_last=True, nulls_first=True)
             )
 
-    def assertQuerysetEqualReversible(self, queryset, sequence):
+    def assertQuerySetEqualReversible(self, queryset, sequence):
         self.assertSequenceEqual(queryset, sequence)
         self.assertSequenceEqual(queryset.reverse(), list(reversed(sequence)))
 
@@ -145,21 +145,21 @@ class OrderingTests(TestCase):
         Article.objects.filter(headline="Article 3").update(author=self.author_1)
         Article.objects.filter(headline="Article 4").update(author=self.author_2)
         # asc and desc are chainable with nulls_last.
-        self.assertQuerysetEqualReversible(
+        self.assertQuerySetEqualReversible(
             Article.objects.order_by(F("author").desc(nulls_last=True), "headline"),
             [self.a4, self.a3, self.a1, self.a2],
         )
-        self.assertQuerysetEqualReversible(
+        self.assertQuerySetEqualReversible(
             Article.objects.order_by(F("author").asc(nulls_last=True), "headline"),
             [self.a3, self.a4, self.a1, self.a2],
         )
-        self.assertQuerysetEqualReversible(
+        self.assertQuerySetEqualReversible(
             Article.objects.order_by(
                 Upper("author__name").desc(nulls_last=True), "headline"
             ),
             [self.a4, self.a3, self.a1, self.a2],
         )
-        self.assertQuerysetEqualReversible(
+        self.assertQuerySetEqualReversible(
             Article.objects.order_by(
                 Upper("author__name").asc(nulls_last=True), "headline"
             ),
@@ -170,21 +170,21 @@ class OrderingTests(TestCase):
         Article.objects.filter(headline="Article 3").update(author=self.author_1)
         Article.objects.filter(headline="Article 4").update(author=self.author_2)
         # asc and desc are chainable with nulls_first.
-        self.assertQuerysetEqualReversible(
+        self.assertQuerySetEqualReversible(
             Article.objects.order_by(F("author").asc(nulls_first=True), "headline"),
             [self.a1, self.a2, self.a3, self.a4],
         )
-        self.assertQuerysetEqualReversible(
+        self.assertQuerySetEqualReversible(
             Article.objects.order_by(F("author").desc(nulls_first=True), "headline"),
             [self.a1, self.a2, self.a4, self.a3],
         )
-        self.assertQuerysetEqualReversible(
+        self.assertQuerySetEqualReversible(
             Article.objects.order_by(
                 Upper("author__name").asc(nulls_first=True), "headline"
             ),
             [self.a1, self.a2, self.a3, self.a4],
         )
-        self.assertQuerysetEqualReversible(
+        self.assertQuerySetEqualReversible(
             Article.objects.order_by(
                 Upper("author__name").desc(nulls_first=True), "headline"
             ),
@@ -209,7 +209,7 @@ class OrderingTests(TestCase):
             )
             .values("last_date")
         )
-        self.assertQuerysetEqualReversible(
+        self.assertQuerySetEqualReversible(
             Author.objects.annotate(
                 last_date=Subquery(article_subquery, output_field=DateTimeField())
             )
@@ -222,7 +222,7 @@ class OrderingTests(TestCase):
         """
         Use the 'stop' part of slicing notation to limit the results.
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.order_by("headline")[:2],
             [
                 "Article 1",
@@ -236,7 +236,7 @@ class OrderingTests(TestCase):
         Use the 'stop' and 'start' parts of slicing notation to offset the
         result list.
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.order_by("headline")[1:3],
             [
                 "Article 2",
@@ -257,7 +257,7 @@ class OrderingTests(TestCase):
         This allows you to extract things like "the last two items" (reverse
         and then take the first two).
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.reverse()[:2],
             [
                 "Article 1",
@@ -269,7 +269,7 @@ class OrderingTests(TestCase):
     def test_reverse_ordering_pure(self):
         qs1 = Article.objects.order_by(F("headline").asc())
         qs2 = qs1.reverse()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs2,
             [
                 "Article 4",
@@ -279,7 +279,7 @@ class OrderingTests(TestCase):
             ],
             attrgetter("headline"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs1,
             [
                 "Article 1",
@@ -303,12 +303,12 @@ class OrderingTests(TestCase):
             author=self.author_2,
             second_author=self.author_1,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline="Article 5").reverse(),
             ["Name 2", "Name 1"],
             attrgetter("author.name"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(headline="Article 5"),
             ["Name 1", "Name 2"],
             attrgetter("author.name"),
@@ -326,7 +326,7 @@ class OrderingTests(TestCase):
         """
         Ordering can be based on fields included from an 'extra' clause
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.extra(
                 select={"foo": "pub_date"}, order_by=["foo", "headline"]
             ),
@@ -344,7 +344,7 @@ class OrderingTests(TestCase):
         If the extra clause uses an SQL keyword for a name, it will be
         protected by quoting.
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.extra(
                 select={"order": "pub_date"}, order_by=["order", "headline"]
             ),
@@ -358,7 +358,7 @@ class OrderingTests(TestCase):
         )
 
     def test_extra_ordering_with_table_name(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.extra(order_by=["ordering_article.headline"]),
             [
                 "Article 1",
@@ -368,7 +368,7 @@ class OrderingTests(TestCase):
             ],
             attrgetter("headline"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.extra(order_by=["-ordering_article.headline"]),
             [
                 "Article 4",
@@ -400,7 +400,7 @@ class OrderingTests(TestCase):
             article.author = author
             article.save(update_fields={"author"})
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.order_by("author_id"),
             [
                 "Article 4",
@@ -416,19 +416,19 @@ class OrderingTests(TestCase):
         self.a1.save()
         self.a2.author = Author.objects.create(editor=self.author_2)
         self.a2.save()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(author__isnull=False).order_by("author__editor"),
             ["Article 2", "Article 1"],
             attrgetter("headline"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.filter(author__isnull=False).order_by("author__editor_id"),
             ["Article 1", "Article 2"],
             attrgetter("headline"),
         )
 
     def test_order_by_f_expression(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.order_by(F("headline")),
             [
                 "Article 1",
@@ -438,7 +438,7 @@ class OrderingTests(TestCase):
             ],
             attrgetter("headline"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.order_by(F("headline").asc()),
             [
                 "Article 1",
@@ -448,7 +448,7 @@ class OrderingTests(TestCase):
             ],
             attrgetter("headline"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Article.objects.order_by(F("headline").desc()),
             [
                 "Article 4",
@@ -468,7 +468,7 @@ class OrderingTests(TestCase):
         sql = str(qs.query).upper()
         fragment = sql[sql.find("ORDER BY") :]
         self.assertEqual(fragment.count("HEADLINE"), 1)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 "Article 1",
@@ -482,7 +482,7 @@ class OrderingTests(TestCase):
         sql = str(qs.query).upper()
         fragment = sql[sql.find("ORDER BY") :]
         self.assertEqual(fragment.count("HEADLINE"), 1)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [
                 "Article 4",
@@ -535,7 +535,7 @@ class OrderingTests(TestCase):
         articles = OrderedByFArticle.objects.all()
         articles.filter(headline="Article 2").update(author=self.author_2)
         articles.filter(headline="Article 3").update(author=self.author_1)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             articles,
             ["Article 1", "Article 4", "Article 3", "Article 2"],
             attrgetter("headline"),

--- a/tests/postgres_tests/test_trigram.py
+++ b/tests/postgres_tests/test_trigram.py
@@ -31,7 +31,7 @@ class TrigramTest(PostgreSQLTestCase):
         )
 
     def test_trigram_search(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.Model.objects.filter(field__trigram_similar="Mathew"),
             ["Matthew"],
             transform=lambda instance: instance.field,
@@ -68,7 +68,7 @@ class TrigramTest(PostgreSQLTestCase):
     def test_trigram_similarity(self):
         search = "Bat sat on cat."
         # Round result of similarity because PostgreSQL uses greater precision.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.Model.objects.filter(
                 field__trigram_similar=search,
             )
@@ -111,7 +111,7 @@ class TrigramTest(PostgreSQLTestCase):
 
     def test_trigram_similarity_alternate(self):
         # Round result of distance because PostgreSQL uses greater precision.
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.Model.objects.annotate(
                 distance=TrigramDistance("field", "Bat sat on cat."),
             )

--- a/tests/postgres_tests/test_unaccent.py
+++ b/tests/postgres_tests/test_unaccent.py
@@ -21,7 +21,7 @@ class UnaccentTest(PostgreSQLTestCase):
         )
 
     def test_unaccent(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.Model.objects.filter(field__unaccent="aeO"),
             ["àéÖ", "aeO"],
             transform=lambda instance: instance.field,
@@ -33,13 +33,13 @@ class UnaccentTest(PostgreSQLTestCase):
         Unaccent can be used chained with a lookup (which should be the case
         since unaccent implements the Transform API)
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.Model.objects.filter(field__unaccent__iexact="aeO"),
             ["àéÖ", "aeO", "aeo"],
             transform=lambda instance: instance.field,
             ordered=False,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.Model.objects.filter(field__unaccent__endswith="éÖ"),
             ["àéÖ", "aeO"],
             transform=lambda instance: instance.field,
@@ -54,7 +54,7 @@ class UnaccentTest(PostgreSQLTestCase):
             if disable_conforming_strings:
                 cursor.execute("SET standard_conforming_strings TO off")
             try:
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     self.Model.objects.filter(field__unaccent__endswith="éÖ"),
                     ["àéÖ", "aeO"],
                     transform=lambda instance: instance.field,
@@ -65,7 +65,7 @@ class UnaccentTest(PostgreSQLTestCase):
                     cursor.execute("SET standard_conforming_strings TO on")
 
     def test_unaccent_accentuated_needle(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.Model.objects.filter(field__unaccent="aéÖ"),
             ["àéÖ", "aeO"],
             transform=lambda instance: instance.field,

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -15,7 +15,7 @@ class QuerySetSetOperationTests(TestCase):
         Number.objects.bulk_create(Number(num=i, other_num=10 - i) for i in range(10))
 
     def assertNumbersEqual(self, queryset, expected_numbers, ordered=True):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             queryset, expected_numbers, operator.attrgetter("num"), ordered
         )
 
@@ -145,7 +145,7 @@ class QuerySetSetOperationTests(TestCase):
     def test_ordering_by_alias(self):
         qs1 = Number.objects.filter(num__lte=1).values(alias=F("num"))
         qs2 = Number.objects.filter(num__gte=2, num__lte=3).values(alias=F("num"))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs1.union(qs2).order_by("-alias"),
             [3, 2, 1, 0],
             operator.itemgetter("alias"),
@@ -159,13 +159,13 @@ class QuerySetSetOperationTests(TestCase):
     def test_ordering_by_f_expression_and_alias(self):
         qs1 = Number.objects.filter(num__lte=1).values(alias=F("other_num"))
         qs2 = Number.objects.filter(num__gte=2, num__lte=3).values(alias=F("other_num"))
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs1.union(qs2).order_by(F("alias").desc()),
             [10, 9, 8, 7],
             operator.itemgetter("alias"),
         )
         Number.objects.create(num=-1)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs1.union(qs2).order_by(F("alias").desc(nulls_last=True)),
             [10, 9, 8, 7, None],
             operator.itemgetter("alias"),
@@ -267,7 +267,7 @@ class QuerySetSetOperationTests(TestCase):
             qs1.union(qs2).order_by("annotation", "num").values_list("num", flat=True),
             [6, 7, 8, 9, 0, 1, 2, 3, 4, 5],
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs1.union(qs2)
             .order_by(
                 F("annotation") * F("multiplier"),

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -662,7 +662,7 @@ class Queries1Tests(TestCase):
 
     def test_tickets_2874_3002(self):
         qs = Item.objects.select_related().order_by("note__note", "name")
-        self.assertQuerysetEqual(qs, [self.i2, self.i4, self.i1, self.i3])
+        self.assertQuerySetEqual(qs, [self.i2, self.i4, self.i1, self.i3])
 
         # This is also a good select_related() test because there are multiple
         # Note entries in the SQL. The two Note items should be different.
@@ -1075,41 +1075,41 @@ class Queries1Tests(TestCase):
             Tag._meta.ordering = original_ordering
 
     def test_exclude(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Item.objects.exclude(tags__name="t4"),
             Item.objects.filter(~Q(tags__name="t4")),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Item.objects.exclude(Q(tags__name="t4") | Q(tags__name="t3")),
             Item.objects.filter(~(Q(tags__name="t4") | Q(tags__name="t3"))),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Item.objects.exclude(Q(tags__name="t4") | ~Q(tags__name="t3")),
             Item.objects.filter(~(Q(tags__name="t4") | ~Q(tags__name="t3"))),
         )
 
     def test_nested_exclude(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Item.objects.exclude(~Q(tags__name="t4")),
             Item.objects.filter(~~Q(tags__name="t4")),
         )
 
     def test_double_exclude(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Item.objects.filter(Q(tags__name="t4")),
             Item.objects.filter(~~Q(tags__name="t4")),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Item.objects.filter(Q(tags__name="t4")),
             Item.objects.filter(~Q(~Q(tags__name="t4"))),
         )
 
     def test_exclude_in(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Item.objects.exclude(Q(tags__name__in=["t4", "t3"])),
             Item.objects.filter(~Q(tags__name__in=["t4", "t3"])),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Item.objects.filter(Q(tags__name__in=["t4", "t3"])),
             Item.objects.filter(~~Q(tags__name__in=["t4", "t3"])),
         )
@@ -1996,7 +1996,7 @@ class SubclassFKTests(TestCase):
 
 class CustomPkTests(TestCase):
     def test_ticket7371(self):
-        self.assertQuerysetEqual(Related.objects.order_by("custom"), [])
+        self.assertQuerySetEqual(Related.objects.order_by("custom"), [])
 
 
 class NullableRelOrderingTests(TestCase):
@@ -2947,8 +2947,8 @@ class WeirdQuerysetSlicingTests(TestCase):
     def test_zero_length_values_slicing(self):
         n = 42
         with self.assertNumQueries(0):
-            self.assertQuerysetEqual(Article.objects.values()[n:n], [])
-            self.assertQuerysetEqual(Article.objects.values_list()[n:n], [])
+            self.assertQuerySetEqual(Article.objects.values()[n:n], [])
+            self.assertQuerySetEqual(Article.objects.values_list()[n:n], [])
 
 
 class EscapingTests(TestCase):
@@ -3479,23 +3479,23 @@ class NullInExcludeTest(TestCase):
 
     def test_null_in_exclude_qs(self):
         none_val = "" if connection.features.interprets_empty_strings_as_nulls else None
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             NullableName.objects.exclude(name__in=[]),
             ["i1", none_val],
             attrgetter("name"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             NullableName.objects.exclude(name__in=["i1"]),
             [none_val],
             attrgetter("name"),
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             NullableName.objects.exclude(name__in=["i3"]),
             ["i1", none_val],
             attrgetter("name"),
         )
         inner_qs = NullableName.objects.filter(name="i1").values_list("name")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             NullableName.objects.exclude(name__in=inner_qs),
             [none_val],
             attrgetter("name"),
@@ -3511,7 +3511,7 @@ class NullInExcludeTest(TestCase):
         SQL's COL NOT IN (list containing null) handling is too weird to
         abstract away.
         """
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             NullableName.objects.exclude(name__in=[None]), ["i1"], attrgetter("name")
         )
 
@@ -3537,14 +3537,14 @@ class EmptyStringsAsNullTest(TestCase):
         cls.nc = NamedCategory.objects.create(name="")
 
     def test_direct_exclude(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             NamedCategory.objects.exclude(name__in=["nonexistent"]),
             [self.nc.pk],
             attrgetter("pk"),
         )
 
     def test_joined_exclude(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             DumbCategory.objects.exclude(namedcategory__name__in=["nonexistent"]),
             [self.nc.pk],
             attrgetter("pk"),
@@ -3552,7 +3552,7 @@ class EmptyStringsAsNullTest(TestCase):
 
     def test_21001(self):
         foo = NamedCategory.objects.create(name="foo")
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             NamedCategory.objects.exclude(name=""), [foo.pk], attrgetter("pk")
         )
 
@@ -3760,7 +3760,7 @@ class NullJoinPromotionOrTest(TestCase):
         qs1_filter = Identifier.objects.filter(
             program__id=p1.id, channel__id=c1.id
         ).order_by("pk")
-        self.assertQuerysetEqual(qs1_doubleneg, qs1_filter, lambda x: x)
+        self.assertQuerySetEqual(qs1_doubleneg, qs1_filter, lambda x: x)
         self.assertEqual(
             str(qs1_filter.query).count("JOIN"), str(qs1_doubleneg.query).count("JOIN")
         )
@@ -3785,7 +3785,7 @@ class NullJoinPromotionOrTest(TestCase):
         qs1_doubleneg = Identifier.objects.exclude(
             ~Q(Q(program__id=p2.id, channel__id=c1.id) | Q(program__id=p1.id))
         ).order_by("pk")
-        self.assertQuerysetEqual(qs1_doubleneg, qs1_filter, lambda x: x)
+        self.assertQuerySetEqual(qs1_doubleneg, qs1_filter, lambda x: x)
         self.assertEqual(
             str(qs1_filter.query).count("JOIN"), str(qs1_doubleneg.query).count("JOIN")
         )
@@ -3811,7 +3811,7 @@ class NullJoinPromotionOrTest(TestCase):
         qs2 = Identifier.objects.filter(
             Q(Q(program__id=p2.id, channel__id=c1.id) | ~Q(program__id=p1.id))
         ).order_by("pk")
-        self.assertQuerysetEqual(qs1, qs2, lambda x: x)
+        self.assertQuerySetEqual(qs1, qs2, lambda x: x)
         self.assertEqual(str(qs1.query).count("JOIN"), str(qs2.query).count("JOIN"))
         self.assertEqual(0, str(qs1.query).count("INNER JOIN"))
         self.assertEqual(

--- a/tests/save_delete_hooks/tests.py
+++ b/tests/save_delete_hooks/tests.py
@@ -16,7 +16,7 @@ class SaveDeleteHookTests(TestCase):
             ],
         )
 
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Person.objects.all(),
             [
                 "John Smith",
@@ -34,4 +34,4 @@ class SaveDeleteHookTests(TestCase):
                 "After deletion",
             ],
         )
-        self.assertQuerysetEqual(Person.objects.all(), [])
+        self.assertQuerySetEqual(Person.objects.all(), [])

--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -328,7 +328,7 @@ class LiveServerDatabase(LiveServerBase):
         """
         with self.urlopen("/create_model_instance/"):
             pass
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Person.objects.order_by("pk"),
             ["jane", "robert", "emily"],
             lambda b: b.name,

--- a/tests/signals/tests.py
+++ b/tests/signals/tests.py
@@ -178,7 +178,7 @@ class SignalTests(BaseSignalSetup, TestCase):
             )
             data[:] = []
 
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 Person.objects.all(),
                 [
                     "James Jones",

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -264,47 +264,56 @@ class AssertNumQueriesUponConnectionTests(TransactionTestCase):
                 list(Car.objects.all())
 
 
-class AssertQuerysetEqualTests(TestCase):
+class AssertQuerySetEqualTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.p1 = Person.objects.create(name="p1")
         cls.p2 = Person.objects.create(name="p2")
 
-    def test_empty(self):
+    def test_rename_assertquerysetequal_deprecation_warning(self):
+        msg = "assertQuerysetEqual() is deprecated in favor of assertQuerySetEqual()."
+        with self.assertRaisesMessage(RemovedInDjango51Warning, msg):
+            self.assertQuerysetEqual()
+
+    @ignore_warnings(category=RemovedInDjango51Warning)
+    def test_deprecated_assertquerysetequal(self):
         self.assertQuerysetEqual(Person.objects.filter(name="p3"), [])
 
+    def test_empty(self):
+        self.assertQuerySetEqual(Person.objects.filter(name="p3"), [])
+
     def test_ordered(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Person.objects.order_by("name"),
             [self.p1, self.p2],
         )
 
     def test_unordered(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Person.objects.order_by("name"), [self.p2, self.p1], ordered=False
         )
 
     def test_queryset(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Person.objects.order_by("name"),
             Person.objects.order_by("name"),
         )
 
     def test_flat_values_list(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Person.objects.order_by("name").values_list("name", flat=True),
             ["p1", "p2"],
         )
 
     def test_transform(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Person.objects.order_by("name"),
             [self.p1.pk, self.p2.pk],
             transform=lambda x: x.pk,
         )
 
     def test_repr_transform(self):
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Person.objects.order_by("name"),
             [repr(self.p1), repr(self.p2)],
             transform=repr,
@@ -318,16 +327,16 @@ class AssertQuerysetEqualTests(TestCase):
             "ordered value."
         )
         with self.assertRaisesMessage(ValueError, msg):
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 Person.objects.all(),
                 [self.p1, self.p2],
             )
         # No error for one value.
-        self.assertQuerysetEqual(Person.objects.filter(name="p1"), [self.p1])
+        self.assertQuerySetEqual(Person.objects.filter(name="p1"), [self.p1])
 
     def test_repeated_values(self):
         """
-        assertQuerysetEqual checks the number of appearance of each item
+        assertQuerySetEqual checks the number of appearance of each item
         when used with option ordered=False.
         """
         batmobile = Car.objects.create(name="Batmobile")
@@ -343,10 +352,10 @@ class AssertQuerysetEqualTests(TestCase):
             ]
         )
         with self.assertRaises(AssertionError):
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 self.p1.cars.all(), [batmobile, k2000], ordered=False
             )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             self.p1.cars.all(), [batmobile] * 2 + [k2000] * 4, ordered=False
         )
 
@@ -356,7 +365,7 @@ class AssertQuerysetEqualTests(TestCase):
         names.append("Extra Person")
 
         with self.assertRaises(AssertionError) as ctx:
-            self.assertQuerysetEqual(
+            self.assertQuerySetEqual(
                 Person.objects.filter(name__startswith="Joe"),
                 names,
                 ordered=False,
@@ -368,7 +377,7 @@ class AssertQuerysetEqualTests(TestCase):
         self.maxDiff = None
         try:
             with self.assertRaises(AssertionError) as ctx:
-                self.assertQuerysetEqual(
+                self.assertQuerySetEqual(
                     Person.objects.filter(name__startswith="Joe"),
                     names,
                     ordered=False,

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -240,19 +240,19 @@ class LegacyDatabaseTests(TestCase):
         )
         morning_min_dt = datetime.datetime(2011, 9, 1, 3, 20, 40)
         afternoon_min_dt = datetime.datetime(2011, 9, 1, 13, 20, 30)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Session.objects.annotate(dt=Min("events__dt")).order_by("dt"),
             [morning_min_dt, afternoon_min_dt],
             transform=lambda d: d.dt,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Session.objects.annotate(dt=Min("events__dt")).filter(
                 dt__lt=afternoon_min_dt
             ),
             [morning_min_dt],
             transform=lambda d: d.dt,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Session.objects.annotate(dt=Min("events__dt")).filter(
                 dt__gte=afternoon_min_dt
             ),
@@ -536,19 +536,19 @@ class NewDatabaseTests(TestCase):
         )
         morning_min_dt = datetime.datetime(2011, 9, 1, 3, 20, 40, tzinfo=EAT)
         afternoon_min_dt = datetime.datetime(2011, 9, 1, 13, 20, 30, tzinfo=EAT)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Session.objects.annotate(dt=Min("events__dt")).order_by("dt"),
             [morning_min_dt, afternoon_min_dt],
             transform=lambda d: d.dt,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Session.objects.annotate(dt=Min("events__dt")).filter(
                 dt__lt=afternoon_min_dt
             ),
             [morning_min_dt],
             transform=lambda d: d.dt,
         )
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             Session.objects.annotate(dt=Min("events__dt")).filter(
                 dt__gte=afternoon_min_dt
             ),


### PR DESCRIPTION
Fixes https://code.djangoproject.com/ticket/33990.

There are two commits each one fixing one function.

Related `django-upgrade` PR is https://github.com/adamchainz/django-upgrade/pull/253.