### PR TITLE
Updated header lookups to use request.headers.

### DIFF
--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -38,7 +38,7 @@ class CommonMiddleware(MiddlewareMixin):
         """
 
         # Check for denied User-Agents
-        user_agent = request.META.get("HTTP_USER_AGENT")
+        user_agent = request.headers.get("User-Agent")
         if user_agent is not None:
             for user_agent_regex in settings.DISALLOWED_USER_AGENTS:
                 if user_agent_regex.search(user_agent):
@@ -121,10 +121,10 @@ class BrokenLinkEmailsMiddleware(MiddlewareMixin):
         if response.status_code == 404 and not settings.DEBUG:
             domain = request.get_host()
             path = request.get_full_path()
-            referer = request.META.get("HTTP_REFERER", "")
+            referer = request.headers.get("Referer", "")
 
             if not self.is_ignorable_request(request, path, domain, referer):
-                ua = request.META.get("HTTP_USER_AGENT", "<none>")
+                ua = request.headers.get("User-Agent", "<none>")
                 ip = request.META.get("REMOTE_ADDR", "<none>")
                 mail_managers(
                     "Broken %slink on %s"

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -442,7 +442,7 @@ class CsrfViewMiddleware(MiddlewareMixin):
         if "HTTP_ORIGIN" in request.META:
             if not self._origin_verified(request):
                 return self._reject(
-                    request, REASON_BAD_ORIGIN % request.META["HTTP_ORIGIN"]
+                    request, REASON_BAD_ORIGIN % request.headers["Origin"]
                 )
         elif request.is_secure():
             # If the Origin header wasn't provided, reject HTTPS requests if

--- a/django/middleware/gzip.py
+++ b/django/middleware/gzip.py
@@ -24,7 +24,7 @@ class GZipMiddleware(MiddlewareMixin):
 
         patch_vary_headers(response, ("Accept-Encoding",))
 
-        ae = request.META.get("HTTP_ACCEPT_ENCODING", "")
+        ae = request.headers.get("Accept-Encoding", "")
         if not re_accepts_gzip.search(ae):
             return response
 

--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -168,13 +168,13 @@ def get_conditional_response(request, etag=None, last_modified=None, response=No
         return response
 
     # Get HTTP request headers.
-    if_match_etags = parse_etags(request.META.get("HTTP_IF_MATCH", ""))
-    if_unmodified_since = request.META.get("HTTP_IF_UNMODIFIED_SINCE")
+    if_match_etags = parse_etags(request.headers.get("If-Match", ""))
+    if_unmodified_since = request.headers.get("If-Unmodified-Since")
     if_unmodified_since = if_unmodified_since and parse_http_date_safe(
         if_unmodified_since
     )
-    if_none_match_etags = parse_etags(request.META.get("HTTP_IF_NONE_MATCH", ""))
-    if_modified_since = request.META.get("HTTP_IF_MODIFIED_SINCE")
+    if_none_match_etags = parse_etags(request.headers.get("If-None-Match", ""))
+    if_modified_since = request.headers.get("If-Modified-Since")
     if_modified_since = if_modified_since and parse_http_date_safe(if_modified_since)
 
     # Step 1 of section 6 of RFC 7232: Test the If-Match precondition.

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -566,7 +566,7 @@ def get_language_from_request(request, check_path=False):
     except LookupError:
         pass
 
-    accept = request.META.get("HTTP_ACCEPT_LANGUAGE", "")
+    accept = request.headers.get("Accept-Language", "")
     for accept_lang, unused in parse_accept_lang_header(accept):
         if accept_lang == "*":
             break

--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -35,7 +35,7 @@ def set_language(request):
         allowed_hosts={request.get_host()},
         require_https=request.is_secure(),
     ):
-        next_url = request.META.get("HTTP_REFERER")
+        next_url = request.headers.get("Referer")
         if not url_has_allowed_host_and_scheme(
             url=next_url,
             allowed_hosts={request.get_host()},

--- a/django/views/static.py
+++ b/django/views/static.py
@@ -41,7 +41,7 @@ def serve(request, path, document_root=None, show_indexes=False):
     # Respect the If-Modified-Since header.
     statobj = fullpath.stat()
     if not was_modified_since(
-        request.META.get("HTTP_IF_MODIFIED_SINCE"), statobj.st_mtime
+        request.headers.get("If-Modified-Since"), statobj.st_mtime
     ):
         return HttpResponseNotModified()
     content_type, encoding = mimetypes.guess_type(str(fullpath))

--- a/tests/asgi/urls.py
+++ b/tests/asgi/urls.py
@@ -12,7 +12,7 @@ def hello(request):
 
 def hello_meta(request):
     return HttpResponse(
-        "From %s" % request.META.get("HTTP_REFERER") or "",
+        "From %s" % request.headers.get("Referer") or "",
         content_type=request.META.get("CONTENT_TYPE"),
     )
 

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1757,52 +1757,32 @@ class MiscTests(SimpleTestCase):
         """
         Now test that we parse a literal HTTP header correctly.
         """
-        g = get_language_from_request
-        r = self.rf.get("/")
-        r.COOKIES = {}
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "pt-br"}
-        self.assertEqual("pt-br", g(r))
-
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "pt"}
-        self.assertEqual("pt", g(r))
-
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "es,de"}
-        self.assertEqual("es", g(r))
-
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "es-ar,de"}
-        self.assertEqual("es-ar", g(r))
-
-        # This test assumes there won't be a Django translation to a US
-        # variation of the Spanish language, a safe assumption. When the
-        # user sets it as the preferred language, the main 'es'
-        # translation should be selected instead.
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "es-us"}
-        self.assertEqual(g(r), "es")
-
-        # This tests the following scenario: there isn't a main language (zh)
-        # translation of Django but there is a translation to variation (zh-hans)
-        # the user sets zh-hans as the preferred language, it should be selected
-        # by Django without falling back nor ignoring it.
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "zh-hans,de"}
-        self.assertEqual(g(r), "zh-hans")
-
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "NL"}
-        self.assertEqual("nl", g(r))
-
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "fy"}
-        self.assertEqual("fy", g(r))
-
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "ia"}
-        self.assertEqual("ia", g(r))
-
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "sr-latn"}
-        self.assertEqual("sr-latn", g(r))
-
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "zh-hans"}
-        self.assertEqual("zh-hans", g(r))
-
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "zh-hant"}
-        self.assertEqual("zh-hant", g(r))
+        tests = [
+            ("pt-br", "pt-br"),
+            ("pt", "pt"),
+            ("es,de", "es"),
+            ("es-a,de", "es"),
+            # This test assumes there won't be a Django translation to a US
+            # variation of the Spanish language, a safe assumption. When the
+            # user sets it as the preferred language, the main 'es'
+            # translation should be selected instead.
+            ("es-us", "es"),
+            # This tests the following scenario: there isn't a main language (zh)
+            # translation of Django but there is a translation to variation (zh-hans)
+            # the user sets zh-hans as the preferred language, it should be selected
+            # by Django without falling back nor ignoring it.
+            ("zh-hans,de", "zh-hans"),
+            ("NL", "nl"),
+            ("fy", "fy"),
+            ("ia", "ia"),
+            ("sr-latn", "sr-latn"),
+            ("zh-hans", "zh-hans"),
+            ("zh-hant", "zh-hant"),
+        ]
+        for header, expected in tests:
+            with self.subTest(header=header):
+                request = self.rf.get("/", HTTP_ACCEPT_LANGUAGE=header)
+                self.assertEqual(get_language_from_request(request), expected)
 
     @override_settings(
         LANGUAGES=[
@@ -1822,23 +1802,19 @@ class MiscTests(SimpleTestCase):
         refs #18419 -- this is explicitly for browser compatibility
         """
         g = get_language_from_request
-        r = self.rf.get("/")
-        r.COOKIES = {}
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "zh-cn,en"}
-        self.assertEqual(g(r), "zh-hans")
+        request = self.rf.get("/", HTTP_ACCEPT_LANGUAGE="zh-cn,en")
+        self.assertEqual(g(request), "zh-hans")
 
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "zh-tw,en"}
-        self.assertEqual(g(r), "zh-hant")
+        request = self.rf.get("/", HTTP_ACCEPT_LANGUAGE="zh-tw,en")
+        self.assertEqual(g(request), "zh-hant")
 
     def test_special_fallback_language(self):
         """
         Some languages may have special fallbacks that don't follow the simple
         'fr-ca' -> 'fr' logic (notably Chinese codes).
         """
-        r = self.rf.get("/")
-        r.COOKIES = {}
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "zh-my,en"}
-        self.assertEqual(get_language_from_request(r), "zh-hans")
+        request = self.rf.get("/", HTTP_ACCEPT_LANGUAGE="zh-my,en")
+        self.assertEqual(get_language_from_request(request), "zh-hans")
 
     def test_subsequent_code_fallback_language(self):
         """
@@ -1853,46 +1829,42 @@ class MiscTests(SimpleTestCase):
             ("zh-hant-tw", "zh-hant"),
             ("zh-hant-SG", "zh-hant"),
         ]
-        r = self.rf.get("/")
-        r.COOKIES = {}
         for value, expected in tests:
             with self.subTest(value=value):
-                r.META = {"HTTP_ACCEPT_LANGUAGE": f"{value},en"}
-                self.assertEqual(get_language_from_request(r), expected)
+                request = self.rf.get("/", HTTP_ACCEPT_LANGUAGE=f"{value},en")
+                self.assertEqual(get_language_from_request(request), expected)
 
     def test_parse_language_cookie(self):
         """
         Now test that we parse language preferences stored in a cookie correctly.
         """
         g = get_language_from_request
-        r = self.rf.get("/")
-        r.COOKIES = {settings.LANGUAGE_COOKIE_NAME: "pt-br"}
-        r.META = {}
-        self.assertEqual("pt-br", g(r))
+        request = self.rf.get("/")
+        request.COOKIES[settings.LANGUAGE_COOKIE_NAME] = "pt-br"
+        self.assertEqual("pt-br", g(request))
 
-        r.COOKIES = {settings.LANGUAGE_COOKIE_NAME: "pt"}
-        r.META = {}
-        self.assertEqual("pt", g(r))
+        request.COOKIES[settings.LANGUAGE_COOKIE_NAME] = "pt"
+        self.assertEqual("pt", g(request))
 
-        r.COOKIES = {settings.LANGUAGE_COOKIE_NAME: "es"}
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "de"}
-        self.assertEqual("es", g(r))
+        request = self.rf.get("/", HTTP_ACCEPT_LANGUAGE="de")
+        request.COOKIES[settings.LANGUAGE_COOKIE_NAME] = "es"
+        self.assertEqual("es", g(request))
 
         # This test assumes there won't be a Django translation to a US
         # variation of the Spanish language, a safe assumption. When the
         # user sets it as the preferred language, the main 'es'
         # translation should be selected instead.
-        r.COOKIES = {settings.LANGUAGE_COOKIE_NAME: "es-us"}
-        r.META = {}
-        self.assertEqual(g(r), "es")
+        request = self.rf.get("/")
+        request.COOKIES[settings.LANGUAGE_COOKIE_NAME] = "es-us"
+        self.assertEqual(g(request), "es")
 
         # This tests the following scenario: there isn't a main language (zh)
         # translation of Django but there is a translation to variation (zh-hans)
         # the user sets zh-hans as the preferred language, it should be selected
         # by Django without falling back nor ignoring it.
-        r.COOKIES = {settings.LANGUAGE_COOKIE_NAME: "zh-hans"}
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "de"}
-        self.assertEqual(g(r), "zh-hans")
+        request = self.rf.get("/", HTTP_ACCEPT_LANGUAGE="de")
+        request.COOKIES[settings.LANGUAGE_COOKIE_NAME] = "zh-hans"
+        self.assertEqual(g(request), "zh-hans")
 
     @override_settings(
         USE_I18N=True,
@@ -1993,12 +1965,10 @@ class MiscTests(SimpleTestCase):
         previously valid should not be used (#14170).
         """
         g = get_language_from_request
-        r = self.rf.get("/")
-        r.COOKIES = {}
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "pt-br"}
-        self.assertEqual("pt-br", g(r))
+        request = self.rf.get("/", HTTP_ACCEPT_LANGUAGE="pt-br")
+        self.assertEqual("pt-br", g(request))
         with self.settings(LANGUAGES=[("en", "English")]):
-            self.assertNotEqual("pt-br", g(r))
+            self.assertNotEqual("pt-br", g(request))
 
     def test_i18n_patterns_returns_list(self):
         with override_settings(USE_I18N=False):
@@ -2238,15 +2208,16 @@ class CountrySpecificLanguageTests(SimpleTestCase):
 
     def test_get_language_from_request(self):
         # issue 19919
-        r = self.rf.get("/")
-        r.COOKIES = {}
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "en-US,en;q=0.8,bg;q=0.6,ru;q=0.4"}
-        lang = get_language_from_request(r)
+        request = self.rf.get(
+            "/", HTTP_ACCEPT_LANGUAGE="en-US,en;q=0.8,bg;q=0.6,ru;q=0.4"
+        )
+        lang = get_language_from_request(request)
         self.assertEqual("en-us", lang)
-        r = self.rf.get("/")
-        r.COOKIES = {}
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "bg-bg,en-US;q=0.8,en;q=0.6,ru;q=0.4"}
-        lang = get_language_from_request(r)
+
+        request = self.rf.get(
+            "/", HTTP_ACCEPT_LANGUAGE="bg-bg,en-US;q=0.8,en;q=0.6,ru;q=0.4"
+        )
+        lang = get_language_from_request(request)
         self.assertEqual("bg", lang)
 
     def test_get_language_from_request_null(self):
@@ -2258,15 +2229,16 @@ class CountrySpecificLanguageTests(SimpleTestCase):
 
     def test_specific_language_codes(self):
         # issue 11915
-        r = self.rf.get("/")
-        r.COOKIES = {}
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "pt,en-US;q=0.8,en;q=0.6,ru;q=0.4"}
-        lang = get_language_from_request(r)
+        request = self.rf.get(
+            "/", HTTP_ACCEPT_LANGUAGE="pt,en-US;q=0.8,en;q=0.6,ru;q=0.4"
+        )
+        lang = get_language_from_request(request)
         self.assertEqual("pt-br", lang)
-        r = self.rf.get("/")
-        r.COOKIES = {}
-        r.META = {"HTTP_ACCEPT_LANGUAGE": "pt-pt,en-US;q=0.8,en;q=0.6,ru;q=0.4"}
-        lang = get_language_from_request(r)
+
+        request = self.rf.get(
+            "/", HTTP_ACCEPT_LANGUAGE="pt-pt,en-US;q=0.8,en;q=0.6,ru;q=0.4"
+        )
+        lang = get_language_from_request(request)
         self.assertEqual("pt-br", lang)
 
 

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -1340,4 +1340,4 @@ class RequestFactoryEnvironmentTests(SimpleTestCase):
         factory = RequestFactory()
         factory.cookies.load('A="B"; C="D"; Path=/; Version=1')
         request = factory.get("/")
-        self.assertEqual(request.META["HTTP_COOKIE"], 'A="B"; C="D"')
+        self.assertEqual(request.headers["Cookie"], 'A="B"; C="D"')

--- a/tests/test_client_regress/views.py
+++ b/tests/test_client_regress/views.py
@@ -140,7 +140,7 @@ def return_text_file(request):
 def check_headers(request):
     "A view that responds with value of the X-ARG-CHECK header"
     return HttpResponse(
-        "HTTP_X_ARG_CHECK: %s" % request.META.get("HTTP_X_ARG_CHECK", "Undefined")
+        "HTTP_X_ARG_CHECK: %s" % request.headers.get("X-Arg-Check", "Undefined")
     )
 
 


### PR DESCRIPTION
Ran django-upgrade on Django to see what it changed. The moves to `request.headers` seemed the most useful. This also discovered that some i18n tests were completely mocking `request.META` rather than setting headers through the test client API, so I added a commit that updates those tests.