### PR TITLE
Fixed #34754 -- Fixed JSONField check constraints validation on NULL values.

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -607,6 +607,11 @@ class IsNull(BuiltinLookup):
             raise ValueError(
                 "The QuerySet value for an isnull lookup must be True or False."
             )
+        if isinstance(self.lhs, Value) and self.lhs.value is None:
+            if self.rhs:
+                raise FullResultSet
+            else:
+                raise EmptyResultSet
         sql, params = self.process_lhs(compiler, connection)
         if self.rhs:
             return "%s IS NULL" % sql, params

--- a/docs/releases/4.2.5.txt
+++ b/docs/releases/4.2.5.txt
@@ -9,4 +9,6 @@ Django 4.2.5 fixes several bugs in 4.2.4.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 4.2 that caused an incorrect validation of
+  ``CheckConstraints`` on ``__isnull`` lookups against ``JSONField``
+  (:ticket:`34754`).

--- a/tests/constraints/models.py
+++ b/tests/constraints/models.py
@@ -121,3 +121,10 @@ class AbstractModel(models.Model):
 
 class ChildModel(AbstractModel):
     pass
+
+
+class JSONFieldModel(models.Model):
+    data = models.JSONField(null=True)
+
+    class Meta:
+        required_db_features = {"supports_json_field"}


### PR DESCRIPTION
The __isnull lookup of JSONField must special case Value(None, JSONField()) left-hand-side in order to be coherent with its convoluted null handling.

Regression in 5c23d9f0c32f166c81ecb6f3f01d5077a6084318.

Thanks Alexandre Collet for the report.