### PR TITLE
Fixed #34310 -- Added deletion example to one-to-one topic.

### DIFF
--- a/docs/topics/db/examples/one_to_one.txt
+++ b/docs/topics/db/examples/one_to_one.txt
@@ -137,6 +137,16 @@ This also works in reverse::
     >>> Place.objects.get(restaurant__place__name__startswith="Demon")
     <Place: Demon Dogs the place>
 
+If you delete a place, its restaurant will be deleted (assuming that the
+``OneToOneField`` was defined with
+:attr:`~django.db.models.ForeignKey.on_delete` set to ``CASCADE``, which is the
+default)::
+
+    >>> p2.delete()
+    (2, {'one_to_one.Restaurant': 1, 'one_to_one.Place': 1})
+    >>> Restaurant.objects.all()
+    <QuerySet [<Restaurant: Demon Dogs the restaurant>]>
+
 Add a Waiter to the Restaurant::
 
     >>> w = r.waiter_set.create(name='Joe')


### PR DESCRIPTION
Hello!

I had a bug at my job related with a wrong OneToOne model definition but when I "googled" it to fix it, I realized there was no example in the Django documentation:

At https://docs.djangoproject.com/en/4.1/topics/db/examples/ -> [One-to-one relationships](https://docs.djangoproject.com/en/4.1/topics/db/examples/one_to_one/) is the only one which don't have any example, so I would like to add one!

I appreciate any feedback!

Thank you