### PR TITLE
Refs #31445 -- Added test for nesting QuerySet.union().

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -154,6 +154,16 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                     },
                 }
             )
+        if self.connection.mysql_version < (8, 0, 31):
+            skips.update(
+                {
+                    "Nesting of UNIONs at the right-hand side is not supported on "
+                    "MySQL < 8.0.31": {
+                        "queries.test_qs_combinators.QuerySetSetOperationTests."
+                        "test_union_nested"
+                    },
+                }
+            )
         return skips
 
     @cached_property

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -114,6 +114,15 @@ class QuerySetSetOperationTests(TestCase):
             [1, 2, 3, 4, 6, 7, 8, 9, 10, None],
         )
 
+    def test_union_nested(self):
+        qs1 = Number.objects.all()
+        qs2 = qs1.union(qs1)
+        self.assertNumbersEqual(
+            qs1.union(qs2),
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ordered=False,
+        )
+
     @skipUnlessDBFeature("supports_select_intersection")
     def test_intersection_with_empty_qs(self):
         qs1 = Number.objects.all()


### PR DESCRIPTION
ticket-31445.

This was fixed in MySQL 8.0.31, see [release notes](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-31.html#mysqld-8-0-31-optimizer).