### PR TITLE
Fixed #34313 -- Thousands separator for Spanish language is incorrect

### DIFF
--- a/django/conf/locale/es/formats.py
+++ b/django/conf/locale/es/formats.py
@@ -26,5 +26,5 @@ DATETIME_INPUT_FORMATS = [
     "%d/%m/%y %H:%M",
 ]
 DECIMAL_SEPARATOR = ","
-THOUSAND_SEPARATOR = "."
+THOUSAND_SEPARATOR = "\xa0"  # non-breaking space
 NUMBER_GROUPING = 3


### PR DESCRIPTION
Fixed [ticket #34313](https://code.djangoproject.com/ticket/34313).
Changed the Spanish digit separator to non breaking space . 

ref: [wikipedia - Decimal_separator#Examples_of_use)](https://en.wikipedia.org/wiki/Decimal_separator#Examples_of_use)