### PR TITLE
Fixed #34878 -- Fixed AttributeErrror on reload when using TemplatesSetting for FORM_RENDERER.

### DIFF
--- a/django/template/autoreload.py
+++ b/django/template/autoreload.py
@@ -39,9 +39,10 @@ def reset_loaders():
         for loader in backend.engine.template_loaders:
             loader.reset()
 
-    backend = get_default_renderer().engine
-    if isinstance(backend, DjangoTemplates):
-        for loader in backend.engine.template_loaders:
+    renderer = get_default_renderer()
+
+    if hasattr(renderer, "engine") and isinstance(renderer.engine, DjangoTemplates):
+        for loader in renderer.engine.engine.template_loaders:
             loader.reset()
 
 

--- a/tests/template_tests/test_autoreloader.py
+++ b/tests/template_tests/test_autoreloader.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from unittest import mock
 
+from django.forms.renderers import get_default_renderer
 from django.template import autoreload
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import require_jinja2
@@ -32,6 +33,17 @@ EXTRA_TEMPLATES_DIR = ROOT / "templates_extra"
     ],
 )
 class TemplateReloadTests(SimpleTestCase):
+    @override_settings(FORM_RENDERER="django.forms.renderers.TemplatesSetting")
+    @mock.patch("django.template.loaders.cached.Loader.reset")
+    def test_form_template_reset_template_change_no_djangotemplates(
+        self, mock_loader_reset
+    ):
+        get_default_renderer.cache_clear()
+        template_path = Path(__file__).parent / "templates" / "index.html"
+        self.assertIs(autoreload.template_changed(None, template_path), True)
+        mock_loader_reset.assert_not_called()
+        get_default_renderer.cache_clear()
+
     @mock.patch("django.template.autoreload.reset_loaders")
     def test_template_changed(self, mock_reset):
         template_path = Path(__file__).parent / "templates" / "index.html"


### PR DESCRIPTION
This checks that the renderer has an engine property and is a DjangoTemplates instance before calling reset() on its loaders.

See https://code.djangoproject.com/ticket/34878 add suggested change by @felixxm 