### PR TITLE
Refs #30397 -- Optimized interpolation of index and constraint names a bit.

### DIFF
--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -203,10 +203,9 @@ class Options:
             self.unique_together = normalize_together(self.unique_together)
             # App label/class name interpolation for names of constraints and
             # indexes.
-            if not getattr(cls._meta, "abstract", False):
-                for attr_name in {"constraints", "indexes"}:
-                    objs = getattr(self, attr_name, [])
-                    setattr(self, attr_name, self._format_names_with_class(cls, objs))
+            if not self.abstract:
+                self.constraints = self._format_names_with_class(cls, self.constraints)
+                self.indexes = self._format_names_with_class(cls, self.indexes)
 
             # verbose_name_plural is a special case because it uses a 's'
             # by default.
@@ -234,13 +233,14 @@ class Options:
 
     def _format_names_with_class(self, cls, objs):
         """App label/class name interpolation for object names."""
+        names = {
+            "app_label": cls._meta.app_label.lower(),
+            "class": cls.__name__.lower(),
+        }
         new_objs = []
         for obj in objs:
             obj = obj.clone()
-            obj.name = obj.name % {
-                "app_label": cls._meta.app_label.lower(),
-                "class": cls.__name__.lower(),
-            }
+            obj.name = obj.name % names
             new_objs.append(obj)
         return new_objs
 


### PR DESCRIPTION
# Trac ticket number

ticket-30397

# Branch description

Some small tidy-ups:

1. In `contribute_to_class`, `cls._meta` can be replaced with the clearer `self` line 175 above does `cls._meta = self`.
2. `getattr` and `setattr` can be replaced with simple attribute access and setting because they always exist.
3. The `names` dictionary can be created just once in `_format_names_with_class()`.

The original PR #11279 had lots of review comments already so it looks like these improvements were missed in all the noise.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
