### PR TITLE
Refs #28477 -- Fixed handling aliased annotations on aggregation.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -443,7 +443,7 @@ class Query(BaseExpression):
             return {}
         existing_annotations = {
             alias: annotation
-            for alias, annotation in self.annotation_select.items()
+            for alias, annotation in self.annotations.items()
             if alias not in added_aggregate_names
         }
         # Existing usage of aggregation can be determined by the presence of

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -2088,13 +2088,41 @@ class AggregateTestCase(TestCase):
 
 
 class AggregateAnnotationPruningTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.a1 = Author.objects.create(age=1)
+        cls.a2 = Author.objects.create(age=2)
+        cls.p1 = Publisher.objects.create(num_awards=1)
+        cls.p2 = Publisher.objects.create(num_awards=0)
+        cls.b1 = Book.objects.create(
+            name="b1",
+            publisher=cls.p1,
+            pages=100,
+            rating=4.5,
+            price=10,
+            contact=cls.a1,
+            pubdate=datetime.date.today(),
+        )
+        cls.b1.authors.add(cls.a1)
+        cls.b2 = Book.objects.create(
+            name="b2",
+            publisher=cls.p2,
+            pages=1000,
+            rating=3.2,
+            price=50,
+            contact=cls.a2,
+            pubdate=datetime.date.today(),
+        )
+        cls.b2.authors.add(cls.a1, cls.a2)
+
     def test_unused_aliased_aggregate_pruned(self):
         with CaptureQueriesContext(connection) as ctx:
-            Book.objects.alias(
+            cnt = Book.objects.alias(
                 authors_count=Count("authors"),
             ).count()
+        self.assertEqual(cnt, 2)
         sql = ctx.captured_queries[0]["sql"].lower()
-        self.assertEqual(sql.count("select"), 1, "No subquery wrapping required")
+        self.assertEqual(sql.count("select"), 2, "Subquery wrapping required")
         self.assertNotIn("authors_count", sql)
 
     def test_non_aggregate_annotation_pruned(self):
@@ -2108,9 +2136,10 @@ class AggregateAnnotationPruningTests(TestCase):
 
     def test_unreferenced_aggregate_annotation_pruned(self):
         with CaptureQueriesContext(connection) as ctx:
-            Book.objects.annotate(
+            cnt = Book.objects.annotate(
                 authors_count=Count("authors"),
             ).count()
+        self.assertEqual(cnt, 2)
         sql = ctx.captured_queries[0]["sql"].lower()
         self.assertEqual(sql.count("select"), 2, "Subquery wrapping required")
         self.assertNotIn("authors_count", sql)


### PR DESCRIPTION
Just like when using .annotate(), the .alias() method will generate the necessary JOINs to resolve the alias even if not selected.

Since these JOINs could be multi-valued non-selected aggregates must be considered to require subquery wrapping as a GROUP BY is required to combine duplicated tuples from the base table.

---

Small regression discovered while playing with the SQL comparison tool. I wrongly assumed that `QuerySet.alias` wouldn't generate joins until actually used but it does and thus must be treated just like `.annotate`.