### PR TITLE
Corrected logger in CsrfViewMiddlewareTestMixin.test_ensures_csrf_cookie_no_logging().

### DIFF
--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -857,7 +857,7 @@ class CsrfViewMiddlewareTestMixin(CsrfFunctionTestMixin):
         """
         ensure_csrf_cookie() doesn't log warnings (#19436).
         """
-        with self.assertNoLogs("django.request", "WARNING"):
+        with self.assertNoLogs("django.security.csrf", "WARNING"):
             req = self._get_request()
             ensure_csrf_cookie_view(req)
 


### PR DESCRIPTION
Logger was changed in 55fec16aafed30a9daa06d6ecdf8ca3ad361279e.