### PR TITLE
Fixed #34347 -- Added __all__ to django.contrib.gis.utils.

### DIFF
--- a/django/contrib/gis/utils/__init__.py
+++ b/django/contrib/gis/utils/__init__.py
@@ -1,17 +1,24 @@
 """
  This module contains useful utilities for GeoDjango.
 """
-from django.contrib.gis.utils.ogrinfo import ogrinfo  # NOQA
-from django.contrib.gis.utils.ogrinspect import mapping, ogrinspect  # NOQA
-from django.contrib.gis.utils.srs import add_srs_entry  # NOQA
+from django.contrib.gis.utils.ogrinfo import ogrinfo
+from django.contrib.gis.utils.ogrinspect import mapping, ogrinspect
+from django.contrib.gis.utils.srs import add_srs_entry
 from django.core.exceptions import ImproperlyConfigured
+
+__all__ = [
+    "add_srs_entry",
+    "mapping",
+    "ogrinfo",
+    "ogrinspect",
+]
 
 try:
     # LayerMapping requires DJANGO_SETTINGS_MODULE to be set,
     # and ImproperlyConfigured is raised if that's not the case.
-    from django.contrib.gis.utils.layermapping import (  # NOQA
-        LayerMapError,
-        LayerMapping,
-    )
+    from django.contrib.gis.utils.layermapping import LayerMapError, LayerMapping
+
+    __all__ += ["LayerMapError", "LayerMapping"]
+
 except ImproperlyConfigured:
     pass


### PR DESCRIPTION
Mypy complaint: module "django.contrib.gis.utils" does not explicitly export attribute "LayerMapping"

Since the documentation uses that import path, for example: [​https://docs.djangoproject.com/en/4.1/ref/contrib/gis/layermapping/](https://docs.djangoproject.com/en/4.1/ref/contrib/gis/layermapping/)

I guess django.contrib.gis.utils.\_\_init__ should contain \_\_all__?