### PR TITLE
Refs #34976 -- Print directory structure after startapp and startproject

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ permissions:
 
 jobs:
   windows:
+    env:
+      # Python 3.15 will make UTF-8 Mode the default.
+      PYTHONUTF8: 1
     runs-on: windows-latest
     strategy:
       matrix:

--- a/AUTHORS
+++ b/AUTHORS
@@ -307,6 +307,7 @@ answer newbie questions, and generally made Django that much better:
     Egidijus Macijauskas <e.macijauskas@outlook.com>
     eibaan@gmail.com
     elky <http://elky.me/>
+    Emmanuel T. Katchy <https://github.com/TobeTek>
     Emmanuelle Delescolle <https://github.com/nanuxbe>
     Emil Stenström <em@kth.se>
     enlight

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -271,6 +271,7 @@ class BaseCommand:
     def __init__(self, stdout=None, stderr=None, no_color=False, force_color=False):
         self.stdout = OutputWrapper(stdout or sys.stdout)
         self.stderr = OutputWrapper(stderr or sys.stderr)
+        self.no_color = no_color
         if no_color and force_color:
             raise CommandError("'no_color' and 'force_color' can't be used together.")
         if no_color:
@@ -442,6 +443,7 @@ class BaseCommand:
         if options["force_color"]:
             self.style = color_style(force_color=True)
         elif options["no_color"]:
+            self.no_color = options["no_color"]
             self.style = no_style()
             self.stderr.style_func = None
         if options.get("stdout"):

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management.utils import (
     find_formatters,
+    get_directory_tree,
     handle_extensions,
     run_formatters,
 )
@@ -230,6 +231,8 @@ class TemplateCommand(BaseCommand):
                     shutil.rmtree(path_to_remove)
 
         run_formatters([top_dir], **formatter_paths)
+        for subpath in get_directory_tree(top_dir, no_color=self.no_color):
+            self.stdout.write(subpath)
 
     def handle_template(self, template, subdir):
         """

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2405,6 +2405,31 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
         self.assertOutput(err, "usage:")
         self.assertOutput(err, "You must provide a project name.")
 
+    def test_output_directory_structure(self):
+
+        dirs = {
+            "testproject": self.test_dir,
+            "testproject1": os.path.join(self.test_dir, "otherdirectory"),
+        }
+        for name_project, dir in dirs.items():
+            with self.subTest(name_project=name_project, dir=dir):
+                args = ["startproject", name_project]
+                if not os.path.exists(dir):
+                    os.mkdir(dir)
+                    args.append(dir)
+                out, err = self.run_django_admin(args)
+
+                # Confirm the directory structure is as expected
+                self.assertIn(name_project, out)
+                self.assertIn("|___ manage.py", out)
+                self.assertIn("|___ testproject", out)
+                self.assertIn("    |___ __init__.py", out)
+                self.assertIn("    |___ asgi.py", out)
+                self.assertIn("    |___ settings.py", out)
+                self.assertIn("    |___ urls.py", out)
+                self.assertIn("    |___ wsgi.py", out)
+                self.assertNoOutput(err)
+
     def test_simple_project(self):
         "Make sure the startproject management command creates a project"
         args = ["startproject", "testproject"]
@@ -2878,6 +2903,28 @@ class StartApp(AdminScriptTestCase):
                     "sure the name is a valid identifier.".format(bad_name),
                 )
                 self.assertFalse(os.path.exists(testproject_dir))
+
+    def test_output_directory_structure(self):
+        dirs = {
+            "foo": self.test_dir,
+            "bar": os.path.join(self.test_dir, "otherdir"),
+        }
+        for name_app, dir in dirs.items():
+            with self.subTest(name_project=name_app, dir=dir):
+                args = ["startapp", name_app]
+                out, err = self.run_django_admin(args)
+
+                # Confirm the directory structure is as expected
+                self.assertIn(name_app, out)
+                self.assertIn("|___ __init__.py", out)
+                self.assertIn("|___ admin.py", out)
+                self.assertIn("|___ apps.py", out)
+                self.assertIn("|___ migrations", out)
+                self.assertIn("|   |___ __init__.py", out)
+                self.assertIn("|___ models.py", out)
+                self.assertIn("|___ tests.py", out)
+                self.assertIn("|___ views.py", out)
+                self.assertNoOutput(err)
 
     def test_importable_name(self):
         """


### PR DESCRIPTION
Print the newly created directory structure after running the startapp and startproject commands.
This provides feedback that a command has successfully run.

Refs #34976

*Sample output*:
![Screenshot from 2024-02-15 12-51-01](https://github.com/django/django/assets/82294671/2455dffc-e2df-4f63-8136-80888e2546af)
![Screenshot from 2024-02-15 12-51-44](https://github.com/django/django/assets/82294671/fbb48964-906d-4656-b9dc-808496aa5829)

