### PR TITLE
Fixed isolation of DatabaseWrapperLoggingTests.test_commit_debug_log().

### DIFF
--- a/tests/backends/base/test_base.py
+++ b/tests/backends/base/test_base.py
@@ -62,7 +62,7 @@ class DatabaseWrapperTests(SimpleTestCase):
 
 
 class DatabaseWrapperLoggingTests(TransactionTestCase):
-    available_apps = []
+    available_apps = ["backends"]
 
     @override_settings(DEBUG=True)
     def test_commit_debug_log(self):


### PR DESCRIPTION
```bash
./runtests.py backends.tests.BackendTestCase.test_unicode_fetches backends.base.test_base.DatabaseWrapperLoggingTests.test_commit_debug_log --shuffle=9343874669 --parallel=1
Testing against Django installed in '/django/django'
Using shuffle seed: 9343874669 (given)
Found 2 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.F
======================================================================
FAIL: test_unicode_fetches (backends.tests.BackendTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/tests/backends/tests.py", line 402, in test_unicode_fetches
    self.assertEqual(
AssertionError: Lists differ: [('first', 'last'), ('Jane', 'Doe')] != [('Jane', 'Doe'), ('John', 'Doe')]

First differing element 0:
('first', 'last')
('Jane', 'Doe')

- [('first', 'last'), ('Jane', 'Doe')]
+ [('Jane', 'Doe'), ('John', 'Doe')]

----------------------------------------------------------------------
Ran 2 tests in 0.076s

FAILED (failures=1)
Used shuffle seed: 9343874669 (given)
Destroying test database for alias 'default'...
```

Check out [logs](https://djangoci.com/job/main-random/database=postgis,label=focal,python=python3.11/122/testReport/junit/backends.tests/BackendTestCase/test_unicode_fetches/).