### PR TITLE
RFC: Removed unused DiscoverRunner.build_suite() kwargs parameter.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -874,7 +874,7 @@ class DiscoverRunner:
         self.test_loader._top_level_dir = None
         return tests
 
-    def build_suite(self, test_labels=None, **kwargs):
+    def build_suite(self, test_labels=None):
         test_labels = test_labels or ["."]
 
         discover_kwargs = {}


### PR DESCRIPTION
Unused since introduced in 9012833.

Can we remove this? I can't see what it's for. Any thoughts? 