### PR TITLE
Fixed typo in docs/ref/contrib/admin/index.txt.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1278,7 +1278,7 @@ subclass::
     ======  ====================
     Prefix  Lookup
     ======  ====================
-    ^       :lookup:`startswith`
+    ^       :lookup:`istartswith`
     =       :lookup:`iexact`
     @       :lookup:`search`
     None    :lookup:`icontains`


### PR DESCRIPTION
https://github.com/django/django/pull/9357/ enabled admin `search_fields` to use verbose lookups like `__istartswith` as an alternative to using the shortcut prefixes like `^`. The PR linked the lookup for `^` to be `startswith` but [the implementation](https://github.com/django/django/blob/11695b8fdd002362be8d5dc48bc78db09ddf33d8/django/contrib/admin/options.py#L1177-L1178) actually uses `istartswith`.



