### PR TITLE
Fixed #34899 -- Added blank choice to callable choices lazily.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -16,6 +16,7 @@ from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query_utils import DeferredAttribute, RegisterLookupMixin
 from django.utils import timezone
 from django.utils.choices import (
+    BlankChoiceIterator,
     CallableChoiceIterator,
     flatten_choices,
     normalize_choices,
@@ -1055,14 +1056,9 @@ class Field(RegisterLookupMixin):
         as <select> choices for this field.
         """
         if self.choices is not None:
-            choices = list(self.choices)
             if include_blank:
-                blank_defined = any(
-                    choice in ("", None) for choice, _ in self.flatchoices
-                )
-                if not blank_defined:
-                    choices = blank_choice + choices
-            return choices
+                return BlankChoiceIterator(self.choices, blank_choice)
+            return self.choices
         rel_model = self.remote_field.model
         limit_choices_to = limit_choices_to or self.get_limit_choices_to()
         choice_func = operator.attrgetter(

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -15,7 +15,11 @@ from django.db import connection, connections, router
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query_utils import DeferredAttribute, RegisterLookupMixin
 from django.utils import timezone
-from django.utils.choices import CallableChoiceIterator, normalize_choices
+from django.utils.choices import (
+    CallableChoiceIterator,
+    flatten_choices,
+    normalize_choices,
+)
 from django.utils.datastructures import DictWrapper
 from django.utils.dateparse import (
     parse_date,
@@ -1080,19 +1084,10 @@ class Field(RegisterLookupMixin):
         """
         return str(self.value_from_object(obj))
 
-    def _get_flatchoices(self):
+    @property
+    def flatchoices(self):
         """Flattened version of choices tuple."""
-        if self.choices is None:
-            return []
-        flat = []
-        for choice, value in self.choices:
-            if isinstance(value, (list, tuple)):
-                flat.extend(value)
-            else:
-                flat.append((choice, value))
-        return flat
-
-    flatchoices = property(_get_flatchoices)
+        return list(flatten_choices(self.choices))
 
     def save_form_data(self, instance, data):
         setattr(instance, self.name, data)

--- a/django/utils/choices.py
+++ b/django/utils/choices.py
@@ -1,10 +1,11 @@
 from collections.abc import Callable, Iterable, Iterator, Mapping
-from itertools import islice, zip_longest
+from itertools import islice, tee, zip_longest
 
 from django.utils.functional import Promise
 
 __all__ = [
     "BaseChoiceIterator",
+    "BlankChoiceIterator",
     "CallableChoiceIterator",
     "flatten_choices",
     "normalize_choices",
@@ -32,6 +33,20 @@ class BaseChoiceIterator:
         raise NotImplementedError(
             "BaseChoiceIterator subclasses must implement __iter__()."
         )
+
+
+class BlankChoiceIterator(BaseChoiceIterator):
+    """Iterator to lazily inject a blank choice."""
+
+    def __init__(self, choices, blank_choice):
+        self.choices = choices
+        self.blank_choice = blank_choice
+
+    def __iter__(self):
+        choices, other = tee(self.choices)
+        if not any(value in ("", None) for value, _ in flatten_choices(other)):
+            yield from self.blank_choice
+        yield from choices
 
 
 class CallableChoiceIterator(BaseChoiceIterator):

--- a/django/utils/choices.py
+++ b/django/utils/choices.py
@@ -1,10 +1,36 @@
 from collections.abc import Callable, Iterable, Iterator, Mapping
+from itertools import islice, zip_longest
 
 from django.utils.functional import Promise
+
+__all__ = [
+    "BaseChoiceIterator",
+    "CallableChoiceIterator",
+    "normalize_choices",
+]
 
 
 class BaseChoiceIterator:
     """Base class for lazy iterators for choices."""
+
+    def __eq__(self, other):
+        if isinstance(other, Iterable):
+            return all(a == b for a, b in zip_longest(self, other, fillvalue=object()))
+        return super().__eq__(other)
+
+    def __getitem__(self, index):
+        if index < 0:
+            # Suboptimally consume whole iterator to handle negative index.
+            return list(self)[index]
+        try:
+            return next(islice(self, index, index + 1))
+        except StopIteration:
+            raise IndexError("index out of range") from None
+
+    def __iter__(self):
+        raise NotImplementedError(
+            "BaseChoiceIterator subclasses must implement __iter__()."
+        )
 
 
 class CallableChoiceIterator(BaseChoiceIterator):

--- a/django/utils/choices.py
+++ b/django/utils/choices.py
@@ -6,6 +6,7 @@ from django.utils.functional import Promise
 __all__ = [
     "BaseChoiceIterator",
     "CallableChoiceIterator",
+    "flatten_choices",
     "normalize_choices",
 ]
 
@@ -41,6 +42,15 @@ class CallableChoiceIterator(BaseChoiceIterator):
 
     def __iter__(self):
         yield from normalize_choices(self.func())
+
+
+def flatten_choices(choices):
+    """Flatten choices by removing nested values."""
+    for value_or_group, label_or_nested in choices or ():
+        if isinstance(label_or_nested, (list, tuple)):
+            yield from label_or_nested
+        else:
+            yield value_or_group, label_or_nested
 
 
 def normalize_choices(value, *, depth=0):


### PR DESCRIPTION
ticket-34899

So the challenge was that adding the blank choice was performed eagerly. The easiest solution is, therefore, to make the addition of the blank entry lazy. Unfortunately this also means that we need to extract the handling of flattening of choices into a helper function -- `flatten_choices()` (which is done in the first commit). From there, a `BlankChoiceIterator` falls out quite nicely...

...but then we have a handful of issues in testing. It seems that these can be overcome by implementing `__eq__()` and `__getitem__()` on `BaseChoiceIterator`. Alternatively we could use 7e35b749c5add17ba58bc2e40a0183d8b33e4b16 to only use `BlankChoiceIterator` where we encounter a `BaseChoiceIterator` subclass, but then we're duplicating logic which is not so nice... And it also means that comparisons against or subscript access for lazy choices will still fail.