### PR TITLE
Fixed #34217 -- Fixed migration crash when removing check constraints on MySQL < 8.0.16.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1651,6 +1651,8 @@ class BaseDatabaseSchemaEditor:
         )
 
     def _delete_check_sql(self, model, name):
+        if not self.connection.features.supports_table_check_constraints:
+            return None
         return self._delete_constraint_sql(self.sql_delete_check, model, name)
 
     def _delete_constraint_sql(self, template, model, name):


### PR DESCRIPTION
[Ticket 34217](https://code.djangoproject.com/ticket/34217)