### PR TITLE
Added Python documentation link & removed Dive Into Python

### DIFF
--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -26,9 +26,7 @@ Who's this tutorial for?
 For this tutorial, we expect that you have at least a basic understanding of
 how Django works. This means you should be comfortable going through the
 existing tutorials on :doc:`writing your first Django app</intro/tutorial01>`.
-In addition, you should have a good understanding of Python itself. But if you
-don't, `Dive Into Python`__ is a fantastic (and free) online book for
-beginning Python programmers.
+In addition, you should have a good understanding of Python itself.
 
 Those of you who are unfamiliar with version control systems and Trac will find
 that this tutorial and its links include just enough information to get started.

--- a/docs/intro/index.txt
+++ b/docs/intro/index.txt
@@ -32,10 +32,10 @@ place: read this material to quickly get up and running.
     `list of Python resources for non-programmers`_
 
     If you already know a few other languages and want to get up to speed with
-    Python quickly, we recommend `Dive Into Python`_. If that's not quite your
+    Python quickly, we recommend `Python documentation`_. If that's not quite your
     style, there are many other `books about Python`_.
 
     .. _python: https://www.python.org/
     .. _list of Python resources for non-programmers: https://wiki.python.org/moin/BeginnersGuide/NonProgrammers
-    .. _Dive Into Python: https://diveinto.org/python3/table-of-contents.html
+    .. _Python documentation: https://docs.python.org/3/
     .. _books about Python: https://wiki.python.org/moin/PythonBooks


### PR DESCRIPTION
Hey there, recently I came across an outdated (old) resource link in the Django documentation, and I had a little discussion about it on the mailing list and the Discord server to replace it with the Python documentation. And I got a positive response from both places.

Kindly check the discussion here  - https://groups.google.com/g/django-developers/c/j28iN_WdTRA

As you can see from the image, I've used `ripgrep` to locate the resource that I wanted to replace, i.e, `Dive Into Python`. From `docs/intro/index.txt`, I've replaced `Dive Into Python` with 'Python Documentation` and from `docs/intro/contributing.txt`, I've removed `Dive Into Python` resource, followed by a few words. 

I've tested the changes locally using `Sphinx`, and everything seems to be working fine.

![DiveInto](https://github.com/django/django/assets/35860305/34a62fc3-9757-43c6-b8f7-c3a3e0bc3210)
