### PR TITLE
Deprecated django.contrib.gis.geoip2.GeoIP2.open().

### DIFF
--- a/django/contrib/gis/geoip2/base.py
+++ b/django/contrib/gis/geoip2/base.py
@@ -230,4 +230,9 @@ class GeoIP2:
 
     @classmethod
     def open(cls, full_path, cache):
+        warnings.warn(
+            "GeoIP2.open() is deprecated. Use GeoIP2() instead.",
+            RemovedInDjango60Warning,
+            stacklevel=2,
+        )
         return GeoIP2(full_path, cache)

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -66,6 +66,8 @@ details on these changes.
 
 * The ``django.contrib.gis.geoip2.GeoIP2.coords()`` method will be removed.
 
+* The ``django.contrib.gis.geoip2.GeoIP2.open()`` method will be removed.
+
 .. _deprecation-removed-in-5.1:
 
 5.1

--- a/docs/ref/contrib/gis/geoip2.txt
+++ b/docs/ref/contrib/gis/geoip2.txt
@@ -100,6 +100,10 @@ Instantiating
 This classmethod instantiates the GeoIP object from the given database path
 and given cache setting.
 
+.. deprecated:: 5.1
+
+   Use the :class:`GeoIP2()` constructor instead.
+
 Querying
 --------
 

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -310,6 +310,9 @@ Miscellaneous
 * The ``django.contrib.gis.geoip2.GeoIP2.coords()`` method is deprecated. Use
   ``django.contrib.gis.geoip2.GeoIP2.lon_lat()`` instead.
 
+* The ``django.contrib.gis.geoip2.GeoIP2.open()`` method is deprecated. Use the
+  :class:`~django.contrib.gis.geoip2.GeoIP2` constructor instead.
+
 Features removed in 5.1
 =======================
 

--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -29,14 +29,13 @@ class GeoIPTest(SimpleTestCase):
         g1 = GeoIP2()  # Everything inferred from GeoIP path
         path = settings.GEOIP_PATH
         g2 = GeoIP2(path, 0)  # Passing in data path explicitly.
-        g3 = GeoIP2.open(path, 0)  # MaxMind Python API syntax.
         # path accepts str and pathlib.Path.
         if isinstance(path, str):
-            g4 = GeoIP2(pathlib.Path(path))
+            g3 = GeoIP2(pathlib.Path(path))
         else:
-            g4 = GeoIP2(str(path))
+            g3 = GeoIP2(str(path))
 
-        for g in (g1, g2, g3, g4):
+        for g in (g1, g2, g3):
             self.assertTrue(g._country)
             self.assertTrue(g._city)
 
@@ -198,3 +197,10 @@ class GeoIPTest(SimpleTestCase):
             e1, e2 = g.coords(self.fqdn)
         self.assertIsInstance(e1, float)
         self.assertIsInstance(e2, float)
+
+    def test_open_deprecation_warning(self):
+        msg = "GeoIP2.open() is deprecated. Use GeoIP2() instead."
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+            g = GeoIP2.open(settings.GEOIP_PATH, 0)
+        self.assertTrue(g._country)
+        self.assertTrue(g._city)


### PR DESCRIPTION
Another bit of preparation, deprecating `GeoIP2.open()` which adds nothing over the constructor.