### PR TITLE
Fixed #35281 - Set HTTP 413 for RequestDataTooBig.

### DIFF
--- a/django/conf/urls/__init__.py
+++ b/django/conf/urls/__init__.py
@@ -1,9 +1,17 @@
 from django.urls import include
 from django.views import defaults
 
-__all__ = ["handler400", "handler403", "handler404", "handler500", "include"]
+__all__ = [
+    "handler400",
+    "handler403",
+    "handler404",
+    "handler413",
+    "handler500",
+    "include",
+]
 
 handler400 = defaults.bad_request
 handler403 = defaults.permission_denied
 handler404 = defaults.page_not_found
+handler413 = defaults.content_too_large
 handler500 = defaults.server_error

--- a/django/core/handlers/exception.py
+++ b/django/core/handlers/exception.py
@@ -116,6 +116,11 @@ def response_for_exception(request, exc):
             # exception would be raised.
             request._mark_post_parse_error()
 
+        if isinstance(exc, RequestDataTooBig):
+            status_code = 413
+        else:
+            status_code = 400
+
         # The request logger receives events for any problematic request
         # The security logger receives events for all SuspiciousOperations
         security_logger = logging.getLogger(
@@ -124,15 +129,15 @@ def response_for_exception(request, exc):
         security_logger.error(
             str(exc),
             exc_info=exc,
-            extra={"status_code": 400, "request": request},
+            extra={"status_code": status_code, "request": request},
         )
         if settings.DEBUG:
             response = debug.technical_500_response(
-                request, *sys.exc_info(), status_code=400
+                request, *sys.exc_info(), status_code=status_code
             )
         else:
             response = get_exception_response(
-                request, get_resolver(get_urlconf()), 400, exc
+                request, get_resolver(get_urlconf()), status_code, exc
             )
 
     else:

--- a/django/views/defaults.py
+++ b/django/views/defaults.py
@@ -148,3 +148,16 @@ def permission_denied(request, exception, template_name=ERROR_403_TEMPLATE_NAME)
     return HttpResponseForbidden(
         template.render(request=request, context={"exception": str(exception)})
     )
+
+
+@requires_csrf_token
+def content_too_large(request, exception, template_name=ERROR_400_TEMPLATE_NAME):
+    """
+    413 error handler.
+
+    Templates: :template:`400.html`
+    Context: None
+    """
+    response = bad_request(request, exception, template_name)
+    response.status_code = 413
+    return response

--- a/tests/handlers/test_exception.py
+++ b/tests/handlers/test_exception.py
@@ -23,7 +23,7 @@ class ExceptionHandlerTests(SimpleTestCase):
     @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=12)
     def test_data_upload_max_memory_size_exceeded(self):
         response = WSGIHandler()(self.get_suspicious_environ(), lambda *a, **k: None)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 413)
 
     @override_settings(DATA_UPLOAD_MAX_NUMBER_FIELDS=2)
     def test_data_upload_max_number_fields_exceeded(self):


### PR DESCRIPTION
Added a new `django.conf.urls.defaults.content_too_large` error handler used as `handler413` when handling `RequestDataTooBig` exceptions.

This handler uses `ERROR_400_TEMPLATE_NAME` and sets the response status_code` to 413.

# Trac ticket number

ticket-35281

# Branch description

This change makes Django return the usual status code [413 Content Too Large](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413) when a `RequestDataTooBig` exception is raised. The motivation is to make a stack with a reverse proxy and Django behave predictably regardless of where the upload size limit is smaller. 

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [ ] I have added or updated relevant **docs**, including release notes if applicable.
- [ ] For UI changes, I have attached **screenshots** in both light and dark modes.
