### PR TITLE
Fixed #34580 -- Avoided unnecessary computation of selected expressions in SQLCompiler.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -331,7 +331,9 @@ class SQLCompiler:
             default_order, _ = ORDER_DIR["DESC"]
 
         selected_exprs = {}
-        if select := self.select:
+        # Avoid computing `selected_exprs` if there is no `ordering` as it's
+        # relatively expensive.
+        if ordering and (select := self.select):
             for ordinal, (expr, _, alias) in enumerate(select, start=1):
                 pos_expr = PositionRef(ordinal, alias, expr)
                 if alias:

--- a/docs/releases/4.2.2.txt
+++ b/docs/releases/4.2.2.txt
@@ -22,3 +22,6 @@ Bugfixes
 
 * Fixed a bug in Django 4.2 where :option:`makemigrations --update` didn't
   respect the ``--name`` option (:ticket:`34568`).
+
+* Fixed a performance regression in Django 4.2 when compiling queries without
+  ordering (:ticket:`34580`).


### PR DESCRIPTION
This is @charettes's commit not mine, so commit author will need changing if this works. See [Ticket #34580](https://code.djangoproject.com/ticket/34580)

I'm just opening this to see if the benchmark script can see a performance gain (it's about a 20%-30% improvement locally). 


```
       before           after         ratio
     [ca5d3c99]       [2aa6996a]
     <form_docs>       <SQLCompiler>
-     1.81±0.01ms         1.43±0ms     0.79  query_benchmarks.query_exists.benchmark.QueryExists.time_query_exists
-         876±7μs          625±8μs     0.71  query_benchmarks.query_aggregate.benchmark.QueryAggr.time_aggregate
-     1.30±0.01ms          914±9μs     0.70  query_benchmarks.query_count.benchmark.QueryCount.time_query_count

```