### PR TITLE
Made inspectdb used Cursor.description.display_size for CharFields' max_length.

### DIFF
--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -328,8 +328,8 @@ class Command(BaseCommand):
             field_notes.append("This field type is a guess.")
 
         # Add max_length for all CharFields.
-        if field_type == "CharField" and row.internal_size:
-            field_params["max_length"] = int(row.internal_size)
+        if field_type == "CharField" and row.display_size:
+            field_params["max_length"] = int(row.display_size)
 
         if field_type in {"CharField", "TextField"} and row.collation:
             field_params["db_collation"] = row.collation

--- a/django/db/backends/mysql/introspection.py
+++ b/django/db/backends/mysql/introspection.py
@@ -148,7 +148,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             info = field_info[line[0]]
             fields.append(
                 FieldInfo(
-                    *line[:3],
+                    *line[:2],
+                    to_int(info.max_len) or line[2],
                     to_int(info.max_len) or line[3],
                     to_int(info.num_prec) or line[4],
                     to_int(info.num_scale) or line[5],

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -116,7 +116,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                     WHEN user_tab_cols.char_used IS NULL
                     THEN user_tab_cols.data_length
                     ELSE user_tab_cols.char_length
-                END as internal_size,
+                END as display_size,
                 CASE
                     WHEN user_tab_cols.identity_column = 'YES' THEN 1
                     ELSE 0
@@ -141,7 +141,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         )
         field_map = {
             column: (
-                internal_size,
+                display_size,
                 default if default != "NULL" else None,
                 collation,
                 is_autofield,
@@ -151,7 +151,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 column,
                 default,
                 collation,
-                internal_size,
+                display_size,
                 is_autofield,
                 is_json,
             ) in cursor.fetchall()
@@ -165,13 +165,14 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         description = []
         for desc in cursor.description:
             name = desc[0]
-            internal_size, default, collation, is_autofield, is_json = field_map[name]
+            display_size, default, collation, is_autofield, is_json = field_map[name]
             name %= {}  # cx_Oracle, for some reason, doubles percent signs.
             description.append(
                 FieldInfo(
                     self.identifier_converter(name),
-                    *desc[1:3],
-                    internal_size,
+                    desc[1],
+                    display_size,
+                    desc[3],
                     desc[4] or 0,
                     desc[5] or 0,
                     *desc[6:],

--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -113,7 +113,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             FieldInfo(
                 line.name,
                 line.type_code,
-                line.display_size,
+                # display_size is always None on psycopg2.
+                line.internal_size if line.display_size is None else line.display_size,
                 line.internal_size,
                 line.precision,
                 line.scale,

--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -119,8 +119,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             FieldInfo(
                 name,
                 data_type,
-                None,
                 get_field_size(data_type),
+                None,
                 None,
                 None,
                 not notnull,

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -409,6 +409,10 @@ Miscellaneous
 
 * The minimum supported version of SQLite is increased from 3.9.0 to 3.21.0.
 
+* :djadmin:`inspectdb` now uses ``display_size`` from
+  ``DatabaseIntrospection.get_table_description()`` rather than
+  ``internal_size`` for ``CharField``.
+
 .. _deprecated-features-4.2:
 
 Features deprecated in 4.2

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -132,7 +132,7 @@ class IntrospectionTests(TransactionTestCase):
             )
         self.assertEqual(
             [
-                r[3]
+                r[2]
                 for r in desc
                 if connection.introspection.get_field_type(r[1], r) == "CharField"
             ],


### PR DESCRIPTION
`internal_size` is size for fixed-size types not for char types.