### PR TITLE
Bumped gh-problem-matcher-wrap version to 2.0.0.

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -30,8 +30,8 @@ jobs:
           python-version: '3.11'
       - run: python -m pip install flake8
       - name: flake8
-        # Pinned to v1.0.2.
-        uses: liskin/gh-problem-matcher-wrap@e7d110d699a16b3dead9ef8b1f9470f93765ae95
+        # Pinned to v2.0.0.
+        uses: liskin/gh-problem-matcher-wrap@d8afa2cfb66dd3f982b1950429e652bc14d0d7d2
         with:
           linters: flake8
           run: flake8
@@ -47,8 +47,8 @@ jobs:
           python-version: '3.11'
       - run: python -m pip install isort
       - name: isort
-        # Pinned to v1.0.2.
-        uses: liskin/gh-problem-matcher-wrap@e7d110d699a16b3dead9ef8b1f9470f93765ae95
+        # Pinned to v2.0.0.
+        uses: liskin/gh-problem-matcher-wrap@d8afa2cfb66dd3f982b1950429e652bc14d0d7d2
         with:
           linters: isort
           run: isort --check --diff django tests scripts


### PR DESCRIPTION
This avoids issues with using deprecated Node.js 12 actions:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: liskin/gh-problem-matcher-wrap@e7d110d699a16b3dead9ef8b1f9470f93765ae95
```