### PR TITLE
Add util to strip BOM from UTF-8 text

### DIFF
--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -453,3 +453,9 @@ def _format_lazy(format_string, *args, **kwargs):
 
 
 format_lazy = lazy(_format_lazy, str)
+
+
+@keep_lazy_text
+def strip_bom(value):
+    """Strip Byte Order Mark from UTF-8 text."""
+    return value.encode("utf-8").decode("utf-8-sig")

--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -5,7 +5,7 @@ from django.core.exceptions import SuspiciousFileOperation
 from django.test import SimpleTestCase
 from django.utils import text
 from django.utils.functional import lazystr
-from django.utils.text import format_lazy
+from django.utils.text import format_lazy, strip_bom
 from django.utils.translation import gettext_lazy, override
 
 IS_WIDE_BUILD = len("\U0001F4A9") == 1
@@ -312,3 +312,8 @@ class TestUtilsText(SimpleTestCase):
         )
         with override("fr"):
             self.assertEqual("Ajout de article «\xa0My first try\xa0».", s)
+
+    def test_strip_bom(self):
+        self.assertEqual(
+            strip_bom(b"\xef\xbb\xbfDummy text".decode("utf-8")), "Dummy text"
+        )


### PR DESCRIPTION
This PR aims to suggest a util to strip the [Byte Order Mark](https://it.wikipedia.org/wiki/Byte_Order_Mark) from UTF-8 text.

The util eases the pain in those situations where text "A" needs to be compared against some other clean text "B", with the BOM standing in the way of having a clean text "A" for such a purpose.