### PR TITLE
Fixed #12075 -- Added wsgiorg.routing args support

### DIFF
--- a/django/middleware/routing_args.py
+++ b/django/middleware/routing_args.py
@@ -1,0 +1,26 @@
+__all__ = ("RoutingArgsMiddleware",)
+from django.utils.deprecation import MiddlewareMixin
+
+
+class RoutingArgsMiddleware(MiddlewareMixin):
+    """
+    Middleware that stores the view's positional and named arguments in the
+    request.
+
+    This implements the `wsgiorg.routing_args
+    <http://wsgi.readthedocs.org/en/latest/specifications/routing_args.html>`_
+    standard.
+
+    This implementation is not complete because we would have to move
+    a part of PATH_INFO to SCRIPT_NAME, which would break backwards
+    compatibility. It's also incomplete because `Django does not
+    support mixing positional and named arguments
+    <http://docs.djangoproject.com/en/dev/topics/http/urls/#the-matching-grouping-algorithm>`_.
+
+    """
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        request.environ["wsgiorg.routing_args"] = (
+            view_args,
+            view_kwargs.copy(),
+        )

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -246,7 +246,8 @@ Models
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The new standard environment key ``environ['wsgiorg.routing_args']``
+  represents the results of more complicated URL parsing strategies.
 
 Security
 ~~~~~~~~

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -718,11 +718,9 @@ class ConditionalGetMiddlewareTest(SimpleTestCase):
 
 class TestRoutingArgs(SimpleTestCase):
     def setUp(self):
-        super(TestRoutingArgs, self).setUp()
-
+        super().setUp()
         environ = {"REQUEST_METHOD": "GET", "wsgi.input": BytesIO(b"")}
         self.request = WSGIRequest(environ)
-
         self.mw = RoutingArgsMiddleware(self.request)
 
     def test_arguments_are_stored(self):

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -87,6 +87,7 @@ class RequestsTests(SimpleTestCase):
                 "SCRIPT_NAME",
                 "CONTENT_TYPE",
                 "wsgi.input",
+                "wsgiorg.routing_args",
             },
         )
         self.assertEqual(request.META["PATH_INFO"], "bogus")


### PR DESCRIPTION
According to the [wsgi.routing_args](https://wsgi.readthedocs.io/en/latest/specifications/routing_args.html) standards introduced in 2006 WSGI proposed a new standard environment key `environ['wsgiorg.routing_args']` to represent the results of more complicated URL parsing strategies.

Some key points:
- This key is optional.
- If a dispatcher (like [routes](http://routes.groovie.org/) or [selector](https://github.com/lukearno/selector)) pulls named information out of the portion of the request path it parses, it can put that information into environ['wsgiorg.routing_args']. routing_args must be a two-tuple of `(positional_args, named_args)`, where `positional_args` is a sequence of arguments that were captured positionally, and `named_args` is a dictionary of the arguments that were given names.