### PR TITLE
Improved readability of string interpolation in frequently used examples in docs.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -558,7 +558,7 @@ subclass::
 
           @admin.display(description='Name')
           def upper_case_name(obj):
-              return ("%s %s" % (obj.first_name, obj.last_name)).upper()
+              return f"{obj.first_name} {obj.last_name}".upper()
 
           class PersonAdmin(admin.ModelAdmin):
               list_display = [upper_case_name]
@@ -571,7 +571,7 @@ subclass::
 
               @admin.display(description='Name')
               def upper_case_name(self, obj):
-                  return ("%s %s" % (obj.first_name, obj.last_name)).upper()
+                  return f"{obj.first_name} {obj.last_name}".upper()
 
     * A string representing a model attribute or method (without any required
       arguments). For example::
@@ -585,7 +585,8 @@ subclass::
 
               @admin.display(description='Birth decade')
               def decade_born_in(self):
-                  return '%d’s' % (self.birthday.year // 10 * 10)
+                  decade = self.birthday.year // 10 * 10
+                  return f'{decade}’s'
 
           class PersonAdmin(admin.ModelAdmin):
               list_display = ['name', 'decade_born_in']

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -707,7 +707,7 @@ For example::
         last_name = models.CharField(max_length=50)
 
         def __str__(self):
-            return '%s %s' % (self.first_name, self.last_name)
+            return f'{self.first_name} {self.last_name}'
 
 ``__eq__()``
 ------------

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -473,7 +473,7 @@ login page::
 
     def my_view(request):
         if not request.user.is_authenticated:
-            return redirect('%s?next=%s' % (settings.LOGIN_URL, request.path))
+            return redirect(f'{settings.LOGIN_URL}?next={request.path}')
         # ...
 
 ...or display an error message::

--- a/docs/topics/db/examples/many_to_one.txt
+++ b/docs/topics/db/examples/many_to_one.txt
@@ -15,7 +15,7 @@ objects, but an ``Article`` can only have one ``Reporter`` object::
         email = models.EmailField()
 
         def __str__(self):
-            return "%s %s" % (self.first_name, self.last_name)
+            return f"{self.first_name} {self.last_name}"
 
     class Article(models.Model):
         headline = models.CharField(max_length=100)

--- a/docs/topics/db/examples/one_to_one.txt
+++ b/docs/topics/db/examples/one_to_one.txt
@@ -14,7 +14,7 @@ In this example, a ``Place`` optionally can be a ``Restaurant``::
         address = models.CharField(max_length=80)
 
         def __str__(self):
-            return "%s the place" % self.name
+            return f"{self.name} the place"
 
     class Restaurant(models.Model):
         place = models.OneToOneField(

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -762,7 +762,7 @@ For example, this model has a few custom methods::
         @property
         def full_name(self):
             "Returns the person's full name."
-            return '%s %s' % (self.first_name, self.last_name)
+            return f'{self.first_name} {self.last_name}'
 
 The last method in this example is a :term:`property`.
 

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -561,7 +561,7 @@ the historical model and iterate over the rows::
         # version than this migration expects. We use the historical version.
         Person = apps.get_model('yourappname', 'Person')
         for person in Person.objects.all():
-            person.name = '%s %s' % (person.first_name, person.last_name)
+            person.name = f'{person.first_name} {person.last_name}'
             person.save()
 
     class Migration(migrations.Migration):

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -969,7 +969,7 @@ The code for this test may look as follows::
             super().tearDownClass()
 
         def test_login(self):
-            self.selenium.get('%s%s' % (self.live_server_url, '/login/'))
+            self.selenium.get(f'{self.live_server_url}/login/')
             username_input = self.selenium.find_element(By.NAME, "username")
             username_input.send_keys('myuser')
             password_input = self.selenium.find_element(By.NAME, "password")


### PR DESCRIPTION
When I teach Django, I frequently link to particular pages in the Django documentation.
Many of my students are much more familiar with Python's f-string syntax than with the old `%`-style formatting.
To that end, this pull request updates 10 examples (that are likely commonly seen by new Django users) to f-strings.

I've read the recommendations that came out of the [2020 discussion on string formatting in Django](https://groups.google.com/g/django-developers/c/XNhpOHam0zE/m/D38Uq6wbBgAJ) and I believe this PR is well-aligned with the aim of that conversation. Namely:

1. This isn't a bulk update of all the documentation (I attempted only to update a few key pages frequented by new Django users)
2. Each of these changes improves readability (if any do not, I'm happy to revert the update)
3. This is a documentation update only and while a similar to update to Django's source code may be spurious, these docs pages are often read by folks newer to Python (who are often less familiar with `%` than many long-time Python users are)