### PR TITLE
Ticket 35317 added the possibility to do prefetches for only a subset of instances with a new argument Prefetch.filter_callback

### DIFF
--- a/django/contrib/contenttypes/prefetch.py
+++ b/django/contrib/contenttypes/prefetch.py
@@ -3,7 +3,7 @@ from django.db.models.query import ModelIterable, RawQuerySet
 
 
 class GenericPrefetch(Prefetch):
-    def __init__(self, lookup, querysets=None, to_attr=None):
+    def __init__(self, lookup, querysets=None, to_attr=None, filter_callback=None):
         for queryset in querysets:
             if queryset is not None and (
                 isinstance(queryset, RawQuerySet)
@@ -16,7 +16,7 @@ class GenericPrefetch(Prefetch):
                     "Prefetch querysets cannot use raw(), values(), and values_list()."
                 )
         self.querysets = querysets
-        super().__init__(lookup, to_attr=to_attr)
+        super().__init__(lookup, to_attr=to_attr, filter_callback=filter_callback)
 
     def __getstate__(self):
         obj_dict = self.__dict__.copy()

--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -603,7 +603,7 @@ information.
 
 .. versionadded:: 5.0
 
-.. class:: GenericPrefetch(lookup, querysets=None, to_attr=None)
+.. class:: GenericPrefetch(lookup, querysets=None, to_attr=None, filter_callback=None)
 
 This lookup is similar to ``Prefetch()`` and it should only be used on
 ``GenericForeignKey``. The ``querysets`` argument accepts a list of querysets,

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1460,10 +1460,7 @@ instance and returns a boolean.
 
     >>> # Only books with odd ids will have author prefetched.
     >>> Book.objects.prefetch_related(
-    ...     Prefetch(
-    ...         "author",
-    ...         filter_callback=lambda b: bool(b.id % 2)
-    ...     ),
+    ...     Prefetch("author", filter_callback=lambda b: bool(b.id % 2)),
     ... )
 
 .. note::
@@ -4157,10 +4154,7 @@ The ``filter_callback`` argument limits the prefetch operation to a subset of in
 
     >>> # Only books with odd ids will have author prefetched.
     >>> Book.objects.prefetch_related(
-    ...     Prefetch(
-    ...         "author",
-    ...         filter_callback=lambda b: bool(b.id % 2)
-    ...     ),
+    ...     Prefetch("author", filter_callback=lambda b: bool(b.id % 2)),
     ... )
 
 ``prefetch_related_objects()``

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1451,6 +1451,21 @@ database selected by the outer query. All of the following are valid:
     ...     Prefetch("pizzas__toppings", queryset=Toppings.objects.using("replica")),
     ... ).using("cold-storage")
 
+You can also prefetch only for a subset of the current nesting level instances
+with the optional ``filter_callback`` argument.
+The value of this argument, if not None, should be a function that takes an
+instance and returns a boolean.
+
+.. code-block:: pycon
+
+    >>> # Only books with odd ids will have author prefetched.
+    >>> Book.objects.prefetch_related(
+    ...     Prefetch(
+    ...         "author",
+    ...         filter_callback=lambda b: bool(b.id % 2)
+    ...     ),
+    ... )
+
 .. note::
 
     The ordering of lookups matters.
@@ -4085,7 +4100,7 @@ combine them using operators such as ``|`` (``OR``), ``&`` (``AND``), and ``^``
 ``Prefetch()`` objects
 ----------------------
 
-.. class:: Prefetch(lookup, queryset=None, to_attr=None)
+.. class:: Prefetch(lookup, queryset=None, to_attr=None, filter_callback=None)
 
 The ``Prefetch()`` object can be used to control the operation of
 :meth:`~django.db.models.query.QuerySet.prefetch_related()`.
@@ -4135,6 +4150,18 @@ attribute:
     provide a significant speed improvement over traditional
     ``prefetch_related`` calls which store the cached result within a
     ``QuerySet`` instance.
+
+The ``filter_callback`` argument limits the prefetch operation to a subset of instances:
+
+.. code-block:: pycon
+
+    >>> # Only books with odd ids will have author prefetched.
+    >>> Book.objects.prefetch_related(
+    ...     Prefetch(
+    ...         "author",
+    ...         filter_callback=lambda b: bool(b.id % 2)
+    ...     ),
+    ... )
 
 ``prefetch_related_objects()``
 ------------------------------

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -275,6 +275,9 @@ Models
 * The new ``"transaction_mode"`` option is now supported in :setting:`OPTIONS`
   on SQLite to allow specifying the :ref:`sqlite-transaction-behavior`.
 
+* The new ``filter_callback`` field of :class:`~django.db.models.query.Prefetch`
+  enables prefetching related objects only for a subset of instances.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -275,7 +275,7 @@ Models
 * The new ``"transaction_mode"`` option is now supported in :setting:`OPTIONS`
   on SQLite to allow specifying the :ref:`sqlite-transaction-behavior`.
 
-* The new ``filter_callback`` field of :class:`~django.db.models.query.Prefetch`
+* The new ``filter_callback`` field of :class:`~django.db.models.Prefetch`
   enables prefetching related objects only for a subset of instances.
 
 Requests and Responses


### PR DESCRIPTION
# Trac ticket number

ticket-35317

# Branch description

Some expensive prefetches should not be done on all instances of a queryset.
Moreover, the logic to filter the good instances may be complex and not easily translated in SQL.
Hence, it is simpler and more efficient to call a Python callback to filter out instances,
before generating and executing the prefetch query.


# Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
