### PR TITLE
Corrected AsyncRequestFactory's docstring.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -623,8 +623,8 @@ class AsyncRequestFactory(RequestFactory):
     testing. Usage:
 
     rf = AsyncRequestFactory()
-    get_request = await rf.get('/hello/')
-    post_request = await rf.post('/submit/', {'foo': 'bar'})
+    get_request = rf.get("/hello/")
+    post_request = rf.post("/submit/", {"foo": "bar"})
 
     Once you have a request object you can pass it to any view function,
     including synchronous ones. The reason we have a separate class here is:


### PR DESCRIPTION
All `AsyncRequestFactory` methods are still [synchronous callables](https://docs.djangoproject.com/en/4.2/topics/testing/advanced/#asyncrequestfactory).