### PR TITLE
Refs #34900, Refs #34118 -- Updated assertion in test_skip_class_unless_db_feature() test on Python 3.12.1+.

### DIFF
--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 import warnings
 from io import StringIO
@@ -180,7 +181,9 @@ class SkippingClassTestCase(TestCase):
         except unittest.SkipTest:
             self.fail("SkipTest should not be raised here.")
         result = unittest.TextTestRunner(stream=StringIO()).run(test_suite)
-        self.assertEqual(result.testsRun, 3)
+        # PY312: Python 3.12.1+ no longer includes skipped tests in the number
+        # of running tests.
+        self.assertEqual(result.testsRun, 1 if sys.version_info >= (3, 12, 1) else 3)
         self.assertEqual(len(result.skipped), 2)
         self.assertEqual(result.skipped[0][1], "Database has feature(s) __class__")
         self.assertEqual(result.skipped[1][1], "Database has feature(s) __class__")


### PR DESCRIPTION
Python 3.12.1+ no longer includes skipped tests in the number of running tests. Check out:

https://github.com/python/cpython/issues/110890#issuecomment-1763458686
https://github.com/python/cpython/pull/106588