### PR TITLE
Fixed #14810 -- Added reusable blocks to the inline templates

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,7 +8,7 @@ answer newbie questions, and generally made Django that much better:
     Aaron Cannon <cannona@fireantproductions.com>
     Aaron Swartz <http://www.aaronsw.com/>
     Aaron T. Myers <atmyers@gmail.com>
-    Abdulrahman Alfawal <abdulrahman.hadi4@gmail.com>
+    Abdulrahman Alfawal <https://github.com/alfawal/>
     Abeer Upadhyay <ab.esquarer@gmail.com>
     Abhijeet Viswa <abhijeetviswa@gmail.com>
     Abhinav Patil <https://github.com/ubadub/>

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ answer newbie questions, and generally made Django that much better:
     Aaron Cannon <cannona@fireantproductions.com>
     Aaron Swartz <http://www.aaronsw.com/>
     Aaron T. Myers <atmyers@gmail.com>
+    Abdulrahman Alfawal <abdulrahman.hadi4@gmail.com>
     Abeer Upadhyay <ab.esquarer@gmail.com>
     Abhijeet Viswa <abhijeetviswa@gmail.com>
     Abhinav Patil <https://github.com/ubadub/>

--- a/django/contrib/admin/templates/admin/edit_inline/stacked.html
+++ b/django/contrib/admin/templates/admin/edit_inline/stacked.html
@@ -1,61 +1,33 @@
 {% load i18n admin_urls %}
 <div class="js-inline-admin-formset inline-group"
-    id="{{ inline_admin_formset.formset.prefix }}-group"
-    data-inline-type="stacked"
-    data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
-  <fieldset class="module {{ inline_admin_formset.classes }}">
-    {% block title %}
-      {% if inline_admin_formset.formset.max_num == 1 %}
-        <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
-      {% else %}
-        <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
-      {% endif %}
-    {% endblock %}
-    {{ inline_admin_formset.formset.management_form }}
-    {{ inline_admin_formset.formset.non_form_errors }}
+     id="{{ inline_admin_formset.formset.prefix }}-group"
+     data-inline-type="stacked"
+     data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
+<fieldset class="module {{ inline_admin_formset.classes }}">
+  {% block title %}
+    {% if inline_admin_formset.formset.max_num == 1 %}
+      <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
+    {% else %}
+      <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
+    {% endif %}
+  {% endblock %}
+{{ inline_admin_formset.formset.management_form }}
+{{ inline_admin_formset.formset.non_form_errors }}
 
-    {% block field-elements %}
-      {% for inline_admin_form in inline_admin_formset %}
-        <div class="inline-related{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form last-related{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
-          <h3>
-            <b>
-              {{ inline_admin_formset.opts.verbose_name|capfirst }}:
-            </b>
-            <span class="inline_label">
-              {% if inline_admin_form.original %}
-                {{ inline_admin_form.original }}
-                {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}
-                  <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>
-                {% endif %}
-              {% else %}
-                #{{ forloop.counter }}
-              {% endif %}
-            </span>
-            {% if inline_admin_form.show_url %}
-              <a href="{{ inline_admin_form.absolute_url }}">
-                {% translate "View on site" %}
-              </a>
-            {% endif %}
-            {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission and inline_admin_form.original %}
-              <span class="delete">
-                {{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}
-              </span>
-            {% endif %}
-          </h3>
-          {% if inline_admin_form.form.non_field_errors %}
-            {{ inline_admin_form.form.non_field_errors }}
-          {% endif %}
-          {% for fieldset in inline_admin_form %}
-            {% include "admin/includes/fieldset.html" %}
-          {% endfor %}
-          {% if inline_admin_form.needs_explicit_pk_field %}
-            {{ inline_admin_form.pk_field.field }}
-          {% endif %}
-          {% if inline_admin_form.fk_field %}
-            {{ inline_admin_form.fk_field.field }}
-          {% endif %}
-        </div>
-      {% endfor %}
-    {% endblock %}
-  </fieldset>
+{% block field-elements %}
+  {% for inline_admin_form in inline_admin_formset %}<div class="inline-related{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form last-related{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
+    <h3><b>{{ inline_admin_formset.opts.verbose_name|capfirst }}:</b> <span class="inline_label">{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %} <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}
+  {% else %}#{{ forloop.counter }}{% endif %}</span>
+        {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% translate "View on site" %}</a>{% endif %}
+      {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission and inline_admin_form.original %}<span class="delete">{{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}</span>{% endif %}
+    </h3>
+    {% if inline_admin_form.form.non_field_errors %}{{ inline_admin_form.form.non_field_errors }}{% endif %}
+    {% for fieldset in inline_admin_form %}
+      {% include "admin/includes/fieldset.html" %}
+    {% endfor %}
+    {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+    {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
+  </div>{% endfor %}
+{% endblock %}
+</fieldset>
 </div>

--- a/django/contrib/admin/templates/admin/edit_inline/stacked.html
+++ b/django/contrib/admin/templates/admin/edit_inline/stacked.html
@@ -1,29 +1,61 @@
 {% load i18n admin_urls %}
 <div class="js-inline-admin-formset inline-group"
-     id="{{ inline_admin_formset.formset.prefix }}-group"
-     data-inline-type="stacked"
-     data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
-<fieldset class="module {{ inline_admin_formset.classes }}">
-  {% if inline_admin_formset.formset.max_num == 1 %}
-    <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
-  {% else %}
-    <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
-  {% endif %}
-{{ inline_admin_formset.formset.management_form }}
-{{ inline_admin_formset.formset.non_form_errors }}
+    id="{{ inline_admin_formset.formset.prefix }}-group"
+    data-inline-type="stacked"
+    data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
+  <fieldset class="module {{ inline_admin_formset.classes }}">
+    {% block title %}
+      {% if inline_admin_formset.formset.max_num == 1 %}
+        <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
+      {% else %}
+        <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
+      {% endif %}
+    {% endblock %}
+    {{ inline_admin_formset.formset.management_form }}
+    {{ inline_admin_formset.formset.non_form_errors }}
 
-{% for inline_admin_form in inline_admin_formset %}<div class="inline-related{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form last-related{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
-  <h3><b>{{ inline_admin_formset.opts.verbose_name|capfirst }}:</b> <span class="inline_label">{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %} <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}
-{% else %}#{{ forloop.counter }}{% endif %}</span>
-      {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% translate "View on site" %}</a>{% endif %}
-    {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission and inline_admin_form.original %}<span class="delete">{{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}</span>{% endif %}
-  </h3>
-  {% if inline_admin_form.form.non_field_errors %}{{ inline_admin_form.form.non_field_errors }}{% endif %}
-  {% for fieldset in inline_admin_form %}
-    {% include "admin/includes/fieldset.html" %}
-  {% endfor %}
-  {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
-  {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
-</div>{% endfor %}
-</fieldset>
+    {% block field-elements %}
+      {% for inline_admin_form in inline_admin_formset %}
+        <div class="inline-related{% if inline_admin_form.original or inline_admin_form.show_url %} has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form last-related{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
+          <h3>
+            <b>
+              {{ inline_admin_formset.opts.verbose_name|capfirst }}:
+            </b>
+            <span class="inline_label">
+              {% if inline_admin_form.original %}
+                {{ inline_admin_form.original }}
+                {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}
+                  <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>
+                {% endif %}
+              {% else %}
+                #{{ forloop.counter }}
+              {% endif %}
+            </span>
+            {% if inline_admin_form.show_url %}
+              <a href="{{ inline_admin_form.absolute_url }}">
+                {% translate "View on site" %}
+              </a>
+            {% endif %}
+            {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission and inline_admin_form.original %}
+              <span class="delete">
+                {{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}
+              </span>
+            {% endif %}
+          </h3>
+          {% if inline_admin_form.form.non_field_errors %}
+            {{ inline_admin_form.form.non_field_errors }}
+          {% endif %}
+          {% for fieldset in inline_admin_form %}
+            {% include "admin/includes/fieldset.html" %}
+          {% endfor %}
+          {% if inline_admin_form.needs_explicit_pk_field %}
+            {{ inline_admin_form.pk_field.field }}
+          {% endif %}
+          {% if inline_admin_form.fk_field %}
+            {{ inline_admin_form.fk_field.field }}
+          {% endif %}
+        </div>
+      {% endfor %}
+    {% endblock %}
+  </fieldset>
 </div>

--- a/django/contrib/admin/templates/admin/edit_inline/tabular.html
+++ b/django/contrib/admin/templates/admin/edit_inline/tabular.html
@@ -1,102 +1,72 @@
 {% load i18n admin_urls static admin_modify %}
 <div class="js-inline-admin-formset inline-group" id="{{ inline_admin_formset.formset.prefix }}-group"
-    data-inline-type="tabular"
-    data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
+     data-inline-type="tabular"
+     data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
-    {{ inline_admin_formset.formset.management_form }}
-    <fieldset class="module {{ inline_admin_formset.classes }}">
-      {% block title %}
-        {% if inline_admin_formset.formset.max_num == 1 %}
-          <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
-        {% else %}
-          <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
-        {% endif %}
-        {{ inline_admin_formset.formset.non_form_errors }}
-      {% endblock %}
-      <table>
-        <thead>
-          <tr>
-            <th class="original"></th>
-            {% block table-headers %}
-              {% for field in inline_admin_formset.fields %}
-                <th class="column-{{ field.name }}{% if field.required %} required{% endif %}{% if field.widget.is_hidden %} hidden{% endif %}">{{ field.label|capfirst }}
-                  {% if field.help_text %}
-                    <img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">
-                  {% endif %}
-                </th>
-              {% endfor %}
-            {% endblock %}
-            {% block table-delete-header %}
-              {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission %}
-                <th>
-                  {% translate "Delete?" %}
-                </th>
-              {% endif %}
-            {% endblock %}
-          </tr>
-        </thead>
+{{ inline_admin_formset.formset.management_form }}
+<fieldset class="module {{ inline_admin_formset.classes }}">
+  {% block title %}
+    {% if inline_admin_formset.formset.max_num == 1 %}
+      <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
+    {% else %}
+      <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
+    {% endif %}
+  {% endblock %}
+   {{ inline_admin_formset.formset.non_form_errors }}
+   <table>
+     <thead><tr>
+       <th class="original"></th>
+        {% block table-headers %}
+          {% for field in inline_admin_formset.fields %}
+            <th class="column-{{ field.name }}{% if field.required %} required{% endif %}{% if field.widget.is_hidden %} hidden{% endif %}">{{ field.label|capfirst }}
+            {% if field.help_text %}<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">{% endif %}
+            </th>
+          {% endfor %}
+          {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission %}<th>{% translate "Delete?" %}</th>{% endif %}
+        {% endblock %}
+     </tr></thead>
 
-        <tbody>
-          {% block table-body %}
-            {% for inline_admin_form in inline_admin_formset %}
-              {% if inline_admin_form.form.non_field_errors %}
-                <tr class="row-form-errors"><td colspan="{{ inline_admin_form|cell_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
+     <tbody>
+      {% block table-body %}
+        {% for inline_admin_form in inline_admin_formset %}
+            {% if inline_admin_form.form.non_field_errors %}
+            <tr class="row-form-errors"><td colspan="{{ inline_admin_form|cell_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
+            {% endif %}
+            <tr class="form-row {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}"
+                id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
+            <td class="original">
+              {% if inline_admin_form.original or inline_admin_form.show_url %}<p>
+              {% if inline_admin_form.original %}
+              {{ inline_admin_form.original }}
+              {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}<a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}
               {% endif %}
-              <tr class="form-row {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}"
-                  id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
-                <td class="original">
-                  {% if inline_admin_form.original or inline_admin_form.show_url %}
-                    <p>
-                      {% if inline_admin_form.original %}
-                        {{ inline_admin_form.original }}
-                        {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}
-                          <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>
-                        {% endif %}
-                      {% endif %}
-                      {% if inline_admin_form.show_url %}
-                        <a href="{{ inline_admin_form.absolute_url }}">
-                          {% translate "View on site" %}
-                        </a>
-                      {% endif %}
-                    </p>
+              {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% translate "View on site" %}</a>{% endif %}
+                </p>{% endif %}
+              {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+              {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
+            </td>
+            {% for fieldset in inline_admin_form %}
+              {% for line in fieldset %}
+                {% for field in line %}
+                  <td class="{% if field.field.name %}field-{{ field.field.name }}{% endif %}{% if field.field.is_hidden %} hidden{% endif %}">
+                  {% if field.is_readonly %}
+                      <p>{{ field.contents }}</p>
+                  {% else %}
+                      {{ field.field.errors.as_ul }}
+                      {{ field.field }}
                   {% endif %}
-                  {% if inline_admin_form.needs_explicit_pk_field %}
-                    {{ inline_admin_form.pk_field.field }}
-                  {% endif %}
-                  {% if inline_admin_form.fk_field %}
-                    {{ inline_admin_form.fk_field.field }}
-                  {% endif %}
-                </td>
-                {% for fieldset in inline_admin_form %}
-                  {% for line in fieldset %}
-                    {% for field in line %}
-                      <td class="{% if field.field.name %}field-{{ field.field.name }}{% endif %}{% if field.field.is_hidden %} hidden{% endif %}">
-                        {% if field.is_readonly %}
-                          <p>{{ field.contents }}</p>
-                        {% else %}
-                          {{ field.field.errors.as_ul }}
-                          {{ field.field }}
-                        {% endif %}
-                      </td>
-                    {% endfor %}
-                  {% endfor %}
-                {% endfor %}
-                {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission %}
-                  <td class="delete">
-                    {% if inline_admin_form.original %}
-                      {{ inline_admin_form.deletion_field.field }}
-                    {% endif %}
                   </td>
-                {% endif %}
-              </tr>
+                {% endfor %}
+              {% endfor %}
             {% endfor %}
-          {% endblock %}
-        </tbody>
-        <tfoot>
-          {% block table-footer %}
-          {% endblock %}
-        </tfoot>
-      </table>
-    </fieldset>
+            {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission %}
+              <td class="delete">{% if inline_admin_form.original %}{{ inline_admin_form.deletion_field.field }}{% endif %}</td>
+            {% endif %}
+            </tr>
+        {% endfor %}
+      {% endblock %}
+     </tbody>
+   </table>
+</fieldset>
   </div>
 </div>

--- a/django/contrib/admin/templates/admin/edit_inline/tabular.html
+++ b/django/contrib/admin/templates/admin/edit_inline/tabular.html
@@ -1,66 +1,102 @@
 {% load i18n admin_urls static admin_modify %}
 <div class="js-inline-admin-formset inline-group" id="{{ inline_admin_formset.formset.prefix }}-group"
-     data-inline-type="tabular"
-     data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
+    data-inline-type="tabular"
+    data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
-{{ inline_admin_formset.formset.management_form }}
-<fieldset class="module {{ inline_admin_formset.classes }}">
-   {% if inline_admin_formset.formset.max_num == 1 %}
-     <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
-   {% else %}
-     <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
-   {% endif %}
-   {{ inline_admin_formset.formset.non_form_errors }}
-   <table>
-     <thead><tr>
-       <th class="original"></th>
-     {% for field in inline_admin_formset.fields %}
-       <th class="column-{{ field.name }}{% if field.required %} required{% endif %}{% if field.widget.is_hidden %} hidden{% endif %}">{{ field.label|capfirst }}
-       {% if field.help_text %}<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">{% endif %}
-       </th>
-     {% endfor %}
-     {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission %}<th>{% translate "Delete?" %}</th>{% endif %}
-     </tr></thead>
-
-     <tbody>
-     {% for inline_admin_form in inline_admin_formset %}
-        {% if inline_admin_form.form.non_field_errors %}
-        <tr class="row-form-errors"><td colspan="{{ inline_admin_form|cell_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
+    {{ inline_admin_formset.formset.management_form }}
+    <fieldset class="module {{ inline_admin_formset.classes }}">
+      {% block title %}
+        {% if inline_admin_formset.formset.max_num == 1 %}
+          <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
+        {% else %}
+          <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
         {% endif %}
-        <tr class="form-row {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}"
-             id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
-        <td class="original">
-          {% if inline_admin_form.original or inline_admin_form.show_url %}<p>
-          {% if inline_admin_form.original %}
-          {{ inline_admin_form.original }}
-          {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}<a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>{% endif %}
-          {% endif %}
-          {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% translate "View on site" %}</a>{% endif %}
-            </p>{% endif %}
-          {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
-          {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
-        </td>
-        {% for fieldset in inline_admin_form %}
-          {% for line in fieldset %}
-            {% for field in line %}
-              <td class="{% if field.field.name %}field-{{ field.field.name }}{% endif %}{% if field.field.is_hidden %} hidden{% endif %}">
-              {% if field.is_readonly %}
-                  <p>{{ field.contents }}</p>
-              {% else %}
-                  {{ field.field.errors.as_ul }}
-                  {{ field.field }}
+        {{ inline_admin_formset.formset.non_form_errors }}
+      {% endblock %}
+      <table>
+        <thead>
+          <tr>
+            <th class="original"></th>
+            {% block table-headers %}
+              {% for field in inline_admin_formset.fields %}
+                <th class="column-{{ field.name }}{% if field.required %} required{% endif %}{% if field.widget.is_hidden %} hidden{% endif %}">{{ field.label|capfirst }}
+                  {% if field.help_text %}
+                    <img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">
+                  {% endif %}
+                </th>
+              {% endfor %}
+            {% endblock %}
+            {% block table-delete-header %}
+              {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission %}
+                <th>
+                  {% translate "Delete?" %}
+                </th>
               {% endif %}
-              </td>
+            {% endblock %}
+          </tr>
+        </thead>
+
+        <tbody>
+          {% block table-body %}
+            {% for inline_admin_form in inline_admin_formset %}
+              {% if inline_admin_form.form.non_field_errors %}
+                <tr class="row-form-errors"><td colspan="{{ inline_admin_form|cell_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
+              {% endif %}
+              <tr class="form-row {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}"
+                  id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
+                <td class="original">
+                  {% if inline_admin_form.original or inline_admin_form.show_url %}
+                    <p>
+                      {% if inline_admin_form.original %}
+                        {{ inline_admin_form.original }}
+                        {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}
+                          <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="{{ inline_admin_formset.has_change_permission|yesno:'inlinechangelink,inlineviewlink' }}">{% if inline_admin_formset.has_change_permission %}{% translate "Change" %}{% else %}{% translate "View" %}{% endif %}</a>
+                        {% endif %}
+                      {% endif %}
+                      {% if inline_admin_form.show_url %}
+                        <a href="{{ inline_admin_form.absolute_url }}">
+                          {% translate "View on site" %}
+                        </a>
+                      {% endif %}
+                    </p>
+                  {% endif %}
+                  {% if inline_admin_form.needs_explicit_pk_field %}
+                    {{ inline_admin_form.pk_field.field }}
+                  {% endif %}
+                  {% if inline_admin_form.fk_field %}
+                    {{ inline_admin_form.fk_field.field }}
+                  {% endif %}
+                </td>
+                {% for fieldset in inline_admin_form %}
+                  {% for line in fieldset %}
+                    {% for field in line %}
+                      <td class="{% if field.field.name %}field-{{ field.field.name }}{% endif %}{% if field.field.is_hidden %} hidden{% endif %}">
+                        {% if field.is_readonly %}
+                          <p>{{ field.contents }}</p>
+                        {% else %}
+                          {{ field.field.errors.as_ul }}
+                          {{ field.field }}
+                        {% endif %}
+                      </td>
+                    {% endfor %}
+                  {% endfor %}
+                {% endfor %}
+                {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission %}
+                  <td class="delete">
+                    {% if inline_admin_form.original %}
+                      {{ inline_admin_form.deletion_field.field }}
+                    {% endif %}
+                  </td>
+                {% endif %}
+              </tr>
             {% endfor %}
-          {% endfor %}
-        {% endfor %}
-        {% if inline_admin_formset.formset.can_delete and inline_admin_formset.has_delete_permission %}
-          <td class="delete">{% if inline_admin_form.original %}{{ inline_admin_form.deletion_field.field }}{% endif %}</td>
-        {% endif %}
-        </tr>
-     {% endfor %}
-     </tbody>
-   </table>
-</fieldset>
+          {% endblock %}
+        </tbody>
+        <tfoot>
+          {% block table-footer %}
+          {% endblock %}
+        </tfoot>
+      </table>
+    </fieldset>
   </div>
 </div>

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -139,6 +139,15 @@ Minor features
 
 * ``XRegExp`` is upgraded from version 3.2.0 to 5.1.1.
 
+* The ``admin/edit_inline/stacked.html`` template has been updated with two new
+  blocks, ``title`` for customizing the inline's title and ``field-elements``
+  for customizing the row elements within the inline.
+
+* The ``admin/edit_inline/tabular.html`` template has been updated with three
+  new blocks, ``title`` to customize the title of the inline, ``table-headers``
+  to customize the table headers of the inline table and ``table-body`` to
+  customize the table body of the inline table.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
There was no blocks in the inline templates which takes away the inheritance opportunity.
I believe that this change is going to open up a new door for developers who wish to adjust the inlines!

The added blocks:
- Tabular:
    - `title`
    - `table-headers`
    - `table-body`

- Stacked:
    - `title`
    - `field-elements`

I wanted to write some tests but I'm not sure if its necessary.
The scenario would be, creating a template using the blocks and testing whether the content is contained inside of the response.

[ticket-14810](https://code.djangoproject.com/ticket/14810)