### PR TITLE
Fixed #35021 Debug query capturing on psycopg3 disregards execute wrappers.

### DIFF
--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -298,7 +298,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         def last_executed_query(self, cursor, sql, params):
             try:
                 # With psycopg3, use the _query attribute get the executed query
-                if hasattr(cursor, '_query'):
+                if hasattr(cursor, "_query"):
                     query = cursor._query
                     return query.decode() if isinstance(query, bytes) else query
                 else:


### PR DESCRIPTION
In this documentation [_query](https://www.psycopg.org/psycopg3/docs/api/cursors.html#psycopg.Cursor._query), it states that `_query` is a helper object which contains the query sent to PostgreSQL with the placeholders replaced with PostgreSQL ones, along with other details such as parameters and types. 

With this in mind, we can adjust the current code to use this, `_query` attribute with caution, and only when using psycopg3. 

The `last_executed_query` method is designed to retrieve the last SQL query that was executed by the database cursor. It's a method that would typically be part of a Django database backend class which interacts with a specific database, such as PostgreSQL in this case. Here's a breakdown of what the method does:

- The method takes three parameters:
  - `self` refers to the instance of the class where this method is defined, which would be a class related to database operations in Django.
  - `cursor` is the database cursor object. In the context of database operations, a cursor is a control structure that enables traversal over the records in a database. Cursors are used to execute SQL statements and fetch data from the result set returned by a query.
  - `sql` is a string containing the SQL query template that may have placeholders for parameters.
  - `params` is a list or tuple containing parameters that will replace the placeholders in the SQL template before the query is executed against the database.

- The method first checks if `is_psycopg3` is `True`, which is a boolean value indicating whether psycopg3 (the Python adapter for PostgreSQL) is being used. If it is, the method enters the `if` block to handle the psycopg3-specific logic:
  - It checks if the `cursor` object has an attribute named `_query` using `hasattr`. This attribute is expected to exist in psycopg3 and to contain the fully formed SQL query as a byte string, after all parameters have been applied and any additional modifications (like those from an execute wrapper) have been made.
  - If the `_query` attribute is present, the method attempts to return its value. Since the attribute might be in bytes, it checks if `_query` is an instance of `bytes` and decodes it to a string if necessary using `.decode()`. If `_query` is already a string, it is returned as is.

- If `is_psycopg3` is `False`, which implies that psycopg2 is being used, the method falls back to using the `query` attribute of the cursor, which is the psycopg2 way of accessing the executed query. The `cursor.query` attribute contains the query after it has been executed, including any modifications made by execute wrappers.
  - It checks if `cursor.query` is not `None` and then decodes it from bytes to a string if necessary.

- The method returns `None` if neither of these attributes (`_query` for psycopg3 or `query` for psycopg2) is available, which could happen if no query has been executed or if there is an error.

This method is a compatibility layer between psycopg2 and psycopg3, ensuring that regardless of which version of the psycopg library is being used, the Django backend can still retrieve and return the last executed SQL query.

