### PR TITLE
Fixed #34818 -- Prevented GenericIPAddressField from mutating error messages.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -276,14 +276,18 @@ def validate_ipv4_address(value):
         ipaddress.IPv4Address(value)
     except ValueError:
         raise ValidationError(
-            _("Enter a valid IPv4 address."), code="invalid", params={"value": value}
+            _("Enter a valid IPv4 address."),
+            code="invalid",
+            params={"value": value, "protocol": "IPv4"},
         )
 
 
 def validate_ipv6_address(value):
     if not is_valid_ipv6_address(value):
         raise ValidationError(
-            _("Enter a valid IPv6 address."), code="invalid", params={"value": value}
+            _("Enter a valid IPv6 address."),
+            code="invalid",
+            params={"value": value, "protocol": "IPv6"},
         )
 
 
@@ -297,7 +301,7 @@ def validate_ipv46_address(value):
             raise ValidationError(
                 _("Enter a valid IPv4 or IPv6 address."),
                 code="invalid",
-                params={"value": value},
+                params={"value": value, "protocol": "IPv4 or IPv6"},
             )
 
 

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -278,7 +278,7 @@ def validate_ipv4_address(value):
         raise ValidationError(
             _("Enter a valid IPv4 address."),
             code="invalid",
-            params={"value": value, "protocol": "IPv4"},
+            params={"value": value},
         )
 
 
@@ -287,7 +287,7 @@ def validate_ipv6_address(value):
         raise ValidationError(
             _("Enter a valid IPv6 address."),
             code="invalid",
-            params={"value": value, "protocol": "IPv6"},
+            params={"value": value},
         )
 
 
@@ -301,7 +301,7 @@ def validate_ipv46_address(value):
             raise ValidationError(
                 _("Enter a valid IPv4 or IPv6 address."),
                 code="invalid",
-                params={"value": value, "protocol": "IPv4 or IPv6"},
+                params={"value": value},
             )
 
 

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -276,18 +276,18 @@ def validate_ipv4_address(value):
         ipaddress.IPv4Address(value)
     except ValueError:
         raise ValidationError(
-            _("Enter a valid IPv4 address."),
+            _("Enter a valid %(protocol)s address."),
             code="invalid",
-            params={"value": value},
+            params={"protocol": _("IPv4"), "value": value},
         )
 
 
 def validate_ipv6_address(value):
     if not is_valid_ipv6_address(value):
         raise ValidationError(
-            _("Enter a valid IPv6 address."),
+            _("Enter a valid %(protocol)s address."),
             code="invalid",
-            params={"value": value},
+            params={"protocol": _("IPv6"), "value": value},
         )
 
 
@@ -299,16 +299,16 @@ def validate_ipv46_address(value):
             validate_ipv6_address(value)
         except ValidationError:
             raise ValidationError(
-                _("Enter a valid IPv4 or IPv6 address."),
+                _("Enter a valid %(protocol)s address."),
                 code="invalid",
-                params={"value": value},
+                params={"protocol": _("IPv4 or IPv6"), "value": value},
             )
 
 
 ip_address_validator_map = {
-    "both": ([validate_ipv46_address], _("Enter a valid IPv4 or IPv6 address.")),
-    "ipv4": ([validate_ipv4_address], _("Enter a valid IPv4 address.")),
-    "ipv6": ([validate_ipv6_address], _("Enter a valid IPv6 address.")),
+    "both": [validate_ipv46_address],
+    "ipv4": [validate_ipv4_address],
+    "ipv6": [validate_ipv6_address],
 }
 
 

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2205,7 +2205,7 @@ class IPAddressField(Field):
 class GenericIPAddressField(Field):
     empty_strings_allowed = False
     description = _("IP address")
-    default_error_messages = {}
+    default_error_messages = {"invalid": _("Enter a valid %(protocol)s address.")}
 
     def __init__(
         self,
@@ -2222,7 +2222,6 @@ class GenericIPAddressField(Field):
             self.default_validators,
             invalid_error_message,
         ) = validators.ip_address_validators(protocol, unpack_ipv4)
-        self.default_error_messages["invalid"] = invalid_error_message
         kwargs["max_length"] = 39
         super().__init__(verbose_name, name, *args, **kwargs)
 

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2205,7 +2205,7 @@ class IPAddressField(Field):
 class GenericIPAddressField(Field):
     empty_strings_allowed = False
     description = _("IP address")
-    default_error_messages = {"invalid": _("Enter a valid %(protocol)s address.")}
+    default_error_messages = {}
 
     def __init__(
         self,
@@ -2213,6 +2213,7 @@ class GenericIPAddressField(Field):
         name=None,
         protocol="both",
         unpack_ipv4=False,
+        error_messages=None,
         *args,
         **kwargs,
     ):
@@ -2222,7 +2223,10 @@ class GenericIPAddressField(Field):
             self.default_validators,
             invalid_error_message,
         ) = validators.ip_address_validators(protocol, unpack_ipv4)
+        _error_messages = {"invalid": invalid_error_message}
+        _error_messages.update(error_messages or {})
         kwargs["max_length"] = 39
+        kwargs["error_messages"] = _error_messages
         super().__init__(verbose_name, name, *args, **kwargs)
 
     def check(self, **kwargs):

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2205,7 +2205,7 @@ class IPAddressField(Field):
 class GenericIPAddressField(Field):
     empty_strings_allowed = False
     description = _("IP address")
-    default_error_messages = {}
+    default_error_messages = {"invalid": _("Enter a valid %(protocol)s address.")}
 
     def __init__(
         self,
@@ -2213,20 +2213,15 @@ class GenericIPAddressField(Field):
         name=None,
         protocol="both",
         unpack_ipv4=False,
-        error_messages=None,
         *args,
         **kwargs,
     ):
         self.unpack_ipv4 = unpack_ipv4
         self.protocol = protocol
-        (
-            self.default_validators,
-            invalid_error_message,
-        ) = validators.ip_address_validators(protocol, unpack_ipv4)
-        _error_messages = {"invalid": invalid_error_message}
-        _error_messages.update(error_messages or {})
+        self.default_validators = validators.ip_address_validators(
+            protocol, unpack_ipv4
+        )
         kwargs["max_length"] = 39
-        kwargs["error_messages"] = _error_messages
         super().__init__(verbose_name, name, *args, **kwargs)
 
     def check(self, **kwargs):

--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1288,7 +1288,7 @@ class GenericIPAddressField(CharField):
         self.unpack_ipv4 = unpack_ipv4
         self.default_validators = validators.ip_address_validators(
             protocol, unpack_ipv4
-        )[0]
+        )
         super().__init__(**kwargs)
 
     def to_python(self, value):

--- a/django/utils/ipv6.py
+++ b/django/utils/ipv6.py
@@ -26,7 +26,9 @@ def clean_ipv6_address(
     try:
         addr = ipaddress.IPv6Address(int(ipaddress.IPv6Address(ip_str)))
     except ValueError:
-        raise ValidationError(error_message, code="invalid")
+        raise ValidationError(
+            error_message, code="invalid", params={"protocol": _("IPv6")}
+        )
 
     if unpack_ipv4 and addr.ipv4_mapped:
         return str(addr.ipv4_mapped)

--- a/django/utils/ipv6.py
+++ b/django/utils/ipv6.py
@@ -26,7 +26,9 @@ def clean_ipv6_address(
     try:
         addr = ipaddress.IPv6Address(int(ipaddress.IPv6Address(ip_str)))
     except ValueError:
-        raise ValidationError(error_message, code="invalid")
+        raise ValidationError(
+            error_message, code="invalid", params={"protocol": "IPv6"}
+        )
 
     if unpack_ipv4 and addr.ipv4_mapped:
         return str(addr.ipv4_mapped)

--- a/django/utils/ipv6.py
+++ b/django/utils/ipv6.py
@@ -26,9 +26,7 @@ def clean_ipv6_address(
     try:
         addr = ipaddress.IPv6Address(int(ipaddress.IPv6Address(ip_str)))
     except ValueError:
-        raise ValidationError(
-            error_message, code="invalid", params={"protocol": "IPv6"}
-        )
+        raise ValidationError(error_message, code="invalid")
 
     if unpack_ipv4 and addr.ipv4_mapped:
         return str(addr.ipv4_mapped)

--- a/tests/validation/tests.py
+++ b/tests/validation/tests.py
@@ -206,3 +206,17 @@ class GenericIPAddressFieldTests(ValidationAssertions, TestCase):
         self.assertIsNone(giptm.full_clean())
         giptm = GenericIPAddressTestModel(generic_ip=None)
         self.assertIsNone(giptm.full_clean())
+
+    def test_multiple_invalid_ip_raises_error(self):
+        giptm = GenericIPAddressTestModel(
+            v6_ip="1.2.3.4", v4_ip="::ffff:10.10.10.10", generic_ip="fsad"
+        )
+        self.assertFieldFailsValidationWithMessage(
+            giptm.full_clean, "v6_ip", ["Enter a valid IPv6 address."]
+        )
+        self.assertFieldFailsValidationWithMessage(
+            giptm.full_clean, "v4_ip", ["Enter a valid IPv4 address."]
+        )
+        self.assertFieldFailsValidationWithMessage(
+            giptm.full_clean, "generic_ip", ["Enter a valid IPv4 or IPv6 address."]
+        )


### PR DESCRIPTION
Refactored the ValidationError messages raised by GenericIPAddressField to include a protocol param to avoid using the shared instance of `default_error_messages` to track the message for different protocols