### PR TITLE
Fixed #22055 -- Show traceback when Resolver404 is raised in views

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -310,7 +310,7 @@ class BaseHandler:
         else:
             resolver = get_resolver()
         # Resolve the view, and assign the match object back to the request.
-        resolver_match = resolver.resolve(request.path_info)
+        resolver_match = resolver.resolve(request.path_info, traceback=False)
         request.resolver_match = resolver_match
         return resolver_match
 

--- a/django/urls/exceptions.py
+++ b/django/urls/exceptions.py
@@ -2,7 +2,9 @@ from django.http import Http404
 
 
 class Resolver404(Http404):
-    pass
+    def __init__(self, msg, traceback=True):
+        self.traceback = traceback
+        super(Resolver404, self).__init__(msg)
 
 
 class NoReverseMatch(Exception):

--- a/django/urls/exceptions.py
+++ b/django/urls/exceptions.py
@@ -3,6 +3,9 @@ from django.http import Http404
 
 class Resolver404(Http404):
     def __init__(self, msg, traceback=True):
+        # traceback changes the handling of Resolver404 when DEBUG=True
+        # traceback=True results in a 500 error page with a traceback
+        # traceback=False results in the standard 404 page
         self.traceback = traceback
         super(Resolver404, self).__init__(msg)
 

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -652,7 +652,7 @@ class URLResolver:
             self._populate()
         return name in self._callback_strs
 
-    def resolve(self, path):
+    def resolve(self, path, traceback=True):
         path = str(path)  # path may be a reverse_lazy object
         tried = []
         match = self.pattern.match(path)
@@ -697,8 +697,8 @@ class URLResolver:
                             },
                         )
                     tried.append([pattern])
-            raise Resolver404({"tried": tried, "path": new_path})
-        raise Resolver404({"path": path})
+            raise Resolver404({"tried": tried, "path": new_path}, traceback=traceback)
+        raise Resolver404({"path": path}, traceback=traceback)
 
     @cached_property
     def urlconf_module(self):

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -489,4 +489,3 @@ Exception Value: {{ exception_value|force_escape }}{% if exception_notes %}{{ ex
 {% endif %}
 </body>
 </html>
-<!-- technical_500.html -->

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -489,3 +489,4 @@ Exception Value: {{ exception_value|force_escape }}{% if exception_notes %}{{ ex
 {% endif %}
 </body>
 </html>
+<!-- technical_500.html -->

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -260,7 +260,6 @@ class DebugViewTests(SimpleTestCase):
             status_code=500,
             html=True,
         )
-
         with self.assertLogs("django.request", "ERROR"):
             response = self.client.get("/raises500/", headers={"accept": "text/plain"})
         self.assertContains(

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -150,11 +150,18 @@ class DebugViewTests(SimpleTestCase):
         self.assertContains(response, "test template", status_code=403)
         self.assertContains(response, "(Insufficient Permissions).", status_code=403)
 
-    def test_404(self):
-        response = self.client.get("/raises404/")
+    def test_resolver404(self):
+        """Ensure Resolver404 raised in a view renders a technical 500 error page"""
+        response = self.client.get("/raises_resolver404/")
         self.assertContains(
             response,
-            "<th>Raised during:</th><td>view_tests.views.raises404</td>",
+            "<th>Raised during:</th><td>view_tests.views.raises_resolver404</td>",
+            status_code=404,
+            html=True,
+        )
+        self.assertContains(
+            response,
+            "<th>Exception Type:</th><td>Resolver404</td>",
             status_code=404,
             html=True,
         )
@@ -163,9 +170,11 @@ class DebugViewTests(SimpleTestCase):
             "<p>The current path, <code>not-in-urls</code>, didn’t match any "
             "of these.</p>",
             status_code=404,
+            html=True,
         )
 
     def test_404_not_in_urls(self):
+        """Ensure a technical 404 error is rendered, not a technical 500"""
         response = self.client.get("/not-in-urls")
         self.assertNotContains(response, "Raised by:", status_code=404)
         self.assertNotContains(
@@ -191,12 +200,6 @@ class DebugViewTests(SimpleTestCase):
         # Pattern and view name of a RoutePattern appear.
         self.assertContains(response, r"path-post/&lt;int:pk&gt;/", status_code=404)
         self.assertContains(response, "[name='path-post']", status_code=404)
-        self.assertContains(
-            response,
-            "<!-- technical_500.html -->",
-            status_code=404,
-            html=True,
-        )
 
     @override_settings(ROOT_URLCONF=WithoutEmptyPathUrls)
     def test_404_empty_path_not_in_urls(self):
@@ -207,16 +210,10 @@ class DebugViewTests(SimpleTestCase):
             status_code=404,
             html=True,
         )
-        self.assertContains(
-            response,
-            "<!-- technical_500.html -->",
-            status_code=404,
-            html=True,
-        )
 
     def test_technical_404(self):
+        """Test raising Http404 in a view displays the technical 404 page"""
         response = self.client.get("/technical404/")
-        self.assertNotIn(response.content.decode(), "<!-- technical_500.html -->")
         self.assertContains(
             response,
             '<pre class="exception_value">Testing technical 404.</pre>',
@@ -238,11 +235,18 @@ class DebugViewTests(SimpleTestCase):
         )
 
     def test_classbased_technical_404(self):
+        """Test raising Http404 in a class based view displays the technical 404 page"""
         response = self.client.get("/classbased404/")
-        self.assertNotIn(response.content.decode(), "<!-- technical_500.html -->")
         self.assertContains(
             response,
             "<th>Raised by:</th><td>view_tests.views.Http404View</td>",
+            status_code=404,
+            html=True,
+        )
+        self.assertContains(
+            response,
+            "<p>The current path, <code>classbased404/</code>, matched the "
+            "last one.</p>",
             status_code=404,
             html=True,
         )
@@ -256,18 +260,17 @@ class DebugViewTests(SimpleTestCase):
             status_code=500,
             html=True,
         )
-        self.assertContains(
-            response,
-            "<!-- technical_500.html -->",
-            status_code=500,
-            html=True,
-        )
 
         with self.assertLogs("django.request", "ERROR"):
             response = self.client.get("/raises500/", headers={"accept": "text/plain"})
         self.assertContains(
             response,
             "Raised during: view_tests.views.raises500",
+            status_code=500,
+        )
+        self.assertContains(
+            response,
+            "Exception Type: Exception",
             status_code=500,
         )
 
@@ -287,6 +290,11 @@ class DebugViewTests(SimpleTestCase):
         self.assertContains(
             response,
             "Raised during: view_tests.views.Raises500View",
+            status_code=500,
+        )
+        self.assertContains(
+            response,
+            "Exception Type: Exception",
             status_code=500,
         )
 

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -152,17 +152,17 @@ class DebugViewTests(SimpleTestCase):
 
     def test_404(self):
         response = self.client.get("/raises404/")
-        self.assertNotContains(
-            response,
-            '<pre class="exception_value">',
-            status_code=404,
-        )
         self.assertContains(
+            response,
+            "<th>Raised during:</th><td>view_tests.views.raises404</td>",
+            status_code=404,
+            html=True,
+        )
+        self.assertNotContains(
             response,
             "<p>The current path, <code>not-in-urls</code>, didn’t match any "
             "of these.</p>",
             status_code=404,
-            html=True,
         )
 
     def test_404_not_in_urls(self):
@@ -191,6 +191,12 @@ class DebugViewTests(SimpleTestCase):
         # Pattern and view name of a RoutePattern appear.
         self.assertContains(response, r"path-post/&lt;int:pk&gt;/", status_code=404)
         self.assertContains(response, "[name='path-post']", status_code=404)
+        self.assertContains(
+            response,
+            "<!-- technical_500.html -->",
+            status_code=404,
+            html=True,
+        )
 
     @override_settings(ROOT_URLCONF=WithoutEmptyPathUrls)
     def test_404_empty_path_not_in_urls(self):
@@ -201,9 +207,16 @@ class DebugViewTests(SimpleTestCase):
             status_code=404,
             html=True,
         )
+        self.assertContains(
+            response,
+            "<!-- technical_500.html -->",
+            status_code=404,
+            html=True,
+        )
 
     def test_technical_404(self):
         response = self.client.get("/technical404/")
+        self.assertNotIn(response.content.decode(), "<!-- technical_500.html -->")
         self.assertContains(
             response,
             '<pre class="exception_value">Testing technical 404.</pre>',
@@ -226,6 +239,7 @@ class DebugViewTests(SimpleTestCase):
 
     def test_classbased_technical_404(self):
         response = self.client.get("/classbased404/")
+        self.assertNotIn(response.content.decode(), "<!-- technical_500.html -->")
         self.assertContains(
             response,
             "<th>Raised by:</th><td>view_tests.views.Http404View</td>",
@@ -242,6 +256,13 @@ class DebugViewTests(SimpleTestCase):
             status_code=500,
             html=True,
         )
+        self.assertContains(
+            response,
+            "<!-- technical_500.html -->",
+            status_code=500,
+            html=True,
+        )
+
         with self.assertLogs("django.request", "ERROR"):
             response = self.client.get("/raises500/", headers={"accept": "text/plain"})
         self.assertContains(

--- a/tests/view_tests/urls.py
+++ b/tests/view_tests/urls.py
@@ -22,7 +22,7 @@ urlpatterns = [
     path("raises400/", views.raises400),
     path("raises400_bad_request/", views.raises400_bad_request),
     path("raises403/", views.raises403),
-    path("raises404/", views.raises404),
+    path("raises_resolver404/", views.raises_resolver404),
     path("raises500/", views.raises500),
     path("custom_reporter_class_view/", views.custom_reporter_class_view),
     path("technical404/", views.technical404, name="my404"),

--- a/tests/view_tests/views.py
+++ b/tests/view_tests/views.py
@@ -70,7 +70,7 @@ def raises403(request):
     raise PermissionDenied("Insufficient Permissions")
 
 
-def raises404(request):
+def raises_resolver404(request):
     resolver = get_resolver(None)
     resolver.resolve("/not-in-urls")
 


### PR DESCRIPTION
This is an initial draft to fix [ticket #22055 - 404 page does not display stack trace when Resolver404 is raised from a view](https://code.djangoproject.com/ticket/22055).

The desired behaviour is that, in debug mode:

- `Resolver404` raised from `django.core` returns a 404 page.
- `Http404` raised at any time returns a 404 page.
- `Resolver404` raised in a view (as in by an incorrect lookup) returns a 500 page with a 404 status code (for backwards compatibility) and a backtrace to enable debugging of which call to `resolve` requires amendment.

The implementation is as such:

1. `Resolver404` exception now has a class attribute of `traceback=True` which can be set at initialisation. 
2. `django.urls.resolve` also accepts a keyword argument of `traceback`, defaulting to `True`, which is passed to `Resolver404` if raised by the function.
3. If a `Resolver404` is raised with the default value of `traceback=True`, a 500 error page with a status code of 404 will be shown instead of a 404 error page.
4. In `django.core`, calls to `django.urls.resolve` are made with `traceback=False` to suppress the 500 page and display the normal 404 page.

Some tests have been added to verify this behaviour.

I would be interested in any feedback on whether there are additional locations where `traceback=False` might need to be set on calls to `django.urls.resolve`.

I did consider implementing the "urlconf traceback" seen on the regular 404 page - where Django tells the user what url patterns have been tried to find the page - in the 500 page template, but this would require a considerable refactor of `django.core.views.debug` and so I have left it for now.

Thanks! 