### PR TITLE
Refs #32398 -- Added is_nullable() to BaseExpression.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -9,8 +9,8 @@ from uuid import UUID
 
 from django.core.exceptions import EmptyResultSet, FieldError, FullResultSet
 from django.db import (
-    DatabaseError,
     DEFAULT_DB_ALIAS,
+    DatabaseError,
     NotSupportedError,
     connection,
     connections,

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -8,7 +8,13 @@ from types import NoneType
 from uuid import UUID
 
 from django.core.exceptions import EmptyResultSet, FieldError, FullResultSet
-from django.db import DatabaseError, NotSupportedError, connection
+from django.db import (
+    DatabaseError,
+    DEFAULT_DB_ALIAS,
+    NotSupportedError,
+    connection,
+    connections,
+)
 from django.db.models import fields
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query_utils import Q
@@ -341,6 +347,28 @@ class BaseExpression:
                         )
                     )
             return output_field
+
+    def is_nullable(self, field=None):
+        """
+        Check if the given field should be treated as nullable.
+
+        Some backends treat '' as null and Django treats such fields as
+        nullable for those backends. In such situations field.null can be
+        False even if we should treat the field as nullable.
+        """
+        # We need to use DEFAULT_DB_ALIAS here, as QuerySet does not have
+        # (nor should it have) knowledge of which connection is going to be
+        # used. The proper fix would be to defer all decisions where
+        # is_nullable() is needed to the compiler stage, but that is not easy
+        # to do currently.
+        if field is None:
+            field = self._output_field_or_none
+        if not isinstance(field, fields.Field):
+            return False
+        return field.null or (
+            field.empty_strings_allowed
+            and connections[DEFAULT_DB_ALIAS].features.interprets_empty_strings_as_nulls
+        )
 
     @staticmethod
     def _convert_value_noop(value, expression, connection):

--- a/django/db/models/functions/comparison.py
+++ b/django/db/models/functions/comparison.py
@@ -1,5 +1,5 @@
 """Database functions that do comparisons or type conversions."""
-from django.db import connections, DEFAULT_DB_ALIAS, NotSupportedError
+from django.db import DEFAULT_DB_ALIAS, NotSupportedError, connections
 from django.db.models.expressions import Func, Value
 from django.db.models.fields import TextField
 from django.db.models.fields.json import JSONField
@@ -11,8 +11,11 @@ class TextFuncMixin:
     Text functions should not be considered nullable on databases that
     cannot distinguish between empty strings and nulls.
     """
+
     def is_nullable(self, field=None):
-        return not connections[DEFAULT_DB_ALIAS].features.interprets_empty_strings_as_nulls
+        return not connections[
+            DEFAULT_DB_ALIAS
+        ].features.interprets_empty_strings_as_nulls
 
 
 class Cast(Func):

--- a/django/db/models/functions/comparison.py
+++ b/django/db/models/functions/comparison.py
@@ -114,7 +114,7 @@ class Coalesce(Func):
         return self.as_sql(compiler, connection, **extra_context)
 
 
-class Collate(Func, TextFuncMixin):
+class Collate(TextFuncMixin, Func):
     function = "COLLATE"
     template = "%(expressions)s %(function)s %(collation)s"
     # Inspired from

--- a/django/db/models/functions/comparison.py
+++ b/django/db/models/functions/comparison.py
@@ -1,9 +1,18 @@
 """Database functions that do comparisons or type conversions."""
-from django.db import NotSupportedError
+from django.db import connections, DEFAULT_DB_ALIAS, NotSupportedError
 from django.db.models.expressions import Func, Value
 from django.db.models.fields import TextField
 from django.db.models.fields.json import JSONField
 from django.utils.regex_helper import _lazy_re_compile
+
+
+class TextFuncMixin:
+    """
+    Text functions should not be considered nullable on databases that
+    cannot distinguish between empty strings and nulls.
+    """
+    def is_nullable(self, field=None):
+        return not connections[DEFAULT_DB_ALIAS].features.interprets_empty_strings_as_nulls
 
 
 class Cast(Func):
@@ -102,7 +111,7 @@ class Coalesce(Func):
         return self.as_sql(compiler, connection, **extra_context)
 
 
-class Collate(Func):
+class Collate(Func, TextFuncMixin):
     function = "COLLATE"
     template = "%(expressions)s %(function)s %(collation)s"
     # Inspired from
@@ -186,6 +195,9 @@ class JSONObject(Func):
             template="%(function)s(%(expressions)s RETURNING CLOB)",
             **extra_context,
         )
+
+    def is_nullable(self, field=None):
+        return False
 
 
 class Least(Func):

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -215,6 +215,9 @@ class Now(Func):
     template = "CURRENT_TIMESTAMP"
     output_field = DateTimeField()
 
+    def is_nullable(self, field=None):
+        return False
+
     def as_postgresql(self, compiler, connection, **extra_context):
         # PostgreSQL's CURRENT_TIMESTAMP means "the time at the start of the
         # transaction". Use STATEMENT_TIMESTAMP to be cross-compatible with

--- a/django/db/models/functions/math.py
+++ b/django/db/models/functions/math.py
@@ -130,6 +130,9 @@ class Pi(NumericOutputFieldMixin, Func):
     function = "PI"
     arity = 0
 
+    def is_nullable(self, field=None):
+        return False
+
     def as_oracle(self, compiler, connection, **extra_context):
         return super().as_sql(
             compiler, connection, template=str(math.pi), **extra_context
@@ -157,6 +160,9 @@ class Radians(NumericOutputFieldMixin, Transform):
 class Random(NumericOutputFieldMixin, Func):
     function = "RANDOM"
     arity = 0
+
+    def is_nullable(self, field=None):
+        return False
 
     def as_mysql(self, compiler, connection, **extra_context):
         return super().as_sql(compiler, connection, function="RAND", **extra_context)

--- a/django/db/models/functions/text.py
+++ b/django/db/models/functions/text.py
@@ -2,6 +2,7 @@ from django.db import NotSupportedError
 from django.db.models.expressions import Func, Value
 from django.db.models.fields import CharField, IntegerField, TextField
 from django.db.models.functions import Cast, Coalesce
+from django.db.models.functions.comparison import TextFuncMixin
 from django.db.models.lookups import Transform
 
 
@@ -142,8 +143,11 @@ class Concat(Func):
             return ConcatPair(*expressions)
         return ConcatPair(expressions[0], self._paired(expressions[1:]))
 
+    def is_nullable(self, field=None):
+        return False
 
-class Left(Func):
+
+class Left(Func, TextFuncMixin):
     function = "LEFT"
     arity = 2
     output_field = CharField()
@@ -168,7 +172,7 @@ class Left(Func):
         return self.get_substr().as_sqlite(compiler, connection, **extra_context)
 
 
-class Length(Transform):
+class Length(Transform, TextFuncMixin):
     """Return the number of characters in the expression."""
 
     function = "LENGTH"
@@ -181,12 +185,12 @@ class Length(Transform):
         )
 
 
-class Lower(Transform):
+class Lower(Transform, TextFuncMixin):
     function = "LOWER"
     lookup_name = "lower"
 
 
-class LPad(Func):
+class LPad(Func, TextFuncMixin):
     function = "LPAD"
     output_field = CharField()
 
@@ -200,17 +204,17 @@ class LPad(Func):
         super().__init__(expression, length, fill_text, **extra)
 
 
-class LTrim(Transform):
+class LTrim(Transform, TextFuncMixin):
     function = "LTRIM"
     lookup_name = "ltrim"
 
 
-class MD5(OracleHashMixin, Transform):
+class MD5(OracleHashMixin, Transform, TextFuncMixin):
     function = "MD5"
     lookup_name = "md5"
 
 
-class Ord(Transform):
+class Ord(Transform, TextFuncMixin):
     function = "ASCII"
     lookup_name = "ord"
     output_field = IntegerField()
@@ -222,7 +226,7 @@ class Ord(Transform):
         return super().as_sql(compiler, connection, function="UNICODE", **extra_context)
 
 
-class Repeat(Func):
+class Repeat(Func, TextFuncMixin):
     function = "REPEAT"
     output_field = CharField()
 
@@ -242,14 +246,14 @@ class Repeat(Func):
         return rpad.as_sql(compiler, connection, **extra_context)
 
 
-class Replace(Func):
+class Replace(Func, TextFuncMixin):
     function = "REPLACE"
 
     def __init__(self, expression, text, replacement=Value(""), **extra):
         super().__init__(expression, text, replacement, **extra)
 
 
-class Reverse(Transform):
+class Reverse(Transform, TextFuncMixin):
     function = "REVERSE"
     lookup_name = "reverse"
 
@@ -282,17 +286,17 @@ class RPad(LPad):
     function = "RPAD"
 
 
-class RTrim(Transform):
+class RTrim(Transform, TextFuncMixin):
     function = "RTRIM"
     lookup_name = "rtrim"
 
 
-class SHA1(OracleHashMixin, PostgreSQLSHAMixin, Transform):
+class SHA1(OracleHashMixin, PostgreSQLSHAMixin, Transform, TextFuncMixin):
     function = "SHA1"
     lookup_name = "sha1"
 
 
-class SHA224(MySQLSHA2Mixin, PostgreSQLSHAMixin, Transform):
+class SHA224(MySQLSHA2Mixin, PostgreSQLSHAMixin, Transform, TextFuncMixin):
     function = "SHA224"
     lookup_name = "sha224"
 
@@ -300,22 +304,28 @@ class SHA224(MySQLSHA2Mixin, PostgreSQLSHAMixin, Transform):
         raise NotSupportedError("SHA224 is not supported on Oracle.")
 
 
-class SHA256(MySQLSHA2Mixin, OracleHashMixin, PostgreSQLSHAMixin, Transform):
+class SHA256(
+    MySQLSHA2Mixin, OracleHashMixin, PostgreSQLSHAMixin, Transform, TextFuncMixin
+):
     function = "SHA256"
     lookup_name = "sha256"
 
 
-class SHA384(MySQLSHA2Mixin, OracleHashMixin, PostgreSQLSHAMixin, Transform):
+class SHA384(
+    MySQLSHA2Mixin, OracleHashMixin, PostgreSQLSHAMixin, Transform, TextFuncMixin
+):
     function = "SHA384"
     lookup_name = "sha384"
 
 
-class SHA512(MySQLSHA2Mixin, OracleHashMixin, PostgreSQLSHAMixin, Transform):
+class SHA512(
+    MySQLSHA2Mixin, OracleHashMixin, PostgreSQLSHAMixin, Transform, TextFuncMixin
+):
     function = "SHA512"
     lookup_name = "sha512"
 
 
-class StrIndex(Func):
+class StrIndex(Func, TextFuncMixin):
     """
     Return a positive integer corresponding to the 1-indexed position of the
     first occurrence of a substring inside another string, or 0 if the
@@ -330,7 +340,7 @@ class StrIndex(Func):
         return super().as_sql(compiler, connection, function="STRPOS", **extra_context)
 
 
-class Substr(Func):
+class Substr(Func, TextFuncMixin):
     function = "SUBSTRING"
     output_field = CharField()
 
@@ -355,11 +365,11 @@ class Substr(Func):
         return super().as_sql(compiler, connection, function="SUBSTR", **extra_context)
 
 
-class Trim(Transform):
+class Trim(Transform, TextFuncMixin):
     function = "TRIM"
     lookup_name = "trim"
 
 
-class Upper(Transform):
+class Upper(Transform, TextFuncMixin):
     function = "UPPER"
     lookup_name = "upper"

--- a/django/db/models/functions/text.py
+++ b/django/db/models/functions/text.py
@@ -147,7 +147,7 @@ class Concat(Func):
         return False
 
 
-class Left(Func, TextFuncMixin):
+class Left(TextFuncMixin, Func):
     function = "LEFT"
     arity = 2
     output_field = CharField()
@@ -172,7 +172,7 @@ class Left(Func, TextFuncMixin):
         return self.get_substr().as_sqlite(compiler, connection, **extra_context)
 
 
-class Length(Transform, TextFuncMixin):
+class Length(TextFuncMixin, Transform):
     """Return the number of characters in the expression."""
 
     function = "LENGTH"
@@ -185,12 +185,12 @@ class Length(Transform, TextFuncMixin):
         )
 
 
-class Lower(Transform, TextFuncMixin):
+class Lower(TextFuncMixin, Transform):
     function = "LOWER"
     lookup_name = "lower"
 
 
-class LPad(Func, TextFuncMixin):
+class LPad(TextFuncMixin, Func):
     function = "LPAD"
     output_field = CharField()
 
@@ -204,17 +204,17 @@ class LPad(Func, TextFuncMixin):
         super().__init__(expression, length, fill_text, **extra)
 
 
-class LTrim(Transform, TextFuncMixin):
+class LTrim(TextFuncMixin, Transform):
     function = "LTRIM"
     lookup_name = "ltrim"
 
 
-class MD5(OracleHashMixin, Transform, TextFuncMixin):
+class MD5(OracleHashMixin, TextFuncMixin, Transform):
     function = "MD5"
     lookup_name = "md5"
 
 
-class Ord(Transform, TextFuncMixin):
+class Ord(TextFuncMixin, Transform):
     function = "ASCII"
     lookup_name = "ord"
     output_field = IntegerField()
@@ -226,7 +226,7 @@ class Ord(Transform, TextFuncMixin):
         return super().as_sql(compiler, connection, function="UNICODE", **extra_context)
 
 
-class Repeat(Func, TextFuncMixin):
+class Repeat(TextFuncMixin, Func):
     function = "REPEAT"
     output_field = CharField()
 
@@ -246,14 +246,14 @@ class Repeat(Func, TextFuncMixin):
         return rpad.as_sql(compiler, connection, **extra_context)
 
 
-class Replace(Func, TextFuncMixin):
+class Replace(TextFuncMixin, Func):
     function = "REPLACE"
 
     def __init__(self, expression, text, replacement=Value(""), **extra):
         super().__init__(expression, text, replacement, **extra)
 
 
-class Reverse(Transform, TextFuncMixin):
+class Reverse(TextFuncMixin, Transform):
     function = "REVERSE"
     lookup_name = "reverse"
 
@@ -286,17 +286,17 @@ class RPad(LPad):
     function = "RPAD"
 
 
-class RTrim(Transform, TextFuncMixin):
+class RTrim(TextFuncMixin, Transform):
     function = "RTRIM"
     lookup_name = "rtrim"
 
 
-class SHA1(OracleHashMixin, PostgreSQLSHAMixin, Transform, TextFuncMixin):
+class SHA1(OracleHashMixin, PostgreSQLSHAMixin, TextFuncMixin, Transform):
     function = "SHA1"
     lookup_name = "sha1"
 
 
-class SHA224(MySQLSHA2Mixin, PostgreSQLSHAMixin, Transform, TextFuncMixin):
+class SHA224(MySQLSHA2Mixin, PostgreSQLSHAMixin, TextFuncMixin, Transform):
     function = "SHA224"
     lookup_name = "sha224"
 
@@ -305,27 +305,27 @@ class SHA224(MySQLSHA2Mixin, PostgreSQLSHAMixin, Transform, TextFuncMixin):
 
 
 class SHA256(
-    MySQLSHA2Mixin, OracleHashMixin, PostgreSQLSHAMixin, Transform, TextFuncMixin
+    MySQLSHA2Mixin, OracleHashMixin, PostgreSQLSHAMixin, TextFuncMixin, Transform
 ):
     function = "SHA256"
     lookup_name = "sha256"
 
 
 class SHA384(
-    MySQLSHA2Mixin, OracleHashMixin, PostgreSQLSHAMixin, Transform, TextFuncMixin
+    MySQLSHA2Mixin, OracleHashMixin, PostgreSQLSHAMixin, TextFuncMixin, Transform
 ):
     function = "SHA384"
     lookup_name = "sha384"
 
 
 class SHA512(
-    MySQLSHA2Mixin, OracleHashMixin, PostgreSQLSHAMixin, Transform, TextFuncMixin
+    MySQLSHA2Mixin, OracleHashMixin, PostgreSQLSHAMixin, TextFuncMixin, Transform
 ):
     function = "SHA512"
     lookup_name = "sha512"
 
 
-class StrIndex(Func, TextFuncMixin):
+class StrIndex(TextFuncMixin, Func):
     """
     Return a positive integer corresponding to the 1-indexed position of the
     first occurrence of a substring inside another string, or 0 if the
@@ -340,7 +340,7 @@ class StrIndex(Func, TextFuncMixin):
         return super().as_sql(compiler, connection, function="STRPOS", **extra_context)
 
 
-class Substr(Func, TextFuncMixin):
+class Substr(TextFuncMixin, Func):
     function = "SUBSTRING"
     output_field = CharField()
 
@@ -365,11 +365,11 @@ class Substr(Func, TextFuncMixin):
         return super().as_sql(compiler, connection, function="SUBSTR", **extra_context)
 
 
-class Trim(Transform, TextFuncMixin):
+class Trim(TextFuncMixin, Transform):
     function = "TRIM"
     lookup_name = "trim"
 
 
-class Upper(Transform, TextFuncMixin):
+class Upper(TextFuncMixin, Transform):
     function = "UPPER"
     lookup_name = "upper"

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2536,24 +2536,6 @@ class Query(BaseExpression):
         self.set_select([f.get_col(select_alias) for f in select_fields])
         return trimmed_prefix, contains_louter
 
-    def is_nullable(self, field):
-        """
-        Check if the given field should be treated as nullable.
-
-        Some backends treat '' as null and Django treats such fields as
-        nullable for those backends. In such situations field.null can be
-        False even if we should treat the field as nullable.
-        """
-        # We need to use DEFAULT_DB_ALIAS here, as QuerySet does not have
-        # (nor should it have) knowledge of which connection is going to be
-        # used. The proper fix would be to defer all decisions where
-        # is_nullable() is needed to the compiler stage, but that is not easy
-        # to do currently.
-        return field.null or (
-            field.empty_strings_allowed
-            and connections[DEFAULT_DB_ALIAS].features.interprets_empty_strings_as_nulls
-        )
-
 
 def get_order_dir(field, default="ASC"):
     """

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -1026,6 +1026,13 @@ calling the appropriate methods on the wrapped expression.
         :py:data:`NotImplemented` which forces the expression to be computed on
         the database.
 
+    .. method:: is_nullable(field=None)
+
+        .. versionadded:: 5.0
+
+        Tells Django that this expression can return nulls. When ``False``,
+        the ORM will avoid adding ``WHERE ... IS NULL`` clauses in negations.
+
     .. method:: resolve_expression(query=None, allow_joins=True, reuse=None, summarize=False, for_save=False)
 
         Provides the chance to do any preprocessing or validation of

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -284,9 +284,8 @@ Models
   :ref:`Choices classes <field-choices-enum-types>` directly instead of
   requiring expansion with the ``choices`` attribute.
 
-* The ``is_nullable(field)`` method was promoted from
-  :class:`~django.db.models.sql.query.Query` to
-  :class:`~django.db.models.expressions.BaseExpression`.
+* The ``is_nullable(field)`` method was promoted from ``Query`` to
+  ``BaseExpression``.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -284,6 +284,10 @@ Models
   :ref:`Choices classes <field-choices-enum-types>` directly instead of
   requiring expansion with the ``choices`` attribute.
 
+* The ``is_nullable(field)`` method was promoted from
+  :class:`~django.db.models.sql.query.Query` to
+  :class:`~django.db.models.expressions.BaseExpression`.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1302,7 +1302,8 @@ class SimpleExpressionTests(SimpleTestCase):
         self.assertIs(Concat(field, other_field).is_nullable(), False)
         self.assertIs(
             Lower(field).is_nullable(),
-            not connection.features.interprets_empty_strings_as_nulls)
+            not connection.features.interprets_empty_strings_as_nulls,
+        )
 
 
 class ExpressionsNumericTests(TestCase):

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1289,6 +1289,21 @@ class SimpleExpressionTests(SimpleTestCase):
             hash(Expression(TestModel._meta.get_field("other_field"))),
         )
 
+    def test_is_nullable(self):
+        class TestModel(Model):
+            field = IntegerField(null=True)
+            other_field = IntegerField()
+
+        field = TestModel._meta.get_field("field")
+        other_field = TestModel._meta.get_field("other_field")
+
+        self.assertIs(Expression(field).is_nullable(), True)
+        self.assertIs(Expression(other_field).is_nullable(), False)
+        self.assertIs(Concat(field, other_field).is_nullable(), False)
+        self.assertIs(
+            Lower(field).is_nullable(),
+            not connection.features.interprets_empty_strings_as_nulls)
+
 
 class ExpressionsNumericTests(TestCase):
     @classmethod


### PR DESCRIPTION
ticket-32398

Before fixing the SQL for `QuerySet.exclude()` for further nullable expressions mentioned in ticket-32398, it was [suggested](https://github.com/django/django/pull/14065#discussion_r635006119) to add a `nullable` property to `BaseExpression` so as to avoid treating as nullable some expressions that can never be nullable even when all of their columns are.

I considered doing this with an attribute rather than a method, but I wasn't able to access the `connections` object at class-building time.