### PR TITLE
Fixed Unnecessary list comprehension

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -382,14 +382,12 @@ class BaseFormSet(RenderableFormMixin):
             return False
         # Accessing errors triggers a full clean the first time only.
         self.errors
-        # List comprehension ensures is_valid() is called for all forms.
+        # Generator ensures is_valid() is called for all forms.
         # Forms due to be deleted shouldn't cause the formset to be invalid.
         forms_valid = all(
-            [
-                form.is_valid()
-                for form in self.forms
-                if not (self.can_delete and self._should_delete_form(form))
-            ]
+            form.is_valid()
+            for form in self.forms
+            if not (self.can_delete and self._should_delete_form(form))
         )
         return forms_valid and not self.non_form_errors()
 
@@ -575,5 +573,5 @@ def formset_factory(
 
 def all_valid(formsets):
     """Validate every formset and return True if all are valid."""
-    # List comprehension ensures is_valid() is called for all formsets.
-    return all([formset.is_valid() for formset in formsets])
+    # Generator ensures is_valid() is called for all formsets.
+    return all(formset.is_valid() for formset in formsets)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -301,7 +301,7 @@ class SchemaTests(TransactionTestCase):
     def assert_column_comment_not_exists(self, table, column):
         with connection.cursor() as cursor:
             columns = connection.introspection.get_table_description(cursor, table)
-        self.assertFalse(any([c.name == column and c.comment for c in columns]))
+        self.assertFalse(any(c.name == column and c.comment for c in columns))
 
     def assertIndexOrder(self, table, index, order):
         constraints = self.get_constraints(table)

--- a/tests/servers/test_basehttp.py
+++ b/tests/servers/test_basehttp.py
@@ -157,7 +157,7 @@ class WSGIRequestHandlerTestCase(SimpleTestCase):
         # The body is not returned in a HEAD response.
         self.assertEqual(body, b"\r\n")
         self.assertIs(
-            any([line.startswith(b"Content-Length:") for line in lines]), False
+            any(line.startswith(b"Content-Length:") for line in lines), False
         )
         self.assertNotIn(b"Connection: close\r\n", lines)
 

--- a/tests/servers/test_basehttp.py
+++ b/tests/servers/test_basehttp.py
@@ -156,9 +156,7 @@ class WSGIRequestHandlerTestCase(SimpleTestCase):
         body = lines[-1]
         # The body is not returned in a HEAD response.
         self.assertEqual(body, b"\r\n")
-        self.assertIs(
-            any(line.startswith(b"Content-Length:") for line in lines), False
-        )
+        self.assertIs(any(line.startswith(b"Content-Length:") for line in lines), False)
         self.assertNotIn(b"Connection: close\r\n", lines)
 
     def test_non_zero_content_length_set_head_request(self):


### PR DESCRIPTION
```
➜ ruff check --select=C419
django/forms/formsets.py:388:13: C419 Unnecessary list comprehension
django/forms/formsets.py:579:16: C419 Unnecessary list comprehension
tests/schema/tests.py:304:30: C419 Unnecessary list comprehension
tests/servers/test_basehttp.py:160:17: C419 Unnecessary list comprehension
Found 4 errors.
```

Rule description: https://docs.astral.sh/ruff/rules/unnecessary-comprehension-any-all/

# Why is this bad?
`any` and `all` take any iterators, including generators. Converting a generator to a list by way of a list comprehension is unnecessary and reduces performance due to the overhead of creating the list.

For example, compare the performance of `all` with a list comprehension against that of a generator (~40x faster here):
```
In [1]: %timeit all([i for i in range(1000)])
8.14 µs ± 25.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [2]: %timeit all(i for i in range(1000))
212 ns ± 0.892 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```