### PR TITLE
Fixed #34626 - Replaced test_make_toast.py with tests_make_toast.py in contributing docs

### DIFF
--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -320,7 +320,7 @@ In order to resolve this ticket, we'll add a ``make_toast()`` function to the
 use the function and check that its output looks correct.
 
 Navigate to Django's ``tests/shortcuts/`` folder and create a new file
-``test_make_toast.py``. Add the following code::
+``tests_make_toast.py``. Add the following code::
 
     from django.shortcuts import make_toast
     from django.test import SimpleTestCase
@@ -509,11 +509,11 @@ Use the arrow keys to move up and down.
     +.. versionadded:: 2.2
     +
     +Returns ``'toast'``.
-    diff --git a/tests/shortcuts/test_make_toast.py b/tests/shortcuts/test_make_toast.py
+    diff --git a/tests/shortcuts/tests_make_toast.py b/tests/shortcuts/tests_make_toast.py
     new file mode 100644
     index 0000000000..6f4c627b6e
     --- /dev/null
-    +++ b/tests/shortcuts/test_make_toast.py
+    +++ b/tests/shortcuts/tests_make_toast.py
     @@ -0,0 +1,7 @@
     +from django.shortcuts import make_toast
     +from django.test import SimpleTestCase


### PR DESCRIPTION
While going through the documentation for [​Writing your first patch for Django - Writing a test for ticket #99999](https://docs.djangoproject.com/en/dev/intro/contributing/#writing-some-tests-for-your-ticket), I created the file "test_make_toast.py" and after executing "./runtests.py shortcuts" the test run still succeeds. At this point in the walkthrough the tests should file with the error message "ImportError: cannot import name 'make_toast' from 'django.shortcuts'". It turned out the word "test" in the file name "test_make_toast.py" must be in plural to be loaded by the test suite: "tests_make_toast.py".

Solution:
Rename "test_make_toast.py" to "tests_make_toast.py" on this documentation page.