### PR TITLE
Fixed #34437 -- Made values() resolving error mention selected annotations.

### DIFF
--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -33,6 +33,7 @@ from django.db.models.functions import (
     Lower,
     Trim,
 )
+from django.db.models.sql.query import get_field_names_from_opts
 from django.test import TestCase, skipUnlessDBFeature
 from django.test.utils import register_lookup
 
@@ -464,6 +465,16 @@ class NonAggregateAnnotationTestCase(TestCase):
                     sum_rating=F("nope")
                 )
             )
+
+    def test_values_wrong_annotation(self):
+        expected_message = (
+            "Cannot resolve keyword 'annotation_typo' into field. Choices are: %s"
+        )
+        article_fields = ", ".join(
+            ["annotation"] + sorted(get_field_names_from_opts(Book._meta))
+        )
+        with self.assertRaisesMessage(FieldError, expected_message % article_fields):
+            Book.objects.annotate(annotation=Value(1)).values_list("annotation_typo")
 
     def test_decimal_annotation(self):
         salary = Decimal(10) ** -Employee._meta.get_field("salary").decimal_places


### PR DESCRIPTION
While the `add_fields()` call from `set_values()` does trigger validation it does so after annotations are masked resulting in them being excluded from the choices of valid options surfaced through a `FieldError`.

---

This was discovered while exploring the deprecation of `QuerySet.extra(select)` in #16681.