### PR TITLE
Fixed typo in ManagementUtility.autocomplete()'s docstring.

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -279,8 +279,8 @@ class ManagementUtility:
         """
         Output completion suggestions for BASH.
 
-        The output of this function is passed to BASH's `COMREPLY` variable and
-        treated as completion suggestions. `COMREPLY` expects a space
+        The output of this function is passed to BASH's `COMPREPLY` variable
+        and treated as completion suggestions. `COMPREPLY` expects a space
         separated string as the result.
 
         The `COMP_WORDS` and `COMP_CWORD` BASH environment variables are used


### PR DESCRIPTION
Hi! 

As I studied the `ManagementUtility` class, this typo in the `autocomplete`'s docstring had my attention. 

👉🏻 [Source](https://www.gnu.org/software/bash/manual/html_node/A-Programmable-Completion-Example.html)

Please let me know if I should open a ticket!