### PR TITLE
Fixed some unnecessary comprehensions

### DIFF
--- a/django/contrib/gis/management/commands/ogrinspect.py
+++ b/django/contrib/gis/management/commands/ogrinspect.py
@@ -127,7 +127,7 @@ class Command(BaseCommand):
             for k, v in options.items()
             if k in get_func_args(_ogrinspect) and v is not None
         }
-        output = [s for s in _ogrinspect(ds, model_name, **ogr_options)]
+        output = list(_ogrinspect(ds, model_name, **ogr_options))
 
         if options["mapping"]:
             # Constructing the keyword arguments for `mapping`, and

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -319,7 +319,7 @@ class CaseInsensitiveMapping(Mapping):
         return (original_key for original_key, value in self._store.values())
 
     def __repr__(self):
-        return repr({key: value for key, value in self._store.values()})
+        return repr(dict(self._store.values()))
 
     def copy(self):
         return self


### PR DESCRIPTION
Fixed 2 of 7 errors (where readability will not be degraded):
```
➜  ruff check --select=C416
django/contrib/gis/management/commands/ogrinspect.py:130:18: C416 Unnecessary `list` comprehension (rewrite using `list()`)
django/template/backends/django.py:116:12: C416 Unnecessary `dict` comprehension (rewrite using `dict()`)
django/utils/datastructures.py:322:21: C416 Unnecessary `dict` comprehension (rewrite using `dict()`)
tests/forms_tests/tests/test_forms.py:4780:17: C416 Unnecessary `list` comprehension (rewrite using `list()`)
tests/gis_tests/gdal_tests/test_ds.py:319:17: C416 Unnecessary `list` comprehension (rewrite using `list()`)
tests/gis_tests/gdal_tests/test_ds.py:331:17: C416 Unnecessary `list` comprehension (rewrite using `list()`)
tests/gis_tests/geo3d/tests.py:48:13: C416 Unnecessary `dict` comprehension (rewrite using `dict()`)
Found 7 errors.
```

Rule description: https://docs.astral.sh/ruff/rules/unnecessary-comprehension/