### PR TITLE
Refs #18468 -- Used obj_description() with a catalog name on PostgreSQL.

### DIFF
--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -64,7 +64,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                     WHEN c.relkind IN ('m', 'v') THEN 'v'
                     ELSE 't'
                 END,
-                obj_description(c.oid)
+                obj_description(c.oid, 'pg_class')
             FROM pg_catalog.pg_class c
             LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
             WHERE c.relkind IN ('f', 'm', 'p', 'r', 'v')


### PR DESCRIPTION
`obj_description(object oid)` without a catalog name is deprecated since there is no guarantee that OIDs are unique across different system catalogs.

Thanks Tim Graham for the [report](https://github.com/django/django/pull/14463#discussion_r1067313439).