### PR TITLE
Fixed #28236 - Integrate dj-database-url into Django

### DIFF
--- a/django/conf/service_url.py
+++ b/django/conf/service_url.py
@@ -123,7 +123,7 @@ register_cache_backend("memory", "django.core.cache.backends.locmem.LocMemCache"
 register_cache_backend("db", "django.core.cache.backends.db.DatabaseCache")
 register_cache_backend("dummy", "django.core.cache.backends.dummy.DummyCache")
 register_cache_backend(
-    "memcached", "django.core.cache.backends.memcached.MemcachedCache"
+    "memcached+pymemcache", "django.core.cache.backends.memcached.PyMemcacheCache"
 )
 register_cache_backend(
     "memcached+pylibmccache", "django.core.cache.backends.memcached.PyLibMCCache"

--- a/django/conf/service_url.py
+++ b/django/conf/service_url.py
@@ -1,0 +1,122 @@
+import inspect
+from collections import defaultdict
+from urllib import parse
+
+from django.core.exceptions import ImproperlyConfigured
+from django.utils import module_loading
+
+BACKENDS = defaultdict(dict)
+
+
+def parse_url(url):
+    """
+    A method to parse URLs into components that handles quirks
+    with the stdlib urlparse, such as lower-cased hostnames.
+    Also parses querystrings into typed components.
+    """
+    # This method may be called with an already parsed URL
+    if isinstance(url, dict):
+        return url
+    parsed = parse.urlparse(url)
+    # parsed.hostname always returns a lower-cased hostname
+    # this isn't correct if hostname is a file path, so use '_hostinfo'
+    # to get the actual host
+    hostname, port = parsed._hostinfo
+    query = parse.parse_qs(parsed.query)
+    options = {}
+
+    for key, values in query.items():
+        value = values[-1]
+        if value.isdigit():
+            value = int(value)
+        elif value.lower() == 'true':
+            value = True
+        elif value.lower() == 'false':
+            value = False
+
+        options[key] = value
+
+    path = parsed.path[1:]
+    if port:
+        port = int(port)
+
+    return {
+        'scheme': parsed.scheme,
+        'username': parsed.username,
+        'password': parsed.password,
+        'hostname': hostname,
+        'port': port,
+        'path': path,
+        'options': options
+    }
+
+
+def _register_backend(backend_type, scheme, path):
+    if scheme in BACKENDS[backend_type]:
+        raise ImproperlyConfigured('Scheme {0} has already been registered as a {1} handler'.format(scheme,
+                                                                                                    backend_type))
+    BACKENDS[backend_type][scheme] = path
+
+
+def _get_backend(backend_type, scheme):
+    if scheme not in BACKENDS[backend_type]:
+        raise ImproperlyConfigured('No {0} handler configured for {1}'.format(backend_type, scheme))
+    return BACKENDS[backend_type][scheme]
+
+
+def _get_config(backend_type, value):
+    scheme = value.split(':', 1)[0]
+
+    backend_path = _get_backend(backend_type, scheme)
+    handler = module_loading.import_string(backend_path)
+
+    if not hasattr(handler, 'config_from_url'):
+        raise TypeError('{0} has no config_from_url method'.format(backend_path))
+
+    if not inspect.ismethod(handler.config_from_url):
+        raise TypeError('{0} is not a class method'.format(handler.config_from_url))
+
+    if backend_path.endswith('.base.DatabaseWrapper'):
+        backend_path = backend_path.replace('.base.DatabaseWrapper', '')
+
+    return handler.config_from_url(backend_path, scheme, value)
+
+
+# Convenience functions
+
+
+def configure_db(value):
+    return _get_config('db', value)
+
+
+def configure_cache(value):
+    return _get_config('cache', value)
+
+
+def register_db_backend(scheme, path):
+    if not path.endswith('.base.DatabaseWrapper'):
+        path += '.base.DatabaseWrapper'
+
+    _register_backend('db', scheme, path)
+
+
+def register_cache_backend(scheme, path):
+    _register_backend('cache', scheme, path)
+
+
+register_db_backend('mysql', 'django.db.backends.mysql')
+register_db_backend('oracle', 'django.db.backends.oracle')
+register_db_backend('postgres', 'django.db.backends.postgresql')
+register_db_backend('sqlite', 'django.db.backends.sqlite3')
+
+register_db_backend('mysql+gis', 'django.contrib.gis.db.backends.mysql')
+register_db_backend('oracle+gis', 'django.contrib.gis.db.backends.oracle')
+register_db_backend('postgis', 'django.contrib.gis.db.backends.postgis')
+register_db_backend('spatialite', 'django.contrib.gis.db.backends.spatialite')
+
+register_cache_backend('memory', 'django.core.cache.backends.locmem.LocMemCache')
+register_cache_backend('db', 'django.core.cache.backends.db.DatabaseCache')
+register_cache_backend('dummy', 'django.core.cache.backends.dummy.DummyCache')
+register_cache_backend('memcached', 'django.core.cache.backends.memcached.MemcachedCache')
+register_cache_backend('memcached+pylibmccache', 'django.core.cache.backends.memcached.PyLibMCCache')
+register_cache_backend('file', 'django.core.cache.backends.filebased.FileBasedCache')

--- a/django/conf/service_url.py
+++ b/django/conf/service_url.py
@@ -29,9 +29,9 @@ def parse_url(url):
         value = values[-1]
         if value.isdigit():
             value = int(value)
-        elif value.lower() == 'true':
+        elif value.lower() == "true":
             value = True
-        elif value.lower() == 'false':
+        elif value.lower() == "false":
             value = False
 
         options[key] = value
@@ -41,43 +41,48 @@ def parse_url(url):
         port = int(port)
 
     return {
-        'scheme': parsed.scheme,
-        'username': parsed.username,
-        'password': parsed.password,
-        'hostname': hostname,
-        'port': port,
-        'path': path,
-        'options': options
+        "scheme": parsed.scheme,
+        "username": parsed.username,
+        "password": parsed.password,
+        "hostname": hostname,
+        "port": port,
+        "path": path,
+        "options": options,
     }
 
 
 def _register_backend(backend_type, scheme, path):
     if scheme in BACKENDS[backend_type]:
-        raise ImproperlyConfigured('Scheme {0} has already been registered as a {1} handler'.format(scheme,
-                                                                                                    backend_type))
+        raise ImproperlyConfigured(
+            "Scheme {0} has already been registered as a {1} handler".format(
+                scheme, backend_type
+            )
+        )
     BACKENDS[backend_type][scheme] = path
 
 
 def _get_backend(backend_type, scheme):
     if scheme not in BACKENDS[backend_type]:
-        raise ImproperlyConfigured('No {0} handler configured for {1}'.format(backend_type, scheme))
+        raise ImproperlyConfigured(
+            "No {0} handler configured for {1}".format(backend_type, scheme)
+        )
     return BACKENDS[backend_type][scheme]
 
 
 def _get_config(backend_type, value):
-    scheme = value.split(':', 1)[0]
+    scheme = value.split(":", 1)[0]
 
     backend_path = _get_backend(backend_type, scheme)
     handler = module_loading.import_string(backend_path)
 
-    if not hasattr(handler, 'config_from_url'):
-        raise TypeError('{0} has no config_from_url method'.format(backend_path))
+    if not hasattr(handler, "config_from_url"):
+        raise TypeError("{0} has no config_from_url method".format(backend_path))
 
     if not inspect.ismethod(handler.config_from_url):
-        raise TypeError('{0} is not a class method'.format(handler.config_from_url))
+        raise TypeError("{0} is not a class method".format(handler.config_from_url))
 
-    if backend_path.endswith('.base.DatabaseWrapper'):
-        backend_path = backend_path.replace('.base.DatabaseWrapper', '')
+    if backend_path.endswith(".base.DatabaseWrapper"):
+        backend_path = backend_path.replace(".base.DatabaseWrapper", "")
 
     return handler.config_from_url(backend_path, scheme, value)
 
@@ -86,37 +91,41 @@ def _get_config(backend_type, value):
 
 
 def configure_db(value):
-    return _get_config('db', value)
+    return _get_config("db", value)
 
 
 def configure_cache(value):
-    return _get_config('cache', value)
+    return _get_config("cache", value)
 
 
 def register_db_backend(scheme, path):
-    if not path.endswith('.base.DatabaseWrapper'):
-        path += '.base.DatabaseWrapper'
+    if not path.endswith(".base.DatabaseWrapper"):
+        path += ".base.DatabaseWrapper"
 
-    _register_backend('db', scheme, path)
+    _register_backend("db", scheme, path)
 
 
 def register_cache_backend(scheme, path):
-    _register_backend('cache', scheme, path)
+    _register_backend("cache", scheme, path)
 
 
-register_db_backend('mysql', 'django.db.backends.mysql')
-register_db_backend('oracle', 'django.db.backends.oracle')
-register_db_backend('postgres', 'django.db.backends.postgresql')
-register_db_backend('sqlite', 'django.db.backends.sqlite3')
+register_db_backend("mysql", "django.db.backends.mysql")
+register_db_backend("oracle", "django.db.backends.oracle")
+register_db_backend("postgres", "django.db.backends.postgresql")
+register_db_backend("sqlite", "django.db.backends.sqlite3")
 
-register_db_backend('mysql+gis', 'django.contrib.gis.db.backends.mysql')
-register_db_backend('oracle+gis', 'django.contrib.gis.db.backends.oracle')
-register_db_backend('postgis', 'django.contrib.gis.db.backends.postgis')
-register_db_backend('spatialite', 'django.contrib.gis.db.backends.spatialite')
+register_db_backend("mysql+gis", "django.contrib.gis.db.backends.mysql")
+register_db_backend("oracle+gis", "django.contrib.gis.db.backends.oracle")
+register_db_backend("postgis", "django.contrib.gis.db.backends.postgis")
+register_db_backend("spatialite", "django.contrib.gis.db.backends.spatialite")
 
-register_cache_backend('memory', 'django.core.cache.backends.locmem.LocMemCache')
-register_cache_backend('db', 'django.core.cache.backends.db.DatabaseCache')
-register_cache_backend('dummy', 'django.core.cache.backends.dummy.DummyCache')
-register_cache_backend('memcached', 'django.core.cache.backends.memcached.MemcachedCache')
-register_cache_backend('memcached+pylibmccache', 'django.core.cache.backends.memcached.PyLibMCCache')
-register_cache_backend('file', 'django.core.cache.backends.filebased.FileBasedCache')
+register_cache_backend("memory", "django.core.cache.backends.locmem.LocMemCache")
+register_cache_backend("db", "django.core.cache.backends.db.DatabaseCache")
+register_cache_backend("dummy", "django.core.cache.backends.dummy.DummyCache")
+register_cache_backend(
+    "memcached", "django.core.cache.backends.memcached.MemcachedCache"
+)
+register_cache_backend(
+    "memcached+pylibmccache", "django.core.cache.backends.memcached.PyLibMCCache"
+)
+register_cache_backend("file", "django.core.cache.backends.filebased.FileBasedCache")

--- a/django/conf/service_url.py
+++ b/django/conf/service_url.py
@@ -91,14 +91,27 @@ def _get_config(backend_type, value):
 
 
 def configure_db(value):
+    """
+    Generate a configuration dictionary for a database based on a URL.
+    """
     return _get_config("db", value)
 
 
 def configure_cache(value):
+    """
+    Generate a configuration dictionary for a cache based on a URL.
+    """
     return _get_config("cache", value)
 
 
 def register_db_backend(scheme, path):
+    """
+    Register a custom protocol scheme for database URL connection configuration. path should
+    be the name of the custom backend.
+
+    Custom backends requiring custom URL parsing should override the backend's config_from_url
+    method.
+    """
     if not path.endswith(".base.DatabaseWrapper"):
         path += ".base.DatabaseWrapper"
 
@@ -106,6 +119,13 @@ def register_db_backend(scheme, path):
 
 
 def register_cache_backend(scheme, path):
+    """
+    Register a custom protocol scheme for cache URL connection configuration. path should be
+    the name of the custom backend.
+
+    Custom backends requiring custom URL parsing should override the backend's config_from_url
+    method.
+    """
     _register_backend("cache", scheme, path)
 
 

--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -1,9 +1,9 @@
 "Base Cache class."
 import time
 import warnings
+from urllib import parse
 
 from asgiref.sync import sync_to_async
-from urllib import parse
 
 from django.conf.service_url import parse_url
 from django.core.exceptions import ImproperlyConfigured

--- a/django/core/cache/backends/filebased.py
+++ b/django/core/cache/backends/filebased.py
@@ -12,7 +12,6 @@ from django.core.cache.backends.base import DEFAULT_TIMEOUT, BaseCache
 from django.core.files import locks
 from django.core.files.move import file_move_safe
 from django.utils.crypto import md5
-from django.utils.url_config import parse_url
 
 
 class FileBasedCache(BaseCache):

--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -3,14 +3,13 @@
 import re
 import time
 
+from django.conf.service_url import parse_url
 from django.core.cache.backends.base import (
     DEFAULT_TIMEOUT,
     BaseCache,
     InvalidCacheKey,
     memcache_key_warnings,
 )
-from django.conf.service_url import parse_url
-from django.core.cache.backends.base import DEFAULT_TIMEOUT, BaseCache
 from django.utils.functional import cached_property
 
 
@@ -184,11 +183,12 @@ class PyLibMCCache(BaseMemcachedCache):
     @classmethod
     def config_from_url(cls, engine, scheme, url):
         parsed = parse_url(url)
-        # We are dealing with a URI like memcached://unix:/abc
-        # Set the hostname to be the unix path
-        parsed["hostname"] = "{0}:/{1}".format(parsed["hostname"], parsed["path"])
-        parsed["hostname_with_port"] = parsed["hostname"]
-        parsed["path"] = None
+        if parsed["path"]:
+            # We are dealing with a URI like memcached://unix:/abc
+            # Set the hostname to be the unix path
+            parsed["hostname"] = "{0}:/{1}".format(parsed["hostname"], parsed["path"])
+            parsed["hostname_with_port"] = parsed["hostname"]
+            parsed["path"] = None
         return super().config_from_url(engine, scheme, parsed)
 
 

--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -7,6 +7,7 @@ import time
 import warnings
 from collections import deque
 from contextlib import contextmanager
+from urllib import parse
 
 from django.db.backends.utils import debug_transaction
 
@@ -16,6 +17,7 @@ except ImportError:
     from backports import zoneinfo
 
 from django.conf import settings
+from django.conf.service_url import parse_url
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DEFAULT_DB_ALIAS, DatabaseError, NotSupportedError
 from django.db.backends import utils
@@ -137,6 +139,21 @@ class BaseDatabaseWrapper:
             f"<{self.__class__.__qualname__} "
             f"vendor={self.vendor!r} alias={self.alias!r}>"
         )
+
+    @classmethod
+    def config_from_url(cls, engine, scheme, url):
+        parsed = parse_url(url)
+        result = {
+            "ENGINE": engine,
+            "NAME": parse.unquote(parsed["path"] or ""),
+            "USER": parse.unquote(parsed["username"] or ""),
+            "PASSWORD": parse.unquote(parsed["password"] or ""),
+            "HOST": parsed["hostname"],
+            "PORT": parsed["port"] or "",
+            "OPTIONS": parsed["options"],
+        }
+
+        return result
 
     def ensure_timezone(self):
         """

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -203,6 +203,16 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def get_database_version(self):
         return self.mysql_version
 
+    @classmethod
+    def config_from_url(cls, engine, scheme, url):
+        result = super().config_from_url(engine, scheme, url)
+
+        if "ssl-ca" in result["OPTIONS"]:
+            value = result["OPTIONS"].pop("ssl")
+            result["OPTIONS"]["ssl"] = {"ca": value}
+
+        return result
+
     def get_connection_params(self):
         kwargs = {
             "conv": django_conversions,

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -243,6 +243,36 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def get_database_version(self):
         return self.oracle_version
 
+    def _connect_string(self):
+        settings_dict = self.settings_dict
+        if not settings_dict["HOST"].strip():
+            settings_dict["HOST"] = "localhost"
+        if settings_dict["PORT"]:
+            dsn = Database.makedsn(
+                settings_dict["HOST"], int(settings_dict["PORT"]), settings_dict["NAME"]
+            )
+        else:
+            dsn = settings_dict["NAME"]
+        return "%s/%s@%s" % (settings_dict["USER"], settings_dict["PASSWORD"], dsn)
+
+    @classmethod
+    def config_from_url(cls, engine, scheme, url):
+        result = super().config_from_url(engine, scheme, url)
+        result["PORT"] = str(result["PORT"])
+        return result
+
+    def _connect_string(self):
+        settings_dict = self.settings_dict
+        if not settings_dict["HOST"].strip():
+            settings_dict["HOST"] = "localhost"
+        if settings_dict["PORT"]:
+            dsn = Database.makedsn(
+                settings_dict["HOST"], int(settings_dict["PORT"]), settings_dict["NAME"]
+            )
+        else:
+            dsn = settings_dict["NAME"]
+        return "%s/%s@%s" % (settings_dict["USER"], settings_dict["PASSWORD"], dsn)
+
     def get_connection_params(self):
         conn_params = self.settings_dict["OPTIONS"].copy()
         if "use_returning_into" in conn_params:

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -11,7 +11,6 @@ from contextlib import contextmanager
 from urllib import parse
 
 from django.conf import settings
-from django.conf.service_url import parse_url
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DatabaseError as WrappedDatabaseError
 from django.db import connections
@@ -20,7 +19,7 @@ from django.db.backends.utils import CursorDebugWrapper as BaseCursorDebugWrappe
 from django.utils.asyncio import async_unsafe
 from django.utils.functional import cached_property
 from django.utils.safestring import SafeString
-from django.utils.url_config import parse_url
+from django.conf.service_url import parse_url
 from django.utils.version import get_version_tuple
 
 try:

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from urllib import parse
 
 from django.conf import settings
+from django.conf.service_url import parse_url
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DatabaseError as WrappedDatabaseError
 from django.db import connections
@@ -19,7 +20,6 @@ from django.db.backends.utils import CursorDebugWrapper as BaseCursorDebugWrappe
 from django.utils.asyncio import async_unsafe
 from django.utils.functional import cached_property
 from django.utils.safestring import SafeString
-from django.conf.service_url import parse_url
 from django.utils.version import get_version_tuple
 
 try:

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -143,6 +143,17 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     introspection_class = DatabaseIntrospection
     ops_class = DatabaseOperations
 
+    @classmethod
+    def config_from_url(cls, engine, scheme, url):
+        # These special URLs cannot be parsed correctly.
+        if url in ('sqlite://:memory:', 'sqlite://'):
+            return {
+                'ENGINE': engine,
+                'NAME': ':memory:'
+            }
+
+        return super().config_from_url(engine, scheme, url)
+
     def get_connection_params(self):
         settings_dict = self.settings_dict
         if not settings_dict["NAME"]:

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -146,11 +146,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     @classmethod
     def config_from_url(cls, engine, scheme, url):
         # These special URLs cannot be parsed correctly.
-        if url in ('sqlite://:memory:', 'sqlite://'):
-            return {
-                'ENGINE': engine,
-                'NAME': ':memory:'
-            }
+        if url in ("sqlite://:memory:", "sqlite://"):
+            return {"ENGINE": engine, "NAME": ":memory:"}
 
         return super().config_from_url(engine, scheme, url)
 

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -25,6 +25,23 @@ reference manuals.
 General notes
 =============
 
+.. _database-url-support:
+
+Database URL Support
+--------------------
+
+Database connection URLs can be used to configure database backends by calling
+:func:`django.conf.service_url.configure_db`::
+
+    import os
+    from django.conf.service_url import configure_db
+
+    DATABASES = {
+       "default": configure_db(os.environ['DATABASE_URL'])
+    }
+
+more information can be found in the documentation for :func:`~django.conf.service_url.configure_db`
+
 .. _persistent-database-connections:
 
 Persistent connections

--- a/docs/ref/index.txt
+++ b/docs/ref/index.txt
@@ -24,6 +24,7 @@ API Reference
    request-response
    schema-editor
    settings
+   service-url
    signals
    templates/index
    template-response

--- a/docs/ref/service-url.txt
+++ b/docs/ref/service-url.txt
@@ -1,0 +1,77 @@
+===============
+Connection URLs
+===============
+
+The following helpers within ``django.conf.service_url`` are meant to
+simplify connection configuration to databases and caches via URLs,
+for example Heroku's usage of the ``DATABASE_URL`` environment variable
+to provide connection details for hosted databases.
+
+
+.. currentmodule:: django.conf.service_url
+
+Database URLs
+=============
+
+.. function: configure_db(value)
+
+Provide a database URL and receive a configuration dictionary meant for
+the DATABASES Django setting.
+
+For example::
+
+    import os
+    from django.conf.service_url import configure_db
+
+    DATABASES = {
+       "default": configure_db(os.environ['DATABASE_URL'], max_conn_age=)
+    }
+
+
+The backend that is used will depend on the protocol within the URL. For
+example ``postgres://localhost:5432`` will map to the ``django.db.backends.postgresl``
+backend.
+
+The database protocol mappings that come with Django are the following:
+
+- ``mysql://`` -> ``django.db.backends.mysql``
+- ``oracle://`` -> ``django.db.backends.oracle``
+- ``postgres://`` -> ``django.db.backends.postgresql``
+- ``sqlite://`` -> ``django.db.backends.sqlite3``
+- ``mysql+gis://`` -> ``django.contrib.gis.db.backends.mysql``
+- ``oracle+gis://`` -> ``django.contrib.gis.db.backends.oracle``
+- ``postgis://`` -> ``django.contrib.gis.db.backends.postgis``
+- ``spatialite://`` -> ``django.contrib.gis.db.backends.spatialite``
+
+.. function: register_db_backend(scheme, path)
+
+Register a custom protocol to an associated database backend.
+
+Cache URLs
+==========
+
+.. function: configure_cache(value)
+
+Provide a database URL and receive a configuration dictionary meant for
+the CACHES Django setting.
+
+    import os
+    from django.conf.service_url import configure_cache
+
+    CACHES = {
+       "default": configure_cache("memcached+pymemcache://localhost:11211")
+    }
+
+The backend use depends on the protocol specified in the URL. The following protocol mappings
+are defined by Django:
+
+- ``file://`` -> ``django.core.cache.backends.filebased.FileBasedCache``
+- ``memory://`` -> ``django.core.cache.backends.locmem.LocMemCache``
+- ``db://`` -> ``django.core.cache.backends.db.DatabaseCache``
+- ``dummy://`` -> ``django.core.cache.backends.dummy.DummyCache``
+- ``memcached+pymemcache://`` -> ``django.core.cache.backends.memcached.PyMemcacheCache``
+- ``memcached+pylibmccache://`` -> ``django.core.cache.backends.memcached.PyLibMCCache``
+
+.. function: register_cache_backend(scheme, path)
+
+Register a custom protocol to an associated cache backend.

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -113,6 +113,7 @@ In this example, Memcached is available through a local Unix socket file
         }
     }
 
+
 One excellent feature of Memcached is its ability to share a cache over
 multiple servers. This means you can run Memcached daemons on multiple
 machines, and the program will treat the group of machines as a *single*
@@ -443,6 +444,25 @@ as reference implementations. You'll find the code in the
 Note: Without a really compelling reason, such as a host that doesn't support
 them, you should stick to the cache backends included with Django. They've
 been well-tested and are well-documented.
+
+
+.. _connection_url_support:
+
+Connection URL Support
+----------------------
+
+Cache connection URLs can be used to configure cache backends by calling
+:func:`~django.conf.service_url.configure_cache`::
+
+    import os
+    from django.conf.service_url import configure_cache
+
+    CACHES = {
+       "default": configure_cache("memcached+pymemcache://localhost:11211")
+    }
+
+More information can be found in the documentation for :func:`django.conf.service_url.configure_cache`
+
 
 .. _cache_arguments:
 

--- a/tests/utils_tests/test_url_config.py
+++ b/tests/utils_tests/test_url_config.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+# !/usr/bin/env python
+
+import unittest
+
+from django.conf.service_url import configure_cache, configure_db, parse_url
+from django.db import connection
+
+GENERIC_TESTS = [
+    (
+        'username:password@domain/database',
+        ('username', 'password', 'domain', '', 'database', {})
+    ),
+    (
+        'username:password@domain:123/database',
+        ('username', 'password', 'domain', 123, 'database', {})
+    ),
+    (
+        'domain:123/database',
+        ('', '', 'domain', 123, 'database', {})
+    ),
+    (
+        'user@domain:123/database',
+        ('user', '', 'domain', 123, 'database', {})
+    ),
+    (
+        'username:password@[2001:db8:1234::1234:5678:90af]:123/database',
+        ('username', 'password', '2001:db8:1234::1234:5678:90af', 123, 'database', {})
+    ),
+    (
+        'username:password@host:123/database?reconnect=true',
+        ('username', 'password', 'host', 123, 'database', {'reconnect': True})
+    ),
+    (
+        'username:password@/database',
+        ('username', 'password', '', '', 'database', {})
+    ),
+]
+
+
+class BaseURLTests:
+    SCHEME = None
+    STRING_PORTS = False  # Workaround for Oracle
+
+    def test_parsing(self):
+        for value, (user, passw, host, port, database, options) in GENERIC_TESTS:
+            value = '{scheme}://{value}'.format(scheme=self.SCHEME, value=value)
+
+            with self.subTest(value=value):
+                result = configure_db(value)
+                self.assertEqual(result['NAME'], database)
+                self.assertEqual(result['HOST'], host)
+                self.assertEqual(result['USER'], user)
+                self.assertEqual(result['PASSWORD'], passw)
+                self.assertEqual(result['PORT'], port if not self.STRING_PORTS else str(port))
+                self.assertDictEqual(result['OPTIONS'], options)
+
+
+@unittest.skipUnless(connection.vendor == 'sqlite', 'Sqlite tests')
+class SqliteTests(BaseURLTests, unittest.TestCase):
+    SCHEME = 'sqlite'
+
+    def test_empty_url(self):
+        url = 'sqlite://'
+        url = configure_db(url)
+
+        self.assertEqual(url['ENGINE'], 'django.db.backends.sqlite3')
+        self.assertEqual(url['NAME'], ':memory:')
+
+    def test_memory_url(self):
+        url = 'sqlite://:memory:'
+        url = configure_db(url)
+
+        self.assertEqual(url['ENGINE'], 'django.db.backends.sqlite3')
+        self.assertEqual(url['NAME'], ':memory:')
+
+
+@unittest.skipUnless(connection.vendor == 'postgresql', 'Postgres tests')
+class PostgresTests(BaseURLTests, unittest.TestCase):
+    SCHEME = 'postgres'
+
+    def test_unix_socket_parsing(self):
+        url = 'postgres://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn'
+        url = configure_db(url)
+
+        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(url['HOST'], '/var/run/postgresql')
+        self.assertEqual(url['USER'], '')
+        self.assertEqual(url['PASSWORD'], '')
+        self.assertEqual(url['PORT'], '')
+
+        url = 'postgres://%2FUsers%2Fpostgres%2FRuN/d8r82722r2kuvn'
+        url = configure_db(url)
+
+        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(url['HOST'], '/Users/postgres/RuN')
+        self.assertEqual(url['USER'], '')
+        self.assertEqual(url['PASSWORD'], '')
+        self.assertEqual(url['PORT'], '')
+
+    def test_search_path_parsing(self):
+        url = ('postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431'
+               '/d8r82722r2kuvn?currentSchema=otherschema')
+        url = configure_db(url)
+        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
+        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(url['PASSWORD'], 'wegauwhgeuioweg')
+        self.assertEqual(url['PORT'], 5431)
+        self.assertEqual(url['OPTIONS']['options'], '-c search_path=otherschema')
+        self.assertNotIn('currentSchema', url['OPTIONS'])
+
+    def test_parsing_with_special_characters(self):
+        url = 'postgres://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database'
+        url = configure_db(url)
+
+        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(url['NAME'], '#database')
+        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
+        self.assertEqual(url['USER'], '#user')
+        self.assertEqual(url['PASSWORD'], '#password')
+        self.assertEqual(url['PORT'], 5431)
+
+    def test_database_url_with_options(self):
+        # Test full options
+        url = ('postgres://uf07k1i6d8ia0v:wegauwhgeuioweg'
+               '@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn'
+               '?sslrootcert=rds-combined-ca-bundle.pem&sslmode=verify-full')
+        url = configure_db(url)
+
+        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
+        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
+        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(url['PASSWORD'], 'wegauwhgeuioweg')
+        self.assertEqual(url['PORT'], 5431)
+        self.assertEqual(url['OPTIONS'], {
+            'sslrootcert': 'rds-combined-ca-bundle.pem',
+            'sslmode': 'verify-full'
+        })
+
+    def test_gis_search_path_parsing(self):
+        url = ('postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431'
+               '/d8r82722r2kuvn?currentSchema=otherschema')
+        url = configure_db(url)
+        self.assertEqual(url['ENGINE'], 'django.contrib.gis.db.backends.postgis')
+        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
+        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(url['PASSWORD'], 'wegauwhgeuioweg')
+        self.assertEqual(url['PORT'], 5431)
+        self.assertEqual(url['OPTIONS']['options'], '-c search_path=otherschema')
+        self.assertNotIn('currentSchema', url['OPTIONS'])
+
+
+@unittest.skipUnless(connection.vendor == 'mysql', 'Mysql tests')
+class MysqlTests(BaseURLTests, unittest.TestCase):
+    SCHEME = 'mysql'
+
+    def test_with_sslca_options(self):
+        url = 'mysql://uf07k1i6d8ia0v:wegauwhgeuioweg' \
+              '@ec2-107-21-253-135.compute-1.amazonaws.com:3306/d8r82722r2kuvn' \
+              '?ssl-ca=rds-combined-ca-bundle.pem'
+        url = configure_db(url)
+
+        self.assertEqual(url['ENGINE'], 'django.db.backends.mysql')
+        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
+        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
+        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
+        self.assertEqual(url['PASSWORD'], 'wegauwhgeuioweg')
+        self.assertEqual(url['PORT'], 3306)
+        self.assertEqual(url['OPTIONS'], {
+            'ssl': {
+                'ca': 'rds-combined-ca-bundle.pem'
+            }
+        })
+
+
+@unittest.skipUnless(connection.vendor == 'oracle', 'Oracle Tests')
+class OracleTests(BaseURLTests, unittest.TestCase):
+    SCHEME = 'oracle'
+    STRING_PORTS = True
+
+    def test_dsn_parsing(self):
+        dsn = (
+            '(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)'
+            '(HOST=oraclehost)(PORT=1521)))'
+            '(CONNECT_DATA=(SID=hr)))'
+        )
+
+        url = configure_db('oracle://scott:tiger@/' + dsn)
+
+        self.assertEqual(url['ENGINE'], 'django.db.backends.oracle')
+        self.assertEqual(url['USER'], 'scott')
+        self.assertEqual(url['PASSWORD'], 'tiger')
+        self.assertEqual(url['HOST'], '')
+        self.assertEqual(url['PORT'], '')
+
+        url = configure_db(dsn)
+
+        self.assertEqual(url['NAME'], dsn)
+
+
+class TestCaches(unittest.TestCase):
+    def test_local_caching_no_params(self):
+        result = configure_cache('memory://')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.locmem.LocMemCache')
+        self.assertNotIn('LOCATION', result)
+
+    def test_local_caching_with_location(self):
+        result = configure_cache('memory://abc')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.locmem.LocMemCache')
+        self.assertEqual(result['LOCATION'], 'abc')
+
+    def test_database_caching(self):
+        result = configure_cache('db://table-name')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.db.DatabaseCache')
+        self.assertEqual(result['LOCATION'], 'table-name')
+
+    def test_dummy_caching_no_params(self):
+        result = configure_cache('dummy://')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.dummy.DummyCache')
+        self.assertNotIn('LOCATION', result)
+
+    def test_dummy_caching_with_location(self):
+        result = configure_cache('dummy://abc')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.dummy.DummyCache')
+        self.assertEqual(result['LOCATION'], 'abc')
+
+    def test_memcached_with_ip(self):
+        result = configure_cache('memcached://1.2.3.4:1567')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.MemcachedCache')
+        self.assertEqual(result['LOCATION'], '1.2.3.4:1567')
+
+    def test_memcached_without_port(self):
+        result = configure_cache('memcached://1.2.3.4')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.MemcachedCache')
+        self.assertEqual(result['LOCATION'], '1.2.3.4')
+
+    def test_memcached_socket_path(self):
+        result = configure_cache('memcached:///tmp/memcached.sock')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.MemcachedCache')
+        self.assertEqual(result['LOCATION'], '/tmp/memcached.sock')
+
+    def test_pylibmccache_memcached_unix_socket(self):
+        result = configure_cache('memcached+pylibmccache://unix:/tmp/memcached.sock')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.PyLibMCCache')
+        self.assertEqual(result['LOCATION'], 'unix:/tmp/memcached.sock')
+
+    def test_file_cache_windows_path(self):
+        result = configure_cache('file://C:/abc/def/xyz')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.filebased.FileBasedCache')
+        self.assertEqual(result['LOCATION'], 'C:/abc/def/xyz')
+
+    def test_file_cache_unix_path(self):
+        result = configure_cache('file:///abc/def/xyz')
+        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.filebased.FileBasedCache')
+        self.assertEqual(result['LOCATION'], '/abc/def/xyz')
+
+
+class TestParseURL(unittest.TestCase):
+    def test_hostname_sensitivity(self):
+        parsed = parse_url('http://CaseSensitive')
+        self.assertEqual(parsed['hostname'], 'CaseSensitive')
+
+    def test_port_is_an_integer(self):
+        parsed = parse_url('http://CaseSensitive:123')
+        self.assertIsInstance(parsed['port'], int)
+
+    def test_path_strips_leading_slash(self):
+        parsed = parse_url('http://test/abc')
+        self.assertEqual(parsed['path'], 'abc')
+
+    def test_query_parameters_integer(self):
+        parsed = parse_url('http://test/?a=1')
+        self.assertDictEqual(parsed['options'], {'a': 1})
+
+    def test_query_parameters_boolean(self):
+        parsed = parse_url('http://test/?a=true&b=false')
+        self.assertDictEqual(parsed['options'], {'a': True, 'b': False})
+
+    def test_query_last_parameter(self):
+        parsed = parse_url('http://test/?a=one&a=two')
+        self.assertDictEqual(parsed['options'], {'a': 'two'})
+
+    def test_does_not_reparse(self):
+        parsed = parse_url('http://test/abc')
+        self.assertIs(parse_url(parsed), parsed)

--- a/tests/utils_tests/test_url_config.py
+++ b/tests/utils_tests/test_url_config.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # !/usr/bin/env python
-
 import unittest
 
 from django.conf.service_url import configure_cache, configure_db, parse_url
@@ -8,33 +7,24 @@ from django.db import connection
 
 GENERIC_TESTS = [
     (
-        'username:password@domain/database',
-        ('username', 'password', 'domain', '', 'database', {})
+        "username:password@domain/database",
+        ("username", "password", "domain", "", "database", {}),
     ),
     (
-        'username:password@domain:123/database',
-        ('username', 'password', 'domain', 123, 'database', {})
+        "username:password@domain:123/database",
+        ("username", "password", "domain", 123, "database", {}),
+    ),
+    ("domain:123/database", ("", "", "domain", 123, "database", {})),
+    ("user@domain:123/database", ("user", "", "domain", 123, "database", {})),
+    (
+        "username:password@[2001:db8:1234::1234:5678:90af]:123/database",
+        ("username", "password", "2001:db8:1234::1234:5678:90af", 123, "database", {}),
     ),
     (
-        'domain:123/database',
-        ('', '', 'domain', 123, 'database', {})
+        "username:password@host:123/database?reconnect=true",
+        ("username", "password", "host", 123, "database", {"reconnect": True}),
     ),
-    (
-        'user@domain:123/database',
-        ('user', '', 'domain', 123, 'database', {})
-    ),
-    (
-        'username:password@[2001:db8:1234::1234:5678:90af]:123/database',
-        ('username', 'password', '2001:db8:1234::1234:5678:90af', 123, 'database', {})
-    ),
-    (
-        'username:password@host:123/database?reconnect=true',
-        ('username', 'password', 'host', 123, 'database', {'reconnect': True})
-    ),
-    (
-        'username:password@/database',
-        ('username', 'password', '', '', 'database', {})
-    ),
+    ("username:password@/database", ("username", "password", "", "", "database", {})),
 ]
 
 
@@ -44,247 +34,275 @@ class BaseURLTests:
 
     def test_parsing(self):
         for value, (user, passw, host, port, database, options) in GENERIC_TESTS:
-            value = '{scheme}://{value}'.format(scheme=self.SCHEME, value=value)
+            value = "{scheme}://{value}".format(scheme=self.SCHEME, value=value)
 
             with self.subTest(value=value):
                 result = configure_db(value)
-                self.assertEqual(result['NAME'], database)
-                self.assertEqual(result['HOST'], host)
-                self.assertEqual(result['USER'], user)
-                self.assertEqual(result['PASSWORD'], passw)
-                self.assertEqual(result['PORT'], port if not self.STRING_PORTS else str(port))
-                self.assertDictEqual(result['OPTIONS'], options)
+                self.assertEqual(result["NAME"], database)
+                self.assertEqual(result["HOST"], host)
+                self.assertEqual(result["USER"], user)
+                self.assertEqual(result["PASSWORD"], passw)
+                self.assertEqual(
+                    result["PORT"], port if not self.STRING_PORTS else str(port)
+                )
+                self.assertDictEqual(result["OPTIONS"], options)
 
 
-@unittest.skipUnless(connection.vendor == 'sqlite', 'Sqlite tests')
+@unittest.skipUnless(connection.vendor == "sqlite", "Sqlite tests")
 class SqliteTests(BaseURLTests, unittest.TestCase):
-    SCHEME = 'sqlite'
+    SCHEME = "sqlite"
 
     def test_empty_url(self):
-        url = 'sqlite://'
+        url = "sqlite://"
         url = configure_db(url)
 
-        self.assertEqual(url['ENGINE'], 'django.db.backends.sqlite3')
-        self.assertEqual(url['NAME'], ':memory:')
+        self.assertEqual(url["ENGINE"], "django.db.backends.sqlite3")
+        self.assertEqual(url["NAME"], ":memory:")
 
     def test_memory_url(self):
-        url = 'sqlite://:memory:'
+        url = "sqlite://:memory:"
         url = configure_db(url)
 
-        self.assertEqual(url['ENGINE'], 'django.db.backends.sqlite3')
-        self.assertEqual(url['NAME'], ':memory:')
+        self.assertEqual(url["ENGINE"], "django.db.backends.sqlite3")
+        self.assertEqual(url["NAME"], ":memory:")
 
 
-@unittest.skipUnless(connection.vendor == 'postgresql', 'Postgres tests')
+@unittest.skipUnless(connection.vendor == "postgresql", "Postgres tests")
 class PostgresTests(BaseURLTests, unittest.TestCase):
-    SCHEME = 'postgres'
+    SCHEME = "postgres"
 
     def test_unix_socket_parsing(self):
-        url = 'postgres://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn'
+        url = "postgres://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn"
         url = configure_db(url)
 
-        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
-        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
-        self.assertEqual(url['HOST'], '/var/run/postgresql')
-        self.assertEqual(url['USER'], '')
-        self.assertEqual(url['PASSWORD'], '')
-        self.assertEqual(url['PORT'], '')
+        self.assertEqual(url["ENGINE"], "django.db.backends.postgresql")
+        self.assertEqual(url["NAME"], "d8r82722r2kuvn")
+        self.assertEqual(url["HOST"], "/var/run/postgresql")
+        self.assertEqual(url["USER"], "")
+        self.assertEqual(url["PASSWORD"], "")
+        self.assertEqual(url["PORT"], "")
 
-        url = 'postgres://%2FUsers%2Fpostgres%2FRuN/d8r82722r2kuvn'
+        url = "postgres://%2FUsers%2Fpostgres%2FRuN/d8r82722r2kuvn"
         url = configure_db(url)
 
-        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
-        self.assertEqual(url['HOST'], '/Users/postgres/RuN')
-        self.assertEqual(url['USER'], '')
-        self.assertEqual(url['PASSWORD'], '')
-        self.assertEqual(url['PORT'], '')
+        self.assertEqual(url["ENGINE"], "django.db.backends.postgresql")
+        self.assertEqual(url["HOST"], "/Users/postgres/RuN")
+        self.assertEqual(url["USER"], "")
+        self.assertEqual(url["PASSWORD"], "")
+        self.assertEqual(url["PORT"], "")
 
     def test_search_path_parsing(self):
-        url = ('postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431'
-               '/d8r82722r2kuvn?currentSchema=otherschema')
+        url = (
+            "postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431"
+            "/d8r82722r2kuvn?currentSchema=otherschema"
+        )
         url = configure_db(url)
-        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
-        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
-        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
-        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
-        self.assertEqual(url['PASSWORD'], 'wegauwhgeuioweg')
-        self.assertEqual(url['PORT'], 5431)
-        self.assertEqual(url['OPTIONS']['options'], '-c search_path=otherschema')
-        self.assertNotIn('currentSchema', url['OPTIONS'])
+        self.assertEqual(url["ENGINE"], "django.db.backends.postgresql")
+        self.assertEqual(url["NAME"], "d8r82722r2kuvn")
+        self.assertEqual(url["HOST"], "ec2-107-21-253-135.compute-1.amazonaws.com")
+        self.assertEqual(url["USER"], "uf07k1i6d8ia0v")
+        self.assertEqual(url["PASSWORD"], "wegauwhgeuioweg")
+        self.assertEqual(url["PORT"], 5431)
+        self.assertEqual(url["OPTIONS"]["options"], "-c search_path=otherschema")
+        self.assertNotIn("currentSchema", url["OPTIONS"])
 
     def test_parsing_with_special_characters(self):
-        url = 'postgres://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database'
+        url = "postgres://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database"
         url = configure_db(url)
 
-        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
-        self.assertEqual(url['NAME'], '#database')
-        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
-        self.assertEqual(url['USER'], '#user')
-        self.assertEqual(url['PASSWORD'], '#password')
-        self.assertEqual(url['PORT'], 5431)
+        self.assertEqual(url["ENGINE"], "django.db.backends.postgresql")
+        self.assertEqual(url["NAME"], "#database")
+        self.assertEqual(url["HOST"], "ec2-107-21-253-135.compute-1.amazonaws.com")
+        self.assertEqual(url["USER"], "#user")
+        self.assertEqual(url["PASSWORD"], "#password")
+        self.assertEqual(url["PORT"], 5431)
 
     def test_database_url_with_options(self):
         # Test full options
-        url = ('postgres://uf07k1i6d8ia0v:wegauwhgeuioweg'
-               '@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn'
-               '?sslrootcert=rds-combined-ca-bundle.pem&sslmode=verify-full')
+        url = (
+            "postgres://uf07k1i6d8ia0v:wegauwhgeuioweg"
+            "@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
+            "?sslrootcert=rds-combined-ca-bundle.pem&sslmode=verify-full"
+        )
         url = configure_db(url)
 
-        self.assertEqual(url['ENGINE'], 'django.db.backends.postgresql')
-        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
-        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
-        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
-        self.assertEqual(url['PASSWORD'], 'wegauwhgeuioweg')
-        self.assertEqual(url['PORT'], 5431)
-        self.assertEqual(url['OPTIONS'], {
-            'sslrootcert': 'rds-combined-ca-bundle.pem',
-            'sslmode': 'verify-full'
-        })
+        self.assertEqual(url["ENGINE"], "django.db.backends.postgresql")
+        self.assertEqual(url["NAME"], "d8r82722r2kuvn")
+        self.assertEqual(url["HOST"], "ec2-107-21-253-135.compute-1.amazonaws.com")
+        self.assertEqual(url["USER"], "uf07k1i6d8ia0v")
+        self.assertEqual(url["PASSWORD"], "wegauwhgeuioweg")
+        self.assertEqual(url["PORT"], 5431)
+        self.assertEqual(
+            url["OPTIONS"],
+            {"sslrootcert": "rds-combined-ca-bundle.pem", "sslmode": "verify-full"},
+        )
 
     def test_gis_search_path_parsing(self):
-        url = ('postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431'
-               '/d8r82722r2kuvn?currentSchema=otherschema')
+        url = (
+            "postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431"
+            "/d8r82722r2kuvn?currentSchema=otherschema"
+        )
         url = configure_db(url)
-        self.assertEqual(url['ENGINE'], 'django.contrib.gis.db.backends.postgis')
-        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
-        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
-        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
-        self.assertEqual(url['PASSWORD'], 'wegauwhgeuioweg')
-        self.assertEqual(url['PORT'], 5431)
-        self.assertEqual(url['OPTIONS']['options'], '-c search_path=otherschema')
-        self.assertNotIn('currentSchema', url['OPTIONS'])
+        self.assertEqual(url["ENGINE"], "django.contrib.gis.db.backends.postgis")
+        self.assertEqual(url["NAME"], "d8r82722r2kuvn")
+        self.assertEqual(url["HOST"], "ec2-107-21-253-135.compute-1.amazonaws.com")
+        self.assertEqual(url["USER"], "uf07k1i6d8ia0v")
+        self.assertEqual(url["PASSWORD"], "wegauwhgeuioweg")
+        self.assertEqual(url["PORT"], 5431)
+        self.assertEqual(url["OPTIONS"]["options"], "-c search_path=otherschema")
+        self.assertNotIn("currentSchema", url["OPTIONS"])
 
 
-@unittest.skipUnless(connection.vendor == 'mysql', 'Mysql tests')
+@unittest.skipUnless(connection.vendor == "mysql", "Mysql tests")
 class MysqlTests(BaseURLTests, unittest.TestCase):
-    SCHEME = 'mysql'
+    SCHEME = "mysql"
 
     def test_with_sslca_options(self):
-        url = 'mysql://uf07k1i6d8ia0v:wegauwhgeuioweg' \
-              '@ec2-107-21-253-135.compute-1.amazonaws.com:3306/d8r82722r2kuvn' \
-              '?ssl-ca=rds-combined-ca-bundle.pem'
+        url = (
+            "mysql://uf07k1i6d8ia0v:wegauwhgeuioweg"
+            "@ec2-107-21-253-135.compute-1.amazonaws.com:3306/d8r82722r2kuvn"
+            "?ssl-ca=rds-combined-ca-bundle.pem"
+        )
         url = configure_db(url)
 
-        self.assertEqual(url['ENGINE'], 'django.db.backends.mysql')
-        self.assertEqual(url['NAME'], 'd8r82722r2kuvn')
-        self.assertEqual(url['HOST'], 'ec2-107-21-253-135.compute-1.amazonaws.com')
-        self.assertEqual(url['USER'], 'uf07k1i6d8ia0v')
-        self.assertEqual(url['PASSWORD'], 'wegauwhgeuioweg')
-        self.assertEqual(url['PORT'], 3306)
-        self.assertEqual(url['OPTIONS'], {
-            'ssl': {
-                'ca': 'rds-combined-ca-bundle.pem'
-            }
-        })
+        self.assertEqual(url["ENGINE"], "django.db.backends.mysql")
+        self.assertEqual(url["NAME"], "d8r82722r2kuvn")
+        self.assertEqual(url["HOST"], "ec2-107-21-253-135.compute-1.amazonaws.com")
+        self.assertEqual(url["USER"], "uf07k1i6d8ia0v")
+        self.assertEqual(url["PASSWORD"], "wegauwhgeuioweg")
+        self.assertEqual(url["PORT"], 3306)
+        self.assertEqual(url["OPTIONS"], {"ssl": {"ca": "rds-combined-ca-bundle.pem"}})
 
 
-@unittest.skipUnless(connection.vendor == 'oracle', 'Oracle Tests')
+@unittest.skipUnless(connection.vendor == "oracle", "Oracle Tests")
 class OracleTests(BaseURLTests, unittest.TestCase):
-    SCHEME = 'oracle'
+    SCHEME = "oracle"
     STRING_PORTS = True
 
     def test_dsn_parsing(self):
         dsn = (
-            '(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)'
-            '(HOST=oraclehost)(PORT=1521)))'
-            '(CONNECT_DATA=(SID=hr)))'
+            "(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)"
+            "(HOST=oraclehost)(PORT=1521)))"
+            "(CONNECT_DATA=(SID=hr)))"
         )
 
-        url = configure_db('oracle://scott:tiger@/' + dsn)
+        url = configure_db("oracle://scott:tiger@/" + dsn)
 
-        self.assertEqual(url['ENGINE'], 'django.db.backends.oracle')
-        self.assertEqual(url['USER'], 'scott')
-        self.assertEqual(url['PASSWORD'], 'tiger')
-        self.assertEqual(url['HOST'], '')
-        self.assertEqual(url['PORT'], '')
+        self.assertEqual(url["ENGINE"], "django.db.backends.oracle")
+        self.assertEqual(url["USER"], "scott")
+        self.assertEqual(url["PASSWORD"], "tiger")
+        self.assertEqual(url["HOST"], "")
+        self.assertEqual(url["PORT"], "")
 
         url = configure_db(dsn)
 
-        self.assertEqual(url['NAME'], dsn)
+        self.assertEqual(url["NAME"], dsn)
 
 
 class TestCaches(unittest.TestCase):
     def test_local_caching_no_params(self):
-        result = configure_cache('memory://')
-        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.locmem.LocMemCache')
-        self.assertNotIn('LOCATION', result)
+        result = configure_cache("memory://")
+        self.assertEqual(
+            result["BACKEND"], "django.core.cache.backends.locmem.LocMemCache"
+        )
+        self.assertNotIn("LOCATION", result)
 
     def test_local_caching_with_location(self):
-        result = configure_cache('memory://abc')
-        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.locmem.LocMemCache')
-        self.assertEqual(result['LOCATION'], 'abc')
+        result = configure_cache("memory://abc")
+        self.assertEqual(
+            result["BACKEND"], "django.core.cache.backends.locmem.LocMemCache"
+        )
+        self.assertEqual(result["LOCATION"], "abc")
 
     def test_database_caching(self):
-        result = configure_cache('db://table-name')
-        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.db.DatabaseCache')
-        self.assertEqual(result['LOCATION'], 'table-name')
+        result = configure_cache("db://table-name")
+        self.assertEqual(
+            result["BACKEND"], "django.core.cache.backends.db.DatabaseCache"
+        )
+        self.assertEqual(result["LOCATION"], "table-name")
 
     def test_dummy_caching_no_params(self):
-        result = configure_cache('dummy://')
-        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.dummy.DummyCache')
-        self.assertNotIn('LOCATION', result)
+        result = configure_cache("dummy://")
+        self.assertEqual(
+            result["BACKEND"], "django.core.cache.backends.dummy.DummyCache"
+        )
+        self.assertNotIn("LOCATION", result)
 
     def test_dummy_caching_with_location(self):
-        result = configure_cache('dummy://abc')
-        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.dummy.DummyCache')
-        self.assertEqual(result['LOCATION'], 'abc')
+        result = configure_cache("dummy://abc")
+        self.assertEqual(
+            result["BACKEND"], "django.core.cache.backends.dummy.DummyCache"
+        )
+        self.assertEqual(result["LOCATION"], "abc")
 
     def test_memcached_with_ip(self):
-        result = configure_cache('memcached://1.2.3.4:1567')
-        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.MemcachedCache')
-        self.assertEqual(result['LOCATION'], '1.2.3.4:1567')
+        result = configure_cache("memcached://1.2.3.4:1567")
+        self.assertEqual(
+            result["BACKEND"], "django.core.cache.backends.memcached.MemcachedCache"
+        )
+        self.assertEqual(result["LOCATION"], "1.2.3.4:1567")
 
     def test_memcached_without_port(self):
-        result = configure_cache('memcached://1.2.3.4')
-        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.MemcachedCache')
-        self.assertEqual(result['LOCATION'], '1.2.3.4')
+        result = configure_cache("memcached://1.2.3.4")
+        self.assertEqual(
+            result["BACKEND"], "django.core.cache.backends.memcached.MemcachedCache"
+        )
+        self.assertEqual(result["LOCATION"], "1.2.3.4")
 
     def test_memcached_socket_path(self):
-        result = configure_cache('memcached:///tmp/memcached.sock')
-        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.MemcachedCache')
-        self.assertEqual(result['LOCATION'], '/tmp/memcached.sock')
+        result = configure_cache("memcached:///tmp/memcached.sock")
+        self.assertEqual(
+            result["BACKEND"], "django.core.cache.backends.memcached.MemcachedCache"
+        )
+        self.assertEqual(result["LOCATION"], "/tmp/memcached.sock")
 
     def test_pylibmccache_memcached_unix_socket(self):
-        result = configure_cache('memcached+pylibmccache://unix:/tmp/memcached.sock')
-        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.memcached.PyLibMCCache')
-        self.assertEqual(result['LOCATION'], 'unix:/tmp/memcached.sock')
+        result = configure_cache("memcached+pylibmccache://unix:/tmp/memcached.sock")
+        self.assertEqual(
+            result["BACKEND"], "django.core.cache.backends.memcached.PyLibMCCache"
+        )
+        self.assertEqual(result["LOCATION"], "unix:/tmp/memcached.sock")
 
     def test_file_cache_windows_path(self):
-        result = configure_cache('file://C:/abc/def/xyz')
-        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.filebased.FileBasedCache')
-        self.assertEqual(result['LOCATION'], 'C:/abc/def/xyz')
+        result = configure_cache("file://C:/abc/def/xyz")
+        self.assertEqual(
+            result["BACKEND"], "django.core.cache.backends.filebased.FileBasedCache"
+        )
+        self.assertEqual(result["LOCATION"], "C:/abc/def/xyz")
 
     def test_file_cache_unix_path(self):
-        result = configure_cache('file:///abc/def/xyz')
-        self.assertEqual(result['BACKEND'], 'django.core.cache.backends.filebased.FileBasedCache')
-        self.assertEqual(result['LOCATION'], '/abc/def/xyz')
+        result = configure_cache("file:///abc/def/xyz")
+        self.assertEqual(
+            result["BACKEND"], "django.core.cache.backends.filebased.FileBasedCache"
+        )
+        self.assertEqual(result["LOCATION"], "/abc/def/xyz")
 
 
 class TestParseURL(unittest.TestCase):
     def test_hostname_sensitivity(self):
-        parsed = parse_url('http://CaseSensitive')
-        self.assertEqual(parsed['hostname'], 'CaseSensitive')
+        parsed = parse_url("http://CaseSensitive")
+        self.assertEqual(parsed["hostname"], "CaseSensitive")
 
     def test_port_is_an_integer(self):
-        parsed = parse_url('http://CaseSensitive:123')
-        self.assertIsInstance(parsed['port'], int)
+        parsed = parse_url("http://CaseSensitive:123")
+        self.assertIsInstance(parsed["port"], int)
 
     def test_path_strips_leading_slash(self):
-        parsed = parse_url('http://test/abc')
-        self.assertEqual(parsed['path'], 'abc')
+        parsed = parse_url("http://test/abc")
+        self.assertEqual(parsed["path"], "abc")
 
     def test_query_parameters_integer(self):
-        parsed = parse_url('http://test/?a=1')
-        self.assertDictEqual(parsed['options'], {'a': 1})
+        parsed = parse_url("http://test/?a=1")
+        self.assertDictEqual(parsed["options"], {"a": 1})
 
     def test_query_parameters_boolean(self):
-        parsed = parse_url('http://test/?a=true&b=false')
-        self.assertDictEqual(parsed['options'], {'a': True, 'b': False})
+        parsed = parse_url("http://test/?a=true&b=false")
+        self.assertDictEqual(parsed["options"], {"a": True, "b": False})
 
     def test_query_last_parameter(self):
-        parsed = parse_url('http://test/?a=one&a=two')
-        self.assertDictEqual(parsed['options'], {'a': 'two'})
+        parsed = parse_url("http://test/?a=one&a=two")
+        self.assertDictEqual(parsed["options"], {"a": "two"})
 
     def test_does_not_reparse(self):
-        parsed = parse_url('http://test/abc')
+        parsed = parse_url("http://test/abc")
         self.assertIs(parse_url(parsed), parsed)

--- a/tests/utils_tests/test_url_config.py
+++ b/tests/utils_tests/test_url_config.py
@@ -236,23 +236,23 @@ class TestCaches(unittest.TestCase):
         self.assertEqual(result["LOCATION"], "abc")
 
     def test_memcached_with_ip(self):
-        result = configure_cache("memcached://1.2.3.4:1567")
+        result = configure_cache("memcached+pymemcache://1.2.3.4:1567")
         self.assertEqual(
-            result["BACKEND"], "django.core.cache.backends.memcached.MemcachedCache"
+            result["BACKEND"], "django.core.cache.backends.memcached.PyMemcacheCache"
         )
         self.assertEqual(result["LOCATION"], "1.2.3.4:1567")
 
     def test_memcached_without_port(self):
-        result = configure_cache("memcached://1.2.3.4")
+        result = configure_cache("memcached+pylibmccache://1.2.3.4")
         self.assertEqual(
-            result["BACKEND"], "django.core.cache.backends.memcached.MemcachedCache"
+            result["BACKEND"], "django.core.cache.backends.memcached.PyLibMCCache"
         )
         self.assertEqual(result["LOCATION"], "1.2.3.4")
 
     def test_memcached_socket_path(self):
-        result = configure_cache("memcached:///tmp/memcached.sock")
+        result = configure_cache("memcached+pymemcache:///tmp/memcached.sock")
         self.assertEqual(
-            result["BACKEND"], "django.core.cache.backends.memcached.MemcachedCache"
+            result["BACKEND"], "django.core.cache.backends.memcached.PyMemcacheCache"
         )
         self.assertEqual(result["LOCATION"], "/tmp/memcached.sock")
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/28236

(EDIT: started discussion in [the mailing list](https://groups.google.com/g/django-developers/c/qDgdOj0KTqE))

This is a revival of https://github.com/django/django/pull/8562, and I've gone in and rebased, along with adding some documentation. Having some Restructured Text issues regarding function definitions, so I'm clearly doing something wrong with the documentation, I would appreciate pointers on there.

The core thing here is I tried to get this to a state to where we can ship `configure_db` as a helper to ingest Database URLs. I think this is very important for us to integrate given how ubiquitous database URLs have become. the cache-related URLs are a bit more confusing for me, though.

While I think it makes sense for people to use this as a default, given this is a new thing, I think it's not a good idea to say "OK, now the default template uses this" just yet. There are likely hard edges to this that need to be improved with contact with usecases beyond Heroku/fly.io/whatever. 

EDIT: Just to clarify what this looks like, an initial document snippet:

```
Database URL Support
--------------------

Database connection URLs can be used to configure database backends by calling
:func:`django.conf.service_url.configure_db`::

    import os
    from django.conf.service_url import configure_db

    DATABASES = {
       "default": configure_db(os.environ['DATABASE_URL'])
    }
```
