### PR TITLE
Removed unused, undocumented, and untested GeoIP2.info property.

### DIFF
--- a/django/contrib/gis/geoip2/base.py
+++ b/django/contrib/gis/geoip2/base.py
@@ -225,16 +225,6 @@ class GeoIP2:
         else:
             return None
 
-    # #### GeoIP Database Information Routines ####
-    @property
-    def info(self):
-        "Return information about the GeoIP library and databases in use."
-        meta = self._reader.metadata()
-        return "GeoIP Library:\n\t%s.%s\n" % (
-            meta.binary_format_major_version,
-            meta.binary_format_minor_version,
-        )
-
     @classmethod
     def open(cls, full_path, cache):
         return GeoIP2(full_path, cache)


### PR DESCRIPTION
_Am coming back round to a bunch of patches for improving the GeoIP stuff._
_Trying to break this down into small pull requests, extracting some of the minor clean up and fixes._

----

I don't think we need a deprecation for this, but let me know if you think otherwise.