### PR TITLE
Fixed #34857 -- Made calendar "Cancel" button in admin use color variables.

### DIFF
--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -533,17 +533,17 @@ span.clearable-file-input label {
     margin: 0;
     padding: 4px 0;
     font-size: 0.75rem;
-    background: #eee;
+    background: var(--close-button-bg);
     border-top: 1px solid var(--border-color);
-    color: var(--body-fg);
+    color: var(--button-fg);
 }
 
 .calendar-cancel:focus, .calendar-cancel:hover {
-    background: #ddd;
+    background: var(--close-button-hover-bg);
 }
 
 .calendar-cancel a {
-    color: black;
+    color: var(--button-fg);
     display: block;
 }
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34857

## CSS variables

In `widget.css` (admin) the colors for the date picker cancel buttons are hard-coded leading to a light theme of (only) the cancel button irrespectively of user preferences. 

This µ-PR replaces the hard-coded colors with the appropriate CSS variables:
* `--button-fg`
* `--close-button-bg`
* `--close-button-hover-bg`

This affects versions 3.2, 4.2, 5.0a1.

## Before patch
The cancel button has a fixed bright colour (which almost hurts if you've got a dark theme).

<img width="400" alt="image" src="https://github.com/django/django/assets/16904477/93f6fb1e-70a2-41e9-92bd-1ddb014cfa14">  <img width="400" alt="image" src="https://github.com/django/django/assets/16904477/28c518b2-d8ee-4a4e-9214-656ca27c1745">

## After patch
Colours are defined by the theme (which changes both dark and light theme).

<img width="400" alt="image" src="https://github.com/django/django/assets/16904477/c7599893-1dce-4899-890f-456ce53dc35b"><img width="400" alt="image" src="https://github.com/django/django/assets/16904477/a243ade4-591a-4fa0-9d0a-a7348bff0945">


