### PR TITLE
Please see: https://cx-oracle.readthedocs.io/en/latest/user_guide/con…

### DIFF
--- a/django/db/backends/oracle/utils.py
+++ b/django/db/backends/oracle/utils.py
@@ -93,5 +93,9 @@ class BulkInsertMapper:
 def dsn(settings_dict):
     if settings_dict["PORT"]:
         host = settings_dict["HOST"].strip() or "localhost"
-        return Database.makedsn(host, int(settings_dict["PORT"]), settings_dict["NAME"])
+        return Database.makedsn(
+            host,
+            int(settings_dict["PORT"]),
+            service_name=settings_dict["NAME"],
+        )
     return settings_dict["NAME"]


### PR DESCRIPTION
please see: https://cx-oracle.readthedocs.io/en/latest/user_guide/connection_handling.html?highlight=makedsn#oracle-net-connect-descriptor-strings

"Note the use of the named argument `service_name`. By default, the third parameter of makedsn() is a database System Identifier (SID), not a service name. However, almost all current databases use service names."