### PR TITLE
Refs #31949 -- Made @vary_on_(cookie/headers) decorators work with async functions.

### DIFF
--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -268,6 +268,8 @@ Decorators
   * :func:`~django.views.decorators.http.require_GET`
   * :func:`~django.views.decorators.http.require_POST`
   * :func:`~django.views.decorators.http.require_safe`
+  * :func:`~django.views.decorators.vary.vary_on_cookie`
+  * :func:`~django.views.decorators.vary.vary_on_headers`
   * ``xframe_options_deny()``
   * ``xframe_options_sameorigin()``
   * ``xframe_options_exempt()``

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -94,6 +94,8 @@ view functions:
 * :func:`~django.views.decorators.http.require_GET`
 * :func:`~django.views.decorators.http.require_POST`
 * :func:`~django.views.decorators.http.require_safe`
+* :func:`~django.views.decorators.vary.vary_on_cookie`
+* :func:`~django.views.decorators.vary.vary_on_headers`
 * ``xframe_options_deny()``
 * ``xframe_options_sameorigin()``
 * ``xframe_options_exempt()``

--- a/docs/topics/http/decorators.txt
+++ b/docs/topics/http/decorators.txt
@@ -115,12 +115,20 @@ caching based on specific request headers.
 
 .. function:: vary_on_cookie(func)
 
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
+
 .. function:: vary_on_headers(*headers)
 
     The ``Vary`` header defines which request headers a cache mechanism should take
     into account when building its cache key.
 
     See :ref:`using vary headers <using-vary-headers>`.
+
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
 
 .. module:: django.views.decorators.cache
 

--- a/tests/decorators/test_vary.py
+++ b/tests/decorators/test_vary.py
@@ -1,0 +1,69 @@
+from asgiref.sync import iscoroutinefunction
+
+from django.http import HttpRequest, HttpResponse
+from django.test import SimpleTestCase
+from django.views.decorators.vary import vary_on_cookie, vary_on_headers
+
+
+class VaryOnHeadersTests(SimpleTestCase):
+    def test_wrapped_sync_function_is_not_coroutine_function(self):
+        def sync_view(request):
+            return HttpResponse()
+
+        wrapped_view = vary_on_headers()(sync_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), False)
+
+    def test_wrapped_async_function_is_coroutine_function(self):
+        async def async_view(request):
+            return HttpResponse()
+
+        wrapped_view = vary_on_headers()(async_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), True)
+
+    def test_vary_on_headers_decorator(self):
+        @vary_on_headers("Header", "Another-header")
+        def sync_view(request):
+            return HttpResponse()
+
+        response = sync_view(HttpRequest())
+        self.assertEqual(response.get("Vary"), "Header, Another-header")
+
+    async def test_vary_on_headers_decorator_async_view(self):
+        @vary_on_headers("Header", "Another-header")
+        async def async_view(request):
+            return HttpResponse()
+
+        response = await async_view(HttpRequest())
+        self.assertEqual(response.get("Vary"), "Header, Another-header")
+
+
+class VaryOnCookieTests(SimpleTestCase):
+    def test_wrapped_sync_function_is_not_coroutine_function(self):
+        def sync_view(request):
+            return HttpResponse()
+
+        wrapped_view = vary_on_cookie(sync_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), False)
+
+    def test_wrapped_async_function_is_coroutine_function(self):
+        async def async_view(request):
+            return HttpResponse()
+
+        wrapped_view = vary_on_cookie(async_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), True)
+
+    def test_vary_on_cookie_decorator(self):
+        @vary_on_cookie
+        def sync_view(request):
+            return HttpResponse()
+
+        response = sync_view(HttpRequest())
+        self.assertEqual(response.get("Vary"), "Cookie")
+
+    async def test_vary_on_cookie_decorator_async_view(self):
+        @vary_on_cookie
+        async def async_view(request):
+            return HttpResponse()
+
+        response = await async_view(HttpRequest())
+        self.assertEqual(response.get("Vary"), "Cookie")


### PR DESCRIPTION
Reference to [#31949](https://code.djangoproject.com/ticket/31949).

This PR makes the `vary_on_cookie` and `vary_on_headers` decorators able to handle both sync and async views.