### PR TITLE
Made PostgreSQL's SchemaEditor._create_index_sql() respect the "sql" argument.

### DIFF
--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -354,7 +354,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         include=None,
         expressions=None,
     ):
-        sql = (
+        sql = sql or (
             self.sql_create_index
             if not concurrently
             else self.sql_create_index_concurrently


### PR DESCRIPTION
The DatabaseSchemaEditor._create_index_sql() previously ignored the sql parameter if it was provided and was overridden. This caused an error in creating the correct sql migration command.
