### PR TITLE
Made MigrationRecorder cache has_table() result if django_migrations table exists.

### DIFF
--- a/django/db/migrations/recorder.py
+++ b/django/db/migrations/recorder.py
@@ -47,6 +47,7 @@ class MigrationRecorder:
 
     def __init__(self, connection):
         self.connection = connection
+        self._has_table = False
 
     @property
     def migration_qs(self):
@@ -54,9 +55,16 @@ class MigrationRecorder:
 
     def has_table(self):
         """Return True if the django_migrations table exists."""
+        # If the migrations table has already been confirmed to exist, don't
+        # recheck it's existence.
+        if self._has_table:
+            return True
+        # It hasn't been confirmed to exist, recheck.
         with self.connection.cursor() as cursor:
             tables = self.connection.introspection.table_names(cursor)
-        return self.Migration._meta.db_table in tables
+
+        self._has_table = self.Migration._meta.db_table in tables
+        return self._has_table
 
     def ensure_schema(self):
         """Ensure the table exists and has the correct schema."""

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -48,6 +48,16 @@ class RecorderTests(TestCase):
             set(),
         )
 
+    def test_has_table_cached(self):
+        """
+        The has_table() method caches a positive result and not continually
+        query for the existence of the migrations table.
+        """
+        recorder = MigrationRecorder(connection)
+        with self.assertNumQueries(1):
+            self.assertEqual(recorder.has_table(), True)
+            self.assertEqual(recorder.has_table(), True)
+
 
 class LoaderTests(TestCase):
     """


### PR DESCRIPTION
While debugging the speed of our migrations I noticed that on Postgres we repeatedly query for the existence of the migrations table. Once we confirm that it exists we can cache the result between calls?

Each introspection query isn't _slow_, but across thousands of migrations it can add up and isn't required as far as I can tell?