### PR TITLE
Fixed #34905 -- Corrected admin's main content element rendered in <main> tag.

### DIFF
--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -81,13 +81,13 @@
     {% endblock %}
     {% endif %}
 
-    <main class="main" id="main">
+    <div class="main" id="main">
       {% if not is_popup and is_nav_sidebar_enabled %}
         {% block nav-sidebar %}
           {% include "admin/nav_sidebar.html" %}
         {% endblock %}
       {% endif %}
-      <div id="content-start" class="content" tabindex="-1">
+      <main id="content-start" class="content" tabindex="-1">
         {% block messages %}
           {% if messages %}
             <ul class="messagelist">{% for message in messages %}
@@ -109,8 +109,8 @@
         </div>
         <!-- END Content -->
         {% block footer %}<div id="footer"></div>{% endblock %}
-      </div>
-    </main>
+      </main>
+    </div>
 </div>
 <!-- END Container -->
 

--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -42,9 +42,7 @@ class AdminSidebarTests(TestCase):
 
     def test_sidebar_not_on_index(self):
         response = self.client.get(reverse("test_with_sidebar:index"))
-        self.assertContains(
-            response, '<main id="content-start" class="content" tabindex="-1">'
-        )
+        self.assertContains(response, '<div class="main" id="main">')
         self.assertNotContains(
             response, '<nav class="sticky" id="nav-sidebar" aria-label="Sidebar">'
         )

--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -42,7 +42,9 @@ class AdminSidebarTests(TestCase):
 
     def test_sidebar_not_on_index(self):
         response = self.client.get(reverse("test_with_sidebar:index"))
-        self.assertContains(response, '<main id="content-start" class="content" tabindex="-1">')
+        self.assertContains(
+            response, '<main id="content-start" class="content" tabindex="-1">'
+        )
         self.assertNotContains(
             response, '<nav class="sticky" id="nav-sidebar" aria-label="Sidebar">'
         )

--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -42,7 +42,7 @@ class AdminSidebarTests(TestCase):
 
     def test_sidebar_not_on_index(self):
         response = self.client.get(reverse("test_with_sidebar:index"))
-        self.assertContains(response, '<main class="main" id="main">')
+        self.assertContains(response, '<main id="content-start" class="content" tabindex="-1">')
         self.assertNotContains(
             response, '<nav class="sticky" id="nav-sidebar" aria-label="Sidebar">'
         )

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1598,6 +1598,13 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         response = self.client.get(reverse("admin:login"))
         self.assertContains(response, '<header id="header">')
 
+    def test_main_content(self):
+        response = self.client.get(reverse("admin:index"))
+        self.assertContains(
+            response,
+            '<main id="content-start" class="content" tabindex="-1">',
+        )
+
 
 @override_settings(
     AUTH_PASSWORD_VALIDATORS=[


### PR DESCRIPTION
Switched the landmarks for div and main so the main does not wrap the sidebar.