### PR TITLE
I have Implemented ABS method in expressions for Django models to use ABS method in Django ORM.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -12,7 +12,6 @@ from django.core.exceptions import EmptyResultSet, FieldError, FullResultSet
 from django.db import DatabaseError, NotSupportedError, connection
 from django.db.models import fields
 from django.db.models.fields import IntegerField, FloatField, DecimalField
-
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query_utils import Q
 from django.utils.deconstruct import deconstructible
@@ -2028,7 +2027,6 @@ class ValueRange(WindowFrame):
 
     def window_frame_start_end(self, connection, start, end):
         return connection.ops.window_frame_range_start_end(start, end)
-
 
 @deconstructible(path="django.db.models.ABS")
 class ABS(Func):

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -11,6 +11,8 @@ from uuid import UUID
 from django.core.exceptions import EmptyResultSet, FieldError, FullResultSet
 from django.db import DatabaseError, NotSupportedError, connection
 from django.db.models import fields
+from django.db.models.fields import IntegerField, FloatField, DecimalField
+
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query_utils import Q
 from django.utils.deconstruct import deconstructible
@@ -2026,3 +2028,23 @@ class ValueRange(WindowFrame):
 
     def window_frame_start_end(self, connection, start, end):
         return connection.ops.window_frame_range_start_end(start, end)
+
+
+@deconstructible(path="django.db.models.ABS")
+class ABS(Func):
+    function = "ABS"
+
+    def as_sql(self, compiler, connection, function=None, template=None):
+        # Determine the output field based on the type of the input field
+        output_field_class = self.output_field.__class__
+        if output_field_class == IntegerField:
+            output_field = IntegerField()
+        elif output_field_class == FloatField:
+            output_field = FloatField()
+        elif output_field_class == DecimalField:
+            output_field = DecimalField(max_digits=self.output_field.max_digits, decimal_places=self.output_field.decimal_places)
+        else:
+            raise ValueError("Unsupported field type for ABS function")
+
+        self.output_field = output_field
+        return super().as_sql(compiler, connection, function=function, template=template)


### PR DESCRIPTION

**Use Case:**
This pull request introduces the ABS (absolute value) method in Django expressions. The ABS method can be used in expressions to calculate the absolute value of a numerical field, providing flexibility for developers when implementing various formulas or computations in Django models.


**Details:**
Added ABS method in expressions.
Supports Integer, Float, and Decimal fields.
Use cases include implementing custom formulas or calculations in Django models.

**How developers can use this:**

# views.py
from django.shortcuts import render
from django.db.models import F, ABS
from .models import NumberModel

def abs_example(request):
    # Annotate the queryset with the absolute value of the 'value' field
    queryset = NumberModel.objects.annotate(abs_value=ABS(F('value')))

    # Retrieve the annotated values
    result_list = list(queryset.values('value', 'abs_value'))

    return render(request, 'abs_example.html', {'result_list': result_list})

<!-- abs_example.html -->
{% for result in result_list %}
    Value: {{ result.value }} | Absolute Value: {{ result.abs_value }}<br>
{% endfor %}

Thanks :)