### PR TITLE
Refs #33517 -- Prevented __second lookup from returning fractional seconds on Oracle.

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -95,12 +95,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests."
             "test_trunc_week_before_1000",
         },
-        "Oracle extracts seconds including fractional seconds (#33517).": {
-            "db_functions.datetime.test_extract_trunc.DateFunctionTests."
-            "test_extract_second_func_no_fractional",
-            "db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests."
-            "test_extract_second_func_no_fractional",
-        },
         "Oracle doesn't support bitwise XOR.": {
             "expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_xor",
             "expressions.tests.ExpressionOperatorTests.test_lefthand_bitwise_xor_null",

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -165,6 +165,9 @@ END;
 
     def datetime_extract_sql(self, lookup_type, sql, params, tzname):
         sql, params = self._convert_sql_to_tz(sql, params, tzname)
+        if lookup_type == "second":
+            # Truncate fractional seconds.
+            return f"FLOOR(EXTRACT(SECOND FROM {sql}))", params
         return self.date_extract_sql(lookup_type, sql, params)
 
     def datetime_trunc_sql(self, lookup_type, sql, params, tzname):
@@ -187,6 +190,12 @@ END;
             # Cast to DATE removes sub-second precision.
             return f"CAST({sql} AS DATE)", params
         return f"TRUNC({sql}, %s)", (*params, trunc_param)
+
+    def time_extract_sql(self, lookup_type, sql, params):
+        if lookup_type == "second":
+            # Truncate fractional seconds.
+            return f"FLOOR(EXTRACT(SECOND FROM {sql}))", params
+        return self.date_extract_sql(lookup_type, sql, params)
 
     def time_trunc_sql(self, lookup_type, sql, params, tzname=None):
         # The implementation is similar to `datetime_trunc_sql` as both


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/33517