### PR TITLE
Refs #34233 -- Bumped minimum supported version of docutils to 0.19.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -282,7 +282,7 @@ dependencies:
 * :pypi:`asgiref` 3.7.0+ (required)
 * :pypi:`bcrypt`
 * :pypi:`colorama` 0.4.6+
-* :pypi:`docutils`
+* :pypi:`docutils` 0.19+
 * :pypi:`geoip2`
 * :pypi:`Jinja2` 2.11+
 * :pypi:`numpy`

--- a/docs/ref/contrib/admin/admindocs.txt
+++ b/docs/ref/contrib/admin/admindocs.txt
@@ -23,7 +23,7 @@ the following:
   your ``urlpatterns``. Make sure it's included *before* the
   ``'admin/'`` entry, so that requests to ``/admin/doc/`` don't get
   handled by the latter entry.
-* Install the :pypi:`docutils` package.
+* Install the :pypi:`docutils` 0.19+ package.
 * **Optional:** Using the admindocs bookmarklets requires
   ``django.contrib.admindocs.middleware.XViewMiddleware`` to be installed.
 

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -632,6 +632,8 @@ Miscellaneous
 
 * The minimum supported version of ``colorama`` is increased to 0.4.6.
 
+* The minimum supported version of ``docutils`` is increased to 0.19.
+
 .. _deprecated-features-5.0:
 
 Features deprecated in 5.0

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -3,7 +3,7 @@ asgiref >= 3.7.0
 argon2-cffi >= 19.2.0
 bcrypt
 black
-docutils
+docutils >= 0.19
 geoip2; python_version < '3.12'
 jinja2 >= 2.11.0
 numpy; python_version < '3.12'

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -50,10 +50,6 @@ warnings.simplefilter("error", RemovedInDjango51Warning)
 # patterns.
 warnings.simplefilter("error", ResourceWarning)
 warnings.simplefilter("error", RuntimeWarning)
-# Ignore known warnings in test dependencies.
-warnings.filterwarnings(
-    "ignore", "'U' mode is deprecated", DeprecationWarning, module="docutils.io"
-)
 
 # Reduce garbage collection frequency to improve performance. Since CPython
 # uses refcounting, garbage collection only collects objects with cyclic


### PR DESCRIPTION
`docutils.io` [resolved](https://sourceforge.net/p/docutils/code/8228/) their deprecation warning for `'u'` mode in 2018.