### PR TITLE
Fixed #34556 -- Doc'd that StreamingHttpResponse accepts memoryviews and strings iterators.

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1213,9 +1213,9 @@ The :class:`StreamingHttpResponse` is not a subclass of :class:`HttpResponse`,
 because it features a slightly different API. However, it is almost identical,
 with the following notable differences:
 
-* It should be given an iterator that yields bytestrings as content. When
-  serving under WSGI, this should be a sync iterator. When serving under ASGI,
-  this is should an async iterator.
+* It should be given an iterator that yields bytestrings, :class:`memoryview`,
+  or strings as content. When serving under WSGI, this should be a sync
+  iterator. When serving under ASGI, then it should be an async iterator.
 
 * You cannot access its content, except by iterating the response object
   itself. This should only occur when the response is returned to the client:


### PR DESCRIPTION
Proposed solution for https://code.djangoproject.com/ticket/34556

This is a pretty minor change, but allows to explicitly tell what the code is doing. 