### PR TITLE
Fixed #34946 -- Preserved db_default on combined default field addition.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -744,9 +744,9 @@ class BaseDatabaseSchemaEditor:
         }
         self.execute(sql, params)
         # Drop the default if we need to
-        # (Django usually does not use in-database defaults)
         if (
-            not self.skip_default_on_alter(field)
+            field.db_default is NOT_PROVIDED
+            and not self.skip_default_on_alter(field)
             and self.effective_default(field) is not None
         ):
             changes_sql, params = self._alter_column_default_sql(

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -2257,6 +2257,23 @@ class SchemaTests(TransactionTestCase):
         columns = self.column_classes(AuthorDbDefault)
         self.assertEqual(columns["renamed_year"][1].default, "1985")
 
+    @isolate_apps("schema")
+    def test_add_field_both_defaults_preserves_db_default(self):
+        class Author(Model):
+            class Meta:
+                app_label = "schema"
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+
+        field = IntegerField(default=1985, db_default=1988)
+        field.set_attributes_from_name("birth_year")
+        field.model = Author
+        with connection.schema_editor() as editor:
+            editor.add_field(Author, field)
+        columns = self.column_classes(Author)
+        self.assertEqual(columns["birth_year"][1].default, "1988")
+
     @skipUnlessDBFeature(
         "supports_column_check_constraints", "can_introspect_check_constraints"
     )


### PR DESCRIPTION
[The documentation](https://docs.djangoproject.com/en/dev/ref/models/fields/#db-default) for `Field.db_default` states

> If both `db_default` and `Field.default` are set, `default` will take precedence when creating instances in Python code. `db_default` will still be set at the database level and will be used when inserting rows outside of the ORM or when adding a new field in a migration.

However adding a field with both results in the following SQL

```sql
ALTER TABLE "foo" ADD COLUMN "bar" integer DEFAULT 42 NOT NULL;
ALTER TABLE "foo" ALTER COLUMN "bar" DROP DEFAULT;
```

The `DEFAULT` should never be dropped if the field has a `db_default` defined.