### PR TITLE
Fixed #29510 - TemporaryUploadedFile can't be deep copied

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -241,6 +241,7 @@ answer newbie questions, and generally made Django that much better:
     Daniel Wiesmann <daniel.wiesmann@gmail.com>
     Danilo Bargen
     Dan Johnson <danj.py@gmail.com>
+    Dan Madere <dan@danmadere.com>
     Dan Palmer <dan@danpalmer.me>
     Dan Poirier <poirier@pobox.com>
     Dan Stephenson <http://dan.io/>

--- a/django/core/files/uploadedfile.py
+++ b/django/core/files/uploadedfile.py
@@ -79,6 +79,9 @@ class TemporaryUploadedFile(UploadedFile):
         )
         super().__init__(file, name, content_type, size, charset, content_type_extra)
 
+    def __deepcopy__(self, memo):
+        return None
+
     def temporary_file_path(self):
         """Return the full path of this file."""
         return self.file.name

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -236,7 +236,8 @@ Models
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* ``QueryDict`` instances now can be deep copied, but will drop any
+  ``TemporaryUploadedFile`` values (:ticket:`29510`).
 
 Security
 ~~~~~~~~

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -4,7 +4,7 @@ import json
 import uuid
 
 from django.core.exceptions import NON_FIELD_ERRORS
-from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.files.uploadedfile import SimpleUploadedFile, TemporaryUploadedFile
 from django.core.validators import MaxValueValidator, RegexValidator
 from django.forms import (
     BooleanField,
@@ -239,6 +239,14 @@ class FormsTestCase(SimpleTestCase):
             '<ul class="errorlist"><li>This field is required.</li></ul>'
             '<input type="text" name="birthday" required id="id_birthday"></div>',
         )
+
+    def test_copying_querydict_with_temp_file(self):
+        data = QueryDict(mutable=True)
+        data["file"] = TemporaryUploadedFile("test", "text/plain", 1, "utf8")
+        data["file"].write(b"1")
+        data["file"].seek(0)
+        copied_data = copy.deepcopy(data)
+        self.assertIsNone(copied_data["file"])
 
     def test_empty_querydict_args(self):
         data = QueryDict()


### PR DESCRIPTION
Ticket https://code.djangoproject.com/ticket/29510

* Skips over instances of `TemporaryUploadedFile` when deep copying a `QueryDict` instance