### PR TITLE
Made GeoIP2.__del__() close all databases.

### DIFF
--- a/django/contrib/gis/geoip2/base.py
+++ b/django/contrib/gis/geoip2/base.py
@@ -130,8 +130,10 @@ class GeoIP2:
 
     def __del__(self):
         # Cleanup any GeoIP file handles lying around.
-        if self._reader:
-            self._reader.close()
+        if self._city:
+            self._city.close()
+        if self._country:
+            self._country.close()
 
     def __repr__(self):
         meta = self._reader.metadata()

--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -154,6 +154,16 @@ class GeoIPTest(SimpleTestCase):
         self.assertEqual("Lawrence", d["city"])
         self.assertEqual("KS", d["region"])
 
+    def test_del(self):
+        g = GeoIP2()
+        city = g._city
+        country = g._country
+        self.assertIs(city._db_reader.closed, False)
+        self.assertIs(country._db_reader.closed, False)
+        del g
+        self.assertIs(city._db_reader.closed, True)
+        self.assertIs(country._db_reader.closed, True)
+
     def test_repr(self):
         path = settings.GEOIP_PATH
         g = GeoIP2(path=path)


### PR DESCRIPTION
_Am coming back round to a bunch of patches for improving the GeoIP stuff._
_Trying to break this down into small pull requests, extracting some of the minor clean up and fixes._

---

If a directory is provided containing both the city and country databases, then both will be opened.

This fix and test ensures that all databases are properly closed.