### PR TITLE
Fixed #34331: Add support for prefetch_related to QuerySet.aiterator()

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -567,7 +567,10 @@ class QuerySet(AltersData):
                 chunk.clear()
                 num_items = 0
 
-        if num_items:
+        if chunk:
+           await sync_to_async(prefetch_related_objects)(
+                chunk, *self._prefetch_related_lookups
+            )
             for each_item in chunk:
                 yield each_item
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2535,11 +2535,6 @@ evaluated will force it to evaluate again, repeating the query.
 long as ``chunk_size`` is given. Larger values will necessitate fewer queries
 to accomplish the prefetching at the cost of greater memory usage.
 
-.. note::
-
-    ``aiterator()`` is *not* compatible with previous calls to
-    ``prefetch_related()``.
-
 On some databases (e.g. Oracle, `SQLite
 <https://www.sqlite.org/limits.html#max_variable_number>`_), the maximum number
 of terms in an SQL ``IN`` clause might be limited. Hence values below this

--- a/tests/async/test_async_queryset.py
+++ b/tests/async/test_async_queryset.py
@@ -8,7 +8,7 @@ from django.db import NotSupportedError, connection
 from django.db.models import Sum
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
-from .models import SimpleModel, RelatedModel
+from .models import RelatedModel, SimpleModel
 
 
 class AsyncQuerySetTest(TestCase):


### PR DESCRIPTION
If possible, including this in the 4.2 production release would be very much appreciated...  we'll be on that LTS release until release 5.2 becomes available quite a long time from now.

This patch uses the "chunked" prefetch approach originally implemented in .iterator(), suitably modified for async.  For the sake of simplicity, It wraps the call to prefetch_related_items() within sync_to_async, instead of building a complete async version of that method.