### PR TITLE
Fixed #29022 -- Fixed handling protocol-relative URLs in ManifestStaticFilesStorage when STATIC_URL is set to /.

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -221,7 +221,7 @@ class HashedFilesMixin:
             url = matches["url"]
 
             # Ignore absolute/protocol-relative and data-uri URLs.
-            if re.match(r"^[a-z]+:", url):
+            if re.match(r"^[a-z]+:", url) or url.startswith("//"):
                 return matched
 
             # Ignore absolute URLs that don't point to a static file (dynamic

--- a/tests/staticfiles_tests/project/static_url_slash/ignored.css
+++ b/tests/staticfiles_tests/project/static_url_slash/ignored.css
@@ -1,0 +1,3 @@
+body {
+    background: url("//foobar");
+}


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29022