### PR TITLE
Fixed some "currentmodule" references in docs.

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -662,7 +662,7 @@ details on these changes.
   :func:`~django.template.loader.get_template` and
   :func:`~django.template.loader.select_template` won't accept a
   :class:`~django.template.Context` in their
-  :meth:`~django.template.backends.base.Template.render()` method anymore.
+  :meth:`~django.template.base.Template.render()` method anymore.
 
 * :doc:`Template response APIs </ref/template-response>` will enforce the use
   of :class:`dict` and backend-dependent template objects instead of

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -34,7 +34,7 @@ lower level APIs:
    return a ``django.template.backends.django.Template`` which wraps the
    actual :class:`django.template.Template`.
 3. The ``Template`` obtained in the previous step has a
-   :meth:`~django.template.backends.base.Template.render` method which
+   :meth:`~django.template.base.Template.render` method which
    marshals a context and possibly a request into a :class:`Context` and
    delegates the rendering to the underlying :class:`Template`.
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -1290,7 +1290,7 @@ to remove usage of these features.
   :func:`~django.template.loader.get_template` and
   :func:`~django.template.loader.select_template` no longer accept a
   :class:`~django.template.Context` in their
-  :meth:`~django.template.backends.base.Template.render()` method.
+  :meth:`~django.template.base.Template.render()` method.
 
 * :doc:`Template response APIs </ref/template-response>` enforce the use of
   :class:`dict` and backend-dependent template objects instead of

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -280,8 +280,8 @@ Models
   backends, only Oracle supports it.
 
 * The new :meth:`connection.execute_wrapper()
-  <django.db.backends.base.DatabaseWrapper.execute_wrapper>` method allows
-  :doc:`installing wrappers around execution of database queries
+  <django.db.backends.base.base.BaseDatabaseWrapper.execute_wrapper>` method
+  allows :doc:`installing wrappers around execution of database queries
   </topics/db/instrumentation>`.
 
 * The new ``filter`` argument for built-in aggregates allows :ref:`adding

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -115,7 +115,7 @@ Cache
 * The :ref:`local-memory cache backend <local-memory-caching>` now uses a
   least-recently-used (LRU) culling strategy rather than a pseudo-random one.
 
-* The new :meth:`~django.core.caches.cache.touch` method of the :ref:`low-level
+* The new :meth:`~django.core.cache.cache.touch` method of the :ref:`low-level
   cache API <low-level-cache-api>` updates the timeout of cache keys.
 
 CSRF

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -259,7 +259,7 @@ Cache
   field names in the ``no-cache`` directive for the ``Cache-Control`` header,
   according to :rfc:`7234#section-5.2.2.2`.
 
-* :meth:`~django.core.caches.cache.delete` now returns ``True`` if the key was
+* :meth:`~django.core.cache.cache.delete` now returns ``True`` if the key was
   successfully deleted, ``False`` otherwise.
 
 CSRF

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -895,7 +895,7 @@ Accessing the cache
 Basic usage
 -----------
 
-.. currentmodule:: django.core.caches
+.. currentmodule:: django.core.cache
 
 The basic interface is:
 

--- a/docs/topics/db/instrumentation.txt
+++ b/docs/topics/db/instrumentation.txt
@@ -94,12 +94,12 @@ To use this, you would create a logger object and install it as a wrapper::
     # Now we can print the log.
     print(ql.queries)
 
-.. currentmodule:: django.db.backends.base.DatabaseWrapper
+.. currentmodule:: django.db.backends.base.base
 
 ``connection.execute_wrapper()``
 --------------------------------
 
-.. method:: execute_wrapper(wrapper)
+.. method:: BaseDatabaseWrapper.execute_wrapper(wrapper)
 
 Returns a context manager which, when entered, installs a wrapper around
 database query executions, and when exited, removes the wrapper. The wrapper is

--- a/docs/topics/templates.txt
+++ b/docs/topics/templates.txt
@@ -329,7 +329,7 @@ If loading a template fails, the following two exceptions, defined in
 ``Template`` objects returned by ``get_template()`` and ``select_template()``
 must provide a ``render()`` method with the following signature:
 
-.. currentmodule:: django.template.backends.base
+.. currentmodule:: django.template.base
 
 .. method:: Template.render(context=None, request=None)
 


### PR DESCRIPTION
When running Sphinx in verbose mode I spotted that some of the module references required updating. I've not yet done a full audit (the output is _long_!), but wanted some validation before I put more time into it. 