### PR TITLE
Refs #34118 -- Fixed FunctionalTests.test_cached_property_reuse_different_names() on Python 3.12+.

### DIFF
--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from django.test import SimpleTestCase
 from django.utils.functional import cached_property, classproperty, lazy
+from django.utils.version import PY312
 
 
 class FunctionalTests(SimpleTestCase):
@@ -130,7 +131,18 @@ class FunctionalTests(SimpleTestCase):
 
     def test_cached_property_reuse_different_names(self):
         """Disallow this case because the decorated function wouldn't be cached."""
-        with self.assertRaises(RuntimeError) as ctx:
+        type_msg = (
+            "Cannot assign the same cached_property to two different names ('a' and "
+            "'b')."
+        )
+        if PY312:
+            error_type = TypeError
+            msg = type_msg
+        else:
+            error_type = RuntimeError
+            msg = "Error calling __set_name__"
+
+        with self.assertRaisesMessage(error_type, msg) as ctx:
 
             class ReusedCachedProperty:
                 @cached_property
@@ -139,15 +151,8 @@ class FunctionalTests(SimpleTestCase):
 
                 b = a
 
-        self.assertEqual(
-            str(ctx.exception.__context__),
-            str(
-                TypeError(
-                    "Cannot assign the same cached_property to two different "
-                    "names ('a' and 'b')."
-                )
-            ),
-        )
+        if not PY312:
+            self.assertEqual(str(ctx.exception.__context__), str(TypeError(type_msg)))
 
     def test_cached_property_reuse_same_name(self):
         """


### PR DESCRIPTION
Python 3.12+ no longer wraps exceptions in `__set_name__`, see https://github.com/python/cpython/commit/55c99d97e14618dfce41472dd4446f763b0da13f.