### PR TITLE
Fixed #34148 -- Reverted "Fixed #32901 -- Optimized BaseForm.__getitem__()."

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -330,6 +330,7 @@ answer newbie questions, and generally made Django that much better:
     Florian Demmer <fdemmer@gmail.com>
     Florian Moussous <florian.moussous@gmail.com>
     Fran Hrženjak <fran.hrzenjak@gmail.com>
+    Francesco Panico <panico.francesco@gmail.com>
     Francisco Albarran Cristobal <pahko.xd@gmail.com>
     Francisco Couzo <franciscouzo@gmail.com>
     François Freitag <mail@franek.fr>

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -175,10 +175,6 @@ class BaseForm(RenderableFormMixin):
     def __getitem__(self, name):
         """Return a BoundField with the given name."""
         try:
-            return self._bound_fields_cache[name]
-        except KeyError:
-            pass
-        try:
             field = self.fields[name]
         except KeyError:
             raise KeyError(
@@ -189,9 +185,9 @@ class BaseForm(RenderableFormMixin):
                     ", ".join(sorted(self.fields)),
                 )
             )
-        bound_field = field.get_bound_field(self, name)
-        self._bound_fields_cache[name] = bound_field
-        return bound_field
+        if name not in self._bound_fields_cache:
+            self._bound_fields_cache[name] = field.get_bound_field(self, name)
+        return self._bound_fields_cache[name]
 
     @property
     def errors(self):

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -4579,6 +4579,22 @@ Options: <select multiple name="options" required>
             '<legend number="9999" for="id_first_name">First name:</legend>',
         )
 
+    def test_remove_cached_field(self):
+        class TestForm(Form):
+            name = CharField(max_length=10)
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                # Populate fields cache.
+                [field for field in self]
+                # Removed cached field.
+                del self.fields["name"]
+
+        f = TestForm({"name": "abcde"})
+
+        with self.assertRaises(KeyError):
+            f["name"]
+
 
 @jinja2_tests
 class Jinja2FormsTestCase(FormsTestCase):


### PR DESCRIPTION
Clearing a form field after it was cached had no effect. Thanks to @jieter for the report