### PR TITLE
Simplified dropping spatial indexes on MySQL and Oracle.

### DIFF
--- a/django/contrib/gis/db/backends/mysql/schema.py
+++ b/django/contrib/gis/db/backends/mysql/schema.py
@@ -9,7 +9,6 @@ logger = logging.getLogger("django.contrib.gis")
 
 class MySQLGISSchemaEditor(DatabaseSchemaEditor):
     sql_add_spatial_index = "CREATE SPATIAL INDEX %(index)s ON %(table)s(%(column)s)"
-    sql_drop_spatial_index = "DROP INDEX %(index)s ON %(table)s"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -56,11 +55,8 @@ class MySQLGISSchemaEditor(DatabaseSchemaEditor):
 
     def remove_field(self, model, field):
         if isinstance(field, GeometryField) and field.spatial_index:
-            qn = self.connection.ops.quote_name
-            sql = self.sql_drop_spatial_index % {
-                "index": qn(self._create_spatial_index_name(model, field)),
-                "table": qn(model._meta.db_table),
-            }
+            index_name = self._create_spatial_index_name(model, field)
+            sql = self._delete_index_sql(model, index_name)
             try:
                 self.execute(sql)
             except OperationalError:

--- a/django/contrib/gis/db/backends/oracle/schema.py
+++ b/django/contrib/gis/db/backends/oracle/schema.py
@@ -20,7 +20,6 @@ class OracleGISSchemaEditor(DatabaseSchemaEditor):
         "CREATE INDEX %(index)s ON %(table)s(%(column)s) "
         "INDEXTYPE IS MDSYS.SPATIAL_INDEX"
     )
-    sql_drop_spatial_index = "DROP INDEX %(index)s"
     sql_clear_geometry_table_metadata = (
         "DELETE FROM USER_SDO_GEOM_METADATA WHERE TABLE_NAME = %(table)s"
     )
@@ -98,14 +97,8 @@ class OracleGISSchemaEditor(DatabaseSchemaEditor):
                 }
             )
             if field.spatial_index:
-                self.execute(
-                    self.sql_drop_spatial_index
-                    % {
-                        "index": self.quote_name(
-                            self._create_spatial_index_name(model, field)
-                        ),
-                    }
-                )
+                index_name = self._create_spatial_index_name(model, field)
+                self.execute(self._delete_index_sql(model, index_name))
         super().remove_field(model, field)
 
     def run_geometry_sql(self):


### PR DESCRIPTION
There is nothing special in dropping spatial indexes on MySQL or Oracle, so we should reuse existing hooks.