### PR TITLE
Fixed utils_tests.test_lazyobject.SimpleLazyObjectPickleTestCase.

### DIFF
--- a/tests/utils_tests/test_lazyobject.py
+++ b/tests/utils_tests/test_lazyobject.py
@@ -1,9 +1,10 @@
 import copy
 import pickle
 import sys
+import unittest
 import warnings
-from unittest import TestCase
 
+from django.test import TestCase
 from django.utils.functional import LazyObject, SimpleLazyObject, empty
 
 from .models import Category, CategoryInfo
@@ -20,7 +21,7 @@ class Foo:
         return self.foo == other.foo
 
 
-class LazyObjectTestCase(TestCase):
+class LazyObjectTestCase(unittest.TestCase):
     def lazy_wrap(self, wrapped_object):
         """
         Wrap the given object into a LazyObject


### PR DESCRIPTION
`SimpleLazyObjectPickleTestCase` executes database queries so it must inherit from `django.test.TestCase`:

```bash
$ ./runtests.py utils_tests.test_lazyobject

Testing against Django installed in '/django/django' with up to 8 processes
Found 69 test(s).
System check identified no issues (0 silenced).
...................................................................E.
======================================================================
ERROR: test_pickle_model (utils_tests.test_lazyobject.SimpleLazyObjectPickleTestCase)
Test on an actual model, based on the report in #25426.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
  File "/django/django/db/backends/sqlite3/base.py", line 328, in execute
    return super().execute(query, params)
sqlite3.OperationalError: no such table: utils_tests_category

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/local/lib/python3.10/unittest/case.py", line 591, in run
    self._callTestMethod(testMethod)
  File "/usr/local/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File "/django/tests/utils_tests/test_lazyobject.py", line 492, in test_pickle_model
    category = Category.objects.create(name="thing1")
  File "/django/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/django/django/db/models/query.py", line 676, in create
    obj.save(force_insert=True, using=self.db)
  File "/django/django/db/models/base.py", line 814, in save
    self.save_base(
  File "/django/django/db/models/base.py", line 901, in save_base
    updated = self._save_table(
  File "/django/django/db/models/base.py", line 1058, in _save_table
    results = self._do_insert(
  File "/django/django/db/models/base.py", line 1099, in _do_insert
    return manager._insert(
  File "/django/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/django/django/db/models/query.py", line 1842, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "/django/django/db/models/sql/compiler.py", line 1822, in execute_sql
    cursor.execute(sql, params)
  File "/django/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
  File "/django/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/django/django/db/backends/utils.py", line 84, in _execute
    with self.db.wrap_database_errors:
  File "/django/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/django/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
  File "/django/django/db/backends/sqlite3/base.py", line 328, in execute
    return super().execute(query, params)
django.db.utils.OperationalError: no such table: utils_tests_category

----------------------------------------------------------------------
Ran 69 tests in 0.025s

FAILED (errors=1)
```