### PR TITLE
[4.2.x] Fixed #35022 -- RenameIndex crashed when index and unique together existed on the same fields.

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -1036,7 +1036,10 @@ class RenameIndex(IndexOperation):
                 from_model._meta.get_field(field).column for field in self.old_fields
             ]
             matching_index_name = schema_editor._constraint_names(
-                from_model, column_names=columns, index=True
+                from_model,
+                column_names=columns,
+                index=True,
+                unique=False,
             )
             if len(matching_index_name) != 1:
                 raise ValueError(

--- a/docs/releases/4.2.9.txt
+++ b/docs/releases/4.2.9.txt
@@ -11,3 +11,7 @@ Bugfixes
 
 * Fixed a regression in Django 4.2.8 where admin fields on the same line could
   overflow the page and become non-interactive (:ticket:`35012`).
+
+* Fixed a bug in Django 4.2.8 that caused a crash during migration when
+  changing a ``Meta.index_together`` to :class:`~django.db.models.Index`, when
+  a ``Meta.unique_together`` existed on the same fields (:ticket:`35022`).

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -3287,6 +3287,23 @@ class OperationTests(OperationTestBase):
             },
         )
 
+    @ignore_warnings(category=RemovedInDjango51Warning)
+    def test_rename_index_unnamed_index_with_unique_index(self):
+        app_label = "test_rninuiwui"
+        project_state = self.set_up_test_model(app_label, index_together=True)
+        operations = [
+            migrations.AlterUniqueTogether("Pony", ["weight", "pink"]),
+        ]
+        self.apply_operations(app_label, project_state, operations)
+
+        operation = migrations.RenameIndex(
+            "Pony", new_name="new_pony_test_idx", old_fields=("weight", "pink")
+        )
+        new_state = project_state.clone()
+        operation.state_forwards(app_label, new_state)
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
+
     def test_rename_index_unknown_unnamed_index(self):
         app_label = "test_rninuui"
         project_state = self.set_up_test_model(app_label)


### PR DESCRIPTION
[ticket-35022](https://code.djangoproject.com/ticket/35022)

4.2.x port of https://github.com/django/django/pull/17632