### PR TITLE
Fixed #24686 - Modify the autodetector to identify models moved to ot…

### DIFF
--- a/django/db/migrations/operations/special.py
+++ b/django/db/migrations/operations/special.py
@@ -13,9 +13,15 @@ class SeparateDatabaseAndState(Operation):
 
     serialization_expand_args = ["database_operations", "state_operations"]
 
-    def __init__(self, database_operations=None, state_operations=None):
+    def __init__(
+        self,
+        database_operations=None,
+        state_operations=None,
+        description="Custom state/database change combination",
+    ):
         self.database_operations = database_operations or []
         self.state_operations = state_operations or []
+        self.description = description
 
     def deconstruct(self):
         kwargs = {}
@@ -57,7 +63,7 @@ class SeparateDatabaseAndState(Operation):
             )
 
     def describe(self):
-        return "Custom state/database change combination"
+        return self.description
 
 
 class RunSQL(Operation):

--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -72,6 +72,10 @@ class MigrationQuestioner:
         """Was this model really renamed?"""
         return self.defaults.get("ask_rename_model", False)
 
+    def ask_move_model(self, old_model_state, new_model_state):
+        """Was this model really moved?"""
+        return self.defaults.get("ask_move_model", False)
+
     def ask_merge(self, app_label):
         """Should these migrations really be merged?"""
         return self.defaults.get("ask_merge", False)
@@ -235,6 +239,19 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
         return self._boolean_input(
             msg
             % (old_model_state.app_label, old_model_state.name, new_model_state.name),
+            False,
+        )
+
+    def ask_move_model(self, old_model_state, new_model_state):
+        """Was this model really moved?"""
+        msg = "Was the model '%s' moved from app '%s' to app '%s'? [y/N]"
+        return self._boolean_input(
+            msg
+            % (
+                old_model_state.name,
+                old_model_state.app_label,
+                new_model_state.app_label,
+            ),
             False,
         )
 


### PR DESCRIPTION
## Summary
This Pull Request implements the generate_moved_models function to handle moved models in the project. The function now finds and generates the necessary operations for any moved models.

## Problem
When a model is moved from one Django app to another, the default behavior is to delete the existing table in the old app and create a new empty table in the new app. This leads to loss of data and downtime for the application. And most of the time the developer only sought to refactor the code, joining or separating some models.

## Solution

This Pull Request introduces the `generate_moved_models` function to handle moved models properly. The function detects any moved models, generates the necessary operations, and ensures that the data is not lost.

This is approach (unlike this other one here: TODO ADD Link), uses the existing migrations operations to log the changes made to the tables related to the moved models. By doing so, anyone reading the migration history in the future will be able to understand that a particular column in a table was modified because a model was moved to another app.

## Benefits
* Automates the creation of migrations when moving models, reducing manual effort and the risk of error.
* Avoids loss of data and downtime during migrations running.
* Makes it easier for developers to refactor the codebase and separate or merge models.
* Preserves the history of changes made to models

## Ticket
This Pull Request is related to the ticket [#24686](https://code.djangoproject.com/ticket/24686)
I opened a thread about this ticket in django-developers at https://groups.google.com/g/django-developers/c/loSDLrVA0o8