### PR TITLE
Fixed #34882 -- Fixed no options in AsGeoJSON() for geometries in non-default CRS.

### DIFF
--- a/django/contrib/gis/db/models/functions.py
+++ b/django/contrib/gis/db/models/functions.py
@@ -195,8 +195,7 @@ class AsGeoJSON(GeoFunc):
             options = 1
         elif crs:
             options = 2
-        if options:
-            expressions.append(options)
+        expressions.append(options)
         super().__init__(*expressions, **extra)
 
     def as_oracle(self, compiler, connection, **extra_context):


### PR DESCRIPTION
When calling AssGeoJSON, if bbox and crs are both false, then options = 0, there fore not added to the expression. 

In [Postgis](https://code.djangoproject.com/changeset/1/), with geometries, the default is not 0 but 8, meaning the CRS is returned, not respecting the original call arguments.


fixes #34882 https://code.djangoproject.com/ticket/34882#ticket