### PR TITLE
Fixed lookup.tests.LookupTests.test_exclude() on PostgreSQL 16 beta 1.

### DIFF
--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -691,15 +691,14 @@ class LookupTests(TestCase):
         )
 
     def test_exclude(self):
-        pub_date = datetime(2005, 11, 20)
         a8 = Article.objects.create(
-            headline="Article_ with underscore", pub_date=pub_date
+            headline="Article_ with underscore", pub_date=datetime(2005, 11, 20)
         )
         a9 = Article.objects.create(
-            headline="Article% with percent sign", pub_date=pub_date
+            headline="Article% with percent sign", pub_date=datetime(2005, 11, 21)
         )
         a10 = Article.objects.create(
-            headline="Article with \\ backslash", pub_date=pub_date
+            headline="Article with \\ backslash", pub_date=datetime(2005, 11, 22)
         )
         # exclude() is the opposite of filter() when doing lookups:
         self.assertSequenceEqual(


### PR DESCRIPTION
Order doesn't matter for this test, and on PostgreSQL 16 `"%"` is ordered before `"_"`, so switch to sort by `pub_date`.

https://www.postgresql.org/about/news/postgresql-16-beta-1-released-2643/