### PR TITLE
Removed obsolete sentence in custom model field docs.

### DIFF
--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -433,7 +433,7 @@ called when constructing a ``WHERE`` clause that includes the model field --
 that is, when you retrieve data using QuerySet methods like ``get()``,
 ``filter()``, and ``exclude()`` and have the model field as an argument. They
 are not called at any other time, so it can afford to execute slightly complex
-code, such as the ``connection.settings_dict`` check in the above example.
+code, such as the ``connection.vendor`` check in the above example.
 
 Some database column types accept parameters, such as ``CHAR(25)``, where the
 parameter ``25`` represents the maximum column length. In cases like these,

--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -431,9 +431,7 @@ Django when the framework constructs the ``CREATE TABLE`` statements for your
 application -- that is, when you first create your tables. The methods are also
 called when constructing a ``WHERE`` clause that includes the model field --
 that is, when you retrieve data using QuerySet methods like ``get()``,
-``filter()``, and ``exclude()`` and have the model field as an argument. They
-are not called at any other time, so it can afford to execute slightly complex
-code, such as the ``connection.vendor`` check in the above example.
+``filter()``, and ``exclude()`` and have the model field as an argument.
 
 Some database column types accept parameters, such as ``CHAR(25)``, where the
 parameter ``25`` represents the maximum column length. In cases like these,


### PR DESCRIPTION
I was having a read and I noticed an inconsistency in the `MyDateField` example. When explaining the behavior below the code example, `connection.settings_dict` is referenced while the code checks on `connection.vendor`.
(the example was changed [here](https://github.com/django/django/commit/d7394cfa13a4d1a02356e3a83e10ec100fbb9948) without updating the text below it)