### PR TITLE
Fixed #34405 -- Fixed setting Content-Type header in FileResponse for compress and brotli.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -609,7 +609,9 @@ class FileResponse(StreamingHttpResponse):
                 # Encoding isn't set to prevent browsers from automatically
                 # uncompressing files.
                 content_type = {
+                    "br": "application/x-brotli",
                     "bzip2": "application/x-bzip",
+                    "compress": "application/x-compress",
                     "gzip": "application/gzip",
                     "xz": "application/x-xz",
                 }.get(encoding, content_type)

--- a/tests/responses/test_fileresponse.py
+++ b/tests/responses/test_fileresponse.py
@@ -253,8 +253,10 @@ class FileResponseTests(SimpleTestCase):
         """
         test_tuples = (
             (".tar.gz", "application/gzip"),
+            (".tar.br", "application/x-brotli"),
             (".tar.bz2", "application/x-bzip"),
             (".tar.xz", "application/x-xz"),
+            (".tar.Z", "application/x-compress"),
         )
         for extension, mimetype in test_tuples:
             with self.subTest(ext=extension):


### PR DESCRIPTION
ticket-34405

Thanks Chamal De Silva for the report.