### PR TITLE
Refs #34233 -- Updated black target-version to Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ requires = ['setuptools>=40.8.0']
 build-backend = 'setuptools.build_meta'
 
 [tool.black]
-target-version = ['py38']
+target-version = ['py310']
 force-exclude = 'tests/test_runner_apps/tagged/tests_syntax_error.py'


### PR DESCRIPTION
I'm not sure if there is there a reason why we kept black's target version at 3.8 when we dropped support for Python 3.8 and 3.9? [See PR](https://github.com/django/django/pull/16467)

The need here is that black currently errors if you try to write Python 3.10 code (e.g. match / case statements). 

