### PR TITLE
Fixed Subclasses of `str` should define `__slots__`

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -34,6 +34,7 @@ class SettingsReference(str):
     String subclass which references a current settings value. It's treated as
     the value in memory but serializes to a settings.NAME attribute reference.
     """
+    __slots__ = ('setting_name',)
 
     def __new__(self, value, setting_name):
         return str.__new__(self, value)

--- a/django/db/models/enums.py
+++ b/django/db/models/enums.py
@@ -20,7 +20,7 @@ else:
         pass
 
     class StrEnum(str, ReprEnum):
-        pass
+        __slots__ = ()
 
 
 __all__ = ["Choices", "IntegerChoices", "TextChoices"]

--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1339,11 +1339,11 @@ class UUIDField(CharField):
 
 
 class InvalidJSONInput(str):
-    pass
+    __slots__ = ()
 
 
 class JSONString(str):
-    pass
+    __slots__ = ()
 
 
 class JSONField(CharField):

--- a/tests/backends/base/test_schema.py
+++ b/tests/backends/base/test_schema.py
@@ -8,6 +8,8 @@ class SchemaEditorTests(SimpleTestCase):
         """SchemaEditor.effective_default() shouldn't call callable defaults."""
 
         class MyStr(str):
+            __slots__ = ()
+
             def __call__(self):
                 return self
 

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -492,6 +492,8 @@ class TranslationThreadSafetyTests(SimpleTestCase):
         # here we rely on .split() being called inside the _fetch()
         # in trans_real.translation()
         class sideeffect_str(str):
+            __slots__ = ()
+
             def split(self, *args, **kwargs):
                 res = str.split(self, *args, **kwargs)
                 trans_real._translations["en-YY"] = None

--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -248,6 +248,8 @@ class FunctionalTests(SimpleTestCase):
 
     def test_lazy_format(self):
         class QuotedString(str):
+            __slots__ = ()
+
             def __format__(self, format_spec):
                 value = super().__format__(format_spec)
                 return f"“{value}”"

--- a/tests/utils_tests/test_safestring.py
+++ b/tests/utils_tests/test_safestring.py
@@ -7,6 +7,8 @@ from django.utils.translation import gettext_lazy
 
 
 class customescape(str):
+    __slots__ = ()
+
     def __html__(self):
         # Implement specific and wrong escaping in order to be able to detect
         # when it runs.


### PR DESCRIPTION
```
➜  ruff check --select=SLOT000
django/conf/__init__.py:32:7: SLOT000 Subclasses of `str` should define `__slots__`
django/db/models/enums.py:22:11: SLOT000 Subclasses of `str` should define `__slots__`
django/forms/fields.py:1341:7: SLOT000 Subclasses of `str` should define `__slots__`
django/forms/fields.py:1345:7: SLOT000 Subclasses of `str` should define `__slots__`
tests/backends/base/test_schema.py:10:15: SLOT000 Subclasses of `str` should define `__slots__`
tests/i18n/tests.py:494:15: SLOT000 Subclasses of `str` should define `__slots__`
tests/utils_tests/test_functional.py:250:15: SLOT000 Subclasses of `str` should define `__slots__`
tests/utils_tests/test_safestring.py:9:7: SLOT000 Subclasses of `str` should define `__slots__`
Found 8 errors.
```

Rule description: https://docs.astral.sh/ruff/rules/no-slots-in-str-subclass/

# Why is this bad?
In Python, the `__slots__` attribute allows you to explicitly define the attributes (instance variables) that a class can have. By default, Python uses a dictionary to store an object's attributes, which incurs some memory overhead. However, when `__slots__` is defined, Python uses a more compact internal structure to store the object's attributes, resulting in memory savings.

Subclasses of `str` inherit all the attributes and methods of the built-in `str` class. Since strings are typically immutable, they don't require additional attributes beyond what the str class provides. Defining `__slots__` for subclasses of str prevents the creation of a dictionary for each instance, reducing memory consumption.