### PR TITLE
Fixed DatabaseCreation.get_test_db_clone_settings() for empty database name on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/creation.py
+++ b/django/db/backends/sqlite3/creation.py
@@ -53,7 +53,7 @@ class DatabaseCreation(BaseDatabaseCreation):
 
     def get_test_db_clone_settings(self, suffix):
         orig_settings_dict = self.connection.settings_dict
-        source_database_name = orig_settings_dict["NAME"]
+        source_database_name = orig_settings_dict["NAME"] or ":memory:"
 
         if not self.is_in_memory_db(source_database_name):
             root, ext = os.path.splitext(source_database_name)


### PR DESCRIPTION
Empty string should be considered an in-memory SQLite database:
```bash
$ /runtests.py backends.sqlite.test_creation.TestDbSignatureTests.test_get_test_db_clone_settings_not_supported
Testing against Django installed in '/django/django' with up to 8 processes
Found 1 test(s).
System check identified no issues (0 silenced).
F
======================================================================
FAIL: test_get_test_db_clone_settings_not_supported (backends.sqlite.test_creation.TestDbSignatureTests.test_get_test_db_clone_settings_not_supported)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/cpython/Lib/unittest/mock.py", line 1417, in patched
    return func(*newargs, **newkeywargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/django/tests/backends/sqlite/test_creation.py", line 42, in test_get_test_db_clone_settings_not_supported
    with self.assertRaisesMessage(NotSupportedError, msg):
  File "/cpython/Lib/contextlib.py", line 148, in __exit__
    next(self.gen)
  File "/django/django/test/testcases.py", line 739, in _assert_raises_or_warns_cm
    with func(expected_exception) as cm:
AssertionError: NotSupportedError not raised

----------------------------------------------------------------------
Ran 1 test in 0.003s

FAILED (failures=1)
```

This only fails when running in isolation, because when creating a test database, an empty string in the connection name is changed to `file:memorydb_default?mode=memory&cache=shared`.