### PR TITLE
Ticket 35317 added the possibility to do prefetches for only a subset of instances or with post-processing

### DIFF
--- a/django/contrib/contenttypes/prefetch.py
+++ b/django/contrib/contenttypes/prefetch.py
@@ -3,7 +3,14 @@ from django.db.models.query import ModelIterable, RawQuerySet
 
 
 class GenericPrefetch(Prefetch):
-    def __init__(self, lookup, querysets=None, to_attr=None, filter_callback=None):
+    def __init__(
+        self,
+        lookup,
+        querysets=None,
+        to_attr=None,
+        filter_callback=None,
+        post_prefetch_callback=None,
+    ):
         for queryset in querysets:
             if queryset is not None and (
                 isinstance(queryset, RawQuerySet)
@@ -16,7 +23,12 @@ class GenericPrefetch(Prefetch):
                     "Prefetch querysets cannot use raw(), values(), and values_list()."
                 )
         self.querysets = querysets
-        super().__init__(lookup, to_attr=to_attr, filter_callback=filter_callback)
+        super().__init__(
+            lookup,
+            to_attr=to_attr,
+            filter_callback=filter_callback,
+            post_prefetch_callback=post_prefetch_callback,
+        )
 
     def __getstate__(self):
         obj_dict = self.__dict__.copy()

--- a/django/contrib/contenttypes/prefetch.py
+++ b/django/contrib/contenttypes/prefetch.py
@@ -3,7 +3,7 @@ from django.db.models.query import ModelIterable, RawQuerySet
 
 
 class GenericPrefetch(Prefetch):
-    def __init__(self, lookup, querysets=None, to_attr=None):
+    def __init__(self, lookup, querysets=None, to_attr=None, filter_callback=None):
         for queryset in querysets:
             if queryset is not None and (
                 isinstance(queryset, RawQuerySet)
@@ -16,7 +16,7 @@ class GenericPrefetch(Prefetch):
                     "Prefetch querysets cannot use raw(), values(), and values_list()."
                 )
         self.querysets = querysets
-        super().__init__(lookup, to_attr=to_attr)
+        super().__init__(lookup, to_attr=to_attr, filter_callback=filter_callback)
 
     def __getstate__(self):
         obj_dict = self.__dict__.copy()

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -2296,7 +2296,8 @@ def prefetch_related_objects(model_instances, *related_lookups):
     # We need to be able to dynamically add to the list of prefetch_related
     # lookups that we look up (see below).  So we need some book keeping to
     # ensure we don't do duplicate work.
-    done_queries = {"": model_instances}  # dictionary of things like 'foo__bar': [results]
+    # dictionary of things like 'foo__bar': [results]
+    done_queries = {"": model_instances}
 
     auto_lookups = set()  # we add to this as we go through.
     followed_descriptors = set()  # recursion protection

--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -603,7 +603,7 @@ information.
 
 .. versionadded:: 5.0
 
-.. class:: GenericPrefetch(lookup, querysets=None, to_attr=None)
+.. class:: GenericPrefetch(lookup, querysets=None, to_attr=None, filter_callback=None)
 
 This lookup is similar to ``Prefetch()`` and it should only be used on
 ``GenericForeignKey``. The ``querysets`` argument accepts a list of querysets,

--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -603,7 +603,7 @@ information.
 
 .. versionadded:: 5.0
 
-.. class:: GenericPrefetch(lookup, querysets=None, to_attr=None, filter_callback=None)
+.. class:: GenericPrefetch(lookup, querysets=None, to_attr=None, filter_callback=None, post_prefetch_callback=None)
 
 This lookup is similar to ``Prefetch()`` and it should only be used on
 ``GenericForeignKey``. The ``querysets`` argument accepts a list of querysets,

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1460,10 +1460,7 @@ instance and returns a boolean.
 
     >>> # Only books with odd ids will have author prefetched.
     >>> Book.objects.prefetch_related(
-    ...     Prefetch(
-    ...         "author",
-    ...         filter_callback=lambda b: bool(b.id % 2)
-    ...     ),
+    ...     Prefetch("author", filter_callback=lambda b: bool(b.id % 2)),
     ... )
 
 .. note::
@@ -4157,10 +4154,7 @@ The ``filter_callback`` argument limits the prefetch operation to a subset of in
 
     >>> # Only books with odd ids will have author prefetched.
     >>> Book.objects.prefetch_related(
-    ...     Prefetch(
-    ...         "author",
-    ...         filter_callback=lambda b: bool(b.id % 2)
-    ...     ),
+    ...     Prefetch("author", filter_callback=lambda b: bool(b.id % 2)),
     ... )
 
 ``prefetch_related_objects()``

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1463,6 +1463,23 @@ instance and returns a boolean.
     ...     Prefetch("author", filter_callback=lambda b: bool(b.id % 2)),
     ... )
 
+You can also use a callback after prefetching one level
+with the optional ``post_prefetch_callback`` argument.
+The value of this argument, if not None, should be a function that takes
+as argument a lookup (``Prefetch``) and the done_queries dict of
+``prefetch_related_objects``.
+
+.. code-block:: pycon
+
+    >>> total_number_of_distinct_authors = None
+    >>> def fill_total_number_of_distinct_authors(lookup, done_queries):
+    ...     nonlocal total_number_of_distinct_authors
+    ...     total_number_of_distinct_authors = len(done_queries[lookup.prefetch_to])
+    ...
+    >>> Book.objects.prefetch_related(
+    ...     Prefetch("author", post_prefetch_callback=fill_total_number_of_distinct_authors),
+    ... )
+
 .. note::
 
     The ordering of lookups matters.
@@ -4097,7 +4114,7 @@ combine them using operators such as ``|`` (``OR``), ``&`` (``AND``), and ``^``
 ``Prefetch()`` objects
 ----------------------
 
-.. class:: Prefetch(lookup, queryset=None, to_attr=None, filter_callback=None)
+.. class:: Prefetch(lookup, queryset=None, to_attr=None, filter_callback=None, post_prefetch_callback=None)
 
 The ``Prefetch()`` object can be used to control the operation of
 :meth:`~django.db.models.query.QuerySet.prefetch_related()`.
@@ -4155,6 +4172,20 @@ The ``filter_callback`` argument limits the prefetch operation to a subset of in
     >>> # Only books with odd ids will have author prefetched.
     >>> Book.objects.prefetch_related(
     ...     Prefetch("author", filter_callback=lambda b: bool(b.id % 2)),
+    ... )
+
+The ``post_prefetch_callback`` argument enables post-processing
+after intermediate or final prefetches:
+
+.. code-block:: pycon
+
+    >>> total_number_of_distinct_authors = None
+    >>> def fill_total_number_of_distinct_authors(lookup, done_queries):
+    ...     nonlocal total_number_of_distinct_authors
+    ...     total_number_of_distinct_authors = len(done_queries[lookup.prefetch_to])
+    ...
+    >>> Book.objects.prefetch_related(
+    ...     Prefetch("author", post_prefetch_callback=fill_total_number_of_distinct_authors),
     ... )
 
 ``prefetch_related_objects()``

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1471,13 +1471,17 @@ as argument a lookup (``Prefetch``) and the done_queries dict of
 
 .. code-block:: pycon
 
-    >>> total_number_of_distinct_authors = None
-    >>> def fill_total_number_of_distinct_authors(lookup, done_queries):
-    ...     nonlocal total_number_of_distinct_authors
-    ...     total_number_of_distinct_authors = len(done_queries[lookup.prefetch_to])
+    >>> total_distinct_authors_number = None
+    >>> def fill_total_distinct_authors_number(lookup, done_queries):
+    ...     global total_distinct_authors_number
+    ...     # Beware of many-many relationships with implicit through
+    ...     # since it can fill done_queries with repeated objects.
+    ...     total_distinct_authors_number = len(
+    ...         set((author.id for author in done_queries[lookup.prefetch_to]))
+    ...     )
     ...
     >>> Book.objects.prefetch_related(
-    ...     Prefetch("author", post_prefetch_callback=fill_total_number_of_distinct_authors),
+    ...     Prefetch("author", post_prefetch_callback=fill_total_distinct_authors_number),
     ... )
 
 .. note::
@@ -4179,13 +4183,17 @@ after intermediate or final prefetches:
 
 .. code-block:: pycon
 
-    >>> total_number_of_distinct_authors = None
-    >>> def fill_total_number_of_distinct_authors(lookup, done_queries):
-    ...     nonlocal total_number_of_distinct_authors
-    ...     total_number_of_distinct_authors = len(done_queries[lookup.prefetch_to])
+    >>> total_distinct_authors_number = None
+    >>> def fill_total_distinct_authors_number(lookup, done_queries):
+    ...     global total_distinct_authors_number
+    ...     # Beware of many-many relationships with implicit through
+    ...     # since it can fill done_queries with repeated objects.
+    ...     total_distinct_authors_number = len(
+    ...         set((author.id for author in done_queries[lookup.prefetch_to]))
+    ...     )
     ...
     >>> Book.objects.prefetch_related(
-    ...     Prefetch("author", post_prefetch_callback=fill_total_number_of_distinct_authors),
+    ...     Prefetch("author", post_prefetch_callback=fill_total_distinct_authors_number),
     ... )
 
 ``prefetch_related_objects()``

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1451,6 +1451,21 @@ database selected by the outer query. All of the following are valid:
     ...     Prefetch("pizzas__toppings", queryset=Toppings.objects.using("replica")),
     ... ).using("cold-storage")
 
+You can also prefetch only for a subset of the current nesting level instances
+with the optional ``filter_callback`` argument.
+The value of this argument, if not None, should be a function that takes an
+instance and returns a boolean.
+
+.. code-block:: pycon
+
+    >>> # Only books with odd ids will have author prefetched.
+    >>> Book.objects.prefetch_related(
+    ...     Prefetch(
+    ...         "author",
+    ...         filter_callback=lambda b: bool(b.id % 2)
+    ...     ),
+    ... )
+
 .. note::
 
     The ordering of lookups matters.
@@ -4085,7 +4100,7 @@ combine them using operators such as ``|`` (``OR``), ``&`` (``AND``), and ``^``
 ``Prefetch()`` objects
 ----------------------
 
-.. class:: Prefetch(lookup, queryset=None, to_attr=None)
+.. class:: Prefetch(lookup, queryset=None, to_attr=None, filter_callback=None)
 
 The ``Prefetch()`` object can be used to control the operation of
 :meth:`~django.db.models.query.QuerySet.prefetch_related()`.
@@ -4135,6 +4150,18 @@ attribute:
     provide a significant speed improvement over traditional
     ``prefetch_related`` calls which store the cached result within a
     ``QuerySet`` instance.
+
+The ``filter_callback`` argument limits the prefetch operation to a subset of instances:
+
+.. code-block:: pycon
+
+    >>> # Only books with odd ids will have author prefetched.
+    >>> Book.objects.prefetch_related(
+    ...     Prefetch(
+    ...         "author",
+    ...         filter_callback=lambda b: bool(b.id % 2)
+    ...     ),
+    ... )
 
 ``prefetch_related_objects()``
 ------------------------------

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -275,6 +275,9 @@ Models
 * The new ``"transaction_mode"`` option is now supported in :setting:`OPTIONS`
   on SQLite to allow specifying the :ref:`sqlite-transaction-behavior`.
 
+* The new ``filter_callback`` field of :class:`~django.db.models.query.Prefetch`
+  enables prefetching related objects only for a subset of instances.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -275,7 +275,7 @@ Models
 * The new ``"transaction_mode"`` option is now supported in :setting:`OPTIONS`
   on SQLite to allow specifying the :ref:`sqlite-transaction-behavior`.
 
-* The new ``filter_callback`` field of :class:`~django.db.models.query.Prefetch`
+* The new ``filter_callback`` field of :class:`~django.db.models.Prefetch`
   enables prefetching related objects only for a subset of instances.
 
 Requests and Responses

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -278,6 +278,9 @@ Models
 * The new ``filter_callback`` field of :class:`~django.db.models.Prefetch`
   enables prefetching related objects only for a subset of instances.
 
+* The new ``post_prefetch_callback`` field of :class:`~django.db.models.Prefetch`
+  enables post-processing after intermediate or final prefetches.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35317

# Branch description

Some expensive prefetches should not be done on all instances of a queryset.
Moreover, the logic to filter the good instances may be complex and not easily translated in SQL.
Hence, it is simpler and more efficient to call a Python callback to filter out instances,
before generating and executing the prefetch query.
This approach can be further combined with post prefetch processing.
It enables to fill backward partial cache for example,
which can be used for filtering further below,  etc.
Two new arguments Prefetch.filter_callback and Prefetch.post_prefetch_callback
were added for these purposes.


# Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
