### PR TITLE
Refs #34070 -- Fixed date format in Now() on SQLite.

### DIFF
--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -232,7 +232,7 @@ class Now(Func):
         return self.as_sql(
             compiler,
             connection,
-            template="STRFTIME('%%Y-%%m-%%d %%H:%%M:%%f', 'NOW')",
+            template="STRFTIME('%%%%Y-%%%%m-%%%%d %%%%H:%%%%M:%%%%f', 'NOW')",
             **extra_context,
         )
 


### PR DESCRIPTION
See https://github.com/django/django/pull/16111#discussion_r986252539.

Regression in 649b28eab6765cd6b2b40c779a18ecafc99b43d7.


```
./runtests.py aggregation --debug-sql
...
  File "/django/django/db/backends/sqlite3/operations.py", line 183, in last_executed_query
    return sql % params
ValueError: unsupported format character 'Y' (0x59) at index 120
```