### PR TITLE
Fixed #29084 -- Skipped some postgres_tests.test_search tests when pg_catalog isn't English.

### DIFF
--- a/tests/postgres_tests/__init__.py
+++ b/tests/postgres_tests/__init__.py
@@ -4,6 +4,7 @@ from forms_tests.widget_tests.base import WidgetTest
 
 from django.db import connection
 from django.test import SimpleTestCase, TestCase, modify_settings
+from django.utils.functional import cached_property
 
 
 @unittest.skipUnless(connection.vendor == "postgresql", "PostgreSQL specific tests")
@@ -17,7 +18,16 @@ class PostgreSQLSimpleTestCase(SimpleTestCase):
 # To register type handlers and locate the widget's template.
 @modify_settings(INSTALLED_APPS={"append": "django.contrib.postgres"})
 class PostgreSQLTestCase(TestCase):
-    pass
+    @cached_property
+    def default_text_search_config(self):
+        with connection.cursor() as cursor:
+            cursor.execute("SHOW default_text_search_config")
+            row = cursor.fetchone()
+            return row[0] if row else None
+
+    def check_default_text_search_config(self):
+        if self.default_text_search_config != "pg_catalog.english":
+            self.skipTest("The default text search config is not 'english'.")
 
 
 @unittest.skipUnless(connection.vendor == "postgresql", "PostgreSQL specific tests")

--- a/tests/postgres_tests/test_search.py
+++ b/tests/postgres_tests/test_search.py
@@ -108,10 +108,12 @@ class SimpleSearchTest(GrailTestData, PostgreSQLTestCase):
         self.assertSequenceEqual(searched, [self.verse1])
 
     def test_non_exact_match(self):
+        self.check_default_text_search_config()
         searched = Line.objects.filter(dialogue__search="hearts")
         self.assertSequenceEqual(searched, [self.verse2])
 
     def test_search_two_terms(self):
+        self.check_default_text_search_config()
         searched = Line.objects.filter(dialogue__search="heart bowel")
         self.assertSequenceEqual(searched, [self.verse2])
 
@@ -366,6 +368,7 @@ class TestCombinations(GrailTestData, PostgreSQLTestCase):
             Line.objects.filter(dialogue__search=None + SearchVector("character__name"))
 
     def test_combine_different_vector_configs(self):
+        self.check_default_text_search_config()
         searched = Line.objects.annotate(
             search=(
                 SearchVector("dialogue", config="english")
@@ -438,6 +441,7 @@ class TestCombinations(GrailTestData, PostgreSQLTestCase):
         self.assertSequenceEqual(searched, [self.verse2])
 
     def test_combine_raw_phrase(self):
+        self.check_default_text_search_config()
         searched = Line.objects.filter(
             dialogue__search=(
                 SearchQuery("burn:*", search_type="raw", config="simple")
@@ -658,6 +662,7 @@ class SearchQueryTests(PostgreSQLSimpleTestCase):
 
 class SearchHeadlineTests(GrailTestData, PostgreSQLTestCase):
     def test_headline(self):
+        self.check_default_text_search_config()
         searched = Line.objects.annotate(
             headline=SearchHeadline(
                 F("dialogue"),
@@ -673,6 +678,7 @@ class SearchHeadlineTests(GrailTestData, PostgreSQLTestCase):
         )
 
     def test_headline_untyped_args(self):
+        self.check_default_text_search_config()
         searched = Line.objects.annotate(
             headline=SearchHeadline("dialogue", "killed", config="english"),
         ).get(pk=self.verse0.pk)
@@ -725,6 +731,7 @@ class SearchHeadlineTests(GrailTestData, PostgreSQLTestCase):
         )
 
     def test_headline_highlight_all_option(self):
+        self.check_default_text_search_config()
         searched = Line.objects.annotate(
             headline=SearchHeadline(
                 "dialogue",
@@ -739,6 +746,7 @@ class SearchHeadlineTests(GrailTestData, PostgreSQLTestCase):
         )
 
     def test_headline_short_word_option(self):
+        self.check_default_text_search_config()
         searched = Line.objects.annotate(
             headline=SearchHeadline(
                 "dialogue",
@@ -756,6 +764,7 @@ class SearchHeadlineTests(GrailTestData, PostgreSQLTestCase):
         )
 
     def test_headline_fragments_words_options(self):
+        self.check_default_text_search_config()
         searched = Line.objects.annotate(
             headline=SearchHeadline(
                 "dialogue",


### PR DESCRIPTION
When the conf in postgresql.conf is not default_text_search_config = 'pg_catalog.english' some test fail. Now check the pg_catalog before run the tests.