### PR TITLE
Fixed #33747 -- Added exception notes to the technical 500 debug page.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -396,6 +396,8 @@ class ExceptionReporter:
             c["exception_type"] = self.exc_type.__name__
         if self.exc_value:
             c["exception_value"] = str(self.exc_value)
+            if exc_notes := getattr(self.exc_value, "__notes__", None):
+                c["exception_notes"] = "\n" + "\n".join(exc_notes)
         if frames:
             c["lastframe"] = frames[-1]
         return c

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -100,7 +100,7 @@
 <div id="summary">
   <h1>{% if exception_type %}{{ exception_type }}{% else %}Report{% endif %}
       {% if request %} at {{ request.path_info }}{% endif %}</h1>
-  <pre class="exception_value">{% if exception_value %}{{ exception_value|force_escape }}{% else %}No exception message supplied{% endif %}</pre>
+  <pre class="exception_value">{% if exception_value %}{{ exception_value|force_escape }}{% if exception_notes %}{{ exception_notes }}{% endif %}{% else %}No exception message supplied{% endif %}</pre>
   <table class="meta">
 {% if request %}
     <tr>
@@ -330,7 +330,7 @@ During handling of the above exception ({{ frame.exc_cause|force_escape }}), ano
 {% if frame.context_line %}    {% spaceless %}{{ frame.context_line }}{% endspaceless %}{% endif %}{% elif forloop.first %}None{% else %}Traceback: None{% endif %}{% endfor %}
 
 Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
-Exception Value: {{ exception_value|force_escape }}
+Exception Value: {{ exception_value|force_escape }}{% if exception_notes %}{{ exception_notes }}{% endif %}
 </textarea>
   <br><br>
   <input type="submit" value="Share this traceback on a public website">

--- a/django/views/templates/technical_500.txt
+++ b/django/views/templates/technical_500.txt
@@ -34,7 +34,7 @@ Traceback (most recent call last):
 {% if frame.context_line %}    {% spaceless %}{{ frame.context_line }}{% endspaceless %}{% endif %}{% elif forloop.first %}None{% else %}Traceback: None{% endif %}
 {% endfor %}
 {% if exception_type %}Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
-{% if exception_value %}Exception Value: {{ exception_value }}{% endif %}{% endif %}{% endif %}
+{% if exception_value %}Exception Value: {{ exception_value }}{% endif %}{% if exception_notes %}{{ exception_notes }}{% endif %}{% endif %}{% endif %}
 {% if raising_view_name %}Raised during: {{ raising_view_name }}{% endif %}
 {% if request %}Request information:
 {% if user_str %}USER: {{ user_str }}{% endif %}

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -158,7 +158,7 @@ Email
 Error Reporting
 ~~~~~~~~~~~~~~~
 
-* ...
+* The debug page now shows :pep:`exception notes <678>` on Python 3.11+.
 
 File Storage
 ~~~~~~~~~~~~


### PR DESCRIPTION
Solves Ticket [#33747](https://code.djangoproject.com/ticket/33747)

The 500 debug page now also displays the exception notes for Python 3.11+. Currently the notes are displayed at the top, which I think makes the most sense. But I am open for feedback.

![exception_notes](https://user-images.githubusercontent.com/39874595/203101744-75bfc49f-d293-4272-83a1-a86508ff7f1b.PNG)
