### PR TITLE
Fixed #34013 -- Added QuerySet.order_by() support for annotation transforms.

### DIFF
--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -181,6 +181,9 @@ Models
   :class:`~django.db.models.expressions.ValueRange` allows excluding rows,
   groups, and ties from the window frames.
 
+* :meth:`.QuerySet.order_by` now supports ordering by annotation transforms
+  such as ``JSONObject`` keys and ``ArrayAgg`` indices.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -25,6 +25,7 @@ from django.db.models import (
     Subquery,
     Sum,
     TimeField,
+    Transform,
     Value,
     Variance,
     When,
@@ -1725,6 +1726,28 @@ class AggregateTestCase(TestCase):
             ],
             lambda a: (a.name, a.contact_count),
             ordered=False,
+        )
+
+    def test_order_by_aggregate_transform(self):
+        class Mod100(Mod, Transform):
+            def __init__(self, expr):
+                super().__init__(expr, 100)
+
+        sum_field = IntegerField()
+        sum_field.register_instance_lookup(Mod100, "mod100")
+        publisher_pages = (
+            Book.objects.values("publisher")
+            .annotate(sum_pages=Sum("pages", output_field=sum_field))
+            .order_by("sum_pages__mod100")
+        )
+        self.assertQuerySetEqual(
+            publisher_pages,
+            [
+                {"publisher": self.p2.id, "sum_pages": 528},
+                {"publisher": self.p4.id, "sum_pages": 946},
+                {"publisher": self.p1.id, "sum_pages": 747},
+                {"publisher": self.p3.id, "sum_pages": 1482},
+            ],
         )
 
     def test_empty_result_optimization(self):

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -469,6 +469,16 @@ class TestQuerying(PostgreSQLTestCase):
         self.assertIn("GROUP BY 2", sql)
         self.assertIn("ORDER BY 2", sql)
 
+    def test_order_by_arrayagg_index(self):
+        qs = (
+            NullableIntegerArrayModel.objects.values("order")
+            .annotate(ids=ArrayAgg("id"))
+            .order_by("-ids__0")
+        )
+        self.assertQuerySetEqual(
+            qs, [{"order": obj.order, "ids": [obj.id]} for obj in reversed(self.objs)]
+        )
+
     def test_index(self):
         self.assertSequenceEqual(
             NullableIntegerArrayModel.objects.filter(field__0=2), self.objs[1:3]

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -1,7 +1,16 @@
 import operator
 
 from django.db import DatabaseError, NotSupportedError, connection
-from django.db.models import Exists, F, IntegerField, OuterRef, Subquery, Value
+from django.db.models import (
+    Exists,
+    F,
+    IntegerField,
+    OuterRef,
+    Subquery,
+    Transform,
+    Value,
+)
+from django.db.models.functions import Mod
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 from django.test.utils import CaptureQueriesContext
 
@@ -321,6 +330,23 @@ class QuerySetSetOperationTests(TestCase):
             [6, 7, 8, 9, 0, 1, 2, 3, 4, 5],
             operator.itemgetter("num"),
         )
+
+    def test_order_by_annotation_transform(self):
+        class Mod2(Mod, Transform):
+            def __init__(self, expr):
+                super().__init__(expr, 2)
+
+        output_field = IntegerField()
+        output_field.register_instance_lookup(Mod2, "mod2")
+        qs1 = Number.objects.annotate(
+            annotation=Value(1, output_field=output_field),
+        )
+        qs2 = Number.objects.annotate(
+            annotation=Value(2, output_field=output_field),
+        )
+        msg = "Ordering combined queries by transforms is not implemented."
+        with self.assertRaisesMessage(NotImplementedError, msg):
+            list(qs1.union(qs2).order_by("annotation__mod2"))
 
     def test_union_with_select_related_and_order(self):
         e1 = ExtraInfo.objects.create(value=7, info="e1")


### PR DESCRIPTION
Thanks Eugene Morozov and Ben Nace for the reports.