### PR TITLE
Fixed #34137 -- Made Model.refresh_from_db() clear cached generic relations.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -737,6 +737,11 @@ class Model(AltersData, metaclass=ModelBase):
             if field.is_cached(self):
                 field.delete_cached_value(self)
 
+        # Clear cached private relations.
+        for field in self._meta.private_fields:
+            if field.is_relation and field.is_cached(self):
+                field.delete_cached_value(self)
+
         self._state.db = db_instance._state.db
 
     async def arefresh_from_db(self, using=None, fields=None):

--- a/tests/contenttypes_tests/test_fields.py
+++ b/tests/contenttypes_tests/test_fields.py
@@ -43,6 +43,14 @@ class GenericForeignKeyTests(TestCase):
             self.assertIsNone(post.parent)
             self.assertIsNone(post.parent)
 
+    def test_clear_cached_generic_relation(self):
+        question = Question.objects.create(text="What is your name?")
+        answer = Answer.objects.create(text="Answer", question=question)
+        old_entity = answer.question
+        answer.refresh_from_db()
+        new_entity = answer.question
+        self.assertNotEqual(id(old_entity), id(new_entity))
+
 
 class GenericRelationTests(TestCase):
     def test_value_to_string(self):

--- a/tests/contenttypes_tests/test_fields.py
+++ b/tests/contenttypes_tests/test_fields.py
@@ -49,7 +49,7 @@ class GenericForeignKeyTests(TestCase):
         old_entity = answer.question
         answer.refresh_from_db()
         new_entity = answer.question
-        self.assertNotEqual(id(old_entity), id(new_entity))
+        self.assertIsNot(old_entity, new_entity)
 
 
 class GenericRelationTests(TestCase):


### PR DESCRIPTION
[Ticket #34137](https://code.djangoproject.com/ticket/34137)