### PR TITLE
Refs #34118 -- Improved sanitize_address() error message for tuple with empty strings.

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -97,6 +97,8 @@ def sanitize_address(addr, encoding):
             domain = token.domain or ""
     else:
         nm, address = addr
+        if "@" not in address:
+            raise ValueError(f'Invalid address "{address}"')
         localpart, domain = address.rsplit("@", 1)
 
     address_parts = nm + localpart + domain

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -1084,9 +1084,10 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             "@",
             "to@",
             "@example.com",
+            ("", ""),
         ):
             with self.subTest(email_address=email_address):
-                with self.assertRaises(ValueError):
+                with self.assertRaisesMessage(ValueError, "Invalid address"):
                     sanitize_address(email_address, encoding="utf-8")
 
     def test_sanitize_address_header_injection(self):


### PR DESCRIPTION
This is related with a [regression](https://github.com/python/cpython/issues/106669) in Python 3.12.0b4 that will be [reverted](https://github.com/python/cpython/pull/106733). I think, it's still worth improving `sanitize_address()` error messages and raise `Invalid address ""` instead of `not enough values to unpack (expected 2, got 1)`.