### PR TITLE
Fixed docs tutorial 7 missing  `model` attribute for ChoiceInline class

### DIFF
--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -174,7 +174,8 @@ tabular way of displaying inline related objects. To use it, change the
 .. code-block:: python
     :caption: ``polls/admin.py``
 
-    class ChoiceInline(admin.TabularInline): ...
+    class ChoiceInline(admin.TabularInline):
+        model = Choice
 
 With that ``TabularInline`` (instead of ``StackedInline``), the
 related objects are displayed in a more compact, table-based format:


### PR DESCRIPTION
Due to lack of model attribute in ChoiceInline,  it is breaking the code. I am following the docs as it is and I faced this problem.
