### PR TITLE
Fixed date_time_picker_shortcuts() tests on Windows.

### DIFF
--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -23,6 +23,7 @@ from django.db.models import (
     UUIDField,
 )
 from django.test import SimpleTestCase, TestCase, ignore_warnings, override_settings
+from django.test.utils import requires_tz_support
 from django.urls import reverse
 from django.utils import translation
 from django.utils.deprecation import RemovedInDjango60Warning
@@ -1116,6 +1117,7 @@ class DateTimePickerSeleniumTests(AdminWidgetSeleniumTestCase):
                 self.wait_for_text("#calendarin0 caption", expected_caption)
 
 
+@requires_tz_support
 @override_settings(TIME_ZONE="Asia/Singapore")
 class DateTimePickerShortcutsSeleniumTests(AdminWidgetSeleniumTestCase):
     def test_date_time_picker_shortcuts(self):


### PR DESCRIPTION
Windows does not allow overriding TIME_ZONE as time.tzset() is only available on Unix. https://docs.python.org/3/library/time.html#time.tzset

Instead create a naive server time to use in the comparison to submitted data.