### PR TITLE
Add alias for show_migrations

### DIFF
--- a/django/core/management/commands/show_migrations.py
+++ b/django/core/management/commands/show_migrations.py
@@ -1,0 +1,7 @@
+"""
+An alias to the `showmigrations` command
+
+All other `show*` management commands contain an underscore except this one, which makes
+it harder for muscle memory to call this command correctly.
+"""
+from .showmigrations import Command

--- a/django/core/management/commands/show_migrations.py
+++ b/django/core/management/commands/show_migrations.py
@@ -4,4 +4,5 @@ An alias to the `showmigrations` command
 All other `show*` management commands contain an underscore except this one, which makes
 it harder for muscle memory to call this command correctly.
 """
+# flake8: noqa
 from .showmigrations import Command


### PR DESCRIPTION
Whenever I want to show migrations I end up running `./manage.py show_migrations` because the other `show*` management commands contain an underscore.  This patch add the alias `show_migrations` so that the command works with and without the underscore.

Thank you!