### PR TITLE
Add platform check in django.core.management.color

### DIFF
--- a/django/core/management/color.py
+++ b/django/core/management/color.py
@@ -4,8 +4,8 @@ Sets up the terminal color scheme.
 
 import functools
 import os
-import sys
 import platform
+import sys
 
 from django.utils import termcolors
 

--- a/django/core/management/color.py
+++ b/django/core/management/color.py
@@ -5,17 +5,21 @@ Sets up the terminal color scheme.
 import functools
 import os
 import sys
+import platform
 
 from django.utils import termcolors
 
-try:
-    import colorama
+if platform.system() == "Windows":
+    try:
+        import colorama
 
-    colorama.init()
-except (ImportError, OSError):
-    HAS_COLORAMA = False
+        colorama.init()
+    except (ImportError, OSError):
+        HAS_COLORAMA = False
+    else:
+        HAS_COLORAMA = True
 else:
-    HAS_COLORAMA = True
+    HAS_COLORAMA = False
 
 
 def supports_color():


### PR DESCRIPTION
colorama will not be installed if the user is not on Windows.