### PR TITLE
Clarified a few points about DATABASES.TIME_ZONE

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -663,8 +663,10 @@ A string representing the time zone for this database connection or ``None``.
 This inner option of the :setting:`DATABASES` setting accepts the same values
 as the general :setting:`TIME_ZONE` setting.
 
-When :setting:`USE_TZ` is ``True`` and this option is set, reading datetimes
-from the database returns aware datetimes in this time zone instead of UTC.
+When :setting:`USE_TZ` is ``True``, reading datetimes from the database
+returns aware datetimes with the timezone set to this option's value if not
+``None``, or to UTC otherwise.
+
 When :setting:`USE_TZ` is ``False``, it is an error to set this option.
 
 * If the database backend doesn't support time zones (e.g. SQLite, MySQL,
@@ -687,13 +689,18 @@ When :setting:`USE_TZ` is ``False``, it is an error to set this option.
     third-party systems connect to the same database and expect to find
     datetimes in local time, then you must set this option.
 
-* If the database backend supports time zones (e.g. PostgreSQL), the
-  ``TIME_ZONE`` option is very rarely needed. It can be changed at any time;
-  the database takes care of converting datetimes to the desired time zone.
+* If the database backend supports time zones (e.g., PostgreSQL), then the
+  database connection's time zone is set to this value.
 
-  Setting the time zone of the database connection may be useful for running
-  raw SQL queries involving date/time functions provided by the database, such
-  as ``date_trunc``, because their results depend on the time zone.
+  Although setting the ``TIME_ZONE`` option is very rarely needed, there are
+  situations where it becomes necessary. Specifically, it's recommended to
+  match the general :setting:`TIME_ZONE` setting when dealing with raw queries
+  involving date/time functions like PostgreSQL's ``date_trunc()`` or
+  ``generate_series()``, especially when generating time-based series that
+  transition daylight savings.
+
+  This value can be changed at any time, the database will handle the
+  conversion of datetimes to the configured time zone.
 
   However, this has a downside: receiving all datetimes in local time makes
   datetime arithmetic more tricky — you must account for possible offset


### PR DESCRIPTION
(as per the commit message)

I felt the `DATABASE.TIME_ZONE` description was leaving out a few important points:

1. The default used is UTC if the value is set to `None` & `USE_TZ=True`. This is in the time zone section of the docs but would be good to explicitly state it here.
2. When set & using postgres, it sets the database connection's `TIME ZONE` setting (I got that we were trying to be general in the description so I just said "database connection's time zone")
3. In my experience I found it's wise to set this to the same as the general `TIME_ZONE` if a.) your `TIME_ZONE` is something other than UTC and b.) you're using date/time processing in raw sql
4. While you can use `date_trunc()` with UTC set as it has a param to tell it what time zone to use, there's no such equivalent param for the `generate_series()` function. I found if you generate a series transitioning daylight savings then the only way to get it to work 100% is to set the connection's `TIME ZONE`. I had this happen to me when generating daily totals of data that went across a daylight savings transition 🙄