### PR TITLE
Fixed #34593 extra query in admin list if there are no filters.

### DIFF
--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -311,11 +311,15 @@ class ChangeList:
         # Get the number of objects, with admin filters applied.
         result_count = paginator.count
 
-        # Get the total number of objects, with no admin filters applied.
-        if self.model_admin.show_full_result_count:
+        if not self.model_admin.show_full_result_count:
+            full_result_count = None
+        elif self.has_active_filters:
+            # Get the total number of objects, with no admin filters applied.
             full_result_count = self.root_queryset.count()
         else:
-            full_result_count = None
+            # If there are no filters, no need for an extra query.
+            full_result_count = result_count
+
         can_show_all = result_count <= self.list_max_show_all
         multi_page = result_count > self.list_per_page
 

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1219,10 +1219,10 @@ class ChangeListTests(TestCase):
         with CaptureQueriesContext(connection) as context:
             response = self.client.post(changelist_url, data=data)
             self.assertEqual(response.status_code, 200)
-            self.assertIn("WHERE", context.captured_queries[4]["sql"])
-            self.assertIn("IN", context.captured_queries[4]["sql"])
+            self.assertIn("WHERE", context.captured_queries[3]["sql"])
+            self.assertIn("IN", context.captured_queries[3]["sql"])
             # Check only the first few characters since the UUID may have dashes.
-            self.assertIn(str(a.pk)[:8], context.captured_queries[4]["sql"])
+            self.assertIn(str(a.pk)[:8], context.captured_queries[3]["sql"])
 
     def test_deterministic_order_for_unordered_model(self):
         """

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -1828,7 +1828,7 @@ class ListFiltersTests(TestCase):
         request.user = self.alfred
         changelist = modeladmin.get_changelist_instance(request)
         changelist.get_results(request)
-        self.assertEqual(changelist.full_result_count, 4)
+        self.assertEqual(changelist.full_result_count, 3)
 
     def test_emptylistfieldfilter(self):
         empty_description = Department.objects.create(code="EMPT", description="")

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4774,9 +4774,10 @@ class AdminCustomQuerysetTest(TestCase):
         Person.objects.create(name="person2", gender=2)
         changelist_url = reverse("admin:admin_views_person_changelist")
 
-        # 5 queries are expected: 1 for the session, 1 for the user,
-        # 2 for the counts and 1 for the objects on the page
-        with self.assertNumQueries(5):
+        # 4 or 5 queries are expected: 1 for the session, 1 for the user,
+        # 1 for the objects on the page,
+        # and 1 for the count if there are no filters or 2 if there are.
+        with self.assertNumQueries(4):
             resp = self.client.get(changelist_url)
             self.assertEqual(resp.context["selection_note"], "0 of 2 selected")
             self.assertEqual(resp.context["selection_note_all"], "All 2 selected")


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/34593#ticket

Forum discussion: https://forum.djangoproject.com/t/django-admin-list-does-count-query-twice/21100

Thanks to @shangxiao for suggesting a better way to do the if/else.