### PR TITLE
Fixed random delete.tests.DeletionTests.test_deletion_order failures.

### DIFF
--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -397,18 +397,35 @@ class DeletionTests(TestCase):
         models.signals.post_delete.connect(log_post_delete)
         models.signals.pre_delete.connect(log_pre_delete)
 
-        r = R.objects.create(pk=1)
-        s1 = S.objects.create(pk=1, r=r)
-        s2 = S.objects.create(pk=2, r=r)
-        T.objects.create(pk=1, s=s1)
-        T.objects.create(pk=2, s=s2)
-        RChild.objects.create(r_ptr=r)
+        r = R.objects.create()
+        s1 = S.objects.create(r=r)
+        s2 = S.objects.create(r=r)
+        t1 = T.objects.create(s=s1)
+        t2 = T.objects.create(s=s2)
+        rchild = RChild.objects.create(r_ptr=r)
+        r_pk = r.pk
         r.delete()
         self.assertEqual(
-            pre_delete_order, [(T, 2), (T, 1), (RChild, 1), (S, 2), (S, 1), (R, 1)]
+            pre_delete_order,
+            [
+                (T, t2.pk),
+                (T, t1.pk),
+                (RChild, rchild.pk),
+                (S, s2.pk),
+                (S, s1.pk),
+                (R, r_pk),
+            ],
         )
         self.assertEqual(
-            post_delete_order, [(T, 1), (T, 2), (RChild, 1), (S, 1), (S, 2), (R, 1)]
+            post_delete_order,
+            [
+                (T, t1.pk),
+                (T, t2.pk),
+                (RChild, rchild.pk),
+                (S, s1.pk),
+                (S, s2.pk),
+                (R, r_pk),
+            ],
         )
 
         models.signals.post_delete.disconnect(log_post_delete)


### PR DESCRIPTION
```
./runtests.py delete --parallel=1 --shuffle=8492401310
Testing against Django installed in '/django/django'
Using shuffle seed: 8492401310 (given)
Found 58 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.............s..E.........................................
======================================================================
ERROR: test_deletion_order (delete.tests.DeletionTests)
----------------------------------------------------------------------
Traceback (most recent call last):
...
django.db.utils.IntegrityError: duplicate key value violates unique constraint "delete_r_pkey"
DETAIL:  Key (id)=(1) already exists.
```
See [logs](https://djangoci.com/job/main-random/database=postgres,label=focal,python=python3.11/lastCompletedBuild/testReport/delete.tests/DeletionTests/test_deletion_order/).