### PR TITLE
Fixed #34036 -- Improved color contrast in admin light theme.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -22,11 +22,11 @@ html[data-theme="light"],
 
     --breadcrumbs-fg: #c4dce8;
     --breadcrumbs-link-fg: var(--body-bg);
-    --breadcrumbs-bg: var(--primary);
+    --breadcrumbs-bg: #264b5d;
 
     --link-fg: #417893;
     --link-hover-color: #036;
-    --link-selected-fg: #5b80b2;
+    --link-selected-fg: var(--secondary);
 
     --hairline-color: #e8e8e8;
     --border-color: #ccc;
@@ -42,10 +42,10 @@ html[data-theme="light"],
     --selected-row: #ffc;
 
     --button-fg: #fff;
-    --button-bg: var(--primary);
-    --button-hover-bg: #609ab6;
-    --default-button-bg: var(--secondary);
-    --default-button-hover-bg: #205067;
+    --button-bg: var(--secondary);
+    --button-hover-bg: #205067;
+    --default-button-bg: #205067;
+    --default-button-hover-bg: var(--secondary);
     --close-button-bg: #747474;
     --close-button-hover-bg: #333;
     --delete-button-bg: #ba2121;
@@ -102,7 +102,7 @@ body {
 /* LINKS */
 
 a:link, a:visited {
-    color: var(--link-fg);
+    color: var(--body-fg);
     text-decoration: none;
     transition: color 0.15s, background 0.15s;
 }
@@ -584,7 +584,7 @@ input[type=button][disabled].default {
     font-weight: 400;
     font-size: 0.8125rem;
     text-align: left;
-    background: var(--primary);
+    background: var(--header-bg);
     color: var(--header-link-color);
 }
 

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -41,7 +41,7 @@
 }
 
 .selector-chosen h2 {
-    background: var(--primary);
+    background: var(--secondary);
     color: var(--header-link-color);
 }
 
@@ -446,7 +446,7 @@ span.clearable-file-input label {
 }
 
 .calendar td.selected a {
-    background: var(--primary);
+    background: var(--secondary);
     color: var(--button-fg);
 }
 


### PR DESCRIPTION
Fix for [ticket 34036](https://code.djangoproject.com/ticket/34036) to improve text contrast over light blue backgrounds in admin light-theme

Based on @nimra200's  patch [#16268](https://github.com/django/django/pull/16268)

![Screenshot 2023-07-14 at 23 13 24](https://github.com/django/django/assets/7084246/5aec594c-ade8-4897-b5e6-3489ab237dad)
