### PR TITLE
Fixed AdminViewDeletedObjectsTest.test_cyclic failure when using --keepdb.

### DIFF
--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -3371,8 +3371,8 @@ class AdminViewDeletedObjectsTest(TestCase):
         cls.ssh1 = SuperSecretHideout.objects.create(
             location="super floating castle!", supervillain=cls.sv1
         )
-        cls.cy1 = CyclicOne.objects.create(name="I am recursive", two_id=1)
-        cls.cy2 = CyclicTwo.objects.create(name="I am recursive too", one_id=1)
+        cls.cy1 = CyclicOne.objects.create(pk=1, name="I am recursive", two_id=1)
+        cls.cy2 = CyclicTwo.objects.create(pk=1, name="I am recursive too", one_id=1)
 
     def setUp(self):
         self.client.force_login(self.superuser)


### PR DESCRIPTION
This changes to hardcoded pks when hardcoded fks are used.

```
django.db.utils.IntegrityError: insert or update on table "admin_views_cyclicone" violates foreign key constraint "admin_views_cyclicon_two_id_c76cbd61_fk_admin_vie"
DETAIL:  Key (two_id)=(1) is not present in table "admin_views_cyclictwo".
```