### PR TITLE
Fixed #33647 -- bulk_update silently truncating values for size limied fields(PostgreSQL)

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -267,6 +267,7 @@ class BaseDatabaseFeatures:
 
     # Does the backend support CAST with precision?
     supports_cast_with_precision = True
+    supports_cast_char_field_with_precision = True
 
     # How many second decimals does the database return when casting a value to
     # a type with time?

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -72,6 +72,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_covering_indexes = True
     supports_stored_generated_columns = True
     supports_virtual_generated_columns = False
+    supports_cast_char_field_with_precision = False
     can_rename_index = True
     test_collations = {
         "non_default": "sv-x-icu",

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -43,6 +43,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         "AutoField": "integer",
         "BigAutoField": "bigint",
         "SmallAutoField": "smallint",
+        "CharField": cast_char_field_without_max_length,
     }
 
     if is_psycopg3:

--- a/tests/db_functions/comparison/test_cast.py
+++ b/tests/db_functions/comparison/test_cast.py
@@ -34,6 +34,7 @@ class CastTests(TestCase):
     # Silence "Truncated incorrect CHAR(1) value: 'Bob'".
     @ignore_warnings(module="django.db.backends.mysql.base")
     @skipUnlessDBFeature("supports_cast_with_precision")
+    @skipUnlessDBFeature("supports_cast_char_field_with_precision")
     def test_cast_to_char_field_with_max_length(self):
         names = Author.objects.annotate(
             cast_string=Cast("name", models.CharField(max_length=1))

--- a/tests/queries/test_bulk_update.py
+++ b/tests/queries/test_bulk_update.py
@@ -261,6 +261,7 @@ class BulkUpdateTests(TestCase):
                     CustomDbColumn.objects.filter(ip_address=ip), models
                 )
 
+    @skipUnlessDBFeature("supports_cast_with_precision")
     def test_charfield_constraint(self):
         article1 = Article.objects.create(
             name="a" * 20, created=datetime.datetime.today()


### PR DESCRIPTION
Ticket : [#33647](https://code.djangoproject.com/ticket/33647)