### PR TITLE
Fixed #34810 -- Measured test coverage on django-admin commands.

### DIFF
--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 branch = True
 concurrency = multiprocessing,thread
-data_file = .coverages/.coverage
+data_file = ${RUNTESTS_DIR-.}/.coverages/.coverage
 omit =
     */django/utils/autoreload.py
 source = django

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -71,6 +71,10 @@ tempfile.tempdir = os.environ["TMPDIR"] = TMPDIR
 # Removing the temporary TMPDIR.
 atexit.register(shutil.rmtree, TMPDIR)
 
+# Add variables enabling coverage to trace code in subprocesses.
+os.environ["RUNTESTS_DIR"] = RUNTESTS_DIR
+os.environ["COVERAGE_PROCESS_START"] = os.path.join(RUNTESTS_DIR, ".coveragerc")
+
 
 # This is a dict mapping RUNTESTS_DIR subdirectory to subdirectories of that
 # directory to skip when searching for test modules.

--- a/tests/sitecustomize.py
+++ b/tests/sitecustomize.py
@@ -1,0 +1,6 @@
+try:
+    import coverage
+except ImportError:
+    pass
+else:
+    coverage.process_startup()


### PR DESCRIPTION
Improve code coverage calculation for django-admin commands.

ticket-34810

#### Demo ####
```sh
coverage run ./runtests.py
coverage combine
coverage html
```
Before, this was 12%.
<img width="1351" alt="templates-coverage" src="https://github.com/django/django/assets/38668450/3b7ad73f-d118-4dd4-af66-f66edd1fe1e7">



#### Resources ####
[1] https://coverage.readthedocs.io/en/stable/subprocess.html
Configuration for measuring test coverage on subprocesses: suggests using sitecustomize.py and being defensive in case coverage is not installed. Any folder on the python path can be used, and `tests` meets that criterion.
[2] https://github.com/nedbat/coveragepy/issues/1093#issuecomment-769480418
This coverage.py issue thread describes how to cope with subprocesses run from different working directories: the trick suggested by Ned Batchelder is to use environment variable-substitution in the coveragerc file.