### PR TITLE
Fixed #34922 -- Added CSS Classes to ChangeList table rows.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -899,6 +899,7 @@ answer newbie questions, and generally made Django that much better:
     Scott Cranfill <scott@scottcranfill.com>
     Scott Fitsimones <scott@airgara.ge>
     Scott Pashley <github@scottpashley.co.uk>
+    Scott Vella
     scott@staplefish.com
     Sean Brant
     Sebastian Hillig <sebastian.hillig@gmail.com>

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -640,6 +640,7 @@ class ModelAdmin(BaseModelAdmin):
     """Encapsulate all admin options and functionality for a given model."""
 
     list_display = ("__str__",)
+    list_display_classes = ()
     list_display_links = ()
     list_filter = ()
     list_select_related = False
@@ -874,6 +875,7 @@ class ModelAdmin(BaseModelAdmin):
             self,
             sortable_by,
             self.search_help_text,
+            list_display_classes=self.get_list_display_classes(request),
         )
 
     def get_object(self, request, object_id, from_field=None):
@@ -1093,6 +1095,13 @@ class ModelAdmin(BaseModelAdmin):
         changelist.
         """
         return self.list_display
+
+    def get_list_display_classes(self, request):
+        """
+        Return a sequence containing the fields to be added as CSS classes
+        on each row of the changelist.
+        """
+        return self.list_display_classes
 
     def get_list_display_links(self, request, list_display):
         """

--- a/django/contrib/admin/templates/admin/change_list_results.html
+++ b/django/contrib/admin/templates/admin/change_list_results.html
@@ -28,7 +28,7 @@
 {% if result.form and result.form.non_field_errors %}
     <tr><td colspan="{{ result|length }}">{{ result.form.non_field_errors }}</td></tr>
 {% endif %}
-<tr>{% for item in result %}{{ item }}{% endfor %}</tr>
+<tr{{ result.row_classes }}>{% for item in result %}{{ item }}{% endfor %}</tr>
 {% endfor %}
 </tbody>
 </table>

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -83,12 +83,14 @@ class ChangeList:
         model_admin,
         sortable_by,
         search_help_text,
+        list_display_classes=(),
     ):
         self.model = model
         self.opts = model._meta
         self.lookup_opts = self.opts
         self.root_queryset = model_admin.get_queryset(request)
         self.list_display = list_display
+        self.list_display_classes = list_display_classes
         self.list_display_links = list_display_links
         self.list_filter = list_filter
         self.has_filters = None

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -841,6 +841,147 @@ subclass::
       as a ``ModelAdmin`` attribute, the model field will be used.
 
 
+.. attribute:: ModelAdmin.list_display_classes
+
+    .. versionadded:: 5.0
+
+    Set ``list_display_classes`` to control which fields are used to add
+    CSS classes to the table row for an object.
+
+    Example::
+
+        list_display_classes = ["first_name", "last_name"]
+
+    If you don't set ``list_display_classes``, no CSS class attribute will be  
+    set for the table row element. 
+
+    There are four types of values that can be used in ``list_display_classes``.
+
+    * The name of a model field. For example::
+
+          class PersonAdmin(admin.ModelAdmin):
+              list_display_classes = ["first_name", "last_name"]
+
+    * A callable that accepts one argument, the model instance. For example::
+
+          def upper_case_names(obj):
+              return [obj.first_name.upper(), obj.last_name.upper()]
+
+
+          class PersonAdmin(admin.ModelAdmin):
+              list_display_classes = [upper_case_name]
+
+    * A string representing a ``ModelAdmin`` method that accepts one argument,
+      the model instance. For example::
+
+          class PersonAdmin(admin.ModelAdmin):
+              list_display = ["upper_case_name"]
+
+              def upper_case_names(self, obj):
+                  return [obj.first_name.upper(), obj.last_name.upper()]
+
+    * A string representing a model attribute or method (without any required
+      arguments). For example::
+
+          from django.contrib import admin
+          from django.db import models
+
+
+          class Person(models.Model):
+              name = models.CharField(max_length=50)
+              birthday = models.DateField()
+
+              def decade_born_in(self):
+                  decade = self.birthday.year // 10 * 10
+                  return f"{decade}"
+
+
+          class PersonAdmin(admin.ModelAdmin):
+              list_display_classes = ["decade_born_in"]
+
+    A few special cases to note about ``list_display_classes``:
+
+    * If the field is a ``ForeignKey``, Django will display the
+      ``__str__()`` of the related object.
+
+    * ``ManyToManyField`` fields aren't supported, because that would
+      entail executing a separate SQL statement for each row in the table.
+      If you want to do this nonetheless, give your model a custom method,
+      and add that method's name to ``list_display``. (See below for more
+      on custom methods in ``list_display``.)
+
+    * If the field is a ``BooleanField``, Django will display a pretty "yes",
+      "no", or "unknown" icon instead of ``True``, ``False``, or ``None``.
+
+    * If the string given is a method of the model, ``ModelAdmin`` or a
+      callable, Django will HTML-escape the output by default. To escape
+      user input and allow your own unescaped tags, use
+      :func:`~django.utils.html.format_html`.
+
+    * If the string given contains the space character, Django will replace it 
+      with an underscore, since the space character is reserved as the CSS
+      class name separator. To add multiple CSS classes with a single 
+      function, return a list containing the desired CSS class strings.
+
+    Here's a full example model::
+
+          from django.contrib import admin
+          from django.db import models
+          from django.utils.html import format_html
+
+
+          class Person(models.Model):
+              first_name = models.CharField(max_length=50)
+              last_name = models.CharField(max_length=50)
+              color_name = models.CharField(max_length=50)
+              shaded = models.BooleanField()
+
+              @property
+              def color_and_name(self):
+                  if self.shaded:
+                      return [self.color_name, 'shaded_text']
+                  return [self.color_name]
+
+
+          class PersonAdmin(admin.ModelAdmin):
+              list_display_classes = ["color_and_name"]
+
+    * If the value of a field is ``None``, an empty string, or an iterable
+      without elements, Django will not add any CSS classes from the field.
+
+    * The ``__str__()`` method is just as valid in ``list_display_classes`` as 
+      any other model method, so it's perfectly OK to do this::
+
+          list_display_classes = ["__str__", "some_other_field"]
+
+    * Elements of ``list_display_classes`` can also be properties
+      ::
+
+          class Person(models.Model):
+              name = models.CharField(max_length=50)
+              birthday = models.DateField()
+
+              @property
+              def decade_born_in(self):
+                  decade = self.birthday.year // 10 * 10
+                  return f"{decade}"
+
+
+          class PersonAdmin(admin.ModelAdmin):
+              list_display_classes = ["decade_born_in"]
+
+    * Django will try to interpret every element of ``list_display_classes`` 
+      in this order:
+
+      * A field of the model.
+      * A callable.
+      * A string representing a ``ModelAdmin`` attribute.
+      * A string representing a model attribute.
+
+      For example if you have ``first_name`` as a model field and
+      as a ``ModelAdmin`` attribute, the model field will be used.
+
+
 .. attribute:: ModelAdmin.list_display_links
 
     Use ``list_display_links`` to control if and which fields in
@@ -1537,6 +1678,15 @@ templates used by the :class:`ModelAdmin` views:
     expected to return a ``list`` or ``tuple`` of field names that will be
     displayed on the changelist view as described above in the
     :attr:`ModelAdmin.list_display` section.
+
+.. method:: ModelAdmin.get_list_display_classes(request)
+
+    .. versionadded:: 5.0
+
+    The ``get_list_display_classes`` method is given the ``HttpRequest`` and 
+    is expected to return a ``list`` or ``tuple`` of field names that will be
+    added as CSS classes on the table rows of the changelist view as described 
+    above in the :attr:`ModelAdmin.list_display_classes` section.
 
 .. method:: ModelAdmin.get_list_display_links(request, list_display)
 

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -222,6 +222,10 @@ Minor features
 * Properties in :attr:`.ModelAdmin.list_display` now support ``boolean``
   attribute.
 
+* The new :attr:`.ModelAdmin.list_display_classes` and  
+  :meth:`.ModelAdmin.get_list_display_classes` method allows CSS classes to
+  be added to changelist table rows.
+
 * jQuery is upgraded from version 3.6.4 to 3.7.1.
 
 

--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -127,6 +127,20 @@ class DynamicListDisplayChildAdmin(admin.ModelAdmin):
         return my_list_display
 
 
+class ListDisplayClassesChildAdmin(admin.ModelAdmin):
+    def get_html_classes(self, obj):
+        return ["shaded", "green", obj.name] if obj is not None else []
+
+    def get_html_class(self, obj):
+        return f'age_{obj.age}' if obj is not None else None
+
+    def get_empty(self, obj):
+        return ''
+
+    def get_none(self, obj):
+        return None
+
+
 class DynamicListDisplayLinksChildAdmin(admin.ModelAdmin):
     list_display = ("parent", "name", "age")
     list_display_links = ["parent", "name"]


### PR DESCRIPTION
Added new ModelAdmin and ChangeList attributes for fields providing HTML/CSS classes for a given Model. Modified admin_list template tags to construct the CSS class string for an object alongside the list_display field values. Added tests and documentation for the new feature.