### PR TITLE
Fix #34477: Add asyncio Base, Console, and Dummy email backends

### DIFF
--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -32,8 +32,11 @@ __all__ = [
     "BadHeaderError",
     "forbid_multi_line_headers",
     "get_connection",
+    "aget_connection",
     "send_mail",
+    "asend_mail",
     "send_mass_mail",
+    "asend_mass_mail",
     "mail_admins",
     "mail_managers",
 ]
@@ -49,6 +52,15 @@ def get_connection(backend=None, fail_silently=False, **kwds):
     """
     klass = import_string(backend or settings.EMAIL_BACKEND)
     return klass(fail_silently=fail_silently, **kwds)
+
+
+async def aget_connection(backend=None, fail_silently=False, **kwds):
+    """See get_connection()."""
+    klass = import_string(backend or settings.EMAIL_BACKEND)
+    connection = klass(fail_silently=fail_silently, **kwds)
+    if hasattr(connection, "astart"):
+        await connection.astart()
+    return connection
 
 
 def send_mail(
@@ -87,6 +99,37 @@ def send_mail(
     return mail.send()
 
 
+async def asend_mail(
+    subject,
+    message,
+    from_email,
+    recipient_list,
+    fail_silently=False,
+    auth_user=None,
+    auth_password=None,
+    connection=None,
+    html_message=None,
+):
+    """
+    See send_mail().
+
+    Note: The API for this method is frozen. New code wanting to extend the
+    functionality should use the EmailMessage class directly.
+    """
+    connection = connection or await aget_connection(
+        username=auth_user,
+        password=auth_password,
+        fail_silently=fail_silently,
+    )
+    mail = EmailMultiAlternatives(
+        subject, message, from_email, recipient_list, connection=connection
+    )
+    if html_message:
+        mail.attach_alternative(html_message, "text/html")
+
+    return await mail.asend()
+
+
 def send_mass_mail(
     datatuple, fail_silently=False, auth_user=None, auth_password=None, connection=None
 ):
@@ -114,10 +157,27 @@ def send_mass_mail(
     return connection.send_messages(messages)
 
 
-def mail_admins(
+async def asend_mass_mail(
+    datatuple, fail_silently=False, auth_user=None, auth_password=None, connection=None
+):
+    """
+    See send_mass_mail().
+    """
+    connection = connection or await aget_connection(
+        username=auth_user,
+        password=auth_password,
+        fail_silently=fail_silently,
+    )
+    messages = [
+        EmailMessage(subject, message, sender, recipient, connection=connection)
+        for subject, message, sender, recipient in datatuple
+    ]
+    return await connection.asend_messages(messages)
+
+
+def _base_mail_admins(
     subject, message, fail_silently=False, connection=None, html_message=None
 ):
-    """Send a message to the admins, as defined by the ADMINS setting."""
     if not settings.ADMINS:
         return
     if not all(isinstance(a, (list, tuple)) and len(a) == 2 for a in settings.ADMINS):
@@ -131,13 +191,27 @@ def mail_admins(
     )
     if html_message:
         mail.attach_alternative(html_message, "text/html")
+    return mail
+
+
+def mail_admins(
+    subject, message, fail_silently=False, connection=None, html_message=None
+):
+    """Send a message to the admins, as defined by the ADMINS setting."""
+    mail = _base_mail_admins(subject, message, fail_silently, connection, html_message)
     mail.send(fail_silently=fail_silently)
 
 
-def mail_managers(
+async def amail_admins(
     subject, message, fail_silently=False, connection=None, html_message=None
 ):
-    """Send a message to the managers, as defined by the MANAGERS setting."""
+    mail = _base_mail_admins(subject, message, fail_silently, connection, html_message)
+    await mail.asend(fail_silently=fail_silently)
+
+
+def _base_mail_managers(
+    subject, message, fail_silently=False, connection=None, html_message=None
+):
     if not settings.MANAGERS:
         return
     if not all(isinstance(a, (list, tuple)) and len(a) == 2 for a in settings.MANAGERS):
@@ -151,4 +225,24 @@ def mail_managers(
     )
     if html_message:
         mail.attach_alternative(html_message, "text/html")
+    return mail
+
+
+def mail_managers(
+    subject, message, fail_silently=False, connection=None, html_message=None
+):
+    """Send a message to the managers, as defined by the MANAGERS setting."""
+    mail = _base_mail_managers(
+        subject, message, fail_silently, connection, html_message
+    )
     mail.send(fail_silently=fail_silently)
+
+
+async def amail_managers(
+    subject, message, fail_silently=False, connection=None, html_message=None
+):
+    """Send a message to the managers, as defined by the MANAGERS setting."""
+    mail = _base_mail_managers(
+        subject, message, fail_silently, connection, html_message
+    )
+    await mail.asend(fail_silently=fail_silently)

--- a/django/core/mail/backends/base.py
+++ b/django/core/mail/backends/base.py
@@ -37,8 +37,16 @@ class BaseEmailBackend:
         """
         pass
 
+    async def aopen(self):
+        """See open()."""
+        pass
+
     def close(self):
         """Close a network connection."""
+        pass
+
+    async def aclose(self):
+        """See close()."""
         pass
 
     def __enter__(self):
@@ -52,7 +60,27 @@ class BaseEmailBackend:
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
+    async def __aenter__(self):
+        try:
+            await self.aopen()
+        except Exception:
+            await self.aclose()
+            raise
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.aclose()
+
     def send_messages(self, email_messages):
+        """
+        Send one or more EmailMessage objects and return the number of email
+        messages sent.
+        """
+        raise NotImplementedError(
+            "subclasses of BaseEmailBackend must override send_messages() method"
+        )
+
+    async def asend_messages(self, email_messages):
         """
         Send one or more EmailMessage objects and return the number of email
         messages sent.

--- a/django/core/mail/backends/console.py
+++ b/django/core/mail/backends/console.py
@@ -1,6 +1,7 @@
 """
 Email backend that writes messages to console instead of sending them.
 """
+import asyncio
 import sys
 import threading
 
@@ -11,7 +12,23 @@ class EmailBackend(BaseEmailBackend):
     def __init__(self, *args, **kwargs):
         self.stream = kwargs.pop("stream", sys.stdout)
         self._lock = threading.RLock()
+        self.astream = kwargs.pop("astream", None)
+        self._alock = asyncio.Lock()
         super().__init__(*args, **kwargs)
+
+    async def astart(self):
+        _, self.astream = await self.get_default_astream()
+
+    async def get_default_astream(self):
+        loop = asyncio.get_event_loop()
+        reader = asyncio.StreamReader()
+        protocol = asyncio.StreamReaderProtocol(reader)
+        await loop.connect_read_pipe(lambda: protocol, sys.stdin)
+        w_transport, w_protocol = await loop.connect_write_pipe(
+            asyncio.streams.FlowControlMixin, sys.stdout
+        )
+        writer = asyncio.StreamWriter(w_transport, w_protocol, reader, loop)
+        return reader, writer
 
     def write_message(self, message):
         msg = message.message()
@@ -38,6 +55,36 @@ class EmailBackend(BaseEmailBackend):
                     msg_count += 1
                 if stream_created:
                     self.close()
+            except Exception:
+                if not self.fail_silently:
+                    raise
+        return msg_count
+
+    async def awrite_messages(self, message):
+        msg = message.message()
+        msg_data = msg.as_bytes()
+        charset = (
+            msg.get_charset().get_output_charset() if msg.get_charset() else "utf-8"
+        )
+        msg_data = msg_data.decode(charset)
+        self.astream.write(("%s\n" % msg_data).encode())
+        self.astream.write(("-" * 79).encode())
+        self.astream.write(b"\n")
+
+    async def asend_messages(self, email_messages):
+        """Write all messages to the stream in a thread-safe way."""
+        if not email_messages:
+            return
+        msg_count = 0
+        async with self._alock:
+            try:
+                stream_created = await self.aopen()
+                for message in email_messages:
+                    self.write_message(message)
+                    self.stream.flush()  # flush after each message
+                    msg_count += 1
+                if stream_created:
+                    await self.aclose()
             except Exception:
                 if not self.fail_silently:
                     raise

--- a/django/core/mail/backends/dummy.py
+++ b/django/core/mail/backends/dummy.py
@@ -8,3 +8,6 @@ from django.core.mail.backends.base import BaseEmailBackend
 class EmailBackend(BaseEmailBackend):
     def send_messages(self, email_messages):
         return len(list(email_messages))
+
+    async def asend_messages(self, email_messages):
+        return self.send_messages(email_messages)

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -255,6 +255,13 @@ class EmailMessage:
             self.connection = get_connection(fail_silently=fail_silently)
         return self.connection
 
+    async def aget_connection(self, fail_silently=False):
+        from django.core.mail import aget_connection
+
+        if not self.connection:
+            self.connection = await aget_connection(fail_silently=fail_silently)
+        return self.connection
+
     def message(self):
         encoding = self.encoding or settings.DEFAULT_CHARSET
         msg = SafeMIMEText(self.body, self.content_subtype, encoding)
@@ -296,6 +303,14 @@ class EmailMessage:
             # send to.
             return 0
         return self.get_connection(fail_silently).send_messages([self])
+
+    async def asend(self, fail_silently=False):
+        """Send the email message."""
+        if not self.recipients():
+            # Don't bother creating the network connection if there's nobody to
+            # send to.
+            return 0
+        return await (await self.aget_connection(fail_silently)).asend_messages([self])
 
     def attach(self, filename=None, content=None, mimetype=None):
         """


### PR DESCRIPTION
WIP

[#34477](https://code.djangoproject.com/ticket/34477#ticket)

Migrated from personal project; it differs from my implementation in that it adds an `aget_connection` function.

Does not implement locmem backend because it needs further discussion (possibility that we'll need to replace the list being set in the mail module with a contextvar).