### PR TITLE
add ability to name default database

### DIFF
--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -10,7 +10,7 @@ from django.utils.connection import BaseConnectionHandler
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 
-DEFAULT_DB_ALIAS = "default"
+DEFAULT_DB_ALIAS = "default" or getattr(settings, "MAIN_DATABASE_NAME", "default")
 DJANGO_VERSION_PICKLE_KEY = "_django_version"
 
 
@@ -150,7 +150,8 @@ class ConnectionHandler(BaseConnectionHandler):
             databases[DEFAULT_DB_ALIAS] = {"ENGINE": "django.db.backends.dummy"}
         elif DEFAULT_DB_ALIAS not in databases:
             raise ImproperlyConfigured(
-                f"You must define a '{DEFAULT_DB_ALIAS}' database."
+                f"You must define a database called '{DEFAULT_DB_ALIAS}' or set "
+                "a value in settings.py for MAIN_DATABASE_NAME."
             )
         elif databases[DEFAULT_DB_ALIAS] == {}:
             databases[DEFAULT_DB_ALIAS]["ENGINE"] = "django.db.backends.dummy"

--- a/tests/db_utils/tests.py
+++ b/tests/db_utils/tests.py
@@ -36,7 +36,7 @@ class ConnectionHandlerTests(SimpleTestCase):
     def test_no_default_database(self):
         DATABASES = {"other": {}}
         conns = ConnectionHandler(DATABASES)
-        msg = "You must define a 'default' database."
+        msg = "You must define a database called 'default' or set a value in settings.py for MAIN_DATABASE_NAME."
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             conns["other"].ensure_connection()
 


### PR DESCRIPTION
Potential fix for #16752

This PR allows a user to specify the name of the default database which will (I believe) meet the spirit of the request. Docs would still need to be updated, but I wanted to get some input on the code before making doc changes