### PR TITLE
Made SeleniumTests.test_select_multiple less flaky by adding explicit Selenium wait.

### DIFF
--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -494,7 +494,8 @@ class SeleniumTests(AdminSeleniumTestCase):
             + reverse("autocomplete_admin:admin_views_question_add")
         )
         elem = self.selenium.find_element(By.CSS_SELECTOR, ".select2-selection")
-        elem.click()  # Open the autocomplete dropdown.
+        with self.select2_ajax_wait():
+            elem.click()  # Open the autocomplete dropdown.
         results = self.selenium.find_element(By.CSS_SELECTOR, ".select2-results")
         self.assertTrue(results.is_displayed())
         option = self.selenium.find_element(By.CSS_SELECTOR, ".select2-results__option")


### PR DESCRIPTION
This fixes a failure that I have with #16965.