### PR TITLE
Fixes #29942 -- Link docs to github source

### DIFF
--- a/docs/_ext/github_links.py
+++ b/docs/_ext/github_links.py
@@ -13,7 +13,7 @@ class CodeLocator(ast.NodeVisitor):
         self.import_locations = {}
 
     @classmethod
-    def from_code(cls, code: str) -> "CodeLocator":
+    def from_code(cls, code):
         tree = ast.parse(code)
         locator = cls()
         locator.visit(tree)
@@ -50,8 +50,8 @@ class CodeNotFound(Exception):
     pass
 
 
-def module_name_to_file_path(module_name: str) -> pathlib.Path:
-    # Avoid importlib machinery as locating a module involves importing its 
+def module_name_to_file_path(module_name):
+    # Avoid importlib machinery as locating a module involves importing its
     # parent, which would trigger import side effects.
 
     for suffix in [".py", "/__init__.py"]:
@@ -62,7 +62,7 @@ def module_name_to_file_path(module_name: str) -> pathlib.Path:
     raise CodeNotFound
 
 
-def get_path_and_line(module: str, fullname: str) -> tuple[str, int]:
+def get_path_and_line(module, fullname):
     path = module_name_to_file_path(module_name=module)
 
     locator = get_locator(path)
@@ -103,14 +103,14 @@ def get_path_and_line(module: str, fullname: str) -> tuple[str, int]:
         )
 
 
-def get_branch(version: str, next_version: str) -> str:
+def get_branch(version, next_version):
     if version == next_version:
         return "main"
     else:
         return f"stable/{version}.x"
 
 
-def github_linkcode_resolve(domain, info, *, version: str, next_version: str):
+def github_linkcode_resolve(domain, info, *, version, next_version):
     """ """
     if domain != "py":
         return None

--- a/docs/_ext/github_links.py
+++ b/docs/_ext/github_links.py
@@ -3,8 +3,6 @@ import functools
 import importlib.util
 import pathlib
 
-BASE_PATH = pathlib.Path(__file__).parents[2]
-
 
 class CodeLocator(ast.NodeVisitor):
     def __init__(self):
@@ -55,7 +53,7 @@ def module_name_to_file_path(module_name):
     # parent, which would trigger import side effects.
 
     for suffix in [".py", "/__init__.py"]:
-        file_path = BASE_PATH / (module_name.replace(".", "/") + suffix)
+        file_path = pathlib.Path(__file__).parents[2] / (module_name.replace(".", "/") + suffix)
         if file_path.exists():
             return file_path
 
@@ -129,7 +127,7 @@ def github_linkcode_resolve(domain, info, *, version, next_version):
 
     branch = get_branch(version=version, next_version=next_version)
 
-    relative_path = path.relative_to(BASE_PATH)
+    relative_path = path.relative_to(pathlib.Path(__file__).parents[2])
     # Use a /-separated path otherwise on windows, str(file) returns \-separated path.
     url_path = "/".join(relative_path.parts)
 

--- a/docs/_ext/github_links.py
+++ b/docs/_ext/github_links.py
@@ -78,14 +78,13 @@ def get_path_and_line(module, fullname):
     except KeyError:
         raise CodeNotFound
 
-    # let's say we do
+    # From a statement such as:
     # from . import y.z
     # - either y.z might be an object in the parent module
     # - or y might be a module, and z be an object in y
     # also:
-    # - either the current file is x/__init__.py, and we should be looking in
-    #   x.y
-    # - or the current file is x/a.py, and we should be looking in x.a.y
+    # - either the current file is x/__init__.py, and z would be in x.y
+    # - or the current file is x/a.py, and z would be in x.a.y
     if path.name != "__init__.py":
         # Look in parent module
         module = module.rsplit(".", maxsplit=1)[0]
@@ -131,8 +130,7 @@ def github_linkcode_resolve(domain, info, *, version, next_version):
     branch = get_branch(version=version, next_version=next_version)
 
     relative_path = path.relative_to(BASE_PATH)
-    # We need to explicitly make a /-separated path otherwise on windows,
-    # str(file) returns \-separated path.
+    # Use a /-separated path otherwise on windows, str(file) returns \-separated path.
     url_path = "/".join(relative_path.parts)
 
     return f"https://github.com/django/django/blob/{branch}/{url_path}{linespec}"

--- a/docs/_ext/github_links.py
+++ b/docs/_ext/github_links.py
@@ -1,0 +1,143 @@
+import ast
+import functools
+import importlib.util
+import pathlib
+
+BASE_PATH = pathlib.Path(__file__).parents[2]
+
+
+class CodeLocator(ast.NodeVisitor):
+    def __init__(self):
+        self.current_path = []
+        self.node_line_numbers = {}
+        self.import_locations = {}
+
+    @classmethod
+    def from_code(cls, code: str) -> "CodeLocator":
+        tree = ast.parse(code)
+        locator = cls()
+        locator.visit(tree)
+        return locator
+
+    def visit_node(self, node):
+        self.current_path.append(node.name)
+        self.node_line_numbers[".".join(self.current_path)] = node.lineno
+        ast.NodeVisitor.generic_visit(self, node)
+        self.current_path.pop()
+
+    def visit_FunctionDef(self, node):
+        self.visit_node(node)
+
+    def visit_ClassDef(self, node):
+        self.visit_node(node)
+
+    def visit_ImportFrom(self, node):
+        for alias in node.names:
+            if alias.asname:
+                # It could make sense to follow aliases (`import x as y`), but
+                # in our case, it would mean that someone would click
+                # "[Source]" on MyClassA and might receive a link to MyClassB
+                # if there was `import MyClassB as MyClassA`, and we're
+                # afraid it would be more confusing that useful.
+                # Feel free to challenge this assumption.
+                continue
+            self.import_locations[alias.name] = ("." * node.level) + (node.module or "")
+
+
+@functools.lru_cache(maxsize=1024)
+def get_locator(file: pathlib.Path) -> CodeLocator:
+    file_contents = file.read_text()
+    return CodeLocator.from_code(file_contents)
+
+
+class CodeNotFound(Exception):
+    pass
+
+
+def module_name_to_file_path(module_name: str) -> pathlib.Path:
+    # sadly, we can't use the importlib machinery here because locating a
+    # module involves importing its parent, and we want to avoid importing
+    # anything, so we need to guess the file location from the module name
+
+    for suffix in [".py", "/__init__.py"]:
+        file_path = BASE_PATH / (module_name.replace(".", "/") + suffix)
+        if file_path.exists():
+            return file_path
+
+    raise CodeNotFound
+
+
+def get_path_and_line(module: str, fullname: str) -> tuple[str, int]:
+    path = module_name_to_file_path(module_name=module)
+
+    locator = get_locator(path)
+
+    lineno = locator.node_line_numbers.get(fullname)
+
+    if lineno is not None:
+        return path, lineno
+
+    imported_object = fullname.split(".", maxsplit=1)[0]
+    try:
+        imported_path = locator.import_locations[imported_object]
+    except KeyError:
+        raise CodeNotFound
+
+    # let's say we do
+    # from . import y.z
+    # - either y.z might be an object in the parent module
+    # - or y might be a module, and z be an object in y
+    # also:
+    # - either the current file is x/__init__.py, and we should be looking in
+    #   x.y
+    # - or the current file is x/a.py, and we should be looking in x.a.y
+    if path.name != "__init__.py":
+        # Look in parent module
+        module = module.rsplit(".", maxsplit=1)[0]
+    imported_module = importlib.util.resolve_name(name=imported_path, package=module)
+    try:
+        return get_path_and_line(module=imported_module, fullname=fullname)
+    except CodeNotFound:
+        if "." not in fullname:
+            raise
+
+        first_element, remainder = fullname.rsplit(".", maxsplit=1)
+        # Retrying, assuming the first element of of the fullname is a module
+        return get_path_and_line(
+            module=f"{imported_module}.{first_element}", fullname=remainder
+        )
+
+
+def get_branch(version: str, next_version: str) -> str:
+    if version == next_version:
+        return "main"
+    else:
+        return f"stable/{version}.x"
+
+
+def github_linkcode_resolve(domain, info, *, version: str, next_version: str):
+    """ """
+    if domain != "py":
+        return None
+
+    if not info.get("module", None):
+        return None
+
+    module: str = info["module"]
+    fullname: str = info["fullname"]
+
+    try:
+        path, lineno = get_path_and_line(module=module, fullname=fullname)
+    except CodeNotFound:
+        return None
+
+    linespec = f"#L{lineno}"
+
+    branch = get_branch(version=version, next_version=next_version)
+
+    relative_path = path.relative_to(BASE_PATH)
+    # We need to explicitly make a /-separated path otherwise on windows,
+    # str(file) returns \-separated path.
+    url_path = "/".join(relative_path.parts)
+
+    return f"https://github.com/django/django/blob/{branch}/{url_path}{linespec}"

--- a/docs/_ext/github_links.py
+++ b/docs/_ext/github_links.py
@@ -41,7 +41,7 @@ class CodeLocator(ast.NodeVisitor):
 
 
 @functools.lru_cache(maxsize=1024)
-def get_locator(file: pathlib.Path) -> CodeLocator:
+def get_locator(file):
     file_contents = file.read_text(encoding="utf-8")
     return CodeLocator.from_code(file_contents)
 

--- a/docs/_ext/github_links.py
+++ b/docs/_ext/github_links.py
@@ -34,12 +34,8 @@ class CodeLocator(ast.NodeVisitor):
     def visit_ImportFrom(self, node):
         for alias in node.names:
             if alias.asname:
-                # It could make sense to follow aliases (`import x as y`), but
-                # in our case, it would mean that someone would click
-                # "[Source]" on MyClassA and might receive a link to MyClassB
-                # if there was `import MyClassB as MyClassA`, and we're
-                # afraid it would be more confusing that useful.
-                # Feel free to challenge this assumption.
+                # Exclude linking aliases (`import x as y`) to avoid confusion when
+                # clicking a source link to a differently named entity.
                 continue
             self.import_locations[alias.name] = ("." * node.level) + (node.module or "")
 
@@ -55,9 +51,8 @@ class CodeNotFound(Exception):
 
 
 def module_name_to_file_path(module_name: str) -> pathlib.Path:
-    # sadly, we can't use the importlib machinery here because locating a
-    # module involves importing its parent, and we want to avoid importing
-    # anything, so we need to guess the file location from the module name
+    # Avoid importlib machinery as locating a module involves importing its 
+    # parent, which would trigger import side effects.
 
     for suffix in [".py", "/__init__.py"]:
         file_path = BASE_PATH / (module_name.replace(".", "/") + suffix)

--- a/docs/_ext/github_links.py
+++ b/docs/_ext/github_links.py
@@ -42,7 +42,7 @@ class CodeLocator(ast.NodeVisitor):
 
 @functools.lru_cache(maxsize=1024)
 def get_locator(file: pathlib.Path) -> CodeLocator:
-    file_contents = file.read_text()
+    file_contents = file.read_text(encoding="utf-8")
     return CodeLocator.from_code(file_contents)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,8 +40,8 @@ extensions = [
     "djangodocs",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
-    "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
+    "sphinx.ext.linkcode",
 ]
 
 # AutosectionLabel settings.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import functools
 import sys
 from os.path import abspath, dirname, join
 
@@ -28,6 +29,10 @@ sys.path.insert(1, dirname(dirname(abspath(__file__))))
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.append(abspath(join(dirname(__file__), "_ext")))
+
+# Use the module to GitHub url resolver, but import it after the _ext directoy
+# it lives in has been added to sys.path.
+import github_links  # NOQA
 
 # -- General configuration -----------------------------------------------------
 
@@ -432,3 +437,9 @@ epub_cover = ("", "epub-cover.html")
 
 # If false, no index is generated.
 # epub_use_index = True
+
+linkcode_resolve = functools.partial(
+    github_links.github_linkcode_resolve,
+    version=version,
+    next_version=django_next_version,
+)

--- a/tests/sphinx/test_github_links.py
+++ b/tests/sphinx/test_github_links.py
@@ -8,7 +8,7 @@ class GitHubLinkTests(SimpleTestCase):
     @classmethod
     def setUpClass(cls):
         # The file implementing the code under test cannot be imported through
-        # standard means, so include its parent in the pythonpath for the 
+        # standard means, so include its parent in the pythonpath for the
         # duration of the tests.
         cls.ext_path = str((pathlib.Path(__file__).parents[2] / "docs/_ext").resolve())
         sys.path.insert(0, cls.ext_path)

--- a/tests/sphinx/test_github_links.py
+++ b/tests/sphinx/test_github_links.py
@@ -8,8 +8,8 @@ class GitHubLinkTests(SimpleTestCase):
     @classmethod
     def setUpClass(cls):
         # The file implementing the code under test cannot be imported through
-        # standard means, so we cheat a little bit an include its parent in
-        # the pythonpath for the duration of the tests.
+        # standard means, so include its parent in the pythonpath for the 
+        # duration of the tests.
         cls.ext_path = str((pathlib.Path(__file__).parents[2] / "docs/_ext").resolve())
         sys.path.insert(0, cls.ext_path)
 
@@ -20,14 +20,9 @@ class GitHubLinkTests(SimpleTestCase):
 
     @property
     def github_links(self):
-        # We need the import to happen *after* setUpClass, so we can't
-        # have it at the top of the file and it's displeasant to have it
-        # in each and every test. A property is the simplest alternative.
-
-        # No linter/IDE will ever be able to tell that this is a valid import,
-        # so don't worry if the next import gets flagged by your IDE as
-        # invalid, the IDE just doesn't know that we manipulated the
-        # pythonpath.
+        # The import must happen after setUpClass, so it can't be imported at
+        # the top of the file. A property is used to avoid the import in every test.
+        # Linters/IDEs may not be able to detect this as a valid import.
         import github_links
 
         return github_links

--- a/tests/sphinx/test_github_links.py
+++ b/tests/sphinx/test_github_links.py
@@ -1,0 +1,189 @@
+import pathlib
+import sys
+
+from django.test import SimpleTestCase
+
+
+class GitHubLinkTests(SimpleTestCase):
+    @classmethod
+    def setUpClass(cls):
+        # The file implementing the code under test cannot be imported through
+        # standard means, so we cheat a little bit an include its parent in
+        # the pythonpath for the duration of the tests.
+        cls.ext_path = str((pathlib.Path(__file__).parents[2] / "docs/_ext").resolve())
+        sys.path.insert(0, cls.ext_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        sys.path.remove(cls.ext_path)
+        sys.modules.pop("github_links", None)
+
+    @property
+    def github_links(self):
+        # We need the import to happen *after* setUpClass, so we can't
+        # have it at the top of the file and it's displeasant to have it
+        # in each and every test. A property is the simplest alternative.
+
+        # No linter/IDE will ever be able to tell that this is a valid import,
+        # so don't worry if the next import gets flagged by your IDE as
+        # invalid, the IDE just doesn't know that we manipulated the
+        # pythonpath.
+        import github_links
+
+        return github_links
+
+    def test_code_locator(self):
+        locator = self.github_links.CodeLocator.from_code(
+            """
+from a import b, c
+from .d import e, f as g
+
+def h():
+    pass
+
+class I:
+    def j(self):
+        pass"""
+        )
+
+        self.assertEqual(locator.node_line_numbers, {"h": 5, "I": 8, "I.j": 9})
+        self.assertEqual(locator.import_locations, {"b": "a", "c": "a", "e": ".d"})
+
+    def test_module_name_to_file_path_package(self):
+        self.assertTrue(
+            str(self.github_links.module_name_to_file_path("django")).endswith(
+                "/django/__init__.py"
+            )
+        )
+
+    def test_module_name_to_file_path_module(self):
+        self.assertTrue(
+            str(
+                self.github_links.module_name_to_file_path("django.shortcuts")
+            ).endswith("/django/shortcuts.py")
+        )
+
+    def test_get_path_and_line_class(self):
+        path, line = self.github_links.get_path_and_line(
+            module="tests.sphinx.testdata.package.module", fullname="MyClass"
+        )
+
+        self.assertEqual(
+            "/".join(path.parts[-5:]), "tests/sphinx/testdata/package/module.py"
+        )
+        self.assertEqual(line, 15)
+
+    def test_get_path_and_line_func(self):
+        path, line = self.github_links.get_path_and_line(
+            module="tests.sphinx.testdata.package.module", fullname="my_function"
+        )
+
+        self.assertEqual(
+            "/".join(path.parts[-5:]), "tests/sphinx/testdata/package/module.py"
+        )
+        self.assertEqual(line, 27)
+
+    def test_get_path_and_line_method(self):
+        path, line = self.github_links.get_path_and_line(
+            module="tests.sphinx.testdata.package.module", fullname="MyClass.my_method"
+        )
+
+        self.assertEqual(
+            "/".join(path.parts[-5:]), "tests/sphinx/testdata/package/module.py"
+        )
+        self.assertEqual(line, 19)
+
+    def test_get_path_and_line_cached_property(self):
+        path, line = self.github_links.get_path_and_line(
+            module="tests.sphinx.testdata.package.module",
+            fullname="MyClass.my_cached_property",
+        )
+
+        self.assertEqual(
+            "/".join(path.parts[-5:]), "tests/sphinx/testdata/package/module.py"
+        )
+        self.assertEqual(line, 23)
+
+    def test_get_path_and_line_forwarded_import(self):
+        path, line = self.github_links.get_path_and_line(
+            module="tests.sphinx.testdata.package.module", fullname="MyOtherClass"
+        )
+
+        self.assertEqual(
+            "/".join(path.parts[-5:]), "tests/sphinx/testdata/package/other_module.py"
+        )
+        self.assertEqual(line, 1)
+
+    def test_get_path_and_line_forwarded_import_module(self):
+        path, line = self.github_links.get_path_and_line(
+            module="tests.sphinx.testdata.package.module",
+            fullname="other_module.MyOtherClass",
+        )
+
+        self.assertEqual(
+            "/".join(path.parts[-5:]), "tests/sphinx/testdata/package/other_module.py"
+        )
+        self.assertEqual(line, 1)
+
+    def test_get_branch_stable(self):
+        branch = self.github_links.get_branch(version="2.2", next_version="3.2")
+        self.assertEqual(branch, "stable/2.2.x")
+
+    def test_get_branch_latest(self):
+        branch = self.github_links.get_branch(version="3.2", next_version="3.2")
+        self.assertEqual(branch, "main")
+
+    def test_github_linkcode_resolve_unspecified_domain(self):
+        domain = "unspecified"
+        info = {}
+        self.assertIsNone(
+            self.github_links.github_linkcode_resolve(
+                domain, info, version="3.2", next_version="3.2"
+            )
+        )
+
+    def test_github_linkcode_resolve_unspecified_info(self):
+        domain = "py"
+        info = {}
+        self.assertIsNone(
+            self.github_links.github_linkcode_resolve(
+                domain, info, version="3.2", next_version="3.2"
+            )
+        )
+
+    def test_github_linkcode_resolve_not_found(self):
+        info = {
+            "module": "foo.bar.baz.hopefully_non_existant_module",
+            "fullname": "MyClass",
+        }
+        self.assertIsNone(
+            self.github_links.github_linkcode_resolve(
+                "py", info, version="3.2", next_version="3.2"
+            )
+        )
+
+    def test_github_linkcode_resolve_link_to_object(self):
+        info = {
+            "module": "tests.sphinx.testdata.package.module",
+            "fullname": "MyClass",
+        }
+        self.assertEqual(
+            self.github_links.github_linkcode_resolve(
+                "py", info, version="3.2", next_version="3.2"
+            ),
+            "https://github.com/django/django/blob/main/tests/sphinx/"
+            "testdata/package/module.py#L15",
+        )
+
+    def test_github_linkcode_resolve_link_to_class_older_version(self):
+        info = {
+            "module": "tests.sphinx.testdata.package.module",
+            "fullname": "MyClass",
+        }
+        self.assertEqual(
+            self.github_links.github_linkcode_resolve(
+                "py", info, version="2.2", next_version="3.2"
+            ),
+            "https://github.com/django/django/blob/stable/2.2.x/tests/sphinx/"
+            "testdata/package/module.py#L15",
+        )

--- a/tests/sphinx/test_github_links.py
+++ b/tests/sphinx/test_github_links.py
@@ -45,18 +45,14 @@ class I:
         self.assertEqual(locator.import_locations, {"b": "a", "c": "a", "e": ".d"})
 
     def test_module_name_to_file_path_package(self):
-        self.assertTrue(
-            str(self.github_links.module_name_to_file_path("django")).endswith(
-                "/django/__init__.py"
-            )
-        )
+        path = self.github_links.module_name_to_file_path("django")
+
+        self.assertEqual("/".join(path.parts[-2:]), "django/__init__.py")
 
     def test_module_name_to_file_path_module(self):
-        self.assertTrue(
-            str(
-                self.github_links.module_name_to_file_path("django.shortcuts")
-            ).endswith("/django/shortcuts.py")
-        )
+        path = self.github_links.module_name_to_file_path("django.shortcuts")
+
+        self.assertEqual("/".join(path.parts[-2:]), "django/shortcuts.py")
 
     def test_get_path_and_line_class(self):
         path, line = self.github_links.get_path_and_line(

--- a/tests/sphinx/testdata/package/__init__.py
+++ b/tests/sphinx/testdata/package/__init__.py
@@ -1,0 +1,2 @@
+# This file should never get imported. If it is, then something failed already.
+raise Exception

--- a/tests/sphinx/testdata/package/module.py
+++ b/tests/sphinx/testdata/package/module.py
@@ -1,0 +1,28 @@
+"""
+Example docstring
+"""
+from django.utils.functional import cached_property
+
+from . import other_module
+from .other_module import MyOtherClass
+
+# This file should never get imported. If it is, then something failed already.
+raise Exception
+
+__all__ = ["other_module", "MyOtherClass"]
+
+
+class MyClass(object):
+    def __init__(self):
+        pass
+
+    def my_method(self):
+        pass
+
+    @cached_property
+    def my_cached_property(self):
+        pass
+
+
+def my_function(self):
+    pass

--- a/tests/sphinx/testdata/package/other_module.py
+++ b/tests/sphinx/testdata/package/other_module.py
@@ -1,0 +1,2 @@
+class MyOtherClass:
+    pass


### PR DESCRIPTION
This was implemented during the DjangoCon Europe sprint, thanks to @sarahboyce and partly based on #16203 by @zachborboa 

This fixes 2 issues at once:
- Adding source links again in the docs. They used to be there and then didn't anymore. That's [29942](https://code.djangoproject.com/ticket/29942). The way to fix that is to identify line numbers for function by reading AST only, instead of importing the whole function. This should work in 99% (guesstimate) of cases where Python code is writen as simple functions, classes and methods.
- Links now link to GitHub, on the (hopefully) correct branch as discussed in the [forum](https://forum.djangoproject.com/t/do-you-use-the-view-source-feature-in-the-documentation/20769)