### PR TITLE
Removed obsolete test_get_or_create_raises_IntegrityError_plus_traceback() test.

### DIFF
--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -227,19 +227,6 @@ class GetOrCreateTestsWithManualPKs(TestCase):
             ManualPrimaryKeyTest.objects.get_or_create(id=1, data="Different")
         self.assertEqual(ManualPrimaryKeyTest.objects.get(id=1).data, "Original")
 
-    def test_get_or_create_raises_IntegrityError_plus_traceback(self):
-        """
-        get_or_create should raise IntegrityErrors with the full traceback.
-        This is tested by checking that a known method call is in the traceback.
-        We cannot use assertRaises here because we need to inspect
-        the actual traceback. Refs #16340.
-        """
-        try:
-            ManualPrimaryKeyTest.objects.get_or_create(id=1, data="Different")
-        except IntegrityError:
-            formatted_traceback = traceback.format_exc()
-            self.assertIn("obj.save", formatted_traceback)
-
     def test_savepoint_rollback(self):
         """
         The database connection is still usable after a DatabaseError in


### PR DESCRIPTION
This test was added in 31b1cbc623c246570e7301c0334df938d840638f, but is no longer needed, as the fix was reverted in 746caf3ef821dbf7588797cb2600fa81b9df9d1d without any consequences, so it now tests Python behavior rather than Django. Moreover, traceback introspection is problematic for .pyc-only installations.