### PR TITLE
Fixed closing connections in test_utils.tests.AllowedDatabaseQueriesTests.

### DIFF
--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -2132,12 +2132,34 @@ class AllowedDatabaseQueriesTests(SimpleTestCase):
         next(Car.objects.iterator(), None)
 
     def test_allowed_threaded_database_queries(self):
+        connections_dict = {}
+
         def thread_func():
+            # Passing django.db.connection between threads doesn't work while
+            # connections[DEFAULT_DB_ALIAS] does.
+            from django.db import connections
+
+            connection = connections["default"]
+
             next(Car.objects.iterator(), None)
 
-        t = threading.Thread(target=thread_func)
-        t.start()
-        t.join()
+            # Allow thread sharing so the connection can be closed by the main
+            # thread.
+            connection.inc_thread_sharing()
+            connections_dict[id(connection)] = connection
+
+        try:
+            t = threading.Thread(target=thread_func)
+            t.start()
+            t.join()
+        finally:
+            # Finish by closing the connections opened by the other threads
+            # (the connection opened in the main thread will automatically be
+            # closed on teardown).
+            for conn in connections_dict.values():
+                if conn is not connection and conn.allow_thread_sharing:
+                    conn.close()
+                    conn.dec_thread_sharing()
 
 
 class DatabaseAliasTests(SimpleTestCase):


### PR DESCRIPTION
Noticed while working on [#35226](https://code.djangoproject.com/ticket/35226).
It crashes on Oracle, but new connection from thread is not closed properly in other databases either:
```
$ ./runtests.py test_utils.tests.AllowedDatabaseQueriesTests
Testing against Django installed in '/django/django' with up to 8 processes
Found 3 test(s).
Creating test database for alias 'default'...
Destroying old test database for alias 'default'...
Creating test user...
Destroying old test user...
Creating test user...
System check identified no issues (0 silenced).
...
----------------------------------------------------------------------
Ran 3 tests in 0.044s

OK
Destroying test database for alias 'default'...
Destroying test user...
Failed (ORA-01940: cannot drop a user who is currently connected
Help: https://docs.oracle.com/error-help/db/ora-01940/)
Traceback (most recent call last):
...
  File "src/oracledb/impl/thin/cursor.pyx", line 173, in oracledb.thin_impl.ThinCursorImpl.execute
  File "src/oracledb/impl/thin/protocol.pyx", line 425, in oracledb.thin_impl.Protocol._process_single_message
  File "src/oracledb/impl/thin/protocol.pyx", line 426, in oracledb.thin_impl.Protocol._process_single_message
  File "src/oracledb/impl/thin/protocol.pyx", line 419, in oracledb.thin_impl.Protocol._process_message
django.db.utils.DatabaseError: ORA-01940: cannot drop a user who is currently connected
Help: https://docs.oracle.com/error-help/db/ora-01940/
```