### PR TITLE
Fixed unnecessary `map` usage

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -118,7 +118,7 @@ class TemplateCommand(BaseCommand):
         extra_files = []
         excluded_directories = [".git", "__pycache__"]
         for file in options["files"]:
-            extra_files.extend([s.strip() for s in file.split(",")])
+            extra_files.extend(s.strip() for s in file.split(","))
         if exclude := options.get("exclude"):
             for directory in exclude:
                 excluded_directories.append(directory.strip())

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -118,7 +118,7 @@ class TemplateCommand(BaseCommand):
         extra_files = []
         excluded_directories = [".git", "__pycache__"]
         for file in options["files"]:
-            extra_files.extend(map(lambda x: x.strip(), file.split(",")))
+            extra_files.extend([s.strip() for s in file.split(",")])
         if exclude := options.get("exclude"):
             for directory in exclude:
                 excluded_directories.append(directory.strip())


### PR DESCRIPTION
```
➜ ruff check --select=C417
django/core/management/templates.py:121:32: C417 Unnecessary `map` usage (rewrite using a generator expression)
Found 1 error.
```

Rule description: https://docs.astral.sh/ruff/rules/unnecessary-map/

# Why is this bad?
Using `map(func, iterable)` when `func` is a `lambda` is slower than using a generator expression or a comprehension, as the latter approach avoids the function call overhead, in addition to being more readable.