### PR TITLE
Fixed #34333 -- Fixed migration operations ordering when adding index/constraint on new foreign key.

### DIFF
--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -2720,6 +2720,65 @@ class AutodetectorTests(BaseAutodetectorTests):
             changes, "testapp", 0, 0, model_name="author", constraint=added_constraint
         )
 
+    def test_add_constraints_with_new_model(self):
+        book_with_unique_title_and_pony = ModelState(
+            "otherapp",
+            "Book",
+            [
+                ("id", models.AutoField(primary_key=True)),
+                ("title", models.CharField(max_length=200)),
+                ("pony", models.ForeignKey("otherapp.Pony", models.CASCADE)),
+            ],
+            {
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=["title", "pony"],
+                        name="unique_title_pony",
+                    )
+                ]
+            },
+        )
+        changes = self.get_changes(
+            [self.book_with_no_author],
+            [book_with_unique_title_and_pony, self.other_pony],
+        )
+
+        self.assertNumberMigrations(changes, "otherapp", 1)
+        self.assertOperationTypes(
+            changes,
+            "otherapp",
+            0,
+            ["CreateModel", "AddField", "AddConstraint"],
+        )
+
+    def test_add_index_with_new_model(self):
+        book_with_index_title_and_pony = ModelState(
+            "otherapp",
+            "Book",
+            [
+                ("id", models.AutoField(primary_key=True)),
+                ("title", models.CharField(max_length=200)),
+                ("pony", models.ForeignKey("otherapp.Pony", models.CASCADE)),
+            ],
+            {
+                "indexes": [
+                    models.Index(fields=["title", "pony"], name="index_title_pony"),
+                ]
+            },
+        )
+        changes = self.get_changes(
+            [self.book_with_no_author],
+            [book_with_index_title_and_pony, self.other_pony],
+        )
+
+        self.assertNumberMigrations(changes, "otherapp", 1)
+        self.assertOperationTypes(
+            changes,
+            "otherapp",
+            0,
+            ["CreateModel", "AddField", "AddIndex"],
+        )
+
     def test_remove_constraints(self):
         """Test change detection of removed constraints."""
         changes = self.get_changes(


### PR DESCRIPTION
## Summary
This Pull Request modifies the _generate_added_constraints_ function in the _MigrationAutodetector_ class to seek the fields dependencies related to the model which is gaining new constraints. This ensures that any dependent operations are placed before the add constraint operation, preventing the bug related on [ticket #34333](https://code.djangoproject.com/ticket/34333).

## Related Ticket
This PR is related to Django [ticket #34333](https://code.djangoproject.com/ticket/34333), which addresses the issue of dependent operations not being ordered correctly when adding constraints to models.

## Changes Made
The main changes made in this PR include modifying the generate_added_constraints function to include a search for field dependencies related to the model gaining new constraints. By including these dependencies in the generated migration, any dependent operations will be placed before the add constraint operation, ensuring proper ordering.
