### PR TITLE
Fixed #35171 -- Updated the design of the "Congrats" page.

### DIFF
--- a/django/views/templates/default_urlconf.html
+++ b/django/views/templates/default_urlconf.html
@@ -2,251 +2,251 @@
 <!doctype html>
 {% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
 <html lang="{{ LANGUAGE_CODE|default:'en-us' }}" dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr,auto' }}">
-    <head>
-        <meta charset="utf-8">
-        <title>{% translate "The install worked successfully! Congratulations!" %}</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <style>
-          html {
-            line-height: 1.15;
-          }
-          a {
-            color: #19865C;
-          }
-          header {
-            border-bottom: 1px solid #efefef;
-          }
-          body {
-            max-width: 960px;
-            color: #525252;
-            font-family: "Segoe UI", system-ui, sans-serif;
-            margin: 0 auto;
-          }
-          main {
-            text-align: center;
-          }
-          h1, h2, h3, h4, h5, p, ul {
-            padding: 0;
-            margin: 0;
-            font-weight: 400;
-          }
-          header {
-            display: grid;
-            grid-template-columns: auto auto;
-            align-items: self-end;
-            justify-content: space-between;
-            gap: 7px;
-            padding-top: 20px;
-            padding-bottom: 10px;
-          }
-          .logo {
-            font-weight: 700;
-            font-size: 1.375rem;
-            text-decoration: none;
-          }
-          .figure {
-            margin-top: 19vh;
-            max-width: 265px;
-            position: relative;
-            z-index: -9;
-            overflow: visible;
-          }
-          .exhaust__line {
-            animation: thrust 70ms 100 ease-in-out alternate;
-          }
-          .smoke {
-            animation: smoke .1s 70 ease-in-out alternate;
-          }
-          @keyframes smoke {
-            0% {
-              transform: translate3d(-5px, 0, 0);
-            }
-            100% {
-              transform: translate3d(5px, 0, 0);
-            }
-          }
-          .flame {
-            animation: burnInner2 .1s 70 ease-in-out alternate;
-          }
-          @keyframes burnInner2 {
-            0% {
-              transform: translate3d(0, 0, 0);
-            }
-            100% {
-              transform: translate3d(0, 3px, 0);
-            }
-          }
-          @keyframes thrust {
-            0% {
-              opacity: 1;
-            }
-            100% {
-              opacity: .5;
-            }
-          }
-          @media (prefers-reduced-motion: reduce) {
-            .exhaust__line,
-            .smoke,
-            .flame {
-              animation: none;
-            }
-          }
-          h1 {
-            font-size: 1.375rem;
-            max-width: 32rem;
-            margin: 5px auto 0;
-          }
-          main p {
-            line-height: 1.25;
-            max-width: 26rem;
-            margin: 15px auto 0;
-          }
-          footer {
-            display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            gap: 5px;
-            padding: 25px 0;
-            position: fixed;
-            box-sizing: border-box;
-            left: 50%;
-            bottom: 0;
-            width: 960px;
-            transform: translateX(-50%);
-            transform-style: preserve-3d;
-            border-top: 1px solid #efefef;
-          }
-          .option {
-            display: grid;
-            grid-template-columns: min-content 1fr;
-            gap: 10px;
-            box-sizing: border-box;
-            text-decoration: none;
-          }
-          .option svg {
-            width: 1.5rem;
-            height: 1.5rem;
-            fill: gray;
-            border: 1px solid #d6d6d6;
-            padding: 5px;
-            border-radius: 100%;
-          }
-          .option p {
-            font-weight: 300;
-            line-height: 1.25;
-            color: #525252;
-            display: table;
-          }
-          .option .option__heading {
-            color: #19865C;
-            font-size: 1.25rem;
-            font-weight: 400;
-          }
-          @media (max-width: 996px) {
-            body, footer {
-              max-width: 780px;
-            }
-          }
-          @media (max-width: 800px) {
-            footer {
-              height: 100%;
-              grid-template-columns: 1fr;
-              gap: 60px;
-              position: relative;
-              padding: 25px;
-            }
-            .figure {
-              margin-top: 10px;
-            }
-            main {
-              padding: 0 25px;
-            }
-            main h1 {
-              font-size: 1.25rem;
-            }
-            header {
-              grid-template-columns: 1fr;
-              padding-left: 20px;
-              padding-right: 20px;
-            }
-            footer {
-              width: 100%;
-              margin-top: 50px;
-            }
-          }
-          @media (min-width: 801px) and (max-height: 730px) {
-            .figure {
-              margin-top: 80px;
-            }
-          }
-          @media (min-width: 801px) and (max-height: 600px) {
-            footer {
-              position: relative;
-              margin: 135px auto 0;
-            }
-            .figure {
-              margin-top: 50px;
-            }
-          }
-          .sr-only {
-            clip: rect(1px, 1px, 1px, 1px);
-            clip-path: inset(50%);
-            height: 1px;
-            overflow: hidden;
-            position: absolute;
-            white-space: nowrap;
-            width: 1px;
-          }
-        </style>
-    </head>
-    <body>
-      <header>
-          <a class="logo" href="https://www.djangoproject.com/" target="_blank" rel="noopener">
-            django
-          </a>
-          <p>{% blocktranslate %}View <a href="https://docs.djangoproject.com/en/{{ version }}/releases/" target="_blank" rel="noopener">release notes</a> for Django {{ version }}{% endblocktranslate %}</p>
-      </header>
-      <main>
-        <svg class="figure" viewBox="0 0 508 268" aria-hidden="true">
-          <path d="M305.2 156.6c0 4.6-.5 9-1.6 13.2-2.5-4.4-5.6-8.4-9.2-12-4.6-4.6-10-8.4-16-11.2 2.8-11.2 4.5-22.9 5-34.6 1.8 1.4 3.5 2.9 5 4.5 10.5 10.3 16.8 24.5 16.8 40.1zm-75-10c-6 2.8-11.4 6.6-16 11.2-3.5 3.6-6.6 7.6-9.1 12-1-4.3-1.6-8.7-1.6-13.2 0-15.7 6.3-29.9 16.6-40.1 1.6-1.6 3.3-3.1 5.1-4.5.6 11.8 2.2 23.4 5 34.6z" fill="#2E3B39" fill-rule="nonzero"/>
-          <path d="M282.981 152.6c16.125-48.1 6.375-104-29.25-142.6-35.625 38.5-45.25 94.5-29.25 142.6h58.5z" stroke="#FFF" stroke-width="3.396" fill="#6DDCBD"/>
-          <path d="M271 29.7c-4.4-10.6-9.9-20.6-16.6-29.7-6.7 9-12.2 19-16.6 29.7H271z" stroke="#FFF" stroke-width="3" fill="#2E3B39"/>
-          <circle stroke="#FFF" stroke-width="7" fill="none" cx="254.3" cy="76.8" r="12.2"/>
-          <path class="smoke" d="M507.812 234.24c0-2.16-.632-4.32-1.58-6.24-3.318-6.72-11.85-11.52-21.804-11.52-1.106 0-2.212.12-3.318.24-.474-11.52-12.956-20.76-28.282-20.76-3.318 0-6.636.48-9.638 1.32-4.74-6.72-14.062-11.28-24.806-11.28-.79 0-1.58 0-2.37.12-.79 0-1.58-.12-2.37-.12-10.744 0-20.066 4.56-24.806 11.28a35.326 35.326 0 00-9.638-1.32c-15.642 0-28.282 9.6-28.282 21.48 0 1.32.158 2.76.474 3.96a26.09 26.09 0 00-4.424-.36c-8.058 0-15.01 3.12-19.118 7.8-3.476-1.68-7.742-2.76-12.324-2.76-12.008 0-21.804 7.08-22.752 15.96h-.158c-9.322 0-17.38 4.32-20.856 10.44-4.108-3.6-10.27-6-17.222-6h-1.264c-6.794 0-12.956 2.28-17.222 6-3.476-6.12-11.534-10.44-20.856-10.44h-.158c-.948-9-10.744-15.96-22.752-15.96-4.582 0-8.69.96-12.324 2.76-4.108-4.68-11.06-7.8-19.118-7.8-1.422 0-3.002.12-4.424.36.316-1.32.474-2.64.474-3.96 0-11.88-12.64-21.48-28.282-21.48-3.318 0-6.636.48-9.638 1.32-4.74-6.72-14.062-11.28-24.806-11.28-.79 0-1.58 0-2.37.12-.79 0-1.58-.12-2.37-.12-10.744 0-20.066 4.56-24.806 11.28a35.326 35.326 0 00-9.638-1.32c-15.326 0-27.808 9.24-28.282 20.76-1.106-.12-2.212-.24-3.318-.24-9.954 0-18.486 4.8-21.804 11.52-.948 1.92-1.58 4.08-1.58 6.24 0 4.8 2.528 9.12 6.636 12.36-.79 1.44-1.264 3.12-1.264 4.8 0 7.2 7.742 13.08 17.222 13.08h462.15c9.48 0 17.222-5.88 17.222-13.08 0-1.68-.474-3.36-1.264-4.8 4.582-3.24 7.11-7.56 7.11-12.36z" fill="#E6E9EE"/>
-          <path fill="#6DDCBD" d="M239 152h30v8h-30z"/>
-          <path class="exhaust__line" fill="#E6E9EE" d="M250 172h7v90h-7z"/>
-          <path class="flame" d="M250.27 178.834l-5.32-8.93s-2.47-5.7 3.458-6.118h10.26s6.232.266 3.306 6.194l-5.244 8.93s-3.23 4.37-6.46 0v-.076z" fill="#AA2247"/>
+  <head>
+    <meta charset="utf-8">
+    <title>{% translate "The install worked successfully! Congratulations!" %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      html {
+        line-height: 1.15;
+      }
+      a {
+        color: #19865C;
+      }
+      header {
+        border-bottom: 1px solid #efefef;
+      }
+      body {
+        max-width: 960px;
+        color: #525252;
+        font-family: "Segoe UI", system-ui, sans-serif;
+        margin: 0 auto;
+      }
+      main {
+        text-align: center;
+      }
+      h1, h2, h3, h4, h5, p, ul {
+        padding: 0;
+        margin: 0;
+        font-weight: 400;
+      }
+      header {
+        display: grid;
+        grid-template-columns: auto auto;
+        align-items: self-end;
+        justify-content: space-between;
+        gap: 7px;
+        padding-top: 20px;
+        padding-bottom: 10px;
+      }
+      .logo {
+        font-weight: 700;
+        font-size: 1.375rem;
+        text-decoration: none;
+      }
+      .figure {
+        margin-top: 19vh;
+        max-width: 265px;
+        position: relative;
+        z-index: -9;
+        overflow: visible;
+      }
+      .exhaust__line {
+        animation: thrust 70ms 100 ease-in-out alternate;
+      }
+      .smoke {
+        animation: smoke .1s 70 ease-in-out alternate;
+      }
+      @keyframes smoke {
+        0% {
+          transform: translate3d(-5px, 0, 0);
+        }
+        100% {
+          transform: translate3d(5px, 0, 0);
+        }
+      }
+      .flame {
+        animation: burnInner2 .1s 70 ease-in-out alternate;
+      }
+      @keyframes burnInner2 {
+        0% {
+          transform: translate3d(0, 0, 0);
+        }
+        100% {
+          transform: translate3d(0, 3px, 0);
+        }
+      }
+      @keyframes thrust {
+        0% {
+          opacity: 1;
+        }
+        100% {
+          opacity: .5;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .exhaust__line,
+        .smoke,
+        .flame {
+          animation: none;
+        }
+      }
+      h1 {
+        font-size: 1.375rem;
+        max-width: 32rem;
+        margin: 5px auto 0;
+      }
+      main p {
+        line-height: 1.25;
+        max-width: 26rem;
+        margin: 15px auto 0;
+      }
+      footer {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 5px;
+        padding: 25px 0;
+        position: fixed;
+        box-sizing: border-box;
+        left: 50%;
+        bottom: 0;
+        width: 960px;
+        transform: translateX(-50%);
+        transform-style: preserve-3d;
+        border-top: 1px solid #efefef;
+      }
+      .option {
+        display: grid;
+        grid-template-columns: min-content 1fr;
+        gap: 10px;
+        box-sizing: border-box;
+        text-decoration: none;
+      }
+      .option svg {
+        width: 1.5rem;
+        height: 1.5rem;
+        fill: gray;
+        border: 1px solid #d6d6d6;
+        padding: 5px;
+        border-radius: 100%;
+      }
+      .option p {
+        font-weight: 300;
+        line-height: 1.25;
+        color: #525252;
+        display: table;
+      }
+      .option .option__heading {
+        color: #19865C;
+        font-size: 1.25rem;
+        font-weight: 400;
+      }
+      @media (max-width: 996px) {
+        body, footer {
+          max-width: 780px;
+        }
+      }
+      @media (max-width: 800px) {
+        footer {
+          height: 100%;
+          grid-template-columns: 1fr;
+          gap: 60px;
+          position: relative;
+          padding: 25px;
+        }
+        .figure {
+          margin-top: 10px;
+        }
+        main {
+          padding: 0 25px;
+        }
+        main h1 {
+          font-size: 1.25rem;
+        }
+        header {
+          grid-template-columns: 1fr;
+          padding-left: 20px;
+          padding-right: 20px;
+        }
+        footer {
+          width: 100%;
+          margin-top: 50px;
+        }
+      }
+      @media (min-width: 801px) and (max-height: 730px) {
+        .figure {
+          margin-top: 80px;
+        }
+      }
+      @media (min-width: 801px) and (max-height: 600px) {
+        footer {
+          position: relative;
+          margin: 135px auto 0;
+        }
+        .figure {
+          margin-top: 50px;
+        }
+      }
+      .sr-only {
+        clip: rect(1px, 1px, 1px, 1px);
+        clip-path: inset(50%);
+        height: 1px;
+        overflow: hidden;
+        position: absolute;
+        white-space: nowrap;
+        width: 1px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <a class="logo" href="https://www.djangoproject.com/" target="_blank" rel="noopener">
+        django
+      </a>
+      <p>{% blocktranslate %}View <a href="https://docs.djangoproject.com/en/{{ version }}/releases/" target="_blank" rel="noopener">release notes</a> for Django {{ version }}{% endblocktranslate %}</p>
+    </header>
+    <main>
+      <svg class="figure" viewBox="0 0 508 268" aria-hidden="true">
+        <path d="M305.2 156.6c0 4.6-.5 9-1.6 13.2-2.5-4.4-5.6-8.4-9.2-12-4.6-4.6-10-8.4-16-11.2 2.8-11.2 4.5-22.9 5-34.6 1.8 1.4 3.5 2.9 5 4.5 10.5 10.3 16.8 24.5 16.8 40.1zm-75-10c-6 2.8-11.4 6.6-16 11.2-3.5 3.6-6.6 7.6-9.1 12-1-4.3-1.6-8.7-1.6-13.2 0-15.7 6.3-29.9 16.6-40.1 1.6-1.6 3.3-3.1 5.1-4.5.6 11.8 2.2 23.4 5 34.6z" fill="#2E3B39" fill-rule="nonzero"/>
+        <path d="M282.981 152.6c16.125-48.1 6.375-104-29.25-142.6-35.625 38.5-45.25 94.5-29.25 142.6h58.5z" stroke="#FFF" stroke-width="3.396" fill="#6DDCBD"/>
+        <path d="M271 29.7c-4.4-10.6-9.9-20.6-16.6-29.7-6.7 9-12.2 19-16.6 29.7H271z" stroke="#FFF" stroke-width="3" fill="#2E3B39"/>
+        <circle stroke="#FFF" stroke-width="7" fill="none" cx="254.3" cy="76.8" r="12.2"/>
+        <path class="smoke" d="M507.812 234.24c0-2.16-.632-4.32-1.58-6.24-3.318-6.72-11.85-11.52-21.804-11.52-1.106 0-2.212.12-3.318.24-.474-11.52-12.956-20.76-28.282-20.76-3.318 0-6.636.48-9.638 1.32-4.74-6.72-14.062-11.28-24.806-11.28-.79 0-1.58 0-2.37.12-.79 0-1.58-.12-2.37-.12-10.744 0-20.066 4.56-24.806 11.28a35.326 35.326 0 00-9.638-1.32c-15.642 0-28.282 9.6-28.282 21.48 0 1.32.158 2.76.474 3.96a26.09 26.09 0 00-4.424-.36c-8.058 0-15.01 3.12-19.118 7.8-3.476-1.68-7.742-2.76-12.324-2.76-12.008 0-21.804 7.08-22.752 15.96h-.158c-9.322 0-17.38 4.32-20.856 10.44-4.108-3.6-10.27-6-17.222-6h-1.264c-6.794 0-12.956 2.28-17.222 6-3.476-6.12-11.534-10.44-20.856-10.44h-.158c-.948-9-10.744-15.96-22.752-15.96-4.582 0-8.69.96-12.324 2.76-4.108-4.68-11.06-7.8-19.118-7.8-1.422 0-3.002.12-4.424.36.316-1.32.474-2.64.474-3.96 0-11.88-12.64-21.48-28.282-21.48-3.318 0-6.636.48-9.638 1.32-4.74-6.72-14.062-11.28-24.806-11.28-.79 0-1.58 0-2.37.12-.79 0-1.58-.12-2.37-.12-10.744 0-20.066 4.56-24.806 11.28a35.326 35.326 0 00-9.638-1.32c-15.326 0-27.808 9.24-28.282 20.76-1.106-.12-2.212-.24-3.318-.24-9.954 0-18.486 4.8-21.804 11.52-.948 1.92-1.58 4.08-1.58 6.24 0 4.8 2.528 9.12 6.636 12.36-.79 1.44-1.264 3.12-1.264 4.8 0 7.2 7.742 13.08 17.222 13.08h462.15c9.48 0 17.222-5.88 17.222-13.08 0-1.68-.474-3.36-1.264-4.8 4.582-3.24 7.11-7.56 7.11-12.36z" fill="#E6E9EE"/>
+        <path fill="#6DDCBD" d="M239 152h30v8h-30z"/>
+        <path class="exhaust__line" fill="#E6E9EE" d="M250 172h7v90h-7z"/>
+        <path class="flame" d="M250.27 178.834l-5.32-8.93s-2.47-5.7 3.458-6.118h10.26s6.232.266 3.306 6.194l-5.244 8.93s-3.23 4.37-6.46 0v-.076z" fill="#AA2247"/>
+      </svg>
+      <h1>{% translate "The install worked successfully! Congratulations!" %}</h1>
+      <p>{% blocktranslate %}You are seeing this page because <a href="https://docs.djangoproject.com/en/{{ version }}/ref/settings/#debug" target="_blank" rel="noopener">DEBUG=True</a> is in your settings file and you have not configured any URLs.{% endblocktranslate %}</p>
+    </main>
+    <footer>
+      <a class="option" href="https://docs.djangoproject.com/en/{{ version }}/" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7zm2.85 11.1l-.85.6V16h-4v-2.3l-.85-.6A4.997 4.997 0 017 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.63-.8 3.16-2.15 4.1z"></path>
         </svg>
-        <h1>{% translate "The install worked successfully! Congratulations!" %}</h1>
-        <p>{% blocktranslate %}You are seeing this page because <a href="https://docs.djangoproject.com/en/{{ version }}/ref/settings/#debug" target="_blank" rel="noopener">DEBUG=True</a> is in your settings file and you have not configured any URLs.{% endblocktranslate %}</p>
-      </main>
-      <footer>
-        <a class="option" href="https://docs.djangoproject.com/en/{{ version }}/" target="_blank" rel="noopener">
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7zm2.85 11.1l-.85.6V16h-4v-2.3l-.85-.6A4.997 4.997 0 017 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.63-.8 3.16-2.15 4.1z"></path>
-          </svg>
-          <p>
-            <span class="option__heading">{% translate "Django Documentation" %}</span><span class="sr-only">.</span><br>
-            {% translate 'Topics, references, &amp; how-to’s' %}
-          </p>
-        </a>
-        <a class="option" href="https://docs.djangoproject.com/en/{{ version }}/intro/tutorial01/" target="_blank" rel="noopener">
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"></path>
-          </svg>
-          <p>
-            <span class="option__heading">{% translate "Tutorial: A Polling App" %}</span><span class="sr-only">.</span><br>
-            {% translate "Get started with Django" %}
-          </p>
-        </a>
-        <a class="option" href="https://www.djangoproject.com/community/" target="_blank" rel="noopener">
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M16.5 13c-1.2 0-3.07.34-4.5 1-1.43-.67-3.3-1-4.5-1C5.33 13 1 14.08 1 16.25V19h22v-2.75c0-2.17-4.33-3.25-6.5-3.25zm-4 4.5h-10v-1.25c0-.54 2.56-1.75 5-1.75s5 1.21 5 1.75v1.25zm9 0H14v-1.25c0-.46-.2-.86-.52-1.22.88-.3 1.96-.53 3.02-.53 2.44 0 5 1.21 5 1.75v1.25zM7.5 12c1.93 0 3.5-1.57 3.5-3.5S9.43 5 7.5 5 4 6.57 4 8.5 5.57 12 7.5 12zm0-5.5c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zm9 5.5c1.93 0 3.5-1.57 3.5-3.5S18.43 5 16.5 5 13 6.57 13 8.5s1.57 3.5 3.5 3.5zm0-5.5c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2z"></path>
-          </svg>
-          <p>
-            <span class="option__heading">{% translate "Django Community" %}</span><span class="sr-only">.</span><br>
-            {% translate "Connect, get help, or contribute" %}
-          </p>
-        </a>
-      </footer>
-    </body>
+        <p>
+          <span class="option__heading">{% translate "Django Documentation" %}</span><span class="sr-only">.</span><br>
+          {% translate 'Topics, references, &amp; how-to’s' %}
+        </p>
+      </a>
+      <a class="option" href="https://docs.djangoproject.com/en/{{ version }}/intro/tutorial01/" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"></path>
+        </svg>
+        <p>
+          <span class="option__heading">{% translate "Tutorial: A Polling App" %}</span><span class="sr-only">.</span><br>
+          {% translate "Get started with Django" %}
+        </p>
+      </a>
+      <a class="option" href="https://www.djangoproject.com/community/" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M16.5 13c-1.2 0-3.07.34-4.5 1-1.43-.67-3.3-1-4.5-1C5.33 13 1 14.08 1 16.25V19h22v-2.75c0-2.17-4.33-3.25-6.5-3.25zm-4 4.5h-10v-1.25c0-.54 2.56-1.75 5-1.75s5 1.21 5 1.75v1.25zm9 0H14v-1.25c0-.46-.2-.86-.52-1.22.88-.3 1.96-.53 3.02-.53 2.44 0 5 1.21 5 1.75v1.25zM7.5 12c1.93 0 3.5-1.57 3.5-3.5S9.43 5 7.5 5 4 6.57 4 8.5 5.57 12 7.5 12zm0-5.5c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zm9 5.5c1.93 0 3.5-1.57 3.5-3.5S18.43 5 16.5 5 13 6.57 13 8.5s1.57 3.5 3.5 3.5zm0-5.5c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2z"></path>
+        </svg>
+        <p>
+          <span class="option__heading">{% translate "Django Community" %}</span><span class="sr-only">.</span><br>
+          {% translate "Connect, get help, or contribute" %}
+        </p>
+      </a>
+    </footer>
+  </body>
 </html>

--- a/django/views/templates/default_urlconf.html
+++ b/django/views/templates/default_urlconf.html
@@ -11,10 +11,7 @@
         line-height: 1.15;
       }
       a {
-        color: #19865C;
-      }
-      header {
-        border-bottom: 1px solid #efefef;
+        color: #092e20;
       }
       body {
         max-width: 960px;
@@ -30,22 +27,21 @@
         margin: 0;
         font-weight: 400;
       }
-      header {
-        display: grid;
-        grid-template-columns: auto auto;
-        align-items: self-end;
-        justify-content: space-between;
-        gap: 7px;
-        padding-top: 20px;
-        padding-bottom: 10px;
-      }
       .logo {
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 19.16 6.696'%3E%3Cg fill='rgb(9 46 32)'%3E%3Cpath d='m2.259 3.55e-8h1.048v4.851c-0.5377 0.1021-0.9324 0.1429-1.361 0.1429-1.279 0-1.946-0.5784-1.946-1.688 0-1.068 0.7078-1.763 1.804-1.763 0.1701 0 0.2994 0.01365 0.456 0.0544v-1.598zm0 2.442c-0.1225-0.04079-0.2246-0.0544-0.3539-0.0544-0.5308 0-0.8371 0.3267-0.8371 0.8983 0 0.5582 0.2927 0.8644 0.8303 0.8644 0.1156 0 0.211-0.00681 0.3607-0.02713z'/%3E%3Cpath d='m4.975 1.618v2.43c0 0.837-0.06125 1.239-0.245 1.586-0.1702 0.3335-0.3948 0.5444-0.8575 0.7758l-0.9732-0.4628c0.4628-0.2178 0.6874-0.4082 0.8303-0.701 0.1498-0.2994 0.1974-0.6466 0.1974-1.559v-2.069zm-1.048-1.613h1.048v1.075h-1.048z'/%3E%3Cpath d='m5.608 1.857c0.4628-0.2178 0.9052-0.313 1.388-0.313 0.5377 0 0.8915 0.1429 1.048 0.422 0.08842 0.1565 0.1156 0.3606 0.1156 0.7963v2.13c-0.4696 0.06814-1.062 0.1157-1.497 0.1157-0.8779 0-1.273-0.3063-1.273-0.9868 0-0.7351 0.524-1.075 1.81-1.184v-0.2314c0-0.1905-0.09527-0.2585-0.3607-0.2585-0.3879 0-0.8235 0.1088-1.232 0.3198v-0.8099zm1.64 1.667c-0.6942 0.06814-0.9188 0.177-0.9188 0.4492 0 0.2042 0.1293 0.2995 0.4152 0.2995 0.1566 0 0.2994-0.01365 0.5036-0.04759z'/%3E%3Cpath d='m8.671 1.782c0.6193-0.1634 1.13-0.2382 1.647-0.2382 0.5377 0 0.9256 0.1224 1.157 0.3607 0.2178 0.2245 0.2858 0.4695 0.2858 0.9936v2.055h-1.048v-2.015c0-0.4015-0.1361-0.5513-0.5104-0.5513-0.1429 0-0.2722 0.01365-0.4833 0.0749v2.491h-1.048v-3.171z'/%3E%3Cpath d='m12.17 5.525c0.3676 0.1905 0.735 0.279 1.123 0.279 0.6873 0 0.98-0.279 0.98-0.946v-0.0205c-0.2042 0.1021-0.4084 0.143-0.6805 0.143-0.9188 0-1.504-0.6058-1.504-1.565 0-1.191 0.8644-1.865 2.396-1.865 0.4492 0 0.8644 0.04759 1.368 0.1496l-0.3589 0.7561c-0.2791-0.05449-0.02235-0.00733-0.2332-0.02775v0.1089l0.01357 0.4423 0.0068 0.5717c0.0068 0.1428 0.0068 0.2858 0.01365 0.4287v0.2859c0 0.8984-0.07486 1.32-0.2994 1.667-0.3267 0.5105-0.8916 0.7623-1.695 0.7623-0.4084 0-0.7622-0.06129-1.13-0.2042v-0.9663zm2.083-3.131h-0.03398-0.0749c-0.2041-0.00681-0.4423 0.04759-0.6057 0.1497-0.2517 0.143-0.3811 0.4016-0.3811 0.7691 0 0.5241 0.2587 0.8235 0.7214 0.8235 0.1429 0 0.2586-0.02722 0.3947-0.06805v-0.3607c0-0.1225-0.0068-0.2587-0.0068-0.4016l-0.0068-0.4832-0.0068-0.3471v-0.08171z'/%3E%3Cpath d='m17.48 1.53c1.048 0 1.688 0.6602 1.688 1.729 0 1.096-0.6669 1.783-1.729 1.783-1.048 0-1.695-0.6601-1.695-1.722 4.4e-5 -1.103 0.667-1.79 1.736-1.79zm-0.0205 2.668c0.4016 0 0.6398-0.3335 0.6398-0.912 0-0.5716-0.2314-0.9119-0.6329-0.9119-0.4152 0-0.6535 0.3336-0.6535 0.9119 4.4e-5 0.5786 0.2383 0.912 0.6465 0.912z'/%3E%3C/g%3E%3C/svg%3E");
+        color: #092e20;
+        background-position-x: center;
+        background-repeat: no-repeat;
+        font-size: 2rem;
         font-weight: 700;
-        font-size: 1.375rem;
+        margin-top: 16px;
+        overflow: hidden;
         text-decoration: none;
+        text-indent: 100%;
+        display: inline-block;
       }
       .figure {
-        margin-top: 19vh;
+        margin-top: 22vh;
         max-width: 265px;
         position: relative;
         z-index: -9;
@@ -137,7 +133,7 @@
         display: table;
       }
       .option .option__heading {
-        color: #19865C;
+        color: #092e20;
         font-size: 1.25rem;
         font-weight: 400;
       }
@@ -162,11 +158,6 @@
         }
         main h1 {
           font-size: 1.25rem;
-        }
-        header {
-          grid-template-columns: 1fr;
-          padding-left: 20px;
-          padding-right: 20px;
         }
         footer {
           width: 100%;
@@ -199,12 +190,6 @@
     </style>
   </head>
   <body>
-    <header>
-      <a class="logo" href="https://www.djangoproject.com/" target="_blank" rel="noopener">
-        django
-      </a>
-      <p>{% blocktranslate %}View <a href="https://docs.djangoproject.com/en/{{ version }}/releases/" target="_blank" rel="noopener">release notes</a> for Django {{ version }}{% endblocktranslate %}</p>
-    </header>
     <main>
       <svg class="figure" viewBox="0 0 508 268" aria-hidden="true">
         <path d="M305.2 156.6c0 4.6-.5 9-1.6 13.2-2.5-4.4-5.6-8.4-9.2-12-4.6-4.6-10-8.4-16-11.2 2.8-11.2 4.5-22.9 5-34.6 1.8 1.4 3.5 2.9 5 4.5 10.5 10.3 16.8 24.5 16.8 40.1zm-75-10c-6 2.8-11.4 6.6-16 11.2-3.5 3.6-6.6 7.6-9.1 12-1-4.3-1.6-8.7-1.6-13.2 0-15.7 6.3-29.9 16.6-40.1 1.6-1.6 3.3-3.1 5.1-4.5.6 11.8 2.2 23.4 5 34.6z" fill="#2E3B39" fill-rule="nonzero"/>
@@ -217,7 +202,11 @@
         <path class="flame" d="M250.27 178.834l-5.32-8.93s-2.47-5.7 3.458-6.118h10.26s6.232.266 3.306 6.194l-5.244 8.93s-3.23 4.37-6.46 0v-.076z" fill="#AA2247"/>
       </svg>
       <h1>{% translate "The install worked successfully! Congratulations!" %}</h1>
+      <p>
+        {% blocktranslate %}View <a href="https://docs.djangoproject.com/en/{{ version }}/releases/" target="_blank" rel="noopener">release notes</a> for Django {{ version }}{% endblocktranslate %}
+      </p>
       <p>{% blocktranslate %}You are seeing this page because <a href="https://docs.djangoproject.com/en/{{ version }}/ref/settings/#debug" target="_blank" rel="noopener">DEBUG=True</a> is in your settings file and you have not configured any URLs.{% endblocktranslate %}</p>
+      <a class="logo" href="https://www.djangoproject.com/" target="_blank" rel="noopener">Django</a>
     </main>
     <footer>
       <a class="option" href="https://docs.djangoproject.com/en/{{ version }}/" target="_blank" rel="noopener">


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/35171
Discussion: https://forum.djangoproject.com/t/changing-the-congrats-page/27557

# Why

- on big screens the parts of the page are pretty much stretched out and so the actual version of the installation is easy to overlook (see for example https://nextcloud.e11bits.com/s/2FF9cbEocKnTSMk)
- the Django "logo" was just text in the font of the page
- the used color for links and the logo was not a "Django color"



# What

- header of the original congrats page is moved to the center with the other content
- links are now in a "Django color" #092e20
- logo is now a SVG and in a "Django color" #092e20

# How

- removed the header and increased the top margin of the rocket figure accordingly
- moved the "View the __release notes__ for Django X.Y" to the center as second paragraph
- added a SVG logo at the bottom of the center paragraph with a link to the Django project pages

I tried various things to embed the SVG logo into the page and use it as a link to the project page. What I ended up with is to mimic what's used on the Django project page, mainly for accessibility reasons.

The logo is now a background of the link to the project page. So the link element has the content "Django", which is not visible, but I hope could be picked up by screen readers. Also the box that one can see when navigating using the TAB key fits properly around the logo.

# Tests

There are no automated tests included, but I looked at some renderings of the page at different sizes and different languages and using the TAB navigation. Images for the new and old page can be found here:

https://nextcloud.e11bits.com/s/D7HJZmfop6BcGTn

This is my sixth PR for Django, so please advise as you see fit.