### PR TITLE
Refs #32355 -- Bumped minimum supported versions of 3rd-party packages.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -277,24 +277,24 @@ If you want to run the full suite of tests, you'll need to install a number of
 dependencies:
 
 *  aiosmtpd_
-*  argon2-cffi_ 19.1.0+
+*  argon2-cffi_ 19.2.0+
 *  asgiref_ 3.6.0+ (required)
 *  bcrypt_
 *  colorama_
 *  docutils_
 *  geoip2_
-*  jinja2_ 2.7+
+*  jinja2_ 2.11+
 *  numpy_
-*  Pillow_ 6.2.0+
+*  Pillow_ 6.2.1+
 *  PyYAML_
 *  pytz_ (required)
 *  pywatchman_
-*  redis_
+*  redis_ 3.4+
 *  setuptools_
 *  memcached_, plus a :ref:`supported Python binding <memcached>`
 *  gettext_ (:ref:`gettext_on_windows`)
 *  selenium_
-*  sqlparse_ 0.2.3+ (required)
+*  sqlparse_ 0.3.1+ (required)
 *  tblib_ 1.5.0+
 
 You can find these dependencies in `pip requirements files`_ inside the

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -486,7 +486,7 @@ Miscellaneous
 * The ``alias`` argument for :meth:`.Expression.get_group_by_cols` is removed.
 
 * The minimum supported version of ``sqlparse`` is increased from 0.2.2 to
-  0.2.3.
+  0.3.1.
 
 * The undocumented ``negated`` parameter of the
   :class:`~django.db.models.Exists` expression is removed.
@@ -509,6 +509,19 @@ Miscellaneous
 
 * The minimum supported version of ``mysqlclient`` is increased from 1.4.0 to
   1.4.3.
+
+* The minimum supported version of ``argon2-cffi`` is increased  from 19.1.0 to
+  19.2.0.
+
+* The minimum supported version of ``Pillow`` is increased from 6.2.0 to 6.2.1.
+
+* The minimum supported version of ``jinja2`` is increased from 2.9.2 to
+  2.11.0.
+
+* The minimum supported version of `redis-py`_ is increased from 3.0.0 to
+  3.4.0.
+
+.. _`redis-py`: https://pypi.org/project/redis/
 
 .. _deprecated-features-4.2:
 

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,23 +1,23 @@
 aiosmtpd
 asgiref >= 3.6.0
-argon2-cffi >= 16.1.0
+argon2-cffi >= 19.2.0
 backports.zoneinfo; python_version < '3.9'
 bcrypt
 black
 docutils
 geoip2; python_version < '3.12'
-jinja2 >= 2.9.2
+jinja2 >= 2.11.0
 numpy; python_version < '3.12'
-Pillow >= 6.2.0; sys.platform != 'win32' or python_version < '3.12'
+Pillow >= 6.2.1; sys.platform != 'win32' or python_version < '3.12'
 # pylibmc/libmemcached can't be built on Windows.
 pylibmc; sys.platform != 'win32'
 pymemcache >= 3.4.0
 pytz
 pywatchman; sys.platform != 'win32'
 PyYAML
-redis >= 3.0.0
+redis >= 3.4.0
 selenium
-sqlparse >= 0.2.3
+sqlparse >= 0.3.1
 tblib >= 1.5.0
 tzdata
 colorama; sys.platform == 'win32'


### PR DESCRIPTION
This bumps minimum supported versions of 3rd-party packages to the first releases to support Python 3.8.


ticket-32355