### PR TITLE
Refs #33690 -- Updated tutorial for admin dark mode toggle.

### DIFF
--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -368,6 +368,9 @@ a section of code like:
 
     {% block branding %}
     <div id="site-name"><a href="{% url 'admin:index' %}">Polls Administration</a></div>
+    {% if user.is_anonymous %}
+      {% include "admin/color_theme_toggle.html" %}
+    {% endif %}
     {% endblock %}
 
 We use this approach to teach you how to override templates. In an actual


### PR DESCRIPTION
bc7aa2a5e91cf65fc7510edaf1776528c7ad07b4 fixed ticket-33690, and added new code to `base_site.html`. Updating this corresponding “copy-paste-modify” section from the tutorial was missed, which this PR fixes.