### PR TITLE
Fix ruff issues related to comprehensions

### DIFF
--- a/django/contrib/gis/management/commands/ogrinspect.py
+++ b/django/contrib/gis/management/commands/ogrinspect.py
@@ -127,7 +127,7 @@ class Command(BaseCommand):
             for k, v in options.items()
             if k in get_func_args(_ogrinspect) and v is not None
         }
-        output = [s for s in _ogrinspect(ds, model_name, **ogr_options)]
+        output = list(_ogrinspect(ds, model_name, **ogr_options))
 
         if options["mapping"]:
             # Constructing the keyword arguments for `mapping`, and

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -118,7 +118,7 @@ class TemplateCommand(BaseCommand):
         extra_files = []
         excluded_directories = [".git", "__pycache__"]
         for file in options["files"]:
-            extra_files.extend(map(lambda x: x.strip(), file.split(",")))
+            extra_files.extend(x.strip() for x in file.split(","))
         if exclude := options.get("exclude"):
             for directory in exclude:
                 excluded_directories.append(directory.strip())

--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -385,7 +385,7 @@ class BaseFormSet(RenderableFormMixin):
         # List comprehension ensures is_valid() is called for all forms.
         # Forms due to be deleted shouldn't cause the formset to be invalid.
         forms_valid = all(
-            [
+            [  # noqa: C419
                 form.is_valid()
                 for form in self.forms
                 if not (self.can_delete and self._should_delete_form(form))
@@ -576,4 +576,4 @@ def formset_factory(
 def all_valid(formsets):
     """Validate every formset and return True if all are valid."""
     # List comprehension ensures is_valid() is called for all formsets.
-    return all([formset.is_valid() for formset in formsets])
+    return all([formset.is_valid() for formset in formsets])  # noqa: C419

--- a/django/template/backends/django.py
+++ b/django/template/backends/django.py
@@ -113,9 +113,7 @@ def get_installed_libraries():
     individual module names, not the full module paths. Example:
     django.templatetags.i18n is stored as i18n.
     """
-    return {
-        module_name: full_name for module_name, full_name in get_template_tag_modules()
-    }
+    return dict(get_template_tag_modules())
 
 
 def get_package_libraries(pkg):

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -1053,9 +1053,9 @@ class DiscoverRunner:
         self.setup_test_environment()
         suite = self.build_suite(test_labels)
         databases = self.get_databases(suite)
-        suite.serialized_aliases = set(
+        suite.serialized_aliases = {
             alias for alias, serialize in databases.items() if serialize
-        )
+        }
         suite.used_aliases = set(databases)
         with self.time_keeper.timed("Total database setup"):
             old_config = self.setup_databases(

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -319,7 +319,7 @@ class CaseInsensitiveMapping(Mapping):
         return (original_key for original_key, value in self._store.values())
 
     def __repr__(self):
-        return repr({key: value for key, value in self._store.values()})
+        return repr(dict(self._store.values()))
 
     def copy(self):
         return self

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -4777,7 +4777,7 @@ Options: <select multiple name="options" aria-invalid="true" required>
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
                 # Populate fields cache.
-                [field for field in self]
+                list(self)
                 # Removed cached field.
                 del self.fields["name"]
 

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -170,7 +170,7 @@ class ArchiveIndexViewTests(TestDataMixin, TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(
             list(res.context["date_list"]),
-            list(reversed(sorted(res.context["date_list"]))),
+            sorted(res.context["date_list"], reverse=True),
         )
 
     def test_archive_view_custom_sorting(self):
@@ -357,7 +357,7 @@ class YearArchiveViewTests(TestDataMixin, TestCase):
         _make_books(10, base_date=datetime.date(2011, 12, 25))
         res = self.client.get("/dates/books/2011/")
         self.assertEqual(
-            list(res.context["date_list"]), list(sorted(res.context["date_list"]))
+            list(res.context["date_list"]), sorted(res.context["date_list"])
         )
 
     @mock.patch("django.views.generic.list.MultipleObjectMixin.get_context_data")
@@ -542,7 +542,7 @@ class MonthArchiveViewTests(TestDataMixin, TestCase):
         _make_books(10, base_date=datetime.date(2011, 12, 25))
         res = self.client.get("/dates/books/2011/dec/")
         self.assertEqual(
-            list(res.context["date_list"]), list(sorted(res.context["date_list"]))
+            list(res.context["date_list"]), sorted(res.context["date_list"])
         )
 
 

--- a/tests/gis_tests/gdal_tests/test_ds.py
+++ b/tests/gis_tests/gdal_tests/test_ds.py
@@ -316,7 +316,7 @@ class DataSourceTest(SimpleTestCase):
         filter_extent = (-105.609252, 37.255001, -103.609252, 39.255001)
         lyr.spatial_filter = (-105.609252, 37.255001, -103.609252, 39.255001)
         self.assertEqual(OGRGeometry.from_bbox(filter_extent), lyr.spatial_filter)
-        feats = [feat for feat in lyr]
+        feats = list(lyr)
         self.assertEqual(1, len(feats))
         self.assertEqual("Pueblo", feats[0].get("Name"))
 
@@ -328,7 +328,7 @@ class DataSourceTest(SimpleTestCase):
         )
         lyr.spatial_filter = filter_geom
         self.assertEqual(filter_geom, lyr.spatial_filter)
-        feats = [feat for feat in lyr]
+        feats = list(lyr)
         self.assertEqual(1, len(feats))
         self.assertEqual("Houston", feats[0].get("Name"))
 

--- a/tests/gis_tests/geo3d/tests.py
+++ b/tests/gis_tests/geo3d/tests.py
@@ -45,7 +45,7 @@ city_data = (
 )
 
 # Reference mapping of city name to its altitude (Z value).
-city_dict = {name: coords for name, coords in city_data}
+city_dict = dict(city_data)
 
 # 3D freeway data derived from the National Elevation Dataset:
 #  http://seamless.usgs.gov/products/9arc.php

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -301,7 +301,7 @@ class SchemaTests(TransactionTestCase):
     def assert_column_comment_not_exists(self, table, column):
         with connection.cursor() as cursor:
             columns = connection.introspection.get_table_description(cursor, table)
-        self.assertFalse(any([c.name == column and c.comment for c in columns]))
+        self.assertFalse(any(c.name == column and c.comment for c in columns))
 
     def assertIndexOrder(self, table, index, order):
         constraints = self.get_constraints(table)

--- a/tests/servers/test_basehttp.py
+++ b/tests/servers/test_basehttp.py
@@ -156,9 +156,7 @@ class WSGIRequestHandlerTestCase(SimpleTestCase):
         body = lines[-1]
         # The body is not returned in a HEAD response.
         self.assertEqual(body, b"\r\n")
-        self.assertIs(
-            any([line.startswith(b"Content-Length:") for line in lines]), False
-        )
+        self.assertIs(any(line.startswith(b"Content-Length:") for line in lines), False)
         self.assertNotIn(b"Connection: close\r\n", lines)
 
 


### PR DESCRIPTION
% `ruff --select=C4 . ` # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
```
django/contrib/gis/management/commands/ogrinspect.py:130:18: C416 Unnecessary `list` comprehension (rewrite using `list()`)
django/core/management/templates.py:121:32: C417 Unnecessary `map` usage (rewrite using a generator expression)
django/forms/formsets.py:388:13: C419 Unnecessary list comprehension.
django/forms/formsets.py:579:16: C419 Unnecessary list comprehension.
django/template/backends/django.py:116:12: C416 Unnecessary `dict` comprehension (rewrite using `dict()`)
django/test/runner.py:1056:36: C401 Unnecessary generator (rewrite as a `set` comprehension)
django/utils/datastructures.py:322:21: C416 Unnecessary `dict` comprehension (rewrite using `dict()`)
tests/forms_tests/tests/test_forms.py:4780:17: C416 Unnecessary `list` comprehension (rewrite using `list()`)
tests/generic_views/test_dates.py:173:18: C413 Unnecessary `reversed` call around `sorted()`
tests/generic_views/test_dates.py:360:45: C413 [*] Unnecessary `list` call around `sorted()`
tests/generic_views/test_dates.py:545:45: C413 [*] Unnecessary `list` call around `sorted()`
```
% `ruff rule C413`
# unnecessary-call-around-sorted (C413)

Derived from the **flake8-comprehensions** linter.

Fix is always available.

## What it does
Checks for unnecessary `list` or `reversed` calls around `sorted`
calls.

## Why is this bad?
It is unnecessary to use `list` around `sorted`, as the latter already
returns a list.

It is also unnecessary to use `reversed` around `sorted`, as the latter
has a `reverse` argument that can be used in lieu of an additional
`reversed` call.

In both cases, it's clearer to avoid the redundant call.

## Examples
```python
reversed(sorted(iterable))
```

Use instead:
```python
sorted(iterable, reverse=True)
```

## Fix safety
This rule's fix is marked as unsafe, as `reversed` and `reverse=True` will
yield different results in the event of custom sort keys or equality
functions. Specifically, `reversed` will reverse the order of the
collection, while `sorted` with `reverse=True` will perform a stable
reverse sort, which will preserve the order of elements that compare as
equal.
