### PR TITLE
Fixed non-deterministic order in SubqueryTests.test_slice_subquery_and_query.

### DIFF
--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2373,18 +2373,18 @@ class SubqueryTests(TestCase):
         """
         query = DumbCategory.objects.filter(
             id__in=DumbCategory.objects.order_by("-id")[0:2]
-        )[0:2]
-        self.assertEqual({x.id for x in query}, {3, 4})
+        ).order_by("id")[0:2]
+        self.assertSequenceEqual([x.id for x in query], [3, 4])
 
         query = DumbCategory.objects.filter(
             id__in=DumbCategory.objects.order_by("-id")[1:3]
-        )[1:3]
-        self.assertEqual({x.id for x in query}, {3})
+        ).order_by("id")[1:3]
+        self.assertSequenceEqual([x.id for x in query], [3])
 
         query = DumbCategory.objects.filter(
             id__in=DumbCategory.objects.order_by("-id")[2:]
-        )[1:]
-        self.assertEqual({x.id for x in query}, {2})
+        ).order_by("id")[1:]
+        self.assertSequenceEqual([x.id for x in query], [2])
 
     def test_related_sliced_subquery(self):
         """


### PR DESCRIPTION
Slice on unordered subquery may be non-deterministic in some databases.

Noticed while checking `queries` tests on Oracle 23c.