### PR TITLE
Fixed #33647 -- bulk_update silently truncating values for size limied fields(PostgreSQL)

### DIFF
--- a/django/db/models/functions/comparison.py
+++ b/django/db/models/functions/comparison.py
@@ -12,11 +12,17 @@ class Cast(Func):
     function = "CAST"
     template = "%(function)s(%(expressions)s AS %(db_type)s)"
 
-    def __init__(self, expression, output_field):
+    def __init__(self, expression, output_field, charfield_without_max_length=False):
+        self.charfield_without_max_length = charfield_without_max_length
         super().__init__(expression, output_field=output_field)
 
     def as_sql(self, compiler, connection, **extra_context):
         extra_context["db_type"] = self.output_field.cast_db_type(connection)
+        if (
+            self.charfield_without_max_length
+            and self.output_field.get_internal_type() == "CharField"
+        ):
+            extra_context["db_type"] = connection.ops.cast_char_field_without_max_length
         return super().as_sql(compiler, connection, **extra_context)
 
     def as_sqlite(self, compiler, connection, **extra_context):

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -912,7 +912,11 @@ class QuerySet(AltersData):
                     when_statements.append(When(pk=obj.pk, then=attr))
                 case_statement = Case(*when_statements, output_field=field)
                 if requires_casting:
-                    case_statement = Cast(case_statement, output_field=field)
+                    case_statement = Cast(
+                        case_statement,
+                        output_field=field,
+                        charfield_without_max_length=True,
+                    )
                 update_kwargs[field.attname] = case_statement
             updates.append(([obj.pk for obj in batch_objs], update_kwargs))
         rows_updated = 0

--- a/tests/queries/test_bulk_update.py
+++ b/tests/queries/test_bulk_update.py
@@ -3,7 +3,7 @@ import datetime
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import F
 from django.db.models.functions import Lower
-from django.db.utils import IntegrityError
+from django.db.utils import DataError, IntegrityError
 from django.test import TestCase, override_settings, skipUnlessDBFeature
 
 from .models import (
@@ -260,6 +260,19 @@ class BulkUpdateTests(TestCase):
                 self.assertCountEqual(
                     CustomDbColumn.objects.filter(ip_address=ip), models
                 )
+
+    @skipUnlessDBFeature("supports_cast_with_precision")
+    def test_charfield_constraint(self):
+        article1 = Article.objects.create(
+            name="a" * 20, created=datetime.datetime.today()
+        )
+        article2 = Article.objects.create(
+            name="a" * 20, created=datetime.datetime.today()
+        )
+        article1.name = "b" * 50
+        article2.name = "b" * 50
+        with self.assertRaises(DataError):
+            Article.objects.bulk_update([article1, article2], ["name"])
 
     def test_datetime_field(self):
         articles = [


### PR DESCRIPTION
https://code.djangoproject.com/ticket/33647

Approach :  Introduce a new parameter to the `Cast()` so that we can specify if we do not want to cast charfield with max length.