### PR TITLE
fix: django.db.utils.OperationalError: no such column: django_migrations.id

### DIFF
--- a/django/db/migrations/recorder.py
+++ b/django/db/migrations/recorder.py
@@ -30,6 +30,7 @@ class MigrationRecorder:
         if cls._migration_class is None:
 
             class Migration(models.Model):
+                id = models.IntegerField(primary_key=True)
                 app = models.CharField(max_length=255)
                 name = models.CharField(max_length=255)
                 applied = models.DateTimeField(default=now)


### PR DESCRIPTION
i got this error when running [archivebox](https://github.com/ArchiveBox/ArchiveBox)

<details>
<summary>
error stack
</summary>


```
Traceback (most recent call last):
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/sqlite3/base.py", line 328, in execute
    return super().execute(query, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sqlite3.OperationalError: no such column: django_migrations.id

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/migrations/executor.py", line 254, in apply_migration
    self.record_migration(migration)
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/migrations/executor.py", line 269, in record_migration
    self.recorder.record_applied(migration.app_label, migration.name)
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/migrations/recorder.py", line 94, in record_applied
    self.migration_qs.create(app=app, name=name)
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/models/query.py", line 658, in create
    obj.save(force_insert=True, using=self.db)
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/models/base.py", line 814, in save
    self.save_base(
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/models/base.py", line 877, in save_base
    updated = self._save_table(
              ^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/models/base.py", line 1020, in _save_table
    results = self._do_insert(
              ^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/models/base.py", line 1061, in _do_insert
    return manager._insert(
           ^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/models/query.py", line 1805, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1822, in execute_sql
    cursor.execute(sql, params)
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/utils.py", line 84, in _execute
    with self.db.wrap_database_errors:
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/sqlite3/base.py", line 328, in execute
    return super().execute(query, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django.db.utils.OperationalError: no such column: django_migrations.id

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/nix/store/ry2xibh8xwwiazjryd4lh1sa2zgfs9ib-archivebox-0.7.2/bin/.archivebox-wrapped", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/nix/store/ry2xibh8xwwiazjryd4lh1sa2zgfs9ib-archivebox-0.7.2/lib/python3.11/site-packages/archivebox/cli/__init__.py", line 140, in main
    run_subcommand(
  File "/nix/store/ry2xibh8xwwiazjryd4lh1sa2zgfs9ib-archivebox-0.7.2/lib/python3.11/site-packages/archivebox/cli/__init__.py", line 80, in run_subcommand
    module.main(args=subcommand_args, stdin=stdin, pwd=pwd)    # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ry2xibh8xwwiazjryd4lh1sa2zgfs9ib-archivebox-0.7.2/lib/python3.11/site-packages/archivebox/cli/archivebox_init.py", line 43, in main
    init(
  File "/nix/store/ry2xibh8xwwiazjryd4lh1sa2zgfs9ib-archivebox-0.7.2/lib/python3.11/site-packages/archivebox/util.py", line 116, in typechecked_function
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ry2xibh8xwwiazjryd4lh1sa2zgfs9ib-archivebox-0.7.2/lib/python3.11/site-packages/archivebox/main.py", line 366, in init
    for migration_line in apply_migrations(out_dir):
                          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ry2xibh8xwwiazjryd4lh1sa2zgfs9ib-archivebox-0.7.2/lib/python3.11/site-packages/archivebox/util.py", line 116, in typechecked_function
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ry2xibh8xwwiazjryd4lh1sa2zgfs9ib-archivebox-0.7.2/lib/python3.11/site-packages/archivebox/index/sql.py", line 146, in apply_migrations
    call_command("migrate", interactive=False, stdout=out)
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/core/management/__init__.py", line 194, in call_command
    return command.execute(*args, **defaults)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/core/management/base.py", line 106, in wrapper
    res = handle_func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/core/management/commands/migrate.py", line 356, in handle
    post_migrate_state = executor.migrate(
                         ^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/migrations/executor.py", line 135, in migrate
    state = self._migrate_all_forwards(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/migrations/executor.py", line 167, in _migrate_all_forwards
    state = self.apply_migration(
            ^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/migrations/executor.py", line 249, in apply_migration
    with self.connection.schema_editor(
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/sqlite3/schema.py", line 40, in __exit__
    self.connection.check_constraints()
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/sqlite3/base.py", line 244, in check_constraints
    violations = cursor.execute("PRAGMA foreign_key_check").fetchall()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/utils.py", line 83, in _execute
    self.db.validate_no_broken_transaction()
  File "/nix/store/i4xn2l7r4a1md2xcma1xkm812wci1fky-python3.11-Django-4.2.9/lib/python3.11/site-packages/django/db/backends/base/base.py", line 531, in validate_no_broken_transaction
    raise TransactionManagementError(
django.db.transaction.TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.
```

</details>

