### PR TITLE
Fixed #34752 -- Fixed handling ASGI http.disconnect for streaming responses.

### DIFF
--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -187,30 +187,41 @@ class ASGIHandler(base.BaseHandler):
             body_file.close()
             await self.send_response(error_response, send)
             return
+
+        async def process_request(request, send):
+            response = await self.run_get_response(request)
+            await self.send_response(response, send)
+
         # Try to catch a disconnect while getting response.
         tasks = [
-            asyncio.create_task(self.run_get_response(request)),
+            # Check the status of these tasks and (optionally) terminate them
+            # in this order. The listen_for_disconnect() task goes first
+            # because it should not raise unexpected errors that would prevent
+            # us from cancelling process_request().
             asyncio.create_task(self.listen_for_disconnect(receive)),
+            asyncio.create_task(process_request(request, send)),
         ]
-        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-        done, pending = done.pop(), pending.pop()
-        # Allow views to handle cancellation.
-        pending.cancel()
-        try:
-            await pending
-        except asyncio.CancelledError:
-            # Task re-raised the CancelledError as expected.
-            pass
-        try:
-            response = done.result()
-        except RequestAborted:
-            body_file.close()
-            return
-        except AssertionError:
-            body_file.close()
-            raise
-        # Send the response.
-        await self.send_response(response, send)
+        await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        # Now wait on both tasks (they may have both finished by now).
+        for task in tasks:
+            if task.done():
+                try:
+                    task.result()
+                except RequestAborted:
+                    # Ignore client disconnects.
+                    pass
+                except AssertionError:
+                    body_file.close()
+                    raise
+            else:
+                # Allow views to handle cancellation.
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    # Task re-raised the CancelledError as expected.
+                    pass
+        body_file.close()
 
     async def listen_for_disconnect(self, receive):
         """Listen for disconnect from the client."""

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1282,6 +1282,36 @@ Attributes
     This is useful for middleware needing to wrap
     :attr:`StreamingHttpResponse.streaming_content`.
 
+.. _request-response-streaming-disconnect:
+
+Handling disconnects
+--------------------
+
+.. versionadded:: 5.0
+
+If the client disconnects during a streaming response, Django will cancel the
+coroutine that is handling the response. If you want to clean up resources
+manually, you can do so by catching the ``asyncio.CancelledError``::
+
+    async def streaming_response():
+        try:
+            # Do some work here
+            async for chunk in my_streaming_iterator():
+                yield chunk
+        except asyncio.CancelledError:
+            # Handle disconnect
+            ...
+            raise
+
+
+    async def my_streaming_view(request):
+        return StreamingHttpResponse(streaming_response())
+
+This example only shows how to handle client disconnection while the response
+is streaming. If you perform long-running operations in your view before
+returning the ``StreamingHttpResponse`` object, then you may also want to
+:ref:`handle disconnections in the view <async-handling-disconnect>` itself.
+
 ``FileResponse`` objects
 ========================
 

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -197,6 +197,9 @@ cleanup::
             # Handle disconnect
             raise
 
+You can also :ref:`handle client disconnects in streaming responses
+<request-response-streaming-disconnect>`.
+
 .. _async-safety:
 
 Async safety

--- a/tests/asgi/urls.py
+++ b/tests/asgi/urls.py
@@ -1,7 +1,8 @@
+import asyncio
 import threading
 import time
 
-from django.http import FileResponse, HttpResponse
+from django.http import FileResponse, HttpResponse, StreamingHttpResponse
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 
@@ -44,6 +45,17 @@ sync_waiter.lock = threading.Lock()
 sync_waiter.barrier = threading.Barrier(2)
 
 
+async def streaming_inner(sleep_time):
+    yield b"first\n"
+    await asyncio.sleep(sleep_time)
+    yield b"last\n"
+
+
+async def streaming_view(request):
+    sleep_time = float(request.GET["sleep"])
+    return StreamingHttpResponse(streaming_inner(sleep_time))
+
+
 test_filename = __file__
 
 
@@ -54,4 +66,5 @@ urlpatterns = [
     path("post/", post_echo),
     path("wait/", sync_waiter),
     path("delayed_hello/", hello_with_delay),
+    path("streaming/", streaming_view),
 ]


### PR DESCRIPTION
See this ticket for details: https://code.djangoproject.com/ticket/34752

This PR:

- [x] Adds some tests to ensures that ASGI `http.disconnect` is handled correctly during `StreamingHttpResponses`.
- [x] Modifies the existing ASGI handler so that the test passes.
- [x] Updates the `StreamingHttpResponse` documentation to document this new feature.

Additional context from a comment I made on the ticket:

> One subtlety: I originally made a smaller modification to the handler that put view logic and response logic in the same coroutine, but otherwise  followed the same flow. I found this broke in practice because sometimes  //both// coroutines would return at once. This caused the previous  `pending.pop()`/`done.pop()` logic to error out because one of those two  sets would be empty. I think that this problem is particularly likely to  happen in situations where some coroutines are long-lived. I haven't added  a test for this edge case yet, though.
