### PR TITLE
Refs #33996 -- Updated CheckConstraint validation on NULL values on Oracle 23c+.

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -78,7 +78,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_slicing_ordering_in_compound = True
     requires_compound_order_by_subquery = True
     allows_multiple_constraints_on_same_fields = False
-    supports_comparing_boolean_expr = False
     supports_json_field_contains = False
     supports_collation_on_textfield = False
     test_now_utc_template = "CURRENT_TIMESTAMP AT TIME ZONE 'UTC'"
@@ -172,6 +171,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     @cached_property
     def supports_boolean_expr_in_select_clause(self):
+        return self.connection.oracle_version >= (23,)
+
+    @cached_property
+    def supports_comparing_boolean_expr(self):
         return self.connection.oracle_version >= (23,)
 
     @cached_property

--- a/docs/ref/models/constraints.txt
+++ b/docs/ref/models/constraints.txt
@@ -131,10 +131,10 @@ ensures the age field is never less than 18.
             name="age_gte_18_and_others",
         )
 
-.. admonition:: Oracle
+.. admonition:: Oracle < 23c
 
-    Checks with nullable fields on Oracle must include a condition allowing for
-    ``NULL`` values in order for :meth:`validate() <BaseConstraint.validate>`
+    Checks with nullable fields on Oracle < 23c must include a condition
+    allowing for ``NULL`` values in order for :meth:`~BaseConstraint.validate`
     to behave the same as check constraints validation. For example, if ``age``
     is a nullable field::
 


### PR DESCRIPTION
Oracle 23c supports comparing boolean expressions.

ticket-33996