### PR TITLE
Removed unnecessary ForeignKey.get_reverse_path_info().

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1060,22 +1060,6 @@ class ForeignKey(ForeignObject):
     def target_field(self):
         return self.foreign_related_fields[0]
 
-    def get_reverse_path_info(self, filtered_relation=None):
-        """Get path from the related model to this field's model."""
-        opts = self.model._meta
-        from_opts = self.remote_field.model._meta
-        return [
-            PathInfo(
-                from_opts=from_opts,
-                to_opts=opts,
-                target_fields=(opts.pk,),
-                join_field=self.remote_field,
-                m2m=not self.unique,
-                direct=False,
-                filtered_relation=filtered_relation,
-            )
-        ]
-
     def validate(self, value, model_instance):
         if self.remote_field.parent_link:
             return


### PR DESCRIPTION
`get_reverse_path_info()` is already inherited from `ForeignObject`:

https://github.com/django/django/blob/51faf4bd172cd4cb219a9793facbfa00246c9f3c/django/db/models/fields/related.py#L839-L853