### PR TITLE
Corrected documentation of Log database function.

### DIFF
--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -1205,7 +1205,7 @@ It can also be registered as a transform. For example:
 .. class:: Log(expression1, expression2, **extra)
 
 Accepts two numeric fields or expressions and returns the logarithm of
-the first to base of the second.
+the second to base of the first.
 
 Usage example:
 


### PR DESCRIPTION
I tried to follow the docs and was confused by the description for the `Log` function. I'm not an English native, but I have the impression that the docs are incorrect. The current phrasing makes you think that Log(2, 4) = 0.5.

The code example, however, shows that `Log(2, 4)  = 2`, I think this would be phrased this way: Log of 4 to the base of 2, i.e. log of the second number to the base of the first.

An alternative and more concise phrasing would be this:

> Accepts two numeric fields or expressions and returns their logarithm. `expression1` is the base and `expression2` is the number.


Additionaly the function signature could be represented like this:

```
.. class:: Log(expression_base, expression_number, **extra)
```