### PR TITLE
Fixed #35261 -- Corrected Media JS example of object-based paths in docs.

### DIFF
--- a/docs/topics/forms/media.txt
+++ b/docs/topics/forms/media.txt
@@ -287,7 +287,7 @@ outputting the complete HTML ``<script>`` or ``<link>`` tag content:
     >>> @html_safe
     ... class JSPath:
     ...     def __str__(self):
-    ...         return '<script src="https://example.org/asset.js" rel="stylesheet">'
+    ...         return '<script src="https://example.org/asset.js" defer>'
     ...
 
     >>> class SomeWidget(forms.TextInput):


### PR DESCRIPTION
Replaced the `rel` attribute on the `<script>` tag, according to MDN the attr is only valid for `<link>` tags, used a valid attribute (`defer`) to illustrate the use case for this class.

Relevant links:
Ticket [35261](https://code.djangoproject.com/ticket/35261)
Forum discussion [28470 - Media Path as objects](https://forum.djangoproject.com/t/media-path-as-objects/28470)