### PR TITLE
Add devcontainer for django package

### DIFF
--- a/.devcontainer/cmds.sh
+++ b/.devcontainer/cmds.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -U pip setuptools wheel
+pip install -e .
+
+# django-admin startproject hello_django
+# cd hello_django
+# python manage.py migrate

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "name": "django/django",
+    "image": "mcr.microsoft.com/devcontainers/python:3",
+    "customizations": {
+      "vscode": {
+        "settings": {
+          "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
+          "python.terminal.activateEnvInCurrentTerminal": true,
+          "python.terminal.launchArgs": [
+            "-X",
+            "dev"
+          ]
+        }
+      }
+    },
+    "postCreateCommand": "chmod +x .devcontainer/cmds.sh && ./.devcontainer/cmds.sh"
+}


### PR DESCRIPTION
Hello,
This pull request adds a dev container with GitHub Codespaces for the Django project. This will allow developers to quickly and easily set up a development environment for Django projects, without having to worry about installing and configuring all of the necessary dependencies.

The user can click on `Code` button on the GitHub repository preferably on his/her fork of Django and create a CodeSpace with Github. This will make the environment for a Django package, by installing the source package and making commands like `django-admin` available to use and test.
We can additionally add tests for the container so to make sure the changes don't break any functionality in the core.

Let me know if it is a valid PR or if it doesn't align with the Django standards. I'm eager to make changes and turn this into a good developer experience.

Awaiting feedback,
Thank you