### PR TITLE
Ticket #34631 Optimize Column expression identity

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1141,6 +1141,7 @@ class Col(Expression):
             output_field = target
         super().__init__(output_field=output_field)
         self.alias, self.target = alias, target
+        self.identity = (self.__class__, self.alias, self.target, output_field)
 
     def __repr__(self):
         alias, target = self.alias, self.target

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1144,7 +1144,7 @@ class Col(Expression):
 
     @cached_property
     def identity(self):
-        return (self.__class__, self.alias, self.target, self.output_field)
+        return self.__class__, self.alias, self.target, self.output_field
 
     def __repr__(self):
         alias, target = self.alias, self.target

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1141,7 +1141,10 @@ class Col(Expression):
             output_field = target
         super().__init__(output_field=output_field)
         self.alias, self.target = alias, target
-        self.identity = (self.__class__, self.alias, self.target, output_field)
+
+    @cached_property
+    def identity(self):
+        return (self.__class__, self.alias, self.target, self.output_field)
 
     def __repr__(self):
         alias, target = self.alias, self.target


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34631#ticket

Based on some profiling I noticed a lot of time is spent doing reflection/inspect family of calls. The culprit looks like `identity`  property, especially that on Col class. We can easily avoid reflection here. 

Running a relatively simple query with a good number of columns in our codebase gives a nice boost.

```
qs = Asset.objects.filter(pk=3).select_related("asset_contract")[:21]
%timeit str(qs.query)
```

Before:
`440us`
After:
`280us`