### PR TITLE
Display cursor as pointer on admin filter summaries

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -153,6 +153,7 @@
     font-weight: 400;
     padding: 0 15px;
     margin-bottom: 10px;
+    cursor: pointer;
 }
 
 #changelist-filter details summary > * {


### PR DESCRIPTION
On the django admin site, it is not clear that the filters can be collapsed. Styling the cursor as pointer should solve that.

![](https://github.com/django/django/assets/22097904/632eea63-13d4-454b-b621-fd7a23242e92)
