### PR TITLE
Solved #10743: Support lookup separators

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ answer newbie questions, and generally made Django that much better:
     Albert Wang <https://github.com/albertyw/>
     Alcides Fonseca
     Aldian Fazrihady <mobile@aldian.net>
+    Alejandro García Ruiz de Oteiza <https://github.com/AlexOteiza>
     Aleksandra Sendecka <asendecka@hauru.eu>
     Aleksi Häkli <aleksi.hakli@iki.fi>
     Alex Dutton <django@alexdutton.co.uk>

--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -901,21 +901,24 @@ class ModelAdminChecks(BaseModelAdminChecks):
             try:
                 field = getattr(obj.model, item)
             except AttributeError:
-                return [
-                    checks.Error(
-                        "The value of '%s' refers to '%s', which is not a "
-                        "callable, an attribute of '%s', or an attribute or "
-                        "method on '%s'."
-                        % (
-                            label,
-                            item,
-                            obj.__class__.__name__,
-                            obj.model._meta.label,
-                        ),
-                        obj=obj.__class__,
-                        id="admin.E108",
-                    )
-                ]
+                try:
+                    field = get_fields_from_path(obj.model, item)[-1]
+                except (FieldDoesNotExist, NotRelationField):
+                    return [
+                        checks.Error(
+                            "The value of '%s' refers to '%s', which is not a "
+                            "callable, an attribute, field of '%s', "
+                            "or an attribute or method on '%s'."
+                            % (
+                                label,
+                                item,
+                                obj.__class__.__name__,
+                                obj.model._meta.label,
+                            ),
+                            obj=obj.__class__,
+                            id="admin.E108",
+                        )
+                    ]
         if isinstance(field, models.ManyToManyField):
             return [
                 checks.Error(

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -565,7 +565,7 @@ subclass::
     If you don't set ``list_display``, the admin site will display a single
     column that displays the ``__str__()`` representation of each object.
 
-    There are four types of values that can be used in ``list_display``. All
+    There are five types of values that can be used in ``list_display``. All
     but the simplest may use the  :func:`~django.contrib.admin.display`
     decorator, which is used to customize how the field is presented:
 
@@ -573,6 +573,11 @@ subclass::
 
           class PersonAdmin(admin.ModelAdmin):
               list_display = ["first_name", "last_name"]
+
+    * The name of foreign field, using the ``__`` notation. For example::
+
+          class PersonAdmin(admin.ModelAdmin):
+              list_display = ["city__name"]
 
     * A callable that accepts one argument, the model instance. For example::
 

--- a/tests/admin_changelist/models.py
+++ b/tests/admin_changelist/models.py
@@ -19,6 +19,12 @@ class Child(models.Model):
     age = models.IntegerField(null=True, blank=True)
 
 
+class GrandChild(models.Model):
+    parent = models.ForeignKey(Child, models.SET_NULL, editable=False, null=True)
+    name = models.CharField(max_length=30, blank=True)
+    age = models.IntegerField(null=True, blank=True)
+
+
 class Genre(models.Model):
     name = models.CharField(max_length=20)
 

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -62,6 +62,7 @@ from .models import (
     CustomIdUser,
     Event,
     Genre,
+    GrandChild,
     Group,
     Invitation,
     Membership,
@@ -1612,6 +1613,21 @@ class ChangeListTests(TestCase):
                 self.assertContains(
                     response, f'0 results (<a href="{href}">1 total</a>)'
                 )
+
+    def test_list_display_foreign_field(self):
+        parent = Parent.objects.create(name="I am your father")
+        child = Child.objects.create(name="I am your child", parent=parent)
+        GrandChild.objects.create(name="I am your grandchild", parent=child)
+        request = self.factory.get("/grandchild/")
+        request.user = self.superuser
+
+        class GrandChildAdminCustom(admin.ModelAdmin):
+            list_display = ["parent__name", "parent__parent__name"]
+
+        m = GrandChildAdminCustom(GrandChild, custom_site)
+        response = m.changelist_view(request)
+        self.assertContains(response, parent.name)
+        self.assertContains(response, child.name)
 
 
 class GetAdminLogTests(TestCase):

--- a/tests/admin_checks/tests.py
+++ b/tests/admin_checks/tests.py
@@ -1008,3 +1008,18 @@ class SystemChecksTestCase(SimpleTestCase):
             self.assertEqual(errors, [])
         finally:
             Book._meta.apps.ready = True
+
+    def test_foreign_list_display(self):
+        class SongAdmin(admin.ModelAdmin):
+            list_display = ["pk", "original_release", "album__title"]
+
+        errors = SongAdmin(Song, AdminSite()).check()
+        self.assertEqual(errors, [])
+
+    def test_foreign_list_display_wrong_field(self):
+        class SongAdmin(admin.ModelAdmin):
+            list_display = ["pk", "original_release", "album__hello"]
+
+        errors = SongAdmin(Song, AdminSite()).check()
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].id, "admin.E108")

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -525,7 +525,7 @@ class ListDisplayTests(CheckTestCase):
             TestModelAdmin,
             ValidationTestModel,
             "The value of 'list_display[0]' refers to 'non_existent_field', "
-            "which is not a callable, an attribute of 'TestModelAdmin', "
+            "which is not a callable, an attribute, field of 'TestModelAdmin', "
             "or an attribute or method on 'modeladmin.ValidationTestModel'.",
             "admin.E108",
         )


### PR DESCRIPTION
Allows using `__` for list_display as in: https://code.djangoproject.com/ticket/10743
Includes doc and tests.

It's my first time contributing to this project, apologies in advance if I got something wrong in the contributing process.

Note: this does not include select_related for the nested fields as stated in the comments since list_view already does use the empty select_related() if there are foreign fields.

```
> python .\runtests.py admin_views
............................ss.................................................................................................................................................................................................................................................................sss...s.ssssssssssssssssssssssssssssss............................................................................................................................
----------------------------------------------------------------------
Ran 449 tests in 26.252s

OK (skipped=36)


> python .\runtests.py admin_checks
..........................................................
----------------------------------------------------------------------
Ran 58 tests in 0.098s

OK


> python .\runtests.py admin_changelist

....ssssssss..................................................................
----------------------------------------------------------------------
Ran 78 tests in 7.247s

OK (skipped=8)
```