### PR TITLE
Fixed #34486 -- Fixed DatabaseOperations.compose_sql() crash with no existing database connection on PostgreSQL.

### DIFF
--- a/django/db/backends/postgresql/psycopg_any.py
+++ b/django/db/backends/postgresql/psycopg_any.py
@@ -18,7 +18,8 @@ try:
     TSTZRANGE_OID = types["tstzrange"].oid
 
     def mogrify(sql, params, connection):
-        return ClientCursor(connection.connection).mogrify(sql, params)
+        with connection.cursor() as cursor:
+            return ClientCursor(cursor.connection).mogrify(sql, params)
 
     # Adapters.
     class BaseTzLoader(TimestamptzLoader):

--- a/docs/releases/4.2.1.txt
+++ b/docs/releases/4.2.1.txt
@@ -37,3 +37,7 @@ Bugfixes
 * Fixed a regression in Django 4.2 where ``timesince`` and ``timeuntil``
   template filters returned incorrect results for a datetime with a non-UTC
   timezone when a time difference is less than 1 day (:ticket:`34483`).
+
+* Fixed a regression in Django 4.2 that caused a crash of
+  :class:`~django.contrib.postgres.search.SearchHeadline` function with
+  ``psycopg`` 3 (:ticket:`34486`).

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -420,3 +420,13 @@ class Tests(TestCase):
         with self.assertRaisesMessage(NotSupportedError, msg):
             connection.check_database_version_supported()
         self.assertTrue(mocked_get_database_version.called)
+
+    def test_compose_sql_when_no_connection(self):
+        new_connection = connection.copy()
+        try:
+            self.assertEqual(
+                new_connection.ops.compose_sql("SELECT %s", ["test"]),
+                "SELECT 'test'",
+            )
+        finally:
+            new_connection.close()


### PR DESCRIPTION
Resolves [#34486](https://code.djangoproject.com/ticket/34486#comment:10): SearchHeadline crashes without an active connection. Both the regression test and the fix were graciously but shamelessly copied from Mariusz's comments on that ticket!

One new regression test added to `backends.postgres`.

`tests.postgres_tests` produces the same output before and after this change.