### PR TITLE
Fixed #34977: Make change password form reachable through button

### DIFF
--- a/django/contrib/auth/templates/auth/widgets/read_only_password_hash.html
+++ b/django/contrib/auth/templates/auth/widgets/read_only_password_hash.html
@@ -1,5 +1,8 @@
 <div{% include 'django/forms/widgets/attrs.html' %}>
-{% for entry in summary %}
-<strong>{{ entry.label }}</strong>{% if entry.value %}: <bdi>{{ entry.value }}</bdi>{% endif %}
-{% endfor %}
+  <p>
+    {% for entry in summary %}
+    <strong>{{ entry.label }}</strong>{% if entry.value %}: <bdi>{{ entry.value }}</bdi>{% endif %}
+    {% endfor %}
+  </p>
+  <p><a class="button" href="{{ password_url|default:"../password/" }}">{{ button_label }}</a></p>
 </div>

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -57,6 +57,12 @@ Minor features
   :func:`~.django.contrib.auth.decorators.user_passes_test` decorators now
   support wrapping asynchronous view functions.
 
+* ``ReadOnlyPasswordHashWidget`` now includes a button to reset the user's
+  password, which replaces the link previously embedded in the
+  ``ReadOnlyPasswordHashField``'s help text, improving the overall
+  accessibility of the
+  :class:`~django.contrib.auth.forms.UserChangeForm`.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -1442,7 +1442,7 @@ class ChangelistTests(MessagesTestMixin, AuthViewsTestCase):
         response = self.client.get(user_change_url)
         # Test the link inside password field help_text.
         rel_link = re.search(
-            r'change or unset the password using <a href="([^"]*)">this form</a>',
+            r'<a class="button" href="([^"]*)">Reset password</a>',
             response.content.decode(),
         )[1]
         self.assertEqual(urljoin(user_change_url, rel_link), password_change_url)
@@ -1538,7 +1538,7 @@ class ChangelistTests(MessagesTestMixin, AuthViewsTestCase):
         response = self.client.get(user_change_url)
         # Test the link inside password field help_text.
         rel_link = re.search(
-            r'by setting a password using <a href="([^"]*)">this form</a>',
+            r'<a class="button" href="([^"]*)">Set password</a>',
             response.content.decode(),
         )[1]
         self.assertEqual(urljoin(user_change_url, rel_link), password_change_url)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34977

To improve usability and accessibility, this PR replaces the link to change a user's password within the help text of the password field of the change user form by a button.

<img width="1015" alt="image" src="https://github.com/django/django/assets/16904477/06956475-5563-4f04-9692-e14c518bba4b">

Besides an improved user experience, I would expect this PR to also improve accessibility. But since I am anything but an expert on accessibility, I would like to ask the accessibility team to review and give hints on hot to improve accessibility.

<!-- bot: {"reminders":[{"id":1,"who":"nessita","what":"re-check the status of this PR","when":"2024-03-28T09:00:00.000Z"}]} -->