### PR TITLE
Fixed formatting typo in docs/topics/forms/index.txt.

### DIFF
--- a/docs/topics/forms/index.txt
+++ b/docs/topics/forms/index.txt
@@ -567,7 +567,7 @@ Reusable field group templates
 .. versionadded:: 5.0
 
 Each field is available as an attribute of the form, using
-``{{form.name_of_field }}`` in a template. A field has a
+``{{ form.name_of_field }}`` in a template. A field has a
 :meth:`~django.forms.BoundField.as_field_group` method which renders the
 related elements of the field as a group, its label, widget, errors, and help
 text.


### PR DESCRIPTION
![formatting-error-screenshot](https://github.com/django/django/assets/64686/160fe540-1a96-497a-8d9b-425ec906336a)
