### PR TITLE
Refs #31949 -- Made @xframe_options_(deny/sameorigin/exempt) decorators to work with async functions.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -137,6 +137,7 @@ answer newbie questions, and generally made Django that much better:
     Ben Godfrey <http://aftnn.org>
     Benjamin Wohlwend <piquadrat@gmail.com>
     Ben Khoo <khoobks@westnet.com.au>
+    Ben Lomax <lomax.on.the.run@gmail.com>
     Ben Slavin <benjamin.slavin@gmail.com>
     Ben Sturmfels <ben@sturm.com.au>
     Berker Peksag <berker.peksag@gmail.com>

--- a/django/views/decorators/clickjacking.py
+++ b/django/views/decorators/clickjacking.py
@@ -1,5 +1,7 @@
 from functools import wraps
 
+from asgiref.sync import iscoroutinefunction
+
 
 def xframe_options_deny(view_func):
     """
@@ -12,14 +14,23 @@ def xframe_options_deny(view_func):
         ...
     """
 
-    @wraps(view_func)
-    def wrapper_view(*args, **kwargs):
-        resp = view_func(*args, **kwargs)
-        if resp.get("X-Frame-Options") is None:
-            resp["X-Frame-Options"] = "DENY"
-        return resp
+    if iscoroutinefunction(view_func):
 
-    return wrapper_view
+        async def _view_wrapper(*args, **kwargs):
+            response = await view_func(*args, **kwargs)
+            if response.get("X-Frame-Options") is None:
+                response["X-Frame-Options"] = "DENY"
+            return response
+
+    else:
+
+        def _view_wrapper(*args, **kwargs):
+            response = view_func(*args, **kwargs)
+            if response.get("X-Frame-Options") is None:
+                response["X-Frame-Options"] = "DENY"
+            return response
+
+    return wraps(view_func)(_view_wrapper)
 
 
 def xframe_options_sameorigin(view_func):
@@ -33,14 +44,23 @@ def xframe_options_sameorigin(view_func):
         ...
     """
 
-    @wraps(view_func)
-    def wrapper_view(*args, **kwargs):
-        resp = view_func(*args, **kwargs)
-        if resp.get("X-Frame-Options") is None:
-            resp["X-Frame-Options"] = "SAMEORIGIN"
-        return resp
+    if iscoroutinefunction(view_func):
 
-    return wrapper_view
+        async def _view_wrapper(*args, **kwargs):
+            response = await view_func(*args, **kwargs)
+            if response.get("X-Frame-Options") is None:
+                response["X-Frame-Options"] = "SAMEORIGIN"
+            return response
+
+    else:
+
+        def _view_wrapper(*args, **kwargs):
+            response = view_func(*args, **kwargs)
+            if response.get("X-Frame-Options") is None:
+                response["X-Frame-Options"] = "SAMEORIGIN"
+            return response
+
+    return wraps(view_func)(_view_wrapper)
 
 
 def xframe_options_exempt(view_func):
@@ -53,10 +73,18 @@ def xframe_options_exempt(view_func):
         ...
     """
 
-    @wraps(view_func)
-    def wrapper_view(*args, **kwargs):
-        resp = view_func(*args, **kwargs)
-        resp.xframe_options_exempt = True
-        return resp
+    if iscoroutinefunction(view_func):
 
-    return wrapper_view
+        async def _view_wrapper(*args, **kwargs):
+            response = await view_func(*args, **kwargs)
+            response.xframe_options_exempt = True
+            return response
+
+    else:
+
+        def _view_wrapper(*args, **kwargs):
+            response = view_func(*args, **kwargs)
+            response.xframe_options_exempt = True
+            return response
+
+    return wraps(view_func)(_view_wrapper)

--- a/docs/ref/clickjacking.txt
+++ b/docs/ref/clickjacking.txt
@@ -90,6 +90,11 @@ that tells the middleware not to set the header::
     iframe, you may need to modify the :setting:`CSRF_COOKIE_SAMESITE` or
     :setting:`SESSION_COOKIE_SAMESITE` settings.
 
+.. versionchanged:: 5.0
+
+    Support for wrapping asynchronous view functions was added to the
+    ``@xframe_options_exempt`` decorator.
+
 Setting ``X-Frame-Options`` per view
 ------------------------------------
 
@@ -112,6 +117,11 @@ decorators::
 
 Note that you can use the decorators in conjunction with the middleware. Use of
 a decorator overrides the middleware.
+
+.. versionchanged:: 5.0
+
+    Support for wrapping asynchronous view functions was added to the
+    ``@xframe_options_deny`` and ``@xframe_options_sameorigin`` decorators.
 
 Limitations
 ===========

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -233,9 +233,13 @@ CSRF
 Decorators
 ~~~~~~~~~~
 
-* The :func:`~django.views.decorators.cache.cache_control` and
-  :func:`~django.views.decorators.cache.never_cache` decorators now support
-  wrapping asynchronous view functions.
+* The following decorators now support wrapping asynchronous view functions:
+
+  * :func:`~django.views.decorators.cache.cache_control`
+  * :func:`~django.views.decorators.cache.never_cache`
+  * ``xframe_options_deny()``
+  * ``xframe_options_sameorigin()``
+  * ``xframe_options_exempt()``
 
 Email
 ~~~~~

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -83,6 +83,9 @@ view functions:
 
 * :func:`~django.views.decorators.cache.cache_control`
 * :func:`~django.views.decorators.cache.never_cache`
+* ``xframe_options_deny()``
+* ``xframe_options_sameorigin()``
+* ``xframe_options_exempt()``
 
 For example::
 

--- a/tests/decorators/test_clickjacking.py
+++ b/tests/decorators/test_clickjacking.py
@@ -1,0 +1,50 @@
+from django.http import HttpRequest, HttpResponse
+from django.middleware.clickjacking import XFrameOptionsMiddleware
+from django.test import SimpleTestCase
+from django.views.decorators.clickjacking import (
+    xframe_options_deny,
+    xframe_options_exempt,
+    xframe_options_sameorigin,
+)
+
+
+class XFrameOptionsDenyTests(SimpleTestCase):
+    def test_decorator_sets_x_frame_options_to_deny(self):
+        @xframe_options_deny
+        def a_view(request):
+            return HttpResponse()
+
+        response = a_view(HttpRequest())
+        self.assertEqual(response.headers["X-Frame-Options"], "DENY")
+
+
+class XFrameOptionsSameoriginTests(SimpleTestCase):
+    def test_decorator_sets_x_frame_options_to_sameorigin(self):
+        @xframe_options_sameorigin
+        def a_view(request):
+            return HttpResponse()
+
+        response = a_view(HttpRequest())
+        self.assertEqual(response.headers["X-Frame-Options"], "SAMEORIGIN")
+
+
+class XFrameOptionsExemptTests(SimpleTestCase):
+    def test_decorator_stops_x_frame_options_being_set(self):
+        """
+        @xframe_options_exempt instructs the XFrameOptionsMiddleware to NOT set
+        the header.
+        """
+
+        @xframe_options_exempt
+        def a_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        response = a_view(request)
+        self.assertIsNone(response.get("X-Frame-Options", None))
+        self.assertIs(response.xframe_options_exempt, True)
+
+        # The real purpose of the exempt decorator is to suppress the
+        # middleware's functionality.
+        middleware_response = XFrameOptionsMiddleware(a_view)(request)
+        self.assertIsNone(middleware_response.get("X-Frame-Options"))

--- a/tests/decorators/test_clickjacking.py
+++ b/tests/decorators/test_clickjacking.py
@@ -1,3 +1,5 @@
+from asgiref.sync import iscoroutinefunction
+
 from django.http import HttpRequest, HttpResponse
 from django.middleware.clickjacking import XFrameOptionsMiddleware
 from django.test import SimpleTestCase
@@ -9,6 +11,20 @@ from django.views.decorators.clickjacking import (
 
 
 class XFrameOptionsDenyTests(SimpleTestCase):
+    def test_wrapped_sync_function_is_not_coroutine_function(self):
+        def sync_view(request):
+            return HttpResponse()
+
+        wrapped_view = xframe_options_deny(sync_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), False)
+
+    def test_wrapped_async_function_is_coroutine_function(self):
+        async def async_view(request):
+            return HttpResponse()
+
+        wrapped_view = xframe_options_deny(async_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), True)
+
     def test_decorator_sets_x_frame_options_to_deny(self):
         @xframe_options_deny
         def a_view(request):
@@ -17,8 +33,30 @@ class XFrameOptionsDenyTests(SimpleTestCase):
         response = a_view(HttpRequest())
         self.assertEqual(response.headers["X-Frame-Options"], "DENY")
 
+    async def test_decorator_sets_x_frame_options_to_deny_async_view(self):
+        @xframe_options_deny
+        async def an_async_view(request):
+            return HttpResponse()
+
+        response = await an_async_view(HttpRequest())
+        self.assertEqual(response.headers["X-Frame-Options"], "DENY")
+
 
 class XFrameOptionsSameoriginTests(SimpleTestCase):
+    def test_wrapped_sync_function_is_not_coroutine_function(self):
+        def sync_view(request):
+            return HttpResponse()
+
+        wrapped_view = xframe_options_sameorigin(sync_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), False)
+
+    def test_wrapped_async_function_is_coroutine_function(self):
+        async def async_view(request):
+            return HttpResponse()
+
+        wrapped_view = xframe_options_sameorigin(async_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), True)
+
     def test_decorator_sets_x_frame_options_to_sameorigin(self):
         @xframe_options_sameorigin
         def a_view(request):
@@ -27,8 +65,30 @@ class XFrameOptionsSameoriginTests(SimpleTestCase):
         response = a_view(HttpRequest())
         self.assertEqual(response.headers["X-Frame-Options"], "SAMEORIGIN")
 
+    async def test_decorator_sets_x_frame_options_to_sameorigin_async_view(self):
+        @xframe_options_sameorigin
+        async def an_async_view(request):
+            return HttpResponse()
+
+        response = await an_async_view(HttpRequest())
+        self.assertEqual(response.headers["X-Frame-Options"], "SAMEORIGIN")
+
 
 class XFrameOptionsExemptTests(SimpleTestCase):
+    def test_wrapped_sync_function_is_not_coroutine_function(self):
+        def sync_view(request):
+            return HttpResponse()
+
+        wrapped_view = xframe_options_exempt(sync_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), False)
+
+    def test_wrapped_async_function_is_coroutine_function(self):
+        async def async_view(request):
+            return HttpResponse()
+
+        wrapped_view = xframe_options_exempt(async_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), True)
+
     def test_decorator_stops_x_frame_options_being_set(self):
         """
         @xframe_options_exempt instructs the XFrameOptionsMiddleware to NOT set
@@ -47,4 +107,19 @@ class XFrameOptionsExemptTests(SimpleTestCase):
         # The real purpose of the exempt decorator is to suppress the
         # middleware's functionality.
         middleware_response = XFrameOptionsMiddleware(a_view)(request)
+        self.assertIsNone(middleware_response.get("X-Frame-Options"))
+
+    async def test_exempt_decorator_async_view(self):
+        @xframe_options_exempt
+        async def an_async_view(request):
+            return HttpResponse()
+
+        request = HttpRequest()
+        response = await an_async_view(request)
+        self.assertIsNone(response.get("X-Frame-Options"))
+        self.assertIs(response.xframe_options_exempt, True)
+
+        # The real purpose of the exempt decorator is to suppress the
+        # middleware's functionality.
+        middleware_response = await XFrameOptionsMiddleware(an_async_view)(request)
         self.assertIsNone(middleware_response.get("X-Frame-Options"))

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -8,17 +8,11 @@ from django.contrib.auth.decorators import (
     user_passes_test,
 )
 from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed
-from django.middleware.clickjacking import XFrameOptionsMiddleware
 from django.test import SimpleTestCase
 from django.utils.decorators import method_decorator
 from django.utils.functional import keep_lazy, keep_lazy_text, lazy
 from django.utils.safestring import mark_safe
 from django.views.decorators.cache import cache_control, cache_page, never_cache
-from django.views.decorators.clickjacking import (
-    xframe_options_deny,
-    xframe_options_exempt,
-    xframe_options_sameorigin,
-)
 from django.views.decorators.http import (
     condition,
     require_GET,
@@ -463,54 +457,3 @@ class MethodDecoratorTests(SimpleTestCase):
         Test().method()
         self.assertEqual(func_name, "method")
         self.assertIsNotNone(func_module)
-
-
-class XFrameOptionsDecoratorsTests(TestCase):
-    """
-    Tests for the X-Frame-Options decorators.
-    """
-
-    def test_deny_decorator(self):
-        """
-        Ensures @xframe_options_deny properly sets the X-Frame-Options header.
-        """
-
-        @xframe_options_deny
-        def a_view(request):
-            return HttpResponse()
-
-        r = a_view(HttpRequest())
-        self.assertEqual(r.headers["X-Frame-Options"], "DENY")
-
-    def test_sameorigin_decorator(self):
-        """
-        Ensures @xframe_options_sameorigin properly sets the X-Frame-Options
-        header.
-        """
-
-        @xframe_options_sameorigin
-        def a_view(request):
-            return HttpResponse()
-
-        r = a_view(HttpRequest())
-        self.assertEqual(r.headers["X-Frame-Options"], "SAMEORIGIN")
-
-    def test_exempt_decorator(self):
-        """
-        Ensures @xframe_options_exempt properly instructs the
-        XFrameOptionsMiddleware to NOT set the header.
-        """
-
-        @xframe_options_exempt
-        def a_view(request):
-            return HttpResponse()
-
-        req = HttpRequest()
-        resp = a_view(req)
-        self.assertIsNone(resp.get("X-Frame-Options", None))
-        self.assertTrue(resp.xframe_options_exempt)
-
-        # Since the real purpose of the exempt decorator is to suppress
-        # the middleware's functionality, let's make sure it actually works...
-        r = XFrameOptionsMiddleware(a_view)(req)
-        self.assertIsNone(r.get("X-Frame-Options", None))


### PR DESCRIPTION
Reference to [#31949](https://code.djangoproject.com/ticket/31949).

This PR makes the `xframe_options_deny`, `xframe_options_sameorigin` and `xframe_options_exempt` decorators able to handle both sync and async views.