### PR TITLE
Fixed #34570 -- Silenced noop deferral of many-to-many and GFK.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -738,7 +738,15 @@ class Query(BaseExpression):
                 field_select_mask = select_mask.setdefault((field_name, relation), {})
                 field = relation.field
             else:
-                field = opts.get_field(field_name).field
+                reverse_rel = opts.get_field(field_name)
+                # While virtual fields such as many-to-many and generic foreign
+                # keys cannot be effectively deferred we've historically
+                # allowed them to be passed to QuerySet.defer(). Ignore such
+                # field references until a layer of validation at mask
+                # alteration time will be implemented eventually.
+                if not hasattr(reverse_rel, "field"):
+                    continue
+                field = reverse_rel.field
                 field_select_mask = select_mask.setdefault(field, {})
             related_model = field.model._meta.concrete_model
             self._get_defer_select_mask(

--- a/docs/releases/4.2.2.txt
+++ b/docs/releases/4.2.2.txt
@@ -15,3 +15,7 @@ Bugfixes
 
 * Restored, following a regression in Django 4.2, ``get_prep_value()`` call in
   ``JSONField`` subclasses (:ticket:`34539`).
+
+* Fixed a regression in Django 4.2 that caused a crash of ``QuerySet.defer()``
+  when passing a ``ManyToManyField`` or ``GenericForeignKey`` reference. While
+  doing so is a no-op, it was allowed in older version (:ticket:`34570`).

--- a/tests/defer_regress/tests.py
+++ b/tests/defer_regress/tests.py
@@ -271,6 +271,12 @@ class DeferRegressionTest(TestCase):
         with self.assertNumQueries(1):
             self.assertEqual(leaf.second_child.value, 64)
 
+    def test_defer_many_to_many_ignored(self):
+        location = Location.objects.create()
+        request = Request.objects.create(location=location)
+        with self.assertNumQueries(1):
+            self.assertEqual(Request.objects.defer("items").get(), request)
+
 
 class DeferDeletionSignalsTests(TestCase):
     senders = [Item, Proxy]


### PR DESCRIPTION
While deferring many-to-many and GFK has no effect the previous implementation of QuerySet.defer ignore them instead of crashing.

Refs #21204

Thanks Paco Martínez for the report.