### PR TITLE
Fixed #29725 -- Removed unnecessary join in QuerySet.count() and exists() on a many to many relation.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -1076,7 +1076,7 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
         def get_prefetch_cache(self):
             try:
                 return self.instance._prefetched_objects_cache[self.prefetch_cache_name]
-            except:
+            except (AttributeError, KeyError):
                 return None
 
         def _remove_prefetched_objects(self):
@@ -1147,27 +1147,33 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
             db = router.db_for_read(self.through, instance=self.instance)
             if not connections[db].features.supports_foreign_keys:
                 return None
-            hints = {'instance': self.instance}
+            hints = {"instance": self.instance}
             manager = self.through._base_manager.db_manager(db, hints=hints)
             filters = {self.source_field_name: self.instance.pk}
             # Nullable target rows must be excluded as well as they would have
             # been filtered out from an INNER JOIN.
             if self.target_field.null:
-                filters['%s__isnull' % self.target_field_name] = False
+                filters["%s__isnull" % self.target_field_name] = False
             return manager.filter(**filters)
 
         def exists(self):
             constrained_target = self.constrained_target
-            if constrained_target is not None and superclass is Manager and (
-                    self.get_prefetch_cache() is None):
+            if (
+                constrained_target is not None
+                and superclass is Manager
+                and (self.get_prefetch_cache() is None)
+            ):
                 return constrained_target.exists()
             else:
                 return super().exists()
 
         def count(self):
             constrained_target = self.constrained_target
-            if constrained_target is not None and superclass is Manager and (
-                    self.get_prefetch_cache() is None):
+            if (
+                constrained_target is not None
+                and superclass is Manager
+                and (self.get_prefetch_cache() is None)
+            ):
                 return constrained_target.count()
             else:
                 return super().count()

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -65,7 +65,6 @@ and two directions (forward and reverse) for a total of six combinations.
 
 from asgiref.sync import sync_to_async
 
-from django.db import models
 from django.core.exceptions import FieldError
 from django.db import (
     DEFAULT_DB_ALIAS,
@@ -74,7 +73,7 @@ from django.db import (
     router,
     transaction,
 )
-from django.db.models import Q, Window, signals
+from django.db.models import Manager, Q, Window, signals
 from django.db.models.functions import RowNumber
 from django.db.models.lookups import GreaterThan, LessThanOrEqual
 from django.db.models.query import QuerySet
@@ -1152,14 +1151,16 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
 
         def exists(self):
             constrained_target = self.constrained_target
-            if constrained_target and ManyRelatedManager.__class__ == models.Manager:
+            if constrained_target is not None and superclass is Manager and (
+                self.prefetch_cache_name is not None):
                 return constrained_target.exists()
             else:
                 return super().exists()
 
         def count(self):
             constrained_target = self.constrained_target
-            if constrained_target and ManyRelatedManager.__class__ == models.Manager:
+            if constrained_target is not None and superclass is Manager and (
+                self.prefetch_cache_name is not None):
                 return constrained_target.count()
             else:
                 return super().count()

--- a/tests/many_to_many/models.py
+++ b/tests/many_to_many/models.py
@@ -82,7 +82,7 @@ class InheritedArticleB(AbstractArticle):
 class NullableTargetArticle(models.Model):
     headline = models.CharField(max_length=100)
     publications = models.ManyToManyField(
-        Publication, through='NullablePublicationThrough'
+        Publication, through="NullablePublicationThrough"
     )
 
 

--- a/tests/many_to_many/models.py
+++ b/tests/many_to_many/models.py
@@ -82,8 +82,7 @@ class InheritedArticleB(AbstractArticle):
 class NullableTargetArticle(models.Model):
     headline = models.CharField(max_length=100)
     publications = models.ManyToManyField(
-        Publication,
-        through='NullablePublicationThrough'
+        Publication, through='NullablePublicationThrough'
     )
 
 

--- a/tests/many_to_many/models.py
+++ b/tests/many_to_many/models.py
@@ -91,6 +91,7 @@ class NullablePublicationThrough(models.Model):
     article = models.ForeignKey(NullableTargetArticle, models.CASCADE)
     publication = models.ForeignKey(Publication, models.CASCADE, null=True)
 
+
 # Manager and models to test if custom managers disable the SQL Optimization in #29725
 class CustomManager(models.Manager):
     pass

--- a/tests/many_to_many/models.py
+++ b/tests/many_to_many/models.py
@@ -78,11 +78,27 @@ class InheritedArticleA(AbstractArticle):
 class InheritedArticleB(AbstractArticle):
     pass
 
+
 class NullableTargetArticle(models.Model):
     headline = models.CharField(max_length=100)
-    publications = models.ManyToManyField(Publication, through='NullablePublicationThrough')
+    publications = models.ManyToManyField(
+        Publication,
+        through='NullablePublicationThrough'
+    )
 
 
 class NullablePublicationThrough(models.Model):
     article = models.ForeignKey(NullableTargetArticle, models.CASCADE)
     publication = models.ForeignKey(Publication, models.CASCADE, null=True)
+
+# Manager and models to test if custom managers disable the SQL Optimization in #29725
+class CustomManager(models.Manager):
+    pass
+
+
+class CustomArticle(models.Model):
+    # Same as the Article class above
+    headline = models.CharField(max_length=100)
+    publications = models.ManyToManyField(Publication, name="publications")
+
+    objects = CustomManager()

--- a/tests/many_to_many/models.py
+++ b/tests/many_to_many/models.py
@@ -77,3 +77,12 @@ class InheritedArticleA(AbstractArticle):
 
 class InheritedArticleB(AbstractArticle):
     pass
+
+class NullableTargetArticle(models.Model):
+    headline = models.CharField(max_length=100)
+    publications = models.ManyToManyField(Publication, through='NullablePublicationThrough')
+
+
+class NullablePublicationThrough(models.Model):
+    article = models.ForeignKey(NullableTargetArticle, models.CASCADE)
+    publication = models.ForeignKey(Publication, models.CASCADE, null=True)

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -628,9 +628,7 @@ class ManyToManyQueryTests(TestCase):
 
     def test_exists_join_optimization_disabled(self):
         with mock.patch.object(
-            connection.features,
-            "supports_foreign_keys",
-            False
+            connection.features, "supports_foreign_keys", False
         ), CaptureQueriesContext(connection) as query:
             self.article.publications.exists()
             self.custom_article.publications.exists()

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -1,14 +1,19 @@
+from unittest import mock
+
 from django.db import connection, transaction
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 from django.test.utils import CaptureQueriesContext
 
 from .models import (
-    Article, CustomArticle, InheritedArticleA, InheritedArticleB,
-    NullablePublicationThrough, NullableTargetArticle, Publication,
-    User
+    Article,
+    CustomArticle,
+    InheritedArticleA,
+    InheritedArticleB,
+    NullablePublicationThrough,
+    NullableTargetArticle,
+    Publication,
+    User,
 )
-
-from unittest import mock
 
 
 class ManyToManyTests(TestCase):
@@ -585,7 +590,6 @@ class ManyToManyQueryTests(TestCase):
             headline='Django lets you build Web apps easily'
         )
 
-
     @skipUnlessDBFeature('supports_foreign_keys')
     def test_count_join_optimization(self):
         with self.assertNumQueries(1) as queries:
@@ -598,7 +602,6 @@ class ManyToManyQueryTests(TestCase):
 
         self.assertNotIn('JOIN', queries[0]['sql'])
         self.assertEqual(self.nullable_target_article.publications.count(), 0)
-
 
     def test_count_join_optimization_disabled(self):
         with mock.patch.object(connection.features, 'supports_foreign_keys', False), \

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -604,7 +604,9 @@ class ManyToManyQueryTests(TestCase):
 
     def test_count_join_optimization_disabled(self):
         with mock.patch.object(
-            connection.features, "supports_foreign_keys", False,
+            connection.features,
+            "supports_foreign_keys",
+            False,
         ), CaptureQueriesContext(connection) as query:
             self.article.publications.count()
             self.custom_article.publications.count()
@@ -626,8 +628,10 @@ class ManyToManyQueryTests(TestCase):
 
     def test_exists_join_optimization_disabled(self):
         with mock.patch.object(
-            connection.features, "supports_foreign_keys", False
-            ), CaptureQueriesContext(connection) as query:
+            connection.features,
+            "supports_foreign_keys",
+            False
+        ), CaptureQueriesContext(connection) as query:
             self.article.publications.exists()
             self.custom_article.publications.exists()
 


### PR DESCRIPTION
I am working on #10366 (ticket can be found [here](https://code.djangoproject.com/ticket/29725))

I modified the code that previous contributors submitted, adding an extra check so that the SQL optimization would not apply if a custom manager is defined, as per comment #16's suggestion on the thread.

The edited code passes, skips, or expectedly fails all test cases when running ./runtests.py

*This is my first time submitting a PR. Please tell me if theres anything I'm doing wrong--Feedback would be greatly appreciated!