### PR TITLE
Add new feature to PasswordResetView, PasswordResetForm and modify associated password_reset_email.html template

### DIFF
--- a/django/contrib/admin/templates/registration/password_reset_email.html
+++ b/django/contrib/admin/templates/registration/password_reset_email.html
@@ -3,7 +3,7 @@
 
 {% translate "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
-{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+{{ protocol }}://{{ domain }}{% url password_reset_confirm uidb64=uid token=token %}
 {% endblock %}
 {% translate 'Your username, in case you’ve forgotten:' %} {{ user.get_username }}
 

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -348,6 +348,7 @@ class PasswordResetForm(forms.Form):
         request=None,
         html_email_template_name=None,
         extra_email_context=None,
+        app_name=None,
     ):
         """
         Generate a one-use only link for resetting password and send it to the
@@ -373,6 +374,10 @@ class PasswordResetForm(forms.Form):
                 "protocol": "https" if use_https else "http",
                 **(extra_email_context or {}),
             }
+            if app_name != "":
+                context['password_reset_confirm'] = f"{app_name}:password_reset_confirm"
+            else:
+                context['password_reset_confirm'] = 'password_reset_confirm'            
             self.send_mail(
                 subject_template_name,
                 email_template_name,

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -377,7 +377,7 @@ class PasswordResetForm(forms.Form):
             if app_name != "":
                 context['password_reset_confirm'] = f"{app_name}:password_reset_confirm"
             else:
-                context['password_reset_confirm'] = 'password_reset_confirm'            
+                context['password_reset_confirm'] = 'password_reset_confirm'
             self.send_mail(
                 subject_template_name,
                 email_template_name,

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -375,9 +375,9 @@ class PasswordResetForm(forms.Form):
                 **(extra_email_context or {}),
             }
             if app_name != "":
-                context['password_reset_confirm'] = f"{app_name}:password_reset_confirm"
+                context["password_reset_confirm"] = f"{app_name}:password_reset_confirm"
             else:
-                context['password_reset_confirm'] = 'password_reset_confirm'
+                context["password_reset_confirm"] = "password_reset_confirm"
             self.send_mail(
                 subject_template_name,
                 email_template_name,

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -224,6 +224,11 @@ class PasswordResetView(PasswordContextMixin, FormView):
 
     @method_decorator(csrf_protect)
     def dispatch(self, *args, **kwargs):
+        self.app_name = self.request.resolver_match.app_name
+        if self.app_name != "":
+            self.success_url = reverse_lazy(f"{self.app_name}:password_reset_done")
+        else:
+            self.success_url = reverse_lazy("password_reset_done")
         return super().dispatch(*args, **kwargs)
 
     def form_valid(self, form):
@@ -236,6 +241,7 @@ class PasswordResetView(PasswordContextMixin, FormView):
             "request": self.request,
             "html_email_template_name": self.html_email_template_name,
             "extra_email_context": self.extra_email_context,
+            "app_name": self.app_name,
         }
         form.save(**opts)
         return super().form_valid(form)


### PR DESCRIPTION
I'm not fluent in English, and I use a translation tool, so please forgive me for any possible mistranslations.

Update PasswordResetView, PasswordResetForm to include new feature in password reset logic. Previously, when using the PasswordReset feature, it was not allowed to use a namespace, but now it is allowed.
It works whether you use a namespace in urls.py or not

![image](https://github.com/django/django/assets/105529609/2de0701f-b9a8-4728-8079-699685dcf1d4)

