### PR TITLE
Fixed #34368 -- Made subquery raise NotSupportedError when referencing outer window expression.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -857,6 +857,11 @@ class ResolvedOuterRef(F):
 
     def resolve_expression(self, *args, **kwargs):
         col = super().resolve_expression(*args, **kwargs)
+        if col.contains_over_clause:
+            raise NotSupportedError(
+                f"Referencing outer query window expression is not supported: "
+                f"{self.name}."
+            )
         # FIXME: Rename possibly_multivalued to multivalued and fix detection
         # for non-multivalued JOINs (e.g. foreign key fields). This should take
         # into account only many-to-many and one-to-many relationships.

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -676,7 +676,7 @@ class SQLCompiler:
                 )
             )
         inner_query_compiler = inner_query.get_compiler(
-            self.using, elide_empty=self.elide_empty
+            self.using, connection=self.connection, elide_empty=self.elide_empty
         )
         inner_sql, inner_params = inner_query_compiler.as_sql(
             # The limits must be applied to the outer query to avoid pruning

--- a/tests/expressions_window/tests.py
+++ b/tests/expressions_window/tests.py
@@ -1587,6 +1587,25 @@ class WindowUnsupportedTests(TestCase):
                     dense_rank=Window(expression=DenseRank())
                 ).get()
 
+    def test_filter_subquery(self):
+        qs = Employee.objects.annotate(
+            department_salary_rank=Window(
+                Rank(), partition_by="department", order_by="-salary"
+            )
+        )
+        msg = (
+            "Referencing outer query window expression is not supported: "
+            "department_salary_rank."
+        )
+        with self.assertRaisesMessage(NotSupportedError, msg):
+            qs.annotate(
+                employee_name=Subquery(
+                    Employee.objects.filter(
+                        age=OuterRef("department_salary_rank")
+                    ).values("name")[:1]
+                )
+            )
+
 
 class NonQueryWindowTests(SimpleTestCase):
     def test_window_repr(self):


### PR DESCRIPTION
At first the query compilation failed because `connection` was not passed to the compiler. I changed this but I am unsure about the correctness of the resulting query.

I added the test `WindowFunctionTests.test_filter_subquery` to describe the behaviour I expected to see. Maybe this is out of scope for the referenced feature #15922 or completely intentional. I am not sure.

This is the query in the failing test is currently generated:

```sql
SELECT "expressions_window_employee"."name",
  (SELECT "col1"
   FROM
     (SELECT *
      FROM
        (SELECT U0."code" AS "col1",
                RANK() OVER (PARTITION BY "expressions_window_employee"."department"
                             ORDER BY "expressions_window_employee"."salary" DESC) AS "qual0"
         FROM "expressions_window_classification" U0) "qualify"
      WHERE "col1" = ("qual0") ) "qualify_mask"
   LIMIT 1) AS "code"
FROM "expressions_window_employee"
```

Whereas this is what I would expect:

```sql
SELECT name,
  (SELECT "code"
   FROM "expressions_window_classification"
   WHERE "code" = "department_salary_rank"
   LIMIT 1) AS code
FROM (
  SELECT 
     "expressions_window_employee"."name",
     RANK() OVER (PARTITION BY "expressions_window_employee"."department"
                  ORDER BY "expressions_window_employee"."salary" DESC) AS "department_salary_rank"
   FROM "expressions_window_employee"
) 
```