### PR TITLE
Refs #30060 -- Made SchemaEditor not generate SQL for CheckConstraint if not supported.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1726,6 +1726,8 @@ class BaseDatabaseSchemaEditor:
         }
 
     def _create_check_sql(self, model, name, check):
+        if not self.connection.features.supports_table_check_constraints:
+            return None
         return Statement(
             self.sql_create_check,
             table=Table(model._meta.db_table, self.quote_name),


### PR DESCRIPTION
Thanks Tim Graham for the [report](https://github.com/django/django/pull/16405#issuecomment-1439269890).