### PR TITLE
Fixed #34912 -- Fixed size of back links and bookmarklet help in admindocs pages.

### DIFF
--- a/django/contrib/admindocs/templates/admin_doc/bookmarklets.html
+++ b/django/contrib/admindocs/templates/admin_doc/bookmarklets.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 
-<p class="help">{% blocktranslate trimmed %}
+<p class="quiet">{% blocktranslate trimmed %}
 To install bookmarklets, drag the link to your bookmarks toolbar, or right-click
 the link and add it to your bookmarks. Now you can select the bookmarklet
 from any page in the site.

--- a/django/contrib/admindocs/templates/admin_doc/model_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/model_detail.html
@@ -73,6 +73,6 @@
 </div>
 {% endif %}
 
-<p class="small"><a href="{% url 'django-admindocs-models-index' %}">&lsaquo; {% translate 'Back to Model documentation' %}</a></p>
+<p><a href="{% url 'django-admindocs-models-index' %}">&lsaquo; {% translate 'Back to Model documentation' %}</a></p>
 </div>
 {% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/template_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/template_detail.html
@@ -23,5 +23,5 @@
 {% endfor %}
 </ol>
 
-<p class="small"><a href="{% url 'django-admindocs-docroot' %}">&lsaquo; {% translate 'Back to Documentation' %}</a></p>
+<p><a href="{% url 'django-admindocs-docroot' %}">&lsaquo; {% translate 'Back to Documentation' %}</a></p>
 {% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/view_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/view_detail.html
@@ -29,5 +29,5 @@
 <p>{{ meta.Templates }}</p>
 {% endif %}
 
-<p class="small"><a href="{% url 'django-admindocs-views-index' %}">&lsaquo; {% translate 'Back to View documentation' %}</a></p>
+<p><a href="{% url 'django-admindocs-views-index' %}">&lsaquo; {% translate 'Back to View documentation' %}</a></p>
 {% endblock %}


### PR DESCRIPTION
Made the text visible in the back links on 4 pages, removing the wrongg css class and attributes when only one css class was present