### PR TITLE
Fixed #34386 -- Made SMTP backend load default system root CA certificates by default.

### DIFF
--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -57,10 +57,12 @@ class EmailBackend(BaseEmailBackend):
 
     @cached_property
     def ssl_context(self):
-        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
         if self.ssl_certfile or self.ssl_keyfile:
+            ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
             ssl_context.load_cert_chain(self.ssl_certfile, self.ssl_keyfile)
-        return ssl_context
+            return ssl_context
+        else:
+            return ssl.create_default_context()
 
     def open(self):
         """


### PR DESCRIPTION
when no EMAIL_SSL_CERTFILE / EMAIL_SSL_KEYFILE are specified in project settings.