### PR TITLE
Refs #21442 -- Added content-type aware request.data property.

### DIFF
--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -108,20 +108,22 @@ class ASGIRequest(HttpRequest):
     def _get_scheme(self):
         return self.scope.get("scheme") or super()._get_scheme()
 
-    def _get_post(self):
+    @property
+    def data(self):
+        # TODO: rename _post and load method.
         if not hasattr(self, "_post"):
             self._load_post_and_files()
         return self._post
 
-    def _set_post(self, post):
-        self._post = post
+    @data.setter
+    def data(self, value):
+        self._post = value
 
     def _get_files(self):
         if not hasattr(self, "_files"):
             self._load_post_and_files()
         return self._files
 
-    POST = property(_get_post, _set_post)
     FILES = property(_get_files)
 
     @cached_property

--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -108,13 +108,16 @@ class WSGIRequest(HttpRequest):
         raw_query_string = get_bytes_from_wsgi(self.environ, "QUERY_STRING", "")
         return QueryDict(raw_query_string, encoding=self._encoding)
 
-    def _get_post(self):
+    @property
+    def data(self):
+        # TODO: rename _post and load method.
         if not hasattr(self, "_post"):
             self._load_post_and_files()
         return self._post
 
-    def _set_post(self, post):
-        self._post = post
+    @data.setter
+    def data(self, value):
+        self._post = value
 
     @cached_property
     def COOKIES(self):
@@ -126,8 +129,6 @@ class WSGIRequest(HttpRequest):
         if not hasattr(self, "_files"):
             self._load_post_and_files()
         return self._files
-
-    POST = property(_get_post, _set_post)
 
 
 class WSGIHandler(base.BaseHandler):

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -59,7 +59,7 @@ class HttpRequest:
         # `WSGIRequest.__init__()`.
 
         self.GET = QueryDict(mutable=True)
-        self.POST = QueryDict(mutable=True)
+        self.data = QueryDict(mutable=True)
         self.COOKIES = {}
         self.META = {}
         self.FILES = MultiValueDict()
@@ -366,12 +366,6 @@ class HttpRequest:
 
     def _load_post_and_files(self):
         """Populate self._post and self._files if the content-type is a form type"""
-        if self.method != "POST":
-            self._post, self._files = (
-                QueryDict(encoding=self._encoding),
-                MultiValueDict(),
-            )
-            return
         if self._read_started and not hasattr(self, "_body"):
             self._mark_post_parse_error()
             return
@@ -434,6 +428,18 @@ class HttpRequest:
 
     def readlines(self):
         return list(self)
+
+    def _get_post(self):
+        # Not quite equivalent as files could still be accessed.
+        # But NOT a covered behaviour.
+        if self.method != "POST":
+            return QueryDict(encoding=self._encoding)
+        return self.data
+
+    def _set_post(self, post):
+        self.data = post
+
+    POST = property(_get_post, _set_post)
 
 
 class HttpHeaders(CaseInsensitiveMapping):

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -197,6 +197,7 @@ class TestingHttpRequest(HttpRequest):
         return getattr(self, "_is_secure_override", False)
 
 
+# TODO: review tests using this to use .data.
 class PostErrorRequest(TestingHttpRequest):
     """
     TestingHttpRequest that can raise errors when accessing POST data.
@@ -207,10 +208,10 @@ class PostErrorRequest(TestingHttpRequest):
     def _get_post(self):
         if self.post_error is not None:
             raise self.post_error
-        return self._post
+        return self.data
 
     def _set_post(self, post):
-        self._post = post
+        self.data = post
 
     POST = property(_get_post, _set_post)
 


### PR DESCRIPTION
Hey @adamchainz — I broke ground on the `request.data` PR for ticket-21442. 

- [x] Currently just adds the `request.data` property, aliases `request.POST` back to that, and adds a couple of new tests for the behaviour. 

Next up for me: 

- [ ] Add tests for `application/json` handling, and make that work. 
- [ ] Do the same for the multipart parser. 

Then there's a big tidy-up and rename, and I need to get some thoughts on the changes you suggested for the body parsing errors. As I've blocked it out (thus far, which isn't far) any change would propagate back to POST, but there's a space there for a try/except. 

I'm opening early to see if I could get your view, and if you wanted to input on the other request attributes from your #13764? 
I think, and I think @apollo13 thinks, that we need to do it in one batch — it would be weird to introduce `request.data` in one release but not `request.query_params` &co in the same one. (To be clear: If you wanted to input, that would be very welcome! 🎁)

Just from a committing POV, as I start to eyeball it though, there's no obvious natural boundaries between changes: everything starts to leak into a big do-it-all at once. I thinking by discussing it with you, we can perhaps find some boundaries between changes that make sense. (Once it's laid down, it'll likely be clearer.) 

No urgency here: I'm planning on chipping away at it over the next couple of weeks, and the feature freeze is not until Jan 16th. (Worse case is it goes into 5.0. 😜) 

Thanks 🦄
