### PR TITLE
Fixed #34410 - Re-enable support for dynamic db connections

### DIFF
--- a/tests/db_utils/tests.py
+++ b/tests/db_utils/tests.py
@@ -58,6 +58,17 @@ class ConnectionHandlerTests(SimpleTestCase):
         with self.assertRaisesMessage(ConnectionDoesNotExist, msg):
             conns["nonexistent"]
 
+    def test_ensure_defaults_dynamic_db(self):
+        msg = "No default values set for dynamic connection 'test_dynamic_db'."
+        conns = ConnectionHandler(
+            {
+                DEFAULT_DB_ALIAS: {"ENGINE": "django.db.backends.dummy"},
+            }
+        )
+        conns.settings["test_dynamic_db"] = {"ENGINE": "django.db.backends.dummy"}
+        conns.create_connection("test_dynamic_db")
+        self.assertTrue("TIME_ZONE" in conns.settings["test_dynamic_db"], msg)
+
 
 class DatabaseErrorWrapperTests(TestCase):
     @unittest.skipUnless(connection.vendor == "postgresql", "PostgreSQL test")


### PR DESCRIPTION
Dynamically adding databases caused application to crash if some db connection parameters was missing, even if they aren't required. This behaviour did not occur before Django 4.1.

I traced the bug to changes made in PR #15490. "ensure_defaults" was being called in create_connection earlier and that was removed, causing the application to never set defaults to any db connection that was dynamically added.

Other repos have faced an issue with that change as well: https://github.com/Opus10/django-pgconnection/issues/12

I've brought back ensure_defaults, while retaining its usage during initialization in configure_settings. I've added the necessary test.

Let me know if something needs to be changed or if there is a workaround for our use case of adding db connections dynamically (apart from sending all the parameters while setting the new db conn, which is harder to maintain in the long run)

Ticket ref: https://code.djangoproject.com/ticket/34410