### PR TITLE
Refs #34995 -- Made Selenium tests more robust for admin_views and admin_widgets suites.

### DIFF
--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -6259,6 +6259,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.assertEqual(select2_display.text, "×\nnew section")
 
     def test_inline_uuid_pk_edit_with_popup(self):
+        from selenium.webdriver import ActionChains
         from selenium.webdriver.common.by import By
         from selenium.webdriver.support.ui import Select
 
@@ -6271,8 +6272,10 @@ class SeleniumTests(AdminSeleniumTestCase):
             "admin:admin_views_relatedwithuuidpkmodel_change",
             args=(related_with_parent.id,),
         )
-        self.selenium.get(self.live_server_url + change_url)
-        self.selenium.find_element(By.ID, "change_id_parent").click()
+        with self.wait_page_loaded():
+            self.selenium.get(self.live_server_url + change_url)
+        change_parent = self.selenium.find_element(By.ID, "change_id_parent")
+        ActionChains(self.selenium).move_to_element(change_parent).click().perform()
         self.wait_for_and_switch_to_popup()
         self.selenium.find_element(By.XPATH, '//input[@value="Save"]').click()
         self.selenium.switch_to.window(self.selenium.window_handles[0])
@@ -6305,6 +6308,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.assertEqual(select.first_selected_option.get_attribute("value"), uuid_id)
 
     def test_inline_uuid_pk_delete_with_popup(self):
+        from selenium.webdriver import ActionChains
         from selenium.webdriver.common.by import By
         from selenium.webdriver.support.ui import Select
 
@@ -6317,8 +6321,10 @@ class SeleniumTests(AdminSeleniumTestCase):
             "admin:admin_views_relatedwithuuidpkmodel_change",
             args=(related_with_parent.id,),
         )
-        self.selenium.get(self.live_server_url + change_url)
-        self.selenium.find_element(By.ID, "delete_id_parent").click()
+        with self.wait_page_loaded():
+            self.selenium.get(self.live_server_url + change_url)
+        delete_parent = self.selenium.find_element(By.ID, "delete_id_parent")
+        ActionChains(self.selenium).move_to_element(delete_parent).click().perform()
         self.wait_for_and_switch_to_popup()
         self.selenium.find_element(By.XPATH, '//input[@value="Yes, I’m sure"]').click()
         self.selenium.switch_to.window(self.selenium.window_handles[0])
@@ -6329,6 +6335,7 @@ class SeleniumTests(AdminSeleniumTestCase):
 
     def test_inline_with_popup_cancel_delete(self):
         """Clicking ""No, take me back" on a delete popup closes the window."""
+        from selenium.webdriver import ActionChains
         from selenium.webdriver.common.by import By
 
         parent = ParentWithUUIDPK.objects.create(title="test")
@@ -6340,8 +6347,10 @@ class SeleniumTests(AdminSeleniumTestCase):
             "admin:admin_views_relatedwithuuidpkmodel_change",
             args=(related_with_parent.id,),
         )
-        self.selenium.get(self.live_server_url + change_url)
-        self.selenium.find_element(By.ID, "delete_id_parent").click()
+        with self.wait_page_loaded():
+            self.selenium.get(self.live_server_url + change_url)
+        delete_parent = self.selenium.find_element(By.ID, "delete_id_parent")
+        ActionChains(self.selenium).move_to_element(delete_parent).click().perform()
         self.wait_for_and_switch_to_popup()
         self.selenium.find_element(By.XPATH, '//a[text()="No, take me back"]').click()
         self.selenium.switch_to.window(self.selenium.window_handles[0])
@@ -6528,6 +6537,7 @@ class SeleniumTests(AdminSeleniumTestCase):
             self.assertIs(field_title.is_displayed(), False)
 
     def test_updating_related_objects_updates_fk_selects_except_autocompletes(self):
+        from selenium.webdriver import ActionChains
         from selenium.webdriver.common.by import By
         from selenium.webdriver.support.ui import Select
 
@@ -6589,7 +6599,8 @@ class SeleniumTests(AdminSeleniumTestCase):
         )
 
         # Add new Country from the living_country select.
-        self.selenium.find_element(By.ID, f"add_{living_country_select_id}").click()
+        element = self.selenium.find_element(By.ID, f"add_{living_country_select_id}")
+        ActionChains(self.selenium).move_to_element(element).click(element).perform()
         self.wait_for_and_switch_to_popup()
         self.selenium.find_element(By.ID, "id_name").send_keys("Spain")
         continent_select = Select(

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -1717,13 +1717,15 @@ class AdminRawIdWidgetSeleniumTests(AdminWidgetSeleniumTestCase):
 
 class RelatedFieldWidgetSeleniumTests(AdminWidgetSeleniumTestCase):
     def test_ForeignKey_using_to_field(self):
+        from selenium.webdriver import ActionChains
         from selenium.webdriver.common.by import By
         from selenium.webdriver.support.ui import Select
 
         self.admin_login(username="super", password="secret", login_url="/")
-        self.selenium.get(
-            self.live_server_url + reverse("admin:admin_widgets_profile_add")
-        )
+        with self.wait_page_loaded():
+            self.selenium.get(
+                self.live_server_url + reverse("admin:admin_widgets_profile_add")
+            )
 
         main_window = self.selenium.current_window_handle
         # Click the Add User button to add new
@@ -1769,7 +1771,8 @@ class RelatedFieldWidgetSeleniumTests(AdminWidgetSeleniumTestCase):
             By.CSS_SELECTOR, "#id_user option[value=changednewuser]"
         )
 
-        self.selenium.find_element(By.ID, "view_id_user").click()
+        element = self.selenium.find_element(By.ID, "view_id_user")
+        ActionChains(self.selenium).move_to_element(element).click(element).perform()
         self.wait_for_value("#id_username", "changednewuser")
         self.selenium.back()
 


### PR DESCRIPTION
Depending on screen sizes, the selenium tests that would "click" or interact with an element outside the scope of the visible window would produce test failures (raising ElementNotInteractableException in CI runs).

This branch switches those to using ActionChains, which ensures that the click (or other interaction) is performed only after successfully completing the move to the relevant element.