### PR TITLE
Fixed typo in docs/ref/models/querysets.txt.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2769,7 +2769,7 @@ number of authors that have contributed blog entries:
 .. code-block:: pycon
 
     >>> from django.db.models import Count
-    >>> q = Blog.objects.aggregate(Count("entry"))
+    >>> Blog.objects.aggregate(Count("entry"))
     {'entry__count': 16}
 
 By using a keyword argument to specify the aggregate function, you can
@@ -2777,7 +2777,7 @@ control the name of the aggregation value that is returned:
 
 .. code-block:: pycon
 
-    >>> q = Blog.objects.aggregate(number_of_entries=Count("entry"))
+    >>> Blog.objects.aggregate(number_of_entries=Count("entry"))
     {'number_of_entries': 16}
 
 For an in-depth discussion of aggregation, see :doc:`the topic guide on


### PR DESCRIPTION
The edited examples were changed so if the reader executes the shown line, the returned printed result matches what is in the docs. Otherwise, leaving the `q = ` assignment, results in no printed feedback.