### PR TITLE
Fixed #12241 -- Preserved query strings when using "Save and continue/add another" in admin.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2,7 +2,9 @@ import copy
 import json
 import re
 from functools import partial, update_wrapper
+from urllib.parse import parse_qsl
 from urllib.parse import quote as urlquote
+from urllib.parse import urlparse
 
 from django import forms
 from django.conf import settings
@@ -1379,8 +1381,14 @@ class ModelAdmin(BaseModelAdmin):
             self.message_user(request, format_html(msg, **msg_dict), messages.SUCCESS)
             if post_url_continue is None:
                 post_url_continue = obj_url
+            query_string = urlparse(request.build_absolute_uri()).query
+            preserved_qsl = parse_qsl(query_string.replace(preserved_filters, ""))
             post_url_continue = add_preserved_filters(
-                {"preserved_filters": preserved_filters, "opts": opts},
+                {
+                    "preserved_filters": preserved_filters,
+                    "preserved_qsl": preserved_qsl,
+                    "opts": opts,
+                },
                 post_url_continue,
             )
             return HttpResponseRedirect(post_url_continue)
@@ -1394,9 +1402,16 @@ class ModelAdmin(BaseModelAdmin):
                 **msg_dict,
             )
             self.message_user(request, msg, messages.SUCCESS)
+            query_string = urlparse(request.build_absolute_uri()).query
+            preserved_qsl = parse_qsl(query_string.replace(preserved_filters, ""))
             redirect_url = request.path
             redirect_url = add_preserved_filters(
-                {"preserved_filters": preserved_filters, "opts": opts}, redirect_url
+                {
+                    "preserved_filters": preserved_filters,
+                    "preserved_qsl": preserved_qsl,
+                    "opts": opts,
+                },
+                redirect_url,
             )
             return HttpResponseRedirect(redirect_url)
 
@@ -1456,9 +1471,16 @@ class ModelAdmin(BaseModelAdmin):
                 **msg_dict,
             )
             self.message_user(request, msg, messages.SUCCESS)
+            query_string = urlparse(request.build_absolute_uri()).query
+            preserved_qsl = parse_qsl(query_string.replace(preserved_filters, ""))
             redirect_url = request.path
             redirect_url = add_preserved_filters(
-                {"preserved_filters": preserved_filters, "opts": opts}, redirect_url
+                {
+                    "preserved_filters": preserved_filters,
+                    "preserved_qsl": preserved_qsl,
+                    "opts": opts,
+                },
+                redirect_url,
             )
             return HttpResponseRedirect(redirect_url)
 
@@ -1494,8 +1516,15 @@ class ModelAdmin(BaseModelAdmin):
                 "admin:%s_%s_add" % (opts.app_label, opts.model_name),
                 current_app=self.admin_site.name,
             )
+            query_string = urlparse(request.build_absolute_uri()).query
+            preserved_qsl = parse_qsl(query_string.replace(preserved_filters, ""))
             redirect_url = add_preserved_filters(
-                {"preserved_filters": preserved_filters, "opts": opts}, redirect_url
+                {
+                    "preserved_filters": preserved_filters,
+                    "preserved_qsl": preserved_qsl,
+                    "opts": opts,
+                },
+                redirect_url,
             )
             return HttpResponseRedirect(redirect_url)
 

--- a/django/contrib/admin/templatetags/admin_urls.py
+++ b/django/contrib/admin/templatetags/admin_urls.py
@@ -22,10 +22,14 @@ def admin_urlquote(value):
 def add_preserved_filters(context, url, popup=False, to_field=None):
     opts = context.get("opts")
     preserved_filters = context.get("preserved_filters")
+    preserved_qsl = context.get("preserved_qsl")
 
     parsed_url = list(urlparse(url))
     parsed_qs = dict(parse_qsl(parsed_url[4]))
     merged_qs = {}
+
+    if preserved_qsl:
+        merged_qs.update(preserved_qsl)
 
     if opts and preserved_filters:
         preserved_filters = dict(parse_qsl(preserved_filters))

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -334,6 +334,43 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
             msg_prefix="Couldn't find an input with the right value in the response",
         )
 
+    def test_add_query_string_persists(self):
+        tests = [
+            {"_addanother": "1"},  # "Save and add another".
+            {"_continue": "1"},  # "Save and continue editing".
+        ]
+        for i, save_option in enumerate(tests):
+            with self.subTest(save_option):
+                url = reverse("admin:auth_user_add")
+                response = self.client.post(
+                    f"{url}?username=newuser",
+                    {
+                        "username": f"newuser{i}",
+                        "password1": "newpassword",
+                        "password2": "newpassword",
+                        **save_option,
+                    },
+                )
+                self.assertIn("username=newuser", response.url)
+
+    def test_change_query_string_persists(self):
+        tests = [
+            {"_addanother": "1"},  # "Save and add another".
+            {"_continue": "1"},  # "Save and continue editing".
+        ]
+        for save_option in tests:
+            with self.subTest(save_option):
+                url = reverse("admin:admin_views_color_change", args=(self.color1.pk,))
+                response = self.client.post(
+                    f"{url}?value=blue",
+                    {
+                        "value": "gold",
+                        "warm": True,
+                        **save_option,
+                    },
+                )
+                self.assertIn("value=blue", response.url)
+
     def test_basic_edit_GET(self):
         """
         A smoke test to ensure GET on the change_view works.


### PR DESCRIPTION
https://code.djangoproject.com/ticket/12241

Ensure querystring persists when 'save and add another' is clicked. Add a test case.

Co-authored-by: Grady Yu <gradyy@users.noreply.github.com>
