### PR TITLE
Refs #32987 -- Relaxed system check for template tag modules with the same name by turning into a warning.

### DIFF
--- a/django/core/checks/templates.py
+++ b/django/core/checks/templates.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from django.conf import settings
 from django.template.backends.django import get_template_tag_modules
 
-from . import Error, Tags, register
+from . import Error, Tags, Warning, register
 
 E001 = Error(
     "You have 'APP_DIRS': True in your TEMPLATES but also specify 'loaders' "
@@ -15,7 +15,7 @@ E002 = Error(
     "'string_if_invalid' in TEMPLATES OPTIONS must be a string but got: {} ({}).",
     id="templates.E002",
 )
-E003 = Error(
+W003 = Warning(
     "{} is used for multiple template tag modules: {}",
     id="templates.E003",
 )
@@ -63,12 +63,12 @@ def check_for_template_tags_with_the_same_name(app_configs, **kwargs):
     for library_name, items in libraries.items():
         if len(items) > 1:
             errors.append(
-                Error(
-                    E003.msg.format(
+                Warning(
+                    W003.msg.format(
                         repr(library_name),
                         ", ".join(repr(item) for item in sorted(items)),
                     ),
-                    id=E003.id,
+                    id=W003.id,
                 )
             )
 

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -553,6 +553,9 @@ configured:
   :setting:`OPTIONS <TEMPLATES-OPTIONS>` must be a string but got: ``{value}``
   (``{type}``).
 * **templates.E003**:``<name>`` is used for multiple template tag modules:
+  ``<module list>``. *This check was changed to* ``templates.W003`` *in Django
+  4.1.2*.
+* **templates.W003**:``<name>`` is used for multiple template tag modules:
   ``<module list>``.
 
 Translation

--- a/docs/releases/4.1.2.txt
+++ b/docs/releases/4.1.2.txt
@@ -47,3 +47,6 @@ Bugfixes
 * Reverted caching related managers for ``ForeignKey``, ``ManyToManyField``,
   and ``GenericRelation`` that caused the incorrect refreshing of related
   objects (:ticket:`33984`).
+
+* Relaxed the system check added in Django 4.1 for the same name used for
+  multiple template tag modules to a warning (:ticket:`32987`).

--- a/tests/check_framework/test_templates.py
+++ b/tests/check_framework/test_templates.py
@@ -1,10 +1,10 @@
 from copy import copy, deepcopy
 
-from django.core.checks import Error
+from django.core.checks import Warning
 from django.core.checks.templates import (
     E001,
     E002,
-    E003,
+    W003,
     check_for_template_tags_with_the_same_name,
     check_setting_app_dirs_loaders,
     check_string_if_invalid_is_string,
@@ -108,15 +108,15 @@ class CheckTemplateTagLibrariesWithSameName(SimpleTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.error_same_tags = Error(
-            E003.msg.format(
+        cls.warning_same_tags = Warning(
+            W003.msg.format(
                 "'same_tags'",
                 "'check_framework.template_test_apps.same_tags_app_1."
                 "templatetags.same_tags', "
                 "'check_framework.template_test_apps.same_tags_app_2."
                 "templatetags.same_tags'",
             ),
-            id=E003.id,
+            id=W003.id,
         )
 
     @staticmethod
@@ -139,7 +139,7 @@ class CheckTemplateTagLibrariesWithSameName(SimpleTestCase):
     def test_template_tags_with_same_name(self):
         self.assertEqual(
             check_for_template_tags_with_the_same_name(None),
-            [self.error_same_tags],
+            [self.warning_same_tags],
         )
 
     def test_template_tags_with_same_library_name(self):
@@ -155,7 +155,7 @@ class CheckTemplateTagLibrariesWithSameName(SimpleTestCase):
         ):
             self.assertEqual(
                 check_for_template_tags_with_the_same_name(None),
-                [self.error_same_tags],
+                [self.warning_same_tags],
             )
 
     @override_settings(
@@ -186,15 +186,15 @@ class CheckTemplateTagLibrariesWithSameName(SimpleTestCase):
             self.assertEqual(
                 check_for_template_tags_with_the_same_name(None),
                 [
-                    Error(
-                        E003.msg.format(
+                    Warning(
+                        W003.msg.format(
                             "'same_tags'",
                             "'check_framework.template_test_apps.different_tags_app."
                             "templatetags.different_tags', "
                             "'check_framework.template_test_apps.same_tags_app_1."
                             "templatetags.same_tags'",
                         ),
-                        id=E003.id,
+                        id=W003.id,
                     )
                 ],
             )


### PR DESCRIPTION
Thanks Claude Paroz for the [report](https://code.djangoproject.com/ticket/32987#comment:13).

Regression in 004b4620f6f4ad87261e149898940f2dcd5757ef.