### PR TITLE
Refs #31169 -- Skipped test_get_test_db_clone_settings_not_supported on not in-memory SQLite database.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -124,6 +124,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                         "servers.tests.LiveServerInMemoryDatabaseLockTest."
                         "test_in_memory_database_lock",
                     },
+                    "multiprocessing's start method is checked only for in-memory "
+                    "SQLite databases": {
+                        "backends.sqlite.test_creation.TestDbSignatureTests."
+                        "test_get_test_db_clone_settings_not_supported",
+                    },
                 }
             )
         return skips


### PR DESCRIPTION
`multiprocessing`'s start method is checked only for in-memory SQLite databases:

https://github.com/django/django/blob/662497cece5480b39d1d0c7f68c7b0ca395be923/django/db/backends/sqlite3/creation.py#L58-L62

```
======================================================================
FAIL: test_get_test_db_clone_settings_not_supported (backends.sqlite.test_creation.TestDbSignatureTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  ...
  File "/django/tests/backends/sqlite/test_creation.py", line 43, in test_get_test_db_clone_settings_not_supported
    connection.creation.get_test_db_clone_settings(1)
  File "/usr/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/home/felixx/repo/django/django/test/testcases.py", line 889, in _assert_raises_or_warns_cm
    yield cm
  File "/usr/lib/python3.8/unittest/case.py", line 227, in __exit__
    self._raiseFailure("{} not raised".format(exc_name))
  File "/usr/lib/python3.8/unittest/case.py", line 164, in _raiseFailure
    raise self.test_case.failureException(msg)
AssertionError: NotSupportedError not raised
```