### PR TITLE
Fixed #34564: Prevent Count to return None

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,6 +99,7 @@ answer newbie questions, and generally made Django that much better:
     Antti Kaihola <http://djangopeople.net/akaihola/>
     Anubhav Joshi <anubhav9042@gmail.com>
     Anvesh Mishra <anveshgreat11@gmail.com>
+    Amin Aminian <a.aminian321@gmail.com>
     Aram Dulyan
     arien <regexbot@gmail.com>
     Armin Ronacher

--- a/django/contrib/postgres/aggregates/statistics.py
+++ b/django/contrib/postgres/aggregates/statistics.py
@@ -48,7 +48,11 @@ class RegrAvgY(StatAggregate):
 class RegrCount(StatAggregate):
     function = "REGR_COUNT"
     output_field = IntegerField()
-    empty_result_set_value = 0
+
+    def __init__(self, y, x, output_field=None, filter=None, default=0):
+        super().__init__(
+            y, x, output_field=output_field, filter=filter, default=default
+        )
 
 
 class RegrIntercept(StatAggregate):

--- a/django/contrib/postgres/aggregates/statistics.py
+++ b/django/contrib/postgres/aggregates/statistics.py
@@ -50,7 +50,7 @@ class RegrCount(StatAggregate):
     output_field = IntegerField()
 
     def __init__(self, y, x, output_field=None, filter=None, default=0):
-        if default:
+        if default != 0:
             raise TypeError(f"{self.__class__.__name__} does not allow default.")
 
         super().__init__(

--- a/django/contrib/postgres/aggregates/statistics.py
+++ b/django/contrib/postgres/aggregates/statistics.py
@@ -50,6 +50,9 @@ class RegrCount(StatAggregate):
     output_field = IntegerField()
 
     def __init__(self, y, x, output_field=None, filter=None, default=0):
+        if default:
+            raise TypeError(f"{self.__class__.__name__} does not allow default.")
+
         super().__init__(
             y, x, output_field=output_field, filter=filter, default=default
         )

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -157,7 +157,7 @@ class Count(Aggregate):
     allow_distinct = True
 
     def __init__(self, expression, filter=None, default=0, **extra):
-        if default:
+        if default != 0:
             raise TypeError(f"{self.__class__.__name__} does not allow default.")
 
         if expression == "*":

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -155,14 +155,13 @@ class Count(Aggregate):
     name = "Count"
     output_field = IntegerField()
     allow_distinct = True
-    empty_result_set_value = 0
 
-    def __init__(self, expression, filter=None, **extra):
+    def __init__(self, expression, filter=None, default=0, **extra):
         if expression == "*":
             expression = Star()
         if isinstance(expression, Star) and filter is not None:
             raise ValueError("Star cannot be used with filter. Please specify a field.")
-        super().__init__(expression, filter=filter, **extra)
+        super().__init__(expression, filter=filter, default=default, **extra)
 
 
 class Max(Aggregate):

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -157,6 +157,9 @@ class Count(Aggregate):
     allow_distinct = True
 
     def __init__(self, expression, filter=None, default=0, **extra):
+        if default:
+            raise TypeError(f"{self.__class__.__name__} does not allow default.")
+
         if expression == "*":
             expression = Star()
         if isinstance(expression, Star) and filter is not None:

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -539,7 +539,10 @@ class AggregateTestCase(TestCase):
             vals = Book.objects.aggregate(Count("rating"))
         self.assertEqual(vals, {"rating__count": 6})
         sql = ctx.captured_queries[0]["sql"]
-        self.assertIn('SELECT COALESCE(COUNT("aggregation_book"."rating"), 0)', sql)
+        self.assertRegex(
+            sql,
+            r"SELECT COALESCE\(COUNT\(.aggregation_book.+rating.\), 0\)",
+        )
 
     def test_count_star(self):
         with self.assertNumQueries(1) as ctx:

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -1793,6 +1793,11 @@ class AggregateTestCase(TestCase):
                 datetime.datetime,
             )
 
+    def test_aggregation_default_unsupported_by_count(self):
+        msg = "Count does not allow default."
+        with self.assertRaisesMessage(TypeError, msg):
+            Count("age", default=1)
+
     def test_aggregation_default_unset(self):
         for Aggregate in [Avg, Max, Min, StdDev, Sum, Variance]:
             with self.subTest(Aggregate):

--- a/tests/postgres_tests/test_aggregates.py
+++ b/tests/postgres_tests/test_aggregates.py
@@ -929,7 +929,7 @@ class TestStatisticsAggregate(PostgreSQLTestCase):
     def test_regr_count_default(self):
         msg = "RegrCount does not allow default."
         with self.assertRaisesMessage(TypeError, msg):
-            RegrCount(y="int2", x="int1", default=0)
+            RegrCount(y="int2", x="int1", default=1)
 
     def test_regr_intercept_general(self):
         values = StatTestModel.objects.aggregate(

--- a/tests/postgres_tests/test_aggregates.py
+++ b/tests/postgres_tests/test_aggregates.py
@@ -926,6 +926,11 @@ class TestStatisticsAggregate(PostgreSQLTestCase):
             sql,
         )
 
+    def test_regr_count_default(self):
+        msg = "RegrCount does not allow default."
+        with self.assertRaisesMessage(TypeError, msg):
+            RegrCount(y="int2", x="int1", default=0)
+
     def test_regr_intercept_general(self):
         values = StatTestModel.objects.aggregate(
             regrintercept=RegrIntercept(y="int2", x="int1")

--- a/tests/test_runner/test_debug_sql.py
+++ b/tests/test_runner/test_debug_sql.py
@@ -89,22 +89,22 @@ class TestDebugSQL(unittest.TestCase):
 
     expected_outputs = [
         (
-            """SELECT COUNT(*) AS "__count"\n"""
+            """SELECT COALESCE(COUNT(*), 0) AS "__count"\n"""
             """FROM "test_runner_person"\n"""
             """WHERE "test_runner_person"."first_name" = 'error';"""
         ),
         (
-            """SELECT COUNT(*) AS "__count"\n"""
+            """SELECT COALESCE(COUNT(*), 0) AS "__count"\n"""
             """FROM "test_runner_person"\n"""
             """WHERE "test_runner_person"."first_name" = 'fail';"""
         ),
         (
-            """SELECT COUNT(*) AS "__count"\n"""
+            """SELECT COALESCE(COUNT(*), 0) AS "__count"\n"""
             """FROM "test_runner_person"\n"""
             """WHERE "test_runner_person"."first_name" = 'subtest-error';"""
         ),
         (
-            """SELECT COUNT(*) AS "__count"\n"""
+            """SELECT COALESCE(COUNT(*), 0) AS "__count"\n"""
             """FROM "test_runner_person"\n"""
             """WHERE "test_runner_person"."first_name" = 'subtest-fail';"""
         ),
@@ -122,12 +122,12 @@ class TestDebugSQL(unittest.TestCase):
         f"runTest ({test_class_path}.FailingSubTest{method_name}) ...",
         f"runTest ({test_class_path}.ErrorSubTest{method_name}) ...",
         (
-            """SELECT COUNT(*) AS "__count" """
+            """SELECT COALESCE(COUNT(*), 0) AS "__count" """
             """FROM "test_runner_person" WHERE """
             """"test_runner_person"."first_name" = 'pass';"""
         ),
         (
-            """SELECT COUNT(*) AS "__count" """
+            """SELECT COALESCE(COUNT(*), 0) AS "__count" """
             """FROM "test_runner_person" WHERE """
             """"test_runner_person"."first_name" = 'subtest-pass';"""
         ),

--- a/tests/update/tests.py
+++ b/tests/update/tests.py
@@ -228,7 +228,7 @@ class AdvancedTests(TestCase):
     def test_update_ordered_by_m2m_aggregation_annotation(self):
         msg = (
             "Cannot update when ordering by an aggregate: "
-            "Count(Col(update_bar_m2m_foo, update.Bar_m2m_foo.foo))"
+            "Coalesce(Count(Col(update_bar_m2m_foo, update.Bar_m2m_foo.foo)), Value(0))"
         )
         with self.assertRaisesMessage(FieldError, msg):
             Bar.objects.annotate(m2m_count=Count("m2m_foo")).order_by(


### PR DESCRIPTION
Reference to [#34564](https://code.djangoproject.com/ticket/34564).

This PR prevents Count function to return None by using `default=0`.