### PR TITLE
WIP -- Handle http.disconnect with a request body (ticket #33738 )

### DIFF
--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -198,12 +198,10 @@ class ASGIHandler(base.BaseHandler):
             ]
             await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
             for task in tasks:
-                if task.done():
-                    exception = task.exception()
-                    if exception:
-                        break
+                if task.done() and task.exception():
+                    break
         except RequestAborted:
-            raise RequestAborted()
+            return
         except asyncio.CancelledError:
             pass
 

--- a/tests/asgi/tests.py
+++ b/tests/asgi/tests.py
@@ -235,6 +235,15 @@ class ASGITest(SimpleTestCase):
         with self.assertRaises(asyncio.TimeoutError):
             await communicator.receive_output()
 
+    async def test_disconnect_with_body(self):
+        application = get_asgi_application()
+        scope = self.async_request_factory._base_scope(path="/")
+        communicator = ApplicationCommunicator(application, scope)
+        await communicator.send_input({"type": "http.request"})
+        await communicator.send_input({"type": "http.disconnect"})
+        with self.assertRaises(asyncio.TimeoutError):
+            await communicator.receive_output()
+
     async def test_wrong_connection_type(self):
         application = get_asgi_application()
         scope = self.async_request_factory._base_scope(path="/", type="other")


### PR DESCRIPTION
A work in progress to fix [#33738](https://code.djangoproject.com/ticket/33738). 

If a user sends a disconnect while an initial request was yet to receive a response, it will be best to asynchronously call a self.listen_for_disconnect while also processing the self.send_response. 

Am currently having issues with propagating exceptions as they are caught by asycio. 