### PR TITLE
Fixed typo in subtitle in fixtures.txt

### DIFF
--- a/docs/topics/db/fixtures.txt
+++ b/docs/topics/db/fixtures.txt
@@ -30,8 +30,8 @@ Fixtures can be used to pre-populate database with data for
 :ref:`tests <topics-testing-fixtures>` or to provide some :ref:`initial data
 <initial-data-via-fixtures>`.
 
-Were Django looks for fixtures?
-===============================
+Where Django looks for fixtures?
+================================
 
 Django will search in three locations for fixtures:
 


### PR DESCRIPTION
I think this adheres to the contribution guidelines -- is a single commit for a trivial typo fix. Let me know if I need to change anything. 