### PR TITLE
Fixed #35018 -- Fixed migrations crash on GeneratedField with BooleanField as output_field on Oracle < 23c.

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -76,7 +76,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_slicing_ordering_in_compound = True
     requires_compound_order_by_subquery = True
     allows_multiple_constraints_on_same_fields = False
-    supports_boolean_expr_in_select_clause = False
     supports_comparing_boolean_expr = False
     supports_json_field_contains = False
     supports_collation_on_textfield = False
@@ -118,6 +117,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         },
         "Oracle doesn't support comparing NCLOB to NUMBER.": {
             "generic_relations_regress.tests.GenericRelationTests.test_textlink_filter",
+        },
+        "Oracle doesn't support casting filters to NUMBER.": {
+            "lookup.tests.LookupQueryingTests.test_aggregate_combined_lookup",
         },
     }
     django_test_expected_failures = {
@@ -170,3 +172,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def supports_frame_exclusion(self):
         return self.connection.oracle_version >= (21,)
+
+    @cached_property
+    def supports_boolean_expr_in_select_clause(self):
+        return self.connection.oracle_version >= (23,)

--- a/django/db/backends/oracle/utils.py
+++ b/django/db/backends/oracle/utils.py
@@ -21,6 +21,7 @@ class InsertVar:
         "PositiveBigIntegerField": int,
         "PositiveSmallIntegerField": int,
         "PositiveIntegerField": int,
+        "BooleanField": int,
         "FloatField": Database.DB_TYPE_BINARY_DOUBLE,
         "DateTimeField": Database.DB_TYPE_TIMESTAMP,
         "DateField": Database.Date,

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1705,10 +1705,13 @@ class OrderBy(Expression):
         return (template % placeholders).rstrip(), params
 
     def as_oracle(self, compiler, connection):
-        # Oracle doesn't allow ORDER BY EXISTS() or filters unless it's wrapped
-        # in a CASE WHEN.
-        if connection.ops.conditional_expression_supported_in_where_clause(
-            self.expression
+        # Oracle < 23c doesn't allow ORDER BY EXISTS() or filters unless it's
+        # wrapped in a CASE WHEN.
+        if (
+            not connection.features.supports_boolean_expr_in_select_clause
+            and connection.ops.conditional_expression_supported_in_where_clause(
+                self.expression
+            )
         ):
             copy = self.copy()
             copy.expression = Case(

--- a/django/db/models/fields/generated.py
+++ b/django/db/models/fields/generated.py
@@ -58,7 +58,13 @@ class GeneratedField(Field):
         resolved_expression = self.expression.resolve_expression(
             self._query, allow_joins=False
         )
-        return compiler.compile(resolved_expression)
+        sql, params = compiler.compile(resolved_expression)
+        if (
+            getattr(self.expression, "conditional", False)
+            and not connection.features.supports_boolean_expr_in_select_clause
+        ):
+            sql = f"CASE WHEN {sql} THEN 1 ELSE 0 END"
+        return sql, params
 
     def check(self, **kwargs):
         databases = kwargs.get("databases") or []

--- a/docs/releases/5.0.1.txt
+++ b/docs/releases/5.0.1.txt
@@ -20,3 +20,7 @@ Bugfixes
 * Fixed a regression in Django 5.0 that caused a crash of ``Model.save()`` for
   models with both ``GeneratedField`` and ``ForeignKey`` fields
   (:ticket:`35019`).
+
+* Fixed a bug in Django 5.0 that caused a migration crash on Oracle < 23c when
+  adding a ``GeneratedField`` with ``output_field=BooleanField``
+  (:ticket:`35018`).

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -1522,7 +1522,6 @@ class LookupQueryingTests(TestCase):
         qs = Season.objects.order_by(LessThan(F("year"), 1910), F("year"))
         self.assertSequenceEqual(qs, [self.s1, self.s3, self.s2])
 
-    @skipUnlessDBFeature("supports_boolean_expr_in_select_clause")
     def test_aggregate_combined_lookup(self):
         expression = Cast(GreaterThan(F("year"), 1900), models.IntegerField())
         qs = Season.objects.aggregate(modern=models.Sum(expression))

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -847,6 +847,27 @@ class SchemaTests(TransactionTestCase):
         )
 
     @isolate_apps("schema")
+    @skipUnlessDBFeature("supports_virtual_generated_columns")
+    def test_add_generated_boolean_field(self):
+        class GeneratedBooleanFieldModel(Model):
+            value = IntegerField(null=True)
+            has_value = GeneratedField(
+                expression=Q(value__isnull=False),
+                output_field=BooleanField(),
+                db_persist=False,
+            )
+
+            class Meta:
+                app_label = "schema"
+
+        with connection.schema_editor() as editor:
+            editor.create_model(GeneratedBooleanFieldModel)
+        obj = GeneratedBooleanFieldModel.objects.create()
+        self.assertIs(obj.has_value, False)
+        obj = GeneratedBooleanFieldModel.objects.create(value=1)
+        self.assertIs(obj.has_value, True)
+
+    @isolate_apps("schema")
     @skipUnlessDBFeature("supports_stored_generated_columns")
     def test_add_generated_field(self):
         class GeneratedFieldOutputFieldModel(Model):


### PR DESCRIPTION
Thanks Václav Řehák for the report.

Regression in f333e3513e8bdf5ffeb6eeb63021c230082e6f95.

:rotating_light:  ~~**WiP** because it introduces a regression on Oracle 23c by adding unnecessary wrapping.~~