### PR TITLE
Add flake8 compliant docstring to the AppConfig template

### DIFF
--- a/django/conf/app_template/apps.py-tpl
+++ b/django/conf/app_template/apps.py-tpl
@@ -3,5 +3,6 @@ from django.apps import AppConfig
 
 class {{ camel_case_app_name }}Config(AppConfig):
     """Configure the metadata registered with this application."""
+
     default_auto_field = 'django.db.models.BigAutoField'
     name = '{{ app_name }}'

--- a/django/conf/app_template/apps.py-tpl
+++ b/django/conf/app_template/apps.py-tpl
@@ -2,5 +2,6 @@ from django.apps import AppConfig
 
 
 class {{ camel_case_app_name }}Config(AppConfig):
+    """Configure the metadata registered with this application."""
     default_auto_field = 'django.db.models.BigAutoField'
     name = '{{ app_name }}'


### PR DESCRIPTION
The current starter template is not compliant with flake8-docstrings because it lacks a docstring. This patch would add one.