### PR TITLE
Refs #32873 -- Adjusted formatting note on USE_L10N default.

### DIFF
--- a/docs/topics/i18n/formatting.txt
+++ b/docs/topics/i18n/formatting.txt
@@ -13,8 +13,8 @@ When it's enabled, two users accessing the same content may see dates, times and
 numbers formatted in different ways, depending on the formats for their current
 locale.
 
-The formatting system is disabled by default. To enable it, it's
-necessary to set :setting:`USE_L10N = True <USE_L10N>` in your settings file.
+The formatting system is enabled by default. To disable it, it's
+necessary to set :setting:`USE_L10N = False <USE_L10N>` in your settings file.
 
 .. note::
 


### PR DESCRIPTION
The paragraph 

> The formatting system is enabled by default. To disable it, it's necessary to set :setting:`USE_L10N = False <USE_L10N>` in your settings file. 

was correct in Django 3, but from Django 4 and later USE_L10N is set to True by default.

I guess there will be bigger changes needed to this document in the 5.x branch.