### PR TITLE
Fix #8307 -- Saving a model with an ImageField with width_field or height_field no longer results in an extra read operation

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1361,6 +1361,13 @@ can change the maximum length using the :attr:`~CharField.max_length` argument.
 The default form widget for this field is a
 :class:`~django.forms.ClearableFileInput`.
 
+.. versionchanged:: 5.1
+
+    Prior to version 5.1, auto-populating height_field and width_field would always
+    result in re-reading the file from the storage backend. If your storage backend
+    modifies files, it's possible that the retrieved image's width and height will
+    not match the auto-populated fields.
+
 ``IntegerField``
 ----------------
 

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -13,6 +13,8 @@ from django.db.models.functions import Lower
 from django.utils.functional import SimpleLazyObject
 from django.utils.translation import gettext_lazy as _
 
+from .storage import NoReadFileSystemStorage
+
 try:
     from PIL import Image
 except ImportError:
@@ -372,6 +374,22 @@ if Image:
             height_field="headshot_height",
             width_field="headshot_width",
         )
+
+    class NoReadImageModel(models.Model):
+        """
+        Model that defines an ImageField with a storage backend that does not
+        support reading.
+
+        This supports a test to avoid a double-read performance problem."""
+
+        testimage = models.ImageField(
+            upload_to="tests",
+            storage=NoReadFileSystemStorage(),
+            width_field="width",
+            height_field="height",
+        )
+        width = models.IntegerField()
+        height = models.IntegerField()
 
 
 class CustomJSONDecoder(json.JSONDecoder):

--- a/tests/model_fields/storage.py
+++ b/tests/model_fields/storage.py
@@ -1,0 +1,18 @@
+
+from django.core.files.storage.filesystem import FileSystemStorage
+
+
+class NoReadException(Exception):
+    pass
+
+
+class NoReadStorageMixin:
+    def open(self, *args, **kwargs):
+        raise NoReadException("This storage class does not support reading.")
+
+
+class NoReadFileSystemStorage(NoReadStorageMixin, FileSystemStorage):
+    """A storage backend which does not support reading.
+
+    Use this to test the behavior of Django when a storage backend is not
+    supposed to do any additional reads."""

--- a/tests/model_fields/storage.py
+++ b/tests/model_fields/storage.py
@@ -1,4 +1,3 @@
-
 from django.core.files.storage.filesystem import FileSystemStorage
 
 

--- a/tests/model_fields/test_imagefield.py
+++ b/tests/model_fields/test_imagefield.py
@@ -16,6 +16,7 @@ except ImproperlyConfigured:
 
 if Image:
     from .models import (
+        NoReadImageModel,
         Person,
         PersonDimensionsFirst,
         PersonTwoImages,
@@ -469,3 +470,32 @@ class TwoImageFieldTests(ImageFieldTestMixin, TestCase):
         # Dimensions were recalculated, and hence file should have opened.
         self.assertIs(p.mugshot.was_opened, True)
         self.assertIs(p.headshot.was_opened, True)
+
+
+@skipIf(Image is None, "Pillow is required to test ImageField")
+class NoReadTests(ImageFieldTestMixin, TestCase):
+
+    NoReadImageModel = NoReadImageModel
+
+    def test_width_height_correct_name_mangling_correct(self):
+
+        instance1 = self.NoReadImageModel()
+
+        instance1.testimage.save("mug", self.file1)
+
+        self.assertEqual(instance1.width, 4)
+        self.assertEqual(instance1.height, 8)
+
+        instance1.save()
+
+        self.assertEqual(instance1.width, 4)
+        self.assertEqual(instance1.height, 8)
+
+        instance2 = self.NoReadImageModel()
+        instance2.testimage.save("mug", self.file1)
+        instance2.save()
+
+        self.assertNotEqual(instance1.testimage.name, instance2.testimage.name)
+
+        self.assertEqual(instance1.width, instance2.width)
+        self.assertEqual(instance1.height, instance2.height)


### PR DESCRIPTION
This makes a slight change to how the FieldFileDescriptor works to fix #8307.

The previous pre-save/save/post-save flow worked something like this

* When you assign a file/image, the descriptor's __set__ method is called
* Just before you save the model, the storage backend figures out what a reasonable filename would be and returns that back to the descriptor
* The descriptor sets the attribute to be that string, erasing any reference to the original object that was set

And then in the case of the ImageField with width_field/height_field

* The descriptor then calls a method to calculate the width/height, but because the value of the attribute is a string and no reference to the old object is kept around, it must work its way through the storage API and re-fetch the object, resulting in disk access or network overhead

What this change does is make it so that when the save() method is called on the fieldfile, that it passes an fieldfile with the data necessary to perform whatever additional logic needs to be handled by the descriptor without doing additional IO. It will usually end up calling Pillow again and doing some extra work there, I believe. It should be possible to work around that as well, but that was outside of the scope of this, I think.

I had considered passing a special object type to the descriptor and not re-constructing the fieldfile. I don't know if this is considered part of the public API? I'll need some guidance on what to document.

I did write some tests, and I verified that tests are passing. There were a few on my machine that failed, but I think they're already failing.

# Edit

It looks like I have some linter issues, and my test is not really written the way that other tests are.

I noticed there's some 4x8.png and 8x4.png files. I can move the tests to that same folder and reuse those images. That's probably better than base64 encoding a jpeg.