### PR TITLE
Fixed #35012 -- Restored wrapping admin fieldsets with multiple fields per line.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -26,6 +26,10 @@ form .form-row p {
     display: flex;
 }
 
+.form-multiline {
+    flex-wrap: wrap;
+}
+
 .form-multiline > div {
     padding-bottom: 10px;
 }

--- a/docs/releases/4.2.9.txt
+++ b/docs/releases/4.2.9.txt
@@ -9,4 +9,5 @@ Django 4.2.9 fixes a bug in 4.2.8.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 4.2.8 where admin fields on the same line could
+  overflow the page and become non-interactive (:ticket:`35012`).

--- a/docs/releases/5.0.1.txt
+++ b/docs/releases/5.0.1.txt
@@ -24,3 +24,6 @@ Bugfixes
 * Fixed a bug in Django 5.0 that caused a migration crash on Oracle < 23c when
   adding a ``GeneratedField`` with ``output_field=BooleanField``
   (:ticket:`35018`).
+
+* Fixed a regression in Django 5.0 where admin fields on the same line could
+  overflow the page and become non-interactive (:ticket:`35012`).


### PR DESCRIPTION
Wasn't sure about which release notes to add to since it affects both.

Before:

<img width="612" alt="Screenshot 2023-12-08 at 17 28 51" src="https://github.com/django/django/assets/3871354/b15a5b5d-bf55-4014-9a8b-02d0965da5f4">

After:

<img width="629" alt="Screenshot 2023-12-08 at 17 29 19" src="https://github.com/django/django/assets/3871354/08ace402-4183-4c8e-aaee-7097a09f654f">
