### PR TITLE
Refs #34118 -- Avoided repeat coroutine checks in MiddlewareMixin.

### DIFF
--- a/django/utils/deprecation.py
+++ b/django/utils/deprecation.py
@@ -100,7 +100,13 @@ class MiddlewareMixin:
         if get_response is None:
             raise ValueError("get_response must be provided.")
         self.get_response = get_response
-        self._async_check()
+        # If get_response is a coroutine function, turns us into async mode so
+        # a thread is not consumed during a whole request.
+        self.async_mode = iscoroutinefunction(self.get_response)
+        if self.async_mode:
+            # Mark the class as async-capable, but do the actual switch inside
+            # __call__ to avoid swapping out dunder methods.
+            markcoroutinefunction(self)
         super().__init__()
 
     def __repr__(self):
@@ -113,19 +119,9 @@ class MiddlewareMixin:
             ),
         )
 
-    def _async_check(self):
-        """
-        If get_response is a coroutine function, turns us into async mode so
-        a thread is not consumed during a whole request.
-        """
-        if iscoroutinefunction(self.get_response):
-            # Mark the class as async-capable, but do the actual switch
-            # inside __call__ to avoid swapping out dunder methods
-            markcoroutinefunction(self)
-
     def __call__(self, request):
         # Exit out to async mode, if needed
-        if iscoroutinefunction(self):
+        if self.async_mode:
             return self.__acall__(request)
         response = None
         if hasattr(self, "process_request"):


### PR DESCRIPTION
32d70b2f55b1f74736fd11bc8efce890ad5fa2f0 changed `MiddlewareMixin` to call `iscoroutinefunction` on every request. Whilst fast, it’s not free, with many function calls and unwrapping in its tree: https://github.com/python/cpython/blob/88bac5d5044e577825db1f9367af908dc9a3ad82/Lib/inspect.py#L420 . Multiplying this by many middlewares it will add up.

This PR changes to cache the result in an instance variable, as it did before.

Quick benchmark shows `iscoroutinefunction` can take ~0.5us on a function with one decorator:

```
Python 3.12.0 (main, Oct  5 2023, 12:02:11) [Clang 15.0.0 (clang-1500.0.40.1)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import inspect

In [2]: def f(): pass

In [3]: %timeit inspect.iscoroutinefunction(f)
358 ns ± 1.62 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [4]: from functools import cache

In [5]: @cache
   ...: def g(): pass

In [6]: %timeit inspect.iscoroutinefunction(g)
544 ns ± 1.22 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```