### PR TITLE
fix: Add db_index=True to username

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -349,6 +349,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
             "Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only."
         ),
         validators=[username_validator],
+       
         error_messages={
             "unique": _("A user with that username already exists."),
         },


### PR DESCRIPTION
I changed this 
![django before edit](https://user-images.githubusercontent.com/96469579/232207716-d0146f7f-7353-4da4-b844-9738bfcf9a9f.png)
into this 
![django after edit](https://user-images.githubusercontent.com/96469579/232207755-8521e234-60ad-45e5-98d0-53290ab71c54.png)
Q: Why I did this ?
A: This field is used for login user and find user to most of time, as the number of user increases applications get slow in finding users by usernames. So I thought to add this in that. Every time I have to create a custom user field and I think most of developers does too. I think this will help for beginners too. 
