### PR TITLE
Made SeleniumTests.test_select_multiple less flaky by improving Selenium waits.

### DIFF
--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -493,6 +493,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         )
 
     def test_select_multiple(self):
+        from selenium.common import NoSuchElementException
         from selenium.webdriver.common.by import By
         from selenium.webdriver.common.keys import Keys
         from selenium.webdriver.support.ui import Select
@@ -519,7 +520,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         result_container = self.selenium.find_element(
             By.CSS_SELECTOR, ".select2-results"
         )
-        self.assertTrue(result_container.is_displayed())
+        self.assertIs(result_container.is_displayed(), True)
         self.assertCountSeleniumElements(
             ".select2-results__option",
             PAGINATOR_SIZE + 1,
@@ -527,8 +528,8 @@ class SeleniumTests(AdminSeleniumTestCase):
         )
         search = self.selenium.find_element(By.CSS_SELECTOR, ".select2-search__field")
         # Load next page of results by scrolling to the bottom of the list.
-        with self.select2_ajax_wait():
-            for _ in range(PAGINATOR_SIZE + 1):
+        for _ in range(PAGINATOR_SIZE + 1):
+            with self.select2_ajax_wait():
                 search.send_keys(Keys.ARROW_DOWN)
         self.assertCountSeleniumElements(
             ".select2-results__option", 31, root_element=result_container
@@ -537,11 +538,11 @@ class SeleniumTests(AdminSeleniumTestCase):
         with self.select2_ajax_wait():
             search.send_keys("Who")
             # Ajax request is delayed.
-            self.assertTrue(result_container.is_displayed())
+            self.assertIs(result_container.is_displayed(), True)
             self.assertCountSeleniumElements(
                 ".select2-results__option", 32, root_element=result_container
             )
-        self.assertTrue(result_container.is_displayed())
+        self.assertIs(result_container.is_displayed(), True)
 
         self.assertCountSeleniumElements(
             ".select2-results__option", 1, root_element=result_container
@@ -549,8 +550,18 @@ class SeleniumTests(AdminSeleniumTestCase):
         with self.select2_ajax_wait():
             # Select the result.
             search.send_keys(Keys.RETURN)
-            # Reopen the dropdown and add the first result to the selection.
+        with self.disable_implicit_wait():
+            with self.assertRaises(NoSuchElementException):
+                self.selenium.find_element(By.CSS_SELECTOR, ".select2-results")
+        with self.select2_ajax_wait():
+            # Reopen the dropdown.
             elem.click()
+        result_container = self.selenium.find_element(
+            By.CSS_SELECTOR, ".select2-results"
+        )
+        self.assertIs(result_container.is_displayed(), True)
+        with self.select2_ajax_wait():
+            # Add the first result to the selection.
             search.send_keys(Keys.ARROW_DOWN)
             search.send_keys(Keys.RETURN)
         select = Select(self.selenium.find_element(By.ID, "id_related_questions"))


### PR DESCRIPTION
Looking at the scheduled tests. This test looks to fail ~20% of the time on postgres. 
Running 12 times to hopefully be sure it's passing (enough the chances I'm lucky are pretty slim)
I'm 90% sure it's fixed 👍 

1. https://github.com/django/django/actions/runs/6564707931/ ✅ 
2. https://github.com/django/django/actions/runs/6564788843/ ✅ 
3. https://github.com/django/django/actions/runs/6564850894/ ✅ 
4. https://github.com/django/django/actions/runs/6565254722/ ✅ 
5. https://github.com/django/django/actions/runs/6565357711/ ✅ 
6. https://github.com/django/django/actions/runs/6565468560/ ✅ 
7. https://github.com/django/django/actions/runs/6565518554/ ✅ 
8. https://github.com/django/django/actions/runs/6565564859/ ✅ 
9. https://github.com/django/django/actions/runs/6566061331/ ✅ 
10. https://github.com/django/django/actions/runs/6566136094/ ✅ 
11. https://github.com/django/django/actions/runs/6566215234/ ✅
12. https://github.com/django/django/actions/runs/6566276026/ ✅ 