### PR TITLE
New feature #34348 -- Added default middle path

### DIFF
--- a/django/conf/project_template/project_name/settings.py-tpl
+++ b/django/conf/project_template/project_name/settings.py-tpl
@@ -117,6 +117,11 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 
+# Media files (Images, Video, Audio, Documents)
+# https://docs.djangoproject.com/en/{{ docs_version }}/topics/files/
+
+MEDIA_URL = 'media/'
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/#default-auto-field
 


### PR DESCRIPTION
New ticket feature [https://code.djangoproject.com/ticket/34348](https://code.djangoproject.com/ticket/34348) thanks to 
 estuardodev
The default path 'medium' was added to the settings.py file, as well as this 'static', this way it will be easier to understand which files the media saves.

Before:
```
# Static files (CSS, JavaScript, Images)
# https://docs.djangoproject.com/en/dev/howto/static-files/

STATIC_URL = 'static/'
```

Now: 
```
# Static files (CSS, JavaScript, Images)
# https://docs.djangoproject.com/en/dev/howto/static-files/

STATIC_URL = 'static/'

# Media files (MP4, MP3, GIF)
# https://docs.djangoproject.com/en/dev/topics/files/

MEDIA_URL = 'media/'
```