### PR TITLE
Fixed #34483 -- Fixed timesince()/timeuntil() with timezone-aware dates and interval less than 1 day.

### DIFF
--- a/django/utils/timesince.py
+++ b/django/utils/timesince.py
@@ -77,7 +77,8 @@ def timesince(d, now=None, reversed=False, time_strings=None, depth=2):
 
     # Get years and months.
     total_months = (now.year - d.year) * 12 + (now.month - d.month)
-    if d.day > now.day or (d.day == now.day and d.time() > now.time()):
+    time_delta = delta - datetime.timedelta(days=delta.days)
+    if d.day > now.day or (d.day == now.day and time_delta.total_seconds() < 0):
         total_months -= 1
     years, months = divmod(total_months, 12)
 

--- a/docs/releases/4.2.1.txt
+++ b/docs/releases/4.2.1.txt
@@ -33,3 +33,7 @@ Bugfixes
 * Fixed a regression in Django 4.2 where creating copies and deep copies of
   ``HttpRequest``, ``HttpResponse``, and their subclasses didn't always work
   correctly (:ticket:`34482`, :ticket:`34484`).
+
+* Fixed a regression in Django 4.2 where ``timesince`` and ``timeuntil``
+  template filters returned incorrect results for a datetime with a non-UTC
+  timezone when a time difference is less than 1 day (:ticket:`34483`).

--- a/tests/utils_tests/test_timesince.py
+++ b/tests/utils_tests/test_timesince.py
@@ -1,4 +1,5 @@
 import datetime
+import zoneinfo
 
 from django.test import TestCase
 from django.test.utils import override_settings, requires_tz_support
@@ -240,6 +241,22 @@ class TimesinceTests(TestCase):
         msg = "depth must be greater than 0."
         with self.assertRaisesMessage(ValueError, msg):
             timesince(self.t, self.t, depth=0)
+
+    @requires_tz_support
+    def test_less_than_a_day_with_zoneinfo(self):
+        now_with_zoneinfo = timezone.now().astimezone(
+            zoneinfo.ZoneInfo(key="Asia/Kathmandu")  # UTC+05:45
+        )
+        tests = [
+            (now_with_zoneinfo, "0\xa0minutes"),
+            (now_with_zoneinfo - self.onemicrosecond, "0\xa0minutes"),
+            (now_with_zoneinfo - self.onesecond, "0\xa0minutes"),
+            (now_with_zoneinfo - self.oneminute, "1\xa0minute"),
+            (now_with_zoneinfo - self.onehour, "1\xa0hour"),
+        ]
+        for value, expected in tests:
+            with self.subTest(value):
+                self.assertEqual(timesince(value), expected)
 
 
 @requires_tz_support


### PR DESCRIPTION
Regression in 8d67e16493c903adc9d049141028bc0fff43f8c8.

Thanks Lorenzo Peña for the report.