### PR TITLE
Fixed #34878 -- Fixed autoreloader crash when FORM_RENDERER is set to TemplatesSetting.

### DIFF
--- a/django/template/autoreload.py
+++ b/django/template/autoreload.py
@@ -39,7 +39,7 @@ def reset_loaders():
         for loader in backend.engine.template_loaders:
             loader.reset()
 
-    backend = get_default_renderer().engine
+    backend = getattr(get_default_renderer(), "engine", None)
     if isinstance(backend, DjangoTemplates):
         for loader in backend.engine.template_loaders:
             loader.reset()

--- a/tests/template_tests/test_autoreloader.py
+++ b/tests/template_tests/test_autoreloader.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from unittest import mock
 
+from django.forms.renderers import get_default_renderer
 from django.template import autoreload
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import require_jinja2
@@ -67,6 +68,17 @@ class TemplateReloadTests(SimpleTestCase):
         template_path = Path(__file__).parent / "templates" / "index.html"
         self.assertIs(autoreload.template_changed(None, template_path), True)
         mock_loader_reset.assert_called_once()
+
+    @override_settings(FORM_RENDERER="django.forms.renderers.TemplatesSetting")
+    @mock.patch("django.template.loaders.cached.Loader.reset")
+    def test_form_template_reset_template_change_no_djangotemplates(
+        self, mock_loader_reset
+    ):
+        self.addCleanup(get_default_renderer.cache_clear)
+        get_default_renderer.cache_clear()
+        template_path = Path(__file__).parent / "templates" / "index.html"
+        self.assertIs(autoreload.template_changed(None, template_path), True)
+        mock_loader_reset.assert_not_called()
 
     @mock.patch("django.forms.renderers.get_default_renderer")
     def test_form_template_reset_non_template_change(self, mock_renderer):


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/34878