### PR TITLE
Refs #33768 -- Fixed ordering compound queries by nulls on SQLite < 3…

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -41,6 +41,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_frame_range_fixed_distance = Database.sqlite_version_info >= (3, 28, 0)
     supports_aggregate_filter_clause = Database.sqlite_version_info >= (3, 30, 1)
     supports_order_by_nulls_modifier = Database.sqlite_version_info >= (3, 30, 0)
+    # NULLS LAST/FIRST emulation on < 3.30 requires subquery wrapping.
+    requires_compound_order_by_subquery = Database.sqlite_version_info < (3, 30)
     order_by_nulls_first = True
     supports_json_field_contains = False
     supports_update_conflicts = Database.sqlite_version_info >= (3, 24, 0)


### PR DESCRIPTION
The lack of support for native nulls last/first on SQLite 3.28 and 3.29 requires the compound query to be wrapped for emulation layer to work properly.

---

@felixxm the test added in c58a8acd413ccc992dd30afd98ed900897e1f719 for MySQL happens to fail against SQLite 3.28 and 3.29 which don't support native `NULLS LAST/FIRST` yet (only added in 3.30).

@shangxiao this explains the `1st ORDER BY term does not match any column in the result set` reported message over there.