### PR TITLE
Fixed #34629 -- Added filtering support to GIS aggregates.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -756,6 +756,7 @@ answer newbie questions, and generally made Django that much better:
     oggy <ognjen.maric@gmail.com>
     Oliver Beattie <oliver@obeattie.com>
     Oliver Rutherfurd <http://rutherfurd.net/>
+    Olivier Le Thanh Duong <olivier@lethanh.be>
     Olivier Sels <olivier.sels@gmail.com>
     Olivier Tabone <olivier.tabone@ripplemotion.fr>
     Orestis Markou <orestis@orestis.gr>

--- a/django/contrib/gis/db/models/aggregates.py
+++ b/django/contrib/gis/db/models/aggregates.py
@@ -53,8 +53,8 @@ class GeoAggregate(Aggregate):
         self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False
     ):
         c = super().resolve_expression(query, allow_joins, reuse, summarize, for_save)
-        for expr in c.get_source_expressions():
-            if not hasattr(expr.field, "geom_type"):
+        for field in c.get_source_fields():
+            if not hasattr(field, "geom_type"):
                 raise ValueError(
                     "Geospatial aggregates only allowed on geometry fields."
                 )

--- a/docs/ref/contrib/gis/geoquerysets.txt
+++ b/docs/ref/contrib/gis/geoquerysets.txt
@@ -839,6 +839,8 @@ Oracle      ``SDO_WITHIN_DISTANCE(poly, geom, 5)``
 SpatiaLite  ``PtDistWithin(poly, geom, 5)``
 ==========  ======================================
 
+.. _gis-aggregation-functions:
+
 Aggregate Functions
 -------------------
 
@@ -868,7 +870,7 @@ Example:
 ``Collect``
 ~~~~~~~~~~~
 
-.. class:: Collect(geo_field)
+.. class:: Collect(geo_field, filter=None)
 
 *Availability*: `PostGIS <https://postgis.net/docs/ST_Collect.html>`__,
 SpatiaLite
@@ -879,10 +881,14 @@ aggregate, except it can be several orders of magnitude faster than performing
 a union because it rolls up geometries into a collection or multi object, not
 caring about dissolving boundaries.
 
+.. versionchanged:: 5.0
+
+    Support for using the ``filter`` argument was added.
+
 ``Extent``
 ~~~~~~~~~~
 
-.. class:: Extent(geo_field)
+.. class:: Extent(geo_field, filter=None)
 
 *Availability*: `PostGIS <https://postgis.net/docs/ST_Extent.html>`__,
 Oracle, SpatiaLite
@@ -898,10 +904,14 @@ Example:
     >>> print(qs["poly__extent"])
     (-96.8016128540039, 29.7633724212646, -95.3631439208984, 32.782058715820)
 
+.. versionchanged:: 5.0
+
+    Support for using the ``filter`` argument was added.
+
 ``Extent3D``
 ~~~~~~~~~~~~
 
-.. class:: Extent3D(geo_field)
+.. class:: Extent3D(geo_field, filter=None)
 
 *Availability*: `PostGIS <https://postgis.net/docs/ST_3DExtent.html>`__
 
@@ -917,10 +927,14 @@ Example:
     >>> print(qs["poly__extent3d"])
     (-96.8016128540039, 29.7633724212646, 0, -95.3631439208984, 32.782058715820, 0)
 
+.. versionchanged:: 5.0
+
+    Support for using the ``filter`` argument was added.
+
 ``MakeLine``
 ~~~~~~~~~~~~
 
-.. class:: MakeLine(geo_field)
+.. class:: MakeLine(geo_field, filter=None)
 
 *Availability*: `PostGIS <https://postgis.net/docs/ST_MakeLine.html>`__,
 SpatiaLite
@@ -936,10 +950,14 @@ Example:
     >>> print(qs["poly__makeline"])
     LINESTRING (-95.3631510000000020 29.7633739999999989, -96.8016109999999941 32.7820570000000018)
 
+.. versionchanged:: 5.0
+
+    Support for using the ``filter`` argument was added.
+
 ``Union``
 ~~~~~~~~~
 
-.. class:: Union(geo_field)
+.. class:: Union(geo_field, filter=None)
 
 *Availability*: `PostGIS <https://postgis.net/docs/ST_Union.html>`__,
 Oracle, SpatiaLite
@@ -962,6 +980,10 @@ Example:
     >>> u = Zipcode.objects.filter(poly__within=bbox).aggregate(
     ...     Union(poly)
     ... )  # A more sensible approach.
+
+.. versionchanged:: 5.0
+
+    Support for using the ``filter`` argument was added.
 
 .. rubric:: Footnotes
 .. [#fnde9im] *See* `OpenGIS Simple Feature Specification For SQL <https://portal.ogc.org/files/?artifact_id=829>`_, at Ch. 2.1.13.2, p. 2-13 (The Dimensionally Extended Nine-Intersection Model).

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -170,6 +170,9 @@ Minor features
   function returns a 2-dimensional point on the geometry that is closest to
   another geometry.
 
+* :ref:`GIS aggregates <gis-aggregation-functions>` now support the ``filter``
+  argument.
+
 :mod:`django.contrib.messages`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/gis_tests/relatedapp/fixtures/initial.json
+++ b/tests/gis_tests/relatedapp/fixtures/initial.json
@@ -135,5 +135,53 @@
       "title": "Patry on Copyright",
       "author": 2
     }
- }
+  },
+  {
+    "model": "relatedapp.parcel",
+    "pk": 1,
+    "fields": {
+      "name": "Aurora Parcel Alpha",
+      "city": 1,
+      "center1": "POINT (1.7128 -2.0060)",
+      "center2": "POINT (3.7128 -5.0060)",
+      "border1": "POLYGON((0 0, 5 5, 12 12, 0 0))",
+      "border2": "POLYGON((0 0, 5 5, 8 8, 0 0))"
+    }
+  },
+  {
+    "model": "relatedapp.parcel",
+    "pk": 2,
+    "fields": {
+      "name": "Aurora Parcel Beta",
+      "city": 1,
+      "center1": "POINT (4.7128 5.0060)",
+      "center2": "POINT (12.75 10.05)",
+      "border1": "POLYGON((10 10, 15 15, 22 22, 10 10))",
+      "border2": "POLYGON((10 10, 15 15, 22 22, 10 10))"
+    }
+  },
+  {
+    "model": "relatedapp.parcel",
+    "pk": 3,
+    "fields": {
+      "name": "Aurora Parcel Ignore",
+      "city": 1,
+      "center1": "POINT (9.7128 12.0060)",
+      "center2": "POINT (1.7128 -2.0060)",
+      "border1": "POLYGON ((24 23, 25 25, 32 32, 24 23))",
+      "border2": "POLYGON ((24 23, 25 25, 32 32, 24 23))"
+    }
+  },
+  {
+    "model": "relatedapp.parcel",
+    "pk": 4,
+    "fields": {
+      "name": "Roswell Parcel Ignore",
+      "city": 2,
+      "center1": "POINT (-9.7128 -12.0060)",
+      "center2": "POINT (-1.7128 2.0060)",
+      "border1": "POLYGON ((30 30, 35 35, 42 32, 30 30))",
+      "border2": "POLYGON ((30 30, 35 35, 42 32, 30 30))"
+    }
+  }
 ]


### PR DESCRIPTION
This fix an AttributeError when trying to use a filter argument in django.contrib.gis.db.models.aggregates.Collect and other GeoAggregate

Unit test have been added to check that this is now fixed.

See for description https://code.djangoproject.com/ticket/34629#ticket