### PR TITLE
Fixed #34010 -- Made parallel tests using spawn set up Django.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 from importlib import import_module
 from io import StringIO
 
+import django
 from django.core.management import call_command
 from django.db import connections
 from django.test import SimpleTestCase, TestCase
@@ -418,6 +419,7 @@ def _init_worker(
             if process_setup_args is None:
                 process_setup_args = ()
             process_setup(*process_setup_args)
+        django.setup()
         setup_test_environment()
 
     for alias in connections:

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -398,6 +398,7 @@ def _init_worker(
     serialized_contents=None,
     process_setup=None,
     process_setup_args=None,
+    debug_mode=None,
 ):
     """
     Switch to databases dedicated to this worker.
@@ -420,7 +421,7 @@ def _init_worker(
                 process_setup_args = ()
             process_setup(*process_setup_args)
         django.setup()
-        setup_test_environment()
+        setup_test_environment(debug=debug_mode)
 
     for alias in connections:
         connection = connections[alias]
@@ -473,10 +474,13 @@ class ParallelTestSuite(unittest.TestSuite):
     run_subsuite = _run_subsuite
     runner_class = RemoteTestRunner
 
-    def __init__(self, subsuites, processes, failfast=False, buffer=False):
+    def __init__(
+        self, subsuites, processes, failfast=False, debug_mode=False, buffer=False
+    ):
         self.subsuites = subsuites
         self.processes = processes
         self.failfast = failfast
+        self.debug_mode = debug_mode
         self.buffer = buffer
         self.initial_settings = None
         self.serialized_contents = None
@@ -508,6 +512,7 @@ class ParallelTestSuite(unittest.TestSuite):
                 self.serialized_contents,
                 self.process_setup.__func__,
                 self.process_setup_args,
+                self.debug_mode,
             ],
         )
         args = [
@@ -933,6 +938,7 @@ class DiscoverRunner:
                     subsuites,
                     processes,
                     self.failfast,
+                    self.debug_mode,
                     self.buffer,
                 )
         return suite

--- a/docs/releases/4.1.2.txt
+++ b/docs/releases/4.1.2.txt
@@ -31,3 +31,7 @@ Bugfixes
 * Fixed a regression in Django 4.1 where the app registry was not populated
   when running parallel tests with the ``multiprocessing`` start method
   ``spawn`` (:ticket:`34010`).
+
+* Fixed a regression in Django 4.1 where the ``--debug-mode`` argument to
+  ``test`` did not work when running parallel tests with the
+  ``multiprocessing`` start method ``spawn`` (:ticket:`34010`).

--- a/docs/releases/4.1.2.txt
+++ b/docs/releases/4.1.2.txt
@@ -27,3 +27,7 @@ Bugfixes
 * Fixed a bug in Django 4.1 that caused :attr:`.ModelAdmin.autocomplete_fields`
   to be incorrectly selected after adding/changing related instances via popups
   (:ticket:`34025`).
+
+* Fixed a regression in Django 4.1 where the app registry was not populated
+  when running parallel tests with the ``multiprocessing`` start method
+  ``spawn`` (:ticket:`34010`).

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -713,7 +713,9 @@ class TestRunnerInitializerTests(SimpleTestCase):
                 runner = self.test_runner(**kwargs)
                 return runner.run(suite)
 
-        runner = StubTestRunner(verbosity=0, interactive=False, parallel=2)
+        runner = StubTestRunner(
+            verbosity=0, interactive=False, parallel=2, debug_mode=True
+        )
         with self.assertRaisesMessage(Exception, "multiprocessing.Pool()"):
             runner.run_tests(
                 [
@@ -723,6 +725,9 @@ class TestRunnerInitializerTests(SimpleTestCase):
             )
         # Initializer must be a function.
         self.assertIs(mocked_pool.call_args.kwargs["initializer"], _init_worker)
+        initargs = mocked_pool.call_args.kwargs["initargs"]
+        self.assertEqual(len(initargs), 6)
+        self.assertEqual(initargs[5], True)  # debug_mode
 
 
 class Ticket17477RegressionTests(AdminScriptTestCase):


### PR DESCRIPTION
ticket-34010

Includes an extra fix for `--debug-mode` that I spotted on the way.

I'm not exactly sure how to test this - the original commit ( 3b3f38b3b09b0f2373e51406ecb8c9c45d36aebc ) doesn't seem to have added many tests for checking x/y/z work within parallel mode.