### PR TITLE
Fixed contenttypes_tests tests failures when using --keepdb.

### DIFF
--- a/tests/contenttypes_tests/test_migrations.py
+++ b/tests/contenttypes_tests/test_migrations.py
@@ -4,14 +4,14 @@ from django.apps import apps
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db import DEFAULT_DB_ALIAS, connections
-from django.test import TransactionTestCase
+from django.test import TestCase
 
 remove_content_type_name = import_module(
     "django.contrib.contenttypes.migrations.0002_remove_content_type_name"
 )
 
 
-class MultiDBRemoveContentTypeNameTests(TransactionTestCase):
+class MultiDBRemoveContentTypeNameTests(TestCase):
     databases = {"default", "other"}
     available_apps = ["django.contrib.auth", "django.contrib.contenttypes"]
 


### PR DESCRIPTION
```
./runtests.py --parallel=8 --settings=test_pg contenttypes_tests --keepdb --debug-sql 
...
./runtests.py --parallel=8 --settings=test_pg contenttypes_tests --keepdb --debug-sql 
Testing against Django installed in '/home/felixx/repo/django/django' with up to 8 processes
Found 70 test(s).
Using existing test database for alias 'default'...
Using existing clone for alias 'default'...
Using existing clone for alias 'default'...
Using existing clone for alias 'default'...
Using existing clone for alias 'default'...
Using existing clone for alias 'default'...
Using existing clone for alias 'default'...
Using existing clone for alias 'default'...
Using existing clone for alias 'default'...
Using existing test database for alias 'other'...
Using existing clone for alias 'other'...
Using existing clone for alias 'other'...
Using existing clone for alias 'other'...
Using existing clone for alias 'other'...
Using existing clone for alias 'other'...
Using existing clone for alias 'other'...
Using existing clone for alias 'other'...
Using existing clone for alias 'other'...
System check identified no issues (0 silenced).
.F...E.................................................................
======================================================================
ERROR: test_get_object_cache_respects_deleted_objects (contenttypes_tests.test_fields.GenericForeignKeyTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/repo/django/django/db/backends/utils.py", line 87, in _execute
    return self.cursor.execute(sql)
psycopg2.errors.ForeignKeyViolation: insert or update on table "contenttypes_tests_post" violates foreign key constraint "contenttypes_tests_p_content_type_id_0dd6aec7_fk_django_co"
DETAIL:  Key (content_type_id)=(92) is not present in table "django_content_type".


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/repo/django/django/test/testcases.py", line 421, in _setup_and_call
    self._post_teardown()
  File "/repo/django/django/test/testcases.py", line 1281, in _post_teardown
    self._fixture_teardown()
  File "/repo/django/django/test/testcases.py", line 1511, in _fixture_teardown
    connections[db_name].check_constraints()
  File "/repo/django/django/db/backends/postgresql/base.py", line 313, in check_constraints
    cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
  File "/repo/django/django/db/backends/utils.py", line 103, in execute
    return super().execute(sql, params)
  File "/repo/django/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
  File "/repo/django/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/repo/django/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
  File "/repo/django/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/repo/django/django/db/backends/utils.py", line 87, in _execute
    return self.cursor.execute(sql)
django.db.utils.IntegrityError: insert or update on table "contenttypes_tests_post" violates foreign key constraint "contenttypes_tests_p_content_type_id_0dd6aec7_fk_django_co"
DETAIL:  Key (content_type_id)=(92) is not present in table "django_content_type".


----------------------------------------------------------------------

======================================================================
FAIL: test_multidb (contenttypes_tests.test_models.ContentTypesMultidbTests)
When using multiple databases, ContentType.objects.get_for_model() uses
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/usr/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/home/felixx/repo/django/tests/contenttypes_tests/test_models.py", line 326, in test_multidb
    ContentType.objects.get_for_model(Author)
  File "/home/felixx/repo/django/django/test/testcases.py", line 100, in __exit__
    self.test_case.assertEqual(
  File "/usr/lib/python3.8/unittest/case.py", line 912, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/lib/python3.8/unittest/case.py", line 905, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: 4 != 0 : 4 queries executed, 0 expected
Captured queries were:
1. SELECT "django_content_type"."id", "django_content_type"."app_label", "django_content_type"."model" FROM "django_content_type" WHERE ("django_content_type"."app_label" = 'contenttypes_tests' AND "django_content_type"."model" = 'author') LIMIT 21
2. SAVEPOINT "s140271990785856_x2"
3. INSERT INTO "django_content_type" ("app_label", "model") VALUES ('contenttypes_tests', 'author') RETURNING "django_content_type"."id"
4. RELEASE SAVEPOINT "s140271990785856_x2"

----------------------------------------------------------------------

----------------------------------------------------------------------
Ran 70 tests in 1.139s

FAILED (failures=1, errors=1)
Preserving test database for alias 'default'...
Preserving test database for alias 'default'...
Preserving test database for alias 'default'...
Preserving test database for alias 'default'...
Preserving test database for alias 'default'...
Preserving test database for alias 'default'...
Preserving test database for alias 'default'...
Preserving test database for alias 'default'...
Preserving test database for alias 'default'...
Preserving test database for alias 'other'...
Preserving test database for alias 'other'...
Preserving test database for alias 'other'...
Preserving test database for alias 'other'...
Preserving test database for alias 'other'...
Preserving test database for alias 'other'...
Preserving test database for alias 'other'...
Preserving test database for alias 'other'...
Preserving test database for alias 'other'...
```