### PR TITLE
Fixed #34824 -- Prevented unnecessary AlterField when ForeignObject.from_fields/to_fields is not a tuple.

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1157,6 +1157,9 @@ class MigrationAutodetector:
                             for to_field in new_field.to_fields
                         ]
                     )
+                    if old_from_fields := getattr(old_field, "from_fields", None):
+                        old_field.from_fields = tuple(old_from_fields)
+                        old_field.to_fields = tuple(old_field.to_fields)
                 dependencies.extend(
                     self._get_dependencies_for_foreign_key(
                         app_label,

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import re
 from unittest import mock
@@ -1626,6 +1627,37 @@ class AutodetectorTests(BaseAutodetectorTests):
         self.assertOperationAttributes(
             changes, "app", 0, 0, old_name="field", new_name="renamed_field"
         )
+
+    def test_foreign_object_from_to_fields_list(self):
+        author_state = ModelState(
+            "app",
+            "Author",
+            [("id", models.AutoField(primary_key=True))],
+        )
+        book_state = ModelState(
+            "app",
+            "Book",
+            [
+                ("id", models.AutoField(primary_key=True)),
+                ("name", models.CharField()),
+                ("author_id", models.IntegerField()),
+                (
+                    "author",
+                    models.ForeignObject(
+                        "app.Author",
+                        models.CASCADE,
+                        from_fields=["author_id"],
+                        to_fields=["id"],
+                    ),
+                ),
+            ],
+        )
+        book_state_copy = copy.deepcopy(book_state)
+        changes = self.get_changes(
+            [author_state, book_state],
+            [author_state, book_state_copy],
+        )
+        self.assertEqual(changes, {})
 
     def test_rename_foreign_object_fields(self):
         fields = ("first", "second")


### PR DESCRIPTION
Change the from_fields and to_fields of ForeignObject’s existing migration records to tuple types