### PR TITLE
Defined PASSWORD_HASHERS for auth_tests.test_views.ChangelistTests.

### DIFF
--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -1361,7 +1361,10 @@ def get_perm(Model, perm):
 
 # Redirect in test_user_change_password will fail if session auth hash
 # isn't updated after password change (#21649)
-@override_settings(ROOT_URLCONF="auth_tests.urls_admin")
+@override_settings(
+    ROOT_URLCONF="auth_tests.urls_admin",
+    PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"],
+)
 class ChangelistTests(AuthViewsTestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
`auth_tests.test_views.ChangelistTests.test_view_user_password_is_readonly` depends on the password hasher having the three components `algorithm`, `salt` and `hash`.

The default password hasher (`PBKDF2PasswordHasher`) has an extra `iterations` component, breaking the test.

The `MD5PasswordHasher` fits this requirement and is recommended in the `test_sqlite.py` example settings file for test performance.

Override settings for the entire test class because the hasher is used in `setUpTestData`.