### PR TITLE
Fixed #34812 -- Raised ImproperlyConfigured if urlpatterns is missing.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -774,6 +774,7 @@ answer newbie questions, and generally made Django that much better:
     Paolo Melchiorre <paolo@melchiorre.org>
     Pascal Hartig <phartig@rdrei.net>
     Pascal Varet
+    Pat <theepic.dev.83@gmail.com>
     Patrik Sletmo <patrik.sletmo@gmail.com>
     Paul Bissex <http://e-scribe.com/>
     Paul Collier <paul@paul-collier.com>

--- a/django/urls/conf.py
+++ b/django/urls/conf.py
@@ -1,6 +1,7 @@
 """Functions for use in URLsconfs."""
 from functools import partial
 from importlib import import_module
+from types import ModuleType
 
 from django.core.exceptions import ImproperlyConfigured
 
@@ -46,6 +47,11 @@ def include(arg, namespace=None):
             "app_name instead.",
         )
     namespace = namespace or app_name
+    # Ensure the user did not include a module without urlpatterns.
+    if isinstance(patterns, ModuleType):
+        raise ImproperlyConfigured(
+            "Could not find urlpatterns object in module %s." % arg
+        )
     # Make sure the patterns can be iterated through (without this, some
     # testcases will break).
     if isinstance(patterns, (list, tuple)):

--- a/tests/urlpatterns/bad_urlconf.py
+++ b/tests/urlpatterns/bad_urlconf.py
@@ -1,0 +1,3 @@
+"""URLConf module with an intentionally misspelled name."""
+
+urlspatterns = []

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -4,7 +4,15 @@ import uuid
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-from django.urls import NoReverseMatch, Resolver404, path, re_path, resolve, reverse
+from django.urls import (
+    NoReverseMatch,
+    Resolver404,
+    include,
+    path,
+    re_path,
+    resolve,
+    reverse,
+)
 from django.views import View
 
 from .converters import DynamicConverter
@@ -192,6 +200,11 @@ class SimplifiedURLTests(SimpleTestCase):
         msg = "URL route 'foo/<nonexistent:var>/' uses invalid converter 'nonexistent'."
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             path("foo/<nonexistent:var>/", empty_view)
+
+    def test_invalid_urlconf_module(self):
+        msg = "Could not find urlpatterns object in module urlpatterns.bad_urlconf."
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            include("urlpatterns.bad_urlconf")
 
     def test_invalid_view(self):
         msg = "view must be a callable or a list/tuple in the case of include()."


### PR DESCRIPTION
Hello everyone.

As described in [the tracker](https://code.djangoproject.com/ticket/34812), Django users may get slightly confusing errors about circular imports when they try to `include()` URLConf modules that lack the `urlpatterns` attribute.

This PR modifies the `django.urls.include()` function to check if the `arg` argument is a module without a `urlpatterns` attribute, and raises `ImproperlyConfigured` if that is the case.