### PR TITLE
Fixed #34036 -- Corrected low link color contrast in admin light-theme. 

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -108,7 +108,7 @@ body {
 
 a:link,
 a:visited {
-    color: var(--link-fg);
+    color: var(--link-hover-color);
     text-decoration: none;
     transition: color 0.15s, background 0.15s;
 }
@@ -664,7 +664,7 @@ input[type=button][disabled].default {
     font-weight: 400;
     font-size: 0.8125rem;
     text-align: left;
-    background: var(--primary);
+    background: var(--header-bg);
     color: var(--header-link-color);
 }
 
@@ -863,7 +863,7 @@ a.deletelink:hover {
     float: left;
     padding: 3px 12px;
     background: var(--object-tools-bg);
-    color: var(--object-tools-fg);
+    color: var(--primary-fg);
     font-weight: 400;
     font-size: 0.6875rem;
     text-transform: uppercase;

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -21,7 +21,7 @@ html[data-theme="light"],
     --header-link-color: var(--primary-fg);
 
     --breadcrumbs-fg: #c4dce8;
-    --breadcrumbs-link-fg: var(--body-bg);
+    --breadcrumbs-link-fg: var(--body-loud-color);
     --breadcrumbs-bg: var(--primary);
 
     --link-fg: #417893;
@@ -709,7 +709,7 @@ div.breadcrumbs {
 }
 
 div.breadcrumbs a {
-    color: var(--body-loud-color);
+    color: var(--breadcrumbs-link-fg);
 }
 
 div.breadcrumbs a:focus, div.breadcrumbs a:hover {

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -37,8 +37,10 @@ html[data-theme="light"],
     --message-warning-bg: #ffc;
     --message-error-bg: #ffefef;
 
-    --darkened-bg: #f8f8f8; /* A bit darker than --body-bg */
-    --selected-bg: #e4e4e4; /* E.g. selected table cells */
+    --darkened-bg: #f8f8f8;
+    /* A bit darker than --body-bg */
+    --selected-bg: #e4e4e4;
+    /* E.g. selected table cells */
     --selected-row: #ffc;
 
     --button-fg: #fff;
@@ -88,7 +90,8 @@ html[data-theme="light"],
         "Noto Color Emoji";
 }
 
-html, body {
+html,
+body {
     height: 100%;
 }
 
@@ -103,13 +106,15 @@ body {
 
 /* LINKS */
 
-a:link, a:visited {
+a:link,
+a:visited {
     color: var(--link-fg);
     text-decoration: none;
     transition: color 0.15s, background 0.15s;
 }
 
-a:focus, a:hover {
+a:focus,
+a:hover {
     color: var(--link-hover-color);
 }
 
@@ -121,18 +126,23 @@ a img {
     border: none;
 }
 
-a.section:link, a.section:visited {
+a.section:link,
+a.section:visited {
     color: var(--header-link-color);
     text-decoration: none;
 }
 
-a.section:focus, a.section:hover {
+a.section:focus,
+a.section:hover {
     text-decoration: underline;
 }
 
 /* GLOBAL DEFAULTS */
 
-p, ol, ul, dl {
+p,
+ol,
+ul,
+dl {
     margin: .2em 0 .8em 0;
 }
 
@@ -141,7 +151,11 @@ p {
     line-height: 140%;
 }
 
-h1,h2,h3,h4,h5 {
+h1,
+h2,
+h3,
+h4,
+h5 {
     font-weight: bold;
 }
 
@@ -183,7 +197,7 @@ h5 {
     letter-spacing: 1px;
 }
 
-ul > li {
+ul>li {
     list-style-type: square;
     padding: 1px 0;
 }
@@ -192,7 +206,9 @@ li ul {
     margin-bottom: 0;
 }
 
-li, dt, dd {
+li,
+dt,
+dd {
     font-size: 0.8125rem;
     line-height: 20px;
 }
@@ -227,7 +243,8 @@ blockquote {
     border-left: 5px solid #ddd;
 }
 
-code, pre {
+code,
+pre {
     font-family: var(--font-family-monospace);
     color: var(--body-quiet-color);
     font-size: 0.75rem;
@@ -265,24 +282,36 @@ hr {
     font-size: 0.625rem;
 }
 
-.help, p.help, form p.help, div.help, form div.help, div.help li {
+.help,
+p.help,
+form p.help,
+div.help,
+form div.help,
+div.help li {
     font-size: 0.6875rem;
     color: var(--body-quiet-color);
 }
 
 div.help ul {
-     margin-bottom: 0;
+    margin-bottom: 0;
 }
 
 .help-tooltip {
     cursor: help;
 }
 
-p img, h1 img, h2 img, h3 img, h4 img, td img {
+p img,
+h1 img,
+h2 img,
+h3 img,
+h4 img,
+td img {
     vertical-align: middle;
 }
 
-.quiet, a.quiet:link, a.quiet:visited {
+.quiet,
+a.quiet:link,
+a.quiet:visited {
     color: var(--body-quiet-color);
     font-weight: normal;
 }
@@ -306,7 +335,8 @@ table {
     border-color: var(--border-color);
 }
 
-td, th {
+td,
+th {
     font-size: 0.8125rem;
     line-height: 16px;
     border-bottom: 1px solid var(--hairline-color);
@@ -344,14 +374,15 @@ tr.alt {
     background: var(--darkened-bg);
 }
 
-tr:nth-child(odd), .row-form-errors {
+tr:nth-child(odd),
+.row-form-errors {
     background: var(--body-bg);
 }
 
 tr:nth-child(even),
 tr:nth-child(even) .errorlist,
-tr:nth-child(odd) + .row-form-errors,
-tr:nth-child(odd) + .row-form-errors .errorlist {
+tr:nth-child(odd)+.row-form-errors,
+tr:nth-child(odd)+.row-form-errors .errorlist {
     background: var(--darkened-bg);
 }
 
@@ -364,7 +395,8 @@ thead th {
     background: var(--darkened-bg);
 }
 
-thead th a:link, thead th a:visited {
+thead th a:link,
+thead th a:visited {
     color: var(--body-quiet-color);
 }
 
@@ -387,7 +419,8 @@ table thead th .text a {
     padding: 8px 10px;
 }
 
-table thead th .text a:focus, table thead th .text a:hover {
+table thead th .text a:focus,
+table thead th .text a:hover {
     background: var(--selected-bg);
 }
 
@@ -469,7 +502,11 @@ table thead th.sorted .sortoptions a.descending:hover {
 
 /* FORM DEFAULTS */
 
-input, textarea, select, .form-row p, form .button {
+input,
+textarea,
+select,
+.form-row p,
+form .button {
     margin: 2px 0;
     padding: 2px 3px;
     vertical-align: middle;
@@ -477,6 +514,7 @@ input, textarea, select, .form-row p, form .button {
     font-weight: normal;
     font-size: 0.8125rem;
 }
+
 .form-row div.help {
     padding: 2px 3px;
 }
@@ -485,8 +523,15 @@ textarea {
     vertical-align: top;
 }
 
-input[type=text], input[type=password], input[type=email], input[type=url],
-input[type=number], input[type=tel], textarea, select, .vTextField {
+input[type=text],
+input[type=password],
+input[type=email],
+input[type=url],
+input[type=number],
+input[type=tel],
+textarea,
+select,
+.vTextField {
     border: 1px solid var(--border-color);
     border-radius: 4px;
     padding: 5px 6px;
@@ -495,9 +540,15 @@ input[type=number], input[type=tel], textarea, select, .vTextField {
     background-color: var(--body-bg);
 }
 
-input[type=text]:focus, input[type=password]:focus, input[type=email]:focus,
-input[type=url]:focus, input[type=number]:focus, input[type=tel]:focus,
-textarea:focus, select:focus, .vTextField:focus {
+input[type=text]:focus,
+input[type=password]:focus,
+input[type=email]:focus,
+input[type=url]:focus,
+input[type=number]:focus,
+input[type=tel]:focus,
+textarea:focus,
+select:focus,
+.vTextField:focus {
     border-color: var(--body-quiet-color);
 }
 
@@ -513,12 +564,16 @@ select[multiple] {
 
 /* FORM BUTTONS */
 
-.button, input[type=submit], input[type=button], .submit-row input, a.button {
+.button,
+input[type=submit],
+input[type=button],
+.submit-row input,
+a.button {
     background: var(--button-bg);
     padding: 10px 15px;
     border: none;
     border-radius: 4px;
-    color: var(--button-fg);
+    color: var(--body-fg);
     cursor: pointer;
     transition: background 0.15s;
 }
@@ -527,25 +582,39 @@ a.button {
     padding: 4px 5px;
 }
 
-.button:active, input[type=submit]:active, input[type=button]:active,
-.button:focus, input[type=submit]:focus, input[type=button]:focus,
-.button:hover, input[type=submit]:hover, input[type=button]:hover {
+.button:active,
+input[type=submit]:active,
+input[type=button]:active,
+.button:focus,
+input[type=submit]:focus,
+input[type=button]:focus,
+.button:hover,
+input[type=submit]:hover,
+input[type=button]:hover {
     background: var(--button-hover-bg);
 }
 
-.button[disabled], input[type=submit][disabled], input[type=button][disabled] {
+.button[disabled],
+input[type=submit][disabled],
+input[type=button][disabled] {
     opacity: 0.4;
 }
 
-.button.default, input[type=submit].default, .submit-row input.default {
+.button.default,
+input[type=submit].default,
+.submit-row input.default {
     border: none;
     font-weight: 400;
     background: var(--default-button-bg);
+    color: var(--button-fg);
 }
 
-.button.default:active, input[type=submit].default:active,
-.button.default:focus, input[type=submit].default:focus,
-.button.default:hover, input[type=submit].default:hover {
+.button.default:active,
+input[type=submit].default:active,
+.button.default:focus,
+input[type=submit].default:focus,
+.button.default:hover,
+input[type=submit].default:hover {
     background: var(--default-button-hover-bg);
 }
 
@@ -564,7 +633,12 @@ input[type=button][disabled].default {
     background: var(--body-bg);
 }
 
-.module p, .module ul, .module h3, .module h4, .module dl, .module pre {
+.module p,
+.module ul,
+.module h3,
+.module h4,
+.module dl,
+.module pre {
     padding-left: 10px;
     padding-right: 10px;
 }
@@ -573,7 +647,8 @@ input[type=button][disabled].default {
     margin-left: 12px;
 }
 
-.module ul, .module ol {
+.module ul,
+.module ol {
     margin-left: 1.5em;
 }
 
@@ -581,7 +656,9 @@ input[type=button][disabled].default {
     margin-top: .6em;
 }
 
-.module h2, .module caption, .inline-group h2 {
+.module h2,
+.module caption,
+.inline-group h2 {
     margin: 0;
     padding: 8px;
     font-weight: 400;
@@ -688,8 +765,12 @@ td ul.errorlist li {
     padding-left: 0;
 }
 
-.errors input, .errors select, .errors textarea,
-td ul.errorlist + input, td ul.errorlist + select, td ul.errorlist + textarea {
+.errors input,
+.errors select,
+.errors textarea,
+td ul.errorlist+input,
+td ul.errorlist+select,
+td ul.errorlist+textarea {
     border: 1px solid var(--error-fg);
 }
 
@@ -712,13 +793,15 @@ div.breadcrumbs a {
     color: var(--breadcrumbs-link-fg);
 }
 
-div.breadcrumbs a:focus, div.breadcrumbs a:hover {
+div.breadcrumbs a:focus,
+div.breadcrumbs a:hover {
     color: var(--breadcrumbs-fg);
 }
 
 /* ACTION ICONS */
 
-.viewlink, .inlineviewlink {
+.viewlink,
+.inlineviewlink {
     padding-left: 16px;
     background: url(../img/icon-viewlink.svg) 0 1px no-repeat;
 }
@@ -728,7 +811,8 @@ div.breadcrumbs a:focus, div.breadcrumbs a:hover {
     background: url(../img/icon-addlink.svg) 0 1px no-repeat;
 }
 
-.changelink, .inlinechangelink {
+.changelink,
+.inlinechangelink {
     padding-left: 16px;
     background: url(../img/icon-changelink.svg) 0 1px no-repeat;
 }
@@ -738,12 +822,16 @@ div.breadcrumbs a:focus, div.breadcrumbs a:hover {
     background: url(../img/icon-deletelink.svg) 0 1px no-repeat;
 }
 
-a.deletelink:link, a.deletelink:visited {
-    color: #CC3434; /* XXX Probably unused? */
+a.deletelink:link,
+a.deletelink:visited {
+    color: #CC3434;
+    /* XXX Probably unused? */
 }
 
-a.deletelink:focus, a.deletelink:hover {
-    color: #993333; /* XXX Probably unused? */
+a.deletelink:focus,
+a.deletelink:hover {
+    color: #993333;
+    /* XXX Probably unused? */
     text-decoration: none;
 }
 
@@ -769,7 +857,8 @@ a.deletelink:focus, a.deletelink:hover {
     border-radius: 15px;
 }
 
-.object-tools a:link, .object-tools a:visited {
+.object-tools a:link,
+.object-tools a:visited {
     display: block;
     float: left;
     padding: 3px 12px;
@@ -781,15 +870,17 @@ a.deletelink:focus, a.deletelink:hover {
     letter-spacing: 0.5px;
 }
 
-.object-tools a:focus, .object-tools a:hover {
+.object-tools a:focus,
+.object-tools a:hover {
     background-color: var(--object-tools-hover-bg);
 }
 
-.object-tools a:focus{
+.object-tools a:focus {
     text-decoration: none;
 }
 
-.object-tools a.viewsitelink, .object-tools a.addlink {
+.object-tools a.viewsitelink,
+.object-tools a.addlink {
     background-repeat: no-repeat;
     background-position: right 7px center;
     padding-right: 26px;
@@ -832,17 +923,17 @@ a.deletelink:focus, a.deletelink:hover {
     height: 100%;
 }
 
-#container > div {
+#container>div {
     flex-shrink: 0;
 }
 
-#container > .main {
+#container>.main {
     display: flex;
     flex: 1 0 auto;
 }
 
-.main > .content {
-    flex:  1 0;
+.main>.content {
+    flex: 1 0;
     max-width: 100%;
 }
 
@@ -923,11 +1014,14 @@ a.deletelink:focus, a.deletelink:hover {
     overflow: hidden;
 }
 
-#header a:link, #header a:visited, #logout-form button {
+#header a:link,
+#header a:visited,
+#logout-form button {
     color: var(--header-link-color);
 }
 
-#header a:focus , #header a:hover {
+#header a:focus,
+#header a:hover {
     text-decoration: underline;
 }
 
@@ -943,7 +1037,8 @@ a.deletelink:focus, a.deletelink:hover {
     color: var(--header-branding-color);
 }
 
-#branding h1 a:link, #branding h1 a:visited {
+#branding h1 a:link,
+#branding h1 a:visited {
     color: var(--accent);
 }
 
@@ -976,7 +1071,8 @@ a.deletelink:focus, a.deletelink:hover {
     text-align: right;
 }
 
-#user-tools, #logout-form button{
+#user-tools,
+#logout-form button {
     padding: 0;
     font-weight: 300;
     font-size: 0.6875rem;
@@ -984,17 +1080,21 @@ a.deletelink:focus, a.deletelink:hover {
     text-transform: uppercase;
 }
 
-#user-tools a, #logout-form button {
+#user-tools a,
+#logout-form button {
     border-bottom: 1px solid rgba(255, 255, 255, 0.25);
 }
 
-#user-tools a:focus, #user-tools a:hover,
-#logout-form button:active, #logout-form button:hover {
+#user-tools a:focus,
+#user-tools a:hover,
+#logout-form button:active,
+#logout-form button:hover {
     text-decoration: none;
     border-bottom: 0;
 }
 
-#logout-form button:active, #logout-form button:hover {
+#logout-form button:active,
+#logout-form button:hover {
     margin-bottom: 1px;
 }
 
@@ -1099,7 +1199,8 @@ a.deletelink:focus, a.deletelink:hover {
     width: 100%;
 }
 
-.paginator a:link, .paginator a:visited {
+.paginator a:link,
+.paginator a:visited {
     padding: 2px 6px;
     background: var(--button-bg);
     text-decoration: none;
@@ -1112,7 +1213,8 @@ a.deletelink:focus, a.deletelink:hover {
     color: var(--link-fg);
 }
 
-.paginator a.showall:focus, .paginator a.showall:hover {
+.paginator a.showall:focus,
+.paginator a.showall:hover {
     background: none;
     color: var(--link-hover-color);
 }
@@ -1128,7 +1230,8 @@ a.deletelink:focus, a.deletelink:hover {
     vertical-align: top;
 }
 
-.paginator a:focus, .paginator a:hover {
+.paginator a:focus,
+.paginator a:hover {
     color: white;
     background: var(--link-hover-color);
 }

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -785,12 +785,12 @@ div.breadcrumbs {
     background: var(--breadcrumbs-bg);
     padding: 10px 40px;
     border: none;
-    color: var(--breadcrumbs-fg);
+    color: var(--body-fg);
     text-align: left;
 }
 
 div.breadcrumbs a {
-    color: var(--breadcrumbs-link-fg);
+    color: var(--body-loud-color);
 }
 
 div.breadcrumbs a:focus,

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -24,7 +24,7 @@ html[data-theme="light"],
     --breadcrumbs-link-fg: var(--body-bg);
     --breadcrumbs-bg: var(--primary);
 
-    --link-fg: #447e9b;
+    --link-fg: #417893;
     --link-hover-color: #036;
     --link-selected-fg: #5b80b2;
 
@@ -104,7 +104,7 @@ body {
 /* LINKS */
 
 a:link, a:visited {
-    color: var(--link-hover-color);
+    color: var(--link-fg);
     text-decoration: none;
     transition: color 0.15s, background 0.15s;
 }

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -51,7 +51,7 @@ html[data-theme="light"],
     --delete-button-bg: #ba2121;
     --delete-button-hover-bg: #a41515;
 
-    --object-tools-fg: var(--button-fg);
+    --object-tools-fg: var(--primary-fg);
     --object-tools-bg: var(--close-button-bg);
     --object-tools-hover-bg: var(--close-button-hover-bg);
 
@@ -774,7 +774,7 @@ a.deletelink:focus, a.deletelink:hover {
     float: left;
     padding: 3px 12px;
     background: var(--object-tools-bg);
-    color: var(--primary-fg);
+    color: var(--object-tools-fg);
     font-weight: 400;
     font-size: 0.6875rem;
     text-transform: uppercase;

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -37,10 +37,8 @@ html[data-theme="light"],
     --message-warning-bg: #ffc;
     --message-error-bg: #ffefef;
 
-    --darkened-bg: #f8f8f8;
-    /* A bit darker than --body-bg */
-    --selected-bg: #e4e4e4;
-    /* E.g. selected table cells */
+    --darkened-bg: #f8f8f8; /* A bit darker than --body-bg */
+    --selected-bg: #e4e4e4; /* E.g. selected table cells */
     --selected-row: #ffc;
 
     --button-fg: #fff;
@@ -90,8 +88,7 @@ html[data-theme="light"],
         "Noto Color Emoji";
 }
 
-html,
-body {
+html, body {
     height: 100%;
 }
 
@@ -106,15 +103,13 @@ body {
 
 /* LINKS */
 
-a:link,
-a:visited {
+a:link, a:visited {
     color: var(--link-hover-color);
     text-decoration: none;
     transition: color 0.15s, background 0.15s;
 }
 
-a:focus,
-a:hover {
+a:focus, a:hover {
     color: var(--link-hover-color);
 }
 
@@ -126,23 +121,18 @@ a img {
     border: none;
 }
 
-a.section:link,
-a.section:visited {
+a.section:link, a.section:visited {
     color: var(--header-link-color);
     text-decoration: none;
 }
 
-a.section:focus,
-a.section:hover {
+a.section:focus, a.section:hover {
     text-decoration: underline;
 }
 
 /* GLOBAL DEFAULTS */
 
-p,
-ol,
-ul,
-dl {
+p, ol, ul, dl {
     margin: .2em 0 .8em 0;
 }
 
@@ -151,11 +141,7 @@ p {
     line-height: 140%;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5 {
+h1,h2,h3,h4,h5 {
     font-weight: bold;
 }
 
@@ -197,7 +183,7 @@ h5 {
     letter-spacing: 1px;
 }
 
-ul>li {
+ul > li {
     list-style-type: square;
     padding: 1px 0;
 }
@@ -206,9 +192,7 @@ li ul {
     margin-bottom: 0;
 }
 
-li,
-dt,
-dd {
+li, dt, dd {
     font-size: 0.8125rem;
     line-height: 20px;
 }
@@ -243,8 +227,7 @@ blockquote {
     border-left: 5px solid #ddd;
 }
 
-code,
-pre {
+code, pre {
     font-family: var(--font-family-monospace);
     color: var(--body-quiet-color);
     font-size: 0.75rem;
@@ -282,36 +265,24 @@ hr {
     font-size: 0.625rem;
 }
 
-.help,
-p.help,
-form p.help,
-div.help,
-form div.help,
-div.help li {
+.help, p.help, form p.help, div.help, form div.help, div.help li {
     font-size: 0.6875rem;
     color: var(--body-quiet-color);
 }
 
 div.help ul {
-    margin-bottom: 0;
+     margin-bottom: 0;
 }
 
 .help-tooltip {
     cursor: help;
 }
 
-p img,
-h1 img,
-h2 img,
-h3 img,
-h4 img,
-td img {
+p img, h1 img, h2 img, h3 img, h4 img, td img {
     vertical-align: middle;
 }
 
-.quiet,
-a.quiet:link,
-a.quiet:visited {
+.quiet, a.quiet:link, a.quiet:visited {
     color: var(--body-quiet-color);
     font-weight: normal;
 }
@@ -335,8 +306,7 @@ table {
     border-color: var(--border-color);
 }
 
-td,
-th {
+td, th {
     font-size: 0.8125rem;
     line-height: 16px;
     border-bottom: 1px solid var(--hairline-color);
@@ -374,15 +344,14 @@ tr.alt {
     background: var(--darkened-bg);
 }
 
-tr:nth-child(odd),
-.row-form-errors {
+tr:nth-child(odd), .row-form-errors {
     background: var(--body-bg);
 }
 
 tr:nth-child(even),
 tr:nth-child(even) .errorlist,
-tr:nth-child(odd)+.row-form-errors,
-tr:nth-child(odd)+.row-form-errors .errorlist {
+tr:nth-child(odd) + .row-form-errors,
+tr:nth-child(odd) + .row-form-errors .errorlist {
     background: var(--darkened-bg);
 }
 
@@ -395,8 +364,7 @@ thead th {
     background: var(--darkened-bg);
 }
 
-thead th a:link,
-thead th a:visited {
+thead th a:link, thead th a:visited {
     color: var(--body-quiet-color);
 }
 
@@ -419,8 +387,7 @@ table thead th .text a {
     padding: 8px 10px;
 }
 
-table thead th .text a:focus,
-table thead th .text a:hover {
+table thead th .text a:focus, table thead th .text a:hover {
     background: var(--selected-bg);
 }
 
@@ -502,11 +469,7 @@ table thead th.sorted .sortoptions a.descending:hover {
 
 /* FORM DEFAULTS */
 
-input,
-textarea,
-select,
-.form-row p,
-form .button {
+input, textarea, select, .form-row p, form .button {
     margin: 2px 0;
     padding: 2px 3px;
     vertical-align: middle;
@@ -514,7 +477,6 @@ form .button {
     font-weight: normal;
     font-size: 0.8125rem;
 }
-
 .form-row div.help {
     padding: 2px 3px;
 }
@@ -523,15 +485,8 @@ textarea {
     vertical-align: top;
 }
 
-input[type=text],
-input[type=password],
-input[type=email],
-input[type=url],
-input[type=number],
-input[type=tel],
-textarea,
-select,
-.vTextField {
+input[type=text], input[type=password], input[type=email], input[type=url],
+input[type=number], input[type=tel], textarea, select, .vTextField {
     border: 1px solid var(--border-color);
     border-radius: 4px;
     padding: 5px 6px;
@@ -540,15 +495,9 @@ select,
     background-color: var(--body-bg);
 }
 
-input[type=text]:focus,
-input[type=password]:focus,
-input[type=email]:focus,
-input[type=url]:focus,
-input[type=number]:focus,
-input[type=tel]:focus,
-textarea:focus,
-select:focus,
-.vTextField:focus {
+input[type=text]:focus, input[type=password]:focus, input[type=email]:focus,
+input[type=url]:focus, input[type=number]:focus, input[type=tel]:focus,
+textarea:focus, select:focus, .vTextField:focus {
     border-color: var(--body-quiet-color);
 }
 
@@ -564,11 +513,7 @@ select[multiple] {
 
 /* FORM BUTTONS */
 
-.button,
-input[type=submit],
-input[type=button],
-.submit-row input,
-a.button {
+.button, input[type=submit], input[type=button], .submit-row input, a.button {
     background: var(--button-bg);
     padding: 10px 15px;
     border: none;
@@ -582,39 +527,25 @@ a.button {
     padding: 4px 5px;
 }
 
-.button:active,
-input[type=submit]:active,
-input[type=button]:active,
-.button:focus,
-input[type=submit]:focus,
-input[type=button]:focus,
-.button:hover,
-input[type=submit]:hover,
-input[type=button]:hover {
+.button:active, input[type=submit]:active, input[type=button]:active,
+.button:focus, input[type=submit]:focus, input[type=button]:focus,
+.button:hover, input[type=submit]:hover, input[type=button]:hover {
     background: var(--button-hover-bg);
 }
 
-.button[disabled],
-input[type=submit][disabled],
-input[type=button][disabled] {
+.button[disabled], input[type=submit][disabled], input[type=button][disabled] {
     opacity: 0.4;
 }
 
-.button.default,
-input[type=submit].default,
-.submit-row input.default {
+.button.default, input[type=submit].default, .submit-row input.default {
     border: none;
     font-weight: 400;
-    background: var(--default-button-bg);
     color: var(--button-fg);
 }
 
-.button.default:active,
-input[type=submit].default:active,
-.button.default:focus,
-input[type=submit].default:focus,
-.button.default:hover,
-input[type=submit].default:hover {
+.button.default:active, input[type=submit].default:active,
+.button.default:focus, input[type=submit].default:focus,
+.button.default:hover, input[type=submit].default:hover {
     background: var(--default-button-hover-bg);
 }
 
@@ -633,12 +564,7 @@ input[type=button][disabled].default {
     background: var(--body-bg);
 }
 
-.module p,
-.module ul,
-.module h3,
-.module h4,
-.module dl,
-.module pre {
+.module p, .module ul, .module h3, .module h4, .module dl, .module pre {
     padding-left: 10px;
     padding-right: 10px;
 }
@@ -647,8 +573,7 @@ input[type=button][disabled].default {
     margin-left: 12px;
 }
 
-.module ul,
-.module ol {
+.module ul, .module ol {
     margin-left: 1.5em;
 }
 
@@ -656,9 +581,7 @@ input[type=button][disabled].default {
     margin-top: .6em;
 }
 
-.module h2,
-.module caption,
-.inline-group h2 {
+.module h2, .module caption, .inline-group h2 {
     margin: 0;
     padding: 8px;
     font-weight: 400;
@@ -765,12 +688,8 @@ td ul.errorlist li {
     padding-left: 0;
 }
 
-.errors input,
-.errors select,
-.errors textarea,
-td ul.errorlist+input,
-td ul.errorlist+select,
-td ul.errorlist+textarea {
+.errors input, .errors select, .errors textarea,
+td ul.errorlist + input, td ul.errorlist + select, td ul.errorlist + textarea {
     border: 1px solid var(--error-fg);
 }
 
@@ -793,15 +712,13 @@ div.breadcrumbs a {
     color: var(--body-loud-color);
 }
 
-div.breadcrumbs a:focus,
-div.breadcrumbs a:hover {
+div.breadcrumbs a:focus, div.breadcrumbs a:hover {
     color: var(--breadcrumbs-fg);
 }
 
 /* ACTION ICONS */
 
-.viewlink,
-.inlineviewlink {
+.viewlink, .inlineviewlink {
     padding-left: 16px;
     background: url(../img/icon-viewlink.svg) 0 1px no-repeat;
 }
@@ -811,8 +728,7 @@ div.breadcrumbs a:hover {
     background: url(../img/icon-addlink.svg) 0 1px no-repeat;
 }
 
-.changelink,
-.inlinechangelink {
+.changelink, .inlinechangelink {
     padding-left: 16px;
     background: url(../img/icon-changelink.svg) 0 1px no-repeat;
 }
@@ -822,16 +738,12 @@ div.breadcrumbs a:hover {
     background: url(../img/icon-deletelink.svg) 0 1px no-repeat;
 }
 
-a.deletelink:link,
-a.deletelink:visited {
-    color: #CC3434;
-    /* XXX Probably unused? */
+a.deletelink:link, a.deletelink:visited {
+    color: #CC3434; /* XXX Probably unused? */
 }
 
-a.deletelink:focus,
-a.deletelink:hover {
-    color: #993333;
-    /* XXX Probably unused? */
+a.deletelink:focus, a.deletelink:hover {
+    color: #993333; /* XXX Probably unused? */
     text-decoration: none;
 }
 
@@ -857,8 +769,7 @@ a.deletelink:hover {
     border-radius: 15px;
 }
 
-.object-tools a:link,
-.object-tools a:visited {
+.object-tools a:link, .object-tools a:visited {
     display: block;
     float: left;
     padding: 3px 12px;
@@ -870,17 +781,15 @@ a.deletelink:hover {
     letter-spacing: 0.5px;
 }
 
-.object-tools a:focus,
-.object-tools a:hover {
+.object-tools a:focus, .object-tools a:hover {
     background-color: var(--object-tools-hover-bg);
 }
 
-.object-tools a:focus {
+.object-tools a:focus{
     text-decoration: none;
 }
 
-.object-tools a.viewsitelink,
-.object-tools a.addlink {
+.object-tools a.viewsitelink, .object-tools a.addlink {
     background-repeat: no-repeat;
     background-position: right 7px center;
     padding-right: 26px;
@@ -923,17 +832,17 @@ a.deletelink:hover {
     height: 100%;
 }
 
-#container>div {
+#container > div {
     flex-shrink: 0;
 }
 
-#container>.main {
+#container > .main {
     display: flex;
     flex: 1 0 auto;
 }
 
-.main>.content {
-    flex: 1 0;
+.main > .content {
+    flex:  1 0;
     max-width: 100%;
 }
 
@@ -1014,14 +923,11 @@ a.deletelink:hover {
     overflow: hidden;
 }
 
-#header a:link,
-#header a:visited,
-#logout-form button {
+#header a:link, #header a:visited, #logout-form button {
     color: var(--header-link-color);
 }
 
-#header a:focus,
-#header a:hover {
+#header a:focus , #header a:hover {
     text-decoration: underline;
 }
 
@@ -1037,8 +943,7 @@ a.deletelink:hover {
     color: var(--header-branding-color);
 }
 
-#branding h1 a:link,
-#branding h1 a:visited {
+#branding h1 a:link, #branding h1 a:visited {
     color: var(--accent);
 }
 
@@ -1071,8 +976,7 @@ a.deletelink:hover {
     text-align: right;
 }
 
-#user-tools,
-#logout-form button {
+#user-tools, #logout-form button{
     padding: 0;
     font-weight: 300;
     font-size: 0.6875rem;
@@ -1080,21 +984,17 @@ a.deletelink:hover {
     text-transform: uppercase;
 }
 
-#user-tools a,
-#logout-form button {
+#user-tools a, #logout-form button {
     border-bottom: 1px solid rgba(255, 255, 255, 0.25);
 }
 
-#user-tools a:focus,
-#user-tools a:hover,
-#logout-form button:active,
-#logout-form button:hover {
+#user-tools a:focus, #user-tools a:hover,
+#logout-form button:active, #logout-form button:hover {
     text-decoration: none;
     border-bottom: 0;
 }
 
-#logout-form button:active,
-#logout-form button:hover {
+#logout-form button:active, #logout-form button:hover {
     margin-bottom: 1px;
 }
 
@@ -1199,8 +1099,7 @@ a.deletelink:hover {
     width: 100%;
 }
 
-.paginator a:link,
-.paginator a:visited {
+.paginator a:link, .paginator a:visited {
     padding: 2px 6px;
     background: var(--button-bg);
     text-decoration: none;
@@ -1213,8 +1112,7 @@ a.deletelink:hover {
     color: var(--link-fg);
 }
 
-.paginator a.showall:focus,
-.paginator a.showall:hover {
+.paginator a.showall:focus, .paginator a.showall:hover {
     background: none;
     color: var(--link-hover-color);
 }
@@ -1230,8 +1128,7 @@ a.deletelink:hover {
     vertical-align: top;
 }
 
-.paginator a:focus,
-.paginator a:hover {
+.paginator a:focus, .paginator a:hover {
     color: white;
     background: var(--link-hover-color);
 }

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -44,7 +44,7 @@ html[data-theme="light"],
     --button-fg: #fff;
     --button-bg: var(--primary);
     --button-hover-bg: #609ab6;
-    --default-button-bg: var(--secondary);
+    --default-button-bg: var(--button-fg);
     --default-button-hover-bg: #205067;
     --close-button-bg: #747474;
     --close-button-hover-bg: #333;
@@ -540,7 +540,7 @@ a.button {
 .button.default, input[type=submit].default, .submit-row input.default {
     border: none;
     font-weight: 400;
-    color: var(--button-fg);
+    background: var(--default-button-bg);
 }
 
 .button.default:active, input[type=submit].default:active,

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -12,7 +12,8 @@
     flex: 1 0 auto;
 }
 
-.selector-available, .selector-chosen {
+.selector-available,
+.selector-chosen {
     width: 380px;
     text-align: center;
     margin-bottom: 5px;
@@ -20,7 +21,8 @@
     flex-direction: column;
 }
 
-.selector-available h2, .selector-chosen h2 {
+.selector-available h2,
+.selector-chosen h2 {
     border: 1px solid var(--border-color);
     border-radius: 4px 4px 0 0;
 }
@@ -36,12 +38,13 @@
     color: var(--header-link-color);
     cursor: pointer;
 }
+
 .selector-chosen .list-footer-display__clear {
     color: var(--breadcrumbs-fg);
 }
 
 .selector-chosen h2 {
-    background: var(--primary);
+    background: var(--secondary);
     color: var(--header-link-color);
 }
 
@@ -98,6 +101,7 @@
     margin: 0 0 10px;
     border-radius: 0 0 4px 4px;
 }
+
 .selector .selector-chosen--with-filtered select {
     margin: 0;
     border-radius: 0;
@@ -108,7 +112,8 @@
     display: none;
 }
 
-.selector-add, .selector-remove {
+.selector-add,
+.selector-remove {
     width: 16px;
     height: 16px;
     display: block;
@@ -118,11 +123,13 @@
     opacity: 0.55;
 }
 
-.active.selector-add, .active.selector-remove {
+.active.selector-add,
+.active.selector-remove {
     opacity: 1;
 }
 
-.active.selector-add:hover, .active.selector-remove:hover {
+.active.selector-add:hover,
+.active.selector-remove:hover {
     cursor: pointer;
 }
 
@@ -130,7 +137,8 @@
     background: url(../img/selector-icons.svg) 0 -96px no-repeat;
 }
 
-.active.selector-add:focus, .active.selector-add:hover {
+.active.selector-add:focus,
+.active.selector-add:hover {
     background-position: 0 -112px;
 }
 
@@ -138,11 +146,13 @@
     background: url(../img/selector-icons.svg) 0 -64px no-repeat;
 }
 
-.active.selector-remove:focus, .active.selector-remove:hover {
+.active.selector-remove:focus,
+.active.selector-remove:hover {
     background-position: 0 -80px;
 }
 
-a.selector-chooseall, a.selector-clearall {
+a.selector-chooseall,
+a.selector-clearall {
     display: inline-block;
     height: 16px;
     text-align: left;
@@ -155,16 +165,20 @@ a.selector-chooseall, a.selector-clearall {
     opacity: 0.55;
 }
 
-a.active.selector-chooseall:focus, a.active.selector-clearall:focus,
-a.active.selector-chooseall:hover, a.active.selector-clearall:hover {
+a.active.selector-chooseall:focus,
+a.active.selector-clearall:focus,
+a.active.selector-chooseall:hover,
+a.active.selector-clearall:hover {
     color: var(--link-fg);
 }
 
-a.active.selector-chooseall, a.active.selector-clearall {
+a.active.selector-chooseall,
+a.active.selector-clearall {
     opacity: 1;
 }
 
-a.active.selector-chooseall:hover, a.active.selector-clearall:hover {
+a.active.selector-chooseall:hover,
+a.active.selector-clearall:hover {
     cursor: pointer;
 }
 
@@ -174,7 +188,8 @@ a.selector-chooseall {
     cursor: default;
 }
 
-a.active.selector-chooseall:focus, a.active.selector-chooseall:hover {
+a.active.selector-chooseall:focus,
+a.active.selector-chooseall:hover {
     background-position: 100% -176px;
 }
 
@@ -184,7 +199,8 @@ a.selector-clearall {
     cursor: default;
 }
 
-a.active.selector-clearall:focus, a.active.selector-clearall:hover {
+a.active.selector-clearall:focus,
+a.active.selector-clearall:hover {
     background-position: 0 -144px;
 }
 
@@ -201,7 +217,8 @@ a.active.selector-clearall:focus, a.active.selector-clearall:hover {
     height: 10.1em;
 }
 
-.stacked .selector-available, .stacked .selector-chosen {
+.stacked .selector-available,
+.stacked .selector-chosen {
     width: 480px;
 }
 
@@ -227,7 +244,8 @@ a.active.selector-clearall:focus, a.active.selector-clearall:hover {
     padding: 3px 3px 3px 5px;
 }
 
-.stacked .selector-chooseall, .stacked .selector-clearall {
+.stacked .selector-chooseall,
+.stacked .selector-clearall {
     display: none;
 }
 
@@ -241,7 +259,8 @@ a.active.selector-clearall:focus, a.active.selector-clearall:hover {
     cursor: pointer;
 }
 
-.stacked .active.selector-add:focus, .stacked .active.selector-add:hover {
+.stacked .active.selector-add:focus,
+.stacked .active.selector-add:hover {
     background-position: 0 -48px;
     cursor: pointer;
 }
@@ -256,7 +275,8 @@ a.active.selector-clearall:focus, a.active.selector-clearall:hover {
     cursor: pointer;
 }
 
-.stacked .active.selector-remove:focus, .stacked .active.selector-remove:hover {
+.stacked .active.selector-remove:focus,
+.stacked .active.selector-remove:hover {
     background-position: 0 -16px;
     cursor: pointer;
 }
@@ -298,7 +318,9 @@ p.datetime {
     color: var(--body-quiet-color);
 }
 
-.datetime input, .form-row .datetime input.vDateField, .form-row .datetime input.vTimeField {
+.datetime input,
+.form-row .datetime input.vDateField,
+.form-row .datetime input.vTimeField {
     margin-left: 5px;
     margin-bottom: 4px;
 }
@@ -309,7 +331,8 @@ table p.datetime {
     padding-left: 0;
 }
 
-.datetimeshortcuts .clock-icon, .datetimeshortcuts .date-icon {
+.datetimeshortcuts .clock-icon,
+.datetimeshortcuts .date-icon {
     position: relative;
     display: inline-block;
     vertical-align: middle;
@@ -389,7 +412,8 @@ span.clearable-file-input label {
 
 /* CALENDARS & CLOCKS */
 
-.calendarbox, .clockbox {
+.calendarbox,
+.clockbox {
     margin: 5px auto;
     font-size: 0.75rem;
     width: 19em;
@@ -420,7 +444,8 @@ span.clearable-file-input label {
     width: 100%;
 }
 
-.calendar caption, .calendarbox h2 {
+.calendar caption,
+.calendarbox h2 {
     margin: 0;
     text-align: center;
     border-top: none;
@@ -462,7 +487,8 @@ span.clearable-file-input label {
     font-weight: 700;
 }
 
-.calendar td a, .timelist a {
+.calendar td a,
+.timelist a {
     display: block;
     font-weight: 400;
     padding: 6px;
@@ -470,13 +496,16 @@ span.clearable-file-input label {
     color: var(--body-quiet-color);
 }
 
-.calendar td a:focus, .timelist a:focus,
-.calendar td a:hover, .timelist a:hover {
+.calendar td a:focus,
+.timelist a:focus,
+.calendar td a:hover,
+.timelist a:hover {
     background: var(--primary);
     color: white;
 }
 
-.calendar td a:active, .timelist a:active {
+.calendar td a:active,
+.timelist a:active {
     background: var(--header-bg);
     color: white;
 }
@@ -489,8 +518,10 @@ span.clearable-file-input label {
     padding: 1px 3px;
 }
 
-.calendarnav a:link, #calendarnav a:visited,
-#calendarnav a:focus, #calendarnav a:hover {
+.calendarnav a:link,
+#calendarnav a:visited,
+#calendarnav a:focus,
+#calendarnav a:hover {
     color: var(--body-quiet-color);
 }
 
@@ -503,7 +534,8 @@ span.clearable-file-input label {
     padding: 8px 0;
 }
 
-.calendarbox .calendarnav-previous, .calendarbox .calendarnav-next {
+.calendarbox .calendarnav-previous,
+.calendarbox .calendarnav-next {
     display: block;
     position: absolute;
     top: 8px;
@@ -542,7 +574,8 @@ span.clearable-file-input label {
     color: var(--body-fg);
 }
 
-.calendar-cancel:focus, .calendar-cancel:hover {
+.calendar-cancel:focus,
+.calendar-cancel:hover {
     background: #ddd;
 }
 
@@ -551,7 +584,8 @@ span.clearable-file-input label {
     display: block;
 }
 
-ul.timelist, .timelist li {
+ul.timelist,
+.timelist li {
     list-style-type: none;
     margin: 0;
     padding: 0;
@@ -572,14 +606,17 @@ ul.timelist, .timelist li {
     border: 0px none;
 }
 
-.inline-deletelink:focus, .inline-deletelink:hover {
+.inline-deletelink:focus,
+.inline-deletelink:hover {
     cursor: pointer;
 }
 
 /* RELATED WIDGET WRAPPER */
 .related-widget-wrapper {
-    float: left;       /* display properly in form rows with multiple fields */
-    overflow: hidden;  /* clear floated contents */
+    float: left;
+    /* display properly in form rows with multiple fields */
+    overflow: hidden;
+    /* clear floated contents */
 }
 
 .related-widget-wrapper-link {
@@ -595,8 +632,8 @@ ul.timelist, .timelist li {
     opacity: 1;
 }
 
-select + .related-widget-wrapper-link,
-.related-widget-wrapper-link + .related-widget-wrapper-link {
+select+.related-widget-wrapper-link,
+.related-widget-wrapper-link+.related-widget-wrapper-link {
     margin-left: 7px;
 }
 

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -12,8 +12,7 @@
     flex: 1 0 auto;
 }
 
-.selector-available,
-.selector-chosen {
+.selector-available, .selector-chosen {
     width: 380px;
     text-align: center;
     margin-bottom: 5px;
@@ -21,8 +20,7 @@
     flex-direction: column;
 }
 
-.selector-available h2,
-.selector-chosen h2 {
+.selector-available h2, .selector-chosen h2 {
     border: 1px solid var(--border-color);
     border-radius: 4px 4px 0 0;
 }
@@ -38,7 +36,6 @@
     color: var(--header-link-color);
     cursor: pointer;
 }
-
 .selector-chosen .list-footer-display__clear {
     color: var(--breadcrumbs-fg);
 }
@@ -101,7 +98,6 @@
     margin: 0 0 10px;
     border-radius: 0 0 4px 4px;
 }
-
 .selector .selector-chosen--with-filtered select {
     margin: 0;
     border-radius: 0;
@@ -112,8 +108,7 @@
     display: none;
 }
 
-.selector-add,
-.selector-remove {
+.selector-add, .selector-remove {
     width: 16px;
     height: 16px;
     display: block;
@@ -123,13 +118,11 @@
     opacity: 0.55;
 }
 
-.active.selector-add,
-.active.selector-remove {
+.active.selector-add, .active.selector-remove {
     opacity: 1;
 }
 
-.active.selector-add:hover,
-.active.selector-remove:hover {
+.active.selector-add:hover, .active.selector-remove:hover {
     cursor: pointer;
 }
 
@@ -137,8 +130,7 @@
     background: url(../img/selector-icons.svg) 0 -96px no-repeat;
 }
 
-.active.selector-add:focus,
-.active.selector-add:hover {
+.active.selector-add:focus, .active.selector-add:hover {
     background-position: 0 -112px;
 }
 
@@ -146,13 +138,11 @@
     background: url(../img/selector-icons.svg) 0 -64px no-repeat;
 }
 
-.active.selector-remove:focus,
-.active.selector-remove:hover {
+.active.selector-remove:focus, .active.selector-remove:hover {
     background-position: 0 -80px;
 }
 
-a.selector-chooseall,
-a.selector-clearall {
+a.selector-chooseall, a.selector-clearall {
     display: inline-block;
     height: 16px;
     text-align: left;
@@ -165,20 +155,16 @@ a.selector-clearall {
     opacity: 0.55;
 }
 
-a.active.selector-chooseall:focus,
-a.active.selector-clearall:focus,
-a.active.selector-chooseall:hover,
-a.active.selector-clearall:hover {
+a.active.selector-chooseall:focus, a.active.selector-clearall:focus,
+a.active.selector-chooseall:hover, a.active.selector-clearall:hover {
     color: var(--link-fg);
 }
 
-a.active.selector-chooseall,
-a.active.selector-clearall {
+a.active.selector-chooseall, a.active.selector-clearall {
     opacity: 1;
 }
 
-a.active.selector-chooseall:hover,
-a.active.selector-clearall:hover {
+a.active.selector-chooseall:hover, a.active.selector-clearall:hover {
     cursor: pointer;
 }
 
@@ -188,8 +174,7 @@ a.selector-chooseall {
     cursor: default;
 }
 
-a.active.selector-chooseall:focus,
-a.active.selector-chooseall:hover {
+a.active.selector-chooseall:focus, a.active.selector-chooseall:hover {
     background-position: 100% -176px;
 }
 
@@ -199,8 +184,7 @@ a.selector-clearall {
     cursor: default;
 }
 
-a.active.selector-clearall:focus,
-a.active.selector-clearall:hover {
+a.active.selector-clearall:focus, a.active.selector-clearall:hover {
     background-position: 0 -144px;
 }
 
@@ -217,8 +201,7 @@ a.active.selector-clearall:hover {
     height: 10.1em;
 }
 
-.stacked .selector-available,
-.stacked .selector-chosen {
+.stacked .selector-available, .stacked .selector-chosen {
     width: 480px;
 }
 
@@ -244,8 +227,7 @@ a.active.selector-clearall:hover {
     padding: 3px 3px 3px 5px;
 }
 
-.stacked .selector-chooseall,
-.stacked .selector-clearall {
+.stacked .selector-chooseall, .stacked .selector-clearall {
     display: none;
 }
 
@@ -259,8 +241,7 @@ a.active.selector-clearall:hover {
     cursor: pointer;
 }
 
-.stacked .active.selector-add:focus,
-.stacked .active.selector-add:hover {
+.stacked .active.selector-add:focus, .stacked .active.selector-add:hover {
     background-position: 0 -48px;
     cursor: pointer;
 }
@@ -275,8 +256,7 @@ a.active.selector-clearall:hover {
     cursor: pointer;
 }
 
-.stacked .active.selector-remove:focus,
-.stacked .active.selector-remove:hover {
+.stacked .active.selector-remove:focus, .stacked .active.selector-remove:hover {
     background-position: 0 -16px;
     cursor: pointer;
 }
@@ -318,9 +298,7 @@ p.datetime {
     color: var(--body-quiet-color);
 }
 
-.datetime input,
-.form-row .datetime input.vDateField,
-.form-row .datetime input.vTimeField {
+.datetime input, .form-row .datetime input.vDateField, .form-row .datetime input.vTimeField {
     margin-left: 5px;
     margin-bottom: 4px;
 }
@@ -331,8 +309,7 @@ table p.datetime {
     padding-left: 0;
 }
 
-.datetimeshortcuts .clock-icon,
-.datetimeshortcuts .date-icon {
+.datetimeshortcuts .clock-icon, .datetimeshortcuts .date-icon {
     position: relative;
     display: inline-block;
     vertical-align: middle;
@@ -412,8 +389,7 @@ span.clearable-file-input label {
 
 /* CALENDARS & CLOCKS */
 
-.calendarbox,
-.clockbox {
+.calendarbox, .clockbox {
     margin: 5px auto;
     font-size: 0.75rem;
     width: 19em;
@@ -444,8 +420,7 @@ span.clearable-file-input label {
     width: 100%;
 }
 
-.calendar caption,
-.calendarbox h2 {
+.calendar caption, .calendarbox h2 {
     margin: 0;
     text-align: center;
     border-top: none;
@@ -487,8 +462,7 @@ span.clearable-file-input label {
     font-weight: 700;
 }
 
-.calendar td a,
-.timelist a {
+.calendar td a, .timelist a {
     display: block;
     font-weight: 400;
     padding: 6px;
@@ -496,16 +470,13 @@ span.clearable-file-input label {
     color: var(--body-quiet-color);
 }
 
-.calendar td a:focus,
-.timelist a:focus,
-.calendar td a:hover,
-.timelist a:hover {
+.calendar td a:focus, .timelist a:focus,
+.calendar td a:hover, .timelist a:hover {
     background: var(--primary);
     color: white;
 }
 
-.calendar td a:active,
-.timelist a:active {
+.calendar td a:active, .timelist a:active {
     background: var(--header-bg);
     color: white;
 }
@@ -518,10 +489,8 @@ span.clearable-file-input label {
     padding: 1px 3px;
 }
 
-.calendarnav a:link,
-#calendarnav a:visited,
-#calendarnav a:focus,
-#calendarnav a:hover {
+.calendarnav a:link, #calendarnav a:visited,
+#calendarnav a:focus, #calendarnav a:hover {
     color: var(--body-quiet-color);
 }
 
@@ -534,8 +503,7 @@ span.clearable-file-input label {
     padding: 8px 0;
 }
 
-.calendarbox .calendarnav-previous,
-.calendarbox .calendarnav-next {
+.calendarbox .calendarnav-previous, .calendarbox .calendarnav-next {
     display: block;
     position: absolute;
     top: 8px;
@@ -574,8 +542,7 @@ span.clearable-file-input label {
     color: var(--body-fg);
 }
 
-.calendar-cancel:focus,
-.calendar-cancel:hover {
+.calendar-cancel:focus, .calendar-cancel:hover {
     background: #ddd;
 }
 
@@ -584,8 +551,7 @@ span.clearable-file-input label {
     display: block;
 }
 
-ul.timelist,
-.timelist li {
+ul.timelist, .timelist li {
     list-style-type: none;
     margin: 0;
     padding: 0;
@@ -606,17 +572,14 @@ ul.timelist,
     border: 0px none;
 }
 
-.inline-deletelink:focus,
-.inline-deletelink:hover {
+.inline-deletelink:focus, .inline-deletelink:hover {
     cursor: pointer;
 }
 
 /* RELATED WIDGET WRAPPER */
 .related-widget-wrapper {
-    float: left;
-    /* display properly in form rows with multiple fields */
-    overflow: hidden;
-    /* clear floated contents */
+    float: left;       /* display properly in form rows with multiple fields */
+    overflow: hidden;  /* clear floated contents */
 }
 
 .related-widget-wrapper-link {
@@ -632,8 +595,8 @@ ul.timelist,
     opacity: 1;
 }
 
-select+.related-widget-wrapper-link,
-.related-widget-wrapper-link+.related-widget-wrapper-link {
+select + .related-widget-wrapper-link,
+.related-widget-wrapper-link + .related-widget-wrapper-link {
     margin-left: 7px;
 }
 


### PR DESCRIPTION
This PR is for [improving color contrast in the admin light theme](https://code.djangoproject.com/ticket/34036). Google Chrome has a useful tool for website readability called [CSS Overview](https://developer.chrome.com/docs/devtools/accessibility/contrast/#overview-contrast). The tool indicates the color contrast ratios now meet AA guidelines of [WebAIM ](https://webaim.org/standards/wcag/#current).
![Screen Shot 2022-11-07 at 3 43 34 PM](https://user-images.githubusercontent.com/56455442/200411483-9922079c-0719-4186-9b49-b394398eb706.png)
@carltongibson - Would appreciate if you could look at this!