### PR TITLE
Refs #31949 -- Made http decorators to work with async functions.

### DIFF
--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -243,6 +243,13 @@ Decorators
   * :func:`~django.views.decorators.common.no_append_slash`
   * :func:`~django.views.decorators.debug.sensitive_variables`
   * :func:`~django.views.decorators.debug.sensitive_post_parameters`
+  * :func:`~django.views.decorators.http.condition`
+  * :func:`~django.views.decorators.http.etag`
+  * :func:`~django.views.decorators.http.last_modified`
+  * :func:`~django.views.decorators.http.require_http_methods`
+  * :func:`~django.views.decorators.http.require_GET`
+  * :func:`~django.views.decorators.http.require_POST`
+  * :func:`~django.views.decorators.http.require_safe`
   * ``xframe_options_deny()``
   * ``xframe_options_sameorigin()``
   * ``xframe_options_exempt()``

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -84,6 +84,13 @@ view functions:
 * :func:`~django.views.decorators.cache.cache_control`
 * :func:`~django.views.decorators.cache.never_cache`
 * :func:`~django.views.decorators.common.no_append_slash`
+* :func:`~django.views.decorators.http.condition`
+* :func:`~django.views.decorators.http.etag`
+* :func:`~django.views.decorators.http.last_modified`
+* :func:`~django.views.decorators.http.require_http_methods`
+* :func:`~django.views.decorators.http.require_GET`
+* :func:`~django.views.decorators.http.require_POST`
+* :func:`~django.views.decorators.http.require_safe`
 * ``xframe_options_deny()``
 * ``xframe_options_sameorigin()``
 * ``xframe_options_exempt()``

--- a/docs/topics/http/decorators.txt
+++ b/docs/topics/http/decorators.txt
@@ -33,13 +33,25 @@ a :class:`django.http.HttpResponseNotAllowed` if the conditions are not met.
 
     Note that request methods should be in uppercase.
 
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
+
 .. function:: require_GET()
 
     Decorator to require that a view only accepts the GET method.
 
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
+
 .. function:: require_POST()
 
     Decorator to require that a view only accepts the POST method.
+
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
 
 .. function:: require_safe()
 
@@ -54,6 +66,10 @@ a :class:`django.http.HttpResponseNotAllowed` if the conditions are not met.
         requests exactly like GET requests in your views. Since some software,
         such as link checkers, rely on HEAD requests, you might prefer
         using ``require_safe`` instead of ``require_GET``.
+
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
 
 Conditional view processing
 ===========================
@@ -70,6 +86,10 @@ control caching behavior on particular views.
     These decorators can be used to generate ``ETag`` and ``Last-Modified``
     headers; see
     :doc:`conditional view processing </topics/conditional-view-processing>`.
+
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
 
 .. module:: django.views.decorators.gzip
 

--- a/tests/decorators/test_http.py
+++ b/tests/decorators/test_http.py
@@ -1,11 +1,27 @@
 import datetime
 
+from asgiref.sync import iscoroutinefunction
+
 from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed
 from django.test import SimpleTestCase
 from django.views.decorators.http import condition, require_http_methods, require_safe
 
 
 class RequireHttpMethodsTest(SimpleTestCase):
+    def test_wrapped_sync_function_is_not_coroutine_function(self):
+        def sync_view(request):
+            return HttpResponse()
+
+        wrapped_view = require_http_methods(["GET"])(sync_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), False)
+
+    def test_wrapped_async_function_is_coroutine_function(self):
+        async def async_view(request):
+            return HttpResponse()
+
+        wrapped_view = require_http_methods(["GET"])(async_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), True)
+
     def test_require_http_methods_methods(self):
         @require_http_methods(["GET", "PUT"])
         def my_view(request):
@@ -22,6 +38,23 @@ class RequireHttpMethodsTest(SimpleTestCase):
         self.assertIsInstance(my_view(request), HttpResponseNotAllowed)
         request.method = "DELETE"
         self.assertIsInstance(my_view(request), HttpResponseNotAllowed)
+
+    async def test_require_http_methods_methods_async_view(self):
+        @require_http_methods(["GET", "PUT"])
+        async def my_view(request):
+            return HttpResponse("OK")
+
+        request = HttpRequest()
+        request.method = "GET"
+        self.assertIsInstance(await my_view(request), HttpResponse)
+        request.method = "PUT"
+        self.assertIsInstance(await my_view(request), HttpResponse)
+        request.method = "HEAD"
+        self.assertIsInstance(await my_view(request), HttpResponseNotAllowed)
+        request.method = "POST"
+        self.assertIsInstance(await my_view(request), HttpResponseNotAllowed)
+        request.method = "DELETE"
+        self.assertIsInstance(await my_view(request), HttpResponseNotAllowed)
 
 
 class RequireSafeDecoratorTest(SimpleTestCase):
@@ -42,6 +75,23 @@ class RequireSafeDecoratorTest(SimpleTestCase):
         request.method = "DELETE"
         self.assertIsInstance(my_safe_view(request), HttpResponseNotAllowed)
 
+    async def test_require_safe_accepts_only_safe_methods_async_view(self):
+        @require_safe
+        async def async_view(request):
+            return HttpResponse("OK")
+
+        request = HttpRequest()
+        request.method = "GET"
+        self.assertIsInstance(await async_view(request), HttpResponse)
+        request.method = "HEAD"
+        self.assertIsInstance(await async_view(request), HttpResponse)
+        request.method = "POST"
+        self.assertIsInstance(await async_view(request), HttpResponseNotAllowed)
+        request.method = "PUT"
+        self.assertIsInstance(await async_view(request), HttpResponseNotAllowed)
+        request.method = "DELETE"
+        self.assertIsInstance(await async_view(request), HttpResponseNotAllowed)
+
 
 class ConditionDecoratorTest(SimpleTestCase):
     def etag_func(request, *args, **kwargs):
@@ -49,6 +99,24 @@ class ConditionDecoratorTest(SimpleTestCase):
 
     def latest_entry(request, *args, **kwargs):
         return datetime.datetime(2023, 1, 2, 23, 21, 47)
+
+    def test_wrapped_sync_function_is_not_coroutine_function(self):
+        def sync_view(request):
+            return HttpResponse()
+
+        wrapped_view = condition(
+            etag_func=self.etag_func, last_modified_func=self.latest_entry
+        )(sync_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), False)
+
+    def test_wrapped_async_function_is_coroutine_function(self):
+        async def async_view(request):
+            return HttpResponse()
+
+        wrapped_view = condition(
+            etag_func=self.etag_func, last_modified_func=self.latest_entry
+        )(async_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), True)
 
     def test_condition_decorator(self):
         @condition(
@@ -61,6 +129,25 @@ class ConditionDecoratorTest(SimpleTestCase):
         request = HttpRequest()
         request.method = "GET"
         response = my_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["ETag"], '"b4246ffc4f62314ca13147c9d4f76974"')
+        self.assertEqual(
+            response.headers["Last-Modified"],
+            "Mon, 02 Jan 2023 23:21:47 GMT",
+        )
+
+    async def test_condition_decorator_async_view(self):
+        @condition(
+            etag_func=self.etag_func,
+            last_modified_func=self.latest_entry,
+        )
+        async def async_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "GET"
+        response = await async_view(request)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers["ETag"], '"b4246ffc4f62314ca13147c9d4f76974"')

--- a/tests/decorators/test_http.py
+++ b/tests/decorators/test_http.py
@@ -1,6 +1,27 @@
+import datetime
+
 from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed
 from django.test import SimpleTestCase
-from django.views.decorators.http import require_safe
+from django.views.decorators.http import condition, require_http_methods, require_safe
+
+
+class RequireHttpMethodsTest(SimpleTestCase):
+    def test_require_http_methods_methods(self):
+        @require_http_methods(["GET", "PUT"])
+        def my_view(request):
+            return HttpResponse("OK")
+
+        request = HttpRequest()
+        request.method = "GET"
+        self.assertIsInstance(my_view(request), HttpResponse)
+        request.method = "PUT"
+        self.assertIsInstance(my_view(request), HttpResponse)
+        request.method = "HEAD"
+        self.assertIsInstance(my_view(request), HttpResponseNotAllowed)
+        request.method = "POST"
+        self.assertIsInstance(my_view(request), HttpResponseNotAllowed)
+        request.method = "DELETE"
+        self.assertIsInstance(my_view(request), HttpResponseNotAllowed)
 
 
 class RequireSafeDecoratorTest(SimpleTestCase):
@@ -20,3 +41,30 @@ class RequireSafeDecoratorTest(SimpleTestCase):
         self.assertIsInstance(my_safe_view(request), HttpResponseNotAllowed)
         request.method = "DELETE"
         self.assertIsInstance(my_safe_view(request), HttpResponseNotAllowed)
+
+
+class ConditionDecoratorTest(SimpleTestCase):
+    def etag_func(request, *args, **kwargs):
+        return '"b4246ffc4f62314ca13147c9d4f76974"'
+
+    def latest_entry(request, *args, **kwargs):
+        return datetime.datetime(2023, 1, 2, 23, 21, 47)
+
+    def test_condition_decorator(self):
+        @condition(
+            etag_func=self.etag_func,
+            last_modified_func=self.latest_entry,
+        )
+        def my_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        request.method = "GET"
+        response = my_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["ETag"], '"b4246ffc4f62314ca13147c9d4f76974"')
+        self.assertEqual(
+            response.headers["Last-Modified"],
+            "Mon, 02 Jan 2023 23:21:47 GMT",
+        )

--- a/tests/decorators/test_http.py
+++ b/tests/decorators/test_http.py
@@ -1,0 +1,22 @@
+from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed
+from django.test import SimpleTestCase
+from django.views.decorators.http import require_safe
+
+
+class RequireSafeDecoratorTest(SimpleTestCase):
+    def test_require_safe_accepts_only_safe_methods(self):
+        def my_view(request):
+            return HttpResponse("OK")
+
+        my_safe_view = require_safe(my_view)
+        request = HttpRequest()
+        request.method = "GET"
+        self.assertIsInstance(my_safe_view(request), HttpResponse)
+        request.method = "HEAD"
+        self.assertIsInstance(my_safe_view(request), HttpResponse)
+        request.method = "POST"
+        self.assertIsInstance(my_safe_view(request), HttpResponseNotAllowed)
+        request.method = "PUT"
+        self.assertIsInstance(my_safe_view(request), HttpResponseNotAllowed)
+        request.method = "DELETE"
+        self.assertIsInstance(my_safe_view(request), HttpResponseNotAllowed)

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import (
     permission_required,
     user_passes_test,
 )
-from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed
+from django.http import HttpResponse
 from django.test import SimpleTestCase
 from django.utils.decorators import method_decorator
 from django.utils.functional import keep_lazy, keep_lazy_text, lazy
@@ -116,29 +116,6 @@ class DecoratorsTest(TestCase):
         response = callback(request)
 
         self.assertEqual(response, ["test2", "test1"])
-
-    def test_require_safe_accepts_only_safe_methods(self):
-        """
-        Test for the require_safe decorator.
-        A view returns either a response or an exception.
-        Refs #15637.
-        """
-
-        def my_view(request):
-            return HttpResponse("OK")
-
-        my_safe_view = require_safe(my_view)
-        request = HttpRequest()
-        request.method = "GET"
-        self.assertIsInstance(my_safe_view(request), HttpResponse)
-        request.method = "HEAD"
-        self.assertIsInstance(my_safe_view(request), HttpResponse)
-        request.method = "POST"
-        self.assertIsInstance(my_safe_view(request), HttpResponseNotAllowed)
-        request.method = "PUT"
-        self.assertIsInstance(my_safe_view(request), HttpResponseNotAllowed)
-        request.method = "DELETE"
-        self.assertIsInstance(my_safe_view(request), HttpResponseNotAllowed)
 
 
 # For testing method_decorator, a decorator that assumes a single argument.


### PR DESCRIPTION
Reference to [#31949](https://code.djangoproject.com/ticket/31949).

This PR attempts to improve `require_http_methods` view decorator so it's able to handle both sync and async views.