### PR TITLE
Fixed Unnecessary parentheses on raised exception

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -326,7 +326,7 @@ def _get_non_gfk_field(opts, name):
         # Generic foreign keys OR reverse relations
         ((field.many_to_one and not field.related_model) or field.one_to_many)
     ):
-        raise FieldDoesNotExist()
+        raise FieldDoesNotExist
 
     # Avoid coercing <FK>_id fields to FK
     if (
@@ -335,7 +335,7 @@ def _get_non_gfk_field(opts, name):
         and hasattr(field, "attname")
         and field.attname == name
     ):
-        raise FieldIsAForeignKeyColumnName()
+        raise FieldIsAForeignKeyColumnName
 
     return field
 

--- a/django/core/files/uploadhandler.py
+++ b/django/core/files/uploadhandler.py
@@ -209,7 +209,7 @@ class MemoryFileUploadHandler(FileUploadHandler):
         super().new_file(*args, **kwargs)
         if self.activated:
             self.file = BytesIO()
-            raise StopFutureHandlers()
+            raise StopFutureHandlers
 
     def receive_data_chunk(self, raw_data, start):
         """Add the data to the BytesIO file."""

--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -227,7 +227,7 @@ class ASGIHandler(base.BaseHandler):
         """Listen for disconnect from the client."""
         message = await receive()
         if message["type"] == "http.disconnect":
-            raise RequestAborted()
+            raise RequestAborted
         # This should never happen.
         assert False, "Invalid ASGI message after request body: %s" % message["type"]
 
@@ -253,7 +253,7 @@ class ASGIHandler(base.BaseHandler):
             if message["type"] == "http.disconnect":
                 body_file.close()
                 # Early client disconnect.
-                raise RequestAborted()
+                raise RequestAborted
             # Add a body chunk from the message, if provided.
             if "body" in message:
                 body_file.write(message["body"])

--- a/django/core/serializers/json.py
+++ b/django/core/serializers/json.py
@@ -71,7 +71,7 @@ def Deserializer(stream_or_string, **options):
     except (GeneratorExit, DeserializationError):
         raise
     except Exception as exc:
-        raise DeserializationError() from exc
+        raise DeserializationError from exc
 
 
 class DjangoJSONEncoder(json.JSONEncoder):

--- a/django/core/serializers/jsonl.py
+++ b/django/core/serializers/jsonl.py
@@ -54,4 +54,4 @@ def Deserializer(stream_or_string, **options):
         except (GeneratorExit, DeserializationError):
             raise
         except Exception as exc:
-            raise DeserializationError() from exc
+            raise DeserializationError from exc

--- a/django/core/serializers/pyyaml.py
+++ b/django/core/serializers/pyyaml.py
@@ -79,4 +79,4 @@ def Deserializer(stream_or_string, **options):
     except (GeneratorExit, DeserializationError):
         raise
     except Exception as exc:
-        raise DeserializationError() from exc
+        raise DeserializationError from exc

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -470,7 +470,7 @@ class BaseDatabaseSchemaEditor:
         for particularly tricky backends (defaults are not user-defined, though,
         so this is safe).
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     # Actions
 

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1724,7 +1724,7 @@ class DecimalField(Field):
         try:
             decimal_places = int(self.decimal_places)
             if decimal_places < 0:
-                raise ValueError()
+                raise ValueError
         except TypeError:
             return [
                 checks.Error(
@@ -1748,7 +1748,7 @@ class DecimalField(Field):
         try:
             max_digits = int(self.max_digits)
             if max_digits <= 0:
-                raise ValueError()
+                raise ValueError
         except TypeError:
             return [
                 checks.Error(

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -545,11 +545,11 @@ class ChunkIter:
         try:
             data = self.flo.read(self.chunk_size)
         except InputStreamExhausted:
-            raise StopIteration()
+            raise StopIteration
         if data:
             return data
         else:
-            raise StopIteration()
+            raise StopIteration
 
     def __iter__(self):
         return self
@@ -571,7 +571,7 @@ class InterBoundaryIter:
         try:
             return LazyStream(BoundaryIter(self._stream, self._boundary))
         except InputStreamExhausted:
-            raise StopIteration()
+            raise StopIteration
 
 
 class BoundaryIter:
@@ -598,7 +598,7 @@ class BoundaryIter:
         # use Python find. Wrap the latter for consistency.
         unused_char = self._stream.read(1)
         if not unused_char:
-            raise InputStreamExhausted()
+            raise InputStreamExhausted
         self._stream.unget(unused_char)
 
     def __iter__(self):
@@ -606,7 +606,7 @@ class BoundaryIter:
 
     def __next__(self):
         if self._done:
-            raise StopIteration()
+            raise StopIteration
 
         stream = self._stream
         rollback = self._rollback
@@ -624,7 +624,7 @@ class BoundaryIter:
             self._done = True
 
         if not chunks:
-            raise StopIteration()
+            raise StopIteration
 
         chunk = b"".join(chunks)
         boundary = self._find_boundary(chunk)

--- a/tests/backends/postgresql/test_creation.py
+++ b/tests/backends/postgresql/test_creation.py
@@ -74,11 +74,11 @@ class DatabaseCreationTests(SimpleTestCase):
         error = errors.DuplicateDatabase(
             "database %s already exists" % parameters["dbname"]
         )
-        raise DatabaseError() from error
+        raise DatabaseError from error
 
     def _execute_raise_permission_denied(self, cursor, parameters, keepdb=False):
         error = errors.InsufficientPrivilege("permission denied to create database")
-        raise DatabaseError() from error
+        raise DatabaseError from error
 
     def patch_test_db_creation(self, execute_create_test_db):
         return mock.patch.object(

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -33,7 +33,7 @@ class Tests(TestCase):
 
         def mocked_connect(self):
             if self.settings_dict["NAME"] is None:
-                raise DatabaseError()
+                raise DatabaseError
             return orig_connect(self)
 
         with connection._nodb_cursor() as cursor:
@@ -89,7 +89,7 @@ class Tests(TestCase):
         """
 
         def mocked_connect(self):
-            raise DatabaseError()
+            raise DatabaseError
 
         def mocked_all(self):
             test_connection = copy.copy(connections[DEFAULT_DB_ALIAS])

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -77,7 +77,7 @@ class C:
 
 class Unpicklable:
     def __getstate__(self):
-        raise pickle.PickleError()
+        raise pickle.PickleError
 
 
 def empty_response(request):

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -436,9 +436,9 @@ class FileStorageTests(SimpleTestCase):
             elif path == os.path.join(self.temp_dir, "raced"):
                 real_makedirs(path, mode, exist_ok)
                 if not exist_ok:
-                    raise FileExistsError()
+                    raise FileExistsError
             elif path == os.path.join(self.temp_dir, "error"):
-                raise PermissionError()
+                raise PermissionError
             else:
                 self.fail("unexpected argument %r" % path)
 
@@ -472,9 +472,9 @@ class FileStorageTests(SimpleTestCase):
                 real_remove(path)
             elif path == os.path.join(self.temp_dir, "raced.file"):
                 real_remove(path)
-                raise FileNotFoundError()
+                raise FileNotFoundError
             elif path == os.path.join(self.temp_dir, "error.file"):
-                raise PermissionError()
+                raise PermissionError
             else:
                 self.fail("unexpected argument %r" % path)
 

--- a/tests/file_uploads/uploadhandler.py
+++ b/tests/file_uploads/uploadhandler.py
@@ -37,7 +37,7 @@ class StopUploadTemporaryFileHandler(TemporaryFileUploadHandler):
     """A handler that raises a StopUpload exception."""
 
     def receive_data_chunk(self, raw_data, start):
-        raise StopUpload()
+        raise StopUpload
 
 
 class CustomUploadError(Exception):

--- a/tests/handlers/views.py
+++ b/tests/handlers/views.py
@@ -44,7 +44,7 @@ def not_in_transaction_using_text(request):
 
 
 def bad_request(request):
-    raise BadRequest()
+    raise BadRequest
 
 
 def suspicious(request):

--- a/tests/logging_tests/views.py
+++ b/tests/logging_tests/views.py
@@ -38,7 +38,7 @@ def internal_server_error(request):
 
 
 def permission_denied(request):
-    raise PermissionDenied()
+    raise PermissionDenied
 
 
 def multi_part_parser_error(request):

--- a/tests/middleware_exceptions/views.py
+++ b/tests/middleware_exceptions/views.py
@@ -20,7 +20,7 @@ def server_error(request):
 
 
 def permission_denied(request):
-    raise PermissionDenied()
+    raise PermissionDenied
 
 
 def exception_in_render(request):

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -359,7 +359,7 @@ class StateTests(SimpleTestCase):
         with self.assertRaises(ValueError):
             with apps.bulk_update():
                 self.assertFalse(apps.ready)
-                raise ValueError()
+                raise ValueError
         self.assertTrue(apps.ready)
 
     def test_render(self):

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -679,7 +679,7 @@ class ListDisplayTests(CheckTestCase):
 
             def __get__(self, instance, owner):
                 if instance is None:
-                    raise AttributeError()
+                    raise AttributeError
 
         class TestModel(Model):
             field = PositionField()

--- a/tests/servers/test_basehttp.py
+++ b/tests/servers/test_basehttp.py
@@ -219,7 +219,7 @@ class WSGIServerTestCase(SimpleTestCase):
                 try:
                     server = WSGIServer(("localhost", 0), WSGIRequestHandler)
                     try:
-                        raise exception()
+                        raise exception
                     except Exception:
                         with captured_stderr() as err:
                             with self.assertLogs("django.server", "INFO") as cm:

--- a/tests/template_tests/utils.py
+++ b/tests/template_tests/utils.py
@@ -152,7 +152,7 @@ class TestObj:
         return False
 
     def is_bad(self):
-        raise ShouldNotExecuteException()
+        raise ShouldNotExecuteException
 
 
 class SilentGetItemClass:

--- a/tests/test_client_regress/views.py
+++ b/tests/test_client_regress/views.py
@@ -25,7 +25,7 @@ def staff_only_view(request):
     if request.user.is_staff:
         return HttpResponse()
     else:
-        raise CustomTestException()
+        raise CustomTestException
 
 
 @login_required

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -1899,7 +1899,7 @@ class TestBadSetUpTestData(TestCase):
     @classmethod
     def setUpTestData(cls):
         # Simulate a broken setUpTestData() method.
-        raise cls.MyException()
+        raise cls.MyException
 
     def test_failure_in_setUpTestData_should_rollback_transaction(self):
         # setUpTestData() should call _rollback_atomics() so that the

--- a/tests/transaction_hooks/tests.py
+++ b/tests/transaction_hooks/tests.py
@@ -24,7 +24,7 @@ class TestConnectionOnCommit(TransactionTestCase):
 
     def notify(self, id_):
         if id_ == "error":
-            raise ForcedError()
+            raise ForcedError
         self.notified.append(id_)
 
     def do(self, num):
@@ -94,7 +94,7 @@ class TestConnectionOnCommit(TransactionTestCase):
         try:
             with transaction.atomic():
                 self.do(1)
-                raise ForcedError()
+                raise ForcedError
         except ForcedError:
             pass
 
@@ -117,7 +117,7 @@ class TestConnectionOnCommit(TransactionTestCase):
             try:
                 with transaction.atomic():
                     self.do(2)
-                    raise ForcedError()
+                    raise ForcedError
             except ForcedError:
                 pass
             # another successful savepoint
@@ -133,7 +133,7 @@ class TestConnectionOnCommit(TransactionTestCase):
             with transaction.atomic():
                 with transaction.atomic():
                     self.do(1)
-                raise ForcedError()
+                raise ForcedError
         except ForcedError:
             pass
 
@@ -145,7 +145,7 @@ class TestConnectionOnCommit(TransactionTestCase):
                 with transaction.atomic():
                     with transaction.atomic():
                         self.do(1)
-                    raise ForcedError()
+                    raise ForcedError
             except ForcedError:
                 pass
             self.do(2)
@@ -158,7 +158,7 @@ class TestConnectionOnCommit(TransactionTestCase):
                 self.do(1)
                 try:
                     with transaction.atomic(savepoint=False):
-                        raise ForcedError()
+                        raise ForcedError
                 except ForcedError:
                     pass
 
@@ -170,7 +170,7 @@ class TestConnectionOnCommit(TransactionTestCase):
                 self.do(1)
                 try:
                     with transaction.atomic():
-                        raise ForcedError()
+                        raise ForcedError
                 except ForcedError:
                     pass
 
@@ -197,7 +197,7 @@ class TestConnectionOnCommit(TransactionTestCase):
         try:
             with transaction.atomic():
                 self.do(1)
-                raise ForcedError()
+                raise ForcedError
         except ForcedError:
             pass
 

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -387,7 +387,7 @@ class ConversionExceptionTests(SimpleTestCase):
     def test_resolve_value_error_means_no_match(self):
         @DynamicConverter.register_to_python
         def raises_value_error(value):
-            raise ValueError()
+            raise ValueError
 
         with self.assertRaises(Resolver404):
             resolve("/dynamic/abc/")

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -1008,7 +1008,7 @@ class ExceptionReporterTests(SimpleTestCase):
                     return b"EXC\xe9EXC"
 
             somevar = b"VAL\xe9VAL"  # NOQA
-            raise NonUtf8Output()
+            raise NonUtf8Output
         except Exception:
             exc_type, exc_value, tb = sys.exc_info()
         reporter = ExceptionReporter(None, exc_type, exc_value, tb)
@@ -1039,7 +1039,7 @@ class ExceptionReporterTests(SimpleTestCase):
                     raise MemoryError("OOM")
 
             oomvalue = OomOutput()  # NOQA
-            raise ValueError()
+            raise ValueError
         except Exception:
             exc_type, exc_value, tb = sys.exc_info()
         reporter = ExceptionReporter(None, exc_type, exc_value, tb)
@@ -1057,7 +1057,7 @@ class ExceptionReporterTests(SimpleTestCase):
                     return repr("A" * large)
 
             largevalue = LargeOutput()  # NOQA
-            raise ValueError()
+            raise ValueError
         except Exception:
             exc_type, exc_value, tb = sys.exc_info()
         reporter = ExceptionReporter(None, exc_type, exc_value, tb)
@@ -1173,7 +1173,7 @@ class ExceptionReporterTests(SimpleTestCase):
 
         class ExceptionUser:
             def __str__(self):
-                raise Exception()
+                raise Exception
 
         request = self.rf.get("/test_view/")
         request.user = ExceptionUser()


### PR DESCRIPTION
```
➜  ruff check --select=RSE102
django/contrib/admin/utils.py:329:32: RSE102 Unnecessary parentheses on raised exception
django/contrib/admin/utils.py:338:43: RSE102 [*] Unnecessary parentheses on raised exception
django/contrib/auth/forms.py:254:51: RSE102 Unnecessary parentheses on raised exception
django/core/files/uploadhandler.py:212:37: RSE102 [*] Unnecessary parentheses on raised exception
django/core/handlers/asgi.py:230:33: RSE102 Unnecessary parentheses on raised exception
django/core/handlers/asgi.py:256:37: RSE102 Unnecessary parentheses on raised exception
django/core/serializers/json.py:74:35: RSE102 Unnecessary parentheses on raised exception
django/core/serializers/jsonl.py:57:39: RSE102 Unnecessary parentheses on raised exception
django/core/serializers/pyyaml.py:82:35: RSE102 Unnecessary parentheses on raised exception
django/db/backends/base/schema.py:473:34: RSE102 [*] Unnecessary parentheses on raised exception
django/db/models/fields/__init__.py:1727:33: RSE102 [*] Unnecessary parentheses on raised exception
django/db/models/fields/__init__.py:1751:33: RSE102 [*] Unnecessary parentheses on raised exception
django/http/multipartparser.py:548:32: RSE102 [*] Unnecessary parentheses on raised exception
django/http/multipartparser.py:552:32: RSE102 [*] Unnecessary parentheses on raised exception
django/http/multipartparser.py:574:32: RSE102 [*] Unnecessary parentheses on raised exception
django/http/multipartparser.py:601:39: RSE102 [*] Unnecessary parentheses on raised exception
django/http/multipartparser.py:609:32: RSE102 [*] Unnecessary parentheses on raised exception
django/http/multipartparser.py:627:32: RSE102 [*] Unnecessary parentheses on raised exception
tests/backends/postgresql/test_creation.py:77:28: RSE102 Unnecessary parentheses on raised exception
tests/backends/postgresql/test_creation.py:81:28: RSE102 Unnecessary parentheses on raised exception
tests/backends/postgresql/tests.py:36:36: RSE102 Unnecessary parentheses on raised exception
tests/backends/postgresql/tests.py:92:32: RSE102 Unnecessary parentheses on raised exception
tests/cache/tests.py:80:33: RSE102 Unnecessary parentheses on raised exception
tests/file_storage/tests.py:439:42: RSE102 [*] Unnecessary parentheses on raised exception
tests/file_storage/tests.py:441:38: RSE102 [*] Unnecessary parentheses on raised exception
tests/file_storage/tests.py:475:40: RSE102 [*] Unnecessary parentheses on raised exception
tests/file_storage/tests.py:477:38: RSE102 [*] Unnecessary parentheses on raised exception
tests/file_uploads/uploadhandler.py:40:25: RSE102 Unnecessary parentheses on raised exception
tests/handlers/views.py:47:21: RSE102 Unnecessary parentheses on raised exception
tests/logging_tests/views.py:41:27: RSE102 Unnecessary parentheses on raised exception
tests/middleware_exceptions/views.py:23:27: RSE102 Unnecessary parentheses on raised exception
tests/migrations/test_state.py:362:33: RSE102 [*] Unnecessary parentheses on raised exception
tests/modeladmin/test_checks.py:682:41: RSE102 [*] Unnecessary parentheses on raised exception
tests/servers/test_basehttp.py:222:40: RSE102 Unnecessary parentheses on raised exception
tests/template_tests/utils.py:155:40: RSE102 [*] Unnecessary parentheses on raised exception
tests/test_client_regress/views.py:28:34: RSE102 [*] Unnecessary parentheses on raised exception
tests/test_utils/tests.py:1902:30: RSE102 Unnecessary parentheses on raised exception
tests/transaction_hooks/tests.py:27:30: RSE102 [*] Unnecessary parentheses on raised exception
tests/transaction_hooks/tests.py:97:34: RSE102 [*] Unnecessary parentheses on raised exception
tests/transaction_hooks/tests.py:120:38: RSE102 [*] Unnecessary parentheses on raised exception
tests/transaction_hooks/tests.py:136:34: RSE102 [*] Unnecessary parentheses on raised exception
tests/transaction_hooks/tests.py:148:38: RSE102 [*] Unnecessary parentheses on raised exception
tests/transaction_hooks/tests.py:161:42: RSE102 [*] Unnecessary parentheses on raised exception
tests/transaction_hooks/tests.py:173:42: RSE102 [*] Unnecessary parentheses on raised exception
tests/transaction_hooks/tests.py:200:34: RSE102 [*] Unnecessary parentheses on raised exception
tests/urlpatterns/tests.py:390:29: RSE102 [*] Unnecessary parentheses on raised exception
tests/view_tests/tests/test_debug.py:1011:32: RSE102 [*] Unnecessary parentheses on raised exception
tests/view_tests/tests/test_debug.py:1042:29: RSE102 [*] Unnecessary parentheses on raised exception
tests/view_tests/tests/test_debug.py:1060:29: RSE102 [*] Unnecessary parentheses on raised exception
tests/view_tests/tests/test_debug.py:1176:32: RSE102 [*] Unnecessary parentheses on raised exception
Found 50 errors.
```

Not fixed only (function call): `django/contrib/auth/forms.py:254:51`

Rule description: https://docs.astral.sh/ruff/rules/unnecessary-paren-on-raise-exception/

# Why is this bad?
If an exception is raised without any arguments, parentheses are not required, as the `raise` statement accepts either an exception instance or an exception class (which is then implicitly instantiated).

Removing the parentheses makes the code more concise.

# Known problems
Parentheses can only be omitted if the exception is a class, as opposed to a function call. This rule isn't always capable of distinguishing between the two.

For example, if you import a function `module.get_exception` from another module, and `module.get_exception` returns an exception object, this rule will incorrectly mark the parentheses in `raise module.get_exception()` as unnecessary.