### PR TITLE
Fixed Call `endswith` once with a `tuple`

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -526,7 +526,7 @@ class FormatStylePlaceholderCursor:
         # it does want a trailing ';' but not a trailing '/'.  However, these
         # characters must be included in the original query in case the query
         # is being passed to SQL*Plus.
-        if query.endswith(";") or query.endswith("/"):
+        if query.endswith((";", "/")):
             query = query[:-1]
         if params is None:
             params = []


### PR DESCRIPTION
```
➜  ruff check --select=PIE810
django/db/backends/oracle/base.py:529:12: PIE810 Call `endswith` once with a `tuple`
Found 1 error.
```

Rule description: https://docs.astral.sh/ruff/rules/multiple-starts-ends-with/

# Why is this bad?
The `startswith` and `endswith` methods accept tuples of prefixes or suffixes respectively. Passing a tuple of prefixes or suffixes is more more efficient and readable than calling the method multiple times.