### PR TITLE
Refs #33662 -- Corrected Sitemap.get_languages_for_item() signature in docs.

### DIFF
--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -314,7 +314,7 @@ Note:
           The latest ``lastmod`` returned by calling the method with all
           items returned by :meth:`Sitemap.items`.
 
-    .. method:: Sitemap.get_languages_for_item(item, lang_code)
+    .. method:: Sitemap.get_languages_for_item(item)
 
         .. versionadded:: 4.2
 


### PR DESCRIPTION
Reference to [#33662](https://code.djangoproject.com/ticket/33662)

This PR fixes a typo in `Sitemap.get_languages_for_item` signature -- the method takes `item` only.