### PR TITLE
Fixed #26261 -- Fixed queryset crash when excluding reverse GenericRelation.

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -461,7 +461,7 @@ class GenericRelation(ForeignObject):
                 to_opts=opts,
                 target_fields=(opts.pk,),
                 join_field=self,
-                m2m=not self.unique,
+                m2m=False,
                 direct=False,
                 filtered_relation=filtered_relation,
             )

--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -308,3 +308,13 @@ class GenericRelationTests(TestCase):
         thing = HasLinkThing.objects.create()
         link = Link.objects.create(content_object=thing)
         self.assertCountEqual(link.targets.all(), [thing])
+
+    def test_generic_reverse_relation_exclude_filter(self):
+        place1 = Place.objects.create(name="Test Place 1")
+        place2 = Place.objects.create(name="Test Place 2")
+        Link.objects.create(content_object=place1)
+        link2 = Link.objects.create(content_object=place2)
+        qs = Link.objects.filter(~Q(places__name="Test Place 1"))
+        self.assertSequenceEqual(qs, [link2])
+        qs = Link.objects.exclude(places__name="Test Place 1")
+        self.assertSequenceEqual(qs, [link2])


### PR DESCRIPTION
Ticket 26261
Negative filtration via reverse GenericRelation is now working!
Changed bool "m2m" kwarg in PathInfo in GenericRelation get_reverse_path_info to False from "not self.unique".
In case of GenericRelation, it was created with default "unique"=False attribute that leaded to wrong query building - Django "think" that it is "many" relation and try to apply "many" logic to direct ForeignKey like relation.
With this fix negative filtration via reverse GenericRelation behave like negative direct ForeignKey filtration.