### PR TITLE
Fixed #34142 -- Add file encoding for dumpdata

### DIFF
--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -258,7 +258,7 @@ class Command(BaseCommand):
                         f"Fixtures saved in '{file_name}'.",
                         RuntimeWarning,
                     )
-                stream = open_method(file_path, "wt", **kwargs)
+                stream = open_method(file_path, "wt", encoding="utf-8", **kwargs)
             else:
                 stream = None
             try:


### PR DESCRIPTION
Add a file encoding while writing data to the file, so if dumped data contains utf-8 chars like Farsi, the created file would be a utf-8 file.