### PR TITLE
Fixed #34085 -- Fixed Black call for startproject/app commands.

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -232,7 +232,7 @@ class TemplateCommand(BaseCommand):
                 else:
                     shutil.rmtree(path_to_remove)
 
-        run_formatters(self.written_files, **formatter_paths)
+        run_formatters([top_dir], **formatter_paths)
 
     def handle_template(self, template, subdir):
         """

--- a/tests/admin_scripts/custom_templates/project_template/additional_dir/requirements.in
+++ b/tests/admin_scripts/custom_templates/project_template/additional_dir/requirements.in
@@ -1,0 +1,5 @@
+# File should not be processed by black
+Django<4.2
+environs[django]
+psycopg2-binary
+django-extensions


### PR DESCRIPTION
(Note: Draft PR to complete during "Getting started contributing to Django" sprints workshop at DjangoCon US.)

* Adjusted command call with suggestion from ticket. 
* Added example requirements file to the test template. 
* Needs test to verify that the requirements file will not be modified. 

From d113b5a837f726d1c638d76c4e88445e6cd59fd5 test will be needed in `tests/admin_scripts/tests.py`