### PR TITLE
Fixed #34759 -- Confirmed support for SpatiaLite 5.1.

### DIFF
--- a/docs/ref/contrib/gis/install/geolibs.txt
+++ b/docs/ref/contrib/gis/install/geolibs.txt
@@ -13,7 +13,7 @@ Program                   Description                           Required        
 :doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               3.7, 3.6, 3.5, 3.4, 3.3, 3.2, 3.1, 3.0, 2.4
 :doc:`GeoIP <../geoip2>`  IP-based geolocation library          No                                2
 `PostGIS`__               Spatial extensions for PostgreSQL     Yes (PostgreSQL only)             3.4, 3.3, 3.2, 3.1, 3.0
-`SpatiaLite`__            Spatial extensions for SQLite         Yes (SQLite only)                 5.0, 4.3
+`SpatiaLite`__            Spatial extensions for SQLite         Yes (SQLite only)                 5.1, 5.0, 4.3
 ========================  ====================================  ================================  ===========================================
 
 Note that older or more recent versions of these libraries *may* also work
@@ -48,6 +48,7 @@ totally fine with GeoDjango. Your mileage may vary.
     PROJ 5.0.0 2018-03-01
     SpatiaLite 4.3.0 2015-09-07
     SpatiaLite 5.0.0 2020-08-23
+    SpatiaLite 5.1.0 2023-08-04
 
 .. note::
 

--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -141,7 +141,7 @@ class GISFunctionsTests(FuncTestMixin, TestCase):
             )
         else:
             gml_regex = re.compile(
-                r'^<gml:Point srsName="EPSG:4326"><gml:coordinates>'
+                r'^<gml:Point srsName="(urn:ogc:def:crs:)?EPSG:4326"><gml:coordinates>'
                 r"-104\.60925\d+,38\.255001</gml:coordinates></gml:Point>"
             )
         self.assertTrue(gml_regex.match(ptown.gml))


### PR DESCRIPTION
Updated the scope of what a valid GML string output looks like in the test_asgml function. 
Findings on why the "new" GML output is valid and other info about the problem: https://docs.google.com/document/d/1MKw2OnhmoWP4h00tCo85oziGBv1g747RxaBIaYwmctc/edit?addon_store
