### PR TITLE
Fixed #35056 -- Fixed system check crash on reverse m2m relations with related_name in ModelAdmin.filter_horizontal/vertical.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -532,7 +532,7 @@ class BaseModelAdminChecks:
                 field=field_name, option=label, obj=obj, id="admin.E019"
             )
         else:
-            if not field.many_to_many:
+            if not field.many_to_many or isinstance(field, models.ManyToManyRel):
                 return must_be(
                     "a many-to-many field", option=label, obj=obj, id="admin.E020"
                 )

--- a/docs/releases/5.0.1.txt
+++ b/docs/releases/5.0.1.txt
@@ -32,3 +32,7 @@ Bugfixes
 
 * Fixed a regression in Django 5.0 where querysets referenced incorrect field
   names from ``FilteredRelation()`` (:ticket:`35050`).
+
+* Fixed a regression in Django 5.0 that caused a system check crash when
+  ``ModelAdmin.filter_horizontal`` or ``filter_vertical`` contained a reverse
+  many-to-many relation with ``related_name`` (:ticket:`35056`).

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -323,6 +323,24 @@ class FilterVerticalCheckTests(CheckTestCase):
         )
 
     @isolate_apps("modeladmin")
+    def test_invalid_reverse_m2m_field_with_related_name(self):
+        class Contact(Model):
+            pass
+
+        class Customer(Model):
+            contacts = ManyToManyField("Contact", related_name="customers")
+
+        class TestModelAdmin(ModelAdmin):
+            filter_vertical = ["customers"]
+
+        self.assertIsInvalid(
+            TestModelAdmin,
+            Contact,
+            "The value of 'filter_vertical[0]' must be a many-to-many field.",
+            "admin.E020",
+        )
+
+    @isolate_apps("modeladmin")
     def test_invalid_m2m_field_with_through(self):
         class Artist(Model):
             bands = ManyToManyField("Band", through="BandArtist")
@@ -380,6 +398,24 @@ class FilterHorizontalCheckTests(CheckTestCase):
         self.assertIsInvalid(
             TestModelAdmin,
             ValidationTestModel,
+            "The value of 'filter_horizontal[0]' must be a many-to-many field.",
+            "admin.E020",
+        )
+
+    @isolate_apps("modeladmin")
+    def test_invalid_reverse_m2m_field_with_related_name(self):
+        class Contact(Model):
+            pass
+
+        class Customer(Model):
+            contacts = ManyToManyField("Contact", related_name="customers")
+
+        class TestModelAdmin(ModelAdmin):
+            filter_horizontal = ["customers"]
+
+        self.assertIsInvalid(
+            TestModelAdmin,
+            Contact,
             "The value of 'filter_horizontal[0]' must be a many-to-many field.",
             "admin.E020",
         )


### PR DESCRIPTION
ticket-35056

Thanks Thomas Feldmann for the report.

Regression in 107865780aa44914e21d27fdf4ca269bc61c7f01.