### PR TITLE
Fixed #34846 -- Added copy button to code snippets in docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,8 +42,9 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
+    "sphinx_copybutton",
 ]
-
+copybutton_prompt_text = "$ "
 # AutosectionLabel settings.
 # Uses a <page>:<label> schema which doesn't work for duplicate sub-section
 # labels, so set max depth.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 pyenchant
 Sphinx>=4.5.0
 sphinxcontrib-spelling
+sphinx-copybutton


### PR DESCRIPTION
Before : 

<img width="668" alt="Screenshot 2022-11-26 at 10 56 32 AM" src="https://user-images.githubusercontent.com/111889155/204821320-f55e618e-0271-4649-89b8-3519bf7eefb2.png">

After : 

<img width="663" alt="Screenshot 2022-11-26 at 10 56 24 AM" src="https://user-images.githubusercontent.com/111889155/204821341-674ceb59-4db5-4d1a-bc68-6dc19cb47b2c.png">

Copies the whole command using the Sphinx copy button leaving the "$" sign which makes it's lot easier to copy the commands