### PR TITLE
Refs #34119 -- Skipped test_callable_default_hidden_widget_value_not_overridden when JSONField is not supported.

### DIFF
--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -4,7 +4,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import models
 from django.forms import CharField, FileField, Form, ModelForm
 from django.forms.models import ModelFormMetaclass
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
 
 from ..models import (
     BoundaryModel,
@@ -203,6 +203,7 @@ class ModelFormCallableModelDefault(TestCase):
             """,
         )
 
+    @skipUnlessDBFeature("supports_json_field")
     def test_callable_default_hidden_widget_value_not_overridden(self):
         class FieldWithCallableDefaultsModel(models.Model):
             int_field = models.IntegerField(default=lambda: 1)


### PR DESCRIPTION
Added in 25904db9154c5be3ecda9585d96f536841af9126.

See [logs on Python 3.8](https://github.com/django/django/actions/runs/3519988582/jobs/5900481758#step:1:7).