### PR TITLE
Documentation error for blocktranslate

### DIFF
--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -668,7 +668,7 @@ This tag also provides for pluralization. To use it:
 
 An example::
 
-    {% blocktranslate count counter=list|length %}
+    {% blocktranslate with count counter=list|length %}
     There is only one {{ name }} object.
     {% plural %}
     There are {{ counter }} {{ name }} objects.


### PR DESCRIPTION
`{% blocktranslate count counter=list|length %}`
should be
`{% blocktranslate with count counter=list|length %}`

This code doesn't pass through the template parser. Pity the code examples in the docs aren't run by a machine.