### PR TITLE
Fixed #34085 -- Made management commands don't use black for non-Python files.

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -84,7 +84,6 @@ class TemplateCommand(BaseCommand):
         )
 
     def handle(self, app_or_project, name, target=None, **options):
-        self.written_files = []
         self.app_or_project = app_or_project
         self.a_or_an = "an" if app_or_project == "app" else "a"
         self.paths_to_remove = []
@@ -209,7 +208,6 @@ class TemplateCommand(BaseCommand):
                 else:
                     shutil.copyfile(old_path, new_path)
 
-                self.written_files.append(new_path)
                 if self.verbosity >= 2:
                     self.stdout.write("Creating %s" % new_path)
                 try:
@@ -232,7 +230,7 @@ class TemplateCommand(BaseCommand):
                 else:
                     shutil.rmtree(path_to_remove)
 
-        run_formatters(self.written_files, **formatter_paths)
+        run_formatters([top_dir], **formatter_paths)
 
     def handle_template(self, template, subdir):
         """

--- a/docs/releases/4.1.3.txt
+++ b/docs/releases/4.1.3.txt
@@ -9,4 +9,6 @@ Django 4.1.3 fixes several bugs in 4.1.2.
 Bugfixes
 ========
 
-* ...
+* Fixed a bug in Django 4.1 that caused non-Python files created by
+  ``startproject`` and ``startapp`` management commands from custom templates
+  to be incorrectly formatted using the ``black`` command (:ticket:`34085`).

--- a/tests/admin_scripts/custom_templates/project_template/additional_dir/requirements.in
+++ b/tests/admin_scripts/custom_templates/project_template/additional_dir/requirements.in
@@ -1,0 +1,5 @@
+# Should not be processed by `black`.
+Django<4.2
+environs[django]
+psycopg2-binary
+django-extensions

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2483,6 +2483,23 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         self.assertTrue(os.path.isdir(testproject_dir))
         self.assertTrue(os.path.exists(os.path.join(testproject_dir, "additional_dir")))
 
+    def test_custom_project_template_non_python_files_not_formatted(self):
+        template_path = os.path.join(custom_templates_dir, "project_template")
+        args = ["startproject", "--template", template_path, "customtestproject"]
+        testproject_dir = os.path.join(self.test_dir, "customtestproject")
+
+        _, err = self.run_django_admin(args)
+        self.assertNoOutput(err)
+        with open(
+            os.path.join(template_path, "additional_dir", "requirements.in")
+        ) as f:
+            expected = f.read()
+        with open(
+            os.path.join(testproject_dir, "additional_dir", "requirements.in")
+        ) as f:
+            result = f.read()
+        self.assertEqual(expected, result)
+
     def test_template_dir_with_trailing_slash(self):
         "Ticket 17475: Template dir passed has a trailing path separator"
         template_path = os.path.join(custom_templates_dir, "project_template" + os.sep)


### PR DESCRIPTION
Supercedes #16192 adds a missing test case. 

Thanks to @programmylife for coauthoring, 