### PR TITLE
Fixed #34982 -- Fixed helptext and password widget alignment on tablet.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -24,7 +24,6 @@ form .form-row p {
 
 .flex-container {
     display: flex;
-    flex-wrap: wrap;
 }
 
 .form-multiline > div {
@@ -78,6 +77,7 @@ form ul.inline li {
 .aligned label {
     display: block;
     padding: 4px 10px 0 0;
+    min-width: 160px;
     width: 160px;
     word-wrap: break-word;
     line-height: 1;

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -588,6 +588,7 @@ input[type="submit"], button {
 
     .aligned label {
         width: 100%;
+        min-width: auto;
         padding: 0 0 10px;
     }
 

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -69,6 +69,7 @@
     padding: 0;
     overflow: hidden;
     line-height: 1;
+    min-width: auto;
 }
 
 .selector .selector-available input,

--- a/docs/releases/4.2.8.txt
+++ b/docs/releases/4.2.8.txt
@@ -31,3 +31,7 @@ Bugfixes
 * Fixed a regression in Django 4.2 that caused a crash of querysets with
   aggregations on MariaDB when the ``ONLY_FULL_GROUP_BY`` SQL mode was enabled
   (:ticket:`34992`).
+
+* Fixed a regression in Django 4.2 where the admin's read-only password widget
+  and some help texts were incorrectly aligned at tablet widths
+  (:ticket:`34982`).

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5754,6 +5754,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         and with stacked and tabular inlines.
         Refs #13068, #9264, #9983, #9784.
         """
+        from selenium.webdriver import ActionChains
         from selenium.webdriver.common.by import By
 
         self.admin_login(
@@ -5766,6 +5767,8 @@ class SeleniumTests(AdminSeleniumTestCase):
 
         # Main form ----------------------------------------------------------
         self.selenium.find_element(By.ID, "id_pubdate").send_keys("2012-02-18")
+        status = self.selenium.find_element(By.ID, "id_status")
+        ActionChains(self.selenium).move_to_element(status).click(status).perform()
         self.select_option("#id_status", "option two")
         self.selenium.find_element(By.ID, "id_name").send_keys(
             " the mAin nÀMë and it's awεšomeıııİ"
@@ -5784,6 +5787,10 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.selenium.find_element(
             By.ID, "id_relatedprepopulated_set-0-pubdate"
         ).send_keys("2011-12-17")
+        status = self.selenium.find_element(
+            By.ID, "id_relatedprepopulated_set-0-status"
+        )
+        ActionChains(self.selenium).move_to_element(status).click(status).perform()
         self.select_option("#id_relatedprepopulated_set-0-status", "option one")
         self.selenium.find_element(
             By.ID, "id_relatedprepopulated_set-0-name"
@@ -5815,6 +5822,10 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.selenium.find_element(
             By.ID, "id_relatedprepopulated_set-1-pubdate"
         ).send_keys("1999-01-25")
+        status = self.selenium.find_element(
+            By.ID, "id_relatedprepopulated_set-1-status"
+        )
+        ActionChains(self.selenium).move_to_element(status).click(status).perform()
         self.select_option("#id_relatedprepopulated_set-1-status", "option two")
         self.selenium.find_element(
             By.ID, "id_relatedprepopulated_set-1-name"
@@ -5838,10 +5849,10 @@ class SeleniumTests(AdminSeleniumTestCase):
 
         # Tabular inlines ----------------------------------------------------
         # Initial inline
-        element = self.selenium.find_element(
+        status = self.selenium.find_element(
             By.ID, "id_relatedprepopulated_set-2-0-status"
         )
-        self.selenium.execute_script("window.scrollTo(0, %s);" % element.location["y"])
+        ActionChains(self.selenium).move_to_element(status).click(status).perform()
         self.selenium.find_element(
             By.ID, "id_relatedprepopulated_set-2-0-pubdate"
         ).send_keys("1234-12-07")
@@ -5872,6 +5883,10 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.selenium.find_element(
             By.ID, "id_relatedprepopulated_set-2-1-pubdate"
         ).send_keys("1981-08-22")
+        status = self.selenium.find_element(
+            By.ID, "id_relatedprepopulated_set-2-1-status"
+        )
+        ActionChains(self.selenium).move_to_element(status).click(status).perform()
         self.select_option("#id_relatedprepopulated_set-2-1-status", "option one")
         self.selenium.find_element(
             By.ID, "id_relatedprepopulated_set-2-1-name"
@@ -5898,6 +5913,8 @@ class SeleniumTests(AdminSeleniumTestCase):
         # Initial inline.
         row_id = "id_relatedprepopulated_set-4-0-"
         self.selenium.find_element(By.ID, f"{row_id}pubdate").send_keys("2011-12-12")
+        status = self.selenium.find_element(By.ID, f"{row_id}status")
+        ActionChains(self.selenium).move_to_element(status).click(status).perform()
         self.select_option(f"#{row_id}status", "option one")
         self.selenium.find_element(By.ID, f"{row_id}name").send_keys(
             " sŤāÇkeð  inline !  "
@@ -5917,6 +5934,8 @@ class SeleniumTests(AdminSeleniumTestCase):
         )[3].click()
         row_id = "id_relatedprepopulated_set-4-1-"
         self.selenium.find_element(By.ID, f"{row_id}pubdate").send_keys("1999-01-20")
+        status = self.selenium.find_element(By.ID, f"{row_id}status")
+        ActionChains(self.selenium).move_to_element(status).click(status).perform()
         self.select_option(f"#{row_id}status", "option two")
         self.selenium.find_element(By.ID, f"{row_id}name").send_keys(
             " now you haVe anöther   sŤāÇkeð  inline with a very loooong "


### PR DESCRIPTION
https://code.djangoproject.com/ticket/34982

# Before

<img width="762" alt="Screenshot 2023-11-23 at 18 30 29" src="https://github.com/django/django/assets/3871354/7644f8e7-8d11-4fce-b75e-711a7dd01483">

<img width="805" alt="Screenshot 2023-11-23 at 18 27 21" src="https://github.com/django/django/assets/3871354/786f27bb-a090-48d8-9725-4d0822740fbe">

# After

<img width="768" alt="Screenshot 2023-11-23 at 18 27 46" src="https://github.com/django/django/assets/3871354/6c8a4a02-eb93-4014-862b-07831764c872">

<img width="785" alt="Screenshot 2023-11-23 at 18 27 58" src="https://github.com/django/django/assets/3871354/2e25bb05-b653-48d2-9cb4-06b9efab48fc">
