### PR TITLE
Fixed #19215 -- Fixed rendering ClearableFileInput when editing with invalid files.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -677,10 +677,8 @@ class FileField(Field):
             return initial
         return super().clean(data)
 
-    def bound_data(self, data, initial):
-        if data in (None, FILE_INPUT_CONTRADICTION):
-            return initial
-        return data
+    def bound_data(self, _, initial):
+        return initial
 
     def has_changed(self, initial, data):
         return not self.disabled and data is not None

--- a/tests/admin_widgets/models.py
+++ b/tests/admin_widgets/models.py
@@ -1,7 +1,12 @@
+import tempfile
 import uuid
 
 from django.contrib.auth.models import User
+from django.core.files.storage import FileSystemStorage
 from django.db import models
+
+temp_storage_dir = tempfile.mkdtemp()
+temp_storage = FileSystemStorage(temp_storage_dir)
 
 
 class MyFileField(models.FileField):
@@ -177,6 +182,9 @@ class Advisor(models.Model):
 
 class Student(models.Model):
     name = models.CharField(max_length=255)
+    photo = models.ImageField(
+        storage=temp_storage, upload_to="photos", blank=True, null=True
+    )
 
     class Meta:
         ordering = ("name",)

--- a/tests/admin_widgets/widgetadmin.py
+++ b/tests/admin_widgets/widgetadmin.py
@@ -13,6 +13,7 @@ from .models import (
     Profile,
     ReleaseEvent,
     School,
+    Student,
     User,
     VideoStream,
 )
@@ -72,5 +73,6 @@ site.register(Bee)
 site.register(Advisor)
 
 site.register(School, SchoolAdmin)
+site.register(Student)
 
 site.register(Profile)


### PR DESCRIPTION
Hello!

Thanks Mariusz for Cc'me in this [ticket](https://code.djangoproject.com/ticket/19215)!

I just applied the [mcardillo55's fix](https://github.com/django/django/pull/600/commits/69808dfaf9c96b0a60121671ab7d0dac7d625b56) + added a selenium test. In [his pull request](https://github.com/django/django/pull/600) I didn't see any review/comment/change required to apply.

To run the test please do: `./runtests.py admin_widgets.tests.ImageFieldWidgetsSeleniumTests --selenium=<chrome|firefox|safari> --parallel=1`

Thanks!