### PR TITLE
Updated docs example to use cookie-based storage for timezone handling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -857,6 +857,7 @@ answer newbie questions, and generally made Django that much better:
     Robert Wittams
     Rob Golding-Day <rob@golding-day.com>
     Rob Hudson <https://rob.cogit8.org/>
+    Rob McCombie
     Rob Nguyen <tienrobertnguyenn@gmail.com>
     Robin Munn <http://www.geekforgod.com/>
     Rodrigo Pinheiro Marques de Araújo <fenrrir@gmail.com>

--- a/docs/topics/i18n/timezones.txt
+++ b/docs/topics/i18n/timezones.txt
@@ -156,7 +156,7 @@ the time zone of their primary audience or UTC.
 :func:`zoneinfo.available_timezones` provides a set of available timezones that
 you can use to build a map from likely locations to time zones.
 
-Here's an example that stores the current timezone in the session. (It skips
+Here's an example that stores the current timezone in cookies. (It skips
 error handling entirely for the sake of simplicity.)
 
 Add the following middleware to :setting:`MIDDLEWARE`::
@@ -171,7 +171,7 @@ Add the following middleware to :setting:`MIDDLEWARE`::
             self.get_response = get_response
 
         def __call__(self, request):
-            tzname = request.session.get("django_timezone")
+            tzname = request.COOKIES.get("django_timezone")
             if tzname:
                 timezone.activate(zoneinfo.ZoneInfo(tzname))
             else:
@@ -191,11 +191,11 @@ Create a view that can set the current timezone::
 
 
     def set_timezone(request):
+        response = render(request, "template.html", {"timezones": common_timezones})
         if request.method == "POST":
-            request.session["django_timezone"] = request.POST["timezone"]
-            return redirect("/")
-        else:
-            return render(request, "template.html", {"timezones": common_timezones})
+            tzname = request.POST["timezone"]
+            response.set_cookie("django_timezone", tzname)
+        return response
 
 Include a form in ``template.html`` that will ``POST`` to this view:
 


### PR DESCRIPTION
The current example for TimezoneMiddleware in the Django documentation uses sessions to store the user's time zone. With Django 4.0, the framework has deprecated the use of sessions for storing the user's language preference, opting for cookies instead. It seems logical to align the handling of time zones with this change for consistency and the advantages it offers.

See https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0 and https://docs.djangoproject.com/en/dev/releases/3.0/#id3