### PR TITLE
Refs #33308 -- Avoided passing None to RawSQL's params.

### DIFF
--- a/tests/queries/test_query.py
+++ b/tests/queries/test_query.py
@@ -164,12 +164,12 @@ class TestQuery(SimpleTestCase):
 class TestQueryNoModel(TestCase):
     def test_rawsql_annotation(self):
         query = Query(None)
-        sql = "%s IS NULL"
+        sql = "%s = 1"
         # Wrap with a CASE WHEN expression if a database backend (e.g. Oracle)
         # doesn't support boolean expression in SELECT list.
         if not connection.features.supports_boolean_expr_in_select_clause:
             sql = f"CASE WHEN {sql} THEN 1 ELSE 0 END"
-        query.add_annotation(RawSQL(sql, (None,), BooleanField()), "_check")
+        query.add_annotation(RawSQL(sql, (1,), BooleanField()), "_check")
         result = query.get_compiler(using=DEFAULT_DB_ALIAS).execute_sql(SINGLE)
         self.assertEqual(result[0], 1)
 
@@ -183,8 +183,7 @@ class TestQueryNoModel(TestCase):
     def test_q_annotation(self):
         query = Query(None)
         check = ExpressionWrapper(
-            Q(RawSQL("%s IS NULL", (None,), BooleanField()))
-            | Q(Exists(Item.objects.all())),
+            Q(RawSQL("%s = 1", (1,), BooleanField())) | Q(Exists(Item.objects.all())),
             BooleanField(),
         )
         query.add_annotation(check, "_check")


### PR DESCRIPTION
Passing `None` to `params` causes errors in determining the data type on `psycopg3`.