### PR TITLE
Refs #24686 -- Made AlterField operation a noop when renaming related model with db_table.

### DIFF
--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -997,6 +997,18 @@ class OperationTests(OperationTestBase):
         with connection.schema_editor() as editor, self.assertNumQueries(0):
             operation.database_forwards(app_label, editor, project_state, new_state)
 
+    @skipUnlessDBFeature("supports_foreign_keys")
+    def test_rename_model_with_db_table_and_fk_noop(self):
+        app_label = "test_rmwdbtfk"
+        project_state = self.set_up_test_model(
+            app_label, db_table="my_pony", related_model=True
+        )
+        new_state = project_state.clone()
+        operation = migrations.RenameModel("Pony", "LittleHorse")
+        operation.state_forwards(app_label, new_state)
+        with connection.schema_editor() as editor, self.assertNumQueries(0):
+            operation.database_forwards(app_label, editor, project_state, new_state)
+
     def test_rename_model_with_self_referential_m2m(self):
         app_label = "test_rename_model_with_self_referential_m2m"
 


### PR DESCRIPTION
Ref PR : #16905 
Ref Ticket : [#24686](https://code.djangoproject.com/ticket/24686)