### PR TITLE
Fixed #34535 -- Fixed SQLite dbshell crash on pathlib.Path when handling exceptions.

### DIFF
--- a/django/core/management/commands/dbshell.py
+++ b/django/core/management/commands/dbshell.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
             raise CommandError(
                 '"%s" returned non-zero exit status %s.'
                 % (
-                    " ".join(e.cmd),
+                    " ".join(map(str, e.cmd)),
                     e.returncode,
                 ),
                 returncode=e.returncode,

--- a/tests/dbshell/test_sqlite.py
+++ b/tests/dbshell/test_sqlite.py
@@ -1,5 +1,9 @@
+import subprocess
 from pathlib import Path
+from unittest import mock, skipUnless
 
+from django.core.management import CommandError, call_command
+from django.db import connection
 from django.db.backends.sqlite3.client import DatabaseClient
 from django.test import SimpleTestCase
 
@@ -21,3 +25,18 @@ class SqliteDbshellCommandTestCase(SimpleTestCase):
             self.settings_to_cmd_args_env({"NAME": "test.db.sqlite3"}, ["-help"]),
             (["sqlite3", "test.db.sqlite3", "-help"], None),
         )
+
+    @skipUnless(connection.vendor == "sqlite", "SQLite test")
+    def test_non_zero_exit_status_when_path_to_db_is_path(self):
+        sqlite_with_path = {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": Path("test.db.sqlite3"),
+        }
+        cmd_args = self.settings_to_cmd_args_env(sqlite_with_path)[0]
+
+        msg = '"sqlite3 test.db.sqlite3" returned non-zero exit status 1.'
+        with mock.patch(
+            "django.db.backends.sqlite3.client.DatabaseClient.runshell",
+            side_effect=subprocess.CalledProcessError(returncode=1, cmd=cmd_args),
+        ), self.assertRaisesMessage(CommandError, msg):
+            call_command("dbshell")


### PR DESCRIPTION
With a sqlite database configured in `settings.py` like this:
```python
DATABASES = {
    "default": {
        "ENGINE": "django.db.backends.sqlite3",
        "NAME": BASE_DIR / "db.sqlite3",
    }
}
```
exiting `./manage.py dbshell` using <kbd>Control</kbd>-<kbd>d</kbd> sometimes results in this exception:

```
Traceback (most recent call last):
  File "/home/ubuntu/virtualenv/lib/python3.11/site-packages/django/core/management/commands/dbshell.py", line 30, in handle
    connection.client.runshell(options["parameters"])
  File "/home/ubuntu/virtualenv/lib/python3.11/site-packages/django/db/backends/base/client.py", line 28, in runshell
    subprocess.run(args, env=env, check=True)
  File "/usr/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['sqlite3', PosixPath('/home/ubuntu/planning-poker/db.sqlite3')]' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/planning-poker/./manage.py", line 30, in <module>
    main()
  File "/home/ubuntu/planning-poker/./manage.py", line 26, in main
    execute_from_command_line(sys.argv)
  File "/home/ubuntu/virtualenv/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/home/ubuntu/virtualenv/lib/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/ubuntu/virtualenv/lib/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/ubuntu/virtualenv/lib/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/virtualenv/lib/python3.11/site-packages/django/core/management/commands/dbshell.py", line 44, in handle
    " ".join(e.cmd),
    ^^^^^^^^^^^^^^^
TypeError: sequence item 1: expected str instance, PosixPath found
```

coercing each item in `e.cmd` to string should fix this.

(Please let me know if a trac ticket is required)