### PR TITLE
Removed contrib.sites docs link to lawrence.com.

### DIFF
--- a/docs/ref/contrib/sites.txt
+++ b/docs/ref/contrib/sites.txt
@@ -47,7 +47,7 @@ Why would you use sites? It's best explained through examples.
 Associating content with multiple sites
 ---------------------------------------
 
-The LJWorld.com_ and Lawrence.com_ sites are operated by the same news
+The LJWorld.com_ and Lawrence.com sites were operated by the same news
 organization -- the Lawrence Journal-World newspaper in Lawrence, Kansas.
 LJWorld.com focused on news, while Lawrence.com focused on local entertainment.
 But sometimes editors wanted to publish an article on *both* sites.
@@ -94,7 +94,6 @@ This accomplishes several things quite nicely:
           # ...
 
 .. _ljworld.com: https://www2.ljworld.com/
-.. _lawrence.com: http://www.lawrence.com/
 
 Associating content with a single site
 --------------------------------------


### PR DESCRIPTION
lawrence.com has since become a redirect to LJWorld.com, making the link pointless.