### PR TITLE
#30149 -- Empty value selected check in Admin Filter prevents subclassing

### DIFF
--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -226,7 +226,7 @@ class RelatedFieldListNotIsNullFilter(RelatedFieldListFilter):
     def choices(self, changelist):
         yield from super().choices(changelist)
         yield {
-            'selected': self.lookup_val_isnull == 'False',
+            'selected': self.lookup_val_isnull is False,
             'query_string': changelist.get_query_string(
                 {self.lookup_kwarg_isnull: 'False'}, [self.lookup_kwarg]
             ),


### PR DESCRIPTION
For more information read
[Issue](https://code.djangoproject.com/ticket/30149)
[Original PR](https://github.com/django/django/pull/10951)