### PR TITLE
Fixed #28900 -- Fixed crashing QuerySet.values() and values_list() for compound queries with annotation.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2426,6 +2426,9 @@ class Query(BaseExpression):
         self._extra_select_cache = None
 
     def set_values(self, fields):
+        if self.combinator:
+            for comb in self.combined_queries:
+                comb.set_values(fields)
         self.select_related = False
         self.clear_deferred_loading()
         self.clear_select_fields()

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -382,6 +382,13 @@ class QuerySetSetOperationTests(TestCase):
             [("c1", -10, "cb"), ("rn1", 10, "rn")],
         )
 
+    def test_union_same_model_with_annotations_subsequent_values_list(self):
+        ReservedName.objects.create(name="rn1", order=10)
+        qs1 = ReservedName.objects.annotate(row_type=Value("rn"))
+        self.assertSequenceEqual(
+            qs1.union(qs1).values_list("row_type", flat=True), ["rn"]
+        )
+
     def test_union_in_subquery(self):
         ReservedName.objects.bulk_create(
             [


### PR DESCRIPTION
[ticket-28900](https://code.djangoproject.com/ticket/28900)