### PR TITLE
Signing session keys #34672 [WIP]

### DIFF
--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -4,10 +4,10 @@ from importlib import import_module
 from django.conf import settings
 from django.contrib.sessions.backends.base import UpdateError
 from django.contrib.sessions.exceptions import SessionInterrupted
+from django.core.signing import Signer
 from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.http import http_date
-from django.core.signing import Signer
 
 
 class SessionMiddleware(MiddlewareMixin):


### PR DESCRIPTION
This is a work in progress pull request.

Currently the session keys in `django_auth` is used to authenticate users (or any other session data).

If we sign the session keys when setting them in the cookie, and unsign them when reading, a BadSignature will be thrown if the session key is not signed or signed with a different secret key.
