### PR TITLE
issue #35244: resolution with a reference to the view function does not work in case of an `.app_name`.

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -561,10 +561,10 @@ class URLResolver:
                         for name in url_pattern.reverse_dict:
                             if not isinstance(name, str):
                                 for (
-                                        matches,
-                                        pat,
-                                        defaults,
-                                        converters,
+                                    matches,
+                                    pat,
+                                    defaults,
+                                    converters,
                                 ) in url_pattern.reverse_dict.getlist(name):
                                     new_matches = normalize(p_pattern + pat)
                                     lookups.appendlist(

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -558,6 +558,28 @@ class URLResolver:
                                 url_pattern.pattern.converters,
                             ),
                         )
+                        for name in url_pattern.reverse_dict:
+                            if not isinstance(name, str):
+                                for (
+                                        matches,
+                                        pat,
+                                        defaults,
+                                        converters,
+                                ) in url_pattern.reverse_dict.getlist(name):
+                                    new_matches = normalize(p_pattern + pat)
+                                    lookups.appendlist(
+                                        name,
+                                        (
+                                            new_matches,
+                                            p_pattern + pat,
+                                            {**defaults, **url_pattern.default_kwargs},
+                                            {
+                                                **self.pattern.converters,
+                                                **url_pattern.pattern.converters,
+                                                **converters,
+                                            },
+                                        ),
+                                    )
                 else:  # url_pattern is a URLResolver.
                     url_pattern._populate()
                     if url_pattern.app_name:


### PR DESCRIPTION
The view function references were *not* backpropagated, now these are backpropagated by checking if this is a view function, and if so thus added to the parent `.reverse_dict`. The approach is however a bit hacky and thus might be redesigned.

cref: https://code.djangoproject.com/ticket/35244
cref: https://stackoverflow.com/questions/78035103/in-django-is-it-possible-to-use-reverse-redirect-with-a-view-function-not-stri