### PR TITLE
Doc'd that Count("*") is equivalent to COUNT(*) SQL.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -3898,8 +3898,8 @@ by the aggregate.
 .. class:: Count(expression, distinct=False, filter=None, **extra)
 
     Returns the number of objects that are related through the provided
-    expression. ``Count('*')`` is shorthand for the SQL expression
-    ``COUNT(*)``.
+    expression. ``Count('*')`` is equivalent to the SQL ``COUNT(*)``
+    expression.
 
     * Default alias: ``<field>__count``
     * Return type: ``int``

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -3898,7 +3898,8 @@ by the aggregate.
 .. class:: Count(expression, distinct=False, filter=None, **extra)
 
     Returns the number of objects that are related through the provided
-    expression.
+    expression. ``Count('*')`` is shorthand for the SQL expression
+    ``COUNT(*)``.
 
     * Default alias: ``<field>__count``
     * Return type: ``int``


### PR DESCRIPTION
I've always known that `Count("*")` is a [valid shorthand for `expression=Star()`](https://github.com/django/django/blob/4bf4222010fd8e413963c6c873e4088614332ef9/django/db/models/aggregates.py#L161-L162), but I'm surprised that it's not documented. This was added by https://github.com/django/django/pull/2496 / f59fd15c4928caf3dfcbd50f6ab47be409a43b01 back in 2014.

If we do want to document this, because it is quite useful, then this seems like a simple way to do it. However I'm open to a larger snippet if needed?