### PR TITLE
Refs #34711 -- Added reference to TypedChoiceField in ChoiceField docs.

### DIFF
--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -494,6 +494,12 @@ For each field, we describe the default widget used if you don't specify
         time the field's form is initialized, in addition to during rendering.
         Defaults to an empty list.
 
+    .. admonition:: Choice type
+
+        This field normalizes choices to strings, so if choices are required in
+        other data types, such as integers or booleans, consider using
+        :class:`TypedChoiceField` instead.
+
     .. versionchanged:: 5.0
 
         Support for using :ref:`enumeration types <field-choices-enum-types>`


### PR DESCRIPTION
Added a small note referring users to TypedChoiceField in the ChoiceField description if they are dealing with types other than strings – I thought this may help avoid confusion in cases like [Ticket 34711](https://code.djangoproject.com/ticket/34711#comment:5)

I didn't fuss over the wording too much, please update as needed.