### PR TITLE
Improved wording in auth.models.User field docs.

### DIFF
--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -67,14 +67,14 @@ Fields
 
     .. attribute:: is_staff
 
-        Boolean. Designates whether this user can access the admin site.
+        Boolean. Allows this user to access the admin site.
 
     .. attribute:: is_active
 
-        Boolean. Designates whether this user account should be considered
-        active. We recommend that you set this flag to ``False`` instead of
-        deleting accounts; that way, if your applications have any foreign keys
-        to users, the foreign keys won't break.
+        Boolean. Marks this user account as active. We recommend that you set
+        this flag to ``False`` instead of deleting accounts. That way, if your
+        applications have any foreign keys to users, the foreign keys won't
+        break.
 
         This doesn't necessarily control whether or not the user can log in.
         Authentication backends aren't required to check for the ``is_active``
@@ -94,8 +94,8 @@ Fields
 
     .. attribute:: is_superuser
 
-        Boolean. Designates that this user has all permissions without
-        explicitly assigning them.
+        Boolean. Treats this user as having all permissions without assigning
+        any permission to it in particular.
 
     .. attribute:: last_login
 
@@ -103,8 +103,7 @@ Fields
 
     .. attribute:: date_joined
 
-        A datetime designating when the account was created. Is set to the
-        current date/time by default when the account is created.
+        The date/time when the account was created.
 
 Attributes
 ----------


### PR DESCRIPTION
The motivation behind this PR is two-fold:

1. (linguistic point) _designates whether_ is, to my hear, an usual construct; I think  _designate_ is mostly used transitively. So I am suggesting to replace _designate whether_ by more colloquial phrases.

2. (programming semantics point) Even if I squint and try to move past the oddity, the sentence _[is_staff] designates whether a user can access the admin site_ is ambiguous between:
    a. `is_staff` is conventionally used by Django programmers to report that a user can access the admin site (namely it's just a flag to indicate some other state-of-affair); and
    b. a user can access the admin site if and only if `is_staff` is true of it (namely, this instance attribute is used in checks that the user will pass just in case it evaluates to `True`) . 

So I am suggesting `determines whether` to tip the scale for the b-interpretation. Of course I can give more details if this is desired.

I've spotted a few other places where this distinction can be clarified, using "indicate" for the a-interpretation and "determine" for the b-interpretaton.

I did not open a ticket, believing that this was too small a change to need one.