### PR TITLE
Fixed #34578 -- Made "join" template filter respect autoescape for joiner.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -586,8 +586,9 @@ def join(value, arg, autoescape=True):
     """Join a list with a string, like Python's ``str.join(list)``."""
     try:
         if autoescape:
-            value = [conditional_escape(v) for v in value]
-        data = conditional_escape(arg).join(value)
+            data = conditional_escape(arg).join([conditional_escape(v) for v in value])
+        else:
+            data = arg.join(value)
     except TypeError:  # Fail silently if arg isn't iterable.
         return value
     return mark_safe(data)

--- a/tests/template_tests/filter_tests/test_join.py
+++ b/tests/template_tests/filter_tests/test_join.py
@@ -55,6 +55,22 @@ class JoinTests(SimpleTestCase):
         )
         self.assertEqual(output, "alpha & beta &amp; me")
 
+    @setup(
+        {
+            "join_autoescape_off": (
+                "{% autoescape off %}"
+                "{{ var_list|join:var_joiner }}"
+                "{% endautoescape %}"
+            ),
+        }
+    )
+    def test_join_autoescape_off(self):
+        var_list = ["<p>Hello World!</p>", "beta & me", "<script>Hi!</script>"]
+        context = {"var_list": var_list, "var_joiner": "<br/>"}
+        output = self.engine.render_to_string("join_autoescape_off", context)
+        expected_result = "<p>Hello World!</p><br/>beta & me<br/><script>Hi!</script>"
+        self.assertEqual(output, expected_result)
+
 
 class FunctionTests(SimpleTestCase):
     def test_list(self):
@@ -69,7 +85,7 @@ class FunctionTests(SimpleTestCase):
     def test_autoescape_off(self):
         self.assertEqual(
             join(["<a>", "<img>", "</a>"], "<br>", autoescape=False),
-            "<a>&lt;br&gt;<img>&lt;br&gt;</a>",
+            "<a><br><img><br></a>",
         )
 
     def test_noniterable_arg(self):


### PR DESCRIPTION
* If `autoescape` is `off`, `join` filter will not escape the joining string now.