### PR TITLE
Fixed #34991 -- Fixed pagination links and input layout in admin's change list page when using list_editable.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -1100,6 +1100,9 @@ a.deletelink:focus, a.deletelink:hover {
 /* PAGINATOR */
 
 .paginator {
+    display: flex;
+    align-items: center;
+    gap: 4px;
     font-size: 0.8125rem;
     padding-top: 10px;
     padding-bottom: 10px;
@@ -1141,6 +1144,10 @@ a.deletelink:focus, a.deletelink:hover {
 .paginator a:focus, .paginator a:hover {
     color: white;
     background: var(--link-hover-color);
+}
+
+.paginator input {
+    margin-left: auto;
 }
 
 .base-svgs {

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -107,6 +107,16 @@ thead th.sorted .text {
     border-left: none;
 }
 
+.paginator .end {
+    margin-left: 6px;
+    margin-right: 0;
+}
+
+.paginator input {
+    margin-left: 0;
+    margin-right: auto;
+}
+
 /* FORMS */
 
 .aligned label {

--- a/docs/releases/4.2.8.txt
+++ b/docs/releases/4.2.8.txt
@@ -20,3 +20,7 @@ Bugfixes
 * Fixed a regression in Django 4.2 that caused a crash when annotating a
   ``QuerySet`` with a ``Window`` expressions composed of a ``partition_by``
   clause mixing field types and aggregation expressions (:ticket:`34987`).
+
+* Fixed a regression in Django 4.2 where the admin's change list page had
+  misaligned pagination links and inputs when using ``list_editable``
+  (:ticket:`34991`).


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34991

Okay, it doesn't look perfectly the same as before, but IMO it looks better so I won't lose sleep over it.

I also fixed a small pre-existing RTL bug you can see in the first RTL screenshot (margin on the last pagination link is in the wrong direction).

# Before

## LTR

<img width="912" alt="Screenshot 2023-11-23 at 11 13 55" src="https://github.com/django/django/assets/3871354/65156248-296f-4c1a-8f65-d73d007d32f8">

## RTL

Note the gap also is between 3 and 4, should be between 4 and "318 releases".

<img width="907" alt="Screenshot 2023-11-23 at 11 14 19" src="https://github.com/django/django/assets/3871354/959f5291-d53b-457c-9e7f-c4ef02a3ad66">

# After

## LTR

<img width="924" alt="Screenshot 2023-11-23 at 11 14 41" src="https://github.com/django/django/assets/3871354/2b023716-73dc-4464-90ba-56faf35c3c3f">

## RTL

<img width="948" alt="Screenshot 2023-11-23 at 11 15 07" src="https://github.com/django/django/assets/3871354/e96f872f-afdb-404f-a93b-2a394266a20b">

## Worst I could make it look

Smallest tablet size, sidebar open, with filter sidebar to right.

<img width="270" alt="Screenshot 2023-11-23 at 11 15 57" src="https://github.com/django/django/assets/3871354/a2600544-b319-4f36-9496-76ce50b977a1">
