### PR TITLE
Fixed #35223 -- Made Model.full_clean() ignore fields with db_default when validating empty values.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -29,6 +29,7 @@ from django.db import (
 from django.db.models import NOT_PROVIDED, ExpressionWrapper, IntegerField, Max, Value
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.deletion import CASCADE, Collector
+from django.db.models.expressions import DatabaseDefault
 from django.db.models.fields.related import (
     ForeignObjectRel,
     OneToOneField,
@@ -1632,6 +1633,9 @@ class Model(AltersData, metaclass=ModelBase):
             # is responsible for making sure they have a valid value.
             raw_value = getattr(self, f.attname)
             if f.blank and raw_value in f.empty_values:
+                continue
+            # Skip validation for empty fields when db_default is used.
+            if isinstance(raw_value, DatabaseDefault):
                 continue
             try:
                 setattr(self, f.attname, f.clean(raw_value, self))

--- a/docs/releases/5.0.4.txt
+++ b/docs/releases/5.0.4.txt
@@ -9,4 +9,7 @@ Django 5.0.4 fixes several bugs in 5.0.3.
 Bugfixes
 ========
 
-* ...
+* Fixed a bug in Django 5.0 that caused a crash of ``Model.full_clean()`` on
+  fields with expressions in ``db_default``. As a consequence,
+  ``Model.full_clean()`` no longer validates for empty values in fields with
+  ``db_default`` (:ticket:`35223`).


### PR DESCRIPTION
# Trac ticket number
ticket-35223

# Branch description
`full_clean()` should not raise a `ValidationError` for an empty field with a `db_default`.

# Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
