### PR TITLE
Refs #34944 -- Enhanced Concat(Pair)? output_field resolving.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1082,7 +1082,7 @@ class Value(SQLiteNumericMixin, Expression):
 
     def _resolve_output_field(self):
         if isinstance(self.value, str):
-            return fields.CharField()
+            return fields.CharField(max_length=len(self.value))
         if isinstance(self.value, bool):
             return fields.BooleanField()
         if isinstance(self.value, int):

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -2227,6 +2227,7 @@ class ValueTests(TestCase):
             with self.subTest(type=type(value)):
                 expr = Value(value)
                 self.assertIsInstance(expr.output_field, output_field_type)
+        self.assertEqual(Value("foo").output_field.max_length, 3)
 
     def test_resolve_output_field_failure(self):
         msg = "Cannot resolve expression type, unknown output_field"


### PR DESCRIPTION
I'm not convinced that we should include this in 5.0 given `Concat` had this limitation since it's creation (see the adjusted `test_mixed_char_text` test that now passes) and this is not a replacement for the proposed `GeneratedField._check_output_field` method but I figured I'd throw the test suite at it.