### PR TITLE
Fixed #34105 -- Fixed crash of ordering by nested selected expression.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -445,11 +445,6 @@ class SQLCompiler:
         """
         result = []
         seen = set()
-        replacements = {
-            expr: Ref(alias, expr)
-            for alias, expr in self.query.annotation_select.items()
-        }
-
         for expr, is_ref in self._order_by_pairs():
             resolved = expr.resolve_expression(self.query, allow_joins=True, reuse=None)
             if not is_ref and self.query.combinator and self.select:
@@ -478,7 +473,7 @@ class SQLCompiler:
                         q.add_annotation(expr_src, col_name)
                     self.query.add_select_col(resolved, col_name)
                     resolved.set_source_expressions([RawSQL(f"{order_by_idx}", ())])
-            sql, params = self.compile(resolved.replace_expressions(replacements))
+            sql, params = self.compile(resolved)
             # Don't add the same column twice, but the order direction is
             # not taken into account so we strip it. When this entire method
             # is refactored into expressions, then we can check each part as we

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -12,7 +12,7 @@ from django.db.models import (
     Subquery,
     Value,
 )
-from django.db.models.functions import Upper
+from django.db.models.functions import Length, Upper
 from django.test import TestCase
 
 from .models import (
@@ -598,4 +598,12 @@ class OrderingTests(TestCase):
         self.assertSequenceEqual(
             OrderedByExpressionGrandChild.objects.order_by("parent"),
             [g1, g2, g3],
+        )
+
+    def test_order_by_expression_ref(self):
+        self.assertQuerySetEqual(
+            Author.objects.annotate(upper_name=Upper("name")).order_by(
+                Length("upper_name")
+            ),
+            Author.objects.order_by(Length(Upper("name"))),
         )


### PR DESCRIPTION
It's not supported on PostgreSQL and not required to support psycopg3.

Thanks @gasman for the report.