### PR TITLE
Fixed #34450 -- Fixed multi-valued JOIN reuse when filtering by expressions.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1373,7 +1373,7 @@ class Query(BaseExpression):
             if not getattr(filter_expr, "conditional", False):
                 raise TypeError("Cannot filter against a non-conditional expression.")
             condition = filter_expr.resolve_expression(
-                self, allow_joins=allow_joins, summarize=summarize
+                self, allow_joins=allow_joins, reuse=can_reuse, summarize=summarize
             )
             if not isinstance(condition, Lookup):
                 condition = self.build_lookup(["exact"], condition, True)

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -1540,9 +1540,17 @@ class LookupQueryingTests(TestCase):
             Season.objects.get(Exact(F("games__home"), "NY") & Q(games__away="Boston")),
             self.s1,
         )
+        with self.assertNumQueries(1) as ctx:
+            self.assertEqual(
+                Season.objects.get(
+                    Exact(F("games__home"), "NY") & Exact(F("games__away"), "Boston")
+                ),
+                self.s1,
+            )
+        self.assertNotIn("LEFT OUTER", ctx.captured_queries[0]["sql"])
+
+    def test_multivalued_isnull(self):
         self.assertEqual(
-            Season.objects.get(
-                Exact(F("games__home"), "NY") & Exact(F("games__away"), "Boston")
-            ),
-            self.s1,
+            Season.objects.get(IsNull(F("games"), True)),
+            self.s2,
         )


### PR DESCRIPTION
Thanks Roman Odaisky for the report.

---

First commit addresses the issue, second one is an optimization for [join promotion](https://gist.github.com/akaariai/a4c1acbfedac0f2cbf3e) that was missing when passing expressions to `filter()`.