### PR TITLE
[4.2.x] Refs #34320 -- Skipped SchemaTests.test_rename_field_with_check_to_truncated_name on MariaBD 10.5.2+.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -154,6 +154,21 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                     },
                 }
             )
+        if self.connection.mysql_is_mariadb and self.connection.mysql_version >= (
+            10,
+            5,
+            2,
+        ):
+            skips.update(
+                {
+                    "ALTER TABLE ... RENAME COLUMN statement doesn't rename inline "
+                    "constraints on MariaDB 10.5.2+, this is fixed in Django 5.0+ "
+                    "(#34320).": {
+                        "schema.tests.SchemaTests."
+                        "test_rename_field_with_check_to_truncated_name",
+                    },
+                }
+            )
         return skips
 
     @cached_property


### PR DESCRIPTION
This was fixed by 9953c804a9375956a542da94665662d306dff48d (`main`, `stable/5.0.x`) and crashes since MariaDB was bumped to 10.5 on Jenkins, check out [logs](https://djangoci.com/view/Main/job/django-mariadb-4.2/lastCompletedBuild/testReport/).

