### PR TITLE
Update operations.py

### DIFF
--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -332,7 +332,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         return value
 
     def convert_uuidfield_value(self, value, expression, connection):
-        if value is not None:
+        if value is not None and value.strip():
             value = uuid.UUID(value)
         return value
 


### PR DESCRIPTION
fix this error:
```
  File "/django/db/backends/mysql/operations.py", line 318, in convert_uuidfield_value
    value = uuid.UUID(value)
  File "/usr/lib/python3.8/uuid.py", line 175, in __init__
    raise ValueError('badly formed hexadecimal UUID string')
ValueError: badly formed hexadecimal UUID string
```

**because our value is equal to blank**