### PR TITLE
Fixed #32833 -- Fixed ContentTypeManager.get_for_models() crash when using in migrations.

### DIFF
--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -89,7 +89,9 @@ class ContentTypeManager(models.Manager):
             )
             cts = self.filter(condition)
             for ct in cts:
-                opts_models = needed_opts.pop(ct.model_class()._meta, [])
+                opts_models = needed_opts.pop(
+                    ct._meta.apps.get_model(ct.app_label, ct.model)._meta, []
+                )
                 for model in opts_models:
                     results[model] = ct
                 self._add_to_cache(self.db, ct)

--- a/tests/contenttypes_tests/test_models.py
+++ b/tests/contenttypes_tests/test_models.py
@@ -1,5 +1,7 @@
+from django.apps import apps
 from django.contrib.contenttypes.models import ContentType, ContentTypeManager
 from django.db import models
+from django.db.migrations.state import ProjectState
 from django.test import TestCase, override_settings
 from django.test.utils import isolate_apps
 
@@ -88,6 +90,14 @@ class ContentTypesTests(TestCase):
                 ContentType: ContentType.objects.get_for_model(ContentType),
                 FooWithUrl: ContentType.objects.get_for_model(FooWithUrl),
             },
+        )
+
+    def test_get_for_models_migrations(self):
+        state = ProjectState.from_apps(apps.get_app_config("contenttypes"))
+        ContentType = state.apps.get_model("contenttypes", "ContentType")
+        cts = ContentType.objects.get_for_models(ContentType)
+        self.assertEqual(
+            cts, {ContentType: ContentType.objects.get_for_model(ContentType)}
         )
 
     def test_get_for_models_full_cache(self):


### PR DESCRIPTION
Credit to @HMaker for the patch https://github.com/django/django/pull/14525
Ticket: https://code.djangoproject.com/ticket/32833

Hopefully addressed the comments :+1: 