### PR TITLE
Refs #32114 -- Fixed test crash on non-picklable objects in subtests when PickleError is raised.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -100,7 +100,7 @@ def is_pickable(obj):
     """
     try:
         pickle.loads(pickle.dumps(obj))
-    except (AttributeError, TypeError):
+    except (AttributeError, TypeError, pickle.PickleError):
         return False
     return True
 

--- a/tests/test_utils/test_testcase.py
+++ b/tests/test_utils/test_testcase.py
@@ -3,9 +3,19 @@ from functools import wraps
 
 from django.db import IntegrityError, connections, transaction
 from django.test import TestCase, skipUnlessDBFeature
-from django.test.testcases import DatabaseOperationForbidden, SimpleTestCase, TestData
+from django.test.testcases import (
+    DatabaseOperationForbidden,
+    SimpleTestCase,
+    TestData,
+    is_pickable,
+)
 
 from .models import Car, Person, PossessedCar
+
+
+class UnpicklableObject:
+    def __getstate__(self):
+        raise pickle.PickleError("cannot be pickled for testing reasons")
 
 
 class TestSimpleTestCase(SimpleTestCase):
@@ -13,6 +23,10 @@ class TestSimpleTestCase(SimpleTestCase):
         """ParallelTestSuite requires that all TestCases are picklable."""
         self.non_picklable = lambda: 0
         self.assertEqual(self, pickle.loads(pickle.dumps(self)))
+
+    def test_is_picklable_with_non_picklable_object(self):
+        unpicklable_obj = UnpicklableObject()
+        self.assertEqual(is_pickable(unpicklable_obj), False)
 
 
 class TestTestCase(TestCase):


### PR DESCRIPTION
Refs https://github.com/django/django/pull/17650 and [ticket-32114](https://code.djangoproject.com/ticket/32114).

Probably related to https://github.com/python/cpython/issues/73373.
Reproducing the same behaviour between CPython 3.10 and PyPy 3.10