### PR TITLE
Primary key

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -457,6 +457,8 @@ The primary key field is read-only. If you change the value of the primary
 key on an existing object and then save it, a new object will be created
 alongside the old one.
 
+If you specified the primary_key to an actual data field, after :ref:`topics-db-queries-delete` the primary_key will be set to None.
+
 ``unique``
 ----------
 

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1108,6 +1108,8 @@ can change the maximum length using the :attr:`~CharField.max_length` argument.
 
 A floating-point number represented in Python by a ``float`` instance.
 
+Values have to pass math.isfinite check, therefore +inf, -inf, and nan are invalid values
+
 The default form widget for this field is a :class:`~django.forms.NumberInput`
 when :attr:`~django.forms.Field.localize` is ``False`` or
 :class:`~django.forms.TextInput` otherwise.

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -457,6 +457,8 @@ The primary key field is read-only. If you change the value of the primary
 key on an existing object and then save it, a new object will be created
 alongside the old one.
 
+If you have specified the primary_key to an actual data field, after :ref:`topics-db-queries-delete` the primary_key will be set to None.
+
 ``unique``
 ----------
 

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -457,8 +457,6 @@ The primary key field is read-only. If you change the value of the primary
 key on an existing object and then save it, a new object will be created
 alongside the old one.
 
-If you specified the primary_key to an actual data field, after :ref:`topics-db-queries-delete` the primary_key will be set to None.
-
 ``unique``
 ----------
 

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -664,7 +664,7 @@ Deleting objects
 
 Issues an SQL ``DELETE`` for the object. This only deletes the object in the
 database; the Python instance will still exist and will still have data in
-its fields. This method returns the number of objects deleted and a dictionary
+its fields, except the primary_key which will be set to None. This method returns the number of objects deleted and a dictionary
 with the number of deletions per object type.
 
 For more details, including how to delete objects in bulk, see

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -664,7 +664,7 @@ Deleting objects
 
 Issues an SQL ``DELETE`` for the object. This only deletes the object in the
 database; the Python instance will still exist and will still have data in
-its fields, except the primary_key which will be set to None. This method returns the number of objects deleted and a dictionary
+its fields. This method returns the number of objects deleted and a dictionary
 with the number of deletions per object type.
 
 For more details, including how to delete objects in bulk, see


### PR DESCRIPTION
Clarified the docs about primary_key after deletion, so if you specified the primary_key in the model then after the deletion of that object the data inside primary_key will be lost and set to None.