### PR TITLE
Fixed enforce max_num=1 if it's less than one for `inlineformset_factory`

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1302,7 +1302,8 @@ def inlineformset_factory(
     fk = _get_foreign_key(parent_model, model, fk_name=fk_name)
     # enforce a max_num=1 when the foreign key to the parent model is unique.
     if fk.unique:
-        max_num = 1
+        max_num = 1 if max_num is None else max_num
+        max_num = min(max_num, 1)
     kwargs = {
         "form": form,
         "formfield_callback": formfield_callback,

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -1358,6 +1358,20 @@ class ModelFormsetTest(TestCase):
             'id="id_location_set-0-id"></p>',
         )
 
+    def test_unique_true_max_num_less_than_one(self):
+        # ForeignKey with unique=True and max_num
+        # less than one shouldn't enforce max_num=1
+
+        place = Place.objects.create(pk=1, name="Giordanos", city="Chicago")
+
+        FormSet = inlineformset_factory(
+            Place, Location, can_delete=False, fields="__all__", max_num=0
+        )
+        self.assertEqual(FormSet.max_num, 0)
+
+        formset = FormSet(instance=place)
+        self.assertEqual(len(formset.forms), 0)
+
     def test_foreign_keys_in_parents(self):
         self.assertEqual(type(_get_foreign_key(Restaurant, Owner)), models.ForeignKey)
         self.assertEqual(


### PR DESCRIPTION
If the inline form should not display the "Add another" button, you can use the `max_num` parameter
But in the case of relation with unique foreign key `max_num` will enforce to 1, which makes it impossible to remove the add button. This behavior cannot be overridden in the case of usage a custom queryset.
This fix allows you to specify `max_num=0` and the value will be successfully applied, and the "Add another" button will not be displayed