### PR TITLE
Used model's Options.model_name instead of object_name.lower().

### DIFF
--- a/django/contrib/admin/templatetags/base.py
+++ b/django/contrib/admin/templatetags/base.py
@@ -32,7 +32,7 @@ class InclusionAdminNode(InclusionNode):
     def render(self, context):
         opts = context["opts"]
         app_label = opts.app_label.lower()
-        object_name = opts.object_name.lower()
+        object_name = opts.model_name
         # Load template for this render call. (Setting self.filename isn't
         # thread-safe.)
         context.render_context[self] = context.template.engine.select_template(

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -202,7 +202,7 @@ class ForeignKeyRawIdWidget(forms.TextInput):
                 % (
                     self.admin_site.name,
                     obj._meta.app_label,
-                    obj._meta.object_name.lower(),
+                    obj._meta.model_name,
                 ),
                 args=(obj.pk,),
             )


### PR DESCRIPTION
Follow up to 20d487c27b40bb70496ddc7419011ca78b7d4940.