### PR TITLE
Fixed #34235 -- Added ManifestFilesMixin.manifest_hash attribute.

### DIFF
--- a/docs/ref/contrib/staticfiles.txt
+++ b/docs/ref/contrib/staticfiles.txt
@@ -336,6 +336,14 @@ argument. For example::
     Support for finding paths to JavaScript modules in ``import`` and
     ``export`` statements was added.
 
+.. attribute:: storage.ManifestStaticFilesStorage.manifest_hash
+
+.. versionadded:: 4.2
+
+This attribute provides a single hash that changes whenever a file in the
+manifest changes. This can be useful to communicate to SPAs that the assets on
+the server have changed (due to a new deployment).
+
 .. attribute:: storage.ManifestStaticFilesStorage.max_post_process_passes
 
 Since static files might reference other static files that need to have their

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -201,6 +201,10 @@ Minor features
   replaces paths to JavaScript modules in ``import`` and ``export`` statements
   with their hashed counterparts.
 
+* The new :attr:`.ManifestStaticFilesStorage.manifest_hash` attribute provides
+  a hash over all files in the manifest and changes whenever one of the files
+  changes.
+
 :mod:`django.contrib.syndication`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/staticfiles_tests/project/documents/staticfiles_v1.json
+++ b/tests/staticfiles_tests/project/documents/staticfiles_v1.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "paths": {
+    "dummy.txt": "dummy.txt"
+  }
+}


### PR DESCRIPTION
Adds a `manifest_hash` attribute to `ManifestFilesMixin` exposing a "hash" of the full manifest. This allows applications to determine when their static files have changed.