### PR TITLE
QuerySet from subquery

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -23,7 +23,7 @@ from django.db import (
 from django.db.models import AutoField, DateField, DateTimeField, Field, sql
 from django.db.models.constants import LOOKUP_SEP, OnConflict
 from django.db.models.deletion import Collector
-from django.db.models.expressions import Case, F, Value, When, Star
+from django.db.models.expressions import Case, F, Value, When
 from django.db.models.functions import Cast, Trunc
 from django.db.models.query_utils import FilteredRelation, Q
 from django.db.models.sql.constants import CURSOR, GET_ITERATOR_CHUNK_SIZE
@@ -565,8 +565,6 @@ class QuerySet(AltersData):
         clone.query.qualify = True
         clone.query.inner_query = self.query.chain()
         clone.query.inner_query.subquery = True
-        # clone.query.default_cols = False
-        # clone.query.select = [Star()]
         return clone
 
     def aggregate(self, *args, **kwargs):

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -682,9 +682,9 @@ class SQLCompiler:
             # The limits must be applied to the outer query to avoid pruning
             # results too eagerly.
             with_limits=False,
-            # Force unique aliasing of selected columns to avoid collisions
-            # and make rhs predicates referencing easier.
-            with_col_aliases=True,
+            # # Force unique aliasing of selected columns to avoid collisions
+            # # and make rhs predicates referencing easier.
+            # with_col_aliases=True,
         )
         qualify_sql, qualify_params = self.compile(self.qualify)
         result = [
@@ -1112,6 +1112,14 @@ class SQLCompiler:
         might change the tables that are needed. This means the select columns,
         ordering, and distinct must be done first.
         """
+
+        if self.query.inner_query is not None:
+            clause_sql, clause_params = self.compile(self.query.inner_query)
+            table_name = next(iter(self.query.alias_map.keys()))
+            table_name = self.connection.ops.quote_name(table_name)
+            clause_sql = f"{clause_sql} {table_name}"
+            return [clause_sql], clause_params
+
         result = []
         params = []
         for alias in tuple(self.query.alias_map):

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -682,9 +682,6 @@ class SQLCompiler:
             # The limits must be applied to the outer query to avoid pruning
             # results too eagerly.
             with_limits=False,
-            # # Force unique aliasing of selected columns to avoid collisions
-            # # and make rhs predicates referencing easier.
-            # with_col_aliases=True,
         )
         qualify_sql, qualify_params = self.compile(self.qualify)
         result = [

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -186,6 +186,7 @@ class Query(BaseExpression):
 
     filter_is_sticky = False
     subquery = False
+    inner_query = None
 
     # SQL-related attributes.
     # Select and related select clauses are expressions to use in the SELECT

--- a/tests/queries/test_subquery.py
+++ b/tests/queries/test_subquery.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+
 from .models import NamedCategory, Tag
 
 

--- a/tests/queries/test_subquery.py
+++ b/tests/queries/test_subquery.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from .models import NamedCategory, Tag
+
+
+class TestSubquery(TestCase):
+    def test_simple_subquery(self):
+        c1 = NamedCategory(name="c1")
+        c2 = NamedCategory(name="c2")
+        c1.save()
+        c2.save()
+        t1 = Tag(name="t11", category=c1)
+        t2 = Tag(name="t12", category=c1)
+        t3 = Tag(name="t21", category=c2)
+        t4 = Tag(name="t22", category=c2)
+        t1.save()
+        t2.save()
+        t3.save()
+        t4.save()
+
+        qs1 = Tag.objects.exclude(name__startswith="t11").as_subquery()
+        self.assertEqual(qs1.count(), 3)
+        qs2 = qs1.filter(name__startswith="t2")
+        self.assertEqual(qs2.count(), 2)


### PR DESCRIPTION
<details>
  <summary><h2>1. Problem</h2></summary>

Django 4.2 enabled us to filter by calculated values and this is awesome! But for now it's impossible to perform a filter exactly after a filter by annotated value. The following Django ORM code:
```py
Model.objects.all() \
    .annotate(
        ord=Window(
            expression=RowNumber(),
            partition_by=F('related_id'),
            order_by=[F("date_created").desc()]
        )
    ) \
    .filter(ord=1) \
    .filter(date_created__lte=some_datetime)
```

Leads to this SQL query:
```sql
SELECT * 
FROM (
    SELECT 
      id, related_id, values, date_created
      ROW_NUMBER() OVER (
        PARTITION BY related_id
        ORDER BY date_created DESC
      ) AS ord
    FROM model_table
    WHERE date_created <= '2022-02-24 00:00:00+00:00'
)
WHERE ord = 1
```
However, in some cases the order of filtering statements leads to different result data and hence is highly important.
</details>

<details>
  <summary><h2>2. Existing Solutions</h2></summary>

To overcome this problem, it's possible to use subquery in WHERE clause:

```py
sub = Model.objects.all() \
    .annotate(
        ord=Window(
            expression=RowNumber(),
            partition_by=F('related_id'),
            order_by=[F('date_created').desc()]
        )
    ) \
    .filter(ord=1)

result = Model.objects.all() \
    .filter(id__in=sub.values_list('id')) \
    .filter(date_created__lte=some_datetime)
```

Which has bad performance due to hash join.

Or RawSQL could be used:
```py
sub = Model.objects.all() \
    .annotate(
        ord=Window(
            expression=RowNumber(),
            partition_by=F('related_id'),
            order_by=[F('date_created').desc()]
        )
    ) \
    .filter(ord=1)
sql, params = sub.query.sql_with_params()

result = Model.objects.raw(
    'SELECT * FROM ({}) "model_table" WHERE date_created <= %s'.format(sql),
    params + (some_datetime,)
)
```
But this breaks ORM philosophy and prevents it's features.

<!---
[StackOverflow: move filter after annotate subquery](https://stackoverflow.com/q/76128230/5308802)
[Google Groups / Django: move filter after annotate subquery](https://groups.google.com/g/django-users/c/Dm3KuOnOpnk)
--->

There are external libraries solving the problem, but they are limited and unmaintained, e.g [PyPI: django-sub-query](https://pypi.org/project/django-sub-query/). Meanwhile, the described logic is pretty simple and could be better implemented inside Django ORM itself.
<sub>Honestly, I tried to do it as a separate library, but this was too monstrous. I also aimed to create subqueries without much new code, using existing features that generate `FROM (...)`, but it also was overcomplicated.</sub>
</details>

<details>
  <summary><h2>3. My Solution with From-Subquery Feature</h2></summary>

Now `QuerySet` provides `as_subquery` method:

```py
Model.objects.all() \
    .annotate(
        ord=Window(
            expression=RowNumber(),
            partition_by=F('related_id'),
            order_by=[F("date_created").desc()]
        )
    ) \
    .filter(ord=1) \
    .as_subquery() \
    .filter(date_created__lte=some_datetime)
```

Which leads to a SQL query like:

```sql
SELECT id, related_id, values, date_created
FROM (
    SELECT * 
    FROM (
        SELECT 
          id, related_id, values, date_created
          ROW_NUMBER() OVER (
            PARTITION BY related_id
            ORDER BY date_created DESC
          ) AS ord
        FROM model_table
    )
    WHERE ord = 1
) model_table
WHERE date_created <= '2022-02-24 00:00:00+00:00'
```

To achieve this, I:
- Added `as_subquery` method to `QuerySet` class which created a separate `django.db.models.sql.Query` object referencing old one as a subquery.
- Added `inner_query` property to `django.db.models.sql.Query` class
- Removed forced unique aliasing in `SQLCompiler.get_qualify_sql`. I'm not into this masking stuff, but, as far as I understood, this could be better done with unmasking and masking again... But I don't understand why to add aliases at all?
- `SQLCompiler.get_from_clause` returns subquery when it is presented.
- Checked unit tests got no new fails.
- Added new test case for the added feature.
</details>