### PR TITLE
Fixed #15799 -- Doc'd that Storage._open() should raise FileNotFoundError when file doesn't exist.

### DIFF
--- a/docs/howto/custom-file-storage.txt
+++ b/docs/howto/custom-file-storage.txt
@@ -76,7 +76,8 @@ objects. These are:
 Called by ``Storage.open()``, this is the actual mechanism the storage class
 uses to open the file. This must return a ``File`` object, though in most cases,
 you'll want to return some subclass here that implements logic specific to the
-backend storage system.
+backend storage system. The :exc:`FileNotFoundError` exception should be raised
+when a file doesn't exist.
 
 .. method:: _save(name, content)
 


### PR DESCRIPTION
Section in documentation:

https://docs.djangoproject.com/en/4.2/howto/custom-file-storage/#django.core.files.storage._open

Thanks!