### PR TITLE
Refs #34900 -- Skipped Selenium requirement on daily builds for Python 3.13.

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -14,7 +14,7 @@ pymemcache >= 3.4.0
 pywatchman; sys.platform != 'win32'
 PyYAML
 redis >= 3.4.0
-selenium >= 4.8.0
+selenium >= 4.8.0; sys.platform != 'win32' or python_version < '3.13'
 sqlparse >= 0.3.1
 tblib >= 1.5.0
 tzdata


### PR DESCRIPTION
Selenium requires `trio` and `trio` requires `cffi` on [Windows](https://github.com/python-trio/trio/blob/fd175c9d16a52983cd8b1321e4e3883f99e14c6c/pyproject.toml#L46C7-L48).