### PR TITLE
Refs #34882 -- Fixed GISFunctionsTests.test_asgeojson_option_0() test on Oracle.

### DIFF
--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -122,7 +122,7 @@ class GISFunctionsTests(FuncTestMixin, TestCase):
     @skipUnlessDBFeature("has_AsGeoJSON_function")
     def test_asgeojson_option_0(self):
         p1 = Point(1, 1, srid=4326)
-        p2 = Point(2, 2, srid=4326)
+        p2 = Point(-87.65018, 41.85039, srid=4326)
         obj = ManyPointModel.objects.create(
             point1=p1,
             point2=p2,
@@ -134,7 +134,7 @@ class GISFunctionsTests(FuncTestMixin, TestCase):
             .geojson,
             # GeoJSON without CRS.
             json.loads(
-                '{"type":"Point","coordinates":[222638.98158655,222684.20850554]}'
+                '{"type":"Point","coordinates":[-9757173.40553877, 5138594.87034608]}'
             ),
         )
 


### PR DESCRIPTION
This uses an example with the same precision for all databases.

Follow up to 96e7a752b6c44a84e18d82d37524c1df64b32e12.

Check out [logs](https://djangoci.com/job/django-oracle/database=oragis19,label=oracle,python=python3.11/1172/testReport/gis_tests.geoapp.test_functions/GISFunctionsTests/test_asgeojson_option_0/).