### PR TITLE
postgresql jsonField save dict

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -89,6 +89,9 @@ class JSONField(CheckFieldDefaultMixin, Field):
         if isinstance(expression, KeyTransform) and not isinstance(value, str):
             return value
         try:
+            # PostgreSQL database save json return dict
+            if isinstance(value, dict):
+                return value
             return json.loads(value, cls=self.decoder)
         except json.JSONDecodeError:
             return value


### PR DESCRIPTION
Store dictionary data in a PostgreSQL database and retrieve it in Python as a dictionary object, not a JSON object.