### PR TITLE
Fixed #34187 -- Made UserCreationForm save many-to-many fields.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -141,6 +141,8 @@ class UserCreationForm(forms.ModelForm):
         user.set_password(self.cleaned_data["password1"])
         if commit:
             user.save()
+            if hasattr(self, "save_m2m"):
+                self.save_m2m()
         return user
 
 

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -65,6 +65,9 @@ Minor features
 * The default iteration count for the PBKDF2 password hasher is increased from
   390,000 to 480,000.
 
+* :class:`~django.contrib.auth.forms.UserCreationForm` now saves many-to-many
+  form fields for a custom user model.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -840,6 +840,11 @@ extend these forms in this manner::
             model = CustomUser
             fields = UserCreationForm.Meta.fields + ('custom_field',)
 
+.. versionchanged:: 4.2
+
+    In older versions, :class:`~django.contrib.auth.forms.UserCreationForm`
+    didn't save many-to-many form fields for a custom user model.
+
 Custom users and :mod:`django.contrib.admin`
 --------------------------------------------
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1665,6 +1665,11 @@ provides several built-in forms located in :mod:`django.contrib.auth.forms`:
     sets the user's password using
     :meth:`~django.contrib.auth.models.User.set_password()`.
 
+    .. versionchanged:: 4.2
+
+        In older versions, :class:`UserCreationForm` didn't save many-to-many
+        form fields for a custom user model.
+
 .. currentmodule:: django.contrib.auth
 
 Authentication data in templates


### PR DESCRIPTION
Previously UserCreationForm.save(commit=True) did not save many-to-many form fields. This is now fixed.