### PR TITLE
Fixed thread termination in servers.tests.LiveServerPort on Python 3.10.9+, 3.11.1+, and 3.12+.

### DIFF
--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -377,12 +377,15 @@ class LiveServerPort(LiveServerBase):
                 return
             # Unexpected error.
             raise
-        self.assertNotEqual(
-            self.live_server_url,
-            TestCase.live_server_url,
-            f"Acquired duplicate server addresses for server threads: "
-            f"{self.live_server_url}",
-        )
+        try:
+            self.assertNotEqual(
+                self.live_server_url,
+                TestCase.live_server_url,
+                f"Acquired duplicate server addresses for server threads: "
+                f"{self.live_server_url}",
+            )
+        finally:
+            TestCase.doClassCleanups()
 
     def test_specified_port_bind(self):
         """LiveServerTestCase.port customizes the server's port."""
@@ -393,12 +396,15 @@ class LiveServerPort(LiveServerBase):
         TestCase.port = s.getsockname()[1]
         s.close()
         TestCase._start_server_thread()
-        self.assertEqual(
-            TestCase.port,
-            TestCase.server_thread.port,
-            f"Did not use specified port for LiveServerTestCase thread: "
-            f"{TestCase.port}",
-        )
+        try:
+            self.assertEqual(
+                TestCase.port,
+                TestCase.server_thread.port,
+                f"Did not use specified port for LiveServerTestCase thread: "
+                f"{TestCase.port}",
+            )
+        finally:
+            TestCase.doClassCleanups()
 
 
 class LiveServerThreadedTests(LiveServerBase):


### PR DESCRIPTION
Class cleanups registered in `TestCase` subclasses are no longer called as `TestCase.doClassCleanups()` only cleans up the particular class, see https://github.com/python/cpython/commit/c2102136be569e6fc8ed90181f229b46d07142f8 and https://github.com/python/cpython/issues/99645.