### PR TITLE
Fixed #34970 -- Clarified password validator docs.

### DIFF
--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -526,8 +526,9 @@ can write your own as well.
 
 Each password validator must provide a help text to explain the requirements to
 the user, validate a given password and return an error message if it does not
-meet the requirements, and optionally receive passwords that have been set.
-Validators can also have optional settings to fine tune their behavior.
+meet the requirements, and optionally define a callback to be notified when
+the password for a user has been changed. Validators can also have optional
+settings to fine tune their behavior.
 
 Validation is controlled by the :setting:`AUTH_PASSWORD_VALIDATORS` setting.
 The default for the setting is an empty list, which means no validators are


### PR DESCRIPTION
It wasn't clear this part of the sentence was about the `password_changed()` mechanism, so this clarifies the language on that.