### PR TITLE
Fixed #34481 -- Added system check for reverse related fields in ModelAdmin.list_display.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -916,10 +916,13 @@ class ModelAdminChecks(BaseModelAdminChecks):
                         id="admin.E108",
                     )
                 ]
-        if isinstance(field, models.ManyToManyField):
+        if isinstance(field, models.ManyToManyField) or (
+            getattr(field, "rel", None) and field.rel.field.many_to_one
+        ):
             return [
                 checks.Error(
-                    "The value of '%s' must not be a ManyToManyField." % label,
+                    f"The value of '{label}' must not be a many-to-many field or a "
+                    f"reverse foreign key.",
                     obj=obj.__class__,
                     id="admin.E109",
                 )

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -703,8 +703,8 @@ with the admin site:
 * **admin.E108**: The value of ``list_display[n]`` refers to ``<label>``,
   which is not a callable, an attribute of ``<ModelAdmin class>``, or an
   attribute or method on ``<model>``.
-* **admin.E109**: The value of ``list_display[n]`` must not be a
-  ``ManyToManyField`` field.
+* **admin.E109**: The value of ``list_display[n]`` must not be a many-to-many
+  field or a reverse foreign key.
 * **admin.E110**: The value of ``list_display_links`` must be a list, a tuple,
   or ``None``.
 * **admin.E111**: The value of ``list_display_links[n]`` refers to ``<label>``,

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -537,7 +537,20 @@ class ListDisplayTests(CheckTestCase):
         self.assertIsInvalid(
             TestModelAdmin,
             ValidationTestModel,
-            "The value of 'list_display[0]' must not be a ManyToManyField.",
+            "The value of 'list_display[0]' must not be a many-to-many field or a "
+            "reverse foreign key.",
+            "admin.E109",
+        )
+
+    def test_invalid_reverse_related_field(self):
+        class TestModelAdmin(ModelAdmin):
+            list_display = ["song_set"]
+
+        self.assertIsInvalid(
+            TestModelAdmin,
+            Band,
+            "The value of 'list_display[0]' must not be a many-to-many field or a "
+            "reverse foreign key.",
             "admin.E109",
         )
 


### PR DESCRIPTION
Fixed [ticket #34481](https://code.djangoproject.com/ticket/34481)
Add reverse related fields checking in admin module.