### PR TITLE
Fixed #35033 -- Avoid repeated header in email message

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -251,7 +251,6 @@ class EmailMessage:
         self.headers_with_one_occurrence = {
             "To": self.to,
             "Cc": self.cc,
-            "Bcc": self.bcc,
             "Reply-To": self.reply_to,
         }
         self.connection = connection

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -248,6 +248,12 @@ class EmailMessage:
                 else:
                     self.attach(*attachment)
         self.extra_headers = headers or {}
+        self.headers_with_one_occurrence = {
+            "To": self.to,
+            "Cc": self.cc,
+            "Bcc": self.bcc,
+            "Reply-To": self.reply_to,
+        }
         self.connection = connection
 
     def get_connection(self, fail_silently=False):
@@ -286,6 +292,10 @@ class EmailMessage:
                 raise ValueError("Cannot insert repeated headers")
             if name.lower() != "from":  # From is already handled
                 msg[name] = value
+        for header, value_header in self.headers_with_one_occurrence.items():
+            # extra_headers takes precedence over to/cc/bcc/reply_to parameters.
+            if msg.get(header) is None and value_header:
+                msg[header] = ", ".join(str(v) for v in value_header)
         return msg
 
     def recipients(self):

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -258,6 +258,8 @@ class EmailMessage:
         return self.connection
 
     def message(self):
+        HEADER_WITH_ONE_OCCURRENCE = ["to", "reply-to", "cc"]
+
         encoding = self.encoding or settings.DEFAULT_CHARSET
         msg = SafeMIMEText(self.body, self.content_subtype, encoding)
         msg = self._create_message(msg)
@@ -280,6 +282,8 @@ class EmailMessage:
             # Use cached DNS_NAME for performance
             msg["Message-ID"] = make_msgid(domain=DNS_NAME)
         for name, value in self.extra_headers.items():
+            if name.lower() in HEADER_WITH_ONE_OCCURRENCE and msg[name] is not None:
+                raise ValueError("Cannot insert repeated headers")
             if name.lower() != "from":  # From is already handled
                 msg[name] = value
         return msg

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -129,6 +129,28 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             email.recipients(), ["to@example.com", "cc@example.com", "bcc@example.com"]
         )
 
+    def test_headers_not_repeated(self):
+        tests = ["To", "Cc", "Bcc", "Reply_To"]
+        for header in tests:
+            with self.subTest(header=header):
+                header_attr = header.lower()
+                header = header.replace("_", "-")
+                email = EmailMessage(
+                    "Subject",
+                    "Content",
+                    from_email="bounce@example.com",
+                    **{
+                        header_attr: ["test@example.com"],
+                        "headers": {header: "precedence@example.com"},
+                    },
+                )
+                message = email.message()
+                self.assertEqual(
+                    message.get_all(header),
+                    ["precedence@example.com"],
+                )
+                self.assertEqual(getattr(email, header_attr), ["test@example.com"])
+
     def test_cc(self):
         """Regression test for #7722"""
         email = EmailMessage(

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -130,7 +130,7 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
         )
 
     def test_headers_not_repeated(self):
-        tests = ["To", "Cc", "Bcc", "Reply_To"]
+        tests = ["To", "Cc", "Reply_To"]
         for header in tests:
             with self.subTest(header=header):
                 header_attr = header.lower()

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -191,9 +191,8 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             "bounce@example.com",
             ["to@example.com"],
             cc=["foo@example.com"],
-            headers={"Cc": "override@example.com"},
         ).message()
-        self.assertEqual(message["Cc"], "override@example.com")
+        self.assertEqual(message["Cc"], "foo@example.com")
 
     def test_cc_in_headers_only(self):
         message = EmailMessage(
@@ -359,14 +358,17 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             "Subject",
             "Content",
             "bounce@example.com",
-            ["list-subscriber@example.com", "list-subscriber2@example.com"],
-            headers={"To": "mailing-list@example.com"},
+            headers={
+                "To": ", ".join(
+                    ["guy1@example.com", "guy2@example.com", "guy3@example.com"]
+                )
+            },
         )
         message = email.message()
-        self.assertEqual(message["To"], "mailing-list@example.com")
         self.assertEqual(
-            email.to, ["list-subscriber@example.com", "list-subscriber2@example.com"]
+            message["To"], "guy1@example.com, guy2@example.com, guy3@example.com"
         )
+        self.assertEqual(email.to, [])
 
         # If we don't set the To header manually, it should default to the `to`
         # argument to the constructor.
@@ -403,10 +405,9 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             "bounce@example.com",
             ["to@example.com"],
             reply_to=["foo@example.com"],
-            headers={"Reply-To": "override@example.com"},
         )
         message = email.message()
-        self.assertEqual(message["Reply-To"], "override@example.com")
+        self.assertEqual(message["Reply-To"], "foo@example.com")
 
     def test_reply_to_in_headers_only(self):
         message = EmailMessage(


### PR DESCRIPTION
Fixed bug of ticket [35033](https://code.djangoproject.com/ticket/35033)

The solution that I thought is to raise a ValueError exception, as suggested in the ticket conversation, when it happens that the same header parameter is passed 2 times 