### PR TITLE
Fixed #34846 -- Added Copy button to Code Snippets.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,10 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
+    "sphinx_copybutton",
 ]
+copybutton_prompt_text = r"\.\.\.\\\> |\$ "
+copybutton_prompt_is_regexp = True
 
 # AutosectionLabel settings.
 # Uses a <page>:<label> schema which doesn't work for duplicate sub-section

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ pyenchant
 Sphinx>=4.5.0
 sphinxcontrib-spelling
 blacken-docs
+sphinx-copybutton


### PR DESCRIPTION
Ticket Number : [34846](https://code.djangoproject.com/ticket/34846)

Continued From : #16342 

Added Copy button functionality to Code Blocks in the documentation

# Before

![image](https://github.com/django/django/assets/94912101/41775287-6666-40f5-93fd-77e7bcba8efe)

# After

![image](https://github.com/django/django/assets/94912101/0d994792-1b59-4c67-a0bf-f38d624942b6)
![image](https://github.com/django/django/assets/94912101/045ea130-5fb4-408e-bab3-f726ac7e26e0)
![image](https://github.com/django/django/assets/94912101/c812c88f-53df-4cf5-b3d9-5190a5d1f694)

Actual [Link](https://docs.djangoproject.com/en/4.2/intro/tutorial01/) where these example changes would be reflected