### PR TITLE
Fixed HTML code snippet in Tutorial's part 7 when customizing the admin's site header.

### DIFF
--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -367,7 +367,7 @@ a section of code like:
 .. code-block:: html+django
 
     {% block branding %}
-    <div id="site-name"><a href="{% url 'admin:index' %}">Polls Administration</a><div>
+    <div id="site-name"><a href="{% url 'admin:index' %}">Polls Administration</a></div>
     {% endblock %}
 
 We use this approach to teach you how to override templates. In an actual


### PR DESCRIPTION
On Tutorial "Customize the admin look and feel" in "Writing your first Django app, part 7", when replacing the site header, the div tag was not closed and the layout was broken.