### PR TITLE
Removed redundant definition of DatabaseFeatures.can_release_savepoints on MySQL.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -16,7 +16,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_date_lookup_using_string = False
     supports_timezones = False
     requires_explicit_null_ordering_when_grouping = True
-    can_release_savepoints = True
     atomic_transactions = False
     can_clone_databases = True
     supports_temporal_subtraction = True


### PR DESCRIPTION
See:

https://github.com/django/django/blob/344593893b6fc5fdda45a74013fc8622401c5058/django/db/backends/mysql/features.py#L278