### PR TITLE
Fixed #34985 -- Fixed GeneratedFields.contribute_to_class() crash when apps are not populated.

### DIFF
--- a/django/db/models/fields/generated.py
+++ b/django/db/models/fields/generated.py
@@ -13,7 +13,6 @@ class GeneratedField(Field):
     db_returning = True
 
     _query = None
-    _resolved_expression = None
     output_field = None
 
     def __init__(self, *, expression, output_field, db_persist=None, **kwargs):
@@ -48,9 +47,6 @@ class GeneratedField(Field):
         super().contribute_to_class(*args, **kwargs)
 
         self._query = Query(model=self.model, alias_cols=False)
-        self._resolved_expression = self.expression.resolve_expression(
-            self._query, allow_joins=False
-        )
         # Register lookups from the output_field class.
         for lookup_name, lookup in self.output_field.get_class_lookups().items():
             self.register_lookup(lookup, lookup_name=lookup_name)
@@ -59,7 +55,10 @@ class GeneratedField(Field):
         compiler = connection.ops.compiler("SQLCompiler")(
             self._query, connection=connection, using=None
         )
-        return compiler.compile(self._resolved_expression)
+        resolved_expression = self.expression.resolve_expression(
+            self._query, allow_joins=False
+        )
+        return compiler.compile(resolved_expression)
 
     def check(self, **kwargs):
         databases = kwargs.get("databases") or []


### PR DESCRIPTION
ticket-34985

Thanks Paolo Melchiorre for the report.

Regression in f333e3513e8bdf5ffeb6eeb63021c230082e6f95.