### PR TITLE
[4.2.x] Increased the default PBKDF2 iterations for Django 4.2.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -296,7 +296,7 @@ class PBKDF2PasswordHasher(BasePasswordHasher):
     """
 
     algorithm = "pbkdf2_sha256"
-    iterations = 480000
+    iterations = 600000
     digest = hashlib.sha256
 
     def encode(self, password, salt, iterations=None):

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -141,7 +141,7 @@ Minor features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * The default iteration count for the PBKDF2 password hasher is increased from
-  390,000 to 480,000.
+  390,000 to 600,000.
 
 * :class:`~django.contrib.auth.forms.UserCreationForm` now saves many-to-many
   form fields for a custom user model.

--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -84,7 +84,7 @@ class TestUtilsHashPass(SimpleTestCase):
         encoded = make_password("lètmein", "seasalt", "pbkdf2_sha256")
         self.assertEqual(
             encoded,
-            "pbkdf2_sha256$480000$seasalt$G4ja8YRtfnNyEx4Ii2pbFMp/l8s4nnbMdJ+Fob/qNK8=",
+            "pbkdf2_sha256$600000$seasalt$OAXyhAQ/4ZDA9V5RMExt3C1OwQdUpLZ99vm1McFlLRA=",
         )
         self.assertTrue(is_password_usable(encoded))
         self.assertTrue(check_password("lètmein", encoded))
@@ -440,8 +440,8 @@ class TestUtilsHashPass(SimpleTestCase):
         encoded = hasher.encode("lètmein", "seasalt2")
         self.assertEqual(
             encoded,
-            "pbkdf2_sha256$480000$seasalt2$WlORJKPl5w3Lubr7rYLOwSQCEOm4Or/NCA"
-            "aECnB1PE0=",
+            "pbkdf2_sha256$600000$seasalt2$OSllgFdJjYQjb0RfMzrx8u0XYl4Fkt+wKpI1yq4lZlo"
+            "=",
         )
         self.assertTrue(hasher.verify("lètmein", encoded))
 
@@ -449,7 +449,7 @@ class TestUtilsHashPass(SimpleTestCase):
         hasher = PBKDF2SHA1PasswordHasher()
         encoded = hasher.encode("lètmein", "seasalt2")
         self.assertEqual(
-            encoded, "pbkdf2_sha1$480000$seasalt2$qyT+EkK5g82hk2r+fRecFeoe28E="
+            encoded, "pbkdf2_sha1$600000$seasalt2$2CLsaL1MZhq6JOG6QOHtVbiopHE="
         )
         self.assertTrue(hasher.verify("lètmein", encoded))
 


### PR DESCRIPTION
See https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2.

Thanks Markus Holtermann for the report.

In #16522 I increased the number of iteration for Django 5.0 to 720,000.