### PR TITLE
Refs #31435 -- Doc'd potential danger of referring to model fields within __init__

### DIFF
--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -30,7 +30,9 @@ need to :meth:`~Model.save()`.
     You may be tempted to customize the model by overriding the ``__init__``
     method. If you do so, however, take care not to change the calling
     signature as any change may prevent the model instance from being saved.
-    Rather than overriding ``__init__``, try using one of these approaches:
+    Additionally, referring to model fields within ``__init__`` may potentially
+    result in infinite recursion errors in some circumstances.  Rather than
+    overriding ``__init__``, try using one of these approaches:
 
     #. Add a classmethod on the model class::
 


### PR DESCRIPTION
This came up in https://code.djangoproject.com/ticket/31435 and again in https://code.djangoproject.com/ticket/34847 where people were doing

```
class Foo(Model):
    foo = <some model field>

    def __init__(self, …):
        super().__init__(…)
        
        self._old_foo = self.foo
```

which potentially leads to infinite recursion in some cases.

ATM the docs only warn against modifying the signature. Also mentioning refraining from accessing model fields may be a worthy addition.

Simon's recommendation was to access the fields like `self.__dict__.get(field_name)` if it was a must to use `__init__()` - this could also be something to add.