### PR TITLE
Reordered file extensions for improved validation.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -567,9 +567,9 @@ class FileExtensionValidator:
 
     def __init__(self, allowed_extensions=None, message=None, code=None):
         if allowed_extensions is not None:
-            allowed_extensions = [
-                allowed_extension.lower() for allowed_extension in allowed_extensions
-            ]
+            allowed_extensions = sorted(
+                [allowed_extension.lower() for allowed_extension in allowed_extensions]
+            )
         self.allowed_extensions = allowed_extensions
         if message is not None:
             self.message = message

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -805,6 +805,10 @@ class TestValidatorEquality(TestCase):
             FileExtensionValidator(["txt", "png"]),
         )
         self.assertEqual(
+            FileExtensionValidator(["jpg", "png", "txt"]),
+            FileExtensionValidator(["txt", "jpg", "png"]),
+        )
+        self.assertEqual(
             FileExtensionValidator(["txt"]),
             FileExtensionValidator(["txt"], code="invalid_extension"),
         )


### PR DESCRIPTION
- Sort the `allowed_extensions` list before assigning it in `FileExtensionValidator` class in `django/core/validators.py`
- Add assertion to check the equality of two instances of `FileExtensionValidator` with different order of file extensions in `tests/validators/tests.py`