### PR TITLE
errors in internationalization

### DIFF
--- a/django/contrib/admin/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/django/contrib/admin/locale/zh_Hans/LC_MESSAGES/django.po
@@ -496,7 +496,7 @@ msgid ""
 "Are you sure you want to delete the selected %(objects_name)s? All of the "
 "following objects and their related items will be deleted:"
 msgstr ""
-"请确认要删除选中的 %(objects_name)s 吗？以下所有对象和余它们相关的条目将都会"
+"请确认要删除选中的 %(objects_name)s 吗？以下所有对象和与它们相关的条目将都会"
 "被删除："
 
 msgid "Delete?"


### PR DESCRIPTION
errors in internationalization  "余" should "与“