### PR TITLE
Fixed #34010 -- Ensured app registry is populated running parallel tests with spawn start method.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -17,6 +17,8 @@ from contextlib import contextmanager
 from importlib import import_module
 from io import StringIO
 
+from django.apps import apps
+from django.conf import settings
 from django.core.management import call_command
 from django.db import connections
 from django.test import SimpleTestCase, TestCase
@@ -444,8 +446,8 @@ def _run_subsuite(args):
 
 
 def _process_setup_stub(*args):
-    """Stub method to simplify run() implementation."""
-    pass
+    """Setup app registry in subprocesses."""
+    apps.populate(settings.INSTALLED_APPS)
 
 
 class ParallelTestSuite(unittest.TestSuite):

--- a/docs/releases/4.1.2.txt
+++ b/docs/releases/4.1.2.txt
@@ -23,3 +23,6 @@ Bugfixes
 * Fixed a regression in Django 4.1 that caused a
   ``QuerySet.values()/values_list()`` crash on ``ArrayAgg()`` and
   ``JSONBAgg()`` (:ticket:`34016`).
+
+* Fixed a regression in Django 4.1 where the app registry was not populated
+  running parallel tests with the spawn start-method (:ticket:`340101`).


### PR DESCRIPTION
ticket-34010 Regression in 3b3f38b3b09b0f2373e51406ecb8c9c45d36aebc.

Thanks to Kevin Renskers for the report.

For The Django test suite we ensure the subprocesses correctly set the app registry:

https://github.com/django/django/blob/1a7b6909ac030d2c4dae2664b08ee0bce9c4c915/tests/runtests.py#L414-L415

This wasn't being done by default for `ParallelTestSuite`. Adding this resolves the issue for the minimal reproduce I attached to the ticket, as well as another project I was able to reproduce in. 

@kevinrenskers are you able to give this a run to confirm if it works for you? 

I wonder if we need anything more complex? 🤔 — I tested with `django.setup()` which works equally, but the correct `settings.SETTINGS_MODULE`, for example, was set in the subprocess **without** it, so I **think** it's just the `apps.popluate()` that's needed. (Any thoughts there welcome. 🙂)