### PR TITLE
Removed unnecessary list() calls on sorted().

### DIFF
--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -170,7 +170,7 @@ class ArchiveIndexViewTests(TestDataMixin, TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(
             list(res.context["date_list"]),
-            list(reversed(sorted(res.context["date_list"]))),
+            sorted(res.context["date_list"], reverse=True),
         )
 
     def test_archive_view_custom_sorting(self):
@@ -357,7 +357,7 @@ class YearArchiveViewTests(TestDataMixin, TestCase):
         _make_books(10, base_date=datetime.date(2011, 12, 25))
         res = self.client.get("/dates/books/2011/")
         self.assertEqual(
-            list(res.context["date_list"]), list(sorted(res.context["date_list"]))
+            list(res.context["date_list"]), sorted(res.context["date_list"])
         )
 
     @mock.patch("django.views.generic.list.MultipleObjectMixin.get_context_data")
@@ -542,7 +542,7 @@ class MonthArchiveViewTests(TestDataMixin, TestCase):
         _make_books(10, base_date=datetime.date(2011, 12, 25))
         res = self.client.get("/dates/books/2011/dec/")
         self.assertEqual(
-            list(res.context["date_list"]), list(sorted(res.context["date_list"]))
+            list(res.context["date_list"]), sorted(res.context["date_list"])
         )
 
 


### PR DESCRIPTION
As suggested at https://github.com/django/django/pull/17649#issuecomment-1870370811

% `ruff --select=C4 tests/generic_views/test_dates.py ` # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
```
tests/generic_views/test_dates.py:173:18: C413 Unnecessary `reversed` call around `sorted()`
tests/generic_views/test_dates.py:360:45: C413 [*] Unnecessary `list` call around `sorted()`
tests/generic_views/test_dates.py:545:45: C413 [*] Unnecessary `list` call around `sorted()`
Found 3 errors.
```
% `ruff rule C413`
# unnecessary-call-around-sorted (C413)

Derived from the **flake8-comprehensions** linter.

Fix is always available.

## What it does
Checks for unnecessary `list` or `reversed` calls around `sorted`
calls.

## Why is this bad?
It is unnecessary to use `list` around `sorted`, as the latter already
returns a list.

It is also unnecessary to use `reversed` around `sorted`, as the latter
has a `reverse` argument that can be used in lieu of an additional
`reversed` call.

In both cases, it's clearer to avoid the redundant call.

## Examples
```python
reversed(sorted(iterable))
```

Use instead:
```python
sorted(iterable, reverse=True)
```

## Fix safety
This rule's fix is marked as unsafe, as `reversed` and `reverse=True` will
yield different results in the event of custom sort keys or equality
functions. Specifically, `reversed` will reverse the order of the
collection, while `sorted` with `reverse=True` will perform a stable
reverse sort, which will preserve the order of elements that compare as
equal.
