### PR TITLE
Fixed #34247 -- Ordered CreateModel operations first when sorting migrations.

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -395,7 +395,7 @@ class MigrationAutodetector:
                 elif type(op) == CreateModel:
                     create.append(op)
                 else:
-                    rest.append(operation)
+                    rest.append(op)
             self.generated_operations[app_label] = create + proxy_create + rest
 
         for app_label, ops in sorted(self.generated_operations.items()):

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -390,9 +390,9 @@ class MigrationAutodetector:
             proxy_create = []
             rest = []
             for op in ops:
-                if type(op) == CreateModel and "proxy" in op.options:
+                if isinstance(op, CreateModel) and "proxy" in op.options:
                     proxy_create.append(op)
-                elif type(op) == CreateModel:
+                elif isinstance(op, CreateModel):
                     create.append(op)
                 else:
                     rest.append(op)

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -390,7 +390,7 @@ class MigrationAutodetector:
             proxy_create = []
             rest = []
             for op in ops:
-                if type(op) == CreateModel and 'proxy' in op.options:
+                if type(op) == CreateModel and "proxy" in op.options:
                     proxy_create.append(op)
                 elif type(op) == CreateModel:
                     create.append(op)


### PR DESCRIPTION
I've been having trouble regenerating all my Django migrations from scratch.  We have hundreds of models and many complex relationships.  I kept getting the error `Cannot resolve operation dependencies` when generating and I noticed that proxy models that were foreign keys of other models seemed to be the culprit.  This is an update to the sort method that ensures that we put proxy model based CreateModel and regular model CreateModel operations at the top and fixes my problem.