### PR TITLE
Support database connection pooling for postgresql

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -224,6 +224,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                 open=False,  # Do not open the pool during startup
                 configure=self._configure_connection,
                 reset=self._reset_connection,
+                **pool_options,
             )
 
     def get_database_version(self):

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -224,7 +224,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                     kwargs=connect_kwargs,
                     open=False,  # Do not open the pool during startup
                     configure=self._configure_connection,
-                    reset=self._reset_connection,
                     **pool_options,
                 )
 
@@ -362,11 +361,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         commit_role = ensure_role(connection, self.ops, role_name)
 
         return commit_role or commit_tz
-
-    def _reset_connection(self, connection):
-        # TODO: How would we like our connection state to look like?
-
-        pass  # We have nothing to do here (yet)
 
     def _close(self):
         if self.connection is not None:

--- a/tests/requirements/postgres.txt
+++ b/tests/requirements/postgres.txt
@@ -1,1 +1,1 @@
-psycopg[binary]>=3.1.8
+psycopg[binary,pool]>=3.1.8


### PR DESCRIPTION
So this needs tests and release notes. But I figured there might be one or two people out there who want to try this as is.

To get the pool running either set `pool` to True in the database `OPTIONS` dict or set it to a dict which then gets passed on to https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.ConnectionPool

Please note that this pool is most likely only really useful in the async case. Using a pool with a multi-process deployment (like standard gunicorn workers) is kinda useless since the will be just one concurrent request per process. Realistically speaking, this only becomes interesting in the sync case once we can have multithreaded gil-free python :D