### PR TITLE
Fixed #34657 -- Testing assertions are made more understandable

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -534,7 +534,8 @@ class SimpleTestCase(unittest.TestCase):
             )
         else:
             self.assertTrue(
-                real_count != 0, msg_prefix + "%s not found in %s" % (safe_repr(text_repr), safe_repr(response.content))
+                real_count != 0, msg_prefix + "%s not found in %s" % (safe_repr(text_repr), 
+                                                                      safe_repr(response.content))
             )
 
     def assertNotContains(
@@ -900,7 +901,8 @@ class SimpleTestCase(unittest.TestCase):
             )
         else:
             self.assertTrue(
-                real_count != 0, msg_prefix + "%s not found in %s" % (safe_repr(needle), safe_repr(haystack))
+                real_count != 0, msg_prefix + "%s not found in %s" % (safe_repr(needle), 
+                                                                      safe_repr(haystack))
             )
 
     def assertJSONEqual(self, raw, expected_data, msg=None):

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -534,7 +534,7 @@ class SimpleTestCase(unittest.TestCase):
             )
         else:
             self.assertTrue(
-                real_count != 0, msg_prefix + "Couldn't find %s in response" % text_repr
+                real_count != 0, msg_prefix + "%s not found in %s" % (safe_repr(text_repr), safe_repr(response.content))
             )
 
     def assertNotContains(
@@ -900,7 +900,7 @@ class SimpleTestCase(unittest.TestCase):
             )
         else:
             self.assertTrue(
-                real_count != 0, msg_prefix + "Couldn't find '%s' in response" % needle
+                real_count != 0, msg_prefix + "%s not found in %s" % (safe_repr(needle), safe_repr(haystack))
             )
 
     def assertJSONEqual(self, raw, expected_data, msg=None):

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -534,8 +534,8 @@ class SimpleTestCase(unittest.TestCase):
             )
         else:
             self.assertTrue(
-                real_count != 0, msg_prefix + "%s not found in %s" % (safe_repr(text_repr), 
-                                                                      safe_repr(response.content))
+                real_count != 0, msg_prefix + "%s not found in %s" % (
+                    safe_repr(text_repr), safe_repr(response.content))
             )
 
     def assertNotContains(
@@ -901,8 +901,8 @@ class SimpleTestCase(unittest.TestCase):
             )
         else:
             self.assertTrue(
-                real_count != 0, msg_prefix + "%s not found in %s" % (safe_repr(needle), 
-                                                                      safe_repr(haystack))
+                real_count != 0, msg_prefix + "%s not found in %s" % (
+                    safe_repr(needle), safe_repr(haystack))
             )
 
     def assertJSONEqual(self, raw, expected_data, msg=None):


### PR DESCRIPTION
When `assertContains` and `assertInHTML` tests failed, it was not clear why the tests failed, because general information was displayed and it took a long time to find what caused the tests to fail.

In this regard, a [ticket](https://code.djangoproject.com/ticket/34657)was created and in this PR I fixed this drawback and made the tests more understandable.