### PR TITLE
Fixed #28948 -- Optimized CookieStorage performances.

### DIFF
--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -1,5 +1,6 @@
 import json
 import random
+from unittest import TestCase
 
 from django.conf import settings
 from django.contrib.messages import constants
@@ -8,6 +9,8 @@ from django.contrib.messages.storage.cookie import (
     CookieStorage,
     MessageDecoder,
     MessageEncoder,
+    bisect_keep_left,
+    bisect_keep_right,
 )
 from django.test import SimpleTestCase, override_settings
 from django.utils.crypto import get_random_string
@@ -204,3 +207,20 @@ class CookieTests(BaseTests, SimpleTestCase):
                     self.encode_decode("message", extra_tags=extra_tags).extra_tags,
                     extra_tags,
                 )
+
+
+class BisectTests(TestCase):
+    def test_bisect_keep_left(self):
+        self.assertEqual(bisect_keep_left([1, 1, 1], fn=lambda arr: sum(arr) != 2), 2)
+        self.assertEqual(bisect_keep_left([1, 1, 1], fn=lambda arr: sum(arr) != 0), 0)
+        self.assertEqual(bisect_keep_left([], fn=lambda arr: sum(arr) != 0), 0)
+
+    def test_bisect_keep_right(self):
+        self.assertEqual(bisect_keep_right([1, 1, 1], fn=lambda arr: sum(arr) != 2), 1)
+        self.assertEqual(
+            bisect_keep_right([1, 1, 1, 1], fn=lambda arr: sum(arr) != 2), 2
+        )
+        self.assertEqual(
+            bisect_keep_right([1, 1, 1, 1, 1], fn=lambda arr: sum(arr) != 1), 4
+        )
+        self.assertEqual(bisect_keep_right([], fn=lambda arr: sum(arr) != 0), 0)

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -73,7 +73,7 @@ class CookieTests(BaseTests, SimpleTestCase):
         self.assertEqual(list(storage), example_messages)
 
     @override_settings(SESSION_COOKIE_SAMESITE="Strict")
-    def test_cookie_setings(self):
+    def test_cookie_settings(self):
         """
         CookieStorage honors SESSION_COOKIE_DOMAIN, SESSION_COOKIE_SECURE, and
         SESSION_COOKIE_HTTPONLY (#15618, #20972).

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -60,9 +60,9 @@ class CookieTests(BaseTests, SimpleTestCase):
 
     def encode_decode(self, *args, **kwargs):
         storage = self.get_storage()
-        message = Message(constants.DEBUG, *args, **kwargs)
+        message = [Message(constants.DEBUG, *args, **kwargs)]
         encoded = storage._encode(message)
-        return storage._decode(encoded)
+        return storage._decode(encoded)[0]
 
     def test_get(self):
         storage = self.storage_class(self.get_request())


### PR DESCRIPTION
[ticket-28948](https://code.djangoproject.com/ticket/28948)

While this PR is open, one can review commit-by-commit.
So the issue arises when too many messages have to be stored in the `CookieStorage`, which cannot fit in one cookie.
The algorithm is in this case sub-optimal.

**TL;DR**: don't compute everything all over on each iteration and do a binary search instead of a linear one.

# The current approach on `main`
- Serialize all messages => compress => sign
- If the size is too big => remove one message
- Start again

## Timings
| No. messages | Time taken | Rest of timeit |
| --- | --- | --- |
| 10 | 31.6 µs | ± 254 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each) |
| 110 | 125 µs | ± 868 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each) |
| 1110 | 316 ms | ± 7.49 ms per loop (mean ± std. dev. of 7 runs, 1 loop each) |
| 6110 | 14 s | ± 76.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each) |

Associated profiling:
![main](https://user-images.githubusercontent.com/8582749/221571634-22fba36f-2320-48c6-a0cc-d82f178f5051.svg)

For now, we spend over 80% of the time serializing the same messages over and over.

# First patch: precompute serialized messages

Serialize the messages to JSON strings once, and then leverage those.

## Timings
| No. messages | Time taken | Rest of timeit |
| --- | --- | --- |
| 10 | 45.2 µs | 979 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each) |
| 110 | 291 µs | ± 3.1 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each) |
| 1110 | 72.7 ms | ± 929 µs per loop (mean ± std. dev. of 7 runs, 10 loops each) |
| 6110 | 3.37 s | ± 16.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each) |

Associated profiling:
![patch1](https://user-images.githubusercontent.com/8582749/221572154-f6808c63-bc5c-4e4b-ab02-abe7c79c18c0.svg)
(`_encode2` <=> `_encode_parts`)

However, we are still linearly trying to find which message will be the one that allows us to have a fitting message.
We therefore spend over 90% of time now compressing and signing the message.

# Second patch: binary search the breaking point

Instead of removing messages one by one and trying again, do a binary search.

## Timings
| No. messages | Time taken | Rest of timeit |
| --- | --- | --- |
| 10 | 44.5 µs | ± 218 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each) |
| 110 | 290 µs | ± 2.65 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each) |
| 1110 | 3.96 ms | ± 33.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each) |
| 6110 | 16.8 ms | ± 28.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each) |

Associated profiling:
![patch1_2](https://user-images.githubusercontent.com/8582749/221572660-dee35c89-cd0d-4d8e-bdd6-949850587580.svg)

The time spent seems now good enough to me :)


<details><summary>Script how I got timings</summary>
<p>

(on an MB Pro M1)

```python
from django.conf import settings
settings.configure(MESSAGE_TAGS={}, SECRET_KEY="x")
from django.contrib.messages.storage.cookie import CookieStorage
from django.http.request import HttpRequest
from django.http.response import HttpResponse
from timeit import timeit

storage = CookieStorage(HttpRequest())

for x in range(10):
    storage.add(20, f"m:{x}")

%timeit storage.update(HttpResponse())

for x in range(100):
    storage.add(20, f"m:{x}")

%timeit storage.update(HttpResponse())

for x in range(1000):
    storage.add(20, f"m:{x}")

%timeit storage.update(HttpResponse())

for x in range(5000):
    storage.add(20, f"m:{x}")

%timeit storage.update(HttpResponse())

```

</p>
</details>

-------

I couldn't leverage the existing `bisect.bisect` function from the stdlib because our function is quite specific to our use case. The comparison function is an accumulation of either all elements before or after the pivot.
I therefore had to write specific binary search functions.
Perhaps they are not tested enough 🤔 