### PR TITLE
Refs #29061 -- Added regression test for multi-line translation strings.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'tests/requirements/py3.txt'
+      - name: Install gettext by installing poedit
+        run: choco install poedit
+      - run: xgettext --version
       - name: Install and upgrade packaging tools
         run: python -m pip install --upgrade pip setuptools wheel
       - run: python -m pip install -r tests/requirements/py3.txt -e .

--- a/tests/i18n/commands/locale/de/LC_MESSAGES/django.po
+++ b/tests/i18n/commands/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,25 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2011-12-04 04:59-0600\n"
+"PO-Revision-Date: 2011-12-10 19:12-0300\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+
+msgid ""
+"This is a multi-line "
+"translation."
+msgstr ""
+"Dies ist eine mehrzeilige "
+"Übersetzung."

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -703,6 +703,17 @@ class SymlinkExtractorTests(ExtractorTests):
         )
 
 
+class MultilineTranslationTests(ExtractorTests):
+    LOCALE = "de"
+
+    @requires_gettext_019
+    def test_windows_new_lines_in_po_file(self):
+        management.call_command(
+            "makemessages", locale=[LOCALE], verbosity=0, keep_pot=True
+        )
+        self.assertTrue(os.path.exists(self.PO_FILE))
+
+
 class CopyPluralFormsExtractorTests(ExtractorTests):
     PO_FILE_ES = "locale/es/LC_MESSAGES/django.po"
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29061#comment:8

The test replicates my best guess as to the issue reported in the ticket.
Our GitHub action for windows did not have `gettext` installed and would skip a few tests, now a version of gettext is installed by installing `poedit` [via chocolatey](https://community.chocolatey.org/packages/poedit) which has `gettext` bundled. This was the only way I could get this installed on the action :sweat_smile: 
But the test still passed

Maybe this PR is useful, but maybe not, I am very tempted to close the ticket as "worksforme" or „needsinfo“ but I will let a merger decide what's most appropriate. :star: 