### PR TITLE
Refs #32915 -- easier to understand traceback from _gcd_import

### DIFF
--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -189,8 +189,12 @@ class AppConfig:
                     msg += " Choices are: %s." % ", ".join(candidates)
                 raise ImportError(msg)
             else:
-                # Re-trigger the module import exception.
-                import_module(entry)
+                try:
+                    # Re-trigger the module import exception.
+                    import_module(entry)
+                except ModuleNotFoundError:
+                    raise ImportError(
+                        f"The following module was not found, install the dependency or remove it from INSTALLED_APPS: {entry}")
 
         # Check for obvious errors. (This check prevents duck typing, but
         # it could be removed if it became a problem in practice.)


### PR DESCRIPTION
While upgrading from django 3.2 to 4.1.2, I spent a lot of time trying to understand what `_gcd_import` meant, in this 1 case, it was because I didn't remove `compat`, from `INSTALLED_APPS` after uninstalling `django-compat`:

```
Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/home/jm/.pyenv/versions/3.9.10/lib/python3.9/threading.py", line 973, in _bootstrap_inner
    self.run()
  File "/home/jm/.pyenv/versions/3.9.10/lib/python3.9/threading.py", line 910, in run
    self._target(*self._args, **self._kwargs)
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/core/management/commands/runserver.py", line 125, in inner_run
    autoreload.raise_last_exception()
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/utils/autoreload.py", line 87, in raise_last_exception
    raise _exception[1]
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/core/management/__init__.py", line 398, in execute
    autoreload.check_errors(django.setup)()
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/apps/registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/apps/config.py", line 193, in create
    import_module(entry)
  File "/home/jm/.pyenv/versions/3.9.10/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'compat'
```

VS

```
Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/apps/config.py", line 194, in create
    import_module(entry)
  File "/home/jm/.pyenv/versions/3.9.10/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'compat'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jm/.pyenv/versions/3.9.10/lib/python3.9/threading.py", line 973, in _bootstrap_inner
    self.run()
  File "/home/jm/.pyenv/versions/3.9.10/lib/python3.9/threading.py", line 910, in run
    self._target(*self._args, **self._kwargs)
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/core/management/commands/runserver.py", line 125, in inner_run
    autoreload.raise_last_exception()
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/utils/autoreload.py", line 87, in raise_last_exception
    raise _exception[1]
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/core/management/__init__.py", line 398, in execute
    autoreload.check_errors(django.setup)()
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/apps/registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
  File "/home/jm/pycharm_projects/spam/venv_3_9_10/lib/python3.9/site-packages/django/apps/config.py", line 196, in create
    raise ImportError(f"The following module was not found, install the dependency or remove it from INSTALLED_APPS: {entry}")
ImportError: The following module was not found, install the dependency or remove it from INSTALLED_APPS: compat
```

Just wondering if it'd help to have at least a little bit of a pointer to where to look? not sure what other places might be here, or if it can be raised dynamically, but just a first try on this and in this instance this would have helped me alot on the upgrade.