### PR TITLE
Fixed #28344 -- Added for_update parameter to Model.refresh_from_db()

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -672,7 +672,7 @@ class Model(AltersData, metaclass=ModelBase):
             if f.attname not in self.__dict__
         }
 
-    def refresh_from_db(self, using=None, fields=None):
+    def refresh_from_db(self, using=None, fields=None, for_update=False):
         """
         Reload field values from the database.
 
@@ -708,6 +708,9 @@ class Model(AltersData, metaclass=ModelBase):
         db_instance_qs = self.__class__._base_manager.db_manager(
             using, hints=hints
         ).filter(pk=self.pk)
+
+        if for_update:
+            db_instance_qs = db_instance_qs.select_for_update()
 
         # Use provided fields, if not set then reload all non-deferred fields.
         deferred_fields = self.get_deferred_fields()

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -142,8 +142,8 @@ value from the database:
     >>> del obj.field
     >>> obj.field  # Loads the field from the database
 
-.. method:: Model.refresh_from_db(using=None, fields=None)
-.. method:: Model.arefresh_from_db(using=None, fields=None)
+.. method:: Model.refresh_from_db(using=None, fields=None, for_update=False)
+.. method:: Model.arefresh_from_db(using=None, fields=None, for_update=False)
 
 *Asynchronous version*: ``arefresh_from_db()``
 
@@ -196,6 +196,15 @@ all of the instance's fields when a deferred field is reloaded::
                     # then load all of them
                     fields = fields.union(deferred_fields)
             super().refresh_from_db(using, fields, **kwargs)
+
+The ``for_update`` parameter can be used to lock the row until the end of
+transaction before reloading model's values. Underneath it uses
+:meth:`~django.db.models.query.QuerySet.select_for_update` and it is an optimized
+shorthand for::
+
+    _ = MyModel.objects.select_for_update().get(pk=obj.pk)
+    obj.refresh_from_db()
+
 
 .. method:: Model.get_deferred_fields()
 

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -181,6 +181,9 @@ Models
   :class:`~django.db.models.expressions.ValueRange` allows excluding rows,
   groups, and ties from the window frames.
 
+* The new ``for_update`` argument of :meth:`.Model.refresh_from_db` can be used
+  to lock the row before reloading model's values (:ticket:`28344`).
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The for_update parameter can be used to lock the row until the end of transaction before reloading model's values.