### PR TITLE
Fixed #34909 -- Associated links in admin navigation sidebar with row descriptions.

### DIFF
--- a/django/contrib/admin/templates/admin/app_list.html
+++ b/django/contrib/admin/templates/admin/app_list.html
@@ -8,29 +8,33 @@
           <a href="{{ app.app_url }}" class="section" title="{% blocktranslate with name=app.name %}Models in the {{ name }} application{% endblocktranslate %}">{{ app.name }}</a>
         </caption>
         {% for model in app.models %}
-          <tr class="model-{{ model.object_name|lower }}{% if model.admin_url in request.path|urlencode %} current-model{% endif %}">
-            {% if model.admin_url %}
-              <th scope="row"><a href="{{ model.admin_url }}"{% if model.admin_url in request.path|urlencode %} aria-current="page"{% endif %}>{{ model.name }}</a></th>
-            {% else %}
-              <th scope="row">{{ model.name }}</th>
-            {% endif %}
+          {% with model_name=model.object_name|lower %}
+            <tr class="model-{{ model_name }}{% if model.admin_url in request.path|urlencode %} current-model{% endif %}">
+              <th scope="row">
+                {% if model.admin_url %}
+                  <a href="{{ model.admin_url }}"{% if model.admin_url in request.path|urlencode %} aria-current="page"{% endif %}>{{ model.name }}</a>
+                {% else %}
+                  {{ model.name }}
+                {% endif %}
+              </th>
 
-            {% if model.add_url %}
-              <td><a href="{{ model.add_url }}" class="addlink">{% translate 'Add' %}</a></td>
-            {% else %}
-              <td></td>
-            {% endif %}
-
-            {% if model.admin_url and show_changelinks %}
-              {% if model.view_only %}
-                <td><a href="{{ model.admin_url }}" class="viewlink">{% translate 'View' %}</a></td>
+              {% if model.add_url %}
+                <td><a href="{{ model.add_url }}" class="addlink">{% translate 'Add' %}</a></td>
               {% else %}
-                <td><a href="{{ model.admin_url }}" class="changelink">{% translate 'Change' %}</a></td>
+                <td></td>
               {% endif %}
-            {% elif show_changelinks %}
-              <td></td>
-            {% endif %}
-          </tr>
+
+              {% if model.admin_url and show_changelinks %}
+                {% if model.view_only %}
+                  <td><a href="{{ model.admin_url }}" class="viewlink">{% translate 'View' %}</a></td>
+                {% else %}
+                  <td><a href="{{ model.admin_url }}" class="changelink">{% translate 'Change' %}</a></td>
+                {% endif %}
+              {% elif show_changelinks %}
+                <td></td>
+              {% endif %}
+            </tr>
+          {% endwith %}
         {% endfor %}
       </table>
     </div>

--- a/django/contrib/admin/templates/admin/app_list.html
+++ b/django/contrib/admin/templates/admin/app_list.html
@@ -10,7 +10,7 @@
         {% for model in app.models %}
           {% with model_name=model.object_name|lower %}
             <tr class="model-{{ model_name }}{% if model.admin_url in request.path|urlencode %} current-model{% endif %}">
-              <th scope="row">
+              <th scope="row" id="{{ app.app_label }}-{{ model_name }}">
                 {% if model.admin_url %}
                   <a href="{{ model.admin_url }}"{% if model.admin_url in request.path|urlencode %} aria-current="page"{% endif %}>{{ model.name }}</a>
                 {% else %}
@@ -19,16 +19,16 @@
               </th>
 
               {% if model.add_url %}
-                <td><a href="{{ model.add_url }}" class="addlink">{% translate 'Add' %}</a></td>
+                <td><a href="{{ model.add_url }}" class="addlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{% translate 'Add' %}</a></td>
               {% else %}
                 <td></td>
               {% endif %}
 
               {% if model.admin_url and show_changelinks %}
                 {% if model.view_only %}
-                  <td><a href="{{ model.admin_url }}" class="viewlink">{% translate 'View' %}</a></td>
+                  <td><a href="{{ model.admin_url }}" class="viewlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{% translate 'View' %}</a></td>
                 {% else %}
-                  <td><a href="{{ model.admin_url }}" class="changelink">{% translate 'Change' %}</a></td>
+                  <td><a href="{{ model.admin_url }}" class="changelink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{% translate 'Change' %}</a></td>
                 {% endif %}
               {% elif show_changelinks %}
                 <td></td>

--- a/tests/admin_views/test_nav_sidebar.py
+++ b/tests/admin_views/test_nav_sidebar.py
@@ -111,9 +111,10 @@ class AdminSidebarTests(TestCase):
         self.assertContains(response, '<tr class="model-héllo current-model">')
         self.assertContains(
             response,
-            '<th scope="row">'
+            '<th scope="row" id="admin_views-héllo">'
             '<a href="/test_sidebar/admin/admin_views/h%C3%A9llo/" aria-current="page">'
             "Héllos</a></th>",
+            html=True,
         )
 
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1605,6 +1605,29 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
             '<main id="content-start" class="content" tabindex="-1">',
         )
 
+    def test_aria_describedby_for_add_and_change_links(self):
+        response = self.client.get(reverse("admin:index"))
+        tests = [
+            ("admin_views", "actor"),
+            ("admin_views", "worker"),
+            ("auth", "group"),
+            ("auth", "user"),
+        ]
+        for app_label, model_name in tests:
+            with self.subTest(app_label=app_label, model_name=model_name):
+                row_id = f"{app_label}-{model_name}"
+                self.assertContains(response, f'<th scope="row" id="{row_id}">')
+                self.assertContains(
+                    response,
+                    f'<a href="/test_admin/admin/{app_label}/{model_name}/" '
+                    f'class="changelink" aria-describedby="{row_id}">Change</a>',
+                )
+                self.assertContains(
+                    response,
+                    f'<a href="/test_admin/admin/{app_label}/{model_name}/add/" '
+                    f'class="addlink" aria-describedby="{row_id}">Add</a>',
+                )
+
 
 @override_settings(
     AUTH_PASSWORD_VALIDATORS=[


### PR DESCRIPTION
## Problem
Fixed [#34909](https://code.djangoproject.com/ticket/34909). 

In the Admin home page that lists your apps and their models (see screenshot below), there is an `Add` and a `Change` button for each model. All these buttons had the same accessible name, `"Add"` and `"Change"` respectively. This could be confusing for users using screen readers, since all the buttons would be called the same. It's better if the screen reader reads out something like `"Add <model-name>"` instead of just `"Add"`, so that it's clearer for the user _what_ they're adding or changing. See [accessible naming guidelines](https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#composingeffectiveanduser-friendlyaccessiblenames) for more information on this topic.

## Alternative option
Adding something like `aria-label="Add <model-name>"` to the buttons would fix the issue for screen reader users, but could impact the experience of voice control users. An example of this is that a user could use voice control saying something like "Click Add", but because the `Add` button now has a "hidden" name that's different (`Add <model-name>`), the voice control might not recognize this button when the user says "Click Add". This kind of issue is explained in more detail in [this post about voice control usability considerations](https://www.smashingmagazine.com/2022/06/voice-control-usability-considerations-partially-visually-hidden-link-names/). 

## Implemented solution
The implemented fix was to use `aria-describedby` with a reference to the model name, so that screen reader users can hear something like "Add" followed by the model name after a brief pause, while the accessible name of the button remains `Add` and voice control users are not affected. This fix was tested using both the Mac VoiceOver utility and the Mac Voice Control utility (both in Ventura 13.4).

The Admin screens that were updated are the following:
<img width="600" alt="Screenshot of Django Admin homepage" src="https://github.com/django/django/assets/67162025/5b55961c-c765-4014-afb8-a663e6624be6">
<img width="600" alt="Screenshot of Django Admin page that lists all models for a specific app" src="https://github.com/django/django/assets/67162025/42f92cac-6fe0-411d-a645-e93731c55666">



