### PR TITLE
Updated "Dive Into Python" links.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1087,6 +1087,6 @@ A big THANK YOU goes to:
 
     Ian Bicking for convincing Adrian to ditch code generation.
 
-    Mark Pilgrim for "Dive Into Python" (https://www.diveinto.org/python3/).
+    Mark Pilgrim for "Dive Into Python" (https://diveintopython3.net/).
 
     Guido van Rossum for creating Python.

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -27,8 +27,8 @@ For this tutorial, we expect that you have at least a basic understanding of
 how Django works. This means you should be comfortable going through the
 existing tutorials on :doc:`writing your first Django app</intro/tutorial01>`.
 In addition, you should have a good understanding of Python itself. But if you
-don't, `Dive Into Python`__ is a fantastic (and free) online book for
-beginning Python programmers.
+don't, `Dive Into Python`_ is a fantastic (and free) online book for beginning
+Python programmers.
 
 Those of you who are unfamiliar with version control systems and Trac will find
 that this tutorial and its links include just enough information to get started.
@@ -45,8 +45,8 @@ so that it can be of use to the widest audience.
     `#django-dev on irc.libera.chat`__ to chat with other Django users who
     might be able to help.
 
-__ https://diveinto.org/python3/table-of-contents.html
 __ https://web.libera.chat/#django-dev
+.. _Dive Into Python: https://diveintopython3.net/
 .. _Django Forum: https://forum.djangoproject.com/
 
 What does this tutorial cover?
@@ -350,7 +350,7 @@ This test checks that the ``make_toast()`` returns ``'toast'``.
     * After reading those, if you want something a little meatier to sink
       your teeth into, there's always the Python :mod:`unittest` documentation.
 
-__ https://diveinto.org/python3/unit-testing.html
+__ https://diveintopython3.net/unit-testing.html
 
 Running your new test
 ---------------------

--- a/docs/intro/index.txt
+++ b/docs/intro/index.txt
@@ -32,10 +32,12 @@ place: read this material to quickly get up and running.
     `list of Python resources for non-programmers`_
 
     If you already know a few other languages and want to get up to speed with
-    Python quickly, we recommend `Dive Into Python`_. If that's not quite your
-    style, there are many other `books about Python`_.
+    Python quickly, we recommend referring the official
+    `Python documentation`_, which provides comprehensive and authoritative
+    information about the language, as well as links to other resources such as
+    a list of `books about Python`_.
 
     .. _python: https://www.python.org/
     .. _list of Python resources for non-programmers: https://wiki.python.org/moin/BeginnersGuide/NonProgrammers
-    .. _Dive Into Python: https://diveinto.org/python3/table-of-contents.html
+    .. _Python documentation: https://docs.python.org/3/
     .. _books about Python: https://wiki.python.org/moin/PythonBooks

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1797,9 +1797,9 @@ allows for the following options by default:
 
 .. django-admin-option:: --pythonpath PYTHONPATH
 
-Adds the given filesystem path to the Python `import search path`_. If this
-isn't provided, ``django-admin`` will use the :envvar:`PYTHONPATH` environment
-variable.
+Adds the given filesystem path to the Python :py:data:`sys.path` module
+attribute. If this isn't provided, ``django-admin`` will use the
+:envvar:`PYTHONPATH` environment variable.
 
 This option is unnecessary in ``manage.py``, because it takes care of setting
 the Python path for you.
@@ -1809,8 +1809,6 @@ Example usage:
 .. console::
 
     django-admin migrate --pythonpath='/home/djangoprojects/myproject'
-
-.. _import search path: https://diveinto.org/python3/your-first-python-program.html#importsearchpath
 
 .. django-admin-option:: --settings SETTINGS
 

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -2484,8 +2484,8 @@ individual elements of the sequence.
 
 Returns a slice of the list.
 
-Uses the same syntax as Python's list slicing. See
-https://diveinto.org/python3/native-datatypes.html#slicinglists for an
+Uses the same syntax as Python's list slicing. See the `Python documentation
+<https://docs.python.org/3/tutorial/introduction.html#lists>`_ for an
 introduction.
 
 Example:

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -44,9 +44,8 @@ by using an environment variable, :envvar:`DJANGO_SETTINGS_MODULE`.
 
 The value of :envvar:`DJANGO_SETTINGS_MODULE` should be in Python path syntax,
 e.g. ``mysite.settings``. Note that the settings module should be on the
-Python `import search path`_.
+Python :py:data:`sys.path`.
 
-.. _import search path: https://diveinto.org/python3/your-first-python-program.html#importsearchpath
 
 The ``django-admin`` utility
 ----------------------------


### PR DESCRIPTION
Revised Django documentation to highlight the official Python documentation as the primary resource for the language, replacing Dive into Python. Outdated links for Dive into Python were also updated

This PR builds on @The-Amoghavarsha 's work on #17353 