### PR TITLE
Simplified call_command() calls.

### DIFF
--- a/django/core/management/commands/testserver.py
+++ b/django/core/management/commands/testserver.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
         )
 
         # Import the fixture data into the test database.
-        call_command("loaddata", *fixture_labels, **{"verbosity": verbosity})
+        call_command("loaddata", *fixture_labels, verbosity=verbosity)
 
         # Run the development server. Turn off auto-reloading because it causes
         # a strange error -- it causes this handle() method to be called

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1085,11 +1085,7 @@ class TransactionTestCase(SimpleTestCase):
                     apps.set_available_apps(self.available_apps)
 
             if self.fixtures:
-                # We have to use this slightly awkward syntax due to the fact
-                # that we're using *args and **kwargs together.
-                call_command(
-                    "loaddata", *self.fixtures, **{"verbosity": 0, "database": db_name}
-                )
+                call_command("loaddata", *self.fixtures, verbosity=0, database=db_name)
 
     def _should_reload_connections(self):
         return True
@@ -1282,7 +1278,8 @@ class TestCase(TransactionTestCase):
                     call_command(
                         "loaddata",
                         *cls.fixtures,
-                        **{"verbosity": 0, "database": db_name},
+                        verbosity=0,
+                        database=db_name,
                     )
                 except Exception:
                     cls._rollback_atomics(cls.cls_atomics)

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -2075,7 +2075,7 @@ Running management commands from your code
 
 .. function:: django.core.management.call_command(name, *args, **options)
 
-To call a management command from code use ``call_command``.
+To call a management command from code use ``call_command()``.
 
 ``name``
   the name of the command to call or a command object. Passing the name is

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -351,7 +351,8 @@ class CommandTests(SimpleTestCase):
                     management.call_command(
                         command,
                         *args,
-                        **{**kwargs, "stdout": out},
+                        **kwargs,
+                        stdout=out,
                     )
                     self.assertIn("foo_list=[1, 2]", out.getvalue())
 
@@ -378,7 +379,7 @@ class CommandTests(SimpleTestCase):
         )
         self.assertIn(expected_output, out.getvalue())
         out.truncate(0)
-        management.call_command("required_constant_option", **{**args, "stdout": out})
+        management.call_command("required_constant_option", **args, stdout=out)
         self.assertIn(expected_output, out.getvalue())
 
     def test_subparser(self):


### PR DESCRIPTION
A smattering of small clean ups related to `django.core.management.call_command()`.