### PR TITLE
Fixed #33037 -- Fixed Trunc() with offset timezones on MySQL, SQLite, Oracle.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -919,6 +919,7 @@ answer newbie questions, and generally made Django that much better:
     Sergey Fedoseev <fedoseev.sergey@gmail.com>
     Sergey Kolosov <m17.admin@gmail.com>
     Seth Hill <sethrh@gmail.com>
+    Shafiya Adzhani <adz.arsym@gmail.com>
     Shai Berger <shai@platonix.com>
     Shannon -jj Behrens <https://www.jjinux.com/>
     Shawn Milochik <shawn@milochik.com>

--- a/django/db/backends/sqlite3/_functions.py
+++ b/django/db/backends/sqlite3/_functions.py
@@ -118,7 +118,10 @@ def _sqlite_datetime_parse(dt, tzname=None, conn_tzname=None):
             hours, minutes = offset.split(":")
             offset_delta = timedelta(hours=int(hours), minutes=int(minutes))
             dt += offset_delta if sign == "+" else -offset_delta
-        dt = timezone.localtime(dt, zoneinfo.ZoneInfo(tzname))
+        # The tzname may originally be just the offset e.g. "+3:00",
+        # which becomes an empty string after splitting the sign and offset.
+        # In this case, use the conn_tzname as fallback.
+        dt = timezone.localtime(dt, zoneinfo.ZoneInfo(tzname or conn_tzname))
     return dt
 
 

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -200,6 +200,8 @@ def split_tzname_delta(tzname):
         if sign in tzname:
             name, offset = tzname.rsplit(sign, 1)
             if offset and parse_time(offset):
+                if ":" not in offset:
+                    offset = f"{offset}:00"
                 return name, sign, offset
     return tzname, None, None
 

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -939,73 +939,74 @@ class DateFunctionTests(TestCase):
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
 
-        def test_datetime_kind(kind):
-            self.assertQuerySetEqual(
-                DTModel.objects.annotate(
-                    truncated=Trunc(
-                        "start_datetime", kind, output_field=DateTimeField()
-                    )
-                ).order_by("start_datetime"),
+        def assertDatetimeKind(kind):
+            truncated_start = truncate_to(start_datetime, kind)
+            truncated_end = truncate_to(end_datetime, kind)
+            queryset = DTModel.objects.annotate(
+                truncated=Trunc("start_datetime", kind, output_field=DateTimeField())
+            ).order_by("start_datetime")
+            self.assertSequenceEqual(
+                queryset.values_list("start_datetime", "truncated"),
                 [
-                    (start_datetime, truncate_to(start_datetime, kind)),
-                    (end_datetime, truncate_to(end_datetime, kind)),
+                    (start_datetime, truncated_start),
+                    (end_datetime, truncated_end),
                 ],
-                lambda m: (m.start_datetime, m.truncated),
             )
 
-        def test_date_kind(kind):
-            self.assertQuerySetEqual(
-                DTModel.objects.annotate(
-                    truncated=Trunc("start_date", kind, output_field=DateField())
-                ).order_by("start_datetime"),
+        def assertDateKind(kind):
+            truncated_start = truncate_to(start_datetime.date(), kind)
+            truncated_end = truncate_to(end_datetime.date(), kind)
+            queryset = DTModel.objects.annotate(
+                truncated=Trunc("start_date", kind, output_field=DateField())
+            ).order_by("start_datetime")
+            self.assertSequenceEqual(
+                queryset.values_list("start_datetime", "truncated"),
                 [
-                    (start_datetime, truncate_to(start_datetime.date(), kind)),
-                    (end_datetime, truncate_to(end_datetime.date(), kind)),
+                    (start_datetime, truncated_start),
+                    (end_datetime, truncated_end),
                 ],
-                lambda m: (m.start_datetime, m.truncated),
             )
 
-        def test_time_kind(kind):
-            self.assertQuerySetEqual(
-                DTModel.objects.annotate(
-                    truncated=Trunc("start_time", kind, output_field=TimeField())
-                ).order_by("start_datetime"),
+        def assertTimeKind(kind):
+            truncated_start = truncate_to(start_datetime.time(), kind)
+            truncated_end = truncate_to(end_datetime.time(), kind)
+            queryset = DTModel.objects.annotate(
+                truncated=Trunc("start_time", kind, output_field=TimeField())
+            ).order_by("start_datetime")
+            self.assertSequenceEqual(
+                queryset.values_list("start_datetime", "truncated"),
                 [
-                    (start_datetime, truncate_to(start_datetime.time(), kind)),
-                    (end_datetime, truncate_to(end_datetime.time(), kind)),
+                    (start_datetime, truncated_start),
+                    (end_datetime, truncated_end),
                 ],
-                lambda m: (m.start_datetime, m.truncated),
             )
 
-        def test_datetime_to_time_kind(kind):
-            self.assertQuerySetEqual(
-                DTModel.objects.annotate(
-                    truncated=Trunc("start_datetime", kind, output_field=TimeField()),
-                ).order_by("start_datetime"),
+        def assertDatetimeToTimeKind(kind):
+            truncated_start = truncate_to(start_datetime.time(), kind)
+            truncated_end = truncate_to(end_datetime.time(), kind)
+            queryset = DTModel.objects.annotate(
+                truncated=Trunc("start_datetime", kind, output_field=TimeField()),
+            ).order_by("start_datetime")
+            self.assertSequenceEqual(
+                queryset.values_list("start_datetime", "truncated"),
                 [
-                    (start_datetime, truncate_to(start_datetime.time(), kind)),
-                    (end_datetime, truncate_to(end_datetime.time(), kind)),
+                    (start_datetime, truncated_start),
+                    (end_datetime, truncated_end),
                 ],
-                lambda m: (m.start_datetime, m.truncated),
             )
 
-        test_date_kind("year")
-        test_date_kind("quarter")
-        test_date_kind("month")
-        test_date_kind("day")
-        test_time_kind("hour")
-        test_time_kind("minute")
-        test_time_kind("second")
-        test_datetime_kind("year")
-        test_datetime_kind("quarter")
-        test_datetime_kind("month")
-        test_datetime_kind("day")
-        test_datetime_kind("hour")
-        test_datetime_kind("minute")
-        test_datetime_kind("second")
-        test_datetime_to_time_kind("hour")
-        test_datetime_to_time_kind("minute")
-        test_datetime_to_time_kind("second")
+        date_truncations = ["year", "quarter", "month", "day"]
+        time_truncations = ["hour", "minute", "second"]
+        tests = [
+            (assertDateKind, date_truncations),
+            (assertTimeKind, time_truncations),
+            (assertDatetimeKind, [*date_truncations, *time_truncations]),
+            (assertDatetimeToTimeKind, time_truncations),
+        ]
+        for assertion, truncations in tests:
+            for truncation in truncations:
+                with self.subTest(assertion=assertion.__name__, truncation=truncation):
+                    assertion(truncation)
 
         qs = DTModel.objects.filter(
             start_datetime__date=Trunc(
@@ -1833,91 +1834,74 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
         self.create_model(end_datetime, start_datetime)
         melb = zoneinfo.ZoneInfo("Australia/Melbourne")
 
-        def test_datetime_kind(kind):
-            self.assertQuerySetEqual(
-                DTModel.objects.annotate(
-                    truncated=Trunc(
-                        "start_datetime",
-                        kind,
-                        output_field=DateTimeField(),
-                        tzinfo=melb,
-                    )
-                ).order_by("start_datetime"),
+        def assertDatetimeKind(kind):
+            truncated_start = truncate_to(start_datetime.astimezone(melb), kind, melb)
+            truncated_end = truncate_to(end_datetime.astimezone(melb), kind, melb)
+            queryset = DTModel.objects.annotate(
+                truncated=Trunc(
+                    "start_datetime",
+                    kind,
+                    output_field=DateTimeField(),
+                    tzinfo=melb,
+                )
+            ).order_by("start_datetime")
+            self.assertSequenceEqual(
+                queryset.values_list("start_datetime", "truncated"),
                 [
-                    (
-                        start_datetime,
-                        truncate_to(start_datetime.astimezone(melb), kind, melb),
-                    ),
-                    (
-                        end_datetime,
-                        truncate_to(end_datetime.astimezone(melb), kind, melb),
-                    ),
+                    (start_datetime, truncated_start),
+                    (end_datetime, truncated_end),
                 ],
-                lambda m: (m.start_datetime, m.truncated),
             )
 
-        def test_datetime_to_date_kind(kind):
-            self.assertQuerySetEqual(
-                DTModel.objects.annotate(
-                    truncated=Trunc(
-                        "start_datetime",
-                        kind,
-                        output_field=DateField(),
-                        tzinfo=melb,
-                    ),
-                ).order_by("start_datetime"),
+        def assertDatetimeToDateKind(kind):
+            truncated_start = truncate_to(start_datetime.astimezone(melb).date(), kind)
+            truncated_end = truncate_to(end_datetime.astimezone(melb).date(), kind)
+            queryset = DTModel.objects.annotate(
+                truncated=Trunc(
+                    "start_datetime",
+                    kind,
+                    output_field=DateField(),
+                    tzinfo=melb,
+                ),
+            ).order_by("start_datetime")
+            self.assertSequenceEqual(
+                queryset.values_list("start_datetime", "truncated"),
                 [
-                    (
-                        start_datetime,
-                        truncate_to(start_datetime.astimezone(melb).date(), kind),
-                    ),
-                    (
-                        end_datetime,
-                        truncate_to(end_datetime.astimezone(melb).date(), kind),
-                    ),
+                    (start_datetime, truncated_start),
+                    (end_datetime, truncated_end),
                 ],
-                lambda m: (m.start_datetime, m.truncated),
             )
 
-        def test_datetime_to_time_kind(kind):
-            self.assertQuerySetEqual(
-                DTModel.objects.annotate(
-                    truncated=Trunc(
-                        "start_datetime",
-                        kind,
-                        output_field=TimeField(),
-                        tzinfo=melb,
-                    )
-                ).order_by("start_datetime"),
+        def assertDatetimeToTimeKind(kind):
+            truncated_start = truncate_to(start_datetime.astimezone(melb).time(), kind)
+            truncated_end = truncate_to(end_datetime.astimezone(melb).time(), kind)
+            queryset = DTModel.objects.annotate(
+                truncated=Trunc(
+                    "start_datetime",
+                    kind,
+                    output_field=TimeField(),
+                    tzinfo=melb,
+                )
+            ).order_by("start_datetime")
+            self.assertSequenceEqual(
+                queryset.values_list("start_datetime", "truncated"),
                 [
-                    (
-                        start_datetime,
-                        truncate_to(start_datetime.astimezone(melb).time(), kind),
-                    ),
-                    (
-                        end_datetime,
-                        truncate_to(end_datetime.astimezone(melb).time(), kind),
-                    ),
+                    (start_datetime, truncated_start),
+                    (end_datetime, truncated_end),
                 ],
-                lambda m: (m.start_datetime, m.truncated),
             )
 
-        test_datetime_to_date_kind("year")
-        test_datetime_to_date_kind("quarter")
-        test_datetime_to_date_kind("month")
-        test_datetime_to_date_kind("week")
-        test_datetime_to_date_kind("day")
-        test_datetime_to_time_kind("hour")
-        test_datetime_to_time_kind("minute")
-        test_datetime_to_time_kind("second")
-        test_datetime_kind("year")
-        test_datetime_kind("quarter")
-        test_datetime_kind("month")
-        test_datetime_kind("week")
-        test_datetime_kind("day")
-        test_datetime_kind("hour")
-        test_datetime_kind("minute")
-        test_datetime_kind("second")
+        date_truncations = ["year", "quarter", "month", "week", "day"]
+        time_truncations = ["hour", "minute", "second"]
+        tests = [
+            (assertDatetimeToDateKind, date_truncations),
+            (assertDatetimeToTimeKind, time_truncations),
+            (assertDatetimeKind, [*date_truncations, *time_truncations]),
+        ]
+        for assertion, truncations in tests:
+            for truncation in truncations:
+                with self.subTest(assertion=assertion.__name__, truncation=truncation):
+                    assertion(truncation)
 
         qs = DTModel.objects.filter(
             start_datetime__date=Trunc(


### PR DESCRIPTION
Fixed ticket: [33037](https://code.djangoproject.com/ticket/33037)

Changes:
- Fixing `split_tzname_delta` by adding `:00` to offset if the offset does not have minute format. 
Example, offset that will be passed into this function is `10`, but [MySQL](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_convert-tz)  and [Oracle](https://docs.oracle.com/cd/B13789_01/server.101/b10759/expressions006.htm)  cannot parse it since it didn't follow correct format, e.g: `10:00`. 
This fix will also fix [bug on SQLite](https://github.com/adzshaf/django/blob/82d1171f4127e8aaf31aae4e8aed02de087c7a09/django/db/backends/sqlite3/_functions.py#L117). Previously, the tuple unpacking returned error since the offset will be `"10"` and its split result become `["10"]`.
- Add fallback during parse datetime on SQLite. `tzname` become empty from `split_tzname_delta` result, so it would be error. Hence, use `conn_tzname` for fallback value.

I added test which is nearly identical of [this part of test](https://github.com/django/django/blob/main/tests/db_functions/datetime/test_extract_trunc.py#L1823-L1927), with its difference on which timezone that is used. I think we can extract test functions from these parts. 