### PR TITLE
Added ModelState.from_model() test for abstract model with unnamed indexes.

### DIFF
--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -1856,8 +1856,11 @@ class ModelStateTests(SimpleTestCase):
         class Child2(Abstract):
             pass
 
+        abstract_state = ModelState.from_model(Abstract)
         child1_state = ModelState.from_model(Child1)
         child2_state = ModelState.from_model(Child2)
+        index_names = [index.name for index in abstract_state.options["indexes"]]
+        self.assertEqual(index_names, ["migrations__name_ae16a4_idx"])
         index_names = [index.name for index in child1_state.options["indexes"]]
         self.assertEqual(index_names, ["migrations__name_b0afd7_idx"])
         index_names = [index.name for index in child2_state.options["indexes"]]


### PR DESCRIPTION
Unused since d3cf75ec6fbdd2c1f1bb1e6ccb48d4de1da2952b, but unnecessary since its introduction in 3d19d1428a05b514afb771b52870d1f7c25670d1.

`set_name_with_model()` is already called for all unnamed indexes in `ModelBase._prepare()`.