### PR TITLE
Refs #34551 -- Add a test on aggregations over annotated fields

### DIFF
--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -39,9 +39,9 @@ from django.db.models.functions import (
     Mod,
     Now,
     Pi,
+    Round,
     TruncDate,
     TruncHour,
-    Round,
 )
 from django.test import TestCase
 from django.test.testcases import skipUnlessDBFeature


### PR DESCRIPTION
Refs [#34551](https://code.djangoproject.com/ticket/34551)

- Adds a test to ensure the aggregation over annotated fields fail on 4.2.X versions.