### PR TITLE
Fixed #34624 - Removed edit and view options in RelatedFieldWidgetWrapper for radioselects.

### DIFF
--- a/django/contrib/admin/tests.py
+++ b/django/contrib/admin/tests.py
@@ -23,6 +23,7 @@ class AdminSeleniumTestCase(SeleniumTestCase, StaticLiveServerTestCase):
         "django.contrib.contenttypes",
         "django.contrib.sessions",
         "django.contrib.sites",
+        "django.contrib.redirects",
     ]
 
     def wait_until(self, callback, timeout=10):

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -270,13 +270,15 @@ class RelatedFieldWidgetWrapper(forms.Widget):
         if can_add_related is None:
             can_add_related = admin_site.is_registered(rel.model)
         self.can_add_related = can_add_related
-        # XXX: The UX does not support multiple selected values.
-        multiple = getattr(widget, "allow_multiple_selected", False)
-        self.can_change_related = not multiple and can_change_related
+        # Widgets that display multiple values are not supported.
+        supported = not getattr(
+            widget, "allow_multiple_selected", False
+        ) and not isinstance(widget, AdminRadioSelect)
+        self.can_change_related = supported and can_change_related
         # XXX: The deletion UX can be confusing when dealing with cascading deletion.
         cascade = getattr(rel, "on_delete", None) is CASCADE
-        self.can_delete_related = not multiple and not cascade and can_delete_related
-        self.can_view_related = not multiple and can_view_related
+        self.can_delete_related = supported and not cascade and can_delete_related
+        self.can_view_related = supported and can_view_related
         # so we can check if the related object is registered with this AdminSite
         self.admin_site = admin_site
 

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -8,6 +8,10 @@ from django.contrib.admin import BooleanFieldListFilter
 from django.contrib.admin.views.main import ChangeList
 from django.contrib.auth.admin import GroupAdmin, UserAdmin
 from django.contrib.auth.models import Group, User
+from django.contrib.redirects.admin import RedirectAdmin
+from django.contrib.redirects.models import Redirect
+from django.contrib.sites.admin import SiteAdmin
+from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.core.mail import EmailMessage
 from django.db import models
@@ -1299,9 +1303,11 @@ site.register(Box)
 site.register(Country, CountryAdmin)
 site.register(Traveler, TravelerAdmin)
 
-# Register core models we need in our tests
+# Register core and contrib models we need in our tests
 site.register(User, UserAdmin)
 site.register(Group, GroupAdmin)
+site.register(Redirect, RedirectAdmin)
+site.register(Site, SiteAdmin)
 
 # Used to test URL namespaces
 site2 = admin.AdminSite(name="namespaced_admin")

--- a/tests/admin_views/test_related_object_lookups.py
+++ b/tests/admin_views/test_related_object_lookups.py
@@ -76,3 +76,32 @@ class SeleniumTests(AdminSeleniumTestCase):
             with self.subTest(link_id):
                 link = self.selenium.find_element(By.XPATH, f'//*[@id="{link_id}"]')
                 self.assertIsNone(link.get_attribute("aria-disabled"))
+
+    def test_radio_select_add_related_object(self):
+        from selenium.webdriver.common.by import By
+
+        redirect_add_url = reverse("admin:redirects_redirect_add")
+        self.selenium.get(self.live_server_url + redirect_add_url)
+
+        # There is an add icon and it points to add site page.
+        # There are some query parameters in the URL. Check the start.
+        add_link = self.selenium.find_element(By.ID, "add_id_site")
+        href = add_link.get_attribute("href")
+        add_site_url = self.live_server_url + reverse("admin:sites_site_add")
+        self.assertTrue(href.startswith(add_site_url))
+
+        # The view_related and delete_related icons should not exist.
+        # Selenium takes too much time searching for non-existing elements.
+        # The strategy is to check that the preceding sibling of the add link is
+        # the radio select, and the parent element should contain two elements:
+        # the radio select and the add link, but nothing else.
+
+        # The preceding sibling is the radio select.
+        radio_select = self.selenium.find_element(By.ID, "id_site")
+        self.assertEqual(radio_select.get_attribute("class"), "radiolist")
+        preceding_sibling = add_link.find_element(By.XPATH, "preceding-sibling::*")
+        self.assertEqual(radio_select, preceding_sibling)
+
+        # The parent contains the radio select and the add link, but nothing else.
+        parent = radio_select.find_element(By.XPATH, "..")
+        self.assertEqual(len(parent.find_elements(By.XPATH, "*")), 2)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -90,6 +90,7 @@ ALWAYS_INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.admin.apps.SimpleAdminConfig",
     "django.contrib.staticfiles",
+    "django.contrib.redirects",
 ]
 
 ALWAYS_MIDDLEWARE = [


### PR DESCRIPTION
Ref: https://code.djangoproject.com/ticket/34624

# Before

Current situation: There is only one pencil and eye, and they are disabled.
Expected: A pencil and eye for each item, and enabled OR no pencils and eyes.

In the code I found the comment: `# XXX: The UX does not support multiple selected values.`. But radio select was not excluded. I went for the solution to remove the pencils and eyes to make radio select behave the same as multi-select.

<img width="1029" alt="Screenshot 2023-08-11 at 14 25 12" src="https://github.com/django/django/assets/1969342/3ac65f3c-6d56-4b92-866f-17b369d30a80">

# After

<img width="1029" alt="Screenshot 2023-08-11 at 14 25 31" src="https://github.com/django/django/assets/1969342/0ff3cdb9-be77-478b-ac3e-27d8fa110241">


I'd like to know if this approach is acceptable. If so, I'll update the PR with tests.