### PR TITLE
Fixed duplicated related model field wrapper.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -195,12 +195,13 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
                             request
                         ),
                     )
-                formfield.widget = widgets.RelatedFieldWidgetWrapper(
-                    formfield.widget,
-                    db_field.remote_field,
-                    self.admin_site,
-                    **wrapper_kwargs,
-                )
+                if not isinstance(formfield.widget, widgets.RelatedFieldWidgetWrapper):
+                    formfield.widget = widgets.RelatedFieldWidgetWrapper(
+                        formfield.widget,
+                        db_field.remote_field,
+                        self.admin_site,
+                        **wrapper_kwargs,
+                    )
 
             return formfield
 


### PR DESCRIPTION
Wrapper `div` in template duplicates if the user tried to use a custom RelatedFieldWidgetWrapper field's widget in metaclass.

**Describe the Bug**
Wrapper `div` in template duplicate if the user uses a custom widget in the `Form` `metaclass`.

This is how it looks:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/30384731/196998594-8bd39f6b-6eeb-4bf2-99fd-bf00e56d17b0.png">

- Because the user used or customized the `RelatedFieldWidgetWrapper`.
- If attribute `can_add_related`, `can_delete_related` or `can_change_related` was provided to the `RelatedFieldWidgetWrapper` with the value of `False` it creates two wrappers one with the permission provided and one without.

```
widgets = {
            'fieldname': RelatedFieldWidgetWrapper(
                autocomplete.ModelSelect2(
                    url='myurl',
                    forward=(forward.Const('myforward', 'auto_type'),),
                ),
                apps.get_model('appname', 'modelname')._meta.get_field('fieldname').remote_field,
                admin.site,
                can_add_related=True,
                can_delete_related=True,
                can_change_related=False,
            )
        }
```
This will produce the following result:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/30384731/197002606-f87ad1fa-02f7-466e-9ed9-a7976d0f5448.png">

**Possible fixes**

Hook for changing the field widget to `RelatedFieldWidgetWrapper` widget should not run if the field already has a widget of type `RelatedFieldWidgetWrapper`