### PR TITLE
Fixed typo in docs/internals/contributing/writing-code/coding-style.txt.

### DIFF
--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -310,8 +310,8 @@ Model style
 
     class MyModel(models.Model):
         class Direction(models.TextChoices):
-            UP = U, "Up"
-            DOWN = D, "Down"
+            UP = "U", "Up"
+            DOWN = "D", "Down"
 
 Use of ``django.conf.settings``
 ===============================


### PR DESCRIPTION
https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#model-style

I think this should be string `"U"` and `"D"`, not identitier.