### PR TITLE
Refs #33690 -- Added missing data-theme selector to example in theming support docs.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2803,7 +2803,7 @@ template override to your project:
 
     {% block extrastyle %}{{ block.super }}
     <style>
-    :root {
+    html[data-theme="light"], :root {
       --primary: #9774d5;
       --secondary: #785cab;
       --link-fg: #7c449b;


### PR DESCRIPTION
From 4.2 on, the Admin Theming example at line 2806 was missing the html[data-theme="light"] part of the html[data-theme="light"], :root CSS selector in the provided example code.