### PR TITLE
Doc's check_password()'s setter and preferred arguments.

### DIFF
--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -474,14 +474,18 @@ The :mod:`django.contrib.auth.hashers` module provides a set of functions
 to create and validate hashed passwords. You can use them independently
 from the ``User`` model.
 
-.. function:: check_password(password, encoded)
+.. function:: check_password(password, encoded, setter=None, preferred="default")
 
     If you'd like to manually authenticate a user by comparing a plain-text
     password to the hashed password in the database, use the convenience
-    function :func:`check_password`. It takes two arguments: the plain-text
-    password to check, and the full value of a user's ``password`` field in the
-    database to check against, and returns ``True`` if they match, ``False``
-    otherwise.
+    function :func:`check_password`. It takes two mandatory arguments: the
+    plain-text password to check, and the full value of a user's ``password``
+    field in the database to check against. It returns ``True`` if they match,
+    ``False`` otherwise. Optionally, you can pass a callable ``setter`` that
+    takes the password and will be called when you need to regenerate it. You
+    can also pass ``preferred`` to change a hashing algorithm if you don't want
+    to use the default (first entry of ``PASSWORD_HASHERS`` setting). See
+    :ref:`auth-included-hashers` for the algorithm name of each hasher.
 
 .. function:: make_password(password, salt=None, hasher='default')
 


### PR DESCRIPTION
Follow up to 90e05aaeac612a4251640564aa65f103ac635e12.