### PR TITLE
Added RowNumber() link in Rank() docs.

### DIFF
--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -1975,7 +1975,7 @@ Row # Value Rank Calculation  Relative Rank
 
 .. class:: Rank(*expressions, **extra)
 
-Comparable to ``RowNumber``, this function ranks rows in the window. The
+Comparable to :class:`RowNumber`, this function ranks rows in the window. The
 computed rank contains gaps. Use :class:`DenseRank` to compute rank without
 gaps.
 


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

# Branch description

I found an unlinked instance of `RowNumber` in the docs and made it a link. Leaving it unlinked seemed inconsistent even though the `RowNumber` section is directly below.

# Checklist

- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
