### PR TITLE
fix: PermissionError: Permission denied: site-packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     asgiref >= 3.7.0
     sqlparse >= 0.3.1
     tzdata; sys_platform == 'win32'
+    platformdirs
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
`PermissionError` can happen with [nix](https://github.com/NixOS/nix)
where django apps are installed in the read-only `/nix/store`
and there is no way to make the app path writable

example

> `PermissionError: [Errno 13] Permission denied: '/nix/store/ry2xibh8xwwiazjryd4lh1sa2zgfs9ib-archivebox-0.7.2/lib/python3.11/site-packages/archivebox/core/migrations/0023_remove_archiveresult_id_alter_archiveresult_uuid_and_more.py'`

with this patch, django will write the migration file to
`$HOME/.cache/django-db-migrations` plus the original path

example

> `/home/user/.cache/django-db-migrations/nix/store/ry2xibh8xwwiazjryd4lh1sa2zgfs9ib-archivebox-0.7.2/lib/python3.11/site-packages/archivebox/core/migrations/0023_remove_archiveresult_id_alter_archiveresult_uuid_and_more.py`

## todo

`MigrationWriter` should allow the app to set a custom path for the db migrations files

django/db/migrations/writer.py

```py
class MigrationWriter:
    # ...
    @property
    def basedir(self):
        migrations_package_name, _ = MigrationLoader.migrations_module(
            self.migration.app_label
        )
```
