### PR TITLE
Fixed #34913 -- Added borders on high contrast mode in the admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -878,6 +878,12 @@ a.deletelink:focus, a.deletelink:hover {
     margin-right: -300px;
 }
 
+@media (forced-colors: active) {
+  #content-related {
+      border: 1px solid;
+  }
+}
+
 #footer {
     clear: both;
     padding: 10px;
@@ -926,6 +932,12 @@ a.deletelink:focus, a.deletelink:hover {
 
 #header a:focus , #header a:hover {
     text-decoration: underline;
+}
+
+@media (forced-colors: active) {
+  #header {
+      border-bottom: 1px solid;
+  }
 }
 
 #branding {

--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -139,6 +139,12 @@
     margin: 0 0 0 30px;
 }
 
+@media (forced-colors: active) {
+  #changelist-filter {
+      border: 1px solid;
+  }
+}
+
 #changelist-filter h2 {
     font-size: 0.875rem;
     text-transform: uppercase;


### PR DESCRIPTION
Before there are no borders for high contrast view

<img width="1057" alt="Screenshot 2023-10-19 at 16 02 01" src="https://github.com/django/django/assets/28761465/5a91fb8c-818e-4aad-a0e9-76eab9da6450">

Now borders are added

<img width="1177" alt="Screenshot 2023-10-19 at 16 47 30" src="https://github.com/django/django/assets/28761465/5b6d0fe0-7304-4f95-95f2-e528d91fefe6">
