### PR TITLE
Fixed #34975 -- Fixed crash of conditional aggregate() over aggregations

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -417,6 +417,8 @@ class BaseExpression:
     def get_refs(self):
         refs = set()
         for expr in self.get_source_expressions():
+            if expr is None:
+                continue
             refs |= expr.get_refs()
         return refs
 

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -471,6 +471,14 @@ class IntegerLessThanOrEqual(IntegerFieldOverflow, LessThanOrEqual):
 class In(FieldGetDbPrepValueIterableMixin, BuiltinLookup):
     lookup_name = "in"
 
+    def get_refs(self):
+        refs = super().get_refs()
+        if self.rhs_is_direct_value():
+            for rhs in self.rhs:
+                if get_rhs_refs := getattr(rhs, "get_refs", None):
+                    refs |= get_rhs_refs()
+        return refs
+
     def get_prep_lookup(self):
         from django.db.models.sql.query import Query  # avoid circular import
 

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -451,13 +451,14 @@ class Query(BaseExpression):
             # Temporarily add aggregate to annotations to allow remaining
             # members of `aggregates` to resolve against each others.
             self.append_annotation_mask([alias])
+            aggregate_refs = aggregate.get_refs()
             refs_subquery |= any(
                 getattr(self.annotations[ref], "contains_subquery", False)
-                for ref in aggregate.get_refs()
+                for ref in aggregate_refs
             )
             refs_window |= any(
                 getattr(self.annotations[ref], "contains_over_clause", True)
-                for ref in aggregate.get_refs()
+                for ref in aggregate_refs
             )
             aggregate = aggregate.replace_expressions(replacements)
             self.annotations[alias] = aggregate

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1268,7 +1268,7 @@ class Query(BaseExpression):
             # The items of the iterable may be expressions and therefore need
             # to be resolved independently.
             values = (
-                self.resolve_lookup_value(sub_value, can_reuse, allow_joins)
+                self.resolve_lookup_value(sub_value, can_reuse, allow_joins, summarize)
                 for sub_value in value
             )
             type_ = type(value)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1256,12 +1256,13 @@ class Query(BaseExpression):
             sql = "(%s)" % sql
         return sql, params
 
-    def resolve_lookup_value(self, value, can_reuse, allow_joins):
+    def resolve_lookup_value(self, value, can_reuse, allow_joins, summarize=False):
         if hasattr(value, "resolve_expression"):
             value = value.resolve_expression(
                 self,
                 reuse=can_reuse,
                 allow_joins=allow_joins,
+                summarize=summarize,
             )
         elif isinstance(value, (list, tuple)):
             # The items of the iterable may be expressions and therefore need
@@ -1487,7 +1488,7 @@ class Query(BaseExpression):
             raise FieldError("Joined field references are not permitted in this query")
 
         pre_joins = self.alias_refcount.copy()
-        value = self.resolve_lookup_value(value, can_reuse, allow_joins)
+        value = self.resolve_lookup_value(value, can_reuse, allow_joins, summarize)
         used_joins = {
             k for k, v in self.alias_refcount.items() if v > pre_joins.get(k, 0)
         }

--- a/docs/releases/4.2.8.txt
+++ b/docs/releases/4.2.8.txt
@@ -11,3 +11,7 @@ Bugfixes
 
 * Fixed a regression in Django 4.2 that caused :option:`makemigrations --check`
   to stop displaying pending migrations (:ticket:`34457`).
+
+* Fixed a regression in Django 4.2 that caused a crash of
+  ``QuerySet.aggregate()`` with aggregates referencing other aggregates or
+  window functions through conditional expressions (:ticket:`34975`).

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -2309,3 +2309,9 @@ class AggregateAnnotationPruningTests(TestCase):
             aggregate,
             {"sum_avg_publisher_pages": 1100.0, "books_count": 2},
         )
+
+    def test_aggregate_reference_lookup_rhs(self):
+        aggregates = Author.objects.annotate(
+            max_book_author=Max("book__authors"),
+        ).aggregate(count=Count("id", filter=Q(id=F("max_book_author"))))
+        self.assertEqual(aggregates, {"count": 1})

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -2315,3 +2315,9 @@ class AggregateAnnotationPruningTests(TestCase):
             max_book_author=Max("book__authors"),
         ).aggregate(count=Count("id", filter=Q(id=F("max_book_author"))))
         self.assertEqual(aggregates, {"count": 1})
+
+    def test_aggregate_reference_lookup_rhs_iter(self):
+        aggregates = Author.objects.annotate(
+            max_book_author=Max("book__authors"),
+        ).aggregate(count=Count("id", filter=Q(id__in=[F("max_book_author"), 0])))
+        self.assertEqual(aggregates, {"count": 1})


### PR DESCRIPTION
Regression in b181cae2e3697b2e53b5b67ac67e59f3b05a6f0d.

Only the first commit relates to the regression and should be backported.

The four other ones are cleanups and related problems found along the way when debugging this issue.

Thanks @Zwergpro for the report.