### PR TITLE
Fixed #35226 -- Reallowed executing queries for dynamically created connections.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -280,6 +280,8 @@ class SimpleTestCase(unittest.TestCase):
                 self.connection is None
                 and self.alias not in cls.databases
                 and self.alias != NO_DB_ALIAS
+                # Dynamically created connections are always allowed.
+                and self.alias in connections
             ):
                 # Connection has not yet been established, but the alias is not allowed.
                 message = cls._disallowed_database_msg % {

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -2161,6 +2161,16 @@ class AllowedDatabaseQueriesTests(SimpleTestCase):
                     conn.close()
                     conn.dec_thread_sharing()
 
+    def test_allowed_database_copy_queries(self):
+        new_connection = connection.copy("dynamic_connection")
+        try:
+            with new_connection.cursor() as cursor:
+                sql = f"SELECT 1{new_connection.features.bare_select_suffix}"
+                cursor.execute(sql)
+                self.assertEqual(cursor.fetchone()[0], 1)
+        finally:
+            new_connection.close()
+
 
 class DatabaseAliasTests(SimpleTestCase):
     def setUp(self):


### PR DESCRIPTION
Regression in 8fb0be3500cc7519a56985b1b6f415d75ac6fedb.

Thanks Florian Apolloner for the report.