### PR TITLE
[fix] Use USERNAME_FIELD to pass in authenticate when custom user model is applied

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -191,7 +191,7 @@ class AuthenticationForm(forms.Form):
         password = self.cleaned_data.get('password')
 
         if username is not None and password:
-            self.user_cache = authenticate(self.request, username=username, password=password)
+            self.user_cache = authenticate(self.request, **{UserModel.USERNAME_FIELD: username}, password=password)
             if self.user_cache is None:
                 raise self.get_invalid_login_error()
             else:


### PR DESCRIPTION
For e.g. when email is used as username, we need to pass email param in authenticate method. To make it flexible we can pass UserModel.USERNAME_FIELD as param while authentication.