### PR TITLE
Fixed #34822 -- Added support for serializing functions decorated with functools.lru_cache in migrations.

### DIFF
--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -350,6 +350,7 @@ class Serializer:
             types.FunctionType,
             types.BuiltinFunctionType,
             types.MethodType,
+            functools._lru_cache_wrapper,
         ): FunctionTypeSerializer,
         collections.abc.Iterable: IterableSerializer,
         (COMPILED_REGEX_TYPE, RegexObject): RegexSerializer,

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -401,7 +401,9 @@ Management Commands
 Migrations
 ~~~~~~~~~~
 
-* ...
+* Serialization of functions decorated with :func:`functools.cache` or
+  :func:`functools.lru_cache` is now supported without the need to write a
+  custom serializer.
 
 Models
 ~~~~~~

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -783,7 +783,12 @@ Django can serialize the following:
 - ``LazyObject`` instances which wrap a serializable value.
 - Enumeration types (e.g. ``TextChoices`` or ``IntegerChoices``) instances.
 - Any Django field
-- Any function or method reference (e.g. ``datetime.datetime.today``) (must be in module's top-level scope)
+- Any function or method reference (e.g. ``datetime.datetime.today``) (must be
+  in module's top-level scope)
+
+  - Functions may be decorated if wrapped properly, i.e. using
+    :func:`functools.wraps`
+
 - Unbound methods used from within the class body
 - Any class reference (must be in module's top-level scope)
 - Anything with a custom ``deconstruct()`` method (:ref:`see below <custom-deconstruct-method>`)

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -788,6 +788,8 @@ Django can serialize the following:
 
   - Functions may be decorated if wrapped properly, i.e. using
     :func:`functools.wraps`
+  - The :func:`functools.cache` and :func:`functools.lru_cache` decorators are
+    explicitly supported
 
 - Unbound methods used from within the class body
 - Any class reference (must be in module's top-level scope)
@@ -796,6 +798,11 @@ Django can serialize the following:
 .. versionchanged:: 4.2
 
     Serialization support for ``enum.Flag`` was added.
+
+.. versionchanged:: 5.0
+
+    Serialization support for functions decorated with :func:`functools.cache`
+    or :func:`functools.lru_cache` was added.
 
 Django cannot serialize:
 

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -90,6 +90,16 @@ def function_with_decorator():
     pass
 
 
+@functools.cache
+def function_with_cache():
+    pass
+
+
+@functools.lru_cache(maxsize=10)
+def function_with_lru_cache():
+    pass
+
+
 class OperationWriterTests(SimpleTestCase):
     def test_empty_signature(self):
         operation = custom_migration_operations.operations.TestOperation()
@@ -581,6 +591,8 @@ class WriterTests(SimpleTestCase):
 
     def test_serialize_decorated_functions(self):
         self.assertSerializedEqual(function_with_decorator)
+        self.assertSerializedEqual(function_with_cache)
+        self.assertSerializedEqual(function_with_lru_cache)
 
     def test_serialize_datetime(self):
         self.assertSerializedEqual(datetime.datetime.now())

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -77,6 +77,19 @@ class IntFlagEnum(enum.IntFlag):
     B = 2
 
 
+def decorator(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+@decorator
+def function_with_decorator():
+    pass
+
+
 class OperationWriterTests(SimpleTestCase):
     def test_empty_signature(self):
         operation = custom_migration_operations.operations.TestOperation()
@@ -565,6 +578,9 @@ class WriterTests(SimpleTestCase):
         string, imports = MigrationWriter.serialize(models.SET(42))
         self.assertEqual(string, "models.SET(42)")
         self.serialize_round_trip(models.SET(42))
+
+    def test_serialize_decorated_functions(self):
+        self.assertSerializedEqual(function_with_decorator)
 
     def test_serialize_datetime(self):
         self.assertSerializedEqual(datetime.datetime.now())


### PR DESCRIPTION
ticket-34822