### PR TITLE
Fixed #34588 -- Removed usage of nonexistent stylesheet in the 'Congrats' page.

### DIFF
--- a/django/views/templates/default_urlconf.html
+++ b/django/views/templates/default_urlconf.html
@@ -6,7 +6,6 @@
         <meta charset="utf-8">
         <title>{% translate "The install worked successfully! Congratulations!" %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="/static/admin/css/fonts.css">
         <style>
           html {
             line-height: 1.15;

--- a/docs/releases/4.2.2.txt
+++ b/docs/releases/4.2.2.txt
@@ -25,3 +25,6 @@ Bugfixes
 
 * Fixed a performance regression in Django 4.2 when compiling queries without
   ordering (:ticket:`34580`).
+
+* Fixed a regression in Django 4.2 where nonexistent stylesheet was linked on a
+  “Congratulations!” page (:ticket:`34588`).


### PR DESCRIPTION
In PR #15960 , the `@import 'fonts.css';` rule was removed from `base.css`, but the reference to `fonts.css` in `default_urlconf.html` was not removed, resulting in a 404 error. This pull request aims to fix that error.

Changes Made:
- Updated `default_urlconf.html` to remove the reference to `fonts.css`.