### PR TITLE
replaced list.insert(0, ...) with deque.appendleft(...)

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import types
+from collections import deque
 
 from asgiref.sync import async_to_sync, iscoroutinefunction, sync_to_async
 
@@ -29,7 +30,7 @@ class BaseHandler:
 
         Must be called after the environment is fixed (see __call__ in subclasses).
         """
-        self._view_middleware = []
+        self._view_middleware = deque()
         self._template_response_middleware = []
         self._exception_middleware = []
 
@@ -75,8 +76,7 @@ class BaseHandler:
                 )
 
             if hasattr(mw_instance, "process_view"):
-                self._view_middleware.insert(
-                    0,
+                self._view_middleware.appendleft(
                     self.adapt_method_mode(is_async, mw_instance.process_view),
                 )
             if hasattr(mw_instance, "process_template_response"):


### PR DESCRIPTION
Replaced list with deque because it's faster to use.

Main drawback is memory usage.

```
import sys
from collections import deque
sys.getsizeof(deque())
# 760
sys.getsizeof([])
# 56
```
I searched around the github for "def process_view" with "path:**middleware**", found that on avg people have 1-2 middleware per project.

If it's not a good idea to put deque here, maybe it can be considered to replace other instances of `list.insert(0, ...)` with deque