### PR TITLE
Fixed #31679 -- Delayed annotating aggregations.

### DIFF
--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -395,6 +395,9 @@ Miscellaneous
 * The undocumented ``negated`` parameter of the
   :class:`~django.db.models.Exists` expression is removed.
 
+* The ``is_summary`` argument of the undocumented ``Query.add_annotation()``
+  method is removed.
+
 .. _deprecated-features-4.2:
 
 Features deprecated in 4.2


### PR DESCRIPTION
By avoiding to annotate aggregations meant to be possibly pushed to an outer query until their references are resolved it is possible to aggregate over a query with the same alias.

Even if #34176 is a convoluted case to support, this refactor seems worth it given the reduction in complexity it brings with regards to annotation removal when performing a subquery pushdown.