### PR TITLE
Made phrasing consistent when referencing HTTP requests in database docs.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -98,7 +98,7 @@ appropriate value at the beginning of each request, or disable persistent
 connections.
 
 If a connection is created in a long-running process, outside of Django’s
-request-response cycle, the connection will remain open until explicitly
+request/response cycle, the connection will remain open until explicitly
 closed, or timeout occurs.
 
 Encoding


### PR DESCRIPTION
A small paragraph was added in e901407e2369ddb16a5c866e1f2fbf8ea8acf549 that references the HTTP request cycle as "request-response cycle",  but most of the existing docs use "request/response", so this change matches that format for the similar phrasing.