### PR TITLE
Fixed #34420 -- Corrected the order of imports in generated migration files.

### DIFF
--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -175,7 +175,10 @@ class MigrationWriter:
 
         # Sort imports by the package / module to be imported (the part after
         # "from" in "from ... import ..." or after "import" in "import ...").
-        sorted_imports = sorted(imports, key=lambda i: i.split()[1])
+        # First group the "import" statements, then "from ... import ...".
+        sorted_imports = sorted(
+            imports, key=lambda i: (i.split()[0] == "from", i.split()[1])
+        )
         items["imports"] = "\n".join(sorted_imports) + "\n" if imports else ""
         if migration_imports:
             items["imports"] += (

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import re
 import sys
+import time
 import uuid
 import zoneinfo
 from types import NoneType
@@ -912,13 +913,18 @@ class WriterTests(SimpleTestCase):
                             ),
                         ),
                     ),
+                    migrations.AddField(
+                        "mymodel",
+                        "myfield2",
+                        models.FloatField(default=time.time),
+                    ),
                 ]
             },
         )
         writer = MigrationWriter(migration)
         output = writer.as_string()
         self.assertIn(
-            "import datetime\nfrom django.db import migrations, models\n",
+            "import datetime\nimport time\nfrom django.db import migrations, models\n",
             output,
         )
 


### PR DESCRIPTION
New migration files are generated with imports sorted by module, independent of import style. For example:

```py
import datetime
from django.db import migrations, models
import time
```

[The Django coding style](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#imports) specifies:

> Place all import module statements before from module import objects in each section.

This guidance is the same as what isort does by default, as documented [here](https://pycqa.github.io/isort/docs/configuration/custom_sections_and_ordering.html#controlling-how-isort-sections-from-imports). Newly generated migrations can fail isort for this reason.

This commit changes migration file generation so that imports are ordered according to this guidance, like this:

```py
import datetime
import time
from django.db import migrations, models
```