### PR TITLE
[4.2.x] Pinned black == 23.12.1 for blacken-docs checks.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: python -m pip install blacken-docs
+      - run: python -m pip install "black==23.12.1" blacken-docs
       - name: Build docs
         run: |
           cd docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 pyenchant
 Sphinx>=4.5.0
 sphinxcontrib-spelling
+black==23.12.1
 blacken-docs


### PR DESCRIPTION
This wasn't caught in PR #17781 because there wasn't any change in the `docs` folder.