### PR TITLE
Fixed #34316 -- Fixed layout of admin password change forms and help texts.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -202,6 +202,7 @@ fieldset .fieldBox {
 }
 
 form .wide p,
+form .wide ul.errorlist,
 form .wide input + p.help,
 form .wide input + div.help {
     margin-left: 200px;
@@ -209,7 +210,7 @@ form .wide input + div.help {
 
 form .wide p.help,
 form .wide div.help {
-    padding-left: 38px;
+    padding-left: 50px;
 }
 
 form div.help ul {

--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -32,7 +32,7 @@
 
 <div class="form-row">
   {{ form.password1.errors }}
-  {{ form.password1.label_tag }} {{ form.password1 }}
+  <div>{{ form.password1.label_tag }} {{ form.password1 }}</div>
   {% if form.password1.help_text %}
   <div class="help"{% if form.password1.id_for_label %} id="{{ form.password1.id_for_label }}_helptext">{% endif %}{{ form.password1.help_text|safe }}</div>
   {% endif %}
@@ -40,7 +40,7 @@
 
 <div class="form-row">
   {{ form.password2.errors }}
-  {{ form.password2.label_tag }} {{ form.password2 }}
+  <div>{{ form.password2.label_tag }} {{ form.password2 }}</div>
   {% if form.password2.help_text %}
   <div class="help"{% if form.password2.id_for_label %} id="{{ form.password2.id_for_label }}_helptext"{% endif %}>{{ form.password2.help_text|safe }}</div>
   {% endif %}

--- a/django/contrib/admin/templates/admin/includes/fieldset.html
+++ b/django/contrib/admin/templates/admin/includes/fieldset.html
@@ -22,7 +22,7 @@
                 </div>
                 {% if field.field.help_text %}
                     <div class="help"{% if field.field.id_for_label %} id="{{ field.field.id_for_label }}_helptext"{% endif %}>
-                        {{ field.field.help_text|safe }}
+                        <div>{{ field.field.help_text|safe }}</div>
                     </div>
                 {% endif %}
             {% endfor %}

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -33,20 +33,20 @@
 
 <div class="form-row">
     {{ form.old_password.errors }}
-    {{ form.old_password.label_tag }} {{ form.old_password }}
+    <div>{{ form.old_password.label_tag }} {{ form.old_password }}</div>
 </div>
 
 <div class="form-row">
     {{ form.new_password1.errors }}
-    {{ form.new_password1.label_tag }} {{ form.new_password1 }}
+    <div>{{ form.new_password1.label_tag }} {{ form.new_password1 }}</div>
     {% if form.new_password1.help_text %}
     <div class="help"{% if form.new_password1.id_for_label %} id="{{ form.new_password1.id_for_label }}_helptext"{% endif %}>{{ form.new_password1.help_text|safe }}</div>
     {% endif %}
 </div>
 
 <div class="form-row">
-{{ form.new_password2.errors }}
-    {{ form.new_password2.label_tag }} {{ form.new_password2 }}
+    {{ form.new_password2.errors }}
+    <div>{{ form.new_password2.label_tag }} {{ form.new_password2 }}</div>
     {% if form.new_password2.help_text %}
     <div class="help"{% if form.new_password2.id_for_label %} id="{{ form.new_password2.id_for_label }}_helptext"{% endif %}>{{ form.new_password2.help_text|safe }}</div>
     {% endif %}

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -6549,20 +6549,20 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
         self.assertContains(response, '<div class="help"', 3)
         self.assertContains(
             response,
-            '<div class="help" id="id_title_helptext">Some help text for the title '
-            "(with Unicode ŠĐĆŽćžšđ)</div>",
+            '<div class="help" id="id_title_helptext"><div>Some help text for the '
+            "title (with Unicode ŠĐĆŽćžšđ)</div></div>",
             html=True,
         )
         self.assertContains(
             response,
-            '<div class="help" id="id_content_helptext">Some help text for the content '
-            "(with Unicode ŠĐĆŽćžšđ)</div>",
+            '<div class="help" id="id_content_helptext"><div>Some help text for the '
+            "content (with Unicode ŠĐĆŽćžšđ)</div></div>",
             html=True,
         )
         self.assertContains(
             response,
-            '<div class="help">Some help text for the date (with Unicode ŠĐĆŽćžšđ)'
-            "</div>",
+            '<div class="help"><div>Some help text for the date (with Unicode ŠĐĆŽćžšđ)'
+            "</div></div>",
             html=True,
         )
 
@@ -6744,7 +6744,7 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
         )
         self.assertContains(
             response,
-            '<div class="help">Overridden help text for the date</div>',
+            '<div class="help"><div>Overridden help text for the date</div></div>',
             html=True,
         )
         self.assertContains(


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/34316

[781f7ef](https://github.com/django/django/pull/16548/commits/781f7ef3c464d998d2dbf5c29212df721e2056dc)
Help text now has gap before "this form" link
![image](https://user-images.githubusercontent.com/42296566/218402502-ec405757-446a-41ed-bbec-8d74c11ea0a7.png)


[535a737](https://github.com/django/django/pull/16548/commits/535a73754fbbcf8d6d2a1033895deb1ab7fb953f)
Form input alignments for change password forms fixed
![image](https://user-images.githubusercontent.com/42296566/218402646-d934db3f-fce5-4281-9a13-778b72f625c9.png)

![image](https://user-images.githubusercontent.com/42296566/218402818-e96d35b0-5455-4244-b089-bf0426f3171c.png)
