### PR TITLE
Fixed #35316 -- Support scalars as query parameters in admin changelist filters.

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -80,6 +80,8 @@ def prepare_lookup_value(key, value, separator=","):
 def build_q_object_from_lookup_parameters(parameters):
     q_object = models.Q()
     for param, param_item_list in parameters.items():
+        if isinstance(param_item_list, (bool, int, str)):
+            param_item_list = (param_item_list,)
         q_object &= reduce(or_, (models.Q((param, item)) for item in param_item_list))
     return q_object
 

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -451,3 +451,19 @@ class UtilsTests(SimpleTestCase):
             & models.Q(hist__iexact="history")
             & (models.Q(site__pk=1) | models.Q(site__pk=2)),
         )
+
+    def test_build_q_object_from_lookup_parameters_scalar(self):
+        parameters = {
+            "title__in": [["Article 1", "Article 2"]],
+            "hist__iexact": "history",
+            "site__pk": 1,
+            "is_published": True,
+        }
+        q_obj = build_q_object_from_lookup_parameters(parameters)
+        self.assertEqual(
+            q_obj,
+            models.Q(title__in=["Article 1", "Article 2"])
+            & models.Q(hist__iexact="history")
+            & models.Q(site__pk=1)
+            & models.Q(is_published=True),
+        )


### PR DESCRIPTION
# Trac ticket number
ticket-35316 

# Branch description
Ticket [#1873](https://code.djangoproject.com/ticket/1873) / #16621 added support for multi-valued query parameters in admin changelist filters. Because only list types are now supported, older code that e.g. extends SimpleListFilter or BooleanFieldListFilter will break.

The latter (extending BooleanFieldListFilter) may even be completely unsupported. See notes in PR for [#1873](https://code.djangoproject.com/ticket/1873) / #16621.

Overall, user code needs to introduce version conditionals if it is required to support both Django 4.x and Django 5. The reason is that Django 4.x only supports scalar types as changelist query parameter values, while Django 5 only supports lists.

Since supporting both scalars and lists should be possible without adding complexity to the Django codebase, it would be good to continue supporting scalars, perhaps with a deprecation warning, if necessary.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
