### PR TITLE
Refs #31949 -- Made @never_cache and @cache_control() decorators to work with async functions.

### DIFF
--- a/django/views/decorators/cache.py
+++ b/django/views/decorators/cache.py
@@ -1,5 +1,7 @@
 from functools import wraps
 
+from asgiref.sync import iscoroutinefunction
+
 from django.middleware.cache import CacheMiddleware
 from django.utils.cache import add_never_cache_headers, patch_cache_control
 from django.utils.decorators import decorator_from_middleware_with_args
@@ -26,22 +28,34 @@ def cache_page(timeout, *, cache=None, key_prefix=None):
     )
 
 
+def _check_request(request, decorator_name):
+    # Ensure argument looks like a request.
+    if not hasattr(request, "META"):
+        raise TypeError(
+            f"{decorator_name} didn't receive an HttpRequest. If you are "
+            "decorating a classmethod, be sure to use @method_decorator."
+        )
+
+
 def cache_control(**kwargs):
     def _cache_controller(viewfunc):
-        @wraps(viewfunc)
-        def _cache_controlled(request, *args, **kw):
-            # Ensure argument looks like a request.
-            if not hasattr(request, "META"):
-                raise TypeError(
-                    "cache_control didn't receive an HttpRequest. If you are "
-                    "decorating a classmethod, be sure to use "
-                    "@method_decorator."
-                )
-            response = viewfunc(request, *args, **kw)
-            patch_cache_control(response, **kwargs)
-            return response
+        if iscoroutinefunction(viewfunc):
 
-        return _cache_controlled
+            async def _view_wrapper(request, *args, **kw):
+                _check_request(request, "cache_control")
+                response = await viewfunc(request, *args, **kw)
+                patch_cache_control(response, **kwargs)
+                return response
+
+        else:
+
+            def _view_wrapper(request, *args, **kw):
+                _check_request(request, "cache_control")
+                response = viewfunc(request, *args, **kw)
+                patch_cache_control(response, **kwargs)
+                return response
+
+        return wraps(viewfunc)(_view_wrapper)
 
     return _cache_controller
 
@@ -51,16 +65,20 @@ def never_cache(view_func):
     Decorator that adds headers to a response so that it will never be cached.
     """
 
-    @wraps(view_func)
-    def _wrapper_view_func(request, *args, **kwargs):
-        # Ensure argument looks like a request.
-        if not hasattr(request, "META"):
-            raise TypeError(
-                "never_cache didn't receive an HttpRequest. If you are "
-                "decorating a classmethod, be sure to use @method_decorator."
-            )
-        response = view_func(request, *args, **kwargs)
-        add_never_cache_headers(response)
-        return response
+    if iscoroutinefunction(view_func):
 
-    return _wrapper_view_func
+        async def _view_wrapper(request, *args, **kwargs):
+            _check_request(request, "never_cache")
+            response = await view_func(request, *args, **kwargs)
+            add_never_cache_headers(response)
+            return response
+
+    else:
+
+        def _view_wrapper(request, *args, **kwargs):
+            _check_request(request, "never_cache")
+            response = view_func(request, *args, **kwargs)
+            add_never_cache_headers(response)
+            return response
+
+    return wraps(view_func)(_view_wrapper)

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -214,7 +214,9 @@ CSRF
 Decorators
 ~~~~~~~~~~
 
-* ...
+* The :func:`~django.views.decorators.cache.cache_control` and
+  :func:`~django.views.decorators.cache.never_cache` decorators now support
+  wrapping asynchronous view functions.
 
 Email
 ~~~~~

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -73,6 +73,31 @@ from an async view, you will trigger Django's
 :ref:`asynchronous safety protection <async-safety>` to protect your data from
 corruption.
 
+Decorators
+----------
+
+.. versionadded:: 5.0
+
+The following decorators can be used with both synchronous and asynchronous
+view functions:
+
+* :func:`~django.views.decorators.cache.cache_control`
+* :func:`~django.views.decorators.cache.never_cache`
+
+For example::
+
+    from django.views.decorators.cache import never_cache
+
+
+    @never_cache
+    def my_sync_view(request):
+        ...
+
+
+    @never_cache
+    async def my_async_view(request):
+        ...
+
 Queries & the ORM
 -----------------
 

--- a/docs/topics/http/decorators.txt
+++ b/docs/topics/http/decorators.txt
@@ -117,6 +117,10 @@ client-side caching.
     :func:`~django.utils.cache.patch_cache_control` for the details of the
     transformation.
 
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
+
 .. function:: never_cache(view_func)
 
     This decorator adds an ``Expires`` header to the current date/time.
@@ -126,6 +130,10 @@ client-side caching.
     should never be cached.
 
     Each header is only added if it isn't already set.
+
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
 
 .. module:: django.views.decorators.common
 

--- a/tests/decorators/test_cache.py
+++ b/tests/decorators/test_cache.py
@@ -42,6 +42,25 @@ class CacheControlDecoratorTest(SimpleTestCase):
         response = MyClass().a_view(HttpRequestProxy(request))
         self.assertEqual(response.headers["Cache-Control"], "a=b")
 
+    def test_cache_control_empty_decorator(self):
+        @cache_control()
+        def a_view(request):
+            return HttpResponse()
+
+        response = a_view(HttpRequest())
+        self.assertEqual(response.get("Cache-Control"), "")
+
+    def test_cache_control_full_decorator(self):
+        @cache_control(max_age=123, private=True, public=True, custom=456)
+        def a_view(request):
+            return HttpResponse()
+
+        response = a_view(HttpRequest())
+        cache_control_items = response.get("Cache-Control").split(", ")
+        self.assertEqual(
+            set(cache_control_items), {"max-age=123", "private", "public", "custom=456"}
+        )
+
 
 class CachePageDecoratorTest(SimpleTestCase):
     def test_cache_page(self):


### PR DESCRIPTION
Reference to [#31949](https://code.djangoproject.com/ticket/31949).

This PR makes the `cache_control` and `never_cache` view decorators able to handle both sync and async views.