### PR TITLE
Fixed #34539 -- Restored get_prep_value() call when adapting JSONFields.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -532,6 +532,7 @@ answer newbie questions, and generally made Django that much better:
     Julia Elman
     Julia Matsieva <julia.matsieva@gmail.com>
     Julian Bez
+    Julie Rymer <rymerjulie.pro@gmail.com>
     Julien Phalip <jphalip@gmail.com>
     Junyoung Choi <cupjoo@gmail.com>
     junzhang.jn@gmail.com

--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -99,6 +99,8 @@ class JSONField(CheckFieldDefaultMixin, Field):
         return "JSONField"
 
     def get_db_prep_value(self, value, connection, prepared=False):
+        if not prepared:
+            value = self.get_prep_value(value)
         # RemovedInDjango51Warning: When the deprecation ends, replace with:
         # if (
         #     isinstance(value, expressions.Value)

--- a/docs/releases/4.2.2.txt
+++ b/docs/releases/4.2.2.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Fixed a regression in Django 4.2 that caused an unnecessary
   ``DBMS_LOB.SUBSTR()`` wrapping in the ``__isnull`` and ``__exact=None``
   lookups for ``TextField()``/``BinaryField()`` on Oracle (:ticket:`34544`).
+
+* Restored, following a regression in Django 4.2, ``get_prep_value()`` call in
+  ``JSONField`` subclasses (:ticket:`34539`).

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -103,6 +103,29 @@ class TestMethods(SimpleTestCase):
         with self.assertRaisesMessage(TypeError, msg):
             KeyTransformTextLookupMixin(transform)
 
+    def test_get_prep_value(self):
+        class JSONFieldGetPrepValue(models.JSONField):
+            def get_prep_value(self, value):
+                if value is True:
+                    return {"value": True}
+                return value
+
+        def noop_adapt_json_value(value, encoder):
+            return value
+
+        field = JSONFieldGetPrepValue()
+        with mock.patch.object(
+            connection.ops, "adapt_json_value", noop_adapt_json_value
+        ):
+            self.assertEqual(
+                field.get_db_prep_value(True, connection, prepared=False),
+                {"value": True},
+            )
+            self.assertIs(
+                field.get_db_prep_value(True, connection, prepared=True), True
+            )
+            self.assertEqual(field.get_db_prep_value(1, connection, prepared=False), 1)
+
 
 class TestValidation(SimpleTestCase):
     def test_invalid_encoder(self):


### PR DESCRIPTION
Regression in 5c23d9f0c32f166c81ecb6f3f01d5077a6084318, JSONField was not following the Field API anymore by not calling get_prep_value from get_db_prep_value