### PR TITLE
Fixed #34989 -- Set Content-Length: 0 on APPEND_SLASH redirects

### DIFF
--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -105,7 +105,9 @@ class CommonMiddleware(MiddlewareMixin):
         # If the given URL is "Not Found", then check if we should redirect to
         # a path with a slash appended.
         if response.status_code == 404 and self.should_redirect_with_slash(request):
-            return self.response_redirect_class(self.get_full_path_with_slash(request))
+            response = self.response_redirect_class(
+                self.get_full_path_with_slash(request)
+            )
 
         # Add the Content-Length header to non-streaming responses if not
         # already set.


### PR DESCRIPTION
Empirically, this prevents a timeout in uWSGI with the `http11-socket` option.

https://code.djangoproject.com/ticket/34989