### PR TITLE
Fixed wrapping of long model names in the admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -312,6 +312,7 @@ td, th {
     border-bottom: 1px solid var(--hairline-color);
     vertical-align: top;
     padding: 8px;
+    word-break: break-word;
 }
 
 th {


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/2865885/194823590-d6300a45-7280-4ca2-a287-734f45bf8d63.png)
----
![image](https://user-images.githubusercontent.com/2865885/194823889-99ec1d8e-96ae-4b86-92d0-7b0144d52095.png)
----
![image](https://user-images.githubusercontent.com/2865885/194823998-85676c99-b7c6-4057-bb43-1e756ab6c80b.png)
----

After:

![image](https://user-images.githubusercontent.com/2865885/194823647-e2b37d0a-ff11-42bc-a7af-def1e841384f.png)
----
![image](https://user-images.githubusercontent.com/2865885/194823817-d0012a47-129c-47ab-923f-eb2950e372ea.png)
----
![image](https://user-images.githubusercontent.com/2865885/194824072-52875460-d118-4eea-9ba4-6d6029372337.png)
----