### PR TITLE
Fixed #33984 -- Reverted "Fixed #32980 -- Made models cache related managers."

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -552,14 +552,6 @@ class ReverseGenericManyToOneDescriptor(ReverseManyToOneDescriptor):
             self.rel,
         )
 
-    @cached_property
-    def related_manager_cache_key(self):
-        # By default, GenericRel instances will be marked as hidden unless
-        # related_query_name is given (their accessor name being "+" when
-        # hidden), which would cause multiple GenericRelations declared on a
-        # single model to collide, so always use the remote field's name.
-        return self.field.get_cache_name()
-
 
 def create_generic_related_manager(superclass, rel):
     """

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -591,14 +591,6 @@ class ReverseManyToOneDescriptor:
         self.field = rel.field
 
     @cached_property
-    def related_manager_cache_key(self):
-        # Being able to access the manager instance precludes it from being
-        # hidden. The rel's accessor name is used to allow multiple managers
-        # to the same model to coexist. e.g. post.attached_comment_set and
-        # post.attached_link_set are separately cached.
-        return self.rel.get_cache_name()
-
-    @cached_property
     def related_manager_cls(self):
         related_model = self.rel.related_model
 
@@ -619,11 +611,8 @@ class ReverseManyToOneDescriptor:
         """
         if instance is None:
             return self
-        key = self.related_manager_cache_key
-        instance_cache = instance._state.related_managers_cache
-        if key not in instance_cache:
-            instance_cache[key] = self.related_manager_cls(instance)
-        return instance_cache[key]
+
+        return self.related_manager_cls(instance)
 
     def _get_set_deprecation_msg_params(self):
         return (
@@ -940,17 +929,6 @@ class ManyToManyDescriptor(ReverseManyToOneDescriptor):
             self.rel,
             reverse=self.reverse,
         )
-
-    @cached_property
-    def related_manager_cache_key(self):
-        if self.reverse:
-            # Symmetrical M2Ms won't have an accessor name, but should never
-            # end up in the reverse branch anyway, as the related_name ends up
-            # being hidden, and no public manager is created.
-            return self.rel.get_cache_name()
-        else:
-            # For forward managers, defer to the field name.
-            return self.field.get_cache_name()
 
     def _get_set_deprecation_msg_params(self):
         return (

--- a/docs/releases/4.1.2.txt
+++ b/docs/releases/4.1.2.txt
@@ -43,3 +43,7 @@ Bugfixes
 * Fixed a regression in Django 4.1 that caused a crash for :class:`View`
   subclasses with asynchronous handlers when handling non-allowed HTTP methods
   (:ticket:`34062`).
+
+* Reverted caching related managers for ``ForeignKey``, ``ManyToManyField``,
+  and ``GenericRelation`` that caused the incorrect refreshing of related
+  objects (:ticket:`33984`).

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -530,7 +530,8 @@ Miscellaneous
 * Related managers for :class:`~django.db.models.ForeignKey`,
   :class:`~django.db.models.ManyToManyField`, and
   :class:`~django.contrib.contenttypes.fields.GenericRelation` are now cached
-  on the :class:`~django.db.models.Model` instance to which they belong.
+  on the :class:`~django.db.models.Model` instance to which they belong. *This
+  change was reverted in Django 4.1.2.*
 
 * The Django test runner now returns a non-zero error code for unexpected
   successes from tests marked with :py:func:`unittest.expectedFailure`.

--- a/tests/custom_managers/models.py
+++ b/tests/custom_managers/models.py
@@ -164,22 +164,6 @@ class Book(models.Model):
         base_manager_name = "annotated_objects"
 
 
-class ConfusedBook(models.Model):
-    title = models.CharField(max_length=50)
-    author = models.CharField(max_length=30)
-    favorite_things = GenericRelation(
-        Person,
-        content_type_field="favorite_thing_type",
-        object_id_field="favorite_thing_id",
-    )
-    less_favorite_things = GenericRelation(
-        FunPerson,
-        content_type_field="favorite_thing_type",
-        object_id_field="favorite_thing_id",
-        related_query_name="favorite_things",
-    )
-
-
 class FastCarManager(models.Manager):
     def get_queryset(self):
         return super().get_queryset().filter(top_speed__gt=150)

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -92,6 +92,25 @@ class ManyToManyTests(TestCase):
         a5.authors.remove(user_2.username)
         self.assertSequenceEqual(a5.authors.all(), [])
 
+    def test_related_manager_refresh(self):
+        user_1 = User.objects.create(username="Jean")
+        user_2 = User.objects.create(username="Joe")
+        self.a3.authors.add(user_1.username)
+        self.assertSequenceEqual(user_1.article_set.all(), [self.a3])
+        # Change the username on a different instance of the same user.
+        user_1_from_db = User.objects.get(pk=user_1.pk)
+        self.assertSequenceEqual(user_1_from_db.article_set.all(), [self.a3])
+        user_1_from_db.username = "Paul"
+        self.a3.authors.set([user_2.username])
+        user_1_from_db.save()
+        # Assign a different article.
+        self.a4.authors.add(user_1_from_db.username)
+        self.assertSequenceEqual(user_1_from_db.article_set.all(), [self.a4])
+        # Refresh the instance with an evaluated related manager.
+        user_1.refresh_from_db()
+        self.assertEqual(user_1.username, "Paul")
+        self.assertSequenceEqual(user_1.article_set.all(), [self.a4])
+
     def test_add_remove_invalid_type(self):
         msg = "Field 'id' expected a number but got 'invalid'."
         for method in ["add", "remove"]:

--- a/tests/model_inheritance_regress/tests.py
+++ b/tests/model_inheritance_regress/tests.py
@@ -416,11 +416,6 @@ class ModelInheritanceTest(TestCase):
         parties = list(p4.bachelorparty_set.all())
         self.assertEqual(parties, [bachelor, messy_parent])
 
-    def test_abstract_base_class_m2m_relation_inheritance_manager_reused(self):
-        p1 = Person.objects.create(name="Alice")
-        self.assertIs(p1.birthdayparty_set, p1.birthdayparty_set)
-        self.assertIs(p1.bachelorparty_set, p1.bachelorparty_set)
-
     def test_abstract_verbose_name_plural_inheritance(self):
         """
         verbose_name_plural correctly inherited from ABC if inheritance chain

--- a/tests/model_regress/test_state.py
+++ b/tests/model_regress/test_state.py
@@ -1,12 +1,7 @@
-from django.db.models.base import ModelState, ModelStateCacheDescriptor
+from django.db.models.base import ModelState, ModelStateFieldsCacheDescriptor
 from django.test import SimpleTestCase
 
 
 class ModelStateTests(SimpleTestCase):
     def test_fields_cache_descriptor(self):
-        self.assertIsInstance(ModelState.fields_cache, ModelStateCacheDescriptor)
-
-    def test_related_managers_descriptor(self):
-        self.assertIsInstance(
-            ModelState.related_managers_cache, ModelStateCacheDescriptor
-        )
+        self.assertIsInstance(ModelState.fields_cache, ModelStateFieldsCacheDescriptor)

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -1358,14 +1358,6 @@ class ForeignKeyToFieldTest(TestCase):
                 ],
             )
 
-    def test_m2m_manager_reused(self):
-        author = Author.objects.prefetch_related(
-            "favorite_authors",
-            "favors_me",
-        ).first()
-        self.assertIs(author.favorite_authors, author.favorite_authors)
-        self.assertIs(author.favors_me, author.favors_me)
-
 
 class LookupOrderingTest(TestCase):
     """


### PR DESCRIPTION
This reverts 4f8c7fd9d91b35e2c2922de4bb50c8c8066cbbc6 and adds two regression tests:
- `test_related_manager_refresh()`, and
- `test_create_copy_with_m2m()`.

Thanks @joeli for the report.

ticket-33984