### PR TITLE
Refs #34200 -- Removed unnecessary check in DatabaseWrapper.ensure_role() on PostgreSQL.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -296,8 +296,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return False
 
     def ensure_role(self):
-        if self.connection is None:
-            return False
         if new_role := self.settings_dict["OPTIONS"].get("assume_role"):
             with self.connection.cursor() as cursor:
                 sql = self.ops.compose_sql("SET ROLE %s", [new_role])


### PR DESCRIPTION
`ensure_role()` is only called in `init_connection_state()` where a new connection is established.