### PR TITLE
Refs #34768 -- Ignored lack of just_fix_windows_console() for colorama < 0.4.6.

### DIFF
--- a/django/core/management/color.py
+++ b/django/core/management/color.py
@@ -13,7 +13,13 @@ try:
 
     # Avoid initializing colorama in non-Windows platforms.
     colorama.just_fix_windows_console()
-except (ImportError, OSError):
+except (
+    AttributeError,  # colorama <= 0.4.6.
+    ImportError,  # colorama is not installed.
+    # If just_fix_windows_console() accesses sys.stdout with
+    # WSGIRestrictedStdout.
+    OSError,
+):
     HAS_COLORAMA = False
 else:
     HAS_COLORAMA = True


### PR DESCRIPTION
Check out [comment](https://code.djangoproject.com/ticket/34768#comment:9).