### PR TITLE
Refs #22936 -- Doc'd Lookup.prepare_rhs.

### DIFF
--- a/docs/ref/models/lookups.txt
+++ b/docs/ref/models/lookups.txt
@@ -213,6 +213,14 @@ following methods:
         The name of this lookup, used to identify it on parsing query
         expressions. It cannot contain the string ``"__"``.
 
+    .. attribute:: prepare_rhs
+
+        Defaults to ``True``. When :attr:`rhs` is a plain value,
+        :attr:`prepare_rhs` determines whether it should be prepared for use as
+        a parameter in a query. In order to do so,
+        ``lhs.output_field.get_prep_value()`` is called if defined, or ``rhs``
+        is wrapped in :class:`Value() <django.db.models.Value>` otherwise.
+
     .. method:: process_lhs(compiler, connection, lhs=None)
 
         Returns a tuple ``(lhs_string, lhs_params)``, as returned by


### PR DESCRIPTION
`Lookup.prepare_rhs` was added in 388bb5bd9aa3cd43825cd8a3632a57d8204f875f and it's quite important when you want to implement custom lookups. IMO, we should document it.

![image](https://github.com/django/django/assets/2865885/d900cbe1-0a4a-4a04-b713-1f728b85a094)
