### PR TITLE
Refs #34720 - Fixed path resolution for watched directories in BaseReloader

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -512,6 +512,7 @@ answer newbie questions, and generally made Django that much better:
     Josef Rousek <josef.rousek@gmail.com>
     Joseph Kocherhans <joseph@jkocherhans.com>
     Josh Smeaton <josh.smeaton@gmail.com>
+    Josh Thomas <josh@joshthomas.dev>
     Joshua Cannon <joshdcannon@gmail.com>
     Joshua Ginsberg <jag@flowtheory.net>
     Jozko Skrablin <jozko.skrablin@gmail.com>

--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -285,7 +285,7 @@ class BaseReloader:
     def watch_dir(self, path, glob):
         path = Path(path)
         try:
-            path = path.absolute()
+            path = path.resolve(strict=True)
         except FileNotFoundError:
             logger.debug(
                 "Unable to watch directory %s as it cannot be resolved.",

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -674,7 +674,8 @@ class BaseReloaderTests(ReloaderTests):
 
     def test_watch_dir_with_unresolvable_path(self):
         path = Path("unresolvable_directory")
-        self.reloader.watch_dir(path, "**/*.mo")
+        with self.assertLogs("django.utils.autoreload", level="DEBUG"):
+            self.reloader.watch_dir(path, "**/*.mo")
         self.assertEqual(list(self.reloader.directory_globs), [])
 
     def test_watch_with_glob(self):

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -674,8 +674,7 @@ class BaseReloaderTests(ReloaderTests):
 
     def test_watch_dir_with_unresolvable_path(self):
         path = Path("unresolvable_directory")
-        with mock.patch.object(Path, "absolute", side_effect=FileNotFoundError):
-            self.reloader.watch_dir(path, "**/*.mo")
+        self.reloader.watch_dir(path, "**/*.mo")
         self.assertEqual(list(self.reloader.directory_globs), [])
 
     def test_watch_with_glob(self):


### PR DESCRIPTION
`Path.absolute()`, which does not raise an FileNotFoundError, has been swapped for `Path.resolve(strict=True)`, which does.