### PR TITLE
Fixed #34370 -- Added integer fields validation as 64-bit on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -382,8 +382,15 @@ class DatabaseOperations(BaseDatabaseOperations):
         return "django_format_dtdelta(%s)" % ", ".join(fn_params)
 
     def integer_field_range(self, internal_type):
-        # SQLite doesn't enforce any integer constraints
-        return (None, None)
+        # SQLite doesn't enforce any integer constraints, but sqlite3 supports
+        # integers up to 64 bits.
+        if internal_type in [
+            "PositiveBigIntegerField",
+            "PositiveIntegerField",
+            "PositiveSmallIntegerField",
+        ]:
+            return (0, 9223372036854775807)
+        return (-9223372036854775808, 9223372036854775807)
 
     def subtract_temporals(self, internal_type, lhs, rhs):
         lhs_sql, lhs_params = lhs

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -279,6 +279,9 @@ Miscellaneous
 
 * The undocumented ``django.contrib.admin.helpers.checkbox`` is removed.
 
+* Integer fields are now validated as 64-bit integers on SQLite to match the
+  behavior of ``sqlite3``.
+
 .. _deprecated-features-5.0:
 
 Features deprecated in 5.0


### PR DESCRIPTION
Fixes [34370](https://code.djangoproject.com/ticket/34370)