### PR TITLE
Fixed #34063 -- Made AsyncClient populate request.POST from form data body. 

### DIFF
--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -1103,6 +1103,14 @@ class AsyncClientTest(TestCase):
         response = await self.async_client.get("/get_view/", {"var": "val"})
         self.assertContains(response, "This is a test. val is the value.")
 
+    async def test_post_data(self):
+        response = await self.async_client.post("/post_view/", {"value": 37})
+        self.assertContains(response, "Data received: 37 is the value.")
+
+    async def test_body_read_on_get_data(self):
+        response = await self.async_client.get("/post_view/")
+        self.assertContains(response, "Viewing GET page.")
+
 
 @override_settings(ROOT_URLCONF="test_client.urls")
 class AsyncRequestFactoryTest(SimpleTestCase):
@@ -1146,6 +1154,16 @@ class AsyncRequestFactoryTest(SimpleTestCase):
         response = await async_generic_view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b'{"example": "data"}')
+
+    async def test_request_limited_read(self):
+        tests = ["GET", "POST"]
+        for method in tests:
+            with self.subTest(method=method):
+                request = self.request_factory.generic(
+                    method,
+                    "/somewhere",
+                )
+                self.assertEqual(request.read(200), b"")
 
     def test_request_factory_sets_headers(self):
         request = self.request_factory.get(

--- a/tests/test_client/views.py
+++ b/tests/test_client/views.py
@@ -90,6 +90,8 @@ def post_view(request):
             c = Context()
     else:
         t = Template("Viewing GET page.", name="Empty GET Template")
+        # Used by test_body_read_on_get_data.
+        request.read(200)
         c = Context()
     return HttpResponse(t.render(c))
 


### PR DESCRIPTION
[Trac issue](https://code.djangoproject.com/ticket/34063)

We found that when `FakePayload` tries to `read` and is given a number of bytes that is larger than the available content, it hits an assert statement and fails.

When we (@kevswanberg @carltongibson) compared this to the WSGI `TestClient`, we noticed that it converted its `_stream` member to a `LimitedStream`, which has a more robust `read` method.

When we made this change to `asgi.py` we found that the `test_client` tests still passed