### PR TITLE
Fixed #34835 -- Made admin's changelist filters render in <nav> tag.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -589,6 +589,7 @@ answer newbie questions, and generally made Django that much better:
     Leandra Finger <leandra.finger@gmail.com>
     Lee Reilly <lee@leereilly.net>
     Lee Sanghyuck <shlee322@elab.kr>
+    Lemuel Sta Ana <https://github.com/lstaana>
     Leo "hylje" Honkanen <sealage@gmail.com>
     Leo Shklovskii
     Leo Soto <leo.soto@gmail.com>

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -73,8 +73,8 @@
       </div>
       {% block filters %}
         {% if cl.has_filters %}
-          <div id="changelist-filter">
-            <h2>{% translate 'Filter' %}</h2>
+          <nav id="changelist-filter" aria-labelledby="changelist-filter-header">
+            <h2 id="changelist-filter-header">{% translate 'Filter' %}</h2>
             {% if cl.is_facets_optional or cl.has_active_filters %}<div id="changelist-filter-extra-actions">
               {% if cl.is_facets_optional %}<h3>
                 {% if cl.add_facets %}<a href="{{ cl.remove_facet_link }}" class="hidelink">{% translate "Hide counts" %}</a>
@@ -85,7 +85,7 @@
               </h3>{% endif %}
             </div>{% endif %}
             {% for spec in cl.filter_specs %}{% admin_list_filter cl spec %}{% endfor %}
-          </div>
+          </nav>
         {% endif %}
       {% endblock %}
     </div>

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -248,7 +248,8 @@ PostgreSQL 13 and higher.
 Miscellaneous
 -------------
 
-* ...
+* In order to improve accessibility, the admin's changelist filter is now
+  rendered in a ``<nav>`` tag instead of a ``<div>``.
 
 .. _deprecated-features-5.1:
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -812,7 +812,7 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         response = self.client.get(reverse("admin:admin_views_thing_changelist"))
         self.assertContains(
             response,
-            '<div id="changelist-filter">',
+            '<nav id="changelist-filter" aria-labelledby="changelist-filter-header">',
             msg_prefix="Expected filter not found in changelist view",
         )
         self.assertNotContains(
@@ -865,7 +865,10 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
     def test_relation_spanning_filters(self):
         changelist_url = reverse("admin:admin_views_chapterxtra1_changelist")
         response = self.client.get(changelist_url)
-        self.assertContains(response, '<div id="changelist-filter">')
+        self.assertContains(
+            response,
+            '<nav id="changelist-filter" aria-labelledby="changelist-filter-header">',
+        )
         filters = {
             "chap__id__exact": {
                 "values": [c.id for c in Chapter.objects.all()],
@@ -1002,7 +1005,10 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
             "Changelist filter isn't showing options contained inside a model "
             "field 'choices' option named group."
         )
-        self.assertContains(response, '<div id="changelist-filter">')
+        self.assertContains(
+            response,
+            '<nav id="changelist-filter" aria-labelledby="changelist-filter-header">',
+        )
         self.assertContains(
             response,
             '<a href="?surface__exact=x">Horizontal</a>',


### PR DESCRIPTION
Hello,

I noticed that after the modification of the changelist filter from div to nav, a couple of tests were impacted:

1. test_limited_filter
2. test_named_group_field_choices_filter
3. test_relation_spanning_filters

I have made modifications on the tests above as part of this PR, please review and suggest necessary improvements.

Thanks,
Lem