### PR TITLE
Simplified django.http.request.split_domain_port().

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -30,7 +30,7 @@ from django.utils.regex_helper import _lazy_re_compile
 
 RAISE_ERROR = object()
 host_validation_re = _lazy_re_compile(
-    r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(:[0-9]+)?$"
+    r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9.:]+\])(?::([0-9]+))?$"
 )
 
 
@@ -698,19 +698,11 @@ def split_domain_port(host):
     Returned domain is lowercased. If the host is invalid, the domain will be
     empty.
     """
-    host = host.lower()
-
-    if not host_validation_re.match(host):
-        return "", ""
-
-    if host[-1] == "]":
-        # It's an IPv6 address without a port.
-        return host, ""
-    bits = host.rsplit(":", 1)
-    domain, port = bits if len(bits) == 2 else (bits[0], "")
-    # Remove a trailing dot (if present) from the domain.
-    domain = domain.removesuffix(".")
-    return domain, port
+    if match := host_validation_re.fullmatch(host.lower()):
+        domain, port = match.groups(default="")
+        # Remove a trailing dot (if present) from the domain.
+        return domain.removesuffix("."), port
+    return "", ""
 
 
 def validate_host(host, allowed_hosts):

--- a/tests/requests_tests/tests.py
+++ b/tests/requests_tests/tests.py
@@ -1013,10 +1013,37 @@ class HostValidationTests(SimpleTestCase):
         ):
             request.get_host()
 
-    def test_split_domain_port_removes_trailing_dot(self):
-        domain, port = split_domain_port("example.com.:8080")
-        self.assertEqual(domain, "example.com")
-        self.assertEqual(port, "8080")
+    def test_split_domain_port(self):
+        for host, expected in [
+            ("<invalid>", ("", "")),
+            ("<invalid>:8080", ("", "")),
+            ("example.com 8080", ("", "")),
+            ("example.com:invalid", ("", "")),
+            ("[::1]", ("[::1]", "")),
+            ("[::1]:8080", ("[::1]", "8080")),
+            ("[::ffff:127.0.0.1]", ("[::ffff:127.0.0.1]", "")),
+            ("[::ffff:127.0.0.1]:8080", ("[::ffff:127.0.0.1]", "8080")),
+            (
+                "[1851:0000:3238:DEF1:0177:0000:0000:0125]",
+                ("[1851:0000:3238:def1:0177:0000:0000:0125]", ""),
+            ),
+            (
+                "[1851:0000:3238:DEF1:0177:0000:0000:0125]:8080",
+                ("[1851:0000:3238:def1:0177:0000:0000:0125]", "8080"),
+            ),
+            ("127.0.0.1", ("127.0.0.1", "")),
+            ("127.0.0.1:8080", ("127.0.0.1", "8080")),
+            ("example.com", ("example.com", "")),
+            ("example.com:8080", ("example.com", "8080")),
+            ("example.com.", ("example.com", "")),
+            ("example.com.:8080", ("example.com", "8080")),
+            ("xn--n28h.test", ("xn--n28h.test", "")),
+            ("xn--n28h.test:8080", ("xn--n28h.test", "8080")),
+            ("subdomain.example.com", ("subdomain.example.com", "")),
+            ("subdomain.example.com:8080", ("subdomain.example.com", "8080")),
+        ]:
+            with self.subTest(host=host):
+                self.assertEqual(split_domain_port(host), expected)
 
 
 class BuildAbsoluteURITests(SimpleTestCase):


### PR DESCRIPTION
Use the capture groups from the regular expression that has already been matched to avoid re-splitting and the need to special case for IPv6.