### PR TITLE
Fixed #33586 -- Reloaded delayed apps cache during backwards migrations for RunPython operation

### DIFF
--- a/django/db/migrations/operations/special.py
+++ b/django/db/migrations/operations/special.py
@@ -193,6 +193,7 @@ class RunPython(Operation):
             self.code(from_state.apps, schema_editor)
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        from_state.clear_delayed_apps_cache()
         if self.reverse_code is None:
             raise NotImplementedError("You cannot reverse this operation")
         if router.allow_migrate(


### PR DESCRIPTION
[Ticket #33586](https://code.djangoproject.com/ticket/33586)
