### PR TITLE
Refs #34391 -- Updated asgiref dependency for 5.0 release series.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -279,7 +279,7 @@ dependencies:
 
 * :pypi:`aiosmtpd`
 * :pypi:`argon2-cffi` 19.2.0+
-* :pypi:`asgiref` 3.6.0+ (required)
+* :pypi:`asgiref` 3.7.0+ (required)
 * :pypi:`bcrypt`
 * :pypi:`colorama`
 * :pypi:`docutils`

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -438,6 +438,9 @@ Miscellaneous
   odd number of operands rather than exactly one operand. This is consistent
   with the behavior of MySQL, MariaDB, and Python.
 
+* The minimum supported version of ``asgiref`` is increased from 3.6.0 to
+  3.7.0.
+
 .. _deprecated-features-5.0:
 
 Features deprecated in 5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ packages = find:
 include_package_data = true
 zip_safe = false
 install_requires =
-    asgiref >= 3.6.0
+    asgiref >= 3.7.0
     sqlparse >= 0.3.1
     tzdata; sys_platform == 'win32'
 

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,5 +1,5 @@
 aiosmtpd
-asgiref >= 3.6.0
+asgiref >= 3.7.0
 argon2-cffi >= 19.2.0
 bcrypt
 black


### PR DESCRIPTION
See https://github.com/django/django/pull/16636#issuecomment-1537296703. We would update `asgiref` dependency before Django 5.0 final release, so we can do this now to simplify #16636.