### PR TITLE
Fixed #34833 -- Made admin's main content render in <main> tag.

### DIFF
--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -81,7 +81,7 @@
     {% endblock %}
     {% endif %}
 
-    <div class="main" id="main">
+    <main class="main" id="main">
       {% if not is_popup and is_nav_sidebar_enabled %}
         {% block nav-sidebar %}
           {% include "admin/nav_sidebar.html" %}
@@ -110,7 +110,7 @@
         <!-- END Content -->
         {% block footer %}<div id="footer"></div>{% endblock %}
       </div>
-    </div>
+    </main>
 </div>
 <!-- END Container -->
 

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -622,6 +622,9 @@ Miscellaneous
   a page. Having two ``<h1>`` elements was confusing and the site header wasn't
   helpful as it is repeated on all pages.
 
+* In order to improve accessibility, the admin's main content area is now
+  rendered in a ``<main>`` tag instead of ``<div>``.
+
 * On databases without native support for the SQL ``XOR`` operator, ``^`` as
   the exclusive or (``XOR``) operator now returns rows that are matched by an
   odd number of operands rather than exactly one operand. This is consistent

--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -42,7 +42,7 @@ class AdminSidebarTests(TestCase):
 
     def test_sidebar_not_on_index(self):
         response = self.client.get(reverse("test_with_sidebar:index"))
-        self.assertContains(response, '<div class="main" id="main">')
+        self.assertContains(response, '<main class="main" id="main">')
         self.assertNotContains(
             response, '<nav class="sticky" id="nav-sidebar" aria-label="Sidebar">'
         )


### PR DESCRIPTION
Main tag was changed to `<main>` to get the landmark main for accessibility.

Result:
<img width="1512" alt="Capture d’écran 2023-09-14 à 00 04 43" src="https://github.com/django/django/assets/17890338/1874bd83-adef-48ad-ab40-958df8d4173c">
