### PR TITLE
Fixed Unnecessary generator

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -1053,9 +1053,9 @@ class DiscoverRunner:
         self.setup_test_environment()
         suite = self.build_suite(test_labels)
         databases = self.get_databases(suite)
-        suite.serialized_aliases = set(
+        suite.serialized_aliases = {
             alias for alias, serialize in databases.items() if serialize
-        )
+        }
         suite.used_aliases = set(databases)
         with self.time_keeper.timed("Total database setup"):
             old_config = self.setup_databases(


### PR DESCRIPTION
```
➜  ruff check --select=C401
django/test/runner.py:1056:36: C401 Unnecessary generator (rewrite as a `set` comprehension)
Found 1 error.
```

Rule description: https://docs.astral.sh/ruff/rules/unnecessary-generator-set/

There are already many of the same examples in the code, there is no point in leaving one single example written differently