### PR TITLE
Improved error message for ASCIIUsernameValidator.

### DIFF
--- a/django/contrib/auth/validators.py
+++ b/django/contrib/auth/validators.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 class ASCIIUsernameValidator(validators.RegexValidator):
     regex = r"^[\w.@+-]+\Z"
     message = _(
-        "Enter a valid username. This value may contain only English letters, "
+        "Enter a valid username. This value may contain only ASCII letters, "
         "numbers, and @/./+/-/_ characters."
     )
     flags = re.ASCII


### PR DESCRIPTION
The error message for the ASCII user name value contains a reference to the "English" language which is partial and misleading for non-English speaking users.

I propose to replace the word "English" with the more correct "ASCII", unless other clearer proposals.