### PR TITLE
Fixed #34849 -- Avoided raising RuntimeWarning about import-time queries when apps are reinitialized with test tools.

### DIFF
--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -61,7 +61,9 @@ class CursorWrapper:
                 "Keyword parameters for callproc are not supported on this "
                 "database backend."
             )
-        if not apps.ready:
+        # Raise a warning during app initialization (stored_app_configs is only
+        # ever set during testing).
+        if not apps.ready and not apps.stored_app_configs:
             warnings.warn(self.APPS_NOT_READY_WARNING_MSG, category=RuntimeWarning)
         self.db.validate_no_broken_transaction()
         with self.db.wrap_database_errors:
@@ -90,7 +92,9 @@ class CursorWrapper:
         return executor(sql, params, many, context)
 
     def _execute(self, sql, params, *ignored_wrapper_args):
-        if not apps.ready:
+        # Raise a warning during app initialization (stored_app_configs is only
+        # ever set during testing).
+        if not apps.ready and not apps.stored_app_configs:
             warnings.warn(self.APPS_NOT_READY_WARNING_MSG, category=RuntimeWarning)
         self.db.validate_no_broken_transaction()
         with self.db.wrap_database_errors:
@@ -101,7 +105,9 @@ class CursorWrapper:
                 return self.cursor.execute(sql, params)
 
     def _executemany(self, sql, param_list, *ignored_wrapper_args):
-        if not apps.ready:
+        # Raise a warning during app initialization (stored_app_configs is only
+        # ever set during testing).
+        if not apps.ready and not apps.stored_app_configs:
             warnings.warn(self.APPS_NOT_READY_WARNING_MSG, category=RuntimeWarning)
         self.db.validate_no_broken_transaction()
         with self.db.wrap_database_errors:

--- a/tests/apps/tests.py
+++ b/tests/apps/tests.py
@@ -607,10 +607,9 @@ class QueryPerformingAppTests(TransactionTestCase):
         custom_settings = override_settings(
             INSTALLED_APPS=[f"apps.query_performing_app.apps.{app_config_name}"]
         )
-        # Ignore the RuntimeWarning, as override_settings.enable() calls
-        # AppConfig.ready() which will trigger the warning.
-        with self.assertWarnsMessage(RuntimeWarning, self.expected_msg):
-            custom_settings.enable()
+        custom_settings.enable()
+        old_stored_app_configs = apps.stored_app_configs
+        apps.stored_app_configs = []
         try:
             with patch.multiple(apps, ready=False, loading=False, app_configs={}):
                 with self.assertWarnsMessage(RuntimeWarning, self.expected_msg):
@@ -619,4 +618,5 @@ class QueryPerformingAppTests(TransactionTestCase):
                 app_config = apps.get_app_config("query_performing_app")
                 return app_config.query_results
         finally:
+            setattr(apps, "stored_app_configs", old_stored_app_configs)
             custom_settings.disable()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34849