### PR TITLE
Fixed #34778 -- Avoided importing modules in startapp/startproject.

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -5,7 +5,7 @@ import posixpath
 import shutil
 import stat
 import tempfile
-from importlib import import_module
+from importlib.util import find_spec
 from urllib.request import build_opener
 
 import django
@@ -275,12 +275,8 @@ class TemplateCommand(BaseCommand):
                     type=name_or_dir,
                 )
             )
-        # Check it cannot be imported.
-        try:
-            import_module(name)
-        except ImportError:
-            pass
-        else:
+        # Check that __spec__ doesn't exist.
+        if find_spec(name) is not None:
             raise CommandError(
                 "'{name}' conflicts with the name of an existing Python "
                 "module and cannot be used as {an} {app} {type}. Please try "

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2447,6 +2447,28 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         )
         self.assertFalse(os.path.exists(testproject_dir))
 
+    def test_command_does_not_import(self):
+        """
+        startproject doesn't import modules (and cannot be fooled by a module
+        raising ImportError).
+        """
+        bad_name = "raises_import_error"
+        args = ["startproject", bad_name]
+        testproject_dir = os.path.join(self.test_dir, bad_name)
+
+        with open(os.path.join(self.test_dir, "raises_import_error.py"), "w") as f:
+            f.write("raise ImportError")
+
+        out, err = self.run_django_admin(args)
+        self.assertOutput(
+            err,
+            "CommandError: 'raises_import_error' conflicts with the name of an "
+            "existing Python module and cannot be used as a project name. Please try "
+            "another name.",
+        )
+        self.assertNoOutput(out)
+        self.assertFalse(os.path.exists(testproject_dir))
+
     def test_simple_project_different_directory(self):
         """
         The startproject management command creates a project in a specific


### PR DESCRIPTION
ticket-34778

[Forum discussion](https://forum.djangoproject.com/t/check-for-name-clashes-in-startproject-without-importing-modules/23091)

Avoid side effects from importing modules by using `find_spec()`. That method might still import parent modules if given a dotted path, but startproject checks for dotted paths just a bit earlier than this block.