### PR TITLE
Refs #34233 -- Used aiter() and anext().

### DIFF
--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -268,7 +268,7 @@ class ASGIHandler(base.BaseHandler):
             #   allow mapping of a sync iterator.
             # - Use aclosing() when consuming aiter.
             #   See https://github.com/python/cpython/commit/6e8dcda
-            async with aclosing(response.__aiter__()) as content:
+            async with aclosing(aiter(response)) as content:
                 async for part in content:
                     for chunk, _ in self.chunk_bytes(part):
                         await send(

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -502,7 +502,7 @@ class StreamingHttpResponse(HttpResponseBase):
             self._iterator = iter(value)
             self.is_async = False
         except TypeError:
-            self._iterator = value.__aiter__()
+            self._iterator = aiter(value)
             self.is_async = True
         if hasattr(value, "close"):
             self._resource_closers.append(value.close)

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -754,7 +754,7 @@ class StreamingHttpResponseTests(SimpleTestCase):
             "serve them asynchronously. Use an asynchronous iterator instead."
         )
         with self.assertWarnsMessage(Warning, msg):
-            self.assertEqual(b"hello", await r.__aiter__().__anext__())
+            self.assertEqual(b"hello", await anext(aiter(r)))
 
 
 class FileCloseTests(SimpleTestCase):


### PR DESCRIPTION
Available since Python 3.10.