### PR TITLE
Refs #18597 -- Refactor new hooks for BaseModelFormSet and BaseInlineFormSet

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -732,6 +732,9 @@ class BaseModelFormSet(BaseFormSet, AltersData):
             field = field.remote_field.get_related_field()
         return field.to_python
 
+    def get_instance_by_queryset_index(self, i):
+        return self.get_queryset()[i]
+
     def _construct_form(self, i, **kwargs):
         pk_required = i < self.initial_form_count()
         if pk_required:
@@ -754,7 +757,7 @@ class BaseModelFormSet(BaseFormSet, AltersData):
                     else:
                         kwargs["instance"] = self._existing_object(pk)
             else:
-                kwargs["instance"] = self.get_queryset()[i]
+                kwargs["instance"] = self.get_instance_by_queryset_index(i)
         elif self.initial_extra:
             # Set initial values for extra forms
             try:
@@ -1017,7 +1020,7 @@ class BaseModelFormSet(BaseFormSet, AltersData):
             else:
                 try:
                     if index is not None:
-                        pk_value = self.get_queryset()[index].pk
+                        pk_value = self.get_instance_by_queryset_index(index).pk
                     else:
                         pk_value = None
                 except IndexError:
@@ -1126,12 +1129,7 @@ class BaseInlineFormSet(BaseModelFormSet):
         else:
             self.instance = instance
         self.save_as_new = save_as_new
-        if queryset is None:
-            queryset = self.model._default_manager
-        if self.instance._is_pk_set():
-            qs = queryset.filter(**{self.fk.name: self.instance})
-        else:
-            qs = queryset.none()
+        qs = self.prepare_queryset(queryset)
         self.unique_fields = {self.fk.name}
         super().__init__(data, files, prefix=prefix, queryset=qs, **kwargs)
 
@@ -1145,6 +1143,13 @@ class BaseInlineFormSet(BaseModelFormSet):
         if self.save_as_new:
             return 0
         return super().initial_form_count()
+
+    def prepare_queryset(self, queryset):
+        if queryset is None:
+            queryset = self.model._default_manager
+        if self.instance._is_pk_set():
+            return queryset.filter(**{self.fk.name: self.instance})
+        return queryset.none()
 
     def _construct_form(self, i, **kwargs):
         form = super()._construct_form(i, **kwargs)

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -155,7 +155,10 @@ File Uploads
 Forms
 ~~~~~
 
-* ...
+* New hooks were added to :class:`~django.forms.models.BaseModelFormSet` and
+  :class:`~django.forms.models.BaseInlineFormSet` to allow custom subclasses to
+  utilize :meth:`~django.db.models.query.QuerySet.prefetch_related`.
+  See :ref:`inline-formset-interaction-with-prefetching` for more details.
 
 Generic Views
 ~~~~~~~~~~~~~

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -1323,6 +1323,52 @@ Then when you create your inline formset, pass in the optional argument
     >>> author = Author.objects.get(name="Mike Royko")
     >>> formset = BookFormSet(instance=author)
 
+.. _inline-formset-interaction-with-prefetching:
+
+Interaction with prefetching
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.1
+
+The default ``InlineFormSet`` will trigger an extra query to fetch related objects
+even if :meth:`~django.db.models.query.QuerySet.prefetch_related` was used on
+the main instance. You'll need to create a subclass to take advantage of
+``prefetch_related`` for an inline formset. For example::
+
+    class PrefetchInlineFormSet(BaseInlineFormSet):
+        def get_instance_by_queryset_index(self, i):
+            # Use list() to evaluate the lazy queryset now
+            return list(self.get_queryset())[i]
+
+        def prepare_queryset(self, queryset):
+            if self.instance.pk:
+                rel_name = self.fk.remote_field.get_accessor_name(model=self.model)
+                queryset = getattr(self.instance, rel_name).get_queryset()
+                if queryset is not None:
+                    return queryset
+            return super().prepare_queryset(queryset)
+
+Note that you'll also need to ensure that the related object has a default
+ordering. Otherwise a new query will be triggered anyway to ensure that all
+formsets constructed have the same form order. For example::
+
+    class Book(models.Model):
+        ...
+
+        class Meta:
+            ordering = ["title"]
+
+With the new subclass, and a default ordering, you can pass in an instance that
+uses ``prefetch_related`` to skip an extra query for all related objects.
+
+.. code-block:: pycon
+
+    >>> BookFormSet = inlineformset_factory(
+    ...     Author, Book, fields=["title"], formset=PrefetchInlineFormSet
+    ... )
+    >>> author_with_books = Author.objects.prefetch_related("book_set").get(name="Mike Royko")
+    >>> formset = BookFormSet(instance=author_with_books)
+
 More than one foreign key to the same model
 -------------------------------------------
 


### PR DESCRIPTION
Added two new hooks:

- BaseModelFormSet.get_instance_by_queryset_index
- BaseInlineFormSet.prepare_queryset

Added documentation showing how new hooks can be used to allow an inline formset to use prefetch_related. Added a test for this scenario.

---
Context:

* https://code.djangoproject.com/ticket/5372 Inline forms should use prefetch_related to reduce queries
* https://code.djangoproject.com/ticket/18597 prefetch_related doesn't work as expected for inline forms
* https://github.com/django/django/pull/14188 [agalazis](https://github.com/agalazis) started it, but it needed docs/tests. Last worked on November 2021
    * My pull request is based on his, but with the added docs and tests

Because it's been ~2 years since there's been progress on these tickets, I'm sure extra time will be needed to determine if this is still the best direction to fix the inline/cache problem.

Also, this is my first major pull request for Django, so all feedback is welcome. In particular my documentation and tests may need changes.