### PR TITLE
Refs #34718: allow filter details to be collapsed

### DIFF
--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -25,6 +25,7 @@ from django.utils.translation import gettext_lazy as _
 class ListFilter:
     title = None  # Human-readable title to appear in the right sidebar.
     template = "admin/filter.html"
+    details_collapsed = False
 
     def __init__(self, request, params, model, model_admin):
         self.request = request

--- a/django/contrib/admin/templates/admin/filter.html
+++ b/django/contrib/admin/templates/admin/filter.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<details data-filter-title="{{ title }}" open>
+<details data-filter-title="{{ title }}"{% if not details_collapsed %} open{% endif %}>
   <summary>
     {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
   </summary>

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -499,6 +499,7 @@ def admin_list_filter(cl, spec):
             "title": spec.title,
             "choices": list(spec.choices(cl)),
             "spec": spec,
+            "details_collapsed": spec.details_collapsed,
         }
     )
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34718

Allows filters in django admin to be collapsed by default when `ListFilter.details_collapsed` is `True`.