### PR TITLE
Refs #34118 -- Fixed CustomChoicesTests.test_uuid_unsupported on Python 3.11.4+

### DIFF
--- a/tests/model_enums/tests.py
+++ b/tests/model_enums/tests.py
@@ -8,7 +8,6 @@ from django.template import Context, Template
 from django.test import SimpleTestCase
 from django.utils.functional import Promise
 from django.utils.translation import gettext_lazy as _
-from django.utils.version import PY312
 
 
 class Suit(models.IntegerChoices):
@@ -312,11 +311,7 @@ class CustomChoicesTests(SimpleTestCase):
                 pass
 
     def test_uuid_unsupported(self):
-        if PY312:
-            msg = "_value_ not set in __new__, unable to create it"
-        else:
-            msg = "UUID objects are immutable"
-        with self.assertRaisesMessage(TypeError, msg):
+        with self.assertRaises(TypeError):
 
             class Identifier(uuid.UUID, models.Choices):
                 A = "972ce4eb-a95f-4a56-9339-68c208a76f18"


### PR DESCRIPTION
Unfortunately https://github.com/python/cpython/commit/2a4d8c0a9e88f45047da640ce5a92b304d2d39b1 was backported to Python 3.11 https://github.com/python/cpython/commit/5342f5e713e0cc45b6f226d2d053a8cde1b4d68e

I don't think it's worth checking an error message anymore.

Follow up to 38e63c9e61152682f3ff982c85a73793ab6d3267.