### PR TITLE
Fixed #35000 -- Skipped declaring empty string defaults on BLOB/TEXT field on MySQL.

### DIFF
--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -69,12 +69,22 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             and db_type.lower() in self.connection._limited_data_types
         )
 
+    def _is_text_or_blob(self, field):
+        db_type = field.db_type(self.connection)
+        return db_type and db_type.lower().endswith(("blob", "text"))
+
     def skip_default(self, field):
+        default_is_empty = self.effective_default(field) in ("", b"")
+        if default_is_empty and self._is_text_or_blob(field):
+            return True
         if not self._supports_limited_data_type_defaults:
             return self._is_limited_data_type(field)
         return False
 
     def skip_default_on_alter(self, field):
+        default_is_empty = self.effective_default(field) in ("", b"")
+        if default_is_empty and self._is_text_or_blob(field):
+            return True
         if self._is_limited_data_type(field) and not self.connection.mysql_is_mariadb:
             # MySQL doesn't support defaults for BLOB and TEXT in the
             # ALTER COLUMN statement.

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1078,11 +1078,14 @@ class SchemaTests(TransactionTestCase):
     def test_alter_text_field_to_not_null_with_default_value(self):
         with connection.schema_editor() as editor:
             editor.create_model(Note)
+        note = Note.objects.create(address=None)
         old_field = Note._meta.get_field("address")
         new_field = TextField(blank=True, default="", null=False)
         new_field.set_attributes_from_name("address")
         with connection.schema_editor() as editor:
             editor.alter_field(Note, old_field, new_field, strict=True)
+        note.refresh_from_db()
+        self.assertEqual(note.address, "")
 
     @skipUnlessDBFeature("can_defer_constraint_checks", "can_rollback_ddl")
     def test_alter_fk_checks_deferred_constraints(self):


### PR DESCRIPTION
Heyo! This is to improve the performance of **MySQL** migrations that add columns to large tables (https://code.djangoproject.com/ticket/27676#comment:8).  MySQL 8+ is capable of adding new columns instantly just by editing the meta information. It automatically chooses the fasted algorithm for `ALTER TABLE` statements (https://dev.mysql.com/doc/refman/8.0/en/alter-table.html), so I was wondering if the migration SQL code generated by django actually makes use of this. However, the generated SQL (while artificially enforcing `ALGORITHM=INSTANT`)

```sql
ALTER TABLE `<table>` ADD COLUMN `<column>` longtext NOT NULL DEFAULT(''), ALGORITHM=INSTANT;
```

is raising this error:

```
Error Code: 1845. ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.
```

This shows that django migrations can never benefit from `INSTANT` table altering on mysql, when adding columns. Skipping the default will yield SQL, that can run with `INSTANT` altering:

```sql
ALTER TABLE `<table>` ADD COLUMN `<column>` longtext NOT NULL, ALGORITHM=INSTANT;
```

The resulting DB schema is the same, because default handling is already done in python by django. This is "just" a performance fix, but IMO a very desirable one. Thank you for getting this merged. See also https://code.djangoproject.com/ticket/27676#comment:8 for my workaround.