### PR TITLE
Fixed #34028 -- Allow usage of script prefix in middleware init

### DIFF
--- a/django/core/asgi.py
+++ b/django/core/asgi.py
@@ -9,5 +9,5 @@ def get_asgi_application():
     Avoids making django.core.handlers.ASGIHandler a public API, in case the
     internal implementation changes or moves in the future.
     """
-    django.setup(set_prefix=False)
+    django.setup()
     return ASGIHandler()

--- a/django/core/wsgi.py
+++ b/django/core/wsgi.py
@@ -9,5 +9,5 @@ def get_wsgi_application():
     Avoids making django.core.handlers.WSGIHandler a public API, in case the
     internal WSGI implementation changes or moves in the future.
     """
-    django.setup(set_prefix=False)
+    django.setup()
     return WSGIHandler()


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/34028

An issue people seem to be having is that Whitenoise wants to access the script prefix in the middleware initialisation (see [here](https://github.com/evansd/whitenoise/blob/08a176a6a3069c5941b3b07328ce0ee896170723/src/whitenoise/middleware.py#L97)). This is giving an unexpected result.

I believe this kind of relates to this ticket: https://code.djangoproject.com/ticket/16734 and this PR: https://github.com/django/django/pull/5470

I'm not sure why this `set_prefix=False` option was created, @claudep I know this is quite a long time ago, but maybe you can add some context?

If we agree with this change, it means all internal usages of `set_prefix` are removed which probably means it makes sense to depreciate it :thinking: I'm not sure, I've never depreciated anything


~Note: asgi is also doing the same`set_prefix=False` - I can remove from there also just not comfortable writing anything async so might need help with the test case~