### PR TITLE
Removed unreachable code from ModelAdmin.response_change().

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1513,25 +1513,6 @@ class ModelAdmin(BaseModelAdmin):
             )
             return HttpResponseRedirect(redirect_url)
 
-        elif "_saveasnew" in request.POST:
-            msg = format_html(
-                _(
-                    "The {name} “{obj}” was added successfully. You may edit it again "
-                    "below."
-                ),
-                **msg_dict,
-            )
-            self.message_user(request, msg, messages.SUCCESS)
-            redirect_url = reverse(
-                "admin:%s_%s_change" % (opts.app_label, opts.model_name),
-                args=(obj.pk,),
-                current_app=self.admin_site.name,
-            )
-            redirect_url = add_preserved_filters(
-                {"preserved_filters": preserved_filters, "opts": opts}, redirect_url
-            )
-            return HttpResponseRedirect(redirect_url)
-
         elif "_addanother" in request.POST:
             msg = format_html(
                 _(


### PR DESCRIPTION
Related to https://github.com/django/django/pull/17194#issuecomment-1712352486

Deleted the `_saveasnew` condition from `response_change` method as it is never reached