### PR TITLE
Fixed #34177 -- Fixed QuerySet.bulk_create() crash on "pk" in unique_fields.

### DIFF
--- a/docs/releases/4.1.4.txt
+++ b/docs/releases/4.1.4.txt
@@ -20,3 +20,6 @@ Bugfixes
 * Fixed a bug in Django 4.1 that caused a crash of ``acreate()``,
   ``aget_or_create()``, and ``aupdate_or_create()`` asynchronous methods for
   related managers (:ticket:`34139`).
+
+* Fixed a bug in Django 4.1 that caused a crash of ``QuerySet.bulk_create()``
+  with ``"pk"`` in ``unique_fields`` (:ticket:`34177`).


### PR DESCRIPTION
Noticed when reviewing #16315.

Bug in 0f6946495a8ec955b471ca1baaf408ceb53d4796.

ticket-34177