### PR TITLE
Fix an improper implementation of a special function supporting a binary operation

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -95,9 +95,7 @@ class Combinable:
     def __and__(self, other):
         if getattr(self, "conditional", False) and getattr(other, "conditional", False):
             return Q(self) & Q(other)
-        raise NotImplementedError(
-            "Use .bitand(), .bitor(), and .bitxor() for bitwise logical operations."
-        )
+        return NotImplemented
 
     def bitand(self, other):
         return self._combine(other, self.BITAND, False)
@@ -111,9 +109,7 @@ class Combinable:
     def __xor__(self, other):
         if getattr(self, "conditional", False) and getattr(other, "conditional", False):
             return Q(self) ^ Q(other)
-        raise NotImplementedError(
-            "Use .bitand(), .bitor(), and .bitxor() for bitwise logical operations."
-        )
+        return NotImplemented
 
     def bitxor(self, other):
         return self._combine(other, self.BITXOR, False)
@@ -121,9 +117,7 @@ class Combinable:
     def __or__(self, other):
         if getattr(self, "conditional", False) and getattr(other, "conditional", False):
             return Q(self) | Q(other)
-        raise NotImplementedError(
-            "Use .bitand(), .bitor(), and .bitxor() for bitwise logical operations."
-        )
+        return NotImplemented
 
     def bitor(self, other):
         return self._combine(other, self.BITOR, False)
@@ -147,19 +141,13 @@ class Combinable:
         return self._combine(other, self.POW, True)
 
     def __rand__(self, other):
-        raise NotImplementedError(
-            "Use .bitand(), .bitor(), and .bitxor() for bitwise logical operations."
-        )
+        return NotImplemented
 
     def __ror__(self, other):
-        raise NotImplementedError(
-            "Use .bitand(), .bitor(), and .bitxor() for bitwise logical operations."
-        )
+        return NotImplemented
 
     def __rxor__(self, other):
-        raise NotImplementedError(
-            "Use .bitand(), .bitor(), and .bitxor() for bitwise logical operations."
-        )
+        return NotImplemented
 
     def __invert__(self):
         return NegatedExpression(self)


### PR DESCRIPTION
In file: expressions.py, class: `Combinable`, there is six special methods (`__xor__`, `__and__`, `__or__`,`__rxor__`, `__rand__`, `__ror__`, etc.,) that raises a [`NotImplementedError`](https://docs.python.org/3/library/exceptions.html#NotImplementedError). If a special method supporting a binary operation is not implemented it should return [`NotImplemented`](https://docs.python.org/3/library/constants.html#NotImplemented). On the other hand, `NotImplementedError` should be raised from abstract methods inside user defined base classes to indicate that derived classes should override those methods. I suggested that the special methods should return `NotImplemented` instead of raising an exception. An example of how `NotImplemented` helps the interpreter support a binary operation is [here](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations). 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.