### PR TITLE
Fixed #34466 -- Reallowed setting cursor_factory in DATABASES["options"] on PostgreSQL.

### DIFF
--- a/docs/releases/4.2.1.txt
+++ b/docs/releases/4.2.1.txt
@@ -18,3 +18,7 @@ Bugfixes
 
 * Fixed a regression in Django 4.2 that caused aggregation over query that
   uses explicit grouping to group against the wrong columns (:ticket:`34464`).
+
+* Reallowed, following a regression in Django 4.2, setting the
+  ``"cursor_factory"`` option in :setting:`OPTIONS` on PostgreSQL
+  (:ticket:`34466`).

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -296,6 +296,24 @@ class Tests(TestCase):
         finally:
             new_connection.close()
 
+    def test_connect_custom_cursor_factory(self):
+        """
+        A custom cursor factory can be configured with DATABASES["options"]
+        ["cursor_factory"].
+        """
+        from django.db.backends.postgresql.base import Cursor
+
+        class MyCursor(Cursor):
+            pass
+
+        new_connection = connection.copy()
+        new_connection.settings_dict["OPTIONS"]["cursor_factory"] = MyCursor
+        try:
+            new_connection.connect()
+            self.assertEqual(new_connection.connection.cursor_factory, MyCursor)
+        finally:
+            new_connection.close()
+
     def test_connect_no_is_usable_checks(self):
         new_connection = connection.copy()
         try:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34466