### PR TITLE
Fixed #34286 -- Fixed admindocs markups for case-sensitive template/view names.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -808,6 +808,7 @@ answer newbie questions, and generally made Django that much better:
     Radek Švarz <https://www.svarz.cz/translate/>
     Rafael Giebisch <rafael@giebisch-mail.de>
     Raffaele Salmaso <raffaele@salmaso.org>
+    Rahmat Faisal <mad.skidipap@gmail.com>
     Rajesh Dhawan <rajesh.dhawan@gmail.com>
     Ramez Ashraf <ramezashraf@gmail.com>
     Ramil Yanbulatov <rayman1104@gmail.com>

--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -101,6 +101,9 @@ ROLES = {
 
 
 def create_reference_role(rolename, urlbase):
+    # Views and template names are case-sensitive.
+    is_case_sensitive = rolename in ["template", "view"]
+
     def _role(name, rawtext, text, lineno, inliner, options=None, content=None):
         if options is None:
             options = {}
@@ -111,7 +114,7 @@ def create_reference_role(rolename, urlbase):
                 urlbase
                 % (
                     inliner.document.settings.link_base,
-                    text.lower(),
+                    text if is_case_sensitive else text.lower(),
                 )
             ),
             **options,

--- a/tests/admin_docs/test_utils.py
+++ b/tests/admin_docs/test_utils.py
@@ -104,6 +104,22 @@ class TestUtils(AdminDocsSimpleTestCase):
             self.assertEqual(parse_rst(body, ""), "<p>second line</p>\n")
         self.assertEqual(stderr.getvalue(), "")
 
+    def test_parse_rst_view_case_sensitive(self):
+        source = ":view:`myapp.views.Index`"
+        rendered = (
+            '<p><a class="reference external" '
+            'href="/admindocs/views/myapp.views.Index/">myapp.views.Index</a></p>'
+        )
+        self.assertHTMLEqual(parse_rst(source, "view"), rendered)
+
+    def test_parse_rst_template_case_sensitive(self):
+        source = ":template:`Index.html`"
+        rendered = (
+            '<p><a class="reference external" href="/admindocs/templates/Index.html/">'
+            "Index.html</a></p>"
+        )
+        self.assertHTMLEqual(parse_rst(source, "template"), rendered)
+
     def test_publish_parts(self):
         """
         Django shouldn't break the default role for interpreted text


### PR DESCRIPTION
ticket from https://code.djangoproject.com/ticket/34286

add conditional logic for :view: and prevent href reference change to lowercase