### PR TITLE
Fixed #35021 -- Fixed capturing queries when using client-side parameters binding with psycopg 3+.

### DIFF
--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -105,6 +105,15 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                     },
                 }
             )
+        if self.uses_server_side_binding:
+            skips.update(
+                {
+                    "The actual query cannot be determined for server side bindings": {
+                        "backends.base.test_base.ExecuteWrapperTests."
+                        "test_wrapper_debug",
+                    }
+                },
+            )
         return skips
 
     @cached_property

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -296,9 +296,14 @@ class DatabaseOperations(BaseDatabaseOperations):
     if is_psycopg3:
 
         def last_executed_query(self, cursor, sql, params):
-            try:
-                return self.compose_sql(sql, params)
-            except errors.DataError:
+            if self.connection.features.uses_server_side_binding:
+                try:
+                    return self.compose_sql(sql, params)
+                except errors.DataError:
+                    return None
+            else:
+                if cursor._query and cursor._query.query is not None:
+                    return cursor._query.query.decode()
                 return None
 
     else:

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -89,6 +89,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                 "db_functions.math.test_round.RoundTests."
                 "test_integer_with_negative_precision",
             },
+            "The actual query cannot be determined on SQLite": {
+                "backends.base.test_base.ExecuteWrapperTests.test_wrapper_debug",
+            },
         }
         if self.connection.is_in_memory_db():
             skips.update(

--- a/tests/backends/base/test_base.py
+++ b/tests/backends/base/test_base.py
@@ -211,6 +211,16 @@ class ExecuteWrapperTests(TestCase):
         self.assertEqual(connection.execute_wrappers, [])
         self.assertEqual(connections["other"].execute_wrappers, [])
 
+    def test_wrapper_debug(self):
+        def wrap_with_comment(execute, sql, params, many, context):
+            return execute(f"/* My comment */ {sql}", params, many, context)
+
+        with CaptureQueriesContext(connection) as ctx:
+            with connection.execute_wrapper(wrap_with_comment):
+                list(Person.objects.all())
+        last_query = ctx.captured_queries[-1]["sql"]
+        self.assertTrue(last_query.startswith("/* My comment */"))
+
 
 class ConnectionHealthChecksTests(SimpleTestCase):
     databases = {"default"}


### PR DESCRIPTION
Tested the added test with all databases. 
It fails only for sqlite.

Sqlite does not use the cursor to construct the last_executed_query().
Therefore, it has no knowledge of any wrapper applied. 
Not much can be done about that without major refactoring, hence I think it is out of the scope of this ticket.

If all looks good I can proceed to write the documentation.