### PR TITLE
Refs #21442 -- Modernising Request Object attribute names.

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -323,7 +323,7 @@ class AdminSite:
         For sites running on a subpath, use the SCRIPT_NAME value if site_url
         hasn't been customized.
         """
-        script_name = request.META["SCRIPT_NAME"]
+        script_name = request.meta["SCRIPT_NAME"]
         site_url = (
             script_name if self.site_url == "/" and script_name else self.site_url
         )

--- a/django/contrib/admindocs/middleware.py
+++ b/django/contrib/admindocs/middleware.py
@@ -25,7 +25,7 @@ class XViewMiddleware(MiddlewareMixin):
                 "'django.contrib.auth.middleware.AuthenticationMiddleware'."
             )
         if request.method == "HEAD" and (
-            request.META.get("REMOTE_ADDR") in settings.INTERNAL_IPS
+            request.meta.get("REMOTE_ADDR") in settings.INTERNAL_IPS
             or (request.user.is_active and request.user.is_staff)
         ):
             response = HttpResponse()

--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -49,7 +49,7 @@ class RemoteUserMiddleware(MiddlewareMixin):
     """
 
     # Name of request header to grab username from.  This will be the key as
-    # used in the request.META dictionary, i.e. the normalization of headers to
+    # used in the request.meta dictionary, i.e. the normalization of headers to
     # all uppercase and the addition of "HTTP_" prefix apply.
     header = "REMOTE_USER"
     force_logout_if_no_header = True
@@ -65,7 +65,7 @@ class RemoteUserMiddleware(MiddlewareMixin):
                 " before the RemoteUserMiddleware class."
             )
         try:
-            username = request.META[self.header]
+            username = request.meta[self.header]
         except KeyError:
             # If specified header doesn't exist then remove any existing
             # authenticated remote-user, or return (leaving request.user set to

--- a/django/contrib/messages/api.py
+++ b/django/contrib/messages/api.py
@@ -26,7 +26,7 @@ def add_message(request, level, message, extra_tags="", fail_silently=False):
     try:
         messages = request._messages
     except AttributeError:
-        if not hasattr(request, "META"):
+        if not hasattr(request, "meta"):
             raise TypeError(
                 "add_message() argument must be an HttpRequest object, not "
                 "'%s'." % request.__class__.__name__

--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -60,7 +60,7 @@ class DisallowedRedirect(SuspiciousOperation):
 
 class TooManyFieldsSent(SuspiciousOperation):
     """
-    The number of fields in a GET or POST request exceeded
+    The number of fields in a request.query_params or POST request exceeded
     settings.DATA_UPLOAD_MAX_NUMBER_FIELDS.
     """
 

--- a/django/core/files/uploadhandler.py
+++ b/django/core/files/uploadhandler.py
@@ -91,7 +91,7 @@ class FileUploadHandler:
             :input_data:
                 An object that supports reading via .read().
             :META:
-                ``request.META``.
+                ``request.meta``.
             :content_length:
                 The (integer) value of the Content-Length header from the
                 client.

--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -71,7 +71,7 @@ class ASGIRequest(HttpRequest):
         query_string = self.scope.get("query_string", "")
         if isinstance(query_string, bytes):
             query_string = query_string.decode()
-        self.META = {
+        self.meta = {
             "REQUEST_METHOD": self.method,
             "QUERY_STRING": query_string,
             "SCRIPT_NAME": self.script_name,
@@ -81,16 +81,16 @@ class ASGIRequest(HttpRequest):
             "wsgi.multiprocess": True,
         }
         if self.scope.get("client"):
-            self.META["REMOTE_ADDR"] = self.scope["client"][0]
-            self.META["REMOTE_HOST"] = self.META["REMOTE_ADDR"]
-            self.META["REMOTE_PORT"] = self.scope["client"][1]
+            self.meta["REMOTE_ADDR"] = self.scope["client"][0]
+            self.meta["REMOTE_HOST"] = self.meta["REMOTE_ADDR"]
+            self.meta["REMOTE_PORT"] = self.scope["client"][1]
         if self.scope.get("server"):
-            self.META["SERVER_NAME"] = self.scope["server"][0]
-            self.META["SERVER_PORT"] = str(self.scope["server"][1])
+            self.meta["SERVER_NAME"] = self.scope["server"][0]
+            self.meta["SERVER_PORT"] = str(self.scope["server"][1])
         else:
-            self.META["SERVER_NAME"] = "unknown"
-            self.META["SERVER_PORT"] = "0"
-        # Headers go into META.
+            self.meta["SERVER_NAME"] = "unknown"
+            self.meta["SERVER_PORT"] = "0"
+        # Headers go into meta.
         for name, value in self.scope.get("headers", []):
             name = name.decode("latin1")
             if name == "content-length":
@@ -102,19 +102,19 @@ class ASGIRequest(HttpRequest):
             # HTTP/2 say only ASCII chars are allowed in headers, but decode
             # latin1 just in case.
             value = value.decode("latin1")
-            if corrected_name in self.META:
-                value = self.META[corrected_name] + "," + value
-            self.META[corrected_name] = value
+            if corrected_name in self.meta:
+                value = self.meta[corrected_name] + "," + value
+            self.meta[corrected_name] = value
         # Pull out request encoding, if provided.
-        self._set_content_type_params(self.META)
+        self._set_content_type_params(self.meta)
         # Directly assign the body file to be our stream.
         self._stream = body_file
         # Other bits.
         self.resolver_match = None
 
     @cached_property
-    def GET(self):
-        return QueryDict(self.META["QUERY_STRING"])
+    def query_params(self):
+        return QueryDict(self.meta["QUERY_STRING"])
 
     def _get_scheme(self):
         return self.scope.get("scheme") or super()._get_scheme()
@@ -137,7 +137,7 @@ class ASGIRequest(HttpRequest):
 
     @cached_property
     def COOKIES(self):
-        return parse_cookie(self.META.get("HTTP_COOKIE", ""))
+        return parse_cookie(self.meta.get("HTTP_COOKIE", ""))
 
     def close(self):
         super().close()

--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -65,9 +65,9 @@ class WSGIRequest(HttpRequest):
         # http://test/something and http://test//something being different as
         # stated in RFC 3986.
         self.path = "%s/%s" % (script_name.rstrip("/"), path_info.replace("/", "", 1))
-        self.META = environ
-        self.META["PATH_INFO"] = path_info
-        self.META["SCRIPT_NAME"] = script_name
+        self.meta = environ
+        self.meta["PATH_INFO"] = path_info
+        self.meta["SCRIPT_NAME"] = script_name
         self.method = environ["REQUEST_METHOD"].upper()
         # Set content_type, content_params, and encoding.
         self._set_content_type_params(environ)
@@ -83,7 +83,7 @@ class WSGIRequest(HttpRequest):
         return self.environ.get("wsgi.url_scheme")
 
     @cached_property
-    def GET(self):
+    def query_params(self):
         # The WSGI spec says 'QUERY_STRING' may be absent.
         raw_query_string = get_bytes_from_wsgi(self.environ, "QUERY_STRING", "")
         return QueryDict(raw_query_string, encoding=self._encoding)

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -54,12 +54,12 @@ class MultiPartParser:
 
     boundary_re = _lazy_re_compile(r"[ -~]{0,200}[!-~]")
 
-    def __init__(self, META, input_data, upload_handlers, encoding=None):
+    def __init__(self, meta, input_data, upload_handlers, encoding=None):
         """
         Initialize the MultiPartParser object.
 
-        :META:
-            The standard ``META`` dictionary in Django request objects.
+        :meta:
+            The standard ``meta`` dictionary in Django request objects.
         :input_data:
             The raw post data, as a file-like object.
         :upload_handlers:
@@ -69,7 +69,7 @@ class MultiPartParser:
             The encoding with which to treat the incoming data.
         """
         # Content-Type should contain multipart and the boundary information.
-        content_type = META.get("CONTENT_TYPE", "")
+        content_type = meta.get("CONTENT_TYPE", "")
         if not content_type.startswith("multipart/"):
             raise MultiPartParserError("Invalid Content-Type: %s" % content_type)
 
@@ -92,7 +92,7 @@ class MultiPartParser:
         # Content-Length should contain the length of the body we are about
         # to receive.
         try:
-            content_length = int(META.get("CONTENT_LENGTH", 0))
+            content_length = int(meta.get("CONTENT_LENGTH", 0))
         except (ValueError, TypeError):
             content_length = 0
 
@@ -108,7 +108,7 @@ class MultiPartParser:
         possible_sizes = [x.chunk_size for x in upload_handlers if x.chunk_size]
         self._chunk_size = min([2**31 - 4] + possible_sizes)
 
-        self._meta = META
+        self._meta = meta
         self._encoding = encoding or settings.DEFAULT_CHARSET
         self._content_length = content_length
         self._upload_handlers = upload_handlers
@@ -202,7 +202,7 @@ class MultiPartParser:
                     # last boundary.
                     if settings.DATA_UPLOAD_MAX_NUMBER_FIELDS + 2 < num_post_keys:
                         raise TooManyFieldsSent(
-                            "The number of GET/POST parameters exceeded "
+                            "The number of query_params/POST parameters exceeded "
                             "settings.DATA_UPLOAD_MAX_NUMBER_FIELDS."
                         )
 

--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -38,7 +38,7 @@ class CommonMiddleware(MiddlewareMixin):
         """
 
         # Check for denied User-Agents
-        user_agent = request.META.get("HTTP_USER_AGENT")
+        user_agent = request.meta.get("HTTP_USER_AGENT")
         if user_agent is not None:
             for user_agent_regex in settings.DISALLOWED_USER_AGENTS:
                 if user_agent_regex.search(user_agent):
@@ -121,11 +121,11 @@ class BrokenLinkEmailsMiddleware(MiddlewareMixin):
         if response.status_code == 404 and not settings.DEBUG:
             domain = request.get_host()
             path = request.get_full_path()
-            referer = request.META.get("HTTP_REFERER", "")
+            referer = request.meta.get("HTTP_REFERER", "")
 
             if not self.is_ignorable_request(request, path, domain, referer):
-                ua = request.META.get("HTTP_USER_AGENT", "<none>")
-                ip = request.META.get("REMOTE_ADDR", "<none>")
+                ua = request.meta.get("HTTP_USER_AGENT", "<none>")
+                ip = request.meta.get("REMOTE_ADDR", "<none>")
                 mail_managers(
                     "Broken %slink on %s"
                     % (

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -81,9 +81,9 @@ def _unmask_cipher_token(token):
 
 
 def _add_new_csrf_cookie(request):
-    """Generate a new random CSRF_COOKIE value, and add it to request.META."""
+    """Generate a new random CSRF_COOKIE value, and add it to request.meta."""
     csrf_secret = _get_new_csrf_string()
-    request.META.update(
+    request.meta.update(
         {
             "CSRF_COOKIE": csrf_secret,
             "CSRF_COOKIE_NEEDS_UPDATE": True,
@@ -102,12 +102,12 @@ def get_token(request):
     header to the outgoing response.  For this reason, you may need to use this
     function lazily, as is done by the csrf context processor.
     """
-    if "CSRF_COOKIE" in request.META:
-        csrf_secret = request.META["CSRF_COOKIE"]
+    if "CSRF_COOKIE" in request.meta:
+        csrf_secret = request.meta["CSRF_COOKIE"]
         # Since the cookie is being used, flag to send the cookie in
         # process_response() (even if the client already has it) in order to
         # renew the expiry timer.
-        request.META["CSRF_COOKIE_NEEDS_UPDATE"] = True
+        request.meta["CSRF_COOKIE_NEEDS_UPDATE"] = True
     else:
         csrf_secret = _add_new_csrf_cookie(request)
     return _mask_cipher_secret(csrf_secret)
@@ -251,12 +251,12 @@ class CsrfViewMiddleware(MiddlewareMixin):
 
     def _set_csrf_cookie(self, request, response):
         if settings.CSRF_USE_SESSIONS:
-            if request.session.get(CSRF_SESSION_KEY) != request.META["CSRF_COOKIE"]:
-                request.session[CSRF_SESSION_KEY] = request.META["CSRF_COOKIE"]
+            if request.session.get(CSRF_SESSION_KEY) != request.meta["CSRF_COOKIE"]:
+                request.session[CSRF_SESSION_KEY] = request.meta["CSRF_COOKIE"]
         else:
             response.set_cookie(
                 settings.CSRF_COOKIE_NAME,
-                request.META["CSRF_COOKIE"],
+                request.meta["CSRF_COOKIE"],
                 max_age=settings.CSRF_COOKIE_AGE,
                 domain=settings.CSRF_COOKIE_DOMAIN,
                 path=settings.CSRF_COOKIE_PATH,
@@ -268,7 +268,7 @@ class CsrfViewMiddleware(MiddlewareMixin):
             patch_vary_headers(response, ("Cookie",))
 
     def _origin_verified(self, request):
-        request_origin = request.META["HTTP_ORIGIN"]
+        request_origin = request.meta["HTTP_ORIGIN"]
         try:
             good_host = request.get_host()
         except DisallowedHost:
@@ -294,7 +294,7 @@ class CsrfViewMiddleware(MiddlewareMixin):
         )
 
     def _check_referer(self, request):
-        referer = request.META.get("HTTP_REFERER")
+        referer = request.meta.get("HTTP_REFERER")
         if referer is None:
             raise RejectRequest(REASON_NO_REFERER)
 
@@ -380,7 +380,7 @@ class CsrfViewMiddleware(MiddlewareMixin):
                 # depending on whether the client obtained the token from
                 # the DOM or the cookie (and if the cookie, whether the cookie
                 # was masked or unmasked).
-                request_csrf_token = request.META[settings.CSRF_HEADER_NAME]
+                request_csrf_token = request.meta[settings.CSRF_HEADER_NAME]
             except KeyError:
                 raise RejectRequest(REASON_CSRF_TOKEN_MISSING)
             token_source = settings.CSRF_HEADER_NAME
@@ -408,13 +408,13 @@ class CsrfViewMiddleware(MiddlewareMixin):
                 # masked, this also causes it to be replaced with the unmasked
                 # form, but only in cases where the secret is already getting
                 # saved anyways.
-                request.META["CSRF_COOKIE"] = csrf_secret
+                request.meta["CSRF_COOKIE"] = csrf_secret
 
     def process_view(self, request, callback, callback_args, callback_kwargs):
         if getattr(request, "csrf_processing_done", False):
             return None
 
-        # Wait until request.META["CSRF_COOKIE"] has been manipulated before
+        # Wait until request.meta["CSRF_COOKIE"] has been manipulated before
         # bailing out, so that get_token still works
         if getattr(callback, "csrf_exempt", False):
             return None
@@ -432,10 +432,10 @@ class CsrfViewMiddleware(MiddlewareMixin):
 
         # Reject the request if the Origin header doesn't match an allowed
         # value.
-        if "HTTP_ORIGIN" in request.META:
+        if "HTTP_ORIGIN" in request.meta:
             if not self._origin_verified(request):
                 return self._reject(
-                    request, REASON_BAD_ORIGIN % request.META["HTTP_ORIGIN"]
+                    request, REASON_BAD_ORIGIN % request.meta["HTTP_ORIGIN"]
                 )
         elif request.is_secure():
             # If the Origin header wasn't provided, reject HTTPS requests if
@@ -468,7 +468,7 @@ class CsrfViewMiddleware(MiddlewareMixin):
         return self._accept(request)
 
     def process_response(self, request, response):
-        if request.META.get("CSRF_COOKIE_NEEDS_UPDATE"):
+        if request.meta.get("CSRF_COOKIE_NEEDS_UPDATE"):
             self._set_csrf_cookie(request, response)
             # Unset the flag to prevent _set_csrf_cookie() from being
             # unnecessarily called again in process_response() by other
@@ -477,6 +477,6 @@ class CsrfViewMiddleware(MiddlewareMixin):
             # CSRF_COOKIE_NEEDS_UPDATE is still respected in subsequent calls
             # e.g. in case rotate_token() is called in process_response() later
             # by custom middleware but before those subsequent calls.
-            request.META["CSRF_COOKIE_NEEDS_UPDATE"] = False
+            request.meta["CSRF_COOKIE_NEEDS_UPDATE"] = False
 
         return response

--- a/django/middleware/gzip.py
+++ b/django/middleware/gzip.py
@@ -26,7 +26,7 @@ class GZipMiddleware(MiddlewareMixin):
 
         patch_vary_headers(response, ("Accept-Encoding",))
 
-        ae = request.META.get("HTTP_ACCEPT_ENCODING", "")
+        ae = request.meta.get("HTTP_ACCEPT_ENCODING", "")
         if not re_accepts_gzip.search(ae):
             return response
 

--- a/django/template/context_processors.py
+++ b/django/template/context_processors.py
@@ -38,7 +38,7 @@ def debug(request):
     Return context variables helpful for debugging.
     """
     context_extras = {}
-    if settings.DEBUG and request.META.get("REMOTE_ADDR") in settings.INTERNAL_IPS:
+    if settings.DEBUG and request.meta.get("REMOTE_ADDR") in settings.INTERNAL_IPS:
         context_extras["debug"] = True
         from django.db import connections
 

--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -166,13 +166,13 @@ def get_conditional_response(request, etag=None, last_modified=None, response=No
         return response
 
     # Get HTTP request headers.
-    if_match_etags = parse_etags(request.META.get("HTTP_IF_MATCH", ""))
-    if_unmodified_since = request.META.get("HTTP_IF_UNMODIFIED_SINCE")
+    if_match_etags = parse_etags(request.meta.get("HTTP_IF_MATCH", ""))
+    if_unmodified_since = request.meta.get("HTTP_IF_UNMODIFIED_SINCE")
     if_unmodified_since = if_unmodified_since and parse_http_date_safe(
         if_unmodified_since
     )
-    if_none_match_etags = parse_etags(request.META.get("HTTP_IF_NONE_MATCH", ""))
-    if_modified_since = request.META.get("HTTP_IF_MODIFIED_SINCE")
+    if_none_match_etags = parse_etags(request.meta.get("HTTP_IF_NONE_MATCH", ""))
+    if_modified_since = request.meta.get("HTTP_IF_MODIFIED_SINCE")
     if_modified_since = if_modified_since and parse_http_date_safe(if_modified_since)
 
     # Evaluation of request preconditions below follows RFC 9110 Section
@@ -350,7 +350,7 @@ def _generate_cache_key(request, method, headerlist, key_prefix):
     """Return a cache key from the headers given in the header list."""
     ctx = md5(usedforsecurity=False)
     for header in headerlist:
-        value = request.META.get(header)
+        value = request.meta.get(header)
         if value is not None:
             ctx.update(value.encode())
     url = md5(request.build_absolute_uri().encode("ascii"), usedforsecurity=False)

--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -98,7 +98,7 @@ class AdminEmailHandler(logging.Handler):
                 record.levelname,
                 (
                     "internal"
-                    if request.META.get("REMOTE_ADDR") in settings.INTERNAL_IPS
+                    if request.meta.get("REMOTE_ADDR") in settings.INTERNAL_IPS
                     else "EXTERNAL"
                 ),
                 record.getMessage(),

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -571,7 +571,7 @@ def get_language_from_request(request, check_path=False):
     except LookupError:
         pass
 
-    accept = request.META.get("HTTP_ACCEPT_LANGUAGE", "")
+    accept = request.meta.get("HTTP_ACCEPT_LANGUAGE", "")
     for accept_lang, unused in parse_accept_lang_header(accept):
         if accept_lang == "*":
             break

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -158,11 +158,11 @@ class SafeExceptionReporterFilter:
 
     def get_safe_request_meta(self, request):
         """
-        Return a dictionary of request.META with sensitive values redacted.
+        Return a dictionary of request.meta with sensitive values redacted.
         """
-        if not hasattr(request, "META"):
+        if not hasattr(request, "meta"):
             return {}
-        return {k: self.cleanse_setting(k, v) for k, v in request.META.items()}
+        return {k: self.cleanse_setting(k, v) for k, v in request.meta.items()}
 
     def get_safe_cookies(self, request):
         """

--- a/django/views/decorators/cache.py
+++ b/django/views/decorators/cache.py
@@ -30,7 +30,7 @@ def cache_page(timeout, *, cache=None, key_prefix=None):
 
 def _check_request(request, decorator_name):
     # Ensure argument looks like a request.
-    if not hasattr(request, "META"):
+    if not hasattr(request, "meta"):
         raise TypeError(
             f"{decorator_name} didn't receive an HttpRequest. If you are "
             "decorating a classmethod, be sure to use @method_decorator."

--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -248,7 +248,7 @@ class RedirectView(View):
         else:
             return None
 
-        args = self.request.META.get("QUERY_STRING", "")
+        args = self.request.meta.get("QUERY_STRING", "")
         if args and self.query_string:
             url = "%s?%s" % (url, args)
         return url

--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -46,7 +46,7 @@ def set_language(request):
         allowed_hosts={request.get_host()},
         require_https=request.is_secure(),
     ):
-        next_url = request.META.get("HTTP_REFERER")
+        next_url = request.meta.get("HTTP_REFERER")
         if not url_has_allowed_host_and_scheme(
             url=next_url,
             allowed_hosts={request.get_host()},

--- a/django/views/static.py
+++ b/django/views/static.py
@@ -51,7 +51,7 @@ def serve(request, path, document_root=None, show_indexes=False):
     # Respect the If-Modified-Since header.
     statobj = fullpath.stat()
     if not was_modified_since(
-        request.META.get("HTTP_IF_MODIFIED_SINCE"), statobj.st_mtime
+        request.meta.get("HTTP_IF_MODIFIED_SINCE"), statobj.st_mtime
     ):
         return HttpResponseNotModified()
     content_type, encoding = mimetypes.guess_type(str(fullpath))

--- a/docs/howto/auth-remote-user.txt
+++ b/docs/howto/auth-remote-user.txt
@@ -17,8 +17,8 @@ Windows Authentication or Apache and `mod_authnz_ldap`_, `CAS`_, `Cosign`_,
 
 When the web server takes care of authentication it typically sets the
 ``REMOTE_USER`` environment variable for use in the underlying application.  In
-Django, ``REMOTE_USER`` is made available in the :attr:`request.META
-<django.http.HttpRequest.META>` attribute.  Django can be configured to make
+Django, ``REMOTE_USER`` is made available in the :attr:`request.meta
+<django.http.HttpRequest.meta>` attribute.  Django can be configured to make
 use of the ``REMOTE_USER`` value using the ``RemoteUserMiddleware``
 or ``PersistentRemoteUserMiddleware``, and
 :class:`~django.contrib.auth.backends.RemoteUserBackend` classes found in
@@ -48,7 +48,7 @@ with :class:`~django.contrib.auth.backends.RemoteUserBackend` in the
     ]
 
 With this setup, ``RemoteUserMiddleware`` will detect the username in
-``request.META['REMOTE_USER']`` and will authenticate and auto-login that user
+``request.meta['REMOTE_USER']`` and will authenticate and auto-login that user
 using the :class:`~django.contrib.auth.backends.RemoteUserBackend`.
 
 Be aware that this particular setup disables authentication with the default
@@ -77,7 +77,7 @@ regardless of ``AUTHENTICATION_BACKENDS``.
 
 If your authentication mechanism uses a custom HTTP header and not
 ``REMOTE_USER``, you can subclass ``RemoteUserMiddleware`` and set the
-``header`` attribute to the desired ``request.META`` key.  For example::
+``header`` attribute to the desired ``request.meta`` key.  For example::
 
     from django.contrib.auth.middleware import RemoteUserMiddleware
 
@@ -92,13 +92,13 @@ If your authentication mechanism uses a custom HTTP header and not
     strips that header based on the appropriate authentication checks, never
     permitting an end-user to submit a fake (or "spoofed") header value. Since
     the HTTP headers ``X-Auth-User`` and ``X-Auth_User`` (for example) both
-    normalize to the ``HTTP_X_AUTH_USER`` key in ``request.META``, you must
+    normalize to the ``HTTP_X_AUTH_USER`` key in ``request.meta``, you must
     also check that your web server doesn't allow a spoofed header using
     underscores in place of dashes.
 
     This warning doesn't apply to ``RemoteUserMiddleware`` in its default
     configuration with ``header = 'REMOTE_USER'``, since a key that doesn't
-    start with ``HTTP_`` in ``request.META`` can only be set by your WSGI
+    start with ``HTTP_`` in ``request.meta`` can only be set by your WSGI
     server, not directly from an HTTP request header.
 
 If you need more control, you can create your own authentication backend

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -288,7 +288,7 @@ following attributes and methods:
     .. attribute:: hidden_settings
 
         A compiled regular expression object used to match settings and
-        ``request.META`` values considered as sensitive. By default equivalent
+        ``request.meta`` values considered as sensitive. By default equivalent
         to::
 
             import re
@@ -300,7 +300,7 @@ following attributes and methods:
         Returns ``True`` to activate the filtering in
         :meth:`get_post_parameters` and :meth:`get_traceback_frame_variables`.
         By default the filter is active if :setting:`DEBUG` is ``False``. Note
-        that sensitive ``request.META`` values are always filtered along with
+        that sensitive ``request.meta`` values are always filtered along with
         sensitive setting values, as described in the :setting:`DEBUG`
         documentation.
 

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2872,7 +2872,7 @@ Templates can override or extend base admin templates as described in
     ``site_url`` is ``/``. Set it to ``None`` to remove the link.
 
     For sites running on a subpath, the :meth:`each_context` method checks if
-    the current request has ``request.META['SCRIPT_NAME']`` set and uses that
+    the current request has ``request.meta['SCRIPT_NAME']`` set and uses that
     value if ``site_url`` isn't set to something other than ``/``.
 
 .. attribute:: AdminSite.index_title

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -622,7 +622,7 @@ The following backends are available in :mod:`django.contrib.auth.backends`:
 
     Use this backend to take advantage of external-to-Django-handled
     authentication.  It authenticates using usernames passed in
-    :attr:`request.META['REMOTE_USER'] <django.http.HttpRequest.META>`.  See
+    :attr:`request.meta['REMOTE_USER'] <django.http.HttpRequest.meta>`.  See
     the :doc:`Authenticating against REMOTE_USER </howto/auth-remote-user>`
     documentation.
 

--- a/docs/ref/files/uploads.txt
+++ b/docs/ref/files/uploads.txt
@@ -217,14 +217,14 @@ attributes:
     Callback signaling that the upload was interrupted, e.g. when the user
     closed their browser during file upload.
 
-.. method:: FileUploadHandler.handle_raw_input(input_data, META, content_length, boundary, encoding)
+.. method:: FileUploadHandler.handle_raw_input(input_data, meta, content_length, boundary, encoding)
 
     Allows the handler to completely override the parsing of the raw
     HTTP input.
 
     ``input_data`` is a file-like object that supports ``read()``-ing.
 
-    ``META`` is the same object as ``request.META``.
+    ``META`` is the same object as ``request.meta``.
 
     ``content_length`` is the length of the data in ``input_data``. Don't
     read more than ``content_length`` bytes from ``input_data``.

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -135,7 +135,11 @@ All attributes should be considered read-only, unless stated otherwise.
     ``<form>`` that posted to the request had ``enctype="multipart/form-data"``.
     Otherwise, ``FILES`` will be a blank dictionary-like object.
 
-.. attribute:: HttpRequest.META
+.. attribute:: HttpRequest.meta
+
+    .. versionadded:: 5.1
+
+        This is the new name for :attr:`HttpRequest.META`.
 
     A dictionary containing all available HTTP headers. Available headers
     depend on the client and server, but here are some examples:
@@ -284,6 +288,20 @@ middleware class is listed in :setting:`MIDDLEWARE`.
     The :meth:`auser` method does the same thing but can be used from async
     contexts.
 
+Alias attributes
+----------------
+
+These attributes are the old names for other attributes, and are preserved as
+aliases for backwards compatibility.
+
+.. attribute:: HttpRequest.GET
+
+    An alias of :attr:`HttpRequest.query_params`.
+
+.. attribute:: HttpRequest.META
+
+    An alias of :attr:`HttpRequest.meta`.
+
 Methods
 -------
 
@@ -332,10 +350,10 @@ Methods
                     recent proxy is used.
                     """
                     for field in self.FORWARDED_FOR_FIELDS:
-                        if field in request.META:
-                            if "," in request.META[field]:
-                                parts = request.META[field].split(",")
-                                request.META[field] = parts[-1].strip()
+                        if field in request.meta:
+                            if "," in request.meta[field]:
+                                parts = request.meta[field].split(",")
+                                request.meta[field] = parts[-1].strip()
                     return self.get_response(request)
 
         This middleware should be positioned before any other middleware that
@@ -347,7 +365,7 @@ Methods
 
     Returns the originating port of the request using information from the
     ``HTTP_X_FORWARDED_PORT`` (if :setting:`USE_X_FORWARDED_PORT` is enabled)
-    and ``SERVER_PORT`` ``META`` variables, in that order.
+    and ``SERVER_PORT`` :attr:`HttpRequest.meta` variables, in that order.
 
 .. method:: HttpRequest.get_full_path()
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -96,7 +96,7 @@ is validated against ``['.localhost', '127.0.0.1', '[::1]']``.
 <topics-testing-advanced-multiple-hosts>`.
 
 This validation only applies via :meth:`~django.http.HttpRequest.get_host()`;
-if your code accesses the ``Host`` header directly from ``request.META`` you
+if your code accesses the ``Host`` header directly from ``request.meta`` you
 are bypassing this security protection.
 
 .. setting:: APPEND_SLASH
@@ -442,7 +442,7 @@ Default: ``'HTTP_X_CSRFTOKEN'``
 
 The name of the request header used for CSRF authentication.
 
-As with other HTTP headers in ``request.META``, the header name received from
+As with other HTTP headers in ``request.meta``, the header name received from
 the server is normalized by converting all characters to uppercase, replacing
 any hyphens with underscores, and adding an ``'HTTP_'`` prefix to the name.
 For example, if your client sends a ``'X-XSRF-TOKEN'`` header, the setting
@@ -2433,10 +2433,10 @@ in via HTTPS) when:
 You should *only* set this setting if you control your proxy or have some other
 guarantee that it sets/strips this header appropriately.
 
-Note that the header needs to be in the format as used by ``request.META`` --
+Note that the header needs to be in the format as used by ``request.meta`` --
 all caps and likely starting with ``HTTP_``. (Remember, Django automatically
 adds ``'HTTP_'`` to the start of x-header names before making the header
-available in ``request.META``.)
+available in ``request.meta``.)
 
 .. warning::
 
@@ -2942,7 +2942,7 @@ number, in which case you shouldn't use :setting:`USE_X_FORWARDED_PORT`.
 Default: ``False``
 
 A boolean that specifies whether to use the ``X-Forwarded-Port`` header in
-preference to the ``SERVER_PORT`` ``META`` variable. This should only be
+preference to the ``SERVER_PORT`` :attr:`request.meta <.HttpRequest.meta>` variable. This should only be
 enabled if a proxy which sets this header is in use.
 
 :setting:`USE_X_FORWARDED_HOST` takes priority over this setting.

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -681,7 +681,7 @@ example, the :class:`RequestContext` instance gets an ``ip_address`` variable::
 
 
     def ip_address_processor(request):
-        return {"ip_address": request.META["REMOTE_ADDR"]}
+        return {"ip_address": request.meta["REMOTE_ADDR"]}
 
 
     def client_ip_view(request):
@@ -729,7 +729,7 @@ variables:
 
 If this processor is enabled, every ``RequestContext`` will contain these two
 variables -- but only if your :setting:`DEBUG` setting is set to ``True`` and
-the request's IP address (``request.META['REMOTE_ADDR']``) is in the
+the request's IP address (``request.meta['REMOTE_ADDR']``) is in the
 :setting:`INTERNAL_IPS` setting:
 
 * ``debug`` -- ``True``. You can use this in templates to test whether

--- a/docs/ref/urlresolvers.txt
+++ b/docs/ref/urlresolvers.txt
@@ -209,7 +209,7 @@ view would raise a ``Http404`` error before redirecting to it::
 
 
     def myview(request):
-        next = request.META.get("HTTP_REFERER", None) or "/"
+        next = request.meta.get("HTTP_REFERER", None) or "/"
         response = HttpResponseRedirect(next)
 
         # modify the request and response as required, e.g. change locale

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -187,7 +187,13 @@ Models
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* Some request attributes have been renamed:
+
+  * :attr:`.HttpRequest.GET` is now :attr:`.HttpRequest.query_params`.
+  * :attr:`.HttpRequest.META` is now :attr:`.HttpRequest.meta`.
+
+  The old names remain as aliases for backwards compatibility and will not be
+  removed.
 
 Security
 ~~~~~~~~

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1165,7 +1165,7 @@ implementation details see :ref:`using-the-views`.
 
     * ``site_name``: An alias for ``site.name``. If you don't have the site
       framework installed, this will be set to the value of
-      :attr:`request.META['SERVER_NAME'] <django.http.HttpRequest.META>`.
+      :attr:`request.meta['SERVER_NAME'] <django.http.HttpRequest.meta>`.
       For more on sites, see :doc:`/ref/contrib/sites`.
 
     If you'd prefer not to call the template :file:`registration/login.html`,
@@ -1280,7 +1280,7 @@ implementation details see :ref:`using-the-views`.
 
     * ``site_name``: An alias for ``site.name``. If you don't have the site
       framework installed, this will be set to the value of
-      :attr:`request.META['SERVER_NAME'] <django.http.HttpRequest.META>`.
+      :attr:`request.meta['SERVER_NAME'] <django.http.HttpRequest.meta>`.
       For more on sites, see :doc:`/ref/contrib/sites`.
 
 .. function:: logout_then_login(request, login_url=None)
@@ -1455,7 +1455,7 @@ implementation details see :ref:`using-the-views`.
 
     * ``site_name``: An alias for ``site.name``. If you don't have the site
       framework installed, this will be set to the value of
-      :attr:`request.META['SERVER_NAME'] <django.http.HttpRequest.META>`.
+      :attr:`request.meta['SERVER_NAME'] <django.http.HttpRequest.meta>`.
       For more on sites, see :doc:`/ref/contrib/sites`.
 
     * ``domain``: An alias for ``site.domain``. If you don't have the site

--- a/docs/topics/security.txt
+++ b/docs/topics/security.txt
@@ -181,7 +181,7 @@ Because even seemingly-secure web server configurations are susceptible to fake
 :meth:`django.http.HttpRequest.get_host()` method.
 
 This validation only applies via :meth:`~django.http.HttpRequest.get_host()`;
-if your code accesses the ``Host`` header directly from ``request.META`` you
+if your code accesses the ``Host`` header directly from ``request.meta`` you
 are bypassing this security protection.
 
 For more details see the full :setting:`ALLOWED_HOSTS` documentation.

--- a/tests/asgi/urls.py
+++ b/tests/asgi/urls.py
@@ -20,8 +20,8 @@ def hello_with_delay(request):
 
 def hello_meta(request):
     return HttpResponse(
-        "From %s" % request.META.get("HTTP_REFERER") or "",
-        content_type=request.META.get("CONTENT_TYPE"),
+        "From %s" % request.meta.get("HTTP_REFERER") or "",
+        content_type=request.meta.get("CONTENT_TYPE"),
     )
 
 

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -67,7 +67,7 @@ class RemoteUserTest(TestCase):
 
         # This request will call django.contrib.auth.login() which will call
         # django.middleware.csrf.rotate_token() thus changing the value of
-        # request.META['CSRF_COOKIE'] from the user submitted value set by
+        # request.meta['CSRF_COOKIE'] from the user submitted value set by
         # CsrfViewMiddleware.process_request() to the new csrftoken value set
         # by rotate_token(). Csrf validation should still pass when the view is
         # later processed by CsrfViewMiddleware.process_view()
@@ -218,7 +218,7 @@ class CustomRemoteUserBackend(RemoteUserBackend):
         Sets user's email address using the email specified in an HTTP header.
         Sets user's last name for existing users.
         """
-        user.email = request.META.get(RemoteUserTest.email_header, "")
+        user.email = request.meta.get(RemoteUserTest.email_header, "")
         if not created:
             user.last_name = user.username
         user.save()

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -818,10 +818,10 @@ class LoginTest(AuthViewsTestCase):
         # Use POST request to log in
         SessionMiddleware(get_response).process_request(req)
         CsrfViewMiddleware(get_response).process_view(req, LoginView.as_view(), (), {})
-        req.META[
+        req.meta[
             "SERVER_NAME"
         ] = "testserver"  # Required to have redirect work in login view
-        req.META["SERVER_PORT"] = 80
+        req.meta["SERVER_PORT"] = 80
         resp = CsrfViewMiddleware(LoginView.as_view())(req)
         csrf_cookie = resp.cookies.get(settings.CSRF_COOKIE_NAME, None)
         token2 = csrf_cookie.coded_value
@@ -998,8 +998,8 @@ class LogoutThenLoginTests(AuthViewsTestCase):
         csrf_token = get_token(req)
         req.COOKIES[settings.CSRF_COOKIE_NAME] = csrf_token
         req.POST = {"csrfmiddlewaretoken": csrf_token}
-        req.META["SERVER_NAME"] = "testserver"
-        req.META["SERVER_PORT"] = 80
+        req.meta["SERVER_NAME"] = "testserver"
+        req.meta["SERVER_PORT"] = 80
         req.session = self.client.session
         response = logout_then_login(req)
         self.confirm_logged_out()
@@ -1012,8 +1012,8 @@ class LogoutThenLoginTests(AuthViewsTestCase):
         csrf_token = get_token(req)
         req.COOKIES[settings.CSRF_COOKIE_NAME] = csrf_token
         req.POST = {"csrfmiddlewaretoken": csrf_token}
-        req.META["SERVER_NAME"] = "testserver"
-        req.META["SERVER_PORT"] = 80
+        req.meta["SERVER_NAME"] = "testserver"
+        req.meta["SERVER_PORT"] = 80
         req.session = self.client.session
         response = logout_then_login(req, login_url="/custom/")
         self.confirm_logged_out()
@@ -1024,8 +1024,8 @@ class LogoutThenLoginTests(AuthViewsTestCase):
         self.login()
         req = HttpRequest()
         req.method = "GET"
-        req.META["SERVER_NAME"] = "testserver"
-        req.META["SERVER_PORT"] = 80
+        req.meta["SERVER_NAME"] = "testserver"
+        req.meta["SERVER_PORT"] = 80
         req.session = self.client.session
         response = logout_then_login(req)
         self.assertEqual(response.status_code, 405)

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -2263,8 +2263,8 @@ class CacheI18nTest(SimpleTestCase):
 
     def check_accept_language_vary(self, accept_language, vary, reference_key):
         request = self.factory.get(self.path)
-        request.META["HTTP_ACCEPT_LANGUAGE"] = accept_language
-        request.META["HTTP_ACCEPT_ENCODING"] = "gzip;q=1.0, identity; q=0.5, *;q=0"
+        request.meta["HTTP_ACCEPT_LANGUAGE"] = accept_language
+        request.meta["HTTP_ACCEPT_ENCODING"] = "gzip;q=1.0, identity; q=0.5, *;q=0"
         response = HttpResponse()
         response.headers["Vary"] = vary
         key = learn_cache_key(request, response)
@@ -2277,7 +2277,7 @@ class CacheI18nTest(SimpleTestCase):
         lang = translation.get_language()
         self.assertEqual(lang, "en")
         request = self.factory.get(self.path)
-        request.META["HTTP_ACCEPT_ENCODING"] = "gzip;q=1.0, identity; q=0.5, *;q=0"
+        request.meta["HTTP_ACCEPT_ENCODING"] = "gzip;q=1.0, identity; q=0.5, *;q=0"
         response = HttpResponse()
         response.headers["Vary"] = "accept-encoding"
         key = learn_cache_key(request, response)

--- a/tests/contenttypes_tests/test_views.py
+++ b/tests/contenttypes_tests/test_views.py
@@ -229,7 +229,7 @@ class ContentTypesViewsSiteRelTests(TestCase):
 class ShortcutViewTests(TestCase):
     def setUp(self):
         self.request = HttpRequest()
-        self.request.META = {"SERVER_NAME": "Example.com", "SERVER_PORT": "80"}
+        self.request.meta = {"SERVER_NAME": "Example.com", "SERVER_PORT": "80"}
 
     @override_settings(ALLOWED_HOSTS=["example.com"])
     def test_not_dependent_on_sites_app(self):

--- a/tests/csrf_tests/test_context_processor.py
+++ b/tests/csrf_tests/test_context_processor.py
@@ -9,6 +9,6 @@ class TestContextProcessor(CsrfFunctionTestMixin, SimpleTestCase):
     def test_force_token_to_string(self):
         request = HttpRequest()
         test_secret = 32 * "a"
-        request.META["CSRF_COOKIE"] = test_secret
+        request.meta["CSRF_COOKIE"] = test_secret
         token = csrf(request).get("csrf_token")
         self.assertMaskedSecretCorrect(token, test_secret)

--- a/tests/decorators/test_gzip.py
+++ b/tests/decorators/test_gzip.py
@@ -29,7 +29,7 @@ class GzipPageTests(SimpleTestCase):
             return HttpResponse(content=self.content)
 
         request = HttpRequest()
-        request.META["HTTP_ACCEPT_ENCODING"] = "gzip"
+        request.meta["HTTP_ACCEPT_ENCODING"] = "gzip"
         response = sync_view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get("Content-Encoding"), "gzip")
@@ -40,7 +40,7 @@ class GzipPageTests(SimpleTestCase):
             return HttpResponse(content=self.content)
 
         request = HttpRequest()
-        request.META["HTTP_ACCEPT_ENCODING"] = "gzip"
+        request.meta["HTTP_ACCEPT_ENCODING"] = "gzip"
         response = await async_view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get("Content-Encoding"), "gzip")

--- a/tests/requests_tests/test_accept_header.py
+++ b/tests/requests_tests/test_accept_header.py
@@ -68,7 +68,7 @@ class AcceptHeaderTests(TestCase):
 
     def test_accept_headers(self):
         request = HttpRequest()
-        request.META[
+        request.meta[
             "HTTP_ACCEPT"
         ] = "text/html, application/xhtml+xml,application/xml ;q=0.9,*/*;q=0.8"
         self.assertEqual(
@@ -83,18 +83,18 @@ class AcceptHeaderTests(TestCase):
 
     def test_request_accepts_any(self):
         request = HttpRequest()
-        request.META["HTTP_ACCEPT"] = "*/*"
+        request.meta["HTTP_ACCEPT"] = "*/*"
         self.assertIs(request.accepts("application/json"), True)
 
     def test_request_accepts_none(self):
         request = HttpRequest()
-        request.META["HTTP_ACCEPT"] = ""
+        request.meta["HTTP_ACCEPT"] = ""
         self.assertIs(request.accepts("application/json"), False)
         self.assertEqual(request.accepted_types, [])
 
     def test_request_accepts_some(self):
         request = HttpRequest()
-        request.META[
+        request.meta[
             "HTTP_ACCEPT"
         ] = "text/html,application/xhtml+xml,application/xml;q=0.9"
         self.assertIs(request.accepts("text/html"), True)

--- a/tests/requests_tests/test_data_upload_settings.py
+++ b/tests/requests_tests/test_data_upload_settings.py
@@ -10,7 +10,8 @@ from django.test import SimpleTestCase
 from django.test.client import FakePayload
 
 TOO_MANY_FIELDS_MSG = (
-    "The number of GET/POST parameters exceeded settings.DATA_UPLOAD_MAX_NUMBER_FIELDS."
+    "The number of query_params/POST parameters exceeded "
+    "settings.DATA_UPLOAD_MAX_NUMBER_FIELDS."
 )
 TOO_MANY_FILES_MSG = (
     "The number of files exceeded settings.DATA_UPLOAD_MAX_NUMBER_FILES."

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -373,33 +373,33 @@ class SecureProxySslHeaderTest(SimpleTestCase):
     @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"))
     def test_set_with_xheader_wrong(self):
         req = HttpRequest()
-        req.META["HTTP_X_FORWARDED_PROTO"] = "wrongvalue"
+        req.meta["HTTP_X_FORWARDED_PROTO"] = "wrongvalue"
         self.assertIs(req.is_secure(), False)
 
     @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"))
     def test_set_with_xheader_right(self):
         req = HttpRequest()
-        req.META["HTTP_X_FORWARDED_PROTO"] = "https"
+        req.meta["HTTP_X_FORWARDED_PROTO"] = "https"
         self.assertIs(req.is_secure(), True)
 
     @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"))
     def test_set_with_xheader_leftmost_right(self):
         req = HttpRequest()
-        req.META["HTTP_X_FORWARDED_PROTO"] = "https, http"
+        req.meta["HTTP_X_FORWARDED_PROTO"] = "https, http"
         self.assertIs(req.is_secure(), True)
-        req.META["HTTP_X_FORWARDED_PROTO"] = "https  , http"
+        req.meta["HTTP_X_FORWARDED_PROTO"] = "https  , http"
         self.assertIs(req.is_secure(), True)
 
     @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"))
     def test_set_with_xheader_leftmost_not_secure(self):
         req = HttpRequest()
-        req.META["HTTP_X_FORWARDED_PROTO"] = "http, https"
+        req.meta["HTTP_X_FORWARDED_PROTO"] = "http, https"
         self.assertIs(req.is_secure(), False)
 
     @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"))
     def test_set_with_xheader_multiple_not_secure(self):
         req = HttpRequest()
-        req.META["HTTP_X_FORWARDED_PROTO"] = "http ,wrongvalue,http,http"
+        req.meta["HTTP_X_FORWARDED_PROTO"] = "http ,wrongvalue,http,http"
         self.assertIs(req.is_secure(), False)
 
     @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"))
@@ -411,7 +411,7 @@ class SecureProxySslHeaderTest(SimpleTestCase):
 
         # Client connects via HTTP.
         req = ProxyRequest()
-        req.META["HTTP_X_FORWARDED_PROTO"] = "http"
+        req.meta["HTTP_X_FORWARDED_PROTO"] = "http"
         self.assertIs(req.is_secure(), False)
 
 

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -62,7 +62,7 @@ class SitesFrameworkTests(TestCase):
     def test_get_current_site(self):
         # The correct Site object is returned
         request = HttpRequest()
-        request.META = {
+        request.meta = {
             "SERVER_NAME": "example.com",
             "SERVER_PORT": "80",
         }
@@ -85,7 +85,7 @@ class SitesFrameworkTests(TestCase):
     @override_settings(SITE_ID=None, ALLOWED_HOSTS=["example.com"])
     def test_get_current_site_no_site_id(self):
         request = HttpRequest()
-        request.META = {
+        request.meta = {
             "SERVER_NAME": "example.com",
             "SERVER_PORT": "80",
         }
@@ -99,7 +99,7 @@ class SitesFrameworkTests(TestCase):
         The site is matched if the name in the request has a trailing dot.
         """
         request = HttpRequest()
-        request.META = {
+        request.meta = {
             "SERVER_NAME": "example.com.",
             "SERVER_PORT": "80",
         }
@@ -113,32 +113,32 @@ class SitesFrameworkTests(TestCase):
         s2 = Site.objects.create(domain="example.com:80", name="example.com:80")
 
         # Host header without port
-        request.META = {"HTTP_HOST": "example.com"}
+        request.meta = {"HTTP_HOST": "example.com"}
         site = get_current_site(request)
         self.assertEqual(site, s1)
 
         # Host header with port - match, no fallback without port
-        request.META = {"HTTP_HOST": "example.com:80"}
+        request.meta = {"HTTP_HOST": "example.com:80"}
         site = get_current_site(request)
         self.assertEqual(site, s2)
 
         # Host header with port - no match, fallback without port
-        request.META = {"HTTP_HOST": "example.com:81"}
+        request.meta = {"HTTP_HOST": "example.com:81"}
         site = get_current_site(request)
         self.assertEqual(site, s1)
 
         # Host header with non-matching domain
-        request.META = {"HTTP_HOST": "example.net"}
+        request.meta = {"HTTP_HOST": "example.net"}
         with self.assertRaises(ObjectDoesNotExist):
             get_current_site(request)
 
         # Ensure domain for RequestSite always matches host header
         with self.modify_settings(INSTALLED_APPS={"remove": "django.contrib.sites"}):
-            request.META = {"HTTP_HOST": "example.com"}
+            request.meta = {"HTTP_HOST": "example.com"}
             site = get_current_site(request)
             self.assertEqual(site.name, "example.com")
 
-            request.META = {"HTTP_HOST": "example.com:80"}
+            request.meta = {"HTTP_HOST": "example.com:80"}
             site = get_current_site(request)
             self.assertEqual(site.name, "example.com:80")
 
@@ -158,7 +158,7 @@ class SitesFrameworkTests(TestCase):
     @override_settings(ALLOWED_HOSTS=["example.com"])
     def test_clear_site_cache(self):
         request = HttpRequest()
-        request.META = {
+        request.meta = {
             "SERVER_NAME": "example.com",
             "SERVER_PORT": "80",
         }
@@ -180,7 +180,7 @@ class SitesFrameworkTests(TestCase):
     def test_clear_site_cache_domain(self):
         site = Site.objects.create(name="example2.com", domain="example2.com")
         request = HttpRequest()
-        request.META = {
+        request.meta = {
             "SERVER_NAME": "example2.com",
             "SERVER_PORT": "80",
         }
@@ -227,7 +227,7 @@ class SitesFrameworkTests(TestCase):
 class RequestSiteTests(SimpleTestCase):
     def setUp(self):
         request = HttpRequest()
-        request.META = {"HTTP_HOST": "example.com"}
+        request.meta = {"HTTP_HOST": "example.com"}
         self.site = RequestSite(request)
 
     def test_init_attributes(self):

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -1103,7 +1103,7 @@ class RequestFactoryTest(SimpleTestCase):
         url_path = "/somewhere/"
         request = self.request_factory.trace(url_path)
         response = trace_view(request)
-        protocol = request.META["SERVER_PROTOCOL"]
+        protocol = request.meta["SERVER_PROTOCOL"]
         echoed_request_line = "TRACE {} {}".format(url_path, protocol)
         self.assertContains(response, echoed_request_line)
 
@@ -1115,9 +1115,9 @@ class RequestFactoryTest(SimpleTestCase):
             }
         ).get("/somewhere/")
         self.assertEqual(request.headers["authorization"], "Bearer faketoken")
-        self.assertIn("HTTP_AUTHORIZATION", request.META)
+        self.assertIn("HTTP_AUTHORIZATION", request.meta)
         self.assertEqual(request.headers["x-another-header"], "some other value")
-        self.assertIn("HTTP_X_ANOTHER_HEADER", request.META)
+        self.assertIn("HTTP_X_ANOTHER_HEADER", request.meta)
 
         request = RequestFactory(
             headers={
@@ -1126,9 +1126,9 @@ class RequestFactoryTest(SimpleTestCase):
             }
         ).get("/somewhere/")
         self.assertEqual(request.headers["authorization"], "Bearer faketoken")
-        self.assertIn("HTTP_AUTHORIZATION", request.META)
+        self.assertIn("HTTP_AUTHORIZATION", request.meta)
         self.assertEqual(request.headers["x-another-header"], "some other value")
-        self.assertIn("HTTP_X_ANOTHER_HEADER", request.META)
+        self.assertIn("HTTP_X_ANOTHER_HEADER", request.meta)
 
     def test_request_factory_sets_headers(self):
         for method_name, view in self.http_methods_and_views:
@@ -1141,9 +1141,9 @@ class RequestFactoryTest(SimpleTestCase):
                 },
             )
             self.assertEqual(request.headers["authorization"], "Bearer faketoken")
-            self.assertIn("HTTP_AUTHORIZATION", request.META)
+            self.assertIn("HTTP_AUTHORIZATION", request.meta)
             self.assertEqual(request.headers["x-another-header"], "some other value")
-            self.assertIn("HTTP_X_ANOTHER_HEADER", request.META)
+            self.assertIn("HTTP_X_ANOTHER_HEADER", request.meta)
 
             request = method(
                 "/somewhere/",
@@ -1153,9 +1153,9 @@ class RequestFactoryTest(SimpleTestCase):
                 },
             )
             self.assertEqual(request.headers["authorization"], "Bearer faketoken")
-            self.assertIn("HTTP_AUTHORIZATION", request.META)
+            self.assertIn("HTTP_AUTHORIZATION", request.meta)
             self.assertEqual(request.headers["x-another-header"], "some other value")
-            self.assertIn("HTTP_X_ANOTHER_HEADER", request.META)
+            self.assertIn("HTTP_X_ANOTHER_HEADER", request.meta)
 
     def test_request_factory_query_params(self):
         tests = (
@@ -1310,9 +1310,9 @@ class AsyncRequestFactoryTest(SimpleTestCase):
             X_ANOTHER_HEADER="some other value",
         )
         self.assertEqual(request.headers["authorization"], "Bearer faketoken")
-        self.assertIn("HTTP_AUTHORIZATION", request.META)
+        self.assertIn("HTTP_AUTHORIZATION", request.meta)
         self.assertEqual(request.headers["x-another-header"], "some other value")
-        self.assertIn("HTTP_X_ANOTHER_HEADER", request.META)
+        self.assertIn("HTTP_X_ANOTHER_HEADER", request.meta)
 
         request = self.request_factory.get(
             "/somewhere/",
@@ -1322,9 +1322,9 @@ class AsyncRequestFactoryTest(SimpleTestCase):
             },
         )
         self.assertEqual(request.headers["authorization"], "Bearer faketoken")
-        self.assertIn("HTTP_AUTHORIZATION", request.META)
+        self.assertIn("HTTP_AUTHORIZATION", request.meta)
         self.assertEqual(request.headers["x-another-header"], "some other value")
-        self.assertIn("HTTP_X_ANOTHER_HEADER", request.META)
+        self.assertIn("HTTP_X_ANOTHER_HEADER", request.meta)
 
     def test_request_factory_query_string(self):
         request = self.request_factory.get("/somewhere/", {"example": "data"})

--- a/tests/test_client/views.py
+++ b/tests/test_client/views.py
@@ -45,7 +45,7 @@ def trace_view(request):
     elif request.body:
         return HttpResponseBadRequest("TRACE requests MUST NOT include an entity")
     else:
-        protocol = request.META["SERVER_PROTOCOL"]
+        protocol = request.meta["SERVER_PROTOCOL"]
         t = Template(
             "{{ method }} {{ uri }} {{ version }}",
             name="TRACE Template",
@@ -65,7 +65,7 @@ def put_view(request):
         t = Template("Data received: {{ data }} is the body.", name="PUT Template")
         c = Context(
             {
-                "Content-Length": request.META["CONTENT_LENGTH"],
+                "Content-Length": request.meta["CONTENT_LENGTH"],
                 "data": request.body.decode(),
             }
         )
@@ -116,7 +116,7 @@ def json_view(request):
     A view that expects a request with the header 'application/json' and JSON
     data, which is deserialized and included in the context.
     """
-    if request.META.get("CONTENT_TYPE") != "application/json":
+    if request.meta.get("CONTENT_TYPE") != "application/json":
         return HttpResponse()
 
     t = Template("Viewing {} page. With data {{ data }}.".format(request.method))
@@ -191,7 +191,7 @@ def view_with_secure(request):
     "A view that indicates if the request was secure"
     response = HttpResponse()
     response.test_was_secure_request = request.is_secure()
-    response.test_server_port = request.META.get("SERVER_PORT", 80)
+    response.test_server_port = request.meta.get("SERVER_PORT", 80)
     return response
 
 

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -1405,16 +1405,16 @@ class RequestFactoryEnvironmentTests(SimpleTestCase):
     def test_should_set_correct_env_variables(self):
         request = RequestFactory().get("/path/")
 
-        self.assertEqual(request.META.get("REMOTE_ADDR"), "127.0.0.1")
-        self.assertEqual(request.META.get("SERVER_NAME"), "testserver")
-        self.assertEqual(request.META.get("SERVER_PORT"), "80")
-        self.assertEqual(request.META.get("SERVER_PROTOCOL"), "HTTP/1.1")
+        self.assertEqual(request.meta.get("REMOTE_ADDR"), "127.0.0.1")
+        self.assertEqual(request.meta.get("SERVER_NAME"), "testserver")
+        self.assertEqual(request.meta.get("SERVER_PORT"), "80")
+        self.assertEqual(request.meta.get("SERVER_PROTOCOL"), "HTTP/1.1")
         self.assertEqual(
-            request.META.get("SCRIPT_NAME") + request.META.get("PATH_INFO"), "/path/"
+            request.meta.get("SCRIPT_NAME") + request.meta.get("PATH_INFO"), "/path/"
         )
 
     def test_cookies(self):
         factory = RequestFactory()
         factory.cookies.load('A="B"; C="D"; Path=/; Version=1')
         request = factory.get("/")
-        self.assertEqual(request.META["HTTP_COOKIE"], 'A="B"; C="D"')
+        self.assertEqual(request.meta["HTTP_COOKIE"], 'A="B"; C="D"')

--- a/tests/test_client_regress/views.py
+++ b/tests/test_client_regress/views.py
@@ -126,7 +126,7 @@ def return_json_response_latin1(request):
 
 def return_text_file(request):
     "A view that parses and returns text as a file."
-    match = CONTENT_TYPE_RE.match(request.META["CONTENT_TYPE"])
+    match = CONTENT_TYPE_RE.match(request.meta["CONTENT_TYPE"])
     if match:
         charset = match[1]
     else:
@@ -140,7 +140,7 @@ def return_text_file(request):
 def check_headers(request):
     "A view that responds with value of the X-ARG-CHECK header"
     return HttpResponse(
-        "HTTP_X_ARG_CHECK: %s" % request.META.get("HTTP_X_ARG_CHECK", "Undefined")
+        "HTTP_X_ARG_CHECK: %s" % request.meta.get("HTTP_X_ARG_CHECK", "Undefined")
     )
 
 
@@ -171,12 +171,12 @@ def render_template_multiple_times(request):
 
 
 def redirect_based_on_extra_headers_1_view(request):
-    if "HTTP_REDIRECT" in request.META:
+    if "HTTP_REDIRECT" in request.meta:
         return HttpResponseRedirect("/redirect_based_on_extra_headers_2/")
     return HttpResponse()
 
 
 def redirect_based_on_extra_headers_2_view(request):
-    if "HTTP_REDIRECT" in request.META:
+    if "HTTP_REDIRECT" in request.meta:
         return HttpResponseRedirect("/redirects/further/more/")
     return HttpResponse()


### PR DESCRIPTION
Hi @smithdc1, @carltongibson,
As discussed, created a PR which will tackle the project from the other end.
Started with changing `request.META` to `request.meta` in the first commit. (changed `request.GET` to `request.query_params` in few places, will tackle updating that in the next commit)

I plan to change each attribute with each commit.
