### PR TITLE
Fixed #34919 -- Added scope attribute to admindocs model templates.

### DIFF
--- a/django/contrib/admindocs/templates/admin_doc/model_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/model_detail.html
@@ -32,9 +32,9 @@
 <table class="model">
 <thead>
 <tr>
-    <th>{% translate 'Field' %}</th>
-    <th>{% translate 'Type' %}</th>
-    <th>{% translate 'Description' %}</th>
+    <th scope="col">{% translate 'Field' %}</th>
+    <th scope="col">{% translate 'Type' %}</th>
+    <th scope="col">{% translate 'Description' %}</th>
 </tr>
 </thead>
 <tbody>
@@ -55,9 +55,9 @@
 <table class="model">
 <thead>
 <tr>
-    <th>{% translate 'Method' %}</th>
-    <th>{% translate 'Arguments' %}</th>
-    <th>{% translate 'Description' %}</th>
+    <th scope="col">{% translate 'Method' %}</th>
+    <th scope="col">{% translate 'Arguments' %}</th>
+    <th scope="col">{% translate 'Description' %}</th>
 </tr>
 </thead>
 <tbody>

--- a/django/contrib/admindocs/templates/admin_doc/model_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/model_index.html
@@ -27,7 +27,7 @@
 <table class="xfull">
 {% for model in group.list %}
 <tr>
-<th><a href="{% url 'django-admindocs-models-detail' app_label=model.app_label model_name=model.model_name %}">{{ model.object_name }}</a></th>
+<th scope="col"><a href="{% url 'django-admindocs-models-detail' app_label=model.app_label model_name=model.model_name %}">{{ model.object_name }}</a></th>
 </tr>
 {% endfor %}
 </table>

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -240,6 +240,20 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
                 reverse("django-admindocs-models-detail", args=["admin_docs", "Person"])
             )
 
+    def test_table_headers(self):
+        tests = [
+            ("Method", 1),
+            ("Arguments", 1),
+            ("Description", 2),
+            ("Field", 1),
+            ("Type", 1),
+            ("Method", 1),
+        ]
+        for table_header, count in tests:
+            self.assertContains(
+                self.response, f'<th scope="col">{table_header}</th>', count=count
+            )
+
     def test_method_excludes(self):
         """
         Methods that begin with strings defined in


### PR DESCRIPTION
Added scope to files in Django's admin docs that were lacking the scope attribute. Having this attribute in the table headers makes table navigation easier for screen reader users.