### PR TITLE
Fixed typo in docs/releases/4.2.txt.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -220,7 +220,6 @@ answer newbie questions, and generally made Django that much better:
     Chris Wesseling <Chris.Wesseling@cwi.nl>
     Chris Wilson <chris+github@qwirx.com>
     Ciaran McCormick <ciaran@ciaranmccormick.com>
-    Claire Pritchard <claire.m.pritchard@gmail.com>
     Claude Paroz <claude@2xlibre.net>
     Clint Ecker
     colin@owlfish.com

--- a/AUTHORS
+++ b/AUTHORS
@@ -220,6 +220,7 @@ answer newbie questions, and generally made Django that much better:
     Chris Wesseling <Chris.Wesseling@cwi.nl>
     Chris Wilson <chris+github@qwirx.com>
     Ciaran McCormick <ciaran@ciaranmccormick.com>
+    Claire Pritchard <claire.m.pritchard@gmail.com>
     Claude Paroz <claude@2xlibre.net>
     Clint Ecker
     colin@owlfish.com

--- a/docs/releases/4.2.txt
+++ b/docs/releases/4.2.txt
@@ -522,7 +522,7 @@ During the deprecation period string literals will be attempted to be JSON
 decoded and a warning will be emitted on success that points at passing
 non-encoded forms instead.
 
-Code that use to pass JSON encoded string literals::
+Code that used to pass JSON encoded string literals::
 
     Document.objects.bulk_create(
         Document(data=Value("null")),


### PR DESCRIPTION
Changed "use to" to "used to" in 4.2 release notes about JSON encoded string literals.
Added name to AUTHORS file.