### PR TITLE
Refs #32339 -- Fixed super() call in deprecated DivFormRenderers.

### DIFF
--- a/django/forms/renderers.py
+++ b/django/forms/renderers.py
@@ -81,7 +81,7 @@ class DjangoDivFormRenderer(DjangoTemplates):
             "DjangoTemplates instead.",
             RemovedInDjango60Warning,
         )
-        super.__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 # RemovedInDjango60Warning.
@@ -97,7 +97,7 @@ class Jinja2DivFormRenderer(Jinja2):
             "Jinja2 instead.",
             RemovedInDjango60Warning,
         )
-        super.__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class TemplatesSetting(BaseRenderer):

--- a/tests/forms_tests/tests/test_renderers.py
+++ b/tests/forms_tests/tests/test_renderers.py
@@ -9,7 +9,7 @@ from django.forms.renderers import (
     Jinja2DivFormRenderer,
     TemplatesSetting,
 )
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, ignore_warnings
 from django.utils.deprecation import RemovedInDjango60Warning
 
 try:
@@ -74,3 +74,11 @@ class DeprecationTests(SimpleTestCase):
         )
         with self.assertRaisesMessage(RemovedInDjango60Warning, msg):
             Jinja2DivFormRenderer()
+
+    @ignore_warnings(category=RemovedInDjango60Warning)
+    def test_deprecation_renderers_can_be_instantiated(self):
+        tests = [DjangoDivFormRenderer, Jinja2DivFormRenderer]
+        for cls in tests:
+            with self.subTest(renderer_class=cls):
+                renderer = cls()
+                self.assertIsInstance(renderer, cls)


### PR DESCRIPTION
Missing function call `()` leads to:

`TypeError: descriptor '__init__' of 'super' object needs an argument`

Regression in b209518089131c6b4afd18b1d9c320ba3521c5ab.