### PR TITLE
Add a PersistedTemporaryFileUploadHandler for file upload

### DIFF
--- a/django/core/files/uploadedfile.py
+++ b/django/core/files/uploadedfile.py
@@ -15,14 +15,14 @@ __all__ = (
     "TemporaryUploadedFile",
     "InMemoryUploadedFile",
     "SimpleUploadedFile",
-    "PersistedTemporaryUploadedFile"
+    "PersistedTemporaryUploadedFile",
 )
 
 
 class UploadedFile(File):
     """
     An abstract uploaded file (``TemporaryUploadedFile``,
-    ``InMemoryUploadedFile`` and ``PersistedTemporaryUploadedFile`` are 
+    ``InMemoryUploadedFile`` and ``PersistedTemporaryUploadedFile`` are
     the built-in concrete subclasses).
 
     An ``UploadedFile`` object behaves somewhat like a file object and
@@ -161,15 +161,16 @@ class PersistedTemporaryUploadedFile(UploadedFile):
     def __init__(self, name, content_type, size, charset, content_type_extra=None):
         _, ext = os.path.splitext(name)
         file = tempfile.NamedTemporaryFile(
-            suffix=".upload" + ext, dir=settings.FILE_UPLOAD_TEMP_DIR, 
-            delete=False # forbid the file from being deleted automatically
+            suffix=".upload" + ext,
+            dir=settings.FILE_UPLOAD_TEMP_DIR,
+            delete=False,  # forbid the file from being deleted automatically
         )
         super().__init__(file, name, content_type, size, charset, content_type_extra)
 
     def temporary_file_path(self):
         """Return the full path of this file."""
         return self.file.name
-    
+
     def close(self):
         try:
             return self.file.close()

--- a/django/core/files/uploadhandler.py
+++ b/django/core/files/uploadhandler.py
@@ -6,9 +6,9 @@ from io import BytesIO
 
 from django.conf import settings
 from django.core.files.uploadedfile import (
-    InMemoryUploadedFile, 
+    InMemoryUploadedFile,
+    PersistedTemporaryUploadedFile,
     TemporaryUploadedFile,
-    PersistedTemporaryUploadedFile
 )
 from django.utils.module_loading import import_string
 
@@ -19,9 +19,9 @@ __all__ = [
     "FileUploadHandler",
     "TemporaryFileUploadHandler",
     "MemoryFileUploadHandler",
-    "LongTemporaryFileUploadHandler",
     "load_handler",
-    "StopFutureHandlers"
+    "StopFutureHandlers",
+    "PersistedTemporaryFileUploadHandler",
 ]
 
 
@@ -238,7 +238,7 @@ class MemoryFileUploadHandler(FileUploadHandler):
             charset=self.charset,
             content_type_extra=self.content_type_extra,
         )
-    
+
 
 class PersistedTemporaryFileUploadHandler(TemporaryFileUploadHandler):
     """

--- a/django/core/files/uploadhandler.py
+++ b/django/core/files/uploadhandler.py
@@ -5,7 +5,11 @@ import os
 from io import BytesIO
 
 from django.conf import settings
-from django.core.files.uploadedfile import InMemoryUploadedFile, TemporaryUploadedFile
+from django.core.files.uploadedfile import (
+    InMemoryUploadedFile, 
+    TemporaryUploadedFile,
+    PersistedTemporaryUploadedFile
+)
 from django.utils.module_loading import import_string
 
 __all__ = [
@@ -15,8 +19,9 @@ __all__ = [
     "FileUploadHandler",
     "TemporaryFileUploadHandler",
     "MemoryFileUploadHandler",
+    "LongTemporaryFileUploadHandler",
     "load_handler",
-    "StopFutureHandlers",
+    "StopFutureHandlers"
 ]
 
 
@@ -232,6 +237,23 @@ class MemoryFileUploadHandler(FileUploadHandler):
             size=file_size,
             charset=self.charset,
             content_type_extra=self.content_type_extra,
+        )
+    
+
+class PersistedTemporaryFileUploadHandler(TemporaryFileUploadHandler):
+    """
+    Upload handler that streams data into a temporary file.
+    The file does not get deleted after a first read and should
+    be closed after use.
+    """
+
+    def new_file(self, *args, **kwargs):
+        """
+        Create the file object to append to as data is coming in.
+        """
+        super().new_file(*args, **kwargs)
+        self.file = PersistedTemporaryUploadedFile(
+            self.file_name, self.content_type, 0, self.charset, self.content_type_extra
         )
 
 

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -133,7 +133,8 @@ File Storage
 File Uploads
 ~~~~~~~~~~~~
 
-* ...
+* :class:`~django.core.files.uploadhandler.PersistedTemporaryFileUploadHandler`
+   and :class:`~django.core.files.uploadedfile.PersistedTemporaryUploadedFile`
 
 Forms
 ~~~~~

--- a/docs/topics/http/file-uploads.txt
+++ b/docs/topics/http/file-uploads.txt
@@ -377,6 +377,6 @@ Similar to :class:`TemporaryFileUploadHandler`, when using
 :class:`PersistedTemporaryFileUploadHandler`, Django will write the 
 uploaded to a temporary file stored in your system's temporary directory.
 However, the file will not be suppressed after your first read, and will 
-persist until you delete it. This behavior can be usefull when having many 
+persist until you delete it. This behavior can be useful when having many 
 threads reading from the uploaded file.
 

--- a/docs/topics/http/file-uploads.txt
+++ b/docs/topics/http/file-uploads.txt
@@ -360,3 +360,23 @@ list::
             @method_decorator(csrf_protect)
             def post(self, request, *args, **kwargs):
                 ...  # Process request
+
+``PersistedTemporaryFileUploadHandler``
+=======================================
+
+.. versionadded:: 5.1
+
+.. currentmodule:: django.core.files.uploadhandler
+
+When a user uploads a file, Django passes off the file data to an *upload
+handler* -- a small class that handles file data as it gets uploaded. Upload
+handlers are initially defined in the :setting:`FILE_UPLOAD_HANDLERS` setting,
+as described above.
+
+Similar to :class:`TemporaryFileUploadHandler`, when using 
+:class:`PersistedTemporaryFileUploadHandler`, Django will write the 
+uploaded to a temporary file stored in your system's temporary directory.
+However, the file will not be suppressed after your first read, and will 
+persist until you delete it. This behavior can be usefull when having many 
+threads reading from the uploaded file.
+

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -580,6 +580,26 @@ class FileUploadTests(TestCase):
             temp_path = response.json()["temp_path"]
             self.assertIs(os.path.exists(temp_path), False)
 
+    def test_upload_temporary_file_handler(self):
+         with tempfile.NamedTemporaryFile() as temp_file:
+            temp_file.write(b"a")
+            temp_file.seek(0)
+            response = self.client.post("/temp_file/", {"file": temp_file})
+            temp_path = response.json()["temp_path"]
+            # File get deleted after first access
+            self.assertIs(os.path.exists(temp_path), False)
+
+    def test_upload_persisted_temporary_file_handler(self):
+         with tempfile.NamedTemporaryFile() as temp_file:
+            temp_file.write(b"a")
+            temp_file.seek(0)
+            response = self.client.post("/temp_file/persisted_file/", {"file": temp_file})
+            temp_path = response.json()["temp_path"]
+            # File does not get deleted after first access
+            self.assertIs(os.path.exists(temp_path), True)
+            os.remove(temp_path)
+            self.assertIs(os.path.exists(temp_path), False)
+
     def test_upload_interrupted_temporary_file_handler(self):
         # Simulate an interrupted upload by omitting the closing boundary.
         class MockedParser(Parser):

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -581,7 +581,7 @@ class FileUploadTests(TestCase):
             self.assertIs(os.path.exists(temp_path), False)
 
     def test_upload_temporary_file_handler(self):
-         with tempfile.NamedTemporaryFile() as temp_file:
+        with tempfile.NamedTemporaryFile() as temp_file:
             temp_file.write(b"a")
             temp_file.seek(0)
             response = self.client.post("/temp_file/", {"file": temp_file})
@@ -590,10 +590,12 @@ class FileUploadTests(TestCase):
             self.assertIs(os.path.exists(temp_path), False)
 
     def test_upload_persisted_temporary_file_handler(self):
-         with tempfile.NamedTemporaryFile() as temp_file:
+        with tempfile.NamedTemporaryFile() as temp_file:
             temp_file.write(b"a")
             temp_file.seek(0)
-            response = self.client.post("/temp_file/persisted_file/", {"file": temp_file})
+            response = self.client.post(
+                "/temp_file/persisted_file/", {"file": temp_file}
+            )
             temp_path = response.json()["temp_path"]
             # File does not get deleted after first access
             self.assertIs(os.path.exists(temp_path), True)

--- a/tests/file_uploads/urls.py
+++ b/tests/file_uploads/urls.py
@@ -14,6 +14,8 @@ urlpatterns = [
     path("quota/broken/", views.file_upload_quota_broken),
     path("getlist_count/", views.file_upload_getlist_count),
     path("upload_errors/", views.file_upload_errors),
+    path("temp_file/", views.file_upload_temporary_file),
+    path("temp_file/persisted_file/", views.file_upload_persisted_temporary_file),
     path("temp_file/stop_upload/", views.file_stop_upload_temporary_file),
     path("temp_file/upload_interrupted/", views.file_upload_interrupted_temporary_file),
     path("filename_case/", views.file_upload_filename_case_view),

--- a/tests/file_uploads/views.py
+++ b/tests/file_uploads/views.py
@@ -2,7 +2,10 @@ import hashlib
 import os
 
 from django.core.files.uploadedfile import UploadedFile
-from django.core.files.uploadhandler import TemporaryFileUploadHandler, PersistedTemporaryFileUploadHandler
+from django.core.files.uploadhandler import (
+    PersistedTemporaryFileUploadHandler,
+    TemporaryFileUploadHandler,
+)
 from django.http import HttpResponse, HttpResponseServerError, JsonResponse
 
 from .models import FileModel
@@ -123,18 +126,20 @@ def file_stop_upload_temporary_file(request):
         {"temp_path": request.upload_handlers[0].file.temporary_file_path()},
     )
 
+
 def file_upload_temporary_file(request):
     request.upload_handlers.insert(0, TemporaryFileUploadHandler())
     request.upload_handlers.pop(2)
-    request.FILES # Trigger file parsing.
+    request.FILES  # Trigger file parsing.
     return JsonResponse(
         {"temp_path": request.upload_handlers[0].file.temporary_file_path()}
     )
 
+
 def file_upload_persisted_temporary_file(request):
     request.upload_handlers.insert(0, PersistedTemporaryFileUploadHandler())
     request.upload_handlers.pop(2)
-    request.FILES # Trigger file parsing.
+    request.FILES  # Trigger file parsing.
     return JsonResponse(
         {"temp_path": request.upload_handlers[0].file.temporary_file_path()}
     )

--- a/tests/file_uploads/views.py
+++ b/tests/file_uploads/views.py
@@ -2,7 +2,7 @@ import hashlib
 import os
 
 from django.core.files.uploadedfile import UploadedFile
-from django.core.files.uploadhandler import TemporaryFileUploadHandler
+from django.core.files.uploadhandler import TemporaryFileUploadHandler, PersistedTemporaryFileUploadHandler
 from django.http import HttpResponse, HttpResponseServerError, JsonResponse
 
 from .models import FileModel
@@ -121,6 +121,22 @@ def file_stop_upload_temporary_file(request):
     request.FILES  # Trigger file parsing.
     return JsonResponse(
         {"temp_path": request.upload_handlers[0].file.temporary_file_path()},
+    )
+
+def file_upload_temporary_file(request):
+    request.upload_handlers.insert(0, TemporaryFileUploadHandler())
+    request.upload_handlers.pop(2)
+    request.FILES # Trigger file parsing.
+    return JsonResponse(
+        {"temp_path": request.upload_handlers[0].file.temporary_file_path()}
+    )
+
+def file_upload_persisted_temporary_file(request):
+    request.upload_handlers.insert(0, PersistedTemporaryFileUploadHandler())
+    request.upload_handlers.pop(2)
+    request.FILES # Trigger file parsing.
+    return JsonResponse(
+        {"temp_path": request.upload_handlers[0].file.temporary_file_path()}
     )
 
 


### PR DESCRIPTION
##Description

Using the **PersistedTemporaryFileUploadHandler** upload handler, Django will write the uploaded file to a temporary file stored in your system's temporary directory. However, the file will not be suppressed after your first read, and will persist until you delete it.

**PersistedTemporaryFileUploadHandler** class  inherit from the **TemporaryFileUploadHandler** class.

## Use cases

- One use case that I personally faced is having many threads reading from the same uploaded file. When one of the threads reads the file content, file file is automatically deleted, and so became unavailable for the other threads.
- Another use case was find in a [stack overflow](https://stackoverflow.com/questions/11835274/django-control-time-of-temporaryuploadedfile-life/76021825#76021825) question, where a user was looking for a way to control the life time of the uploaded file.

##N.B
Even thought it may be easy to forbid the temporary file from being deleted, I think it's a necessary feature or class to have withing the framework.

