### PR TITLE
Fixed #35016 -- Doc'd that DATABASES["OPTIONS"] are passed to new PostgreSQL connections.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -160,8 +160,14 @@ password from the `password file`_, you must specify them in the
 
     localhost:5432:NAME:USER:PASSWORD
 
+The PostgreSQL backend passes the content of :setting:`OPTIONS` as keyword
+arguments to the connection constructor, allowing for more advanced control
+of driver behavior. All available `parameters`_ are described in detail in the
+PostgreSQL documentation.
+
 .. _connection service file: https://www.postgresql.org/docs/current/libpq-pgservice.html
 .. _password file: https://www.postgresql.org/docs/current/libpq-pgpass.html
+.. _parameters: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
 
 .. warning::
 


### PR DESCRIPTION
[Ticket #35016](https://code.djangoproject.com/ticket/35016)

Page being edited: https://docs.djangoproject.com/en/dev/ref/databases/#postgresql-notes

To let readers know that when a database uses the `PostgreSQL` engine, options from the `OPTIONS` key that are not recognized by the engine are passed directly to the underlying `libpq` library. 
Example: [​`sslmode`](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE).