### PR TITLE
Updated feature flags for Oracle 23c.

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -8,6 +8,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     # Oracle crashes with "ORA-00932: inconsistent datatypes: expected - got
     # BLOB" when grouping by LOBs (#24096).
     allows_group_by_lob = False
+    # Although GROUP BY select index is supported by Oracle 23c+, it requires
+    # GROUP_BY_POSITION_ENABLED to be enabled to avoid backward compatibility
+    # issues. Introspection of this settings is not straightforward.
     allows_group_by_select_index = False
     interprets_empty_strings_as_nulls = True
     has_select_for_update = True

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -179,3 +179,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def supports_boolean_expr_in_select_clause(self):
         return self.connection.oracle_version >= (23,)
+
+    @cached_property
+    def supports_aggregation_over_interval_types(self):
+        return self.connection.oracle_version >= (23,)

--- a/django/db/models/functions/mixins.py
+++ b/django/db/models/functions/mixins.py
@@ -31,7 +31,10 @@ class FixDurationInputMixin:
         return sql, params
 
     def as_oracle(self, compiler, connection, **extra_context):
-        if self.output_field.get_internal_type() == "DurationField":
+        if (
+            self.output_field.get_internal_type() == "DurationField"
+            and not connection.features.supports_aggregation_over_interval_types
+        ):
             expression = self.get_source_expressions()[0]
             options = self._get_repr_options()
             from django.db.backends.oracle.functions import (

--- a/django/db/models/functions/text.py
+++ b/django/db/models/functions/text.py
@@ -261,13 +261,14 @@ class Reverse(Transform):
     def as_oracle(self, compiler, connection, **extra_context):
         # REVERSE in Oracle is undocumented and doesn't support multi-byte
         # strings. Use a special subquery instead.
+        suffix = connection.features.bare_select_suffix
         sql, params = super().as_sql(
             compiler,
             connection,
             template=(
                 "(SELECT LISTAGG(s) WITHIN GROUP (ORDER BY n DESC) FROM "
-                "(SELECT LEVEL n, SUBSTR(%(expressions)s, LEVEL, 1) s "
-                "FROM DUAL CONNECT BY LEVEL <= LENGTH(%(expressions)s)) "
+                f"(SELECT LEVEL n, SUBSTR(%(expressions)s, LEVEL, 1) s{suffix} "
+                "CONNECT BY LEVEL <= LENGTH(%(expressions)s)) "
                 "GROUP BY %(expressions)s)"
             ),
             **extra_context,

--- a/tests/backends/oracle/tests.py
+++ b/tests/backends/oracle/tests.py
@@ -43,8 +43,9 @@ class Tests(TestCase):
         An 'almost right' datetime works with configured NLS parameters
         (#18465).
         """
+        suffix = connection.features.bare_select_suffix
         with connection.cursor() as cursor:
-            query = "select 1 from dual where '1936-12-29 00:00' < sysdate"
+            query = f"SELECT 1{suffix} WHERE '1936-12-29 00:00' < SYSDATE"
             # The query succeeds without errors - pre #18465 this
             # wasn't the case.
             cursor.execute(query)


### PR DESCRIPTION
Oracle 23c adds support for some things:

- Use of the SELECT index in GROUP BY clause
  _We can't support this as it isn't enabled by default due to backward compatibility, but added a note._
- `FROM DUAL` is no longer required for bare `SELECT` statements
  _I have left one case unchanged as it refers to the `DUMMY` column of the `DUAL` table._
- Aggregation over interval types is now supported
  _`FixDurationInputMixin.as_oracle()` can be dropped when 23c is the minimum supported version._