### PR TITLE
Added short description to remove_stale_contenttypes command.

### DIFF
--- a/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
+++ b/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
@@ -8,7 +8,7 @@ from django.db.models.deletion import Collector
 
 
 class Command(BaseCommand):
-    help = "Deletes stale content types in database."
+    help = "Deletes stale content types in the database."
     
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
+++ b/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
@@ -9,7 +9,7 @@ from django.db.models.deletion import Collector
 
 class Command(BaseCommand):
     help = "Deletes stale content types in the database."
-    
+
     def add_arguments(self, parser):
         parser.add_argument(
             "--noinput",

--- a/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
+++ b/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
@@ -8,6 +8,8 @@ from django.db.models.deletion import Collector
 
 
 class Command(BaseCommand):
+    help = "Deletes stale content types in database."
+    
     def add_arguments(self, parser):
         parser.add_argument(
             "--noinput",


### PR DESCRIPTION
Noticed that "python manage.py help remove_stale_contenttypes" doesn't show short description like all other commands so I added one from official documentation.