### PR TITLE
Fixed #34088 -- Fixed Sitemap.get_latest_lastmod() crash with empty items.

### DIFF
--- a/django/contrib/sitemaps/__init__.py
+++ b/django/contrib/sitemaps/__init__.py
@@ -167,7 +167,7 @@ class Sitemap:
             return None
         if callable(self.lastmod):
             try:
-                return max([self.lastmod(item) for item in self.items()])
+                return max([self.lastmod(item) for item in self.items()], default=None)
             except TypeError:
                 return None
         else:

--- a/docs/releases/4.1.4.txt
+++ b/docs/releases/4.1.4.txt
@@ -11,3 +11,8 @@ Bugfixes
 
 * Fixed a regression in Django 4.1 that caused an unnecessary table rebuilt
   when adding ``ManyToManyField`` on SQLite (:ticket:`34138`).
+
+* Fixed a bug in Django 4.1 that caused a crash of the sitemap index view with
+  an empty :meth:`Sitemap.items() <django.contrib.sitemaps.Sitemap.items>` and
+  a callable :attr:`~django.contrib.sitemaps.Sitemap.lastmod`
+  (:ticket:`34088`).

--- a/tests/sitemaps_tests/test_http.py
+++ b/tests/sitemaps_tests/test_http.py
@@ -507,6 +507,16 @@ class HTTPSitemapTests(SitemapTestsBase):
         self.assertXMLEqual(index_response.content.decode(), expected_content_index)
         self.assertXMLEqual(sitemap_response.content.decode(), expected_content_sitemap)
 
+    def test_callable_sitemod_no_items(self):
+        index_response = self.client.get("/callable-lastmod-no-items/index.xml")
+        self.assertNotIn("Last-Modified", index_response)
+        expected_content_index = """<?xml version="1.0" encoding="UTF-8"?>
+        <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <sitemap><loc>http://example.com/simple/sitemap-callable-lastmod.xml</loc></sitemap>
+        </sitemapindex>
+        """
+        self.assertXMLEqual(index_response.content.decode(), expected_content_index)
+
 
 # RemovedInDjango50Warning
 class DeprecatedTests(SitemapTestsBase):

--- a/tests/sitemaps_tests/urls/http.py
+++ b/tests/sitemaps_tests/urls/http.py
@@ -114,6 +114,16 @@ class CallableLastmodFullSitemap(Sitemap):
         return obj.lastmod
 
 
+class CallableLastmodNoItemsSitemap(Sitemap):
+    location = "/location/"
+
+    def items(self):
+        return []
+
+    def lastmod(self, obj):
+        return obj.lastmod
+
+
 class GetLatestLastmodNoneSiteMap(Sitemap):
     changefreq = "never"
     priority = 0.5
@@ -231,6 +241,10 @@ callable_lastmod_partial_sitemap = {
 
 callable_lastmod_full_sitemap = {
     "callable-lastmod": CallableLastmodFullSitemap,
+}
+
+callable_lastmod_no_items_sitemap = {
+    "callable-lastmod": CallableLastmodNoItemsSitemap,
 }
 
 urlpatterns = [
@@ -416,6 +430,11 @@ urlpatterns = [
         "callable-lastmod-full/sitemap.xml",
         views.sitemap,
         {"sitemaps": callable_lastmod_full_sitemap},
+    ),
+    path(
+        "callable-lastmod-no-items/index.xml",
+        views.index,
+        {"sitemaps": callable_lastmod_no_items_sitemap},
     ),
     path(
         "generic-lastmod/index.xml",


### PR DESCRIPTION
Fix for [#34088](https://code.djangoproject.com/ticket/34088). A small bit of help & my first contribution to Django, so pls cut me some slack :)