### PR TITLE
Refs #34083: Exit if mysqldump fails

### DIFF
--- a/django/db/backends/mysql/creation.py
+++ b/django/db/backends/mysql/creation.py
@@ -75,7 +75,7 @@ class DatabaseCreation(BaseDatabaseCreation):
         load_cmd[-1] = target_database_name
 
         with subprocess.Popen(
-            dump_cmd, stdout=subprocess.PIPE, env=dump_env
+            dump_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=dump_env
         ) as dump_proc:
             with subprocess.Popen(
                 load_cmd,
@@ -85,3 +85,11 @@ class DatabaseCreation(BaseDatabaseCreation):
             ):
                 # Allow dump_proc to receive a SIGPIPE if the load process exits.
                 dump_proc.stdout.close()
+
+            err = dump_proc.stderr.read().decode()
+
+        if dump_proc.returncode != 0:
+            self.log("Got a fatal error cloning the test database: %s" % err)
+            sys.exit(2)
+
+        self.log("Got a non-fatal error cloning the test database: %s" % err)


### PR DESCRIPTION
To set up parallel test databases, we initialise the schema of a test database and then copy this to additional databases. In the MySQL case, this is done by dumping the schema of the first database using `mysqldump` and then loading this into the clones using `mysql`. However, we do not currently check the output of the `mysqldump` command, meaning if it fails, Django will happily carry on and tests will fail with errors about missing tables.

Instead of silently continuing, check the return code of the command and quickly fail if it's non-zero.

**Note** I wasn't able to figure out how to run the MySQL tests locally, so the unit test is speculative. If anyone wants to, feel free to modify as you see fit.
