### PR TITLE
Fixed #34779 -- Avoided unnecessary selection of non-nullable m2m fields without natural keys during serialization.

### DIFF
--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -80,7 +80,10 @@ class Serializer(base.Serializer):
 
                 def queryset_iterator(obj, field):
                     return (
-                        getattr(obj, field.name).select_related().only("pk").iterator()
+                        getattr(obj, field.name)
+                        .select_related(None)
+                        .only("pk")
+                        .iterator()
                     )
 
             m2m_iter = getattr(obj, "_prefetched_objects_cache", {}).get(

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -156,7 +156,10 @@ class Serializer(base.Serializer):
 
                 def queryset_iterator(obj, field):
                     return (
-                        getattr(obj, field.name).select_related().only("pk").iterator()
+                        getattr(obj, field.name)
+                        .select_related(None)
+                        .only("pk")
+                        .iterator()
                     )
 
             m2m_iter = getattr(obj, "_prefetched_objects_cache", {}).get(

--- a/docs/releases/4.2.5.txt
+++ b/docs/releases/4.2.5.txt
@@ -16,3 +16,7 @@ Bugfixes
 * Fixed a bug in Django 4.2 where the deprecated ``DEFAULT_FILE_STORAGE`` and
   ``STATICFILES_STORAGE`` settings were not synced with ``STORAGES``
   (:ticket:`34773`).
+
+* Fixed a regression in Django 4.2.2 that caused an unnecessary selection of a
+  non-nullable ``ManyToManyField`` without a natural key during serialization
+  (:ticket:`34779`).

--- a/tests/serializers/models/base.py
+++ b/tests/serializers/models/base.py
@@ -60,7 +60,7 @@ class TopicManager(models.Manager):
 
 class Topic(models.Model):
     name = models.CharField(max_length=255)
-    category = models.ForeignKey(Category, models.CASCADE, null=True)
+    category = models.ForeignKey(Category, models.CASCADE)
     objects = TopicManager()
 
 


### PR DESCRIPTION
By using `select_related(None)` instead of `select_related()`, the unnecessary joins are avoided.
Note that the current tests already covers the change, when the field is not `null=True`.