### PR TITLE
Made urls.py docstring consistent with other files in project template.

### DIFF
--- a/django/conf/project_template/project_name/urls.py-tpl
+++ b/django/conf/project_template/project_name/urls.py-tpl
@@ -1,5 +1,5 @@
 """
-{{ project_name }} URL Configuration
+URL configuration for {{ project_name }} project.
 
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/{{ docs_version }}/topics/http/urls/

--- a/django/conf/project_template/project_name/urls.py-tpl
+++ b/django/conf/project_template/project_name/urls.py-tpl
@@ -1,4 +1,5 @@
-"""{{ project_name }} URL Configuration
+"""
+{{ project_name }} URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/{{ docs_version }}/topics/http/urls/


### PR DESCRIPTION
Corrected urls.py template docstring.

Adjusted a docstring in urls.py template by making the body 
start from the second line. This is consistent with other templates.