### PR TITLE
Fixed typo in docs/ref/contrib/gis/geos.txt.

### DIFF
--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -325,8 +325,7 @@ Properties
     is simple if and only if it does not intersect itself (except at boundary
     points).  For example, a :class:`LineString` object is not simple if it
     intersects itself. Thus, :class:`LinearRing` and :class:`Polygon` objects
-    are always simple because they cannot intersect themselves, by
-    definition.
+    are always simple because they cannot intersect themselves, by definition.
 
 .. attribute:: GEOSGeometry.valid
 

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -325,7 +325,7 @@ Properties
     is simple if and only if it does not intersect itself (except at boundary
     points).  For example, a :class:`LineString` object is not simple if it
     intersects itself. Thus, :class:`LinearRing` and :class:`Polygon` objects
-    are always simple because they do cannot intersect themselves, by
+    are always simple because they cannot intersect themselves, by
     definition.
 
 .. attribute:: GEOSGeometry.valid


### PR DESCRIPTION
The portion of the sentence in question incorrectly read "are always simple because they do cannot intersect themselves" which does not make sense because of the extra word "do". This trivial pull request removes the extra word.