### PR TITLE
Fixed #34687 -- Made Apps.clear_cache() clear get_swappable_settings_name() cache.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -747,6 +747,7 @@ answer newbie questions, and generally made Django that much better:
     Nicolas Lara <nicolaslara@gmail.com>
     Nicolas Noé <nicolas@niconoe.eu>
     Nikita Marchant <nikita.marchant@gmail.com>
+    Nikita Sobolev <mail@sobolevn.me>
     Niran Babalola <niran@niran.org>
     Nis Jørgensen <nis@superlativ.dk>
     Nowell Strite <https://nowell.strite.org/>

--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -373,6 +373,7 @@ class Apps:
 
         This is mostly used in tests.
         """
+        self.get_swappable_settings_name.cache_clear()
         # Call expire cache on each model. This will purge
         # the relation tree and the fields cache.
         self.get_models.cache_clear()

--- a/tests/apps/tests.py
+++ b/tests/apps/tests.py
@@ -197,6 +197,17 @@ class AppsTests(SimpleTestCase):
         with self.assertRaises(ValueError):
             apps.get_model("admin_LogEntry")
 
+    @override_settings(INSTALLED_APPS=SOME_INSTALLED_APPS)
+    def test_clear_cache(self):
+        # Set cache.
+        self.assertIsNone(apps.get_swappable_settings_name("admin.LogEntry"))
+        apps.get_models()
+
+        apps.clear_cache()
+
+        self.assertEqual(apps.get_swappable_settings_name.cache_info().currsize, 0)
+        self.assertEqual(apps.get_models.cache_info().currsize, 0)
+
     @override_settings(INSTALLED_APPS=["apps.apps.RelabeledAppsConfig"])
     def test_relabeling(self):
         self.assertEqual(apps.get_app_config("relabeled").name, "apps")


### PR DESCRIPTION
When `django.apps.apps.clear_cache()` is called,
we now also clean the cache of `@functools.cache`
of `get_swappable_settings_name` method.

Original issue https://code.djangoproject.com/ticket/34687
Refs https://github.com/typeddjango/django-stubs/pull/1601