### PR TITLE
Added extra tests for model field's choices iterable values.

### DIFF
--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -97,6 +97,21 @@ class FieldDeconstructionTests(SimpleTestCase):
             kwargs, {"choices": [("A", "One"), ("B", "Two")], "max_length": 1}
         )
 
+    def test_choices_iterator(self):
+        field = models.IntegerField(choices=((i, str(i)) for i in range(3)))
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.IntegerField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"choices": [(0, "0"), (1, "1"), (2, "2")]})
+
+    def test_choices_iterable(self):
+        # Pass an iterator (but not an iterable) to choices.
+        field = models.IntegerField(choices="012345")
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.IntegerField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"choices": ["0", "1", "2", "3", "4", "5"]})
+
     def test_csi_field(self):
         field = models.CommaSeparatedIntegerField(max_length=100)
         name, path, args, kwargs = field.deconstruct()

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -81,6 +81,7 @@ class Choiceful(models.Model):
     empty_choices_bool = models.BooleanField(choices=())
     empty_choices_text = models.TextField(choices=())
     choices_from_enum = models.IntegerField(choices=Suit)
+    choices_from_iterator = models.IntegerField(choices=((i, str(i)) for i in range(3)))
 
 
 class BigD(models.Model):

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -157,16 +157,27 @@ class ChoicesTests(SimpleTestCase):
         cls.empty_choices_text = Choiceful._meta.get_field("empty_choices_text")
         cls.with_choices = Choiceful._meta.get_field("with_choices")
         cls.choices_from_enum = Choiceful._meta.get_field("choices_from_enum")
+        cls.choices_from_iterator = Choiceful._meta.get_field("choices_from_iterator")
 
     def test_choices(self):
         self.assertIsNone(self.no_choices.choices)
         self.assertEqual(self.empty_choices.choices, ())
+        self.assertEqual(self.empty_choices_bool.choices, ())
+        self.assertEqual(self.empty_choices_text.choices, ())
         self.assertEqual(self.with_choices.choices, [(1, "A")])
+        self.assertEqual(
+            self.choices_from_iterator.choices, [(0, "0"), (1, "1"), (2, "2")]
+        )
 
     def test_flatchoices(self):
         self.assertEqual(self.no_choices.flatchoices, [])
         self.assertEqual(self.empty_choices.flatchoices, [])
+        self.assertEqual(self.empty_choices_bool.flatchoices, [])
+        self.assertEqual(self.empty_choices_text.flatchoices, [])
         self.assertEqual(self.with_choices.flatchoices, [(1, "A")])
+        self.assertEqual(
+            self.choices_from_iterator.flatchoices, [(0, "0"), (1, "1"), (2, "2")]
+        )
 
     def test_check(self):
         self.assertEqual(Choiceful.check(), [])
@@ -196,6 +207,7 @@ class ChoicesTests(SimpleTestCase):
     def test_choices_from_enum(self):
         # Choices class was transparently resolved when given as argument.
         self.assertEqual(self.choices_from_enum.choices, Choiceful.Suit.choices)
+        self.assertEqual(self.choices_from_enum.flatchoices, Choiceful.Suit.choices)
 
 
 class GetFieldDisplayTests(SimpleTestCase):


### PR DESCRIPTION
While reviewing PR #16943, I had to debug an issue with model field's choices being callables and how that was generating [endless migrations](https://github.com/django/django/pull/16943#issuecomment-1673899018) for the field/model that declared them. In that effort, I realized we could have a few extra tests to ensure the behavior in `main` is respected in the referenced PR.