### PR TITLE
Simplified using DATABASES["OPTIONS"].

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -190,9 +190,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def get_connection_params(self):
         settings_dict = self.settings_dict
         # None may be used to connect to the default 'postgres' db
-        if settings_dict["NAME"] == "" and not settings_dict.get("OPTIONS", {}).get(
-            "service"
-        ):
+        if settings_dict["NAME"] == "" and not settings_dict["OPTIONS"].get("service"):
             raise ImproperlyConfigured(
                 "settings.DATABASES is improperly configured. "
                 "Please supply the NAME or OPTIONS['service'] value."
@@ -215,7 +213,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             }
         elif settings_dict["NAME"] is None:
             # Connect to the default 'postgres' db.
-            settings_dict.get("OPTIONS", {}).pop("service", None)
+            settings_dict["OPTIONS"].pop("service", None)
             conn_params = {"dbname": "postgres", **settings_dict["OPTIONS"]}
         else:
             conn_params = {**settings_dict["OPTIONS"]}
@@ -300,7 +298,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def ensure_role(self):
         if self.connection is None:
             return False
-        if new_role := self.settings_dict.get("OPTIONS", {}).get("assume_role"):
+        if new_role := self.settings_dict["OPTIONS"].get("assume_role"):
             with self.connection.cursor() as cursor:
                 sql = self.ops.compose_sql("SET ROLE %s", [new_role])
                 cursor.execute(sql)
@@ -324,8 +322,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def create_cursor(self, name=None):
         if name:
             if is_psycopg3 and (
-                self.settings_dict.get("OPTIONS", {}).get("server_side_binding")
-                is not True
+                self.settings_dict["OPTIONS"].get("server_side_binding") is not True
             ):
                 # psycopg >= 3 forces the usage of server-side bindings for
                 # named cursors so a specialized class that implements

--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -9,7 +9,7 @@ class DatabaseClient(BaseDatabaseClient):
     @classmethod
     def settings_to_cmd_args_env(cls, settings_dict, parameters):
         args = [cls.executable_name]
-        options = settings_dict.get("OPTIONS", {})
+        options = settings_dict["OPTIONS"]
 
         host = settings_dict.get("HOST")
         port = settings_dict.get("PORT")

--- a/tests/dbshell/test_postgresql.py
+++ b/tests/dbshell/test_postgresql.py
@@ -14,6 +14,7 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
     def settings_to_cmd_args_env(self, settings_dict, parameters=None):
         if parameters is None:
             parameters = []
+        settings_dict.setdefault("OPTIONS", {})
         return DatabaseClient.settings_to_cmd_args_env(settings_dict, parameters)
 
     def test_basic(self):


### PR DESCRIPTION
`DATABASES["OPTIONS"]` are always configured:

https://github.com/django/django/blob/b9d539cca79d8100b24b30fabdb21d10154634ec/django/db/utils.py#L167