### PR TITLE
Fixed #35115 -- Made admin's footer render in <footer> tag.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -893,11 +893,6 @@ a.deletelink:focus, a.deletelink:hover {
   }
 }
 
-#footer {
-    clear: both;
-    padding: 10px;
-}
-
 /* COLUMN TYPES */
 
 .colMS {

--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -451,12 +451,8 @@ input[type="submit"], button {
 @media (max-width: 767px) {
     /* Layout */
 
-    #header, #content, #footer {
+    #header, #content {
         padding: 15px;
-    }
-
-    #footer:empty {
-        padding: 0;
     }
 
     div.breadcrumbs {

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -110,7 +110,7 @@
         <!-- END Content -->
       </main>
     </div>
-    {% block footer %}<footer id="footer"></footer>{% endblock %}
+    <footer id="footer">{% block footer %}{% endblock %}</footer>
 </div>
 <!-- END Container -->
 

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -108,9 +108,9 @@
           <br class="clear">
         </div>
         <!-- END Content -->
-        {% block footer %}<div id="footer"></div>{% endblock %}
       </main>
     </div>
+    {% block footer %}<footer id="footer"></footer>{% endblock %}
 </div>
 <!-- END Container -->
 

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -348,6 +348,10 @@ Miscellaneous
 * In order to improve accessibility, the admin's changelist filter is now
   rendered in a ``<nav>`` tag instead of a ``<div>``.
 
+* In order to improve accessibility, the admin's footer is now rendered in
+  a ``<footer>`` tag instead of a ``<div>``. It is now located below the
+  ``<div id="main">`` element.
+
 * :meth:`.SimpleTestCase.assertURLEqual` and
   :meth:`~django.test.SimpleTestCase.assertInHTML` now add ``": "`` to the
   ``msg_prefix``. This is consistent with the behavior of other assertions.

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -349,7 +349,7 @@ Miscellaneous
   rendered in a ``<nav>`` tag instead of a ``<div>``.
 
 * In order to improve accessibility, the admin's footer is now rendered in
-  a ``<footer>`` tag instead of a ``<div>``. It is now located below the
+  a ``<footer>`` tag instead of a ``<div>``, and also moved below the
   ``<div id="main">`` element.
 
 * :meth:`.SimpleTestCase.assertURLEqual` and

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1605,6 +1605,13 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
             '<main id="content-start" class="content" tabindex="-1">',
         )
 
+    def test_footer(self):
+        response = self.client.get(reverse("admin:index"))
+        self.assertContains(response, '<footer id="footer">')
+        self.client.logout()
+        response = self.client.get(reverse("admin:login"))
+        self.assertContains(response, '<footer id="footer">')
+
     def test_aria_describedby_for_add_and_change_links(self):
         response = self.client.get(reverse("admin:index"))
         tests = [


### PR DESCRIPTION
Fixes [ticket #35115](https://code.djangoproject.com/ticket/35115).

**Important notes:**

- Removes all existing footer CSS per recommendations in the ticket.
- Uses the semantic element plus ID of the same name in the same style as the page header.
- ~~Puts the opening tags inside the block tags, also in the same style as the page header.~~
- The now-removed CSS `clear` on the footer did nothing since the parent element is a flexbox.