### PR TITLE
Refs #34060 -- Fixed JSONField __exact lookup for primitivies on Oracle 21c+.

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -313,7 +313,10 @@ class JSONExact(lookups.Exact):
     def as_oracle(self, compiler, connection):
         lhs, lhs_params = self.process_lhs(compiler, connection)
         rhs, rhs_params = self.process_rhs(compiler, connection)
-        return f"JSON_EQUAL({lhs}, {rhs})", (*lhs_params, *rhs_params)
+        if connection.features.supports_primitives_in_json_field:
+            lhs = f"JSON({lhs})"
+            rhs = f"JSON({rhs})"
+        return f"JSON_EQUAL({lhs}, {rhs} ERROR ON ERROR)", (*lhs_params, *rhs_params)
 
 
 class JSONIContains(CaseInsensitiveMixin, lookups.IContains):


### PR DESCRIPTION
It solves an issue raised in [PR #34060 comment](https://github.com/django/django/pull/17855#issuecomment-1947833489).
Tested on Oracle 19c,21c,23c.
There is a difference between v.19 and 21 in support NULL and JSON_EQUAL for JSON. ([Oracle 18c](https://dbfiddle.uk/DomLmamY))
In version 21 there was introduced native JSON data type and this might involve other changes (2 ordering JSON field tests fail in Oracle 21 - [ticket #35225](https://code.djangoproject.com/ticket/35225))