### PR TITLE
Refs #31300 -- Add function-based virtual fields

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -353,6 +353,13 @@ class BaseDatabaseFeatures:
     # Does the backend support column comments in ADD COLUMN statements?
     supports_comments_inline = False
 
+    # Does the backend support generated columns?
+    supports_generated_columns = False
+    # Does the backend allow parameters in generated column definitions?
+    supports_generated_columns_params = False
+    # Does the backend support virtual generated columns?
+    supports_virtual_generated_columns = False
+
     # Does the backend support the logical XOR operator?
     supports_logical_xor = False
 

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -60,6 +60,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     order_by_nulls_first = True
     supports_logical_xor = True
 
+    supports_generated_columns = True
+    supports_generated_columns_params = True
+    supports_virtual_generated_columns = True
+
     @cached_property
     def minimum_database_version(self):
         if self.connection.mysql_is_mariadb:

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -70,6 +70,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_update_conflicts = True
     supports_update_conflicts_with_target = True
     supports_covering_indexes = True
+    supports_generated_columns = True
+    supports_generated_columns_params = True
+    supports_virtual_generated_columns = False
     can_rename_index = True
     test_collations = {
         "non_default": "sv-x-icu",

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -40,6 +40,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_json_field_contains = False
     supports_update_conflicts = True
     supports_update_conflicts_with_target = True
+    supports_generated_columns = Database.sqlite_version_info >= (3, 31, 0)
+    supports_generated_columns_params = False
+    supports_virtual_generated_columns = True
     test_collations = {
         "ci": "nocase",
         "cs": "binary",

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -135,7 +135,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # Choose a default and insert it into the copy map
             if (
                 create_field.db_default is NOT_PROVIDED
-                and not create_field.many_to_many
+                and not (create_field.many_to_many or create_field.generated)
                 and create_field.concrete
             ):
                 mapping[create_field.column] = self.prepare_default(

--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -38,6 +38,7 @@ from django.db.models.expressions import (
 from django.db.models.fields import *  # NOQA
 from django.db.models.fields import __all__ as fields_all
 from django.db.models.fields.files import FileField, ImageField
+from django.db.models.fields.generated import GeneratedField
 from django.db.models.fields.json import JSONField
 from django.db.models.fields.proxy import OrderWrt
 from django.db.models.indexes import *  # NOQA
@@ -112,4 +113,5 @@ __all__ += [
     "ManyToOneRel",
     "ManyToManyRel",
     "OneToOneRel",
+    "GeneratedField",
 ]

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -166,6 +166,7 @@ class Field(RegisterLookupMixin):
     one_to_many = None
     one_to_one = None
     related_model = None
+    generated = False
 
     descriptor_class = DeferredAttribute
 

--- a/django/db/models/fields/generated.py
+++ b/django/db/models/fields/generated.py
@@ -1,0 +1,137 @@
+from django.core import checks
+from django.db import connections
+from django.db.models.sql import Query
+
+from . import Field
+
+__all__ = ["GeneratedField"]
+
+
+class GeneratedField(Field):
+    generated = True
+    db_returning = True
+
+    _query = None
+    _resolved_expression = None
+    output_field = None
+
+    def __init__(self, *, expression, output_field=None, db_persist=True, **kwargs):
+        self.expression = expression
+        self._output_field = output_field
+        self.db_persist = db_persist
+
+        assert "editable" not in kwargs, "Cannot set `editable` for GeneratedField"
+        assert "blank" not in kwargs, "Cannot set `blank` for GeneratedField"
+        assert "default" not in kwargs, "Cannot set `default` for GeneratedField"
+
+        kwargs["editable"] = False
+        kwargs["blank"] = True
+        kwargs["default"] = None
+
+        super().__init__(**kwargs)
+
+    def contribute_to_class(self, *args, **kwargs):
+        super().contribute_to_class(*args, **kwargs)
+
+        self._query = Query(model=self.model, alias_cols=False)
+        self._resolved_expression = self.expression.resolve_expression(
+            self._query, allow_joins=False
+        )
+        self.output_field = (
+            self._output_field
+            if self._output_field is not None
+            else self._resolved_expression.output_field
+        )
+
+    def _expression_sql(self, connection):
+        return self._resolved_expression.as_sql(
+            compiler=connection.ops.compiler("SQLCompiler")(
+                self._query, connection=connection, using=None
+            ),
+            connection=connection,
+        )
+
+    def check(self, **kwargs):
+        databases = kwargs.get("databases") or []
+        return [
+            *super().check(**kwargs),
+            *self._check_sql_expression(databases),
+            *self._check_persistence(databases),
+        ]
+
+    def _check_sql_expression(self, databases):
+        errors = []
+        for db in databases:
+            connection = connections[db]
+
+            if not (
+                connection.features.supports_generated_columns
+                or "supports_generated_columns" in self.model._meta.required_db_features
+            ):
+                errors.append(
+                    checks.Error(
+                        "%s does not support GeneratedFields."
+                        % connection.display_name,
+                        obj=self,
+                        id="fields.E220",
+                    )
+                )
+
+            if connection.features.supports_generated_columns:
+                _, params = self._expression_sql(connection=connection)
+                if params and not (
+                    connection.features.supports_generated_columns_params
+                    or "supports_generated_columns_params"
+                    in self.model._meta.required_db_features
+                ):
+                    errors.append(
+                        checks.Error(
+                            "%s does not support GeneratedFields with "
+                            "parameters." % connection.display_name,
+                            obj=self,
+                            id="fields.E221",
+                        )
+                    )
+
+        return errors
+
+    def _check_persistence(self, databases):
+        errors = []
+
+        for db in databases:
+            connection = connections[db]
+
+            if not self.db_persist and not (
+                connection.features.supports_virtual_generated_columns
+                or "supports_virtual_generated_columns"
+                in self.model._meta.required_db_features
+            ):
+                errors.append(
+                    checks.Error(
+                        "%s does not support non-persisted GeneratedFields."
+                        % connection.display_name,
+                        obj=self,
+                        id="fields.E222",
+                        hint="remove the persisted=False argument",
+                    )
+                )
+
+        return errors
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        del kwargs["blank"]
+        del kwargs["default"]
+        del kwargs["editable"]
+        kwargs["expression"] = self.expression
+        if self._output_field is not None:
+            kwargs["output_field"] = self._output_field
+        if self.db_persist is not True:
+            kwargs["db_persist"] = self.db_persist
+        return name, path, args, kwargs
+
+    def db_parameters(self, connection):
+        db_params = self.output_field.db_parameters(connection)
+        expression_sql, params = self._expression_sql(connection=connection)
+        db_params["generated_parameters"] = (expression_sql, self.db_persist, params)
+        return db_params

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -628,6 +628,19 @@ class Options:
         )
 
     @cached_property
+    def generated_fields(self):
+        """
+        Return a list of all fields on the model that are derived from other columns.
+
+        Private API intended only to be used by Django itself; get_fields()
+        combined with filtering of field properties is the public API for
+        obtaining this field list.
+        """
+        return make_immutable_fields_list(
+            "generated_fields", (f for f in self.fields if f.generated)
+        )
+
+    @cached_property
     def _forward_fields_map(self):
         res = {}
         fields = self._get_fields(reverse=False)

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1829,6 +1829,9 @@ class QuerySet(AltersData):
         Insert a new record for the given model. This provides an interface to
         the InsertQuery class and is how Model.save() is implemented.
         """
+        if self.model._meta.generated_fields and fields:
+            fields = [f for f in fields if not f.generated]
+
         self._for_write = True
         if using is None:
             using = self.db

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -237,6 +237,9 @@ Model fields
 * **fields.W907**: ``django.contrib.postgres.fields.CITextField`` is
   deprecated. Support for it (except in historical migrations) will be removed
   in Django 5.1.
+* **fields.E220**: ``<database>`` does not support ``GeneratedField``\s.
+* **fields.E221**: ``<database>`` does not support ``GeneratedField``\s with constant parameters.
+* **fields.E222**: ``<database>`` does not support ``GeneratedField``\s with no persistence.
 
 File fields
 ~~~~~~~~~~~

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1185,6 +1185,49 @@ when :attr:`~django.forms.Field.localize` is ``False`` or
     information on the difference between the two, see Python's documentation
     for the :mod:`decimal` module.
 
+``GeneratedField``
+------------------
+
+.. versionadded:: 5.0
+
+.. class:: GeneratedField(expression, output_field=None, db_persist=True, **kwargs)
+
+A field which is computed based on other fields in the model. Similar to a
+database view, this field is managed and updated by the database itself. Uses
+the ``GENERATED`` SQL syntax.
+
+There are two kinds of generated columns: stored and virtual. A stored generated
+column is computed when it is written (inserted or updated) and occupies storage
+as if it were a normal column. A virtual generated column occupies no storage and
+is computed when it is read. Thus, a virtual generated column is similar to a view
+and a stored generated column is similar to a materialized view.
+
+``GeneratedField`` is supported on MariaDB, MySQL, PostgreSQL, and SQLite. SQLite
+does not support parameters in generated column definitions.
+
+.. attribute:: GeneratedField.expression
+
+    An :class:`Expression` used by the database to automatically set the field
+    value whenever the model is changed.
+
+    The expressions should be deterministic and only reference fields within
+    the model (in one database table). Generated fields cannot reference other
+    generated fields. Database backends can impose further restrictions.
+
+.. attribute:: GeneratedField.output_field
+
+    An optional :class:`Field` to define the field's data type. This can be
+    used to customize attributes like the field's collation. By default, the
+    output field is derived from ``expression``.
+
+.. attribute:: GeneratedField.db_persist
+
+    Determines if the database column should occupy storage as if it were a real
+    column. If ``False``, the column acts as a virtual column and does
+    not occupy database storage space.
+
+    Default is ``True``. PostgreSQL only supports persisted columns.
+
 ``GenericIPAddressField``
 -------------------------
 

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -389,6 +389,8 @@ Models
 * Django now supports `oracledb`_ version 1.3.2 or higher. Support for
   ``cx_Oracle`` is deprecated as of this release and will be removed in Django
   6.0.
+* The new :class:`~django.db.models.GeneratedField` allows creation of
+  database generated columns.
 
 Pagination
 ~~~~~~~~~~

--- a/tests/model_fields/test_generatedfield.py
+++ b/tests/model_fields/test_generatedfield.py
@@ -1,0 +1,111 @@
+from django.db import IntegrityError, connection
+from django.db.models import F, GeneratedField
+from django.db.models.functions import Lower
+from django.test import TestCase, skipUnlessDBFeature
+
+from .models import (
+    GeneratedModel,
+    GeneratedModelNotNull,
+    GeneratedModelNull,
+    GeneratedModelParams,
+    GeneratedModelVirtual,
+    GeneratedModeOutputField,
+)
+
+
+@skipUnlessDBFeature("supports_generated_columns")
+class GeneratedFieldTests(TestCase):
+    def _refresh_if_needed(self, m):
+        # If the DB doesn't support `INSERT...RETURNING`, the model
+        # must be re-fetched from the database for the computed field
+        # to be set.
+        if connection.features.can_return_columns_from_insert:
+            return m
+        else:
+            return m.__class__.objects.get(id=m.id)
+
+    def test_create(self):
+        m = GeneratedModel.objects.create(a=1, b=2)
+        m = self._refresh_if_needed(m)
+        self.assertEqual(m.field, 3)
+
+    def test_save(self):
+        m = GeneratedModel(a=2, b=4)
+        m.save()
+        self.assertEqual(
+            m.field, 6 if connection.features.can_return_columns_from_insert else None
+        )
+        m = self._refresh_if_needed(m)
+        self.assertEqual(m.field, 6)
+
+    def test_bulk_create(self):
+        (m,) = GeneratedModel.objects.bulk_create([GeneratedModel(a=3, b=4)])
+        self.assertEqual(
+            m.field, 7 if connection.features.can_return_columns_from_insert else None
+        )
+
+    def test_update(self):
+        m = GeneratedModel.objects.create(a=1, b=2)
+        GeneratedModel.objects.update(b=3)
+        m = GeneratedModel.objects.get(id=m.id)
+        self.assertEqual(m.field, 4)
+
+    def test_bulk_update(self):
+        m = GeneratedModel.objects.create(a=1, b=2)
+        m.a = 3
+        GeneratedModel.objects.bulk_update([m], fields=["a"])
+        m = GeneratedModel.objects.get(id=m.id)
+        self.assertEqual(m.field, 5)
+
+    @skipUnlessDBFeature("supports_generated_columns_params")
+    def test_model_with_params(self):
+        m = GeneratedModelParams.objects.create()
+        m = self._refresh_if_needed(m)
+        self.assertEqual(m.field, "Constant")
+
+    @skipUnlessDBFeature("supports_virtual_generated_columns")
+    def test_create_virtual(self):
+        m = GeneratedModelVirtual.objects.create(name="Test")
+        m = self._refresh_if_needed(m)
+        self.assertEqual(m.lower_name, "test")
+
+    def test_output_field(self):
+        collation = connection.features.test_collations.get("non_default")
+        if not collation:
+            self.skipTest("Language collations are not supported.")
+
+        m = GeneratedModeOutputField.objects.create(name="NAME")
+        field = m._meta.get_field("lower_name")
+        db_parameters = field.db_parameters(connection)
+        self.assertEqual(db_parameters["collation"], collation)
+        self.assertEqual(db_parameters["type"], field.output_field.db_type(connection))
+        self.assertNotEqual(
+            db_parameters["type"],
+            field._resolved_expression.output_field.db_type(connection),
+        )
+
+    def test_deconstruct(self):
+        *_, desconstruct_kwargs = GeneratedModel._meta.get_field("field").deconstruct()
+        self.assertEqual(desconstruct_kwargs, dict(expression=F("a") + F("b")))
+
+    def test_nullable(self):
+        m1 = GeneratedModelNull.objects.create(name=None)
+        m1 = self._refresh_if_needed(m1)
+        self.assertEqual(m1.lower_name, None)
+        m2 = GeneratedModelNull.objects.create(name="Name")
+        m2 = self._refresh_if_needed(m2)
+        self.assertEqual(m2.lower_name, "name")
+        with self.assertRaises(IntegrityError):
+            GeneratedModelNotNull.objects.create(name=None)
+
+    def test_editable_unsupported(self):
+        with self.assertRaises(AssertionError):
+            GeneratedField(expression=Lower("name"), editable=False)
+
+    def test_blank_unsupported(self):
+        with self.assertRaises(AssertionError):
+            GeneratedField(expression=Lower("name"), blank=False)
+
+    def test_default_unsupported(self):
+        with self.assertRaises(AssertionError):
+            GeneratedField(expression=Lower("name"), default="")


### PR DESCRIPTION
As proposed in [this forum](https://groups.google.com/g/django-developers/c/9Mf7YqDA4bg/m/wb07E71oAAAJ), [this forum](https://groups.google.com/g/django-developers/c/ADSuUUuZp3Q/m/eZGYZv74AQAJ) and [this ticket](https://code.djangoproject.com/ticket/31300). Kudos to Paolo for the thorough research on backend support for this feature.

Code samples:

```
from django.db import models

# Basic usage
class MyModel(models.Model):
    a = models.IntegerField()
    b = models.IntegerField()
    a_plus_b = models.GeneratedField(expression=F("a") + F("b"))

# Option to customize how field is persisted
class MyModel(models.Model):
    name = models.CharField(max_length=10)
    lower_name = models.GeneratedField(
        expression=Lower("name"),
        output_field=TextField(
            db_collation="fr_FR"
        ),
    )

# Option to not store as column in database (not supported in Postgres)
class MyModel(models.Model):
    name = models.CharField(max_length=10)
    lower_name = models.GeneratedField(
        expression=Lower("name", output_field=TextField()), db_persist=False
    )
```


Implementation notes:
- The feature is implemented for Postgres, SQLite, and MySQL/MariaDB
- This feature has limitations on MySQL/MariaDB and older versions of SQLite because the generated field value won't be set on `save()` since `INSERT...RETURNING` isn't implemented for this DB backend
- Postgres does not support `GENERATED ALWAYS ... VIRTUAL` fields 
- SQLite doesn't support constants being injected into the `CREATE TABLE` statement
- It should be easy to implement this feature for Oracle, I just didn't bother quite yet since it's tedious to run Oracle locally

Please let me know what you think! This is a tentative first draft, so feedback and ideas are greatly appreciated 😄 