### PR TITLE
Fixed #34209 -- Prevented FileBasedCache.has_key() crash caused by a race condition.

### DIFF
--- a/django/core/cache/backends/filebased.py
+++ b/django/core/cache/backends/filebased.py
@@ -90,10 +90,11 @@ class FileBasedCache(BaseCache):
 
     def has_key(self, key, version=None):
         fname = self._key_to_file(key, version)
-        if os.path.exists(fname):
+        try:
             with open(fname, "rb") as f:
                 return not self._is_expired(f)
-        return False
+        except FileNotFoundError:
+            return False
 
     def _cull(self):
         """

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1762,6 +1762,12 @@ class FileBasedCacheTests(BaseCacheTests, TestCase):
         with open(cache_file, "rb") as fh:
             self.assertIs(cache._is_expired(fh), True)
 
+    def test_has_key_race_handling(self):
+        self.assertIs(cache.add("key", "value"), True)
+        with mock.patch("builtins.open", side_effect=FileNotFoundError) as mocked_open:
+            self.assertIs(cache.has_key("key"), False)
+            mocked_open.assert_called_once()
+
 
 @unittest.skipUnless(RedisCache_params, "Redis backend not configured")
 @override_settings(


### PR DESCRIPTION
It was possible for the cache file to be deleted between the `exists()` check and the `open()` call.

The `_is_expired()` method itself deletes the file if it finds it to be expired. So if many threads race to read an expired cache at once, it's not that unlikely to hit this window.

https://code.djangoproject.com/ticket/34209
