### PR TITLE
Fixed #35096 -- Corrected alignment for error lists in admin "wide" forms.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -194,11 +194,8 @@ fieldset .fieldBox {
     width: 200px;
 }
 
-form .wide ul.errorlist {
-    margin-left: 200px;
-}
-
 form .wide p.help,
+form .wide ul.errorlist,
 form .wide div.help {
     padding-left: 50px;
 }

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -194,7 +194,7 @@ fieldset .fieldBox {
     width: 200px;
 }
 
-form .wide.aligned ul.errorlist {
+form .wide ul.errorlist {
     margin-left: 200px;
 }
 

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -194,6 +194,10 @@ fieldset .fieldBox {
     width: 200px;
 }
 
+form .wide.aligned ul.errorlist {
+    margin-left: 200px;
+}
+
 form .wide p.help,
 form .wide div.help {
     padding-left: 50px;

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -165,7 +165,9 @@ form .aligned p.time div.help.timezonewarning {
     padding-right: 0;
 }
 
-form .wide p.help, form .wide div.help {
+form .wide p.help,
+form .wide ul.errorlist,
+form .wide div.help {
     padding-left: 0;
     padding-right: 50px;
 }


### PR DESCRIPTION
https://code.djangoproject.com/ticket/35096

## Styling fix

This PR fixes a styling issues for error messages in a wide django admin fieldset.

I observed this bug first in Django 5.0. In 4.2 things seem ok.

## Before
![image](https://github.com/django/django/assets/16904477/8ba8713b-5864-4b7c-a48a-1d9322ece3bd)

## After
<img width="914" alt="image" src="https://github.com/django/django/assets/16904477/6c73aff0-8f9e-46d7-9d2c-aa220e41a01c">
