### PR TITLE
Fixed #35175 -- Made migraton writer preserve keyword-only arguments.

### DIFF
--- a/django/utils/inspect.py
+++ b/django/utils/inspect.py
@@ -16,13 +16,18 @@ def _get_callable_parameters(meth_or_func):
     return _get_func_parameters(func, remove_first=is_method)
 
 
+ARG_KINDS = frozenset(
+    {
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.KEYWORD_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    }
+)
+
+
 def get_func_args(func):
     params = _get_callable_parameters(func)
-    return [
-        param.name
-        for param in params
-        if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
-    ]
+    return [param.name for param in params if param.kind in ARG_KINDS]
 
 
 def get_func_full_args(func):

--- a/tests/custom_migration_operations/operations.py
+++ b/tests/custom_migration_operations/operations.py
@@ -68,6 +68,11 @@ class ArgsKwargsOperation(TestOperation):
         )
 
 
+class ArgsAndKeywordOnlyArgsOperation(ArgsKwargsOperation):
+    def __init__(self, arg1, arg2, *, kwarg1, kwarg2):
+        super().__init__(arg1, arg2, kwarg1=kwarg1, kwarg2=kwarg2)
+
+
 class ExpandArgsOperation(TestOperation):
     serialization_expand_args = ["arg"]
 

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -152,6 +152,24 @@ class OperationWriterTests(SimpleTestCase):
             "),",
         )
 
+    def test_keyword_only_args_signature(self):
+        operation = (
+            custom_migration_operations.operations.ArgsAndKeywordOnlyArgsOperation(
+                1, 2, kwarg1=3, kwarg2=4
+            )
+        )
+        buff, imports = OperationWriter(operation, indentation=0).serialize()
+        self.assertEqual(imports, {"import custom_migration_operations.operations"})
+        self.assertEqual(
+            buff,
+            "custom_migration_operations.operations.ArgsAndKeywordOnlyArgsOperation(\n"
+            "    arg1=1,\n"
+            "    arg2=2,\n"
+            "    kwarg1=3,\n"
+            "    kwarg2=4,\n"
+            "),",
+        )
+
     def test_nested_args_signature(self):
         operation = custom_migration_operations.operations.ArgsOperation(
             custom_migration_operations.operations.ArgsOperation(1, 2),


### PR DESCRIPTION
`get_func_args()` seems to have be around before the inception of positional-only and keyword-only args, and this just appears to be a case of Python creeping up on the code.