### PR TITLE
Fixed ResourceWarning from unclosed SQLite connection on Python 3.13+.

### DIFF
--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -792,7 +792,8 @@ class ThreadTests(TransactionTestCase):
             # closed on teardown).
             for conn in connections_dict.values():
                 if conn is not connection and conn.allow_thread_sharing:
-                    conn.close()
+                    conn.validate_thread_sharing()
+                    conn._close()
                     conn.dec_thread_sharing()
 
     def test_connections_thread_local(self):

--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -115,6 +115,7 @@ class LiveServerInMemoryDatabaseLockTest(LiveServerBase):
         connection.
         """
         conn = self.server_thread.connections_override[DEFAULT_DB_ALIAS]
+        source_connection = conn.connection
         # Open a connection to the database.
         conn.connect()
         # Create a transaction to lock the database.
@@ -128,6 +129,7 @@ class LiveServerInMemoryDatabaseLockTest(LiveServerBase):
         finally:
             # Release the transaction.
             cursor.execute("ROLLBACK")
+            source_connection.close()
 
 
 class FailingLiveServerThread(LiveServerThread):


### PR DESCRIPTION
- `backends.sqlite.tests.ThreadSharing.test_database_sharing_in_threads`
- `backends.tests.ThreadTests.test_default_connection_thread_local:` on SQLite, `close()` doesn't explicitly close in-memory connections.
- `servers.tests.LiveServerInMemoryDatabaseLockTest`
- `test_runner.tests.SQLiteInMemoryTestDbs.test_transaction_support`

Check out https://github.com/python/cpython/pull/108015.