### PR TITLE
Updated Python's references to be the official docs instead of Dive Into Python.

### DIFF
--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -347,7 +347,7 @@ This test checks that the ``make_toast()`` returns ``'toast'``.
     * After reading those, if you want something a little meatier to sink
       your teeth into, there's always the Python :mod:`unittest` documentation.
 
-__ https://diveinto.org/python3/unit-testing.html
+__ https://diveintopython3.net/unit-testing.html
 
 Running your new test
 ---------------------

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -26,9 +26,7 @@ Who's this tutorial for?
 For this tutorial, we expect that you have at least a basic understanding of
 how Django works. This means you should be comfortable going through the
 existing tutorials on :doc:`writing your first Django app</intro/tutorial01>`.
-In addition, you should have a good understanding of Python itself. But if you
-don't, `Dive Into Python`__ is a fantastic (and free) online book for
-beginning Python programmers.
+In addition, you should have a good understanding of Python itself.
 
 Those of you who are unfamiliar with version control systems and Trac will find
 that this tutorial and its links include just enough information to get started.

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -43,7 +43,6 @@ so that it can be of use to the widest audience.
     `#django-dev on irc.libera.chat`__ to chat with other Django users who
     might be able to help.
 
-__ https://diveinto.org/python3/table-of-contents.html
 __ https://web.libera.chat/#django-dev
 .. _Django Forum: https://forum.djangoproject.com/
 

--- a/docs/intro/index.txt
+++ b/docs/intro/index.txt
@@ -32,10 +32,10 @@ place: read this material to quickly get up and running.
     `list of Python resources for non-programmers`_
 
     If you already know a few other languages and want to get up to speed with
-    Python quickly, we recommend `Python documentation`_. If that's not quite your
+    Python quickly, we recommend `Python Documentation`_. If that's not quite your
     style, there are many other `books about Python`_.
 
     .. _python: https://www.python.org/
     .. _list of Python resources for non-programmers: https://wiki.python.org/moin/BeginnersGuide/NonProgrammers
-    .. _Python documentation: https://docs.python.org/
+    .. _Python Documentation: https://docs.python.org/
     .. _books about Python: https://wiki.python.org/moin/PythonBooks

--- a/docs/intro/index.txt
+++ b/docs/intro/index.txt
@@ -37,5 +37,5 @@ place: read this material to quickly get up and running.
 
     .. _python: https://www.python.org/
     .. _list of Python resources for non-programmers: https://wiki.python.org/moin/BeginnersGuide/NonProgrammers
-    .. _Python documentation: https://docs.python.org/3/
+    .. _Python documentation: https://docs.python.org/
     .. _books about Python: https://wiki.python.org/moin/PythonBooks

--- a/docs/intro/index.txt
+++ b/docs/intro/index.txt
@@ -32,10 +32,10 @@ place: read this material to quickly get up and running.
     `list of Python resources for non-programmers`_
 
     If you already know a few other languages and want to get up to speed with
-    Python quickly, we recommend `Python Documentation`_. If that's not quite your
+    Python quickly, we recommend `Python documentation`_. If that's not quite your
     style, there are many other `books about Python`_.
 
     .. _python: https://www.python.org/
     .. _list of Python resources for non-programmers: https://wiki.python.org/moin/BeginnersGuide/NonProgrammers
-    .. _Python Documentation: https://docs.python.org/
+    .. _Python documentation: https://docs.python.org/
     .. _books about Python: https://wiki.python.org/moin/PythonBooks

--- a/docs/intro/index.txt
+++ b/docs/intro/index.txt
@@ -32,10 +32,10 @@ place: read this material to quickly get up and running.
     `list of Python resources for non-programmers`_
 
     If you already know a few other languages and want to get up to speed with
-    Python quickly, we recommend `Dive Into Python`_. If that's not quite your
+    Python quickly, we recommend `Python documentation`_. If that's not quite your
     style, there are many other `books about Python`_.
 
     .. _python: https://www.python.org/
     .. _list of Python resources for non-programmers: https://wiki.python.org/moin/BeginnersGuide/NonProgrammers
-    .. _Dive Into Python: https://diveinto.org/python3/table-of-contents.html
+    .. _Python documentation: https://docs.python.org/3/
     .. _books about Python: https://wiki.python.org/moin/PythonBooks

--- a/docs/intro/index.txt
+++ b/docs/intro/index.txt
@@ -32,8 +32,7 @@ place: read this material to quickly get up and running.
     `list of Python resources for non-programmers`_
 
     If you already know a few other languages and want to get up to speed with
-    Python quickly, we recommend `Python documentation`_. If that's not quite your
-    style, there are many other `books about Python`_.
+    Python quickly, we recommend referring the official `Python documentation`_, which provides comprehensive and authoritative information about the language, as well as links to other resources such as a list of `books about Python`_.
 
     .. _python: https://www.python.org/
     .. _list of Python resources for non-programmers: https://wiki.python.org/moin/BeginnersGuide/NonProgrammers

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1810,7 +1810,7 @@ Example usage:
 
     django-admin migrate --pythonpath='/home/djangoprojects/myproject'
 
-.. _import search path: https://diveinto.org/python3/your-first-python-program.html#importsearchpath
+.. _import search path: https://docs.python.org/3/library/sys_path_init.html#sys-path-init
 
 .. django-admin-option:: --settings SETTINGS
 

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -2414,7 +2414,7 @@ individual elements of the sequence.
 Returns a slice of the list.
 
 Uses the same syntax as Python's list slicing. See
-https://diveinto.org/python3/native-datatypes.html#slicinglists for an
+https://docs.python.org/3/tutorial/introduction.html#lists for an
 introduction.
 
 Example:

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -46,7 +46,7 @@ The value of :envvar:`DJANGO_SETTINGS_MODULE` should be in Python path syntax,
 e.g. ``mysite.settings``. Note that the settings module should be on the
 Python `import search path`_.
 
-.. _import search path: https://diveinto.org/python3/your-first-python-program.html#importsearchpath
+.. _import search path: https://docs.python.org/3/library/sys_path_init.html#sys-path-init
 
 The ``django-admin`` utility
 ----------------------------


### PR DESCRIPTION
Hey there, recently I came across an outdated (old) resource link in the Django documentation, and I had a little discussion about it on the mailing list and the Discord server to replace it with the Python documentation. And I got a positive response from both places.

Kindly check the discussion here - https://groups.google.com/g/django-developers/c/j28iN_WdTRA

As you can see from the image, I've used `ripgrep` to locate the resource that I wanted to replace, i.e, *Dive Into Python*. From `docs/intro/index.txt`, I've replaced Dive Into Python with `Python Documentation` and from `docs/intro/contributing.txt`, I've removed `Dive Into Python` resource, followed by a few words.

I've tested the changes locally using Sphinx, and everything seems to be working fine.

![DiveInto](https://github.com/django/django/assets/35860305/932c2708-c3eb-425e-8b08-d96a8b45b637)
