### PR TITLE
Warn about persistent connection "feature" in Django 4.0+

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -40,6 +40,12 @@ database connection at the end of each request. To enable persistent
 connections, set :setting:`CONN_MAX_AGE` to a positive integer of seconds. For
 unlimited persistent connections, set it to ``None``.
 
+.. warning::
+
+    Persistent connections :ticket:`do not work <33497>` when running Django
+    under ASGI. Setting :setting:`CONN_MAX_AGE` to anything other than ``0``
+    may cause you to exceed your database connection limit.
+
 Connection management
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Persistent database connections do not work in Django 4.0+ when running under ASGI; this caused a "too many database connections" problem that was difficult for me to find any information on.

Since the ticket (https://code.djangoproject.com/ticket/33497) is marked as a feature and has been open for almost 2 years, I think it would be worth calling this scenario out in the documentation for anyone else who might hit it.