### PR TITLE
Fixed #35065 -- Corrected border color for autocomplete fields with errors in admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/autocomplete.css
+++ b/django/contrib/admin/static/admin/css/autocomplete.css
@@ -273,3 +273,7 @@ select.admin-autocomplete {
     display: block;
     padding: 6px;
 }
+
+.errors .select2-selection {
+    border: 1px solid var(--error-fg);
+}


### PR DESCRIPTION
Fixed #35065 -- Autocomplete Admin field render error color border properly