### PR TITLE
Refs #34900 -- Fixed SafeMIMEText.set_payload() crash on Python 3.13.

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -168,7 +168,8 @@ class SafeMIMEText(MIMEMixin, MIMEText):
     def set_payload(self, payload, charset=None):
         if charset == "utf-8" and not isinstance(charset, Charset.Charset):
             has_long_lines = any(
-                len(line.encode()) > RFC5322_EMAIL_LINE_LENGTH_LIMIT
+                len(line.encode(errors="surrogateescape"))
+                > RFC5322_EMAIL_LINE_LENGTH_LIMIT
                 for line in payload.splitlines()
             )
             # Quoted-Printable encoding has the side effect of shortening long


### PR DESCRIPTION
Payloads with surrogates are passed to the `set_payload()` since https://github.com/python/cpython/commit/f97f25ef5dfcdfec0d9a359fd970abd139cf3428.

ticket-34900

[Logs](https://github.com/django/django/actions/runs/8290581941/job/22692630665)