### PR TITLE
Fixed #35054 -- Fixed crash on Oracle when fetching JSONFields with oracledb 2.0.0.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -453,7 +453,7 @@ class FormatStylePlaceholderCursor:
     def _output_type_handler(cursor, name, defaultType, length, precision, scale):
         """
         Called for each db column fetched from cursors. Return numbers as the
-        appropriate Python type.
+        appropriate Python type, and NCLOB with JSON as strings.
         """
         if defaultType == Database.NUMBER:
             if scale == -127:
@@ -483,6 +483,10 @@ class FormatStylePlaceholderCursor:
                 arraysize=cursor.arraysize,
                 outconverter=outconverter,
             )
+        # oracledb 2.0.0+ returns NLOB columns with IS JSON constraints as
+        # dicts. Use a no-op converter to avoid this.
+        elif defaultType == Database.DB_TYPE_NCLOB:
+            return cursor.var(Database.DB_TYPE_NCLOB, arraysize=cursor.arraysize)
 
     def _format_params(self, params):
         try:

--- a/docs/releases/5.0.1.txt
+++ b/docs/releases/5.0.1.txt
@@ -27,3 +27,5 @@ Bugfixes
 
 * Fixed a regression in Django 5.0 where admin fields on the same line could
   overflow the page and become non-interactive (:ticket:`35012`).
+
+* Added compatibility for ``oracledb`` 2.0.0 (:ticket:`35054`).


### PR DESCRIPTION
ticket-35054

https://cjones-oracle.medium.com/python-oracledb-2-0-has-asyncio-support-2b913e40f9ca