### PR TITLE
fix unnecessary key check

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -277,6 +277,7 @@ answer newbie questions, and generally made Django that much better:
     Deep L. Sukhwani <deepsukhwani@gmail.com>
     Deepak Thukral <deep.thukral@gmail.com>
     Denis Kuzmichyov <kuzmichyov@gmail.com>
+    Denis Veselov <https://github.com/saippuakauppias>
     Dennis Schwertel <dennisschwertel@gmail.com>
     Derek Willis <http://blog.thescoop.org/>
     Deric Crago <deric.crago@gmail.com>

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -161,7 +161,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         # property. This is necessary as the shareability is disabled by
         # default in sqlite3 and it cannot be changed once a connection is
         # opened.
-        if "check_same_thread" in kwargs and kwargs["check_same_thread"]:
+        if kwargs.get("check_same_thread"):
             warnings.warn(
                 "The `check_same_thread` option was provided and set to "
                 "True. It will be overridden with False. Use the "


### PR DESCRIPTION
```
➜ ruff check --select=RUF019
django/db/backends/sqlite3/base.py:164:12: RUF019 [*] Unnecessary key check before dictionary access
Found 1 error.
```

Rule description: https://docs.astral.sh/ruff/rules/unnecessary-key-check/

# Why is this bad?
When working with dictionaries, the `get` can be used to access a value without having to check if the dictionary contains the relevant key, returning `None` if the key is not present.