### PR TITLE
Fixed #34349 -- Fixed FormSet.empty_form crash when deleting extra forms is disabled.

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -490,7 +490,9 @@ class BaseFormSet(RenderableFormMixin):
                     required=False,
                     widget=self.get_ordering_widget(),
                 )
-        if self.can_delete and (self.can_delete_extra or index < initial_form_count):
+        if self.can_delete and (
+            self.can_delete_extra or (index is not None and index < initial_form_count)
+        ):
             form.fields[DELETION_FIELD_NAME] = BooleanField(
                 label=_("Delete"),
                 required=False,

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1480,6 +1480,7 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertIn("DELETE", formset.forms[0].fields)
         self.assertNotIn("DELETE", formset.forms[1].fields)
         self.assertNotIn("DELETE", formset.forms[2].fields)
+        self.assertNotIn("DELETE", formset.empty_form.fields)
 
         formset = ChoiceFormFormset(
             data={


### PR DESCRIPTION
Fixes https://code.djangoproject.com/ticket/34349#ticket 

## Description
Formsets' `add_fields()` method fails in some circumstances if the argument `index` is `None`.

When a FormSet has the attributes `self.can_delete == True` and `self.can_delete_extra == False`, calling the `add_fields()` method on that FormSet fails if the argument `index` is `None`. This occurs for example when calling `FormSet.empty_form()`. The result is that the method raises the exception `TypeError: '<' not supported between instances of 'NoneType' and 'int'`. 

```python
MyFormSet = forms.formset_factory(
    form=MyForm,
    can_delete=True,
    can_delete_extra=False,
)
my_formset = MyFormSet(
    initial=None,
)
print(my_formset.empty_form)
```