### PR TITLE
Refs #34381 -- Fixed InspectDBTransactionalTests.test_foreign_data_wrapper() on Windows.

### DIFF
--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -1,4 +1,3 @@
-import os
 import re
 from io import StringIO
 from unittest import mock, skipUnless
@@ -588,19 +587,17 @@ class InspectDBTransactionalTests(TransactionTestCase):
                 "CREATE SERVER inspectdb_server FOREIGN DATA WRAPPER file_fdw"
             )
             cursor.execute(
-                connection.ops.compose_sql(
-                    """
-                    CREATE FOREIGN TABLE inspectdb_iris_foreign_table (
-                        petal_length real,
-                        petal_width real,
-                        sepal_length real,
-                        sepal_width real
-                    ) SERVER inspectdb_server OPTIONS (
-                        filename %s
-                    )
-                    """,
-                    [os.devnull],
+                """
+                CREATE FOREIGN TABLE inspectdb_iris_foreign_table (
+                    petal_length real,
+                    petal_width real,
+                    sepal_length real,
+                    sepal_width real
+                ) SERVER inspectdb_server OPTIONS (
+                    program 'echo 1,2,3,4',
+                    format 'csv'
                 )
+                """
             )
         out = StringIO()
         foreign_table_model = "class InspectdbIrisForeignTable(models.Model):"


### PR DESCRIPTION
For me (Windows 11, Postgres 15) this test fails since at least 798835112d81b852efaae0e067af389c733cd1b3. That is that fix didn't fix that test on Windows for me.

Using `nul` on Windows gives an error of `could not stat file "nul"`. Further trying to create an empty file and passing that in is also troublesome as it's likely the postgres user does not have access to that file. 

I'm working well beyond my knowledge limits, but it seems that you can pass in either a `filename` or a `program`, see [docs](https://www.postgresql.org/docs/current/file-fdw.html). 

It's not clear if passing in a simple "csv" file is appropriate here, but this atleast passes for me on Windows. I'll open this PR and see if it passes elsewhere too. (Likely I should go install WSL!)

