### PR TITLE
Made some Selenium tests less flaky by adding explicit wait.

### DIFF
--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -431,17 +431,20 @@ class SeleniumTests(AdminSeleniumTestCase):
             self.live_server_url + reverse("autocomplete_admin:admin_views_answer_add")
         )
         elem = self.selenium.find_element(By.CSS_SELECTOR, ".select2-selection")
-        elem.click()  # Open the autocomplete dropdown.
+        with self.select2_ajax_wait():
+            elem.click()  # Open the autocomplete dropdown.
         results = self.selenium.find_element(By.CSS_SELECTOR, ".select2-results")
         self.assertTrue(results.is_displayed())
         option = self.selenium.find_element(By.CSS_SELECTOR, ".select2-results__option")
         self.assertEqual(option.text, "No results found")
-        elem.click()  # Close the autocomplete dropdown.
+        with self.select2_ajax_wait():
+            elem.click()  # Close the autocomplete dropdown.
         q1 = Question.objects.create(question="Who am I?")
         Question.objects.bulk_create(
             Question(question=str(i)) for i in range(PAGINATOR_SIZE + 10)
         )
-        elem.click()  # Reopen the dropdown now that some objects exist.
+        with self.select2_ajax_wait():
+            elem.click()  # Reopen the dropdown now that some objects exist.
         result_container = self.selenium.find_element(
             By.CSS_SELECTOR, ".select2-results"
         )
@@ -478,7 +481,8 @@ class SeleniumTests(AdminSeleniumTestCase):
             ".select2-results__option", 1, root_element=result_container
         )
         # Select the result.
-        search.send_keys(Keys.RETURN)
+        with self.select2_ajax_wait():
+            search.send_keys(Keys.RETURN)
         select = Select(self.selenium.find_element(By.ID, "id_question"))
         self.assertEqual(
             select.first_selected_option.get_attribute("value"), str(q1.pk)
@@ -500,12 +504,14 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.assertTrue(results.is_displayed())
         option = self.selenium.find_element(By.CSS_SELECTOR, ".select2-results__option")
         self.assertEqual(option.text, "No results found")
-        elem.click()  # Close the autocomplete dropdown.
+        with self.select2_ajax_wait():
+            elem.click()  # Close the autocomplete dropdown.
         Question.objects.create(question="Who am I?")
         Question.objects.bulk_create(
             Question(question=str(i)) for i in range(PAGINATOR_SIZE + 10)
         )
-        elem.click()  # Reopen the dropdown now that some objects exist.
+        with self.select2_ajax_wait():
+            elem.click()  # Reopen the dropdown now that some objects exist.
         result_container = self.selenium.find_element(
             By.CSS_SELECTOR, ".select2-results"
         )
@@ -536,12 +542,13 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.assertCountSeleniumElements(
             ".select2-results__option", 1, root_element=result_container
         )
-        # Select the result.
-        search.send_keys(Keys.RETURN)
-        # Reopen the dropdown and add the first result to the selection.
-        elem.click()
-        search.send_keys(Keys.ARROW_DOWN)
-        search.send_keys(Keys.RETURN)
+        with self.select2_ajax_wait():
+            # Select the result.
+            search.send_keys(Keys.RETURN)
+            # Reopen the dropdown and add the first result to the selection.
+            elem.click()
+            search.send_keys(Keys.ARROW_DOWN)
+            search.send_keys(Keys.RETURN)
         select = Select(self.selenium.find_element(By.ID, "id_related_questions"))
         self.assertEqual(len(select.all_selected_options), 2)
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -6111,6 +6111,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         name_input.clear()
         name_input.send_keys("<i>edited section</i>")
         self.selenium.find_element(By.XPATH, '//input[@value="Save"]').click()
+        self.wait_until(lambda d: len(d.window_handles) == 1, 1)
         self.selenium.switch_to.window(self.selenium.window_handles[0])
         # Hide sidebar.
         toggle_button = self.selenium.find_element(
@@ -6133,6 +6134,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.wait_for_text("#content h1", "Add section")
         self.selenium.find_element(By.ID, "id_name").send_keys("new section")
         self.selenium.find_element(By.XPATH, '//input[@value="Save"]').click()
+        self.wait_until(lambda d: len(d.window_handles) == 1, 1)
         self.selenium.switch_to.window(self.selenium.window_handles[0])
         select = Select(self.selenium.find_element(By.ID, "id_form-0-section"))
         self.assertEqual(select.first_selected_option.text, "new section")


### PR DESCRIPTION
Flakey test runs for test_updating_related_objects_updates_fk_selects_except_autocompletes:
- https://github.com/django/django/actions/runs/5450377222/jobs/9915579013
- https://github.com/django/django/actions/runs/5450377222/jobs/9915578779

Flakey test run for test_list_editable_popups:
- https://github.com/django/django/actions/runs/5452823563/jobs/9920858724

Flakey test run for test_select:
- https://github.com/django/django/actions/runs/5452823563/jobs/9920858724

----

Test runs with them passing to show flakiness is hopefully gone:
- https://github.com/django/django/actions/runs/5453005282?pr=17043
- https://github.com/django/django/actions/runs/5453127139?pr=17043
- https://github.com/django/django/actions/runs/5453179602?pr=17043
- https://github.com/django/django/actions/runs/5453225225?pr=17043
- https://github.com/django/django/actions/runs/5453261530?pr=17043
- https://github.com/django/django/actions/runs/5453334823?pr=17043
- https://github.com/django/django/actions/runs/5453382117?pr=17043
- https://github.com/django/django/actions/runs/5454055716?pr=17043
- https://github.com/django/django/actions/runs/5454099125?pr=17043