### PR TITLE
Corrected exception type in safe_join()'s docstring.

### DIFF
--- a/django/utils/_os.py
+++ b/django/utils/_os.py
@@ -11,8 +11,8 @@ def safe_join(base, *paths):
     Join one or more path components to the base path component intelligently.
     Return a normalized, absolute version of the final path.
 
-    Raise ValueError if the final path isn't located inside of the base path
-    component.
+    Raise SuspiciousFileOperation if the final path isn't located inside of the
+    base path component.
     """
     final_path = abspath(join(base, *paths))
     base_path = abspath(base)


### PR DESCRIPTION
[See thread here](https://github.com/django/django/pull/16775#discussion_r1170210924)