### PR TITLE
[4.2.x] Refs #34118 -- Fixed stacklevel in complex_setting_changed on Python 3.12.

### DIFF
--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from django.utils.formats import FORMAT_SETTINGS, reset_format_cache
 from django.utils.functional import empty
 from django.utils.module_loading import import_string
+from django.utils.version import PY312
 
 template_rendered = Signal()
 
@@ -183,7 +184,7 @@ def complex_setting_changed(*, enter, setting, **kwargs):
         # this stacklevel shows the line containing the override_settings call.
         warnings.warn(
             f"Overriding setting {setting} can lead to unexpected behavior.",
-            stacklevel=6,
+            stacklevel=5 if PY312 else 6,
         )
 
 


### PR DESCRIPTION
This fix is unnecessary in Django 5.0+ since e83a88566a71a2353cebc35992c110be0f8628af, because signals no longer use `sync_to_async()`.

Check out [logs](https://djangoci.com/job/django-oracle-4.2/database=oracle19,label=oracle,python=python3.12/88/testReport/junit/settings_tests.tests/TestComplexSettingOverride/test_complex_override_warning/).