### PR TITLE
Refs #34381, Refs #10929 -- Fixed postgres_tests.test_aggregates.TestGeneralAggretate.test_empty_result_set() on PostgreSQL 14+.

### DIFF
--- a/tests/postgres_tests/test_aggregates.py
+++ b/tests/postgres_tests/test_aggregates.py
@@ -98,7 +98,7 @@ class TestGeneralAggregate(PostgreSQLTestCase):
             StringAgg("char_field", delimiter=";"),
         ]
         if connection.features.has_bit_xor:
-            tests.append((BitXor("integer_field"), None))
+            tests.append(BitXor("integer_field"))
         for aggregation in tests:
             with self.subTest(aggregation=aggregation):
                 # Empty result with non-execution optimization.


### PR DESCRIPTION
It seems to me that in 0be8095b254fad65b2480d677ebe6098c41bbad6 this additional test should also have been updated? 🤔 