### PR TITLE
Refs #34380 -- Improved docs for forms.URLField.assume_scheme

### DIFF
--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -1141,12 +1141,16 @@ For each field, we describe the default widget used if you don't specify
     * Error message keys: ``required``, ``invalid``
 
     Has the optional arguments ``max_length``, ``min_length``, ``empty_value``
-    which work just as they do for :class:`CharField`, and ``assume_scheme``
-    that defaults to ``"http"``.
+    which work just as they do for :class:`CharField`, and one more argument:
 
-    .. versionchanged:: 5.0
+    .. attribute:: assume_scheme
 
-        The ``assume_scheme`` argument was added.
+        .. versionadded:: 5.0
+
+        The scheme assumed for URLs provided without one. Defaults to
+        ``"http"``. For example, if ``assume_scheme`` is ``"https"`` and the
+        provided value is ``"example.com"``, the normalized value will be
+        ``"https://example.com"``.
 
     .. deprecated:: 5.0
 

--- a/docs/releases/5.0.txt
+++ b/docs/releases/5.0.txt
@@ -338,8 +338,8 @@ File Storage
 Forms
 ~~~~~
 
-* The new ``assume_scheme`` argument for :class:`~django.forms.URLField` allows
-  specifying a default URL scheme.
+* The new :attr:`~django.forms.URLField.assume_scheme` argument for
+  :class:`~django.forms.URLField` allows specifying a default URL scheme.
 
 * In order to improve accessibility, the following changes are made:
 


### PR DESCRIPTION
ticket-34380

Whilst fixing the deprecation warnings on a project, I found the documentation was a little sparse and didn’t explain what `assume_scheme` actually means. This is my attempt to improve things.