### PR TITLE
Fixed #35015 -- Updated MySQL notes in migrations topic.

### DIFF
--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -77,16 +77,17 @@ meaning that if a migration fails to apply you will have to manually unpick
 the changes in order to try again (it's impossible to roll back to an
 earlier point).
 
-In addition, MySQL will fully rewrite tables for almost every schema operation
-and generally takes a time proportional to the number of rows in the table to
-add or remove columns. On slower hardware this can be worse than a minute per
-million rows - adding a few columns to a table with just a few million rows
-could lock your site up for over ten minutes.
+MySQL 8.0 introduced significant performance enhancements for
+`DDL operations`_, making them more efficient and reducing the need for full
+table rebuilds. However, it cannot guarantee a complete absence of locks or
+interruptions. In situations where locks are still necessary, the duration of
+these operations will be proportionate to the number of rows involved.
 
-Finally, MySQL has relatively small limits on name lengths for columns, tables
-and indexes, as well as a limit on the combined size of all columns an index
-covers. This means that indexes that are possible on other backends will
-fail to be created under MySQL.
+Finally, MySQL has a relatively small limit on the combined size of all columns
+an index covers. This means that indexes that are possible on other backends
+will fail to be created under MySQL.
+
+.. _DDL operations: https://dev.mysql.com/doc/refman/en/innodb-online-ddl-operations.html
 
 SQLite
 ------


### PR DESCRIPTION
[ticket 35015](https://code.djangoproject.com/ticket/35015)

Now that Django dropped support for MySQL 5.0, we can update the information in this section.

## No support for transactions

The first paragraph is still true, MySQL 8.0 will do an implicit COMMIT[ for most DDL operations](https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html)

## DDL and table locks 

I updated the text to reflect the improved [online DDL operations](https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html) in MySQL 8.0.


## Name length limits

I've removed this paragraph, MySQL and Postgres both have limit to 64.

### MySQL 8.0
<img width="1164" alt="image" src="https://github.com/django/django/assets/46227124/187bc5eb-8916-4f9b-bbac-7d742fe2cfb5">

https://dev.mysql.com/doc/refman/5.7/en/identifier-length.html

### Postgres

> The system uses no more than NAMEDATALEN-1 bytes of an identifier; longer names can be written in commands, but they will be truncated. By default, NAMEDATALEN is 64 so the maximum identifier length is 63 bytes. If this limit is problematic, it can be raised by changing the NAMEDATALEN constant in src/include/pg_config_manual.h.

https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS



