### PR TITLE
Fixed #34917 -- Underlined Links in Django Admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -11,6 +11,14 @@
     min-width: 0;
 }
 
+#changelist .changelist-form-container a {
+    text-decoration: underline;
+}
+
+#changelist .changelist-form-container table thead a {
+    text-decoration: none;
+}
+
 #changelist table {
     width: 100%;
 }
@@ -48,6 +56,10 @@
     border-bottom: 1px solid var(--hairline-color);
     background: var(--body-bg);
     overflow: hidden;
+}
+
+#changelist .paginator a{
+    text-decoration: none;
 }
 
 /* CHANGELIST TABLES */


### PR DESCRIPTION
Fixed ticket [#34917](https://code.djangoproject.com/ticket/34917) - Links in the Django admin are now underlined.