### PR TITLE
fix: correct 'decade' computation

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -607,7 +607,7 @@ subclass::
 
               @admin.display(description="Birth decade")
               def decade_born_in(self):
-                  decade = self.birthday.year // 10 * 10
+                  decade = self.birthday.year % (10 * 10)
                   return f"{decade}’s"
 
 


### PR DESCRIPTION
The implementation of `Person.decade_born_in()` method in an example does not cut the year properly. It has no impact about how to use the django framework but it's better to have correct behavior.

Implementation demo:

```python-console
>>> 1950 // 10 * 10
1950
>>> '%d’s' % (1950 // 10 * 10)
'1950’s'
>>> 1950 % (10 * 10)
50
```