### PR TITLE
Fixed #35092 -- Exposed extra fields for GeoIP2.country() and GeoIP2.city() responses.

### DIFF
--- a/django/contrib/gis/geoip2.py
+++ b/django/contrib/gis/geoip2.py
@@ -235,8 +235,11 @@ class GeoIP2:
         enc_query = self._check_query(query, city_or_country=True)
         response = self._country_or_city(enc_query)
         return {
+            "continent_code": response.continent.code,
+            "continent_name": response.continent.name,
             "country_code": response.country.iso_code,
             "country_name": response.country.name,
+            "is_in_european_union": response.country.is_in_european_union,
         }
 
     def coords(self, query, ordering=("longitude", "latitude")):

--- a/django/contrib/gis/geoip2.py
+++ b/django/contrib/gis/geoip2.py
@@ -203,18 +203,23 @@ class GeoIP2:
         response = self._city.city(enc_query)
         region = response.subdivisions[0] if response.subdivisions else None
         return {
+            "accuracy_radius": response.location.accuracy_radius,
             "city": response.city.name,
             "continent_code": response.continent.code,
             "continent_name": response.continent.name,
             "country_code": response.country.iso_code,
             "country_name": response.country.name,
-            "dma_code": response.location.metro_code,
             "is_in_european_union": response.country.is_in_european_union,
             "latitude": response.location.latitude,
             "longitude": response.location.longitude,
+            "metro_code": response.location.metro_code,
             "postal_code": response.postal.code,
-            "region": region.iso_code if region else None,
+            "region_code": region.iso_code if region else None,
+            "region_name": region.name if region else None,
             "time_zone": response.location.time_zone,
+            # Kept for backward compatibility.
+            "dma_code": response.location.metro_code,
+            "region": region.iso_code if region else None,
         }
 
     def country_code(self, query):

--- a/docs/ref/contrib/gis/geoip2.txt
+++ b/docs/ref/contrib/gis/geoip2.txt
@@ -39,18 +39,22 @@ Here is an example of its usage:
      'country_name': 'United States',
      'is_in_european_union': False}
     >>> g.city("72.14.207.99")
-    {'city': 'Mountain View',
-    'continent_code': 'NA',
-    'continent_name': 'North America',
-    'country_code': 'US',
-    'country_name': 'United States',
-    'dma_code': 807,
-    'is_in_european_union': False,
-    'latitude': 37.419200897216797,
-    'longitude': -122.05740356445312,
-    'postal_code': '94043',
-    'region': 'CA',
-    'time_zone': 'America/Los_Angeles'}
+    {'accuracy_radius': 1000,
+     'city': 'Mountain View',
+     'continent_code': 'NA',
+     'continent_name': 'North America',
+     'country_code': 'US',
+     'country_name': 'United States',
+     'is_in_european_union': False,
+     'latitude': 37.419200897216797,
+     'longitude': -122.05740356445312,
+     'metro_code': 807,
+     'postal_code': '94043',
+     'region_code': 'CA',
+     'region_name': 'California',
+     'time_zone': 'America/Los_Angeles',
+     'dma_code': 807,
+     'region': 'CA'}
     >>> g.lat_lon("salon.com")
     (39.0437, -77.4875)
     >>> g.lon_lat("uh.edu")

--- a/docs/ref/contrib/gis/geoip2.txt
+++ b/docs/ref/contrib/gis/geoip2.txt
@@ -33,7 +33,11 @@ Here is an example of its usage:
     >>> from django.contrib.gis.geoip2 import GeoIP2
     >>> g = GeoIP2()
     >>> g.country("google.com")
-    {'country_code': 'US', 'country_name': 'United States'}
+    {'continent_code': 'NA',
+     'continent_name': 'North America',
+     'country_code': 'US',
+     'country_name': 'United States',
+     'is_in_european_union': False}
     >>> g.city("72.14.207.99")
     {'city': 'Mountain View',
     'continent_code': 'NA',

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -65,6 +65,11 @@ Minor features
 * :meth:`.GeoIP2.country` now exposes the ``continent_code``,
   ``continent_name``, and ``is_in_european_union`` values.
 
+* :meth:`.GeoIP2.city` now exposes the ``accuracy_radius`` and ``region_name``
+  values. In addition the ``dma_code`` and ``region`` values are now exposed as
+  ``metro_code`` and ``region_code``, but the previous keys are also retained
+  for backward compatibility.
+
 :mod:`django.contrib.messages`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -62,6 +62,9 @@ Minor features
 * :class:`~django.contrib.gis.geoip2.GeoIP2` now allows querying using
   :class:`ipaddress.IPv4Address` or :class:`ipaddress.IPv6Address` objects.
 
+* :meth:`.GeoIP2.country` now exposes the ``continent_code``,
+  ``continent_name``, and ``is_in_european_union`` values.
+
 :mod:`django.contrib.messages`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -125,18 +125,23 @@ class GeoLite2Test(SimpleTestCase):
                 self.assertEqual(
                     g.city(query),
                     {
+                        "accuracy_radius": 100,
                         "city": "Boxford",
                         "continent_code": "EU",
                         "continent_name": "Europe",
                         "country_code": "GB",
                         "country_name": "United Kingdom",
-                        "dma_code": None,
                         "is_in_european_union": False,
                         "latitude": 51.75,
                         "longitude": -1.25,
+                        "metro_code": None,
                         "postal_code": "OX1",
-                        "region": "ENG",
+                        "region_code": "ENG",
+                        "region_name": "England",
                         "time_zone": "Europe/London",
+                        # Kept for backward compatibility.
+                        "dma_code": None,
+                        "region": "ENG",
                     },
                 )
 

--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -108,8 +108,11 @@ class GeoLite2Test(SimpleTestCase):
                 self.assertEqual(
                     g.country(query),
                     {
+                        "continent_code": "EU",
+                        "continent_name": "Europe",
                         "country_code": "GB",
                         "country_name": "United Kingdom",
+                        "is_in_european_union": False,
                     },
                 )
                 self.assertEqual(g.country_code(query), "GB")
@@ -148,8 +151,11 @@ class GeoLite2Test(SimpleTestCase):
                 self.assertEqual(
                     g.country(query),
                     {
+                        "continent_code": "EU",
+                        "continent_name": "Europe",
                         "country_code": "GB",
                         "country_name": "United Kingdom",
+                        "is_in_european_union": False,
                     },
                 )
                 self.assertEqual(g.country_code(query), "GB")


### PR DESCRIPTION
ticket-35092.