### PR TITLE
Corrected method/function wording in tutorial 3.

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -106,7 +106,7 @@ Wire these new views into the ``polls.urls`` module by adding the following
     ]
 
 Take a look in your browser, at "/polls/34/". It'll run the ``detail()``
-method and display whatever ID you provide in the URL. Try
+function and display whatever ID you provide in the URL. Try
 "/polls/34/results/" and "/polls/34/vote/" too -- these will display the
 placeholder results and voting pages.
 


### PR DESCRIPTION
detail view is a function based view and we used `method` name for this as it is not class based view. It may confuse that what type of view we are using. 