### PR TITLE
[3.2.x] Fixed documented alias of smart_text().

### DIFF
--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -276,7 +276,7 @@ The functions defined in this module share the following properties:
 
     .. deprecated:: 3.0
 
-    Alias of :func:`force_str` for backwards compatibility, especially in code
+    Alias of :func:`smart_str` for backwards compatibility, especially in code
     that supports Python 2.
 
 .. function:: force_text(s, encoding='utf-8', strings_only=False, errors='strict')


### PR DESCRIPTION
Django Utils [documentation](https://docs.djangoproject.com/en/3.2/ref/utils/) (for versions 3.0, 3.1, 3.2) contains:

> smart_text(s, encoding='utf-8', strings_only=False, errors='strict')[[source]](https://docs.djangoproject.com/en/3.0/_modules/django/utils/encoding/#smart_text)[¶](https://docs.djangoproject.com/en/3.0/ref/utils/#django.utils.encoding.smart_text)
>
>     Deprecated since version 3.0.
>     Alias of force_str() for backwards compatibility, especially in code that supports Python 2.

However, the actual function uses `smart_str`:
```
def smart_text(s, encoding='utf-8', strings_only=False, errors='strict'):
    warnings.warn(
        'smart_text() is deprecated in favor of smart_str().',
        RemovedInDjango40Warning, stacklevel=2,
    )
    return smart_str(s, encoding, strings_only, errors)
```