### PR TITLE
Fixed ResourceWarning from unclosed SQLite connection on Python 3.13+.

### DIFF
--- a/tests/backends/sqlite/tests.py
+++ b/tests/backends/sqlite/tests.py
@@ -137,7 +137,7 @@ class Tests(TestCase):
                 value = cursor.fetchone()[0]
                 self.assertEqual(value, 2000)
         finally:
-            connections["default"].close()
+            connections["default"]._close()
 
 
 @unittest.skipUnless(connection.vendor == "sqlite", "SQLite tests")
@@ -321,4 +321,4 @@ class TestTransactionMode(SimpleTestCase):
         try:
             yield new_connection
         finally:
-            new_connection.close()
+            new_connection._close()


### PR DESCRIPTION
On SQLite, `close()` doesn't explicitly close in-memory connections.

Follow up to dd45d5223b3c5640baefcb591782bbcff873b6bf.

```
./runtests.py backends.sqlite --parallel=1
Testing against Django installed in '/django/django'
Found 40 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
........................................
----------------------------------------------------------------------
Ran 40 tests in 0.050s

OK
Destroying test database for alias 'default'...
Exception ignored in: <sqlite3.Connection object at 0x7fdd8a9da200>
ResourceWarning: unclosed database in <sqlite3.Connection object at 0x7fdd8a9da200>
Exception ignored in: <sqlite3.Connection object at 0x7fdd8aa3cd60>
ResourceWarning: unclosed database in <sqlite3.Connection object at 0x7fdd8aa3cd60>
Exception ignored in: <sqlite3.Connection object at 0x7fdd8aa3cf40>
ResourceWarning: unclosed database in <sqlite3.Connection object at 0x7fdd8aa3cf40>
Exception ignored in: <sqlite3.Connection object at 0x7fdd8aa3d210>
ResourceWarning: unclosed database in <sqlite3.Connection object at 0x7fdd8aa3d210>
```