### PR TITLE
Fixed #34138 -- Avoided table rebuild when adding inline m2m fields on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -379,7 +379,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def add_field(self, model, field):
         """Create a field on a model."""
-        if (
+        # Special-case implicit M2M tables.
+        if field.many_to_many and field.remote_field.through._meta.auto_created:
+            self.create_model(field.remote_field.through)
+        elif (
             # Primary keys and unique fields are not supported in ALTER TABLE
             # ADD COLUMN.
             field.primary_key

--- a/docs/releases/4.1.4.txt
+++ b/docs/releases/4.1.4.txt
@@ -9,4 +9,5 @@ Django 4.1.4 fixes several bugs in 4.1.3.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 4.1 that caused an unnecessary table rebuilt
+  when adding ``ManyToManyField`` on SQLite (:ticket:`34138`).

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -2200,8 +2200,25 @@ class SchemaTests(TransactionTestCase):
         with self.assertRaises(DatabaseError):
             self.column_classes(new_field.remote_field.through)
         # Add the field
-        with connection.schema_editor() as editor:
+        with CaptureQueriesContext(
+            connection
+        ) as ctx, connection.schema_editor() as editor:
             editor.add_field(LocalAuthorWithM2M, new_field)
+        # Table is not rebuilt.
+        self.assertEqual(
+            len(
+                [
+                    query["sql"]
+                    for query in ctx.captured_queries
+                    if "CREATE TABLE" in query["sql"]
+                ]
+            ),
+            1,
+        )
+        self.assertIs(
+            any("DROP TABLE" in query["sql"] for query in ctx.captured_queries),
+            False,
+        )
         # Ensure there is now an m2m table there
         columns = self.column_classes(new_field.remote_field.through)
         self.assertEqual(


### PR DESCRIPTION
ticket-34138

Regression in 2f73e5406d54cb8945e187eff302a3a3373350be.

Thanks David Wobrock for the report.