### PR TITLE
Fixed #29942 -- Fixed viewsource links not appearing.

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -6,13 +6,18 @@ This allows it to be built into other forms for easier viewing and browsing.
 
 To create an HTML version of the docs:
 
-* Install Sphinx (using ``python -m pip install Sphinx`` or some other method).
+* From the project root directory, run
+  ``python -m pip install -r docs/requirements.txt``. [1]_
 
-* In this docs/ directory, type ``make html`` (or ``make.bat html`` on
-  Windows) at a shell prompt.
+* Then type ``make html`` (or ``make.bat html`` on Windows) at a shell prompt.
 
 The documentation in ``_build/html/index.html`` can then be viewed in a web
 browser.
 
 .. _ReST: https://docutils.sourceforge.io/rst.html
 .. _Sphinx: https://www.sphinx-doc.org/
+
+.. [1] This command must be run (from the project root) because, due to
+   Sphinx's viewcode extension, the docs are dependent on Django itself.
+   ``docs/requirements.txt`` installs Django from the directory in which the
+   command is run.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
+    "sphinx.ext.inheritance_diagram",
 ]
 
 # AutosectionLabel settings.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,10 @@
 
 import sys
 from os.path import abspath, dirname, join
+from unittest.mock import Mock
+
+from django.apps import apps
+from django.conf import settings
 
 # Workaround for sphinx-build recursion limit overflow:
 # pickle.dump(doctree, f, pickle.HIGHEST_PROTOCOL)
@@ -44,6 +48,34 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.inheritance_diagram",
 ]
+
+# The Sphinx extension 'sphinx.ext.viewcode' generates source code links by
+# importing each of the documented modules. If any module has side effects on
+# import, these are executed when sphinx-build is run. Sometimes configured
+# settings, Django apps and external dependencies are required to import a
+# module. These requirements are satisfied below.
+sys.modules["psycopg.types"] = Mock()
+sys.modules["django.db.backends.postgresql.psycopg_any"] = Mock()
+# Mock modules which require a geospatial library to be installed.
+sys.modules["django.contrib.gis.geos"] = Mock()
+sys.modules["django.contrib.gis.gdal.libgdal"] = Mock()
+sys.modules["django.contrib.gis.gdal.prototypes"] = Mock()
+sys.modules["django.contrib.gis.db.models.functions"] = Mock()
+settings.configure()
+# For Django 3.2, the SECRET_KEY setting must be configured.
+settings.SECRET_KEY = "example-secret-key"
+apps.populate(
+    [
+        "django.contrib.admin",
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "django.contrib.flatpages",
+        "django.contrib.messages",
+        "django.contrib.redirects",
+        "django.contrib.sessions",
+        "django.contrib.sites",
+    ]
+)
 
 # AutosectionLabel settings.
 # Uses a <page>:<label> schema which doesn't work for duplicate sub-section

--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -45,11 +45,16 @@ documentation is transformed into HTML, PDF, and any other output format.
 __ https://www.sphinx-doc.org/
 __ https://docutils.sourceforge.io/
 
-To build the documentation locally, install Sphinx:
+To build the documentation locally, from the project root, install the
+documentation building requirements:
 
 .. console::
 
-     $ python -m pip install Sphinx
+     $ python -m pip install -r docs/requirements.txt
+
+This command must be run (from the project root) because the docs are dependent
+on Django itself. ``docs/requirements.txt`` installs Django from the directory
+in which the command is run.
 
 Then from the ``docs`` directory, build the HTML:
 

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -158,12 +158,12 @@ As HTML, locally
 You can get a local copy of the HTML documentation following a few steps:
 
 * Django's documentation uses a system called Sphinx__ to convert from
-  plain text to HTML. You'll need to install Sphinx by either downloading
-  and installing the package from the Sphinx website, or with ``pip``:
+  plain text to HTML. You'll need to install the documentation dependencies:
 
-  .. console::
+  .. code-block:: console
 
-        $ python -m pip install Sphinx
+        $ cd path/to/django/docs
+        $ python -m pip install -r requirements.txt
 
 * Then, use the included ``Makefile`` to turn the documentation into HTML:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,8 @@ pyenchant
 Sphinx>=4.5.0
 sphinxcontrib-spelling
 blacken-docs
+
+# Due to Sphinx's viewcode extension, the docs are dependent on Django itself.
+# Below Django is installed from the local directory. This assumes installation
+# from the project root, i.e. `python -m pip install -r docs/requirements.txt`.
+.


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/29942

First commit adds more references through better inheritance handling f637453c5525a2d418b3c814e325068baea27a3c

Second commit implements @hramezani solution da6ffd91e382580f7cf2619517c189042f98c1ee (thank you Hasan :star: )
Regression in 9033003d97d29f7754b0840333f6f362c0cd31f7
[Sphinx has a warning](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html) that viewcode essentially imports all files and will therefore try to run any code that is triggered on import 
I did really try to get this to work with `viewcode-find-source` but the only example I can see of this is in a test in the Sphinx source code, I couldn't get it to work

Finally I removed a missing import warning 1c1cb78bddc37c3bcc45aa1375c6c875d96a3707

There are a number of other warnings that we could address but maybe in a new ticket (might be worth us having some GitHub action to check if there are no new warnings being added to the docs or something)


