### PR TITLE
Fixed #34606 -- Fixed Right() function with zero length on Oracle and SQLite.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -545,6 +545,7 @@ answer newbie questions, and generally made Django that much better:
     Justin Michalicek <jmichalicek@gmail.com>
     Justin Myles Holmes <justin@slashrootcafe.com>
     Jyrki Pulliainen <jyrki.pulliainen@gmail.com>
+    Kacper Wolkiewicz <kac.wolkiewicz@gmail.com>
     Kadesarin Sanjek
     Kapil Bansal <kapilbansal.gbpecdelhi@gmail.com>
     Karderio <karderio@gmail.com>

--- a/django/db/models/functions/text.py
+++ b/django/db/models/functions/text.py
@@ -276,7 +276,9 @@ class Right(Left):
 
     def get_substr(self):
         return Substr(
-            self.source_expressions[0], self.source_expressions[1] * Value(-1)
+            self.source_expressions[0],
+            self.source_expressions[1] * Value(-1),
+            self.source_expressions[1],
         )
 
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/34606

Fixed that "Right()" database function on Oracle and SQLite returned whole field value instead of the empty string when the "length" argument was a database expression that evaluated to 0.