### PR TITLE
Fixed #34302 -- Fixed SpatialReference.srid for objects without top-level authority.

### DIFF
--- a/django/contrib/gis/gdal/srs.py
+++ b/django/contrib/gis/gdal/srs.py
@@ -209,7 +209,7 @@ class SpatialReference(GDALBase):
     def srid(self):
         "Return the SRID of top-level authority, or None if undefined."
         try:
-            return int(self.attr_value("AUTHORITY", 1))
+            return int(self.auth_code(target=None))
         except (TypeError, ValueError):
             return None
 

--- a/django/contrib/gis/gdal/srs.py
+++ b/django/contrib/gis/gdal/srs.py
@@ -159,11 +159,15 @@ class SpatialReference(GDALBase):
 
     def auth_name(self, target):
         "Return the authority name for the given string target node."
-        return capi.get_auth_name(self.ptr, force_bytes(target))
+        return capi.get_auth_name(
+            self.ptr, target if target is None else force_bytes(target)
+        )
 
     def auth_code(self, target):
         "Return the authority code for the given string target node."
-        return capi.get_auth_code(self.ptr, force_bytes(target))
+        return capi.get_auth_code(
+            self.ptr, target if target is None else force_bytes(target)
+        )
 
     def clone(self):
         "Return a clone of this SpatialReference object."

--- a/tests/gis_tests/gdal_tests/test_srs.py
+++ b/tests/gis_tests/gdal_tests/test_srs.py
@@ -35,7 +35,11 @@ srlist = (
         ang_name="degree",
         lin_units=1.0,
         ang_units=0.0174532925199,
-        auth={"GEOGCS": ("EPSG", "4326"), "spheroid": ("EPSG", "7030")},
+        auth={
+            None: ("EPSG", "4326"),  # Top-level authority.
+            "GEOGCS": ("EPSG", "4326"),
+            "spheroid": ("EPSG", "7030"),
+        },
         attr=(
             ("DATUM", "WGS_1984"),
             (("SPHEROID", 1), "6378137"),
@@ -64,6 +68,7 @@ srlist = (
         lin_units=1.0,
         ang_units=0.0174532925199,
         auth={
+            None: ("EPSG", "32140"),  # Top-level authority.
             "PROJCS": ("EPSG", "32140"),
             "spheroid": ("EPSG", "7019"),
             "unit": ("EPSG", "9001"),

--- a/tests/gis_tests/gdal_tests/test_srs.py
+++ b/tests/gis_tests/gdal_tests/test_srs.py
@@ -102,7 +102,10 @@ srlist = (
         ang_name="Degree",
         lin_units=0.3048006096012192,
         ang_units=0.0174532925199,
-        auth={"PROJCS": (None, None)},
+        auth={
+            None: (None, None),  # Top-level authority.
+            "PROJCS": (None, None),
+        },
         attr=(
             ("PROJCS|GeOgCs|spheroid", "GRS 1980"),
             (("projcs", 9), "UNIT"),
@@ -391,3 +394,10 @@ class SpatialRefTest(SimpleTestCase):
         self.assertIn('DATUM["D_North_American_1983"', srs.wkt)
         srs.from_esri()
         self.assertIn('DATUM["North_American_Datum_1983"', srs.wkt)
+
+    def test_srid(self):
+        """The srid property returns top-level authority code."""
+        for s in srlist:
+            if hasattr(s, "epsg"):
+                srs = SpatialReference(s.wkt)
+                self.assertEqual(srs.srid, s.epsg)


### PR DESCRIPTION
Django assumed a wrong SRID if the projection does not have a top-level AUTHORITY.
By using `auth_code(target=None)` we correctly get the top-level SRID.

Also:

## Fixed incorrect type cast in SpatialReference

`force_bytes` turns `None` into the byte string `b'None'`.
Since `ctypes.c_char_p` also accepts `None`, we can bypass `force_bytes`
if `target is None`.