### PR TITLE
Fixed #35323 -- Prevented file_move_safe() from trying to overwrite existing file when allow_overwrite is False.

### DIFF
--- a/django/core/files/move.py
+++ b/django/core/files/move.py
@@ -32,13 +32,12 @@ def file_move_safe(
     except OSError:
         pass
 
-    try:
-        if not allow_overwrite and os.access(new_file_name, os.F_OK):
-            raise FileExistsError(
-                "Destination file %s exists and allow_overwrite is False."
-                % new_file_name
-            )
+    if not allow_overwrite and os.access(new_file_name, os.F_OK):
+        raise FileExistsError(
+            f"Destination file {new_file_name} exists and allow_overwrite is False."
+        )
 
+    try:
         os.rename(old_file_name, new_file_name)
         return
     except OSError:

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -426,9 +426,10 @@ class FileMoveSafeTests(unittest.TestCase):
         handle_a, self.file_a = tempfile.mkstemp()
         handle_b, self.file_b = tempfile.mkstemp()
 
-        # file_move_safe() raises OSError if the destination file exists and
-        # allow_overwrite is False.
-        with self.assertRaises(FileExistsError):
+        # file_move_safe() raises FileExistsError if the destination file
+        # exists and allow_overwrite is False.
+        msg = r"Destination file .* exists and allow_overwrite is False\."
+        with self.assertRaisesRegex(FileExistsError, msg):
             file_move_safe(self.file_a, self.file_b, allow_overwrite=False)
 
         # should allow it and continue on if allow_overwrite is True


### PR DESCRIPTION
# Trac ticket number
ticket-35323

# Branch description
FileExistsError was being swallowed by catching OSError exceptions.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
