### PR TITLE
Fixed #34994 -- Fixed checkbox layout on narrow screen widths.

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -565,6 +565,10 @@ input[type="submit"], button {
         flex-flow: column;
     }
 
+    .flex-container.checkbox-row {
+        flex-flow: row;
+    }
+
     textarea {
         max-width: none;
     }
@@ -596,10 +600,6 @@ input[type="submit"], button {
     .aligned .form-row textarea {
         flex: 1 1 auto;
         max-width: 100%;
-    }
-
-    .aligned .checkbox-row {
-        align-items: center;
     }
 
     .aligned .checkbox-row input {

--- a/django/contrib/admin/static/admin/css/responsive_rtl.css
+++ b/django/contrib/admin/static/admin/css/responsive_rtl.css
@@ -78,4 +78,7 @@
         margin-left: 0;
         margin-right: 0;
     }
+    [dir="rtl"] .aligned .vCheckboxLabel {
+        padding: 1px 5px 0 0;
+    }
 }

--- a/docs/releases/4.2.8.txt
+++ b/docs/releases/4.2.8.txt
@@ -24,3 +24,6 @@ Bugfixes
 * Fixed a regression in Django 4.2 where the admin's change list page had
   misaligned pagination links and inputs when using ``list_editable``
   (:ticket:`34991`).
+
+* Fixed a regression in Django 4.2 where checkboxes in the admin would be
+  centered on narrower screen widths (:ticket:`34994`).


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34994

# Before

<img width="664" alt="Screenshot 2023-11-23 at 15 45 06" src="https://github.com/django/django/assets/3871354/edd8f424-2c3c-4fa6-a24d-1f629fd96f6e">

# After

<img width="651" alt="Screenshot 2023-11-23 at 15 45 26" src="https://github.com/django/django/assets/3871354/6decfb76-ac6e-4b67-869f-99ae54b55762">
