### PR TITLE
Updated examples for 2.0+ release numbering in installation FAQ.

### DIFF
--- a/docs/faq/install.txt
+++ b/docs/faq/install.txt
@@ -64,9 +64,9 @@ download page <https://www.python.org/downloads/>`_.
 
 Typically, we will support a Python version up to and including the first
 Django LTS release whose security support ends after security support for that
-version of Python ends. For example, Python 3.3 security support ended
-September 2017 and Django 1.8 LTS security support ended April 2018. Therefore
-Django 1.8 is the last version to support Python 3.3.
+version of Python ends. For example, Python 3.9 security support ends in
+October 2025 and Django 4.2 LTS security support ends in April 2026. Therefore
+Django 4.2 is the last version to support Python 3.9.
 
 What Python version should I use with Django?
 =============================================


### PR DESCRIPTION
```diff
   Django LTS release whose security support ends after security support for that
- version of Python ends. For example, Python 3.3 security support ended
- September 2017 and Django 1.8 LTS security support ended April 2018. Therefore
- Django 1.8 is the last version to support Python 3.3.
+ version of Python ends. For example, Python 3.7 security support ended in
+ June 2023 and Django 3.2 LTS security support ends in April 2024. Therefore
+ Django 3.2 is the last version to support Python 3.7.
```
* https://devguide.python.org/versions/#supported-versions
* https://www.djangoproject.com/download/#supported-versions