### PR TITLE
Fixed #34565 -- Added support for async checking of user passwords.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -34,23 +34,21 @@ def is_password_usable(encoded):
     return encoded is None or not encoded.startswith(UNUSABLE_PASSWORD_PREFIX)
 
 
-def check_password(password, encoded, setter=None, preferred="default"):
+def verify_password(password, encoded, preferred="default"):
     """
-    Return a boolean of whether the raw password matches the three
-    part encoded digest.
-
-    If setter is specified, it'll be called when you need to
-    regenerate the password.
+    Return two booleans. The first is whether the raw password matches the
+    three part encoded digest, and the second whether to regenerate the
+    password.
     """
     if password is None or not is_password_usable(encoded):
-        return False
+        return False, False
 
     preferred = get_hasher(preferred)
     try:
         hasher = identify_hasher(encoded)
     except ValueError:
         # encoded is gibberish or uses a hasher that's no longer installed.
-        return False
+        return False, False
 
     hasher_changed = hasher.algorithm != preferred.algorithm
     must_update = hasher_changed or preferred.must_update(encoded)
@@ -63,8 +61,28 @@ def check_password(password, encoded, setter=None, preferred="default"):
     if not is_correct and not hasher_changed and must_update:
         hasher.harden_runtime(password, encoded)
 
+    return is_correct, must_update
+
+
+def check_password(password, encoded, setter=None, preferred="default"):
+    """
+    Return a boolean of whether the raw password matches the three part encoded
+    digest.
+
+    If setter is specified, it'll be called when you need to regenerate the
+    password.
+    """
+    is_correct, must_update = verify_password(password, encoded, preferred=preferred)
     if setter and is_correct and must_update:
         setter(password)
+    return is_correct
+
+
+async def acheck_password(password, encoded, setter=None, preferred="default"):
+    """See check_password()."""
+    is_correct, must_update = verify_password(password, encoded, preferred=preferred)
+    if setter and is_correct and must_update:
+        await setter(password)
     return is_correct
 
 

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -166,10 +166,17 @@ Methods
         were used.
 
     .. method:: check_password(raw_password)
+    .. method:: acheck_password(raw_password)
+
+        *Asynchronous version*: ``acheck_password()``
 
         Returns ``True`` if the given raw string is the correct password for
         the user. (This takes care of the password hashing in making the
         comparison.)
+
+        .. versionchanged:: 5.0
+
+            ``acheck_password()`` method was added.
 
     .. method:: set_unusable_password()
 

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -153,6 +153,10 @@ Minor features
 * ``AuthenticationMiddleware`` now adds an :meth:`.HttpRequest.auser`
   asynchronous method that returns the currently logged-in user.
 
+* The new :func:`django.contrib.auth.hashers.acheck_password` asynchronous
+  function and :meth:`.AbstractBaseUser.acheck_password` method allow
+  asynchronous checking of user passwords.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -695,10 +695,17 @@ The following attributes and methods are available on any subclass of
         were used.
 
     .. method:: models.AbstractBaseUser.check_password(raw_password)
+    .. method:: models.AbstractBaseUser.acheck_password(raw_password)
+
+        *Asynchronous version*: ``acheck_password()``
 
         Returns ``True`` if the given raw string is the correct password for
         the user. (This takes care of the password hashing in making the
         comparison.)
+
+        .. versionchanged:: 5.0
+
+            ``acheck_password()`` method was added.
 
     .. method:: models.AbstractBaseUser.set_unusable_password()
 

--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -478,6 +478,9 @@ to create and validate hashed passwords. You can use them independently
 from the ``User`` model.
 
 .. function:: check_password(password, encoded, setter=None, preferred="default")
+.. function:: acheck_password(password, encoded, asetter=None, preferred="default")
+
+    *Asynchronous version*: ``acheck_password()``
 
     If you'd like to manually authenticate a user by comparing a plain-text
     password to the hashed password in the database, use the convenience
@@ -489,6 +492,10 @@ from the ``User`` model.
     can also pass ``preferred`` to change a hashing algorithm if you don't want
     to use the default (first entry of ``PASSWORD_HASHERS`` setting). See
     :ref:`auth-included-hashers` for the algorithm name of each hasher.
+
+    .. versionchanged:: 5.0
+
+        ``acheck_password()`` method was added.
 
 .. function:: make_password(password, salt=None, hasher='default')
 

--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -11,6 +11,7 @@ from django.contrib.auth.hashers import (
     PBKDF2PasswordHasher,
     PBKDF2SHA1PasswordHasher,
     ScryptPasswordHasher,
+    acheck_password,
     check_password,
     get_hasher,
     identify_hasher,
@@ -58,6 +59,15 @@ class TestUtilsHashPass(SimpleTestCase):
         self.assertTrue(is_password_usable(blank_encoded))
         self.assertTrue(check_password("", blank_encoded))
         self.assertFalse(check_password(" ", blank_encoded))
+
+    async def test_acheck_password(self):
+        encoded = make_password("lètmein")
+        self.assertIs(await acheck_password("lètmein", encoded), True)
+        self.assertIs(await acheck_password("lètmeinz", encoded), False)
+        # Blank passwords.
+        blank_encoded = make_password("")
+        self.assertIs(await acheck_password("", blank_encoded), True)
+        self.assertIs(await acheck_password(" ", blank_encoded), False)
 
     def test_bytes(self):
         encoded = make_password(b"bytes_password")


### PR DESCRIPTION
Add `acheck_password` method and its unit tests. This method will call the async setter function to update the password field of the user table when the `settings.PASSWORD_HASHERS` is changed.