### PR TITLE
Adds note about sync-only calls in async decorators.

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -2087,7 +2087,9 @@ creates.
     If you are using test decorators, they must be async-compatible to ensure
     they work correctly. Django's built-in decorators will behave correctly, but
     third-party ones may appear to not execute (they will "wrap" the wrong part
-    of the execution flow and not your test).
+    of the execution flow and not your test). Similarly, decorators that perform
+    synchronous database operations cannot be applied directly to an async test
+    function.
 
     If you need to use these decorators, then you should decorate your test
     methods with :func:`~asgiref.sync.async_to_sync` *inside* of them instead::


### PR DESCRIPTION
After a couple of days of digging around with waffle, and writing my own async-friendly decorators, I happened across this documentation block.

I've added a note that this trick can also work when you have a decorator that performs database (or other sync operations that would be prohibited in an async context).