### PR TITLE
Added missing example bits in BaseFormSet.get_form_kwargs

### DIFF
--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -748,6 +748,9 @@ argument - the index of the form in the formset. The index is ``None`` for the
     ...         kwargs['custom_kwarg'] = index
     ...         return kwargs
 
+    >>> ArticleFormSet = formset_factory(MyArticleForm, formset=BaseArticleFormSet)
+    >>> formset = ArticleFormSet()
+
 .. _formset-prefix:
 
 Customizing a formset's prefix


### PR DESCRIPTION
Make use of the imported formset_factory and BaseArticleFormSet