### PR TITLE
Refs #34572 -- Added missing GDAL_PIXEL_TYPES from GDAL 3.5+.

### DIFF
--- a/django/contrib/gis/gdal/raster/const.py
+++ b/django/contrib/gis/gdal/raster/const.py
@@ -1,7 +1,18 @@
 """
 GDAL - Constant definitions
 """
-from ctypes import c_double, c_float, c_int16, c_int32, c_ubyte, c_uint16, c_uint32
+from ctypes import (
+    c_double,
+    c_float,
+    c_int8,
+    c_int16,
+    c_int32,
+    c_int64,
+    c_ubyte,
+    c_uint16,
+    c_uint32,
+    c_uint64,
+)
 
 # See https://gdal.org/api/raster_c_api.html#_CPPv412GDALDataType
 GDAL_PIXEL_TYPES = {
@@ -17,10 +28,13 @@ GDAL_PIXEL_TYPES = {
     9: "GDT_CInt32",  # Complex Int32
     10: "GDT_CFloat32",  # Complex Float32
     11: "GDT_CFloat64",  # Complex Float64
+    12: "GDT_UInt64",  # 64 bit unsigned integer (GDAL 3.5+).
+    13: "GDT_Int64",  # 64 bit signed integer (GDAL 3.5+).
+    14: "GDT_Int8",  # 8 bit signed integer (GDAL 3.7+).
 }
 
 # A list of gdal datatypes that are integers.
-GDAL_INTEGER_TYPES = [1, 2, 3, 4, 5]
+GDAL_INTEGER_TYPES = [1, 2, 3, 4, 5, 12, 13, 14]
 
 # Lookup values to convert GDAL pixel type indices into ctypes objects.
 # The GDAL band-io works with ctypes arrays to hold data to be written
@@ -39,6 +53,9 @@ GDAL_TO_CTYPES = [
     None,
     None,
     None,
+    c_uint64,
+    c_int64,
+    c_int8,
 ]
 
 # List of resampling algorithms that can be used to warp a GDALRaster.

--- a/docs/ref/contrib/gis/gdal.txt
+++ b/docs/ref/contrib/gis/gdal.txt
@@ -1648,11 +1648,9 @@ blue.
     .. method:: datatype(as_string=False)
 
         The data type contained in the band, as an integer constant between 0
-        (Unknown) and 11. If ``as_string`` is ``True``, the data type is
-        returned as a string with the following possible values:
-        ``GDT_Unknown``, ``GDT_Byte``, ``GDT_UInt16``, ``GDT_Int16``,
-        ``GDT_UInt32``, ``GDT_Int32``, ``GDT_Float32``, ``GDT_Float64``,
-        ``GDT_CInt16``, ``GDT_CInt32``, ``GDT_CFloat32``, and ``GDT_CFloat64``.
+        (Unknown) and 14. If ``as_string`` is ``True``, the data type is
+        returned as a string. Check out the "GDAL Pixel Type" column in the
+        :ref:`datatype value table <gdal-raster-datatype>` for possible values.
 
     .. method:: color_interp(as_string=False)
 
@@ -1796,23 +1794,28 @@ Key               Default  Usage
     name starts with ``/vsimem/``, the raster is created in GDAL's virtual
     filesystem.
 
+.. _gdal-raster-datatype:
+
 .. object:: datatype
 
     Integer representing the data type for all the bands. Defaults to ``6``
     (Float32). All bands of a new raster are required to have the same datatype.
     The value mapping is:
 
-    ===== =============== ===============================
+    ===== =============== ===================================
     Value GDAL Pixel Type Description
-    ===== =============== ===============================
-    1     GDT_Byte        Eight bit unsigned integer
-    2     GDT_UInt16      Sixteen bit unsigned integer
-    3     GDT_Int16       Sixteen bit signed integer
-    4     GDT_UInt32      Thirty-two bit unsigned integer
-    5     GDT_Int32       Thirty-two bit signed integer
-    6     GDT_Float32     Thirty-two bit floating point
-    7     GDT_Float64     Sixty-four bit floating point
-    ===== =============== ===============================
+    ===== =============== ===================================
+    1     GDT_Byte        8 bit unsigned integer
+    2     GDT_UInt16      16 bit unsigned integer
+    3     GDT_Int16       16 bit signed integer
+    4     GDT_UInt32      32 bit unsigned integer
+    5     GDT_Int32       32 bit signed integer
+    6     GDT_Float32     32 bit floating point
+    7     GDT_Float64     64 bit floating point
+    12    GDT_UInt64      64 bit unsigned integer (GDAL 3.5+)
+    13    GDT_Int64       64 bit signed integer (GDAL 3.5+)
+    14    GDT_Int8        8 bit signed integer (GDAL 3.7+)
+    ===== =============== ===================================
 
 .. object:: nr_of_bands
 


### PR DESCRIPTION
See https://github.com/OSGeo/gdal/blob/6e9103bd5/gcore/gdal.h#L62