### PR TITLE
Removed hard-coded expected results in SeleniumTests.test_select_multiple test.

### DIFF
--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -461,8 +461,8 @@ class SeleniumTests(AdminSeleniumTestCase):
         )
         search = self.selenium.find_element(By.CSS_SELECTOR, ".select2-search__field")
         # Load next page of results by scrolling to the bottom of the list.
-        with self.select2_ajax_wait():
-            for _ in range(PAGINATOR_SIZE + 1):
+        for _ in range(PAGINATOR_SIZE + 1):
+            with self.select2_ajax_wait():
                 search.send_keys(Keys.ARROW_DOWN)
         # All objects are now loaded.
         self.assertCountSeleniumElements(
@@ -532,7 +532,9 @@ class SeleniumTests(AdminSeleniumTestCase):
             with self.select2_ajax_wait():
                 search.send_keys(Keys.ARROW_DOWN)
         self.assertCountSeleniumElements(
-            ".select2-results__option", 31, root_element=result_container
+            ".select2-results__option",
+            PAGINATOR_SIZE + 11,
+            root_element=result_container,
         )
         # Limit the results with the search field.
         with self.select2_ajax_wait():
@@ -540,7 +542,9 @@ class SeleniumTests(AdminSeleniumTestCase):
             # Ajax request is delayed.
             self.assertIs(result_container.is_displayed(), True)
             self.assertCountSeleniumElements(
-                ".select2-results__option", 32, root_element=result_container
+                ".select2-results__option",
+                PAGINATOR_SIZE + 12,
+                root_element=result_container,
             )
         self.assertIs(result_container.is_displayed(), True)
 


### PR DESCRIPTION
While debugging a Selenium CI failure in PR #17517 for admin_views.test_autocomplete_view.SeleniumTests.test_select, I changed the AutocompleteJsonView.paginate_by to different values and I realized that test_select_multiple was hard-coding the expected results when operating the widget.

This work ensures that both tests, test_select and test_select_multiple, use analogous calculations for the expected amount of results, and for the iteration when presing "arrow down" and waiting for the ajax call to complete.