### PR TITLE
Refs #33308 -- Enabled explicit GROUP BY and ORDER BY aliases.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -10,6 +10,7 @@ class BaseDatabaseFeatures:
     allows_group_by_lob = True
     allows_group_by_pk = False
     allows_group_by_selected_pks = False
+    allows_group_by_refs = True
     empty_fetchmany_value = []
     update_can_self_select = True
 

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -8,6 +8,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     # Oracle crashes with "ORA-00932: inconsistent datatypes: expected - got
     # BLOB" when grouping by LOBs (#24096).
     allows_group_by_lob = False
+    allows_group_by_refs = False
     interprets_empty_strings_as_nulls = True
     has_select_for_update = True
     has_select_for_update_nowait = True

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -419,6 +419,8 @@ class BaseExpression:
 
     def get_group_by_cols(self, alias=None):
         if not self.contains_aggregate:
+            if alias:
+                return [Ref(alias, self)]
             return [self]
         cols = []
         for source in self.get_source_expressions():
@@ -1243,7 +1245,7 @@ class ExpressionWrapper(SQLiteNumericMixin, Expression):
             return expression.get_group_by_cols(alias=alias)
         # For non-expressions e.g. an SQL WHERE clause, the entire
         # `expression` must be included in the GROUP BY clause.
-        return super().get_group_by_cols()
+        return super().get_group_by_cols(alias=alias)
 
     def as_sql(self, compiler, connection):
         return compiler.compile(self.expression)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2220,8 +2220,8 @@ class Query(BaseExpression):
         primary key, and the query would be equivalent, the optimization
         will be made automatically.
         """
-        # Column names from JOINs to check collisions with aliases.
         if allow_aliases:
+            # Column names from JOINs to check collisions with aliases.
             column_names = set()
             seen_models = set()
             for join in list(self.alias_map.values())[1:]:  # Skip base table.
@@ -2231,7 +2231,20 @@ class Query(BaseExpression):
                         {field.column for field in model._meta.local_concrete_fields}
                     )
                     seen_models.add(model)
-
+            if self.values_select:
+                # If grouping by aliases is allowed assign selected values
+                # aliases by moving them to annotations.
+                group_by_annotations = {}
+                values_select = {}
+                for alias, expr in zip(self.values_select, self.select):
+                    if isinstance(expr, Col):
+                        values_select[alias] = expr
+                    else:
+                        group_by_annotations[alias] = expr
+                self.annotations = {**group_by_annotations, **self.annotations}
+                self.append_annotation_mask(group_by_annotations)
+                self.select = tuple(values_select.values())
+                self.values_select = tuple(values_select)
         group_by = list(self.select)
         if self.annotation_select:
             for alias, annotation in self.annotation_select.items():

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -12,7 +12,12 @@ from django.core.management import call_command
 from django.db import IntegrityError, connection, models
 from django.db.models.expressions import Exists, OuterRef, RawSQL, Value
 from django.db.models.functions import Cast, JSONObject, Upper
-from django.test import TransactionTestCase, modify_settings, override_settings
+from django.test import (
+    TransactionTestCase,
+    modify_settings,
+    override_settings,
+    skipUnlessDBFeature,
+)
 from django.test.utils import isolate_apps
 from django.utils import timezone
 
@@ -404,6 +409,27 @@ class TestQuerying(PostgreSQLTestCase):
                     ).values_list("field__0", flat=True),
                     expected,
                 )
+
+    @skipUnlessDBFeature("allows_group_by_refs")
+    def test_group_by_order_by_aliases(self):
+        with self.assertNumQueries(1) as ctx:
+            self.assertSequenceEqual(
+                NullableIntegerArrayModel.objects.filter(
+                    field__0__isnull=False,
+                )
+                .values("field__0")
+                .annotate(arrayagg=ArrayAgg("id"))
+                .order_by("field__0"),
+                [
+                    {"field__0": 1, "arrayagg": [1]},
+                    {"field__0": 2, "arrayagg": [2, 3]},
+                    {"field__0": 20, "arrayagg": [4]},
+                ],
+            )
+        alias = connection.ops.quote_name("field__0")
+        sql = ctx[0]["sql"]
+        self.assertIn(f"GROUP BY {alias}", sql)
+        self.assertIn(f"ORDER BY {alias}", sql)
 
     def test_index(self):
         self.assertSequenceEqual(


### PR DESCRIPTION
This ensures explicit grouping from using values() before annotating an aggregate function groups by selected aliases if supported.

The `GROUP BY` feature is disabled on Oracle because it doesn't support it.