### PR TITLE
Fixed overindentation of AdminURLFieldWidget.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -94,13 +94,8 @@ form ul.inline li {
     padding: 6px 0;
     margin-top: 0;
     margin-bottom: 0;
-    margin-left: 170px;
-    overflow-wrap: break-word;
-}
-
-.aligned label + div.readonly,
-.aligned label + .datetime {
     margin-left: 0;
+    overflow-wrap: break-word;
 }
 
 .aligned ul label {
@@ -139,11 +134,6 @@ form .aligned p.datetime div.help.timezonewarning {
     margin-left: 0;
     padding-left: 0;
     font-weight: normal;
-}
-
-form .aligned .checkbox-row + .help {
-    margin-left: 0;
-    padding-left: 0;
 }
 
 form .aligned p.help:last-child,
@@ -186,12 +176,6 @@ form .aligned table p {
 
 .colM .aligned .vLargeTextField, .colM .aligned .vXMLLargeTextField {
     width: 610px;
-}
-
-.checkbox-row p.help,
-.checkbox-row div.help {
-    margin-left: 0;
-    padding-left: 0;
 }
 
 fieldset .fieldBox {


### PR DESCRIPTION
Regression in 96a598356a9ea8c2c05b22cadc12e256a3b295fd.

(Possibly some removals are overzealous, but without any comments, it's difficult to understand why so much seemingly redundant declarations are needed. I checked checkbox aligned in user admin.)