### PR TITLE
Fixed #34272 -- Fixed floatformat crash on zero with trailing zeros to zero decimal places.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -168,7 +168,7 @@ def floatformat(text, arg=-1):
     except (ValueError, OverflowError, InvalidOperation):
         return input_val
 
-    if not m and p < 0:
+    if not m and p <= 0:
         return mark_safe(
             formats.number_format(
                 "%d" % (int(d)),

--- a/tests/template_tests/filter_tests/test_floatformat.py
+++ b/tests/template_tests/filter_tests/test_floatformat.py
@@ -111,6 +111,8 @@ class FunctionTests(SimpleTestCase):
         self.assertEqual(
             floatformat(0.000000000000000000015, 20), "0.00000000000000000002"
         )
+        self.assertEqual(floatformat("0.00", 0), "0")
+        self.assertEqual(floatformat(Decimal("0.00"), 0), "0")
 
     def test_negative_zero_values(self):
         tests = [


### PR DESCRIPTION
[ticket-34727](https://code.djangoproject.com/ticket/34272)