### PR TITLE
Fixed #34679 - Lazy load staticfiles manifest

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -460,7 +460,28 @@ class ManifestFilesMixin(HashedFilesMixin):
         if manifest_storage is None:
             manifest_storage = self
         self.manifest_storage = manifest_storage
-        self.hashed_files, self.manifest_hash = self.load_manifest()
+        self._hashed_files = None
+        self._manifest_hash = None
+
+    @property
+    def hashed_files(self):
+        if self._hashed_files is None:
+            self._hashed_files, self._manifest_hash = self.load_manifest()
+        return self._hashed_files
+
+    @hashed_files.setter
+    def hashed_files(self, value):
+        self._hashed_files = value
+
+    @property
+    def manifest_hash(self):
+        if self._manifest_hash is None:
+            self._hashed_files, self._manifest_hash = self.load_manifest()
+        return self._manifest_hash
+
+    @manifest_hash.setter
+    def manifest_hash(self, value):
+        self._manifest_hash = value
 
     def read_manifest(self):
         try:

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -892,3 +892,29 @@ class TestCollectionHashedFilesCache(CollectionTestCase):
                 content = relfile.read()
                 self.assertIn(b"foo.57a5cb9ba68d.png", content)
                 self.assertIn(b"xyz.57a5cb9ba68d.png", content)
+
+
+@override_settings(
+    STORAGES={
+        STATICFILES_STORAGE_ALIAS: {
+            "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+        },
+    }
+)
+class TestManifestStaticFilesStorageUnsupportedVersion(CollectionTestCase):
+    run_collectstatic_in_setUp = False
+
+    def test_collectstatic_with_unsupported_version(self):
+        manifest_path = (
+            Path(settings.STATIC_ROOT)
+            / storage.ManifestStaticFilesStorage.manifest_name
+        )
+        manifest = {"version": "0.0"}
+        with manifest_path.open("w") as manifest_file:
+            json.dump(manifest, manifest_file)
+        self.run_collectstatic()
+        with manifest_path.open("r") as manifest_file:
+            manifest = json.load(manifest_file)
+            self.assertEqual(
+                manifest["version"], storage.staticfiles_storage.manifest_version
+            )


### PR DESCRIPTION
Fixed collectstatic when unsupported manifest file already exists.