### PR TITLE
Removed getattr() from some settings accesses.

### DIFF
--- a/django/core/checks/files.py
+++ b/django/core/checks/files.py
@@ -7,7 +7,7 @@ from . import Error, Tags, register
 
 @register(Tags.files)
 def check_setting_file_upload_temp_dir(app_configs, **kwargs):
-    setting = getattr(settings, "FILE_UPLOAD_TEMP_DIR", None)
+    setting = settings.FILE_UPLOAD_TEMP_DIR
     if setting and not Path(setting).is_dir():
         return [
             Error(

--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -40,7 +40,7 @@ def get_internal_wsgi_application():
     """
     from django.conf import settings
 
-    app_path = getattr(settings, "WSGI_APPLICATION")
+    app_path = settings.WSGI_APPLICATION
     if app_path is None:
         return get_wsgi_application()
 

--- a/django/middleware/clickjacking.py
+++ b/django/middleware/clickjacking.py
@@ -45,4 +45,4 @@ class XFrameOptionsMiddleware(MiddlewareMixin):
         This method can be overridden if needed, allowing it to vary based on
         the request or response.
         """
-        return getattr(settings, "X_FRAME_OPTIONS", "DENY").upper()
+        return settings.X_FRAME_OPTIONS.upper()

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -6,7 +6,6 @@ from io import BytesIO
 from unittest import mock
 from urllib.parse import quote
 
-from django.conf import settings
 from django.core import mail
 from django.core.exceptions import PermissionDenied
 from django.http import (
@@ -750,10 +749,8 @@ class XFrameOptionsMiddlewareTest(SimpleTestCase):
         If the X_FRAME_OPTIONS setting is not set then it defaults to
         DENY.
         """
-        with override_settings(X_FRAME_OPTIONS=None):
-            del settings.X_FRAME_OPTIONS  # restored by override_settings
-            r = XFrameOptionsMiddleware(get_response_empty)(HttpRequest())
-            self.assertEqual(r.headers["X-Frame-Options"], "DENY")
+        r = XFrameOptionsMiddleware(get_response_empty)(HttpRequest())
+        self.assertEqual(r.headers["X-Frame-Options"], "DENY")
 
     def test_dont_set_if_set(self):
         """


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description

The modified lines all read settings defined [in `global_settings.py`](https://github.com/django/django/blob/main/django/conf/global_settings.py), which is always copied from when creating the settings object: https://github.com/django/django/blob/549320946dfdaac6ccb6c0d3150c46db92637187/django/conf/__init__.py#L159-L161

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [n/a] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
