### PR TITLE
Refs #32355 -- Bumped mysqlclient requirement to >= 1.4.3.

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -31,9 +31,9 @@ from .schema import DatabaseSchemaEditor
 from .validation import DatabaseValidation
 
 version = Database.version_info
-if version < (1, 4, 0):
+if version < (1, 4, 3):
     raise ImproperlyConfigured(
-        "mysqlclient 1.4.0 or newer is required; you have %s." % Database.__version__
+        "mysqlclient 1.4.3 or newer is required; you have %s." % Database.__version__
     )
 
 

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -450,7 +450,7 @@ Connector/Python includes `its own`_.
 mysqlclient
 ~~~~~~~~~~~
 
-Django requires `mysqlclient`_ 1.4.0 or later.
+Django requires `mysqlclient`_ 1.4.3 or later.
 
 MySQL Connector/Python
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -507,6 +507,9 @@ Miscellaneous
   that differ only in case. If you need the previous behavior, use
   :class:`~django.contrib.auth.forms.BaseUserCreationForm` instead.
 
+* The minimum supported version of ``mysqlclient`` is increased from 1.4.0 to
+  1.4.3.
+
 .. _deprecated-features-4.2:
 
 Features deprecated in 4.2

--- a/tests/requirements/mysql.txt
+++ b/tests/requirements/mysql.txt
@@ -1,1 +1,1 @@
-mysqlclient >= 1.4.0
+mysqlclient >= 1.4.3


### PR DESCRIPTION
`mysqlclient` 1.4.3 is the first release to support Python 3.8.