### PR TITLE
Create default SSL context with certifi.where()

### DIFF
--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -1,4 +1,5 @@
 """SMTP email backend class."""
+import certifi
 import smtplib
 import ssl
 import threading
@@ -57,9 +58,11 @@ class EmailBackend(BaseEmailBackend):
 
     @cached_property
     def ssl_context(self):
-        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
         if self.ssl_certfile or self.ssl_keyfile:
+            ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
             ssl_context.load_cert_chain(self.ssl_certfile, self.ssl_keyfile)
+        else:
+            ssl_context = ssl.create_default_context(cafile=certifi.where())
         return ssl_context
 
     def open(self):

--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -1,5 +1,4 @@
 """SMTP email backend class."""
-import certifi
 import smtplib
 import ssl
 import threading
@@ -62,7 +61,7 @@ class EmailBackend(BaseEmailBackend):
             ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
             ssl_context.load_cert_chain(self.ssl_certfile, self.ssl_keyfile)
         else:
-            ssl_context = ssl.create_default_context(cafile=certifi.where())
+            ssl_context = ssl.create_default_context()
         return ssl_context
 
     def open(self):


### PR DESCRIPTION
When no EMAIL_SSL_CERTFILE / EMAIL_SSL_KEYFILE are speficied, previous stable Django 3.2 version smtp backend was able to send emails via TLS.

With current 4.2b1 it produced the following error:

```
Request Method: | POST
-- | --
http://127.0.0.1:8000/password-reset/
4.2b1
SSLCertVerificationError
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)
/usr/lib/python3.10/ssl.py, line 1342, in do_handshake
isp_user.views.auth.PasswordResetView
/home/user/work/ispdevenv/bin/python3
3.10.6
['/home/user',  '/home/user/work/ispdevenv/ispdev',  '/snap/pycharm-community/315/plugins/python-ce/helpers/pydev',  '/snap/pycharm-community/315/plugins/python-ce/helpers/third_party/thriftpy',  '/snap/pycharm-community/315/plugins/python-ce/helpers/pydev',  '/home/user/work/ispdevenv/ispdev',  '/home/user/.cache/JetBrains/PyCharmCE2022.3/cythonExtensions',  '/home/user/PycharmProjects/ispdev',  '/usr/lib/python310.zip',  '/usr/lib/python3.10',  '/usr/lib/python3.10/lib-dynload',  '/home/user/work/ispdevenv/lib/python3.10/site-packages']
Fri, 03 Mar 2023 23:28:27 +0300
```

This patch fixes that error for me.