### PR TITLE
Refs #34203 -- Bumped required psycopg2 version to 2.9.5

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -35,9 +35,9 @@ def psycopg2_version():
 
 PSYCOPG2_VERSION = psycopg2_version()
 
-if PSYCOPG2_VERSION < (2, 8, 4):
+if PSYCOPG2_VERSION < (2, 9, 5):
     raise ImproperlyConfigured(
-        "psycopg2 version 2.8.4 or newer is required; you have %s"
+        "psycopg2 version 2.9.5 or newer is required; you have %s"
         % psycopg2.__version__
     )
 

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -114,7 +114,7 @@ below for information on how to set up your database correctly.
 PostgreSQL notes
 ================
 
-Django supports PostgreSQL 12 and higher. `psycopg2`_ 2.8.4 or higher is
+Django supports PostgreSQL 12 and higher. `psycopg2`_ 2.9.5 or higher is
 required, though the latest release is recommended.
 
 .. _psycopg2: https://www.psycopg.org/

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -368,6 +368,9 @@ Dropped support for PostgreSQL 11
 Upstream support for PostgreSQL 11 ends in November 2023. Django 4.2 supports
 PostgreSQL 12 and higher.
 
+Also, the minimum supported version of ``psycopg2`` is increased from 2.8.4 to
+2.9.5, as ``psycopg2`` 2.9.5 is the first release to support Python 3.11.
+
 Setting ``update_fields`` in ``Model.save()`` may now be required
 -----------------------------------------------------------------
 

--- a/tests/requirements/postgres.txt
+++ b/tests/requirements/postgres.txt
@@ -1,1 +1,1 @@
-psycopg2>=2.8.4
+psycopg2>=2.9.5


### PR DESCRIPTION
psycopg2 2.9.5 is the first release to support Python 3.11