### PR TITLE
Fixed #34220 -- Moved csrf_input_lazy, csrf_token_lazy imports to the toplevel.

### DIFF
--- a/django/template/backends/jinja2.py
+++ b/django/template/backends/jinja2.py
@@ -8,6 +8,7 @@ from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 
 from .base import BaseEngine
+from .utils import csrf_input_lazy, csrf_token_lazy
 
 
 class Jinja2(BaseEngine):
@@ -62,8 +63,6 @@ class Template:
         )
 
     def render(self, context=None, request=None):
-        from .utils import csrf_input_lazy, csrf_token_lazy
-
         if context is None:
             context = {}
         if request is not None:


### PR DESCRIPTION
adding imports on line 11, thanks to thread by @felixxm 