### PR TITLE
Fixed #34834 -- Added role="search" to the admin changelist search form.

### DIFF
--- a/django/contrib/admin/templates/admin/search_form.html
+++ b/django/contrib/admin/templates/admin/search_form.html
@@ -1,6 +1,6 @@
 {% load i18n static %}
 {% if cl.search_fields %}
-<div id="toolbar"><form id="changelist-search" method="get">
+<div id="toolbar"><form id="changelist-search" method="get" role="search">
 <div><!-- DIV needed for valid HTML -->
 <label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search"></label>
 <input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar"{% if cl.search_help_text %} aria-describedby="searchbar_helptext"{% endif %}>

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1585,6 +1585,16 @@ class ChangeListTests(TestCase):
             'aria-describedby="searchbar_helptext">',
         )
 
+    def test_search_role(self):
+        m = BandAdmin(Band, custom_site)
+        m.search_fields = ["name"]
+        request = self._mocked_authenticated_request("/band/", self.superuser)
+        response = m.changelist_view(request)
+        self.assertContains(
+            response,
+            '<form id="changelist-search" method="get" role="search">',
+        )
+
     def test_search_bar_total_link_preserves_options(self):
         self.client.force_login(self.superuser)
         url = reverse("admin:auth_user_changelist")


### PR DESCRIPTION
Added 'search' role on the admin changelist form for screen reader users.