### PR TITLE
Fixed #34069 -- Made LocaleMiddleware respect language from requests when i18n patterns are used.

### DIFF
--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -16,28 +16,37 @@ class LocaleMiddleware(MiddlewareMixin):
 
     response_redirect_class = HttpResponseRedirect
 
+    def get_fallback_language(self, request):
+        """
+        Return the fallback language for the current request based on the
+        settings. If LANGUAGE_CODE is a variant not included in the supported
+        languages, get_fallback_language() will try to fallback to a supported
+        generic variant.
+
+        Can be overridden to have a fallback language depending on the request,
+        e.g. based on top level domain.
+        """
+        try:
+            return translation.get_supported_language_variant(settings.LANGUAGE_CODE)
+        except LookupError:
+            return settings.LANGUAGE_CODE
+
     def process_request(self, request):
         urlconf = getattr(request, "urlconf", settings.ROOT_URLCONF)
-        (
-            i18n_patterns_used,
-            prefixed_default_language,
-        ) = is_language_prefix_patterns_used(urlconf)
+        i18n_patterns_used, _ = is_language_prefix_patterns_used(urlconf)
         language = translation.get_language_from_request(
             request, check_path=i18n_patterns_used
         )
-        language_from_path = translation.get_language_from_path(request.path_info)
-        if (
-            not language_from_path
-            and i18n_patterns_used
-            and not prefixed_default_language
-        ):
-            language = settings.LANGUAGE_CODE
+        if not language:
+            language = self.get_fallback_language(request)
+
         translation.activate(language)
         request.LANGUAGE_CODE = translation.get_language()
 
     def process_response(self, request, response):
         language = translation.get_language()
         language_from_path = translation.get_language_from_path(request.path_info)
+        language_from_request = translation.get_language_from_request(request)
         urlconf = getattr(request, "urlconf", settings.ROOT_URLCONF)
         (
             i18n_patterns_used,
@@ -48,7 +57,7 @@ class LocaleMiddleware(MiddlewareMixin):
             response.status_code == 404
             and not language_from_path
             and i18n_patterns_used
-            and prefixed_default_language
+            and (prefixed_default_language or language_from_request)
         ):
             # Maybe the language code is missing in the URL? Try adding the
             # language prefix and redirecting to that URL.

--- a/django/utils/translation/trans_null.py
+++ b/django/utils/translation/trans_null.py
@@ -53,7 +53,7 @@ def check_for_language(x):
 
 
 def get_language_from_request(request, check_path=False):
-    return settings.LANGUAGE_CODE
+    return None
 
 
 def get_language_from_path(request):

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -578,11 +578,7 @@ def get_language_from_request(request, check_path=False):
             return get_supported_language_variant(accept_lang)
         except LookupError:
             continue
-
-    try:
-        return get_supported_language_variant(settings.LANGUAGE_CODE)
-    except LookupError:
-        return settings.LANGUAGE_CODE
+    return None
 
 
 @functools.lru_cache(maxsize=1000)

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -186,6 +186,10 @@ Internationalization
 
 * Added support and translations for the Central Kurdish (Sorani) language.
 
+* The :class:`~django.middleware.locale.LocaleMiddleware` now respects a
+  language from the request when :func:`~django.conf.urls.i18n.i18n_patterns`
+  is used with the ``prefix_default_language`` argument set to ``False``.
+
 Logging
 ~~~~~~~
 


### PR DESCRIPTION
## Problem
I wanted to make a middleware that would fallback to a language depending on the TLD of the request.

I found that this was quite difficult, as `get_language_from_request` would return the default app language if no language was provided. This makes it impossible to know if the return of `get_language_from_request` is actually from the request, or if it is just the fallback.  -- https://code.djangoproject.com/ticket/34069 -- and a bit of mix of responsibilities. 

## Solution
Given the name "from_request" I thought it would make sense to return `None` (just like `get_language_from_path`) if there is nothing in the request that hints for the selected language, and move the fallback logic to the middleware. 

In the process of checking this bug, I also found some other issues with the use of Cookies with i18n_patterns - https://code.djangoproject.com/ticket/32886

This should also fix that issue  ~~although it does not test for it.~~

For convenience, and to allow other people to more flexibly decide their fallback language logic, I've isolated the logic to the Middleware class `get_fallback_language` method, allowing for it be easily overriden:

Eg, of my original goal:
```.py
class MyOwnLocaleMiddleware(LocaleMiddleware):
  LANGUAGE_FALLBACKS_TLD = {
     'fi': 'fi',
     'io:': 'en'
   }
  def get_fallback_language(self, request):
    host_tld_lang = request.META['HTTP_HOST'].split('.')[-1]
    fallback_lang = LANGUAGE_FALLBACKS_TLD.get(host_tld_lang, None)
    if fallback_lang:
      return fallback_lang
    return super().get_fallback_language(request)
```


