### PR TITLE
Ticket 35059 - call response.close, or failing that request_finished.send, if processing is cancelled

### DIFF
--- a/docs/releases/5.0.2.txt
+++ b/docs/releases/5.0.2.txt
@@ -28,3 +28,7 @@ Bugfixes
 * Fixed a regression in Django 5.0 that caused a crash of the ``dumpdata``
   management command when a base queryset used ``prefetch_related()``
   (:ticket:`35159`).
+
+* Fixed a regression in Django 5.0 that caused the ``request_finished`` signal to
+  sometimes not be fired when running Django through an ASGI server, resulting
+  in potential resource leaks (:ticket:`35059`).


### PR DESCRIPTION
The ASGIHandler class attempts to cancel view processing when the http connection is closed. This could happen at any point and potentially also cancels the `request.close` cleanup code.

This moves the call to `request.close` outside of the cancellable `send_response` function, and additionally wraps it in `asyncio.shield`.

For consistency, this also invokes the `request_finished` signal if async view processing is cancelled by this method before a response object has been created. This is because the view could have created DB connections during processing and it if the `request_finished` signal is not sent they may not be cleaned up.