### PR TITLE
Fixed typo in docs/topics/class-based-views/mixins.txt.

### DIFF
--- a/docs/topics/class-based-views/mixins.txt
+++ b/docs/topics/class-based-views/mixins.txt
@@ -538,11 +538,11 @@ write our own ``get_context_data()`` to make the
             context["form"] = AuthorInterestForm()
             return context
 
-Then the ``AuthorInterestForm`` is a :class:`FormView`, but we have to bring in
-:class:`~django.views.generic.detail.SingleObjectMixin` so we can find the
-author we're talking about, and we have to remember to set ``template_name`` to
-ensure that form errors will render the same template as ``AuthorDetailView``
-is using on ``GET``::
+Then the ``AuthorInterestFormView`` is a :class:`FormView`, but we have to
+bring in :class:`~django.views.generic.detail.SingleObjectMixin` so we can find
+the author we're talking about, and we have to remember to set
+``template_name`` to ensure that form errors will render the same template as
+``AuthorDetailView`` is using on ``GET``::
 
     from django.http import HttpResponseForbidden
     from django.urls import reverse


### PR DESCRIPTION
In [this section](https://docs.djangoproject.com/en/4.1/topics/class-based-views/mixins/#an-alternative-better-solution) of the page, we created two distinct views as an "alternative better approach".  Now we have two views:
1. `AuthorDetailView`
2. `AuthorInterestFormView`

After the code section the paragraph starts with this sentence: "*Then the **AuthorInterestForm** is a [FormView](https://docs.djangoproject.com/en/4.0/ref/class-based-views/flattened-index/#FormView)*"

`AuthorInterestForm` is not our `FormView`, it's a `Form` but `AuthorInterestFormView` which is gonna get introduced in the next code section is.

So `AuthorInterestForm` should be `AuthorInterestFormView`.

Thanks.