### PR TITLE
Fixed #34071 -- Improved error message for Range(Min/Max)ValueValidator.

### DIFF
--- a/django/contrib/postgres/validators.py
+++ b/django/contrib/postgres/validators.py
@@ -78,7 +78,7 @@ class RangeMaxValueValidator(MaxValueValidator):
         return a.upper is None or a.upper > b
 
     message = _(
-        "Ensure that this range is completely less than or equal to %(limit_value)s."
+        "Ensure that the upper bound of the range is not greater than %(limit_value)s."
     )
 
 
@@ -87,5 +87,5 @@ class RangeMinValueValidator(MinValueValidator):
         return a.lower is None or a.lower < b
 
     message = _(
-        "Ensure that this range is completely greater than or equal to %(limit_value)s."
+        "Ensure that the lower bound of the range is not less than %(limit_value)s."
     )

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -631,7 +631,7 @@ class TestValidators(PostgreSQLSimpleTestCase):
     def test_max(self):
         validator = RangeMaxValueValidator(5)
         validator(NumericRange(0, 5))
-        msg = "Ensure that this range is completely less than or equal to 5."
+        msg = "Ensure that the upper bound of the range is not greater than 5."
         with self.assertRaises(exceptions.ValidationError) as cm:
             validator(NumericRange(0, 10))
         self.assertEqual(cm.exception.messages[0], msg)
@@ -642,7 +642,7 @@ class TestValidators(PostgreSQLSimpleTestCase):
     def test_min(self):
         validator = RangeMinValueValidator(5)
         validator(NumericRange(10, 15))
-        msg = "Ensure that this range is completely greater than or equal to 5."
+        msg = "Ensure that the lower bound of the range is not less than 5."
         with self.assertRaises(exceptions.ValidationError) as cm:
             validator(NumericRange(0, 10))
         self.assertEqual(cm.exception.messages[0], msg)


### PR DESCRIPTION
The wording in the documentation for RangeMaxValueValidator and RangeMinValueValidator is very clear:

- "Validates that the upper bound of the range is not greater than limit_value."
- "Validates that the lower bound of the range is not less than the limit_value."

The wording in the validator messages (and validator test messages) within the code itself is somewhat confusing in comparison:

- "Ensure that this range is completely less than or equal to %(limit_value)s."
- "Ensure that this range is completely greater than or equal to %(limit_value)s."

The patch modifies the messages in the validator (and validator test) code to match the documentation, making it more clear to users exactly what the range validators do.