### PR TITLE
Fixed #33414 -- Fixed creating diamond shaped MTI objects for common ancestor with primary key that has a default.

### DIFF
--- a/tests/model_inheritance/models.py
+++ b/tests/model_inheritance/models.py
@@ -186,3 +186,23 @@ class Child(Parent):
 
 class GrandChild(Child):
     pass
+
+
+class CommonAncestor(models.Model):
+    id = models.IntegerField(primary_key=True, default=1)
+
+
+class FirstParent(CommonAncestor):
+    first_ancestor = models.OneToOneField(
+        CommonAncestor, models.CASCADE, primary_key=True, parent_link=True
+    )
+
+
+class SecondParent(CommonAncestor):
+    second_ancestor = models.OneToOneField(
+        CommonAncestor, models.CASCADE, primary_key=True, parent_link=True
+    )
+
+
+class CommonChild(FirstParent, SecondParent):
+    pass

--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -9,6 +9,7 @@ from django.test.utils import CaptureQueriesContext, isolate_apps
 from .models import (
     Base,
     Chef,
+    CommonChild,
     CommonInfo,
     CustomSupplier,
     GrandChild,
@@ -148,6 +149,14 @@ class ModelInheritanceTests(TestCase):
         # Higher level test for correct query values (title foof not
         # accidentally found).
         self.assertSequenceEqual(s.titles.all(), [])
+
+    def test_create_diamond_mti_default_pk(self):
+        # 1 INSERT for each base.
+        with self.assertNumQueries(4):
+            common_child = CommonChild.objects.create()
+        # 3 SELECTs for the parents, 1 UPDATE for the child.
+        with self.assertNumQueries(4):
+            common_child.save()
 
     def test_update_parent_filtering(self):
         """


### PR DESCRIPTION
- [ticket-33414](https://code.djangoproject.com/ticket/33414)
- [ticket-34634](https://code.djangoproject.com/ticket/34634)
Followed the proposition given by @charettes in the [comment](https://code.djangoproject.com/ticket/33414#comment:6)