### PR TITLE
ngettext returns undefined if there is either invalid plural or catalog with empty array provided.

### DIFF
--- a/django/views/templates/i18n_catalog.js
+++ b/django/views/templates/i18n_catalog.js
@@ -42,7 +42,15 @@
       if (typeof value === 'undefined') {
         return (count == 1) ? singular : plural;
       } else {
-        return value.constructor === Array ? value[django.pluralidx(count)] : value;
+        if (value.constructor === Array) {
+          const text = value[django.pluralidx(count)];
+
+          if (typeof text === 'undefined') {
+            return (count == 1) ? singular : plural;
+          } else {
+            return text;
+          }
+        }
       }
     };
 


### PR DESCRIPTION
# Branch description
We've managed to situation when in catalog we had:
```js
const newcatalog = {
  '%s something': [],
  ...
}
```
When we invoked `window.ngettext('%s something', '%s somethings', 1);` the `ngettext` function returned undefined which caused the `window.interpolate` to be called with undefined and the page crashed.
The proposed solution is to always return string with a fallback to original string provided.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [ ] I have added or updated relevant **tests**.
- [ ] I have added or updated relevant **docs**, including release notes if applicable.
- [ ] For UI changes, I have attached **screenshots** in both light and dark modes.
