### PR TITLE
Fixed #28384 -- Fixed ModelAdmin.lookup_allowed() for foreign keys as primary key

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -461,12 +461,14 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
                 # Lookups on nonexistent fields are ok, since they're ignored
                 # later.
                 break
-            # It is allowed to filter on values that would be found from local
-            # model anyways. For example, if you filter on employee__department__id,
-            # then the id value would be found already from employee__department_id.
             if not prev_field or (
                 prev_field.is_relation
-                and field not in prev_field.path_infos[-1].target_fields
+                and field not in model._meta.parents.values()
+                and field is not model._meta.auto_field
+                and (
+                    model._meta.auto_field is None
+                    or part not in getattr(prev_field, "to_fields", [])
+                )
             ):
                 relation_parts.append(part)
             if not getattr(field, "path_infos", None):

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -154,6 +154,35 @@ class ModelAdminTests(TestCase):
             ma.lookup_allowed("employee__department__code", "test_value"), True
         )
 
+    @isolate_apps("modeladmin")
+    def test_lookup_allowed_foreign_primary(self):
+        class Country(models.Model):
+            name = models.CharField(max_length=256)
+
+        class Place(models.Model):
+            country = models.ForeignKey(Country, models.CASCADE)
+
+        class Restaurant(models.Model):
+            place = models.OneToOneField(Place, models.CASCADE, primary_key=True)
+
+        class Waiter(models.Model):
+            restaurant = models.ForeignKey(Restaurant, models.CASCADE)
+
+        class WaiterAdmin(ModelAdmin):
+            list_filter = [
+                "restaurant__place__country",
+                "restaurant__place__country__name",
+            ]
+
+        ma = WaiterAdmin(Waiter, self.site)
+        self.assertIs(ma.lookup_allowed("restaurant__place__country", "1"), True)
+        self.assertIs(
+            ma.lookup_allowed("restaurant__place__country__id__exact", "1"), True
+        )
+        self.assertIs(
+            ma.lookup_allowed("restaurant__place__country__name", "test_value"), True
+        )
+
     def test_field_arguments(self):
         # If fields is specified, fieldsets_add and fieldsets_change should
         # just stick the fields into a formsets structure and return it.


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/28384

#### Notes:
I am not 100% sure whether there is something I am missing from this comment 
```
            # It is allowed to filter on values that would be found from local
            # model anyways. For example, if you filter on employee__department__id,
            # then the id value would be found already from employee__department_id.
```
I tried to include stuff around it in the test case but I don't really understand what it is getting at

The test itself is copied from the ticket, there is a test above `test_lookup_allowed_onetoone` that is very similar and can be tweaked to include this case but not sure if we want this to be in a separate test