### PR TITLE
Fixed #28050 -- Included template name in TemplateSyntaxError.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -197,6 +197,15 @@ class Template:
         except Exception as e:
             if self.engine.debug:
                 e.template_debug = self.get_exception_info(e, e.token)
+            if self.origin.name != UNKNOWN_SOURCE:
+                try:
+                    raw_message = e.args[0]
+                except IndexError:
+                    pass
+                else:
+                    template_path = "Template: %s, " % self.origin.name
+                    e.raw_template_error_message = raw_message
+                    e.args = (template_path + raw_message, *e.args[1:])
             raise
 
     def get_exception_info(self, exception, token):

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -396,7 +396,10 @@ class ExceptionReporter:
         if self.exc_type:
             c["exception_type"] = self.exc_type.__name__
         if self.exc_value:
-            c["exception_value"] = str(self.exc_value)
+            if raw_msg := getattr(self.exc_value, "raw_template_error_message", None):
+                c["exception_value"] = raw_msg
+            else:
+                c["exception_value"] = str(self.exc_value)
             if exc_notes := getattr(self.exc_value, "__notes__", None):
                 c["exception_notes"] = "\n" + "\n".join(exc_notes)
         if frames:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28050

I came across this about a month back whilst looking through some production logs. Effort has clearly been made to make the error messages useful, and indicating line numbers is a great initiative. But sadly, without the actual template name, this effort becomes nullified. This is made worse when there are multiple `{% include %}`s, making it difficult to figure out which template is referenced.

There have been a few attempts at this ticket before:
 - #8332
 - #8929 (which then became #8974)

The major complaint with the above PRs was: with the template name included in the exception message, the debug view became cluttered and other places where the template name is explicitly listed become redundant. In my view, the value added by including the template name in the error message far outweighs the disadvantage of any additional clutter in the debug view.

None-the-less, there are several ways to achieve the objective of the ticket without cluttering the debug view.

### Approach 1
 - We record the original error message, and add it as an attribute to the exception. The debug page uses the original message if it can.

### Approach 2
 - Only add the template name when debug is off. This way you get useful messages for production logs, sentry etc. However, concerns about the debug page won't matter since this would only be displayed with debug on anyway.

Approach 2 is a lot simpler, however I'm not sure how I feel about introducing additional differences in logic between debug on and off. Especially within core error handling logic. This feels like a recipe for hard-to-debug problems.



