### PR TITLE
Removed hardcoded pks in TestQuerying.test_group_by_order_by_aliases test.

### DIFF
--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -421,9 +421,9 @@ class TestQuerying(PostgreSQLTestCase):
                 .annotate(arrayagg=ArrayAgg("id"))
                 .order_by("field__0"),
                 [
-                    {"field__0": 1, "arrayagg": [1]},
-                    {"field__0": 2, "arrayagg": [2, 3]},
-                    {"field__0": 20, "arrayagg": [4]},
+                    {"field__0": 1, "arrayagg": [self.objs[0].pk]},
+                    {"field__0": 2, "arrayagg": [self.objs[1].pk, self.objs[2].pk]},
+                    {"field__0": 20, "arrayagg": [self.objs[3].pk]},
                 ],
             )
         alias = connection.ops.quote_name("field__0")


### PR DESCRIPTION
See [logs](https://djangoci.com/job/main-random/database=postgis,label=focal,python=python3.10/lastCompletedBuild/testReport/postgres_tests.test_array/TestQuerying/test_group_by_order_by_aliases/).