### PR TITLE
Refs #30240 -- Fixed argument name for MySQLSHA2Mixin.as_mysql() and PostgreSQLSHAMixin.as_postgresql() methods.

### DIFF
--- a/django/db/models/functions/text.py
+++ b/django/db/models/functions/text.py
@@ -6,12 +6,12 @@ from django.db.models.lookups import Transform
 
 
 class MySQLSHA2Mixin:
-    def as_mysql(self, compiler, connection, **extra_content):
+    def as_mysql(self, compiler, connection, **extra_context):
         return super().as_sql(
             compiler,
             connection,
             template="SHA2(%%(expressions)s, %s)" % self.function[3:],
-            **extra_content,
+            **extra_context,
         )
 
 
@@ -29,13 +29,13 @@ class OracleHashMixin:
 
 
 class PostgreSQLSHAMixin:
-    def as_postgresql(self, compiler, connection, **extra_content):
+    def as_postgresql(self, compiler, connection, **extra_context):
         return super().as_sql(
             compiler,
             connection,
             template="ENCODE(DIGEST(%(expressions)s, '%(function)s'), 'hex')",
             function=self.function.lower(),
-            **extra_content,
+            **extra_context,
         )
 
 


### PR DESCRIPTION
Everywhere else this argument is called `extra_context`, but in two places someone had written `extra_content`. Introduced in commit 0b70985f42da7a8eb2e206e6780681b7849564ef.

This doesn't seem significant enough to create a Trac ticket?
