### PR TITLE
Refs #34406 -- Added support for GDAL curved geometries. 

### DIFF
--- a/django/contrib/gis/gdal/prototypes/geom.py
+++ b/django/contrib/gis/gdal/prototypes/geom.py
@@ -85,6 +85,13 @@ is_3d = bool_output(lgdal.OGR_G_Is3D, [c_void_p])
 set_3d = void_output(lgdal.OGR_G_Set3D, [c_void_p, c_int], errcheck=False)
 is_measured = bool_output(lgdal.OGR_G_IsMeasured, [c_void_p])
 set_measured = void_output(lgdal.OGR_G_SetMeasured, [c_void_p, c_int], errcheck=False)
+has_curve_geom = bool_output(lgdal.OGR_G_HasCurveGeometry, [c_void_p, c_int])
+get_linear_geom = geom_output(
+    lgdal.OGR_G_GetLinearGeometry, [c_void_p, c_double, POINTER(c_char_p)]
+)
+get_curve_geom = geom_output(
+    lgdal.OGR_G_GetCurveGeometry, [c_void_p, POINTER(c_char_p)]
+)
 
 # Geometry modification routines.
 add_geom = void_output(lgdal.OGR_G_AddGeometry, [c_void_p, c_void_p])

--- a/docs/ref/contrib/gis/gdal.txt
+++ b/docs/ref/contrib/gis/gdal.txt
@@ -611,6 +611,26 @@ coordinate transformation:
         >>> polygon.geom_count
         1
 
+    .. attribute:: has_curve
+
+    .. versionadded:: 5.2
+
+    A boolean indicating if this geometry is or contains a curve geometry.
+
+    .. method:: get_linear_geometry
+
+    .. versionadded:: 5.2
+
+    Returns a linear version of the geometry. If no conversion can be made, the
+    original geometry is returned.
+
+    .. method:: get_curve_geometry
+
+    .. versionadded:: 5.2
+
+    Returns a curved version of the geometry. If no conversion can be made, the
+    original geometry is returned.
+
     .. attribute:: point_count
 
     Returns the number of points used to describe this geometry:

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -60,7 +60,11 @@ Minor features
 :mod:`django.contrib.gis`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* GDAL now supports curved geometries ``CurvePolygon``, ``CompoundCurve``,
+  ``CircularString``, ``MultiSurface``, and ``MultiCurve`` via the new
+  :attr:`.OGRGeometry.has_curve` property, and the
+  :meth:`.OGRGeometry.get_linear_geometry` and
+  :meth:`.OGRGeometry.get_curve_geometry` methods.
 
 :mod:`django.contrib.messages`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/gis_tests/data/geometries.json
+++ b/tests/gis_tests/data/geometries.json
@@ -137,5 +137,87 @@
   "union_geoms": [
       {"wkt": "POLYGON ((-5 0,-5 10,5 10,5 5,10 5,10 -5,0 -5,0 0,-5 0))"},
       {"wkt": "POLYGON ((2 0, 2 15, 18 15, 18 0, 2 0))"}
+  ],
+"curved_geoms": [
+    {"wkt": "CIRCULARSTRING(1 5, 6 2, 7 3)",
+     "name": "CircularString",
+     "num": 8
+    },
+    {"wkt": "COMPOUNDCURVE((5 3, 5 13), CIRCULARSTRING(5 13, 7 15, 9 13), (9 13, 9 3), CIRCULARSTRING(9 3, 7 1, 5 3))",
+     "name": "CompoundCurve",
+     "num": 9
+    },
+    {"wkt": "CURVEPOLYGON(CIRCULARSTRING(0 0, 4 0, 4 4, 0 4, 0 0),(1 1, 3 3, 3 1, 1 1))",
+     "name": "CurvePolygon",
+     "num": 10
+    },
+    {"wkt": "MULTICURVE((0 0, 5 5), CIRCULARSTRING(4 0, 4 4, 8 4))",
+     "name": "MultiCurve",
+     "num": 11
+    },
+    {"wkt": "MULTISURFACE(((0 0, 0 1, 1 1, 1 0, 0 0)), ((1 1, 1 2, 2 2, 2 1, 1 1)))",
+     "name": "MultiSurface",
+     "num": 12
+    },
+    {"wkt": "CIRCULARSTRING Z (1 5 1, 6 2 2, 7 3 3)",
+     "name": "CircularStringZ",
+     "num": 1008
+    },
+    {"wkt": "COMPOUNDCURVE Z ((5 3 0, 5 13 0), CIRCULARSTRING Z (5 13 0, 7 15 0, 9 13 0), (9 13 0 , 9 3 0), CIRCULARSTRING(9 3 0, 7 1 0, 5 3 0))",
+     "name": "CompoundCurveZ",
+     "num": 1009
+    },
+    {"wkt": "CURVEPOLYGON Z(CIRCULARSTRING Z (0 0 0, 4 0 0, 4 4 0, 0 4 0, 0 0 0),(1 1 0, 3 3 0, 3 1 0, 1 1 0))",
+     "name": "CurvePolygonZ",
+     "num": 1010
+    },
+    {"wkt": "MULTICURVE Z ((0 0 1, 5 5 2), CIRCULARSTRING Z (4 0 0, 4 4 0, 8 4 0))",
+     "name": "MultiCurveZ",
+     "num": 1011
+    },
+    {"wkt": "MULTISURFACE Z (((0 0 1, 0 1 2, 1 1 3, 1 0 4, 0 0 5)), ((1 1 0, 1 2 0, 2 2 0, 2 1 0, 1 1 0)))",
+     "name": "MultiSurfaceZ",
+     "num": 1012
+    },
+    {"wkt": "CIRCULARSTRING M (1 5 1, 6 2 2, 7 3 3)",
+     "name": "CircularStringM",
+     "num": 2008
+    },
+    {"wkt": "COMPOUNDCURVE M ((5 3 0, 5 13 0), CIRCULARSTRING M (5 13 0, 7 15 0, 9 13 0), (9 13 0 , 9 3 0), CIRCULARSTRING M (9 3 0, 7 1 0, 5 3 0))",
+     "name": "CompoundCurveM",
+     "num": 2009
+    },
+    {"wkt": "CURVEPOLYGON M (CIRCULARSTRING M (0 0 0, 4 0 0, 4 4 0, 0 4 0, 0 0 0),(1 1 0, 3 3 1, 3 1 1, 1 1 2))",
+     "name": "CurvePolygonM",
+     "num": 2010
+    },
+    {"wkt": "MULTICURVE M ((0 0 1, 5 5 2), CIRCULARSTRING M (4 0 0, 4 4 0, 8 4 0))",
+     "name": "MultiCurveM",
+     "num": 2011
+    },
+    {"wkt": "MULTISURFACE M (((0 0 1, 0 1 2, 1 1 3, 1 0 4, 0 0 5)), ((1 1 0, 1 2 0, 2 2 0, 2 1 0, 1 1 0)))",
+     "name": "MultiSurfaceM",
+     "num": 2012
+    },
+    {"wkt": "CIRCULARSTRING ZM (1 5 0 1, 6 2 0 2, 7 3 0 3)",
+     "name": "CircularStringZM",
+     "num": 3008
+    },
+    {"wkt": "COMPOUNDCURVE ZM ((5 3 0 0, 5 13 0 0), CIRCULARSTRING ZM (5 13 0 0, 7 15 0 0, 9 13 0 0), (9 13 0 0, 9 3 0 0), CIRCULARSTRING ZM (9 3 0 0, 7 1 0 0, 5 3 0 0))",
+     "name": "CompoundCurveZM",
+     "num": 3009
+    },
+    {"wkt": "CURVEPOLYGON ZM (CIRCULARSTRING ZM (0 0 0 0, 4 0 0 0, 4 4 0 0, 0 4 0 0, 0 0 0 0), (1 1 0 0, 3 3 0 0, 3 1 0 0, 1 1 0 0))",
+     "name": "CurvePolygonZM",
+     "num": 3010
+    },
+    {"wkt": "MULTICURVE ZM ((0 0 0 1, 5 5 0 2), CIRCULARSTRING ZM (4 0 0 0, 4 4 0 0, 8 4 0 0))",
+     "name": "MultiCurveZM",
+     "num": 3011
+    },
+    {"wkt": "MULTISURFACE ZM (((0 0 0 1, 0 1 0 2, 1 1 0 3, 1 0 0 4, 0 0 0 5)), ((1 1 0 0, 1 2 0 0, 2 2 0 0, 2 1 0 0, 1 1 0 0)))",
+     "name": "MultiSurfaceZM",
+     "num": 3012
+    }
   ]
 }


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-34406

# Branch description
Adds curved geometry support for GDAL geometries. 

As part of this I tried to add the `ForceTo*` bindings (e.g. [ForceToPolygon](https://gdal.org/api/vector_c_api.html#_CPPv420OGR_G_ForceToPolygon12OGRGeometryH) ). However, I was unable to achieve this. I think it's likely due to me not understanding the return type. 

> Returns:  the converted geometry (ownership to caller).

While I've been unable to solve that problem I think it's likely reviewing the other work I've done here which adds recognition of these types and allows conversion between linear and curved geometries.


# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
