### PR TITLE
Reverted "Refs #31949 -- Enabled @sensitive_variables to work with async functions."

### DIFF
--- a/django/views/decorators/debug.py
+++ b/django/views/decorators/debug.py
@@ -1,7 +1,5 @@
 from functools import wraps
 
-from asgiref.sync import iscoroutinefunction
-
 from django.http import HttpRequest
 
 
@@ -35,25 +33,13 @@ def sensitive_variables(*variables):
         )
 
     def decorator(func):
-        if iscoroutinefunction(func):
-
-            @wraps(func)
-            async def sensitive_variables_wrapper(*func_args, **func_kwargs):
-                if variables:
-                    sensitive_variables_wrapper.sensitive_variables = variables
-                else:
-                    sensitive_variables_wrapper.sensitive_variables = "__ALL__"
-                return await func(*func_args, **func_kwargs)
-
-        else:
-
-            @wraps(func)
-            def sensitive_variables_wrapper(*func_args, **func_kwargs):
-                if variables:
-                    sensitive_variables_wrapper.sensitive_variables = variables
-                else:
-                    sensitive_variables_wrapper.sensitive_variables = "__ALL__"
-                return func(*func_args, **func_kwargs)
+        @wraps(func)
+        def sensitive_variables_wrapper(*func_args, **func_kwargs):
+            if variables:
+                sensitive_variables_wrapper.sensitive_variables = variables
+            else:
+                sensitive_variables_wrapper.sensitive_variables = "__ALL__"
+            return func(*func_args, **func_kwargs)
 
         return sensitive_variables_wrapper
 
@@ -91,37 +77,19 @@ def sensitive_post_parameters(*parameters):
         )
 
     def decorator(view):
-        if iscoroutinefunction(view):
-
-            @wraps(view)
-            async def sensitive_post_parameters_wrapper(request, *args, **kwargs):
-                if not isinstance(request, HttpRequest):
-                    raise TypeError(
-                        "sensitive_post_parameters didn't receive an HttpRequest "
-                        "object. If you are decorating a classmethod, make sure "
-                        "to use @method_decorator."
-                    )
-                if parameters:
-                    request.sensitive_post_parameters = parameters
-                else:
-                    request.sensitive_post_parameters = "__ALL__"
-                return await view(request, *args, **kwargs)
-
-        else:
-
-            @wraps(view)
-            def sensitive_post_parameters_wrapper(request, *args, **kwargs):
-                if not isinstance(request, HttpRequest):
-                    raise TypeError(
-                        "sensitive_post_parameters didn't receive an HttpRequest "
-                        "object. If you are decorating a classmethod, make sure "
-                        "to use @method_decorator."
-                    )
-                if parameters:
-                    request.sensitive_post_parameters = parameters
-                else:
-                    request.sensitive_post_parameters = "__ALL__"
-                return view(request, *args, **kwargs)
+        @wraps(view)
+        def sensitive_post_parameters_wrapper(request, *args, **kwargs):
+            if not isinstance(request, HttpRequest):
+                raise TypeError(
+                    "sensitive_post_parameters didn't receive an HttpRequest "
+                    "object. If you are decorating a classmethod, make sure "
+                    "to use @method_decorator."
+                )
+            if parameters:
+                request.sensitive_post_parameters = parameters
+            else:
+                request.sensitive_post_parameters = "__ALL__"
+            return view(request, *args, **kwargs)
 
         return sensitive_post_parameters_wrapper
 

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -205,10 +205,6 @@ filtered out of error reports in a production environment (that is, where
         exception reporting, and consider implementing a :ref:`custom filter
         <custom-error-reports>` if necessary.
 
-    .. versionchanged:: 5.0
-
-        Support for wrapping ``async`` functions was added.
-
 .. function:: sensitive_post_parameters(*parameters)
 
     If one of your views receives an :class:`~django.http.HttpRequest` object
@@ -248,10 +244,6 @@ filtered out of error reports in a production environment (that is, where
     ``password_reset_confirm``, ``password_change``, and ``add_view`` and
     ``user_change_password`` in the ``auth`` admin) to prevent the leaking of
     sensitive information such as user passwords.
-
-    .. versionchanged:: 5.0
-
-        Support for wrapping ``async`` functions was added.
 
 .. _custom-error-reports:
 

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -215,9 +215,7 @@ Email
 Error Reporting
 ~~~~~~~~~~~~~~~
 
-* :func:`~django.views.decorators.debug.sensitive_variables` and
-  :func:`~django.views.decorators.debug.sensitive_post_parameters` can now be
-  used with asynchronous functions.
+* ...
 
 File Storage
 ~~~~~~~~~~~~

--- a/tests/view_tests/views.py
+++ b/tests/view_tests/views.py
@@ -178,24 +178,6 @@ def sensitive_view(request):
         return technical_500_response(request, *exc_info)
 
 
-@sensitive_variables("sauce")
-@sensitive_post_parameters("bacon-key", "sausage-key")
-async def async_sensitive_view(request):
-    # Do not just use plain strings for the variables' values in the code
-    # so that the tests don't return false positives when the function's source
-    # is displayed in the exception report.
-    cooked_eggs = "".join(["s", "c", "r", "a", "m", "b", "l", "e", "d"])  # NOQA
-    sauce = "".join(  # NOQA
-        ["w", "o", "r", "c", "e", "s", "t", "e", "r", "s", "h", "i", "r", "e"]
-    )
-    try:
-        raise Exception
-    except Exception:
-        exc_info = sys.exc_info()
-        send_log(request, exc_info)
-        return technical_500_response(request, *exc_info)
-
-
 @sensitive_variables()
 @sensitive_post_parameters()
 def paranoid_view(request):


### PR DESCRIPTION
This reverts commits 23cbed21876bf02f4600c0dac3a5277db5b2afbb and 203a15cadbf8d03b51df1b28d89b2e7ab4264973.

I think it's worth keeping warnings added in b00046d2c25771bed2242680b08b524a44aa9798.