### PR TITLE
Pass response as an extra parameter in log_response

### DIFF
--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -242,6 +242,7 @@ def log_response(
         message,
         *args,
         extra={
+            "response": response,
             "status_code": response.status_code,
             "request": request,
         },


### PR DESCRIPTION
This means that when using a formatter inherited `django.utils.log.ServerFormatter` to log responses, in addition to logging the status_code, you can also log the body (`response.body`) or some other attribute of a `Response` object.