### PR TITLE
Fixed unpacked list comprehension

### DIFF
--- a/django/contrib/gis/gdal/field.py
+++ b/django/contrib/gis/gdal/field.py
@@ -73,7 +73,7 @@ class Field(GDALBase):
         "Retrieve the Field's value as a tuple of date & time components."
         if not self.is_set:
             return None
-        yy, mm, dd, hh, mn, ss, tz = [c_int() for i in range(7)]
+        yy, mm, dd, hh, mn, ss, tz = (c_int() for i in range(7))
         status = capi.get_field_as_datetime(
             self._feat.ptr,
             self._index,

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -1147,7 +1147,7 @@ class SelectDateWidget(Widget):
             if match:
                 # Convert any zeros in the date to empty strings to match the
                 # empty option value.
-                year, month, day = [int(val) or "" for val in match.groups()]
+                year, month, day = (int(val) or "" for val in match.groups())
             else:
                 input_format = get_format("DATE_INPUT_FORMATS")[0]
                 try:

--- a/tests/m2m_multiple/tests.py
+++ b/tests/m2m_multiple/tests.py
@@ -7,10 +7,10 @@ from .models import Article, Category
 
 class M2MMultipleTests(TestCase):
     def test_multiple(self):
-        c1, c2, c3, c4 = [
+        c1, c2, c3, c4 = (
             Category.objects.create(name=name)
             for name in ["Sports", "News", "Crime", "Life"]
-        ]
+        )
 
         a1 = Article.objects.create(
             headline="Parrot steals", pub_date=datetime(2005, 11, 27)

--- a/tests/m2m_recursive/tests.py
+++ b/tests/m2m_recursive/tests.py
@@ -8,10 +8,10 @@ from .models import Person
 class RecursiveM2MTests(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.a, cls.b, cls.c, cls.d = [
+        cls.a, cls.b, cls.c, cls.d = (
             Person.objects.create(name=name)
             for name in ["Anne", "Bill", "Chuck", "David"]
-        ]
+        )
         cls.a.friends.add(cls.b, cls.c)
         # Add m2m for Anne and Chuck in reverse direction.
         cls.d.friends.add(cls.a, cls.c)
@@ -66,10 +66,10 @@ class RecursiveM2MTests(TestCase):
 class RecursiveSymmetricalM2MThroughTests(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.a, cls.b, cls.c, cls.d = [
+        cls.a, cls.b, cls.c, cls.d = (
             Person.objects.create(name=name)
             for name in ["Anne", "Bill", "Chuck", "David"]
-        ]
+        )
         cls.a.colleagues.add(
             cls.b,
             cls.c,

--- a/tests/test_client/views.py
+++ b/tests/test_client/views.py
@@ -138,7 +138,7 @@ def raw_post_view(request):
     if request.method == "POST":
         root = parseString(request.body)
         first_book = root.firstChild.firstChild
-        title, author = [n.firstChild.nodeValue for n in first_book.childNodes]
+        title, author = (n.firstChild.nodeValue for n in first_book.childNodes)
         t = Template("{{ title }} - {{ author }}", name="Book template")
         c = Context({"title": title, "author": author})
     else:


### PR DESCRIPTION
```
➜ ruff check --select=UP027
django/contrib/gis/gdal/field.py:76:38: UP027 [*] Replace unpacked list comprehension with a generator expression
django/forms/widgets.py:1150:36: UP027 [*] Replace unpacked list comprehension with a generator expression
tests/m2m_multiple/tests.py:10:26: UP027 [*] Replace unpacked list comprehension with a generator expression
tests/m2m_recursive/tests.py:11:38: UP027 [*] Replace unpacked list comprehension with a generator expression
tests/m2m_recursive/tests.py:69:38: UP027 [*] Replace unpacked list comprehension with a generator expression
tests/test_client/views.py:141:25: UP027 [*] Replace unpacked list comprehension with a generator expression
Found 6 errors.
```

Rule description: https://docs.astral.sh/ruff/rules/unpacked-list-comprehension/

# Why is this bad?
There is no reason to use a list comprehension if the result is immediately unpacked. Instead, use a generator expression, which is more efficient as it avoids allocating an intermediary list.