### PR TITLE
Refs #32275 -- Added scrypt password hasher to PASSWORD_HASHERS setting docs.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -3083,6 +3083,7 @@ Default::
         "django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher",
         "django.contrib.auth.hashers.Argon2PasswordHasher",
         "django.contrib.auth.hashers.BCryptSHA256PasswordHasher",
+        "django.contrib.auth.hashers.ScryptPasswordHasher",
     ]
 
 .. setting:: AUTH_PASSWORD_VALIDATORS


### PR DESCRIPTION
Hello.
While reading the documentation, I have identified an issue.

Since django4.0 Scrypt is included by default in PASSWORD_HASHERS, but this document was missing it.

ref: Added scrypt password hasher
https://github.com/django/django/pull/13799 
