### PR TITLE
Fixed #26056 -- Added QuerySet.values()/values_list() support for ArrayField's __overlap lookup.

### DIFF
--- a/django/contrib/postgres/lookups.py
+++ b/django/contrib/postgres/lookups.py
@@ -1,6 +1,6 @@
 from django.db.models import Transform
 from django.db.models.lookups import PostgresOperatorLookup
-from django.db.models.sql.compiler import Query
+from django.db.models.sql.query import Query
 
 from .search import SearchVector, SearchVectorExact, SearchVectorField
 
@@ -19,13 +19,12 @@ class Overlap(PostgresOperatorLookup):
     lookup_name = "overlap"
     postgres_operator = "&&"
 
-    def process_rhs(self, qn, connection):
-        if isinstance(self.rhs, Query):
-            from .expressions import ArraySubquery
+    def get_prep_lookup(self):
+        from .expressions import ArraySubquery
 
+        if isinstance(self.rhs, Query):
             self.rhs = ArraySubquery(self.rhs)
-        rhs, params = super().process_rhs(qn, connection)
-        return rhs, params
+        return super().get_prep_lookup()
 
 
 class HasKey(PostgresOperatorLookup):

--- a/django/contrib/postgres/lookups.py
+++ b/django/contrib/postgres/lookups.py
@@ -1,5 +1,6 @@
 from django.db.models import Transform
 from django.db.models.lookups import PostgresOperatorLookup
+from django.db.models.sql.compiler import Query
 
 from .search import SearchVector, SearchVectorExact, SearchVectorField
 
@@ -17,6 +18,14 @@ class ContainedBy(PostgresOperatorLookup):
 class Overlap(PostgresOperatorLookup):
     lookup_name = "overlap"
     postgres_operator = "&&"
+
+    def process_rhs(self, qn, connection):
+        if isinstance(self.rhs, Query):
+            from .expressions import ArraySubquery
+
+            self.rhs = ArraySubquery(self.rhs)
+        rhs, params = super().process_rhs(qn, connection)
+        return rhs, params
 
 
 class HasKey(PostgresOperatorLookup):

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -170,13 +170,16 @@ Returns objects where the data shares any results with the values passed. Uses
 the SQL operator ``&&``. For example::
 
     >>> Post.objects.create(name='First post', tags=['thoughts', 'django'])
-    >>> Post.objects.create(name='Second post', tags=['thoughts'])
+    >>> Post.objects.create(name='Second post', tags=['thoughts', 'tutorial'])
     >>> Post.objects.create(name='Third post', tags=['tutorial', 'django'])
 
     >>> Post.objects.filter(tags__overlap=['thoughts'])
     <QuerySet [<Post: First post>, <Post: Second post>]>
 
     >>> Post.objects.filter(tags__overlap=['thoughts', 'tutorial'])
+    <QuerySet [<Post: First post>, <Post: Second post>, <Post: Third post>]>
+
+    >>> Post.objects.filter(tags__overlap=Post.objects.values_list('tags'))
     <QuerySet [<Post: First post>, <Post: Second post>, <Post: Third post>]>
 
 .. fieldlookup:: arrayfield.len

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -102,8 +102,8 @@ Minor features
   <django.contrib.postgres.search.TrigramStrictWordDistance>` expressions allow
   using trigram strict word similarity.
 
-* Added support for querying against querysets in
-  :lookup:`arrayfield.overlap`.
+* :lookup:`arrayfield.overlap` now supports ``QuerySet.values()`` and
+  ``values_list()`` as right-hand sides.
 
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -102,6 +102,9 @@ Minor features
   <django.contrib.postgres.search.TrigramStrictWordDistance>` expressions allow
   using trigram strict word similarity.
 
+* Added support for querying against querysets in
+  :lookup:`arrayfield.overlap`.
+
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -414,6 +414,24 @@ class TestQuerying(PostgreSQLTestCase):
             [obj_1, obj_2],
         )
 
+    def test_overlap_values_array_field(self):
+        # issue 26056
+        post1 = CharArrayModel(field=["django"])
+        post2 = CharArrayModel(field=["thoughts"])
+        post3 = CharArrayModel(field=["tutorial"])
+        CharArrayModel.objects.bulk_create([post1, post2, post3])
+        qs = CharArrayModel.objects.filter(
+            field__overlap=CharArrayModel.objects.values_list("field", flat=True)
+        )
+        self.assertSequenceEqual(
+            qs.values_list("field", flat=True),
+            [
+                (["django"]),
+                (["thoughts"]),
+                (["tutorial"]),
+            ],
+        )
+
     def test_lookups_autofield_array(self):
         qs = (
             NullableIntegerArrayModel.objects.filter(

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -414,22 +414,15 @@ class TestQuerying(PostgreSQLTestCase):
             [obj_1, obj_2],
         )
 
-    def test_overlap_values_array_field(self):
-        # issue 26056
-        post1 = CharArrayModel(field=["django"])
-        post2 = CharArrayModel(field=["thoughts"])
-        post3 = CharArrayModel(field=["tutorial"])
-        CharArrayModel.objects.bulk_create([post1, post2, post3])
-        qs = CharArrayModel.objects.filter(
-            field__overlap=CharArrayModel.objects.values_list("field", flat=True)
+    def test_overlap_values_list(self):
+        values = NullableIntegerArrayModel.objects.filter(order__lt=3).values_list(
+            "field"
         )
-        self.assertSequenceEqual(
-            qs.values_list("field", flat=True),
-            [
-                (["django"]),
-                (["thoughts"]),
-                (["tutorial"]),
-            ],
+        self.assertCountEqual(
+            NullableIntegerArrayModel.objects.filter(
+                field__overlap=values,
+            ),
+            self.objs[:3],
         )
 
     def test_lookups_autofield_array(self):


### PR DESCRIPTION
This is based on work by Mads Jensen and kosz85 in PR #7838.