### PR TITLE
[FIXED] -- The typo error in docstring has been fixed.

### DIFF
--- a/django/contrib/staticfiles/utils.py
+++ b/django/contrib/staticfiles/utils.py
@@ -41,7 +41,7 @@ def get_files(storage, ignore_patterns=None, location=""):
 
 def check_settings(base_url=None):
     """
-    Check if the staticfiles settings have sane values.
+    Check if the staticfiles settings have same values.
     """
     if base_url is None:
         base_url = settings.STATIC_URL


### PR DESCRIPTION
1. django/contrib/staticfiles/utils.py - Line: 44 Typo error fixed.
2. There is error in docstring, before it is 'sane' and now corrected to 'same'.