### PR TITLE
Fixed #34518 -- Prevented random() filter from crashing on empty list

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -628,7 +628,10 @@ def length_is(value, arg):
 @register.filter(is_safe=True)
 def random(value):
     """Return a random item from the list."""
-    return random_module.choice(value)
+    try:
+        return random_module.choice(value)
+    except IndexError:
+        return ""
 
 
 @register.filter("slice", is_safe=True)

--- a/tests/template_tests/filter_tests/test_random.py
+++ b/tests/template_tests/filter_tests/test_random.py
@@ -24,3 +24,8 @@ class RandomTests(SimpleTestCase):
             "random02", {"a": ["a&b", "a&b"], "b": [mark_safe("a&b"), mark_safe("a&b")]}
         )
         self.assertEqual(output, "a&b a&b")
+
+    @setup({"empty_list": "{{ list|random }}"})
+    def test_empty_list(self):
+        output = self.engine.render_to_string("empty_list", {"list": []})
+        self.assertEqual(output, "")


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34518 