### PR TITLE
Refs #7430 -- Removed broken Template.__iter__(). 

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -153,10 +153,6 @@ class Template:
         self.source = str(template_string)  # May be lazy.
         self.nodelist = self.compile_nodelist()
 
-    def __iter__(self):
-        for node in self.nodelist:
-            yield from node
-
     def __repr__(self):
         return '<%s template_string="%s...">' % (
             self.__class__.__qualname__,


### PR DESCRIPTION
I was trying to walk Templates and found that `Template` had an `__iter__`. I thought great! But alas it's just broken :P 

Deleting this method has no effect on the test suite. You can see that it's broken quite easily with this code:

```py
t = Template('{% load i18n %}')
for node in t:
    pass
```