### PR TITLE
Fixed RecorderTests.test_has_table_cached() on databases that perform multiple queries when introspecting tables.

### DIFF
--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -54,9 +54,9 @@ class RecorderTests(TestCase):
         query for the existence of the migrations table.
         """
         recorder = MigrationRecorder(connection)
-        with self.assertNumQueries(1):
-            self.assertEqual(recorder.has_table(), True)
-            self.assertEqual(recorder.has_table(), True)
+        self.assertIs(recorder.has_table(), True)
+        with self.assertNumQueries(0):
+            self.assertIs(recorder.has_table(), True)
 
 
 class LoaderTests(TestCase):


### PR DESCRIPTION
Thanks Tim Graham for the report and implementation idea.

Follow up to ea8cbca579cc6742e119747fc1eb6ecf90638bce.