### PR TITLE
Refs #34900 -- Skipped argon2-cffi requirement on daily builds for Python 3.13.

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,6 +1,6 @@
 aiosmtpd
 asgiref >= 3.7.0
-argon2-cffi >= 19.2.0
+argon2-cffi >= 19.2.0; sys.platform != 'win32' or python_version < '3.13'
 bcrypt
 black
 docutils >= 0.19


### PR DESCRIPTION
Follow up to 00a950f923435188a6c1d4ccdcb42c37cdc3976a.

Check out [logs](https://github.com/django/django/actions/runs/6938578404/job/18874524150).