### PR TITLE
Refs #34712 -- Doc'd that defining STORAGES overrides the default configuration.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2644,6 +2644,11 @@ A ready-to-use instance of the storage backends can be retrieved from
 :data:`django.core.files.storage.storages`. Use a key corresponding to the
 backend definition in :setting:`STORAGES`.
 
+.. admonition:: Is my value merged with the default value?
+
+    Defining this setting overrides the default value and is *not* merged with
+    it.
+
 .. setting:: TEMPLATES
 
 ``TEMPLATES``


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34712

Add a note to the documentation of the `STORAGES` setting, to warn against potential misconfiguration.

The ticket also discuss adding a system check, however I expect a different backporting for such change, hence I'm planning to submit a separate pull request for it.