### PR TITLE
Fixed #28900 -- Made SELECT respect the order specified by values()/values_list().

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -200,12 +200,15 @@ class ValuesIterable(BaseIterable):
         query = queryset.query
         compiler = query.get_compiler(queryset.db)
 
-        # extra(select=...) cols are always at the start of the row.
-        names = [
-            *query.extra_select,
-            *query.values_select,
-            *query.annotation_select,
-        ]
+        if query.selected:
+            names = list(query.selected)
+        else:
+            # extra(select=...) cols are always at the start of the row.
+            names = [
+                *query.extra_select,
+                *query.values_select,
+                *query.annotation_select,
+            ]
         indexes = range(len(names))
         for row in compiler.results_iter(
             chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size
@@ -223,28 +226,6 @@ class ValuesListIterable(BaseIterable):
         queryset = self.queryset
         query = queryset.query
         compiler = query.get_compiler(queryset.db)
-
-        if queryset._fields:
-            # extra(select=...) cols are always at the start of the row.
-            names = [
-                *query.extra_select,
-                *query.values_select,
-                *query.annotation_select,
-            ]
-            fields = [
-                *queryset._fields,
-                *(f for f in query.annotation_select if f not in queryset._fields),
-            ]
-            if fields != names:
-                # Reorder according to fields.
-                index_map = {name: idx for idx, name in enumerate(names)}
-                rowfactory = operator.itemgetter(*[index_map[f] for f in fields])
-                return map(
-                    rowfactory,
-                    compiler.results_iter(
-                        chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size
-                    ),
-                )
         return compiler.results_iter(
             tuple_expected=True,
             chunked_fetch=self.chunked_fetch,

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -591,20 +591,15 @@ class SQLCompiler:
                 # generate valid SQL.
                 compiler.elide_empty = False
         parts = ()
+        selected = self.query.selected
         for compiler in compilers:
             try:
                 # If the columns list is limited, then all combined queries
                 # must have the same columns list. Set the selects defined on
                 # the query on all combined queries, if not already set.
-                if not compiler.query.values_select and self.query.values_select:
+                if selected is not None and compiler.query.selected is None:
                     compiler.query = compiler.query.clone()
-                    compiler.query.set_values(
-                        (
-                            *self.query.extra_select,
-                            *self.query.values_select,
-                            *self.query.annotation_select,
-                        )
-                    )
+                    compiler.query.set_values(selected)
                 part_sql, part_args = compiler.as_sql(with_col_aliases=True)
                 if compiler.query.combinator:
                     # Wrap in a subquery if wrapping in parentheses isn't

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -260,7 +260,6 @@ class Query(BaseExpression):
     select_for_update_of = ()
     select_for_no_key_update = False
     select_related = False
-    has_select_fields = False
     # Arbitrary limit for select_related to prevents infinite recursion.
     max_depth = 5
     # Holds the selects defined by a call to values() or values_list()
@@ -2448,11 +2447,14 @@ class Query(BaseExpression):
             self.extra_select_mask = set(names)
         self._extra_select_cache = None
 
+    @property
+    def has_select_fields(self):
+        return self.selected is not None
+
     def set_values(self, fields):
         self.select_related = False
         self.clear_deferred_loading()
         self.clear_select_fields()
-        self.has_select_fields = True
 
         selected = {}
         if fields:

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -745,6 +745,11 @@ You can also refer to fields on related models with reverse relations through
     ``"true"``, ``"false"``, and ``"null"`` strings for
     :class:`~django.db.models.JSONField` key transforms.
 
+.. versionchanged:: 5.2
+
+    The ``SELECT`` clause generated when using ``values()`` was updated to
+    respect the order of the specified ``*fields`` and ``**expressions``.
+
 ``values_list()``
 ~~~~~~~~~~~~~~~~~
 
@@ -834,6 +839,11 @@ not having any author:
     ``values_list()`` will return ``True``, ``False``, and ``None`` instead of
     ``"true"``, ``"false"``, and ``"null"`` strings for
     :class:`~django.db.models.JSONField` key transforms.
+
+.. versionchanged:: 5.2
+
+    The ``SELECT`` clause generated when using ``values_list()`` was updated to
+    respect the order of the specified ``*fields``.
 
 ``dates()``
 ~~~~~~~~~~~

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -195,7 +195,13 @@ Migrations
 Models
 ~~~~~~
 
-* ...
+* The ``SELECT`` clause generated when using
+  :meth:`QuerySet.values()<django.db.models.query.QuerySet.values>` and
+  :meth:`~django.db.models.query.QuerySet.values_list` now matches the
+  specified order of the referenced expressions. Previously the order was based
+  of a set of counterintuitive rules which made query combination through
+  methods such as
+  :meth:`QuerySet.union()<django.db.models.query.QuerySet.union>` unpredictable.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -96,6 +96,7 @@ contenttypes
 contrib
 coroutine
 coroutines
+counterintuitive
 criticals
 cron
 crontab

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -568,6 +568,16 @@ class NonAggregateAnnotationTestCase(TestCase):
         self.assertEqual(book["other_rating"], 4)
         self.assertEqual(book["other_isbn"], "155860191")
 
+    def test_values_fields_annotations_order(self):
+        qs = Book.objects.annotate(other_rating=F("rating") - 1).values(
+            "other_rating", "rating"
+        )
+        book = qs.get(pk=self.b1.pk)
+        self.assertEqual(
+            list(book.items()),
+            [("other_rating", self.b1.rating - 1), ("rating", self.b1.rating)],
+        )
+
     def test_values_with_pk_annotation(self):
         # annotate references a field in values() with pk
         publishers = Publisher.objects.values("id", "book__rating").annotate(

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -466,8 +466,8 @@ class TestQuerying(PostgreSQLTestCase):
                 ],
             )
         sql = ctx[0]["sql"]
-        self.assertIn("GROUP BY 2", sql)
-        self.assertIn("ORDER BY 2", sql)
+        self.assertIn("GROUP BY 1", sql)
+        self.assertIn("ORDER BY 1", sql)
 
     def test_order_by_arrayagg_index(self):
         qs = (

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -257,6 +257,23 @@ class QuerySetSetOperationTests(TestCase):
         )
         self.assertCountEqual(qs1.union(qs2), [(1, 0), (1, 2)])
 
+    def test_union_with_field_and_annotation_values(self):
+        qs1 = (
+            Number.objects.filter(num=1)
+            .annotate(
+                zero=Value(0, IntegerField()),
+            )
+            .values_list("num", "zero")
+        )
+        qs2 = (
+            Number.objects.filter(num=2)
+            .annotate(
+                zero=Value(0, IntegerField()),
+            )
+            .values_list("zero", "num")
+        )
+        self.assertCountEqual(qs1.union(qs2), [(1, 0), (0, 2)])
+
     def test_union_with_extra_and_values_list(self):
         qs1 = (
             Number.objects.filter(num=1)
@@ -265,7 +282,11 @@ class QuerySetSetOperationTests(TestCase):
             )
             .values_list("num", "count")
         )
-        qs2 = Number.objects.filter(num=2).extra(select={"count": 1})
+        qs2 = (
+            Number.objects.filter(num=2)
+            .extra(select={"count": 1})
+            .values_list("num", "count")
+        )
         self.assertCountEqual(qs1.union(qs2), [(1, 0), (2, 1)])
 
     def test_union_with_values_list_on_annotated_and_unannotated(self):

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -282,11 +282,7 @@ class QuerySetSetOperationTests(TestCase):
             )
             .values_list("num", "count")
         )
-        qs2 = (
-            Number.objects.filter(num=2)
-            .extra(select={"count": 1})
-            .values_list("num", "count")
-        )
+        qs2 = Number.objects.filter(num=2).extra(select={"count": 1})
         self.assertCountEqual(qs1.union(qs2), [(1, 0), (2, 1)])
 
     def test_union_with_values_list_on_annotated_and_unannotated(self):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2200,7 +2200,7 @@ class Queries6Tests(TestCase):
                 {"tag_per_parent__max": 2},
             )
         sql = captured_queries[0]["sql"]
-        self.assertIn("AS %s" % connection.ops.quote_name("col1"), sql)
+        self.assertIn("AS %s" % connection.ops.quote_name("parent"), sql)
 
     def test_xor_subquery(self):
         self.assertSequenceEqual(

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -1375,6 +1375,16 @@ class Queries1Tests(TestCase):
         self.assertCountEqual(items_after, [self.i2, self.i3, self.i4])
         self.assertCountEqual(items_before, items_after)
 
+    def test_union_values_subquery(self):
+        items = Item.objects.filter(creator=OuterRef("pk"))
+        item_authors = Author.objects.annotate(is_creator=Exists(items)).order_by()
+        reports = Report.objects.filter(creator=OuterRef("pk"))
+        report_authors = Author.objects.annotate(is_creator=Exists(reports)).order_by()
+        all_authors = item_authors.union(report_authors).order_by("is_creator")
+        self.assertEqual(
+            list(all_authors.values_list("is_creator", flat=True)), [False, True]
+        )
+
 
 class Queries2Tests(TestCase):
     @classmethod


### PR DESCRIPTION
ticket-28900

---

The TL;DR here is that previously when using `values` or `values_list` the resulting order of the `SELECT` members was not matching the one explicitly specified.

Instead the order was always `SELECT *extra_fields, *model_fields, *annotations` where each local group respected the explicitly specified order. This was leading to issues particularly when combining queries and trying to combine annotations with model fields as exemplified here

- https://code.djangoproject.com/ticket/28553#comment:3
- https://code.djangoproject.com/ticket/34502#comment:2

What this PR does is
1. Store a global order in `Query.selected`
2. Remove the unnecessary re-mapping of order in `ValuesListIterable`
3. Address ticket-28900 by having the combinator select inheritance logic rely on this new property

---

The only part that I think might be missing is a mention in the release notes. My thoughts are that it's possible that users tried to work around this bug in all sort of weird ways (mixing extras) or might not even realize that they have a buggy query because the swapped columns happen to share compatible types. They would benefit from being explained why this was solved and what to expect. Thoughts?