### PR TITLE
Corrected test_update_or_create_with_model_property_defaults test.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -901,6 +901,7 @@ answer newbie questions, and generally made Django that much better:
     smurf@smurf.noris.de
     sopel
     Sreehari K V <sreeharivijayan619@gmail.com>
+    Sridhar Marella <sridhar562345@gmail.com>
     Srinivas Reddy Thatiparthy <thatiparthysreenivas@gmail.com>
     Stanislas Guerra <stan@slashdev.me>
     Stanislaus Madueke

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -367,7 +367,7 @@ class UpdateOrCreateTests(TestCase):
 
     def test_update_or_create_with_model_property_defaults(self):
         """Using a property with a setter implemented is allowed."""
-        t, _ = Thing.objects.get_or_create(
+        t, _ = Thing.objects.update_or_create(
             defaults={"capitalized_name_property": "annie"}, pk=1
         )
         self.assertEqual(t.name, "Annie")


### PR DESCRIPTION
https://github.com/django/django/blob/09397f5cfade93c2e79a391ded7ab6b01e51730e/tests/get_or_create/tests.py#L368-L373

Testcase name says we are testing update_or_create functionality, but the testcase is using get or create.