### PR TITLE
Bumped grunt-contrib-qunit versions in npm configurations.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "puppeteer": "^19.7.0",
     "grunt": "^1.6.1",
     "grunt-cli": "^1.4.3",
-    "grunt-contrib-qunit": "^6.2.1",
+    "grunt-contrib-qunit": "^7.0.0",
     "qunit": "^2.19.4"
   }
 }


### PR DESCRIPTION
`grunt-contrib-qunit` kindly accepted the patch to update puppeteer, so this warning from the JavaScript tests is now gone
```
npm WARN deprecated puppeteer@9.1.1: < 19.2.0 is no longer supported
```