### PR TITLE
Fixed #35118 -- docs/topics/testing/tools.txt Mock connection note

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -2170,6 +2170,13 @@ manually, assign the empty list to ``mail.outbox``::
     # Empty the test outbox
     mail.outbox = []
 
+.. note::
+    If your application defines a different email backend to be used, you can
+    still ensure emails are redirected to the dummy outbox during testing.
+    Do this by mocking any connection object to be an instance from
+    :meth:`~django.core.mail.get_connection()` (with no backend specified,
+    to ensure the ``locmem`` email backend is used).
+
 .. _topics-testing-management-commands:
 
 Management Commands


### PR DESCRIPTION
As per the [ticket](https://code.djangoproject.com/ticket/35118) description, this PR adds a note about the recommendation to mock a connection object in tests if a different email-backend is used in an application.

Hope it helps.