### PR TITLE
Updated UTC uses to datetime.timezone.utc in docs.

### DIFF
--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -407,7 +407,7 @@ Once you're in the shell, explore the :doc:`database API </topics/db/queries>`::
     >>> q.question_text
     "What's new?"
     >>> q.pub_date
-    datetime.datetime(2012, 2, 26, 13, 0, 0, 775217, tzinfo=<UTC>)
+    datetime.datetime(2012, 2, 26, 13, 0, 0, 775217, tzinfo=datetime.timezone.utc)
 
     # Change values by changing the attributes, then calling save().
     >>> q.question_text = "What's up?"

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -721,8 +721,8 @@ Usage example::
     {'date': datetime.date(2014, 6, 15),
      'day': datetime.datetime(2014, 6, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo('Australia/Melbourne')),
      'hour': datetime.datetime(2014, 6, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo('Australia/Melbourne')),
-     'minute': 'minute': datetime.datetime(2014, 6, 15, 14, 30, tzinfo=zoneinfo.ZoneInfo('UTC')),
-     'second': datetime.datetime(2014, 6, 15, 14, 30, 50, tzinfo=zoneinfo.ZoneInfo('UTC'))
+     'minute': 'minute': datetime.datetime(2014, 6, 15, 14, 30, tzinfo=timezone.utc),
+     'second': datetime.datetime(2014, 6, 15, 14, 30, 50, tzinfo=timezone.utc)
     }
 
 ``TimeField`` truncation

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -80,7 +80,7 @@ Argument    Value
             arguments passed to ``__init__()``)
 
 ``kwargs``  ``{'question_text': "What's new?",``
-            ``'pub_date': datetime.datetime(2012, 2, 26, 13, 0, 0, 775217, tzinfo=<UTC>)}``
+            ``'pub_date': datetime.datetime(2012, 2, 26, 13, 0, 0, 775217, tzinfo=datetime.timezone.utc)}``
 ==========  ===============================================================
 
 ``post_init``


### PR DESCRIPTION
This corrects the scenario in the tutorial where it was using the old Pytz format.