### PR TITLE
Bumped versions in pre-commit and npm configurations.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'npm'
           cache-dependency-path: '**/package.json'
       - run: npm install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     - id: black
       exclude: \.py-tpl$
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/flake8
@@ -13,6 +13,6 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.29.0
+    rev: v8.34.0
     hooks:
       - id: eslint

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
     "test": "grunt test --verbose"
   },
   "engines": {
-    "npm": ">=1.3.0 <3.0.0"
+    "npm": ">=1.3.0"
   },
   "devDependencies": {
-    "eslint": "^8.29.0",
-    "puppeteer": "^18.1.0",
-    "grunt": "^1.5.3",
+    "eslint": "^8.34.0",
+    "puppeteer": "^19.7.0",
+    "grunt": "^1.6.1",
     "grunt-cli": "^1.4.3",
     "grunt-contrib-qunit": "^6.2.1",
-    "qunit": "^2.19.3"
+    "qunit": "^2.19.4"
   }
 }


### PR DESCRIPTION
I was resetting my laptop and found an issue setting up the pre-commit hook

Looks like currently, pre-commit can not be installed/run due to https://github.com/PyCQA/isort/issues/2077.

Release notes: https://github.com/PyCQA/isort/releases/tag/5.12.0