### PR TITLE
Refs #34434 -- Added note about breaking changes in psycopg version 3 to release notes.

### DIFF
--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -42,8 +42,13 @@ supports both libraries.
 Support for ``psycopg2`` is likely to be deprecated and removed at some point
 in the future.
 
+Be aware that ``psycopg`` 3 introduces some breaking changes over ``psycopg2``.
+As a consequence, you may need to make some changes to account for
+`differences from psycopg2`_.
+
 .. _psycopg: https://www.psycopg.org/psycopg3/
 .. _psycopg library: https://pypi.org/project/psycopg/
+.. _differences from psycopg2: https://www.psycopg.org/psycopg3/docs/basic/from_pg2.html
 
 Comments on columns and tables
 ------------------------------


### PR DESCRIPTION
Hey felixx / triage team,

I saw a couple of tickets of people reporting issues with their raw queries & psycopg3.  I 100% agree that documentation should not be duplicated but thought it might be worth just highlighting that psycopg3 isn't exactly backwards compatible + point them to the psycopg docs so folks don't keep reporting issues :)