### PR TITLE
Fixed isolation of SeleniumTests.test_search_input_filtered_page() test.

### DIFF
--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -6437,6 +6437,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         )
         continent_select.select_by_visible_text("South America")
         self.selenium.find_element(By.CSS_SELECTOR, '[type="submit"]').click()
+        self.wait_until(lambda d: len(d.window_handles) == 1, 1)
         self.selenium.switch_to.window(self.selenium.window_handles[0])
 
         self.assertHTMLEqual(
@@ -6473,6 +6474,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         )
         continent_select.select_by_visible_text("Europe")
         self.selenium.find_element(By.CSS_SELECTOR, '[type="submit"]').click()
+        self.wait_until(lambda d: len(d.window_handles) == 1, 1)
         self.selenium.switch_to.window(self.selenium.window_handles[0])
 
         self.assertHTMLEqual(
@@ -6514,6 +6516,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         favorite_name_input.clear()
         favorite_name_input.send_keys("Italy")
         self.selenium.find_element(By.CSS_SELECTOR, '[type="submit"]').click()
+        self.wait_until(lambda d: len(d.window_handles) == 1, 1)
         self.selenium.switch_to.window(self.selenium.window_handles[0])
 
         self.assertHTMLEqual(
@@ -6554,10 +6557,12 @@ class SeleniumTests(AdminSeleniumTestCase):
         )
         continent_select.select_by_visible_text("Asia")
         self.selenium.find_element(By.CSS_SELECTOR, '[type="submit"]').click()
+        self.wait_until(lambda d: len(d.window_handles) == 1, 1)
         self.selenium.switch_to.window(self.selenium.window_handles[0])
 
         # Submit the new Traveler.
-        self.selenium.find_element(By.CSS_SELECTOR, '[name="_save"]').click()
+        with self.wait_page_loaded():
+            self.selenium.find_element(By.CSS_SELECTOR, '[name="_save"]').click()
         traveler = Traveler.objects.get()
         self.assertEqual(traveler.born_country.name, "Argentina")
         self.assertEqual(traveler.living_country.name, "Italy")

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5635,6 +5635,10 @@ class PrePopulatedTest(TestCase):
         self.assertContains(response, '<div class="readonly">%s</div>' % self.p1.slug)
 
 
+def _clean_sidebar_state(driver):
+    driver.execute_script("localStorage.removeItem('django.admin.navSidebarIsOpen')")
+
+
 @override_settings(ROOT_URLCONF="admin_views.urls")
 class SeleniumTests(AdminSeleniumTestCase):
     available_apps = ["admin_views"] + AdminSeleniumTestCase.available_apps
@@ -6113,6 +6117,7 @@ class SeleniumTests(AdminSeleniumTestCase):
             By.CSS_SELECTOR, "#toggle-nav-sidebar"
         )
         toggle_button.click()
+        self.addCleanup(_clean_sidebar_state, self.selenium)
         select = Select(self.selenium.find_element(By.ID, "id_form-0-section"))
         self.assertEqual(select.first_selected_option.text, "<i>edited section</i>")
         # Rendered select2 input.
@@ -6291,6 +6296,12 @@ class SeleniumTests(AdminSeleniumTestCase):
         )
         person_url = reverse("admin:admin_views_person_changelist") + "?q=Gui"
         self.selenium.get(self.live_server_url + person_url)
+        # Hide sidebar.
+        toggle_button = self.selenium.find_element(
+            By.CSS_SELECTOR, "#toggle-nav-sidebar"
+        )
+        toggle_button.click()
+        self.addCleanup(_clean_sidebar_state, self.selenium)
         self.assertGreater(
             self.selenium.find_element(By.ID, "searchbar").rect["width"],
             50,


### PR DESCRIPTION
Test crashed when the sidebar was not closed:
```
$ ./runtests.py --selenium=chrome --headless admin_views.tests.SeleniumTests.test_search_input_filtered_page

Testing against Django installed in '/django/django' with up to 8 processes
Found 1 test(s).
Creating test database for alias 'default'...
System check identified no issues (1 silenced).
F
======================================================================
FAIL: test_search_input_filtered_page (admin_views.tests.SeleniumTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/tests/admin_views/tests.py", line 6294, in test_search_input_filtered_page
    self.assertGreater(
AssertionError: 40 not greater than 50

----------------------------------------------------------------------
Ran 1 test in 3.452s

FAILED (failures=1)
Destroying test database for alias 'default'...
```
------

Before:

![screenshot](https://github.com/django/django/assets/2865885/da8b4218-ceab-4d3d-a299-86baccfa557d)
-------

After:

![screenshot_together](https://github.com/django/django/assets/2865885/a55ee154-d018-4ea9-881c-9b27d8235122)
