### PR TITLE
Fix the autocomplete_fields small screen can not display the add button

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -665,6 +665,7 @@ input[type="submit"], button {
         width: 100%;
         display: flex;
         align-items: flex-start;
+        flex-wrap: wrap;
     }
 
     .related-widget-wrapper .selector {


### PR DESCRIPTION
Before fixing，Can't show add button
<img width="497" alt="image" src="https://github.com/django/django/assets/90906427/a25204e4-8647-4f7d-8bd0-4be339785e36">


After modification
<img width="497" alt="image" src="https://github.com/django/django/assets/90906427/2642c455-1a9b-4edb-96dc-bb9829eed8ba">
