### PR TITLE
#25298 document possibility of SQLite subquery multi return

### DIFF
--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -578,6 +578,13 @@ On PostgreSQL, the SQL looks like:
     write an equivalent queryset that performs the same task more
     clearly or efficiently.
 
+.. warning::
+
+    Unlike other supported database backends, subqueries performed with the
+    SQLite database backend will succeed when the subquery returns multiple
+    results. This can cause unexpected behavior. See
+    :ref:`limiting-the-subquery-to-a-single-row` for prevention steps.
+
 Referencing columns from the outer queryset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -614,6 +621,8 @@ all comments for posts published within the last day:
 
 In this case, the subquery must use :meth:`~.QuerySet.values`
 to return only a single column: the primary key of the post.
+
+.. _limiting-the-subquery-to-a-single-row:
 
 Limiting the subquery to a single row
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As previously outlined in the [referenced ticket](https://code.djangoproject.com/ticket/25298), subqueries performed using SQLite backend do not fail if they return multiple results. Other database backends do error if multiple results are returned. The previous discussion mentioned possibly validating queries and that could in theory be done in the SQLite backend's [check_expression_support](https://github.com/django/django/blob/0be6dde81721e4a61caf45422987c599ebfcfe56/django/db/backends/sqlite3/operations.py#L46) method. However it may prove difficult to capture every case in which this would occur.

This pull request simply adds a warning to the documentation to notify users to the unique behavior of SQLite in this particular use case.