### PR TITLE
Fixed #34254 -- Fixed return value of Exists() with empty queryset.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1546,6 +1546,7 @@ class Subquery(BaseExpression, Combinable):
 class Exists(Subquery):
     template = "EXISTS(%(subquery)s)"
     output_field = fields.BooleanField()
+    empty_result_set_value = False
 
     def __init__(self, queryset, **kwargs):
         super().__init__(queryset, **kwargs)

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -1017,6 +1017,14 @@ class NonAggregateAnnotationTestCase(TestCase):
             ],
         )
 
+    def test_annotation_exists_none_query(self):
+        self.assertIs(
+            Author.objects.annotate(exists=Exists(Company.objects.none()))
+            .get(pk=self.a1.pk)
+            .exists,
+            False,
+        )
+
     def test_annotation_exists_aggregate_values_chaining(self):
         qs = (
             Book.objects.values("publisher")


### PR DESCRIPTION
Adding fix with a simple test case showing annotate exists can now return boolean values to empty queries instead of None or no return values