### PR TITLE
Fixed #35267 -- Clarified time zone topic for PostgreSQL in docs.

### DIFF
--- a/docs/topics/i18n/timezones.txt
+++ b/docs/topics/i18n/timezones.txt
@@ -393,9 +393,15 @@ UTC on storage, and from UTC to the connection's time zone on retrieval.
 
 As a consequence, if you're using PostgreSQL, you can switch between ``USE_TZ
 = False`` and ``USE_TZ = True`` freely. The database connection's time zone
-will be set to :setting:`TIME_ZONE` or ``UTC`` respectively, so that Django
-obtains correct datetimes in all cases. You don't need to perform any data
-conversions.
+will be set to :setting:`DATABASE-TIME_ZONE` or ``UTC`` respectively, so that
+Django obtains correct datetimes in all cases. You don't need to perform any
+data conversions.
+
+.. admonition:: Time zone settings
+
+    The :setting:`time zone <DATABASE-TIME_ZONE>` configured for the connection
+    in the :setting:`DATABASES` setting is distinct from the general
+    :setting:`TIME_ZONE` setting.
 
 Other databases
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35267

# Branch description
Corrects the link to the `DATABASE.TIME_ZONE` setting in the Postgres timezone docs, so that it's clearer that Postgres does not translate retrieved datetimes into `TIME_ZONE` but, rather, uses the timezone of the connection/session.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
