### PR TITLE
Refs #34900, Refs #34118 -- Updated assertion in test_skip_class_unless_db_feature() test on Python 3.12.2+.

### DIFF
--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -184,9 +184,11 @@ class SkippingClassTestCase(TransactionTestCase):
         except unittest.SkipTest:
             self.fail("SkipTest should not be raised here.")
         result = unittest.TextTestRunner(stream=StringIO()).run(test_suite)
-        # PY312: Python 3.12.1+ no longer includes skipped tests in the number
-        # of running tests.
-        self.assertEqual(result.testsRun, 1 if sys.version_info >= (3, 12, 1) else 3)
+        # PY312: Python 3.12.1 does not include skipped tests in the number of
+        # running tests.
+        self.assertEqual(
+            result.testsRun, 1 if sys.version_info[:3] == (3, 12, 1) else 3
+        )
         self.assertEqual(len(result.skipped), 2)
         self.assertEqual(result.skipped[0][1], "Database has feature(s) __class__")
         self.assertEqual(result.skipped[1][1], "Database has feature(s) __class__")


### PR DESCRIPTION
…ss_db_feature() test on Python 3.12.2.

Python 3.12.2 bring back the skipped tests in the number of running tests. It was just removed in 3.12.1.
Check out:

https://github.com/python/cpython/commit/0a737639dcd3b7181250f5d56694b192eaddeef0