### PR TITLE
Added username in AbstractBaseUser as a index

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -349,6 +349,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
             "Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only."
         ),
         validators=[username_validator],
+        db_index=True,
         error_messages={
             "unique": _("A user with that username already exists."),
         },


### PR DESCRIPTION
I changed this
![django after edit](https://user-images.githubusercontent.com/96469579/232210398-c7b2bf11-d3ee-4b1d-8405-a4c33af08101.png)
from this 
![django before edit](https://user-images.githubusercontent.com/96469579/232210408-17ef46fc-8602-4b1a-bbd7-63254c994851.png)
Q Why I did this 
A This field is used for login user and find user to most of time, as the number of user increases applications get slow in finding users by usernames. So I thought to add this in that. Every time I have to create a custom user field and I think most of developers does too. I think this will help for beginners too.