### PR TITLE
Fixed #34482 -- Fixed shallow copy of HttpRequest and HttpResponse objects.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -83,7 +83,7 @@ class HttpRequest:
     def __getstate__(self):
         obj_dict = self.__dict__.copy()
         for attr in self.non_picklable_attrs:
-            if attr in obj_dict:
+            if obj_dict.get(attr, None) is not None:
                 del obj_dict[attr]
         return obj_dict
 

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -385,7 +385,7 @@ class HttpResponse(HttpResponseBase):
     def __getstate__(self):
         obj_dict = self.__dict__.copy()
         for attr in self.non_picklable_attrs:
-            if attr in obj_dict:
+            if obj_dict.get(attr, None) is not None:
                 del obj_dict[attr]
         return obj_dict
 


### PR DESCRIPTION
Fixed the shallow copying of `HttpRequest` and `HttpResponse` objects which could not be shallow copied due to the `non-picklable` attributes being removed in https://github.com/django/django/commit/6220c445c40a6a7f4d442de8bde2628346153963 and https://github.com/django/django/commit/d7f5bfd241666c0a76e90208da1e9ef81aec44db respectively.