### PR TITLE
Fixed #34904 -- Prevented mutating sent emails from outbox in locmem email backend.

### DIFF
--- a/django/core/mail/backends/locmem.py
+++ b/django/core/mail/backends/locmem.py
@@ -1,6 +1,7 @@
 """
 Backend for test environment.
 """
+import copy
 
 from django.core import mail
 from django.core.mail.backends.base import BaseEmailBackend
@@ -26,6 +27,6 @@ class EmailBackend(BaseEmailBackend):
         msg_count = 0
         for message in messages:  # .message() triggers header validation
             message.message()
-            mail.outbox.append(message)
+            mail.outbox.append(copy.deepcopy(message))
             msg_count += 1
         return msg_count

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -1554,6 +1554,19 @@ class LocmemBackendTests(BaseEmailBackendTests, SimpleTestCase):
                 "Subject\nMultiline", "Content", "from@example.com", ["to@example.com"]
             )
 
+    def test_outbox_not_mutated_after_send(self):
+        email = EmailMessage(
+            subject="correct subject",
+            body="test body",
+            from_email="from@example.com",
+            to=["to@example.com"],
+        )
+        email.send()
+        email.subject = "other subject"
+        email.to.append("other@example.com")
+        self.assertEqual(mail.outbox[0].subject, "correct subject")
+        self.assertEqual(mail.outbox[0].to, ["to@example.com"])
+
 
 class FileBackendTests(BaseEmailBackendTests, SimpleTestCase):
     email_backend = "django.core.mail.backends.filebased.EmailBackend"


### PR DESCRIPTION
Ticket [#34904](https://code.djangoproject.com/ticket/34904)

- Deep-copy message when adding to mail.outbox to remove reference to existing object, thereby preventing changes to messages after calling send_messages from modifying message in outbox
- Added regression test