### PR TITLE
Fixed #34830 -- Added request to csrf_failure view's template context.

### DIFF
--- a/django/views/csrf.py
+++ b/django/views/csrf.py
@@ -64,6 +64,7 @@ def csrf_failure(request, reason="", template_name=CSRF_FAILURE_TEMPLATE_NAME):
         "DEBUG": settings.DEBUG,
         "docs_version": get_docs_version(),
         "more": _("More information is available with DEBUG=True."),
+        "request": request,
     }
     try:
         t = loader.get_template(template_name)

--- a/tests/view_tests/tests/test_csrf.py
+++ b/tests/view_tests/tests/test_csrf.py
@@ -131,3 +131,7 @@ class CsrfViewTests(SimpleTestCase):
         with mock.patch.object(Path, "open") as m:
             csrf_failure(mock.MagicMock(), mock.Mock())
             m.assert_called_once_with(encoding="utf-8")
+
+    def test_csrf_response_has_request_context_processor(self):
+        response = self.client.post("/")
+        self.assertIs(response.wsgi_request, response.context.get("request"))


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/34830
Added 'request' context processor to **_'csrf_failure'_** function