### PR TITLE
Recreating useless extra query and tentative fix

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -2416,7 +2416,7 @@ def prefetch_related_objects(model_instances, *related_lookups):
                         new_obj = list(obj._prefetched_objects_cache.get(through_attr))
                     else:
                         try:
-                            new_obj = getattr(obj, through_attr)
+                            new_obj = getattr(obj, to_attr)
                         except exceptions.ObjectDoesNotExist:
                             continue
                     if new_obj is None:

--- a/tests/prefetch_related/models.py
+++ b/tests/prefetch_related/models.py
@@ -259,6 +259,17 @@ class Person(models.Model):
         ordering = ["id"]
 
 
+class Furniture(models.Model):
+    name = models.CharField(max_length=50)
+    room = models.ForeignKey(Room, models.SET_NULL, null=True)
+
+
+class Television(models.Model):
+    name = models.CharField(max_length=50)
+    room = models.OneToOneField("Room", models.SET_NULL, null=True)
+    owner = models.ForeignKey("Person", models.SET_NULL, null=True)
+
+
 # Models for nullable FK tests
 
 

--- a/tests/prefetch_related/test_prefetch_related_objects.py
+++ b/tests/prefetch_related/test_prefetch_related_objects.py
@@ -1,7 +1,16 @@
 from django.db.models import Prefetch, prefetch_related_objects
 from django.test import TestCase
 
-from .models import Author, Book, Reader
+from .models import (
+    Author,
+    Book,
+    Furniture,
+    House,
+    Person,
+    Reader,
+    Room,
+    Television,
+)
 
 
 class PrefetchRelatedObjectsTests(TestCase):
@@ -155,3 +164,38 @@ class PrefetchRelatedObjectsTests(TestCase):
 
         with self.assertNumQueries(0):
             self.assertCountEqual(book1.authors.all(), [self.author1, self.author2])
+
+    def test_prefetch_for_many_to_one_relation_and_to_attr(self):
+        # We have this setup that is traversed by nested prefetches,
+        # custom querysets and `to_attr`.
+        # M1.ForeignKey -> M2 <- 1_1.M3.ForeignKey -> M4
+        # We map these models and attributes to the test "House" schema:
+        # M1.ForeignKey : Furniture.room
+        # M2.reverse_1_1 : Room.television
+        # M3.ForeignKey : Television.owner
+        # M4: Person
+
+        # GIVEN five Models with one instance each
+        house = House.objects.create(name="Home sweet home", address="Earth")
+        room = Room.objects.create(name="bedroom", house=house)
+        tv_owner = Person.objects.create(name="Lucie")
+        tv = Television.objects.create(name="CinemaTV", owner=tv_owner, room=room)
+        furniture = Furniture.objects.create(name="bed", room=room)
+
+        # THEN prefetching from M1 to M4 should only trigger
+        # 3 DB queries.
+        with self.assertNumQueries(3):
+            qs = Furniture.objects.select_related("room").prefetch_related(
+                Prefetch(
+                    "room__television",
+                    queryset=Television.objects.prefetch_related(
+                        Prefetch(
+                            "owner",
+                            queryset=Person.objects.all(),
+                            to_attr="prefetched_owner",
+                        )
+                    ),
+                    to_attr="prefetched_television",
+                )
+            )
+            prefetched_furniture = qs.get(pk=furniture.pk)


### PR DESCRIPTION
Dear Django developpers.

While upgrading our Dashdoc backend to Django 5, our tools noticed an extra query that wasn't in the 4.x series. After long investigations, it seems to stem from `prefetch_related_objects`. In this PR I tried to recreate the error in a regression test.

The fix is tentative. I'm not sure at all that it is the _correct_ fix. We've run our full test suite against it and the extra queries are gone. We also ran the Django tests and AFAICT, all green.

This doesn't mean it is correct. It seems to make sense to us, but this bit of code is a bit involved for us to be confident about the change. We submit this as an open discussion. 