### PR TITLE
Update csrf.py to check even if request.method is not POST

### DIFF
--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -362,7 +362,8 @@ class CsrfViewMiddleware(MiddlewareMixin):
 
         # Check non-cookie token for match.
         request_csrf_token = ""
-        if request.method == "POST":
+        # request.method == "POST" fails if you use custom middleware with form field _method to convert request.method to PUT/DELETE... etc
+        if request.method != "GET":
             try:
                 request_csrf_token = request.POST.get("csrfmiddlewaretoken", "")
             except UnreadablePostError:


### PR DESCRIPTION
When trying to determine request_csrf_token within csrf.py, request.method == "POST" fails if you use custom middle ware that handles a form field _method to convert request.method to PUT/DELETE... etc. I use this middle ware since HTML forms can only use GET and POST.