### PR TITLE
Fixed #34455 -- Restored i18n_patterns() respect of prefix_default_language argument when fallback language is used.

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -23,7 +23,7 @@ from django.utils.datastructures import MultiValueDict
 from django.utils.functional import cached_property
 from django.utils.http import RFC3986_SUBDELIMS, escape_leading_slashes
 from django.utils.regex_helper import _lazy_re_compile, normalize
-from django.utils.translation import get_language
+from django.utils.translation import get_language, get_supported_language_variant
 
 from .converters import get_converter
 from .exceptions import NoReverseMatch, Resolver404
@@ -351,7 +351,8 @@ class LocalePrefixPattern:
     @property
     def language_prefix(self):
         language_code = get_language() or settings.LANGUAGE_CODE
-        if language_code == settings.LANGUAGE_CODE and not self.prefix_default_language:
+        default_language = get_supported_language_variant(settings.LANGUAGE_CODE)
+        if language_code == default_language and not self.prefix_default_language:
             return ""
         else:
             return "%s/" % language_code

--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "get_language_from_request",
     "get_language_info",
     "get_language_bidi",
+    "get_supported_language_variant",
     "check_for_language",
     "to_language",
     "to_locale",

--- a/docs/releases/4.2.1.txt
+++ b/docs/releases/4.2.1.txt
@@ -25,3 +25,7 @@ Bugfixes
 
 * Enforced UTF-8 client encoding on PostgreSQL, following a regression in
   Django 4.2 (:ticket:`34470`).
+
+* Fixed a regression in Django 4.2 where ``i18n_patterns()`` didn't respect the
+  ``prefix_default_language`` argument when a fallback language of the default
+  language was used (:ticket:`34455`).

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1916,6 +1916,12 @@ class UnprefixedDefaultLanguageTests(SimpleTestCase):
         response = self.client.get("/simple/")
         self.assertEqual(response.content, b"Yes")
 
+    @override_settings(LANGUAGE_CODE="en-us")
+    def test_default_lang_fallback_without_prefix(self):
+        response = self.client.get("/simple/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"Yes")
+
     def test_other_lang_with_prefix(self):
         response = self.client.get("/fr/simple/")
         self.assertEqual(response.content, b"Oui")


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/34455