### PR TITLE
Refs #34041 -- Added aria-current="page" to breadcrumbs in admin.

### DIFF
--- a/django/contrib/admin/templates/admin/500.html
+++ b/django/contrib/admin/templates/admin/500.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; {% translate 'Server error' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Server error' %}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admin/templates/admin/app_index.html
+++ b/django/contrib/admin/templates/admin/app_index.html
@@ -8,9 +8,11 @@
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo;
+<a href="#" aria-current="page">
 {% for app in app_list %}
 {{ app.name }}
 {% endfor %}
+</a>
 </div>
 {% endblock %}
 {% endif %}

--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -11,7 +11,7 @@
 &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
 &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
 &rsaquo; <a href="{% url opts|admin_urlname:'change' original.pk|admin_urlquote %}">{{ original|truncatewords:"18" }}</a>
-&rsaquo; {% translate 'Change password' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Change password' %}</a>
 </div>
 {% endblock %}
 {% endif %}

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -74,7 +74,7 @@
         {% block breadcrumbs %}
           <div class="breadcrumbs">
             <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-            {% if title %} &rsaquo; {{ title }}{% endif %}
+            {% if title %} &rsaquo; <a href="#" aria-current="page">{{ title }}</a>{% endif %}
           </div>
         {% endblock %}
       </nav>

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -18,7 +18,7 @@
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
 &rsaquo; {% if has_view_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
-&rsaquo; {% if add %}{% blocktranslate with name=opts.verbose_name %}Add {{ name }}{% endblocktranslate %}{% else %}{{ original|truncatewords:"18" }}{% endif %}
+&rsaquo; {% if add %}{% blocktranslate with name=opts.verbose_name %}<a href="#" aria-current="page">Add {{ name }}</a>{% endblocktranslate %}{% else %}<a href="#" aria-current="page">{{ original|truncatewords:"18" }}</a>{% endif %}
 </div>
 {% endblock %}
 {% endif %}

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -18,7 +18,7 @@
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
 &rsaquo; {% if has_view_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
-&rsaquo; {% if add %}{% blocktranslate with name=opts.verbose_name %}<a href="#" aria-current="page">Add {{ name }}</a>{% endblocktranslate %}{% else %}<a href="#" aria-current="page">{{ original|truncatewords:"18" }}</a>{% endif %}
+&rsaquo; <a href="#" aria-current="page">{% if add %}{% blocktranslate with name=opts.verbose_name %}Add {{ name }}{% endblocktranslate %}{% else %}{{ original|truncatewords:"18" }}{% endif %}</a>
 </div>
 {% endblock %}
 {% endif %}

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -31,7 +31,7 @@
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'admin:app_list' app_label=cl.opts.app_label %}">{{ cl.opts.app_config.verbose_name }}</a>
-&rsaquo; {{ cl.opts.verbose_name_plural|capfirst }}
+&rsaquo; <a href="#" aria-current="page">{{ cl.opts.verbose_name_plural|capfirst }}</a>
 </div>
 {% endblock %}
 {% endif %}

--- a/django/contrib/admin/templates/admin/delete_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_confirmation.html
@@ -15,7 +15,7 @@
 &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
 &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
 &rsaquo; <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ object|truncatewords:"18" }}</a>
-&rsaquo; {% translate 'Delete' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Delete' %}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admin/templates/admin/delete_selected_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_selected_confirmation.html
@@ -14,7 +14,7 @@
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
 &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
-&rsaquo; {% translate 'Delete multiple objects' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Delete multiple objects' %}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admin/templates/admin/invalid_setup.html
+++ b/django/contrib/admin/templates/admin/invalid_setup.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; {{ title }}
+&rsaquo; <a href="#" aria-current="page">{{ title }}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admin/templates/admin/object_history.html
+++ b/django/contrib/admin/templates/admin/object_history.html
@@ -7,7 +7,7 @@
 &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
 &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ module_name }}</a>
 &rsaquo; <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ object|truncatewords:"18" }}</a>
-&rsaquo; {% translate 'History' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'History' %}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admin/templates/registration/logged_out.html
+++ b/django/contrib/admin/templates/registration/logged_out.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
 
-{% block breadcrumbs %}<div class="breadcrumbs"><a href="{% url 'admin:index' %}" aria-current="page">{% translate 'Home' %}</a></div>{% endblock %}
+{% block breadcrumbs %}<div class="breadcrumbs"><a href="{% url 'admin:index' %}">{% translate 'Home' %}</a></div>{% endblock %}
 
 {% block nav-sidebar %}{% endblock %}
 

--- a/django/contrib/admin/templates/registration/logged_out.html
+++ b/django/contrib/admin/templates/registration/logged_out.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
 
-{% block breadcrumbs %}<div class="breadcrumbs"><a href="{% url 'admin:index' %}">{% translate 'Home' %}</a></div>{% endblock %}
+{% block breadcrumbs %}<div class="breadcrumbs"><a href="{% url 'admin:index' %}" aria-current="page">{% translate 'Home' %}</a></div>{% endblock %}
 
 {% block nav-sidebar %}{% endblock %}
 

--- a/django/contrib/admin/templates/registration/password_change_done.html
+++ b/django/contrib/admin/templates/registration/password_change_done.html
@@ -11,7 +11,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; {% translate 'Password change' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Password change' %}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -12,7 +12,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; {% translate 'Password change' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Password change' %}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admin/templates/registration/password_reset_complete.html
+++ b/django/contrib/admin/templates/registration/password_reset_complete.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; {% translate 'Password reset' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Password reset' %}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; {% translate 'Password reset confirmation' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Password reset confirmation' %}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admin/templates/registration/password_reset_done.html
+++ b/django/contrib/admin/templates/registration/password_reset_done.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; {% translate 'Password reset' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Password reset' %}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admin/templates/registration/password_reset_form.html
+++ b/django/contrib/admin/templates/registration/password_reset_form.html
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; {% translate 'Password reset' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Password reset' %}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admindocs/templates/admin_doc/bookmarklets.html
+++ b/django/contrib/admindocs/templates/admin_doc/bookmarklets.html
@@ -5,7 +5,7 @@
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
-&rsaquo; {% translate 'Bookmarklets' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Bookmarklets' %}</a>
 </div>
 {% endblock %}
 {% block title %}{% translate "Documentation bookmarklets" %}{% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/index.html
+++ b/django/contrib/admindocs/templates/admin_doc/index.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; {% translate 'Documentation' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Documentation' %}</a>
 </div>
 {% endblock %}
 {% block title %}{% translate 'Documentation' %}{% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/missing_docutils.html
+++ b/django/contrib/admindocs/templates/admin_doc/missing_docutils.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
-&rsaquo; {% translate 'Documentation' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Documentation' %}</a>
 </div>
 {% endblock %}
 {% block title %}{% translate 'Please install docutils' %}{% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/model_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/model_detail.html
@@ -14,7 +14,7 @@
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
 &rsaquo; <a href="{% url 'django-admindocs-models-index' %}">{% translate 'Models' %}</a>
-&rsaquo; {{ name }}
+&rsaquo; <a href="#" aria-current="page">{{ name }}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admindocs/templates/admin_doc/model_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/model_index.html
@@ -7,7 +7,7 @@
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
-&rsaquo; {% translate 'Models' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Models' %}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admindocs/templates/admin_doc/template_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/template_detail.html
@@ -5,8 +5,7 @@
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
-&rsaquo; <a href="#">{% translate 'Templates' %}</a>
-&rsaquo; <a href="#" aria-current="page">{{ name }}</a>
+&rsaquo; <a href="#" aria-current="page">{% blocktranslate with name=name %}Template: {{ name }}{% endblocktranslate %}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admindocs/templates/admin_doc/template_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/template_detail.html
@@ -5,8 +5,8 @@
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
-&rsaquo; {% translate 'Templates' %}
-&rsaquo; {{ name }}
+&rsaquo; <a href="#">{% translate 'Templates' %}</a>
+&rsaquo; <a href="#" aria-current="page">{{ name }}</a>
 </div>
 {% endblock %}
 

--- a/django/contrib/admindocs/templates/admin_doc/template_filter_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/template_filter_index.html
@@ -6,7 +6,7 @@
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
-&rsaquo; {% translate 'Filters' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Filters' %}</a>
 </div>
 {% endblock %}
 {% block title %}{% translate 'Template filters' %}{% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/template_tag_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/template_tag_index.html
@@ -6,7 +6,7 @@
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
-&rsaquo; {% translate 'Tags' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Tags' %}</a>
 </div>
 {% endblock %}
 {% block title %}{% translate 'Template tags' %}{% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/view_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/view_detail.html
@@ -6,7 +6,7 @@
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
 &rsaquo; <a href="{% url 'django-admindocs-views-index' %}">{% translate 'Views' %}</a>
-&rsaquo; {{ name }}
+&rsaquo; <a href="#" aria-current="page">{{ name }}</a>
 </div>
 {% endblock %}
 {% block title %}{% blocktranslate %}View: {{ name }}{% endblocktranslate %}{% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/view_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/view_index.html
@@ -6,7 +6,7 @@
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'django-admindocs-docroot' %}">{% translate 'Documentation' %}</a>
-&rsaquo; {% translate 'Views' %}
+&rsaquo; <a href="#" aria-current="page">{% translate 'Views' %}</a>
 </div>
 {% endblock %}
 {% block title %}{% translate 'Views' %}{% endblock %}

--- a/tests/admin_views/test_breadcrumbs.py
+++ b/tests/admin_views/test_breadcrumbs.py
@@ -19,7 +19,9 @@ class AdminBreadcrumbsTests(TestCase):
     def test_breadcrumbs_absent(self):
         response = self.client.get(reverse("admin:index"))
         self.assertNotContains(response, '<nav aria-label="Breadcrumbs">')
+        self.assertNotContains(response, '<a href="#" aria-current="page">')
 
     def test_breadcrumbs_present(self):
         response = self.client.get(reverse("admin:auth_user_add"))
         self.assertContains(response, '<nav aria-label="Breadcrumbs">')
+        self.assertContains(response, '<a href="#" aria-current="page">')

--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -93,8 +93,10 @@ class AdminSidebarTests(TestCase):
         )
         # Does not include aria-current attribute.
         self.assertContains(response, '<a href="%s">Users</a>' % url)
-        self.assertNotContains(response, '<a href="%s" aria-current="page">Users</a>' % url)
-
+        self.assertNotContains(
+            response, f'<a href="{url}" aria-current="page">Users</a>'
+        )
+        
     @override_settings(DEBUG=True)
     def test_included_app_list_template_context_fully_set(self):
         # All context variables should be set when rendering the sidebar.

--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -93,7 +93,7 @@ class AdminSidebarTests(TestCase):
         )
         # Does not include aria-current attribute.
         self.assertContains(response, '<a href="%s">Users</a>' % url)
-        self.assertNotContains(response, "aria-current")
+        self.assertNotContains(response, '<a href="%s" aria-current="page">Users</a>' % url)
 
     @override_settings(DEBUG=True)
     def test_included_app_list_template_context_fully_set(self):


### PR DESCRIPTION
This addresses the third item in [#34041](https://code.djangoproject.com/ticket/34041).

The last item in the breadcrumbs list now has an `<a>` tag with `aria-current="page"` attribute. This is a part of the accessibility changes suggested in the [Breadcrumb ARIA authoring practices pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/).