### PR TITLE
Fix UnicodeEncodeError when running unit tests in Windows

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -433,6 +433,26 @@ Run the ``locale`` command to confirm the change. Optionally, add those export
 commands to your shell's startup file (e.g. ``~/.bashrc`` for Bash) to avoid
 having to retype them.
 
+You can resolve this for Windows by passing ``encoding`` when opening the PO_FILE:
+
+.. code-block:: python
+    :caption: ``tests/i18n/test_percents.py``
+
+    with open(self.PO_FILE) as fp:
+
+to:
+
+.. code-block:: python
+    :caption: ``tests/i18n/test_percents.py``
+
+    with open(self.PO_FILE, encoding="utf-8") as fp:
+
+Then run again an individual test method like this (e.g. test_adds_python_format_to_all_percent_signs):
+
+.. console::
+
+    $ ./runtests.py i18n.test_percents.ExtractingStringsWithPercentSigns.test_adds_python_format_to_all_percent_signs
+
 Tests that only fail in combination
 -----------------------------------
 

--- a/tests/i18n/test_percents.py
+++ b/tests/i18n/test_percents.py
@@ -40,7 +40,7 @@ class ExtractingStringsWithPercentSigns(POFileAssertionMixin, FrenchTestCase):
 
     def setUp(self):
         super().setUp()
-        with open(self.PO_FILE) as fp:
+        with open(self.PO_FILE, encoding="utf-8") as fp:
             self.po_contents = fp.read()
 
     def test_trans_tag_with_percent_symbol_at_the_end(self):


### PR DESCRIPTION
When running unit test in Windows, got this error:
UnicodeDecodeError: 'cp950' codec can't decode byte 0xc3 in position 268: illegal multibyte sequence

Besides Linux or MacOS, this is to provide an extra resolution for Windows.
https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/unit-tests/#many-test-failures-with-unicodeencodeerror