### PR TITLE
Used sys_platform in tests requirements.

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,21 +1,21 @@
 aiosmtpd
 asgiref >= 3.7.0
-argon2-cffi >= 19.2.0; sys.platform != 'win32' or python_version < '3.13'
+argon2-cffi >= 19.2.0; sys_platform != 'win32' or python_version < '3.13'
 bcrypt
 black
 docutils >= 0.19
 geoip2; python_version < '3.13'
 jinja2 >= 2.11.0
-numpy; sys.platform != 'win32' or python_version < '3.13'
-Pillow >= 6.2.1; sys.platform != 'win32' or python_version < '3.13'
+numpy; sys_platform != 'win32' or python_version < '3.13'
+Pillow >= 6.2.1; sys_platform != 'win32' or python_version < '3.13'
 # pylibmc/libmemcached can't be built on Windows.
-pylibmc; sys.platform != 'win32'
+pylibmc; sys_platform != 'win32'
 pymemcache >= 3.4.0
-pywatchman; sys.platform != 'win32'
+pywatchman; sys_platform != 'win32'
 PyYAML
 redis >= 3.4.0
-selenium >= 4.8.0; sys.platform != 'win32' or python_version < '3.13'
+selenium >= 4.8.0; sys_platform != 'win32' or python_version < '3.13'
 sqlparse >= 0.3.1
 tblib >= 1.5.0
 tzdata
-colorama >= 0.4.6; sys.platform == 'win32'
+colorama >= 0.4.6; sys_platform == 'win32'


### PR DESCRIPTION
We already use `implementation_name` and `python_version` markers so it's more consistent. Moreover, marker values can be specified via `pip`'s command line options.