### PR TITLE
Refs #33879 -- Fixed plural value deprecation warnings.

### DIFF
--- a/django/utils/timesince.py
+++ b/django/utils/timesince.py
@@ -104,7 +104,7 @@ def timesince(d, now=None, reversed=False, time_strings=None, depth=2):
     remaining_time = (now - pivot).total_seconds()
     partials = [years, months]
     for chunk in TIME_CHUNKS:
-        count = remaining_time // chunk
+        count = int(remaining_time // chunk)
         partials.append(count)
         remaining_time -= chunk * count
 


### PR DESCRIPTION
Plural value must be an integer.

Without this patch:
```
$ python -Wall ./runtests.py humanize_tests
Testing against Django installed in '/django/django' with up to 8 processes
Found 15 test(s).
System check identified no issues (0 silenced).
..../django/django/utils/translation/trans_real.py:270: DeprecationWarning: Plural value must be an integer, got float
  tmsg = self._catalog.plural(msgid1, n)
/django/django/utils/translation/trans_real.py:270: DeprecationWarning: Plural value must be an integer, got float
  tmsg = self._catalog.plural(msgid1, n)
/django/django/utils/translation/trans_real.py:270: DeprecationWarning: Plural value must be an integer, got float
  tmsg = self._catalog.plural(msgid1, n)
/django/django/utils/translation/trans_real.py:270: DeprecationWarning: Plural value must be an integer, got float
  tmsg = self._catalog.plural(msgid1, n)
...........
----------------------------------------------------------------------
Ran 15 tests in 0.079s

OK

```

Regression in 8d67e16493c903adc9d049141028bc0fff43f8c8.