### PR TITLE
Refs #16969 -- Added test for not initializing PostGIS-specific stuff for non-db connections.

### DIFF
--- a/tests/gis_tests/tests.py
+++ b/tests/gis_tests/tests.py
@@ -2,6 +2,7 @@ import unittest
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db import ProgrammingError
+from django.db.backends.base.base import NO_DB_ALIAS
 
 try:
     from django.contrib.gis.db.backends.postgis.operations import PostGISOperations
@@ -83,3 +84,18 @@ class TestPostGISVersionCheck(unittest.TestCase):
         ops = FakePostGISOperations()
         with self.assertRaises(ImproperlyConfigured):
             ops.spatial_version
+
+
+@unittest.skipUnless(HAS_POSTGRES, "PostGIS-specific tests.")
+class TestPostGISBackend(unittest.TestCase):
+    def test_non_db_connection_classes(self):
+        from django.contrib.gis.db.backends.postgis.base import DatabaseWrapper
+        from django.db.backends.postgresql.features import DatabaseFeatures
+        from django.db.backends.postgresql.introspection import DatabaseIntrospection
+        from django.db.backends.postgresql.operations import DatabaseOperations
+
+        wrapper = DatabaseWrapper(settings_dict={}, alias=NO_DB_ALIAS)
+        # PostGIS-specific stuff is not initialized for non-db connections.
+        self.assertIs(wrapper.features_class, DatabaseFeatures)
+        self.assertIs(wrapper.ops_class, DatabaseOperations)
+        self.assertIs(wrapper.introspection_class, DatabaseIntrospection)


### PR DESCRIPTION
A regression test for ticket-16969, see 7e714827ead50f77aa82394cc2511ff96ab67fa4.