### PR TITLE
Updated db_index documentation

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -330,7 +330,8 @@ scenes.
 
 .. attribute:: Field.db_index
 
-If ``True``, a database index will be created for this field.
+If ``True``, one or more database indexes will be created for this field 
+depending on the field type.
 
 ``db_tablespace``
 -----------------


### PR DESCRIPTION
Documentation now correctly explains that multiple indexes might be created when using the db_index attribute