### PR TITLE
Fix the wrong example

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1854,8 +1854,8 @@ For example::
 
     from django.db import transaction
 
-    entries = Entry.objects.select_for_update().filter(author=request.user)
     with transaction.atomic():
+        entries = Entry.objects.select_for_update().filter(author=request.user)
         for entry in entries:
             ...
 


### PR DESCRIPTION
select_for_update should always run within a transaction, otherwise, the query is committed automatically, and no lock anymore. just fix this bad example