### PR TITLE
Add context variables in template commands

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -58,8 +58,8 @@ class TemplateCommand(BaseCommand):
             action="append",
             default=["py"],
             help='The file extension(s) to render (default: "py"). '
-                 "Separate multiple extensions with commas, or use "
-                 "-e multiple times.",
+            "Separate multiple extensions with commas, or use "
+            "-e multiple times.",
         )
         parser.add_argument(
             "--context",
@@ -67,9 +67,9 @@ class TemplateCommand(BaseCommand):
             dest="additional_context",
             action="append",
             default=[],
-            help='Additional context for templates'
-                 "Use -c multiple times. Specify key and value "
-                 "using '='. Example: '-c key=value'",
+            help="Additional context for templates"
+            "Use -c multiple times. Specify key and value "
+            "using '='. Example: '-c key=value'",
         )
         parser.add_argument(
             "--name",
@@ -78,7 +78,7 @@ class TemplateCommand(BaseCommand):
             action="append",
             default=[],
             help="The file name(s) to render. Separate multiple file names "
-                 "with commas, or use -n multiple times.",
+            "with commas, or use -n multiple times.",
         )
         parser.add_argument(
             "--exclude",
@@ -148,8 +148,8 @@ class TemplateCommand(BaseCommand):
         camel_case_value = "".join(x for x in name.title() if x != "_")
 
         additional_context = {}
-        for context_option in options['additional_context']:
-            key, value = context_option.split('=')
+        for context_option in options["additional_context"]:
+            key, value = context_option.split("=")
             additional_context[key] = value
 
         context = Context(

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -58,8 +58,8 @@ class TemplateCommand(BaseCommand):
             action="append",
             default=["py"],
             help='The file extension(s) to render (default: "py"). '
-            "Separate multiple extensions with commas, or use "
-            "-e multiple times.",
+                 "Separate multiple extensions with commas, or use "
+                 "-e multiple times.",
         )
         parser.add_argument(
             "--context",
@@ -68,8 +68,8 @@ class TemplateCommand(BaseCommand):
             action="append",
             default=[],
             help='Additional context for templates'
-            "Use -c multiple times. Specify key and value "
-            "using '='. Example: '-c key=value'",
+                 "Use -c multiple times. Specify key and value "
+                 "using '='. Example: '-c key=value'",
         )
         parser.add_argument(
             "--name",
@@ -78,7 +78,7 @@ class TemplateCommand(BaseCommand):
             action="append",
             default=[],
             help="The file name(s) to render. Separate multiple file names "
-            "with commas, or use -n multiple times.",
+                 "with commas, or use -n multiple times.",
         )
         parser.add_argument(
             "--exclude",
@@ -148,7 +148,7 @@ class TemplateCommand(BaseCommand):
         camel_case_value = "".join(x for x in name.title() if x != "_")
 
         additional_context = {key: value for key, value in [var.split('=') for var in options['additional_context']]}
-        
+
         context = Context(
             {
                 **options,

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -62,6 +62,16 @@ class TemplateCommand(BaseCommand):
             "-e multiple times.",
         )
         parser.add_argument(
+            "--context",
+            "-c",
+            dest="additional_context",
+            action="append",
+            default=[],
+            help='Additional context for templates'
+            "Use -c multiple times. Specify key and value "
+            "using '='. Example: '-c key=value'",
+        )
+        parser.add_argument(
             "--name",
             "-n",
             dest="files",
@@ -137,9 +147,12 @@ class TemplateCommand(BaseCommand):
         camel_case_name = "camel_case_%s_name" % app_or_project
         camel_case_value = "".join(x for x in name.title() if x != "_")
 
+        additional_context = {key: value for key, value in [var.split('=') for var in options['additional_context']]}
+        
         context = Context(
             {
                 **options,
+                **additional_context,
                 base_name: name,
                 base_directory: top_dir,
                 camel_case_name: camel_case_value,

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -147,7 +147,10 @@ class TemplateCommand(BaseCommand):
         camel_case_name = "camel_case_%s_name" % app_or_project
         camel_case_value = "".join(x for x in name.title() if x != "_")
 
-        additional_context = {key: value for key, value in [var.split('=') for var in options['additional_context']]}
+        additional_context = {}
+        for context_option in options['additional_context']:
+            key, value = context_option.split('=')
+            additional_context[key] = value
 
         context = Context(
             {


### PR DESCRIPTION
I wrote this pull request based on this thread https://forum.djangoproject.com/t/startproject-command-context/24445

> Imagine that, I am using docker and I want to overwrite in there the version of python to build. I want to specify the version (or another info, this is just an example) when I create the template. Something like this:
> `python manage.py startproject --template xxx -e py,yml,toml -c python_version=3.11 -c using_drf=true ...`
> This makes the templating much more powerful and this can be applied to startapp command too.

I leave this ready so you can discuss if this feature is valid and, if you agree, we can start the reviews and discuss if this solution is valid and how we can improve it.
