### PR TITLE
Fixed #34255 -- Made PostgreSQL backend use client-side parameters binding with psycopg version 3.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -144,6 +144,16 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                     },
                 }
             )
+        if "ONLY_FULL_GROUP_BY" in self.connection.sql_mode:
+            skips.update(
+                {
+                    "GROUP BY cannot contain nonaggregated column when "
+                    "ONLY_FULL_GROUP_BY mode is enabled on MySQL, see #34262.": {
+                        "aggregation.tests.AggregateTestCase."
+                        "test_group_by_nested_expression_with_params",
+                    },
+                }
+            )
         return skips
 
     @cached_property

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -1,7 +1,7 @@
 """
 PostgreSQL database backend for Django.
 
-Requires psycopg2 >= 2.8.4 or psycopg >= 3.1
+Requires psycopg2 >= 2.8.4 or psycopg >= 3.1.8
 """
 
 import asyncio
@@ -38,9 +38,9 @@ if psycopg_version() < (2, 8, 4):
     raise ImproperlyConfigured(
         f"psycopg2 version 2.8.4 or newer is required; you have {Database.__version__}"
     )
-if (3,) <= psycopg_version() < (3, 1):
+if (3,) <= psycopg_version() < (3, 1, 8):
     raise ImproperlyConfigured(
-        f"psycopg version 3.1 or newer is required; you have {Database.__version__}"
+        f"psycopg version 3.1.8 or newer is required; you have {Database.__version__}"
     )
 
 

--- a/docs/ref/contrib/gis/install/postgis.txt
+++ b/docs/ref/contrib/gis/install/postgis.txt
@@ -24,7 +24,7 @@ platform-specific instructions if you are on :ref:`macos` or :ref:`windows`.
 
 .. versionchanged:: 4.2
 
-    Support for ``psycopg`` 3.1+ was added.
+    Support for ``psycopg`` 3.1.8+ was added.
 
 Post-installation
 =================

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -117,9 +117,6 @@ PostgreSQL notes
 Django supports PostgreSQL 12 and higher. `psycopg`_ 3.1.8+ or `psycopg2`_
 2.8.4+ is required, though the latest `psycopg`_ 3.1.8+ is recommended.
 
-.. _psycopg: https://www.psycopg.org/psycopg3/
-.. _psycopg2: https://www.psycopg.org/
-
 .. note::
 
     Support for ``psycopg2`` is likely to be deprecated and removed at some
@@ -251,6 +248,31 @@ database configuration in :setting:`DATABASES`::
         },
     }
 
+.. _database-server-side-parameters-binding:
+
+Server-side parameters binding
+------------------------------
+
+.. versionadded:: 4.2
+
+With `psycopg`_ 3.1.8+, Django defaults to the :ref:`client-side binding
+cursors <psycopg:client-side-binding-cursors>`. If you want to use the
+:ref:`server-side binding <psycopg:server-side-binding>` set it in the
+:setting:`OPTIONS` part of your database configuration in
+:setting:`DATABASES`::
+
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            # ...
+            "OPTIONS": {
+                "server_side_binding": True,
+            },
+        },
+    }
+
+This option is ignored with ``psycopg2``.
+
 Indexes for ``varchar`` and ``text`` columns
 --------------------------------------------
 
@@ -372,6 +394,9 @@ non-durable <https://www.postgresql.org/docs/current/non-durability.html>`_.
     or corruption in the case of a server crash or power loss. Only use this on
     a development machine where you can easily restore the entire contents of
     all databases in the cluster.
+
+.. _psycopg: https://www.psycopg.org/psycopg3/
+.. _psycopg2: https://www.psycopg.org/
 
 .. _mariadb-notes:
 

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -114,8 +114,8 @@ below for information on how to set up your database correctly.
 PostgreSQL notes
 ================
 
-Django supports PostgreSQL 12 and higher. `psycopg`_ 3.1+ or `psycopg2`_ 2.8.4+
-is required, though the latest `psycopg`_ 3.1+ is recommended.
+Django supports PostgreSQL 12 and higher. `psycopg`_ 3.1.8+ or `psycopg2`_
+2.8.4+ is required, though the latest `psycopg`_ 3.1.8+ is recommended.
 
 .. _psycopg: https://www.psycopg.org/psycopg3/
 .. _psycopg2: https://www.psycopg.org/
@@ -127,7 +127,7 @@ is required, though the latest `psycopg`_ 3.1+ is recommended.
 
 .. versionchanged:: 4.2
 
-    Support for ``psycopg`` 3.1+ was added.
+    Support for ``psycopg`` 3.1.8+ was added.
 
 .. _postgresql-connection-settings:
 

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -29,7 +29,7 @@ What's new in Django 4.2
 Psycopg 3 support
 -----------------
 
-Django now supports `psycopg`_ version 3.1 or higher. To update your code,
+Django now supports `psycopg`_ version 3.1.8 or higher. To update your code,
 install the `psycopg library`_, you don't need to change the
 :setting:`ENGINE <DATABASE-ENGINE>` as ``django.db.backends.postgresql``
 supports both libraries.

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -254,6 +254,10 @@ Database backends
 * The new ``"assume_role"`` option is now supported in :setting:`OPTIONS` on
   PostgreSQL to allow specifying the :ref:`session role <database-role>`.
 
+* The new ``"server_side_binding"`` option is now supported in
+  :setting:`OPTIONS` on PostgreSQL with ``psycopg`` 3.1.8+ to allow using
+  :ref:`server-side binding cursors <database-server-side-parameters-binding>`.
+
 Decorators
 ~~~~~~~~~~
 

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -277,6 +277,25 @@ class Tests(TestCase):
         finally:
             new_connection.close()
 
+    @unittest.skipUnless(is_psycopg3, "psycopg3 specific test")
+    def test_connect_server_side_binding(self):
+        """
+        The server-side parameters binding role can be enabled with DATABASES
+        ["OPTIONS"]["server_side_binding"].
+        """
+        from django.db.backends.postgresql.base import ServerBindingCursor
+
+        new_connection = connection.copy()
+        new_connection.settings_dict["OPTIONS"]["server_side_binding"] = True
+        try:
+            new_connection.connect()
+            self.assertEqual(
+                new_connection.connection.cursor_factory,
+                ServerBindingCursor,
+            )
+        finally:
+            new_connection.close()
+
     def test_connect_no_is_usable_checks(self):
         new_connection = connection.copy()
         try:

--- a/tests/requirements/postgres.txt
+++ b/tests/requirements/postgres.txt
@@ -1,1 +1,1 @@
-psycopg[binary]>=3.1
+psycopg[binary]>=3.1.8


### PR DESCRIPTION
Thanks Guillaume Andreu Sabater for the report.

Co-authored-by: @apollo13

ticket-34255