### PR TITLE
[3.2.x] Fixed Attribute error on OutputWrapper

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -152,7 +152,8 @@ class OutputWrapper(TextIOBase):
         if ending and not msg.endswith(ending):
             msg += ending
         style_func = style_func or self.style_func
-        self._out.write(style_func(msg))
+        if hasattr(self._out, 'write'):
+            self._out.write(style_func(msg))
 
 
 class BaseCommand:


### PR DESCRIPTION
When deploying a project as a non-console (GUI) using PyInstaller with Django embedded as a sub-process. The `OutputWrapper` class throws an Attribute error on `write` method.

This is fixed by checking for attribute like in `flush` method.