### PR TITLE
Refs #32355 -- Removed unnecessary getattr() call.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -790,7 +790,7 @@ if __name__ == "__main__":
                 options.parallel,
                 options.tags,
                 options.exclude_tags,
-                getattr(options, "test_name_patterns", None),
+                options.test_name_patterns,
                 options.start_at,
                 options.start_after,
                 options.pdb,


### PR DESCRIPTION
options.test_name_patterns is always defined.

Follow up to ec0ff406311de88f4e2a135d784363424fe602aa.