### PR TITLE
Refs #31546, Refs #34118 -- Corrected CommandTests.test_requires_system_checks_specific().

### DIFF
--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -199,8 +199,8 @@ class CommandTests(SimpleTestCase):
         with mock.patch(
             "django.core.management.base.BaseCommand.check"
         ) as mocked_check:
-            management.call_command("specific_system_checks")
-        mocked_check.called_once_with(tags=[Tags.staticfiles, Tags.models])
+            management.call_command("specific_system_checks", skip_checks=False)
+        mocked_check.assert_called_once_with(tags=[Tags.staticfiles, Tags.models])
 
     def test_requires_system_checks_invalid(self):
         class Command(BaseCommand):


### PR DESCRIPTION
System checks are never called without `skip_checks=False`. Moreover, `called_once_with()` is not a proper assertion and raise `AttributeError` on Python 3.12:
```
ERROR: test_requires_system_checks_specific (user_commands.tests.CommandTests.test_requires_system_checks_specific)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/tests/user_commands/tests.py", line 203, in test_requires_system_checks_specific
    mocked_check.called_once_with(tags=[Tags.staticfiles, Tags.models])
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/unittest/mock.py", line 657, in __getattr__
    raise AttributeError(
AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_with'?

```