### PR TITLE
Fixed #34731, Refs #34118 -- Replaced assertEquals() with assertEqual() in test_condition_with_func_and_lookup_outside_relation_name().

### DIFF
--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -649,7 +649,7 @@ class FilteredRelationTests(TestCase):
                 ),
             ),
         ).filter(book_editor__isnull=False)
-        self.assertEquals(qs.count(), 1)
+        self.assertEqual(qs.count(), 1)
 
     def test_condition_deeper_relation_name(self):
         msg = (


### PR DESCRIPTION
This has been removed from Python 3.12; use `assertEqual` instead:

https://docs.python.org/3.12/whatsnew/3.12.html#removed