### PR TITLE
Fixed #34749 -- Corrected QuerySet.acreate() signature in docs.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2133,7 +2133,7 @@ can use :exc:`django.core.exceptions.ObjectDoesNotExist`  to handle
 ~~~~~~~~~~~~
 
 .. method:: create(**kwargs)
-.. method:: acreate(*args, **kwargs)
+.. method:: acreate(**kwargs)
 
 *Asynchronous version*: ``acreate()``
 


### PR DESCRIPTION
* Remove `*args` from `acreate` signature in docs to match sync version and function signature.

Very small change. The documentation for the `acreate` method isn't quite right: https://docs.djangoproject.com/en/4.2/ref/models/querysets/#create

Ticket here: https://code.djangoproject.com/ticket/34749