### PR TITLE
Fixed #35044 -- Avoided clearing reverse relations and private fields when accessing deferred fields.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -740,12 +740,16 @@ class Model(AltersData, metaclass=ModelBase):
 
         # Clear cached relations.
         for field in self._meta.related_objects:
-            if field.is_cached(self):
+            if (fields is None or field.name in fields) and field.is_cached(self):
                 field.delete_cached_value(self)
 
         # Clear cached private relations.
         for field in self._meta.private_fields:
-            if field.is_relation and field.is_cached(self):
+            if (
+                (fields is None or field.name in fields)
+                and field.is_relation
+                and field.is_cached(self)
+            ):
                 field.delete_cached_value(self)
 
         self._state.db = db_instance._state.db

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -691,8 +691,8 @@ class Model(AltersData, metaclass=ModelBase):
             self._prefetched_objects_cache = {}
         else:
             prefetched_objects_cache = getattr(self, "_prefetched_objects_cache", ())
-            fields = list(fields)
-            for field in list(fields):
+            fields = set(fields)
+            for field in fields.copy():
                 if field in prefetched_objects_cache:
                     del prefetched_objects_cache[field]
                     fields.remove(field)
@@ -717,11 +717,11 @@ class Model(AltersData, metaclass=ModelBase):
         if fields is not None:
             db_instance_qs = db_instance_qs.only(*fields)
         elif deferred_fields:
-            fields = [
+            fields = {
                 f.attname
                 for f in self._meta.concrete_fields
                 if f.attname not in deferred_fields
-            ]
+            }
             db_instance_qs = db_instance_qs.only(*fields)
 
         db_instance = db_instance_qs.get()

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -966,6 +966,13 @@ class ModelRefreshTests(TestCase):
         article.refresh_from_db()
         self.assertTrue(hasattr(article, "featured"))
 
+    def test_refresh_clears_reverse_related_explicit_fields(self):
+        article = Article.objects.create(headline="Test", pub_date=datetime(2024, 2, 4))
+        self.assertFalse(hasattr(article, "featured"))
+        FeaturedArticle.objects.create(article_id=article.pk)
+        article.refresh_from_db(fields=["featured"])
+        self.assertTrue(hasattr(article, "featured"))
+
     def test_refresh_clears_one_to_one_field(self):
         article = Article.objects.create(
             headline="Parrot programs in Python",

--- a/tests/defer/models.py
+++ b/tests/defer/models.py
@@ -19,6 +19,14 @@ class Primary(models.Model):
         return self.name
 
 
+class PrimaryOneToOne(models.Model):
+    name = models.CharField(max_length=50)
+    value = models.CharField(max_length=50)
+    related = models.OneToOneField(
+        Secondary, models.CASCADE, related_name="primary_o2o"
+    )
+
+
 class Child(Primary):
     pass
 


### PR DESCRIPTION
[ticket-35044](https://code.djangoproject.com/ticket/35044)

Thanks @adamchainz for the report, @charettes for the ideas.
