### PR TITLE
Fixed #34532 -- Made formset_factory() respect Form's default_renderer.

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -566,7 +566,7 @@ def formset_factory(
         "absolute_max": absolute_max,
         "validate_min": validate_min,
         "validate_max": validate_max,
-        "renderer": renderer or get_default_renderer(),
+        "renderer": renderer or form.default_renderer or get_default_renderer()
     }
     return type(form.__name__ + "FormSet", (formset,), attrs)
 

--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -566,7 +566,7 @@ def formset_factory(
         "absolute_max": absolute_max,
         "validate_min": validate_min,
         "validate_max": validate_max,
-        "renderer": renderer or form.default_renderer or get_default_renderer()
+        "renderer": renderer or form.default_renderer or get_default_renderer(),
     }
     return type(form.__name__ + "FormSet", (formset,), attrs)
 

--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -555,6 +555,15 @@ def formset_factory(
         absolute_max = max_num + DEFAULT_MAX_NUM
     if max_num > absolute_max:
         raise ValueError("'absolute_max' must be greater or equal to 'max_num'.")
+
+    if renderer is None:
+        if form.default_renderer is None:
+            renderer = get_default_renderer()
+        else:
+            renderer = form.default_renderer
+            if isinstance(form.default_renderer, type):
+                renderer = renderer()
+
     attrs = {
         "form": form,
         "extra": extra,
@@ -566,7 +575,7 @@ def formset_factory(
         "absolute_max": absolute_max,
         "validate_min": validate_min,
         "validate_max": validate_max,
-        "renderer": renderer or form.default_renderer or get_default_renderer(),
+        "renderer": renderer,
     }
     return type(form.__name__ + "FormSet", (formset,), attrs)
 

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1553,6 +1553,28 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertEqual(formset.non_form_errors().renderer, renderer)
         self.assertEqual(formset.empty_form.renderer, renderer)
 
+    def test_form_default_renderer(self):
+        """
+        In the absense of a renderer passed to formset_factory, the default_renderer
+        attribute of the Form class should be respected.
+        """
+        from django.forms.renderers import Jinja2
+
+        class ChoiceWithDefaultRenderer(Choice):
+            default_renderer = Jinja2
+
+        data = {
+            "choices-TOTAL_FORMS": "1",
+            "choices-INITIAL_FORMS": "0",
+            "choices-MIN_NUM_FORMS": "0",
+        }
+
+        ChoiceFormSet = formset_factory(ChoiceWithDefaultRenderer, renderer=None)
+        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
+        self.assertIsInstance(
+            formset.forms[0].renderer, ChoiceWithDefaultRenderer.default_renderer
+        )
+
     def test_repr(self):
         valid_formset = self.make_choiceformset([("test", 1)])
         valid_formset.full_clean()

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1577,6 +1577,28 @@ class FormsFormsetTestCase(SimpleTestCase):
             formset.forms[0].renderer, ChoiceWithDefaultRenderer.default_renderer
         )
 
+    def test_form_default_renderer_class(self):
+        """
+        In the absence of a renderer passed to the formset_factory(),
+        Form.default_renderer is respected.
+        """
+
+        class CustomRenderer(DjangoTemplates):
+            pass
+
+        class ChoiceWithDefaultRenderer(Choice):
+            default_renderer = CustomRenderer
+
+        data = {
+            "choices-TOTAL_FORMS": "1",
+            "choices-INITIAL_FORMS": "0",
+            "choices-MIN_NUM_FORMS": "0",
+        }
+
+        ChoiceFormSet = formset_factory(ChoiceWithDefaultRenderer, renderer=None)
+        formset = ChoiceFormSet(data, prefix="choices")
+        self.assertIsInstance(formset.forms[0].renderer, CustomRenderer)
+
     def test_repr(self):
         valid_formset = self.make_choiceformset([("test", 1)])
         valid_formset.full_clean()

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1570,7 +1570,7 @@ class FormsFormsetTestCase(SimpleTestCase):
         }
 
         ChoiceFormSet = formset_factory(ChoiceWithDefaultRenderer, renderer=None)
-        formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
+        formset = ChoiceFormSet(data, prefix="choices")
         self.assertEqual(
             formset.forms[0].renderer, ChoiceWithDefaultRenderer.default_renderer
         )

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1561,7 +1561,7 @@ class FormsFormsetTestCase(SimpleTestCase):
         from django.forms.renderers import Jinja2
 
         class ChoiceWithDefaultRenderer(Choice):
-            default_renderer = Jinja2
+            default_renderer = Jinja2()
 
         data = {
             "choices-TOTAL_FORMS": "1",
@@ -1571,7 +1571,7 @@ class FormsFormsetTestCase(SimpleTestCase):
 
         ChoiceFormSet = formset_factory(ChoiceWithDefaultRenderer, renderer=None)
         formset = ChoiceFormSet(data, auto_id=False, prefix="choices")
-        self.assertIsInstance(
+        self.assertEqual(
             formset.forms[0].renderer, ChoiceWithDefaultRenderer.default_renderer
         )
 

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -23,7 +23,7 @@ from django.forms.formsets import (
     all_valid,
     formset_factory,
 )
-from django.forms.renderers import TemplatesSetting
+from django.forms.renderers import DjangoTemplates, TemplatesSetting
 from django.forms.utils import ErrorList
 from django.forms.widgets import HiddenInput
 from django.test import SimpleTestCase
@@ -1558,10 +1558,12 @@ class FormsFormsetTestCase(SimpleTestCase):
         In the absence of a renderer passed to the formset_factory(),
         Form.default_renderer is respected.
         """
-        from django.forms.renderers import Jinja2
+
+        class CustomRenderer(DjangoTemplates):
+            pass
 
         class ChoiceWithDefaultRenderer(Choice):
-            default_renderer = Jinja2()
+            default_renderer = CustomRenderer()
 
         data = {
             "choices-TOTAL_FORMS": "1",

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1555,8 +1555,8 @@ class FormsFormsetTestCase(SimpleTestCase):
 
     def test_form_default_renderer(self):
         """
-        In the absense of a renderer passed to formset_factory, the default_renderer
-        attribute of the Form class should be respected.
+        In the absence of a renderer passed to the formset_factory(),
+        Form.default_renderer is respected.
         """
         from django.forms.renderers import Jinja2
 

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -14,6 +14,7 @@ from django.forms.models import (
     inlineformset_factory,
     modelformset_factory,
 )
+from django.forms.renderers import DjangoTemplates
 from django.http import QueryDict
 from django.test import TestCase, skipUnlessDBFeature
 
@@ -2368,10 +2369,11 @@ class TestModelFormsetOverridesTroughFormMeta(TestCase):
         self.assertEqual(formset.renderer, renderer)
 
     def test_modelformset_factory_default_renderer(self):
-        from django.forms.renderers import Jinja2
+        class CustomRenderer(DjangoTemplates):
+            pass
 
         class ModelFormWithDefaultRenderer(ModelForm):
-            default_renderer = Jinja2()
+            default_renderer = CustomRenderer()
 
         BookFormSet = modelformset_factory(
             Author, form=ModelFormWithDefaultRenderer, fields="__all__"
@@ -2382,10 +2384,11 @@ class TestModelFormsetOverridesTroughFormMeta(TestCase):
         )
 
     def test_inlineformset_factory_default_renderer(self):
-        from django.forms.renderers import Jinja2
+        class CustomRenderer(DjangoTemplates):
+            pass
 
         class ModelFormWithDefaultRenderer(ModelForm):
-            default_renderer = Jinja2()
+            default_renderer = CustomRenderer()
 
         BookFormSet = inlineformset_factory(
             Author,

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.forms.formsets import formset_factory
 from django.forms.models import (
     BaseModelFormSet,
+    ModelForm,
     _get_foreign_key,
     inlineformset_factory,
     modelformset_factory,
@@ -2365,3 +2366,34 @@ class TestModelFormsetOverridesTroughFormMeta(TestCase):
         BookFormSet = modelformset_factory(Author, fields="__all__", renderer=renderer)
         formset = BookFormSet()
         self.assertEqual(formset.renderer, renderer)
+
+    def test_modelformset_factory_default_renderer(self):
+        from django.forms.renderers import Jinja2
+
+        class ModelFormWithDefaultRenderer(ModelForm):
+            default_renderer = Jinja2()
+
+        BookFormSet = modelformset_factory(
+            Author, form=ModelFormWithDefaultRenderer, fields="__all__"
+        )
+        formset = BookFormSet()
+        self.assertEqual(
+            formset.forms[0].renderer, ModelFormWithDefaultRenderer.default_renderer
+        )
+
+    def test_inlineformset_factory_default_renderer(self):
+        from django.forms.renderers import Jinja2
+
+        class ModelFormWithDefaultRenderer(ModelForm):
+            default_renderer = Jinja2()
+
+        BookFormSet = inlineformset_factory(
+            Author,
+            Book,
+            form=ModelFormWithDefaultRenderer,
+            fields="__all__",
+        )
+        formset = BookFormSet()
+        self.assertEqual(
+            formset.renderer, ModelFormWithDefaultRenderer.default_renderer
+        )


### PR DESCRIPTION
This PR addresses the logic used to select the renderer when creating new FormSet subclasses. At present the logic will either choose a renderer function passed a kwarg to the `formset_factory` or the renderer specified by `settings.FORM_RENDERER`. This has been extended to consider the `default_renderer` attribute of the form class passed to `formset_factory`. This maintains a clean "hierarchy" of renderers (formset > form) but also intuitively respects the attributes of the Form class. 