### PR TITLE
Fixed #34964 -- Avoided migrations when combining or inverting the order of CheckConstraint conditions.

### DIFF
--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -94,7 +94,7 @@ class CheckConstraint(BaseConstraint):
     def __init__(
         self, *, check, name, violation_error_code=None, violation_error_message=None
     ):
-        self.check = check
+        self.check = check.sort() if isinstance(check, Q) else check
         if not getattr(check, "conditional", False):
             raise TypeError(
                 "CheckConstraint.check must be a Q instance or boolean expression."

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -157,7 +157,7 @@ class Q(tree.Node):
     def identity(self):
         path, args, kwargs = self.deconstruct()
         identity = [path, *kwargs.items()]
-        for child in args:
+        for child in sorted(args, key=str):
             if isinstance(child, tuple):
                 arg, value = child
                 value = make_hashable(value)

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -157,7 +157,7 @@ class Q(tree.Node):
     def identity(self):
         path, args, kwargs = self.deconstruct()
         identity = [path, *kwargs.items()]
-        for child in sorted(args, key=str):
+        for child in args:
             if isinstance(child, tuple):
                 arg, value = child
                 value = make_hashable(value)
@@ -173,6 +173,25 @@ class Q(tree.Node):
 
     def __hash__(self):
         return hash(self.identity)
+
+    def sort(self):
+        _, args, _ = self.deconstruct()
+        unsorted_hashable_args = []
+        for child in args:
+            if isinstance(child, tuple):
+                arg, value = child
+                value = make_hashable(value)
+                unsorted_hashable_args.append((arg, value))
+            elif isinstance(child, Q):
+                unsorted_hashable_args.append(child.sort())
+            else:
+                unsorted_hashable_args.append(child)
+        sorted_args = sorted(unsorted_hashable_args, key=hash)
+        if tuple(sorted_args) != args:
+            obj = self.copy()
+            obj.children = sorted_args
+            return obj
+        return self
 
 
 class DeferredAttribute:

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -2861,6 +2861,92 @@ class AutodetectorTests(BaseAutodetectorTests):
         changes = self.get_changes([book_with_type], [book_with_resolved_type])
         self.assertEqual(len(changes), 0)
 
+    def test_add_constraints_with_reversed_order(self):
+        author_names_check_constraint = ModelState(
+            "testapp",
+            "Author",
+            [
+                ("id", models.AutoField(primary_key=True)),
+                ("name", models.CharField(max_length=200)),
+            ],
+            {
+                "constraints": [
+                    models.CheckConstraint(
+                        check=models.Q(name__contains="Bob")
+                        | models.Q(name__contains="Barbara"),
+                        name="name_contains_bob_or_barbara",
+                    )
+                ]
+            },
+        )
+        author_names_check_constraint_reversed = ModelState(
+            "testapp",
+            "Author",
+            [
+                ("id", models.AutoField(primary_key=True)),
+                ("name", models.CharField(max_length=200)),
+            ],
+            {
+                "constraints": [
+                    models.CheckConstraint(
+                        check=models.Q(name__contains="Barbara")
+                        | models.Q(name__contains="Bob"),
+                        name="name_contains_bob_or_barbara",
+                    )
+                ]
+            },
+        )
+        changes = self.get_changes(
+            [author_names_check_constraint], [author_names_check_constraint_reversed]
+        )
+        self.assertEqual(len(changes), 0)
+
+    def test_add_constraints_with_reversed_order_in_combined_q(self):
+        author_names_check_constraint = ModelState(
+            "testapp",
+            "Author",
+            [
+                ("id", models.AutoField(primary_key=True)),
+                ("name", models.CharField(max_length=200)),
+            ],
+            {
+                "constraints": [
+                    models.CheckConstraint(
+                        check=models.Q(id__gt=1000)
+                        & (
+                            models.Q(name__contains="Bob")
+                            | models.Q(name__contains="Barbara")
+                        ),
+                        name="name_contains_bob_or_barbara",
+                    )
+                ]
+            },
+        )
+        author_names_check_constraint_reversed = ModelState(
+            "testapp",
+            "Author",
+            [
+                ("id", models.AutoField(primary_key=True)),
+                ("name", models.CharField(max_length=200)),
+            ],
+            {
+                "constraints": [
+                    models.CheckConstraint(
+                        check=models.Q(id__gt=1000)
+                        & (
+                            models.Q(name__contains="Barbara")
+                            | models.Q(name__contains="Bob")
+                        ),
+                        name="name_contains_bob_or_barbara",
+                    )
+                ]
+            },
+        )
+        changes = self.get_changes(
+            [author_names_check_constraint], [author_names_check_constraint_reversed]
+        )
+        self.assertEqual(len(changes), 0)
+
     def test_add_index_with_new_model(self):
         book_with_index_title_and_pony = ModelState(
             "otherapp",

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -2947,6 +2947,45 @@ class AutodetectorTests(BaseAutodetectorTests):
         )
         self.assertEqual(len(changes), 0)
 
+    def test_consolidate_constraint_to_one_q_object(self):
+        author_name_and_id_check_constraint = ModelState(
+            "testapp",
+            "Author",
+            [
+                ("id", models.AutoField(primary_key=True)),
+                ("name", models.CharField(max_length=200)),
+            ],
+            {
+                "constraints": [
+                    models.CheckConstraint(
+                        check=models.Q(name__contains="Bob") & models.Q(id__gt=1000),
+                        name="name_contains_bob_and_id_over_1000",
+                    )
+                ]
+            },
+        )
+        author_name_and_id_check_constraint_consolidated = ModelState(
+            "testapp",
+            "Author",
+            [
+                ("id", models.AutoField(primary_key=True)),
+                ("name", models.CharField(max_length=200)),
+            ],
+            {
+                "constraints": [
+                    models.CheckConstraint(
+                        check=models.Q(name__contains="Bob", id__gt=1000),
+                        name="name_contains_bob_and_id_over_1000",
+                    )
+                ]
+            },
+        )
+        changes = self.get_changes(
+            [author_name_and_id_check_constraint],
+            [author_name_and_id_check_constraint_consolidated],
+        )
+        self.assertEqual(len(changes), 0)
+
     def test_add_index_with_new_model(self):
         book_with_index_title_and_pony = ModelState(
             "otherapp",


### PR DESCRIPTION
ticket-34964