### PR TITLE
Refs #14018 -- Added class_plural %-substitution placeholder for related_name of ForeignKey/ManyToManyField

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -359,6 +359,7 @@ class RelatedField(FieldCacheMixin, Field):
             if related_name:
                 related_name %= {
                     "class": cls.__name__.lower(),
+                    "class_plural": cls._meta.name_plural.lower(),
                     "model_name": cls._meta.model_name.lower(),
                     "app_label": cls._meta.app_label.lower(),
                 }
@@ -367,6 +368,7 @@ class RelatedField(FieldCacheMixin, Field):
             if self.remote_field.related_query_name:
                 related_query_name = self.remote_field.related_query_name % {
                     "class": cls.__name__.lower(),
+                    "class_plural": cls._meta.name_plural.lower(),
                     "app_label": cls._meta.app_label.lower(),
                 }
                 self.remote_field.related_query_name = related_query_name

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -26,6 +26,7 @@ IMMUTABLE_WARNING = (
 DEFAULT_NAMES = (
     "verbose_name",
     "verbose_name_plural",
+    "name_plural",
     "db_table",
     "db_table_comment",
     "ordering",
@@ -108,6 +109,7 @@ class Options:
         self.model_name = None
         self.verbose_name = None
         self.verbose_name_plural = None
+        self.name_plural = None
         self.db_table = ""
         self.db_table_comment = ""
         self.ordering = []
@@ -177,6 +179,7 @@ class Options:
         self.object_name = cls.__name__
         self.model_name = self.object_name.lower()
         self.verbose_name = camel_case_to_spaces(self.object_name)
+        self.name_plural = self.object_name + "s"
 
         # Store the original user-defined values for each option,
         # for use when serializing the model definition

--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -493,6 +493,19 @@ not be looking at your Django code. For example::
 
     If this isn't given, Django will use :attr:`~Options.verbose_name` + ``"s"``.
 
+``name_plural``
+-----------------------
+
+.. versionadded:: 5.1
+.. attribute:: Options.name_plural
+
+    The plural name used by the ``'%(class_plural)s'`` substitution in the
+    :ref:`related names of abstract base models <abstract-related-name>`::
+
+        name_plural = "stored_batteries"
+
+    If this isn't given, Django will use the lowercased class name + ``"s"``.
+
 Read-only ``Meta`` attributes
 =============================
 

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -266,6 +266,11 @@ Models
 * The new ``"transaction_mode"`` option is now supported in :setting:`OPTIONS`
   on SQLite to allow specifying the :ref:`sqlite-transaction-behavior`.
 
+* The new :attr:`~django.db.models.Options.name_plural` Meta option and its
+  corresponding ``'%(class_plural)s'`` substitution support specifying
+  irregular plural names for the :ref:`related names of
+  abstract base models <abstract-related-name>`.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1098,11 +1098,14 @@ classes, with exactly the same values for the attributes (including
 To work around this problem, when you are using
 :attr:`~django.db.models.ForeignKey.related_name` or
 :attr:`~django.db.models.ForeignKey.related_query_name` in an abstract base
-class (only), part of the value should contain ``'%(app_label)s'`` and
-``'%(class)s'``.
+class (only), part of the value should contain ``'%(app_label)s'`` and either
+``'%(class)s'`` or ``'%(class_plural)s'``.
 
 - ``'%(class)s'`` is replaced by the lowercased name of the child class that
   the field is used in.
+- ``'%(class_plural)s'`` is by default equivalent to ``'%(class)ss'``,
+  but may be overridden in child models to support irregular plurals with the
+  :attr:`~django.db.models.Options.name_plural` Meta option.
 - ``'%(app_label)s'`` is replaced by the lowercased name of the app the child
   class is contained within. Each installed application name must be unique and
   the model class names within each app must also be unique, therefore the
@@ -1117,7 +1120,7 @@ For example, given an app ``common/models.py``::
         m2m = models.ManyToManyField(
             OtherModel,
             related_name="%(app_label)s_%(class)s_related",
-            related_query_name="%(app_label)s_%(class)ss",
+            related_query_name="%(app_label)s_%(class_plural)s",
         )
 
         class Meta:
@@ -1137,7 +1140,8 @@ Along with another app ``rare/models.py``::
 
 
     class ChildB(Base):
-        pass
+        class Meta:
+            name_plural = "children"
 
 The reverse name of the ``common.ChildA.m2m`` field will be
 ``common_childa_related`` and the reverse query name will be ``common_childas``.
@@ -1145,7 +1149,7 @@ The reverse name of the ``common.ChildB.m2m`` field will be
 ``common_childb_related`` and the reverse query name will be
 ``common_childbs``. Finally, the reverse name of the ``rare.ChildB.m2m`` field
 will be ``rare_childb_related`` and the reverse query name will be
-``rare_childbs``. It's up to you how you use the ``'%(class)s'`` and
+``rare_children``. It's up to you how you use the ``'%(class)s'``/``'%(class_plural)s'`` and
 ``'%(app_label)s'`` portion to construct your related name or related query name
 but if you forget to use it, Django will raise errors when you perform system
 checks (or run :djadmin:`migrate`).

--- a/tests/model_inheritance/models.py
+++ b/tests/model_inheritance/models.py
@@ -56,7 +56,7 @@ class Attachment(models.Model):
         Post,
         models.CASCADE,
         related_name="attached_%(class)s_set",
-        related_query_name="attached_%(app_label)s_%(class)ss",
+        related_query_name="attached_%(app_label)s_%(class_plural)s",
     )
     content = models.TextField()
 
@@ -70,6 +70,13 @@ class Comment(Attachment):
 
 class Link(Attachment):
     url = models.URLField()
+
+
+class Thesis(Attachment):
+    is_public = models.BooleanField(default=False)
+
+    class Meta:
+        name_plural = "theses"
 
 
 #

--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -106,6 +106,15 @@ class ModelInheritanceTests(TestCase):
         with self.assertRaisesMessage(FieldError, msg):
             Post.objects.filter(attached_comment_set__is_spam=True)
 
+    def test_model_with_overridden_distinct_related_query_name(self):
+        self.assertSequenceEqual(
+            Post.objects.filter(attached_model_inheritance_theses__is_public=True), []
+        )
+
+        msg = "Cannot resolve keyword 'attached_model_inheritance_thesiss' into field."
+        with self.assertRaisesMessage(FieldError, msg):
+            Post.objects.filter(attached_model_inheritance_thesiss__is_public=True)
+
     def test_meta_fields_and_ordering(self):
         # Make sure Restaurant and ItalianRestaurant have the right fields in
         # the right order.


### PR DESCRIPTION
# Trac ticket number
[ticket-14018](https://code.djangoproject.com/ticket/14018)

# Branch description
This implements a solution for supporting grammatically correct irregular plural related names as described in the ticket. The implementation improves upon the original proposal, based on the suggestions of Łukasz Rekucki.

A new `name_plural` Meta option and a corresponding `'%(class_plural)s'` substitution are added to support specifying irregular plural names for the related names of abstract base models. If the Meta option is not specified, the behavior of `'%(class_plural)s'` is equivalent to `'%(class)ss'`.

### Example scenario:

_models.py_
```python
class Factory(Model):
    pass


class AbstractProduct(Model):
    factory = ForeignKey(Factory, on_delete=CASCADE, related_name="%(class_plural)s")

    class Meta:
        abstract = True


class Laptop(AbstractProduct):
    pass


class Battery(AbstractProduct):
    class Meta:
        name_plural = "batteries"
```

`Factory` objects will have two related fields: `laptops` and `batteries`.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [ ] For UI changes, I have attached **screenshots** in both light and dark modes.
