### PR TITLE
Fixed #35179 -- Made admindocs detect positional/keyword-only arguments.

### DIFF
--- a/django/utils/inspect.py
+++ b/django/utils/inspect.py
@@ -68,9 +68,7 @@ def func_accepts_var_args(func):
 
 def method_has_no_args(meth):
     """Return True if a method only accepts 'self'."""
-    count = len(
-        [p for p in _get_callable_parameters(meth) if p.kind == p.POSITIONAL_OR_KEYWORD]
-    )
+    count = len([p for p in _get_callable_parameters(meth) if p.kind in ARG_KINDS])
     return count == 0 if inspect.ismethod(meth) else count == 1
 
 

--- a/tests/admin_docs/models.py
+++ b/tests/admin_docs/models.py
@@ -54,6 +54,12 @@ class Person(models.Model):
     def dummy_function(self, baz, rox, *some_args, **some_kwargs):
         return some_kwargs
 
+    def dummy_function_keyword_only_arg(self, *, keyword_only_arg):
+        return keyword_only_arg
+
+    def all_kinds_arg_function(self, position_only_arg, /, arg, *, kwarg):
+        return position_only_arg, arg, kwarg
+
     @property
     def a_property(self):
         return "a_property"

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -280,6 +280,8 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
         self.assertContains(self.response, "<h3>Methods with arguments</h3>")
         self.assertContains(self.response, "<td>rename_company</td>")
         self.assertContains(self.response, "<td>dummy_function</td>")
+        self.assertContains(self.response, "<td>dummy_function_keyword_only_arg</td>")
+        self.assertContains(self.response, "<td>all_kinds_arg_function</td>")
         self.assertContains(self.response, "<td>suffix_company_name</td>")
 
     def test_methods_with_arguments_display_arguments(self):
@@ -287,6 +289,7 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
         Methods with arguments should have their arguments displayed.
         """
         self.assertContains(self.response, "<td>new_name</td>")
+        self.assertContains(self.response, "<td>keyword_only_arg</td>")
 
     def test_methods_with_arguments_display_arguments_default_value(self):
         """
@@ -302,6 +305,7 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
         self.assertContains(
             self.response, "<td>baz, rox, *some_args, **some_kwargs</td>"
         )
+        self.assertContains(self.response, "<td>position_only_arg, arg, kwarg</td>")
 
     def test_instance_of_property_methods_are_displayed(self):
         """Model properties are displayed as fields."""


### PR DESCRIPTION
Fix [ticket 35179](https://code.djangoproject.com/ticket/35179)