### PR TITLE
Fixed #24128 -- Made admindocs TemplateDetailView respect template_loaders.

### DIFF
--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -404,8 +404,13 @@ class TemplateDetailView(BaseAdminDocsView):
             # Non-trivial TEMPLATES settings aren't supported (#24125).
             pass
         else:
-            # This doesn't account for template loaders (#24128).
-            for index, directory in enumerate(default_engine.dirs):
+            directories = list(default_engine.dirs)
+            for loader in default_engine.template_loaders:
+                if hasattr(loader, "get_dirs"):
+                    for dir_ in loader.get_dirs():
+                        if dir_ not in directories:
+                            directories.append(dir_)
+            for index, directory in enumerate(directories):
                 template_file = Path(safe_join(directory, template))
                 if template_file.exists():
                     template_contents = template_file.read_text()

--- a/tests/admin_docs/templates/view_for_loader_test.html
+++ b/tests/admin_docs/templates/view_for_loader_test.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Template for Test</title>
+</head>
+<body></body>
+</html>

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -138,6 +138,12 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
             html=True,
         )
 
+    def test_template_detail_loader(self):
+        response = self.client.get(
+            reverse("django-admindocs-templates", args=["view_for_loader_test.html"])
+        )
+        self.assertContains(response, "view_for_loader_test.html</code></li>")
+
     def test_missing_docutils(self):
         utils.docutils_is_available = False
         try:


### PR DESCRIPTION
This is the proposed PR #7434 by Kris Avi. I rebased it onto the current main branch and created a ~draft~ PR for it.

I had to remove some duplicate code and revert some outdated changes. I left all the commits in, but could squash them if needed for review.

@ngnpope and @timgraham are the reviewers of the former PR and might want to have a look at this again as well?

This is my third PR for Django, so please advise as you see fit.