### PR TITLE
Ticket 33650 startproject stores files in config dir

### DIFF
--- a/django/conf/project_template/manage.py-tpl
+++ b/django/conf/project_template/manage.py-tpl
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{ project_name }}.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{ settings_dir }}.settings')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/django/conf/project_template/project_name/asgi.py-tpl
+++ b/django/conf/project_template/project_name/asgi.py-tpl
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{ project_name }}.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{ settings_dir }}.settings')
 
 application = get_asgi_application()

--- a/django/conf/project_template/project_name/settings.py-tpl
+++ b/django/conf/project_template/project_name/settings.py-tpl
@@ -49,7 +49,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-ROOT_URLCONF = '{{ project_name }}.urls'
+ROOT_URLCONF = '{{ settings_dir }}.urls'
 
 TEMPLATES = [
     {
@@ -67,7 +67,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = '{{ project_name }}.wsgi.application'
+WSGI_APPLICATION = '{{ settings_dir }}.wsgi.application'
 
 
 # Database

--- a/django/conf/project_template/project_name/wsgi.py-tpl
+++ b/django/conf/project_template/project_name/wsgi.py-tpl
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{ project_name }}.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{ settings_dir }}.settings')
 
 application = get_wsgi_application()

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -90,7 +90,6 @@ class TemplateCommand(BaseCommand):
         self.verbosity = options["verbosity"]
 
         self.validate_name(name)
-
         # if some directory is given, make sure it's nicely expanded
         if target is None:
             top_dir = os.path.join(os.getcwd(), name)
@@ -137,10 +136,12 @@ class TemplateCommand(BaseCommand):
         camel_case_name = "camel_case_%s_name" % app_or_project
         camel_case_value = "".join(x for x in name.title() if x != "_")
 
+        config_dir_name = "config"
         context = Context(
             {
                 **options,
                 base_name: name,
+                "settings_dir": config_dir_name,
                 base_directory: top_dir,
                 camel_case_name: camel_case_value,
                 "docs_version": get_docs_version(),
@@ -159,7 +160,7 @@ class TemplateCommand(BaseCommand):
 
         for root, dirs, files in os.walk(template_dir):
             path_rest = root[prefix_length:]
-            relative_dir = path_rest.replace(base_name, name)
+            relative_dir = path_rest.replace(base_name, config_dir_name)
             if relative_dir:
                 target_dir = os.path.join(top_dir, relative_dir)
                 os.makedirs(target_dir, exist_ok=True)
@@ -177,7 +178,9 @@ class TemplateCommand(BaseCommand):
                     continue
                 old_path = os.path.join(root, filename)
                 new_path = os.path.join(
-                    top_dir, relative_dir, filename.replace(base_name, name)
+                    top_dir,
+                    relative_dir,
+                    filename.replace(base_name, config_dir_name),
                 )
                 for old_suffix, new_suffix in self.rewrite_template_suffixes:
                     if new_path.endswith(old_suffix):

--- a/docs/faq/usage.txt
+++ b/docs/faq/usage.txt
@@ -8,9 +8,9 @@ Why do I get an error about importing :envvar:`DJANGO_SETTINGS_MODULE`?
 Make sure that:
 
 * The environment variable :envvar:`DJANGO_SETTINGS_MODULE` is set to a
-  fully-qualified Python module (i.e. ``mysite.settings``).
+  fully-qualified Python module (i.e. ``config.settings``).
 
-* Said module is on ``sys.path`` (``import mysite.settings`` should work).
+* Said module is on ``sys.path`` (``import config.settings`` should work).
 
 * The module doesn't contain syntax errors.
 

--- a/docs/howto/deployment/asgi/daphne.txt
+++ b/docs/howto/deployment/asgi/daphne.txt
@@ -26,7 +26,7 @@ For a typical Django project, invoking Daphne would look like:
 
 .. code-block:: shell
 
-    daphne myproject.asgi:application
+    daphne config.asgi:application
 
 This will start one process listening on ``127.0.0.1:8000``. It requires that
 your project be on the Python path; to ensure that run this command from the
@@ -49,4 +49,4 @@ to your ASGI application object::
         ...,
     ]
 
-    ASGI_APPLICATION = "myproject.asgi.application"
+    ASGI_APPLICATION = "config.asgi.application"

--- a/docs/howto/deployment/asgi/hypercorn.txt
+++ b/docs/howto/deployment/asgi/hypercorn.txt
@@ -26,7 +26,7 @@ For a typical Django project, invoking Hypercorn would look like:
 
 .. code-block:: shell
 
-    hypercorn myproject.asgi:application
+    hypercorn config.asgi:application
 
 This will start one process listening on ``127.0.0.1:8000``. It
 requires that your project be on the Python path; to ensure that run

--- a/docs/howto/deployment/asgi/index.txt
+++ b/docs/howto/deployment/asgi/index.txt
@@ -29,13 +29,13 @@ provided as an object named ``application`` in a Python module accessible to
 the server.
 
 The :djadmin:`startproject` command creates a file
-:file:`<project_name>/asgi.py` that contains such an ``application`` callable.
+:file:`config/asgi.py` that contains such an ``application`` callable.
 
 It's not used by the development server (``runserver``), but can be used by
 any ASGI server either in development or in production.
 
 ASGI servers usually take the path to the application callable as a string;
-for most Django projects, this will look like ``myproject.asgi:application``.
+for most Django projects, this will look like ``config.asgi:application``.
 
 .. warning::
 

--- a/docs/howto/deployment/asgi/index.txt
+++ b/docs/howto/deployment/asgi/index.txt
@@ -60,7 +60,7 @@ settings module. You can use a different value for development and production;
 it all depends on how you organize your settings.
 
 If this variable isn't set, the default :file:`asgi.py` sets it to
-``mysite.settings``, where ``mysite`` is the name of your project.
+``config.settings``.
 
 Applying ASGI middleware
 ========================

--- a/docs/howto/deployment/asgi/uvicorn.txt
+++ b/docs/howto/deployment/asgi/uvicorn.txt
@@ -26,7 +26,7 @@ For a typical Django project, invoking Uvicorn would look like:
 
 .. code-block:: shell
 
-    python -m uvicorn myproject.asgi:application
+    python -m uvicorn config.asgi:application
 
 This will start one process listening on ``127.0.0.1:8000``. It requires that
 your project be on the Python path; to ensure that run this command from the
@@ -53,7 +53,7 @@ Then start Gunicorn using the Uvicorn worker class like this:
 
 .. code-block:: shell
 
-    python -m gunicorn myproject.asgi:application -k uvicorn.workers.UvicornWorker
+    python -m gunicorn config.asgi:application -k uvicorn.workers.UvicornWorker
 
 .. _Uvicorn: https://www.uvicorn.org/
 .. _Gunicorn: https://gunicorn.org/

--- a/docs/howto/deployment/wsgi/apache-auth.txt
+++ b/docs/howto/deployment/wsgi/apache-auth.txt
@@ -45,7 +45,7 @@ only authenticated users to be able to view:
 
 .. code-block:: apache
 
-    WSGIScriptAlias / /path/to/mysite.com/mysite/wsgi.py
+    WSGIScriptAlias / /path/to/mysite.com/config/wsgi.py
     WSGIPythonPath /path/to/mysite.com
 
     WSGIProcessGroup %{GLOBAL}
@@ -56,7 +56,7 @@ only authenticated users to be able to view:
         AuthName "Top Secret"
         Require valid-user
         AuthBasicProvider wsgi
-        WSGIAuthUserScript /path/to/mysite.com/mysite/wsgi.py
+        WSGIAuthUserScript /path/to/mysite.com/config/wsgi.py
     </Location>
 
 The ``WSGIAuthUserScript`` directive tells mod_wsgi to execute the
@@ -78,13 +78,13 @@ application :doc:`that is created by django-admin startproject
         LoadModule auth_basic_module modules/mod_auth_basic.so
         LoadModule authz_user_module modules/mod_authz_user.so
 
-Finally, edit your WSGI script ``mysite.wsgi`` to tie Apache's authentication
+Finally, edit your WSGI script ``config.wsgi`` to tie Apache's authentication
 to your site's authentication mechanisms by importing the ``check_password``
 function::
 
     import os
 
-    os.environ["DJANGO_SETTINGS_MODULE"] = "mysite.settings"
+    os.environ["DJANGO_SETTINGS_MODULE"] = "config.settings"
 
     from django.contrib.auth.handlers.modwsgi import check_password
 
@@ -111,7 +111,7 @@ In this case, the Apache configuration should look like this:
 
 .. code-block:: apache
 
-    WSGIScriptAlias / /path/to/mysite.com/mysite/wsgi.py
+    WSGIScriptAlias / /path/to/mysite.com/config/wsgi.py
 
     WSGIProcessGroup %{GLOBAL}
     WSGIApplicationGroup %{GLOBAL}
@@ -120,14 +120,14 @@ In this case, the Apache configuration should look like this:
         AuthType Basic
         AuthName "Top Secret"
         AuthBasicProvider wsgi
-        WSGIAuthUserScript /path/to/mysite.com/mysite/wsgi.py
-        WSGIAuthGroupScript /path/to/mysite.com/mysite/wsgi.py
+        WSGIAuthUserScript /path/to/mysite.com/config/wsgi.py
+        WSGIAuthGroupScript /path/to/mysite.com/config/wsgi.py
         Require group secret-agents
         Require valid-user
     </Location>
 
 To support the ``WSGIAuthGroupScript`` directive, the same WSGI script
-``mysite.wsgi`` must also import the ``groups_for_user`` function which
+``config.wsgi`` must also import the ``groups_for_user`` function which
 returns a list groups the given user belongs to.
 
 .. code-block:: python

--- a/docs/howto/deployment/wsgi/gunicorn.txt
+++ b/docs/howto/deployment/wsgi/gunicorn.txt
@@ -25,7 +25,7 @@ location of a module containing a WSGI application object named
 
 .. code-block:: shell
 
-    gunicorn myproject.wsgi
+    gunicorn config.wsgi
 
 This will start one process running one thread listening on ``127.0.0.1:8000``.
 It requires that your project be on the Python path; the simplest way to ensure

--- a/docs/howto/deployment/wsgi/index.txt
+++ b/docs/howto/deployment/wsgi/index.txt
@@ -30,7 +30,7 @@ provided as an object named ``application`` in a Python module accessible to
 the server.
 
 The :djadmin:`startproject` command creates a file
-:file:`<project_name>/wsgi.py` that contains such an ``application`` callable.
+:file:`config/wsgi.py` that contains such an ``application`` callable.
 
 It's used both by Django's development server and in production WSGI
 deployments.
@@ -38,8 +38,8 @@ deployments.
 WSGI servers obtain the path to the ``application`` callable from their
 configuration. Django's built-in server, namely the :djadmin:`runserver`
 command, reads it from the :setting:`WSGI_APPLICATION` setting. By default, it's
-set to ``<project_name>.wsgi.application``, which points to the ``application``
-callable in :file:`<project_name>/wsgi.py`.
+set to ``config.wsgi.application``, which points to the ``application``
+callable in :file:`config/wsgi.py`.
 
 Configuring the settings module
 ===============================

--- a/docs/howto/deployment/wsgi/index.txt
+++ b/docs/howto/deployment/wsgi/index.txt
@@ -53,8 +53,8 @@ settings module. You can use a different value for development and production;
 it all depends on how you organize your settings.
 
 If this variable isn't set, the default :file:`wsgi.py` sets it to
-``mysite.settings``, where ``mysite`` is the name of your project. That's how
-:djadmin:`runserver` discovers the default settings file by default.
+``config.settings``. That's how :djadmin:`runserver` discovers the default
+settings file by default.
 
 .. note::
 
@@ -63,7 +63,7 @@ If this variable isn't set, the default :file:`wsgi.py` sets it to
 
     To avoid this problem, use mod_wsgi's daemon mode with each site in its
     own daemon process, or override the value from the environment by
-    enforcing ``os.environ["DJANGO_SETTINGS_MODULE"] = "mysite.settings"`` in
+    enforcing ``os.environ["DJANGO_SETTINGS_MODULE"] = "config.settings"`` in
     your :file:`wsgi.py`.
 
 

--- a/docs/howto/deployment/wsgi/modwsgi.txt
+++ b/docs/howto/deployment/wsgi/modwsgi.txt
@@ -31,11 +31,11 @@ Once you've got mod_wsgi installed and activated, edit your Apache server's
 
 .. code-block:: apache
 
-    WSGIScriptAlias / /path/to/mysite.com/mysite/wsgi.py
+    WSGIScriptAlias / /path/to/mysite.com/config/wsgi.py
     WSGIPythonHome /path/to/venv
     WSGIPythonPath /path/to/mysite.com
 
-    <Directory /path/to/mysite.com/mysite>
+    <Directory /path/to/mysite.com/config>
     <Files wsgi.py>
     Require all granted
     </Files>
@@ -129,7 +129,7 @@ to the configuration above:
 
 .. code-block:: apache
 
-    WSGIScriptAlias /mysite /path/to/mysite.com/mysite/wsgi.py process-group=example.com
+    WSGIScriptAlias /mysite /path/to/mysite.com/config/wsgi.py process-group=example.com
 
 See the official mod_wsgi documentation for `details on setting up daemon
 mode`_.
@@ -174,7 +174,7 @@ a static file. All other URLs will be served using mod_wsgi:
     Require all granted
     </Directory>
 
-    WSGIScriptAlias / /path/to/mysite.com/mysite/wsgi.py
+    WSGIScriptAlias / /path/to/mysite.com/config/wsgi.py
 
     <Directory /path/to/mysite.com/mysite>
     <Files wsgi.py>

--- a/docs/howto/deployment/wsgi/modwsgi.txt
+++ b/docs/howto/deployment/wsgi/modwsgi.txt
@@ -72,11 +72,11 @@ should put in this file, and what else you can add to it.
     will use the settings of whichever one happens to run first. This can be
     solved by changing::
 
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
     in ``wsgi.py``, to::
 
-        os.environ["DJANGO_SETTINGS_MODULE"] = "{{ project_name }}.settings"
+        os.environ["DJANGO_SETTINGS_MODULE"] = "config.settings"
 
     or by :ref:`using mod_wsgi daemon mode<daemon-mode>` and ensuring that each
     site runs in its own daemon process.

--- a/docs/howto/deployment/wsgi/uwsgi.txt
+++ b/docs/howto/deployment/wsgi/uwsgi.txt
@@ -51,8 +51,8 @@ Here's an example command to start a uWSGI server:
 .. code-block:: shell
 
     uwsgi --chdir=/path/to/your/project \
-        --module=mysite.wsgi:application \
-        --env DJANGO_SETTINGS_MODULE=mysite.settings \
+        --module=config.wsgi:application \
+        --env DJANGO_SETTINGS_MODULE=config.settings \
         --master --pidfile=/tmp/project-master.pid \
         --socket=127.0.0.1:49152 \      # can also be a file
         --processes=5 \                 # number of worker processes
@@ -64,7 +64,7 @@ Here's an example command to start a uWSGI server:
         --daemonize=/var/log/uwsgi/yourproject.log      # background the process
 
 This assumes you have a top-level project package named ``mysite``, and
-within it a module :file:`mysite/wsgi.py` that contains a WSGI ``application``
+within it a module :file:`config/wsgi.py` that contains a WSGI ``application``
 object. This is the layout you'll have if you ran ``django-admin
 startproject mysite`` (using your own project name in place of ``mysite``) with
 a recent version of Django. If this file doesn't exist, you'll need to create
@@ -75,7 +75,7 @@ The Django-specific options here are:
 
 * ``chdir``: The path to the directory that needs to be on Python's import
   path -- i.e., the directory containing the ``mysite`` package.
-* ``module``: The WSGI module to use -- probably the ``mysite.wsgi`` module
+* ``module``: The WSGI module to use -- probably the ``config.wsgi`` module
   that :djadmin:`startproject` creates.
 * ``env``: Should probably contain at least :envvar:`DJANGO_SETTINGS_MODULE`.
 * ``home``: Optional path to your project virtual environment.
@@ -86,7 +86,7 @@ Example ini configuration file:
 
     [uwsgi]
     chdir=/path/to/your/project
-    module=mysite.wsgi:application
+    module=config.wsgi:application
     master=True
     pidfile=/tmp/project-master.pid
     vacuum=True

--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -59,7 +59,7 @@ After the previous tutorials, our project should look like this:
 
     mysite/
         manage.py
-        mysite/
+        config/
             __init__.py
             settings.py
             urls.py
@@ -315,14 +315,14 @@ working. We'll now fix this by installing our new ``django-polls`` package.
 
       python -m pip install --user django-polls/dist/django-polls-0.1.tar.gz
 
-#. Update ``mysite/settings.py`` to point to the new module name::
+#. Update ``config/settings.py`` to point to the new module name::
 
     INSTALLED_APPS = [
         "django_polls.apps.PollsConfig",
         ...,
     ]
 
-#. Update ``mysite/urls.py`` to point to the new module name::
+#. Update ``config/urls.py`` to point to the new module name::
 
     urlpatterns = [
         path("polls/", include("django_polls.urls")),

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -82,7 +82,7 @@ Let's look at what :djadmin:`startproject` created:
 
     mysite/
         manage.py
-        mysite/
+        config/
             __init__.py
             settings.py
             urls.py
@@ -91,39 +91,39 @@ Let's look at what :djadmin:`startproject` created:
 
 These files are:
 
-* The outer :file:`mysite/` root directory is a container for your project. Its
+* The :file:`mysite/` root directory is a container for your project. Its
   name doesn't matter to Django; you can rename it to anything you like.
 
 * :file:`manage.py`: A command-line utility that lets you interact with this
   Django project in various ways. You can read all the details about
   :file:`manage.py` in :doc:`/ref/django-admin`.
 
-* The inner :file:`mysite/` directory is the actual Python package for your
+* The :file:`config/` directory is the actual Python package for your
   project. Its name is the Python package name you'll need to use to import
-  anything inside it (e.g. ``mysite.urls``).
+  anything inside it (e.g. ``config.urls``).
 
-* :file:`mysite/__init__.py`: An empty file that tells Python that this
+* :file:`config/__init__.py`: An empty file that tells Python that this
   directory should be considered a Python package. If you're a Python beginner,
   read :ref:`more about packages <tut-packages>` in the official Python docs.
 
-* :file:`mysite/settings.py`: Settings/configuration for this Django
+* :file:`config/settings.py`: Settings/configuration for this Django
   project.  :doc:`/topics/settings` will tell you all about how settings
   work.
 
-* :file:`mysite/urls.py`: The URL declarations for this Django project; a
+* :file:`config/urls.py`: The URL declarations for this Django project; a
   "table of contents" of your Django-powered site. You can read more about
   URLs in :doc:`/topics/http/urls`.
 
-* :file:`mysite/asgi.py`: An entry-point for ASGI-compatible web servers to
+* :file:`config/asgi.py`: An entry-point for ASGI-compatible web servers to
   serve your project. See :doc:`/howto/deployment/asgi/index` for more details.
 
-* :file:`mysite/wsgi.py`: An entry-point for WSGI-compatible web servers to
+* :file:`config/wsgi.py`: An entry-point for WSGI-compatible web servers to
   serve your project. See :doc:`/howto/deployment/wsgi/index` for more details.
 
 The development server
 ======================
 
-Let's verify your Django project works. Change into the outer :file:`mysite` directory, if
+Let's verify your Django project works. Change into the :file:`mysite` directory, if
 you haven't already, and run the following commands:
 
 .. console::
@@ -142,7 +142,7 @@ You'll see the following output on the command line:
     Run 'python manage.py migrate' to apply them.
 
     |today| - 15:50:53
-    Django version |version|, using settings 'mysite.settings'
+    Django version |version|, using settings 'config.settings'
     Starting development server at http://127.0.0.1:8000/
     Quit the server with CONTROL-C.
 
@@ -290,11 +290,11 @@ In the ``polls/urls.py`` file include the following code:
     ]
 
 The next step is to point the root URLconf at the ``polls.urls`` module. In
-``mysite/urls.py``, add an import for ``django.urls.include`` and insert an
+``config/urls.py``, add an import for ``django.urls.include`` and insert an
 :func:`~django.urls.include` in the ``urlpatterns`` list, so you have:
 
 .. code-block:: python
-    :caption: ``mysite/urls.py``
+    :caption: ``config/urls.py``
 
     from django.contrib import admin
     from django.urls import include, path

--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -14,7 +14,7 @@ introduction to Django's automatically-generated admin site.
 Database setup
 ==============
 
-Now, open up :file:`mysite/settings.py`. It's a normal Python module with
+Now, open up :file:`config/settings.py`. It's a normal Python module with
 module-level variables representing Django settings.
 
 By default, the configuration uses SQLite. If you're new to databases, or
@@ -52,7 +52,7 @@ For more details, see the reference documentation for :setting:`DATABASES`.
     database by this point. Do that with "``CREATE DATABASE database_name;``"
     within your database's interactive prompt.
 
-    Also make sure that the database user provided in :file:`mysite/settings.py`
+    Also make sure that the database user provided in :file:`config/settings.py`
     has "create database" privileges. This allows automatic creation of a
     :ref:`test database <the-test-database>` which will be needed in a later
     tutorial.
@@ -60,7 +60,7 @@ For more details, see the reference documentation for :setting:`DATABASES`.
     If you're using SQLite, you don't need to create anything beforehand - the
     database file will be created automatically when it is needed.
 
-While you're editing :file:`mysite/settings.py`, set :setting:`TIME_ZONE` to
+While you're editing :file:`config/settings.py`, set :setting:`TIME_ZONE` to
 your time zone.
 
 Also, note the :setting:`INSTALLED_APPS` setting at the top of the file. That
@@ -96,7 +96,7 @@ that, run the following command:
 
 The :djadmin:`migrate` command looks at the :setting:`INSTALLED_APPS` setting
 and creates any necessary database tables according to the database settings
-in your :file:`mysite/settings.py` file and the database migrations shipped
+in your :file:`config/settings.py` file and the database migrations shipped
 with the app (we'll cover those later). You'll see a message for each
 migration it applies. If you're interested, run the command-line client for your
 database and type ``\dt`` (PostgreSQL), ``SHOW TABLES;`` (MariaDB, MySQL),
@@ -212,12 +212,12 @@ But first we need to tell our project that the ``polls`` app is installed.
 To include the app in our project, we need to add a reference to its
 configuration class in the :setting:`INSTALLED_APPS` setting. The
 ``PollsConfig`` class is in the :file:`polls/apps.py` file, so its dotted path
-is ``'polls.apps.PollsConfig'``. Edit the :file:`mysite/settings.py` file and
+is ``'polls.apps.PollsConfig'``. Edit the :file:`config/settings.py` file and
 add that dotted path to the :setting:`INSTALLED_APPS` setting. It'll look like
 this:
 
 .. code-block:: python
-    :caption: ``mysite/settings.py``
+    :caption: ``config/settings.py``
 
     INSTALLED_APPS = [
         "polls.apps.PollsConfig",
@@ -379,7 +379,7 @@ API Django gives you. To invoke the Python shell, use this command:
 
 We're using this instead of simply typing "python", because :file:`manage.py`
 sets the :envvar:`DJANGO_SETTINGS_MODULE` environment variable, which gives
-Django the Python import path to your :file:`mysite/settings.py` file.
+Django the Python import path to your :file:`config/settings.py` file.
 
 Once you're in the shell, explore the :doc:`database API </topics/db/queries>`:
 

--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -111,7 +111,7 @@ function and display whatever ID you provide in the URL. Try
 placeholder results and voting pages.
 
 When somebody requests a page from your website -- say, "/polls/34/", Django
-will load the ``mysite.urls`` Python module because it's pointed to by the
+will load the ``config.urls`` Python module because it's pointed to by the
 :setting:`ROOT_URLCONF` setting. It finds the variable named ``urlpatterns``
 and traverses the patterns in order. After finding the match at ``'polls/'``,
 it strips off the matching text (``"polls/"``) and sends the remaining text --

--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -311,11 +311,11 @@ contains ``manage.py``). Templates can live anywhere on your filesystem that
 Django can access. (Django runs as whatever user your server runs.) However,
 keeping your templates within the project is a good convention to follow.
 
-Open your settings file (:file:`mysite/settings.py`, remember) and add a
+Open your settings file (:file:`config/settings.py`, remember) and add a
 :setting:`DIRS <TEMPLATES-DIRS>` option in the :setting:`TEMPLATES` setting:
 
 .. code-block:: python
-    :caption: ``mysite/settings.py``
+    :caption: ``config/settings.py``
 
     TEMPLATES = [
         {

--- a/docs/man/django-admin.1
+++ b/docs/man/django-admin.1
@@ -1790,9 +1790,9 @@ By default, \fI\%the new directory\fP contains
 \fBmanage.py\fP and a project package (containing a \fBsettings.py\fP and other
 files).
 .sp
-If only the project name is given, both the project directory and project
-package will be named \fB<projectname>\fP and the project directory
-will be created in the current working directory.
+If only the project name is given, the project directory will be named
+\fB<projectname>\fP and the project directory will be created in the current
+working directory.
 .sp
 If the optional destination is provided, Django will use that existing
 directory as the project directory, and create \fBmanage.py\fP and the project

--- a/docs/man/django-admin.1
+++ b/docs/man/django-admin.1
@@ -2365,7 +2365,7 @@ django\-admin migrate \-\-pythonpath=\(aq/home/djangoprojects/myproject\(aq
 .UNINDENT
 .sp
 Specifies the settings module to use. The settings module should be in Python
-package syntax, e.g. \fBmysite.settings\fP\&. If this isn\(aqt provided,
+package syntax, e.g. \fBconfig.settings\fP\&. If this isn\(aqt provided,
 \fBdjango\-admin\fP will use the \fI\%DJANGO_SETTINGS_MODULE\fP environment
 variable.
 .sp
@@ -2378,7 +2378,7 @@ Example usage:
 .sp
 .nf
 .ft C
-django\-admin migrate \-\-settings=mysite.settings
+django\-admin migrate \-\-settings=config.settings
 .ft P
 .fi
 .UNINDENT

--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -23,7 +23,7 @@ Projects and applications
 The term **project** describes a Django web application. The project Python
 package is defined primarily by a settings module, but it usually contains
 other things. For example, when you run  ``django-admin startproject mysite``
-you'll get a ``mysite`` project directory that contains a ``mysite`` Python
+you'll get a ``mysite`` project directory that contains a ``config`` Python
 package with ``settings.py``, ``urls.py``, ``asgi.py`` and ``wsgi.py``. The
 project package is often extended to include things like fixtures, CSS, and
 templates which aren't tied to a particular application.

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -1131,7 +1131,7 @@ example:
 
 .. code-block:: text
 
-    mysite/
+    config/
         ...
         mydbengine/
             __init__.py
@@ -1143,7 +1143,7 @@ example of subclassing the PostgreSQL engine to change a feature class
 ``allows_group_by_selected_pks_on_model``:
 
 .. code-block:: python
-    :caption: ``mysite/mydbengine/base.py``
+    :caption: ``config/mydbengine/base.py``
 
     from django.db.backends.postgresql import base, features
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1815,7 +1815,7 @@ Example usage:
 .. django-admin-option:: --settings SETTINGS
 
 Specifies the settings module to use. The settings module should be in Python
-package syntax, e.g. ``mysite.settings``. If this isn't provided,
+package syntax, e.g. ``config.settings``. If this isn't provided,
 ``django-admin`` will use the :envvar:`DJANGO_SETTINGS_MODULE` environment
 variable.
 
@@ -1826,7 +1826,7 @@ Example usage:
 
 .. console::
 
-    django-admin migrate --settings=mysite.settings
+    django-admin migrate --settings=config.settings
 
 .. django-admin-option:: --traceback
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1341,9 +1341,9 @@ By default, :source:`the new directory <django/conf/project_template>` contains
 ``manage.py`` and a project package (containing a ``settings.py`` and other
 files).
 
-If only the project name is given, both the project directory and project
-package will be named ``<projectname>`` and the project directory
-will be created in the current working directory.
+If only the project name is given, the project directory will be named
+``<projectname>`` and the project directory will be created in the current
+working directory.
 
 If the optional destination is provided, Django will use that existing
 directory as the project directory, and create ``manage.py`` and the project

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -326,12 +326,6 @@ Dropped support for PostgreSQL 12
 Upstream support for PostgreSQL 12 ends in November 2024. Django 5.1 supports
 PostgreSQL 13 and higher.
 
-WSGI and ASGI Default Paths
----------------------------
-* The default for :file:`wsgi.py` and :file:`asgi.py` files in new
-  projects is now :file:`config/wsgi.py` and :file:`config/asgi.py` instead of
-  :file:`mysite/wsgi.py` and :file:`mysite/asgi.py` respectively where
-  ``mysite`` is the name of the project.
 
 Miscellaneous
 -------------

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -176,7 +176,9 @@ Logging
 Management Commands
 ~~~~~~~~~~~~~~~~~~~
 
-* ...
+* :djadmin:'startproject' now will store all project files (except
+:files:`manage.py') in a :file'config/' directory instead a directory with the
+project name.
 
 Migrations
 ~~~~~~~~~~
@@ -323,6 +325,13 @@ Dropped support for PostgreSQL 12
 
 Upstream support for PostgreSQL 12 ends in November 2024. Django 5.1 supports
 PostgreSQL 13 and higher.
+
+WSGI and ASGI Default Paths
+---------------------------
+* The default for :file:`wsgi.py` and :file:`asgi.py` files in new
+  projects is now :file:`config/wsgi.py` and :file:`config/asgi.py` instead of
+  :file:`mysite/wsgi.py` and :file:`mysite/asgi.py` respectively where
+  ``mysite`` is the name of the project.
 
 Miscellaneous
 -------------

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -176,9 +176,9 @@ Logging
 Management Commands
 ~~~~~~~~~~~~~~~~~~~
 
-* :djadmin:'startproject' now will store all project files (except
-:files:`manage.py') in a :file'config/' directory instead a directory with the
-project name.
+* :djadmin:`startproject` now will store all project files
+  (except :file:`manage.py`) in a :file:`config/` directory instead a directory
+  with the project name.
 
 Migrations
 ~~~~~~~~~~

--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -404,7 +404,7 @@ several thousand users, depending on the speed of your hardware.
 Finally, we'll add a :setting:`PASSWORD_HASHERS` setting:
 
 .. code-block:: python
-    :caption: ``mysite/settings.py``
+    :caption: ``config/settings.py``
 
     PASSWORD_HASHERS = [
         "django.contrib.auth.hashers.PBKDF2PasswordHasher",

--- a/docs/topics/http/views.txt
+++ b/docs/topics/http/views.txt
@@ -149,22 +149,22 @@ effect).
 The :func:`~django.views.defaults.page_not_found` view is overridden by
 :data:`~django.conf.urls.handler404`::
 
-    handler404 = "mysite.views.my_custom_page_not_found_view"
+    handler404 = "config.views.my_custom_page_not_found_view"
 
 The :func:`~django.views.defaults.server_error` view is overridden by
 :data:`~django.conf.urls.handler500`::
 
-    handler500 = "mysite.views.my_custom_error_view"
+    handler500 = "config.views.my_custom_error_view"
 
 The :func:`~django.views.defaults.permission_denied` view is overridden by
 :data:`~django.conf.urls.handler403`::
 
-    handler403 = "mysite.views.my_custom_permission_denied_view"
+    handler403 = "config.views.my_custom_permission_denied_view"
 
 The :func:`~django.views.defaults.bad_request` view is overridden by
 :data:`~django.conf.urls.handler400`::
 
-    handler400 = "mysite.views.my_custom_bad_request_view"
+    handler400 = "config.views.my_custom_bad_request_view"
 
 .. seealso::
 

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -43,7 +43,7 @@ When you use Django, you have to tell it which settings you're using. Do this
 by using an environment variable, :envvar:`DJANGO_SETTINGS_MODULE`.
 
 The value of :envvar:`DJANGO_SETTINGS_MODULE` should be in Python path syntax,
-e.g. ``mysite.settings``. Note that the settings module should be on the
+e.g. ``config.settings``. Note that the settings module should be on the
 Python `import search path`_.
 
 .. _import search path: https://diveinto.org/python3/your-first-python-program.html#importsearchpath
@@ -59,21 +59,21 @@ Example (Unix Bash shell):
 
 .. code-block:: shell
 
-    export DJANGO_SETTINGS_MODULE=mysite.settings
+    export DJANGO_SETTINGS_MODULE=config.settings
     django-admin runserver
 
 Example (Windows shell):
 
 .. code-block:: doscon
 
-    set DJANGO_SETTINGS_MODULE=mysite.settings
+    set DJANGO_SETTINGS_MODULE=config.settings
     django-admin runserver
 
 Use the ``--settings`` command-line argument to specify the settings manually:
 
 .. code-block:: shell
 
-    django-admin runserver --settings=mysite.settings
+    django-admin runserver --settings=config.settings
 
 .. _django-admin: ../django-admin/
 
@@ -85,7 +85,7 @@ application what settings file to use. Do that with ``os.environ``::
 
     import os
 
-    os.environ["DJANGO_SETTINGS_MODULE"] = "mysite.settings"
+    os.environ["DJANGO_SETTINGS_MODULE"] = "config.settings"
 
 Read the :doc:`Django mod_wsgi documentation
 </howto/deployment/wsgi/modwsgi>` for more information and other common

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -156,7 +156,7 @@ class AdminScriptTestCase(SimpleTestCase):
         with open(test_manage_py) as fp:
             manage_py_contents = fp.read()
         manage_py_contents = manage_py_contents.replace(
-            "{{ project_name }}", "test_project"
+            "{{ settings_dir }}", "test_project"
         )
         with open(test_manage_py, "w") as fp:
             fp.write(manage_py_contents)
@@ -2827,7 +2827,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
                 os.path.exists(os.path.join(testproject_dir, directory)),
                 False,
             )
-        not_excluded = os.path.join(testproject_dir, project_name)
+        not_excluded = os.path.join(testproject_dir, "config")
         self.assertIs(os.path.exists(not_excluded), True)
 
     @unittest.skipIf(
@@ -2841,8 +2841,8 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         self.assertIs(os.path.isdir(testproject_dir), True)
         tests = [
             (["manage.py"], 0o700),
-            (["testproject"], 0o700),
-            (["testproject", "settings.py"], 0o600),
+            (["config"], 0o700),
+            (["config", "settings.py"], 0o600),
         ]
         for paths, expected_mode in tests:
             file_path = os.path.join(testproject_dir, *paths)


### PR DESCRIPTION
When running `django-admin startproject mysite`, instead of storing files such as `settings.py`, `wsgi.py`, `urls.py`, etc inside a `mysite` subdirectory inside the root `mysite` directory, these files will now be stored in a `config` directory.