### PR TITLE
Fixed #34821 -- Prevented DEFAULT_FILE_STORAGE/STATICFILES_STORAGE settings from mutating the main STORAGES.

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -222,8 +222,9 @@ class Settings:
                 raise ImproperlyConfigured(
                     "DEFAULT_FILE_STORAGE/STORAGES are mutually exclusive."
                 )
-            self.STORAGES[DEFAULT_STORAGE_ALIAS] = {
-                "BACKEND": self.DEFAULT_FILE_STORAGE
+            self.STORAGES = {
+                **self.STORAGES,
+                DEFAULT_STORAGE_ALIAS: {"BACKEND": self.DEFAULT_FILE_STORAGE},
             }
             warnings.warn(DEFAULT_FILE_STORAGE_DEPRECATED_MSG, RemovedInDjango51Warning)
 
@@ -232,8 +233,9 @@ class Settings:
                 raise ImproperlyConfigured(
                     "STATICFILES_STORAGE/STORAGES are mutually exclusive."
                 )
-            self.STORAGES[STATICFILES_STORAGE_ALIAS] = {
-                "BACKEND": self.STATICFILES_STORAGE
+            self.STORAGES = {
+                **self.STORAGES,
+                STATICFILES_STORAGE_ALIAS: {"BACKEND": self.STATICFILES_STORAGE},
             }
             warnings.warn(STATICFILES_STORAGE_DEPRECATED_MSG, RemovedInDjango51Warning)
         # RemovedInDjango51Warning.

--- a/docs/releases/4.2.6.txt
+++ b/docs/releases/4.2.6.txt
@@ -9,4 +9,6 @@ Django 4.2.6 fixes several bugs in 4.2.5.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 4.2.5 where overriding the deprecated
+  ``DEFAULT_FILE_STORAGE`` and ``STATICFILES_STORAGE`` settings in tests caused
+  the main ``STORAGES`` to mutate (:ticket:`34821`).

--- a/tests/deprecation/test_storages.py
+++ b/tests/deprecation/test_storages.py
@@ -32,6 +32,7 @@ class StaticfilesStorageDeprecationTests(TestCase):
                 pass
 
     def test_settings_init(self):
+        old_staticfiles_storage = settings.STORAGES.get(STATICFILES_STORAGE_ALIAS)
         settings_module = ModuleType("fake_settings_module")
         settings_module.USE_TZ = True
         settings_module.STATICFILES_STORAGE = (
@@ -48,6 +49,11 @@ class StaticfilesStorageDeprecationTests(TestCase):
                         "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
                     ),
                 },
+            )
+            # settings.STORAGES is not mutated.
+            self.assertEqual(
+                settings.STORAGES.get(STATICFILES_STORAGE_ALIAS),
+                old_staticfiles_storage,
             )
         finally:
             del sys.modules["fake_settings_module"]
@@ -161,6 +167,7 @@ class DefaultStorageDeprecationTests(TestCase):
                 pass
 
     def test_settings_init(self):
+        old_default_storage = settings.STORAGES.get(DEFAULT_STORAGE_ALIAS)
         settings_module = ModuleType("fake_settings_module")
         settings_module.USE_TZ = True
         settings_module.DEFAULT_FILE_STORAGE = "django.core.files.storage.Storage"
@@ -171,6 +178,11 @@ class DefaultStorageDeprecationTests(TestCase):
             self.assertEqual(
                 fake_settings.STORAGES[DEFAULT_STORAGE_ALIAS],
                 {"BACKEND": "django.core.files.storage.Storage"},
+            )
+            # settings.STORAGES is not mutated.
+            self.assertEqual(
+                settings.STORAGES.get(DEFAULT_STORAGE_ALIAS),
+                old_default_storage,
             )
         finally:
             del sys.modules["fake_settings_module"]


### PR DESCRIPTION
ticket-34821, check out [logs](https://djangoci.com/job/main-random/database=mysql,label=focal,python=python3.11/).

Regression in 6b965c600054f970bdf94017ecf2e0e6e0a4326b.