### PR TITLE
Fixed #34662 -- Corrected number in error messages for Array(Min/Max)LengthValidator.

### DIFF
--- a/django/contrib/postgres/validators.py
+++ b/django/contrib/postgres/validators.py
@@ -16,7 +16,7 @@ class ArrayMaxLengthValidator(MaxLengthValidator):
         "%(limit_value)d.",
         "List contains %(show_value)d items, it should contain no more than "
         "%(limit_value)d.",
-        "limit_value",
+        "show_value",
     )
 
 
@@ -26,7 +26,7 @@ class ArrayMinLengthValidator(MinLengthValidator):
         "%(limit_value)d.",
         "List contains %(show_value)d items, it should contain no fewer than "
         "%(limit_value)d.",
-        "limit_value",
+        "show_value",
     )
 
 

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -990,6 +990,13 @@ class TestValidation(PostgreSQLSimpleTestCase):
             "List contains 4 items, it should contain no more than 3.",
         )
 
+    def test_with_size_singular(self):
+        field = ArrayField(models.IntegerField(), size=1)
+        field.clean([1], None)
+        msg = "List contains 2 items, it should contain no more than 1."
+        with self.assertRaisesMessage(exceptions.ValidationError, msg):
+            field.clean([1, 2], None)
+
     def test_nested_array_mismatch(self):
         field = ArrayField(ArrayField(models.IntegerField()))
         field.clean([[1, 2], [3, 4]], None)
@@ -1131,6 +1138,13 @@ class TestSimpleFormField(PostgreSQLSimpleTestCase):
             cm.exception.messages[0],
             "List contains 3 items, it should contain no fewer than 4.",
         )
+
+    def test_min_length_singular(self):
+        field = SimpleArrayField(forms.IntegerField(), min_length=2)
+        field.clean([1, 2])
+        msg = "List contains 1 item, it should contain no fewer than 2."
+        with self.assertRaisesMessage(exceptions.ValidationError, msg):
+            field.clean([1])
 
     def test_required(self):
         field = SimpleArrayField(forms.CharField(), required=True)


### PR DESCRIPTION
It seems that in `ArrayMaxLengthValidator` and `ArrayMinLengthValidator` ngettext's `number` argument depends on wrong key.

https://code.djangoproject.com/ticket/34662