### PR TITLE
Added seam to configure user creation in createsuperuser command

### DIFF
--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -230,9 +230,7 @@ class Command(BaseCommand):
                             pk.strip() for pk in user_data[field_name].split(",")
                         ]
 
-            self.UserModel._default_manager.db_manager(database).create_superuser(
-                **user_data
-            )
+            self.create_superuser(database, user_data)
             if options["verbosity"] >= 1:
                 self.stdout.write("Superuser created successfully.")
         except KeyboardInterrupt:
@@ -305,3 +303,8 @@ class Command(BaseCommand):
             self.username_field.clean(username, None)
         except exceptions.ValidationError as e:
             return "; ".join(e.messages)
+
+    def create_superuser(self, database, user_data):
+        return self.UserModel._default_manager.db_manager(database).create_superuser(
+            **user_data
+        )


### PR DESCRIPTION
The docs already suggest subclassing the `createsuperuser` command to customize data input and validation. This patch adds a seam to allow for further customization of the user creation when subclassing this command.

This is useful in cases where one wants to create associated objects like an Account or a Profile after the user is created. An alternative would to handle it with the post_save signal but implementing this as a signal is problematic if one also uses factories for tests, as it becomes harder to configure the objects created by the signal receiver through the factory.