### PR TITLE
Fixed #34920 -- Made FileExtensionValidator.__eq__() ignore allowed_extensions ordering.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -595,7 +595,8 @@ class FileExtensionValidator:
     def __eq__(self, other):
         return (
             isinstance(other, self.__class__)
-            and self.allowed_extensions == other.allowed_extensions
+            and set(self.allowed_extensions or [])
+            == set(other.allowed_extensions or [])
             and self.message == other.message
             and self.code == other.code
         )

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -805,6 +805,10 @@ class TestValidatorEquality(TestCase):
             FileExtensionValidator(["txt", "png"]),
         )
         self.assertEqual(
+            FileExtensionValidator(["jpg", "png", "txt"]),
+            FileExtensionValidator(["txt", "jpg", "png"]),
+        )
+        self.assertEqual(
             FileExtensionValidator(["txt"]),
             FileExtensionValidator(["txt"], code="invalid_extension"),
         )


### PR DESCRIPTION
Ticket: [#34920](https://code.djangoproject.com/ticket/34920)

- Sort the `allowed_extensions` list before assigning it in `FileExtensionValidator` class in `django/core/validators.py`
- Add assertion to check the equality of two instances of `FileExtensionValidator` with different order of file extensions in `tests/validators/tests.py`