### PR TITLE
Fixed #34949 -- Clarified when UniqueConstraints with include/nulls_distinct are not created.

### DIFF
--- a/docs/ref/models/constraints.txt
+++ b/docs/ref/models/constraints.txt
@@ -229,7 +229,8 @@ For example::
 will allow filtering on ``room`` and ``date``, also selecting ``full_name``,
 while fetching data only from the index.
 
-``include`` is supported only on PostgreSQL.
+Unique constraints with non-key columns are ignored for databases besides
+PostgreSQL.
 
 Non-key columns have the same database restrictions as :attr:`Index.include`.
 
@@ -272,7 +273,8 @@ For example::
 creates a unique constraint that only allows one row to store a ``NULL`` value
 in the ``ordering`` column.
 
-``nulls_distinct`` is ignored for databases besides PostgreSQL 15+.
+Unique constraints with ``nulls_distinct`` are ignored for databases besides
+PostgreSQL 15+.
 
 ``violation_error_code``
 ------------------------


### PR DESCRIPTION
- [Ticket](https://code.djangoproject.com/ticket/34949#comment:7)

when use `Include` option in UniqueConstraint, It needs to create unique constraints on MySQL, Sqlite, etc. and unify document between `include` and `opclasses`.  