### PR TITLE
Update overview.txt

### DIFF
--- a/docs/intro/overview.txt
+++ b/docs/intro/overview.txt
@@ -22,7 +22,7 @@ code.
 .. _object-relational mapper: https://en.wikipedia.org/wiki/Object-relational_mapping
 
 The :doc:`data-model syntax </topics/db/models>` offers many rich ways of
-representing your models -- so far, it's been solving many years' worth of
+representing your models -- so far, it has been solving many years' worth of
 database-schema problems. Here's a quick example:
 
 .. code-block:: python


### PR DESCRIPTION
Correcting "it's" To "it has"
In the line "The data-model syntax offers many rich ways of representing your models – so far, it’s been solving many years’ worth of database-schema problems," "it's" should be "it has."