### PR TITLE
Fixed #34391 -- Added async-compatible interface to auth functions and related methods test clients.

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -1,6 +1,8 @@
 import inspect
 import re
 
+from asgiref.sync import sync_to_async
+
 from django.apps import apps as django_apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
@@ -91,6 +93,12 @@ def authenticate(request=None, **credentials):
     )
 
 
+@sensitive_variables("credentials")
+async def aauthenticate(request=None, **credentials):
+    """See authenticate()."""
+    return await sync_to_async(authenticate)(request, **credentials)
+
+
 def login(request, user, backend=None):
     """
     Persist a user id and a backend in the request. This way a user doesn't
@@ -144,6 +152,11 @@ def login(request, user, backend=None):
     user_logged_in.send(sender=user.__class__, request=request, user=user)
 
 
+async def alogin(request, user, backend=None):
+    """See login()."""
+    return await sync_to_async(login)(request, user, backend)
+
+
 def logout(request):
     """
     Remove the authenticated user's ID from the request and flush their session
@@ -160,6 +173,11 @@ def logout(request):
         from django.contrib.auth.models import AnonymousUser
 
         request.user = AnonymousUser()
+
+
+async def alogout(request):
+    """See logout()."""
+    return await sync_to_async(logout)(request)
 
 
 def get_user_model():
@@ -223,6 +241,11 @@ def get_user(request):
     return user or AnonymousUser()
 
 
+async def aget_user(request):
+    """See get_user()."""
+    return await sync_to_async(get_user)(request)
+
+
 def get_permission_codename(action, opts):
     """
     Return the codename of the permission for the specified action.
@@ -242,3 +265,8 @@ def update_session_auth_hash(request, user):
     request.session.cycle_key()
     if hasattr(user, "get_session_auth_hash") and request.user == user:
         request.session[HASH_SESSION_KEY] = user.get_session_auth_hash()
+
+
+async def aupdate_session_auth_hash(request, user):
+    """See update_session_auth_hash()."""
+    return await sync_to_async(update_session_auth_hash)(request, user)

--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -1,7 +1,5 @@
 from functools import partial
 
-from asgiref.sync import sync_to_async
-
 from django.contrib import auth
 from django.contrib.auth import load_backend
 from django.contrib.auth.backends import RemoteUserBackend
@@ -18,7 +16,7 @@ def get_user(request):
 
 async def auser(request):
     if not hasattr(request, "_acached_user"):
-        request._acached_user = await sync_to_async(auth.get_user)(request)
+        request._acached_user = await auth.aget_user(request)
     return request._acached_user
 
 

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -693,6 +693,9 @@ Utility functions
 .. currentmodule:: django.contrib.auth
 
 .. function:: get_user(request)
+.. function:: aget_user(request)
+
+    *Asynchronous version*: ``aget_user()``
 
     Returns the user model instance associated with the given ``request``’s
     session.
@@ -716,3 +719,7 @@ Utility functions
     .. versionchanged:: 4.1.8
 
         Fallback verification with :setting:`SECRET_KEY_FALLBACKS` was added.
+
+    .. versionchanged:: 5.0
+
+        ``aget_user()`` function was added.

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -150,6 +150,12 @@ Minor features
 * The default iteration count for the PBKDF2 password hasher is increased from
   600,000 to 720,000.
 
+* The new asynchronous functions are now provided, using an
+  ``a`` prefix: :func:`django.contrib.auth.aauthenticate`,
+  :func:`~.django.contrib.auth.aget_user`,
+  :func:`~.django.contrib.auth.alogin`, :func:`~.django.contrib.auth.alogout`,
+  and :func:`~.django.contrib.auth.aupdate_session_auth_hash`.
+
 * ``AuthenticationMiddleware`` now adds an :meth:`.HttpRequest.auser`
   asynchronous method that returns the currently logged-in user.
 
@@ -366,7 +372,11 @@ Templates
 Tests
 ~~~~~
 
-* ...
+* :class:`~django.test.Client` and :class:`~django.test.AsyncClient` now
+  provide asynchronous methods, using an ``a`` prefix:
+  :meth:`~django.test.Client.asession`, :meth:`~django.test.Client.alogin`,
+  :meth:`~django.test.Client.aforce_login`, and
+  :meth:`~django.test.Client.alogout`.
 
 URLs
 ~~~~

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -120,6 +120,9 @@ Authenticating users
 --------------------
 
 .. function:: authenticate(request=None, **credentials)
+.. function:: aauthenticate(request=None, **credentials)
+
+    *Asynchronous version*: ``aauthenticate()``
 
     Use :func:`~django.contrib.auth.authenticate()` to verify a set of
     credentials. It takes credentials as keyword arguments, ``username`` and
@@ -151,6 +154,10 @@ Authenticating users
         you are writing your own authentication system, you probably won't use
         this. Rather if you're looking for a way to login a user, use the
         :class:`~django.contrib.auth.views.LoginView`.
+
+    .. versionchanged:: 5.0
+
+        ``aauthenticate()`` function was added.
 
 .. _topic-authorization:
 
@@ -407,6 +414,9 @@ If you have an authenticated user you want to attach to the current session
 - this is done with a :func:`~django.contrib.auth.login` function.
 
 .. function:: login(request, user, backend=None)
+.. function:: alogin(request, user, backend=None)
+
+    *Asynchronous version*: ``alogin()``
 
     To log a user in, from a view, use :func:`~django.contrib.auth.login()`. It
     takes an :class:`~django.http.HttpRequest` object and a
@@ -436,6 +446,10 @@ If you have an authenticated user you want to attach to the current session
                 # Return an 'invalid login' error message.
                 ...
 
+    .. versionchanged:: 5.0
+
+        ``alogin()`` function was added.
+
 Selecting the authentication backend
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -463,6 +477,9 @@ How to log a user out
 ---------------------
 
 .. function:: logout(request)
+.. function:: alogout(request)
+
+    *Asynchronous version*: ``alogout()``
 
     To log out a user who has been logged in via
     :func:`django.contrib.auth.login()`, use
@@ -487,6 +504,10 @@ How to log a user out
     to put anything into the session that will be available to the user
     immediately after logging out, do that *after* calling
     :func:`django.contrib.auth.logout()`.
+
+    .. versionchanged:: 5.0
+
+        ``alogout()`` function was added.
 
 Limiting access to logged-in users
 ----------------------------------
@@ -935,6 +956,9 @@ and wish to have similar behavior, use the :func:`update_session_auth_hash`
 function.
 
 .. function:: update_session_auth_hash(request, user)
+.. function:: aupdate_session_auth_hash(request, user)
+
+    *Asynchronous version*: ``aupdate_session_auth_hash()``
 
     This function takes the current request and the updated user object from
     which the new session hash will be derived and updates the session hash
@@ -954,6 +978,10 @@ function.
                     update_session_auth_hash(request, form.user)
             else:
                 ...
+
+    .. versionchanged:: 5.0
+
+        ``aupdate_session_auth_hash()`` function was added.
 
 .. note::
 

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -440,6 +440,9 @@ Use the ``django.test.Client`` class to make requests.
             The ``headers`` parameter was added.
 
     .. method:: Client.login(**credentials)
+    .. method:: Client.alogin(**credentials)
+
+        *Asynchronous version*: ``alogin()``
 
         If your site uses Django's :doc:`authentication system</topics/auth/index>`
         and you deal with logging in users, you can use the test client's
@@ -485,7 +488,14 @@ Use the ``django.test.Client`` class to make requests.
         :meth:`~django.contrib.auth.models.UserManager.create_user` helper
         method to create a new user with a correctly hashed password.
 
+        .. versionchanged:: 5.0
+
+            ``alogin()`` method was added.
+
     .. method:: Client.force_login(user, backend=None)
+    .. method:: Client.aforce_login(user, backend=None)
+
+        *Asynchronous version*: ``aforce_login()``
 
         If your site uses Django's :doc:`authentication
         system</topics/auth/index>`, you can use the ``force_login()`` method
@@ -509,7 +519,14 @@ Use the ``django.test.Client`` class to make requests.
         ``login()`` by :ref:`using a weaker hasher while testing
         <speeding-up-tests-auth-hashers>`.
 
+        .. versionchanged:: 5.0
+
+            ``aforce_login()`` method was added.
+
     .. method:: Client.logout()
+    .. method:: Client.alogout()
+
+        *Asynchronous version*: ``alogout()``
 
         If your site uses Django's :doc:`authentication system</topics/auth/index>`,
         the ``logout()`` method can be used to simulate the effect of a user
@@ -518,6 +535,10 @@ Use the ``django.test.Client`` class to make requests.
         After you call this method, the test client will have all the cookies
         and session data cleared to defaults. Subsequent requests will appear
         to come from an :class:`~django.contrib.auth.models.AnonymousUser`.
+
+        .. versionchanged:: 5.0
+
+            ``alogout()`` method was added.
 
 Testing responses
 -----------------
@@ -702,6 +723,13 @@ access these properties as part of a test condition.
             session = self.client.session
             session["somekey"] = "test"
             session.save()
+
+.. method:: Client.asession()
+
+    .. versionadded:: 5.0
+
+    This is similar to the :attr:`session` attribute but it works in async
+    contexts.
 
 Setting the language
 --------------------

--- a/tests/async/test_async_auth.py
+++ b/tests/async/test_async_auth.py
@@ -1,0 +1,98 @@
+from django.contrib.auth import (
+    aauthenticate,
+    aget_user,
+    alogin,
+    alogout,
+    aupdate_session_auth_hash,
+)
+from django.contrib.auth.models import AnonymousUser, User
+from django.http import HttpRequest
+from django.test import TestCase, override_settings
+
+
+class AsyncAuthTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_user = User.objects.create_user(
+            "testuser", "test@example.com", "testpw"
+        )
+
+    async def test_aauthenticate(self):
+        user = await aauthenticate(username="testuser", password="testpw")
+        self.assertIsInstance(user, User)
+        self.assertEqual(user.username, self.test_user.username)
+        user.is_active = False
+        await user.asave()
+        self.assertIsNone(await aauthenticate(username="testuser", password="testpw"))
+
+    async def test_alogin(self):
+        request = HttpRequest()
+        request.session = await self.client.asession()
+        await alogin(request, self.test_user)
+        user = await aget_user(request)
+        self.assertIsInstance(user, User)
+        self.assertEqual(user.username, self.test_user.username)
+
+    async def test_alogin_without_user(self):
+        request = HttpRequest()
+        request.user = self.test_user
+        request.session = await self.client.asession()
+        await alogin(request, None)
+        user = await aget_user(request)
+        self.assertIsInstance(user, User)
+        self.assertEqual(user.username, self.test_user.username)
+
+    async def test_alogout(self):
+        await self.client.alogin(username="testuser", password="testpw")
+        request = HttpRequest()
+        request.session = await self.client.asession()
+        await alogout(request)
+        user = await aget_user(request)
+        self.assertIsInstance(user, AnonymousUser)
+
+    async def test_client_alogout(self):
+        await self.client.alogin(username="testuser", password="testpw")
+        request = HttpRequest()
+        request.session = await self.client.asession()
+        await self.client.alogout()
+        user = await aget_user(request)
+        self.assertIsInstance(user, AnonymousUser)
+
+    async def test_change_password(self):
+        await self.client.alogin(username="testuser", password="testpw")
+        request = HttpRequest()
+        request.session = await self.client.asession()
+        request.user = self.test_user
+        await aupdate_session_auth_hash(request, self.test_user)
+        user = await aget_user(request)
+        self.assertIsInstance(user, User)
+
+    async def test_invalid_login(self):
+        self.assertEqual(
+            await self.client.alogin(username="testuser", password=""), False
+        )
+
+    async def test_client_aforce_login(self):
+        await self.client.aforce_login(self.test_user)
+        request = HttpRequest()
+        request.session = await self.client.asession()
+        user = await aget_user(request)
+        self.assertEqual(user.username, self.test_user.username)
+
+    @override_settings(
+        AUTHENTICATION_BACKENDS=[
+            "django.contrib.auth.backends.ModelBackend",
+            "django.contrib.auth.backends.AllowAllUsersModelBackend",
+        ]
+    )
+    async def test_client_aforce_login_backend(self):
+        self.test_user.is_active = False
+        await self.test_user.asave()
+        await self.client.aforce_login(
+            self.test_user,
+            backend="django.contrib.auth.backends.AllowAllUsersModelBackend",
+        )
+        request = HttpRequest()
+        request.session = await self.client.asession()
+        user = await aget_user(request)
+        self.assertEqual(user.username, self.test_user.username)

--- a/tests/auth_tests/test_auth_backends.py
+++ b/tests/auth_tests/test_auth_backends.py
@@ -6,6 +6,7 @@ from django.contrib.auth import (
     BACKEND_SESSION_KEY,
     SESSION_KEY,
     _clean_credentials,
+    aauthenticate,
     authenticate,
     get_user,
     signals,
@@ -750,6 +751,28 @@ class AuthenticateTests(TestCase):
     def test_authenticate_sensitive_variables(self):
         try:
             authenticate(username="testusername", password=self.sensitive_password)
+        except TypeError:
+            exc_info = sys.exc_info()
+        rf = RequestFactory()
+        response = technical_500_response(rf.get("/"), *exc_info)
+        self.assertNotContains(response, self.sensitive_password, status_code=500)
+        self.assertContains(response, "TypeErrorBackend", status_code=500)
+        self.assertContains(
+            response,
+            '<tr><td>credentials</td><td class="code">'
+            "<pre>&#39;********************&#39;</pre></td></tr>",
+            html=True,
+            status_code=500,
+        )
+
+    @override_settings(
+        AUTHENTICATION_BACKENDS=["auth_tests.test_auth_backends.TypeErrorBackend"]
+    )
+    async def test_aauthenticate_sensitive_variables(self):
+        try:
+            await aauthenticate(
+                username="testusername", password=self.sensitive_password
+            )
         except TypeError:
             exc_info = sys.exc_info()
         rf = RequestFactory()

--- a/tests/auth_tests/test_basic.py
+++ b/tests/auth_tests/test_basic.py
@@ -1,5 +1,7 @@
+from asgiref.sync import sync_to_async
+
 from django.conf import settings
-from django.contrib.auth import get_user, get_user_model
+from django.contrib.auth import aget_user, get_user, get_user_model
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ImproperlyConfigured
 from django.db import IntegrityError
@@ -129,6 +131,12 @@ class TestGetUser(TestCase):
         user = get_user(request)
         self.assertIsInstance(user, AnonymousUser)
 
+    async def test_aget_user_anonymous(self):
+        request = HttpRequest()
+        request.session = await self.client.asession()
+        user = await aget_user(request)
+        self.assertIsInstance(user, AnonymousUser)
+
     def test_get_user(self):
         created_user = User.objects.create_user(
             "testuser", "test@example.com", "testpw"
@@ -162,3 +170,14 @@ class TestGetUser(TestCase):
             user = get_user(request)
             self.assertIsInstance(user, User)
             self.assertEqual(user.username, created_user.username)
+
+    async def test_aget_user(self):
+        created_user = await sync_to_async(User.objects.create_user)(
+            "testuser", "test@example.com", "testpw"
+        )
+        await self.client.alogin(username="testuser", password="testpw")
+        request = HttpRequest()
+        request.session = await self.client.asession()
+        user = await aget_user(request)
+        self.assertIsInstance(user, User)
+        self.assertEqual(user.username, created_user.username)


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/34391
Forum discussion: https://forum.djangoproject.com/t/asyncifying-django-contrib-auth-and-signals-and-maybe-sessions/18770

This adds an async *interface* to `django.contrib.auth`. The actual underlying implementation remains synchronous by way of `sync_to_async` wrappers.

I also took the liberty of updating the implementation given in `AuthenticationMiddleware` to use the new common API, and also updated the test client helpers to use these new methods.

One open question: should we add an async version of `User.objects.create_user()`? After writing this I realized that they go hand in hand, but it wasn't part of the ticket I opened so I'm flagging here. I'm happy to add an async version of that function if reviewers agree.