### PR TITLE
Used more specific link to email backends in ref/settings.txt

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1390,7 +1390,7 @@ This is only used if ``CommonMiddleware`` is installed (see
 Default: ``'``:class:`django.core.mail.backends.smtp.EmailBackend`\ ``'``
 
 The backend to use for sending emails. For the list of available backends see
-:doc:`/topics/email`.
+:ref:`topic-email-backends`.
 
 .. setting:: EMAIL_FILE_PATH
 


### PR DESCRIPTION
Just a tiny change of link (same page but with a more specific target on the page). I figured no ticket was needed for such a small change.

I also used `git grep /topics/email -- docs` to check if other links could be improved the same way, but it seems this was the only instance.