### PR TITLE
Fixed #34448 -- Doc'd and tested --no-obsolete option of makemessages.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -677,6 +677,10 @@ is:
 
 Requires ``gettext`` 0.19 or newer.
 
+.. django-admin-option:: --no-obsolete
+
+Removes obsolete message strings from the ``.po`` files.
+
 .. django-admin-option:: --keep-pot
 
 Prevents deleting the temporary ``.pot`` files generated before creating the

--- a/tests/i18n/obsolete_translations/__init__.py
+++ b/tests/i18n/obsolete_translations/__init__.py
@@ -1,0 +1,5 @@
+from django.utils.translation import gettext as _
+
+string1 = _("This is a translatable string.")
+# Obsolete string.
+# string2 = _("Obsolete string.")

--- a/tests/i18n/obsolete_translations/locale/de/LC_MESSAGES/django.po
+++ b/tests/i18n/obsolete_translations/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-14 01:04+0530\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: __init__.py:3
+msgid "This is a translatable string."
+msgstr "This is a translated string."
+
+#~ msgid "Obsolete string."
+#~ msgstr "Translated obsolete string."

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -868,6 +868,22 @@ class LocationCommentsTests(ExtractorTests):
             )
 
 
+class NoObsoleteExtractorTests(ExtractorTests):
+    work_subdir = "obsolete_translations"
+
+    def test_no_obsolete(self):
+        management.call_command(
+            "makemessages", locale=[LOCALE], verbosity=0, no_obsolete=True
+        )
+        self.assertIs(os.path.exists(self.PO_FILE), True)
+        with open(self.PO_FILE) as fp:
+            po_contents = fp.read()
+            self.assertNotIn('#~ msgid "Obsolete string."', po_contents)
+            self.assertNotIn('#~ msgstr "Translated obsolete string."', po_contents)
+            self.assertMsgId("This is a translatable string.", po_contents)
+            self.assertMsgStr("This is a translated string.", po_contents)
+
+
 class KeepPotFileExtractorTests(ExtractorTests):
     POT_FILE = "locale/django.pot"
 


### PR DESCRIPTION
Fixes [ticket-34448](https://code.djangoproject.com/ticket/34448)

Added docs for the missing option and a simple unit test which runs `--no-obsolete` on a `.po` file that contains obsolete messages and asserts various conditions. 