### PR TITLE
Removed remaining empty sections from 4.2 release notes.

### DIFF
--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -213,16 +213,6 @@ Database backends
   :setting:`OPTIONS` on PostgreSQL with ``psycopg`` 3.1.8+ to allow using
   :ref:`server-side binding cursors <database-server-side-parameters-binding>`.
 
-Decorators
-~~~~~~~~~~
-
-* ...
-
-Email
-~~~~~
-
-* ...
-
 Error Reporting
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Follow up to 772cd2b15b158679b9dc15fb599aa935ec7c25b1.

I'm not sure how I missed them :facepalm: .