### PR TITLE
Reverted "Fixed #33213 -- Doc'd testing code coverage in parallel and used it."

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,6 @@ docs/_build/
 docs/locale/
 node_modules/
 tests/coverage_html/
-tests/.coverage*
+tests/.coverage
 build/
 tests/report/

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -357,19 +357,14 @@ Contributors are encouraged to run coverage on the test suite to identify areas
 that need additional tests. The coverage tool installation and use is described
 in :ref:`testing code coverage<topics-testing-code-coverage>`.
 
-To run coverage on the Django test suite using the standard test settings:
+Coverage should be run in a single process to obtain accurate statistics. To
+run coverage on the Django test suite using the standard test settings:
 
 .. console::
 
-   $ coverage run ./runtests.py --settings=test_sqlite
+   $ coverage run ./runtests.py --settings=test_sqlite --parallel=1
 
-After running coverage, combine all coverage statistics by running:
-
-.. console::
-
-   $ coverage combine
-
-After that generate the html report by running:
+After running coverage, generate the html report by running:
 
 .. console::
 

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,7 +1,5 @@
 [run]
 branch = True
-concurrency = multiprocessing
-data_file = .coverages/.coverage
 omit =
     */django/utils/autoreload.py
 source = django


### PR DESCRIPTION
This reverts commit 69352d85fa8412865db9e0c7f177b333c0eac3e2.

Test coverage for async methods is no longer calculated with this change, see [logs](https://djangoci.com/view/%C2%ADCoverage/job/django-coverage-postgresql/HTML_20Coverage_20Report/).