### PR TITLE
Update index.txt -- cautioned developers against using both form.erro…

### DIFF
--- a/docs/topics/forms/index.txt
+++ b/docs/topics/forms/index.txt
@@ -709,6 +709,10 @@ errors. For example, ``{{ form.non_field_errors }}`` would look like:
 See :doc:`/ref/forms/api` for more on errors, styling, and working with form
 attributes in templates.
 
+.. note::
+
+    If you use ``{{ form.errors }}`` at the top of the form in conjunction with the field-level ``{{ form.name_of_field.errors }}`` in your template file, only ``{{ form.errors }}`` would be rendered on your page, not ``{{ form.name_of_field.errors }}``.
+
 Looping over the form's fields
 ------------------------------
 


### PR DESCRIPTION
…rs and form.name_of_field.errors

Cautioned the developers against using both {{ form.errors }} and {{ form.name_of_field.errors }} in their templates.