### PR TITLE
Add Granian to ASGI and WSGI deployment guide

### DIFF
--- a/docs/howto/deployment/asgi/granian.txt
+++ b/docs/howto/deployment/asgi/granian.txt
@@ -1,0 +1,38 @@
+=====================================
+How to use Django with Granian (ASGI)
+=====================================
+
+Granian_ is an ASGI server written in Rust that supports HTTP/1 and HTTP/2,
+with an emphasis on speed.
+
+Installing Granian
+==================
+
+You can install Granian with ``pip``:
+
+.. code-block:: shell
+
+    python -m pip install granian
+
+Running Django in Granian as a generic ASGI application
+=======================================================
+
+When Granian is installed, a ``granian`` command is available which runs ASGI
+applications. Granian needs to be called with the interface option for the ASGI
+protocol and the location of a module containing an ASGI application object,
+followed by what the application is called (separated by a colon).
+
+For a typical Django project, invoking Granian would look like:
+
+.. code-block:: shell
+
+    granian --interface asgi myproject.asgi:application
+
+This will start one process listening on ``127.0.0.1:8000``. It
+requires that your project be on the Python path; to ensure that
+run this command from the same directory as your ``manage.py`` file.
+
+For more advanced usage, please read the `Granian repository
+<Granian_>`_.
+
+.. _Granian: https://github.com/emmett-framework/granian

--- a/docs/howto/deployment/asgi/index.txt
+++ b/docs/howto/deployment/asgi/index.txt
@@ -17,6 +17,7 @@ Django includes getting-started documentation for the following ASGI servers:
    :maxdepth: 1
 
    daphne
+   granian
    hypercorn
    uvicorn
 

--- a/docs/howto/deployment/wsgi/granian.txt
+++ b/docs/howto/deployment/wsgi/granian.txt
@@ -1,0 +1,38 @@
+=====================================
+How to use Django with Granian (WSGI)
+=====================================
+
+Granian_ is a WSGI server written in Rust that supports HTTP/1 and HTTP/2,
+with an emphasis on speed.
+
+Installing Granian
+==================
+
+You can install Granian with ``pip``:
+
+.. code-block:: shell
+
+    python -m pip install granian
+
+Running Django in Granian as a generic WSGI application
+=======================================================
+
+When Granian is installed, a ``granian`` command is available which runs WSGI
+applications. Granian needs to be called with the interface option for the WSGI
+protocol and the location of a module containing a WSGI application object,
+followed by what the application is called (separated by a colon).
+
+For a typical Django project, invoking Granian would look like:
+
+.. code-block:: shell
+
+    granian --interface wsgi myproject.wsgi:application
+
+This will start one process listening on ``127.0.0.1:8000``. It
+requires that your project be on the Python path; to ensure that
+run this command from the same directory as your ``manage.py`` file.
+
+For more advanced usage, please read the `Granian repository
+<Granian_>`_.
+
+.. _Granian: https://github.com/emmett-framework/granian

--- a/docs/howto/deployment/wsgi/index.txt
+++ b/docs/howto/deployment/wsgi/index.txt
@@ -16,6 +16,7 @@ Django includes getting-started documentation for the following WSGI servers:
 .. toctree::
    :maxdepth: 1
 
+   granian
    gunicorn
    uwsgi
    modwsgi

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -194,6 +194,7 @@ GiB
 gis
 GiST
 Googol
+Granian
 Greenhill
 gunicorn
 GZip


### PR DESCRIPTION
Granian is a Rust HTTP server for Python applications which supports both ASGI and WSGI application protocols.

It isn't as well known in the Django community as an option - hopefully this will help that.