### PR TITLE
Fixed #34820 --Change the properties of ForeignObject object, such as blank, null, and execute migrate to report an error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1005,6 +1005,7 @@ answer newbie questions, and generally made Django that much better:
     Tyson Clugg <tyson@clugg.net>
     Tyson Tate <tyson@fallingbullets.com>
     Unai Zalakain <unai@gisa-elkartea.org>
+    Hao Dong <https://github.com/RelaxedDong>
     Valentina Mukhamedzhanova <umirra@gmail.com>
     valtron
     Vasiliy Stavenko <stavenko@gmail.com>

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1617,6 +1617,8 @@ class BaseDatabaseSchemaEditor:
         return output
 
     def _field_should_be_altered(self, old_field, new_field, ignore=None):
+        if not old_field.column and not new_field.column:
+            return
         ignore = ignore or set()
         _, old_path, old_args, old_kwargs = old_field.deconstruct()
         _, new_path, new_args, new_kwargs = new_field.deconstruct()

--- a/docs/releases/4.2.6.txt
+++ b/docs/releases/4.2.6.txt
@@ -8,5 +8,6 @@ Django 4.2.6 fixes several bugs in 4.2.5.
 
 Bugfixes
 ========
-
+* Fixed changes to ForeignObject object properties in Django 4.2 and
+  reported errors during migration (:ticket:`34820`).
 * ...


### PR DESCRIPTION
… execute migrate to report an error

If the models.ForeignObject attribute is used, changing null or blank to generate a new migration record will result in an error message when executing the migrate again

```
  File "/Users/donghao/test/test_migations/manage.py", line 22, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/core/management/base.py", line 106, in wrapper
    res = handle_func(*args, **kwargs)
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/core/management/commands/migrate.py", line 356, in handle
    post_migrate_state = executor.migrate(
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/db/migrations/executor.py", line 135, in migrate
    state = self._migrate_all_forwards(
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/db/migrations/executor.py", line 167, in _migrate_all_forwards
    state = self.apply_migration(
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/db/migrations/executor.py", line 252, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/db/migrations/migration.py", line 132, in apply
    operation.database_forwards(
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/db/migrations/operations/fields.py", line 235, in database_forwards
    schema_editor.alter_field(from_model, from_field, to_field)
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/db/backends/base/schema.py", line 785, in alter_field
    if not self._field_should_be_altered(old_field, new_field):
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/db/backends/base/schema.py", line 1530, in _field_should_be_altered
    return self.quote_name(old_field.column) != self.quote_name(
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/db/backends/base/schema.py", line 204, in quote_name
    return self.connection.ops.quote_name(name)
  File "/Users/donghao/.virtualenvs/simpleui/lib/python3.9/site-packages/django/db/backends/mysql/operations.py", line 184, in quote_name
    if name.startswith("`") and name.endswith("`"):
AttributeError: 'NoneType' object has no attribute 'startswith'
```

A pre judgment has been added here to avoid this issue

