### PR TITLE
Fixed #28344 -- Allowed customizing queryset in Model.refresh_from_db()/arefresh_from_db().

### DIFF
--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -142,8 +142,8 @@ value from the database:
     >>> del obj.field
     >>> obj.field  # Loads the field from the database
 
-.. method:: Model.refresh_from_db(using=None, fields=None)
-.. method:: Model.arefresh_from_db(using=None, fields=None)
+.. method:: Model.refresh_from_db(using=None, fields=None, from_queryset=None)
+.. method:: Model.arefresh_from_db(using=None, fields=None, from_queryset=None)
 
 *Asynchronous version*: ``arefresh_from_db()``
 
@@ -196,6 +196,27 @@ all of the instance's fields when a deferred field is reloaded::
                     # then load all of them
                     fields = fields.union(deferred_fields)
             super().refresh_from_db(using, fields, **kwargs)
+
+The ``from_queryset`` argument allows using a different queryset than the one
+created from :attr:`~django.db.models.Model._base_manager`. It gives you more
+control over how the model is reloaded. For example, when your model uses soft
+deletion you can make ``refresh_from_db()`` to take this into account::
+
+    obj.refresh_from_db(from_queryset=MyModel.active_objects.all())
+
+You can cache related objects that otherwise would be cleared from the reloaded
+instance::
+
+    obj.refresh_from_db(from_queryset=MyModel.objects.select_related("related_field"))
+
+You can lock the row until the end of transaction before reloading a model's
+values::
+
+    obj.refresh_from_db(from_queryset=MyModel.objects.select_for_update())
+
+.. versionchanged:: 5.1
+
+    The ``from_queryset`` argument was added.
 
 .. method:: Model.get_deferred_fields()
 

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -208,6 +208,11 @@ Models
   :class:`~django.contrib.postgres.fields.ArrayField` can now be :ref:`sliced
   <slicing-using-f>`.
 
+* The new ``from_queryset`` argument of :meth:`.Model.refresh_from_db` and
+  :meth:`.Model.arefresh_from_db`  allows customizing the queryset used to
+  reload a model's value. This can be used to lock the row before reloading or
+  to select related objects.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/async/test_async_model_methods.py
+++ b/tests/async/test_async_model_methods.py
@@ -23,3 +23,14 @@ class AsyncModelOperationTest(TestCase):
         await SimpleModel.objects.filter(pk=self.s1.pk).aupdate(field=20)
         await self.s1.arefresh_from_db()
         self.assertEqual(self.s1.field, 20)
+
+    async def test_arefresh_from_db_from_queryset(self):
+        await SimpleModel.objects.filter(pk=self.s1.pk).aupdate(field=20)
+        with self.assertRaises(SimpleModel.DoesNotExist):
+            await self.s1.arefresh_from_db(
+                from_queryset=SimpleModel.objects.filter(field=0)
+            )
+        await self.s1.arefresh_from_db(
+            from_queryset=SimpleModel.objects.filter(field__gt=0)
+        )
+        self.assertEqual(self.s1.field, 20)


### PR DESCRIPTION
The from_queryset parameter can be used to:
- use a custom Manager supporting soft delete:
    from_queryset=Model.active_objects.all()
- lock the row until the end of transaction:
    from_queryset=Model.objects.select_for_update()
- select additional related objects
    from_queryset=Model.objects.select_related('related_field')