### PR TITLE
Used DatabaseFeatures.django_test_skips to skip AssertNumQueriesUponConnectionTests tests.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -109,6 +109,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                         "servers.tests.LiveServerTestCloseConnectionTest."
                         "test_closes_connections",
                     },
+                    "For SQLite in-memory tests, closing the connection destroys"
+                    "the database.": {
+                        "test_utils.tests.AssertNumQueriesUponConnectionTests."
+                        "test_ignores_connection_configuration_queries",
+                    },
                 }
             )
         else:

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -235,10 +235,6 @@ class AssertNumQueriesTests(TestCase):
         self.assertNumQueries(2, test_func)
 
 
-@unittest.skipUnless(
-    connection.vendor != "sqlite" or not connection.is_in_memory_db(),
-    "For SQLite in-memory tests, closing the connection destroys the database.",
-)
 class AssertNumQueriesUponConnectionTests(TransactionTestCase):
     available_apps = []
 


### PR DESCRIPTION
Based on @felixxm invitation https://github.com/django/django/pull/16309#issuecomment-1326262101