### PR TITLE
Replaced deprecated database type synonyms in Oracle backend.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -386,9 +386,9 @@ class OracleParam:
             self.input_size = param.input_size
         elif string_size > 4000:
             # Mark any string param greater than 4000 characters as a CLOB.
-            self.input_size = Database.CLOB
+            self.input_size = Database.DB_TYPE_CLOB
         elif isinstance(param, datetime.datetime):
-            self.input_size = Database.TIMESTAMP
+            self.input_size = Database.DB_TYPE_TIMESTAMP
         else:
             self.input_size = None
 

--- a/django/db/backends/oracle/utils.py
+++ b/django/db/backends/oracle/utils.py
@@ -21,8 +21,8 @@ class InsertVar:
         "PositiveBigIntegerField": int,
         "PositiveSmallIntegerField": int,
         "PositiveIntegerField": int,
-        "FloatField": Database.NATIVE_FLOAT,
-        "DateTimeField": Database.TIMESTAMP,
+        "FloatField": Database.DB_TYPE_BINARY_DOUBLE,
+        "DateTimeField": Database.DB_TYPE_TIMESTAMP,
         "DateField": Database.Date,
         "DecimalField": decimal.Decimal,
     }
@@ -46,7 +46,7 @@ class Oracle_datetime(datetime.datetime):
     to tell oracledb to save the microseconds too.
     """
 
-    input_size = Database.TIMESTAMP
+    input_size = Database.DB_TYPE_TIMESTAMP
 
     @classmethod
     def from_datetime(cls, dt):


### PR DESCRIPTION
Check out [https://python-oracledb.readthedocs.io/en/latest/api_manual/module.html#database-type-synonyms.](https://python-oracledb.readthedocs.io/en/latest/api_manual/deprecations.html#deprecations-8-0)