### PR TITLE
Type judgment is done using Python's own duck-typing mechanism

### DIFF
--- a/django/utils/_os.py
+++ b/django/utils/_os.py
@@ -55,8 +55,6 @@ def symlinks_supported():
 
 def to_path(value):
     """Convert value to a pathlib.Path instance, if not already a Path."""
-    if isinstance(value, Path):
-        return value
-    elif not isinstance(value, str):
-        raise TypeError("Invalid path type: %s" % type(value).__name__)
-    return Path(value)
+    if not isinstance(value, Path):
+        value = Path(value)
+    return value


### PR DESCRIPTION
Type judgment is done using Python's own duck-typing mechanism
This eliminates the need to explicitly judge the type. If the value passed in is already of the Path type, the Path constructor is not executed and value is directly returned. Otherwise, the Path constructor is executed and the return is converted to the Path type.