### PR TITLE
Fixed typo in BaseModelAdmin.has_delete_permission()'s docstring.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -561,7 +561,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
 
     def has_delete_permission(self, request, obj=None):
         """
-        Return True if the given request has permission to change the given
+        Return True if the given request has permission to delete the given
         Django model instance, the default implementation doesn't examine the
         `obj` parameter.
 


### PR DESCRIPTION
This PR just fixes the verb used in the docstring of `has_delete_permission()` from "change" to "delete".