### PR TITLE
Fixed #33638 -- Fixed GIS lookups crash with geography fields on PostGIS.

### DIFF
--- a/tests/gis_tests/geogapp/models.py
+++ b/tests/gis_tests/geogapp/models.py
@@ -18,6 +18,16 @@ class City(NamedModel):
         app_label = "geogapp"
 
 
+class CityUnique(NamedModel):
+    point = models.PointField(geography=True, unique=True)
+
+    class Meta:
+        required_db_features = {
+            "supports_geography",
+            "supports_geometry_field_unique_index",
+        }
+
+
 class Zipcode(NamedModel):
     code = models.CharField(max_length=10)
     poly = models.PolygonField(geography=True)


### PR DESCRIPTION
ticket-33638

***
A subset of operators are available for geography fields. The [documented workaround](https://docs.djangoproject.com/en/stable/ref/contrib/gis/model-api/#geography-type) is to `Cast` to a geometry type when an operator such as `~=` is unavailable.

This PR does such casting inside ~`validate_unique()`/`_perform_unique_checks()`~ ~`GISLookup.as_sql()`~ `PostGISOperator.check_geography()` to avoid this error:

```
ValueError: PostGIS geography does not support the "~=" function/operator.
```