### PR TITLE
Refs #34925 -- Avoided altering passed by reference refresh_from_db(fields).

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -691,6 +691,7 @@ class Model(AltersData, metaclass=ModelBase):
             self._prefetched_objects_cache = {}
         else:
             prefetched_objects_cache = getattr(self, "_prefetched_objects_cache", ())
+            fields = list(fields)
             for field in list(fields):
                 if field in prefetched_objects_cache:
                     del prefetched_objects_cache[field]
@@ -711,7 +712,6 @@ class Model(AltersData, metaclass=ModelBase):
         # Use provided fields, if not set then reload all non-deferred fields.
         deferred_fields = self.get_deferred_fields()
         if fields is not None:
-            fields = list(fields)
             db_instance_qs = db_instance_qs.only(*fields)
         elif deferred_fields:
             fields = [

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -951,7 +951,9 @@ class ModelRefreshTests(TestCase):
         # Relation is added and prefetch cache is stale.
         self.assertCountEqual(a2_prefetched.selfref_set.all(), [])
         self.assertCountEqual(a2_prefetched.cited.all(), [])
-        a2_prefetched.refresh_from_db(fields=["selfref_set", "cited"])
+        fields = ["selfref_set", "cited"]
+        a2_prefetched.refresh_from_db(fields=fields)
+        self.assertEqual(fields, ["selfref_set", "cited"])
         # Cache was cleared and new results are available.
         self.assertCountEqual(a2_prefetched.selfref_set.all(), [s])
         self.assertCountEqual(a2_prefetched.cited.all(), [s])


### PR DESCRIPTION
As discussed on https://github.com/django/django/pull/17417#issuecomment-1825785903