### PR TITLE
[5.0.x] Refs #26029 -- Improved get_storage_class() deprecation warning with stacklevel=2.

### DIFF
--- a/django/core/files/storage/__init__.py
+++ b/django/core/files/storage/__init__.py
@@ -29,7 +29,11 @@ GET_STORAGE_CLASS_DEPRECATED_MSG = (
 
 
 def get_storage_class(import_path=None):
-    warnings.warn(GET_STORAGE_CLASS_DEPRECATED_MSG, RemovedInDjango51Warning)
+    warnings.warn(
+        GET_STORAGE_CLASS_DEPRECATED_MSG,
+        RemovedInDjango51Warning,
+        stacklevel=2,
+    )
     return import_string(import_path or settings.DEFAULT_FILE_STORAGE)
 
 


### PR DESCRIPTION
Addition of the `stacklevel` argument shows the source of the deprecated call, making updating the client code simpler.

Targeting 5.0.x, since this code is no longer in `main`. Should also be applied to 4.2.x if accepted. 

I bumped into this looking at: 

* https://github.com/django-compressor/django-compressor/issues/1187

ticket-26029