### PR TITLE
Use @functools.cache instead of @functools.lru_cache(maxsize=None)

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -165,7 +165,7 @@ class Apps:
             raise LookupError(message)
 
     # This method is performance-critical at least for Django's test suite.
-    @functools.lru_cache(maxsize=None)
+    @functools.cache
     def get_models(self, include_auto_created=False, include_swapped=False):
         """
         Return a list of all installed models.
@@ -280,7 +280,7 @@ class Apps:
             raise LookupError("Model '%s.%s' not registered." % (app_label, model_name))
         return model
 
-    @functools.lru_cache(maxsize=None)
+    @functools.cache
     def get_swappable_settings_name(self, to_string):
         """
         For a given model string (e.g. "auth.User"), return the name of the

--- a/django/conf/urls/i18n.py
+++ b/django/conf/urls/i18n.py
@@ -20,7 +20,7 @@ def i18n_patterns(*urls, prefix_default_language=True):
     ]
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def is_language_prefix_patterns_used(urlconf):
     """
     Return a tuple of two booleans: (

--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -17,7 +17,7 @@ from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def get_default_password_validators():
     return get_password_validators(settings.AUTH_PASSWORD_VALIDATORS)
 

--- a/django/contrib/staticfiles/finders.py
+++ b/django/contrib/staticfiles/finders.py
@@ -312,7 +312,7 @@ def get_finders():
         yield get_finder(finder_path)
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def get_finder(import_path):
     """
     Import the staticfiles finder class described by import_path, where

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -49,7 +49,7 @@ def load_command_class(app_name, name):
     return module.Command()
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def get_commands():
     """
     Return a dictionary mapping command names to their callback applications.

--- a/django/core/management/color.py
+++ b/django/core/management/color.py
@@ -96,7 +96,7 @@ def make_style(config_string=""):
     return style
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def no_style():
     """
     Return a Style object with no color scheme.

--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -311,7 +311,7 @@ class Command(BaseCommand):
                 fixture_files_in_dir.append((candidate, fixture_dir, fixture_name))
         return fixture_files_in_dir
 
-    @functools.lru_cache(maxsize=None)
+    @functools.cache
     def find_fixtures(self, fixture_label):
         """Find fixture files for a given label."""
         if fixture_label == READ_STDIN:

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -857,7 +857,7 @@ class ForeignObject(RelatedField):
         return self.get_reverse_path_info()
 
     @classmethod
-    @functools.lru_cache(maxsize=None)
+    @functools.cache
     def get_class_lookups(cls):
         bases = inspect.getmro(cls)
         bases = bases[: bases.index(ForeignObject) + 1]

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -213,7 +213,7 @@ class RegisterLookupMixin:
     def _get_lookup(self, lookup_name):
         return self.get_lookups().get(lookup_name, None)
 
-    @functools.lru_cache(maxsize=None)
+    @functools.cache
     def get_class_lookups(cls):
         class_lookups = [
             parent.__dict__.get("class_lookups", {}) for parent in inspect.getmro(cls)

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -108,12 +108,12 @@ def get_resolver(urlconf=None):
     return _get_cached_resolver(urlconf)
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _get_cached_resolver(urlconf=None):
     return URLResolver(RegexPattern(r"^/"), urlconf)
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def get_ns_resolver(ns_pattern, resolver, converters):
     # Build a namespaced resolver for the given parent URLconf pattern.
     # This makes it possible to have captured parameters in the parent

--- a/django/urls/utils.py
+++ b/django/urls/utils.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ViewDoesNotExist
 from django.utils.module_loading import module_has_submodule
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def get_callable(lookup_view):
     """
     Return a callable corresponding to lookup_view.


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34270

`functools.cache` was added in Python 3.9 and returns the same as `functools.lru_cache(maxsize=None)`

https://docs.python.org/3/library/functools.html#functools.cache

Now Python 3.10 is the lowest supported version for Django 5.0, let's use the shorter one.

https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
