### PR TITLE
Fixed #34344 -- Use _class properties for instantiation in postgis DatabaseWrapper

### DIFF
--- a/django/contrib/gis/db/backends/postgis/base.py
+++ b/django/contrib/gis/db/backends/postgis/base.py
@@ -81,6 +81,9 @@ if is_psycopg3:
 
 class DatabaseWrapper(PsycopgDatabaseWrapper):
     SchemaEditorClass = PostGISSchemaEditor
+    features_class = DatabaseFeatures
+    ops_class = PostGISOperations
+    introspection_class = PostGISIntrospection
 
     _type_infos = {
         "geometry": {},
@@ -91,9 +94,9 @@ class DatabaseWrapper(PsycopgDatabaseWrapper):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if kwargs.get("alias", "") != NO_DB_ALIAS:
-            self.features = DatabaseFeatures(self)
-            self.ops = PostGISOperations(self)
-            self.introspection = PostGISIntrospection(self)
+            self.features = self.features_class(self)
+            self.ops = self.ops_class(self)
+            self.introspection = self.introspection_class(self)
 
     def prepare_database(self):
         super().prepare_database()


### PR DESCRIPTION
This allows for extensions to override the _class when extending the backend.

I came across an issue when trying to add PostGIS support to the django-multitenant library:

https://github.com/citusdata/django-multitenant/pull/150/files#diff-0d077af5d4e86f31f478785458ea6a03768a15aea077f49b9a79ffca8b0fe4beR37

Tracking down the issue took a bit of time as it wasn't apparent that the PostGIS backend was explicitly setting the `features` property to the `DatabaseFeatures` 

If there is a desire to ensure that the PostGIS DatabaseFeatures (and ops, introspection) is extended so that the GIS features are enabled another possible solution could be something along the lines of:

```python
class DatabaseWrapper(PsycopgDatabaseWrapper):
    ...

    features_class = DatabaseFeatures
    ops_class = PostGISOperations
    introspection_class = PostGISIntrospection

    ...

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        if kwargs.get("alias", "") != NO_DB_ALIAS:
            if issubclass(self.features_class, DatabaseFeatures):
                self.features = self.features_class(self)
            else:
                raise Exception("PostGIS backend features_class must inherit from django.contrib.gis.db.backends.postgis.features.DatabaseFeatures")
            if issubclass(self.ops_class, PostGISOperations):
                self.ops = self.ops_class(self)
            else:
                raise Exception("PostGIS backend ops_class must inherit from django.contrib.gis.db.backends.postgis.operations.PostGISOperations")
            if issubclass(self.introspection_class, PostGISIntrospection):
                self.introspection = self.introspection_class(self)
            else:
                raise Exception("PostGIS backend introspection_class must inherit from django.contrib.gis.db.backends.postgis.introspection.PostGISIntrospection")

    ...
```

But perhaps the init constructor can be removed entirely and the `_class` properties can be instantiated directly through the `BaseDatabaseWrapper`:

https://github.com/django/django/blob/main/django/db/backends/base/base.py#L114

Related ticket: https://code.djangoproject.com/ticket/34344