### PR TITLE
Fixed database connection for other alias in PostgreSQL tests on GitHub Actions.

### DIFF
--- a/.github/workflows/data/test_postgres.py.tpl
+++ b/.github/workflows/data/test_postgres.py.tpl
@@ -13,5 +13,8 @@ DATABASES = {
         "ENGINE": "django.db.backends.postgresql",
         "USER": "user",
         "NAME": "django2",
+        "PASSWORD": "postgres",
+        "HOST": "localhost",
+        "PORT": 5432,
     },
 }


### PR DESCRIPTION
Until recently this settings file had only been used for testing with Selenium and, looking through the output of the scheduled job for that, we can see:

```
Skipping setup of unused database(s): other.
```

When a scheduled job was added for PyPy, it was unable to connect to the "other" database, even though it had already successfully created the "default" one.