### PR TITLE
Refs #34118 -- Adopted asgiref coroutine detection shims.

### DIFF
--- a/django/core/handlers/exception.py
+++ b/django/core/handlers/exception.py
@@ -1,9 +1,8 @@
-import asyncio
 import logging
 import sys
 from functools import wraps
 
-from asgiref.sync import sync_to_async
+from asgiref.sync import iscoroutinefunction, sync_to_async
 
 from django.conf import settings
 from django.core import signals
@@ -34,7 +33,7 @@ def convert_exception_to_response(get_response):
     no middleware leaks an exception and that the next middleware in the stack
     can rely on getting a response instead of an exception.
     """
-    if asyncio.iscoroutinefunction(get_response):
+    if iscoroutinefunction(get_response):
 
         @wraps(get_response)
         async def inner(request):

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1,4 +1,3 @@
-import asyncio
 import difflib
 import inspect
 import json
@@ -26,7 +25,7 @@ from urllib.parse import (
 )
 from urllib.request import url2pathname
 
-from asgiref.sync import async_to_sync
+from asgiref.sync import async_to_sync, iscoroutinefunction
 
 from django.apps import apps
 from django.conf import settings
@@ -401,7 +400,7 @@ class SimpleTestCase(unittest.TestCase):
         )
 
         # Convert async test methods.
-        if asyncio.iscoroutinefunction(testMethod):
+        if iscoroutinefunction(testMethod):
             setattr(self, self._testMethodName, async_to_sync(testMethod))
 
         if not skipped:

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import collections
 import logging
 import os
@@ -13,6 +12,8 @@ from itertools import chain
 from types import SimpleNamespace
 from unittest import TestCase, skipIf, skipUnless
 from xml.dom.minidom import Node, parseString
+
+from asgiref.sync import iscoroutinefunction
 
 from django.apps import apps
 from django.apps.registry import Apps
@@ -440,7 +441,7 @@ class TestContextDecorator:
         raise TypeError("Can only decorate subclasses of unittest.TestCase")
 
     def decorate_callable(self, func):
-        if asyncio.iscoroutinefunction(func):
+        if iscoroutinefunction(func):
             # If the inner function is an async function, we must execute async
             # as well so that the `with` statement executes at the right time.
             @wraps(func)

--- a/django/utils/deprecation.py
+++ b/django/utils/deprecation.py
@@ -1,8 +1,7 @@
-import asyncio
 import inspect
 import warnings
 
-from asgiref.sync import sync_to_async
+from asgiref.sync import iscoroutinefunction, markcoroutinefunction, sync_to_async
 
 
 class RemovedInDjango50Warning(DeprecationWarning):
@@ -120,16 +119,14 @@ class MiddlewareMixin:
         If get_response is a coroutine function, turns us into async mode so
         a thread is not consumed during a whole request.
         """
-        if asyncio.iscoroutinefunction(self.get_response):
+        if iscoroutinefunction(self.get_response):
             # Mark the class as async-capable, but do the actual switch
             # inside __call__ to avoid swapping out dunder methods
-            self._is_coroutine = asyncio.coroutines._is_coroutine
-        else:
-            self._is_coroutine = None
+            markcoroutinefunction(self)
 
     def __call__(self, request):
         # Exit out to async mode, if needed
-        if self._is_coroutine:
+        if iscoroutinefunction(self):
             return self.__acall__(request)
         response = None
         if hasattr(self, "process_request"):

--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -1,5 +1,6 @@
-import asyncio
 import logging
+
+from asgiref.sync import iscoroutinefunction, markcoroutinefunction
 
 from django.core.exceptions import ImproperlyConfigured
 from django.http import (
@@ -68,8 +69,8 @@ class View:
         ]
         if not handlers:
             return False
-        is_async = asyncio.iscoroutinefunction(handlers[0])
-        if not all(asyncio.iscoroutinefunction(h) == is_async for h in handlers[1:]):
+        is_async = iscoroutinefunction(handlers[0])
+        if not all(iscoroutinefunction(h) == is_async for h in handlers[1:]):
             raise ImproperlyConfigured(
                 f"{cls.__qualname__} HTTP handlers must either be all sync or all "
                 "async."
@@ -117,7 +118,7 @@ class View:
 
         # Mark the callback if the view class is async.
         if cls.view_is_async:
-            view._is_coroutine = asyncio.coroutines._is_coroutine
+            markcoroutinefunction(view)
 
         return view
 

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -278,7 +278,7 @@ dependencies:
 
 *  aiosmtpd_
 *  argon2-cffi_ 19.1.0+
-*  asgiref_ 3.5.2+ (required)
+*  asgiref_ 3.6.0+ (required)
 *  bcrypt_
 *  colorama_
 *  docutils_

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -438,6 +438,9 @@ Miscellaneous
   ``DatabaseIntrospection.get_table_description()`` rather than
   ``internal_size`` for ``CharField``.
 
+* The minimum supported version of ``asgiref`` is increased from 3.5.2 to
+  3.6.0.
+
 .. _deprecated-features-4.2:
 
 Features deprecated in 4.2

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -28,10 +28,10 @@ class-based view, this means declaring the HTTP method handlers, such as
 
 .. note::
 
-    Django uses ``asyncio.iscoroutinefunction`` to test if your view is
+    Django uses ``asgiref.sync.iscoroutinefunction`` to test if your view is
     asynchronous or not. If you implement your own method of returning a
-    coroutine, ensure you set the ``_is_coroutine`` attribute of the view
-    to ``asyncio.coroutines._is_coroutine`` so this function returns ``True``.
+    coroutine, ensure you use ``asgiref.sync.markcoroutinefunction`` so this
+    function returns ``True``.
 
 Under a WSGI server, async views will run in their own, one-off event loop.
 This means you can use async features, like concurrent async HTTP requests,

--- a/docs/topics/http/middleware.txt
+++ b/docs/topics/http/middleware.txt
@@ -312,7 +312,7 @@ If your middleware has both ``sync_capable = True`` and
 ``async_capable = True``, then Django will pass it the request without
 converting it. In this case, you can work out if your middleware will receive
 async requests by checking if the ``get_response`` object you are passed is a
-coroutine function, using ``asyncio.iscoroutinefunction``.
+coroutine function, using ``asgiref.sync.iscoroutinefunction``.
 
 The ``django.utils.decorators`` module contains
 :func:`~django.utils.decorators.sync_only_middleware`,
@@ -331,13 +331,13 @@ at an additional performance penalty.
 
 Here's an example of how to create a middleware function that supports both::
 
-    import asyncio
+    from asgiref.sync import iscoroutinefunction
     from django.utils.decorators import sync_and_async_middleware
 
     @sync_and_async_middleware
     def simple_middleware(get_response):
         # One-time configuration and initialization goes here.
-        if asyncio.iscoroutinefunction(get_response):
+        if iscoroutinefunction(get_response):
             async def middleware(request):
                 # Do something here!
                 response = await get_response(request)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ packages = find:
 include_package_data = true
 zip_safe = false
 install_requires =
-    asgiref >= 3.5.2
+    asgiref >= 3.6.0
     backports.zoneinfo; python_version<"3.9"
     sqlparse >= 0.2.2
     tzdata; sys_platform == 'win32'

--- a/tests/async/tests.py
+++ b/tests/async/tests.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 from unittest import mock
 
-from asgiref.sync import async_to_sync
+from asgiref.sync import async_to_sync, iscoroutinefunction
 
 from django.core.cache import DEFAULT_CACHE_ALIAS, caches
 from django.core.exceptions import ImproperlyConfigured, SynchronousOnlyOperation
@@ -84,7 +84,7 @@ class ViewTests(SimpleTestCase):
             with self.subTest(view_cls=view_cls, is_async=is_async):
                 self.assertIs(view_cls.view_is_async, is_async)
                 callback = view_cls.as_view()
-                self.assertIs(asyncio.iscoroutinefunction(callback), is_async)
+                self.assertIs(iscoroutinefunction(callback), is_async)
 
     def test_mixed_views_raise_error(self):
         class MixedView(View):

--- a/tests/deprecation/test_middleware_mixin.py
+++ b/tests/deprecation/test_middleware_mixin.py
@@ -1,7 +1,6 @@
-import asyncio
 import threading
 
-from asgiref.sync import async_to_sync
+from asgiref.sync import async_to_sync, iscoroutinefunction
 
 from django.contrib.admindocs.middleware import XViewMiddleware
 from django.contrib.auth.middleware import (
@@ -101,11 +100,11 @@ class MiddlewareMixinTests(SimpleTestCase):
                 # Middleware appears as coroutine if get_function is
                 # a coroutine.
                 middleware_instance = middleware(async_get_response)
-                self.assertIs(asyncio.iscoroutinefunction(middleware_instance), True)
+                self.assertIs(iscoroutinefunction(middleware_instance), True)
                 # Middleware doesn't appear as coroutine if get_function is not
                 # a coroutine.
                 middleware_instance = middleware(sync_get_response)
-                self.assertIs(asyncio.iscoroutinefunction(middleware_instance), False)
+                self.assertIs(iscoroutinefunction(middleware_instance), False)
 
     def test_sync_to_async_uses_base_thread_and_connection(self):
         """

--- a/tests/middleware_exceptions/middleware.py
+++ b/tests/middleware_exceptions/middleware.py
@@ -1,4 +1,4 @@
-import asyncio
+from asgiref.sync import iscoroutinefunction, markcoroutinefunction
 
 from django.http import Http404, HttpResponse
 from django.template import engines
@@ -15,9 +15,8 @@ log = []
 class BaseMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
-        if asyncio.iscoroutinefunction(self.get_response):
-            # Mark the class as async-capable.
-            self._is_coroutine = asyncio.coroutines._is_coroutine
+        if iscoroutinefunction(self.get_response):
+            markcoroutinefunction(self)
 
     def __call__(self, request):
         return self.get_response(request)

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,5 +1,5 @@
 aiosmtpd
-asgiref >= 3.5.2
+asgiref >= 3.6.0
 argon2-cffi >= 16.1.0
 backports.zoneinfo; python_version < '3.9'
 bcrypt


### PR DESCRIPTION
ticket-34118 Python 3.12 compatibility. 

Refs https://github.com/python/cpython/pull/99247
Refs https://github.com/django/asgiref/pull/360

This PR requires at least the `asgiref` branch to test. 

Python 3.12 deprecates `asyncio.iscoroutinefunction()` as an alias for
`inspect.iscoroutinefunction()`, whilst also removing the `_is_coroutine` marker.
The latter is replaced with the `inspect.markcoroutinefunction` decorator.
Until 3.12 is the minimum supported Python version, use the shims from `asgiref.sync`. 