### PR TITLE
Note that FloatField must be finite

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1106,7 +1106,9 @@ can change the maximum length using the :attr:`~CharField.max_length` argument.
 
 .. class:: FloatField(**options)
 
-A floating-point number represented in Python by a ``float`` instance.
+A floating-point number represented in Python by a ``float`` instance. Only
+finite values (i.e. not ``float('inf')`` or ``float('nan')`` may be stored
+in a ``FloatField``.
 
 The default form widget for this field is a :class:`~django.forms.NumberInput`
 when :attr:`~django.forms.Field.localize` is ``False`` or


### PR DESCRIPTION
This patch to docs addresses https://code.djangoproject.com/ticket/34260#ticket in dev-version documentation.

I wasn't clear how backports to older versions worked. I'm happy to open PRs against the `stable/*` branches if that's easiest, or perhaps you have some other process. This change can go back to all supported Django versions.