### PR TITLE
Add sort_names to AdminSite

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -61,6 +61,8 @@ class AdminSite:
 
     final_catch_all_view = True
 
+    sort_names = True
+
     def __init__(self, name="admin"):
         self._registry = {}  # model_class class -> admin_class instance
         self.name = name
@@ -535,7 +537,12 @@ class AdminSite:
         registered in this site.
         """
         app_dict = self._build_app_dict(request, app_label)
-
+        
+        # Return unsorted apps and models
+        if not self.sort_names:
+            app_list = app_dict.values()
+            return app_list
+        
         # Sort the apps alphabetically.
         app_list = sorted(app_dict.values(), key=lambda x: x["name"].lower())
 

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -537,12 +537,12 @@ class AdminSite:
         registered in this site.
         """
         app_dict = self._build_app_dict(request, app_label)
-        
+
         # Return unsorted apps and models
         if not self.sort_names:
             app_list = app_dict.values()
             return app_list
-        
+
         # Sort the apps alphabetically.
         app_list = sorted(app_dict.values(), key=lambda x: x["name"].lower())
 

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2936,6 +2936,11 @@ Templates can override or extend base admin templates as described in
     Path to a custom template that will be used by the admin site password
     change done view.
 
+.. attribute:: AdminSite.sort_names
+
+    A boolean value that determines whether sort or not apps and models 
+    in admin panel. By default, it is set to ``True``.
+
 ``AdminSite`` methods
 ---------------------
 


### PR DESCRIPTION
In this pull request, we've introduced an additional attribute, sort_names, for the AdminSite. This addition was necessary for my work, as it enables the option to disable alphabetical sorting in the admin panel. While it's currently achievable by overriding the get_app_list method, I believe it would be beneficial to include this functionality in Django by default.