### PR TITLE
Fixed #23718 -- Doc'd that test mirrors require TransactionTestCase.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -828,7 +828,9 @@ but for all apps.
 Default: ``None``
 
 The alias of the database that this database should mirror during
-testing.
+testing. It depends on transactions and therefore must be used within
+:class:`~django.test.TransactionTestCase` instead of
+:class:`~django.test.TestCase`.
 
 This setting exists to allow for testing of primary/replica
 (referred to as master/slave by some databases)

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -241,7 +241,9 @@ will *not* be created. Instead the connection to ``replica``
 will be redirected to point at ``default``. As a result, writes to
 ``default`` will appear on ``replica`` -- but because they are actually
 the same database, not because there is data replication between the
-two databases.
+two databases. As this depends on transactions, the tests must use
+:class:`~django.test.TransactionTestCase` instead of
+:class:`~django.test.TestCase`.
 
 .. _topics-testing-creation-dependencies:
 


### PR DESCRIPTION
Thank you to @christianbundy for the patch https://github.com/django/django/pull/14811
Added a reference the ["Testing primary/replica configurations"](https://docs.djangoproject.com/en/3.2/topics/testing/advanced/#testing-primary-replica-configurations) section, as per the comment.  