### PR TITLE
Removed obsolete reference to asyncio.iscoroutinefunction.

### DIFF
--- a/docs/topics/http/middleware.txt
+++ b/docs/topics/http/middleware.txt
@@ -312,7 +312,7 @@ If your middleware has both ``sync_capable = True`` and
 ``async_capable = True``, then Django will pass it the request without
 converting it. In this case, you can work out if your middleware will receive
 async requests by checking if the ``get_response`` object you are passed is a
-coroutine function, using :py:func:`asyncio.iscoroutinefunction`.
+coroutine function, using ``asyncio.iscoroutinefunction``.
 
 The ``django.utils.decorators`` module contains
 :func:`~django.utils.decorators.sync_only_middleware`,


### PR DESCRIPTION
Python 3.11 has removed support for `@asyncio.coroutine` and with it removed the documentation references for `asyncio.iscoroutinefunction()` such that the intersphinx reference is unavailable.

The implementation of `asyncio.iscoroutinefunction()` still exists, however:

https://github.com/python/cpython/blob/a1092f62492a3fcd6195bea94eccf8d5a300acb1/Lib/asyncio/coroutines.py#L21-L24

It looks as though it will be removed in the future:

https://github.com/python/cpython/issues/94912

As we still need to support Python < 3.11 where `@asyncio.coroutine` may be used we will likely need to vendor this until Python 3.11 is the minimum supported version when `inspect.iscoroutinefunction()` can be used directly instead. That will likely not be required until 3.12 though.