### PR TITLE
Fixed #34941 -- Fixed fetching decimal db_default for DecimalFields on Oracle.

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -119,12 +119,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "Oracle doesn't support comparing NCLOB to NUMBER.": {
             "generic_relations_regress.tests.GenericRelationTests.test_textlink_filter",
         },
-        "DecimalField.db_default doesn't return decimal.Decimal instances on Oracle "
-        "(#34941).": {
-            "field_defaults.tests.DefaultTests.test_field_db_defaults_returning",
-            "migrations.test_operations.OperationTests."
-            "test_alter_field_change_nullable_to_decimal_database_default_not_null",
-        },
     }
     django_test_expected_failures = {
         # A bug in Django/oracledb with respect to string handling (#23843).

--- a/django/db/backends/oracle/utils.py
+++ b/django/db/backends/oracle/utils.py
@@ -1,4 +1,5 @@
 import datetime
+import decimal
 
 from .base import Database
 
@@ -23,7 +24,7 @@ class InsertVar:
         "FloatField": Database.NATIVE_FLOAT,
         "DateTimeField": Database.TIMESTAMP,
         "DateField": Database.Date,
-        "DecimalField": Database.NUMBER,
+        "DecimalField": decimal.Decimal,
     }
 
     def __init__(self, field):


### PR DESCRIPTION
This is a long standing bug in bc91f27a86090b4c688b56cd4e37f95eebe6e969 that began manifesting in 7414704e88d73dafbcfbb85f9bc54cb6111439d3.

ticket-34941