### PR TITLE
Refs #33713 -- Removed unnecessary version check in DatabaseFeatures.update_can_self_select on MariaDB.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -184,11 +184,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     @cached_property
     def update_can_self_select(self):
-        return self.connection.mysql_is_mariadb and self.connection.mysql_version >= (
-            10,
-            3,
-            2,
-        )
+        return self.connection.mysql_is_mariadb
 
     @cached_property
     def can_introspect_foreign_keys(self):


### PR DESCRIPTION
Follow up to 19297de2fe5a9c47e471c64249366f39fe12f16a.