### PR TITLE
Catch decoding of non-UTF-8 files in storage.py post_process

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -361,7 +361,10 @@ class HashedFilesMixin:
                 # ..to apply each replacement pattern to the content
                 if name in adjustable_paths:
                     old_hashed_name = hashed_name
-                    content = original_file.read().decode("utf-8")
+                    try:
+                        content = original_file.read().decode("utf-8")
+                    except UnicodeDecodeError as exc:
+                        yield name, None, exc, False
                     for extension, patterns in self._patterns.items():
                         if matches_patterns(path, (extension,)):
                             for pattern, template in patterns:


### PR DESCRIPTION
Wrapped decode("utf-8") with a try...catch that yields a UnicodeDecodeError exception if the file fails to decode from UTF-8.

This change is in response to unhandled error when attempting to decode files not encoded with UTF-8 under manage.py collectstatic. Discovered after upgrading to django 4. Previous versions (2 and 3) had not thrown an error for the files with different encoding.