### PR TITLE
Fixes #34566 - ModelAdmin get_field_queryset uses related admin ordering, but not related admin querysets.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -250,9 +250,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         if related_admin is not None:
             ordering = related_admin.get_ordering(request)
             if ordering is not None and ordering != ():
-                return related_admin.get_queryset(request).order_by(
-                    *ordering
-                )
+                return related_admin.get_queryset(request).order_by(*ordering)
         return None
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):


### PR DESCRIPTION
Fix issues if related_admin has annotations in get_queryset that are used in ordering.

See [#34566](https://code.djangoproject.com/ticket/34566) for a better explanation.