### PR TITLE
added span tag for materializecss support

### DIFF
--- a/django/forms/templates/django/forms/widgets/input_option.html
+++ b/django/forms/templates/django/forms/widgets/input_option.html
@@ -1,1 +1,1 @@
-{% if widget.wrap_label %}<label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>{% endif %}{% include "django/forms/widgets/input.html" %}{% if widget.wrap_label %} {{ widget.label }}</label>{% endif %}
+{% if widget.wrap_label %}<label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>{% endif %}{% include "django/forms/widgets/input.html" %}{% if widget.wrap_label %} <span>{{ widget.label }}</span></label>{% endif %}

--- a/tests/forms_tests/tests/test_i18n.py
+++ b/tests/forms_tests/tests/test_i18n.py
@@ -84,12 +84,12 @@ class FormsI18nTests(SimpleTestCase):
             '<div id="id_somechoice">\n'
             '<div><label for="id_somechoice_0">'
             '<input type="radio" id="id_somechoice_0" value="\xc5" name="somechoice" '
-            "required> En tied\xe4</label></div>\n"
+            "required> <span>En tied\xe4</span></label></div>\n"
             '<div><label for="id_somechoice_1">'
             '<input type="radio" id="id_somechoice_1" value="\xf8" name="somechoice" '
-            'required> Mies</label></div>\n<div><label for="id_somechoice_2">'
+            'required> <span>Mies</span></label></div>\n<div><label for="id_somechoice_2">'
             '<input type="radio" id="id_somechoice_2" value="\xdf" name="somechoice" '
-            "required> Nainen</label></div>\n</div></p>",
+            "required> <span>Nainen</span></label></div>\n</div></p>",
         )
 
         # Translated error messages

--- a/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
+++ b/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
@@ -17,13 +17,13 @@ class CheckboxSelectMultipleTest(WidgetTest):
             ["J"],
             html="""
             <div>
-            <div><label><input checked type="checkbox" name="beatles" value="J"> John
+            <div><label><input checked type="checkbox" name="beatles" value="J"> <span>John</span>
             </label></div>
-            <div><label><input type="checkbox" name="beatles" value="P"> Paul
+            <div><label><input type="checkbox" name="beatles" value="P"> <span>Paul</span>
             </label></div>
-            <div><label><input type="checkbox" name="beatles" value="G"> George
+            <div><label><input type="checkbox" name="beatles" value="G"> <span>George</span>
             </label></div>
-            <div><label><input type="checkbox" name="beatles" value="R"> Ringo
+            <div><label><input type="checkbox" name="beatles" value="R"> <span>Ringo</span>
             </label></div>
             </div>
         """,
@@ -36,13 +36,13 @@ class CheckboxSelectMultipleTest(WidgetTest):
             ["J", "P"],
             html="""
             <div>
-            <div><label><input checked type="checkbox" name="beatles" value="J"> John
+            <div><label><input checked type="checkbox" name="beatles" value="J"> <span>John</span>
             </label></div>
-            <div><label><input checked type="checkbox" name="beatles" value="P"> Paul
+            <div><label><input checked type="checkbox" name="beatles" value="P"> <span>Paul</span>
             </label></div>
-            <div><label><input type="checkbox" name="beatles" value="G"> George
+            <div><label><input type="checkbox" name="beatles" value="G"> <span>George</span>
             </label></div>
-            <div><label><input type="checkbox" name="beatles" value="R"> Ringo
+            <div><label><input type="checkbox" name="beatles" value="R"> <span>Ringo</span>
             </label></div>
             </div>
         """,
@@ -59,15 +59,15 @@ class CheckboxSelectMultipleTest(WidgetTest):
             None,
             html="""
             <div>
-            <div><label><input type="checkbox" name="beatles" value=""> Unknown
+            <div><label><input type="checkbox" name="beatles" value=""> <span>Unknown</span>
             </label></div>
-            <div><label><input type="checkbox" name="beatles" value="J"> John
+            <div><label><input type="checkbox" name="beatles" value="J"> <span>John</span>
             </label></div>
-            <div><label><input type="checkbox" name="beatles" value="P"> Paul
+            <div><label><input type="checkbox" name="beatles" value="P"> <span>Paul</span>
             </label></div>
-            <div><label><input type="checkbox" name="beatles" value="G"> George
+            <div><label><input type="checkbox" name="beatles" value="G"> <span>George</span>
             </label></div>
-            <div><label><input type="checkbox" name="beatles" value="R"> Ringo
+            <div><label><input type="checkbox" name="beatles" value="R"> <span>Ringo</span>
             </label></div>
             </div>
         """,
@@ -82,23 +82,23 @@ class CheckboxSelectMultipleTest(WidgetTest):
         html = """
         <div id="media">
         <div> <label for="media_0">
-        <input type="checkbox" name="nestchoice" value="unknown" id="media_0"> Unknown
+        <input type="checkbox" name="nestchoice" value="unknown" id="media_0"> <span>Unknown</span>
         </label></div>
         <div>
-        <label>Audio</label>
+        <label><span>Audio</span></label>
         <div> <label for="media_1_0">
         <input checked type="checkbox" name="nestchoice" value="vinyl" id="media_1_0">
-        Vinyl</label></div>
+        <span>Vinyl</span></label></div>
         <div> <label for="media_1_1">
-        <input type="checkbox" name="nestchoice" value="cd" id="media_1_1"> CD
+        <input type="checkbox" name="nestchoice" value="cd" id="media_1_1"> <span>CD</span>
         </label></div>
         </div><div>
-        <label>Video</label>
+        <label><span>Video</span></label>
         <div> <label for="media_2_0">
-        <input type="checkbox" name="nestchoice" value="vhs" id="media_2_0"> VHS
+        <input type="checkbox" name="nestchoice" value="vhs" id="media_2_0"> <span>VHS</span>
         </label></div>
         <div> <label for="media_2_1">
-        <input type="checkbox" name="nestchoice" value="dvd" id="media_2_1" checked> DVD
+        <input type="checkbox" name="nestchoice" value="dvd" id="media_2_1" checked> <span>DVD</span>
         </label></div>
         </div>
         </div>
@@ -120,20 +120,20 @@ class CheckboxSelectMultipleTest(WidgetTest):
         html = """
         <div>
         <div> <label>
-        <input type="checkbox" name="nestchoice" value="unknown"> Unknown</label></div>
+        <input type="checkbox" name="nestchoice" value="unknown"> <span>Unknown</span></label></div>
         <div>
-        <label>Audio</label>
+        <label><span>Audio</span></label>
         <div> <label>
-        <input checked type="checkbox" name="nestchoice" value="vinyl"> Vinyl
+        <input checked type="checkbox" name="nestchoice" value="vinyl"> <span>Vinyl</span>
         </label></div>
         <div> <label>
-        <input type="checkbox" name="nestchoice" value="cd"> CD</label></div>
+        <input type="checkbox" name="nestchoice" value="cd"> <span>CD</span></label></div>
         </div><div>
-        <label>Video</label>
+        <label><span>Video</span></label>
         <div> <label>
-        <input type="checkbox" name="nestchoice" value="vhs"> VHS</label></div>
+        <input type="checkbox" name="nestchoice" value="vhs"> <span>VHS</span></label></div>
         <div> <label>
-        <input type="checkbox" name="nestchoice" value="dvd"checked> DVD</label></div>
+        <input type="checkbox" name="nestchoice" value="dvd"checked> <span>DVD</span></label></div>
         </div>
         </div>
         """
@@ -153,13 +153,13 @@ class CheckboxSelectMultipleTest(WidgetTest):
         <div id="abc">
         <div>
         <label for="abc_0">
-        <input checked type="checkbox" name="letters" value="a" id="abc_0"> A</label>
+        <input checked type="checkbox" name="letters" value="a" id="abc_0"> <span>A</span></label>
         </div>
         <div><label for="abc_1">
-        <input type="checkbox" name="letters" value="b" id="abc_1"> B</label></div>
+        <input type="checkbox" name="letters" value="b" id="abc_1"> <span>B</span></label></div>
         <div>
         <label for="abc_2">
-        <input checked type="checkbox" name="letters" value="c" id="abc_2"> C</label>
+        <input checked type="checkbox" name="letters" value="c" id="abc_2"> <span>C</span></label>
         </div>
         </div>
         """
@@ -182,13 +182,13 @@ class CheckboxSelectMultipleTest(WidgetTest):
         <div id="abc">
         <div>
         <label for="abc_0">
-        <input checked type="checkbox" name="letters" value="a" id="abc_0"> A</label>
+        <input checked type="checkbox" name="letters" value="a" id="abc_0"> <span>A</span></label>
         </div>
         <div><label for="abc_1">
-        <input type="checkbox" name="letters" value="b" id="abc_1"> B</label></div>
+        <input type="checkbox" name="letters" value="b" id="abc_1"> <span>B</span></label></div>
         <div>
         <label for="abc_2">
-        <input checked type="checkbox" name="letters" value="c" id="abc_2"> C</label>
+        <input checked type="checkbox" name="letters" value="c" id="abc_2"> <span>C</span></label>
         </div>
         </div>
         """
@@ -203,11 +203,11 @@ class CheckboxSelectMultipleTest(WidgetTest):
         ]
         html = """
         <div>
-        <div><label><input type="checkbox" name="numbers" value="1"> One</label></div>
+        <div><label><input type="checkbox" name="numbers" value="1"> <span>One</span></label></div>
         <div><label>
-        <input type="checkbox" name="numbers" value="1000"> One thousand</label></div>
+        <input type="checkbox" name="numbers" value="1000"> <span>One thousand</span></label></div>
         <div><label>
-        <input type="checkbox" name="numbers" value="1000000"> One million</label></div>
+        <input type="checkbox" name="numbers" value="1000000"> <span>One million</span></label></div>
         </div>
         """
         self.check_html(self.widget(choices=choices), "numbers", None, html=html)
@@ -219,9 +219,9 @@ class CheckboxSelectMultipleTest(WidgetTest):
         html = """
         <div>
         <div><label>
-        <input type="checkbox" name="times" value="00:00:00"> midnight</label></div>
+        <input type="checkbox" name="times" value="00:00:00"> <span>midnight</span></label></div>
         <div><label>
-        <input type="checkbox" name="times" value="12:00:00"> noon</label></div>
+        <input type="checkbox" name="times" value="12:00:00"> <span>noon</span></label></div>
         </div>
         """
         self.check_html(self.widget(choices=choices), "times", None, html=html)
@@ -266,12 +266,12 @@ class CheckboxSelectMultipleTest(WidgetTest):
             form.render(),
             '<div><fieldset><legend>Field:</legend><div id="id_field">'
             '<div><label for="id_field_0"><input type="checkbox" '
-            'name="field" value="J" id="id_field_0"> John</label></div>'
+            'name="field" value="J" id="id_field_0"> <span>John</span></label></div>'
             '<div><label for="id_field_1"><input type="checkbox" '
-            'name="field" value="P" id="id_field_1">Paul</label></div>'
+            'name="field" value="P" id="id_field_1"><span>Paul</span></label></div>'
             '<div><label for="id_field_2"><input type="checkbox" '
-            'name="field" value="G" id="id_field_2"> George</label></div>'
+            'name="field" value="G" id="id_field_2"> <span>George</span></label></div>'
             '<div><label for="id_field_3"><input type="checkbox" '
             'name="field" value="R" id="id_field_3">'
-            "Ringo</label></div></div></fieldset></div>",
+            "<span>Ringo</span></label></div></div></fieldset></div>",
         )

--- a/tests/forms_tests/widget_tests/test_radioselect.py
+++ b/tests/forms_tests/widget_tests/test_radioselect.py
@@ -17,13 +17,13 @@ class RadioSelectTest(WidgetTest):
             "J",
             html="""
             <div>
-            <div><label><input type="radio" name="beatle" value=""> ------</label></div>
+            <div><label><input type="radio" name="beatle" value=""> <span>------</span></label></div>
             <div><label>
-            <input checked type="radio" name="beatle" value="J"> John</label></div>
-            <div><label><input type="radio" name="beatle" value="P"> Paul</label></div>
+            <input checked type="radio" name="beatle" value="J"> <span>John</span></label></div>
+            <div><label><input type="radio" name="beatle" value="P"> <span>Paul</span></label></div>
             <div><label>
-            <input type="radio" name="beatle" value="G"> George</label></div>
-            <div><label><input type="radio" name="beatle" value="R"> Ringo</label></div>
+            <input type="radio" name="beatle" value="G"> <span>George</span></label></div>
+            <div><label><input type="radio" name="beatle" value="R"> <span>Ringo</span></label></div>
             </div>
         """,
         )
@@ -38,26 +38,26 @@ class RadioSelectTest(WidgetTest):
         <div id="media">
         <div>
         <label for="media_0">
-        <input type="radio" name="nestchoice" value="unknown" id="media_0"> Unknown
+        <input type="radio" name="nestchoice" value="unknown" id="media_0"> <span>Unknown</span>
         </label></div>
         <div>
-        <label>Audio</label>
+        <label><span>Audio</span></label>
         <div>
         <label for="media_1_0">
-        <input type="radio" name="nestchoice" value="vinyl" id="media_1_0"> Vinyl
+        <input type="radio" name="nestchoice" value="vinyl" id="media_1_0"> <span>Vinyl</span>
         </label></div>
         <div> <label for="media_1_1">
-        <input type="radio" name="nestchoice" value="cd" id="media_1_1"> CD
+        <input type="radio" name="nestchoice" value="cd" id="media_1_1"> <span>CD</span>
         </label></div>
         </div><div>
-        <label>Video</label>
+        <label><span>Video</span></label>
         <div>
         <label for="media_2_0">
-        <input type="radio" name="nestchoice" value="vhs" id="media_2_0"> VHS
+        <input type="radio" name="nestchoice" value="vhs" id="media_2_0"> <span>VHS</span>
         </label></div>
         <div>
         <label for="media_2_1">
-        <input type="radio" name="nestchoice" value="dvd" id="media_2_1" checked> DVD
+        <input type="radio" name="nestchoice" value="dvd" id="media_2_1" checked> <span>DVD</span>
         </label></div>
         </div>
         </div>
@@ -80,14 +80,14 @@ class RadioSelectTest(WidgetTest):
         <div id="foo">
         <div>
         <label for="foo_0">
-        <input checked type="radio" id="foo_0" value="J" name="beatle"> John</label>
+        <input checked type="radio" id="foo_0" value="J" name="beatle"> <span>John</span></label>
         </div>
         <div><label for="foo_1">
-        <input type="radio" id="foo_1" value="P" name="beatle"> Paul</label></div>
+        <input type="radio" id="foo_1" value="P" name="beatle"> <span>Paul</span></label></div>
         <div><label for="foo_2">
-        <input type="radio" id="foo_2" value="G" name="beatle"> George</label></div>
+        <input type="radio" id="foo_2" value="G" name="beatle"> <span>George</span></label></div>
         <div><label for="foo_3">
-        <input type="radio" id="foo_3" value="R" name="beatle"> Ringo</label></div>
+        <input type="radio" id="foo_3" value="R" name="beatle"> <span>Ringo</span></label></div>
         </div>
         """
         self.check_html(widget, "beatle", "J", html=html)
@@ -101,14 +101,14 @@ class RadioSelectTest(WidgetTest):
         <div id="bar">
         <div>
         <label for="bar_0">
-        <input checked type="radio" id="bar_0" value="J" name="beatle"> John</label>
+        <input checked type="radio" id="bar_0" value="J" name="beatle"> <span>John</span></label>
         </div>
         <div><label for="bar_1">
-        <input type="radio" id="bar_1" value="P" name="beatle"> Paul</label></div>
+        <input type="radio" id="bar_1" value="P" name="beatle"> <span>Paul</span></label></div>
         <div><label for="bar_2">
-        <input type="radio" id="bar_2" value="G" name="beatle"> George</label></div>
+        <input type="radio" id="bar_2" value="G" name="beatle"> <span>George</span></label></div>
         <div><label for="bar_3">
-        <input type="radio" id="bar_3" value="R" name="beatle"> Ringo</label></div>
+        <input type="radio" id="bar_3" value="R" name="beatle"> <span>Ringo</span></label></div>
         </div>
         """
         self.check_html(
@@ -127,14 +127,14 @@ class RadioSelectTest(WidgetTest):
         html = """
         <div class="bar">
         <div><label>
-        <input checked type="radio" class="bar" value="J" name="beatle"> John</label>
+        <input checked type="radio" class="bar" value="J" name="beatle"> <span>John</span></label>
         </div>
         <div><label>
-        <input type="radio" class="bar" value="P" name="beatle"> Paul</label></div>
+        <input type="radio" class="bar" value="P" name="beatle"> <span>Paul</span></label></div>
         <div><label>
-        <input type="radio" class="bar" value="G" name="beatle"> George</label></div>
+        <input type="radio" class="bar" value="G" name="beatle"> <span>George</span></label></div>
         <div><label>
-        <input type="radio" class="bar" value="R" name="beatle"> Ringo</label></div>
+        <input type="radio" class="bar" value="R" name="beatle"> <span>Ringo</span></label></div>
         </div>
         """
         self.check_html(
@@ -154,11 +154,11 @@ class RadioSelectTest(WidgetTest):
         ]
         html = """
         <div>
-        <div><label><input type="radio" name="number" value="1"> One</label></div>
+        <div><label><input type="radio" name="number" value="1"> <span>One</span></label></div>
         <div><label>
-        <input type="radio" name="number" value="1000"> One thousand</label></div>
+        <input type="radio" name="number" value="1000"> <span>One thousand</span></label></div>
         <div><label>
-        <input type="radio" name="number" value="1000000"> One million</label></div>
+        <input type="radio" name="number" value="1000000"> <span>One million</span></label></div>
         </div>
         """
         self.check_html(self.widget(choices=choices), "number", None, html=html)
@@ -170,9 +170,9 @@ class RadioSelectTest(WidgetTest):
         html = """
         <div>
         <div><label>
-        <input type="radio" name="time" value="00:00:00"> midnight</label></div>
+        <input type="radio" name="time" value="00:00:00"> <span>midnight</span></label></div>
         <div><label>
-        <input type="radio" name="time" value="12:00:00"> noon</label></div>
+        <input type="radio" name="time" value="12:00:00"> <span>noon</span></label></div>
         </div>
         """
         self.check_html(self.widget(choices=choices), "time", None, html=html)
@@ -187,15 +187,15 @@ class RadioSelectTest(WidgetTest):
             html="""
             <div>
             <div><label>
-            <input type="radio" name="beatle_0" value=""> ------</label></div>
+            <input type="radio" name="beatle_0" value=""> <span>------</span></label></div>
             <div><label>
-            <input checked type="radio" name="beatle_0" value="J"> John</label></div>
+            <input checked type="radio" name="beatle_0" value="J"> <span>John</span></label></div>
             <div><label>
-            <input type="radio" name="beatle_0" value="P"> Paul</label></div>
+            <input type="radio" name="beatle_0" value="P"> <span>Paul</span></label></div>
             <div><label>
-            <input type="radio" name="beatle_0" value="G"> George</label></div>
+            <input type="radio" name="beatle_0" value="G"> <span>George</span></label></div>
             <div><label>
-            <input type="radio" name="beatle_0" value="R"> Ringo</label></div>
+            <input type="radio" name="beatle_0" value="R"> <span>Ringo</span></label></div>
             </div>
         """,
         )
@@ -212,13 +212,13 @@ class RadioSelectTest(WidgetTest):
         self.assertHTMLEqual(
             '<div><fieldset><legend>Field:</legend><div id="id_field">'
             '<div><label for="id_field_0">'
-            '<input type="radio" name="field" value="J" id="id_field_0"> John'
+            '<input type="radio" name="field" value="J" id="id_field_0"> <span>John</span>'
             '</label></div><div><label for="id_field_1">'
-            '<input type="radio" name="field" value="P" id="id_field_1">Paul'
+            '<input type="radio" name="field" value="P" id="id_field_1"><span>Paul</span>'
             '</label></div><div><label for="id_field_2"><input type="radio" '
-            'name="field" value="G" id="id_field_2"> George</label></div>'
+            'name="field" value="G" id="id_field_2"> <span>George</span></label></div>'
             '<div><label for="id_field_3"><input type="radio" name="field" '
-            'value="R" id="id_field_3">Ringo</label></div></div></fieldset>'
+            'value="R" id="id_field_3"><span>Ringo</span></label></div></div></fieldset>'
             "</div>",
             form.render(),
         )


### PR DESCRIPTION
span tag for label text is needed for checkboxes and radio buttons to be visible if using materializecss

examples for using checkboxes [https://materializecss.com/checkboxes.html](https://materializecss.com/checkboxes.html) and for radio buttons [https://materializecss.com/radio-buttons.html](https://materializecss.com/radio-buttons.html) with materializecss