### PR TITLE
Fixed #34832 -- Made admin's header content render in <header> tag.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -887,6 +887,7 @@ answer newbie questions, and generally made Django that much better:
     Sander Dijkhuis <sander.dijkhuis@gmail.com>
     Sanket Saurav <sanketsaurav@gmail.com>
     Sanyam Khurana <sanyam.khurana01@gmail.com>
+    Sarah Abderemane <https://github.com/sabderemane>
     Sarah Boyce <https://github.com/sarahboyce>
     Sarthak Mehrish <sarthakmeh03@gmail.com>
     schwank@gmail.com

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -834,10 +834,6 @@ a.deletelink:focus, a.deletelink:hover {
     height: 100%;
 }
 
-#container > div {
-    flex-shrink: 0;
-}
-
 #container > .main {
     display: flex;
     flex: 1 0 auto;
@@ -922,7 +918,6 @@ a.deletelink:focus, a.deletelink:hover {
     padding: 10px 40px;
     background: var(--header-bg);
     color: var(--header-color);
-    overflow: hidden;
 }
 
 #header a:link, #header a:visited, #logout-form button {

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -32,7 +32,7 @@
     {% if not is_popup %}
     <!-- Header -->
     {% block header %}
-    <div id="header">
+      <header id="header">
         <div id="branding">
         {% block branding %}{% endblock %}
         </div>
@@ -66,7 +66,7 @@
         {% endif %}
         {% endblock %}
         {% block nav-global %}{% endblock %}
-    </div>
+      </header>
     {% endblock %}
     <!-- END Header -->
     {% block nav-breadcrumbs %}

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -629,8 +629,9 @@ Miscellaneous
   a page. Having two ``<h1>`` elements was confusing and the site header wasn't
   helpful as it is repeated on all pages.
 
-* In order to improve accessibility, the admin's main content area is now
-  rendered in a ``<main>`` tag instead of ``<div>``.
+* In order to improve accessibility, the admin's main content area and header
+  content area are now rendered in a ``<main>`` and ``<header>`` tag instead of
+  ``<div>``.
 
 * On databases without native support for the SQL ``XOR`` operator, ``^`` as
   the exclusive or (``XOR``) operator now returns rows that are matched by an

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1516,6 +1516,13 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
             '<meta name="viewport" content="width=device-width, initial-scale=1.0">',
         )
 
+    def test_header(self):
+        response = self.client.get(reverse("admin:index"))
+        self.assertContains(response, '<header id="header">')
+        self.client.logout()
+        response = self.client.get(reverse("admin:login"))
+        self.assertContains(response, '<header id="header">')
+
 
 @override_settings(
     AUTH_PASSWORD_VALIDATORS=[


### PR DESCRIPTION
Header tag was changed to `<header>` get the landmark banner for accessibility.


Note: I remove the `overflow: hidden`, here is why :

Without the overflow ⬇️ 
<img width="1508" alt="Capture d’écran 2023-09-13 à 22 37 16" src="https://github.com/django/django/assets/17890338/cb2bbd61-bcff-4333-ac59-52a06886b3f7">


With the overflow ⬇️ 
<img width="757" alt="Capture d’écran 2023-09-13 à 22 43 38" src="https://github.com/django/django/assets/17890338/77f8992b-2466-4581-adf4-5d9579495182">

