### PR TITLE
Fixed #34324 -- Mentioned Discord server in contributing index.

### DIFF
--- a/docs/internals/contributing/index.txt
+++ b/docs/internals/contributing/index.txt
@@ -65,9 +65,9 @@ Django community and others to maintain a great ecosystem to work in:
   friendly and helpful atmosphere. If you're new to the Django community,
   you should read the `posting guidelines`_.
 
-* Join the `#django IRC channel`_ on Libera.Chat and answer questions. By
-  explaining Django to other users, you're going to learn a lot about the
-  framework yourself.
+* Join the `Django Discord server`_ or the `#django IRC channel`_ on
+  Libera.Chat to discuss and answer questions. By explaining Django to other
+  users, you're going to learn a lot about the framework yourself.
 
 * Blog about Django. We syndicate all the Django blogs we know about on
   the `community page`_; if you'd like to see your blog on that page you
@@ -83,5 +83,6 @@ We're looking forward to working with you. Welcome aboard! ⛵️
 .. _posting guidelines: https://code.djangoproject.com/wiki/UsingTheMailingList
 .. _#django IRC channel: https://web.libera.chat/#django
 .. _community page: https://www.djangoproject.com/community/
+.. _Django Discord server: https://discord.gg/xcRH6mN4fa
 .. _Django forum: https://forum.djangoproject.com/
 .. _register it here: https://www.djangoproject.com/community/add/blogs/


### PR DESCRIPTION
The Section "[Join the Django community ❤️](https://docs.djangoproject.com/en/dev/internals/contributing/#join-the-django-community)" in contributing was missing a link to the Django Discord Server. Added the link in the same bullet point as the IRC Channel one.