### PR TITLE
Allow suppressing logs of management commands of `django.contrib.auth` by emitting to logger instead of stdout directly.

### DIFF
--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -2,8 +2,8 @@
 Creates permissions for all installed apps that need permissions.
 """
 import getpass
-import unicodedata
 import logging
+import unicodedata
 
 from django.apps import apps as global_apps
 from django.contrib.auth import get_permission_codename

--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -3,12 +3,16 @@ Creates permissions for all installed apps that need permissions.
 """
 import getpass
 import unicodedata
+import logging
 
 from django.apps import apps as global_apps
 from django.contrib.auth import get_permission_codename
 from django.contrib.contenttypes.management import create_contenttypes
 from django.core import exceptions
 from django.db import DEFAULT_DB_ALIAS, router
+
+
+logger = logging.getLogger(__name__)
 
 
 def _get_all_permissions(opts):
@@ -108,7 +112,7 @@ def create_permissions(
     Permission.objects.using(using).bulk_create(perms)
     if verbosity >= 2:
         for perm in perms:
-            print("Adding permission '%s'" % perm)
+            logger.debug("Adding permission '%s'", perm)
 
 
 def get_system_username():


### PR DESCRIPTION
I've noticed that `django.contrib.auth`'s `management.create_permissions` is too noisy on stdout without allowing any way to suppress it at runtime. 

```
Loading environment 'development'
...
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying app.0001_initial... OK
  ...
  Applying app.0002_enable_user_permissions... OK
Adding content type 'app | user'
Adding content type 'app | foo'
Adding content type 'app | bar'
...
Adding permission 'app | user | Can add user'
Adding permission 'app | user | Can change user'
... // More logs of the same format.
```

I'm not sure if this was the intended behaviour (and please correct me if it was), but I'd imagine emitting to a `logging.Logger` instead would allow them to be suppressed with a custom logging configuration such as the following:

```python
logging.config.dictConfig({
    ...,
    'loggers': {
        ...,
        'django.contrib.auth': {
            'level': 'ERROR',
            'handlers': ['console']
        }

    }
})
```