### PR TITLE
Expanded test coverage of django.utils.dateformat

### DIFF
--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -296,3 +296,16 @@ class DateFormatTests(SimpleTestCase):
             with self.subTest(hour=hour):
                 self.assertEqual(dateformat.format(dt, "g"), g_expected)
                 self.assertEqual(dateformat.format(dt, "h"), h_expected)
+
+    def test_multibyte_single_char_format(self):
+        tests = [
+            "😀",
+            "à",
+            "ă",
+            "⌚",
+            "ខ",
+        ]
+        dt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        for format_ in tests:
+            with self.subTest(format=format_):
+                self.assertEqual(dateformat.format(dt, format_), format_)

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -142,9 +142,23 @@ class DateFormatTests(SimpleTestCase):
     def test_dateformat(self):
         my_birthday = datetime(1979, 7, 8, 22, 00)
 
-        self.assertEqual(dateformat.format(my_birthday, r"Y z \C\E\T"), "1979 189 CET")
-
-        self.assertEqual(dateformat.format(my_birthday, r"jS \o\f F"), "8th of July")
+        for format_, expected in [
+            # Simple case for escaping a word.
+            (r"jS \o\f F", "8th of July"),
+            # Simple cases with leading or trailing backslash.
+            # (Not using raw strings here as they cannot end with a backslash.)
+            ("\\jS \\o\\f F", "jth of July"),
+            ("jS \\o\\f F\\", "8th of July\\"),
+            # More pathological cases of nested escaping.
+            (r"Y z \C\E\T", "1979 189 CET"),
+            (r"Y z \\\C\\\E\\\T", r"1979 189 \C\E\T"),
+            (r"Y z \\\\\C\\\\\E\\\\\T", r"1979 189 \\C\\E\\T"),
+            # FIXME: These should work, but the current implementation is broken.
+            # (r"Y z \\C\\E\\T", r"1979 189 \C\July\CET"),
+            # (r"Y z \\\\C\\\\E\\\\T", r"1979 189 \\C\\July\\CET"),
+        ]:
+            with self.subTest(format=format_):
+                self.assertEqual(dateformat.format(my_birthday, format_), expected)
 
     def test_futuredates(self):
         the_future = datetime(2100, 10, 25, 0, 00)


### PR DESCRIPTION
Split out from #15405 according to the plan in https://github.com/django/django/pull/15405#issuecomment-1295325606.