### PR TITLE
Fixed #35198 -- Fixed facet filters crash on querysets with no primary key.

### DIFF
--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -140,7 +140,7 @@ class SimpleListFilter(FacetsMixin, ListFilter):
             if lookup_qs is not None:
                 counts[f"{i}__c"] = models.Count(
                     pk_attname,
-                    filter=lookup_qs.query.where,
+                    filter=models.Q(pk__in=lookup_qs),
                 )
         self.used_parameters[self.parameter_name] = original_value
         return counts

--- a/docs/releases/5.0.3.txt
+++ b/docs/releases/5.0.3.txt
@@ -29,3 +29,6 @@ Bugfixes
 * Fixed a regression in Django 5.0 that caused a crash when reloading a test
   database and a base queryset for a base manager used ``prefetch_related()``
   (:ticket:`35238`).
+
+* Fixed a bug in Django 5.0 where facet filters in the admin would crash on a
+  ``SimpleListFilter`` using a queryset without primary keys (:ticket:`35198`).


### PR DESCRIPTION
Fixed ticket-35198.

Existing `SimpleListFilter` can be used for single table lookup. It assumes the filter's condition is only based on the fields that are on the table, hence it just takes the `where` node from the filter and adds that to the aggregate `Count`. This works for simple cases, but it fails when the filter is more complex e.g. if it uses annotations. When an annotation is used, taking just the `where` node would result in an incorrect query that refers to the annotation without including the annotation itself in the query.

This PR changes the approach by taking the full query of the filter as a subquery and wrapping it in a `Count` expression. It's likely to be less performant for the simpler cases, but this ensures that the query used for the aggregate is always correct, regardless of how complex the filter is.