### PR TITLE
Refs #34140 -- Fixed blacken-docs pre-commit configuration.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
       - id: blacken-docs
         additional_dependencies:
         - black==23.10.0
+        files: 'docs/.*\.txt$'
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:


### PR DESCRIPTION
Missed in 6015bab80e28aef2669f6fac53423aa65f70cb08. The default blacken-docs hook definition does not apply to ``.txt`` files, which the Django documentation uses. This commit overrides that definition to point blacken-docs at the appropriate files.