### PR TITLE
Fixed #35006 -- Fixed migrations crash when altering Meta.db_table_comment on SQLite.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -670,13 +670,14 @@ class BaseDatabaseSchemaEditor:
                 sql.rename_table_references(old_db_table, new_db_table)
 
     def alter_db_table_comment(self, model, old_db_table_comment, new_db_table_comment):
-        self.execute(
-            self.sql_alter_table_comment
-            % {
-                "table": self.quote_name(model._meta.db_table),
-                "comment": self.quote_value(new_db_table_comment or ""),
-            }
-        )
+        if self.sql_alter_table_comment and self.connection.features.supports_comments:
+            self.execute(
+                self.sql_alter_table_comment
+                % {
+                    "table": self.quote_name(model._meta.db_table),
+                    "comment": self.quote_value(new_db_table_comment or ""),
+                }
+            )
 
     def alter_db_tablespace(self, model, old_db_tablespace, new_db_tablespace):
         """Move a model's table between tablespaces."""

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -19,6 +19,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_delete_column = "ALTER TABLE %(table)s DROP COLUMN %(column)s"
     sql_create_unique = "CREATE UNIQUE INDEX %(name)s ON %(table)s (%(columns)s)"
     sql_delete_unique = "DROP INDEX %(name)s"
+    sql_alter_table_comment = None
+    sql_alter_column_comment = None
 
     def __enter__(self):
         # Some SQLite schema alterations need foreign key constraints to be

--- a/docs/releases/4.2.8.txt
+++ b/docs/releases/4.2.8.txt
@@ -35,3 +35,6 @@ Bugfixes
 * Fixed a regression in Django 4.2 where the admin's read-only password widget
   and some help texts were incorrectly aligned at tablet widths
   (:ticket:`34982`).
+
+* Fixed a regression in Django 4.2 that caused a migration crash on SQLite when
+  altering unsupported ``Meta.db_table_comment`` (:ticket:`35006`).


### PR DESCRIPTION
Thanks Юрий for the report.

Regression in 78f163a4fb3937aca2e71786fbdd51a0ef39629e.

ticket-35006