### PR TITLE
Refs #34964 -- Doc'd that Q expression order is preserved.

### DIFF
--- a/docs/ref/models/constraints.txt
+++ b/docs/ref/models/constraints.txt
@@ -119,6 +119,18 @@ specifies the check you want the constraint to enforce.
 For example, ``CheckConstraint(check=Q(age__gte=18), name='age_gte_18')``
 ensures the age field is never less than 18.
 
+.. admonition:: Expression order
+
+    ``Q`` argument order is not necessarily preserved, however the order of
+    ``Q`` expressions themselves are preserved. This may be important for
+    databases that preserve check constraint expression order for performance
+    reasons. For example, use the following format if order matters::
+
+        CheckConstraint(
+            check=Q(age__gte=18) & Q(expensive_check=condition),
+            name="age_gte_18_and_others",
+        )
+
 .. admonition:: Oracle
 
     Checks with nullable fields on Oracle must include a condition allowing for


### PR DESCRIPTION
This refs the closed ticket (do we `#Refs` wontfix tickets?) https://code.djangoproject.com/ticket/34964

I'm not really sure what we want to say here - Mariusz or Simon will have better phrasing - but I thought it might be prudent to at least say that:

```
Q(one=One, two=Two)
```
isn't necessarily preserved (I've been told the kwargs are sorted)

but:

```
Q(one=One) & Q(two=Two)
```

_is_ preserved.

This is important for people that wish to control the expression order on databases that do preserve check constraint expressions for performance reasons.

**Edit:** I suppose not documenting this at all is also an option - perhaps this only really effects a niche group of people that use check constraints with performance implications!