### PR TITLE
Fixed #27775 -- Support custom expiry in signed cookies.

### DIFF
--- a/django/contrib/sessions/backends/signed_cookies.py
+++ b/django/contrib/sessions/backends/signed_cookies.py
@@ -13,9 +13,9 @@ class SessionStore(SessionBase):
             return signing.loads(
                 self.session_key,
                 serializer=self.serializer,
-                # This doesn't handle non-default expiry dates, see #19201
                 max_age=self.get_session_cookie_age(),
                 salt="django.contrib.sessions.backends.signed_cookies",
+                expiration_key="_session_expiry",
             )
         except Exception:
             # BadSignature, ValueError, or unpickling exceptions. If any of

--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -283,9 +283,7 @@ class TimestampSigner(Signer):
 
     def unsign_object(self, signed_obj, max_age=None, **kwargs):
         if self.expiration_key is None:
-            return super(TimestampSigner, self).unsign_object(
-                signed_obj, max_age=max_age, **kwargs
-            )
+            return super().unsign_object(signed_obj, max_age=max_age, **kwargs)
 
         # If using expiration key use it's value when present
         value = super().unsign_object(signed_obj, **kwargs, max_age=None)

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -886,7 +886,6 @@ class CookieSessionTests(SessionTestsMixin, SimpleTestCase):
         """
         pass
 
-    @unittest.expectedFailure
     def test_actual_expiry(self):
         # The cookie backend doesn't handle non-default expiry dates, see #19201
         super().test_actual_expiry()

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -886,10 +886,6 @@ class CookieSessionTests(SessionTestsMixin, SimpleTestCase):
         """
         pass
 
-    def test_actual_expiry(self):
-        # The cookie backend doesn't handle non-default expiry dates, see #19201
-        super().test_actual_expiry()
-
     def test_unpickling_exception(self):
         # signed_cookies backend should handle unpickle exceptions gracefully
         # by creating a new session


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27775

Until now signed cookies didn't validate custom expiry times stored in `_session_expiry`. The proposed solution introduces `expiration_key` to `TimestampSinger` and in it's presence defers the age validation to happen after payload serialization.

There was old proposal on tackling this problem - https://github.com/django/django/pull/7885 - and while it was less lines of code I've decided to go with the described approach to avoid calling `signing.loads` twice.