### PR TITLE
Refs #34233 -- Referenced isocalendar() results by names not indexes.

### DIFF
--- a/django/db/backends/sqlite3/_functions.py
+++ b/django/db/backends/sqlite3/_functions.py
@@ -183,11 +183,11 @@ def _sqlite_datetime_extract(lookup_type, dt, tzname=None, conn_tzname=None):
     elif lookup_type == "iso_week_day":
         return dt.isoweekday()
     elif lookup_type == "week":
-        return dt.isocalendar()[1]
+        return dt.isocalendar().week
     elif lookup_type == "quarter":
         return ceil(dt.month / 3)
     elif lookup_type == "iso_year":
-        return dt.isocalendar()[0]
+        return dt.isocalendar().year
     else:
         return getattr(dt, lookup_type)
 

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -257,7 +257,7 @@ class DateFormat(TimeFormat):
 
     def o(self):
         "ISO 8601 year number matching the ISO week number (W)"
-        return self.data.isocalendar()[0]
+        return self.data.isocalendar().year
 
     def r(self):
         "RFC 5322 formatted date; e.g. 'Thu, 21 Dec 2000 16:01:07 +0200'"
@@ -303,7 +303,7 @@ class DateFormat(TimeFormat):
 
     def W(self):
         "ISO-8601 week number of year, weeks starting on Monday"
-        return self.data.isocalendar()[1]
+        return self.data.isocalendar().week
 
     def y(self):
         """Year, 2 digits with leading zeros; e.g. '99'."""


### PR DESCRIPTION
`isocalendar()` returns a `namedtuple()` instead of `tuple` in Python 3.9+, see https://docs.python.org/3.9/whatsnew/3.9.html#datetime.