### PR TITLE
Fixed #34903, Refs #34825 -- Made workers initialization respect empty set of used connections.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -431,7 +431,7 @@ def _init_worker(
         django.setup()
         setup_test_environment(debug=debug_mode)
 
-    db_aliases = used_aliases or connections
+    db_aliases = used_aliases if used_aliases is not None else connections
     for alias in db_aliases:
         connection = connections[alias]
         if start_method == "spawn":


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34903

I think this is better than reverting 2128a73713735fb794ca6565fd5d7792293f5cfa 🤔

Additionally I attempted to trace the cause of workers attempting to open non-existent databases as that *should* have been solved already, but I couldn't recreate the issue on my Windows setup (Windows 11, Python 3.12).