### PR TITLE
Removed redundant check from WKTWriter.__init__().

### DIFF
--- a/django/contrib/gis/geos/prototypes/io.py
+++ b/django/contrib/gis/geos/prototypes/io.py
@@ -189,8 +189,7 @@ class WKTWriter(IOBase):
 
     def __init__(self, dim=2, trim=False, precision=None):
         super().__init__()
-        if bool(trim) != self._trim:
-            self.trim = trim
+        self.trim = trim
         if precision is not None:
             self.precision = precision
         self.outdim = dim


### PR DESCRIPTION
This is already checked in `trim.setter`.