### PR TITLE
Completed test coverage for contrib.auth.forms.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -378,12 +378,11 @@ class SetPasswordForm(forms.Form):
     def clean_new_password2(self):
         password1 = self.cleaned_data.get("new_password1")
         password2 = self.cleaned_data.get("new_password2")
-        if password1 and password2:
-            if password1 != password2:
-                raise ValidationError(
-                    self.error_messages["password_mismatch"],
-                    code="password_mismatch",
-                )
+        if password1 and password2 and password1 != password2:
+            raise ValidationError(
+                self.error_messages["password_mismatch"],
+                code="password_mismatch",
+            )
         password_validation.validate_password(password2, self.user)
         return password2
 


### PR DESCRIPTION
Add tests and small readability improvement to complete `contrib.auth.forms` coverage.

![image](https://user-images.githubusercontent.com/16822952/197390481-c409b375-a785-4322-b784-ed6f21e47177.png)
<img width="1327" alt="image" src="https://user-images.githubusercontent.com/16822952/197390348-5cb7e6cf-0f8f-408c-b21b-41af64a01c80.png">

<img width="1327" alt="image" src="https://user-images.githubusercontent.com/16822952/197390364-139396e3-4e0e-4096-95e2-85d0e4a77b43.png">

<img width="1328" alt="image" src="https://user-images.githubusercontent.com/16822952/197390375-802dfd94-dd2e-4cfd-a40f-9f3ace5f7a79.png">
