### PR TITLE
Fixed #34995 -- Fixed position of related widget's add link on admin pages for smaller screens.

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -237,22 +237,6 @@ input[type="submit"], button {
         padding: 7px;
     }
 
-    /* Related widget */
-
-    .related-widget-wrapper {
-        float: none;
-    }
-
-    .related-widget-wrapper-link + .selector {
-        max-width: calc(100% - 30px);
-        margin-right: 15px;
-    }
-
-    select + .related-widget-wrapper-link,
-    .related-widget-wrapper-link + .related-widget-wrapper-link {
-        margin-left: 10px;
-    }
-
     /* Selector */
 
     .selector {
@@ -270,7 +254,7 @@ input[type="submit"], button {
     }
 
     .selector .selector-filter input {
-        width: auto;
+        width: 100%;
         min-height: 0;
         flex: 1 1;
     }
@@ -292,7 +276,6 @@ input[type="submit"], button {
         width: 26px;
         height: 52px;
         padding: 2px 0;
-        margin: auto 15px;
         border-radius: 20px;
         transform: translateY(-10px);
     }
@@ -336,7 +319,6 @@ input[type="submit"], button {
         width: 52px;
         height: 26px;
         padding: 0 2px;
-        margin: 15px auto;
         transform: none;
     }
 
@@ -684,19 +666,10 @@ input[type="submit"], button {
         align-self: center;
     }
 
-    select + .related-widget-wrapper-link,
-    .related-widget-wrapper-link + .related-widget-wrapper-link {
-        margin-left: 15px;
-    }
-
     /* Selector */
 
     .selector {
         flex-direction: column;
-    }
-
-    .selector > * {
-        float: none;
     }
 
     .selector-available, .selector-chosen {
@@ -710,11 +683,9 @@ input[type="submit"], button {
 
     .selector ul.selector-chooser {
         display: block;
-        float: none;
         width: 52px;
         height: 26px;
         padding: 0 2px;
-        margin: 15px auto 20px;
         transform: none;
     }
 

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -289,3 +289,7 @@ form .form-row p.datetime {
     margin-left: inherit;
     margin-right: 2px;
 }
+
+.selector .selector-chooser {
+    margin: 0;
+}

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -1,23 +1,24 @@
 /* SELECTOR (FILTER INTERFACE) */
 
 .selector {
-    width: 800px;
-    float: left;
     display: flex;
+    flex-grow: 1;
+    gap: 10px;
 }
 
 .selector select {
-    width: 380px;
     height: 17.2em;
     flex: 1 0 auto;
+    overflow: scroll;
+    width: 100%;
 }
 
 .selector-available, .selector-chosen {
-    width: 380px;
     text-align: center;
     margin-bottom: 5px;
     display: flex;
     flex-direction: column;
+    flex: 1 1;
 }
 
 .selector-available h2, .selector-chosen h2 {
@@ -58,6 +59,7 @@
     font-size: 0.625rem;
     margin: 0;
     text-align: left;
+    display: flex;
 }
 
 .selector .selector-filter label,
@@ -72,9 +74,12 @@
     min-width: auto;
 }
 
+.selector-filter input {
+    flex-grow: 1;
+}
+
 .selector .selector-available input,
 .selector .selector-chosen input {
-    width: 320px;
     margin-left: 8px;
 }
 
@@ -83,7 +88,6 @@
     width: 22px;
     background-color: var(--selected-bg);
     border-radius: 10px;
-    margin: 0 5px;
     padding: 0;
     transform: translateY(-17px);
 }
@@ -575,8 +579,9 @@ ul.timelist, .timelist li {
 
 /* RELATED WIDGET WRAPPER */
 .related-widget-wrapper {
-    float: left;       /* display properly in form rows with multiple fields */
-    overflow: hidden;  /* clear floated contents */
+    display: flex;
+    gap: 10px;
+    flex-grow: 1;
 }
 
 .related-widget-wrapper-link {
@@ -587,11 +592,6 @@ ul.timelist, .timelist li {
 .related-widget-wrapper-link:link {
     opacity: 1;
     filter: grayscale(0);
-}
-
-select + .related-widget-wrapper-link,
-.related-widget-wrapper-link + .related-widget-wrapper-link {
-    margin-left: 7px;
 }
 
 /* GIS MAPS */

--- a/django/contrib/admin/static/admin/js/SelectFilter2.js
+++ b/django/contrib/admin/static/admin/js/SelectFilter2.js
@@ -30,6 +30,9 @@ Requires core.js and SelectBox.js.
 
             // <div class="selector"> or <div class="selector stacked">
             const selector_div = quickElement('div', from_box.parentNode);
+            // Make sure the selector div is at the beginning so that the
+            // add link would be displayed to the right of the widget.
+            from_box.parentNode.prepend(selector_div);
             selector_div.className = is_stacked ? 'selector stacked' : 'selector';
 
             // <div class="selector-available">

--- a/js_tests/admin/SelectFilter2.test.js
+++ b/js_tests/admin/SelectFilter2.test.js
@@ -5,9 +5,13 @@ QUnit.module('admin.SelectFilter2');
 
 QUnit.test('init', function(assert) {
     const $ = django.jQuery;
-    $('<form><select id="id"></select></form>').appendTo('#qunit-fixture');
-    $('<option value="0">A</option>').appendTo('#id');
+    $('<form id="test"></form>').appendTo('#qunit-fixture');
+    $('<label for="id_id">Test</label>').appendTo('#test');
+    $('<div class="helptext">This is helpful.</div>').appendTo('#test');
+    $('<select id="id"><option value="0">A</option></select>').appendTo('#test');
     SelectFilter.init('id', 'things', 0);
+    assert.equal($('#test').children().first().prop("tagName"), "DIV");
+    assert.equal($('#test').children().first().attr("class"), "selector");
     assert.equal($('.selector-available h2').text().trim(), "Available things");
     assert.equal($('.selector-chosen h2').text().trim(), "Chosen things");
     assert.equal($('.selector-chosen select')[0].getAttribute('multiple'), '');


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34995

A little tricky. Had to reposition the selector div so the add links are in the right place.

Will wait for the ticket to be accepted before working on it more.

# Before

<img width="906" alt="Screenshot 2023-11-23 at 16 13 01" src="https://github.com/django/django/assets/3871354/1d9a38e6-f95c-47b6-98f1-745ed47bd017">

# After

<img width="1071" alt="Screenshot 2023-11-23 at 17 40 37" src="https://github.com/django/django/assets/3871354/0535f5fb-1c7c-492c-806c-c66107a74406">

<img width="908" alt="Screenshot 2023-11-23 at 17 40 45" src="https://github.com/django/django/assets/3871354/00c3970f-2d0a-4db4-9329-70e3653bb5e4">

<img width="458" alt="Screenshot 2023-11-23 at 17 40 57" src="https://github.com/django/django/assets/3871354/2d695bdf-869b-47b4-a7c5-8cd28d59e039">

<img width="893" alt="Screenshot 2023-11-23 at 17 41 32" src="https://github.com/django/django/assets/3871354/5120d394-a69f-4750-9e14-64b9b9987cc5">

