### PR TITLE
Refs #35004 -- Restored the direction of arrows in admin selector boxes for RTL languages on mobile screens.

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive_rtl.css
+++ b/django/contrib/admin/static/admin/css/responsive_rtl.css
@@ -97,4 +97,20 @@
     [dir="rtl"] .aligned .vCheckboxLabel {
         padding: 1px 5px 0 0;
     }
+
+    [dir="rtl"] .selector-remove {
+        background-position: 0 0;
+    }
+
+    [dir="rtl"] .active.selector-remove:focus, .active.selector-remove:hover {
+        background-position: 0 -20px;
+    }
+
+    [dir="rtl"] .selector-add  {
+        background-position: 0 -40px;
+    }
+
+    [dir="rtl"] .active.selector-add:focus, .active.selector-add:hover {
+        background-position: 0 -60px;
+    }
 }


### PR DESCRIPTION
Regression in 57c1dd466ff0d41760049d6818e82be9d767c7da.
ticket-35004

Before:

![image](https://github.com/django/django/assets/2865885/1618ec7e-7871-4754-b782-0b659002b824)


After:

![image](https://github.com/django/django/assets/2865885/8d2d499b-8a35-4896-a09e-306d8944101d)
