### PR TITLE
Fixed #34551 -- Fixed a crash on combined aggregation over a subquery.

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -65,7 +65,14 @@ class Aggregate(Func):
         c.filter = c.filter and c.filter.resolve_expression(
             query, allow_joins, reuse, summarize
         )
-        if not summarize:
+        if summarize:
+            # Summarized aggregates cannot refer to summarized aggregates.
+            for ref in c.get_refs():
+                if query.annotations[ref].is_summary:
+                    raise FieldError(
+                        f"Cannot compute {c.name}('{ref}'): '{ref}' is an aggregate"
+                    )
+        elif not self.is_summary:
             # Call Aggregate.get_source_expressions() to avoid
             # returning self.filter and including that in this loop.
             expressions = super(Aggregate, c).get_source_expressions()

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1541,6 +1541,7 @@ class Subquery(BaseExpression, Combinable):
     template = "(%(subquery)s)"
     contains_aggregate = False
     empty_result_set_value = None
+    subquery = True
 
     def __init__(self, queryset, output_field=None, **extra):
         # Allow the usage of both QuerySet and sql.Query objects.

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -400,7 +400,10 @@ class Query(BaseExpression):
         """
         if not aggregate_exprs:
             return {}
-        aggregates = {}
+        # Store annotation mask prior to temporarily adding aggregations for
+        # resolving purpose to facilitate their subsequent removal.
+        replacements = {}
+        annotation_select_mask = self.annotation_select_mask
         for alias, aggregate_expr in aggregate_exprs.items():
             self.check_alias(alias)
             aggregate = aggregate_expr.resolve_expression(
@@ -408,7 +411,16 @@ class Query(BaseExpression):
             )
             if not aggregate.contains_aggregate:
                 raise TypeError("%s is not an aggregate expression" % alias)
-            aggregates[alias] = aggregate
+            # Temporarily add aggregate to annotations to allow remaining
+            # members of `aggregates` to resolve against each others.
+            self.append_annotation_mask([alias])
+            aggregate = aggregate.replace_expressions(replacements)
+            self.annotations[alias] = aggregate
+            replacements[Ref(alias, aggregate)] = aggregate
+        # Stash resolved aggregates now that they have been allowed to resolve
+        # against each other.
+        aggregates = {alias: self.annotations.pop(alias) for alias in aggregate_exprs}
+        self.set_annotation_mask(annotation_select_mask)
         # Existing usage of aggregation can be determined by the presence of
         # selected aggregates but also by filters against aliased aggregates.
         _, having, qualify = self.where.split_having_qualify()

--- a/docs/releases/4.2.2.txt
+++ b/docs/releases/4.2.2.txt
@@ -32,3 +32,7 @@ Bugfixes
 * Fixed a regression in Django 4.2 that caused a crash of
   ``QuerySet.aggregate()`` with expressions referencing other aggregates
   (:ticket:`34551`).
+
+* Fixed a regression in Django 4.2 that caused a crash of
+  ``QuerySet.aggregate()`` with aggregates referencing subqueries
+  (:ticket:`34551`).

--- a/docs/releases/4.2.2.txt
+++ b/docs/releases/4.2.2.txt
@@ -28,3 +28,7 @@ Bugfixes
 
 * Fixed a regression in Django 4.2 where nonexistent stylesheet was linked on a
   “Congratulations!” page (:ticket:`34588`).
+
+* Fixed a regression in Django 4.2 that caused a crash of
+  ``QuerySet.aggregate()`` with expressions referencing other aggregates
+  (:ticket:`34551`).

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -2187,3 +2187,23 @@ class AggregateAnnotationPruningTests(TestCase):
             mod_count=Count("*")
         )
         self.assertEqual(queryset.count(), 1)
+
+    def test_referenced_subquery_requires_wrapping(self):
+        total_books_qs = (
+            Author.book_set.through.objects.values("author")
+            .filter(author=OuterRef("pk"))
+            .annotate(total=Count("book"))
+        )
+        with self.assertNumQueries(1) as ctx:
+            aggregate = (
+                Author.objects.annotate(
+                    total_books=Subquery(total_books_qs.values("total"))
+                )
+                .values("pk", "total_books")
+                .aggregate(
+                    sum_total_books=Sum("total_books"),
+                )
+            )
+        sql = ctx.captured_queries[0]["sql"].lower()
+        self.assertEqual(sql.count("select"), 3, "Subquery wrapping required")
+        self.assertEqual(aggregate, {"sum_total_books": 3})


### PR DESCRIPTION
Thanks Denis Roldán and Mariusz for the test.

@felixxm I still want to provide more details here but that'll have to wait tomorrow, this addresses a few issues

1. It has to revert support for aggregating with over a colliding annotation (1297c0d0d76a708017fe196b61a0ab324df76954) as without major `Query.build_filter` changes (mainly having it use `resolve_ref` which is tracked in ticket-24267) this is not doable. I assume we'll want to re-open this ticket.
2. It addresses an issue where aggregations refer to a preceding aggregation (`Q(sum_total_books__isnull=True)`) which we didn't have tests for.
3. It addresses an optimization barrier missed in 59bea9efd2768102fc9d3aedda469502c218e9b7; when a summarized aggregate references a subquery an aggregate subquery pushdown must happen (see `refs_subquery`)

I also had to make adjustment to the test because because your subquery usage was returning many rows due to the lack of `GROUP BY`.