### PR TITLE
Fixed #33701 -- Added fine-grained error locations to the technical 500 debug page.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -802,6 +802,7 @@ answer newbie questions, and generally made Django that much better:
     Rachel Tobin <rmtobin@me.com>
     Rachel Willmer <http://www.willmer.com/kb/>
     Radek Švarz <https://www.svarz.cz/translate/>
+    Rafael Giebisch <rafael@giebisch-mail.de>
     Raffaele Salmaso <raffaele@salmaso.org>
     Rajesh Dhawan <rajesh.dhawan@gmail.com>
     Ramez Ashraf <ramezashraf@gmail.com>

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -242,7 +242,7 @@
                 </ol>
               {% endif %}
               <ol start="{{ frame.lineno }}" class="context-line">
-                <li onclick="toggle('pre{{ frame.id }}', 'post{{ frame.id }}')"><pre>{{ frame.context_line }}</pre>{% if not is_email %} <span>…</span>{% endif %}</li>
+                <li onclick="toggle('pre{{ frame.id }}', 'post{{ frame.id }}')"><pre>{{ frame.context_line }}{{ frame.colno }}</pre>{% if not is_email %} <span>…</span>{% endif %}</li>
               </ol>
               {% if frame.post_context and not is_email  %}
                 <ol start='{{ frame.lineno|add:"1" }}' class="post-context" id="post{{ frame.id }}">
@@ -327,7 +327,7 @@ The above exception ({{ frame.exc_cause|force_escape }}) was the direct cause of
 {% else %}
 During handling of the above exception ({{ frame.exc_cause|force_escape }}), another exception occurred:
 {% endif %}{% endif %}{% endifchanged %}  {% if frame.tb %}File "{{ frame.filename }}"{% if frame.context_line %}, line {{ frame.lineno }}{% endif %}, in {{ frame.function }}
-{% if frame.context_line %}    {% spaceless %}{{ frame.context_line }}{% endspaceless %}{% endif %}{% elif forloop.first %}None{% else %}Traceback: None{% endif %}{% endfor %}
+{% if frame.context_line %}    {% spaceless %}{{ frame.context_line }}{% endspaceless %}{{ frame.tb_area_colno }}{% endif %}{% elif forloop.first %}None{% else %}Traceback: None{% endif %}{% endfor %}
 
 Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
 Exception Value: {{ exception_value|force_escape }}{% if exception_notes %}{{ exception_notes }}{% endif %}

--- a/django/views/templates/technical_500.txt
+++ b/django/views/templates/technical_500.txt
@@ -31,7 +31,7 @@ Traceback (most recent call last):
 {% for frame in frames %}{% ifchanged frame.exc_cause %}{% if frame.exc_cause %}
 {% if frame.exc_cause_explicit %}The above exception ({{ frame.exc_cause }}) was the direct cause of the following exception:{% else %}During handling of the above exception ({{ frame.exc_cause }}), another exception occurred:{% endif %}
 {% endif %}{% endifchanged %}  {% if frame.tb %}File "{{ frame.filename }}"{% if frame.context_line %}, line {{ frame.lineno }}{% endif %}, in {{ frame.function }}
-{% if frame.context_line %}    {% spaceless %}{{ frame.context_line }}{% endspaceless %}{% endif %}{% elif forloop.first %}None{% else %}Traceback: None{% endif %}
+{% if frame.context_line %}    {% spaceless %}{{ frame.context_line }}{% endspaceless %}{{ frame.tb_area_colno }}{% endif %}{% elif forloop.first %}None{% else %}Traceback: None{% endif %}
 {% endfor %}
 {% if exception_type %}Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
 {% if exception_value %}Exception Value: {{ exception_value }}{% endif %}{% if exception_notes %}{{ exception_notes }}{% endif %}{% endif %}{% endif %}

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -161,7 +161,8 @@ Email
 Error Reporting
 ~~~~~~~~~~~~~~~
 
-* The debug page now shows :pep:`exception notes <678>` on Python 3.11+.
+* The debug page now shows :pep:`exception notes <678>` and
+  :pep:`fine-grained error locations <657>` on Python 3.11+.
 
 File Storage
 ~~~~~~~~~~~~

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -766,6 +766,79 @@ class ExceptionReporterTests(SimpleTestCase):
         self.assertIn(implicit_exc.format("<p>Second exception</p>"), text)
         self.assertEqual(3, text.count("<p>Final exception</p>"))
 
+    @skipIf(
+        sys._xoptions.get("no_debug_ranges", False)
+        or os.environ.get("PYTHONNODEBUGRANGES", False),
+        "Fine-grained error locations are disabled.",
+    )
+    @skipUnless(PY311, "Fine-grained error locations were added in Python 3.11.")
+    def test_highlight_error_position(self):
+        request = self.rf.get("/test_view/")
+        try:
+            try:
+                raise AttributeError("Top level")
+            except AttributeError as explicit:
+                try:
+                    raise ValueError(mark_safe("<p>2nd exception</p>")) from explicit
+                except ValueError:
+                    raise IndexError("Final exception")
+        except Exception:
+            exc_type, exc_value, tb = sys.exc_info()
+
+        reporter = ExceptionReporter(request, exc_type, exc_value, tb)
+        html = reporter.get_traceback_html()
+        self.assertIn(
+            "<pre>                raise AttributeError(&quot;Top level&quot;)\n"
+            "                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</pre>",
+            html,
+        )
+        self.assertIn(
+            "<pre>                    raise ValueError(mark_safe("
+            "&quot;&lt;p&gt;2nd exception&lt;/p&gt;&quot;)) from explicit\n"
+            "                         "
+            "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</pre>",
+            html,
+        )
+        self.assertIn(
+            "<pre>                    raise IndexError(&quot;Final exception&quot;)\n"
+            "                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</pre>",
+            html,
+        )
+        # Pastebin.
+        self.assertIn(
+            "    raise AttributeError(&quot;Top level&quot;)\n"
+            "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            html,
+        )
+        self.assertIn(
+            "    raise ValueError(mark_safe("
+            "&quot;&lt;p&gt;2nd exception&lt;/p&gt;&quot;)) from explicit\n"
+            "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            html,
+        )
+        self.assertIn(
+            "    raise IndexError(&quot;Final exception&quot;)\n"
+            "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            html,
+        )
+        # Text traceback.
+        text = reporter.get_traceback_text()
+        self.assertIn(
+            '    raise AttributeError("Top level")\n'
+            "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            text,
+        )
+        self.assertIn(
+            '    raise ValueError(mark_safe("<p>2nd exception</p>")) from explicit\n'
+            "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            text,
+        )
+        self.assertIn(
+            '    raise IndexError("Final exception")\n'
+            "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            text,
+        )
+
     def test_reporting_frames_without_source(self):
         try:
             source = "def funcName():\n    raise Error('Whoops')\nfuncName()"


### PR DESCRIPTION
Solves Ticket [33701](https://code.djangoproject.com/ticket/33701)

With Python 3.11 the technical_500.html debug page now shows, where in the line the error occurred.

![traceback](https://user-images.githubusercontent.com/39874595/199703281-3f755068-fd41-45bc-961c-957a78d51df5.PNG)
