### PR TITLE
Added tests for HttpResponseBase.charset/reason_phrase setters.

### DIFF
--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -309,9 +309,7 @@ class HttpResponseBaseTests(SimpleTestCase):
     def test_reason_phrase_setter(self):
         r = HttpResponseBase()
         r.reason_phrase = "test"
-        self.assertEqual(
-            r.reason_phrase, HttpResponseBase(reason="test").reason_phrase
-        )
+        self.assertEqual(r.reason_phrase, HttpResponseBase(reason="test").reason_phrase)
 
 
 class HttpResponseTests(SimpleTestCase):

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -12,7 +12,6 @@ from django.db import close_old_connections
 from django.http import (
     BadHeaderError,
     HttpResponse,
-    HttpResponseBase,
     HttpResponseNotAllowed,
     HttpResponseNotModified,
     HttpResponsePermanentRedirect,
@@ -298,18 +297,6 @@ class QueryDictTests(SimpleTestCase):
     def test_fromkeys_noniterable(self):
         with self.assertRaises(TypeError):
             QueryDict.fromkeys(0)
-
-
-class HttpResponseBaseTests(SimpleTestCase):
-    def test_charset_setter(self):
-        r = HttpResponseBase()
-        r.charset = "utf-8"
-        self.assertEqual(r.charset, HttpResponseBase(charset="utf-8").charset)
-
-    def test_reason_phrase_setter(self):
-        r = HttpResponseBase()
-        r.reason_phrase = "test"
-        self.assertEqual(r.reason_phrase, HttpResponseBase(reason="test").reason_phrase)
 
 
 class HttpResponseTests(SimpleTestCase):

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -11,6 +11,7 @@ from django.core.signals import request_finished
 from django.db import close_old_connections
 from django.http import (
     BadHeaderError,
+    HttpResponseBase,
     HttpResponse,
     HttpResponseNotAllowed,
     HttpResponseNotModified,
@@ -297,6 +298,18 @@ class QueryDictTests(SimpleTestCase):
     def test_fromkeys_noniterable(self):
         with self.assertRaises(TypeError):
             QueryDict.fromkeys(0)
+
+
+class HttpResponseBaseTests(SimpleTestCase):
+    def test_charset_setter(self):
+        r = HttpResponseBase()
+        r.charset = "utf-8"
+        self.assertEqual(r.charset, HttpResponseBase(charset="utf-8").charset)
+
+    def test_reason_phrase_setter(self):
+        r = HttpResponseBase()
+        r.reason_phrase = "test"
+        self.assertEqual(r.reason_phrase, HttpResponseBase(reason_phrase="test").reason_phrase)
 
 
 class HttpResponseTests(SimpleTestCase):

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -11,8 +11,8 @@ from django.core.signals import request_finished
 from django.db import close_old_connections
 from django.http import (
     BadHeaderError,
-    HttpResponseBase,
     HttpResponse,
+    HttpResponseBase,
     HttpResponseNotAllowed,
     HttpResponseNotModified,
     HttpResponsePermanentRedirect,
@@ -309,7 +309,9 @@ class HttpResponseBaseTests(SimpleTestCase):
     def test_reason_phrase_setter(self):
         r = HttpResponseBase()
         r.reason_phrase = "test"
-        self.assertEqual(r.reason_phrase, HttpResponseBase(reason_phrase="test").reason_phrase)
+        self.assertEqual(
+            r.reason_phrase, HttpResponseBase(reason_phrase="test").reason_phrase
+        )
 
 
 class HttpResponseTests(SimpleTestCase):

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -310,7 +310,7 @@ class HttpResponseBaseTests(SimpleTestCase):
         r = HttpResponseBase()
         r.reason_phrase = "test"
         self.assertEqual(
-            r.reason_phrase, HttpResponseBase(reason_phrase="test").reason_phrase
+            r.reason_phrase, HttpResponseBase(reason="test").reason_phrase
         )
 
 

--- a/tests/responses/tests.py
+++ b/tests/responses/tests.py
@@ -52,6 +52,16 @@ class HttpResponseBaseTests(SimpleTestCase):
         r.setdefault("x-header", "DefaultValue")
         self.assertEqual(r.headers["X-Header"], "DefaultValue")
 
+    def test_charset_setter(self):
+        r = HttpResponseBase()
+        r.charset = "utf-8"
+        self.assertEqual(r.charset, "utf-8")
+
+    def test_reason_phrase_setter(self):
+        r = HttpResponseBase()
+        r.reason_phrase = "test"
+        self.assertEqual(r.reason_phrase, "test")
+
 
 class HttpResponseTests(SimpleTestCase):
     def test_status_code(self):


### PR DESCRIPTION
I found that the setters of properties `charset` and `reason_phrase` in `django/http/response.py` have not been tested,

so I add a new test class `HttpResponseBaseTests` and two test methods to test them.

If anything goes wrong, please tell me. Thanks a lot.