### PR TITLE
Deleted custom "selected" class for actions list

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -262,20 +262,11 @@
     vertical-align: baseline;
 }
 
-/* Once the :has() pseudo-class is supported by all browsers, the tr.selected
-   selector and the JS adding the class can be removed. */
-#changelist tbody tr.selected {
-    background-color: var(--selected-row);
-}
-
 #changelist tbody tr:has(.action-select:checked) {
     background-color: var(--selected-row);
 }
 
 @media (forced-colors: active) {
-    #changelist tbody tr.selected {
-        background-color: SelectedItem;
-    }
     #changelist tbody tr:has(.action-select:checked) {
         background-color: SelectedItem;
     }

--- a/django/contrib/admin/static/admin/js/actions.js
+++ b/django/contrib/admin/static/admin/js/actions.js
@@ -22,7 +22,6 @@
     function showClear(options) {
         show(options.acrossClears);
         hide(options.acrossQuestions);
-        document.querySelector(options.actionContainer).classList.remove(options.selectedClass);
         show(options.allContainer);
         hide(options.counterContainer);
     }
@@ -40,7 +39,6 @@
         acrossInputs.forEach(function(acrossInput) {
             acrossInput.value = 0;
         });
-        document.querySelector(options.actionContainer).classList.remove(options.selectedClass);
     }
 
     function checker(actionCheckboxes, options, checked) {
@@ -51,7 +49,6 @@
         }
         actionCheckboxes.forEach(function(el) {
             el.checked = checked;
-            el.closest('tr').classList.toggle(options.selectedClass, checked);
         });
     }
 
@@ -85,7 +82,6 @@
         acrossQuestions: "div.actions span.question",
         acrossClears: "div.actions span.clear",
         allToggleId: "action-toggle",
-        selectedClass: "selected"
     };
 
     window.Actions = function(actionCheckboxes, options) {

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1712,7 +1712,6 @@ class SeleniumTests(AdminSeleniumTestCase):
         row_selector.click()
         self.assertEqual(selection_indicator.text, "1 of 1 selected")
         self.assertIs(all_selector.get_property("checked"), True)
-        self.assertEqual(row.get_attribute("class"), "selected")
 
         # Deselect a row and check again
         row_selector.click()


### PR DESCRIPTION
As `:has` now is supported by last version of Firefox: https://caniuse.com/css-has

I apply comment suggestion:
>/* Once the :has() pseudo-class is supported by all browsers, the tr.selected
   selector and the JS adding the class can be removed. */

Refers: https://github.com/django/django/pull/15938