### PR TITLE
[3.2.x] Pinned python-memcached == 1.59 in test requirements.

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -12,7 +12,7 @@ Pillow >= 6.2.0
 pylibmc; sys.platform != 'win32'
 pymemcache >= 3.4.0
 # RemovedInDjango41Warning.
-python-memcached >= 1.59
+python-memcached == 1.59
 pytz
 pywatchman; sys.platform != 'win32'
 PyYAML


### PR DESCRIPTION
`python-memcached` 1.60 made breaking changes, e.g. `_deletetouch()` has been removed (https://github.com/linsomniac/python-memcached/commit/ab668ed17887c956af3e2af89555e31d190ab63d).

Django 4.1+ don't support `python-memcached` (05f3a6186efefc9fca2204a745b992501c6fd91f), so Django 3.2 is the only supported version where this needs to be fixed.