### PR TITLE
Refs #35090 -- Fixed urlpatterns.tests.SimplifiedURLTests when run in reverse.

### DIFF
--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -13,7 +13,7 @@ from django.urls import (
     resolve,
     reverse,
 )
-from django.urls.converters import IntConverter
+from django.urls.converters import REGISTERED_CONVERTERS, IntConverter
 from django.utils.deprecation import RemovedInDjango60Warning
 from django.views import View
 
@@ -211,8 +211,11 @@ class SimplifiedURLTests(SimpleTestCase):
             "Converter 'int' is already registered. Support for overriding registered "
             "converters is deprecated and will be removed in Django 6.0."
         )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
-            register_converter(IntConverter, "int")
+        try:
+            with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+                register_converter(IntConverter, "int")
+        finally:
+            REGISTERED_CONVERTERS.pop("int", None)
 
     def test_warning_override_converter(self):
         # RemovedInDjango60Warning: when the deprecation ends, replace with
@@ -222,8 +225,12 @@ class SimplifiedURLTests(SimpleTestCase):
             "Converter 'base64' is already registered. Support for overriding "
             "registered converters is deprecated and will be removed in Django 6.0."
         )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
-            register_converter(Base64Converter, "base64")
+        try:
+            with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+                register_converter(Base64Converter, "base64")
+                register_converter(Base64Converter, "base64")
+        finally:
+            REGISTERED_CONVERTERS.pop("base64", None)
 
     def test_invalid_view(self):
         msg = "view must be a callable or a list/tuple in the case of include()."


### PR DESCRIPTION
[Logs](https://djangoci.com/job/main-reverse/database=sqlite3,label=focal,python=python3.12/261/testReport/)