### PR TITLE
Fixed #34200 -- Made the session role configurable on PostgreSQL.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -230,6 +230,27 @@ configuration in :setting:`DATABASES`::
 
     ``IsolationLevel`` was added.
 
+.. _database-role:
+
+Role
+----
+
+.. versionadded:: 4.2
+
+If you need to use a different role for database connections than the role use
+to establish the connection, set it in the :setting:`OPTIONS` part of your
+database configuration in :setting:`DATABASES`::
+
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            # ...
+            "OPTIONS": {
+                "assume_role": "my_application_role",
+            },
+        },
+    }
+
 Indexes for ``varchar`` and ``text`` columns
 --------------------------------------------
 

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -224,6 +224,12 @@ CSRF
 
 * ...
 
+Database backends
+~~~~~~~~~~~~~~~~~
+
+* The new ``"assume_role"`` option is now supported in :setting:`OPTIONS` on
+  PostgreSQL to allow specifying the :ref:`session role <database-role>`.
+
 Decorators
 ~~~~~~~~~~
 


### PR DESCRIPTION
If a user configures `role` in their database options this will issue the proper `SET ROLE` statement during connection setup. See [ticket 34200](https://code.djangoproject.com/ticket/34200) for more background.

I've tested this in real systems with success but not sure how to test it properly given the current postgres test suite. I'd be willing to add tests if that's required for this change if someone can point me in the right direction.