### PR TITLE
Changed severity levels to list in security policy docs.

### DIFF
--- a/docs/internals/security.txt
+++ b/docs/internals/security.txt
@@ -84,27 +84,24 @@ upcoming security release, as well as the severity of the issues. This is to
 aid organizations that need to ensure they have staff available to handle
 triaging our announcement and upgrade Django as needed. Severity levels are:
 
-High
-----
+* **High**
 
-* Remote code execution
-* SQL injection
+  * Remote code execution
+  * SQL injection
 
-Moderate
---------
+* **Moderate**
 
-* Cross site scripting (XSS)
-* Cross site request forgery (CSRF)
-* Denial-of-service attacks
-* Broken authentication
+  * Cross site scripting (XSS)
+  * Cross site request forgery (CSRF)
+  * Denial-of-service attacks
+  * Broken authentication
 
-Low
----
+* **Low**
 
-* Sensitive data exposure
-* Broken session management
-* Unvalidated redirects/forwards
-* Issues requiring an uncommon configuration option
+  * Sensitive data exposure
+  * Broken session management
+  * Unvalidated redirects/forwards
+  * Issues requiring an uncommon configuration option
 
 Second, we notify a list of :ref:`people and organizations
 <security-notifications>`, primarily composed of operating-system vendors and

--- a/docs/internals/security.txt
+++ b/docs/internals/security.txt
@@ -84,19 +84,22 @@ upcoming security release, as well as the severity of the issues. This is to
 aid organizations that need to ensure they have staff available to handle
 triaging our announcement and upgrade Django as needed. Severity levels are:
 
-**High**:
+High
+----
 
 * Remote code execution
 * SQL injection
 
-**Moderate**:
+Moderate
+--------
 
 * Cross site scripting (XSS)
 * Cross site request forgery (CSRF)
 * Denial-of-service attacks
 * Broken authentication
 
-**Low**:
+Low
+---
 
 * Sensitive data exposure
 * Broken session management


### PR DESCRIPTION
As a part of the Django meetup Cologne (23.01.24) sprint, a quick fix for improving accessibility in Django docs was suggested. 

In this case, the heading-level texts High, Moderate, and Low were improperly configured as bold instead of heading levels. This is fixed in this commit. 

**Before state:**

![image](https://github.com/django/django/assets/15073013/050dc689-3faa-4212-8fd5-7f4b1506aa8c)

![image](https://github.com/django/django/assets/15073013/87e304e7-5edc-4889-8b6e-f14e4932e965)

![image](https://github.com/django/django/assets/15073013/0727f33e-36af-4aab-9c8c-54371fe2664a)


**After state:**

![image](https://github.com/django/django/assets/15073013/eef38151-3f6f-42b2-8ea0-f74fe0227c8e)

![image](https://github.com/django/django/assets/15073013/749c4320-ec12-4263-a3e3-1961b3ed0041)

![image](https://github.com/django/django/assets/15073013/2f8761db-148d-4bcf-be88-3bc4f9d88073)

Looking forward to comments and feedback !

