### PR TITLE
Increase max_length of GenericIPAddressField

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2217,7 +2217,7 @@ class GenericIPAddressField(Field):
         self.default_validators = validators.ip_address_validators(
             protocol, unpack_ipv4
         )
-        kwargs["max_length"] = 39
+        kwargs["max_length"] = 40
         super().__init__(verbose_name, name, *args, **kwargs)
 
     def check(self, **kwargs):
@@ -2244,7 +2244,7 @@ class GenericIPAddressField(Field):
             kwargs["unpack_ipv4"] = self.unpack_ipv4
         if self.protocol != "both":
             kwargs["protocol"] = self.protocol
-        if kwargs.get("max_length") == 39:
+        if kwargs.get("max_length") == 40:
             del kwargs["max_length"]
         return name, path, args, kwargs
 


### PR DESCRIPTION
Some IPv6 addresses end up having netmask 128 when coersed to `inet` and back to `varchar` in PostgreSQL, which is what appears to be happening when GenericIPAddressField is saved to the database:

    => select ('2806:10██:█:████:████:████:████:████'::inet)::varchar;
                     varchar
    ------------------------------------------
     2806:10██:█:████:████:████:████:████/128
    (1 row)

    => select length(('2806:10██:█:████:████:████:████:████'::inet)::varchar) ;
     length 
    --------
         40
    (1 row)


This causes `DataError: value too long for type character(39)`. The error was encountered with a real client IP address received by a live Django app, not a hypothetical example.

While it's not clear why Django isn't using PostgreSQL-specific data type for storing IP addresses instead of varchar, bumping max_length fixes the issue.

If this is not the appropriate way to solve this, please advise an alternative solution. 