### PR TITLE
Ticket #34417 - Remove unnecessary recreation of foreign key constrains while dropping index.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -91,6 +91,10 @@ class BaseDatabaseFeatures:
     # Does the database have a copy of the zoneinfo database?
     has_zoneinfo_database = True
 
+    # Does the backend require the foreign key constraints
+    # to be recreated when dropping index
+    requires_fk_constraints_to_be_recreated = False
+
     # When performing a GROUP BY, is an ORDER BY NULL required
     # to remove any ordering?
     requires_explicit_null_ordering_when_grouping = False

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -864,8 +864,8 @@ class BaseDatabaseSchemaEditor:
         # Drop any FK constraints, we'll remake them later
         fks_dropped = set()
         if (
-            self._fk_constraints_should_be_recreated()
-            and self.connection.features.supports_foreign_keys
+            self.connection.features.supports_foreign_keys
+            and self.connection.features.requires_fk_constraints_to_be_recreated
             and old_field.remote_field
             and old_field.db_constraint
             and self._field_should_be_altered(
@@ -1534,9 +1534,6 @@ class BaseDatabaseSchemaEditor:
         return self.quote_name(old_field.column) != self.quote_name(
             new_field.column
         ) or (old_path, old_args, old_kwargs) != (new_path, new_args, new_kwargs)
-
-    def _fk_constraints_should_be_recreated(self):
-        return self.connection.vendor == "mysql"
 
     def _field_should_be_indexed(self, model, field):
         return field.db_index and not field.unique

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -864,7 +864,8 @@ class BaseDatabaseSchemaEditor:
         # Drop any FK constraints, we'll remake them later
         fks_dropped = set()
         if (
-            self.connection.features.supports_foreign_keys
+            self._fk_constraints_should_be_recreated()
+            and self.connection.features.supports_foreign_keys
             and old_field.remote_field
             and old_field.db_constraint
             and self._field_should_be_altered(
@@ -1533,6 +1534,9 @@ class BaseDatabaseSchemaEditor:
         return self.quote_name(old_field.column) != self.quote_name(
             new_field.column
         ) or (old_path, old_args, old_kwargs) != (new_path, new_args, new_kwargs)
+
+    def _fk_constraints_should_be_recreated(self):
+        return self.connection.vendor == "mysql"
 
     def _field_should_be_indexed(self, model, field):
         return field.db_index and not field.unique

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -15,6 +15,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_regex_backreferencing = False
     supports_date_lookup_using_string = False
     supports_timezones = False
+    requires_fk_constraints_to_be_recreated = True
     requires_explicit_null_ordering_when_grouping = True
     atomic_transactions = False
     can_clone_databases = True

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1701,13 +1701,10 @@ class SchemaTests(TransactionTestCase):
                 editor.alter_field(Book, old_field, new_field, strict=True)
 
         # make sure foreign key constraints are not touched
-        self.assertFalse(
-            any(
-                "schema_book_author_id_c80c8297_fk_schema_author_id" in record.args[0]
-                for record in cm.records
-            ),
-            True,
-        )
+        for record in cm.records:
+            self.assertNotIn(
+                "schema_book_author_id_c80c8297_fk_schema_author_id", record.args[0]
+            )
 
     @skipUnlessDBFeature("requires_fk_constraints_to_be_recreated")
     def test_if_fk_constraint_is_recreated(self):
@@ -1735,10 +1732,10 @@ class SchemaTests(TransactionTestCase):
 
         # Make sure the constraint is dropped and recreated
         self.assertTrue(
-            any("DROP FOREIGN KEY" in record.args[0] for record in cm.records), False
+            any("DROP FOREIGN KEY" in record.args[0] for record in cm.records)
         )
         self.assertTrue(
-            any("ADD CONSTRAINT" in record.args[0] for record in cm.records), False
+            any("ADD CONSTRAINT" in record.args[0] for record in cm.records)
         )
 
     def test_alter_field_o2o_to_fk(self):

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1676,18 +1676,16 @@ class SchemaTests(TransactionTestCase):
             {"fks": expected_fks, "uniques": 0, "indexes": expected_indexes},
         )
 
-    @unittest.skipIf(connection.vendor == "mysql", "All but MySQL")
+    @skipIfDBFeature("requires_fk_constraints_to_be_recreated")
     def test_remove_unnecessary_fk_constraint_drop(self):
         """
-        #34417 - Tests for recreation of foreign key constrains while dropping index.
+        #34417 - Tests for recreation of foreign key constraints while dropping index.
         """
         with connection.schema_editor() as editor:
             editor.create_model(Author)
             editor.create_model(Book)
 
-        author = Author.objects.create(
-            name='Alice'
-        )
+        author = Author.objects.create(name="Alice")
         Book.objects.create(
             author=author,
             title="Much Ado About Foreign Keys",
@@ -1702,23 +1700,25 @@ class SchemaTests(TransactionTestCase):
             with connection.schema_editor() as editor:
                 editor.alter_field(Book, old_field, new_field, strict=True)
 
-        # make sure foreign key constrains are not touched
+        # make sure foreign key constraints are not touched
         self.assertFalse(
-            any('schema_book_author_id_c80c8297_fk_schema_author_id' in record.args[0] for record in cm.records), True
+            any(
+                "schema_book_author_id_c80c8297_fk_schema_author_id" in record.args[0]
+                for record in cm.records
+            ),
+            True,
         )
 
-    @unittest.skipUnless(connection.vendor == "mysql", "MySQL specific")
+    @skipUnlessDBFeature("requires_fk_constraints_to_be_recreated")
     def test_if_fk_constraint_is_recreated(self):
         """
-        #34417 - Tests for recreation of foreign key constrains while dropping index.
+        #34417 - Tests for recreation of foreign key constraints while dropping index.
         """
         with connection.schema_editor() as editor:
             editor.create_model(Author)
             editor.create_model(Book)
 
-        author = Author.objects.create(
-            name='Alice'
-        )
+        author = Author.objects.create(name="Alice")
         Book.objects.create(
             author=author,
             title="Much Ado About Foreign Keys",
@@ -1735,10 +1735,10 @@ class SchemaTests(TransactionTestCase):
 
         # Make sure the constraint is dropped and recreated
         self.assertTrue(
-            any('DROP FOREIGN KEY' in record.args[0] for record in cm.records), False
+            any("DROP FOREIGN KEY" in record.args[0] for record in cm.records), False
         )
         self.assertTrue(
-            any('ADD CONSTRAINT' in record.args[0] for record in cm.records), False
+            any("ADD CONSTRAINT" in record.args[0] for record in cm.records), False
         )
 
     def test_alter_field_o2o_to_fk(self):


### PR DESCRIPTION
[Ticket #34417](https://code.djangoproject.com/ticket/34417)