### PR TITLE
Refs #28404 -- Made displaying property values in admin respect non-None empty values.

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -6,6 +6,7 @@ from functools import reduce
 from operator import or_
 
 from django.core.exceptions import FieldDoesNotExist
+from django.core.validators import EMPTY_VALUES
 from django.db import models, router
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.deletion import Collector
@@ -459,7 +460,7 @@ def display_for_value(value, empty_value_display, boolean=False):
 
     if boolean:
         return _boolean_icon(value)
-    elif value is None:
+    elif value in EMPTY_VALUES:
         return empty_value_display
     elif isinstance(value, bool):
         return str(value)

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -17,6 +17,7 @@ from django.contrib.admin.utils import (
     lookup_field,
     quote,
 )
+from django.core.validators import EMPTY_VALUES
 from django.db import DEFAULT_DB_ALIAS, models
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.utils.formats import localize
@@ -248,6 +249,12 @@ class UtilsTests(SimpleTestCase):
         )
         self.assertEqual(display_for_value(True, ""), "True")
         self.assertEqual(display_for_value(False, ""), "False")
+
+    def test_list_display_for_value_empty(self):
+        for value in EMPTY_VALUES:
+            with self.subTest(empty_value=value):
+                display_value = display_for_value(value, self.empty_value)
+                self.assertEqual(display_value, self.empty_value)
 
     def test_label_for_field(self):
         """


### PR DESCRIPTION
This is a missing piece of PR #17716  and fixes `display_for_value`

I used something like the following to showcase it. Without the patch the string `-very empty-` is not shown in the list:

```
admin.site.empty_value_display = "- N/A -"


@admin.register(SomeModel)
class SomeModelAdmin(admin.ModelAdmin):
    list_display = (
        "name",
        "description",
        "my_description",
    )
    empty_value_display = "-empty-"

    @admin.display(empty_value="-very empty-")
    def my_description(self, obj):
        return ""
```