### PR TITLE
Fixed #34274 -- Add LifeSpan setting suggestion to the docs

### DIFF
--- a/docs/howto/deployment/asgi/uvicorn.txt
+++ b/docs/howto/deployment/asgi/uvicorn.txt
@@ -30,6 +30,9 @@ This will start one process listening on ``127.0.0.1:8000``. It requires that
 your project be on the Python path; to ensure that run this command from the
 same directory as your ``manage.py`` file.
 
+As Django does not currently support LifeSpan events, you can silence the
+related warning by setting ``--lifespan`` accordingly.
+
 In development mode, you can add ``--reload`` to cause the server to reload any
 time a file is changed on disk.
 


### PR DESCRIPTION
Since at work we're disabling the LifeSpan warning in Django by turning off LifeSpan events in Uvicorn altogether, I thought it would be useful to provide such a hint in the relevant bit of the Django documentation. Let me know your thoughts.