### PR TITLE
Refs #34118 -- Fixed CustomChoicesTests.test_uuid_unsupported on Python 3.12+.

### DIFF
--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -16,6 +16,7 @@ PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
 PY310 = sys.version_info >= (3, 10)
 PY311 = sys.version_info >= (3, 11)
+PY312 = sys.version_info >= (3, 12)
 
 
 def get_version(version=None):

--- a/tests/model_enums/tests.py
+++ b/tests/model_enums/tests.py
@@ -8,6 +8,7 @@ from django.template import Context, Template
 from django.test import SimpleTestCase
 from django.utils.functional import Promise
 from django.utils.translation import gettext_lazy as _
+from django.utils.version import PY312
 
 
 class Suit(models.IntegerChoices):
@@ -311,7 +312,10 @@ class CustomChoicesTests(SimpleTestCase):
                 pass
 
     def test_uuid_unsupported(self):
-        msg = "UUID objects are immutable"
+        if PY312:
+            msg = "_value_ not set in __new__, unable to create it"
+        else:
+            msg = "UUID objects are immutable"
         with self.assertRaisesMessage(TypeError, msg):
 
             class Identifier(uuid.UUID, models.Choices):


### PR DESCRIPTION
See https://github.com/python/cpython/commit/2a4d8c0a9e88f45047da640ce5a92b304d2d39b1.