### PR TITLE
Refs #34233 -- Bumped required cx_Oracle to 8.3.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -343,10 +343,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             return True
 
     @cached_property
-    def cx_oracle_version(self):
-        return tuple(int(x) for x in Database.version.split("."))
-
-    @cached_property
     def oracle_version(self):
         with self.temporary_connection():
             return tuple(int(x) for x in self.connection.version.split("."))

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -6,7 +6,6 @@ from django.db import models
 from django.db.backends.base.introspection import BaseDatabaseIntrospection
 from django.db.backends.base.introspection import FieldInfo as BaseFieldInfo
 from django.db.backends.base.introspection import TableInfo as BaseTableInfo
-from django.utils.functional import cached_property
 
 FieldInfo = namedtuple(
     "FieldInfo", BaseFieldInfo._fields + ("is_autofield", "is_json", "comment")
@@ -18,38 +17,20 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     cache_bust_counter = 1
 
     # Maps type objects to Django Field types.
-    @cached_property
-    def data_types_reverse(self):
-        if self.connection.cx_oracle_version < (8,):
-            return {
-                cx_Oracle.BLOB: "BinaryField",
-                cx_Oracle.CLOB: "TextField",
-                cx_Oracle.DATETIME: "DateField",
-                cx_Oracle.FIXED_CHAR: "CharField",
-                cx_Oracle.FIXED_NCHAR: "CharField",
-                cx_Oracle.INTERVAL: "DurationField",
-                cx_Oracle.NATIVE_FLOAT: "FloatField",
-                cx_Oracle.NCHAR: "CharField",
-                cx_Oracle.NCLOB: "TextField",
-                cx_Oracle.NUMBER: "DecimalField",
-                cx_Oracle.STRING: "CharField",
-                cx_Oracle.TIMESTAMP: "DateTimeField",
-            }
-        else:
-            return {
-                cx_Oracle.DB_TYPE_DATE: "DateField",
-                cx_Oracle.DB_TYPE_BINARY_DOUBLE: "FloatField",
-                cx_Oracle.DB_TYPE_BLOB: "BinaryField",
-                cx_Oracle.DB_TYPE_CHAR: "CharField",
-                cx_Oracle.DB_TYPE_CLOB: "TextField",
-                cx_Oracle.DB_TYPE_INTERVAL_DS: "DurationField",
-                cx_Oracle.DB_TYPE_NCHAR: "CharField",
-                cx_Oracle.DB_TYPE_NCLOB: "TextField",
-                cx_Oracle.DB_TYPE_NVARCHAR: "CharField",
-                cx_Oracle.DB_TYPE_NUMBER: "DecimalField",
-                cx_Oracle.DB_TYPE_TIMESTAMP: "DateTimeField",
-                cx_Oracle.DB_TYPE_VARCHAR: "CharField",
-            }
+    data_types_reverse = {
+        cx_Oracle.DB_TYPE_DATE: "DateField",
+        cx_Oracle.DB_TYPE_BINARY_DOUBLE: "FloatField",
+        cx_Oracle.DB_TYPE_BLOB: "BinaryField",
+        cx_Oracle.DB_TYPE_CHAR: "CharField",
+        cx_Oracle.DB_TYPE_CLOB: "TextField",
+        cx_Oracle.DB_TYPE_INTERVAL_DS: "DurationField",
+        cx_Oracle.DB_TYPE_NCHAR: "CharField",
+        cx_Oracle.DB_TYPE_NCLOB: "TextField",
+        cx_Oracle.DB_TYPE_NVARCHAR: "CharField",
+        cx_Oracle.DB_TYPE_NUMBER: "DecimalField",
+        cx_Oracle.DB_TYPE_TIMESTAMP: "DateTimeField",
+        cx_Oracle.DB_TYPE_VARCHAR: "CharField",
+    }
 
     def get_field_type(self, data_type, description):
         if data_type == cx_Oracle.NUMBER:

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -919,7 +919,7 @@ To enable the JSON1 extension you can follow the instruction on
 Oracle notes
 ============
 
-Django supports `Oracle Database Server`_ versions 19c and higher. Version 7.0
+Django supports `Oracle Database Server`_ versions 19c and higher. Version 8.3
 or higher of the `cx_Oracle`_ Python driver is required.
 
 .. _`Oracle Database Server`: https://www.oracle.com/

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -571,6 +571,8 @@ Miscellaneous
 
 * The minimum supported version of SQLite is increased from 3.21.0 to 3.27.0.
 
+* Support for ``cx_Oracle`` < 8.3 is removed.
+
 .. _deprecated-features-5.0:
 
 Features deprecated in 5.0

--- a/tests/requirements/oracle.txt
+++ b/tests/requirements/oracle.txt
@@ -1,1 +1,1 @@
-cx_oracle >= 7.0
+cx_oracle >= 8.3


### PR DESCRIPTION
This bumps minimum supported versions of ``cx_Oracle`` to [the first release](https://cx-oracle.readthedocs.io/en/latest/release_notes.html#version-8-3-november-2021) to support Python 3.10.