### PR TITLE
Fixed #29062 -- Prevented possibility of database lock when using LiveServerTestCase with in-memory SQLite database.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -111,6 +111,16 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                     },
                 }
             )
+        else:
+            skips.update(
+                {
+                    "Only connections to in-memory SQLite databases are passed to the "
+                    "server thread.": {
+                        "servers.tests.LiveServerInMemoryDatabaseLockTest."
+                        "test_in_memory_database_lock",
+                    },
+                }
+            )
         return skips
 
     @cached_property

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1778,7 +1778,9 @@ class LiveServerThread(threading.Thread):
         try:
             # Create the handler for serving static and media files
             handler = self.static_handler(_MediaFilesHandler(WSGIHandler()))
-            self.httpd = self._create_server()
+            self.httpd = self._create_server(
+                connections_override=self.connections_override,
+            )
             # If binding to port zero, assign the port allocated by the OS.
             if self.port == 0:
                 self.port = self.httpd.server_address[1]


### PR DESCRIPTION
in-memory sqlite were used together.

https://code.djangoproject.com/ticket/29062