### PR TITLE
Removed obsolete warnings about asgiref.sync adapters with sensitive variables.

### DIFF
--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -194,17 +194,6 @@ filtered out of error reports in a production environment (that is, where
             def process_info(user):
                 ...
 
-    .. warning::
-
-        Due to the machinery needed to cross the sync/async boundary,
-        :func:`~asgiref.sync.sync_to_async` and
-        :func:`~asgiref.sync.async_to_sync` are **not** compatible with
-        ``sensitive_variables()``.
-
-        If using these adapters with sensitive variables, ensure to audit
-        exception reporting, and consider implementing a :ref:`custom filter
-        <custom-error-reports>` if necessary.
-
     .. versionchanged:: 5.0
 
         Support for wrapping ``async`` functions was added.

--- a/docs/topics/async.txt
+++ b/docs/topics/async.txt
@@ -401,17 +401,3 @@ trigger the thread safety checks:
 Rather, you should encapsulate all database access within a helper function
 that can be called with ``sync_to_async()`` without relying on the connection
 object in the calling code.
-
-Use with exception reporting filters
-------------------------------------
-
-.. warning::
-
-    Due to the machinery needed to cross the sync/async boundary,
-    ``sync_to_async()`` and ``async_to_sync()`` are **not** compatible with
-    :func:`~django.views.decorators.debug.sensitive_variables`, used to mask
-    local variables from exception reports.
-
-    If using these adapters with sensitive variables, ensure to audit exception
-    reporting, and consider implementing a :ref:`custom filter
-    <custom-error-reports>` if necessary.


### PR DESCRIPTION
Django 5.0+ required asgiref 3.7+, and this warning is obsolete for asgiref 3.7+ since https://github.com/django/asgiref/commit/be6635e0e79009e55cf7a999614186f061f9f09b.