### PR TITLE
Refs #34840 -- Fixed test_validate_nullable_textfield_with_isnull_true() on databases that don's support table check constraints.

### DIFF
--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -995,6 +995,7 @@ class UniqueConstraintTests(TestCase):
             exclude={"name"},
         )
 
+    @skipUnlessDBFeature("supports_table_check_constraints")
     def test_validate_nullable_textfield_with_isnull_true(self):
         is_null_constraint = models.UniqueConstraint(
             "price",


### PR DESCRIPTION
Thanks Tim Graham for the report.
