### PR TITLE
Added local copy of Django to deps in tox.ini.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # then run "tox" from this directory.
 
 [tox]
-minversion = 3.18
+minversion = 4.0
 skipsdist = true
 envlist =
     py3
@@ -25,6 +25,7 @@ passenv = DJANGO_SETTINGS_MODULE,PYTHONPATH,HOME,DISPLAY,OBJC_DISABLE_INITIALIZE
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
+    -e .
     py{3,310,311}: -rtests/requirements/py3.txt
     postgres: -rtests/requirements/postgres.txt
     mysql: -rtests/requirements/mysql.txt


### PR DESCRIPTION
Without this fix there is no django installed when running the django tests.

Traceback on `main`:

```
$ tox -epy39
py39: commands[0] /.../django/tests> /.../django/.tox/py39/bin/python runtests.py
Traceback (most recent call last):
  File "/.../django/tests/runtests.py", line 17, in <module>
    import django
ModuleNotFoundError: No module named 'django'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/.../django/tests/runtests.py", line 19, in <module>
    raise RuntimeError(
RuntimeError: Django module not found, reference tests/README.rst for instructions.
py39: exit 1 (0.13 seconds) /.../django/tests> /.../django/.tox/py39/bin/python runtests.py pid=46968
  py39: FAIL code 1 (0.59=setup[0.46]+cmd[0.13] seconds)
  evaluation failed :( (0.65 seconds)
```