### PR TITLE
Removed unnecessary trailing commas in tests.

### DIFF
--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -325,7 +325,7 @@ class UtilsTests(SimpleTestCase):
         )
         msg = "Unable to lookup 'nonexistent' on Article or ArticleForm"
         with self.assertRaisesMessage(AttributeError, msg):
-            label_for_field("nonexistent", Article, form=ArticleForm()),
+            label_for_field("nonexistent", Article, form=ArticleForm())
 
     def test_label_for_property(self):
         class MockModelAdmin:

--- a/tests/auth_tests/test_validators.py
+++ b/tests/auth_tests/test_validators.py
@@ -150,12 +150,12 @@ class UserAttributeSimilarityValidatorTest(TestCase):
         self.assertIsNone(UserAttributeSimilarityValidator().validate("testclient"))
 
         with self.assertRaises(ValidationError) as cm:
-            UserAttributeSimilarityValidator().validate("testclient", user=user),
+            UserAttributeSimilarityValidator().validate("testclient", user=user)
         self.assertEqual(cm.exception.messages, [expected_error % "username"])
         self.assertEqual(cm.exception.error_list[0].code, "password_too_similar")
 
         with self.assertRaises(ValidationError) as cm:
-            UserAttributeSimilarityValidator().validate("example.com", user=user),
+            UserAttributeSimilarityValidator().validate("example.com", user=user)
         self.assertEqual(cm.exception.messages, [expected_error % "email address"])
 
         with self.assertRaises(ValidationError) as cm:
@@ -193,7 +193,7 @@ class UserAttributeSimilarityValidatorTest(TestCase):
                 return "foobar"
 
         with self.assertRaises(ValidationError) as cm:
-            UserAttributeSimilarityValidator().validate("foobar", user=TestUser()),
+            UserAttributeSimilarityValidator().validate("foobar", user=TestUser())
         self.assertEqual(
             cm.exception.messages, ["The password is too similar to the username."]
         )

--- a/tests/custom_pk/tests.py
+++ b/tests/custom_pk/tests.py
@@ -195,7 +195,7 @@ class CustomPKTests(TestCase):
         self.assertEqual(f.bar, new_bar)
 
         f = Foo.objects.get(bar=new_bar)
-        self.assertEqual(f, new_foo),
+        self.assertEqual(f, new_foo)
         self.assertEqual(f.bar, new_bar)
 
     # SQLite lets objects be saved with an empty primary key, even though an

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -94,7 +94,7 @@ class GetStorageClassTests(SimpleTestCase):
     def test_deprecation_warning(self):
         msg = GET_STORAGE_CLASS_DEPRECATED_MSG
         with self.assertRaisesMessage(RemovedInDjango51Warning, msg):
-            get_storage_class("django.core.files.storage.FileSystemStorage"),
+            get_storage_class("django.core.files.storage.FileSystemStorage")
 
 
 class FileSystemStorageTests(unittest.TestCase):

--- a/tests/generic_inline_admin/tests.py
+++ b/tests/generic_inline_admin/tests.py
@@ -490,5 +490,5 @@ class GenericInlineModelAdminTest(SimpleTestCase):
             ("media", MediaInline),
         ):
             request.name = name
-            self.assertEqual(ma.get_inlines(request, None), (inline_class,)),
+            self.assertEqual(ma.get_inlines(request, None), (inline_class,))
             self.assertEqual(type(ma.get_inline_instances(request)[0]), inline_class)

--- a/tests/gis_tests/geoapp/test_serializers.py
+++ b/tests/gis_tests/geoapp/test_serializers.py
@@ -17,7 +17,7 @@ class GeoJSONSerializerTests(TestCase):
         all_formats = set(serializers.get_serializer_formats())
         public_formats = set(serializers.get_public_serializer_formats())
 
-        self.assertIn("geojson", all_formats),
+        self.assertIn("geojson", all_formats)
         self.assertIn("geojson", public_formats)
 
     def test_serialization_base(self):

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -660,8 +660,8 @@ class GeoQuerySetTest(TestCase):
         # flaky.
         for point, ref_city in zip(sorted(line), sorted(ref_points)):
             point_x, point_y = point
-            self.assertAlmostEqual(point_x, ref_city.x, 5),
-            self.assertAlmostEqual(point_y, ref_city.y, 5),
+            self.assertAlmostEqual(point_x, ref_city.x, 5)
+            self.assertAlmostEqual(point_y, ref_city.y, 5)
 
     @skipUnlessDBFeature("supports_union_aggr")
     def test_unionagg(self):

--- a/tests/serializers/tests.py
+++ b/tests/serializers/tests.py
@@ -73,7 +73,7 @@ class SerializerRegistrationTests(SimpleTestCase):
         all_formats = set(serializers.get_serializer_formats())
         public_formats = set(serializers.get_public_serializer_formats())
 
-        self.assertIn("xml", all_formats),
+        self.assertIn("xml", all_formats)
         self.assertIn("xml", public_formats)
 
         self.assertIn("json2", all_formats)

--- a/tests/template_tests/filter_tests/test_urlize.py
+++ b/tests/template_tests/filter_tests/test_urlize.py
@@ -158,7 +158,7 @@ class FunctionTests(SimpleTestCase):
         )
 
     def test_word_with_dot(self):
-        self.assertEqual(urlize("some.organization"), "some.organization"),
+        self.assertEqual(urlize("some.organization"), "some.organization")
 
     def test_https(self):
         self.assertEqual(

--- a/tests/test_runner/runner.py
+++ b/tests/test_runner/runner.py
@@ -21,9 +21,9 @@ class CustomOptionsTestRunner(DiscoverRunner):
 
     @classmethod
     def add_arguments(cls, parser):
-        parser.add_argument("--option_a", "-a", default="1"),
-        parser.add_argument("--option_b", "-b", default="2"),
-        parser.add_argument("--option_c", "-c", default="3"),
+        parser.add_argument("--option_a", "-a", default="1")
+        parser.add_argument("--option_b", "-b", default="2")
+        parser.add_argument("--option_c", "-c", default="3")
 
     def run_tests(self, test_labels, **kwargs):
         print("%s:%s:%s" % (self.option_a, self.option_b, self.option_c))

--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -61,9 +61,9 @@ class TestUtilsText(SimpleTestCase):
         self.assertEqual(
             "The quick brown fox jumped over the lazy dog.", truncator.chars(100)
         ),
-        self.assertEqual("The quick brown fox …", truncator.chars(21)),
-        self.assertEqual("The quick brown fo.....", truncator.chars(23, ".....")),
-        self.assertEqual(".....", truncator.chars(4, ".....")),
+        self.assertEqual("The quick brown fox …", truncator.chars(21))
+        self.assertEqual("The quick brown fo.....", truncator.chars(23, "....."))
+        self.assertEqual(".....", truncator.chars(4, "....."))
 
         nfc = text.Truncator("o\xfco\xfco\xfco\xfc")
         nfd = text.Truncator("ou\u0308ou\u0308ou\u0308ou\u0308")


### PR DESCRIPTION
Some statements in the test cases contain trailing commas, which turns them into tuple expressions even if they were meant to be only a regular expression statements:

```python
UserAttributeSimilarityValidator().validate("testclient", user=user),
```
vs.
```python
UserAttributeSimilarityValidator().validate("testclient", user=user)
```

I'd consider those trivial typo fixes.