### PR TITLE
Fixed #34676 -- Normalized Distance()/Area() exceptions for nonexistent units.

### DIFF
--- a/django/contrib/gis/measure.py
+++ b/django/contrib/gis/measure.py
@@ -232,7 +232,7 @@ class MeasureBase:
         """
         Retrieve the unit attribute name for the given unit string.
         For example, if the given unit string is 'metre', return 'm'.
-        Raise an exception if an attribute cannot be found.
+        Raise an AttributeError if an attribute cannot be found.
         """
         lower = unit_str.lower()
         if unit_str in cls.UNITS:
@@ -242,9 +242,7 @@ class MeasureBase:
         elif lower in cls.LALIAS:
             return cls.LALIAS[lower]
         else:
-            raise Exception(
-                'Could not find a unit keyword associated with "%s"' % unit_str
-            )
+            raise AttributeError(f"Unknown unit type: {unit_str}")
 
 
 class Distance(MeasureBase):

--- a/tests/gis_tests/test_measure.py
+++ b/tests/gis_tests/test_measure.py
@@ -6,9 +6,10 @@ and conversions. Here are some tests.
 import unittest
 
 from django.contrib.gis.measure import A, Area, D, Distance
+from django.test import SimpleTestCase
 
 
-class DistanceTest(unittest.TestCase):
+class DistanceTest(SimpleTestCase):
     "Testing the Distance object"
 
     def test_init(self):
@@ -156,6 +157,13 @@ class DistanceTest(unittest.TestCase):
         for nm, att in unit_tuple:
             with self.subTest(nm=nm):
                 self.assertEqual(att, D.unit_attname(nm))
+
+    def test_unit_att_name_invalid(self):
+        msg = "Unknown unit type: invalid-unit-name"
+        with self.assertRaisesMessage(AttributeError, msg):
+            D.unit_attname("invalid-unit-name")
+        with self.assertRaisesMessage(AttributeError, msg):
+            A.unit_attname("invalid-unit-name")
 
     def test_hash(self):
         d1 = D(m=99)


### PR DESCRIPTION
Fixes [34676](https://code.djangoproject.com/ticket/34676#ticket).