### PR TITLE
Fixed #25230, Fixed #30685 -- Optimized distinct().count().

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -254,6 +254,14 @@ class BaseExpression:
             for expr in self.get_source_expressions()
         )
 
+    @cached_property
+    def deterministic(self):
+        # Can the expression return different values for the same input within a
+        # single query?
+        return all(
+            expr and expr.deterministic for expr in self.get_source_expressions()
+        )
+
     def resolve_expression(
         self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False
     ):

--- a/django/db/models/functions/math.py
+++ b/django/db/models/functions/math.py
@@ -157,6 +157,7 @@ class Radians(NumericOutputFieldMixin, Transform):
 class Random(NumericOutputFieldMixin, Func):
     function = "RANDOM"
     arity = 0
+    deterministic = False
 
     def as_mysql(self, compiler, connection, **extra_context):
         return super().as_sql(compiler, connection, function="RAND", **extra_context)

--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -257,6 +257,16 @@ class WhereNode(tree.Node):
     def is_summary(self):
         return any(child.is_summary for child in self.children)
 
+    @classmethod
+    def _deterministic(cls, obj):
+        if isinstance(obj, tree.Node):
+            return any(cls._deterministic(c) for c in obj.children)
+        return obj.contains_aggregate
+
+    @cached_property
+    def deterministic(self):
+        return self._deterministic(self)
+
     @staticmethod
     def _resolve_leaf(expr, query, *args, **kwargs):
         if hasattr(expr, "resolve_expression"):

--- a/tests/distinct_on_fields/tests.py
+++ b/tests/distinct_on_fields/tests.py
@@ -98,7 +98,7 @@ class DistinctOnTests(TestCase):
         )
         for qset, expected in qsets:
             self.assertSequenceEqual(qset, expected)
-            self.assertEqual(qset.count(), len(expected))
+            self.assertEqual(qset.all().count(), len(expected))
 
         # Combining queries with non-unique query is not allowed.
         base_qs = Celebrity.objects.all()


### PR DESCRIPTION
This still needs a battery of test as the `distinct().count()` coverage is relatively poor in the test suite but this will hopefully address ticket-25230 and ticket-30685.

Missing test coverage
- [ ] `Expression.deterministic`
- [ ] `distinct().count()` with `Random()` annotation
- [ ] `distinct().count()` with existing aggregation
- [ ] `distinct(*on).count()` coverage