### PR TITLE
Refs #34233 -- Bumped minimum supported version of Selenium to 4.8.0.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -296,7 +296,7 @@ dependencies:
   <https://memcached.org/>`_
 * `gettext <https://www.gnu.org/software/gettext/manual/gettext.html>`_
   (:ref:`gettext_on_windows`)
-* :pypi:`selenium` 3.8.0+
+* :pypi:`selenium` 4.8.0+
 * :pypi:`sqlparse` 0.3.1+ (required)
 * :pypi:`tblib` 1.5.0+
 

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -448,6 +448,9 @@ Miscellaneous
 * The minimum supported version of ``asgiref`` is increased from 3.6.0 to
   3.7.0.
 
+* The minimum supported version of ``selenium`` is increased from 3.8.0 to
+  4.8.0.
+
 .. _deprecated-features-5.0:
 
 Features deprecated in 5.0

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1035,7 +1035,7 @@ First of all, you need to install the :pypi:`selenium` package:
 
 .. console::
 
-    $ python -m pip install "selenium >= 3.8.0"
+    $ python -m pip install "selenium >= 4.8.0"
 
 Then, add a ``LiveServerTestCase``-based test to your app's tests module
 (for example: ``myapp/tests.py``). For this example, we'll assume you're using

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -14,7 +14,7 @@ pymemcache >= 3.4.0
 pywatchman; sys.platform != 'win32'
 PyYAML
 redis >= 3.4.0
-selenium >= 3.8.0
+selenium >= 4.8.0
 sqlparse >= 0.3.1
 tblib >= 1.5.0
 tzdata


### PR DESCRIPTION
This bumps minimum supported versions of selenium to the first release to support Python 3.10.

ticket-34233
refs PR #17001