### PR TITLE
Fixed #28553 -- Fixed annotation mismatch with QuerySet.values()/values_list() on compound queries.

### DIFF
--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -295,6 +295,9 @@ Miscellaneous
 * Integer fields are now validated as 64-bit integers on SQLite to match the
   behavior of ``sqlite3``.
 
+* The undocumented ``Query.annotation_select_mask`` attribute is changed from a
+  set of strings to an ordered list of strings.
+
 .. _deprecated-features-5.0:
 
 Features deprecated in 5.0

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -466,8 +466,8 @@ class TestQuerying(PostgreSQLTestCase):
                 ],
             )
         sql = ctx[0]["sql"]
-        self.assertIn("GROUP BY 1", sql)
-        self.assertIn("ORDER BY 1", sql)
+        self.assertIn("GROUP BY 2", sql)
+        self.assertIn("ORDER BY 2", sql)
 
     def test_index(self):
         self.assertSequenceEqual(

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -246,7 +246,7 @@ class QuerySetSetOperationTests(TestCase):
             )
             .values_list("num", "count")
         )
-        self.assertCountEqual(qs1.union(qs2), [(1, 0), (2, 1)])
+        self.assertCountEqual(qs1.union(qs2), [(1, 0), (1, 2)])
 
     def test_union_with_extra_and_values_list(self):
         qs1 = (
@@ -366,6 +366,20 @@ class QuerySetSetOperationTests(TestCase):
         self.assertSequenceEqual(
             qs1.union(qs2).order_by("extra_name").values_list("pk", flat=True),
             [reserved_name.pk],
+        )
+
+    def test_union_multiple_models_with_values_list_and_annotations(self):
+        ReservedName.objects.create(name="rn1", order=10)
+        Celebrity.objects.create(name="c1")
+        qs1 = ReservedName.objects.annotate(row_type=Value("rn")).values_list(
+            "name", "order", "row_type"
+        )
+        qs2 = Celebrity.objects.annotate(
+            row_type=Value("cb"), order=Value(-10)
+        ).values_list("name", "order", "row_type")
+        self.assertSequenceEqual(
+            qs1.union(qs2).order_by("order"),
+            [("c1", -10, "cb"), ("rn1", 10, "rn")],
         )
 
     def test_union_in_subquery(self):


### PR DESCRIPTION
[ticket-28553](https://code.djangoproject.com/ticket/28553)

Unit test taken from https://github.com/django/django/pull/16577.