### PR TITLE
Disabled auto-created table of contents entries on Sphinx 5.2+.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,10 @@ source_suffix = ".txt"
 # The root toctree document.
 root_doc = "contents"
 
+# Disable auto-created table of contents entries for all domain objects (e.g.
+# functions, classes, attributes, etc.) in Sphinx 5.2+.
+toc_object_entries = False
+
 # General substitutions.
 project = "Django"
 copyright = "Django Software Foundation and contributors"


### PR DESCRIPTION
Auto-created table of contents entries for all domain objects (e.g. functions, classes, attributes, etc.) were added in Sphinx 5.2, see https://github.com/sphinx-doc/sphinx/issues/6316.

An option to control new table of contents entries was added in Sphinx 5.2.3, see https://github.com/sphinx-doc/sphinx/pull/10886.

----
`toc_object_entries = True` (default):

![image](https://user-images.githubusercontent.com/2865885/209656630-0504eb87-3349-42d1-a1f7-cc6f24bc95e7.png)
----
`toc_object_entries = False`:

![image](https://user-images.githubusercontent.com/2865885/209656850-f5652fb5-13b1-4e3e-9b83-39fb517aa8f2.png)
