### PR TITLE
Refs #31949 -- Made make_middleware_decorator work with async functions.

### DIFF
--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -170,6 +170,10 @@ class-based views<decorating-class-based-views>`.
             # ...
             return render(request, "a_template.html", c)
 
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
+
 .. function:: requires_csrf_token(view)
 
     Normally the :ttag:`csrf_token` template tag will not work if
@@ -190,9 +194,17 @@ class-based views<decorating-class-based-views>`.
             # ...
             return render(request, "a_template.html", c)
 
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
+
 .. function:: ensure_csrf_cookie(view)
 
     This decorator forces a view to send the CSRF cookie.
+
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
 
 Settings
 ========

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -322,9 +322,14 @@ Decorators
   * :func:`~django.views.decorators.cache.never_cache`
   * :func:`~django.views.decorators.common.no_append_slash`
   * :func:`~django.views.decorators.csrf.csrf_exempt`
+  * :func:`~django.views.decorators.csrf.csrf_protect`
+  * :func:`~django.views.decorators.csrf.ensure_csrf_cookie`
+  * :func:`~django.views.decorators.csrf.requires_csrf_token`
   * :func:`~django.views.decorators.debug.sensitive_variables`
   * :func:`~django.views.decorators.debug.sensitive_post_parameters`
+  * :func:`~django.views.decorators.gzip.gzip_page`
   * :func:`~django.views.decorators.http.condition`
+  * ``conditional_page()``
   * :func:`~django.views.decorators.http.etag`
   * :func:`~django.views.decorators.http.last_modified`
   * :func:`~django.views.decorators.http.require_http_methods`

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -85,9 +85,14 @@ view functions:
 * :func:`~django.views.decorators.cache.never_cache`
 * :func:`~django.views.decorators.common.no_append_slash`
 * :func:`~django.views.decorators.csrf.csrf_exempt`
+* :func:`~django.views.decorators.csrf.csrf_protect`
+* :func:`~django.views.decorators.csrf.ensure_csrf_cookie`
+* :func:`~django.views.decorators.csrf.requires_csrf_token`
 * :func:`~django.views.decorators.debug.sensitive_variables`
 * :func:`~django.views.decorators.debug.sensitive_post_parameters`
+* :func:`~django.views.decorators.gzip.gzip_page`
 * :func:`~django.views.decorators.http.condition`
+* ``conditional_page()``
 * :func:`~django.views.decorators.http.etag`
 * :func:`~django.views.decorators.http.last_modified`
 * :func:`~django.views.decorators.http.require_http_methods`

--- a/docs/topics/http/decorators.txt
+++ b/docs/topics/http/decorators.txt
@@ -105,6 +105,10 @@ compression on a per-view basis.
     It sets the ``Vary`` header accordingly, so that caches will base their
     storage on the ``Accept-Encoding`` header.
 
+    .. versionchanged:: 5.0
+
+        Support for wrapping asynchronous view functions was added.
+
 .. module:: django.views.decorators.vary
 
 Vary headers

--- a/tests/decorators/test_gzip.py
+++ b/tests/decorators/test_gzip.py
@@ -1,3 +1,5 @@
+from asgiref.sync import iscoroutinefunction
+
 from django.http import HttpRequest, HttpResponse
 from django.test import SimpleTestCase
 from django.views.decorators.gzip import gzip_page
@@ -7,6 +9,20 @@ class GzipPageTests(SimpleTestCase):
     # Gzip ignores content that is too short.
     content = "Content " * 100
 
+    def test_wrapped_sync_function_is_not_coroutine_function(self):
+        def sync_view(request):
+            return HttpResponse()
+
+        wrapped_view = gzip_page(sync_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), False)
+
+    def test_wrapped_async_function_is_coroutine_function(self):
+        async def async_view(request):
+            return HttpResponse()
+
+        wrapped_view = gzip_page(async_view)
+        self.assertIs(iscoroutinefunction(wrapped_view), True)
+
     def test_gzip_page_decorator(self):
         @gzip_page
         def sync_view(request):
@@ -15,5 +31,16 @@ class GzipPageTests(SimpleTestCase):
         request = HttpRequest()
         request.META["HTTP_ACCEPT_ENCODING"] = "gzip"
         response = sync_view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get("Content-Encoding"), "gzip")
+
+    async def test_gzip_page_decorator_async_view(self):
+        @gzip_page
+        async def async_view(request):
+            return HttpResponse(content=self.content)
+
+        request = HttpRequest()
+        request.META["HTTP_ACCEPT_ENCODING"] = "gzip"
+        response = await async_view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get("Content-Encoding"), "gzip")


### PR DESCRIPTION
Reference to [#31949](https://code.djangoproject.com/ticket/31949).

This PR makes the `make_middleware_decorator` function able to handle both sync and async views.