### PR TITLE
Fixed #34656 -- Fixed unclosed div in admin password change template.

### DIFF
--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -34,7 +34,7 @@
   {{ form.password1.errors }}
   <div class="flex-container">{{ form.password1.label_tag }} {{ form.password1 }}</div>
   {% if form.password1.help_text %}
-  <div class="help"{% if form.password1.id_for_label %} id="{{ form.password1.id_for_label }}_helptext">{% endif %}{{ form.password1.help_text|safe }}</div>
+  <div class="help"{% if form.password1.id_for_label %} id="{{ form.password1.id_for_label }}_helptext"{% endif %}>{{ form.password1.help_text|safe }}</div>
   {% endif %}
 </div>
 


### PR DESCRIPTION
In `auth/user/change_password.html` there is a condition that checks existence of id_for_label for password1 field, the `{% endif %}` is closed in the wrong position and if the condition return False, the HTML will be corrupted (I'm not sure if it's possible to make the condition falsy)

[Ticket Link](https://code.djangoproject.com/ticket/34656)