### PR TITLE
Removed unnecessary workarounds for Sphinx < 4.3.0.

### DIFF
--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -9,7 +9,6 @@ from docutils import nodes
 from docutils.parsers.rst import Directive
 from docutils.statemachine import ViewList
 from sphinx import addnodes
-from sphinx import version_info as sphinx_version
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.directives.code import CodeBlock
 from sphinx.domains.std import Cmdoption
@@ -118,16 +117,12 @@ class DjangoHTMLTranslator(HTMLTranslator):
         self.context.append(self.compact_p)
         self.compact_p = True
         # Needed by Sphinx.
-        if sphinx_version >= (4, 3):
-            self._table_row_indices.append(0)
-        else:
-            self._table_row_index = 0
+        self._table_row_indices.append(0)
         self.body.append(self.starttag(node, "table", CLASS="docutils"))
 
     def depart_table(self, node):
         self.compact_p = self.context.pop()
-        if sphinx_version >= (4, 3):
-            self._table_row_indices.pop()
+        self._table_row_indices.pop()
         self.body.append("</table>\n")
 
     def visit_desc_parameterlist(self, node):


### PR DESCRIPTION
While trying to figure out how Sphinx works, found we have handling for old versions we do not use (as `needs_sphinx = "4.5.0"`)