### PR TITLE
Fixed #34070 -- Added subsecond support to Now() on SQLite and MySQL.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -81,7 +81,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "swedish_ci": f"{charset}_swedish_ci",
         }
 
-    test_now_utc_template = "UTC_TIMESTAMP"
+    test_now_utc_template = "UTC_TIMESTAMP(6)"
 
     @cached_property
     def django_test_skips(self):

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -223,6 +223,19 @@ class Now(Func):
             compiler, connection, template="STATEMENT_TIMESTAMP()", **extra_context
         )
 
+    def as_mysql(self, compiler, connection, **extra_context):
+        return self.as_sql(
+            compiler, connection, template="CURRENT_TIMESTAMP(6)", **extra_context
+        )
+
+    def as_sqlite(self, compiler, connection, **extra_context):
+        return self.as_sql(
+            compiler,
+            connection,
+            template="STRFTIME('%%Y-%%m-%%d %%H:%%M:%%f', 'NOW')",
+            **extra_context,
+        )
+
 
 class TruncBase(TimezoneMixin, Transform):
     kind = None

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -495,6 +495,11 @@ Usage example::
     ``Now()`` uses ``STATEMENT_TIMESTAMP`` instead. If you need the transaction
     timestamp, use :class:`django.contrib.postgres.functions.TransactionNow`.
 
+.. versionchanged:: 4.2
+
+    Support for microsecond precision on MySQL and millisecond precision on
+    SQLite were added.
+
 ``Trunc``
 ---------
 

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -223,6 +223,9 @@ Models
   the text value of a key, index, or path transform of
   :class:`~django.db.models.JSONField`.
 
+* :class:`~django.db.models.functions.Now` now supports microsecond precision
+  on MySQL and millisecond precision on SQLite.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/db_functions/datetime/test_now.py
+++ b/tests/db_functions/datetime/test_now.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
 
-from django.db.models.functions import Now
+from django.db import connection
+from django.db.models import TextField
+from django.db.models.functions import Cast, Now
 from django.test import TestCase
 from django.utils import timezone
 
@@ -47,3 +49,17 @@ class NowTests(TestCase):
             ["How to Time Travel"],
             lambda a: a.title,
         )
+
+    def test_microseconds(self):
+        Article.objects.create(
+            title="How to Django",
+            text=lorem_ipsum,
+            written=timezone.now(),
+        )
+        now_string = (
+            Article.objects.annotate(now_string=Cast(Now(), TextField()))
+            .get()
+            .now_string
+        )
+        precision = connection.features.time_cast_precision
+        self.assertRegex(now_string, rf"^.*\.\d{{1,{precision}}}")


### PR DESCRIPTION
Extracted from #16092 as suggested in https://github.com/django/django/pull/16092#discussion_r979378001.