### PR TITLE
Fixed #34936 -- Fixed migration crash for DecimalField with db_default on SQLite.

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -119,6 +119,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "Oracle doesn't support comparing NCLOB to NUMBER.": {
             "generic_relations_regress.tests.GenericRelationTests.test_textlink_filter",
         },
+        "DecimalField.db_default doesn't return decimal.Decimal instances on Oracle "
+        "(#34941).": {
+            "field_defaults.tests.DefaultTests.test_field_db_defaults_returning",
+        },
     }
     django_test_expected_failures = {
         # A bug in Django/oracledb with respect to string handling (#23843).

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -28,7 +28,7 @@ class SQLiteNumericMixin:
         sql, params = self.as_sql(compiler, connection, **extra_context)
         try:
             if self.output_field.get_internal_type() == "DecimalField":
-                sql = "CAST(%s AS NUMERIC)" % sql
+                sql = "(CAST(%s AS NUMERIC))" % sql
         except FieldError:
             pass
         return sql, params

--- a/tests/field_defaults/models.py
+++ b/tests/field_defaults/models.py
@@ -10,6 +10,7 @@ field.
 """
 
 from datetime import datetime
+from decimal import Decimal
 
 from django.db import models
 from django.db.models.functions import Coalesce, ExtractYear, Now, Pi
@@ -33,6 +34,9 @@ class DBArticle(models.Model):
 
     headline = models.CharField(max_length=100, db_default="Default headline")
     pub_date = models.DateTimeField(db_default=Now())
+    cost = models.DecimalField(
+        max_digits=3, decimal_places=2, db_default=Decimal("3.33")
+    )
 
     class Meta:
         required_db_features = {"supports_expression_defaults"}

--- a/tests/field_defaults/tests.py
+++ b/tests/field_defaults/tests.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from decimal import Decimal
 from math import pi
 
 from django.db import connection
@@ -44,6 +45,7 @@ class DefaultTests(TestCase):
         self.assertIsInstance(a.id, int)
         self.assertEqual(a.headline, "Default headline")
         self.assertIsInstance(a.pub_date, datetime)
+        self.assertEqual(a.cost, Decimal("3.33"))
 
     @skipIfDBFeature("can_return_columns_from_insert")
     @skipUnlessDBFeature("supports_expression_defaults")
@@ -54,6 +56,7 @@ class DefaultTests(TestCase):
         self.assertIsInstance(a.id, int)
         self.assertEqual(a.headline, "Default headline")
         self.assertIsInstance(a.pub_date, datetime)
+        self.assertEqual(a.cost, Decimal("3.33"))
 
     def test_null_db_default(self):
         obj1 = DBDefaults.objects.create()
@@ -141,12 +144,12 @@ class DefaultTests(TestCase):
         articles = [DBArticle(pub_date=pub_date), DBArticle(pub_date=pub_date)]
         DBArticle.objects.bulk_create(articles)
 
-        headlines = DBArticle.objects.values_list("headline", "pub_date")
+        headlines = DBArticle.objects.values_list("headline", "pub_date", "cost")
         self.assertSequenceEqual(
             headlines,
             [
-                ("Default headline", pub_date),
-                ("Default headline", pub_date),
+                ("Default headline", pub_date, Decimal("3.33")),
+                ("Default headline", pub_date, Decimal("3.33")),
             ],
         )
 

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1,4 +1,5 @@
 import math
+from decimal import Decimal
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import IntegrityError, connection, migrations, models, transaction
@@ -2209,6 +2210,43 @@ class OperationTests(OperationTestBase):
             operation.database_backwards(app_label, editor, new_state, project_state)
         pony = project_state.apps.get_model(app_label, "pony").objects.create(weight=1)
         self.assertIsNone(pony.green)
+
+    def test_alter_field_change_nullable_to_decimal_database_default_not_null(self):
+        app_label = "test_alflcntdddn"
+        project_state = self.set_up_test_model(app_label)
+        operation_1 = migrations.AddField(
+            "Pony",
+            "height",
+            models.DecimalField(null=True, max_digits=5, decimal_places=2),
+        )
+        operation_2 = migrations.AlterField(
+            "Pony",
+            "height",
+            models.DecimalField(
+                max_digits=5, decimal_places=2, db_default=Decimal("12.22")
+            ),
+        )
+        table_name = f"{app_label}_pony"
+        self.assertColumnNotExists(table_name, "height")
+        # Add field.
+        new_state = project_state.clone()
+        operation_1.state_forwards(app_label, new_state)
+        with connection.schema_editor() as editor:
+            operation_1.database_forwards(app_label, editor, project_state, new_state)
+        self.assertColumnExists(table_name, "height")
+        old_pony = new_state.apps.get_model(app_label, "pony").objects.create(weight=1)
+        self.assertIsNone(old_pony.height)
+        # Alter field.
+        project_state, new_state = new_state, new_state.clone()
+        operation_2.state_forwards(app_label, new_state)
+        with connection.schema_editor() as editor:
+            operation_2.database_forwards(app_label, editor, project_state, new_state)
+        old_pony.refresh_from_db()
+        self.assertEqual(old_pony.height, Decimal("12.22"))
+        pony = new_state.apps.get_model(app_label, "pony").objects.create(weight=2)
+        if not connection.features.can_return_columns_from_insert:
+            pony.refresh_from_db()
+        self.assertEqual(pony.height, Decimal("12.22"))
 
     @skipIfDBFeature("interprets_empty_strings_as_nulls")
     def test_alter_field_change_blank_nullable_database_default_to_not_null(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34936

This patch simply wraps `CAST(…)` in parens to allow it to be used with the `DEFAULT …` clause in SQLite.

Ref: https://www.sqlite.org/lang_createtable.html#the_default_clause

**NOTE** The alternative is to change the paren wrapping behaviour of [`DatabaseSchemaEditor.db_default_sql()`](https://github.com/django/django/blob/e4d012ca05b23445f422b0400d6dd7aa85743885/django/db/backends/base/schema.py#L415)

Eg, you could test for `SQLNumericMixin` 🤷‍♂️ This will satisfy the tests in this PR:

```diff
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -410,9 +410,14 @@ class BaseDatabaseSchemaEditor:

     def db_default_sql(self, field):
         """Return the sql and params for the field's database default."""
-        from django.db.models.expressions import Value
+        from django.db.models.expressions import Value, SQLiteNumericMixin

-        sql = "%s" if isinstance(field.db_default, Value) else "(%s)"
+        sql = (
+            "%s"
+            if isinstance(field.db_default, Value)
+            and not isinstance(field.db_default, SQLiteNumericMixin)
+            else "(%s)"
+        )
         query = Query(model=field.model)
         compiler = query.get_compiler(connection=self.connection)
         default_sql, params = compiler.compile(field.db_default)
```

Is just always wrapping an option? Perhaps @LilyFoote would be be able to answer?  Does supplying a constant instead of an expression mean it will store more efficiently in the db?