### PR TITLE
Refs #33134, Refs #34077 -- Adjusted form rendering recursion test.

### DIFF
--- a/tests/forms_tests/templatetags/tags.py
+++ b/tests/forms_tests/templatetags/tags.py
@@ -10,7 +10,7 @@ class CountRenderNode(Node):
         self.count += 1
         for v in context.flatten().values():
             try:
-                v.render()
+                str(v)
             except AttributeError:
                 pass
         return str(self.count)


### PR DESCRIPTION
Adjusted recursion depth test to use str() rather than the form or field’s render() method.

Extracted from #16666 by @smithdc1. Just checking the CI. 👷‍♀️