### PR TITLE
Refs #33620 -- Accessibility in pipeline

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -40,5 +40,9 @@ jobs:
           --config ./pa11y.json
           --runner axe
           --include-warnings)
+          && pa11y http://127.0.0.1:8000/en/admin/demo/artist/7zX2wRWDKLiW2V5QlI4QXU/change/
+          --config ./pa11y.json
+          --runner axe
+          --include-warnings
         # TODO: remove this when the errors are fixed.
         continue-on-error: true

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,48 @@
+name: Accessibility
+
+on:
+  pull_request:
+    branches:
+      - main
+
+
+jobs:
+  accessibility:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Django core
+        uses: actions/checkout@v4
+      - name: Checkout Django admin demo
+        uses: actions/checkout@v4
+        with:
+          repository: knyghty/django-admin-demo
+          ref: a58fa374767a1904dbf0e45e9cc0df1cd2692838
+          path: demo
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: 'demo/requirements.txt'
+      - name: Set up Node
+        uses: actions/setup-node@v4
+      - name: Install Requirements
+        run: pip install -r demo/requirements.txt
+      - name: Launch migrations
+        run: python demo/manage.py migrate
+      - name: Install pa11y
+        run: npm install -g pa11y
+      - name: Run the project and pa11y
+        run: >-
+          python demo/manage.py runserver
+          & (sleep 10 && pa11y http://127.0.0.1:8000/
+          --config ./pa11y.json
+          --runner axe
+          --include-warnings)
+          && pa11y http://127.0.0.1:8000/en/admin/demo/artist/
+          --config ./pa11y.json
+          --runner axe
+          --include-warnings
+        # TODO: remove this when the errors are fixed.
+        continue-on-error: true

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -36,13 +36,9 @@ jobs:
       - name: Run the project and pa11y
         run: >-
           python demo/manage.py runserver
-          & (sleep 10 && pa11y http://127.0.0.1:8000/
+          & (sleep 10 && pa11y http://127.0.0.1:8000/en/admin/demo/artist/
           --config ./pa11y.json
           --runner axe
           --include-warnings)
-          && pa11y http://127.0.0.1:8000/en/admin/demo/artist/
-          --config ./pa11y.json
-          --runner axe
-          --include-warnings
         # TODO: remove this when the errors are fixed.
         continue-on-error: true

--- a/pa11y.json
+++ b/pa11y.json
@@ -1,0 +1,30 @@
+{
+    "defaults": {
+        "timeout": 10000
+    },
+    "chromeLaunchConfig": {
+        "args": [
+            "--no-sandbox",
+            "--disable-setuid-sandbox",
+            "--disable-dev-shm-usage",
+            "--disable-gpu",
+            "--headless"
+        ]
+    },
+    "actions": [
+        "navigate to http://127.0.0.1:8000/en/admin/login/",
+        "wait for element #login-form to be visible",
+        "set field #id_username to admin",
+        "set field #id_password to correcthorsebatterystaple",
+        "click element input[type=submit]",
+        "wait for url to be http://127.0.0.1:8000/en/admin/"
+    ],
+    "urls": [
+        "http://127.0.0.1:8000/en/admin/",
+        "http://127.0.0.1:8000/en/admin/demo/artist/",
+        "http://127.0.0.1:8000/en/admin/demo/artist/7zX2wRWDKLiW2V5QlI4QXU/change/",
+        "http://127.0.0.1:8000/en/admin/demo/release/",
+        "http://127.0.0.1:8000/en/admin/demo/release/7xxg6PunBVeuTliClh4H5p/change/"
+
+    ]
+}


### PR DESCRIPTION
POC CI Accessibility via pa11y combined to axe.

This will add the accessibility github action workflow to the current CI pipeline. There are accessibility errors but the workflow doesn't block the CI for any pull requests. It's using [knyghty/django-admin-demo](https://github.com/knyghty/django-admin-demo) to be able to test the admin properly.

ticket-33620
