### PR TITLE
Fixed #34990 -- Changed link to OWASP in CSRF docs.

### DIFF
--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -18,7 +18,7 @@ The first defense against CSRF attacks is to ensure that GET requests (and other
 Requests via 'unsafe' methods, such as POST, PUT, and DELETE, can then be
 protected by the steps outlined in :ref:`using-csrf`.
 
-.. _Cross Site Request Forgeries: https://www.squarefree.com/securitytips/web-developers.html#CSRF
+.. _Cross Site Request Forgeries: https://owasp.org/www-community/attacks/csrf#overview
 
 .. _how-csrf-works:
 


### PR DESCRIPTION
The OWASP site is the standard resource for web application security information.