### PR TITLE
Fixed #34789 -- Avoided filter_horizontal misbehaving when instance of same model is added via JS add action.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -91,8 +91,12 @@
         // After create/edit a model from the options next to the current
         // select (+ or :pencil:) update ForeignKey PK of the rest of selects
         // in the page.
-
-        const selectsRelated = document.querySelectorAll(`[data-context="available-source"]`);
+        const path = win.location.pathname;
+        // Extract the model from the popup url '.../<model>/add/' or
+        // '.../<model>/<id>/change/' depending the action (add or change).
+        const modelName = path.split('/')[path.split('/').length - (objId ? 4 : 3)];
+        // Select elements with a specific model reference and context of "available-source".
+        const selectsRelated = document.querySelectorAll(`[data-model-ref="${modelName}"] [data-context="available-source"]`);
 
         selectsRelated.forEach(function(select) {
             if (currentSelect === select) {

--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -92,11 +92,6 @@
         // select (+ or :pencil:) update ForeignKey PK of the rest of selects
         // in the page.
 
-        const path = win.location.pathname;
-        // Extract the model from the popup url '.../<model>/add/' or
-        // '.../<model>/<id>/change/' depending the action (add or change).
-        const modelName = path.split('/')[path.split('/').length - (objId ? 4 : 3)];
-        // Exclude autocomplete selects.
         const selectsRelated = document.querySelectorAll(`[data-context="available-source"]`);
 
         selectsRelated.forEach(function(select) {

--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -97,7 +97,7 @@
         // '.../<model>/<id>/change/' depending the action (add or change).
         const modelName = path.split('/')[path.split('/').length - (objId ? 4 : 3)];
         // Exclude autocomplete selects.
-        const selectsRelated = document.querySelectorAll(`[data-model-ref="${modelName}"] select:not(.admin-autocomplete)`);
+        const selectsRelated = document.querySelectorAll(`[data-context="available-source"]`);
 
         selectsRelated.forEach(function(select) {
             if (currentSelect === select) {

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -760,6 +760,7 @@ class Select(ChoiceWidget):
         context = super().get_context(name, value, attrs)
         if self.allow_multiple_selected:
             context["widget"]["attrs"]["multiple"] = True
+            context["widget"]["attrs"]["data-context"] = "available-source"
         return context
 
     @staticmethod

--- a/tests/admin_views/test_related_object_lookups.py
+++ b/tests/admin_views/test_related_object_lookups.py
@@ -79,10 +79,13 @@ class SeleniumTests(AdminSeleniumTestCase):
 
     def test_related_object_lookup_data_context(self):
         from selenium.webdriver.common.by import By
+
         album_add_url = reverse("admin:admin_views_album_add")
         self.selenium.get(self.live_server_url + album_add_url)
 
-        selects = self.selenium.find_elements(By.CSS_SELECTOR,
-                                              '[data-context="available-source"]')
-        self.assertGreater(len(selects), 0,
-                           "No select elements with data-context attribute found")
+        selects = self.selenium.find_elements(
+            By.CSS_SELECTOR, '[data-context="available-source"]'
+        )
+        self.assertGreater(
+            len(selects), 0, "No select elements with data-context attribute found"
+        )

--- a/tests/admin_views/test_related_object_lookups.py
+++ b/tests/admin_views/test_related_object_lookups.py
@@ -76,3 +76,13 @@ class SeleniumTests(AdminSeleniumTestCase):
             with self.subTest(link_id):
                 link = self.selenium.find_element(By.XPATH, f'//*[@id="{link_id}"]')
                 self.assertIsNone(link.get_attribute("aria-disabled"))
+
+    def test_related_object_lookup_data_context(self):
+        from selenium.webdriver.common.by import By
+        album_add_url = reverse("admin:admin_views_album_add")
+        self.selenium.get(self.live_server_url + album_add_url)
+
+        selects = self.selenium.find_elements(By.CSS_SELECTOR,
+                                              '[data-context="available-source"]')
+        self.assertGreater(len(selects), 0,
+                           "No select elements with data-context attribute found")

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -381,7 +381,7 @@ class FilteredSelectMultipleWidgetTest(SimpleTestCase):
         self.assertHTMLEqual(
             w.render("test", "test"),
             '<select multiple name="test" class="selectfilter" '
-            'data-field-name="test\\" data-is-stacked="0">\n</select>',
+            'data-context="available-source" data-field-name="test\\" data-is-stacked="0">\n</select>',
         )
 
     def test_stacked_render(self):
@@ -390,7 +390,7 @@ class FilteredSelectMultipleWidgetTest(SimpleTestCase):
         self.assertHTMLEqual(
             w.render("test", "test"),
             '<select multiple name="test" class="selectfilterstacked" '
-            'data-field-name="test\\" data-is-stacked="1">\n</select>',
+            'data-context="available-source" data-field-name="test\\" data-is-stacked="1">\n</select>',
         )
 
 

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -381,7 +381,8 @@ class FilteredSelectMultipleWidgetTest(SimpleTestCase):
         self.assertHTMLEqual(
             w.render("test", "test"),
             '<select multiple name="test" class="selectfilter" '
-            'data-context="available-source" data-field-name="test\\" data-is-stacked="0">\n</select>',
+            'data-context="available-source" '
+            'data-field-name="test\\" data-is-stacked="0">\n</select>',
         )
 
     def test_stacked_render(self):
@@ -390,7 +391,8 @@ class FilteredSelectMultipleWidgetTest(SimpleTestCase):
         self.assertHTMLEqual(
             w.render("test", "test"),
             '<select multiple name="test" class="selectfilterstacked" '
-            'data-context="available-source" data-field-name="test\\" data-is-stacked="1">\n</select>',
+            'data-context="available-source" data-field-name="test\\" '
+            'data-is-stacked="1">\n</select>',
         )
 
 

--- a/tests/forms_tests/field_tests/test_multivaluefield.py
+++ b/tests/forms_tests/field_tests/test_multivaluefield.py
@@ -159,7 +159,8 @@ class MultiValueFieldTest(SimpleTestCase):
             """
             <tr><th><label>Field1:</label></th>
             <td><input type="text" name="field1_0" id="id_field1_0" required>
-            <select data-context="available-source" multiple name="field1_1" id="id_field1_1" required>
+            <select data-context="available-source" multiple name="field1_1"
+                    id="id_field1_1" required>
             <option value="J">John</option>
             <option value="P">Paul</option>
             <option value="G">George</option>
@@ -185,7 +186,8 @@ class MultiValueFieldTest(SimpleTestCase):
             <tr><th><label>Field1:</label></th>
             <td><input type="text" name="field1_0" value="some text" id="id_field1_0"
                 required>
-            <select data-context="available-source" multiple name="field1_1" id="id_field1_1" required>
+            <select data-context="available-source"
+            multiple name="field1_1" id="id_field1_1" required>
             <option value="J" selected>John</option>
             <option value="P" selected>Paul</option>
             <option value="G">George</option>

--- a/tests/forms_tests/field_tests/test_multivaluefield.py
+++ b/tests/forms_tests/field_tests/test_multivaluefield.py
@@ -159,7 +159,7 @@ class MultiValueFieldTest(SimpleTestCase):
             """
             <tr><th><label>Field1:</label></th>
             <td><input type="text" name="field1_0" id="id_field1_0" required>
-            <select multiple name="field1_1" id="id_field1_1" required>
+            <select data-context="available-source" multiple name="field1_1" id="id_field1_1" required>
             <option value="J">John</option>
             <option value="P">Paul</option>
             <option value="G">George</option>
@@ -185,7 +185,7 @@ class MultiValueFieldTest(SimpleTestCase):
             <tr><th><label>Field1:</label></th>
             <td><input type="text" name="field1_0" value="some text" id="id_field1_0"
                 required>
-            <select multiple name="field1_1" id="id_field1_1" required>
+            <select data-context="available-source" multiple name="field1_1" id="id_field1_1" required>
             <option value="J" selected>John</option>
             <option value="P" selected>Paul</option>
             <option value="G">George</option>

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -1044,7 +1044,7 @@ class FormsTestCase(SimpleTestCase):
         f = SongForm(auto_id=False)
         self.assertHTMLEqual(
             str(f["composers"]),
-            """<select multiple name="composers" required>
+            """<select data-context="available-source" multiple name="composers" required>
 </select>""",
         )
 
@@ -1057,7 +1057,7 @@ class FormsTestCase(SimpleTestCase):
         f = SongForm(auto_id=False)
         self.assertHTMLEqual(
             str(f["composers"]),
-            """<select multiple name="composers" required>
+            """<select data-context="available-source" multiple name="composers" required>
 <option value="J">John Lennon</option>
 <option value="P">Paul McCartney</option>
 </select>""",
@@ -1068,7 +1068,7 @@ class FormsTestCase(SimpleTestCase):
         )
         self.assertHTMLEqual(
             str(f["composers"]),
-            """<select multiple name="composers" required>
+            """<select data-context="available-source" multiple name="composers" required>
 <option value="J">John Lennon</option>
 <option value="P" selected>Paul McCartney</option>
 </select>""",
@@ -1079,7 +1079,7 @@ class FormsTestCase(SimpleTestCase):
             '<tr><th><label for="id_name">Name:</label></th>'
             '<td><input type="text" name="name" required id="id_name"></td>'
             '</tr><tr><th><label for="id_composers">Composers:</label></th>'
-            '<td><select name="composers" required id="id_composers" multiple>'
+            '<td><select data-context="available-source" name="composers" required id="id_composers" multiple>'
             '<option value="J">John Lennon</option>'
             '<option value="P">Paul McCartney</option>'
             "</select></td></tr>",
@@ -1089,7 +1089,7 @@ class FormsTestCase(SimpleTestCase):
             '<li><label for="id_name">Name:</label>'
             '<input type="text" name="name" required id="id_name"></li>'
             '<li><label for="id_composers">Composers:</label>'
-            '<select name="composers" required id="id_composers" multiple>'
+            '<select data-context="available-source" name="composers" required id="id_composers" multiple>'
             '<option value="J">John Lennon</option>'
             '<option value="P">Paul McCartney</option>'
             "</select></li>",
@@ -1099,7 +1099,7 @@ class FormsTestCase(SimpleTestCase):
             '<p><label for="id_name">Name:</label>'
             '<input type="text" name="name" required id="id_name"></p>'
             '<p><label for="id_composers">Composers:</label>'
-            '<select name="composers" required id="id_composers" multiple>'
+            '<select data-context="available-source" name="composers" required id="id_composers" multiple>'
             '<option value="J">John Lennon</option>'
             '<option value="P">Paul McCartney</option>'
             "</select></p>",
@@ -1108,7 +1108,7 @@ class FormsTestCase(SimpleTestCase):
             f.render(f.template_name_div),
             '<div><label for="id_name">Name:</label><input type="text" name="name" '
             'required id="id_name"></div><div><label for="id_composers">Composers:'
-            '</label><select name="composers" required id="id_composers" multiple>'
+            '</label><select data-context="available-source" name="composers" required id="id_composers" multiple>'
             '<option value="J">John Lennon</option><option value="P">Paul McCartney'
             "</option></select></div>",
         )
@@ -2578,7 +2578,7 @@ Password: <input type="password" name="password" aria-invalid="true" required></
             <li>Username: <input type="text" name="username" value="django"
                 maxlength="10" required></li>
             <li>Password: <input type="password" name="password" required></li>
-            <li>Options: <select multiple name="options" required>
+            <li>Options: <select data-context="available-source" multiple name="options" required>
             <option value="f" selected>foo</option>
             <option value="b" selected>bar</option>
             <option value="w">whiz</option>
@@ -2599,7 +2599,7 @@ Username: <input type="text" name="username" maxlength="10" aria-invalid="true"
 required></li><li><ul class="errorlist"><li>This field is required.</li></ul>
 Password: <input type="password" name="password" aria-invalid="true"
 required></li><li><ul class="errorlist"><li>This field is required.</li></ul>
-Options: <select multiple name="options" aria-invalid="true" required>
+Options: <select data-context="available-source" multiple name="options" aria-invalid="true" required>
 <option value="f">foo</option>
 <option value="b">bar</option>
 <option value="w">whiz</option>
@@ -2615,7 +2615,7 @@ Username: <input type="text" name="username" maxlength="10" aria-invalid="true"
 required></li><li><ul class="errorlist"><li>This field is required.</li></ul>
 Password: <input type="password" name="password" aria-invalid="true" required></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Options: <select multiple name="options" aria-invalid="true" required>
+Options: <select data-context="available-source" multiple name="options" aria-invalid="true" required>
 <option value="f">foo</option>
 <option value="b">bar</option>
 <option value="w">whiz</option>
@@ -2633,7 +2633,7 @@ Options: <select multiple name="options" aria-invalid="true" required>
                 required></li>
             <li><ul class="errorlist"><li>This field is required.</li></ul>
             Password: <input type="password" name="password" aria-invalid="true"
-            required></li><li>Options: <select multiple name="options" required>
+            required></li><li>Options: <select data-context="available-source" multiple name="options" required>
             <option value="f" selected>foo</option>
             <option value="b" selected>bar</option>
             <option value="w">whiz</option>
@@ -2669,7 +2669,7 @@ Options: <select multiple name="options" aria-invalid="true" required>
             <li>Username: <input type="text" name="username" value="django"
                 maxlength="10" required></li>
             <li>Password: <input type="password" name="password" required></li>
-            <li>Options: <select multiple name="options" required>
+            <li>Options: <select data-context="available-source" multiple name="options" required>
             <option value="f">foo</option>
             <option value="b" selected>bar</option>
             <option value="w" selected>whiz</option>
@@ -2686,7 +2686,7 @@ Options: <select multiple name="options" aria-invalid="true" required>
             <li>Username: <input type="text" name="username" value="stephane"
                 maxlength="10" required></li>
             <li>Password: <input type="password" name="password" required></li>
-            <li>Options: <select multiple name="options" required>
+            <li>Options: <select data-context="available-source" multiple name="options" required>
             <option value="f" selected>foo</option>
             <option value="b" selected>bar</option>
             <option value="w">whiz</option>

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -1044,7 +1044,8 @@ class FormsTestCase(SimpleTestCase):
         f = SongForm(auto_id=False)
         self.assertHTMLEqual(
             str(f["composers"]),
-            """<select data-context="available-source" multiple name="composers" required>
+            """<select data-context="available-source"
+            multiple name="composers" required>
 </select>""",
         )
 
@@ -1057,7 +1058,8 @@ class FormsTestCase(SimpleTestCase):
         f = SongForm(auto_id=False)
         self.assertHTMLEqual(
             str(f["composers"]),
-            """<select data-context="available-source" multiple name="composers" required>
+            """<select data-context="available-source"
+            multiple name="composers" required>
 <option value="J">John Lennon</option>
 <option value="P">Paul McCartney</option>
 </select>""",
@@ -1068,7 +1070,8 @@ class FormsTestCase(SimpleTestCase):
         )
         self.assertHTMLEqual(
             str(f["composers"]),
-            """<select data-context="available-source" multiple name="composers" required>
+            """<select data-context="available-source"
+            multiple name="composers" required>
 <option value="J">John Lennon</option>
 <option value="P" selected>Paul McCartney</option>
 </select>""",
@@ -1079,7 +1082,8 @@ class FormsTestCase(SimpleTestCase):
             '<tr><th><label for="id_name">Name:</label></th>'
             '<td><input type="text" name="name" required id="id_name"></td>'
             '</tr><tr><th><label for="id_composers">Composers:</label></th>'
-            '<td><select data-context="available-source" name="composers" required id="id_composers" multiple>'
+            '<td><select data-context="available-source" '
+            'name="composers" required id="id_composers" multiple>'
             '<option value="J">John Lennon</option>'
             '<option value="P">Paul McCartney</option>'
             "</select></td></tr>",
@@ -1089,7 +1093,8 @@ class FormsTestCase(SimpleTestCase):
             '<li><label for="id_name">Name:</label>'
             '<input type="text" name="name" required id="id_name"></li>'
             '<li><label for="id_composers">Composers:</label>'
-            '<select data-context="available-source" name="composers" required id="id_composers" multiple>'
+            '<select data-context="available-source" '
+            'name="composers" required id="id_composers" multiple>'
             '<option value="J">John Lennon</option>'
             '<option value="P">Paul McCartney</option>'
             "</select></li>",
@@ -1099,7 +1104,8 @@ class FormsTestCase(SimpleTestCase):
             '<p><label for="id_name">Name:</label>'
             '<input type="text" name="name" required id="id_name"></p>'
             '<p><label for="id_composers">Composers:</label>'
-            '<select data-context="available-source" name="composers" required id="id_composers" multiple>'
+            '<select data-context="available-source" '
+            'name="composers" required id="id_composers" multiple>'
             '<option value="J">John Lennon</option>'
             '<option value="P">Paul McCartney</option>'
             "</select></p>",
@@ -1108,7 +1114,8 @@ class FormsTestCase(SimpleTestCase):
             f.render(f.template_name_div),
             '<div><label for="id_name">Name:</label><input type="text" name="name" '
             'required id="id_name"></div><div><label for="id_composers">Composers:'
-            '</label><select data-context="available-source" name="composers" required id="id_composers" multiple>'
+            '</label><select data-context="available-source" '
+            'name="composers" required id="id_composers" multiple>'
             '<option value="J">John Lennon</option><option value="P">Paul McCartney'
             "</option></select></div>",
         )
@@ -2578,7 +2585,8 @@ Password: <input type="password" name="password" aria-invalid="true" required></
             <li>Username: <input type="text" name="username" value="django"
                 maxlength="10" required></li>
             <li>Password: <input type="password" name="password" required></li>
-            <li>Options: <select data-context="available-source" multiple name="options" required>
+            <li>Options: <select data-context="available-source"
+            multiple name="options" required>
             <option value="f" selected>foo</option>
             <option value="b" selected>bar</option>
             <option value="w">whiz</option>
@@ -2599,7 +2607,8 @@ Username: <input type="text" name="username" maxlength="10" aria-invalid="true"
 required></li><li><ul class="errorlist"><li>This field is required.</li></ul>
 Password: <input type="password" name="password" aria-invalid="true"
 required></li><li><ul class="errorlist"><li>This field is required.</li></ul>
-Options: <select data-context="available-source" multiple name="options" aria-invalid="true" required>
+Options: <select data-context="available-source"
+multiple name="options" aria-invalid="true" required>
 <option value="f">foo</option>
 <option value="b">bar</option>
 <option value="w">whiz</option>
@@ -2615,7 +2624,8 @@ Username: <input type="text" name="username" maxlength="10" aria-invalid="true"
 required></li><li><ul class="errorlist"><li>This field is required.</li></ul>
 Password: <input type="password" name="password" aria-invalid="true" required></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Options: <select data-context="available-source" multiple name="options" aria-invalid="true" required>
+Options: <select data-context="available-source"
+multiple name="options" aria-invalid="true" required>
 <option value="f">foo</option>
 <option value="b">bar</option>
 <option value="w">whiz</option>
@@ -2633,7 +2643,8 @@ Options: <select data-context="available-source" multiple name="options" aria-in
                 required></li>
             <li><ul class="errorlist"><li>This field is required.</li></ul>
             Password: <input type="password" name="password" aria-invalid="true"
-            required></li><li>Options: <select data-context="available-source" multiple name="options" required>
+            required></li><li>Options: <select data-context="available-source"
+            multiple name="options" required>
             <option value="f" selected>foo</option>
             <option value="b" selected>bar</option>
             <option value="w">whiz</option>
@@ -2669,7 +2680,8 @@ Options: <select data-context="available-source" multiple name="options" aria-in
             <li>Username: <input type="text" name="username" value="django"
                 maxlength="10" required></li>
             <li>Password: <input type="password" name="password" required></li>
-            <li>Options: <select data-context="available-source" multiple name="options" required>
+            <li>Options: <select data-context="available-source"
+            multiple name="options" required>
             <option value="f">foo</option>
             <option value="b" selected>bar</option>
             <option value="w" selected>whiz</option>
@@ -2686,7 +2698,8 @@ Options: <select data-context="available-source" multiple name="options" aria-in
             <li>Username: <input type="text" name="username" value="stephane"
                 maxlength="10" required></li>
             <li>Password: <input type="password" name="password" required></li>
-            <li>Options: <select data-context="available-source" multiple name="options" required>
+            <li>Options: <select data-context="available-source"
+            multiple name="options" required>
             <option value="f" selected>foo</option>
             <option value="b" selected>bar</option>
             <option value="w">whiz</option>

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -124,7 +124,8 @@ class ModelFormCallableModelDefault(TestCase):
                 id="initial-id_choice_int">
             </p>
             <p><label for="id_multi_choice">Multi choice:</label>
-            <select data-context="available-source" multiple name="multi_choice" id="id_multi_choice" required>
+            <select data-context="available-source"
+            multiple name="multi_choice" id="id_multi_choice" required>
             <option value="1" selected>ChoiceOption 1</option>
             <option value="2">ChoiceOption 2</option>
             <option value="3">ChoiceOption 3</option>
@@ -133,7 +134,8 @@ class ModelFormCallableModelDefault(TestCase):
                 id="initial-id_multi_choice_0">
             </p>
             <p><label for="id_multi_choice_int">Multi choice int:</label>
-            <select data-context="available-source" multiple name="multi_choice_int" id="id_multi_choice_int" required>
+            <select data-context="available-source"
+            multiple name="multi_choice_int" id="id_multi_choice_int" required>
             <option value="1" selected>ChoiceOption 1</option>
             <option value="2">ChoiceOption 2</option>
             <option value="3">ChoiceOption 3</option>
@@ -179,7 +181,8 @@ class ModelFormCallableModelDefault(TestCase):
                 id="initial-id_choice_int">
             </p>
             <p><label for="id_multi_choice">Multi choice:</label>
-            <select data-context="available-source" multiple name="multi_choice" id="id_multi_choice" required>
+            <select data-context="available-source"
+            multiple name="multi_choice" id="id_multi_choice" required>
             <option value="1">ChoiceOption 1</option>
             <option value="2" selected>ChoiceOption 2</option>
             <option value="3" selected>ChoiceOption 3</option>
@@ -190,7 +193,8 @@ class ModelFormCallableModelDefault(TestCase):
                 id="initial-id_multi_choice_1">
             </p>
             <p><label for="id_multi_choice_int">Multi choice int:</label>
-            <select data-context="available-source" multiple name="multi_choice_int" id="id_multi_choice_int" required>
+            <select data-context="available-source"
+            multiple name="multi_choice_int" id="id_multi_choice_int" required>
             <option value="1">ChoiceOption 1</option>
             <option value="2" selected>ChoiceOption 2</option>
             <option value="3" selected>ChoiceOption 3</option>

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -124,7 +124,7 @@ class ModelFormCallableModelDefault(TestCase):
                 id="initial-id_choice_int">
             </p>
             <p><label for="id_multi_choice">Multi choice:</label>
-            <select multiple name="multi_choice" id="id_multi_choice" required>
+            <select data-context="available-source" multiple name="multi_choice" id="id_multi_choice" required>
             <option value="1" selected>ChoiceOption 1</option>
             <option value="2">ChoiceOption 2</option>
             <option value="3">ChoiceOption 3</option>
@@ -133,7 +133,7 @@ class ModelFormCallableModelDefault(TestCase):
                 id="initial-id_multi_choice_0">
             </p>
             <p><label for="id_multi_choice_int">Multi choice int:</label>
-            <select multiple name="multi_choice_int" id="id_multi_choice_int" required>
+            <select data-context="available-source" multiple name="multi_choice_int" id="id_multi_choice_int" required>
             <option value="1" selected>ChoiceOption 1</option>
             <option value="2">ChoiceOption 2</option>
             <option value="3">ChoiceOption 3</option>
@@ -179,7 +179,7 @@ class ModelFormCallableModelDefault(TestCase):
                 id="initial-id_choice_int">
             </p>
             <p><label for="id_multi_choice">Multi choice:</label>
-            <select multiple name="multi_choice" id="id_multi_choice" required>
+            <select data-context="available-source" multiple name="multi_choice" id="id_multi_choice" required>
             <option value="1">ChoiceOption 1</option>
             <option value="2" selected>ChoiceOption 2</option>
             <option value="3" selected>ChoiceOption 3</option>
@@ -190,7 +190,7 @@ class ModelFormCallableModelDefault(TestCase):
                 id="initial-id_multi_choice_1">
             </p>
             <p><label for="id_multi_choice_int">Multi choice int:</label>
-            <select multiple name="multi_choice_int" id="id_multi_choice_int" required>
+            <select data-context="available-source" multiple name="multi_choice_int" id="id_multi_choice_int" required>
             <option value="1">ChoiceOption 1</option>
             <option value="2" selected>ChoiceOption 2</option>
             <option value="3" selected>ChoiceOption 3</option>

--- a/tests/forms_tests/widget_tests/test_multiwidget.py
+++ b/tests/forms_tests/widget_tests/test_multiwidget.py
@@ -276,7 +276,8 @@ class MultiWidgetTest(WidgetTest):
             html=(
                 """
             <input type="text" name="name_0" value="some text">
-            <select data-context="available-source" multiple name="name_1">
+            <select data-context="available-source"
+            multiple name="name_1">
                 <option value="J" selected>John</option>
                 <option value="P" selected>Paul</option>
                 <option value="G">George</option>
@@ -319,7 +320,8 @@ class MultiWidgetTest(WidgetTest):
         self.assertHTMLEqual(
             "<div><fieldset><legend>Field:</legend>"
             '<input type="text" name="field_0" required id="id_field_0">'
-            '<select data-context="available-source" name="field_1" required id="id_field_1" multiple>'
+            '<select data-context="available-source" '
+            'name="field_1" required id="id_field_1" multiple>'
             '<option value="J">John</option><option value="P">Paul</option>'
             '<option value="G">George</option><option value="R">Ringo</option></select>'
             '<input type="text" name="field_2_0" required id="id_field_2_0">'

--- a/tests/forms_tests/widget_tests/test_multiwidget.py
+++ b/tests/forms_tests/widget_tests/test_multiwidget.py
@@ -276,7 +276,7 @@ class MultiWidgetTest(WidgetTest):
             html=(
                 """
             <input type="text" name="name_0" value="some text">
-            <select multiple name="name_1">
+            <select data-context="available-source" multiple name="name_1">
                 <option value="J" selected>John</option>
                 <option value="P" selected>Paul</option>
                 <option value="G">George</option>
@@ -319,7 +319,7 @@ class MultiWidgetTest(WidgetTest):
         self.assertHTMLEqual(
             "<div><fieldset><legend>Field:</legend>"
             '<input type="text" name="field_0" required id="id_field_0">'
-            '<select name="field_1" required id="id_field_1" multiple>'
+            '<select data-context="available-source" name="field_1" required id="id_field_1" multiple>'
             '<option value="J">John</option><option value="P">Paul</option>'
             '<option value="G">George</option><option value="R">Ringo</option></select>'
             '<input type="text" name="field_2_0" required id="id_field_2_0">'

--- a/tests/forms_tests/widget_tests/test_selectmultiple.py
+++ b/tests/forms_tests/widget_tests/test_selectmultiple.py
@@ -19,7 +19,8 @@ class SelectMultipleTest(WidgetTest):
             "beatles",
             ["J"],
             html=(
-                """<select data-context="available-source" multiple name="beatles">
+                """<select data-context="available-source"
+                multiple name="beatles">
             <option value="J" selected>John</option>
             <option value="P">Paul</option>
             <option value="G">George</option>
@@ -34,7 +35,8 @@ class SelectMultipleTest(WidgetTest):
             "beatles",
             ["J", "P"],
             html=(
-                """<select data-context="available-source" multiple name="beatles">
+                """<select data-context="available-source"
+                multiple name="beatles">
             <option value="J" selected>John</option>
             <option value="P" selected>Paul</option>
             <option value="G">George</option>
@@ -53,7 +55,8 @@ class SelectMultipleTest(WidgetTest):
             "beatles",
             None,
             html=(
-                """<select data-context="available-source" multiple name="beatles">
+                """<select data-context="available-source"
+                multiple name="beatles">
             <option value="">Unknown</option>
             <option value="J">John</option>
             <option value="P">Paul</option>
@@ -73,7 +76,8 @@ class SelectMultipleTest(WidgetTest):
             "beatles",
             ["John"],
             html=(
-                """<select data-context="available-source" multiple name="beatles">
+                """<select data-context="available-source"
+                multiple name="beatles">
             <option value="J">John</option>
             <option value="P">Paul</option>
             <option value="G">George</option>
@@ -91,7 +95,8 @@ class SelectMultipleTest(WidgetTest):
             "choices",
             ["0"],
             html=(
-                """<select data-context="available-source" multiple name="choices">
+                """<select data-context="available-source"
+                multiple name="choices">
             <option value="0" selected>0</option>
             <option value="1">1</option>
             <option value="2">2</option>
@@ -111,7 +116,8 @@ class SelectMultipleTest(WidgetTest):
             "beatles",
             ["J", "G", "foo"],
             html=(
-                """<select data-context="available-source" multiple name="beatles">
+                """<select data-context="available-source"
+                multiple name="beatles">
             <option value="J" selected>John</option>
             <option value="P">Paul</option>
             <option value="G" selected>George</option>
@@ -128,7 +134,8 @@ class SelectMultipleTest(WidgetTest):
             "nums",
             [2],
             html=(
-                """<select data-context="available-source" multiple name="nums">
+                """<select data-context="available-source"
+                multiple name="nums">
             <option value="1">1</option>
             <option value="2" selected>2</option>
             <option value="3">3</option>
@@ -141,7 +148,8 @@ class SelectMultipleTest(WidgetTest):
             "nums",
             ["2"],
             html=(
-                """<select data-context="available-source" multiple name="nums">
+                """<select data-context="available-source"
+                multiple name="nums">
             <option value="1">1</option>
             <option value="2" selected>2</option>
             <option value="3">3</option>
@@ -154,7 +162,8 @@ class SelectMultipleTest(WidgetTest):
             "nums",
             [2],
             html=(
-                """<select data-context="available-source" multiple name="nums">
+                """<select data-context="available-source"
+                multiple name="nums">
             <option value="1">1</option>
             <option value="2" selected>2</option>
             <option value="3">3</option>
@@ -174,7 +183,8 @@ class SelectMultipleTest(WidgetTest):
             "nestchoice",
             ["outer1", "inner2"],
             html=(
-                """<select data-context="available-source" multiple name="nestchoice">
+                """<select data-context="available-source"
+                multiple name="nestchoice">
             <option value="outer1" selected>Outer 1</option>
             <optgroup label="Group &quot;1&quot;">
             <option value="inner1">Inner 1</option>
@@ -202,7 +212,8 @@ class SelectMultipleTest(WidgetTest):
         self.assertIs(self.widget.use_fieldset, False)
         self.assertHTMLEqual(
             '<div><label for="id_field">Field:</label>'
-            '<select data-context="available-source" multiple name="field" id="id_field">'
+            '<select data-context="available-source" '
+            'multiple name="field" id="id_field">'
             '<option value="J">John</option>  <option value="P">Paul</option>'
             '<option value="G">George</option><option value="R">Ringo'
             "</option></select></div>",

--- a/tests/forms_tests/widget_tests/test_selectmultiple.py
+++ b/tests/forms_tests/widget_tests/test_selectmultiple.py
@@ -19,7 +19,7 @@ class SelectMultipleTest(WidgetTest):
             "beatles",
             ["J"],
             html=(
-                """<select multiple name="beatles">
+                """<select data-context="available-source" multiple name="beatles">
             <option value="J" selected>John</option>
             <option value="P">Paul</option>
             <option value="G">George</option>
@@ -34,7 +34,7 @@ class SelectMultipleTest(WidgetTest):
             "beatles",
             ["J", "P"],
             html=(
-                """<select multiple name="beatles">
+                """<select data-context="available-source" multiple name="beatles">
             <option value="J" selected>John</option>
             <option value="P" selected>Paul</option>
             <option value="G">George</option>
@@ -53,7 +53,7 @@ class SelectMultipleTest(WidgetTest):
             "beatles",
             None,
             html=(
-                """<select multiple name="beatles">
+                """<select data-context="available-source" multiple name="beatles">
             <option value="">Unknown</option>
             <option value="J">John</option>
             <option value="P">Paul</option>
@@ -73,7 +73,7 @@ class SelectMultipleTest(WidgetTest):
             "beatles",
             ["John"],
             html=(
-                """<select multiple name="beatles">
+                """<select data-context="available-source" multiple name="beatles">
             <option value="J">John</option>
             <option value="P">Paul</option>
             <option value="G">George</option>
@@ -91,7 +91,7 @@ class SelectMultipleTest(WidgetTest):
             "choices",
             ["0"],
             html=(
-                """<select multiple name="choices">
+                """<select data-context="available-source" multiple name="choices">
             <option value="0" selected>0</option>
             <option value="1">1</option>
             <option value="2">2</option>
@@ -111,7 +111,7 @@ class SelectMultipleTest(WidgetTest):
             "beatles",
             ["J", "G", "foo"],
             html=(
-                """<select multiple name="beatles">
+                """<select data-context="available-source" multiple name="beatles">
             <option value="J" selected>John</option>
             <option value="P">Paul</option>
             <option value="G" selected>George</option>
@@ -128,7 +128,7 @@ class SelectMultipleTest(WidgetTest):
             "nums",
             [2],
             html=(
-                """<select multiple name="nums">
+                """<select data-context="available-source" multiple name="nums">
             <option value="1">1</option>
             <option value="2" selected>2</option>
             <option value="3">3</option>
@@ -141,7 +141,7 @@ class SelectMultipleTest(WidgetTest):
             "nums",
             ["2"],
             html=(
-                """<select multiple name="nums">
+                """<select data-context="available-source" multiple name="nums">
             <option value="1">1</option>
             <option value="2" selected>2</option>
             <option value="3">3</option>
@@ -154,7 +154,7 @@ class SelectMultipleTest(WidgetTest):
             "nums",
             [2],
             html=(
-                """<select multiple name="nums">
+                """<select data-context="available-source" multiple name="nums">
             <option value="1">1</option>
             <option value="2" selected>2</option>
             <option value="3">3</option>
@@ -174,7 +174,7 @@ class SelectMultipleTest(WidgetTest):
             "nestchoice",
             ["outer1", "inner2"],
             html=(
-                """<select multiple name="nestchoice">
+                """<select data-context="available-source" multiple name="nestchoice">
             <option value="outer1" selected>Outer 1</option>
             <optgroup label="Group &quot;1&quot;">
             <option value="inner1">Inner 1</option>
@@ -202,7 +202,7 @@ class SelectMultipleTest(WidgetTest):
         self.assertIs(self.widget.use_fieldset, False)
         self.assertHTMLEqual(
             '<div><label for="id_field">Field:</label>'
-            '<select multiple name="field" id="id_field">'
+            '<select data-context="available-source" multiple name="field" id="id_field">'
             '<option value="J">John</option>  <option value="P">Paul</option>'
             '<option value="G">George</option><option value="R">Ringo'
             "</option></select></div>",

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1536,7 +1536,7 @@ class ModelFormBasicTests(TestCase):
             </select></li>
             <li>Article:
             <textarea rows="10" cols="40" name="article" required></textarea></li>
-            <li>Categories: <select multiple name="categories">
+            <li>Categories: <select data-context="available-source" multiple name="categories">
             <option value="%s" selected>Entertainment</option>
             <option value="%s" selected>It&#x27;s a test</option>
             <option value="%s">Third test</option>
@@ -1590,7 +1590,7 @@ class ModelFormBasicTests(TestCase):
             </select></li>
             <li>Article:
             <textarea rows="10" cols="40" name="article" required>Hello.</textarea></li>
-            <li>Categories: <select multiple name="categories">
+            <li>Categories: <select data-context="available-source" multiple name="categories">
             <option value="%s">Entertainment</option>
             <option value="%s">It&#x27;s a test</option>
             <option value="%s">Third test</option>
@@ -1647,7 +1647,7 @@ class ModelFormBasicTests(TestCase):
             """<li><label for="id_headline">Headline:</label>
 <input id="id_headline" type="text" name="headline" maxlength="50" required></li>
 <li><label for="id_categories">Categories:</label>
-<select multiple name="categories" id="id_categories">
+<select multiple name="categories" data-context="available-source" id="id_categories">
 <option value="%d" selected>Entertainment</option>
 <option value="%d" selected>It&#x27;s a test</option>
 <option value="%d">Third test</option>
@@ -1738,7 +1738,7 @@ class ModelFormBasicTests(TestCase):
                 <textarea name="article" cols="40" rows="10" required></textarea>
             </div>
             <div>Categories:
-                <select name="categories" multiple>
+                <select data-context="available-source" name="categories" multiple>
                     <option value="%s">Entertainment</option>
                     <option value="%s">It&#x27;s a test</option>
                     <option value="%s">Third test</option>
@@ -1785,7 +1785,7 @@ class ModelFormBasicTests(TestCase):
             </select></li>
             <li>Article:
             <textarea rows="10" cols="40" name="article" required>Hello.</textarea></li>
-            <li>Categories: <select multiple name="categories">
+            <li>Categories: <select data-context="available-source" multiple name="categories">
             <option value="%s" selected>Entertainment</option>
             <option value="%s">It&#x27;s a test</option>
             <option value="%s">Third test</option>
@@ -1959,7 +1959,7 @@ class ModelFormBasicTests(TestCase):
             "</select></li>"
             '<li>Article: <textarea rows="10" cols="40" name="article" required>'
             "</textarea></li>"
-            '<li>Categories: <select multiple name="categories">'
+            '<li>Categories: <select data-context="available-source" multiple name="categories">'
             '<option value="%s">Entertainment</option>'
             '<option value="%s">It&#x27;s a test</option>'
             '<option value="%s">Third test</option>'
@@ -1989,7 +1989,7 @@ class ModelFormBasicTests(TestCase):
             "</select></li>"
             '<li>Article: <textarea rows="10" cols="40" name="article" required>'
             "</textarea></li>"
-            '<li>Categories: <select multiple name="categories">'
+            '<li>Categories: <select data-context="available-source" multiple name="categories">'
             '<option value="%s">Entertainment</option>'
             '<option value="%s">It&#x27;s a test</option>'
             '<option value="%s">Third test</option>'
@@ -3076,7 +3076,7 @@ class OtherModelFormTests(TestCase):
             <label for="id_name">Name:</label>
             <input id="id_name" type="text" name="name" maxlength="50" required></p>
             <p><label for="id_colours">Colours:</label>
-            <select multiple name="colours" id="id_colours" required>
+            <select multiple data-context="available-source" name="colours" id="id_colours" required>
             <option value="%(blue_pk)s">Blue</option>
             </select></p>
             """

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1966,7 +1966,6 @@ id="id_categories">
             "</textarea></li>"
             '<li>Categories: <select data-context="available-source" '
             'multiple name="categories">'
-            'multiple name="categories">'
             '<option value="%s">Entertainment</option>'
             '<option value="%s">It&#x27;s a test</option>'
             '<option value="%s">Third test</option>'

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1536,7 +1536,8 @@ class ModelFormBasicTests(TestCase):
             </select></li>
             <li>Article:
             <textarea rows="10" cols="40" name="article" required></textarea></li>
-            <li>Categories: <select data-context="available-source" multiple name="categories">
+            <li>Categories: <select data-context="available-source"
+            multiple name="categories">
             <option value="%s" selected>Entertainment</option>
             <option value="%s" selected>It&#x27;s a test</option>
             <option value="%s">Third test</option>
@@ -1590,7 +1591,8 @@ class ModelFormBasicTests(TestCase):
             </select></li>
             <li>Article:
             <textarea rows="10" cols="40" name="article" required>Hello.</textarea></li>
-            <li>Categories: <select data-context="available-source" multiple name="categories">
+            <li>Categories: <select data-context="available-source"
+            multiple name="categories">
             <option value="%s">Entertainment</option>
             <option value="%s">It&#x27;s a test</option>
             <option value="%s">Third test</option>
@@ -1647,7 +1649,8 @@ class ModelFormBasicTests(TestCase):
             """<li><label for="id_headline">Headline:</label>
 <input id="id_headline" type="text" name="headline" maxlength="50" required></li>
 <li><label for="id_categories">Categories:</label>
-<select multiple name="categories" data-context="available-source" id="id_categories">
+<select multiple name="categories" data-context="available-source"
+id="id_categories">
 <option value="%d" selected>Entertainment</option>
 <option value="%d" selected>It&#x27;s a test</option>
 <option value="%d">Third test</option>
@@ -1738,7 +1741,8 @@ class ModelFormBasicTests(TestCase):
                 <textarea name="article" cols="40" rows="10" required></textarea>
             </div>
             <div>Categories:
-                <select data-context="available-source" name="categories" multiple>
+                <select data-context="available-source"
+                name="categories" multiple>
                     <option value="%s">Entertainment</option>
                     <option value="%s">It&#x27;s a test</option>
                     <option value="%s">Third test</option>
@@ -1785,7 +1789,8 @@ class ModelFormBasicTests(TestCase):
             </select></li>
             <li>Article:
             <textarea rows="10" cols="40" name="article" required>Hello.</textarea></li>
-            <li>Categories: <select data-context="available-source" multiple name="categories">
+            <li>Categories: <select data-context="available-source"
+            multiple name="categories">
             <option value="%s" selected>Entertainment</option>
             <option value="%s">It&#x27;s a test</option>
             <option value="%s">Third test</option>
@@ -1959,7 +1964,9 @@ class ModelFormBasicTests(TestCase):
             "</select></li>"
             '<li>Article: <textarea rows="10" cols="40" name="article" required>'
             "</textarea></li>"
-            '<li>Categories: <select data-context="available-source" multiple name="categories">'
+            '<li>Categories: <select data-context="available-source" '
+            'multiple name="categories">'
+            'multiple name="categories">'
             '<option value="%s">Entertainment</option>'
             '<option value="%s">It&#x27;s a test</option>'
             '<option value="%s">Third test</option>'
@@ -1969,9 +1976,8 @@ class ModelFormBasicTests(TestCase):
             '<option value="1">Draft</option>'
             '<option value="2">Pending</option>'
             '<option value="3">Live</option>'
-            "</select></li>"
-            % (self.w_woodward.pk, self.w_royko.pk, self.c1.pk, self.c2.pk, self.c3.pk),
-        )
+            "</select></li>" %
+            (self.w_woodward.pk, self.w_royko.pk, self.c1.pk, self.c2.pk, self.c3.pk), )
 
         c4 = Category.objects.create(name="Fourth", url="4th")
         w_bernstein = Writer.objects.create(name="Carl Bernstein")
@@ -1989,7 +1995,8 @@ class ModelFormBasicTests(TestCase):
             "</select></li>"
             '<li>Article: <textarea rows="10" cols="40" name="article" required>'
             "</textarea></li>"
-            '<li>Categories: <select data-context="available-source" multiple name="categories">'
+            '<li>Categories: <select data-context="available-source" '
+            'multiple name="categories">'
             '<option value="%s">Entertainment</option>'
             '<option value="%s">It&#x27;s a test</option>'
             '<option value="%s">Third test</option>'
@@ -2000,16 +2007,15 @@ class ModelFormBasicTests(TestCase):
             '<option value="1">Draft</option>'
             '<option value="2">Pending</option>'
             '<option value="3">Live</option>'
-            "</select></li>"
-            % (
-                self.w_woodward.pk,
+            "</select></li>" %
+            (self.w_woodward.pk,
                 w_bernstein.pk,
                 self.w_royko.pk,
                 self.c1.pk,
                 self.c2.pk,
                 self.c3.pk,
                 c4.pk,
-            ),
+             ),
         )
 
     def test_recleaning_model_form_instance(self):
@@ -3076,7 +3082,8 @@ class OtherModelFormTests(TestCase):
             <label for="id_name">Name:</label>
             <input id="id_name" type="text" name="name" maxlength="50" required></p>
             <p><label for="id_colours">Colours:</label>
-            <select multiple data-context="available-source" name="colours" id="id_colours" required>
+            <select multiple data-context="available-source"
+            name="colours" id="id_colours" required>
             <option value="%(blue_pk)s">Blue</option>
             </select></p>
             """

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1976,8 +1976,9 @@ id="id_categories">
             '<option value="1">Draft</option>'
             '<option value="2">Pending</option>'
             '<option value="3">Live</option>'
-            "</select></li>" %
-            (self.w_woodward.pk, self.w_royko.pk, self.c1.pk, self.c2.pk, self.c3.pk), )
+            "</select></li>"
+            % (self.w_woodward.pk, self.w_royko.pk, self.c1.pk, self.c2.pk, self.c3.pk),
+        )
 
         c4 = Category.objects.create(name="Fourth", url="4th")
         w_bernstein = Writer.objects.create(name="Carl Bernstein")
@@ -2007,15 +2008,16 @@ id="id_categories">
             '<option value="1">Draft</option>'
             '<option value="2">Pending</option>'
             '<option value="3">Live</option>'
-            "</select></li>" %
-            (self.w_woodward.pk,
+            "</select></li>"
+            % (
+                self.w_woodward.pk,
                 w_bernstein.pk,
                 self.w_royko.pk,
                 self.c1.pk,
                 self.c2.pk,
                 self.c3.pk,
                 c4.pk,
-             ),
+            ),
         )
 
     def test_recleaning_model_form_instance(self):


### PR DESCRIPTION
Updated query selectors to targe source options which will prevent duplication in "Chosen" column.
Ticket Link: https://code.djangoproject.com/ticket/34789#comment:8

<img width="602" alt="Screenshot 2023-09-02 at 2 46 09 AM" src="https://github.com/django/django/assets/20266220/75891dc8-377a-4290-8925-92a7c3e10fe7">
<img width="1354" alt="Screenshot 2023-09-02 at 2 46 29 AM" src="https://github.com/django/django/assets/20266220/e3964a06-f405-4752-95a7-02b6fad24f2f">
