### PR TITLE
Corrected Spanish spelling in Truncator test.

### DIFF
--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -167,7 +167,7 @@ class TestUtilsText(SimpleTestCase):
 
         # Test html entities
         truncator = text.Truncator(
-            "<i>Buenos d&iacute;as! &#x00bf;C&oacute;mo est&aacute;?</i>"
+            "<i>Buenos d&iacute;as! &#x00bf;C&oacute;mo est&aacute;s?</i>"
         )
         self.assertEqual(
             "<i>Buenos d&iacute;as! &#x00bf;C&oacute;mo…</i>",


### PR DESCRIPTION
Ahead of https://github.com/django/django/pull/16421 could we correct the spelling of this phrase? 

See comment https://github.com/django/django/pull/16421#discussion_r1061179369

