### PR TITLE
Improved error message for ASCIIUsernameValidator.

### DIFF
--- a/django/contrib/auth/validators.py
+++ b/django/contrib/auth/validators.py
@@ -9,8 +9,8 @@ from django.utils.translation import gettext_lazy as _
 class ASCIIUsernameValidator(validators.RegexValidator):
     regex = r"^[\w.@+-]+\Z"
     message = _(
-        "Enter a valid username. This value may contain only ASCII letters, "
-        "numbers, and @/./+/-/_ characters."
+        "Enter a valid username. This value may contain only unaccented lowercase a-z "
+        "and uppercase A-Z letters, numbers, and @/./+/-/_ characters."
     )
     flags = re.ASCII
 


### PR DESCRIPTION
Follow up to 10bb21e71e3668f770493e2af0d0e0271830f7a3.

See https://github.com/django/django/pull/16125#issuecomment-1399535380.