### PR TITLE
Fixed #34791 -- Fixed incorrect Prefetch()'s cache for singly related objects.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -682,6 +682,7 @@ answer newbie questions, and generally made Django that much better:
     Max Derkachev <mderk@yandex.ru>
     Max Smolens <msmolens@gmail.com>
     Maxime Lorant <maxime.lorant@gmail.com>
+    Maxime Toussaint <m.toussaint@mail.com>
     Maxime Turcotte <maxocub@riseup.net>
     Maximilian Merz <django@mxmerz.de>
     Maximillian Dornseif <md@hudora.de>


### PR DESCRIPTION
Changed the cache name used for singly related objects to be the to_attr parameter passed to a Prefetch object. This fixes issues with checking if values have already been fetched in cases where the Field already has some prefetched value, but not for the same model attr.