### PR TITLE
Improved "rebase" example for upstream changes in working with Git docs.

### DIFF
--- a/docs/internals/contributing/writing-code/working-with-git.txt
+++ b/docs/internals/contributing/writing-code/working-with-git.txt
@@ -196,7 +196,7 @@ When upstream (``django/django``) has changed, you should rebase your work. To
 do this, use::
 
   git fetch upstream
-  git rebase
+  git rebase upstream/main
 
 The work is automatically rebased using the branch you forked on, in the
 example case using ``upstream/main``.


### PR DESCRIPTION
In [after upstream has changed](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/working-with-git/#after-upstream-has-changed) section, the code example does not explicitly instruct to `git rebase upstream/main`.
Although, it is mentioned in the next sentence after the code section, for someone new to Git, it is not obvious that `git rebase` alone is not enough. Hopefully this change will save some time for the next newcomer learning to contribute to Django.