### PR TITLE
Fixed #35187 -- Fixed @sensitive_variables/sensitive_post_parameters decorators crash with .pyc-only builds.

### DIFF
--- a/django/views/decorators/debug.py
+++ b/django/views/decorators/debug.py
@@ -47,7 +47,6 @@ def sensitive_variables(*variables):
 
             try:
                 file_path = inspect.getfile(wrapped_func)
-                _, first_file_line = inspect.getsourcelines(wrapped_func)
             except TypeError:  # Raises for builtins or native functions.
                 raise ValueError(
                     f"{func.__name__} cannot safely be wrapped by "
@@ -55,7 +54,10 @@ def sensitive_variables(*variables):
                     "Python file (not a builtin or from a native extension)."
                 )
             else:
-                key = hash(f"{file_path}:{first_file_line}")
+                # A source file may not be available (e.g. in .pyc-only builds),
+                # use the first line number instead.
+                first_line_number = wrapped_func.__code__.co_firstlineno
+                key = hash(f"{file_path}:{first_line_number}")
 
             if variables:
                 coroutine_functions_to_sensitive_variables[key] = variables

--- a/docs/releases/5.0.3.txt
+++ b/docs/releases/5.0.3.txt
@@ -20,3 +20,7 @@ Bugfixes
   would prevent filtering against foreign keys using lookups like ``__isnull``
   when the field was not included in :attr:`.ModelAdmin.list_filter`
   (:ticket:`35173`).
+
+* Fixed a regression in Django 5.0 that caused a crash of
+  ``@sensitive_variables`` and ``@sensitive_post_parameters`` decorators on
+  functions loaded from ``.pyc`` files (:ticket:`35187`).


### PR DESCRIPTION
Thanks Jon Janzen for the implementation idea.

Thanks Marcus Hoffmann for the report.

Regression in 38e391e95fe5258bc6d2467332dc9cd44ce6ba52.

ticket-35187