### PR TITLE
Fixed #34154 -- Made mixin headers consistent in auth docs.

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -565,8 +565,8 @@ The ``login_required`` decorator
 
 .. currentmodule:: django.contrib.auth.mixins
 
-The ``LoginRequired`` mixin
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``LoginRequiredMixin`` mixin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When using :doc:`class-based views </topics/class-based-views/index>`, you can
 achieve the same behavior as with ``login_required`` by using the


### PR DESCRIPTION
Updated the LoginRequiredMixin doc header in the auth topic doc to the same style as other mixin class section headers.

See the nearby PermissionRequiredMixin header: https://github.com/django/django/blob/main/docs/topics/auth/default.txt#L766-L767.