### PR TITLE
Fixed #34627 -- Highlighted active row in admin UI when forced-colors mode is enabled.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -267,10 +267,10 @@
 
 @media (forced-colors: active) {
     #changelist table tbody tr.selected {
-        border: 2px SelectedItem solid;
+        background-color: SelectedItem;
     }
     #changelist table tbody tr:has(input[type=checkbox]:checked) {
-        border: 2px SelectedItem solid;
+        background-color: SelectedItem;
     }
 }
 

--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -265,6 +265,15 @@
     background-color: var(--selected-row);
 }
 
+@media (forced-colors: active) {
+    #changelist table tbody tr.selected {
+        border: 2px SelectedItem solid;
+    }
+    #changelist table tbody tr:has(input[type=checkbox]:checked) {
+        border: 2px SelectedItem solid;
+    }
+}
+
 #changelist .actions {
     padding: 10px;
     background: var(--body-bg);

--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -104,10 +104,8 @@
 
 @media (forced-colors: active) {
     #nav-sidebar .current-model {
-        background: var(--selected-row);
-        border: 2px SelectedItem solid;
+        border: 2px solid SelectedItem;
     }
-
 }
 
 .main > #nav-sidebar + .content {

--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -102,6 +102,14 @@
     background: var(--selected-row);
 }
 
+@media (forced-colors: active) {
+    #nav-sidebar .current-model {
+        background: var(--selected-row);
+        border: 2px SelectedItem solid;
+    }
+
+}
+
 .main > #nav-sidebar + .content {
     max-width: calc(100% - 23px);
 }

--- a/django/contrib/admin/static/admin/css/nav_sidebar.css
+++ b/django/contrib/admin/static/admin/css/nav_sidebar.css
@@ -104,7 +104,7 @@
 
 @media (forced-colors: active) {
     #nav-sidebar .current-model {
-        border: 2px solid SelectedItem;
+        background-color: SelectedItem;
     }
 }
 


### PR DESCRIPTION
Fixes https://code.djangoproject.com/ticket/34627

This PR adds highlighting on selected models in the admin sidebar and changelist when using "forced-colors".

For selected models in the admin and changelist:
![image](https://github.com/django/django/assets/77671865/a552399e-4d81-4350-b319-87375fc96b77)

This is what you currently see with forced-colors: 
![image](https://github.com/django/django/assets/77671865/a7509cb5-df38-4e90-a5dc-b118e19bcb72)

This PR changes this to:
![image](https://github.com/django/django/assets/77671865/f35a2e8e-b939-47e1-8e12-bd30bf351acf)


