### PR TITLE
Refs #30397 -- Optimized interpolation of index and constraint names a bit more.

### DIFF
--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -204,8 +204,8 @@ class Options:
             # App label/class name interpolation for names of constraints and
             # indexes.
             if not self.abstract:
-                self.constraints = self._format_names_with_class(cls, self.constraints)
-                self.indexes = self._format_names_with_class(cls, self.indexes)
+                self.constraints = self._format_names(self.constraints)
+                self.indexes = self._format_names(self.indexes)
 
             # verbose_name_plural is a special case because it uses a 's'
             # by default.
@@ -231,16 +231,13 @@ class Options:
                 self.db_table, connection.ops.max_name_length()
             )
 
-    def _format_names_with_class(self, cls, objs):
+    def _format_names(self, objs):
         """App label/class name interpolation for object names."""
-        names = {
-            "app_label": cls._meta.app_label.lower(),
-            "class": cls.__name__.lower(),
-        }
+        names = {"app_label": self.app_label.lower(), "class": self.model_name}
         new_objs = []
         for obj in objs:
             obj = obj.clone()
-            obj.name = obj.name % names
+            obj.name %= names
             new_objs.append(obj)
         return new_objs
 


### PR DESCRIPTION
# Trac ticket number

ticket-30397

# Branch description

A follow up to #17947 with some further simplifications:

- `cls._meta.app_label.lower()` → `self.app_label.lower()` due to:
  - `cls._meta = self`
- `cls.__name__.lower()` → `self.model_name` due to:
  - `self.object_name = cls.__name__`
  - `self.model_name = self.object_name.lower()`
- No longer passing `cls` so rename `_format_names_with_class()` to `_format_names()`

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
