### PR TITLE
Refs #34118 -- Used delete_on_close argument of tempfile.NamedTemporaryFile on Windows and Python 3.12.

### DIFF
--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -16,6 +16,7 @@ PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
 PY310 = sys.version_info >= (3, 10)
 PY311 = sys.version_info >= (3, 11)
+PY312 = sys.version_info >= (3, 12)
 
 
 def get_version(version=None):


### PR DESCRIPTION
`delete_on_close` is available in Python 3.12:
- https://github.com/python/cpython/issues/58451
- https://github.com/python/cpython/pull/97015

so we don't need a custom `NamedTemporaryFile` implementation anymore.

too soon? :laughing: 