### PR TITLE
Fixed #34470 -- Enforced UTF-8 encoding on PostgreSQL.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -208,7 +208,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                     self.ops.max_name_length(),
                 )
             )
-        conn_params = {"client_encoding": "UTF8"}
         if settings_dict["NAME"]:
             conn_params = {
                 "dbname": settings_dict["NAME"],
@@ -220,6 +219,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             conn_params = {"dbname": "postgres", **settings_dict["OPTIONS"]}
         else:
             conn_params = {**settings_dict["OPTIONS"]}
+        conn_params["client_encoding"] = "UTF8"
 
         conn_params.pop("assume_role", None)
         conn_params.pop("isolation_level", None)

--- a/docs/releases/4.2.1.txt
+++ b/docs/releases/4.2.1.txt
@@ -22,3 +22,6 @@ Bugfixes
 * Reallowed, following a regression in Django 4.2, setting the
   ``"cursor_factory"`` option in :setting:`OPTIONS` on PostgreSQL
   (:ticket:`34466`).
+
+* Enforced UTF-8 client encoding on PostgreSQL, following a regression in
+  Django 4.2 (:ticket:`34470`).

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -323,6 +323,18 @@ class Tests(TestCase):
         finally:
             new_connection.close()
 
+    def test_client_encoding_utf8_enforce(self):
+        new_connection = connection.copy()
+        new_connection.settings_dict["OPTIONS"]["client_encoding"] = "iso-8859-2"
+        try:
+            new_connection.connect()
+            if is_psycopg3:
+                self.assertEqual(new_connection.connection.info.encoding, "utf-8")
+            else:
+                self.assertEqual(new_connection.connection.encoding, "UTF8")
+        finally:
+            new_connection.close()
+
     def _select(self, val):
         with connection.cursor() as cursor:
             cursor.execute("SELECT %s::text[]", (val,))


### PR DESCRIPTION
Regression in 6a2165816394ab4bb259f6171e82417e098e97a6.

ticket-34470