### PR TITLE
Add a mention to ~ (NOT) operator for Q() objects

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -4078,9 +4078,10 @@ elsewhere.
 A ``Q()`` object represents an SQL condition that can be used in
 database-related operations. It's similar to how an
 :class:`F() <django.db.models.F>` object represents the value of a model field
-or annotation. They make it possible to define and reuse conditions, and
-combine them using operators such as ``|`` (``OR``), ``&`` (``AND``), and ``^``
-(``XOR``). See :ref:`complex-lookups-with-q`.
+or annotation. They make it possible to define and reuse conditions. These can
+be negated using the ``~`` (``NOT``) operator, and combined using operators
+such as ``|`` (``OR``), ``&`` (``AND``), and ``^`` (``XOR``). See
+:ref:`complex-lookups-with-q`.
 
 ``Prefetch()`` objects
 ----------------------


### PR DESCRIPTION
It would be much better to mention `~` `(NOT)` operator in `Q()` object references, too. Though it's said "such as" but including NOT is needed.