### PR TITLE
Update runserver.py

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -29,11 +29,19 @@ class Command(BaseCommand):
     requires_system_checks = []
     stealth_options = ("shutdown_message",)
     suppressed_base_arguments = {"--verbosity", "--traceback"}
-
     default_addr = "127.0.0.1"
     default_addr_ipv6 = "::1"
     default_port = "8000"
     protocol = "http"
+    try:
+        # This gets the local hostname
+        hostname = socket.gethostname()
+        # This gets the IP address associated with the hostname
+        default_addr = socket.gethostbyname(hostname)
+
+    except Exception as e:
+        default_addr = "127.0.0.1"
+
     server_cls = WSGIServer
 
     def add_arguments(self, parser):


### PR DESCRIPTION
**Description:**
Modified the default behavior of the `runserver` command to automatically bind to the host machine's IP address instead of the default `127.0.0.1` loopback address. This change allows the Django development server to be accessed by devices on the same network, enhancing accessibility for testing and development.

**Details:**
- Added code to dynamically determine the host machine's IP address using `socket.gethostname()` and `socket.gethostbyname(hostname)`.
- In case of an exception (e.g., if the host machine is not connected to a network), falls back to the default address `127.0.0.1`.

**Impact:**
- Running `python manage.py runserver` now defaults to the host machine's IP address, making the development server accessible to devices within the same network.
- Developers can still specify a different address/port if needed, but the default behavior enhances ease of access for testing on multiple devices.