### PR TITLE
Fixed #34459 -- Fixed SearchVector() crash for parameters with % characters.

### DIFF
--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -144,10 +144,7 @@ class SearchVector(SearchVectorCombinable, Func):
             weight_sql, extra_params = compiler.compile(clone.weight)
             sql = "setweight({}, {})".format(sql, weight_sql)
 
-        # These parameters must be bound on the client side because we may
-        # want to create an index on this expression.
-        sql = connection.ops.compose_sql(sql, config_params + params + extra_params)
-        return sql, []
+        return sql, config_params + params + extra_params
 
 
 class CombinedSearchVector(SearchVectorCombinable, CombinedExpression):

--- a/docs/releases/4.2.1.txt
+++ b/docs/releases/4.2.1.txt
@@ -11,3 +11,7 @@ Bugfixes
 
 * Fixed a regression in Django 4.2 that caused a crash of ``QuerySet.defer()``
   when deferring fields by attribute names (:ticket:`34458`).
+
+* Fixed a regression in Django 4.2 that caused a crash of
+  :class:`~django.contrib.postgres.search.SearchVector` function with ``%``
+  characters (:ticket:`34459`).

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -539,6 +539,21 @@ class SchemaTests(PostgreSQLTestCase):
             editor.remove_index(Scene, index)
         self.assertNotIn(index_name, self.get_constraints(table))
 
+    def test_search_vector(self):
+        """SearchVector generates IMMUTABLE SQL in order to be indexable."""
+        index_name = "test_search_vector"
+        index = Index(SearchVector("id", "scene", config="english"), name=index_name)
+        # Indexed function must be IMMUTABLE.
+        with connection.schema_editor() as editor:
+            editor.add_index(Scene, index)
+        constraints = self.get_constraints(Scene._meta.db_table)
+        self.assertIn(index_name, constraints)
+        self.assertIs(constraints[index_name]["index"], True)
+
+        with connection.schema_editor() as editor:
+            editor.remove_index(Scene, index)
+        self.assertNotIn(index_name, self.get_constraints(Scene._meta.db_table))
+
     def test_hash_index(self):
         # Ensure the table is there and doesn't have an index.
         self.assertNotIn("field", self.get_constraints(CharFieldModel._meta.db_table))

--- a/tests/postgres_tests/test_search.py
+++ b/tests/postgres_tests/test_search.py
@@ -5,7 +5,6 @@ These tests use dialogue from the 1975 film Monty Python and the Holy Grail.
 All text copyright Python (Monty) Pictures. Thanks to sacred-texts.com for the
 transcript.
 """
-from django.db import connection
 from django.db.models import F, Value
 
 from . import PostgreSQLSimpleTestCase, PostgreSQLTestCase
@@ -607,26 +606,6 @@ class TestRankingAndWeights(GrailTestData, PostgreSQLTestCase):
             searched,
             [self.verse2, self.verse1, self.verse0, short_verse],
         )
-
-
-class SearchVectorIndexTests(PostgreSQLTestCase):
-    def test_search_vector_index(self):
-        """SearchVector generates IMMUTABLE SQL in order to be indexable."""
-        # This test should be moved to test_indexes and use a functional
-        # index instead once support lands (see #26167).
-        query = Line.objects.all().query
-        resolved = SearchVector("id", "dialogue", config="english").resolve_expression(
-            query
-        )
-        compiler = query.get_compiler(connection.alias)
-        sql, params = resolved.as_sql(compiler, connection)
-        # Indexed function must be IMMUTABLE.
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "CREATE INDEX search_vector_index ON %s USING GIN (%s)"
-                % (Line._meta.db_table, sql),
-                params,
-            )
 
 
 class SearchQueryTests(PostgreSQLSimpleTestCase):

--- a/tests/postgres_tests/test_search.py
+++ b/tests/postgres_tests/test_search.py
@@ -160,6 +160,12 @@ class SearchVectorFieldTest(GrailTestData, PostgreSQLTestCase):
         )
         self.assertNotIn("COALESCE(COALESCE", str(searched.query))
 
+    def test_values_with_percent(self):
+        searched = Line.objects.annotate(
+            search=SearchVector(Value("This week everything is 10% off"))
+        ).filter(search="10 % off")
+        self.assertEqual(len(searched), 9)
+
 
 class SearchConfigTests(PostgreSQLSimpleTestCase):
     def test_from_parameter(self):


### PR DESCRIPTION
Thanks Patryk Zawadzki for the report.

Regression in 09ffc5c1212d4ced58b708cbbf3dfbfb77b782ca.

TO DO:
- [x] release notes
- [x] ~~test for creating and index with `SearchVector`~~ (already tested in `postgres_tests.test_search.SearchVectorIndexTests.test_search_vector_index`)
- [x] ~~add `adapt_value()` to `psycopg_any` and use it in `SearchHeadline.as_sql()`~~ EDIT: unnecessary as composed options are passed in params)