### PR TITLE
Fixed #34887 -- Allow unlimited CharField for SQLite backend.

### DIFF
--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -50,6 +50,12 @@ Database.register_adapter(datetime.date, adapt_date)
 Database.register_adapter(datetime.datetime, adapt_datetime)
 
 
+def _get_varchar_column(data):
+    if data["max_length"] is None:
+        return "varchar"
+    return "varchar(%(max_length)s)" % data
+
+
 class DatabaseWrapper(BaseDatabaseWrapper):
     vendor = "sqlite"
     display_name = "SQLite"
@@ -61,7 +67,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         "BigAutoField": "integer",
         "BinaryField": "BLOB",
         "BooleanField": "bool",
-        "CharField": "varchar(%(max_length)s)",
+        "CharField": _get_varchar_column,
         "DateField": "date",
         "DateTimeField": "datetime",
         "DecimalField": "decimal",

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -152,3 +152,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_return_rows_from_bulk_insert = property(
         operator.attrgetter("can_return_columns_from_insert")
     )
+    supports_unlimited_charfield = True

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -728,8 +728,8 @@ The default form widget for this field is a :class:`~django.forms.TextInput`.
     The maximum length (in characters) of the field. The ``max_length``
     is enforced at the database level and in Django's validation using
     :class:`~django.core.validators.MaxLengthValidator`. It's required for all
-    database backends included with Django except PostgreSQL, which supports
-    unlimited ``VARCHAR`` columns.
+    database backends included with Django except PostgreSQL and SQLite,
+    which support unlimited ``VARCHAR`` columns..
 
     .. note::
 


### PR DESCRIPTION
- Add unlimited CharField support for SQLite like Django does for PostgreSQL. 
- Allows max_length to be unspecified, which makes more sense for SQLite users.

Relevant PostgreSQL PR: #16302