### PR TITLE
Fixed #10070 -- Added support for pyformat style parameters on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -18,7 +18,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     atomic_transactions = False
     can_rollback_ddl = True
     can_create_inline_fk = False
-    supports_paramstyle_pyformat = False
     requires_literal_defaults = True
     can_clone_databases = True
     supports_temporal_subtraction = True

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -819,14 +819,6 @@ If you're getting this error, you can solve it by:
 SQLite does not support the ``SELECT ... FOR UPDATE`` syntax. Calling it will
 have no effect.
 
-"pyformat" parameter style in raw queries not supported
--------------------------------------------------------
-
-For most backends, raw queries (``Manager.raw()`` or ``cursor.execute()``)
-can use the "pyformat" parameter style, where placeholders in the query
-are given as ``'%(name)s'`` and the parameters are passed as a dictionary
-rather than a list. SQLite does not support this.
-
 .. _sqlite-isolation:
 
 Isolation when using ``QuerySet.iterator()``


### PR DESCRIPTION
Fix to allow named parameters on raw sql queries with sqlite