### PR TITLE
33090 extend sensitive post parameter filtering

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -179,8 +179,11 @@ class BaseHandler:
         """
         response = None
         callback, callback_args, callback_kwargs = self.resolve_request(request)
+        # Mark the request with sensitive_post_parameters if applied.
+        if hasattr(callback, "sensitive_post_parameters"):
+            request.sensitive_post_parameters = callback.sensitive_post_parameters
 
-        # Apply view middleware
+        # Apply view middlewarec;
         for middleware_method in self._view_middleware:
             response = middleware_method(
                 request, callback, callback_args, callback_kwargs
@@ -233,6 +236,10 @@ class BaseHandler:
         """
         response = None
         callback, callback_args, callback_kwargs = self.resolve_request(request)
+
+        # Mark the request with sensitive_post_parameters if applied.
+        if hasattr(callback, "sensitive_post_parameters"):
+            request.sensitive_post_parameters = callback.sensitive_post_parameters
 
         # Apply view middleware.
         for middleware_method in self._view_middleware:

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -240,7 +240,6 @@ class BaseHandler:
         # Mark the request with sensitive_post_parameters if applied.
         if hasattr(callback, "sensitive_post_parameters"):
             request.sensitive_post_parameters = callback.sensitive_post_parameters
-
         # Apply view middleware.
         for middleware_method in self._view_middleware:
             response = await middleware_method(

--- a/django/views/decorators/debug.py
+++ b/django/views/decorators/debug.py
@@ -91,7 +91,6 @@ def sensitive_post_parameters(*parameters):
             else:
                 request.sensitive_post_parameters = "__ALL__"
             return view(request, *args, **kwargs)
-
         # Mark the wrapped view itself in case of middleware errors.
         sensitive_post_parameters_wrapper.sensitive_post_parameters = (
             parameters or "__ALL__"

--- a/django/views/decorators/debug.py
+++ b/django/views/decorators/debug.py
@@ -1,4 +1,3 @@
-
 from functools import wraps
 
 from django.http import HttpRequest
@@ -91,6 +90,7 @@ def sensitive_post_parameters(*parameters):
             else:
                 request.sensitive_post_parameters = "__ALL__"
             return view(request, *args, **kwargs)
+
         # Mark the wrapped view itself in case of middleware errors.
         sensitive_post_parameters_wrapper.sensitive_post_parameters = (
             parameters or "__ALL__"

--- a/django/views/decorators/debug.py
+++ b/django/views/decorators/debug.py
@@ -1,3 +1,4 @@
+
 from functools import wraps
 
 from django.http import HttpRequest
@@ -91,6 +92,10 @@ def sensitive_post_parameters(*parameters):
                 request.sensitive_post_parameters = "__ALL__"
             return view(request, *args, **kwargs)
 
+        # Mark the wrapped view itself in case of middleware errors.
+        sensitive_post_parameters_wrapper.sensitive_post_parameters = (
+            parameters or "__ALL__"
+        )
         return sensitive_post_parameters_wrapper
 
     return decorator

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -1,4 +1,3 @@
-
 import importlib
 import inspect
 import os

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -1971,10 +1971,6 @@ class DecoratorTest(SimpleTestCase):
             def my_view(request):
                 return HttpResponse("Hello, world!")
 
-            my_view = sensitive_post_parameters("password")(my_view)
-
-        print(DemoClass.my_view.__name__)
-
         # Create a mock request object
         request_factory = RequestFactory()
         request = request_factory.post(
@@ -1984,23 +1980,15 @@ class DecoratorTest(SimpleTestCase):
         # Make a request to the view with sensitive post parameters
         DemoClass.my_view(request)
 
-        # create an instance of the class
-        demo = DemoClass()
-
         # Check that the request object has been marked with the sensitive
         # post parameters
         self.assertIn("password", request.sensitive_post_parameters)
 
-        # Check that the sensitive_post_parameters_wrapper function is defined and
-        # has the sensitive_post_parameters attribute
-        self.assertTrue(hasattr(demo.my_view, "sensitive_post_parameters_wrapper"))
-        self.assertTrue(
-            hasattr(
-                demo.my_view.sensitive_post_parameters_wrapper,
-                "sensitive_post_parameters",
-            )
-        )
+        # Check that the sensitive_post_parameters attribute is
+        # set on the wrapper function
+        self.assertTrue(hasattr(DemoClass.my_view, "sensitive_post_parameters"))
+
         self.assertEqual(
-            demo.my_view.sensitive_post_parameters_wrapper.sensitive_post_parameters,
-            ["password"],
+            DemoClass.my_view.sensitive_post_parameters,
+            ("password",),
         )


### PR DESCRIPTION
I created this branch to fix the issue of sensitive post parameter filtering not marking the request until the view is executed, that is, filtering cannot be applied to reports  generated by exceptions in the middleware [for ticket](https://code.djangoproject.com/ticket/33090). Carlton Gibson already suggested a solution which I worked on and also wrote a test for it. 