### PR TITLE
Fixed #34363 -- Fixed floatformat crash on zero with trailing zeros.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -3,7 +3,7 @@ import random as random_module
 import re
 import types
 import warnings
-from decimal import ROUND_HALF_UP, Context, Decimal, InvalidOperation
+from decimal import ROUND_HALF_UP, Context, Decimal, InvalidOperation, getcontext
 from functools import wraps
 from inspect import unwrap
 from operator import itemgetter
@@ -184,7 +184,7 @@ def floatformat(text, arg=-1):
     units = len(tupl[1])
     units += -tupl[2] if m else tupl[2]
     prec = abs(p) + units + 1
-    prec = max(1, prec)  # Prevent out-of-range precision.
+    prec = max(getcontext().prec, prec)
 
     # Avoid conversion to scientific notation by accessing `sign`, `digits`,
     # and `exponent` from Decimal.as_tuple() directly.

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -182,8 +182,11 @@ def floatformat(text, arg=-1):
     # Set the precision high enough to avoid an exception (#15789).
     tupl = d.as_tuple()
     units = len(tupl[1])
-    units += -tupl[2] if m else tupl[2]
+    units += tupl[2]
     prec = abs(p) + units + 1
+    prec = max(1, prec)
+    if d == 0:
+        prec = p
 
     # Avoid conversion to scientific notation by accessing `sign`, `digits`,
     # and `exponent` from Decimal.as_tuple() directly.

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -182,11 +182,9 @@ def floatformat(text, arg=-1):
     # Set the precision high enough to avoid an exception (#15789).
     tupl = d.as_tuple()
     units = len(tupl[1])
-    units += tupl[2]
+    units += -tupl[2] if m else tupl[2]
     prec = abs(p) + units + 1
-    prec = max(1, prec)
-    if d == 0:
-        prec = p
+    prec = max(1, prec)  # Prevent out-of-range precision.
 
     # Avoid conversion to scientific notation by accessing `sign`, `digits`,
     # and `exponent` from Decimal.as_tuple() directly.

--- a/tests/template_tests/filter_tests/test_floatformat.py
+++ b/tests/template_tests/filter_tests/test_floatformat.py
@@ -113,6 +113,10 @@ class FunctionTests(SimpleTestCase):
         )
         self.assertEqual(floatformat("0.00", 0), "0")
         self.assertEqual(floatformat(Decimal("0.00"), 0), "0")
+        self.assertEqual(floatformat("0.0000", 2), "0.00")
+        self.assertEqual(floatformat(Decimal("0.0000"), 2), "0.00")
+        self.assertEqual(floatformat("0.000000", 4), "0.0000")
+        self.assertEqual(floatformat(Decimal("0.000000"), 4), "0.0000")
 
     def test_negative_zero_values(self):
         tests = [


### PR DESCRIPTION
Fix regression in commit commit 08c5a787262c1ae57f6517d4574b54a5fcaad124.

Also see commit 4b066bd.