### PR TITLE
Fixed assert `False`

### DIFF
--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -229,7 +229,7 @@ class ASGIHandler(base.BaseHandler):
         if message["type"] == "http.disconnect":
             raise RequestAborted()
         # This should never happen.
-        assert False, "Invalid ASGI message after request body: %s" % message["type"]
+        raise AssertionError("Invalid ASGI message after request body: %s" % message["type"])
 
     async def run_get_response(self, request):
         """Get async response."""

--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -229,7 +229,9 @@ class ASGIHandler(base.BaseHandler):
         if message["type"] == "http.disconnect":
             raise RequestAborted()
         # This should never happen.
-        raise AssertionError("Invalid ASGI message after request body: %s" % message["type"])
+        raise AssertionError(
+            "Invalid ASGI message after request body: %s" % message["type"]
+        )
 
     async def run_get_response(self, request):
         """Get async response."""

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -79,7 +79,7 @@ class Extract(TimezoneMixin, Transform):
         else:
             # resolve_expression has already validated the output_field so this
             # assert should never be hit.
-            assert False, "Tried to Extract from an invalid type."
+            raise AssertionError("Tried to Extract from an invalid type.")
         return sql, params
 
     def resolve_expression(

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -411,7 +411,7 @@ class ObjectA(models.Model):
 
     def __iter__(self):
         # Ticket #23721
-        assert False, "type checking should happen without calling model __iter__"
+        raise AssertionError("type checking should happen without calling model __iter__")
 
 
 class ProxyObjectA(ObjectA):

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -411,7 +411,9 @@ class ObjectA(models.Model):
 
     def __iter__(self):
         # Ticket #23721
-        raise AssertionError("type checking should happen without calling model __iter__")
+        raise AssertionError(
+            "type checking should happen without calling model __iter__"
+        )
 
 
 class ProxyObjectA(ObjectA):


### PR DESCRIPTION
```
➜ ruff check --select=B011
django/core/handlers/asgi.py:232:16: B011 Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
django/db/models/functions/datetime.py:82:20: B011 Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
tests/queries/models.py:414:16: B011 Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
Found 3 errors.
```

Rule description: https://docs.astral.sh/ruff/rules/assert-false/

# Why is this bad?
Python removes `assert` statements when running in optimized mode (`python -O`), making `assert False` an unreliable means of raising an `AssertionError`.

Instead, raise an `AssertionError` directly.

# Fix safety
Changing an `assert` to a `raise` will change the behavior of your program when running in optimized mode (`python -O`).