### PR TITLE
Fixed #34064 -- Adjusted locale override wording in settings docs.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2886,8 +2886,8 @@ Default: ``False``
 A boolean that specifies whether to display numbers using a thousand separator.
 When set to ``True`` and :setting:`USE_L10N` is also ``True``, Django will
 format numbers using the :setting:`NUMBER_GROUPING` and
-:setting:`THOUSAND_SEPARATOR` settings. These settings may also be dictated by
-the locale, which takes precedence.
+:setting:`THOUSAND_SEPARATOR` settings. The latter two settings may also be
+dictated by the locale, which takes precedence.
 
 See also :setting:`DECIMAL_SEPARATOR`, :setting:`NUMBER_GROUPING` and
 :setting:`THOUSAND_SEPARATOR`.


### PR DESCRIPTION
This is very small change to remove ambiguity from the documentation of the `USE_THOUSAND_SEPARATOR` setting. 

Related ticket: https://code.djangoproject.com/ticket/34064