### PR TITLE
Moved --failfast to DiscoverRunner.

### DIFF
--- a/django/core/management/commands/test.py
+++ b/django/core/management/commands/test.py
@@ -41,11 +41,6 @@ class Command(BaseCommand):
             help="Tells Django to NOT prompt the user for input of any kind.",
         )
         parser.add_argument(
-            "--failfast",
-            action="store_true",
-            help="Tells Django to stop running the test suite after first failed test.",
-        )
-        parser.add_argument(
             "--testrunner",
             help="Tells Django to use specified test runner class instead of "
             "the one specified by the TEST_RUNNER setting.",

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -707,6 +707,11 @@ class DiscoverRunner:
     @classmethod
     def add_arguments(cls, parser):
         parser.add_argument(
+            "--failfast",
+            action="store_true",
+            help="Stops the test suite after the first failure.",
+        )
+        parser.add_argument(
             "-t",
             "--top-level-directory",
             dest="top_level",


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description

`--failfast` was added in 92eec3ef9ae3eed18cef4cb7e87a85df4f06d3f0. Later, 046ffa483ed63faae7b31e7e2cf618f88a3312ba allowed test runners to define custom options, but this was left in the management command.

For better encapsulation, it would be best to define the option in `DiscoverRunner`. This would use of a custom test runner class that doesn't have the option.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
