### PR TITLE
AutocompleteMixin.optgroups uses the unadorned remote field attribute name

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.db.models import CASCADE, UUIDField
+from django.db.models.fields.reverse_related import ForeignObjectRel
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.html import smart_urlquote
@@ -546,6 +547,8 @@ class AutocompleteMixin:
             self.field.remote_field, "field_name", remote_model_opts.pk.attname
         )
         to_field_name = remote_model_opts.get_field(to_field_name).attname
+        if isinstance(self.field, ForeignObjectRel):
+            to_field_name = "%s__%s" % (self.field.name, to_field_name)
         choices = (
             (getattr(obj, to_field_name), self.choices.field.label_from_instance(obj))
             for obj in self.choices.queryset.using(self.db).filter(


### PR DESCRIPTION
While porting an app to Django 4.1 I discovered that AutocompleteMixin generates a query filter using a remote field name without a qualifier. I was getting exceptions saying that "uuid__in" could not be turned into a column. The source model had no "uuid", which was the remote Model's field.

This patch prepends the field's name to the lookup, in my example making "CANs__uuid__in" for the query filter; the "uuid" field is in my "CAN" model.

My understanding of `AutocompleteMixin` is still pretty shallow though. Criticism and rejection of the PR with advice welcomed.

If this PR is correct, backporting to 4.1 would be appreciated (the code hasn't changes between 4.1 and 4.2 - I'm coming all the way from 2.2 to 4.1).