### PR TITLE
Fixed #35022 -- Fixed RenameIndex() crash on unnamed indexes if exists unique constraint on the same fields.

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -1017,7 +1017,10 @@ class RenameIndex(IndexOperation):
                 from_model._meta.get_field(field).column for field in self.old_fields
             ]
             matching_index_name = schema_editor._constraint_names(
-                from_model, column_names=columns, index=True
+                from_model,
+                column_names=columns,
+                index=True,
+                unique=False,
             )
             if len(matching_index_name) != 1:
                 raise ValueError(

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -3626,6 +3626,26 @@ class OperationTests(OperationTestBase):
             with self.assertRaisesMessage(ValueError, msg):
                 operation.database_forwards(app_label, editor, project_state, new_state)
 
+    @skipUnlessDBFeature("allows_multiple_constraints_on_same_fields")
+    def test_rename_index_unnamed_index_with_unique_index(self):
+        app_label = "test_rninuniwui"
+        project_state = self.set_up_test_model(
+            app_label,
+            multicol_index=True,
+            unique_together=True,
+        )
+        table_name = app_label + "_pony"
+        self.assertIndexNotExists(table_name, "new_pony_test_idx")
+        operation = migrations.RenameIndex(
+            "Pony", new_name="new_pony_test_idx", old_fields=["pink", "weight"]
+        )
+        new_state = project_state.clone()
+        operation.state_forwards(app_label, new_state)
+        # Rename index.
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
+        self.assertIndexNameExists(table_name, "new_pony_test_idx")
+
     def test_add_index_state_forwards(self):
         project_state = self.set_up_test_model("test_adinsf")
         index = models.Index(fields=["pink"], name="test_adinsf_pony_pink_idx")


### PR DESCRIPTION
[Ticket 35022](https://code.djangoproject.com/ticket/35022)