### PR TITLE
Fixed #35004 -- Corrected the direction of arrows in admin selector boxes for RTL languages on small screens.

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive_rtl.css
+++ b/django/contrib/admin/static/admin/css/responsive_rtl.css
@@ -58,6 +58,22 @@
         padding-left: 0;
         padding-right: 16px;
     }
+
+    [dir="rtl"] .selector-add {
+        background-position: 0 -80px;
+    }
+
+    [dir="rtl"] .selector-remove {
+        background-position: 0 -120px;
+    }
+
+    [dir="rtl"] .active.selector-add:focus, .active.selector-add:hover {
+        background-position: 0 -100px;
+    }
+
+    [dir="rtl"] .active.selector-remove:focus, .active.selector-remove:hover {
+        background-position: 0 -140px;
+    }
 }
 
 /* MOBILE */


### PR DESCRIPTION
ticket-35004

Follow up to 12617fbd859b1244e91bcf182a2fdf356b388821.

Before:

![image](https://github.com/django/django/assets/2865885/cee9ca85-7e2f-43b6-9208-1e648e6359ab)

After:

![image](https://github.com/django/django/assets/2865885/cb79f942-62c7-4bff-b9cc-c20abd840a8d)
