### PR TITLE
Fixed #34593 extra query in admin list if there are no filters

### DIFF
--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -29,7 +29,7 @@ from django.core.exceptions import (
     SuspiciousOperation,
 )
 from django.core.paginator import InvalidPage
-from django.db.models import F, Field, ManyToOneRel, OrderBy
+from django.db.models import F, Field, ManyToOneRel, OrderBy, Manager
 from django.db.models.expressions import Combinable
 from django.urls import reverse
 from django.utils.deprecation import RemovedInDjango60Warning
@@ -315,10 +315,19 @@ class ChangeList:
         # Note this isn't necessarily the same as result_count in the case of
         # no filtering. Filters defined in list_filters may still apply some
         # default filtering which may be removed with query parameters.
-        if self.model_admin.show_full_result_count:
+        if not self.model_admin.show_full_result_count:
+            full_result_count = None
+        elif (
+            self.has_active_filters
+            or isinstance(self.root_queryset, Manager)
+            or self.queryset.query.where
+        ):
+            # Get the total number of objects, with no admin filters applied.
             full_result_count = self.root_queryset.count()
         else:
-            full_result_count = None
+            # If there are no filters, no need for an extra query.
+            full_result_count = result_count
+
         can_show_all = result_count <= self.list_max_show_all
         multi_page = result_count > self.list_per_page
 

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -29,7 +29,7 @@ from django.core.exceptions import (
     SuspiciousOperation,
 )
 from django.core.paginator import InvalidPage
-from django.db.models import F, Field, ManyToOneRel, OrderBy, Manager
+from django.db.models import F, Field, Manager, ManyToOneRel, OrderBy
 from django.db.models.expressions import Combinable
 from django.urls import reverse
 from django.utils.deprecation import RemovedInDjango60Warning

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1209,7 +1209,7 @@ class ChangeListTests(TestCase):
             response = self.client.post(changelist_url, data=data)
             self.assertEqual(response.status_code, 200)
             self.assertIn("WHERE", context.captured_queries[4]["sql"])
-            self.assertIn("IN", context.captured_queries[4]["sql"])
+            self.assertIn("IN", context.captured_queries[3]["sql"])
             # Check only the first few characters since the UUID may have dashes.
             self.assertIn(str(a.pk)[:8], context.captured_queries[4]["sql"])
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4916,8 +4916,8 @@ class AdminCustomQuerysetTest(TestCase):
         changelist_url = reverse("admin:admin_views_person_changelist")
 
         # 5 queries are expected: 1 for the session, 1 for the user,
-        # 2 for the counts and 1 for the objects on the page
-        with self.assertNumQueries(5):
+        # 1 for the counts if there are no filters, 2 if there are and 1 for the objects on the page
+        with self.assertNumQueries(4):
             resp = self.client.get(changelist_url)
             self.assertEqual(resp.context["selection_note"], "0 of 2 selected")
             self.assertEqual(resp.context["selection_note_all"], "All 2 selected")

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4916,7 +4916,8 @@ class AdminCustomQuerysetTest(TestCase):
         changelist_url = reverse("admin:admin_views_person_changelist")
 
         # 5 queries are expected: 1 for the session, 1 for the user,
-        # 1 for the counts if there are no filters, 2 if there are and 1 for the objects on the page
+        # 1 for the counts if there are no filters, 2 if there are
+        # and 1 for the objects on the page
         with self.assertNumQueries(4):
             resp = self.client.get(changelist_url)
             self.assertEqual(resp.context["selection_note"], "0 of 2 selected")


### PR DESCRIPTION
Based on [extra discussion on the forum](https://forum.djangoproject.com/t/django-admin-list-does-count-query-twice/21100/11), here's another attempt at avoiding the extra count when is not needed.
Previous PR: https://github.com/django/django/pull/16891

The only two tests that I have changed are:
`test_changelist_view_list_editable_changed_objects_uses_filter`
Due to being one less identical count query the IN is now 1 item before in the query list.
`test_changelist_view_count_queries`
Due to being one less identical count query there are now 4 queries intead of 5.

The tests that failed in the last PR are untouched and pass.

