### PR TITLE
Fixed #34374 -- Fixed GIS tests on Windows.

### DIFF
--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -6,11 +6,11 @@ import zipfile
 from pathlib import Path
 from unittest import mock
 
-from django.core.files.temp import NamedTemporaryFile
 from django.contrib.gis.gdal import GDALRaster, SpatialReference
 from django.contrib.gis.gdal.error import GDALException
 from django.contrib.gis.gdal.raster.band import GDALBand
 from django.contrib.gis.shortcuts import numpy
+from django.core.files.temp import NamedTemporaryFile
 from django.test import SimpleTestCase
 
 from ..data.rasters.textrasters import JSON_RASTER

--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -6,6 +6,7 @@ import zipfile
 from pathlib import Path
 from unittest import mock
 
+from django.core.files.temp import NamedTemporaryFile
 from django.contrib.gis.gdal import GDALRaster, SpatialReference
 from django.contrib.gis.gdal.error import GDALException
 from django.contrib.gis.gdal.raster.band import GDALBand
@@ -148,7 +149,7 @@ class GDALRasterTests(SimpleTestCase):
 
     def test_file_based_raster_creation(self):
         # Prepare tempfile
-        rstfile = tempfile.NamedTemporaryFile(suffix=".tif")
+        rstfile = NamedTemporaryFile(suffix=".tif")
 
         # Create file-based raster from scratch
         GDALRaster(
@@ -264,7 +265,7 @@ class GDALRasterTests(SimpleTestCase):
         self.assertIsNone(self.rs.vsi_buffer)
 
     def test_vsi_vsizip_filesystem(self):
-        rst_zipfile = tempfile.NamedTemporaryFile(suffix=".zip")
+        rst_zipfile = NamedTemporaryFile(suffix=".zip")
         with zipfile.ZipFile(rst_zipfile, mode="w") as zf:
             zf.write(self.rs_path, "raster.tif")
         rst_path = "/vsizip/" + os.path.join(rst_zipfile.name, "raster.tif")
@@ -406,7 +407,7 @@ class GDALRasterTests(SimpleTestCase):
         self.assertIn("NAD83 / Florida GDL Albers", infos)
 
     def test_compressed_file_based_raster_creation(self):
-        rstfile = tempfile.NamedTemporaryFile(suffix=".tif")
+        rstfile = NamedTemporaryFile(suffix=".tif")
         # Make a compressed copy of an existing raster.
         compressed = self.rs.warp(
             {"papsz_options": {"compress": "packbits"}, "name": rstfile.name}
@@ -554,7 +555,7 @@ class GDALRasterTests(SimpleTestCase):
         self.assertEqual(result, [23] * 16)
 
     def test_raster_clone(self):
-        rstfile = tempfile.NamedTemporaryFile(suffix=".tif")
+        rstfile = NamedTemporaryFile(suffix=".tif")
         tests = [
             ("MEM", "", 23),  # In memory raster.
             ("tif", rstfile.name, 99),  # In file based raster.
@@ -600,7 +601,7 @@ class GDALRasterTests(SimpleTestCase):
         for srs in tests:
             with self.subTest(srs=srs):
                 # Prepare tempfile and nodata value.
-                rstfile = tempfile.NamedTemporaryFile(suffix=".tif")
+                rstfile = NamedTemporaryFile(suffix=".tif")
                 ndv = 99
                 # Create in file based raster.
                 source = GDALRaster(
@@ -701,7 +702,7 @@ class GDALRasterTests(SimpleTestCase):
     def test_raster_transform_clone(self):
         with mock.patch.object(GDALRaster, "clone") as mocked_clone:
             # Create in file based raster.
-            rstfile = tempfile.NamedTemporaryFile(suffix=".tif")
+            rstfile = NamedTemporaryFile(suffix=".tif")
             source = GDALRaster(
                 {
                     "datatype": 1,
@@ -729,7 +730,7 @@ class GDALRasterTests(SimpleTestCase):
 
     def test_raster_transform_clone_name(self):
         # Create in file based raster.
-        rstfile = tempfile.NamedTemporaryFile(suffix=".tif")
+        rstfile = NamedTemporaryFile(suffix=".tif")
         source = GDALRaster(
             {
                 "datatype": 1,

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -1,4 +1,3 @@
-import tempfile
 from io import StringIO
 
 from django.contrib.gis import gdal
@@ -15,6 +14,7 @@ from django.contrib.gis.geos import (
     Polygon,
     fromstr,
 )
+from django.core.files.temp import NamedTemporaryFile
 from django.core.management import call_command
 from django.db import DatabaseError, NotSupportedError, connection
 from django.db.models import F, OuterRef, Subquery
@@ -232,7 +232,7 @@ class GeoModelTest(TestCase):
         self.assertIn('"point": "%s"' % houston.point.ewkt, result)
 
         # Reload now dumped data
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as tmp:
+        with NamedTemporaryFile(mode="w", suffix=".json") as tmp:
             tmp.write(result)
             tmp.seek(0)
             call_command("loaddata", tmp.name, verbosity=0)


### PR DESCRIPTION
Based on discussion after updating the Docs in https://github.com/django/django/pull/16596 

I believe these tests are failing on Windows because they are trying to open and already open NamedTempFile which raises: 

```python
import tempfile
with tempfile.NamedTemporaryFile(mode="w") as tmp:
    with open(tmp.name) as f: 
      print(tmp.name)    
```
Docs suggest that this is a Windows thing and it should be allowed on Unix systems: https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile

The proposed patch gets the tests passing by just closing the file and adding `delete=False` so it will not get remove on close. I haven't tested on Unix based system, so I'm not sure if it will have problems there. 

