### PR TITLE
Moved release note about the default PBKDF2 iterations into django.contrib.auth section.

### DIFF
--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -48,13 +48,13 @@ Minor features
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* The default iteration count for the PBKDF2 password hasher is increased from
-  480,000 to 580,000.
+* ...
 
 :mod:`django.contrib.auth`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The default iteration count for the PBKDF2 password hasher is increased from
+  480,000 to 580,000.
 
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Thanks Tim Graham for the report.