### PR TITLE
Fixed #33423 -- Migrations, UniqueConstraint lenght of identifier can…

### DIFF
--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -191,6 +191,8 @@ class UniqueConstraint(BaseConstraint):
     ):
         if not name:
             raise ValueError("A unique constraint must be named.")
+        if len(name) > 63:
+            raise ValueError("Name of constraint can not be longer than 63 characters")
         if not expressions and not fields:
             raise ValueError(
                 "At least one field or expression is required to define a "

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -1070,3 +1070,24 @@ class UniqueConstraintTests(TestCase):
         msg = "A unique constraint must be named."
         with self.assertRaisesMessage(ValueError, msg):
             models.UniqueConstraint(fields=["field"])
+
+    def test_unique_constraint_name_length_limit(self):
+        """
+        Databases imposes a limit on the length of an identifier.
+        A longer identifier can probably be used, but it might be truncated and might
+        collide with other identifiers
+        """
+        postgres_identifier_limit = 63
+
+        # Using up to the limit should be fine
+        models.UniqueConstraint(
+            fields=["field"],
+            name="x" * postgres_identifier_limit
+        )
+
+        msg = "Name of constraint can not be longer than 63 characters"
+        with self.assertRaisesMessage(ValueError, msg):
+            models.UniqueConstraint(
+                fields=["field"],
+                name="x" * (postgres_identifier_limit + 1)
+            )


### PR DESCRIPTION
… be too long for Postgres/MySQL

Adding validation for length of name attribute in UniqueConstraint