### PR TITLE
Bugfix/28404 showing empty value for empty strings in django admin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ answer newbie questions, and generally made Django that much better:
     Aleksandra Sendecka <asendecka@hauru.eu>
     Aleksi Häkli <aleksi.hakli@iki.fi>
     Alex Dutton <django@alexdutton.co.uk>
+    Alexander Lazarević <laza@e11bits.com>
     Alexander Myodov <alex@myodov.com>
     Alexandr Tatarinov <tatarinov.dev@gmail.com>
     Alex Aktsipetrov <alex.akts@gmail.com>

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -179,7 +179,7 @@ def result_headers(cl):
 
 def _boolean_icon(field_val):
     icon_url = static(
-        "admin/img/icon-%s.svg" % {True: "yes", False: "no", None: "unknown"}[field_val]
+        "admin/img/icon-%s.svg" % {True: "yes", False: "no"}.get(field_val, "unknown")
     )
     return format_html('<img src="{}" alt="{}">', icon_url, field_val)
 

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -433,7 +433,7 @@ def display_for_field(value, field, empty_value_display):
     # general null test.
     elif isinstance(field, models.BooleanField):
         return _boolean_icon(value)
-    elif value is None:
+    elif value is None or value == "":
         return empty_value_display
     elif isinstance(field, models.DateTimeField):
         return formats.localize(timezone.template_localtime(value))

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -102,6 +102,52 @@ class NestedObjectsTests(TestCase):
 class UtilsTests(SimpleTestCase):
     empty_value = "-empty-"
 
+    def _empty_display_for_field(self, value):
+        display_value = display_for_field(value, models.CharField(), self.empty_value)
+        self.assertEqual(display_value, self.empty_value)
+
+        display_value = display_for_field(
+            value,
+            models.CharField(choices=((value, "test_empty"),)),
+            self.empty_value,
+        )
+        self.assertEqual(display_value, "test_empty")
+
+        display_value = display_for_field(value, models.DateField(), self.empty_value)
+        self.assertEqual(display_value, self.empty_value)
+
+        display_value = display_for_field(value, models.TimeField(), self.empty_value)
+        self.assertEqual(display_value, self.empty_value)
+
+        display_value = display_for_field(
+            value, models.BooleanField(null=True), self.empty_value
+        )
+        expected = '<img src="%sadmin/img/icon-unknown.svg" alt="%s" />' % (
+            settings.STATIC_URL,
+            value,
+        )
+        self.assertHTMLEqual(display_value, expected)
+
+        display_value = display_for_field(
+            value, models.DecimalField(), self.empty_value
+        )
+        self.assertEqual(display_value, self.empty_value)
+
+        display_value = display_for_field(value, models.FloatField(), self.empty_value)
+        self.assertEqual(display_value, self.empty_value)
+
+        display_value = display_for_field(value, models.JSONField(), self.empty_value)
+        self.assertEqual(display_value, self.empty_value)
+
+    def test_empty_display_for_field(self):
+        """
+        Regression test for #12550: display_for_field should handle None value.
+        Regression test for #28404: Django admin empty_value/empty_value_display doesn't
+                                    check for empty strings
+        """
+        for field_value in [None, ""]:
+            self._empty_display_for_field(field_value)
+
     def test_values_from_lookup_field(self):
         """
         Regression test for #12654: lookup_field
@@ -148,43 +194,6 @@ class UtilsTests(SimpleTestCase):
                 )
 
             self.assertEqual(value, resolved_value)
-
-    def test_null_display_for_field(self):
-        """
-        Regression test for #12550: display_for_field should handle None
-        value.
-        """
-        display_value = display_for_field(None, models.CharField(), self.empty_value)
-        self.assertEqual(display_value, self.empty_value)
-
-        display_value = display_for_field(
-            None, models.CharField(choices=((None, "test_none"),)), self.empty_value
-        )
-        self.assertEqual(display_value, "test_none")
-
-        display_value = display_for_field(None, models.DateField(), self.empty_value)
-        self.assertEqual(display_value, self.empty_value)
-
-        display_value = display_for_field(None, models.TimeField(), self.empty_value)
-        self.assertEqual(display_value, self.empty_value)
-
-        display_value = display_for_field(
-            None, models.BooleanField(null=True), self.empty_value
-        )
-        expected = (
-            '<img src="%sadmin/img/icon-unknown.svg" alt="None" />'
-            % settings.STATIC_URL
-        )
-        self.assertHTMLEqual(display_value, expected)
-
-        display_value = display_for_field(None, models.DecimalField(), self.empty_value)
-        self.assertEqual(display_value, self.empty_value)
-
-        display_value = display_for_field(None, models.FloatField(), self.empty_value)
-        self.assertEqual(display_value, self.empty_value)
-
-        display_value = display_for_field(None, models.JSONField(), self.empty_value)
-        self.assertEqual(display_value, self.empty_value)
 
     def test_json_display_for_field(self):
         tests = [

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -49,6 +49,7 @@ from .models import (
     UnsafeLimitChoicesTo,
     VideoStream,
 )
+from .widgetadmin import AlbumAdmin
 from .widgetadmin import site as widget_admin_site
 
 
@@ -639,9 +640,12 @@ class AdminFileWidgetTests(TestDataMixin, TestCase):
             html=True,
         )
         response = self.client.get(reverse("admin:admin_widgets_album_add"))
+        empty_value_display = AlbumAdmin(
+            Album, widget_admin_site
+        ).get_empty_value_display()
         self.assertContains(
             response,
-            '<div class="readonly"></div>',
+            '<div class="readonly">%s</div>' % empty_value_display,
             html=True,
         )
 


### PR DESCRIPTION
This is a PR to pickup ticket 28404 again. Prior PRs are #9391 #8776  and #9390 .

This is my first PR for Django, addressing not showing the empty_display_value if value is the empty string and not None in the admin app. Please advise as you see fit.