### PR TITLE
Simplified and improved django.utils.functional.lazy().

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -163,6 +163,9 @@ def lazy(func, *resultclasses):
         def __mod__(self, other):
             return self.__cast() % other
 
+        def __mul__(self, other):
+            return self.__cast() * other
+
     # Add wrappers for all methods from resultclasses which haven't been
     # wrapped explicitly above.
     for resultclass in resultclasses:

--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -151,6 +151,9 @@ def lazy(func, *resultclasses):
         def __hash__(self):
             return hash(self.__cast())
 
+        def __format__(self, format_spec):
+            return format(self.__cast(), format_spec)
+
         # Explicitly wrap methods which are required for certain operations on
         # int/str objects to function correctly.
 

--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from django.test import SimpleTestCase
 from django.utils.functional import cached_property, classproperty, lazy
 from django.utils.version import PY312
@@ -273,14 +271,10 @@ class FunctionalTests(SimpleTestCase):
         lazy_obj = lazy(lambda: original_object, bytes)
         self.assertEqual(repr(original_object), repr(lazy_obj()))
 
-    def test_lazy_class_preparation_caching(self):
-        # lazy() should prepare the proxy class only once i.e. the first time
-        # it's used.
-        lazified = lazy(lambda: 0, int)
-        __proxy__ = lazified().__class__
-        with mock.patch.object(__proxy__, "__prepare_class__") as mocked:
-            lazified()
-            mocked.assert_not_called()
+    def test_lazy_regular_method(self):
+        original_object = 15
+        lazy_obj = lazy(lambda: original_object, int)
+        self.assertEqual(original_object.bit_length(), lazy_obj().bit_length())
 
     def test_lazy_bytes_and_str_result_classes(self):
         lazy_obj = lazy(lambda: "test", str, bytes)

--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -246,6 +246,17 @@ class FunctionalTests(SimpleTestCase):
         self.assertEqual(lazy_a() * 5, "aaaaa")
         self.assertEqual(lazy_a() * lazy_5(), "aaaaa")
 
+    def test_lazy_format(self):
+        class QuotedString(str):
+            def __format__(self, format_spec):
+                value = super().__format__(format_spec)
+                return f"“{value}”"
+
+        lazy_f = lazy(lambda: QuotedString("Hello!"), QuotedString)
+        self.assertEqual(format(lazy_f(), ""), "“Hello!”")
+        f = lazy_f()
+        self.assertEqual(f"I said, {f}", "I said, “Hello!”")
+
     def test_lazy_equality(self):
         """
         == and != work correctly for Promises.

--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -192,10 +192,60 @@ class FunctionalTests(SimpleTestCase):
         with self.assertRaisesMessage(TypeError, msg):
             Foo().cp
 
-    def test_lazy_add(self):
+    def test_lazy_add_int(self):
         lazy_4 = lazy(lambda: 4, int)
         lazy_5 = lazy(lambda: 5, int)
+        self.assertEqual(4 + lazy_5(), 9)
+        self.assertEqual(lazy_4() + 5, 9)
         self.assertEqual(lazy_4() + lazy_5(), 9)
+
+    def test_lazy_add_list(self):
+        lazy_4 = lazy(lambda: [4], list)
+        lazy_5 = lazy(lambda: [5], list)
+        self.assertEqual([4] + lazy_5(), [4, 5])
+        self.assertEqual(lazy_4() + [5], [4, 5])
+        self.assertEqual(lazy_4() + lazy_5(), [4, 5])
+
+    def test_lazy_add_str(self):
+        lazy_a = lazy(lambda: "a", str)
+        lazy_b = lazy(lambda: "b", str)
+        self.assertEqual("a" + lazy_b(), "ab")
+        self.assertEqual(lazy_a() + "b", "ab")
+        self.assertEqual(lazy_a() + lazy_b(), "ab")
+
+    def test_lazy_mod_int(self):
+        lazy_4 = lazy(lambda: 4, int)
+        lazy_5 = lazy(lambda: 5, int)
+        self.assertEqual(4 % lazy_5(), 4)
+        self.assertEqual(lazy_4() % 5, 4)
+        self.assertEqual(lazy_4() % lazy_5(), 4)
+
+    def test_lazy_mod_str(self):
+        lazy_a = lazy(lambda: "a%s", str)
+        lazy_b = lazy(lambda: "b", str)
+        self.assertEqual("a%s" % lazy_b(), "ab")
+        self.assertEqual(lazy_a() % "b", "ab")
+        self.assertEqual(lazy_a() % lazy_b(), "ab")
+
+    def test_lazy_mul_int(self):
+        lazy_4 = lazy(lambda: 4, int)
+        lazy_5 = lazy(lambda: 5, int)
+        self.assertEqual(4 * lazy_5(), 20)
+        self.assertEqual(lazy_4() * 5, 20)
+
+    def test_lazy_mul_list(self):
+        lazy_4 = lazy(lambda: [4], list)
+        lazy_5 = lazy(lambda: 5, int)
+        self.assertEqual([4] * lazy_5(), [4, 4, 4, 4, 4])
+        self.assertEqual(lazy_4() * 5, [4, 4, 4, 4, 4])
+        self.assertEqual(lazy_4() * lazy_5(), [4, 4, 4, 4, 4])
+
+    def test_lazy_mul_str(self):
+        lazy_a = lazy(lambda: "a", str)
+        lazy_5 = lazy(lambda: 5, int)
+        self.assertEqual("a" * lazy_5(), "aaaaa")
+        self.assertEqual(lazy_a() * 5, "aaaaa")
+        self.assertEqual(lazy_a() * lazy_5(), "aaaaa")
 
     def test_lazy_equality(self):
         """

--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -230,6 +230,7 @@ class FunctionalTests(SimpleTestCase):
         lazy_5 = lazy(lambda: 5, int)
         self.assertEqual(4 * lazy_5(), 20)
         self.assertEqual(lazy_4() * 5, 20)
+        self.assertEqual(lazy_4() * lazy_5(), 20)
 
     def test_lazy_mul_list(self):
         lazy_4 = lazy(lambda: [4], list)


### PR DESCRIPTION
Supersedes PR #11314.

All comments from there should be addressed.

Aside from removing much cruft left over from the Python 2 days related to `str` vs `bytes` and the simplicity and consistency of eagerly preparing the proxy, there is some improvement in performance too in certain cases.

<details>
<summary><strong>Before</strong></summary>

```
Python 3.10.10 (main, Mar  5 2023, 22:26:53) [GCC 12.2.1 20230201]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.12.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from django.utils.functional import lazy
   ...: def identity(x): return x
   ...: %prun for i in range(10000): str(lazy(identity)(1))
         380003 function calls in 0.172 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.059    0.000    0.075    0.000 {built-in method builtins.__build_class__}
    10000    0.017    0.000    0.017    0.000 functional.py:85(__proxy__)
    10000    0.015    0.000    0.024    0.000 functools.py:35(update_wrapper)
    80000    0.014    0.000    0.014    0.000 {built-in method builtins.setattr}
   150000    0.011    0.000    0.011    0.000 {built-in method builtins.getattr}
    10000    0.010    0.000    0.035    0.000 functools.py:188(total_ordering)
    10000    0.010    0.000    0.147    0.000 functional.py:77(lazy)
    10000    0.008    0.000    0.014    0.000 functools.py:191(<setcomp>)
        1    0.007    0.007    0.172    0.172 <string>:1(<module>)
    10000    0.005    0.000    0.008    0.000 functional.py:95(__init__)
    10000    0.003    0.000    0.004    0.000 functional.py:146(__cast)
    10000    0.003    0.000    0.003    0.000 functional.py:111(__prepare_class__)
    10000    0.003    0.000    0.007    0.000 functional.py:152(__str__)
    10000    0.002    0.000    0.011    0.000 functional.py:188(__wrapper__)
    10000    0.002    0.000    0.002    0.000 functools.py:65(wraps)
    10000    0.001    0.000    0.001    0.000 {built-in method builtins.max}
    10000    0.001    0.000    0.001    0.000 {method 'update' of 'dict' objects}
    10000    0.001    0.000    0.001    0.000 <ipython-input-1-79cd33187a71>:2(identity)
        1    0.000    0.000    0.172    0.172 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}

In [2]: from django.utils.functional import lazy
   ...: def identity(x): return x
   ...: %prun for i in range(10000): lazy(identity, str)("a").upper()
         2440003 function calls in 0.807 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.333    0.000    0.650    0.000 functional.py:111(__prepare_class__)
   940000    0.158    0.000    0.158    0.000 {built-in method builtins.hasattr}
   550000    0.104    0.000    0.104    0.000 functional.py:132(__promise__)
   630000    0.069    0.000    0.069    0.000 {built-in method builtins.setattr}
    10000    0.031    0.000    0.052    0.000 {built-in method builtins.__build_class__}
    10000    0.021    0.000    0.021    0.000 functional.py:85(__proxy__)
    10000    0.017    0.000    0.027    0.000 functools.py:35(update_wrapper)
   160000    0.014    0.000    0.014    0.000 {built-in method builtins.getattr}
    10000    0.011    0.000    0.131    0.000 functional.py:77(lazy)
    10000    0.011    0.000    0.039    0.000 functools.py:188(total_ordering)
    10000    0.009    0.000    0.016    0.000 functools.py:191(<setcomp>)
        1    0.008    0.008    0.807    0.807 <string>:1(<module>)
    10000    0.006    0.000    0.009    0.000 functional.py:135(__wrapper__)
    10000    0.005    0.000    0.656    0.000 functional.py:95(__init__)
    10000    0.003    0.000    0.659    0.000 functional.py:188(__wrapper__)
    10000    0.002    0.000    0.002    0.000 functools.py:65(wraps)
    10000    0.001    0.000    0.001    0.000 {built-in method builtins.max}
    10000    0.001    0.000    0.001    0.000 {method 'mro' of 'type' objects}
    10000    0.001    0.000    0.001    0.000 {method 'update' of 'dict' objects}
    10000    0.001    0.000    0.001    0.000 <ipython-input-2-b74d5df0c298>:2(identity)
    10000    0.001    0.000    0.001    0.000 {method 'upper' of 'str' objects}
        1    0.000    0.000    0.807    0.807 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
```

</details>

<details>
<summary><strong>After</strong></summary>

```
Python 3.10.10 (main, Mar  5 2023, 22:26:53) [GCC 12.2.1 20230201]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.12.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from django.utils.functional import lazy
   ...: def identity(x): return x
   ...: %prun for i in range(10000): str(lazy(identity)(1))
         230003 function calls in 0.126 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.041    0.000    0.041    0.000 functional.py:85(__proxy__)
    10000    0.029    0.000    0.070    0.000 {built-in method builtins.__build_class__}
    10000    0.016    0.000    0.026    0.000 functools.py:35(update_wrapper)
    10000    0.009    0.000    0.107    0.000 functional.py:77(lazy)
        1    0.007    0.007    0.126    0.126 <string>:1(<module>)
    70000    0.005    0.000    0.005    0.000 {built-in method builtins.getattr}
    50000    0.004    0.000    0.004    0.000 {built-in method builtins.setattr}
    10000    0.003    0.000    0.006    0.000 functional.py:151(__str__)
    10000    0.003    0.000    0.005    0.000 functional.py:195(__wrapper__)
    10000    0.002    0.000    0.003    0.000 functional.py:96(__cast)
    10000    0.002    0.000    0.002    0.000 functools.py:65(wraps)
    10000    0.002    0.000    0.002    0.000 functional.py:92(__init__)
    10000    0.001    0.000    0.001    0.000 {method 'update' of 'dict' objects}
    10000    0.001    0.000    0.001    0.000 <ipython-input-1-79cd33187a71>:2(identity)
        1    0.000    0.000    0.126    0.126 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}

In [2]: from django.utils.functional import lazy
   ...: def identity(x): return x
   ...: %prun for i in range(10000): lazy(identity, str)("a").upper()
         1720003 function calls in 0.556 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.250    0.000    0.537    0.000 functional.py:77(lazy)
   940000    0.146    0.000    0.146    0.000 {built-in method builtins.hasattr}
   580000    0.050    0.000    0.050    0.000 {built-in method builtins.setattr}
    10000    0.033    0.000    0.033    0.000 functional.py:85(__proxy__)
    10000    0.031    0.000    0.064    0.000 {built-in method builtins.__build_class__}
    10000    0.018    0.000    0.028    0.000 functools.py:35(update_wrapper)
        1    0.007    0.007    0.556    0.556 <string>:1(<module>)
    80000    0.006    0.000    0.006    0.000 {built-in method builtins.getattr}
    10000    0.005    0.000    0.007    0.000 functional.py:187(__wrapper__)
    10000    0.002    0.000    0.005    0.000 functional.py:195(__wrapper__)
    10000    0.002    0.000    0.002    0.000 functools.py:65(wraps)
    10000    0.002    0.000    0.002    0.000 functional.py:92(__init__)
    10000    0.001    0.000    0.001    0.000 {method 'mro' of 'type' objects}
    10000    0.001    0.000    0.001    0.000 {method 'update' of 'dict' objects}
    10000    0.001    0.000    0.001    0.000 <ipython-input-2-b74d5df0c298>:2(identity)
    10000    0.001    0.000    0.001    0.000 {method 'upper' of 'str' objects}
        1    0.000    0.000    0.556    0.556 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}

In [3]: import django
   ...: from django.conf import settings
   ...: from django.utils.translation import gettext_lazy
   ...: settings.configure()
   ...: django.setup()
   ...: %prun for i in range(10000): gettext_lazy("Do you know your %s?") % "ABC"

         260530 function calls (250524 primitive calls) in 0.084 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10000    0.017    0.000    0.031    0.000 local.py:44(_get_context_id)
    10000    0.008    0.000    0.046    0.000 local.py:99(__getattr__)
    10000    0.008    0.000    0.068    0.000 trans_real.py:368(gettext)
20030/10027    0.006    0.000    0.051    0.000 {built-in method builtins.getattr}
    10000    0.005    0.000    0.037    0.000 local.py:80(_get_storage)
        1    0.004    0.004    0.084    0.084 <string>:1(<module>)
    10000    0.003    0.000    0.006    0.000 sync.py:545(get_current_task)
    10000    0.003    0.000    0.007    0.000 gettext.py:496(gettext)
    10000    0.003    0.000    0.076    0.000 functional.py:172(__mod__)
    10000    0.003    0.000    0.004    0.000 trans_real.py:113(get)
    10000    0.002    0.000    0.071    0.000 __init__.py:94(gettext)
    10000    0.002    0.000    0.004    0.000 functional.py:195(__wrapper__)
    10001    0.002    0.000    0.003    0.000 <frozen importlib._bootstrap>:404(parent)
    10000    0.002    0.000    0.073    0.000 functional.py:96(__cast)
    10000    0.002    0.000    0.003    0.000 threading.py:1430(current_thread)
    10000    0.002    0.000    0.003    0.000 tasks.py:35(current_task)
    10000    0.002    0.000    0.002    0.000 functional.py:92(__init__)
    20000    0.001    0.000    0.001    0.000 {method 'replace' of 'str' objects}
    10000    0.001    0.000    0.001    0.000 {built-in method _asyncio.get_running_loop}
    10006    0.001    0.000    0.001    0.000 {method 'rpartition' of 'str' objects}
    10024    0.001    0.000    0.001    0.000 {built-in method builtins.isinstance}
    10002    0.001    0.000    0.001    0.000 {built-in method _thread.get_ident}
    10014    0.001    0.000    0.001    0.000 {built-in method builtins.hasattr}
    10000    0.001    0.000    0.001    0.000 {built-in method sys.getrecursionlimit}
    10006    0.001    0.000    0.001    0.000 {method 'get' of 'dict' objects}
        1    0.000    0.000    0.000    0.000 gettext.py:374(_parse)
      2/1    0.000    0.000    0.084    0.084 {built-in method builtins.exec}
        2    0.000    0.000    0.000    0.000 dispatcher.py:50(connect)
        7    0.000    0.000    0.000    0.000 {built-in method posix.stat}
    18/16    0.000    0.000    0.000    0.000 functional.py:279(__getattribute__)
        5    0.000    0.000    0.000    0.000 posixpath.py:71(join)
        1    0.000    0.000    0.000    0.000 {built-in method marshal.loads}
        1    0.000    0.000    0.000    0.000 {built-in method io.open_code}
        1    0.000    0.000    0.000    0.000 gettext.py:542(find)
        1    0.000    0.000    0.000    0.000 trans_real.py:141(__init__)
        1    0.000    0.000    0.000    0.000 __init__.py:62(__getattr__)
        1    0.000    0.000    0.000    0.000 gettext.py:211(_expand_lang)
        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1536(find_spec)
        1    0.000    0.000    0.000    0.000 gettext.py:583(translation)
...

```

</details>