### PR TITLE
Removed #django-geo IRC channel in docs.

### DIFF
--- a/docs/ref/contrib/gis/install/index.txt
+++ b/docs/ref/contrib/gis/install/index.txt
@@ -107,9 +107,6 @@ Troubleshooting
 If you can't find the solution to your problem here then participate in the
 community!  You can:
 
-* Join the ``#django-geo`` IRC channel on Libera.Chat. Please be patient and
-  polite -- while you may not get an immediate response, someone will attempt
-  to answer your question as soon as they see it.
 * Ask your question on the `GeoDjango`__ forum.
 * File a ticket on the `Django trac`__ if you think there's a bug.  Make
   sure to provide a complete description of the problem, versions used,


### PR DESCRIPTION
It's been inactive for several years. I'm the only folk there :upside_down_face: 