### PR TITLE
Fixed #34052 -- Made migrate --check don't emit signals and output when up to date.

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -240,23 +240,27 @@ class Command(BaseCommand):
                     self.stdout.write("  No migrations to prune.")
 
         plan = executor.migration_plan(targets)
-        exit_dry = plan and options["check_unapplied"]
 
         if options["plan"]:
             self.stdout.write("Planned operations:", self.style.MIGRATE_LABEL)
             if not plan:
                 self.stdout.write("  No planned migration operations.")
-            for migration, backwards in plan:
-                self.stdout.write(str(migration), self.style.MIGRATE_HEADING)
-                for operation in migration.operations:
-                    message, is_error = self.describe_operation(operation, backwards)
-                    style = self.style.WARNING if is_error else None
-                    self.stdout.write("    " + message, style)
-            if exit_dry:
+            else:
+                for migration, backwards in plan:
+                    self.stdout.write(str(migration), self.style.MIGRATE_HEADING)
+                    for operation in migration.operations:
+                        message, is_error = self.describe_operation(
+                            operation, backwards
+                        )
+                        style = self.style.WARNING if is_error else None
+                        self.stdout.write("    " + message, style)
+                if options["check_unapplied"]:
+                    sys.exit(1)
+            return
+        if options["check_unapplied"]:
+            if plan:
                 sys.exit(1)
             return
-        if exit_dry:
-            sys.exit(1)
         if options["prune"]:
             return
 

--- a/tests/migrate_signals/tests.py
+++ b/tests/migrate_signals/tests.py
@@ -156,3 +156,15 @@ class MigrateSignalTests(TransactionTestCase):
             ],
             ["migrate_signals.Signal"],
         )
+        # Migrating with an empty plan and --check doesn't emit signals.
+        pre_migrate_receiver = Receiver(signals.pre_migrate)
+        post_migrate_receiver = Receiver(signals.post_migrate)
+        management.call_command(
+            "migrate",
+            database=MIGRATE_DATABASE,
+            verbosity=MIGRATE_VERBOSITY,
+            interactive=MIGRATE_INTERACTIVE,
+            check_unapplied=True,
+        )
+        self.assertEqual(pre_migrate_receiver.call_counter, 0)
+        self.assertEqual(post_migrate_receiver.call_counter, 0)

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -356,6 +356,26 @@ class MigrateTests(MigrationTestBase):
         self.assertTableNotExists("migrations_book")
 
     @override_settings(
+        INSTALLED_APPS=[
+            "migrations.migrations_test_apps.migrated_app",
+        ]
+    )
+    def test_migrate_check_migrated_app(self):
+        out = io.StringIO()
+        try:
+            call_command("migrate", "migrated_app", verbosity=0)
+            call_command(
+                "migrate",
+                "migrated_app",
+                stdout=out,
+                check_unapplied=True,
+            )
+            self.assertEqual(out.getvalue(), "")
+        finally:
+            # Unmigrate everything.
+            call_command("migrate", "migrated_app", "zero", verbosity=0)
+
+    @override_settings(
         MIGRATION_MODULES={
             "migrations": "migrations.test_migrations_plan",
         }


### PR DESCRIPTION
Fixed [ticket-34052](https://code.djangoproject.com/ticket/34052)


Changes
- 
- Changed migrate condition according to --check and already reflected_changes

Tests
- 
- Added testcase. 
- Tested migrate already reflected changes with check

FYI
-
- ~~In the situation below, output is necessary? In the case `sys.exit(1)` no output is needed, I think.~~
```py
# core.management.commands.migrate.py 
# Line 255
if exit_dry:
    # Is this output necessary?
    if not plan:
        if self.verbosity >= 1:
            # If there's changes that aren't in migrations yet, tell them
            # how to fix it.
            autodetector = MigrationAutodetector(
                executor.loader.project_state(),
                ProjectState.from_apps(apps),
            )
            changes = autodetector.changes(graph=executor.loader.graph)
            if changes:
                self.stdout.write(
                    self.style.NOTICE(
                        "  Your models in app(s): %s have changes that are not "
                        "yet reflected in a migration, and so won't be "
                        "applied." % ", ".join(repr(app) for app in sorted(changes))
                    )
                )
                self.stdout.write(
                    self.style.NOTICE(
                        "  Run 'manage.py makemigrations' to make new "
                        "migrations, and then re-run 'manage.py migrate' to "
                        "apply them."
                    )
                )
    sys.exit(1)
```