### PR TITLE
Fixed #34921 -- Fixed crash of warning for unbound naive datetimes.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1595,10 +1595,13 @@ class DateTimeField(DateField):
                 # local time. This won't work during DST change, but we can't
                 # do much about it, so we let the exceptions percolate up the
                 # call stack.
+                try:
+                    name = f"{self.model.__name__}.{self.name}"
+                except AttributeError:
+                    name = "(unbound)"
                 warnings.warn(
-                    "DateTimeField %s.%s received a naive datetime "
-                    "(%s) while time zone support is active."
-                    % (self.model.__name__, self.name, value),
+                    f"DateTimeField {name} received a naive datetime ({value}) while "
+                    "time zone support is active.",
                     RuntimeWarning,
                 )
                 default_timezone = timezone.get_default_timezone()

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -10,6 +10,7 @@ from django.contrib.auth.models import User
 from django.core import serializers
 from django.db import connection
 from django.db.models import F, Max, Min
+from django.db.models.functions import Now
 from django.http import HttpRequest
 from django.template import (
     Context,
@@ -326,6 +327,13 @@ class NewDatabaseTests(TestCase):
             Event.objects.create(dt=dt)
         event = Event.objects.get()
         self.assertEqual(event.dt, datetime.datetime(2011, 9, 1, tzinfo=EAT))
+
+    @requires_tz_support
+    def test_filter_unbound_datetime_with_naive_date(self):
+        dt = datetime.date(2011, 9, 1)
+        msg = "DateTimeField (unbound) received a naive datetime"
+        with self.assertWarnsMessage(RuntimeWarning, msg):
+            Event.objects.annotate(unbound_datetime=Now()).filter(unbound_datetime=dt)
 
     @requires_tz_support
     def test_naive_datetime_with_microsecond(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34921