### PR TITLE
Fixed #34219 -- Preserved Char/TextField.db_collation when altering column type.

### DIFF
--- a/django/contrib/gis/db/backends/postgis/schema.py
+++ b/django/contrib/gis/db/backends/postgis/schema.py
@@ -50,12 +50,16 @@ class PostGISSchemaEditor(DatabaseSchemaEditor):
             expressions=expressions,
         )
 
-    def _alter_column_type_sql(self, table, old_field, new_field, new_type):
+    def _alter_column_type_sql(
+        self, table, old_field, new_field, new_type, old_collation, new_collation
+    ):
         """
         Special case when dimension changed.
         """
         if not hasattr(old_field, "dim") or not hasattr(new_field, "dim"):
-            return super()._alter_column_type_sql(table, old_field, new_field, new_type)
+            return super()._alter_column_type_sql(
+                table, old_field, new_field, new_type, old_collation, new_collation
+            )
 
         if old_field.dim == 2 and new_field.dim == 3:
             sql_alter = self.sql_alter_column_to_3d
@@ -69,6 +73,7 @@ class PostGISSchemaEditor(DatabaseSchemaEditor):
                 % {
                     "column": self.quote_name(new_field.column),
                     "type": new_type,
+                    "collation": "",
                 },
                 [],
             ),

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -9,8 +9,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     sql_alter_column_null = "MODIFY %(column)s %(type)s NULL"
     sql_alter_column_not_null = "MODIFY %(column)s %(type)s NOT NULL"
-    sql_alter_column_type = "MODIFY %(column)s %(type)s"
-    sql_alter_column_collate = "MODIFY %(column)s %(type)s%(collation)s"
+    sql_alter_column_type = "MODIFY %(column)s %(type)s%(collation)s"
     sql_alter_column_no_default_null = "ALTER COLUMN %(column)s SET DEFAULT NULL"
 
     # No 'CASCADE' which works as a no-op in MySQL but is undocumented
@@ -218,9 +217,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             new_type += " NOT NULL"
         return new_type
 
-    def _alter_column_type_sql(self, model, old_field, new_field, new_type):
+    def _alter_column_type_sql(
+        self, model, old_field, new_field, new_type, old_collation, new_collation
+    ):
         new_type = self._set_field_new_type_null_status(old_field, new_type)
-        return super()._alter_column_type_sql(model, old_field, new_field, new_type)
+        return super()._alter_column_type_sql(
+            model, old_field, new_field, new_type, old_collation, new_collation
+        )
 
     def _rename_field_sql(self, table, old_field, new_field, new_type):
         new_type = self._set_field_new_type_null_status(old_field, new_type)

--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -13,13 +13,12 @@ from django.utils.duration import duration_iso_string
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     sql_create_column = "ALTER TABLE %(table)s ADD %(column)s %(definition)s"
-    sql_alter_column_type = "MODIFY %(column)s %(type)s"
+    sql_alter_column_type = "MODIFY %(column)s %(type)s%(collation)s"
     sql_alter_column_null = "MODIFY %(column)s NULL"
     sql_alter_column_not_null = "MODIFY %(column)s NOT NULL"
     sql_alter_column_default = "MODIFY %(column)s DEFAULT %(default)s"
     sql_alter_column_no_default = "MODIFY %(column)s DEFAULT NULL"
     sql_alter_column_no_default_null = sql_alter_column_no_default
-    sql_alter_column_collate = "MODIFY %(column)s %(type)s%(collation)s"
 
     sql_delete_column = "ALTER TABLE %(table)s DROP COLUMN %(column)s"
     sql_create_column_inline_fk = (
@@ -169,7 +168,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                         self._create_fk_sql(rel.related_model, rel.field, "_fk")
                     )
 
-    def _alter_column_type_sql(self, model, old_field, new_field, new_type):
+    def _alter_column_type_sql(
+        self, model, old_field, new_field, new_type, old_collation, new_collation
+    ):
         auto_field_types = {"AutoField", "BigAutoField", "SmallAutoField"}
         # Drop the identity if migrating away from AutoField.
         if (
@@ -178,7 +179,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             and self._is_identity_column(model._meta.db_table, new_field.column)
         ):
             self._drop_identity(model._meta.db_table, new_field.column)
-        return super()._alter_column_type_sql(model, old_field, new_field, new_type)
+        return super()._alter_column_type_sql(
+            model, old_field, new_field, new_type, old_collation, new_collation
+        )
 
     def normalize_name(self, name):
         """
@@ -242,11 +245,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             )
             return cursor.fetchone()[0]
 
-    def _alter_column_collation_sql(
-        self, model, new_field, new_type, new_collation, old_field
-    ):
-        if new_collation is None:
-            new_collation = self._get_default_collation(model._meta.db_table)
-        return super()._alter_column_collation_sql(
-            model, new_field, new_type, new_collation, old_field
-        )
+    def _collate_sql(self, collation, old_collation=None, table_name=None):
+        if collation is None and old_collation is not None:
+            collation = self._get_default_collation(table_name)
+        return super()._collate_sql(collation, old_collation, table_name)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -4951,6 +4951,38 @@ class SchemaTests(TransactionTestCase):
         self.assertIsNone(self.get_column_collation(Author._meta.db_table, "name"))
 
     @skipUnlessDBFeature("supports_collation_on_charfield")
+    def test_alter_field_type_preserve_db_collation(self):
+        collation = connection.features.test_collations.get("non_default")
+        if not collation:
+            self.skipTest("Language collations are not supported.")
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+
+        old_field = Author._meta.get_field("name")
+        new_field = CharField(max_length=255, db_collation=collation)
+        new_field.set_attributes_from_name("name")
+        new_field.model = Author
+        with connection.schema_editor() as editor:
+            editor.alter_field(Author, old_field, new_field, strict=True)
+        self.assertEqual(
+            self.get_column_collation(Author._meta.db_table, "name"),
+            collation,
+        )
+        # Changing a field type should preserve the collation.
+        old_field = new_field
+        new_field = CharField(max_length=511, db_collation=collation)
+        new_field.set_attributes_from_name("name")
+        new_field.model = Author
+        with connection.schema_editor() as editor:
+            editor.alter_field(Author, new_field, old_field, strict=True)
+        # Collation is preserved.
+        self.assertEqual(
+            self.get_column_collation(Author._meta.db_table, "name"),
+            collation,
+        )
+
+    @skipUnlessDBFeature("supports_collation_on_charfield")
     def test_alter_primary_key_db_collation(self):
         collation = connection.features.test_collations.get("non_default")
         if not collation:


### PR DESCRIPTION
This moves setting a database collation to the column type alteration as both must be set at the same time. This should also avoid another layer of the column type alteration when adding database comments support (ticket-18468).

ticket-34219