### PR TITLE
Fixed #34378 -- Made QuerySet.in_bulk() not clear odering when id_list is passed.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1108,9 +1108,9 @@ class QuerySet(AltersData):
                 qs = ()
                 for offset in range(0, len(id_list), batch_size):
                     batch = id_list[offset : offset + batch_size]
-                    qs += tuple(self.filter(**{filter_key: batch}).order_by())
+                    qs += tuple(self.filter(**{filter_key: batch}))
             else:
-                qs = self.filter(**{filter_key: id_list}).order_by()
+                qs = self.filter(**{filter_key: id_list})
         else:
             qs = self._chain()
         return {getattr(obj, field_name): obj for obj in qs}


### PR DESCRIPTION
Fixes [34378](https://code.djangoproject.com/ticket/34378)