### PR TITLE
Fixed #34858 -- Fix `output_field` resolution for `PositiveIntegerField`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -961,6 +961,7 @@ answer newbie questions, and generally made Django that much better:
     Tim Heap <tim@timheap.me>
     Tim McCurrach <tim.mccurrach@gmail.com>
     Tim Saylor <tim.saylor@gmail.com>
+    Toan Vuong <me@toanvuong.io>
     Tobias Kunze <rixx@cutebit.de>
     Tobias McNulty <https://www.caktusgroup.com/blog/>
     tobias@neuyork.de

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -512,6 +512,25 @@ NoneType = type(None)
 
 _connector_combinations = [
     # Numeric operations - operands of same type.
+    # PositiveIntegerField should take precedence over IntegerField.
+    # Excludes subtraction
+    {
+        connector: [
+            (
+                fields.PositiveIntegerField,
+                fields.PositiveIntegerField,
+                fields.PositiveIntegerField,
+            ),
+        ]
+        for connector in (
+            Combinable.ADD,
+            Combinable.MUL,
+            Combinable.DIV,
+            Combinable.MOD,
+            Combinable.POW,
+        )
+    },
+    # Other numeric operands
     {
         connector: [
             (fields.IntegerField, fields.IntegerField, fields.IntegerField),

--- a/docs/releases/4.2.6.txt
+++ b/docs/releases/4.2.6.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Fixed a regression in Django 4.2.5 where overriding the deprecated
   ``DEFAULT_FILE_STORAGE`` and ``STATICFILES_STORAGE`` settings in tests caused
   the main ``STORAGES`` to mutate (:ticket:`34821`).
+* Fixed a regression in Django 4.x where math expressions involving two
+  ``PositiveIntegerField``s resolve incorrectly resolve to an ``IntegerField``
+  instead of a ``PositiveIntegerField``.

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -34,6 +34,7 @@ from django.db.models import (
     Model,
     OrderBy,
     OuterRef,
+    PositiveIntegerField,
     Q,
     StdDev,
     Subquery,
@@ -2456,6 +2457,25 @@ class CombinableTests(SimpleTestCase):
 
 
 class CombinedExpressionTests(SimpleTestCase):
+    def test_resolve_output_field_positive_integer(self):
+        lhs = rhs = combined = PositiveIntegerField
+        connectors = [
+            Combinable.ADD,
+            Combinable.MUL,
+            Combinable.DIV,
+            Combinable.MOD,
+            Combinable.POW,
+        ]
+
+        for connector in connectors:
+            with self.subTest(lhs=lhs, connector=connector, rhs=rhs, combined=combined):
+                expr = CombinedExpression(
+                    Expression(lhs()),
+                    connector,
+                    Expression(rhs()),
+                )
+                self.assertIsInstance(expr.output_field, combined)
+
     def test_resolve_output_field_number(self):
         tests = [
             (IntegerField, AutoField, IntegerField),


### PR DESCRIPTION
* Math operations involving two `PositiveIntegerField`s should resolve to an output of `PositiveIntegerField` instead of an `IntegerField`. This was a regression introduced in ticket #33397.
* Add my name to AUTHORS.