### PR TITLE
[5.0.x] Updated asgiref dependency for 5.0 release series.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ packages = find:
 include_package_data = true
 zip_safe = false
 install_requires =
-    asgiref >= 3.7.0
+    asgiref >= 3.7.0, < 4
     sqlparse >= 0.3.1
     tzdata; sys_platform == 'win32'
 


### PR DESCRIPTION
We forget to do this before releasing the 5.0.