### PR TITLE
Add space

### DIFF
--- a/docs/ref/contrib/messages.txt
+++ b/docs/ref/contrib/messages.txt
@@ -187,7 +187,7 @@ Displaying messages
 .. code-block:: html+django
 
     {% if messages %}
-    <ul class="messages">
+    <ul> class="messages">
         {% for message in messages %}
         <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
         {% endfor %}

--- a/docs/ref/contrib/messages.txt
+++ b/docs/ref/contrib/messages.txt
@@ -187,9 +187,9 @@ Displaying messages
 .. code-block:: html+django
 
     {% if messages %}
-    <ul> class="messages">
+    <ul class="messages">
         {% for message in messages %}
-        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+        <li {% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
         {% endfor %}
     </ul>
     {% endif %}
@@ -210,7 +210,7 @@ is a mapping of the message level names to their numeric value:
     {% if messages %}
     <ul class="messages">
         {% for message in messages %}
-        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>
+        <li {% if message.tags %} class="{{ message.tags }}"{% endif %}>
             {% if message.level == DEFAULT_MESSAGE_LEVELS.ERROR %}Important: {% endif %}
             {{ message }}
         </li>


### PR DESCRIPTION
I was going through django documents and I found a minor error regarding a space on this address. [https://docs.djangoproject.com/en/4.1/ref/contrib/messages/#displaying-messages ]

Check it out!