### PR TITLE
Fixed the resulting queryset in the documentation.

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -245,7 +245,7 @@ ones:
         >>> fruit.name = 'Pear'
         >>> fruit.save()
         >>> Fruit.objects.values_list('name', flat=True)
-        <QuerySet ['Apple', 'Pear']>
+        <QuerySet ['Pear']>
 
 :attr:`~Field.unique`
     If ``True``, this field must be unique throughout the table.


### PR DESCRIPTION
Under the section https://docs.djangoproject.com/en/4.1/topics/db/models/#field-options, there a example of a snippet where the value of a field is changed and saved. But when querying it afterwards it shows the old field value together with the newer one.
![image](https://user-images.githubusercontent.com/48282663/194481863-89c6baaf-5d89-449e-8d47-d45d281816f1.png)
This PR will resolve the said error.