### PR TITLE
Fixed #34877 -- Fixed migrations crash when adding GeneratedField with output_field with params.

### DIFF
--- a/django/db/models/fields/generated.py
+++ b/django/db/models/fields/generated.py
@@ -159,3 +159,6 @@ class GeneratedField(Field):
 
     def db_parameters(self, connection):
         return self.output_field.db_parameters(connection)
+
+    def db_type_parameters(self, connection):
+        return self.output_field.db_type_parameters(connection)

--- a/tests/model_fields/test_generatedfield.py
+++ b/tests/model_fields/test_generatedfield.py
@@ -181,6 +181,13 @@ class GeneratedFieldTestMixin:
             field._resolved_expression.output_field.db_type(connection),
         )
 
+    @skipUnlessDBFeature("supports_collation_on_charfield")
+    def test_db_type_parameters(self):
+        db_type_parameters = self.output_field_model._meta.get_field(
+            "lower_name"
+        ).db_type_parameters(connection)
+        self.assertEqual(db_type_parameters["max_length"], 11)
+
     def test_model_with_params(self):
         m = self.params_model.objects.create()
         m = self._refresh_if_needed(m)


### PR DESCRIPTION
Ref https://code.djangoproject.com/ticket/34877