### PR TITLE
Fixed #35087 -- Reallowed filtering against foreign keys not listed in ModelAdmin.list_filters.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -467,7 +467,8 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
 
         relation_parts = []
         prev_field = None
-        for part in lookup.split(LOOKUP_SEP):
+        parts = lookup.split(LOOKUP_SEP)
+        for part in parts:
             try:
                 field = model._meta.get_field(part)
             except FieldDoesNotExist:
@@ -491,7 +492,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
             prev_field = field
             model = field.path_infos[-1].to_opts.model
 
-        if not relation_parts:
+        if not relation_parts or len(parts) == 1:
             # Either a local field filter, or no fields at all.
             return True
         valid_lookups = {self.date_hierarchy}

--- a/docs/releases/5.0.2.txt
+++ b/docs/releases/5.0.2.txt
@@ -9,4 +9,6 @@ Django 5.0.2 fixes several bugs in 5.0.1.
 Bugfixes
 ========
 
-* ...
+* Reallowed, following a regression in Django 5.0.1, filtering against local
+  foreign keys not included in :attr:`.ModelAdmin.list_filter`
+  (:ticket:`35087`).

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -163,6 +163,20 @@ class ModelAdminTests(TestCase):
         )
 
     @isolate_apps("modeladmin")
+    def test_lookup_allowed_for_local_fk_fields(self):
+        class Country(models.Model):
+            pass
+
+        class Place(models.Model):
+            country = models.ForeignKey(Country, models.CASCADE)
+
+        class PlaceAdmin(ModelAdmin):
+            pass
+
+        ma = PlaceAdmin(Place, self.site)
+        self.assertIs(ma.lookup_allowed("country", "1", request), True)
+
+    @isolate_apps("modeladmin")
     def test_lookup_allowed_non_autofield_primary_key(self):
         class Country(models.Model):
             id = models.CharField(max_length=2, primary_key=True)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/35087