### PR TITLE
Improved formset docs by using a set instead of a list in the custom validation example.

### DIFF
--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -374,14 +374,14 @@ is where you define your own validation that works at the formset level:
     ...         if any(self.errors):
     ...             # Don't bother validating the formset unless each form is valid on its own
     ...             return
-    ...         titles = []
+    ...         titles = set()
     ...         for form in self.forms:
     ...             if self.can_delete and self._should_delete_form(form):
     ...                 continue
     ...             title = form.cleaned_data.get("title")
     ...             if title in titles:
     ...                 raise ValidationError("Articles in a set must have distinct titles.")
-    ...             titles.append(title)
+    ...             titles.add(title)
     ...
 
     >>> ArticleFormSet = formset_factory(ArticleForm, formset=BaseArticleFormSet)


### PR DESCRIPTION
In the formset validation official example, we decrease the computational complexity from O(n^2) to O(n log n) simply by using a set instead of a list.