### PR TITLE
Swap user_can_authenticate and check_password in if statement

### DIFF
--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -45,7 +45,7 @@ class ModelBackend(BaseBackend):
             # difference between an existing and a nonexistent user (#20760).
             UserModel().set_password(password)
         else:
-            if user.check_password(password) and self.user_can_authenticate(user):
+            if self.user_can_authenticate(user) and user.check_password(password):
                 return user
 
     def user_can_authenticate(self, user):


### PR DESCRIPTION
Make `user_can_authenticate` the left operand and `check_password` the right operand in if statement because `user_can_authenticate` does no complex logic but `check_password` does (like hashing the raw password). This can save computation in case of `user_can_authenticate` just returns `False`.