### PR TITLE
Regex name validator for the AbstractUser class

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -12,7 +12,7 @@ from django.db.models.manager import EmptyManager
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from .validators import UnicodeUsernameValidator
+from .validators import UnicodeUsernameValidator, UnicodeNameValidator
 
 
 def update_last_login(sender, user, **kwargs):
@@ -341,6 +341,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
     """
 
     username_validator = UnicodeUsernameValidator()
+    name_validator = UnicodeNameValidator()
 
     username = models.CharField(
         _("username"),
@@ -354,8 +355,8 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
             "unique": _("A user with that username already exists."),
         },
     )
-    first_name = models.CharField(_("first name"), max_length=150, blank=True)
-    last_name = models.CharField(_("last name"), max_length=150, blank=True)
+    first_name = models.CharField(_("first name"), max_length=150, validators=[name_validator], blank=True)
+    last_name = models.CharField(_("last name"), max_length=150, validators=[name_validator], blank=True)
     email = models.EmailField(_("email address"), blank=True)
     is_staff = models.BooleanField(
         _("staff status"),

--- a/django/contrib/auth/validators.py
+++ b/django/contrib/auth/validators.py
@@ -23,3 +23,13 @@ class UnicodeUsernameValidator(validators.RegexValidator):
         "numbers, and @/./+/-/_ characters."
     )
     flags = 0
+
+
+@deconstructible
+class UnicodeNameValidator(validators.RegexValidator):
+    regex = r"^[\w\s]+\Z"
+    message = _(
+        "Enter a valid name. This value may contain only letters, "
+        "numbers and spaces."
+    )
+    flags = 0


### PR DESCRIPTION
Currently there is a validator for usernames (letters, numbers and @/./+/-/_ characters) but none for names (first name, last name). 

The added name validator only allowed letters, numbers and spaces, for any first or last name will never have anything else (to my knowledge).