### PR TITLE
Fixed #34645 -- Restored alignment for admin date/time timezone warnings.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -130,7 +130,9 @@ form .aligned div.help {
     padding-left: 10px;
 }
 
-form .aligned p.datetime div.help.timezonewarning {
+form .aligned p.date div.help.timezonewarning,
+form .aligned p.datetime div.help.timezonewarning,
+form .aligned p.time div.help.timezonewarning {
     margin-left: 0;
     padding-left: 0;
     font-weight: normal;

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -147,7 +147,9 @@ form .aligned div.help {
 
 form div.help ul,
 form .aligned .checkbox-row + .help,
-form .aligned p.datetime div.help.timezonewarning {
+form .aligned p.date div.help.timezonewarning,
+form .aligned p.datetime div.help.timezonewarning,
+form .aligned p.time div.help.timezonewarning {
     margin-right: 0;
     padding-right: 0;
 }

--- a/django/contrib/admin/templates/admin/widgets/date.html
+++ b/django/contrib/admin/templates/admin/widgets/date.html
@@ -1,0 +1,3 @@
+<p class="date">
+  {% include "django/forms/widgets/date.html" %}
+</p>

--- a/django/contrib/admin/templates/admin/widgets/time.html
+++ b/django/contrib/admin/templates/admin/widgets/time.html
@@ -1,0 +1,3 @@
+<p class="time">
+  {% include "django/forms/widgets/time.html" %}
+</p>

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -48,7 +48,7 @@ class FilteredSelectMultiple(forms.SelectMultiple):
         return context
 
 
-class AdminDateWidget(forms.DateInput):
+class BaseAdminDateWidget(forms.DateInput):
     class Media:
         js = [
             "admin/js/calendar.js",
@@ -60,7 +60,11 @@ class AdminDateWidget(forms.DateInput):
         super().__init__(attrs=attrs, format=format)
 
 
-class AdminTimeWidget(forms.TimeInput):
+class AdminDateWidget(BaseAdminDateWidget):
+    template_name = "admin/widgets/date.html"
+
+
+class BaseAdminTimeWidget(forms.TimeInput):
     class Media:
         js = [
             "admin/js/calendar.js",
@@ -72,6 +76,10 @@ class AdminTimeWidget(forms.TimeInput):
         super().__init__(attrs=attrs, format=format)
 
 
+class AdminTimeWidget(BaseAdminTimeWidget):
+    template_name = "admin/widgets/time.html"
+
+
 class AdminSplitDateTime(forms.SplitDateTimeWidget):
     """
     A SplitDateTime Widget that has some admin-specific styling.
@@ -80,7 +88,7 @@ class AdminSplitDateTime(forms.SplitDateTimeWidget):
     template_name = "admin/widgets/split_datetime.html"
 
     def __init__(self, attrs=None):
-        widgets = [AdminDateWidget, AdminTimeWidget]
+        widgets = [BaseAdminDateWidget, BaseAdminTimeWidget]
         # Note that we're calling MultiWidget, not SplitDateTimeWidget, because
         # we want to define widgets.
         forms.MultiWidget.__init__(self, widgets, attrs)

--- a/docs/releases/4.2.3.txt
+++ b/docs/releases/4.2.3.txt
@@ -9,4 +9,5 @@ Django 4.2.3 fixes several bugs in 4.2.2.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 4.2 that caused incorrect alignment of timezone
+  warnings for ``DateField`` and ``TimeField`` in the admin (:ticket:`34645`).

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -398,15 +398,17 @@ class AdminDateWidgetTest(SimpleTestCase):
         w = widgets.AdminDateWidget()
         self.assertHTMLEqual(
             w.render("test", datetime(2007, 12, 1, 9, 30)),
+            '<p class="date">'
             '<input value="2007-12-01" type="text" class="vDateField" name="test" '
-            'size="10">',
+            'size="10"></p>',
         )
         # pass attrs to widget
         w = widgets.AdminDateWidget(attrs={"size": 20, "class": "myDateField"})
         self.assertHTMLEqual(
             w.render("test", datetime(2007, 12, 1, 9, 30)),
+            '<p class="date">'
             '<input value="2007-12-01" type="text" class="myDateField" name="test" '
-            'size="20">',
+            'size="20"></p>',
         )
 
 
@@ -415,15 +417,17 @@ class AdminTimeWidgetTest(SimpleTestCase):
         w = widgets.AdminTimeWidget()
         self.assertHTMLEqual(
             w.render("test", datetime(2007, 12, 1, 9, 30)),
+            '<p class="time">'
             '<input value="09:30:00" type="text" class="vTimeField" name="test" '
-            'size="8">',
+            'size="8"></p>',
         )
         # pass attrs to widget
         w = widgets.AdminTimeWidget(attrs={"size": 20, "class": "myTimeField"})
         self.assertHTMLEqual(
             w.render("test", datetime(2007, 12, 1, 9, 30)),
+            '<p class="time">'
             '<input value="09:30:00" type="text" class="myTimeField" name="test" '
-            'size="20">',
+            'size="20"></p>',
         )
 
 


### PR DESCRIPTION
Regression in 96a598356a9ea8c2c05b22cadc12e256a3b295fd.

ticket-34645

Before:
![image](https://github.com/django/django/assets/2865885/961b4ade-5f61-4bf4-99b9-fa1f87894910)


After:

![image](https://github.com/django/django/assets/2865885/849b7e83-0608-4381-8f9c-02d1af11d97d)
