### PR TITLE
Removed unused clean() method in file-based session.

### DIFF
--- a/django/contrib/sessions/backends/file.py
+++ b/django/contrib/sessions/backends/file.py
@@ -190,9 +190,6 @@ class SessionStore(SessionBase):
         except OSError:
             pass
 
-    def clean(self):
-        pass
-
     @classmethod
     def clear_expired(cls):
         storage_path = cls._get_storage_path()


### PR DESCRIPTION
Unused since its introduction in bcf7e9a9fe037eff4d5dea0cdd8c35104590e1a8.