### PR TITLE
Fixed #35041 -- Added a guard for improperly configured DATA_UPLOAD_MAX_MEMORY_SIZE

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -172,6 +172,11 @@ class Settings:
             "LOCALE_PATHS",
             "SECRET_KEY_FALLBACKS",
         )
+
+        int_settings = (
+            "DATA_UPLOAD_MAX_MEMORY_SIZE"
+        )
+
         self._explicit_settings = set()
         for setting in dir(mod):
             if setting.isupper():
@@ -182,6 +187,13 @@ class Settings:
                 ):
                     raise ImproperlyConfigured(
                         "The %s setting must be a list or a tuple." % setting
+                    )
+
+                if setting in int_settings and not isinstance(
+                    setting_value, int
+                ):
+                    raise ImproperlyConfigured(
+                        "The %s setting must be an int." % setting
                     )
                 setattr(self, setting, setting_value)
                 self._explicit_settings.add(setting)

--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -173,9 +173,7 @@ class Settings:
             "SECRET_KEY_FALLBACKS",
         )
 
-        int_settings = (
-            "DATA_UPLOAD_MAX_MEMORY_SIZE"
-        )
+        int_settings = "DATA_UPLOAD_MAX_MEMORY_SIZE"
 
         self._explicit_settings = set()
         for setting in dir(mod):
@@ -189,9 +187,7 @@ class Settings:
                         "The %s setting must be a list or a tuple." % setting
                     )
 
-                if setting in int_settings and not isinstance(
-                    setting_value, int
-                ):
+                if setting in int_settings and not isinstance(setting_value, int):
                     raise ImproperlyConfigured(
                         "The %s setting must be an int." % setting
                     )

--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -189,7 +189,7 @@ class Settings:
 
                 if setting in int_settings and not isinstance(setting_value, int):
                     raise ImproperlyConfigured(
-                        "The %s setting must be an int." % setting
+                        "The %s setting must be an integer." % setting
                     )
                 setattr(self, setting, setting_value)
                 self._explicit_settings.add(setting)

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -494,6 +494,29 @@ class TestListSettings(SimpleTestCase):
                 del sys.modules["fake_settings_module"]
                 delattr(settings_module, setting)
 
+class TestIntSettings(SimpleTestCase):
+    """
+        Make sure settings that should be lists or tuples throw
+        ImproperlyConfigured if they are set to a string instead of a list or tuple.
+        """
+
+    int_settings = (
+        "DATA_UPLOAD_MAX_MEMORY_SIZE",
+    )
+
+    def test_int_settings(self):
+        settings_module = ModuleType("fake_settings_module")
+        settings_module.SECRET_KEY = "foo"
+        msg = "The %s setting must be an int."
+        for setting in self.int_settings:
+            setattr(settings_module, setting, (4e7))
+            sys.modules["fake_settings_module"] = settings_module
+            try:
+                with self.assertRaisesMessage(ImproperlyConfigured, msg % setting):
+                    Settings("fake_settings_module")
+            finally:
+                del sys.modules["fake_settings_module"]
+                delattr(settings_module, setting)
 
 class SettingChangeEnterException(Exception):
     pass

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -494,15 +494,14 @@ class TestListSettings(SimpleTestCase):
                 del sys.modules["fake_settings_module"]
                 delattr(settings_module, setting)
 
+
 class TestIntSettings(SimpleTestCase):
     """
-        Make sure settings that should be lists or tuples throw
-        ImproperlyConfigured if they are set to a string instead of a list or tuple.
-        """
+    Make sure settings that should be lists or tuples throw
+    ImproperlyConfigured if they are set to a string instead of a list or tuple.
+    """
 
-    int_settings = (
-        "DATA_UPLOAD_MAX_MEMORY_SIZE",
-    )
+    int_settings = ("DATA_UPLOAD_MAX_MEMORY_SIZE",)
 
     def test_int_settings(self):
         settings_module = ModuleType("fake_settings_module")
@@ -517,6 +516,7 @@ class TestIntSettings(SimpleTestCase):
             finally:
                 del sys.modules["fake_settings_module"]
                 delattr(settings_module, setting)
+
 
 class SettingChangeEnterException(Exception):
     pass

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -497,8 +497,8 @@ class TestListSettings(SimpleTestCase):
 
 class TestIntSettings(SimpleTestCase):
     """
-    Make sure settings that should be lists or tuples throw
-    ImproperlyConfigured if they are set to a string instead of a list or tuple.
+    Make sure settings that should be integers throw
+    ImproperlyConfigured if they are set to a float instead of an integer
     """
 
     int_settings = ("DATA_UPLOAD_MAX_MEMORY_SIZE",)
@@ -506,7 +506,7 @@ class TestIntSettings(SimpleTestCase):
     def test_int_settings(self):
         settings_module = ModuleType("fake_settings_module")
         settings_module.SECRET_KEY = "foo"
-        msg = "The %s setting must be an int."
+        msg = "The %s setting must be an integer."
         for setting in self.int_settings:
             setattr(settings_module, setting, (4e7))
             sys.modules["fake_settings_module"] = settings_module


### PR DESCRIPTION
[Ticket 35041](https://code.djangoproject.com/ticket/35041)

Added a guard to check if the DATA_UPLOAD_MAX_MEMORY_SIZE and a test to verify that this issue is resolved.