### PR TITLE
Improved --list-tags help text for check management command.

### DIFF
--- a/django/core/management/commands/check.py
+++ b/django/core/management/commands/check.py
@@ -21,7 +21,10 @@ class Command(BaseCommand):
         parser.add_argument(
             "--list-tags",
             action="store_true",
-            help="List available tags.",
+            help=(
+                "List available tags. Specify --deploy to include available deployment "
+                "tags."
+            ),
         )
         parser.add_argument(
             "--deploy",


### PR DESCRIPTION
This wasn't obvious to me… I noticed some were missing from the list in the docs and I had to look through the source code to see why 🤯