### PR TITLE
Fixed #34944 -- Made GeneratedField.output_field required.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -286,6 +286,8 @@ class Field(RegisterLookupMixin):
         Check if field name is valid, i.e. 1) does not end with an
         underscore, 2) does not contain "__" and 3) is not "pk".
         """
+        if self.name is None:
+            return []
         if self.name.endswith("_"):
             return [
                 checks.Error(

--- a/django/db/models/fields/generated.py
+++ b/django/db/models/fields/generated.py
@@ -63,11 +63,45 @@ class GeneratedField(Field):
 
     def check(self, **kwargs):
         databases = kwargs.get("databases") or []
-        return [
+        errors = [
             *super().check(**kwargs),
             *self._check_supported(databases),
             *self._check_persistence(databases),
         ]
+        output_field_clone = self.output_field.clone()
+        output_field_clone.model = self.model
+        output_field_checks = output_field_clone.check(databases=databases)
+        if output_field_checks:
+            separator = "\n    "
+            error_messages = separator.join(
+                f"{output_check.msg} ({output_check.id})"
+                for output_check in output_field_checks
+                if isinstance(output_check, checks.Error)
+            )
+            if error_messages:
+                errors.append(
+                    checks.Error(
+                        "GeneratedField.output_field has errors:"
+                        f"{separator}{error_messages}",
+                        obj=self,
+                        id="fields.E223",
+                    )
+                )
+            warning_messages = separator.join(
+                f"{output_check.msg} ({output_check.id})"
+                for output_check in output_field_checks
+                if isinstance(output_check, checks.Warning)
+            )
+            if warning_messages:
+                errors.append(
+                    checks.Warning(
+                        "GeneratedField.output_field has warnings:"
+                        f"{separator}{warning_messages}",
+                        obj=self,
+                        id="fields.W224",
+                    )
+                )
+        return errors
 
     def _check_supported(self, databases):
         errors = []

--- a/django/db/models/fields/generated.py
+++ b/django/db/models/fields/generated.py
@@ -16,7 +16,7 @@ class GeneratedField(Field):
     _resolved_expression = None
     output_field = None
 
-    def __init__(self, *, expression, db_persist=None, output_field=None, **kwargs):
+    def __init__(self, *, expression, output_field, db_persist=None, **kwargs):
         if kwargs.setdefault("editable", False):
             raise ValueError("GeneratedField cannot be editable.")
         if not kwargs.setdefault("blank", True):
@@ -29,7 +29,7 @@ class GeneratedField(Field):
             raise ValueError("GeneratedField.db_persist must be True or False.")
 
         self.expression = expression
-        self._output_field = output_field
+        self.output_field = output_field
         self.db_persist = db_persist
         super().__init__(**kwargs)
 
@@ -50,11 +50,6 @@ class GeneratedField(Field):
         self._query = Query(model=self.model, alias_cols=False)
         self._resolved_expression = self.expression.resolve_expression(
             self._query, allow_joins=False
-        )
-        self.output_field = (
-            self._output_field
-            if self._output_field is not None
-            else self._resolved_expression.output_field
         )
         # Register lookups from the output_field class.
         for lookup_name, lookup in self.output_field.get_class_lookups().items():
@@ -150,8 +145,7 @@ class GeneratedField(Field):
         del kwargs["editable"]
         kwargs["db_persist"] = self.db_persist
         kwargs["expression"] = self.expression
-        if self._output_field is not None:
-            kwargs["output_field"] = self._output_field
+        kwargs["output_field"] = self.output_field
         return name, path, args, kwargs
 
     def get_internal_type(self):

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -213,6 +213,8 @@ Model fields
   ``GeneratedField``\s.
 * **fields.E222**: ``<database>`` does not support persisted
   ``GeneratedField``\s.
+* **fields.E223**: ``GeneratedField.output_field`` has errors: ...
+* **fields.W224**: ``GeneratedField.output_field`` has warnings: ...
 * **fields.E900**: ``IPAddressField`` has been removed except for support in
   historical migrations.
 * **fields.W900**: ``IPAddressField`` has been deprecated. Support for it

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1237,7 +1237,7 @@ when :attr:`~django.forms.Field.localize` is ``False`` or
 
 .. versionadded:: 5.0
 
-.. class:: GeneratedField(expression, db_persist=None, output_field=None, **kwargs)
+.. class:: GeneratedField(expression, output_field, db_persist=None, **kwargs)
 
 A field that is always computed based on other fields in the model. This field
 is managed and updated by the database itself. Uses the ``GENERATED ALWAYS``
@@ -1259,6 +1259,10 @@ materialized view.
     the model (in the same database table). Generated fields cannot reference
     other generated fields. Database backends can impose further restrictions.
 
+.. attribute:: GeneratedField.output_field
+
+    A model field instance to define the field's data type.
+
 .. attribute:: GeneratedField.db_persist
 
     Determines if the database column should occupy storage as if it were a
@@ -1267,12 +1271,6 @@ materialized view.
 
     PostgreSQL only supports persisted columns. Oracle only supports virtual
     columns.
-
-.. attribute:: GeneratedField.output_field
-
-    An optional model field instance to define the field's data type. This can
-    be used to customize attributes like the field's collation. By default, the
-    output field is derived from ``expression``.
 
 .. admonition:: Refresh the data
 

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -142,7 +142,11 @@ to create a field that is always computed from other fields. For example::
 
     class Square(models.Model):
         side = models.IntegerField()
-        area = models.GeneratedField(expression=F("side") * F("side"), db_persist=True)
+        area = models.GeneratedField(
+            expression=F("side") * F("side"),
+            output_field=models.BigIntegerField(),
+            db_persist=True,
+        )
 
 More options for declaring field choices
 ----------------------------------------

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -1147,6 +1147,7 @@ class Square(models.Model):
     area = models.GeneratedField(
         db_persist=True,
         expression=models.F("side") * models.F("side"),
+        output_field=models.BigIntegerField(),
     )
 
     class Meta:

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -1216,7 +1216,9 @@ class GeneratedFieldTests(TestCase):
         class Model(models.Model):
             name = models.IntegerField()
             field = models.GeneratedField(
-                expression=models.F("name"), db_persist=db_persist
+                expression=models.F("name"),
+                output_field=models.IntegerField(),
+                db_persist=db_persist,
             )
 
         expected_errors = []
@@ -1252,7 +1254,11 @@ class GeneratedFieldTests(TestCase):
     def test_not_supported_stored_required_db_features(self):
         class Model(models.Model):
             name = models.IntegerField()
-            field = models.GeneratedField(expression=models.F("name"), db_persist=True)
+            field = models.GeneratedField(
+                expression=models.F("name"),
+                output_field=models.IntegerField(),
+                db_persist=True,
+            )
 
             class Meta:
                 required_db_features = {"supports_stored_generated_columns"}
@@ -1262,7 +1268,11 @@ class GeneratedFieldTests(TestCase):
     def test_not_supported_virtual_required_db_features(self):
         class Model(models.Model):
             name = models.IntegerField()
-            field = models.GeneratedField(expression=models.F("name"), db_persist=False)
+            field = models.GeneratedField(
+                expression=models.F("name"),
+                output_field=models.IntegerField(),
+                db_persist=False,
+            )
 
             class Meta:
                 required_db_features = {"supports_virtual_generated_columns"}
@@ -1273,7 +1283,11 @@ class GeneratedFieldTests(TestCase):
     def test_not_supported_virtual(self):
         class Model(models.Model):
             name = models.IntegerField()
-            field = models.GeneratedField(expression=models.F("name"), db_persist=False)
+            field = models.GeneratedField(
+                expression=models.F("name"),
+                output_field=models.IntegerField(),
+                db_persist=False,
+            )
             a = models.TextField()
 
         excepted_errors = (
@@ -1298,7 +1312,11 @@ class GeneratedFieldTests(TestCase):
     def test_not_supported_stored(self):
         class Model(models.Model):
             name = models.IntegerField()
-            field = models.GeneratedField(expression=models.F("name"), db_persist=True)
+            field = models.GeneratedField(
+                expression=models.F("name"),
+                output_field=models.IntegerField(),
+                db_persist=True,
+            )
             a = models.TextField()
 
         expected_errors = (

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -5664,10 +5664,14 @@ class OperationTests(OperationTestBase):
     def _test_invalid_generated_field_changes(self, db_persist):
         regular = models.IntegerField(default=1)
         generated_1 = models.GeneratedField(
-            expression=F("pink") + F("pink"), db_persist=db_persist
+            expression=F("pink") + F("pink"),
+            output_field=models.IntegerField(),
+            db_persist=db_persist,
         )
         generated_2 = models.GeneratedField(
-            expression=F("pink") + F("pink") + F("pink"), db_persist=db_persist
+            expression=F("pink") + F("pink") + F("pink"),
+            output_field=models.IntegerField(),
+            db_persist=db_persist,
         )
         tests = [
             ("test_igfc_1", regular, generated_1),
@@ -5707,12 +5711,20 @@ class OperationTests(OperationTestBase):
             migrations.AddField(
                 "Pony",
                 "modified_pink",
-                models.GeneratedField(expression=F("pink"), db_persist=True),
+                models.GeneratedField(
+                    expression=F("pink"),
+                    output_field=models.IntegerField(),
+                    db_persist=True,
+                ),
             ),
             migrations.AlterField(
                 "Pony",
                 "modified_pink",
-                models.GeneratedField(expression=F("pink"), db_persist=False),
+                models.GeneratedField(
+                    expression=F("pink"),
+                    output_field=models.IntegerField(),
+                    db_persist=False,
+                ),
             ),
         ]
         msg = (
@@ -5729,7 +5741,9 @@ class OperationTests(OperationTestBase):
             "Pony",
             "modified_pink",
             models.GeneratedField(
-                expression=F("pink") + F("pink"), db_persist=db_persist
+                expression=F("pink") + F("pink"),
+                output_field=models.IntegerField(),
+                db_persist=db_persist,
             ),
         )
         project_state, new_state = self.make_test_state(app_label, operation)
@@ -5760,7 +5774,9 @@ class OperationTests(OperationTestBase):
             "Pony",
             "modified_pink",
             models.GeneratedField(
-                expression=F("pink") + F("pink"), db_persist=db_persist
+                expression=F("pink") + F("pink"),
+                output_field=models.IntegerField(),
+                db_persist=db_persist,
             ),
         )
         project_state, new_state = self.make_test_state(app_label, operation)

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -485,7 +485,11 @@ class UUIDGrandchild(UUIDChild):
 class GeneratedModel(models.Model):
     a = models.IntegerField()
     b = models.IntegerField()
-    field = models.GeneratedField(expression=F("a") + F("b"), db_persist=True)
+    field = models.GeneratedField(
+        expression=F("a") + F("b"),
+        output_field=models.IntegerField(),
+        db_persist=True,
+    )
 
     class Meta:
         required_db_features = {"supports_stored_generated_columns"}
@@ -494,7 +498,11 @@ class GeneratedModel(models.Model):
 class GeneratedModelVirtual(models.Model):
     a = models.IntegerField()
     b = models.IntegerField()
-    field = models.GeneratedField(expression=F("a") + F("b"), db_persist=False)
+    field = models.GeneratedField(
+        expression=F("a") + F("b"),
+        output_field=models.IntegerField(),
+        db_persist=False,
+    )
 
     class Meta:
         required_db_features = {"supports_virtual_generated_columns"}
@@ -503,6 +511,7 @@ class GeneratedModelVirtual(models.Model):
 class GeneratedModelParams(models.Model):
     field = models.GeneratedField(
         expression=Value("Constant", output_field=models.CharField(max_length=10)),
+        output_field=models.CharField(max_length=10),
         db_persist=True,
     )
 
@@ -513,6 +522,7 @@ class GeneratedModelParams(models.Model):
 class GeneratedModelParamsVirtual(models.Model):
     field = models.GeneratedField(
         expression=Value("Constant", output_field=models.CharField(max_length=10)),
+        output_field=models.CharField(max_length=10),
         db_persist=False,
     )
 
@@ -520,7 +530,7 @@ class GeneratedModelParamsVirtual(models.Model):
         required_db_features = {"supports_virtual_generated_columns"}
 
 
-class GeneratedModelOutputField(models.Model):
+class GeneratedModelOutputFieldDbCollation(models.Model):
     name = models.CharField(max_length=10)
     lower_name = models.GeneratedField(
         expression=Lower("name"),
@@ -532,7 +542,7 @@ class GeneratedModelOutputField(models.Model):
         required_db_features = {"supports_stored_generated_columns"}
 
 
-class GeneratedModelOutputFieldVirtual(models.Model):
+class GeneratedModelOutputFieldDbCollationVirtual(models.Model):
     name = models.CharField(max_length=10)
     lower_name = models.GeneratedField(
         expression=Lower("name"),
@@ -547,7 +557,10 @@ class GeneratedModelOutputFieldVirtual(models.Model):
 class GeneratedModelNull(models.Model):
     name = models.CharField(max_length=10, null=True)
     lower_name = models.GeneratedField(
-        expression=Lower("name"), db_persist=True, null=True
+        expression=Lower("name"),
+        output_field=models.CharField(max_length=10),
+        db_persist=True,
+        null=True,
     )
 
     class Meta:
@@ -557,7 +570,10 @@ class GeneratedModelNull(models.Model):
 class GeneratedModelNullVirtual(models.Model):
     name = models.CharField(max_length=10, null=True)
     lower_name = models.GeneratedField(
-        expression=Lower("name"), db_persist=False, null=True
+        expression=Lower("name"),
+        output_field=models.CharField(max_length=10),
+        db_persist=False,
+        null=True,
     )
 
     class Meta:

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -829,7 +829,11 @@ class SchemaTests(TransactionTestCase):
     def test_add_generated_field_with_kt_model(self):
         class GeneratedFieldKTModel(Model):
             data = JSONField()
-            status = GeneratedField(expression=KT("data__status"), db_persist=True)
+            status = GeneratedField(
+                expression=KT("data__status"),
+                output_field=TextField(),
+                db_persist=True,
+            )
 
             class Meta:
                 app_label = "schema"
@@ -844,7 +848,7 @@ class SchemaTests(TransactionTestCase):
 
     @isolate_apps("schema")
     @skipUnlessDBFeature("supports_stored_generated_columns")
-    def test_add_generated_field_with_output_field(self):
+    def test_add_generated_field(self):
         class GeneratedFieldOutputFieldModel(Model):
             price = DecimalField(max_digits=7, decimal_places=2)
             vat_price = GeneratedField(


### PR DESCRIPTION
- [x] Documentation changes.
- [x] More tests.
- [x] Make `GeneratedField.output_field` mandatory.

~~I'll continue tomorrow.~~

ticket-34944