### PR TITLE
Changed the screenshots Github workflow to run in the PR's branch by using pull_request as event trigger.

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,7 +1,7 @@
 name: Visual Regression Tests
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, synchronize, opened, reopened]
     paths-ignore:
       - 'docs/**'
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: '${{ github.event.pull_request.merge_commit_sha }}'
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,7 +1,7 @@
 name: Visual Regression Tests
 
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled, synchronize, opened, reopened]
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,7 +1,7 @@
 name: Visual Regression Tests
 
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled, synchronize, opened, reopened]
     paths-ignore:
       - 'docs/**'
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: '${{ github.event.pull_request.merge_commit_sha }}'
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -47,35 +45,3 @@ jobs:
         with:
           name: screenshots-${{ github.event.pull_request.head.sha }}
           path: tests/screenshots/
-
-      - name: Find comment to update
-        uses: peter-evans/find-comment@v2
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: You can download the generated screenshots from the workflow artifacts.
-
-      - name: Create comment
-        if: steps.find-comment.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            🖼️ **Screenshots created**
-
-            You can download the generated screenshots from the workflow artifacts.
-
-            _Please note that artifacts are only available for download for ${{ github.retention_days }} days._
-
-            - Generated screenshots for ${{ github.event.pull_request.head.sha }} at ${{ steps.generate-screenshots.outputs.date }} ([download](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})).
-
-      - name: Update comment
-        if: steps.find-comment.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          body: |
-            - Generated screenshots for ${{ github.event.pull_request.head.sha }} at ${{ steps.generate-screenshots.outputs.date }} ([download](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})).

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5747,6 +5747,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         # Use assertAlmostEqual to avoid pixel rounding errors.
         self.assertAlmostEqual(offset_left, offset_right, delta=3)
         self.take_screenshot("login")
+        self.take_screenshow("TESTING_IF_YOU_EXIST")
 
     def test_prepopulated_fields(self):
         """

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5747,7 +5747,6 @@ class SeleniumTests(AdminSeleniumTestCase):
         # Use assertAlmostEqual to avoid pixel rounding errors.
         self.assertAlmostEqual(offset_left, offset_right, delta=3)
         self.take_screenshot("login")
-        self.take_screenshot("TESTING_IF_YOU_EXIST")
 
     def test_prepopulated_fields(self):
         """

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5747,7 +5747,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         # Use assertAlmostEqual to avoid pixel rounding errors.
         self.assertAlmostEqual(offset_left, offset_right, delta=3)
         self.take_screenshot("login")
-        self.take_screenshow("TESTING_IF_YOU_EXIST")
+        self.take_screenshot("TESTING_IF_YOU_EXIST")
 
     def test_prepopulated_fields(self):
         """


### PR DESCRIPTION
In debugging #17518 we discovered screenshots added in a PR weren't being run because `pull_request_target` runs against the target branch (main), not the PR. This means any new screenshots added in the PR don't show up, and worse, the screenshots show the results from the main branch, not the PR branch. So we fix this by changing to `pull_request`. However,  this does break the comments.

It might be possible to get the comments working in some way, but it doesn't seem trivial.