### PR TITLE
Fixed #34825 -- Avoided setting unused connections when initializing parallel workers.

### DIFF
--- a/django/db/backends/sqlite3/creation.py
+++ b/django/db/backends/sqlite3/creation.py
@@ -143,7 +143,7 @@ class DatabaseCreation(BaseDatabaseCreation):
                 f"file:memorydb_{alias}_{_worker_id}?mode=memory&cache=shared"
             )
             source_db = self.connection.Database.connect(
-                f"file:{alias}_{_worker_id}.sqlite3", uri=True
+                f"file:{alias}_{_worker_id}.sqlite3?mode=ro", uri=True
             )
             target_db = sqlite3.connect(connection_str, uri=True)
             source_db.backup(target_db)

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -406,6 +406,7 @@ def _init_worker(
     process_setup=None,
     process_setup_args=None,
     debug_mode=None,
+    used_aliases=None,
 ):
     """
     Switch to databases dedicated to this worker.
@@ -430,7 +431,8 @@ def _init_worker(
         django.setup()
         setup_test_environment(debug=debug_mode)
 
-    for alias in connections:
+    db_aliases = used_aliases or connections
+    for alias in db_aliases:
         connection = connections[alias]
         if start_method == "spawn":
             # Restore initial settings in spawned processes.
@@ -491,6 +493,7 @@ class ParallelTestSuite(unittest.TestSuite):
         self.buffer = buffer
         self.initial_settings = None
         self.serialized_contents = None
+        self.used_aliases = None
         super().__init__()
 
     def run(self, result):
@@ -520,6 +523,7 @@ class ParallelTestSuite(unittest.TestSuite):
                 self.process_setup.__func__,
                 self.process_setup_args,
                 self.debug_mode,
+                self.used_aliases,
             ],
         )
         args = [
@@ -1052,6 +1056,7 @@ class DiscoverRunner:
         suite.serialized_aliases = set(
             alias for alias, serialize in databases.items() if serialize
         )
+        suite.used_aliases = set(databases)
         with self.time_keeper.timed("Total database setup"):
             old_config = self.setup_databases(
                 aliases=databases,

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -748,8 +748,9 @@ class TestRunnerInitializerTests(SimpleTestCase):
         # Initializer must be a function.
         self.assertIs(mocked_pool.call_args.kwargs["initializer"], _init_worker)
         initargs = mocked_pool.call_args.kwargs["initargs"]
-        self.assertEqual(len(initargs), 6)
+        self.assertEqual(len(initargs), 7)
         self.assertEqual(initargs[5], True)  # debug_mode
+        self.assertEqual(initargs[6], {db.DEFAULT_DB_ALIAS})  # Used database aliases.
 
 
 class Ticket17477RegressionTests(AdminScriptTestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34825

I'm new to poking around with the test framework but afaict the workers shouldn't have been creating the "other_n.sqlite3" databases. It appears to happen in this method when it tries to clone from nonexistent "other_n.sqlite3" files because `sqlite3.connect()`'s default mode is `rwc` - read, write & create.