### PR TITLE
Fixed #34943 -- Made EmailValidator.__eq__() ignore domain_allowlist ordering.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -244,7 +244,7 @@ class EmailValidator:
     def __eq__(self, other):
         return (
             isinstance(other, EmailValidator)
-            and (self.domain_allowlist == other.domain_allowlist)
+            and (set(self.domain_allowlist) == set(other.domain_allowlist))
             and (self.message == other.message)
             and (self.code == other.code)
         )

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -750,6 +750,10 @@ class TestValidatorEquality(TestCase):
             EmailValidator(message="BAD EMAIL", code="bad"),
             EmailValidator(message="BAD EMAIL", code="bad"),
         )
+        self.assertEqual(
+            EmailValidator(allowlist=["127.0.0.1", "localhost"]),
+            EmailValidator(allowlist=["localhost", "127.0.0.1"]),
+        )
 
     def test_basic_equality(self):
         self.assertEqual(


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/34934#ticket

- Arrange the domain_allowlist by converting it to a set.
- Add assertion to check the equality of two instances of EmailValidator with different order of domain_allowlist in tests/validators/tests.py