### PR TITLE
[5.0.x] Fixed #35022 -- RenameIndex crashed when index and unique together existed on the same fields.

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -1044,7 +1044,10 @@ class RenameIndex(IndexOperation):
                 from_model._meta.get_field(field).column for field in self.old_fields
             ]
             matching_index_name = schema_editor._constraint_names(
-                from_model, column_names=columns, index=True
+                from_model,
+                column_names=columns,
+                index=True,
+                unique=False,
             )
             if len(matching_index_name) != 1:
                 raise ValueError(

--- a/docs/releases/5.0.1.txt
+++ b/docs/releases/5.0.1.txt
@@ -27,3 +27,7 @@ Bugfixes
 
 * Fixed a regression in Django 5.0 where admin fields on the same line could
   overflow the page and become non-interactive (:ticket:`35012`).
+
+* Fixed a bug in Django 5.0 that caused a crash during migration when changing
+  a ``Meta.index_together`` to :class:`~django.db.models.Index`, when a
+  ``Meta.unique_together`` existed on the same fields (:ticket:`35022`).

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -3654,6 +3654,23 @@ class OperationTests(OperationTestBase):
             },
         )
 
+    @ignore_warnings(category=RemovedInDjango51Warning)
+    def test_rename_index_unnamed_index_with_unique_index(self):
+        app_label = "test_rninuiwui"
+        project_state = self.set_up_test_model(app_label, index_together=True)
+        operations = [
+            migrations.AlterUniqueTogether("Pony", ["weight", "pink"]),
+        ]
+        self.apply_operations(app_label, project_state, operations)
+
+        operation = migrations.RenameIndex(
+            "Pony", new_name="new_pony_test_idx", old_fields=("weight", "pink")
+        )
+        new_state = project_state.clone()
+        operation.state_forwards(app_label, new_state)
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
+
     def test_rename_index_unknown_unnamed_index(self):
         app_label = "test_rninuui"
         project_state = self.set_up_test_model(app_label)


### PR DESCRIPTION
[ticket-35022](https://code.djangoproject.com/ticket/35022)

Thanks a lot @felixxm for the fix 👍 
I just put the fix with a unit test and a release note :)

This is not a backport, because on `main`, `Meta.index_together` was deleted after its deprecation period.