### PR TITLE
Fixed #22125 -- Stopped unnecessary creation of index for ManyToManyField

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -360,6 +360,9 @@ class BaseDatabaseFeatures:
     # Does the backend support unlimited character columns?
     supports_unlimited_charfield = False
 
+    # Does this backend use composite index to search by any prefix of its key?
+    composite_index_supports_prefix_search = True
+
     # Collation names for use by the Django test suite.
     test_collations = {
         "ci": None,  # Case-insensitive.

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1308,6 +1308,7 @@ def create_many_to_many_intermediary_model(field, klass):
                 related_name="%s+" % name,
                 db_tablespace=field.db_tablespace,
                 db_constraint=field.remote_field.db_constraint,
+                db_index=not connection.features.composite_index_supports_prefix_search,
                 on_delete=CASCADE,
             ),
             to: models.ForeignKey(

--- a/tests/model_options/test_tablespaces.py
+++ b/tests/model_options/test_tablespaces.py
@@ -97,14 +97,19 @@ class TablespacesTests(TransactionTestCase):
         sql = sql_for_table(Authors).lower()
         # The join table of the ManyToManyField goes to the model's tablespace,
         # and its indexes too, unless DEFAULT_INDEX_TABLESPACE is set.
+        expected_through_indexes = (
+            1 if connection.features.composite_index_supports_prefix_search else 2
+        )
         if settings.DEFAULT_INDEX_TABLESPACE:
             # 1 for the table
             self.assertNumContains(sql, "tbl_tbsp", 1)
             # 1 for the primary key
-            self.assertNumContains(sql, settings.DEFAULT_INDEX_TABLESPACE, 1)
+            self.assertNumContains(
+                sql, settings.DEFAULT_INDEX_TABLESPACE, expected_through_indexes
+            )
         else:
             # 1 for the table + 1 for the index on the primary key
-            self.assertNumContains(sql, "tbl_tbsp", 2)
+            self.assertNumContains(sql, "tbl_tbsp", expected_through_indexes)
         self.assertNumContains(sql, "idx_tbsp", 0)
 
         sql = sql_for_index(Authors).lower()

--- a/tests/model_options/test_tablespaces.py
+++ b/tests/model_options/test_tablespaces.py
@@ -104,21 +104,21 @@ class TablespacesTests(TransactionTestCase):
             # 1 for the table
             self.assertNumContains(sql, "tbl_tbsp", 1)
             # 1 for the primary key
-            self.assertNumContains(
-                sql, settings.DEFAULT_INDEX_TABLESPACE, expected_through_indexes
-            )
+            self.assertNumContains(sql, settings.DEFAULT_INDEX_TABLESPACE, 1)
         else:
             # 1 for the table + 1 for the index on the primary key
-            self.assertNumContains(sql, "tbl_tbsp", expected_through_indexes)
+            self.assertNumContains(sql, "tbl_tbsp", 2)
         self.assertNumContains(sql, "idx_tbsp", 0)
 
         sql = sql_for_index(Authors).lower()
         # The ManyToManyField declares no db_tablespace, its indexes go to
         # the model's tablespace, unless DEFAULT_INDEX_TABLESPACE is set.
         if settings.DEFAULT_INDEX_TABLESPACE:
-            self.assertNumContains(sql, settings.DEFAULT_INDEX_TABLESPACE, 2)
+            self.assertNumContains(
+                sql, settings.DEFAULT_INDEX_TABLESPACE, expected_through_indexes
+            )
         else:
-            self.assertNumContains(sql, "tbl_tbsp", 2)
+            self.assertNumContains(sql, "tbl_tbsp", expected_through_indexes)
         self.assertNumContains(sql, "idx_tbsp", 0)
 
         sql = sql_for_table(Reviewers).lower()
@@ -137,4 +137,4 @@ class TablespacesTests(TransactionTestCase):
         sql = sql_for_index(Reviewers).lower()
         # The ManyToManyField declares db_tablespace, its indexes go there.
         self.assertNumContains(sql, "tbl_tbsp", 0)
-        self.assertNumContains(sql, "idx_tbsp", 2)
+        self.assertNumContains(sql, "idx_tbsp", expected_through_indexes)


### PR DESCRIPTION
- [ticket 22125](https://code.djangoproject.com/ticket/22125)
- Following PR #10435
