### PR TITLE
Add default MIGRATE to global_settings

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -640,6 +640,7 @@ STATICFILES_FINDERS = [
 # MIGRATIONS #
 ##############
 
+MIGRATE = True
 # Migration module overrides for apps, by app label.
 MIGRATION_MODULES = {}
 


### PR DESCRIPTION
Hopefully easy picking. See https://code.djangoproject.com/ticket/35116.