### PR TITLE
[4.2.x] Pinned psf/black@23.12.1.

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -59,4 +59,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: black
-        uses: psf/black@stable
+        uses: psf/black@23.12.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.12.1
     hooks:
     - id: black
       exclude: \.py-tpl$
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies:
-        - black==23.3.0
+        - black==23.12.1
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -3,7 +3,7 @@ asgiref >= 3.6.0
 argon2-cffi >= 19.2.0
 backports.zoneinfo; python_version < '3.9'
 bcrypt
-black
+black == 23.12.1
 docutils
 geoip2; python_version < '3.12'
 jinja2 >= 2.11.0

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands =
 [testenv:black]
 basepython = python3
 usedevelop = false
-deps = black
+deps = black == 23.12.1
 changedir = {toxinidir}
 commands = black --check --diff .
 


### PR DESCRIPTION
While working on some patches targeting older Django versions, I noticed that the lint check for black is failing for `stable/4.2.x` branch. I believe this is caused by the recent black release [version 24.1](https://github.com/psf/black/releases/tag/24.1.0).

See error details at: https://dpaste.com/FN7RVUQZZ