### PR TITLE
Fixed most critical test problems under PyPy3.10

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -52,7 +52,8 @@ warnings.simplefilter("error", RuntimeWarning)
 # references, which are a minority, so the garbage collection threshold can be
 # larger than the default threshold of 700 allocations + deallocations without
 # much increase in memory usage.
-gc.set_threshold(100_000)
+if not hasattr(sys, "pypy_version_info"):
+    gc.set_threshold(100_000)
 
 RUNTESTS_DIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/utils_tests/test_encoding.py
+++ b/tests/utils_tests/test_encoding.py
@@ -43,9 +43,14 @@ class TestEncodingUtils(SimpleTestCase):
         self.assertIs(type(force_str(s)), str)
 
     def test_force_str_DjangoUnicodeDecodeError(self):
+        if hasattr(sys, "pypy_version_info"):
+            error = "unexpected end of data"
+        else:
+            error = "invalid start byte"
+
         msg = (
-            "'utf-8' codec can't decode byte 0xff in position 0: invalid "
-            "start byte. You passed in b'\\xff' (<class 'bytes'>)"
+            f"'utf-8' codec can't decode byte 0xff in position 0: {error}. "
+            "You passed in b'\\xff' (<class 'bytes'>)"
         )
         with self.assertRaisesMessage(DjangoUnicodeDecodeError, msg):
             force_str(b"\xff")


### PR DESCRIPTION
These are two fixes that make it possible to run the test suite under PyPy3.10:

- omitted `gc.set_threshold()` call from PyPy (the function doesn't exist there)
- updated expected exception message in `test_force_str_DjangoUnicodeDecodeError` — the test suite hangs if this test fails

With these changes, I still get a number of test failures but it's a step forward.