### PR TITLE
Fixed #29725 -- Removed unnecessary join in QuerySet.count() and exists() on a many to many relation.

### DIFF
--- a/tests/many_to_many/models.py
+++ b/tests/many_to_many/models.py
@@ -78,3 +78,15 @@ class InheritedArticleA(AbstractArticle):
 
 class InheritedArticleB(AbstractArticle):
     pass
+
+
+class NullableTargetArticle(models.Model):
+    headline = models.CharField(max_length=100)
+    publications = models.ManyToManyField(
+        Publication, through="NullablePublicationThrough"
+    )
+
+
+class NullablePublicationThrough(models.Model):
+    article = models.ForeignKey(NullableTargetArticle, models.CASCADE)
+    publication = models.ForeignKey(Publication, models.CASCADE, null=True)


### PR DESCRIPTION
I am building off of the work from https://github.com/django/django/pull/16863 (ticket [29725](https://code.djangoproject.com/ticket/29725))

I addressed the changes requested from the previous contributor's PR. This does not address chaining all().