### PR TITLE
Fixed #34242 -- Doc'd that primary key is set to None when deleting objects.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -457,6 +457,9 @@ The primary key field is read-only. If you change the value of the primary
 key on an existing object and then save it, a new object will be created
 alongside the old one.
 
+The primary key field is set to ``None`` when
+:meth:`deleting <django.db.models.Model.delete>` an object.
+
 ``unique``
 ----------
 

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -644,8 +644,9 @@ Deleting objects
 
 Issues an SQL ``DELETE`` for the object. This only deletes the object in the
 database; the Python instance will still exist and will still have data in
-its fields. This method returns the number of objects deleted and a dictionary
-with the number of deletions per object type.
+its fields, except for the primary key set to ``None``. This method returns the
+number of objects deleted and a dictionary with the number of deletions per
+object type.
 
 For more details, including how to delete objects in bulk, see
 :ref:`topics-db-queries-delete`.


### PR DESCRIPTION
…ect to some other data field, after deletion of an object the data will be lost since primary key will be set to None. Corrected it in Deleting objects and primary_key section of docs.