### PR TITLE
Fix body not growing

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -87,7 +87,7 @@ html[data-theme="light"],
 }
 
 html, body {
-    height: 100%;
+    min-height: 100%;
 }
 
 body {


### PR DESCRIPTION
When styling the body background color, it will be chopped off beyond one viewport height. This is a legacy hack to make the height at least 100% viewport height, but breaks the usual document flow in terms of styling.

https://greggod.medium.com/css-do-not-put-height-100-on-the-body-html-e36bda3551b3