### PR TITLE
Corrected code-block directives in docs.

### DIFF
--- a/docs/ref/files/file.txt
+++ b/docs/ref/files/file.txt
@@ -135,7 +135,7 @@ below) will also have a couple of extra methods:
     Saves a new file with the file name and contents provided. This will not
     replace the existing file, but will create a new file and update the object
     to point to it. If ``save`` is ``True``, the model's ``save()`` method will
-    be called once the file is saved. That is, these two lines::
+    be called once the file is saved. That is, these two lines:
 
     .. code-block:: pycon
 

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1116,7 +1116,7 @@ Example usage:
         {% resetcycle %}
     {% endfor %}
 
-This example would return this HTML::
+This example would return this HTML:
 
 .. code-block:: html
 


### PR DESCRIPTION
The combination of double colon before the block and `.. code-block: html` leads to the wrong formatting:

https://docs.djangoproject.com/en/4.2/ref/templates/builtins/#resetcycle

![image](https://user-images.githubusercontent.com/206281/236197745-53e93f7c-1dc9-4c9c-aa74-6b1a68f75fa6.png)
