### PR TITLE
Refs #30950, Refs #35187 -- Added tests for byte-compiled Django to daily builds.

### DIFF
--- a/.github/workflows/schedule_tests.yml
+++ b/.github/workflows/schedule_tests.yml
@@ -37,6 +37,32 @@ jobs:
       - name: Run tests
         run: python tests/runtests.py -v2
 
+  pyc-only:
+    runs-on: ubuntu-latest
+    name: Byte-compiled Django with no source files (only .pyc files)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install libmemcached-dev for pylibmc
+        run: sudo apt-get install libmemcached-dev
+      - name: Install and upgrade packaging tools
+        run: python -m pip install --upgrade pip setuptools wheel
+      - run: python -m pip install .
+      - name: Prepare site-packages
+        run: |
+          SITE_PACKAGE_ROOT=$(python -c 'import site; print(site.getsitepackages()[0])')
+          echo $SITE_PACKAGE_ROOT
+          python -m compileall -b $SITE_PACKAGE_ROOT
+          find $SITE_PACKAGE_ROOT -name '*.py' -print -delete
+      - run: python -m pip install -r tests/requirements/py3.txt
+      - name: Run tests
+        run: python tests/runtests.py --verbosity=2
+
   pypy-sqlite:
     runs-on: ubuntu-latest
     name: Ubuntu, SQLite, PyPy3.10


### PR DESCRIPTION
Ref discussion:
1. https://code.djangoproject.com/ticket/35187
2. https://github.com/django/django/pull/17860

The following lines in the [buildroot](https://gitlab.com/buildroot.org/buildroot) project's CI configuration were helpful in the construction of this CI job: https://gitlab.com/buildroot.org/buildroot/-/blob/master/package/python3/python3.mk#L276-300

Test plan:
I ran this workflow on my personal fork at 2 points in Django's history:

At https://github.com/django/django/commit/d1be05b3e9209fd0787841c71a95819d81061187 (which is current HEAD, is the merged version of the above PR, and is the base commit of this branch)
At this point in history, the check passes: https://github.com/bigfootjon/django/actions/runs/7943297826/job/21687498766

I then cherry-picked this commit onto https://github.com/django/django/commit/7a05b8a2fac57e32a61726893d4601352c1d1c8d (which is current `HEAD~1`, in other words the the commit before the fix)
At this point in history, the check fails: https://github.com/bigfootjon/django/actions/runs/7943289205/job/21687479256

AFAICT, this is sufficient to demonstrate that this workflow is working correctly. Any other failures in the above workflows do not appear to be a result of this change.