### PR TITLE
Fixed typo in docs/releases/5.0.txt.

### DIFF
--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -40,7 +40,7 @@ What's new in Django 5.0
 Facet filters in the admin
 --------------------------
 
-Facet counts are now show for applied filters in the admin changelist when
+Facet counts are now shown for applied filters in the admin changelist when
 toggled on via the UI. This behavior can be changed via the new
 :attr:`.ModelAdmin.show_facets` attribute. For more information see
 :ref:`facet-filters`.


### PR DESCRIPTION
I think "shown" is correct, although English is not my first language, so apologies in advance if it's a false alarm.