### PR TITLE
corrected min and max value validators

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -380,7 +380,7 @@ class MaxValueValidator(BaseValidator):
     code = "max_value"
 
     def compare(self, a, b):
-        return a > b
+        return a >= b
 
 
 @deconstructible
@@ -389,7 +389,7 @@ class MinValueValidator(BaseValidator):
     code = "min_value"
 
     def compare(self, a, b):
-        return a < b
+        return a <= b
 
 
 @deconstructible


### PR DESCRIPTION
The messages for MaxValueValidator reads, "Ensure this value is less than or equal to %(limit_value)s.", so the comparison should used `<=`, but it uses `<`.  And likewise for MinValueValidator, but it uses `>` instead of `>=`.  

Both of the bugs detailed above are fixed in this pull request.

Additionally, I looked at the unit tests for both validators, and they look correct.  So, not sure if the corresponding unit tests might have a failure in one or both, but just wanted to make a note of it here.