### PR TITLE
Added test for the sendtestemail command when no recipients are given.

### DIFF
--- a/tests/mail/test_sendtestemail.py
+++ b/tests/mail/test_sendtestemail.py
@@ -1,5 +1,5 @@
 from django.core import mail
-from django.core.management import call_command
+from django.core.management import CommandError, call_command
 from django.test import SimpleTestCase, override_settings
 
 
@@ -45,6 +45,18 @@ class SendTestEmailManagementCommand(SimpleTestCase):
                 "joe@example.com",
             ],
         )
+
+    def test_missing_receivers(self):
+        """
+        The command should complain if no receivers are given (and --admins or
+        --managers are not set).
+        """
+        msg = (
+            "You must specify some email recipients, or pass the --managers or "
+            "--admin options."
+        )
+        with self.assertRaisesMessage(CommandError, msg):
+            call_command("sendtestemail")
 
     def test_manager_receivers(self):
         """


### PR DESCRIPTION
I was reading the code for the `sendtestemail` command (as one does) and was confused as to how it made sure that either some recipients were passed on the command line, or the `--admins` (or `--managers`) flag was set.
Turns out that the presence of the `missing_args_message` argument on the `Command` class trigger some magic validation, but that behavior was not tested for that particular command (commenting out the argument doesn't trigger any failures in the test suite).

So I added a test for it. This seems like a small enough change that it doesn't require a ticket, but let me know if that's not the case.

Thanks!