### PR TITLE
Added TIME_ZONE override test

### DIFF
--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import unittest
+from datetime import datetime
 from types import ModuleType, SimpleNamespace
 from unittest import mock
 
@@ -339,6 +340,12 @@ class SettingsTests(SimpleTestCase):
     def test_incorrect_timezone(self):
         with self.assertRaisesMessage(ValueError, "Incorrect timezone setting: test"):
             settings._setup()
+
+    def test_override_timezone(self):
+        with override_settings(TIME_ZONE="Japan"):
+            now = datetime.now()
+            timezone = now.astimezone()
+            self.assertEqual(str(timezone.tzinfo), "JST")
 
 
 class TestComplexSettingOverride(SimpleTestCase):


### PR DESCRIPTION
Locally, this doesn't work for me on Windows (Python 3.11.3), but it does on Ubuntu WSL (22.04 | Python 3.10.6). On Windows even with the settings overridden I get my local timezone. 

Opening to see if I see the same failure in CI. 