### PR TITLE
Fixed #34317 -- Renamed "instance" argument of BaseModelFormSet.save_existing() method.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -756,7 +756,7 @@ class BaseModelFormSet(BaseFormSet, AltersData):
         """Save and return a new model instance for the given form."""
         return form.save(commit=commit)
 
-    def save_existing(self, form, instance, commit=True):
+    def save_existing(self, form, obj, commit=True):
         """Save and return an existing model instance for the given form."""
         return form.save(commit=commit)
 

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -240,7 +240,8 @@ backends.
 Miscellaneous
 -------------
 
-* ...
+* The ``instance`` argument of the undocumented
+  ``BaseModelFormSet.save_existing()`` method is renamed to ``obj``.
 
 .. _deprecated-features-5.0:
 


### PR DESCRIPTION
Fixed [ticket #34317](https://code.djangoproject.com/ticket/34317)
Renaming the "instance" parameter in BaseModelFormSet.save_existing method to "obj"