### PR TITLE
Fixed ResourceWarning from unclosed SQLite connection in test_utils on Python 3.13+.

### DIFF
--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -2158,7 +2158,8 @@ class AllowedDatabaseQueriesTests(SimpleTestCase):
             # closed on teardown).
             for conn in connections_dict.values():
                 if conn is not connection and conn.allow_thread_sharing:
-                    conn.close()
+                    conn.validate_thread_sharing()
+                    conn._close()
                     conn.dec_thread_sharing()
 
     def test_allowed_database_copy_queries(self):
@@ -2169,7 +2170,8 @@ class AllowedDatabaseQueriesTests(SimpleTestCase):
                 cursor.execute(sql)
                 self.assertEqual(cursor.fetchone()[0], 1)
         finally:
-            new_connection.close()
+            new_connection.validate_thread_sharing()
+            new_connection._close()
 
 
 class DatabaseAliasTests(SimpleTestCase):


### PR DESCRIPTION
On SQLite, `close()` doesn't explicitly close in-memory connections.

Follow up to 921670c6943e9c532137b7d164885f2d3ab436b8 and dd45d5223b3c5640baefcb591782bbcff873b6bf, that's the last one :crossed_fingers: 

```
./runtests.py test_utils.tests.AllowedDatabaseQueriesTests --parallel=1
Testing against Django installed in '/django/django'
Found 4 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
....
----------------------------------------------------------------------
Ran 4 tests in 0.001s

OK
Destroying test database for alias 'default'...
Exception ignored in: <sqlite3.Connection object at 0x7f3223d6aa70>
ResourceWarning: unclosed database in <sqlite3.Connection object at 0x7f3223d6aa70>
Exception ignored in: <sqlite3.Connection object at 0x7f3223d6b790>
ResourceWarning: unclosed database in <sqlite3.Connection object at 0x7f3223d6b790>
```