### PR TITLE
Fixed #33768 -- Fixed ordering compound queries by nulls_first/nulls_last on MySQL.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -235,6 +235,7 @@ class BaseDatabaseFeatures:
     supports_select_difference = True
     supports_slicing_ordering_in_compound = False
     supports_parentheses_in_compound = True
+    requires_compound_order_by_subquery = False
 
     # Does the database support SQL 2003 FILTER (WHERE ...) in aggregate
     # expressions?

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -69,6 +69,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_partial_indexes = False
     can_rename_index = True
     supports_slicing_ordering_in_compound = True
+    requires_compound_order_by_subquery = True
     allows_multiple_constraints_on_same_fields = False
     supports_boolean_expr_in_select_clause = False
     supports_comparing_boolean_expr = False


### PR DESCRIPTION
Columns of the left outer most select statement in a combined query can be referenced by alias just like by index.

This removes combined query ordering by column index and avoids an unnecessary usage of RawSQL which causes issues for backends that specialize the treatment of null ordering.

ticket-33768