### PR TITLE
Fixed #35140 -- Increased font size in debug views.

### DIFF
--- a/django/views/templates/csrf_403.html
+++ b/django/views/templates/csrf_403.html
@@ -8,7 +8,7 @@
     html * { padding:0; margin:0; }
     body * { padding:10px 20px; }
     body * * { padding:0; }
-    body { font:small sans-serif; background:#eee; color:#000; }
+    body { font-family: sans-serif; background:#eee; color:#000; }
     body>div { border-bottom:1px solid #ddd; }
     h1 { font-weight:normal; margin-bottom:.4em; }
     h1 span { font-size:60%; color:#666; font-weight:normal; }

--- a/django/views/templates/technical_404.html
+++ b/django/views/templates/technical_404.html
@@ -8,7 +8,7 @@
     html * { padding:0; margin:0; }
     body * { padding:10px 20px; }
     body * * { padding:0; }
-    body { font:small sans-serif; background:#eee; color:#000; }
+    body { font-family: sans-serif; background:#eee; color:#000; }
     body > :where(header, main, footer) { border-bottom:1px solid #ddd; }
     h1 { font-weight:normal; margin-bottom:.4em; }
     h1 small { font-size:60%; color:#666; font-weight:normal; }

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -9,7 +9,7 @@
     html * { padding:0; margin:0; }
     body * { padding:10px 20px; }
     body * * { padding:0; }
-    body { font:small sans-serif; background-color:#fff; color:#000; }
+    body { font-family: sans-serif; background-color:#fff; color:#000; }
     body > :where(header, main, footer) { border-bottom:1px solid #ddd; }
     h1 { font-weight:normal; }
     h2 { margin-bottom:.8em; }
@@ -21,7 +21,7 @@
     tbody td, tbody th { vertical-align:top; padding:2px 3px; }
     thead th {
       padding:1px 6px 1px 3px; background:#fefefe; text-align:left;
-      font-weight:normal; font-size:11px; border:1px solid #ddd;
+      font-weight:normal; font-size: 0.6875rem; border:1px solid #ddd;
     }
     tbody th { width:12em; text-align:right; color:#666; padding-right:.5em; }
     table.vars { margin:5px 10px 2px 40px; width: auto; }
@@ -61,9 +61,9 @@
     #requestinfo h3 { margin-bottom:-1em; }
     .error { background: #ffc; }
     .specific { color:#cc3300; font-weight:bold; }
-    h2 span.commands { font-size:.7em; font-weight:normal; }
+    h2 span.commands { font-size: 0.7rem; font-weight:normal; }
     span.commands a:link {color:#5E5694;}
-    pre.exception_value { font-family: sans-serif; color: #575757; font-size: 1.5em; margin: 10px 0 10px 0; }
+    pre.exception_value { font-family: sans-serif; color: #575757; font-size: 1.5rem; margin: 10px 0 10px 0; }
     .append-bottom { margin-bottom: 10px; }
     .fname { user-select: all; }
   </style>


### PR DESCRIPTION
## Ticket
https://code.djangoproject.com/ticket/35140

## Description
Removed the `font-size: small` CSS property from Django's debug views (404, 500, etc) that was making some fonts be pretty small (13px). 

## Screenshots

404 Page before changes
<img width="1440" alt="404 page before changes" src="https://github.com/django/django/assets/67162025/1495b66b-e4a8-4e25-afad-f93b2618458d">

404 Page after changes
<img width="1440" alt="404 page after changes; font size is larger" src="https://github.com/django/django/assets/67162025/b86c948e-d318-4d1d-a57e-e69473833226">


500 Page before changes
<img width="1439" alt="500 page before changes" src="https://github.com/django/django/assets/67162025/c3c993bd-7ab6-4ccc-ad05-5de2ed3a82ac">

500 Page after changes
<img width="1440" alt="500 page after changes; font size is larger" src="https://github.com/django/django/assets/67162025/a0df9edf-7369-4c22-b442-4f0e7fff2643">

