### PR TITLE
Refs #31700 -- Added formatted description to highlight different ope…

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -346,7 +346,9 @@ class Command(BaseCommand):
                     migration_string = self.get_relative_path(writer.path)
                     self.log("  %s\n" % self.style.MIGRATE_LABEL(migration_string))
                     for operation in migration.operations:
-                        self.log("    - %s" % operation.describe())
+                        self.log(
+                            " %s" % operation.formatted_description(style=self.style)
+                        )
                     if self.scriptable:
                         self.stdout.write(migration_string)
                 if not self.dry_run:
@@ -454,7 +456,9 @@ class Command(BaseCommand):
                 for migration in merge_migrations:
                     self.log(self.style.MIGRATE_LABEL("  Branch %s" % migration.name))
                     for operation in migration.merged_operations:
-                        self.log("    - %s" % operation.describe())
+                        self.log(
+                            "    %s" % operation.formatted_description(style=self.style)
+                        )
             if questioner.ask_merge(app_label):
                 # If they still want to merge it, then write out an empty
                 # file depending on the migrations needing merging.

--- a/django/db/migrations/operations/base.py
+++ b/django/db/migrations/operations/base.py
@@ -1,4 +1,12 @@
+import enum
+
 from django.db import router
+
+
+class SeverityType(enum.Enum):
+    SAFE = "SAFE"
+    POSSIBLY_DESTRUCTIVE = "POSSIBLY_DESTRUCTIVE"
+    DESTRUCTIVE = "DESTRUCTIVE"
 
 
 class Operation:
@@ -32,6 +40,8 @@ class Operation:
     elidable = False
 
     serialization_expand_args = []
+
+    severity = SeverityType.SAFE
 
     def __new__(cls, *args, **kwargs):
         # We capture the arguments to make returning them trivial
@@ -84,6 +94,17 @@ class Operation:
         Output a brief summary of what the action does.
         """
         return "%s: %s" % (self.__class__.__name__, self._constructor_args)
+
+    def formatted_description(self, style):
+        """
+        Output the describe output in a more informative way.
+        """
+        description = self.describe()
+        if self.severity == SeverityType.SAFE:
+            return style.SUCCESS("+ {}".format(description))
+        elif self.severity == SeverityType.DESTRUCTIVE:
+            return style.ERROR("- {}".format(description))
+        return style.WARNING("~ {}".format(description))
 
     @property
     def migration_name_fragment(self):

--- a/django/db/migrations/operations/fields.py
+++ b/django/db/migrations/operations/fields.py
@@ -2,7 +2,7 @@ from django.db.migrations.utils import field_references
 from django.db.models import NOT_PROVIDED
 from django.utils.functional import cached_property
 
-from .base import Operation
+from .base import Operation, SeverityType
 
 
 class FieldOperation(Operation):
@@ -74,6 +74,8 @@ class FieldOperation(Operation):
 
 class AddField(FieldOperation):
     """Add a field to a model."""
+
+    severity = SeverityType.SAFE
 
     def __init__(self, model_name, name, field, preserve_default=True):
         self.preserve_default = preserve_default
@@ -154,6 +156,8 @@ class AddField(FieldOperation):
 class RemoveField(FieldOperation):
     """Remove a field from a model."""
 
+    severity = SeverityType.DESTRUCTIVE
+
     def deconstruct(self):
         kwargs = {
             "model_name": self.model_name,
@@ -200,6 +204,8 @@ class AlterField(FieldOperation):
     Alter a field's database column (e.g. null, max_length) to the provided
     new field.
     """
+
+    severity = SeverityType.POSSIBLY_DESTRUCTIVE
 
     def __init__(self, model_name, name, field, preserve_default=True):
         self.preserve_default = preserve_default
@@ -269,6 +275,8 @@ class AlterField(FieldOperation):
 
 class RenameField(FieldOperation):
     """Rename a field on the model. Might affect db_column too."""
+
+    severity = SeverityType.POSSIBLY_DESTRUCTIVE
 
     def __init__(self, model_name, old_name, new_name):
         self.old_name = old_name

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.db.migrations.operations.base import Operation
+from django.db.migrations.operations.base import Operation, SeverityType
 from django.db.migrations.state import ModelState
 from django.db.migrations.utils import field_references, resolve_relation
 from django.db.models.options import normalize_together
@@ -40,6 +40,8 @@ class ModelOperation(Operation):
 
 class CreateModel(ModelOperation):
     """Create a model's table."""
+
+    severity = SeverityType.SAFE
 
     serialization_expand_args = ["fields", "options", "managers"]
 
@@ -374,6 +376,8 @@ class CreateModel(ModelOperation):
 class DeleteModel(ModelOperation):
     """Drop a model's table."""
 
+    severity = SeverityType.SAFE
+
     def deconstruct(self):
         kwargs = {
             "name": self.name,
@@ -408,6 +412,8 @@ class DeleteModel(ModelOperation):
 
 class RenameModel(ModelOperation):
     """Rename a model."""
+
+    severity = SeverityType.POSSIBLY_DESTRUCTIVE
 
     def __init__(self, old_name, new_name):
         self.old_name = old_name
@@ -538,6 +544,8 @@ class ModelOptionOperation(ModelOperation):
 class AlterModelTable(ModelOptionOperation):
     """Rename a model's table."""
 
+    severity = SeverityType.POSSIBLY_DESTRUCTIVE
+
     def __init__(self, name, table):
         self.table = table
         super().__init__(name)
@@ -591,6 +599,8 @@ class AlterModelTableComment(ModelOptionOperation):
         self.table_comment = table_comment
         super().__init__(name)
 
+    severity = SeverityType.SAFE
+
     def deconstruct(self):
         kwargs = {
             "name": self.name,
@@ -626,6 +636,8 @@ class AlterModelTableComment(ModelOptionOperation):
 
 class AlterTogetherOptionOperation(ModelOptionOperation):
     option_name = None
+
+    severity = SeverityType.SAFE
 
     def __init__(self, name, option_value):
         if option_value:
@@ -718,6 +730,8 @@ class AlterOrderWithRespectTo(ModelOptionOperation):
 
     option_name = "order_with_respect_to"
 
+    severity = SeverityType.SAFE
+
     def __init__(self, name, order_with_respect_to):
         self.order_with_respect_to = order_with_respect_to
         super().__init__(name)
@@ -803,6 +817,8 @@ class AlterModelOptions(ModelOptionOperation):
         "verbose_name_plural",
     ]
 
+    severity = SeverityType.SAFE
+
     def __init__(self, name, options):
         self.options = options
         super().__init__(name)
@@ -840,6 +856,7 @@ class AlterModelManagers(ModelOptionOperation):
     """Alter the model's managers."""
 
     serialization_expand_args = ["managers"]
+    severity = SeverityType.POSSIBLY_DESTRUCTIVE
 
     def __init__(self, name, managers):
         self.managers = managers
@@ -875,6 +892,8 @@ class IndexOperation(Operation):
 
 class AddIndex(IndexOperation):
     """Add an index on a model."""
+
+    severity = SeverityType.SAFE
 
     def __init__(self, model_name, index):
         self.model_name = model_name
@@ -938,6 +957,8 @@ class AddIndex(IndexOperation):
 class RemoveIndex(IndexOperation):
     """Remove an index from a model."""
 
+    severity = SeverityType.DESTRUCTIVE
+
     def __init__(self, model_name, name):
         self.model_name = model_name
         self.name = name
@@ -980,6 +1001,8 @@ class RemoveIndex(IndexOperation):
 
 class RenameIndex(IndexOperation):
     """Rename an index."""
+
+    severity = SeverityType.SAFE
 
     def __init__(self, model_name, new_name, old_name=None, old_fields=None):
         if not old_name and not old_fields:
@@ -1130,6 +1153,8 @@ class RenameIndex(IndexOperation):
 class AddConstraint(IndexOperation):
     option_name = "constraints"
 
+    severity = SeverityType.POSSIBLY_DESTRUCTIVE
+
     def __init__(self, model_name, constraint):
         self.model_name = model_name
         self.constraint = constraint
@@ -1179,6 +1204,8 @@ class AddConstraint(IndexOperation):
 
 class RemoveConstraint(IndexOperation):
     option_name = "constraints"
+
+    severity = SeverityType.SAFE
 
     def __init__(self, model_name, name):
         self.model_name = model_name

--- a/django/db/migrations/operations/special.py
+++ b/django/db/migrations/operations/special.py
@@ -1,6 +1,6 @@
 from django.db import router
 
-from .base import Operation
+from .base import Operation, SeverityType
 
 
 class SeparateDatabaseAndState(Operation):
@@ -10,6 +10,8 @@ class SeparateDatabaseAndState(Operation):
     that don't support state change to have it applied, or have operations
     that affect the state or not the database, or so on.
     """
+
+    severity = SeverityType.POSSIBLY_DESTRUCTIVE
 
     serialization_expand_args = ["database_operations", "state_operations"]
 
@@ -69,6 +71,7 @@ class RunSQL(Operation):
     """
 
     noop = ""
+    severity = SeverityType.POSSIBLY_DESTRUCTIVE
 
     def __init__(
         self, sql, reverse_sql=None, state_operations=None, hints=None, elidable=False
@@ -139,6 +142,7 @@ class RunPython(Operation):
     """
 
     reduces_to_sql = False
+    severity = SeverityType.POSSIBLY_DESTRUCTIVE
 
     def __init__(
         self, code, reverse_code=None, atomic=None, hints=None, elidable=False

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -2141,7 +2141,7 @@ class MakeMigrationsTests(MigrationTestBase):
             )
 
         # Normal --dry-run output
-        self.assertIn("- Add field silly_char to sillymodel", out.getvalue())
+        self.assertIn("+ Add field silly_char to sillymodel", out.getvalue())
 
         # Additional output caused by verbosity 3
         # The complete migrations file that would be written
@@ -2171,7 +2171,10 @@ class MakeMigrationsTests(MigrationTestBase):
             )
         initial_file = os.path.join(migration_dir, "0001_initial.py")
         self.assertEqual(out.getvalue(), f"{initial_file}\n")
-        self.assertIn("    - Create model ModelWithCustomBase\n", err.getvalue())
+        green = "\033[32;1m"
+        reset = "\033[0m"
+        expected_string = green + "+ Create model ModelWithCustomBase" + reset
+        self.assertIn(expected_string, err.getvalue())
 
     @mock.patch("builtins.input", return_value="Y")
     def test_makemigrations_scriptable_merge(self, mock_input):
@@ -2216,7 +2219,11 @@ class MakeMigrationsTests(MigrationTestBase):
             self.assertTrue(os.path.exists(initial_file))
 
         # Command output indicates the migration is created.
-        self.assertIn(" - Create model SillyModel", out.getvalue())
+        green = "\033[32;1m"
+        reset = "\033[0m"
+        expected_string = green + "+ Create model SillyModel" + reset
+
+        self.assertIn(expected_string, out.getvalue())
 
     @override_settings(MIGRATION_MODULES={"migrations": "some.nonexistent.path"})
     def test_makemigrations_migrations_modules_nonexistent_toplevel_package(self):
@@ -2321,12 +2328,12 @@ class MakeMigrationsTests(MigrationTestBase):
                 out.getvalue().lower(),
                 "merging conflicting_app_with_dependencies\n"
                 "  branch 0002_conflicting_second\n"
-                "    - create model something\n"
+                "    + create model something\n"
                 "  branch 0002_second\n"
-                "    - delete model tribble\n"
-                "    - remove field silly_field from author\n"
-                "    - add field rating to author\n"
-                "    - create model book\n"
+                "    + delete model tribble\n"
+                "    + remove field silly_field from author\n"
+                "    + add field rating to author\n"
+                "    + create model book\n"
                 "\n"
                 "merging will only work if the operations printed above do not "
                 "conflict\n"


### PR DESCRIPTION
Added formatted description to highlight different operations in makemigrations output.

 
I wasn't sure whether to add color style to the output or not as it wasn't determined in the ticket discussions too. I have added it now. If you feel it's too noisy, I can remove it and we can have just text formatting. Plus, I think letting the `describe()` method return two parameters is a clean way to implement such a feature without too overengineering.

Here are sample outputs:
<a href="https://imgbb.com/"><img src="https://i.ibb.co/FwNJj8f/Screenshot-from-2023-08-03-17-13-42.png" alt="Screenshot-from-2023-08-03-17-13-42" border="0"></a>
<a href="https://imgbb.com/"><img src="https://i.ibb.co/PQWRW6Z/Screenshot-from-2023-08-03-17-12-59.png" alt="Screenshot-from-2023-08-03-17-12-59" border="0"></a>