### PR TITLE
Refs #34840 -- Improved release note describing index regression.

### DIFF
--- a/docs/releases/4.2.6.txt
+++ b/docs/releases/4.2.6.txt
@@ -35,9 +35,16 @@ Bugfixes
 * Fixed a regression in Django 4.2 that caused unnecessary casting of string
   based fields (``CharField``, ``EmailField``, ``TextField``, ``CICharField``,
   ``CIEmailField``, and ``CITextField``) used with the ``__isnull`` lookup on
-  PostgreSQL. As a consequence, the pre-Django 4.2 indexes didn't match and
-  were not used by the query planner (:ticket:`34840`).
+  PostgreSQL. As a consequence, indexes using an ``__isnull`` expression or
+  condition created before Django 4.2 wouldn't be used by the query planner,
+  leading to a performance regression (:ticket:`34840`).
 
-  You may need to recreate indexes propagated to the database with Django
-  4.2 - 4.2.5 as they contain unnecessary ``::text`` casting that is avoided as
-  of this release.
+  You may need to recreate such indexes created in your database with Django
+  4.2 to 4.2.5, as they contain unnecessary ``::text`` casting. Find candidate
+  indexes with this query:
+
+  .. code-block:: sql
+
+        SELECT indexname, indexdef
+        FROM pg_indexes
+        WHERE indexdef LIKE '%::text IS %NULL';


### PR DESCRIPTION
ticket-34840

Following [discussion on django-developers](https://groups.google.com/g/django-developers/c/U_piffxKlPM), I decided to dig into this and came up with this improvement.

`TextField`s are actually unaffected, since PostgreSQL optimizes away the `::text` at index creation time. Using this query to find affected indexes seems the most robust solution.