### PR TITLE
Fixed lookup.tests.LookupTests.test_exact_none_transform() test on Oracle.

### DIFF
--- a/tests/lookup/models.py
+++ b/tests/lookup/models.py
@@ -50,10 +50,21 @@ class NulledTextField(models.TextField):
         return None if value == "" else value
 
 
+class NullField(models.Field):
+    pass
+
+
+NullField.register_lookup(IsNull)
+
+
 @NulledTextField.register_lookup
 class NulledTransform(models.Transform):
     lookup_name = "nulled"
     template = "NULL"
+
+    @property
+    def output_field(self):
+        return NullField()
 
 
 @NulledTextField.register_lookup


### PR DESCRIPTION
`NulledTransform` doesn't return `TextField` anymore so it cannot be wrapped with `DBMS_LOB.SUBSTR()`.

Test regression in 09ffc5c1212d4ced58b708cbbf3dfbfb77b782ca.

See [logs](https://djangoci.com/job/django-oracle/lastCompletedBuild/database=oracle19,label=oracle,python=python3.9/testReport/lookup.tests/LookupTests/test_exact_none_transform/).