### PR TITLE
Refs #28011 -- Removed ForeignObjectRel.is_hidden().

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -154,7 +154,7 @@ class RelatedField(FieldCacheMixin, Field):
         return []
 
     def _check_related_query_name_is_valid(self):
-        if self.remote_field.is_hidden():
+        if self.remote_field.hidden:
             return []
         rel_query_name = self.related_query_name()
         errors = []
@@ -253,7 +253,7 @@ class RelatedField(FieldCacheMixin, Field):
         # If the field doesn't install a backward relation on the target model
         # (so `is_hidden` returns True), then there are no clashes to check
         # and we can skip these fields.
-        rel_is_hidden = self.remote_field.is_hidden()
+        rel_is_hidden = self.remote_field.hidden
         rel_name = self.remote_field.accessor_name  # i. e. "model_set"
         rel_query_name = self.related_query_name()  # i. e. "model"
         # i.e. "app_label.Model.field".
@@ -887,10 +887,7 @@ class ForeignObject(RelatedField):
     def contribute_to_related_class(self, cls, related):
         # Internal FK's - i.e., those with a related name ending with '+' -
         # and swapped models don't get a related descriptor.
-        if (
-            not self.remote_field.is_hidden()
-            and not related.related_model._meta.swapped
-        ):
+        if not self.remote_field.hidden and not related.related_model._meta.swapped:
             setattr(
                 cls._meta.concrete_model,
                 related.accessor_name,
@@ -1901,7 +1898,7 @@ class ManyToManyField(RelatedField):
             or self.remote_field.model == cls._meta.object_name
         ):
             self.remote_field.related_name = "%s_rel_+" % name
-        elif self.remote_field.is_hidden():
+        elif self.remote_field.hidden:
             # If the backwards relation is disabled, replace the original
             # related_name with one generated from the m2m field name. Django
             # still uses backwards relations internally and we need to avoid
@@ -1941,10 +1938,7 @@ class ManyToManyField(RelatedField):
     def contribute_to_related_class(self, cls, related):
         # Internal M2Ms (i.e., those with a related name ending with '+')
         # and swapped models don't get a related descriptor.
-        if (
-            not self.remote_field.is_hidden()
-            and not related.related_model._meta.swapped
-        ):
+        if not self.remote_field.hidden and not related.related_model._meta.swapped:
             setattr(
                 cls,
                 related.accessor_name,

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -187,7 +187,7 @@ class ForwardManyToOneDescriptor:
         # (related_name ends with a '+'). Refs #21410.
         # The check for len(...) == 1 is a special case that allows the query
         # to be join-less and smaller. Refs #21760.
-        if remote_field.is_hidden() or len(self.field.foreign_related_fields) == 1:
+        if remote_field.hidden or len(self.field.foreign_related_fields) == 1:
             query = {
                 "%s__in"
                 % related_field.name: {instance_attr(inst)[0] for inst in instances}

--- a/django/db/models/fields/reverse_related.py
+++ b/django/db/models/fields/reverse_related.py
@@ -66,7 +66,8 @@ class ForeignObjectRel(FieldCacheMixin):
     # AttributeError
     @cached_property
     def hidden(self):
-        return self.is_hidden()
+        """Should the related object be hidden?"""
+        return bool(self.related_name) and self.related_name[-1] == "+"
 
     @cached_property
     def name(self):
@@ -190,10 +191,6 @@ class ForeignObjectRel(FieldCacheMixin):
         if ordering:
             qs = qs.order_by(*ordering)
         return (blank_choice if include_blank else []) + [(x.pk, str(x)) for x in qs]
-
-    def is_hidden(self):
-        """Should the related object be hidden?"""
-        return bool(self.related_name) and self.related_name[-1] == "+"
 
     def get_joining_columns(self):
         warnings.warn(

--- a/tests/model_meta/tests.py
+++ b/tests/model_meta/tests.py
@@ -269,7 +269,7 @@ class RelationTreeTests(SimpleTestCase):
             sorted(
                 field.related_query_name()
                 for field in Relation._meta._relation_tree
-                if not field.remote_field.field.remote_field.is_hidden()
+                if not field.remote_field.field.remote_field.hidden
             ),
             sorted(
                 [


### PR DESCRIPTION
ticket-28011

c5a77721e2fccff427374cd987a6d8b92a37f37c removed the only override of `ForeignObjectRel.is_hidden()`, leaving it duplicative of the `hidden` attribute. This PR removes the method, replacing all use with the attribute only.