### PR TITLE
Refs #34597 -- Avoided unnecessary constraints on reused split_exclude.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2020,10 +2020,11 @@ class Query(BaseExpression):
             lookup = lookup_class(pk.get_col(query.select[0].alias), pk.get_col(alias))
             query.where.add(lookup, AND)
             query.external_aliases[alias] = True
+        else:
+            lookup_class = select_field.get_lookup("exact")
+            lookup = lookup_class(col, ResolvedOuterRef(trimmed_prefix))
+            query.where.add(lookup, AND)
 
-        lookup_class = select_field.get_lookup("exact")
-        lookup = lookup_class(col, ResolvedOuterRef(trimmed_prefix))
-        query.where.add(lookup, AND)
         condition, needed_inner = self.build_filter(Exists(query))
 
         if contains_louter:

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2035,11 +2035,10 @@ class Query(BaseExpression):
             )
             condition.add(or_null_condition, OR)
             # Note that the end result will be:
-            # (outercol NOT IN innerq AND outercol IS NOT NULL) OR outercol IS NULL.
-            # This might look crazy but due to how IN works, this seems to be
-            # correct. If the IS NOT NULL check is removed then outercol NOT
-            # IN will return UNKNOWN. If the IS NULL check is removed, then if
-            # outercol IS NULL we will not match the row.
+            # NOT EXISTS (inner_q) OR outercol IS NULL.
+            # This might look crazy but due to how NULL works, this seems to be
+            # correct. If the IS NULL check is removed, then if outercol IS NULL
+            # we will not match the row.
         return condition, needed_inner
 
     def set_empty(self):


### PR DESCRIPTION
Addresses a SQL regression introduced by [8593e162c9cb63a6c0b06daf045bc1c21eb4d7c1](https://code.djangoproject.com/changeset/8593e162c9cb63a6c0b06daf045bc1c21eb4d7c1/) that is detailed in ticket-34597.

The SQL diff of this change is

```diff
--- test_ticket14511 (queries.tests.ExcludeTests):sqlite:89f10a80d7
+++ test_ticket14511 (queries.tests.ExcludeTests):sqlite:500a2087c2
@@ -161,7 +161,6 @@
                   (SELECT %s AS "a"
                    FROM "queries_employment" U1
                    WHERE (U1."title" IN (%s, %s)
-                          AND U1."id" = ("queries_employment"."id")
-                          AND "queries_employment"."employer_id" = ("queries_company"."id"))
+                          AND U1."id" = ("queries_employment"."id"))
                    LIMIT 1)))
 ORDER BY "queries_company"."name" ASC
--- test_ticket_24605 (queries.tests.TestTicket24605):sqlite:89f10a80d7
+++ test_ticket_24605 (queries.tests.TestTicket24605):sqlite:500a2087c2
@@ -25,7 +25,6 @@
               FROM "Individual" U0
               LEFT OUTER JOIN "RelatedIndividual" U1 ON (U0."id" = U1."related_id")
               WHERE (U1."id" IS NULL
-                     AND U0."id" = ("Individual"."id")
-                     AND "Individual"."id" = ("Individual"."id"))
+                     AND U0."id" = ("Individual"."id"))
               LIMIT 1))
 ORDER BY "Individual"."id" ASC
--- test_ticket_23605 (queries.tests.Ticket23605Tests):sqlite:89f10a80d7
+++ test_ticket_23605 (queries.tests.Ticket23605Tests):sqlite:500a2087c2
@@ -22,7 +22,7 @@
      FROM "queries_ticket23605a" W0
      INNER JOIN "queries_ticket23605b" W1 ON (W0."ticket23605aparent_ptr_id" = W1."modela_fk_id")
      INNER JOIN "queries_ticket23605c" W2 ON (W1."modelc_fk_id" = W2."id")
-     INNER JOIN "queries_ticket23605b" W4 ON (W0."ticket23605aparent_ptr_id" = W4."modela_fk_id")
+     INNER JOIN "queries_ticket23605b" W3 ON (W0."ticket23605aparent_ptr_id" = W3."modela_fk_id")
      WHERE (W1."field_b0" >= (%s / W2."field_c0")
             AND W1."field_b1"
             AND NOT (EXISTS
@@ -35,10 +35,9 @@
                                   WHERE NOT (U0."field_b1"
                                              AND U0."field_b0" >= (%s / U1."field_c0")
                                              AND U0."field_b0" IS NOT NULL))
-                               AND V1."id" = (W1."id")
-                               AND W1."modela_fk_id" = (W0."ticket23605aparent_ptr_id"))
+                               AND V1."id" = (W1."id"))
                         LIMIT 1))
-            AND W4."field_b1"))
+            AND W3."field_b1"))
 SELECT "queries_ticket23605aparent"."id",
        "queries_ticket23605a"."ticket23605aparent_ptr_id"
 FROM "queries_ticket23605a"
@@ -48,7 +47,7 @@
               FROM "queries_ticket23605a" W0
               INNER JOIN "queries_ticket23605b" W1 ON (W0."ticket23605aparent_ptr_id" = W1."modela_fk_id")
               INNER JOIN "queries_ticket23605c" W2 ON (W1."modelc_fk_id" = W2."id")
-              INNER JOIN "queries_ticket23605b" W4 ON (W0."ticket23605aparent_ptr_id" = W4."modela_fk_id")
+              INNER JOIN "queries_ticket23605b" W3 ON (W0."ticket23605aparent_ptr_id" = W3."modela_fk_id")
               WHERE (W1."field_b0" >= (%s / W2."field_c0")
                      AND W1."field_b1"
                      AND NOT (EXISTS
@@ -61,7 +60,6 @@
                                            WHERE NOT (U0."field_b1"
                                                       AND U0."field_b0" >= (%s / U1."field_c0")
                                                       AND U0."field_b0" IS NOT NULL))
-                                        AND V1."id" = (W1."id")
-                                        AND W1."modela_fk_id" = (W0."ticket23605aparent_ptr_id"))
+                                        AND V1."id" = (W1."id"))
                                  LIMIT 1))
-                     AND W4."field_b1")))
+                     AND W3."field_b1")))
```