### PR TITLE
Refs #31949 -- Made @csrf_exempt decorator work with async functions.

### DIFF
--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -150,6 +150,10 @@ class-based views<decorating-class-based-views>`.
         def my_view(request):
             return HttpResponse("Hello world")
 
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
+
 .. function:: csrf_protect(view)
 
     Decorator that provides the protection of ``CsrfViewMiddleware`` to a view.

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -258,6 +258,7 @@ Decorators
   * :func:`~django.views.decorators.cache.cache_control`
   * :func:`~django.views.decorators.cache.never_cache`
   * :func:`~django.views.decorators.common.no_append_slash`
+  * :func:`~django.views.decorators.csrf.csrf_exempt`
   * :func:`~django.views.decorators.debug.sensitive_variables`
   * :func:`~django.views.decorators.debug.sensitive_post_parameters`
   * :func:`~django.views.decorators.http.condition`

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -84,6 +84,7 @@ view functions:
 * :func:`~django.views.decorators.cache.cache_control`
 * :func:`~django.views.decorators.cache.never_cache`
 * :func:`~django.views.decorators.common.no_append_slash`
+* :func:`~django.views.decorators.csrf.csrf_exempt`
 * :func:`~django.views.decorators.http.condition`
 * :func:`~django.views.decorators.http.etag`
 * :func:`~django.views.decorators.http.last_modified`

--- a/tests/decorators/test_csrf.py
+++ b/tests/decorators/test_csrf.py
@@ -1,0 +1,37 @@
+from asgiref.sync import iscoroutinefunction
+
+from django.http import HttpRequest, HttpResponse
+from django.test import SimpleTestCase
+from django.views.decorators.csrf import csrf_exempt
+
+
+class CsrfExemptTests(SimpleTestCase):
+    def test_wrapped_sync_function_is_not_coroutine_function(self):
+        def sync_view(request):
+            return HttpResponse()
+
+        wrapped_view = csrf_exempt(sync_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), False)
+
+    def test_wrapped_async_function_is_coroutine_function(self):
+        async def async_view(request):
+            return HttpResponse()
+
+        wrapped_view = csrf_exempt(async_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), True)
+
+    def test_csrf_exempt_decorator(self):
+        @csrf_exempt
+        def sync_view(request):
+            return HttpResponse()
+
+        self.assertIs(sync_view.csrf_exempt, True)
+        self.assertIsInstance(sync_view(HttpRequest()), HttpResponse)
+
+    async def test_csrf_exempt_decorator_async_view(self):
+        @csrf_exempt
+        async def async_view(request):
+            return HttpResponse()
+
+        self.assertIs(async_view.csrf_exempt, True)
+        self.assertIsInstance(await async_view(HttpRequest()), HttpResponse)


### PR DESCRIPTION
Reference to [#31949](https://code.djangoproject.com/ticket/31949).

This PR makes the `csrf_exempt` decorator able to handle both sync and async views.