### PR TITLE
Update suggested faster hashing algorithm to non deprecated one

### DIFF
--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -366,7 +366,7 @@ many users in your tests, you may want to use a custom settings file and set
 the :setting:`PASSWORD_HASHERS` setting to a faster hashing algorithm::
 
     PASSWORD_HASHERS = [
-        "django.contrib.auth.hashers.MD5PasswordHasher",
+        "django.contrib.auth.hashers.ScryptPasswordHasher",
     ]
 
 Don't forget to also include in :setting:`PASSWORD_HASHERS` any hashing


### PR DESCRIPTION
Previously, the docs suggested using the `"django.contrib.auth.hashers.MD5PasswordHasher"` as a faster hashing algorithm for tests. This hasher is deprecated and will be removed in Django 5.1.

This change suggests using the `"django.contrib.auth.hashers.ScryptPasswordHasher"` hasher which is also faster than the default and is not deprecated for removal.