### PR TITLE
Fixed #34240 -- Preserved headers of requests made with django.test.Client in assertRedirects().

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -845,6 +845,7 @@ class Client(ClientMixin, RequestFactory):
         self.raise_request_exception = raise_request_exception
         self.exc_info = None
         self.extra = None
+        self.headers = None
 
     def request(self, **request):
         """
@@ -905,6 +906,7 @@ class Client(ClientMixin, RequestFactory):
     ):
         """Request a response from the server using GET."""
         self.extra = extra
+        self.headers = headers
         response = super().get(path, data=data, secure=secure, headers=headers, **extra)
         if follow:
             response = self._handle_redirects(
@@ -925,6 +927,7 @@ class Client(ClientMixin, RequestFactory):
     ):
         """Request a response from the server using POST."""
         self.extra = extra
+        self.headers = headers
         response = super().post(
             path,
             data=data,
@@ -951,6 +954,7 @@ class Client(ClientMixin, RequestFactory):
     ):
         """Request a response from the server using HEAD."""
         self.extra = extra
+        self.headers = headers
         response = super().head(
             path, data=data, secure=secure, headers=headers, **extra
         )
@@ -973,6 +977,7 @@ class Client(ClientMixin, RequestFactory):
     ):
         """Request a response from the server using OPTIONS."""
         self.extra = extra
+        self.headers = headers
         response = super().options(
             path,
             data=data,
@@ -1000,6 +1005,7 @@ class Client(ClientMixin, RequestFactory):
     ):
         """Send a resource to the server using PUT."""
         self.extra = extra
+        self.headers = headers
         response = super().put(
             path,
             data=data,
@@ -1027,6 +1033,7 @@ class Client(ClientMixin, RequestFactory):
     ):
         """Send a resource to the server using PATCH."""
         self.extra = extra
+        self.headers = headers
         response = super().patch(
             path,
             data=data,
@@ -1054,6 +1061,7 @@ class Client(ClientMixin, RequestFactory):
     ):
         """Send a DELETE request to the server."""
         self.extra = extra
+        self.headers = headers
         response = super().delete(
             path,
             data=data,
@@ -1080,6 +1088,7 @@ class Client(ClientMixin, RequestFactory):
     ):
         """Send a TRACE request to the server."""
         self.extra = extra
+        self.headers = headers
         response = super().trace(
             path, data=data, secure=secure, headers=headers, **extra
         )
@@ -1190,6 +1199,7 @@ class AsyncClient(ClientMixin, AsyncRequestFactory):
         self.raise_request_exception = raise_request_exception
         self.exc_info = None
         self.extra = None
+        self.headers = None
 
     async def request(self, **request):
         """

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -545,10 +545,12 @@ class SimpleTestCase(unittest.TestCase):
                 # Get the redirection page, using the same client that was used
                 # to obtain the original response.
                 extra = response.client.extra or {}
+                headers = response.client.headers or {}
                 redirect_response = response.client.get(
                     path,
                     QueryDict(query),
                     secure=(scheme == "https"),
+                    headers=headers,
                     **extra,
                 )
                 self.assertEqual(

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -601,10 +601,24 @@ class AssertRedirectsTests(SimpleTestCase):
         for method in methods:
             with self.subTest(method=method):
                 req_method = getattr(self.client, method)
+                # HTTP_REDIRECT in "extra".
                 response = req_method(
                     "/redirect_based_on_extra_headers_1/",
                     follow=False,
                     HTTP_REDIRECT="val",
+                )
+                self.assertRedirects(
+                    response,
+                    "/redirect_based_on_extra_headers_2/",
+                    fetch_redirect_response=True,
+                    status_code=302,
+                    target_status_code=302,
+                )
+                # HTTP_REDIRECT in "headers".
+                response = req_method(
+                    "/redirect_based_on_extra_headers_1/",
+                    follow=False,
+                    headers={"redirect": "val"},
                 )
                 self.assertRedirects(
                     response,


### PR DESCRIPTION
ticket-34240

Bug in 67da22f08e05018ea968fcacbac9ac37ea925d85.