### PR TITLE
Restored multiprocessing concurrency on coverage.py settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,6 @@ docs/_build/
 docs/locale/
 node_modules/
 tests/coverage_html/
-tests/.coverage
+tests/.coverage*
 build/
 tests/report/

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -337,14 +337,19 @@ Contributors are encouraged to run coverage on the test suite to identify areas
 that need additional tests. The coverage tool installation and use is described
 in :ref:`testing code coverage<topics-testing-code-coverage>`.
 
-Coverage should be run in a single process to obtain accurate statistics. To
-run coverage on the Django test suite using the standard test settings:
+To run coverage on the Django test suite using the standard test settings:
 
 .. console::
 
-   $ coverage run ./runtests.py --settings=test_sqlite --parallel=1
+   $ coverage run ./runtests.py --settings=test_sqlite
 
-After running coverage, generate the html report by running:
+After running coverage, combine all coverage statistics by running:
+
+.. console::
+
+   $ coverage combine
+
+After that generate the html report by running:
 
 .. console::
 

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-concurrency = multiprocessing
+concurrency = multiprocessing,thread
 data_file = .coverages/.coverage
 omit =
     */django/utils/autoreload.py

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,5 +1,7 @@
 [run]
 branch = True
+concurrency = multiprocessing
+data_file = .coverages/.coverage
 omit =
     */django/utils/autoreload.py
 source = django


### PR DESCRIPTION
This PR reverts https://github.com/django/django/commit/78da5ca0c1f2ab3201f8f6cd629e80d805ea023d and adds `thread` to the `concurrency` setting. This restores thread tracing and covers the async middleware in the coverage.py report.

<img width="822" alt="image" src="https://user-images.githubusercontent.com/1726961/234955720-9f0bfd4d-86cc-4b4d-b9a1-0abed7fd21bb.png">

Refs:
- https://github.com/django/django/pull/16435
- https://github.com/nedbat/coveragepy/issues/1585
- https://github.com/django/django/pull/16655