### PR TITLE
Added missing vars to AdminSite.each_context() docs.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2830,6 +2830,9 @@ Templates can override or extend base admin templates as described in
       * ``admin_url``: admin changelist URL for the model
       * ``add_url``: admin URL to add a new model instance
 
+    * ``is_popup``: whether the current page is displayed in a popup window
+    * ``is_nav_sidebar_enabled``: :attr:`AdminSite.enable_nav_sidebar`
+
 .. method:: AdminSite.get_app_list(request, app_label=None)
 
     Returns a list of applications from the :doc:`application registry


### PR DESCRIPTION
Noticed when reviewing #16514 that these two vars, set in `each_context` were missing from the docs. 

https://github.com/django/django/blob/69069a443a906dd4060a8047e683657d40b4c383/django/contrib/admin/sites.py#L331-L339

