### PR TITLE
Fixed typo in docs/ref/checks.txt.

### DIFF
--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -609,7 +609,7 @@ The following checks are performed on your URL configuration:
   imported.
 * **urls.E009**: Your URL pattern ``<pattern>`` has an invalid view, pass
   ``<view>.as_view()`` instead of ``<view>``.
-* **urls.W010**: Your URL pattern ``<pattern>` has an unmatched
+* **urls.W010**: Your URL pattern ``<pattern>`` has an unmatched
   ``<angle bracket>``.
 
 ``contrib`` app checks


### PR DESCRIPTION
Trivial change not requiring a Trac ticket - close inline code block in docs with a second backtick