### PR TITLE
Fixed #34781 -- Updated logging ref docs for django.server's request extra context value.

### DIFF
--- a/docs/ref/logging.txt
+++ b/docs/ref/logging.txt
@@ -164,7 +164,7 @@ Messages to this logger have the following extra context:
 
 * ``status_code``: The HTTP response code associated with the request.
 
-* ``request``: The request object that generated the logging message.
+* ``request``: The request object (a :py:class:`socket.socket`) that generated the logging message.
 
 .. _django-template-logger:
 


### PR DESCRIPTION
Ticket is [https://code.djangoproject.com/ticket/34781](https://code.djangoproject.com/ticket/34781).

I've not touched the `django.request` equivalent, though I _presume_ that **always** receives an `HttpRequest` subclass instance, in the same way I am _presuming_ that the `.request` under `django.server` is **always** the [raw socket](https://github.com/python/cpython/blob/f51f0466c07eabc6177c2f64f70c952dada050e8/Lib/socketserver.py#L756) ... 🤷

--------

Of course, if anyone can figure out a way to get the _actual_ request, that'd be a much better win ;)