### PR TITLE
Fixed typo in docs/topics/http/sessions.txt.

### DIFF
--- a/docs/topics/http/sessions.txt
+++ b/docs/topics/http/sessions.txt
@@ -122,8 +122,8 @@ and the :setting:`SECRET_KEY` setting.
 
 .. warning::
 
-    **If the ``SECRET_KEY`` or ``SECRET_KEY_FALLBACKS`` are not kept secret and
-    you are using the**
+    **If the** ``SECRET_KEY`` **or** ``SECRET_KEY_FALLBACKS`` **are not kept
+    secret and you are using the**
     ``django.contrib.sessions.serializers.PickleSerializer``, **this can lead
     to arbitrary remote code execution.**
 


### PR DESCRIPTION
Hi, this PR fixes a minor markup error on this section (the first paragram of "Warning"): https://docs.djangoproject.com/en/dev/topics/http/sessions/#using-cookie-based-sessions

I skipped creating a ticket as I think this is a minor issue.

**Before**
![Screenshot 2022-12-16 at 17 42 34](https://user-images.githubusercontent.com/1425259/208060303-44937f49-cce0-4bbd-8cb6-791db3ef11e6.png)

**After**
![Screenshot 2022-12-16 at 17 41 59](https://user-images.githubusercontent.com/1425259/208060309-fa85b71d-bee6-4839-b33b-7d0a74068815.png)
