### PR TITLE
Fixed #34515 -- Updated to redirect to request language when from translated default url.

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -101,6 +101,22 @@ class ResolverMatch:
     def __reduce_ex__(self, protocol):
         raise PicklingError(f"Cannot pickle {self.__class__.__qualname__}.")
 
+    def get_pattern_and_text_subs(self):
+        url_pattern = self.tried[-1][1]
+        result, params = normalize(url_pattern.pattern.regex.pattern)[0]
+        if self.args:
+            subs = dict(zip(params, self.args))
+        else:
+            subs = self.kwargs
+        # Convert the subs to text using Converter.to_url().
+        text_subs = {}
+        for k, v in subs.items():
+            if k in url_pattern.pattern.converters:
+                text_subs[k] = url_pattern.pattern.converters[k].to_url(v)
+            else:
+                text_subs[k] = str(v)
+        return result, text_subs
+
 
 def get_resolver(urlconf=None):
     if urlconf is None:

--- a/docs/releases/4.2.1.txt
+++ b/docs/releases/4.2.1.txt
@@ -30,6 +30,11 @@ Bugfixes
   ``prefix_default_language`` argument when a fallback language of the default
   language was used (:ticket:`34455`).
 
+* Fixed a regression in Django 4.2 where navigating to the translated url of
+  the default language was not possible when ``prefix_default_language`` was
+  False and a different language had been set in the cookie or the headers
+  (:ticket:`34515`).
+
 * Fixed a regression in Django 4.2 where creating copies and deep copies of
   ``HttpRequest``, ``HttpResponse``, and their subclasses didn't always work
   correctly (:ticket:`34482`, :ticket:`34484`).

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -431,6 +431,35 @@ class URLResponseTests(URLTestCaseBase):
         self.assertEqual(response.context["LANGUAGE_CODE"], "nl")
 
 
+@override_settings(ROOT_URLCONF="i18n.urls_default_unprefixed", LANGUAGE_CODE="nl")
+class URLPrefixedFalseTranslatedTests(URLTestCaseBase):
+    def test_en_redirect_from_cookie_with_name(self):
+        self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: "en"})
+        response = self.client.get("/gebruikers/", follow=True)
+        self.assertRedirects(response, "/en/users/", 302)
+        self.assertEqual(response.status_code, 200)
+
+    def test_en_redirect_from_header_with_name(self):
+        response = self.client.get(
+            "/gebruikers/", headers={"accept-language": "en"}, follow=True
+        )
+        self.assertRedirects(response, "/en/users/", 302)
+        self.assertEqual(response.status_code, 200)
+
+    def test_en_redirect_from_cookie_without_name(self):
+        self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: "en"})
+        response = self.client.get("/profiel/", follow=True)
+        self.assertRedirects(response, "/en/account/", 302)
+        self.assertEqual(response.status_code, 200)
+
+    def test_en_redirect_from_header_without_name(self):
+        response = self.client.get(
+            "/profiel/", headers={"accept-language": "en"}, follow=True
+        )
+        self.assertRedirects(response, "/en/account/", 302)
+        self.assertEqual(response.status_code, 200)
+
+
 class URLRedirectWithScriptAliasTests(URLTestCaseBase):
     """
     #21579 - LocaleMiddleware should respect the script prefix.

--- a/tests/i18n/urls_default_unprefixed.py
+++ b/tests/i18n/urls_default_unprefixed.py
@@ -7,5 +7,7 @@ urlpatterns = i18n_patterns(
     re_path(r"^(?P<arg>[\w-]+)-page", lambda request, **arg: HttpResponse(_("Yes"))),
     path("simple/", lambda r: HttpResponse(_("Yes"))),
     re_path(r"^(.+)/(.+)/$", lambda *args: HttpResponse()),
+    re_path(_(r"^users/$"), lambda *args: HttpResponse(), name="users"),
+    re_path(_(r"^account/"), lambda *args: HttpResponse()),
     prefix_default_language=False,
 )


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/34515

I'm not confident I found the issue, but this _might_ be what is happening.
- User has a cookie with a language code (not the default)
- We want to go to the path for the default language (no language prefix here)
- It doesn't let you because of the cookie