### PR TITLE
Added missing import in docs/ref/contrib/contenttypes.txt.

### DIFF
--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -607,6 +607,7 @@ with non-homogeneous set of results.
 
 .. code-block:: pycon
 
+    >>> from django.contrib.contenttypes.prefetch import GenericPrefetch
     >>> bookmark = Bookmark.objects.create(url="https://www.djangoproject.com/")
     >>> animal = Animal.objects.create(name="lion", weight=100)
     >>> TaggedItem.objects.create(tag="great", content_object=bookmark)


### PR DESCRIPTION
Maybe I missed it but I believe the documentation hasn't explicitly shown you how to import `GenericPrefetch`. You can click on the anchor of the class and look at the address bar to get it, but I don't think that's very obvious.

I added this to the Python console example, following the documentation for other classes.