### PR TITLE
Used CSS flex for form rows.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -22,6 +22,11 @@ form .form-row p {
     padding-left: 0;
 }
 
+.form-row > div {
+    display: flex;
+    flex-wrap: wrap;
+}
+
 /* FORM LABELS */
 
 label {
@@ -69,7 +74,6 @@ form ul.inline li {
 .aligned label {
     display: block;
     padding: 4px 10px 0 0;
-    float: left;
     width: 160px;
     word-wrap: break-word;
     line-height: 1;
@@ -82,12 +86,17 @@ form ul.inline li {
     height: 26px;
 }
 
-.aligned label + p, .aligned label + div.help, .aligned label + div.readonly {
+.aligned label + p, .aligned .checkbox-row + div.help, .aligned label + div.readonly {
     padding: 6px 0;
     margin-top: 0;
     margin-bottom: 0;
     margin-left: 170px;
     overflow-wrap: break-word;
+}
+
+.aligned label + div.readonly,
+.aligned label + .datetime {
+    margin-left: 0;
 }
 
 .aligned ul label {
@@ -117,7 +126,6 @@ form .aligned div.radiolist {
 
 form .aligned p.help,
 form .aligned div.help {
-    clear: left;
     margin-top: 0;
     margin-left: 160px;
     padding-left: 10px;
@@ -129,8 +137,7 @@ form .aligned p.datetime div.help.timezonewarning {
     font-weight: normal;
 }
 
-form .aligned label + p.help,
-form .aligned label + div.help {
+form .aligned .checkbox-row + .help {
     margin-left: 0;
     padding-left: 0;
 }

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -111,7 +111,6 @@ thead th.sorted .text {
 
 .aligned label {
     padding: 0 0 3px 1em;
-    float: right;
 }
 
 .submit-row a.deletelink {
@@ -127,10 +126,6 @@ thead th.sorted .text {
     margin-left: 5px;
 }
 
-form .aligned p.help, form .aligned div.help {
-    clear: right;
-}
-
 form .aligned ul {
     margin-right: 163px;
     margin-left: 0;
@@ -140,6 +135,17 @@ form ul.inline li {
     float: right;
     padding-right: 0;
     padding-left: 7px;
+}
+
+form .aligned p.help,
+form .aligned div.help {
+    margin-right: 160px;
+    padding-right: 10px;
+}
+
+form .aligned .checkbox-row + .help {
+    margin-right: 0;
+    padding-right: 0;
 }
 
 .submit-row {

--- a/django/contrib/admin/templates/admin/includes/fieldset.html
+++ b/django/contrib/admin/templates/admin/includes/fieldset.html
@@ -19,12 +19,12 @@
                             {{ field.field }}
                         {% endif %}
                     {% endif %}
-                    {% if field.field.help_text %}
-                        <div class="help"{% if field.field.id_for_label %} id="{{ field.field.id_for_label }}_helptext"{% endif %}>
-                          {{ field.field.help_text|safe }}
-                        </div>
-                    {% endif %}
                 </div>
+                {% if field.field.help_text %}
+                    <div class="help"{% if field.field.id_for_label %} id="{{ field.field.id_for_label }}_helptext"{% endif %}>
+                        {{ field.field.help_text|safe }}
+                    </div>
+                {% endif %}
             {% endfor %}
         </div>
     {% endfor %}


### PR DESCRIPTION
The original idea was just to change the form rows to CSS flex, but on doing that I realised the original (before this patch) RTL pages looked wrong, when using flex this was fixed, so I added a bit into the RTL sheet to align things in the same way we do for LTR.

I'm not an RTL expert, it's possible it was this way intentionally, I am not sure. See screens.

It also could be this PR is fixing two issues, but I don't see a clean way to do them separately.

Before (LTR):
<img width="1061" alt="Screenshot 2022-10-09 at 12 43 05" src="https://user-images.githubusercontent.com/3871354/194752937-1d7a3e4d-1315-4fe1-84bf-6d20dea0a8a7.png">

After (LTR):
<img width="1111" alt="Screenshot 2022-10-09 at 12 50 19" src="https://user-images.githubusercontent.com/3871354/194752946-2aa3d756-9bee-4fe5-9f5a-fb1da2e79907.png">

Before (RTL, note labels on the left):
<img width="1375" alt="Screenshot 2022-10-09 at 12 43 32" src="https://user-images.githubusercontent.com/3871354/194752955-0c3995cb-12e6-492c-a910-5556c0023dc3.png">

After (RTL, note labels on the right and help text aligned):
<img width="1026" alt="Screenshot 2022-10-09 at 12 50 47" src="https://user-images.githubusercontent.com/3871354/194752983-e7e4ca0e-2523-4024-8f66-0dd4c06019ae.png">