### PR TITLE
Fixed #35003 -- Corrected margins in admin for RTL languages.

### DIFF
--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -151,6 +151,7 @@ form ul.inline li {
 
 form .aligned p.help,
 form .aligned div.help {
+    margin-left: 0;
     margin-right: 160px;
     padding-right: 10px;
 }
@@ -167,14 +168,6 @@ form .aligned p.time div.help.timezonewarning {
 form .wide p.help, form .wide div.help {
     padding-left: 0;
     padding-right: 50px;
-}
-
-form .wide p,
-form .wide ul.errorlist,
-form .wide input + p.help,
-form .wide input + div.help {
-    margin-right: 200px;
-    margin-left: 0px;
 }
 
 .submit-row {


### PR DESCRIPTION

<img width="769" alt="Screenshot 2023-11-30 at 09 50 53" src="https://github.com/django/django/assets/3871354/3cea6198-9b73-40be-970a-45dcac7b8ad3">


<img width="562" alt="Screenshot 2023-11-30 at 09 50 04" src="https://github.com/django/django/assets/3871354/2e8a4442-f061-409d-97b3-072d64a6a554">
