### PR TITLE
Corrected used JS libraries in GIS widget docs.

### DIFF
--- a/docs/ref/contrib/gis/forms-api.txt
+++ b/docs/ref/contrib/gis/forms-api.txt
@@ -157,11 +157,11 @@ Widget classes
     This is the default widget used by all GeoDjango form fields.
     ``template_name`` is ``gis/openlayers.html``.
 
-    ``OpenLayersWidget`` and :class:`OSMWidget` use the ``openlayers.js`` file
-    hosted on the ``cdnjs.cloudflare.com`` content-delivery network. You can
-    subclass these widgets in order to specify your own version of the
-    ``OpenLayers.js`` file in the ``js`` property of the inner ``Media`` class
-    (see :ref:`assets-as-a-static-definition`).
+    ``OpenLayersWidget`` and :class:`OSMWidget` use the ``ol.js`` file hosted
+    on the ``cdn.jsdelivr.net`` content-delivery network. You can subclass
+    these widgets in order to specify your own version of the ``ol.js`` file in
+    the ``js`` property of the inner ``Media`` class (see
+    :ref:`assets-as-a-static-definition`).
 
 ``OSMWidget``
 


### PR DESCRIPTION
Follow up to 1833eb3f3e3bda5052637f1a51a27fa1b11b6871.