### PR TITLE
Fixed #34770: Removed autoescape from password_reset templates

### DIFF
--- a/django/contrib/admin/templates/registration/password_reset_email.html
+++ b/django/contrib/admin/templates/registration/password_reset_email.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}
 {% blocktranslate %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktranslate %}
 
 {% translate "Please go to the following page and choose a new password:" %}
@@ -10,5 +10,3 @@
 {% translate "Thanks for using our site!" %}
 
 {% blocktranslate %}The {{ site_name }} team{% endblocktranslate %}
-
-{% endautoescape %}

--- a/django/contrib/auth/templates/registration/password_reset_subject.txt
+++ b/django/contrib/auth/templates/registration/password_reset_subject.txt
@@ -1,3 +1,2 @@
-{% load i18n %}{% autoescape off %}
+{% load i18n %}
 {% blocktranslate %}Password reset on {{ site_name }}{% endblocktranslate %}
-{% endautoescape %}

--- a/tests/auth_tests/templates/registration/password_reset_subject.txt
+++ b/tests/auth_tests/templates/registration/password_reset_subject.txt
@@ -1,1 +1,1 @@
-{% autoescape off %}Custom password reset on {{ site_name }}{% endautoescape %}
+Custom password reset on {{ site_name }}


### PR DESCRIPTION
Removed `{% autoescape off %}`  from password_reset templates to safeguard against html injections