### PR TITLE
Removed unused CSS rules for related widget in RTL.

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive_rtl.css
+++ b/django/contrib/admin/static/admin/css/responsive_rtl.css
@@ -35,11 +35,6 @@
         background-position: calc(100% - 8px) 9px;
     }
 
-    [dir="rtl"] .related-widget-wrapper-link + .selector {
-        margin-right: 0;
-        margin-left: 15px;
-    }
-
     [dir="rtl"] .selector .selector-filter label {
         margin-right: 0;
         margin-left: 8px;


### PR DESCRIPTION
This rule is not longer used since #17517 as the selector was moved before the add links.