### PR TITLE
Fixed #1873 -- Handled multi-valued query parameters in admin changelist filters.

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -54,10 +54,17 @@ def lookup_spawns_duplicates(opts, lookup_path):
     return False
 
 
+def get_last_value_from_parameters(parameters, key):
+    value = parameters.get(key)
+    return value[-1] if isinstance(value, list) else value
+
+
 def prepare_lookup_value(key, value, separator=","):
     """
     Return a lookup value prepared to be used in queryset filtering.
     """
+    if isinstance(value, list):
+        value = value[-1]
     # if key ends with __in, split parameter into separate values
     if key.endswith("__in"):
         value = value.split(separator)

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -2,6 +2,8 @@ import datetime
 import decimal
 import json
 from collections import defaultdict
+from functools import reduce
+from operator import or_
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models, router
@@ -64,7 +66,7 @@ def prepare_lookup_value(key, value, separator=","):
     Return a lookup value prepared to be used in queryset filtering.
     """
     if isinstance(value, list):
-        value = value[-1]
+        return [prepare_lookup_value(key, v, separator=separator) for v in value]
     # if key ends with __in, split parameter into separate values
     if key.endswith("__in"):
         value = value.split(separator)
@@ -72,6 +74,13 @@ def prepare_lookup_value(key, value, separator=","):
     elif key.endswith("__isnull"):
         value = value.lower() not in ("", "false", "0")
     return value
+
+
+def build_q_object_from_lookup_parameters(parameters):
+    q_object = models.Q()
+    for param, param_item_list in parameters.items():
+        q_object &= reduce(or_, (models.Q((param, item)) for item in param_item_list))
+    return q_object
 
 
 def quote(s):

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -54,6 +54,11 @@ Minor features
 * The new :meth:`.AdminSite.get_log_entries` method allows customizing the
   queryset for the site's listed log entries.
 
+* The ``django.contrib.admin.AllValuesFieldListFilter``,
+  ``ChoicesFieldListFilter``, ``RelatedFieldListFilter``, and
+  ``RelatedOnlyFieldListFilter`` admin filters now handle multi-valued query
+  parameters.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/admin_changelist/test_date_hierarchy.py
+++ b/tests/admin_changelist/test_date_hierarchy.py
@@ -25,8 +25,8 @@ class DateHierarchyTests(TestCase):
         request.user = self.superuser
         changelist = EventAdmin(Event, custom_site).get_changelist_instance(request)
         _, _, lookup_params, *_ = changelist.get_filters(request)
-        self.assertEqual(lookup_params["date__gte"], expected_from_date)
-        self.assertEqual(lookup_params["date__lt"], expected_to_date)
+        self.assertEqual(lookup_params["date__gte"], [expected_from_date])
+        self.assertEqual(lookup_params["date__lt"], [expected_to_date])
 
     def test_bounded_params(self):
         tests = (

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -1167,6 +1167,15 @@ class ListFiltersTests(TestCase):
         with self.assertRaises(IncorrectLookupParameters):
             modeladmin.get_changelist_instance(request)
 
+    def test_fieldlistfilter_multiple_invalid_lookup_parameters(self):
+        modeladmin = BookAdmin(Book, site)
+        request = self.request_factory.get(
+            "/", {"author__id__exact": f"{self.alfred.pk},{self.bob.pk}"}
+        )
+        request.user = self.alfred
+        with self.assertRaises(IncorrectLookupParameters):
+            modeladmin.get_changelist_instance(request)
+
     def test_simplelistfilter(self):
         modeladmin = DecadeFilterBookAdmin(Book, site)
 

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -7,6 +7,7 @@ from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import (
     NestedObjects,
+    build_q_object_from_lookup_parameters,
     display_for_field,
     display_for_value,
     flatten,
@@ -424,3 +425,17 @@ class UtilsTests(SimpleTestCase):
 
     def test_quote(self):
         self.assertEqual(quote("something\nor\nother"), "something_0Aor_0Aother")
+
+    def test_build_q_object_from_lookup_parameters(self):
+        parameters = {
+            "title__in": [["Article 1", "Article 2"]],
+            "hist__iexact": ["history"],
+            "site__pk": [1, 2],
+        }
+        q_obj = build_q_object_from_lookup_parameters(parameters)
+        self.assertEqual(
+            q_obj,
+            models.Q(title__in=["Article 1", "Article 2"])
+            & models.Q(hist__iexact="history")
+            & (models.Q(site__pk=1) | models.Q(site__pk=2)),
+        )


### PR DESCRIPTION
While filters are fresh in my head, thought I would have a look at [this ticket](https://code.djangoproject.com/ticket/1873). :rocket:

This enables multi-select filters but it does not add a way to do this from the UI.
The ticket originally suggested a way to do it in the UI but later on, most people just wanted the query parameters to be handled. So I _feel_ like I can get away with not having it in the UI.

In some cases, I decided multi-selects do not make much sense and I don't handle it. These cases are `BooleanFieldListFilter`, `EmptyFieldListFilter`, `DateFieldListFilter` (partly because being able to now do this month or this year etc doesn't add much value) and all of the `isnull` options.

`SimpleListFilter` also does not handle it, this is because the user defined `queryset` method depends on `value` and if this changed from a string to a list, this would probably be a breaking change. If anyone felt passionatlely that they need this, they could overwrite the `value` method to return the list and then handle it.



Not sure if the release note is enough or if I should mention something in the docs also? Happy for any suggestions.
Then yeah let me know what you think :+1: 
