### PR TITLE
Refs #30116 -- Simplified tests related with dictionary order.

### DIFF
--- a/tests/template_tests/templatetags/custom.py
+++ b/tests/template_tests/templatetags/custom.py
@@ -1,5 +1,3 @@
-import operator
-
 from django import template
 from django.template.defaultfilters import stringfilter
 from django.utils.html import escape, format_html
@@ -138,11 +136,9 @@ simple_only_unlimited_args.anything = "Expected simple_only_unlimited_args __dic
 @register.simple_tag
 def simple_unlimited_args_kwargs(one, two="hi", *args, **kwargs):
     """Expected simple_unlimited_args_kwargs __doc__"""
-    # Sort the dictionary by key to guarantee the order for testing.
-    sorted_kwarg = sorted(kwargs.items(), key=operator.itemgetter(0))
     return "simple_unlimited_args_kwargs - Expected result: %s / %s" % (
         ", ".join(str(arg) for arg in [one, two, *args]),
-        ", ".join("%s=%s" % (k, v) for (k, v) in sorted_kwarg),
+        ", ".join("%s=%s" % (k, v) for (k, v) in kwargs.items()),
     )
 
 

--- a/tests/template_tests/templatetags/inclusion.py
+++ b/tests/template_tests/templatetags/inclusion.py
@@ -1,5 +1,3 @@
-import operator
-
 from django.template import Engine, Library
 
 engine = Engine(app_dirs=True)
@@ -257,13 +255,11 @@ inclusion_tag_use_l10n.anything = "Expected inclusion_tag_use_l10n __dict__"
 @register.inclusion_tag("inclusion.html")
 def inclusion_unlimited_args_kwargs(one, two="hi", *args, **kwargs):
     """Expected inclusion_unlimited_args_kwargs __doc__"""
-    # Sort the dictionary by key to guarantee the order for testing.
-    sorted_kwarg = sorted(kwargs.items(), key=operator.itemgetter(0))
     return {
         "result": "inclusion_unlimited_args_kwargs - Expected result: %s / %s"
         % (
             ", ".join(str(arg) for arg in [one, two, *args]),
-            ", ".join("%s=%s" % (k, v) for (k, v) in sorted_kwarg),
+            ", ".join("%s=%s" % (k, v) for (k, v) in kwargs.items()),
         )
     }
 

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -34,18 +34,7 @@ class URLEncodeTests(SimpleTestCase):
 
     def test_dict(self):
         result = urlencode({"a": 1, "b": 2, "c": 3})
-        # Dictionaries are treated as unordered.
-        self.assertIn(
-            result,
-            [
-                "a=1&b=2&c=3",
-                "a=1&c=3&b=2",
-                "b=2&a=1&c=3",
-                "b=2&c=3&a=1",
-                "c=3&a=1&b=2",
-                "c=3&b=2&a=1",
-            ],
-        )
+        self.assertEqual(result, "a=1&b=2&c=3")
 
     def test_dict_containing_sequence_not_doseq(self):
         self.assertEqual(urlencode({"a": [1, 2]}, doseq=False), "a=%5B1%2C+2%5D")
@@ -79,14 +68,7 @@ class URLEncodeTests(SimpleTestCase):
             ),
             doseq=True,
         )
-        # MultiValueDicts are similarly unordered.
-        self.assertIn(
-            result,
-            [
-                "name=Adrian&name=Simon&position=Developer",
-                "position=Developer&name=Adrian&name=Simon",
-            ],
-        )
+        self.assertEqual(result, "name=Adrian&name=Simon&position=Developer")
 
     def test_dict_with_bytes_values(self):
         self.assertEqual(urlencode({"a": b"abc"}, doseq=True), "a=abc")


### PR DESCRIPTION
Dicts preserve order since Python 3.6.