### PR TITLE
Corrected example in CreateCollation() docs.

### DIFF
--- a/docs/ref/contrib/postgres/operations.txt
+++ b/docs/ref/contrib/postgres/operations.txt
@@ -128,9 +128,10 @@ For example, to create a collation for German phone book ordering::
 
         operations = [
             CreateCollation(
-                "german_phonebook",
+                "case_insensitive",
                 provider="icu",
                 locale="und-u-ks-level2",
+                deterministic=False,
             ),
             ...,
         ]


### PR DESCRIPTION
`und-u-ks-level2` is a general purpose case-insensitive collation, so the name `german_phonebook` is misleading, and the `deterministic` flag should be used. I deconstructed what the parts of the name mean in my post: https://adamj.eu/tech/2023/02/23/migrate-django-postgresql-ci-fields-case-insensitive-collation/#what-to-do

I think there must have been some missed edits when writing the docs in #13469.

CC @knyghty @ngnpope 