### PR TITLE
Fixed #34523 -- Fixed TransactionManagementError in QuerySet.update_or_create() with MyISAM storage engine.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -296,9 +296,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         """
         return self._mysql_storage_engine != "MyISAM"
 
-    uses_savepoints = property(operator.attrgetter("supports_transactions"))
-    can_release_savepoints = property(operator.attrgetter("supports_transactions"))
-
     @cached_property
     def ignores_table_name_case(self):
         return self.connection.mysql_server_data["lower_case_table_names"]


### PR DESCRIPTION
`QuerySet.update_or_create()` uses nested atomic to handle possible integrity errors taking savepoints as way to mark back the connection as usable. Savepoints are not returned when `uses_savepoints`/`can_release_savepoints` feature flags are set to `False`. As a consequence, `QuerySet.update_or_create()` assumed the outer atomic block is tainted and raised `TransactionManagementError`.

This commit partly reverts 331a460f8f2e4f447b68fba491464b68c9b21fd1.

Thanks gatello-s for the report.

ticket-34523

Without this patch, `get_or_create` tests crash on MySQL wit MyISAM storage engine:
```
./runtests.py get_or_create
Found 50 test(s).
Creating test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
Cloning test database for alias 'default'...
System check identified no issues (1 silenced).
sss........E............................EE........
======================================================================
ERROR: test_create_with_duplicate_primary_key (get_or_create.tests.UpdateOrCreateTestsWithManualPKs)
If an existing primary key is specified with different values for other
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
  File "/django/django/db/backends/mysql/base.py", line 75, in execute
    return self.cursor.execute(query, args)
  File "/lib/python3.10/site-packages/MySQLdb/cursors.py", line 206, in execute
    res = self._query(query)
  File "/lib/python3.10/site-packages/MySQLdb/cursors.py", line 319, in _query
    db.query(q)
  File "/lib/python3.10/site-packages/MySQLdb/connections.py", line 254, in query
    _mysql.connection.query(self, query)
MySQLdb.IntegrityError: (1062, "Duplicate entry '1' for key 'get_or_create_manualprimarykeytest.PRIMARY'")

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/django/django/db/models/query.py", line 915, in get_or_create
    return self.create(**params), True
  File "/django/django/db/models/query.py", line 650, in create
    obj.save(force_insert=True, using=self.db)
  File "/django/django/db/models/base.py", line 814, in save
    self.save_base(
  File "/django/django/db/models/base.py", line 877, in save_base
    updated = self._save_table(
  File "/django/django/db/models/base.py", line 1020, in _save_table
    results = self._do_insert(
  File "/django/django/db/models/base.py", line 1061, in _do_insert
    return manager._insert(
  File "/django/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/django/django/db/models/query.py", line 1807, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "/django/django/db/models/sql/compiler.py", line 1820, in execute_sql
    cursor.execute(sql, params)
  File "/django/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
  File "/django/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/django/django/db/backends/utils.py", line 84, in _execute
    with self.db.wrap_database_errors:
  File "/django/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/django/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
  File "/django/django/db/backends/mysql/base.py", line 75, in execute
    return self.cursor.execute(query, args)
  File "/lib/python3.10/site-packages/MySQLdb/cursors.py", line 206, in execute
    res = self._query(query)
  File "/lib/python3.10/site-packages/MySQLdb/cursors.py", line 319, in _query
    db.query(q)
  File "/lib/python3.10/site-packages/MySQLdb/connections.py", line 254, in query
    _mysql.connection.query(self, query)
django.db.utils.IntegrityError: (1062, "Duplicate entry '1' for key 'get_or_create_manualprimarykeytest.PRIMARY'")

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/local/lib/python3.10/unittest/case.py", line 591, in run
    self._callTestMethod(testMethod)
  File "/usr/local/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File "/django/tests/get_or_create/tests.py", line 627, in test_create_with_duplicate_primary_key
    ManualPrimaryKeyTest.objects.update_or_create(id=1, data="Different")
  File "/django/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/django/django/db/models/query.py", line 946, in update_or_create
    obj, created = self.select_for_update().get_or_create(
  File "/django/django/db/models/query.py", line 918, in get_or_create
    return self.get(**kwargs), False
  File "/django/django/db/models/query.py", line 625, in get
    num = len(clone)
  File "/django/django/db/models/query.py", line 379, in __len__
    self._fetch_all()
  File "/django/django/db/models/query.py", line 1883, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/django/django/db/models/query.py", line 90, in __iter__
    results = compiler.execute_sql(
  File "/django/django/db/models/sql/compiler.py", line 1560, in execute_sql
    cursor.execute(sql, params)
  File "/django/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
  File "/django/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/django/django/db/backends/utils.py", line 83, in _execute
    self.db.validate_no_broken_transaction()
  File "/django/django/db/backends/base/base.py", line 517, in validate_no_broken_transaction
    raise TransactionManagementError(
django.db.transaction.TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.

======================================================================
ERROR: test_integrity (get_or_create.tests.UpdateOrCreateTests)
If you don't specify a value or default value for all required
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/django/db/models/query.py", line 915, in get_or_create
    return self.create(**params), True
  File "/django/django/db/models/query.py", line 650, in create
    obj.save(force_insert=True, using=self.db)
  File "/django/django/db/models/base.py", line 814, in save
    self.save_base(
  File "/django/django/db/models/base.py", line 877, in save_base
    updated = self._save_table(
  File "/django/django/db/models/base.py", line 1020, in _save_table
    results = self._do_insert(
  File "/django/django/db/models/base.py", line 1061, in _do_insert
    return manager._insert(
  File "/django/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/django/django/db/models/query.py", line 1807, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "/django/django/db/models/sql/compiler.py", line 1820, in execute_sql
    cursor.execute(sql, params)
  File "/django/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
  File "/django/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/django/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
  File "/django/django/db/backends/mysql/base.py", line 80, in execute
    raise IntegrityError(*tuple(e.args))
django.db.utils.IntegrityError: (1048, "Column 'birthday' cannot be null")

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/local/lib/python3.10/unittest/case.py", line 591, in run
    self._callTestMethod(testMethod)
  File "/usr/local/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File "/django/tests/get_or_create/tests.py", line 358, in test_integrity
    Person.objects.update_or_create(first_name="Tom", last_name="Smith")
  File "/django/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/django/django/db/models/query.py", line 946, in update_or_create
    obj, created = self.select_for_update().get_or_create(
  File "/django/django/db/models/query.py", line 918, in get_or_create
    return self.get(**kwargs), False
  File "/django/django/db/models/query.py", line 625, in get
    num = len(clone)
  File "/django/django/db/models/query.py", line 379, in __len__
    self._fetch_all()
  File "/django/django/db/models/query.py", line 1883, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/django/django/db/models/query.py", line 90, in __iter__
    results = compiler.execute_sql(
  File "/django/django/db/models/sql/compiler.py", line 1560, in execute_sql
    cursor.execute(sql, params)
  File "/django/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
  File "/django/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/django/django/db/backends/utils.py", line 83, in _execute
    self.db.validate_no_broken_transaction()
  File "/django/django/db/backends/base/base.py", line 517, in validate_no_broken_transaction
    raise TransactionManagementError(
django.db.transaction.TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.

======================================================================
ERROR: test_manual_primary_key_test (get_or_create.tests.UpdateOrCreateTests)
If you specify an existing primary key, but different other fields,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
  File "/django/django/db/backends/mysql/base.py", line 75, in execute
    return self.cursor.execute(query, args)
  File "/lib/python3.10/site-packages/MySQLdb/cursors.py", line 206, in execute
    res = self._query(query)
  File "/lib/python3.10/site-packages/MySQLdb/cursors.py", line 319, in _query
    db.query(q)
  File "/lib/python3.10/site-packages/MySQLdb/connections.py", line 254, in query
    _mysql.connection.query(self, query)
MySQLdb.IntegrityError: (1062, "Duplicate entry '1' for key 'get_or_create_manualprimarykeytest.PRIMARY'")

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/django/django/db/models/query.py", line 915, in get_or_create
    return self.create(**params), True
  File "/django/django/db/models/query.py", line 650, in create
    obj.save(force_insert=True, using=self.db)
  File "/django/django/db/models/base.py", line 814, in save
    self.save_base(
  File "/django/django/db/models/base.py", line 877, in save_base
    updated = self._save_table(
  File "/django/django/db/models/base.py", line 1020, in _save_table
    results = self._do_insert(
  File "/django/django/db/models/base.py", line 1061, in _do_insert
    return manager._insert(
  File "/django/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/django/django/db/models/query.py", line 1807, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "/django/django/db/models/sql/compiler.py", line 1820, in execute_sql
    cursor.execute(sql, params)
  File "/django/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
  File "/django/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/django/django/db/backends/utils.py", line 84, in _execute
    with self.db.wrap_database_errors:
  File "/django/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/django/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
  File "/django/django/db/backends/mysql/base.py", line 75, in execute
    return self.cursor.execute(query, args)
  File "/lib/python3.10/site-packages/MySQLdb/cursors.py", line 206, in execute
    res = self._query(query)
  File "/lib/python3.10/site-packages/MySQLdb/cursors.py", line 319, in _query
    db.query(q)
  File "/lib/python3.10/site-packages/MySQLdb/connections.py", line 254, in query
    _mysql.connection.query(self, query)
django.db.utils.IntegrityError: (1062, "Duplicate entry '1' for key 'get_or_create_manualprimarykeytest.PRIMARY'")

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/local/lib/python3.10/unittest/case.py", line 591, in run
    self._callTestMethod(testMethod)
  File "/usr/local/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File "/django/tests/get_or_create/tests.py", line 367, in test_manual_primary_key_test
    ManualPrimaryKeyTest.objects.update_or_create(id=1, data="Different")
  File "/django/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/django/django/db/models/query.py", line 946, in update_or_create
    obj, created = self.select_for_update().get_or_create(
  File "/django/django/db/models/query.py", line 918, in get_or_create
    return self.get(**kwargs), False
  File "/django/django/db/models/query.py", line 625, in get
    num = len(clone)
  File "/django/django/db/models/query.py", line 379, in __len__
    self._fetch_all()
  File "/django/django/db/models/query.py", line 1883, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/django/django/db/models/query.py", line 90, in __iter__
    results = compiler.execute_sql(
  File "/django/django/db/models/sql/compiler.py", line 1560, in execute_sql
    cursor.execute(sql, params)
  File "/django/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
  File "/django/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/django/django/db/backends/utils.py", line 83, in _execute
    self.db.validate_no_broken_transaction()
  File "/django/django/db/backends/base/base.py", line 517, in validate_no_broken_transaction
    raise TransactionManagementError(
django.db.transaction.TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.

----------------------------------------------------------------------
Ran 50 tests in 1.711s

FAILED (errors=3, skipped=3)
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
Destroying test database for alias 'default'...
```