### PR TITLE
Fixed #34173 --  Skipped saving sessions on 5xx responses.

### DIFF
--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -53,8 +53,8 @@ class SessionMiddleware(MiddlewareMixin):
                     expires_time = time.time() + max_age
                     expires = http_date(expires_time)
                 # Save the session data and refresh the client cookie.
-                # Skip session save for 500 responses, refs #3881.
-                if response.status_code != 500:
+                # Skip session save for 5xx responses.
+                if response.status_code < 500:
                     try:
                         request.session.save()
                     except UpdateError:

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -715,7 +715,7 @@ class SessionMiddlewareTests(TestCase):
         )
 
     def test_session_save_on_500(self):
-        def response_500(requset):
+        def response_500(request):
             response = HttpResponse("Horrible error")
             response.status_code = 500
             request.session["hello"] = "world"
@@ -723,6 +723,19 @@ class SessionMiddlewareTests(TestCase):
 
         request = self.request_factory.get("/")
         SessionMiddleware(response_500)(request)
+
+        # The value wasn't saved above.
+        self.assertNotIn("hello", request.session.load())
+
+    def test_session_save_on_5xx(self):
+        def response_503(request):
+            response = HttpResponse("Service Unavailable")
+            response.status_code = 503
+            request.session["hello"] = "world"
+            return response
+
+        request = self.request_factory.get("/")
+        SessionMiddleware(response_503)(request)
 
         # The value wasn't saved above.
         self.assertNotIn("hello", request.session.load())


### PR DESCRIPTION
Fixed [#34173](https://code.djangoproject.com/ticket/34173).

Sessions won't be saved when status code is greater than and equal to 500.