### PR TITLE
Change shell prompts to read "python3" vs "python"

### DIFF
--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -172,7 +172,7 @@ Go ahead and install the previously cloned copy of Django:
 
 .. console::
 
-    $ python -m pip install -e /path/to/your/local/clone/django/
+    $ python3 -m pip install -e /path/to/your/local/clone/django/
 
 The installed version of Django is now pointing at your local copy by installing
 in editable mode. You will immediately see any changes you make to it, which is
@@ -204,7 +204,7 @@ Before running the test suite, enter the Django ``tests/`` directory using the
 
 .. console::
 
-    $ python -m pip install -r requirements/py3.txt
+    $ python3 -m pip install -r requirements/py3.txt
 
 If you encounter an error during the installation, your system might be missing
 a dependency for one or more of the Python packages. Consult the failing

--- a/docs/intro/install.txt
+++ b/docs/intro/install.txt
@@ -19,7 +19,7 @@ database called SQLite_ so you won't need to set up a database just yet.
 Get the latest version of Python at https://www.python.org/downloads/ or with
 your operating system's package manager.
 
-You can verify that Python is installed by typing ``python`` from your shell;
+You can verify that Python is installed by typing ``python3`` from your shell;
 you should see something like::
 
     Python 3.x.y
@@ -65,7 +65,7 @@ You've got three options to install Django:
 Verifying
 =========
 
-To verify that Django can be seen by Python, type ``python`` from your shell.
+To verify that Django can be seen by Python, type ``python3`` from your shell.
 Then at the Python prompt, try to import Django:
 
 .. parsed-literal::

--- a/docs/intro/overview.txt
+++ b/docs/intro/overview.txt
@@ -53,8 +53,8 @@ automatically:
 
 .. console::
 
-    $ python manage.py makemigrations
-    $ python manage.py migrate
+    $ python3 manage.py makemigrations
+    $ python3 manage.py migrate
 
 The :djadmin:`makemigrations` command looks at all your available models and
 creates migrations for whichever tables don't already exist. :djadmin:`migrate`

--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -169,7 +169,7 @@ this. For a small app like polls, this process isn't too difficult.
 
            path('polls/', include('polls.urls')),
 
-       3. Run ``python manage.py migrate`` to create the polls models.
+       3. Run ``python3 manage.py migrate`` to create the polls models.
 
        4. Start the development server and visit http://127.0.0.1:8000/admin/
           to create a poll (you'll need the Admin app enabled).
@@ -264,7 +264,7 @@ this. For a small app like polls, this process isn't too difficult.
    you add some files to it. Many Django apps also provide their documentation
    online through sites like `readthedocs.org <https://readthedocs.org>`_.
 
-#. Try building your package with ``python setup.py sdist`` (run from inside
+#. Try building your package with ``python3 setup.py sdist`` (run from inside
    ``django-polls``). This creates a directory called ``dist`` and builds your
    new package, ``django-polls-0.1.tar.gz``.
 
@@ -293,14 +293,14 @@ working. We'll now fix this by installing our new ``django-polls`` package.
 #. To install the package, use pip (you already :ref:`installed it
    <installing-reusable-apps-prerequisites>`, right?)::
 
-    python -m pip install --user django-polls/dist/django-polls-0.1.tar.gz
+    python3 -m pip install --user django-polls/dist/django-polls-0.1.tar.gz
 
 #. With luck, your Django project should now work correctly again. Run the
    server again to confirm this.
 
 #. To uninstall the package, use pip::
 
-    python -m pip uninstall django-polls
+    python3 -m pip uninstall django-polls
 
 Publishing your app
 ===================

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -18,7 +18,7 @@ in a shell prompt (indicated by the $ prefix):
 
 .. console::
 
-    $ python -m django --version
+    $ python3 -m django --version
 
 If Django is installed, you should see the version of your installation. If it
 isn't, you'll get an error telling "No module named django".
@@ -126,7 +126,7 @@ you haven't already, and run the following commands:
 
 .. console::
 
-   $ python manage.py runserver
+   $ python3 manage.py runserver
 
 You'll see the following output on the command line:
 
@@ -172,7 +172,7 @@ It worked!
 
     .. console::
 
-        $ python manage.py runserver 8080
+        $ python3 manage.py runserver 8080
 
     If you want to change the server's IP, pass it along with the port. For
     example, to listen on all available public IPs (which is useful if you are
@@ -181,7 +181,7 @@ It worked!
 
     .. console::
 
-        $ python manage.py runserver 0.0.0.0:8000
+        $ python3 manage.py runserver 0.0.0.0:8000
 
     Full docs for the development server can be found in the
     :djadmin:`runserver` reference.
@@ -222,7 +222,7 @@ and type this command:
 
 .. console::
 
-    $ python manage.py startapp polls
+    $ python3 manage.py startapp polls
 
 That'll create a directory :file:`polls`, which is laid out like this::
 
@@ -319,7 +319,7 @@ the following command:
 
 .. console::
 
-   $ python manage.py runserver
+   $ python3 manage.py runserver
 
 Go to http://localhost:8000/polls/ in your browser, and you should see the
 text "*Hello, world. You're at the polls index.*", which you defined in the

--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -92,7 +92,7 @@ that, run the following command:
 
 .. console::
 
-    $ python manage.py migrate
+    $ python3 manage.py migrate
 
 The :djadmin:`migrate` command looks at the :setting:`INSTALLED_APPS` setting
 and creates any necessary database tables according to the database settings
@@ -233,7 +233,7 @@ Now Django knows to include the ``polls`` app. Let's run another command:
 
 .. console::
 
-    $ python manage.py makemigrations polls
+    $ python3 manage.py makemigrations polls
 
 You should see something similar to the following:
 
@@ -262,7 +262,7 @@ moment - but first, let's see what SQL that migration would run. The
 
 .. console::
 
-    $ python manage.py sqlmigrate polls 0001
+    $ python3 manage.py sqlmigrate polls 0001
 
 You should see something similar to the following (we've reformatted it for
 readability):
@@ -327,14 +327,14 @@ Note the following:
   changes.
 
 If you're interested, you can also run
-:djadmin:`python manage.py check <check>`; this checks for any problems in
+:djadmin:`python3 manage.py check <check>`; this checks for any problems in
 your project without making migrations or touching the database.
 
 Now, run :djadmin:`migrate` again to create those model tables in your database:
 
 .. console::
 
-    $ python manage.py migrate
+    $ python3 manage.py migrate
     Operations to perform:
       Apply all migrations: admin, auth, contenttypes, polls, sessions
     Running migrations:
@@ -354,9 +354,9 @@ losing data. We'll cover them in more depth in a later part of the tutorial,
 but for now, remember the three-step guide to making model changes:
 
 * Change your models (in ``models.py``).
-* Run :djadmin:`python manage.py makemigrations <makemigrations>` to create
+* Run :djadmin:`python3 manage.py makemigrations <makemigrations>` to create
   migrations for those changes
-* Run :djadmin:`python manage.py migrate <migrate>` to apply those changes to
+* Run :djadmin:`python3 manage.py migrate <migrate>` to apply those changes to
   the database.
 
 The reason that there are separate commands to make and apply migrations is
@@ -375,9 +375,9 @@ API Django gives you. To invoke the Python shell, use this command:
 
 .. console::
 
-    $ python manage.py shell
+    $ python3 manage.py shell
 
-We're using this instead of simply typing "python", because :file:`manage.py`
+We're using this instead of simply typing "python3", because :file:`manage.py`
 sets the :envvar:`DJANGO_SETTINGS_MODULE` environment variable, which gives
 Django the Python import path to your :file:`mysite/settings.py` file.
 
@@ -468,7 +468,7 @@ you aren't familiar with time zone handling in Python, you can learn more in
 the :doc:`time zone support docs </topics/i18n/timezones>`.
 
 Save these changes and start a new Python interactive shell by running
-``python manage.py shell`` again::
+``python3 manage.py shell`` again::
 
     >>> from polls.models import Choice, Question
 
@@ -578,7 +578,7 @@ following command:
 
 .. console::
 
-    $ python manage.py createsuperuser
+    $ python3 manage.py createsuperuser
 
 Enter your desired username and press enter.
 
@@ -611,7 +611,7 @@ If the server is not running start it like so:
 
 .. console::
 
-    $ python manage.py runserver
+    $ python3 manage.py runserver
 
 Now, open a web browser and go to "/admin/" on your local domain -- e.g.,
 http://127.0.0.1:8000/admin/. You should see the admin's login screen:

--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -144,7 +144,7 @@ whose date lies in the future:
 
 .. console::
 
-    $ python manage.py shell
+    $ python3 manage.py shell
 
 .. code-block:: pycon
 
@@ -204,7 +204,7 @@ In the terminal, we can run our test:
 
 .. console::
 
-    $ python manage.py test polls
+    $ python3 manage.py test polls
 
 and you'll see something like::
 
@@ -358,7 +358,7 @@ environment in the :djadmin:`shell`:
 
 .. console::
 
-    $ python manage.py shell
+    $ python3 manage.py shell
 
 .. code-block:: pycon
 

--- a/docs/intro/tutorial06.txt
+++ b/docs/intro/tutorial06.txt
@@ -84,7 +84,7 @@ Start the server (or restart it if it's already running):
 
 .. console::
 
-    $ python manage.py runserver
+    $ python3 manage.py runserver
 
 Reload ``http://localhost:8000/polls/`` and you should see that the question
 links are green (Django style!) which means that your stylesheet was properly

--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -352,7 +352,7 @@ template directory in the source code of Django itself
 
     .. console::
 
-        $ python -c "import django; print(django.__path__)"
+        $ python3 -c "import django; print(django.__path__)"
 
 Then, edit the file and replace
 ``{{ site_header|default:_('Django administration') }}`` (including the curly

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -163,7 +163,7 @@ You can get a local copy of the HTML documentation following a few steps:
 
   .. console::
 
-        $ python -m pip install Sphinx
+        $ python3 -m pip install Sphinx
 
 * Then, use the included ``Makefile`` to turn the documentation into HTML:
 


### PR DESCRIPTION
Since this is a tutorial written largely for novices, it is more user-friendly to have the shell prompts be "python3". The tutorial states that "This tutorial is written for Django |version|, which supports Python 3.8 and later." So it is safe to assume the user is using python3 for shell prompts. Any experienced python developer who is using an alias such as python-is-python3 will know to substitute python for python3, but a novice will not necessarily know to do the inverse.