### PR TITLE
Fix inspectdb can process foreign keys that are in another database (MariaDb/Mysql)

### DIFF
--- a/django/db/backends/base/introspection.py
+++ b/django/db/backends/base/introspection.py
@@ -173,11 +173,11 @@ class BaseDatabaseIntrospection:
             "get_relations() method."
         )
 
-    def get_primary_key_column(self, cursor, table_name):
+    def get_primary_key_column(self, cursor, table_name, ref_db_name = ''):
         """
         Return the name of the primary key column for the given table.
         """
-        for constraint in self.get_constraints(cursor, table_name).values():
+        for constraint in self.get_constraints(cursor, table_name, ref_db_name).values():
             if constraint["primary_key"]:
                 return constraint["columns"][0]
         return None


### PR DESCRIPTION
I have modified the files in version 4.1
django/db/backends/mysql/introspection.py
django/db/backends/base/introspection.py

Now inspectdb can process foreign keys that are outside of the current MariaDb/Mysql database.


My first contribution to an important Github repository, I hope to do it well. Thank you for your support.