### PR TITLE
Fixed #34613 -- Add support for partitioned cookie flag 

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -221,6 +221,7 @@ class HttpResponseBase:
         secure=False,
         httponly=False,
         samesite=None,
+        partitioned=False,
     ):
         """
         Set a cookie.
@@ -273,6 +274,8 @@ class HttpResponseBase:
             if samesite.lower() not in ("lax", "none", "strict"):
                 raise ValueError('samesite must be "lax", "none", or "strict".')
             self.cookies[key]["samesite"] = samesite
+        if partitioned:
+            self.cookies[key]["partitioned"] = True
 
     def setdefault(self, key, value):
         """Set a header unless it has already been set."""

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -913,7 +913,7 @@ Methods
 
     Sets a header unless it has already been set.
 
-.. method:: HttpResponse.set_cookie(key, value='', max_age=None, expires=None, path='/', domain=None, secure=False, httponly=False, samesite=None)
+.. method:: HttpResponse.set_cookie(key, value='', max_age=None, expires=None, path='/', domain=None, secure=False, httponly=False, samesite=None, partitioned=False)
 
     Sets a cookie. The parameters are the same as in the
     :class:`~http.cookies.Morsel` cookie object in the Python standard library.
@@ -946,9 +946,12 @@ Methods
 
       Use ``samesite='None'`` (string) to explicitly state that this cookie is
       sent with all same-site and cross-site requests.
+    * Use ``partitioned=True`` if you want to opt a cookie into partitioned
+      storage, with a separate cookie jar per top-level site.
 
     .. _HttpOnly: https://owasp.org/www-community/HttpOnly
     .. _SameSite: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+    .. _Partitioned: https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies
 
     .. warning::
 

--- a/tests/responses/test_cookie.py
+++ b/tests/responses/test_cookie.py
@@ -122,6 +122,15 @@ class SetCookieTests(SimpleTestCase):
         with self.assertRaisesMessage(ValueError, msg):
             HttpResponse().set_cookie("example", samesite="invalid")
 
+    def test_partitioned_cookie(self):
+        response = HttpResponse()
+        response.set_cookie("example", partitioned=True)
+        example_cookie = response.cookies["example"]
+        self.assertIn(
+            "; %s" % cookies.Morsel._reserved["partitioned"], str(example_cookie)
+        )
+        self.assertIs(example_cookie["partitioned"], True)
+
 
 class DeleteCookieTests(SimpleTestCase):
     def test_default(self):


### PR DESCRIPTION
Fixes [ticket-34613](https://code.djangoproject.com/ticket/34613)

This PR depends on https://github.com/python/cpython/pull/112714 and needs to be merged when `Partitioned` flag is supported in python's `http.cookies` . 

Since Google starting [phasing out third party cookies](https://developers.google.com/privacy-sandbox/blog/cookie-countdown-2023oct) in Q1 2024 this feature might become crucial for some businesses. 

Future improvements will contain adding support for partitioned flag for existing cookies used by django (eg similar to [SESSION_COOKIE_HTTPONLY](https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-SESSION_COOKIE_HTTPONLY)).