### PR TITLE
Refs #34338 - Allowed customizing ValidationError code in UniqueConstraint

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1395,7 +1395,7 @@ class Model(AltersData, metaclass=ModelBase):
             },
         )
 
-    def unique_error_message(self, model_class, unique_check):
+    def unique_error_message(self, model_class, unique_check, code=None):
         opts = model_class._meta
 
         params = {
@@ -1411,7 +1411,7 @@ class Model(AltersData, metaclass=ModelBase):
             params["field_label"] = capfirst(field.verbose_name)
             return ValidationError(
                 message=field.error_messages["unique"],
-                code="unique",
+                code=code if code is not None else "unique",
                 params=params,
             )
 
@@ -1423,7 +1423,7 @@ class Model(AltersData, metaclass=ModelBase):
             params["field_labels"] = get_text_list(field_labels, _("and"))
             return ValidationError(
                 message=_("%(model_name)s with this %(field_labels)s already exists."),
-                code="unique_together",
+                code=code if code is not None else "unique_together",
                 params=params,
             )
 

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -428,8 +428,8 @@ class UniqueConstraint(BaseConstraint):
                 for model, constraints in instance.get_constraints():
                     for constraint in constraints:
                         if constraint is self:
-                            raise ValidationError(
-                                instance.unique_error_message(model, self.fields),
+                            raise instance.unique_error_message(
+                                model, self.fields, code=self.violation_error_code
                             )
         else:
             against = instance._get_field_value_map(meta=model._meta, exclude=exclude)

--- a/docs/ref/models/constraints.txt
+++ b/docs/ref/models/constraints.txt
@@ -262,11 +262,10 @@ creates a unique index on ``username`` using ``varchar_pattern_ops``.
 The error code used when ``ValidationError`` is raised during
 :ref:`model validation <validating-objects>`. Defaults to ``None``.
 
-This code is *not used* for :class:`UniqueConstraint`\s with
-:attr:`~UniqueConstraint.fields` and without a
-:attr:`~UniqueConstraint.condition`. Such :class:`~UniqueConstraint`\s have the
-same error code as constraints defined with :attr:`.Field.unique` or in
-:attr:`Meta.unique_together <django.db.models.Options.constraints>`.
+For :class:`UniqueConstraint`\s with :attr:`~UniqueConstraint.fields` and
+without a :attr:`~UniqueConstraint.condition` and if ``violation_error_code``
+is ``None``, the ``ValidationError`` raised will use the ``unique`` or
+``unique_together`` code depending on :attr:`~UniqueConstraint.fields` length.
 
 ``violation_error_message``
 ---------------------------

--- a/tests/constraints/models.py
+++ b/tests/constraints/models.py
@@ -37,8 +37,8 @@ class UniqueConstraintProduct(models.Model):
             models.UniqueConstraint(
                 fields=["name", "color"],
                 name="name_color_uniq",
-                # Custom message and error code are ignored.
                 violation_error_code="custom_code",
+                # Custom message is ignored.
                 violation_error_message="Custom message",
             )
         ]

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -750,7 +750,7 @@ class UniqueConstraintTests(TestCase):
         )
         with self.assertRaisesMessage(ValidationError, msg) as cm:
             constraint.validate(UniqueConstraintProduct, non_unique_product)
-        self.assertEqual(cm.exception.code, "unique_together")
+        self.assertEqual(cm.exception.code, "custom_code")
         # Null values are ignored.
         constraint.validate(
             UniqueConstraintProduct,


### PR DESCRIPTION
Follow-up of https://github.com/django/django/pull/16560#discussion_r1115394898

Since ``violation_error_code`` could never be  defined for `UniqueConstraint` prior to #16560 there is no backward compatibility to bother with.
But if the user bothered to provide a `violation_error_code` to its `UniqueConstraint` it is likely expecting it to be used.