### PR TITLE
Fixed #34768 -- Avoided initializing colorama on non-Windows platforms.

### DIFF
--- a/django/core/management/color.py
+++ b/django/core/management/color.py
@@ -11,7 +11,8 @@ from django.utils import termcolors
 try:
     import colorama
 
-    colorama.init()
+    # Avoid initializing colorama in non-Windows platforms.
+    colorama.just_fix_windows_console()
 except (ImportError, OSError):
     HAS_COLORAMA = False
 else:
@@ -48,7 +49,7 @@ def supports_color():
 
     return is_a_tty and (
         sys.platform != "win32"
-        or HAS_COLORAMA
+        or (HAS_COLORAMA and getattr(colorama, "fixed_windows_console", False))
         or "ANSICON" in os.environ
         or
         # Windows Terminal supports VT codes.

--- a/docs/howto/windows.txt
+++ b/docs/howto/windows.txt
@@ -103,12 +103,12 @@ terminal. In modern terminals this should work for both CMD and PowerShell. If
 for some reason this needs to be disabled, set the environmental variable
 :envvar:`DJANGO_COLORS` to ``nocolor``.
 
-On older Windows versions, or legacy terminals, :pypi:`colorama` must be
+On older Windows versions, or legacy terminals, :pypi:`colorama` 0.4.6+ must be
 installed to enable syntax coloring:
 
 .. code-block:: doscon
 
-    ...\> py -m pip install colorama
+    ...\> py -m pip install "colorama >= 0.4.6"
 
 See :ref:`syntax-coloring` for more information on color settings.
 

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -281,7 +281,7 @@ dependencies:
 * :pypi:`argon2-cffi` 19.2.0+
 * :pypi:`asgiref` 3.7.0+ (required)
 * :pypi:`bcrypt`
-* :pypi:`colorama`
+* :pypi:`colorama` 0.4.6+
 * :pypi:`docutils`
 * :pypi:`geoip2`
 * :pypi:`Jinja2` 2.11+

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1931,7 +1931,7 @@ two third-party libraries are needed:
 
   .. code-block:: doscon
 
-    ...\> py -m pip install colorama
+    ...\> py -m pip install "colorama >= 0.4.6"
 
 * Install `ANSICON`_, a third-party tool that allows ``cmd.exe`` to process
   ANSI color codes. Django commands will detect its presence and will make use

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -630,6 +630,8 @@ Miscellaneous
   requests with the :mimetype:`application/x-www-form-urlencoded` content type.
   See :rfc:`1866` for more details.
 
+* The minimum supported version of ``colorama`` is increased to 0.4.6.
+
 .. _deprecated-features-5.0:
 
 Features deprecated in 5.0

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -18,4 +18,4 @@ selenium >= 4.8.0
 sqlparse >= 0.3.1
 tblib >= 1.5.0
 tzdata
-colorama; sys.platform == 'win32'
+colorama >= 0.4.6; sys.platform == 'win32'


### PR DESCRIPTION
Fixed #34768 -- Added platform check before installing colorama.