### PR TITLE
Refs #10929 -- Fixed aggregates crash when passing strings as defaults.

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -2,7 +2,7 @@
 Classes to represent the definitions of aggregate functions.
 """
 from django.core.exceptions import FieldError, FullResultSet
-from django.db.models.expressions import Case, Func, Star, When
+from django.db.models.expressions import Case, Func, Star, Value, When
 from django.db.models.fields import IntegerField
 from django.db.models.functions.comparison import Coalesce
 from django.db.models.functions.mixins import (
@@ -85,6 +85,8 @@ class Aggregate(Func):
             return c
         if hasattr(default, "resolve_expression"):
             default = default.resolve_expression(query, allow_joins, reuse, summarize)
+        else:
+            default = Value(default, c._output_field_or_none)
         c.default = None  # Reset the default argument before wrapping.
         coalesce = Coalesce(c, default, output_field=c._output_field_or_none)
         coalesce.is_summary = c.is_summary

--- a/tests/postgres_tests/test_aggregates.py
+++ b/tests/postgres_tests/test_aggregates.py
@@ -125,6 +125,7 @@ class TestGeneralAggregate(PostgreSQLTestCase):
             (BoolAnd("boolean_field", default=False), False),
             (BoolOr("boolean_field", default=False), False),
             (JSONBAgg("integer_field", default=Value('["<empty>"]')), ["<empty>"]),
+            (StringAgg("char_field", delimiter=";", default="<empty>"), "<empty>"),
             (
                 StringAgg("char_field", delimiter=";", default=Value("<empty>")),
                 "<empty>",


### PR DESCRIPTION
Previously strings were interpreted as `F()` expressions and `default` crashed with `AttributeError`:
```
AttributeError: 'F' object has no attribute 'empty_result_set_value'
```