### PR TITLE
Fixed #35174 -- Fixed Signal.asend()/asend_robust() crash when all receivers are asynchronous.

### DIFF
--- a/django/dispatch/dispatcher.py
+++ b/django/dispatch/dispatcher.py
@@ -244,7 +244,9 @@ class Signal:
                 return responses
 
         else:
-            sync_send = list
+
+            async def sync_send():
+                return []
 
         responses, async_responses = await asyncio.gather(
             sync_send(),
@@ -380,7 +382,9 @@ class Signal:
                 return responses
 
         else:
-            sync_send = list
+
+            async def sync_send():
+                return []
 
         async def asend_and_wrap_exception(receiver):
             try:

--- a/docs/releases/5.0.3.txt
+++ b/docs/releases/5.0.3.txt
@@ -11,3 +11,7 @@ Bugfixes
 
 * Fixed a regression in Django 5.0.2 where ``intcomma`` template filter could
   return a leading comma for string representation of floats (:ticket:`35172`).
+
+* Fixed a bug in Django 5.0 that caused a crash of ``Signal.asend()`` and
+  ``asend_robust()`` when all receivers were asynchronous functions
+  (:ticket:`35174`).

--- a/tests/signals/tests.py
+++ b/tests/signals/tests.py
@@ -626,3 +626,19 @@ class AsyncReceiversTests(SimpleTestCase):
                 (async_handler, 1),
             ],
         )
+
+    async def test_asend_only_async_receivers(self):
+        async_handler = AsyncHandler()
+        signal = dispatch.Signal()
+        signal.connect(async_handler)
+
+        result = await signal.asend(self.__class__)
+        self.assertEqual(result, [(async_handler, 1)])
+
+    async def test_asend_robust_only_async_receivers(self):
+        async_handler = AsyncHandler()
+        signal = dispatch.Signal()
+        signal.connect(async_handler)
+
+        result = await signal.asend_robust(self.__class__)
+        self.assertEqual(result, [(async_handler, 1)])


### PR DESCRIPTION
Fixed: <https://code.djangoproject.com/ticket/35174>