### PR TITLE
Doc'd HttpResponse.cookies.

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -800,10 +800,16 @@ Attributes
 
     A bytestring representing the content, encoded from a string if necessary.
 
+.. attribute:: HttpResponse.cookies
+
+    A :py:obj:`http.cookies.SimpleCookie` object holding the cookies included
+    in the response.
+
 .. attribute:: HttpResponse.headers
 
     A case insensitive, dict-like object that provides an interface to all
-    HTTP headers on the response. See :ref:`setting-header-fields`.
+    HTTP headers on the response, except a ``Set-Cookie`` header. See
+    :ref:`setting-header-fields` and :attr:`HttpResponse.cookies`.
 
 .. attribute:: HttpResponse.charset
 


### PR DESCRIPTION
This PR documents attribute `HttpRequest.cookies`.

- only cookie-setting is currently documented as `HttpResponse.set_cookie()`, making cookies controllable but not observable
- cookies are also concealed from the lower-level `HttpResponse.headers` and `HttpResponse.items()` interfaces (no `Set-Cookie`)
- this makes it impossible to test the cookie logic of django applications with the current interface. This is particularly problematic when working with modern Single Page Applications which rely on `httpOnly` cookies for authentication.

This PR was solicited in IRC, and its content got a superficial review there. It does the following:

- mention and describe `HttpResponse.cookies` in the "Request and response objects" page.
- mention that `Set-Cookie` headers are omitted from `HttpResponse.headers`

As a side note, the current code is asymmetric: `HttpRequest` uses attribute `HttpRequest.COOKIES`, but `HttpResponse` uses `HttpResponse.cookies`. A perfectionist with deadlines might alias the existing `HttpResponse.cookies` to `HttpResponse.COOKIES` and document the latter – so both interfaces are symmetric and intuitive.

Comments welcome.