### PR TITLE
Refs #29510 -- Adjusted test to show that request.FILES can be copied.

### DIFF
--- a/tests/file_uploads/views.py
+++ b/tests/file_uploads/views.py
@@ -20,7 +20,7 @@ def file_upload_view(request):
     A file upload can be updated into the POST dictionary.
     """
     form_data = request.POST.copy()
-    form_data.update(request.FILES)
+    form_data.update(request.FILES.copy())
     if isinstance(form_data.get("file_field"), UploadedFile) and isinstance(
         form_data["name"], str
     ):


### PR DESCRIPTION
ticket-29510. 

Not sure if it adds much — i.e. absolutely happy to close without merging — but proves that `FILES` multidict can be copied without error. 