### PR TITLE
Add sample output for `./runtests.py` under intro/contributing

### DIFF
--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -249,6 +249,15 @@ to Django's code, the entire test suite **should** pass. If you get failures or
 errors make sure you've followed all of the previous steps properly. See
 :ref:`running-unit-tests` for more information.
 
+If the entire test suite passes, your output should contain something similar to the following:
+
+.. code-block:: text
+
+    ----------------------------------------------------------------------
+    Ran 16875 tests in 68.716s
+
+    OK (skipped=1259, expected failures=5)
+
 Note that the latest Django "main" branch may not always be stable. When
 developing against "main", you can check `Django's continuous integration
 builds`__ to determine if the failures are specific to your machine or if they


### PR DESCRIPTION
I've added a sample output under the contributing guide to better illustrate a passing test suite scenario. While following the guide, I noticed that the criteria for a passing test suite could be more explicitly illustrated. The included sample output aims to provide contributors with a clear benchmark for what to expect when all tests pass. I hope this small documentation enhancement helps clarify the testing process.