### PR TITLE
Modernized enumeration helpers on Python 3.11+.

### DIFF
--- a/django/db/models/enums.py
+++ b/django/db/models/enums.py
@@ -98,6 +98,7 @@ class IntegerChoices(int, Choices):
 class TextChoices(str, Choices):
     """Class for creating enumerated string choices."""
 
+    @staticmethod
     def _generate_next_value_(name, start, count, last_values):
         return name
 

--- a/tests/model_enums/tests.py
+++ b/tests/model_enums/tests.py
@@ -9,6 +9,7 @@ from django.test import SimpleTestCase
 from django.utils.deprecation import RemovedInDjango60Warning
 from django.utils.functional import Promise
 from django.utils.translation import gettext_lazy as _
+from django.utils.version import PY311
 
 
 class Suit(models.IntegerChoices):
@@ -187,6 +188,7 @@ class ChoicesTests(SimpleTestCase):
     def test_do_not_call_in_templates_member(self):
         # do_not_call_in_templates is not implicitly treated as a member.
         Special = models.IntegerChoices("Special", "do_not_call_in_templates")
+        self.assertIn("do_not_call_in_templates", Special.__members__)
         self.assertEqual(
             Special.do_not_call_in_templates.label,
             "Do Not Call In Templates",
@@ -196,6 +198,16 @@ class ChoicesTests(SimpleTestCase):
             Special.do_not_call_in_templates.name,
             "do_not_call_in_templates",
         )
+
+    def test_do_not_call_in_templates_nonmember(self):
+        self.assertNotIn("do_not_call_in_templates", Suit.__members__)
+        if PY311:
+            self.assertIs(Suit.do_not_call_in_templates, True)
+        else:
+            # Using @property on an enum does not behave as expected.
+            self.assertTrue(Suit.do_not_call_in_templates)
+            self.assertIsNot(Suit.do_not_call_in_templates, True)
+            self.assertIsInstance(Suit.do_not_call_in_templates, property)
 
 
 class Separator(bytes, models.Choices):


### PR DESCRIPTION
This series of commits updates to more modern enum usage available in newer versions of Python.
It also makes clearer when backward compatible shims can be removed by use of the `PY311`, etc. constants.

A small "bug" in the handling of `do_not_call_in_templates` is also fixed for Python 3.11+.

Please see each commit in isolation. Commit messages provide context.