### PR TITLE
Removed mention of designers in DTL design philosophy.

### DIFF
--- a/docs/misc/design-philosophies.txt
+++ b/docs/misc/design-philosophies.txt
@@ -254,10 +254,6 @@ enough programming-esque functionality, such as branching and looping, that is
 essential for making presentation-related decisions. The :ref:`Django Template
 Language (DTL) <template-language-intro>` aims to avoid advanced logic.
 
-The Django template system recognizes that templates are most often written by
-*designers*, not *programmers*, and therefore should not assume Python
-knowledge.
-
 Safety and security
 -------------------
 


### PR DESCRIPTION
As per the discussion initiated by @sarahboyce at the forum [Django design philosophies DTL](https://forum.djangoproject.com/t/django-design-philosophies-dtl-confirm-if-should-update/27363), this PR proposes to update the section `Don’t invent a programming language`