### PR TITLE
Fixed #34077 -- Added Renderable BoundField and BoundWidgets

### DIFF
--- a/django/contrib/admin/templates/admin/actions.html
+++ b/django/contrib/admin/templates/admin/actions.html
@@ -2,7 +2,7 @@
 <div class="actions">
   {% block actions %}
     {% block actions-form %}
-    {% for field in action_form %}{% if field.label %}<label>{{ field.label }} {{ field }}</label>{% else %}{{ field }}{% endif %}{% endfor %}
+    {% for field in action_form %}{% if field.label %}<label>{{ field.label }} {{ field.widget }}</label>{% else %}{{ field.widget }}{% endif %}{% endfor %}
     {% endblock %}
     {% block actions-submit %}
     <button type="submit" class="button" title="{% translate "Run the selected action" %}" name="index" value="{{ action_index|default:0 }}">{% translate "Go" %}</button>

--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -32,7 +32,7 @@
 
 <div class="form-row">
   {{ form.password1.errors }}
-  <div>{{ form.password1.label_tag }} {{ form.password1 }}</div>
+  <div>{{ form.password1.label_tag }} {{ form.password1.widget }}</div>
   {% if form.password1.help_text %}
   <div class="help"{% if form.password1.id_for_label %} id="{{ form.password1.id_for_label }}_helptext">{% endif %}{{ form.password1.help_text|safe }}</div>
   {% endif %}
@@ -40,7 +40,7 @@
 
 <div class="form-row">
   {{ form.password2.errors }}
-  <div>{{ form.password2.label_tag }} {{ form.password2 }}</div>
+  <div>{{ form.password2.label_tag }} {{ form.password2.widget }}</div>
   {% if form.password2.help_text %}
   <div class="help"{% if form.password2.id_for_label %} id="{{ form.password2.id_for_label }}_helptext"{% endif %}>{{ form.password2.help_text|safe }}</div>
   {% endif %}

--- a/django/contrib/admin/templates/admin/edit_inline/stacked.html
+++ b/django/contrib/admin/templates/admin/edit_inline/stacked.html
@@ -16,14 +16,14 @@
   <h3><b>{{ inline_admin_formset.opts.verbose_name|capfirst }}:</b> <span class="inline_label">{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %} <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}
 {% else %}#{{ forloop.counter }}{% endif %}</span>
       {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% translate "View on site" %}</a>{% endif %}
-    {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission and inline_admin_form.original %}<span class="delete">{{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}</span>{% endif %}
+    {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission and inline_admin_form.original %}<span class="delete">{{ inline_admin_form.deletion_field.field.widget }} {{ inline_admin_form.deletion_field.label_tag }}</span>{% endif %}
   </h3>
   {% if inline_admin_form.form.non_field_errors %}{{ inline_admin_form.form.non_field_errors }}{% endif %}
   {% for fieldset in inline_admin_form %}
     {% include "admin/includes/fieldset.html" %}
   {% endfor %}
-  {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
-  {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
+  {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field.widget }}{% endif %}
+  {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field.widget }}{% endif %}
 </div>{% endfor %}
 </fieldset>
 </div>

--- a/django/contrib/admin/templates/admin/edit_inline/tabular.html
+++ b/django/contrib/admin/templates/admin/edit_inline/tabular.html
@@ -37,8 +37,8 @@
           {% endif %}
           {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% translate "View on site" %}</a>{% endif %}
             </p>{% endif %}
-          {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
-          {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
+          {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field.widget }}{% endif %}
+          {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field.widget }}{% endif %}
         </td>
         {% for fieldset in inline_admin_form %}
           {% for line in fieldset %}
@@ -48,14 +48,14 @@
                   <p>{{ field.contents }}</p>
               {% else %}
                   {{ field.field.errors.as_ul }}
-                  {{ field.field }}
+                  {{ field.field.widget }}
               {% endif %}
               </td>
             {% endfor %}
           {% endfor %}
         {% endfor %}
         {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission %}
-          <td class="delete">{% if inline_admin_form.original %}{{ inline_admin_form.deletion_field.field }}{% endif %}</td>
+          <td class="delete">{% if inline_admin_form.original %}{{ inline_admin_form.deletion_field.field.widget }}{% endif %}</td>
         {% endif %}
         </tr>
      {% endfor %}

--- a/django/contrib/admin/templates/admin/includes/fieldset.html
+++ b/django/contrib/admin/templates/admin/includes/fieldset.html
@@ -10,13 +10,13 @@
                 <div{% if not line.fields|length == 1 %} class="fieldBox{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %}"{% elif field.is_checkbox %} class="checkbox-row"{% endif %}>
                     {% if not line.fields|length == 1 and not field.is_readonly %}{{ field.errors }}{% endif %}
                     {% if field.is_checkbox %}
-                        {{ field.field }}{{ field.label_tag }}
+                        {{ field.field.widget }}{{ field.label_tag }}
                     {% else %}
                         {{ field.label_tag }}
                         {% if field.is_readonly %}
                             <div class="readonly">{{ field.contents }}</div>
                         {% else %}
-                            {{ field.field }}
+                            {{ field.field.widget }}
                         {% endif %}
                     {% endif %}
                 </div>

--- a/django/contrib/admin/templates/admin/login.html
+++ b/django/contrib/admin/templates/admin/login.html
@@ -46,11 +46,11 @@
 <form action="{{ app_path }}" method="post" id="login-form">{% csrf_token %}
   <div class="form-row">
     {{ form.username.errors }}
-    {{ form.username.label_tag }} {{ form.username }}
+    {{ form.username.label_tag }} {{ form.username.widget }}
   </div>
   <div class="form-row">
     {{ form.password.errors }}
-    {{ form.password.label_tag }} {{ form.password }}
+    {{ form.password.label_tag }} {{ form.password.widget }}
     <input type="hidden" name="next" value="{{ next }}">
   </div>
   {% url 'admin_password_reset' as password_reset_url %}

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -33,12 +33,12 @@
 
 <div class="form-row">
     {{ form.old_password.errors }}
-    <div>{{ form.old_password.label_tag }} {{ form.old_password }}</div>
+    <div>{{ form.old_password.label_tag }} {{ form.old_password.widget }}</div>
 </div>
 
 <div class="form-row">
     {{ form.new_password1.errors }}
-    <div>{{ form.new_password1.label_tag }} {{ form.new_password1 }}</div>
+    <div>{{ form.new_password1.label_tag }} {{ form.new_password1.widget }}</div>
     {% if form.new_password1.help_text %}
     <div class="help"{% if form.new_password1.id_for_label %} id="{{ form.new_password1.id_for_label }}_helptext"{% endif %}>{{ form.new_password1.help_text|safe }}</div>
     {% endif %}
@@ -46,7 +46,7 @@
 
 <div class="form-row">
     {{ form.new_password2.errors }}
-    <div>{{ form.new_password2.label_tag }} {{ form.new_password2 }}</div>
+    <div>{{ form.new_password2.label_tag }} {{ form.new_password2.widget }}</div>
     {% if form.new_password2.help_text %}
     <div class="help"{% if form.new_password2.id_for_label %} id="{{ form.new_password2.id_for_label }}_helptext"{% endif %}>{{ form.new_password2.help_text|safe }}</div>
     {% endif %}

--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -21,12 +21,12 @@
     <div class="form-row field-password1">
         {{ form.new_password1.errors }}
         <label for="id_new_password1">{% translate 'New password:' %}</label>
-        {{ form.new_password1 }}
+        {{ form.new_password1.widget }}
     </div>
     <div class="form-row field-password2">
         {{ form.new_password2.errors }}
         <label for="id_new_password2">{% translate 'Confirm password:' %}</label>
-        {{ form.new_password2 }}
+        {{ form.new_password2.widget }}
     </div>
     <input type="submit" value="{% translate 'Change my password' %}">
 </fieldset>

--- a/django/contrib/admin/templates/registration/password_reset_form.html
+++ b/django/contrib/admin/templates/registration/password_reset_form.html
@@ -18,7 +18,7 @@
     <div class="form-row field-email">
         {{ form.email.errors }}
         <label for="id_email">{% translate 'Email address:' %}</label>
-        {{ form.email }}
+        {{ form.email.widget }}
     </div>
     <input type="submit" value="{% translate 'Reset my password' %}">
 </fieldset>

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -288,10 +288,10 @@ def items_for_result(cl, result, form):
                 )
             ):
                 bf = form[field_name]
-                result_repr = mark_safe(str(bf.errors) + str(bf))
+                result_repr = mark_safe(str(bf.errors) + str(bf.widget))
             yield format_html("<td{}>{}</td>", row_class, result_repr)
     if form and not form[cl.model._meta.pk.name].is_hidden:
-        yield format_html("<td>{}</td>", form[cl.model._meta.pk.name])
+        yield format_html("<td>{}</td>", form[cl.model._meta.pk.name].widget)
 
 
 class ResultList(list):
@@ -319,7 +319,7 @@ def result_hidden_fields(cl):
     if cl.formset:
         for res, form in zip(cl.result_list, cl.formset.forms):
             if form[cl.model._meta.pk.name].is_hidden:
-                yield mark_safe(form[cl.model._meta.pk.name])
+                yield mark_safe(form[cl.model._meta.pk.name].widget)
 
 
 def result_list(cl):

--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -106,6 +106,7 @@ class Field:
         localize=False,
         disabled=False,
         label_suffix=None,
+        template_name=None,
     ):
         # required -- Boolean that specifies whether the field is required.
         #             True by default.
@@ -163,6 +164,7 @@ class Field:
         self.error_messages = messages
 
         self.validators = [*self.default_validators, *validators]
+        self.template_name = template_name
 
         super().__init__()
 

--- a/django/forms/jinja2/django/forms/div.html
+++ b/django/forms/jinja2/django/forms/div.html
@@ -4,16 +4,7 @@
 {% endif %}
 {% for field, errors in fields %}
   <div{% set classes = field.css_classes() %}{% if classes %} class="{{ classes }}"{% endif %}>
-    {% if field.use_fieldset %}
-      <fieldset>
-      {% if field.label %}{{ field.legend_tag() }}{% endif %}
-    {% else %}
-      {% if field.label %}{{ field.label_tag() }}{% endif %}
-    {% endif %}
-    {% if field.help_text %}<div class="helptext">{{ field.help_text|safe }}</div>{% endif %}
-    {{ errors }}
-    {{ field }}
-    {% if field.use_fieldset %}</fieldset>{% endif %}
+    {{ field.as_field() }}
     {% if loop.last %}
       {% for field in hidden_fields %}{{ field }}{% endfor %}
     {% endif %}

--- a/django/forms/jinja2/django/forms/div.html
+++ b/django/forms/jinja2/django/forms/div.html
@@ -1,15 +1,15 @@
 {{ errors }}
 {% if errors and not fields %}
-  <div>{% for field in hidden_fields %}{{ field }}{% endfor %}</div>
+  <div>{% for field in hidden_fields %}{{ field.widget }}{% endfor %}</div>
 {% endif %}
 {% for field, errors in fields %}
   <div{% set classes = field.css_classes() %}{% if classes %} class="{{ classes }}"{% endif %}>
     {{ field.as_field() }}
     {% if loop.last %}
-      {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
     {% endif %}
 </div>
 {% endfor %}
 {% if not fields and not errors %}
-  {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
 {% endif %}

--- a/django/forms/jinja2/django/forms/field.html
+++ b/django/forms/jinja2/django/forms/field.html
@@ -1,0 +1,10 @@
+{% if field.use_fieldset %}
+  <fieldset>
+  {% if field.label %}{{ field.legend_tag() }}{% endif %}
+{% else %}
+  {% if field.label %}{{ field.label_tag() }}{% endif %}
+{% endif %}
+{% if field.help_text %}<div class="helptext">{{ field.help_text|safe }}</div>{% endif %}
+{{ field.errors }}
+{{ field }}
+{% if field.use_fieldset %}</fieldset>{% endif %}

--- a/django/forms/jinja2/django/forms/field.html
+++ b/django/forms/jinja2/django/forms/field.html
@@ -6,5 +6,5 @@
 {% endif %}
 {% if field.help_text %}<div class="helptext">{{ field.help_text|safe }}</div>{% endif %}
 {{ field.errors }}
-{{ field }}
+{{ field.widget }}
 {% if field.use_fieldset %}</fieldset>{% endif %}

--- a/django/forms/jinja2/django/forms/p.html
+++ b/django/forms/jinja2/django/forms/p.html
@@ -1,20 +1,20 @@
 {{ errors }}
 {% if errors and not fields %}
-  <p>{% for field in hidden_fields %}{{ field }}{% endfor %}</p>
+  <p>{% for field in hidden_fields %}{{ field.widget }}{% endfor %}</p>
 {% endif %}
 {% for field, errors in fields %}
   {{ errors }}
   <p{% set classes = field.css_classes() %}{% if classes %} class="{{ classes }}"{% endif %}>
     {% if field.label %}{{ field.label_tag() }}{% endif %}
-    {{ field }}
+    {{ field.widget }}
     {% if field.help_text %}
       <span class="helptext">{{ field.help_text|safe }}</span>
     {% endif %}
     {% if loop.last %}
-      {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
     {% endif %}
   </p>
 {% endfor %}
 {% if not fields and not errors %}
-  {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
 {% endif %}

--- a/django/forms/jinja2/django/forms/table.html
+++ b/django/forms/jinja2/django/forms/table.html
@@ -3,7 +3,7 @@
     <td colspan="2">
       {{ errors }}
       {% if not fields %}
-        {% for field in hidden_fields %}{{ field }}{% endfor %}
+        {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
       {% endif %}
     </td>
   </tr>
@@ -13,17 +13,17 @@
     <th>{% if field.label %}{{ field.label_tag() }}{% endif %}</th>
     <td>
       {{ errors }}
-      {{ field }}
+      {{ field.widget }}
       {% if field.help_text %}
         <br>
         <span class="helptext">{{ field.help_text|safe }}</span>
       {% endif %}
       {% if loop.last %}
-        {% for field in hidden_fields %}{{ field }}{% endfor %}
+        {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
       {% endif %}
     </td>
   </tr>
 {% endfor %}
 {% if not fields and not errors %}
-  {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
 {% endif %}

--- a/django/forms/jinja2/django/forms/ul.html
+++ b/django/forms/jinja2/django/forms/ul.html
@@ -2,7 +2,7 @@
   <li>
     {{ errors }}
   {% if not fields %}
-    {% for field in hidden_fields %}{{ field }}{% endfor %}
+    {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
   {% endif %}
   </li>
 {% endif %}
@@ -10,15 +10,15 @@
   <li{% set classes = field.css_classes() %}{% if classes %} class="{{ classes }}"{% endif %}>
     {{ errors }}
     {% if field.label %}{{ field.label_tag() }}{% endif %}
-    {{ field }}
+    {{ field.widget }}
     {% if field.help_text %}
       <span class="helptext">{{ field.help_text|safe }}</span>
     {% endif %}
     {% if loop.last %}
-      {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
     {% endif %}
   </li>
 {% endfor %}
 {% if not fields and not errors %}
-  {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
 {% endif %}

--- a/django/forms/renderers.py
+++ b/django/forms/renderers.py
@@ -19,6 +19,7 @@ def get_default_renderer():
 class BaseRenderer:
     form_template_name = "django/forms/div.html"
     formset_template_name = "django/forms/formsets/div.html"
+    field_template_name = "django/forms/field.html"
 
     def get_template(self, template_name):
         raise NotImplementedError("subclasses must implement get_template()")

--- a/django/forms/templates/django/forms/div.html
+++ b/django/forms/templates/django/forms/div.html
@@ -4,16 +4,7 @@
 {% endif %}
 {% for field, errors in fields %}
   <div{% with classes=field.css_classes %}{% if classes %} class="{{ classes }}"{% endif %}{% endwith %}>
-    {% if field.use_fieldset %}
-      <fieldset>
-      {% if field.label %}{{ field.legend_tag }}{% endif %}
-    {% else %}
-      {% if field.label %}{{ field.label_tag }}{% endif %}
-    {% endif %}
-    {% if field.help_text %}<div class="helptext">{{ field.help_text|safe }}</div>{% endif %}
-    {{ errors }}
-    {{ field }}
-    {% if field.use_fieldset %}</fieldset>{% endif %}
+    {{ field.as_field }}
     {% if forloop.last %}
       {% for field in hidden_fields %}{{ field }}{% endfor %}
     {% endif %}

--- a/django/forms/templates/django/forms/div.html
+++ b/django/forms/templates/django/forms/div.html
@@ -1,15 +1,15 @@
 {{ errors }}
 {% if errors and not fields %}
-  <div>{% for field in hidden_fields %}{{ field }}{% endfor %}</div>
+  <div>{% for field in hidden_fields %}{{ field.widget }}{% endfor %}</div>
 {% endif %}
 {% for field, errors in fields %}
   <div{% with classes=field.css_classes %}{% if classes %} class="{{ classes }}"{% endif %}{% endwith %}>
     {{ field.as_field }}
     {% if forloop.last %}
-      {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
     {% endif %}
 </div>
 {% endfor %}
 {% if not fields and not errors %}
-  {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
 {% endif %}

--- a/django/forms/templates/django/forms/field.html
+++ b/django/forms/templates/django/forms/field.html
@@ -1,0 +1,10 @@
+{% if field.use_fieldset %}
+  <fieldset>
+  {% if field.label %}{{ field.legend_tag }}{% endif %}
+{% else %}
+  {% if field.label %}{{ field.label_tag }}{% endif %}
+{% endif %}
+{% if field.help_text %}<div class="helptext">{{ field.help_text|safe }}</div>{% endif %}
+{{ field.errors }}
+{{ field }}
+{% if field.use_fieldset %}</fieldset>{% endif %}

--- a/django/forms/templates/django/forms/field.html
+++ b/django/forms/templates/django/forms/field.html
@@ -6,5 +6,5 @@
 {% endif %}
 {% if field.help_text %}<div class="helptext">{{ field.help_text|safe }}</div>{% endif %}
 {{ field.errors }}
-{{ field }}
+{{ field.widget }}
 {% if field.use_fieldset %}</fieldset>{% endif %}

--- a/django/forms/templates/django/forms/p.html
+++ b/django/forms/templates/django/forms/p.html
@@ -1,20 +1,20 @@
 {{ errors }}
 {% if errors and not fields %}
-  <p>{% for field in hidden_fields %}{{ field }}{% endfor %}</p>
+  <p>{% for field in hidden_fields %}{{ field.widget }}{% endfor %}</p>
 {% endif %}
 {% for field, errors in fields %}
   {{ errors }}
   <p{% with classes=field.css_classes %}{% if classes %} class="{{ classes }}"{% endif %}{% endwith %}>
     {% if field.label %}{{ field.label_tag }}{% endif %}
-    {{ field }}
+    {{ field.widget }}
     {% if field.help_text %}
       <span class="helptext">{{ field.help_text|safe }}</span>
     {% endif %}
     {% if forloop.last %}
-      {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
     {% endif %}
   </p>
 {% endfor %}
 {% if not fields and not errors %}
-  {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
 {% endif %}

--- a/django/forms/templates/django/forms/table.html
+++ b/django/forms/templates/django/forms/table.html
@@ -3,7 +3,7 @@
     <td colspan="2">
       {{ errors }}
       {% if not fields %}
-        {% for field in hidden_fields %}{{ field }}{% endfor %}
+        {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
       {% endif %}
     </td>
   </tr>
@@ -13,17 +13,17 @@
     <th>{% if field.label %}{{ field.label_tag }}{% endif %}</th>
     <td>
       {{ errors }}
-      {{ field }}
+      {{ field.widget }}
       {% if field.help_text %}
         <br>
         <span class="helptext">{{ field.help_text|safe }}</span>
       {% endif %}
       {% if forloop.last %}
-        {% for field in hidden_fields %}{{ field }}{% endfor %}
+        {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
       {% endif %}
     </td>
   </tr>
 {% endfor %}
 {% if not fields and not errors %}
-  {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
 {% endif %}

--- a/django/forms/templates/django/forms/ul.html
+++ b/django/forms/templates/django/forms/ul.html
@@ -2,7 +2,7 @@
   <li>
     {{ errors }}
   {% if not fields %}
-    {% for field in hidden_fields %}{{ field }}{% endfor %}
+    {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
   {% endif %}
   </li>
 {% endif %}
@@ -10,15 +10,15 @@
   <li{% with classes=field.css_classes %}{% if classes %} class="{{ classes }}"{% endif %}{% endwith %}>
     {{ errors }}
     {% if field.label %}{{ field.label_tag }}{% endif %}
-    {{ field }}
+    {{ field.widget }}
     {% if field.help_text %}
       <span class="helptext">{{ field.help_text|safe }}</span>
     {% endif %}
     {% if forloop.last %}
-      {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
     {% endif %}
   </li>
 {% endfor %}
 {% if not fields and not errors %}
-  {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
 {% endif %}

--- a/django/forms/utils.py
+++ b/django/forms/utils.py
@@ -1,10 +1,12 @@
 import json
+import warnings
 from collections import UserList
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms.renderers import get_default_renderer
 from django.utils import timezone
+from django.utils.deprecation import RemovedInDjango60Warning
 from django.utils.html import escape, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
@@ -60,25 +62,63 @@ class RenderableMixin:
 
 class RenderableFieldMixin(RenderableMixin):
     def as_field(self):
+        # RemovedInDjango60Warning
+        # Deprecate this in 6.0 for removal in 7.0. Call __str__ instead.
         return self.render()
 
-    # TODO -- I'm not sure how best to structure this as __str__ on boundfield does
-    # something different to RenderableMixin.
-    def as_hidden(self):
-        raise NotImplementedError(
-            "Subclasses of RenderableFieldMixin must provide an as_hidden() method."
+    def __str__(self):
+        # In Django 6.0 change to
+        # return self.render()
+        warnings.warn(
+            "Calling __str__ on BoundField will change from rendering the"
+            "Field's Widget to rendering the whole Field in Django 6.0."
+            "Call __str__ on BoundField.widget to retain current behaviour."
+            f"{self.template_name=}, {self.widget}",
+            category=RemovedInDjango60Warning,
+            stacklevel=2,
         )
+        boundwidget = self.widget
+        return str(boundwidget)
 
     def as_widget(self):
-        raise NotImplementedError(
-            "Subclasses of RenderableFieldMixin must provide an as_widget() method."
+        warnings.warn(
+            "BoundField.as_widget() is deprecated. Use "
+            "BoundField.widget.as_widget() instead.",
+            category=RemovedInDjango60Warning,
+            stacklevel=2,
         )
+        widget = self.widget
+        return widget.as_widget()
 
-    def __str__(self):
-        """Render this field as an HTML widget."""
-        if self.field.show_hidden_initial:
-            return self.as_widget() + self.as_hidden(only_initial=True)
-        return self.as_widget()
+    def as_text(self):
+        warnings.warn(
+            "BoundField.as_text() is deprecated. Use "
+            "BoundField.widget.as_text() instead.",
+            category=RemovedInDjango60Warning,
+            stacklevel=2,
+        )
+        widget = self.widget
+        return widget.as_text()
+
+    def as_textarea(self):
+        warnings.warn(
+            "BoundField.as_textarea() is deprecated. Use "
+            "BoundField.widget.as_textarea() instead.",
+            category=RemovedInDjango60Warning,
+            stacklevel=2,
+        )
+        widget = self.widget
+        return widget.as_textarea()
+
+    def as_hidden(self):
+        warnings.warn(
+            "BoundField.as_hidden() is deprecated. Use "
+            "BoundField.widget.as_hidden() instead.",
+            category=RemovedInDjango60Warning,
+            stacklevel=2,
+        )
+        widget = self.widget
+        return widget.as_hidden()
 
     __html__ = __str__
 

--- a/django/forms/utils.py
+++ b/django/forms/utils.py
@@ -58,6 +58,31 @@ class RenderableMixin:
     __html__ = render
 
 
+class RenderableFieldMixin(RenderableMixin):
+    def as_field(self):
+        return self.render()
+
+    # TODO -- I'm not sure how best to structure this as __str__ on boundfield does
+    # something different to RenderableMixin.
+    def as_hidden(self):
+        raise NotImplementedError(
+            "Subclasses of RenderableFieldMixin must provide an as_hidden() method."
+        )
+
+    def as_widget(self):
+        raise NotImplementedError(
+            "Subclasses of RenderableFieldMixin must provide an as_widget() method."
+        )
+
+    def __str__(self):
+        """Render this field as an HTML widget."""
+        if self.field.show_hidden_initial:
+            return self.as_widget() + self.as_hidden(only_initial=True)
+        return self.as_widget()
+
+    __html__ = __str__
+
+
 class RenderableFormMixin(RenderableMixin):
     def as_p(self):
         """Render as <p> elements."""

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -1232,6 +1232,16 @@ Attributes of ``BoundField``
         >>> print(f['message'].name)
         message
 
+.. attribute:: BoundField.template_name
+
+    .. versionadded:: 4.2
+
+    The name of the template rendered with :meth:`.BoundField.as_field`.
+
+    A property returning the value of the
+    :attr:`~django.forms.Field.template_name` if set otherwise
+    :attr:`~django.forms.renderers.BaseRenderer.field_template_name`.
+
 .. attribute:: BoundField.use_fieldset
 
     Returns the value of this BoundField widget's ``use_fieldset`` attribute.
@@ -1255,6 +1265,15 @@ Attributes of ``BoundField``
 
 Methods of ``BoundField``
 -------------------------
+
+.. method:: BoundField.as_field()
+
+    .. versionadded:: 4.2
+
+    Renders the field using :meth:`.BoundField.render` with default values
+    which renders the ``BoundField``, including its label, help text and errors
+    using the template's :attr:`~django.forms.Field.template_name` if set
+    otherwise :attr:`~django.forms.renderers.BaseRenderer.field_template_name`
 
 .. method:: BoundField.as_hidden(attrs=None, **kwargs)
 
@@ -1295,6 +1314,13 @@ Methods of ``BoundField``
         >>> f = ContactForm(data={'message': ''})
         >>> f['message'].css_classes('foo bar')
         'foo bar required'
+
+.. method:: BoundField.get_context()
+
+    .. versionadded:: 5.0
+
+    Return the template context for rendering the field. The available context
+    is ``field`` being the instance of the bound field.
 
 .. method:: BoundField.label_tag(contents=None, attrs=None, label_suffix=None, tag=None)
 
@@ -1342,6 +1368,20 @@ Methods of ``BoundField``
     ``<legend>`` tags. This is useful when rendering radio and multiple
     checkbox widgets where ``<legend>`` may be more appropriate than a
     ``<label>``.
+
+.. method:: BoundField.render(template_name=None, context=None, renderer=None)
+
+    .. versionadded:: 5.0
+
+    The render method is called by ``as_field``. All arguments are optional and
+    default to:
+
+    * ``template_name``: :attr:`.BoundField.template_name`
+    * ``context``: Value returned by :meth:`.BoundField.get_context`
+    * ``renderer``: Value returned by :attr:`.Form.default_renderer`
+
+    By passing ``template_name`` you can customize the template used for just a
+    single call.
 
 .. method:: BoundField.value()
 

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -1234,7 +1234,7 @@ Attributes of ``BoundField``
 
 .. attribute:: BoundField.template_name
 
-    .. versionadded:: 4.2
+    .. versionadded:: 5.0
 
     The name of the template rendered with :meth:`.BoundField.as_field`.
 
@@ -1268,7 +1268,7 @@ Methods of ``BoundField``
 
 .. method:: BoundField.as_field()
 
-    .. versionadded:: 4.2
+    .. versionadded:: 5.0
 
     Renders the field using :meth:`.BoundField.render` with default values
     which renders the ``BoundField``, including its label, help text and errors

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -330,6 +330,19 @@ using the ``disabled`` HTML attribute so that it won't be editable by users.
 Even if a user tampers with the field's value submitted to the server, it will
 be ignored in favor of the value from the form's initial data.
 
+``template_name``
+-----------------
+
+.. attribute:: Field.template_name
+
+.. versionadded:: 5.0
+
+The ``template_name`` argument allows a custom template to be used when the
+field is rendered with :meth:`~django.forms.BoundField.as_field`. By default
+this value is set to ``"django/forms/field.html"``. The default template can 
+be overridden as with other form and widget templates, see 
+:ref:`overriding-built-in-form-templates`.
+
 Checking if the field data has changed
 ======================================
 

--- a/docs/ref/forms/renderers.txt
+++ b/docs/ref/forms/renderers.txt
@@ -59,6 +59,14 @@ should return a rendered templates (as a string) or raise
 
         Defaults to ``"django/forms/formsets/div.html"`` template.
 
+    .. attribute:: field_template_name
+
+        .. versionadded:: 5.0
+
+        The default name of the template used to render a ``BoundField``.
+
+        Defaults to ``"django/forms/field.html"``
+
     .. method:: get_template(template_name)
 
         Subclasses must implement this method with the appropriate template
@@ -160,6 +168,14 @@ forms receive a dictionary with the following values:
 * ``fields``: All bound fields, except the hidden fields.
 * ``hidden_fields``: All hidden bound fields.
 * ``errors``: All non field related or hidden field related form errors.
+
+Context available in field templates
+====================================
+
+Field templates receive a context from :meth:`.BoundField.get_context`. By
+default, fields receive a dictionary with the following values:
+
+* ``field``: The :class:`~django.forms.BoundField`.
 
 Context available in widget templates
 =====================================

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -37,6 +37,70 @@ compatible with Django 5.0.
 What's new in Django 5.0
 ========================
 
+BoundField becomes renderable
+-----------------------------
+
+The new :meth:`~django.forms.BoundField.as_field` method allows rendering of
+the fields including their label, help text and errors.
+
+``as_field()`` renders fields with the ``"django/forms/field.html"`` template
+by default and can be customized on a per-project, per-field or per-request
+basis.
+
+Custom form templates can now be written more succinctly as defining each
+element for each field can be avoided. For example, the template below::
+
+    <form>
+    ...
+    <div>
+    {{ form.name.label }}
+    {% if form.name.help_text %}<div class="helptext">{{ form.name.help_text|safe }}</div>{% endif %}
+    {{ form.name.errors }}
+    {{ form.name }}
+    <div class="row">
+        <div class="col">
+        {{ form.email.label }}
+        {% if form.email.help_text %}<div class="helptext">{{ form.email.help_text|safe }}</div>{% endif %}
+        {{ form.email.errors }}
+        {{ form.email }}}
+        </div>
+        <div class="col">
+        {{ form.password.label }}
+        {% if form.password.help_text %}<div class="helptext">{{ form.password.help_text|safe }}</div>{% endif %}
+        {{ form.password.errors }}
+        {{ form.password }}}
+        </div>
+    </div>
+    </div>
+    ...
+    </form>
+
+Can now be simplified too::
+
+    <form>
+    ...
+    <div>
+    {{ form.name.as_field }}
+    <div class="row">
+        <div class="col">{{ form.email.as_field }}</div>
+        <div class="col">{{ form.password.as_field }}</div>
+    </div>
+    </div>
+    ...
+    </form>
+
+To customize the default template, the field template can be set:
+
+* At a project level by defining
+  :attr:`~django.forms.renderers.BaseRenderer.field_template_name` on a
+  custom :setting:`FORM_RENDERER`.
+
+* On a per-field basis by using :attr:`~django.forms.Field.template_name` when
+  defining a field in your form.
+
+* On a per-request basis by calling :meth:`~django.forms.BoundField.render` and
+  supplying a template name.
+
 Minor features
 --------------
 

--- a/tests/forms_tests/field_tests/__init__.py
+++ b/tests/forms_tests/field_tests/__init__.py
@@ -6,4 +6,4 @@ class FormFieldAssertionsMixin:
         class Form(forms.Form):
             f = field
 
-        self.assertHTMLEqual(str(Form()["f"]), to)
+        self.assertHTMLEqual(str(Form()["f"].widget), to)

--- a/tests/forms_tests/field_tests/test_datefield.py
+++ b/tests/forms_tests/field_tests/test_datefield.py
@@ -19,7 +19,7 @@ class DateFieldTest(SimpleTestCase):
         # As with any widget that implements get_value_from_datadict(), we must
         # accept the input from the "as_hidden" rendering as well.
         self.assertHTMLEqual(
-            a["mydate"].as_hidden(),
+            a["mydate"].widget.as_hidden(),
             '<input type="hidden" name="mydate" value="2008-04-01" id="id_mydate">',
         )
 

--- a/tests/forms_tests/templates/forms_tests/custom_field.html
+++ b/tests/forms_tests/templates/forms_tests/custom_field.html
@@ -1,3 +1,3 @@
 {{ field.label_tag }}
 <p>Custom Field<p>
-{{ field }}
+{{ field.widget }}

--- a/tests/forms_tests/templates/forms_tests/custom_field.html
+++ b/tests/forms_tests/templates/forms_tests/custom_field.html
@@ -1,0 +1,3 @@
+{{ field.label_tag }}
+<p>Custom Field<p>
+{{ field }}

--- a/tests/forms_tests/templates/forms_tests/form_snippet.html
+++ b/tests/forms_tests/templates/forms_tests/form_snippet.html
@@ -1,6 +1,6 @@
 {% for field in form %}
   <div class="fieldWrapper">
     {{ field.errors }}
-    {{ field.label_tag }} {{ field }}
+    {{ field.label_tag }} {{ field.widget }}
   </div>
 {% endfor %}

--- a/tests/forms_tests/templates/forms_tests/use_fieldset.html
+++ b/tests/forms_tests/templates/forms_tests/use_fieldset.html
@@ -6,13 +6,13 @@
     {% else %}
       {% if field.label %}{{ field.label_tag }}{% endif %}
     {% endif %}
-    {{ field }}
+    {{ field.widget }}
     {% if field.use_fieldset %}</fieldset>{% endif %}
     {% if forloop.last %}
-      {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
     {% endif %}
   </div>
 {% endfor %}
 {% if not fields and not errors %}
-  {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% for field in hidden_fields %}{{ field.widget }}{% endfor %}
 {% endif %}

--- a/tests/forms_tests/templatetags/tags.py
+++ b/tests/forms_tests/templatetags/tags.py
@@ -10,7 +10,7 @@ class CountRenderNode(Node):
         self.count += 1
         for v in context.flatten().values():
             try:
-                v.render()
+                str(v)
             except AttributeError:
                 pass
         return str(self.count)

--- a/tests/forms_tests/templatetags/tags.py
+++ b/tests/forms_tests/templatetags/tags.py
@@ -10,7 +10,7 @@ class CountRenderNode(Node):
         self.count += 1
         for v in context.flatten().values():
             try:
-                str(v)
+                str(v.widget)
             except AttributeError:
                 pass
         return str(self.count)

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -100,17 +100,17 @@ class FormsTestCase(SimpleTestCase):
         self.assertEqual(p.cleaned_data["last_name"], "Lennon")
         self.assertEqual(p.cleaned_data["birthday"], datetime.date(1940, 10, 9))
         self.assertHTMLEqual(
-            str(p["first_name"]),
+            str(p["first_name"].widget),
             '<input type="text" name="first_name" value="John" id="id_first_name" '
             "required>",
         )
         self.assertHTMLEqual(
-            str(p["last_name"]),
+            str(p["last_name"].widget),
             '<input type="text" name="last_name" value="Lennon" id="id_last_name" '
             "required>",
         )
         self.assertHTMLEqual(
-            str(p["birthday"]),
+            str(p["birthday"].widget),
             '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" '
             "required>",
         )
@@ -125,7 +125,7 @@ class FormsTestCase(SimpleTestCase):
         form_output = []
 
         for boundfield in p:
-            form_output.append(str(boundfield))
+            form_output.append(str(boundfield.widget))
 
         self.assertHTMLEqual(
             "\n".join(form_output),
@@ -384,15 +384,15 @@ class FormsTestCase(SimpleTestCase):
 
         p = Person()
         self.assertHTMLEqual(
-            str(p["first_name"]),
+            str(p["first_name"].widget),
             '<input type="text" name="first_name" id="id_first_name" required>',
         )
         self.assertHTMLEqual(
-            str(p["last_name"]),
+            str(p["last_name"].widget),
             '<input type="text" name="last_name" id="id_last_name" required>',
         )
         self.assertHTMLEqual(
-            str(p["birthday"]),
+            str(p["birthday"].widget),
             '<input type="text" name="birthday" id="id_birthday" required>',
         )
 
@@ -546,32 +546,33 @@ class FormsTestCase(SimpleTestCase):
 
         f = SignupForm(auto_id=False)
         self.assertHTMLEqual(
-            str(f["email"]), '<input type="email" name="email" required>'
+            str(f["email"].widget), '<input type="email" name="email" required>'
         )
         self.assertHTMLEqual(
-            str(f["get_spam"]), '<input type="checkbox" name="get_spam" required>'
+            str(f["get_spam"].widget),
+            '<input type="checkbox" name="get_spam" required>',
         )
 
         f = SignupForm({"email": "test@example.com", "get_spam": True}, auto_id=False)
         self.assertHTMLEqual(
-            str(f["email"]),
+            str(f["email"].widget),
             '<input type="email" name="email" value="test@example.com" required>',
         )
         self.assertHTMLEqual(
-            str(f["get_spam"]),
+            str(f["get_spam"].widget),
             '<input checked type="checkbox" name="get_spam" required>',
         )
 
         # 'True' or 'true' should be rendered without a value attribute
         f = SignupForm({"email": "test@example.com", "get_spam": "True"}, auto_id=False)
         self.assertHTMLEqual(
-            str(f["get_spam"]),
+            str(f["get_spam"].widget),
             '<input checked type="checkbox" name="get_spam" required>',
         )
 
         f = SignupForm({"email": "test@example.com", "get_spam": "true"}, auto_id=False)
         self.assertHTMLEqual(
-            str(f["get_spam"]),
+            str(f["get_spam"].widget),
             '<input checked type="checkbox" name="get_spam" required>',
         )
 
@@ -580,14 +581,16 @@ class FormsTestCase(SimpleTestCase):
             {"email": "test@example.com", "get_spam": "False"}, auto_id=False
         )
         self.assertHTMLEqual(
-            str(f["get_spam"]), '<input type="checkbox" name="get_spam" required>'
+            str(f["get_spam"].widget),
+            '<input type="checkbox" name="get_spam" required>',
         )
 
         f = SignupForm(
             {"email": "test@example.com", "get_spam": "false"}, auto_id=False
         )
         self.assertHTMLEqual(
-            str(f["get_spam"]), '<input type="checkbox" name="get_spam" required>'
+            str(f["get_spam"].widget),
+            '<input type="checkbox" name="get_spam" required>',
         )
 
         # A value of '0' should be interpreted as a True value (#16820)
@@ -603,24 +606,24 @@ class FormsTestCase(SimpleTestCase):
 
         f = ContactForm(auto_id=False)
         self.assertHTMLEqual(
-            str(f["subject"]), '<input type="text" name="subject" required>'
+            str(f["subject"].widget), '<input type="text" name="subject" required>'
         )
         self.assertHTMLEqual(
-            str(f["message"]),
+            str(f["message"].widget),
             '<textarea name="message" rows="10" cols="40" required></textarea>',
         )
 
         # as_textarea(), as_text() and as_hidden() are shortcuts for changing the output
         # widget type:
         self.assertHTMLEqual(
-            f["subject"].as_textarea(),
+            f["subject"].widget.as_textarea(),
             '<textarea name="subject" rows="10" cols="40" required></textarea>',
         )
         self.assertHTMLEqual(
-            f["message"].as_text(), '<input type="text" name="message" required>'
+            f["message"].widget.as_text(), '<input type="text" name="message" required>'
         )
         self.assertHTMLEqual(
-            f["message"].as_hidden(), '<input type="hidden" name="message">'
+            f["message"].widget.as_hidden(), '<input type="hidden" name="message">'
         )
 
         # The 'widget' parameter to a Field can also be an instance:
@@ -630,26 +633,26 @@ class FormsTestCase(SimpleTestCase):
 
         f = ContactForm(auto_id=False)
         self.assertHTMLEqual(
-            str(f["message"]),
+            str(f["message"].widget),
             '<textarea name="message" rows="80" cols="20" required></textarea>',
         )
 
         # Instance-level attrs are *not* carried over to as_textarea(), as_text() and
         # as_hidden():
         self.assertHTMLEqual(
-            f["message"].as_text(), '<input type="text" name="message" required>'
+            f["message"].widget.as_text(), '<input type="text" name="message" required>'
         )
         f = ContactForm({"subject": "Hello", "message": "I love you."}, auto_id=False)
         self.assertHTMLEqual(
-            f["subject"].as_textarea(),
+            f["subject"].widget.as_textarea(),
             '<textarea rows="10" cols="40" name="subject" required>Hello</textarea>',
         )
         self.assertHTMLEqual(
-            f["message"].as_text(),
+            f["message"].widget.as_text(),
             '<input type="text" name="message" value="I love you." required>',
         )
         self.assertHTMLEqual(
-            f["message"].as_hidden(),
+            f["message"].widget.as_hidden(),
             '<input type="hidden" name="message" value="I love you.">',
         )
 
@@ -661,7 +664,7 @@ class FormsTestCase(SimpleTestCase):
 
         f = FrameworkForm(auto_id=False)
         self.assertHTMLEqual(
-            str(f["language"]),
+            str(f["language"].widget),
             """<select name="language">
 <option value="P">Python</option>
 <option value="J">Java</option>
@@ -669,7 +672,7 @@ class FormsTestCase(SimpleTestCase):
         )
         f = FrameworkForm({"name": "Django", "language": "P"}, auto_id=False)
         self.assertHTMLEqual(
-            str(f["language"]),
+            str(f["language"].widget),
             """<select name="language">
 <option value="P" selected>Python</option>
 <option value="J">Java</option>
@@ -686,7 +689,7 @@ class FormsTestCase(SimpleTestCase):
 
         f = FrameworkForm(auto_id=False)
         self.assertHTMLEqual(
-            str(f["language"]),
+            str(f["language"].widget),
             """<select name="language" required>
 <option value="" selected>------</option>
 <option value="P">Python</option>
@@ -704,7 +707,7 @@ class FormsTestCase(SimpleTestCase):
 
         f = FrameworkForm(auto_id=False)
         self.assertHTMLEqual(
-            str(f["language"]),
+            str(f["language"].widget),
             """<select class="foo" name="language">
 <option value="P">Python</option>
 <option value="J">Java</option>
@@ -712,7 +715,7 @@ class FormsTestCase(SimpleTestCase):
         )
         f = FrameworkForm({"name": "Django", "language": "P"}, auto_id=False)
         self.assertHTMLEqual(
-            str(f["language"]),
+            str(f["language"].widget),
             """<select class="foo" name="language">
 <option value="P" selected>Python</option>
 <option value="J">Java</option>
@@ -733,7 +736,7 @@ class FormsTestCase(SimpleTestCase):
 
         f = FrameworkForm(auto_id=False)
         self.assertHTMLEqual(
-            str(f["language"]),
+            str(f["language"].widget),
             """<select class="foo" name="language">
 <option value="P">Python</option>
 <option value="J">Java</option>
@@ -741,7 +744,7 @@ class FormsTestCase(SimpleTestCase):
         )
         f = FrameworkForm({"name": "Django", "language": "P"}, auto_id=False)
         self.assertHTMLEqual(
-            str(f["language"]),
+            str(f["language"].widget),
             """<select class="foo" name="language">
 <option value="P" selected>Python</option>
 <option value="J">Java</option>
@@ -755,13 +758,13 @@ class FormsTestCase(SimpleTestCase):
 
         f = FrameworkForm(auto_id=False)
         self.assertHTMLEqual(
-            str(f["language"]),
+            str(f["language"].widget),
             """<select name="language">
 </select>""",
         )
         f.fields["language"].choices = [("P", "Python"), ("J", "Java")]
         self.assertHTMLEqual(
-            str(f["language"]),
+            str(f["language"].widget),
             """<select name="language">
 <option value="P">Python</option>
 <option value="J">Java</option>
@@ -772,7 +775,7 @@ class FormsTestCase(SimpleTestCase):
         # Add widget=RadioSelect to use that widget with a ChoiceField.
         f = FrameworkForm(auto_id=False)
         self.assertHTMLEqual(
-            str(f["language"]),
+            str(f["language"].widget),
             """<div>
 <div><label><input type="radio" name="language" value="P" required> Python</label></div>
 <div><label><input type="radio" name="language" value="J" required> Java</label></div>
@@ -809,7 +812,7 @@ class FormsTestCase(SimpleTestCase):
         # plus the button's zero-based index.
         f = FrameworkForm(auto_id="id_%s")
         self.assertHTMLEqual(
-            str(f["language"]),
+            str(f["language"].widget),
             """
             <div id="id_language">
             <div><label for="id_language_0">
@@ -1030,7 +1033,7 @@ class FormsTestCase(SimpleTestCase):
 
         f = SongForm(auto_id=False)
         self.assertHTMLEqual(
-            str(f["composers"]),
+            str(f["composers"].widget),
             """<select multiple name="composers" required>
 </select>""",
         )
@@ -1043,7 +1046,7 @@ class FormsTestCase(SimpleTestCase):
 
         f = SongForm(auto_id=False)
         self.assertHTMLEqual(
-            str(f["composers"]),
+            str(f["composers"].widget),
             """<select multiple name="composers" required>
 <option value="J">John Lennon</option>
 <option value="P">Paul McCartney</option>
@@ -1051,10 +1054,11 @@ class FormsTestCase(SimpleTestCase):
         )
         f = SongForm({"name": "Yesterday", "composers": ["P"]}, auto_id=False)
         self.assertHTMLEqual(
-            str(f["name"]), '<input type="text" name="name" value="Yesterday" required>'
+            str(f["name"].widget),
+            '<input type="text" name="name" value="Yesterday" required>',
         )
         self.assertHTMLEqual(
-            str(f["composers"]),
+            str(f["composers"].widget),
             """<select multiple name="composers" required>
 <option value="J">John Lennon</option>
 <option value="P" selected>Paul McCartney</option>
@@ -1205,12 +1209,12 @@ class FormsTestCase(SimpleTestCase):
         # tags.
         f = SongForm({"name": "Yesterday", "composers": ["P"]}, auto_id=False)
         self.assertHTMLEqual(
-            f["composers"].as_hidden(),
+            f["composers"].widget.as_hidden(),
             '<input type="hidden" name="composers" value="P">',
         )
         f = SongForm({"name": "From Me To You", "composers": ["P", "J"]}, auto_id=False)
         self.assertHTMLEqual(
-            f["composers"].as_hidden(),
+            f["composers"].widget.as_hidden(),
             """<input type="hidden" name="composers" value="P">
 <input type="hidden" name="composers" value="J">""",
         )
@@ -1222,13 +1226,13 @@ class FormsTestCase(SimpleTestCase):
         f = MessageForm({"when_0": "1992-01-01", "when_1": "01:01"})
         self.assertTrue(f.is_valid())
         self.assertHTMLEqual(
-            str(f["when"]),
+            str(f["when"].widget),
             '<input type="text" name="when_0" value="1992-01-01" id="id_when_0" '
             "required>"
             '<input type="text" name="when_1" value="01:01" id="id_when_1" required>',
         )
         self.assertHTMLEqual(
-            f["when"].as_hidden(),
+            f["when"].widget.as_hidden(),
             '<input type="hidden" name="when_0" value="1992-01-01" id="id_when_0">'
             '<input type="hidden" name="when_1" value="01:01" id="id_when_1">',
         )
@@ -1237,7 +1241,7 @@ class FormsTestCase(SimpleTestCase):
         # MultipleChoiceField can also be used with the CheckboxSelectMultiple widget.
         f = SongForm(auto_id=False)
         self.assertHTMLEqual(
-            str(f["composers"]),
+            str(f["composers"].widget),
             """
             <div>
             <div><label><input type="checkbox" name="composers" value="J">
@@ -1249,7 +1253,7 @@ class FormsTestCase(SimpleTestCase):
         )
         f = SongForm({"composers": ["J"]}, auto_id=False)
         self.assertHTMLEqual(
-            str(f["composers"]),
+            str(f["composers"].widget),
             """
             <div>
             <div><label><input checked type="checkbox" name="composers" value="J">
@@ -1261,7 +1265,7 @@ class FormsTestCase(SimpleTestCase):
         )
         f = SongForm({"composers": ["J", "P"]}, auto_id=False)
         self.assertHTMLEqual(
-            str(f["composers"]),
+            str(f["composers"].widget),
             """
             <div>
             <div><label><input checked type="checkbox" name="composers" value="J">
@@ -1285,7 +1289,7 @@ class FormsTestCase(SimpleTestCase):
 
         f = SongForm(auto_id="%s_id")
         self.assertHTMLEqual(
-            str(f["composers"]),
+            str(f["composers"].widget),
             """
             <div id="composers_id">
             <div><label for="composers_id_0">
@@ -3100,17 +3104,17 @@ Options: <select multiple name="options" required>
             """,
         )
         self.assertHTMLEqual(
-            str(p["first_name"]),
+            str(p["first_name"].widget),
             '<input type="text" name="person1-first_name" value="John" '
             'id="id_person1-first_name" required>',
         )
         self.assertHTMLEqual(
-            str(p["last_name"]),
+            str(p["last_name"].widget),
             '<input type="text" name="person1-last_name" value="Lennon" '
             'id="id_person1-last_name" required>',
         )
         self.assertHTMLEqual(
-            str(p["birthday"]),
+            str(p["birthday"].widget),
             '<input type="text" name="person1-birthday" value="1940-10-9" '
             'id="id_person1-birthday" required>',
         )
@@ -3228,7 +3232,7 @@ Options: <select multiple name="options" required>
 
         p = Person({"name": "Joe"}, auto_id=False)
         self.assertHTMLEqual(
-            str(p["is_cool"]),
+            str(p["is_cool"].widget),
             """<select name="is_cool">
 <option value="unknown" selected>Unknown</option>
 <option value="true">Yes</option>
@@ -3237,7 +3241,7 @@ Options: <select multiple name="options" required>
         )
         p = Person({"name": "Joe", "is_cool": "1"}, auto_id=False)
         self.assertHTMLEqual(
-            str(p["is_cool"]),
+            str(p["is_cool"].widget),
             """<select name="is_cool">
 <option value="unknown" selected>Unknown</option>
 <option value="true">Yes</option>
@@ -3246,7 +3250,7 @@ Options: <select multiple name="options" required>
         )
         p = Person({"name": "Joe", "is_cool": "2"}, auto_id=False)
         self.assertHTMLEqual(
-            str(p["is_cool"]),
+            str(p["is_cool"].widget),
             """<select name="is_cool">
 <option value="unknown">Unknown</option>
 <option value="true" selected>Yes</option>
@@ -3255,7 +3259,7 @@ Options: <select multiple name="options" required>
         )
         p = Person({"name": "Joe", "is_cool": "3"}, auto_id=False)
         self.assertHTMLEqual(
-            str(p["is_cool"]),
+            str(p["is_cool"].widget),
             """<select name="is_cool">
 <option value="unknown">Unknown</option>
 <option value="true">Yes</option>
@@ -3264,7 +3268,7 @@ Options: <select multiple name="options" required>
         )
         p = Person({"name": "Joe", "is_cool": True}, auto_id=False)
         self.assertHTMLEqual(
-            str(p["is_cool"]),
+            str(p["is_cool"].widget),
             """<select name="is_cool">
 <option value="unknown">Unknown</option>
 <option value="true" selected>Yes</option>
@@ -3273,7 +3277,7 @@ Options: <select multiple name="options" required>
         )
         p = Person({"name": "Joe", "is_cool": False}, auto_id=False)
         self.assertHTMLEqual(
-            str(p["is_cool"]),
+            str(p["is_cool"].widget),
             """<select name="is_cool">
 <option value="unknown">Unknown</option>
 <option value="true">Yes</option>
@@ -3282,7 +3286,7 @@ Options: <select multiple name="options" required>
         )
         p = Person({"name": "Joe", "is_cool": "unknown"}, auto_id=False)
         self.assertHTMLEqual(
-            str(p["is_cool"]),
+            str(p["is_cool"].widget),
             """<select name="is_cool">
 <option value="unknown" selected>Unknown</option>
 <option value="true">Yes</option>
@@ -3291,7 +3295,7 @@ Options: <select multiple name="options" required>
         )
         p = Person({"name": "Joe", "is_cool": "true"}, auto_id=False)
         self.assertHTMLEqual(
-            str(p["is_cool"]),
+            str(p["is_cool"].widget),
             """<select name="is_cool">
 <option value="unknown">Unknown</option>
 <option value="true" selected>Yes</option>
@@ -3300,7 +3304,7 @@ Options: <select multiple name="options" required>
         )
         p = Person({"name": "Joe", "is_cool": "false"}, auto_id=False)
         self.assertHTMLEqual(
-            str(p["is_cool"]),
+            str(p["is_cool"].widget),
             """<select name="is_cool">
 <option value="unknown">Unknown</option>
 <option value="true">Yes</option>
@@ -4384,7 +4388,9 @@ Options: <select multiple name="options" required>
         self.assertTrue(hasattr(SimpleForm, "__html__"))
         self.assertEqual(str(form), form.__html__())
         self.assertTrue(hasattr(form["username"], "__html__"))
-        self.assertEqual(str(form["username"]), form["username"].__html__())
+        self.assertEqual(
+            str(form["username"].widget), form["username"].widget.__html__()
+        )
 
     def test_use_required_attribute_true(self):
         class MyForm(Form):
@@ -4704,11 +4710,11 @@ class TemplateTests(SimpleTestCase):
         t = Template(
             "<form>"
             "{{ form.username.errors.as_ul }}"
-            "<p><label>Your username: {{ form.username }}</label></p>"
+            "<p><label>Your username: {{ form.username.widget }}</label></p>"
             "{{ form.password1.errors.as_ul }}"
-            "<p><label>Password: {{ form.password1 }}</label></p>"
+            "<p><label>Password: {{ form.password1.widget }}</label></p>"
             "{{ form.password2.errors.as_ul }}"
-            "<p><label>Password (again): {{ form.password2 }}</label></p>"
+            "<p><label>Password (again): {{ form.password2.widget }}</label></p>"
             '<input type="submit" required>'
             "</form>"
         )
@@ -4747,9 +4753,12 @@ class TemplateTests(SimpleTestCase):
         # underscores converted to spaces, and the initial letter capitalized.
         t = Template(
             "<form>"
-            "<p><label>{{ form.username.label }}: {{ form.username }}</label></p>"
-            "<p><label>{{ form.password1.label }}: {{ form.password1 }}</label></p>"
-            "<p><label>{{ form.password2.label }}: {{ form.password2 }}</label></p>"
+            "<p><label>{{ form.username.label }}: "
+            "{{ form.username.widget }}</label></p>"
+            "<p><label>{{ form.password1.label }}: "
+            "{{ form.password1.widget }}</label></p>"
+            "<p><label>{{ form.password2.label }}: "
+            "{{ form.password2.widget }}</label></p>"
             '<input type="submit" required>'
             "</form>"
         )
@@ -4772,9 +4781,9 @@ class TemplateTests(SimpleTestCase):
         # Form gives each field an "id" attribute.
         t = Template(
             "<form>"
-            "<p>{{ form.username.label_tag }} {{ form.username }}</p>"
-            "<p>{{ form.password1.label_tag }} {{ form.password1 }}</p>"
-            "<p>{{ form.password2.label_tag }} {{ form.password2 }}</p>"
+            "<p>{{ form.username.label_tag }} {{ form.username.widget }}</p>"
+            "<p>{{ form.password1.label_tag }} {{ form.password1.widget }}</p>"
+            "<p>{{ form.password2.label_tag }} {{ form.password2.widget }}</p>"
             '<input type="submit" required>'
             "</form>"
         )
@@ -4808,9 +4817,9 @@ class TemplateTests(SimpleTestCase):
         # Form gives each field an "id" attribute.
         t = Template(
             "<form>"
-            "<p>{{ form.username.legend_tag }} {{ form.username }}</p>"
-            "<p>{{ form.password1.legend_tag }} {{ form.password1 }}</p>"
-            "<p>{{ form.password2.legend_tag }} {{ form.password2 }}</p>"
+            "<p>{{ form.username.legend_tag }} {{ form.username.widget }}</p>"
+            "<p>{{ form.password1.legend_tag }} {{ form.password1.widget }}</p>"
+            "<p>{{ form.password2.legend_tag }} {{ form.password2.widget }}</p>"
             '<input type="submit" required>'
             "</form>"
         )
@@ -4843,10 +4852,10 @@ class TemplateTests(SimpleTestCase):
         # given field does not have help text, nothing will be output.
         t = Template(
             "<form>"
-            "<p>{{ form.username.label_tag }} {{ form.username }}<br>"
+            "<p>{{ form.username.label_tag }} {{ form.username.widget }}<br>"
             "{{ form.username.help_text }}</p>"
-            "<p>{{ form.password1.label_tag }} {{ form.password1 }}</p>"
-            "<p>{{ form.password2.label_tag }} {{ form.password2 }}</p>"
+            "<p>{{ form.password1.label_tag }} {{ form.password1.widget }}</p>"
+            "<p>{{ form.password2.label_tag }} {{ form.password2.widget }}</p>"
             '<input type="submit" required>'
             "</form>"
         )
@@ -4874,11 +4883,11 @@ class TemplateTests(SimpleTestCase):
         t = Template(
             "<form>"
             "{{ form.username.errors.as_ul }}"
-            "<p><label>Your username: {{ form.username }}</label></p>"
+            "<p><label>Your username: {{ form.username.widget }}</label></p>"
             "{{ form.password1.errors.as_ul }}"
-            "<p><label>Password: {{ form.password1 }}</label></p>"
+            "<p><label>Password: {{ form.password1.widget }}</label></p>"
             "{{ form.password2.errors.as_ul }}"
-            "<p><label>Password (again): {{ form.password2 }}</label></p>"
+            "<p><label>Password (again): {{ form.password2.widget }}</label></p>"
             '<input type="submit" required>'
             "</form>"
         )
@@ -4903,11 +4912,11 @@ class TemplateTests(SimpleTestCase):
             "<form>"
             "{{ form.non_field_errors }}"
             "{{ form.username.errors.as_ul }}"
-            "<p><label>Your username: {{ form.username }}</label></p>"
+            "<p><label>Your username: {{ form.username.widget }}</label></p>"
             "{{ form.password1.errors.as_ul }}"
-            "<p><label>Password: {{ form.password1 }}</label></p>"
+            "<p><label>Password: {{ form.password1.widget }}</label></p>"
             "{{ form.password2.errors.as_ul }}"
-            "<p><label>Password (again): {{ form.password2 }}</label></p>"
+            "<p><label>Password (again): {{ form.password2.widget }}</label></p>"
             '<input type="submit" required>'
             "</form>"
         )

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -288,8 +288,8 @@ class FormsModelTestCase(TestCase):
             DefaultsForm().fields["def_date"].initial, datetime.date(1980, 1, 1)
         )
         self.assertEqual(DefaultsForm().fields["value"].initial, 42)
-        r1 = DefaultsForm()["callable_default"].as_widget()
-        r2 = DefaultsForm()["callable_default"].as_widget()
+        r1 = DefaultsForm()["callable_default"].widget.as_widget()
+        r2 = DefaultsForm()["callable_default"].widget.as_widget()
         self.assertNotEqual(r1, r2)
 
         # In a ModelForm that is passed an instance, the initial values come from the

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1376,15 +1376,18 @@ class FormattingTests(SimpleTestCase):
 
         with translation.override("de-at", deactivate=True):
             template = Template(
-                "{% load l10n %}{{ form.date_added }}; {{ form.cents_paid }}"
+                "{% load l10n %}{{ form.date_added.widget }}; "
+                "{{ form.cents_paid.widget }}"
             )
             template_as_text = Template(
                 "{% load l10n %}"
-                "{{ form.date_added.as_text }}; {{ form.cents_paid.as_text }}"
+                "{{ form.date_added.widget.as_text }}; "
+                "{{ form.cents_paid.widget.as_text }}"
             )
             template_as_hidden = Template(
                 "{% load l10n %}"
-                "{{ form.date_added.as_hidden }}; {{ form.cents_paid.as_hidden }}"
+                "{{ form.date_added.widget.as_hidden }}; "
+                "{{ form.cents_paid.widget.as_hidden }}"
             )
             form = CompanyForm(
                 {

--- a/tests/model_forms/test_modelchoicefield.py
+++ b/tests/model_forms/test_modelchoicefield.py
@@ -235,7 +235,7 @@ class ModelChoiceFieldTests(TestCase):
 
         form = ModelChoiceForm()
         field = form["category"]  # BoundField
-        template = Template("{{ field.name }}{{ field }}{{ field.help_text }}")
+        template = Template("{{ field.name }}{{ field.widget }}{{ field.help_text }}")
         with self.assertNumQueries(1):
             template.render(Context({"field": field}))
 

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -929,17 +929,17 @@ class TestFieldOverridesByFormMeta(SimpleTestCase):
     def test_widget_overrides(self):
         form = FieldOverridesByFormMetaForm()
         self.assertHTMLEqual(
-            str(form["name"]),
+            str(form["name"].widget),
             '<textarea id="id_name" rows="10" cols="40" name="name" maxlength="20" '
             "required></textarea>",
         )
         self.assertHTMLEqual(
-            str(form["url"]),
+            str(form["url"].widget),
             '<input id="id_url" type="text" class="url" name="url" maxlength="40" '
             "required>",
         )
         self.assertHTMLEqual(
-            str(form["slug"]),
+            str(form["slug"].widget),
             '<input id="id_slug" type="text" name="slug" maxlength="20" required>',
         )
 
@@ -1478,7 +1478,7 @@ class ModelFormBasicTests(TestCase):
             """,
         )
         self.assertHTMLEqual(
-            str(f["name"]),
+            str(f["name"].widget),
             """<input id="id_name" type="text" name="name" maxlength="20" required>""",
         )
 
@@ -2239,7 +2239,7 @@ class ModelMultipleChoiceFieldTests(TestCase):
 
         form = ModelMultipleChoiceForm()
         field = form["categories"]  # BoundField
-        template = Template("{{ field.name }}{{ field }}{{ field.help_text }}")
+        template = Template("{{ field.name }}{{ field.widget }}{{ field.help_text }}")
         with self.assertNumQueries(1):
             template.render(Context({"field": field}))
 
@@ -2507,7 +2507,8 @@ class FileAndImageFieldTests(TestCase):
         doc = Document.objects.create()
         form = DocumentForm(instance=doc)
         self.assertHTMLEqual(
-            str(form["myfile"]), '<input id="id_myfile" name="myfile" type="file">'
+            str(form["myfile"].widget),
+            '<input id="id_myfile" name="myfile" type="file">',
         )
 
     def test_file_field_data(self):
@@ -2970,7 +2971,7 @@ class OtherModelFormTests(TestCase):
 
         form = InventoryForm(instance=core)
         self.assertHTMLEqual(
-            str(form["parent"]),
+            str(form["parent"].widget),
             """<select name="parent" id="id_parent">
 <option value="">---------</option>
 <option value="86" selected>Apple</option>

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -2104,7 +2104,7 @@ class TestModelFormsetOverridesTroughFormMeta(TestCase):
         PoetFormSet = modelformset_factory(Poet, fields="__all__", widgets=widgets)
         form = PoetFormSet.form()
         self.assertHTMLEqual(
-            str(form["name"]),
+            str(form["name"].widget),
             '<input id="id_name" maxlength="100" type="text" class="poet" name="name" '
             "required>",
         )
@@ -2116,7 +2116,7 @@ class TestModelFormsetOverridesTroughFormMeta(TestCase):
         )
         form = BookFormSet.form()
         self.assertHTMLEqual(
-            str(form["title"]),
+            str(form["title"].widget),
             '<input class="book" id="id_title" maxlength="100" name="title" '
             'type="text" required>',
         )

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -509,7 +509,7 @@ class ModelAdminTests(TestCase):
         form = ma.get_form(request)()
 
         self.assertHTMLEqual(
-            str(form["main_band"]),
+            str(form["main_band"].widget),
             '<div class="related-widget-wrapper" data-model-ref="band">'
             '<select name="main_band" id="id_main_band" required>'
             '<option value="" selected>---------</option>'
@@ -532,7 +532,7 @@ class ModelAdminTests(TestCase):
         form = ma.get_form(request)()
 
         self.assertHTMLEqual(
-            str(form["main_band"]),
+            str(form["main_band"].widget),
             '<div class="related-widget-wrapper" data-model-ref="band">'
             '<select name="main_band" id="id_main_band" required>'
             '<option value="" selected>---------</option>'

--- a/tests/template_backends/jinja2/template_backends/django_escaping.html
+++ b/tests/template_backends/jinja2/template_backends/django_escaping.html
@@ -2,4 +2,4 @@
 
 {{ test_form }}
 
-{{ test_form.test_field }}
+{{ test_form.test_field.widget }}

--- a/tests/template_backends/templates/template_backends/django_escaping.html
+++ b/tests/template_backends/templates/template_backends/django_escaping.html
@@ -2,4 +2,4 @@
 
 {{ test_form }}
 
-{{ test_form.test_field }}
+{{ test_form.test_field.widget }}

--- a/tests/template_backends/test_dummy.py
+++ b/tests/template_backends/test_dummy.py
@@ -72,7 +72,7 @@ class TemplateStringsTests(SimpleTestCase):
         template = self.engine.get_template("template_backends/django_escaping.html")
         content = template.render({"media": media, "test_form": form})
 
-        expected = "{}\n\n{}\n\n{}".format(media, form, form["test_field"])
+        expected = "{}\n\n{}\n\n{}".format(media, form, form["test_field"].widget)
 
         self.assertHTMLEqual(content, expected)
 

--- a/tests/templates/login.html
+++ b/tests/templates/login.html
@@ -7,8 +7,8 @@
 
 <form method="post">
 <table>
-<tr><td><label for="id_username">Username:</label></td><td>{{ form.username }}</td></tr>
-<tr><td><label for="id_password">Password:</label></td><td>{{ form.password }}</td></tr>
+<tr><td><label for="id_username">Username:</label></td><td>{{ form.username.widget }}</td></tr>
+<tr><td><label for="id_password">Password:</label></td><td>{{ form.password.widget }}</td></tr>
 </table>
 
 <input type="submit" value="login">


### PR DESCRIPTION
Hey @ngnpope @carltongibson  👋 

Here's an alternative take on #16247 for ticket-34077

Some of the questions on that PR were about the fact that calling `__str__` on `BoundField` is already taken and renders the widget and along with the various `as_*` methods to do with widget rendering made `RenderableFieldMixin` not as clean as we may like. Also I had suggested that I'd like to see something like this. 

```
{{ field.label }}
{{ field.help_text }}
{{ field.widget }}
...
```

Currently we have a `BoundField` being "a Field plus data", what I've added is "A Widget plus data" so umm err a `BoundWidget` (ok, that name was already taken, so I've had to update that!). However, by doing this I think it allows for a not too bad migration path to allow us to change the purpose of `BoundField.__str__`. 

I also think it's much more clearer that `field.widget` is the widget (it's currently just `field` today). In future `field` will be the _sum of the collected parts_. I appreciate though that this has been like this ~forever and that may be a very good reason not to do this. 

I'm not sure if this is the way to go so as yet I've not updated the docs, and I've not written deprecation tests. Could you let me know your thoughts and if we agree I can go and tackle those. 