### PR TITLE
Fixed #34748 -- Fixed queryset crash when grouping by a reference in a subquery.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1201,7 +1201,9 @@ class Ref(Expression):
         return {self.refs}
 
     def relabeled_clone(self, relabels):
-        return self
+        clone = self.copy()
+        clone.source = self.source.relabeled_clone(relabels)
+        return clone
 
     def as_sql(self, compiler, connection):
         return connection.ops.quote_name(self.refs), []

--- a/docs/releases/4.2.4.txt
+++ b/docs/releases/4.2.4.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Fixed a regression in Django 4.2 that caused a crash of
   ``QuerySet.aggregate()`` with aggregates referencing window functions
   (:ticket:`34717`).
+
+* Fixed a regression in Django 4.2 that caused a crash when grouping by a
+  reference in a subquery (:ticket:`34748`).

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -2116,6 +2116,16 @@ class AggregateTestCase(TestCase):
             },
         )
 
+    def test_group_by_reference_subquery(self):
+        author_qs = (
+            Author.objects.annotate(publisher_id=F("book__publisher"))
+            .values("publisher_id")
+            .annotate(cnt=Count("*"))
+            .values("publisher_id")
+        )
+        qs = Publisher.objects.filter(pk__in=author_qs)
+        self.assertCountEqual(qs, [self.p1, self.p2, self.p3, self.p4])
+
 
 class AggregateAnnotationPruningTests(TestCase):
     @classmethod


### PR DESCRIPTION
Regression in dd68af62b2b27ece50d434f6a351877212e15c3f.

Thanks @Toad2186 for the report.