### PR TITLE
Fixed #34842 -- Fixed ModelAdmin.readonly_fields crash with GeneratedFields.

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -199,7 +199,7 @@ class DeferredAttribute:
             val = self._check_parent_chain(instance)
             if val is None:
                 if instance.pk is None and self.field.generated:
-                    raise FieldError(
+                    raise AttributeError(
                         "Cannot read a generated field from an unsaved model."
                     )
                 instance.refresh_from_db(fields=[field_name])

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -119,6 +119,7 @@ from .models import (
     Simple,
     Sketch,
     Song,
+    Square,
     State,
     Story,
     StumpJoke,
@@ -1175,6 +1176,10 @@ class TravelerAdmin(admin.ModelAdmin):
     autocomplete_fields = ["living_country"]
 
 
+class SquareAdmin(admin.ModelAdmin):
+    readonly_fields = ("area",)
+
+
 site = admin.AdminSite(name="admin")
 site.site_url = "/my-site-url/"
 site.register(Article, ArticleAdmin)
@@ -1298,6 +1303,7 @@ site.register(UserProxy)
 site.register(Box)
 site.register(Country, CountryAdmin)
 site.register(Traveler, TravelerAdmin)
+site.register(Square, SquareAdmin)
 
 # Register core models we need in our tests
 site.register(User, UserAdmin)

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -1134,3 +1134,14 @@ class Traveler(models.Model):
         related_name="favorite_country_to_vacation_set",
         limit_choices_to={"continent": Country.ASIA},
     )
+
+
+class Square(models.Model):
+    side = models.IntegerField()
+    area = models.GeneratedField(
+        db_persist=True,
+        expression=models.F("side") * models.F("side"),
+    )
+
+    class Meta:
+        required_db_features = {"supports_stored_generated_columns"}

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -6861,6 +6861,11 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
         field = self.get_admin_readonly_field(response, "plotdetails")
         self.assertEqual(field.contents(), "-")  # default empty value
 
+    @skipUnlessDBFeature("supports_stored_generated_columns")
+    def test_readonly_unsaved_generated_field(self):
+        response = self.client.get(reverse("admin:admin_views_square_add"))
+        self.assertContains(response, '<div class="readonly">-</div>')
+
     @ignore_warnings(category=RemovedInDjango60Warning)
     def test_readonly_field_overrides(self):
         """

--- a/tests/model_fields/test_generatedfield.py
+++ b/tests/model_fields/test_generatedfield.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import FieldError
 from django.db import IntegrityError, connection
 from django.db.models import F, FloatField, GeneratedField, IntegerField, Model
 from django.db.models.functions import Lower
@@ -93,7 +92,7 @@ class GeneratedFieldTestMixin:
     def test_unsaved_error(self):
         m = self.base_model(a=1, b=2)
         msg = "Cannot read a generated field from an unsaved model."
-        with self.assertRaisesMessage(FieldError, msg):
+        with self.assertRaisesMessage(AttributeError, msg):
             m.field
 
     def test_create(self):


### PR DESCRIPTION
Ref. https://code.djangoproject.com/ticket/34842