### PR TITLE
Fixed #34421 -- Fixed QuerySet.update() on querysets in descending order by annotations.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -108,6 +108,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                 "update.tests.AdvancedTests."
                 "test_update_ordered_by_inline_m2m_annotation",
                 "update.tests.AdvancedTests.test_update_ordered_by_m2m_annotation",
+                "update.tests.AdvancedTests.test_update_ordered_by_m2m_annotation_desc",
             },
         }
         if self.connection.mysql_is_mariadb and (

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1190,11 +1190,18 @@ class QuerySet(AltersData):
         # Inline annotations in order_by(), if possible.
         new_order_by = []
         for col in query.order_by:
-            if annotation := query.annotations.get(col):
+            alias = col
+            descending = False
+            if isinstance(alias, str) and alias.startswith("-"):
+                alias = alias.removeprefix("-")
+                descending = True
+            if annotation := query.annotations.get(alias):
                 if getattr(annotation, "contains_aggregate", False):
                     raise exceptions.FieldError(
                         f"Cannot update when ordering by an aggregate: {annotation}"
                     )
+                if descending:
+                    annotation = annotation.desc()
                 new_order_by.append(annotation)
             else:
                 new_order_by.append(col)

--- a/tests/update/tests.py
+++ b/tests/update/tests.py
@@ -249,6 +249,13 @@ class AdvancedTests(TestCase):
         Bar.objects.annotate(abs_id=Abs("m2m_foo")).order_by("abs_id").update(x=3)
         self.assertEqual(Bar.objects.get().x, 3)
 
+    def test_update_ordered_by_m2m_annotation_desc(self):
+        foo = Foo.objects.create(target="test")
+        Bar.objects.create(foo=foo)
+
+        Bar.objects.annotate(abs_id=Abs("m2m_foo")).order_by("-abs_id").update(x=4)
+        self.assertEqual(Bar.objects.get().x, 4)
+
     def test_update_negated_f(self):
         DataPoint.objects.update(is_active=~F("is_active"))
         self.assertCountEqual(
@@ -305,6 +312,14 @@ class MySQLUpdateOrderByTest(TestCase):
         updated = (
             UniqueNumber.objects.annotate(number_inverse=F("number").desc())
             .order_by("number_inverse")
+            .update(number=F("number") + 1)
+        )
+        self.assertEqual(updated, 2)
+
+    def test_order_by_update_on_unique_constraint_annotation_desc(self):
+        updated = (
+            UniqueNumber.objects.annotate(number_annotation=F("number"))
+            .order_by("-number_annotation")
             .update(number=F("number") + 1)
         )
         self.assertEqual(updated, 2)


### PR DESCRIPTION
I often use admin to manage data, so I wrote an action to update data in bulk, but sometimes it reports an error

```FieldError: Cannot resolve keyword 'message_length' into field. Choices are: message, id, text, x```

And the error is reported in descending order, similar to the execution of the following query statement 

```Model.objects.annotate(message_length=Length('message')).order_by('-message_length').update(text="Can I come on board?")```

Through debug found that the programmer ignored the case of descending order, so wrote this patch to fix the problem, see the code for more details.

First submission, so if there are any questions please guide me.