### PR TITLE
Fixed #34387 --  Update P time formatter character as per PHP 5.1.3 release

### DIFF
--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -143,16 +143,19 @@ class TimeFormat(Formatter):
 
     def P(self):
         """
-        Time, in 12-hour hours, minutes and 'a.m.'/'p.m.', with minutes left off
-        if they're zero and the strings 'midnight' and 'noon' if appropriate.
-        Examples: '1 a.m.', '1:30 p.m.', 'midnight', 'noon', '12:30 p.m.'
-        Proprietary extension.
+        Difference to Greenwich time (GMT) with colon between hours and minutes.
+        Example : +02:00, -05:00
+
+        If timezone information is not available, return an empty string.
         """
-        if self.data.minute == 0 and self.data.hour == 0:
-            return _("midnight")
-        if self.data.minute == 0 and self.data.hour == 12:
-            return _("noon")
-        return "%s %s" % (self.f(), self.a())
+        if self.timezone is None:
+            return ""
+
+        offset = self.timezone.utcoffset(self.data)
+        seconds = offset.days * 86400 + offset.seconds
+        sign = "-" if seconds < 0 else "+"
+        seconds = abs(seconds)
+        return "%s%02d:%02d" % (sign, seconds // 3600, (seconds // 60) % 60)
 
     def s(self):
         "Seconds; i.e. '00' to '59'"

--- a/docs/releases/4.1.8.txt
+++ b/docs/releases/4.1.8.txt
@@ -1,0 +1,12 @@
+==========================
+Django 4.1.8 release notes
+==========================
+
+*Expected April 3, 2023*
+
+Django 4.1.8 fixes several bugs in 4.1.7.
+
+Bugfixes
+========
+
+* ...

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -40,6 +40,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   4.1.8
    4.1.7
    4.1.6
    4.1.5


### PR DESCRIPTION
Hey everyone,
I'm new to this fantastic community and eagerly want to explore the architecture and code base of the Django framework.

I've tried to solve some **easy to fix issue**. I've some queries regarding this issue.
I've seen that in various places `django/tests/utils_tests/test_dateformat.py` we are doing tests as per the previous assumptions for P formatter. 
So do I've to create a new test case of it or fix those test cases only?
[Ticket 34387](https://code.djangoproject.com/ticket/34387)