### PR TITLE
Fixed #34739 -- Added GEOSGeometry.equals_identical() method.

### DIFF
--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -11,7 +11,7 @@ from django.contrib.gis.geos import prototypes as capi
 from django.contrib.gis.geos.base import GEOSBase
 from django.contrib.gis.geos.coordseq import GEOSCoordSeq
 from django.contrib.gis.geos.error import GEOSException
-from django.contrib.gis.geos.libgeos import GEOM_PTR
+from django.contrib.gis.geos.libgeos import GEOM_PTR, geos_version_tuple
 from django.contrib.gis.geos.mutable_list import ListMixin
 from django.contrib.gis.geos.prepared import PreparedGeometry
 from django.contrib.gis.geos.prototypes.io import ewkb_w, wkb_r, wkb_w, wkt_r, wkt_w
@@ -317,6 +317,16 @@ class GEOSGeometryBase(GEOSBase):
         specified tolerance.
         """
         return capi.geos_equalsexact(self.ptr, other.ptr, float(tolerance))
+
+    def equals_identical(self, other):
+        """
+        Return true if the two Geometries are point-wise equivalent.
+        """
+        if geos_version_tuple() < (3, 12):
+            raise GEOSException(
+                "GEOSGeometry.equals_identical() requires GEOS >= 3.12.0."
+            )
+        return capi.geos_equalsidentical(self.ptr, other.ptr)
 
     def intersects(self, other):
         "Return true if disjoint return false."

--- a/django/contrib/gis/geos/prototypes/__init__.py
+++ b/django/contrib/gis/geos/prototypes/__init__.py
@@ -51,6 +51,7 @@ from django.contrib.gis.geos.prototypes.predicates import (  # NOQA
     geos_disjoint,
     geos_equals,
     geos_equalsexact,
+    geos_equalsidentical,
     geos_hasz,
     geos_intersects,
     geos_isclosed,

--- a/django/contrib/gis/geos/prototypes/predicates.py
+++ b/django/contrib/gis/geos/prototypes/predicates.py
@@ -38,6 +38,7 @@ geos_equals = BinaryPredicate("GEOSEquals")
 geos_equalsexact = BinaryPredicate(
     "GEOSEqualsExact", argtypes=[GEOM_PTR, GEOM_PTR, c_double]
 )
+geos_equalsidentical = BinaryPredicate("GEOSEqualsIdentical")
 geos_intersects = BinaryPredicate("GEOSIntersects")
 geos_overlaps = BinaryPredicate("GEOSOverlaps")
 geos_relatepattern = BinaryPredicate(

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -483,6 +483,15 @@ return a boolean.
     ``poly1.equals_exact(poly2, 0.001)`` will compare equality to within
     one thousandth of a unit.
 
+.. method:: GEOSGeometry.equals_identical(other)
+
+    .. versionadded:: 5.0
+
+    Returns ``True`` if the two geometries are point-wise equivalent by
+    checking that the structure, ordering, and values of all vertices are
+    identical in all dimensions. ``NaN`` values are considered to be equal to
+    other ``NaN`` values. Requires GEOS 3.12.
+
 .. method:: GEOSGeometry.intersects(other)
 
     Returns ``True`` if :meth:`GEOSGeometry.disjoint` is ``False``.

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -192,6 +192,9 @@ Minor features
 
 * Added support for GEOS 3.12.
 
+* The new :meth:`.GEOSGeometry.equals_identical` method allows point-wise
+  equivalence checking of geometries.
+
 :mod:`django.contrib.messages`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Implements [#34739](https://code.djangoproject.com/ticket/34739)

GEOSEqualsIdentical compares two geometries and returns True if they are pointwise equivalent.