### PR TITLE
Fixed #35328 - Improved debug messaging behind proxies.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -902,6 +902,7 @@ answer newbie questions, and generally made Django that much better:
     Russ Webber
     Ryan Hall <ryanhall989@gmail.com>
     Ryan Heard <ryanwheard@gmail.com>
+    Ryan Hiebert <ryan@ryanhiebert.com>
     ryankanno
     Ryan Kelly <ryan@rfk.id.au>
     Ryan Niemeyer <https://profiles.google.com/ryan.niemeyer/about>

--- a/django/views/csrf.py
+++ b/django/views/csrf.py
@@ -61,6 +61,16 @@ def csrf_failure(request, reason="", template_name=CSRF_FAILURE_TEMPLATE_NAME):
             "re-enable them, at least for this site, or for “same-origin” "
             "requests."
         ),
+        "bad_origin": reason.startswith("Origin checking failed"),
+        "forwarded_may_fix": (
+            request.headers.get("X-Forwarded-Proto", "") == "https"
+            and not request.is_secure()
+            or request.headers.get("Origin", "").endswith(
+                f'://{request.headers.get("X-Forwarded-Host", "")}'
+            )
+        ),
+        "x_forwarded_proto": request.headers.get("X-Forwarded-Proto"),
+        "x_forwarded_host": request.headers.get("X-Forwarded-Host"),
         "DEBUG": settings.DEBUG,
         "docs_version": get_docs_version(),
         "more": _("More information is available with DEBUG=True."),

--- a/django/views/templates/csrf_403.html
+++ b/django/views/templates/csrf_403.html
@@ -43,6 +43,34 @@
     </pre>
     {% endif %}
 
+  {% if bad_origin %}
+  {% if forwarded_may_fix %}
+  <p>The <code>Origin</code> header does not match
+  the expected server origin,
+  but common proxy headers are present in the request
+  and may include parts of the <code>Origin</code> header.</p>
+  <ul>
+    <li><strong><code>X-Forwarded-Proto</code></strong>:
+      <code>{{ x_forwarded_proto }}</code></li>
+    <li><strong><code>X-Forwarded-Host</code></strong>:
+      <code>{{ x_forwarded_host }}</code></li>
+  </ul>
+  <p>If you’re sure that you are only running behind a secure proxy
+     that always set these headers to avoid spoofing as described in
+     <a href="https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/#secure-proxy-ssl-header">this warning in the docs</a>,
+     you may wish to add one or more of the following
+     settings to permit Django to trust these headers.</p>
+  <p><pre>
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+    USE_X_FORWARDED_HOST = True
+  </pre></p>
+  {% else %}
+  If the expected server origin looks correct,
+  you may wish to add the origin to the <code>CSRF_TRUSTED_ORIGINS</code>
+  setting.
+  {% endif %}
+  {% else %}
+
   <p>In general, this can occur when there is a genuine Cross Site Request Forgery, or when
   <a
   href="https://docs.djangoproject.com/en/{{ docs_version }}/ref/csrf/">Django’s
@@ -68,6 +96,7 @@
     tab or hitting the back button after a login, you may need to reload the
     page with the form, because the token is rotated after a login.</li>
   </ul>
+  {% endif %}
 
   <p>You’re seeing the help section of this page because you have <code>DEBUG =
   True</code> in your Django settings file. Change that to <code>False</code>,

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -198,6 +198,42 @@ Minor features
   session engines now provide async API. The new asynchronous methods all have
   ``a`` prefixed names, e.g. ``aget()``, ``akeys()``, or ``acycle_key()``.
 
+:mod:`django.contrib.sitemaps`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ...
+
+:mod:`django.contrib.sites`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ...
+
+:mod:`django.contrib.staticfiles`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ...
+
+:mod:`django.contrib.syndication`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ...
+
+Asynchronous views
+~~~~~~~~~~~~~~~~~~
+
+* ...
+
+Cache
+~~~~~
+
+* ...
+
+CSRF
+~~~~
+
+* The error messaging is improved when ``Origin`` checking fails,
+  including better hints when likely proxy headers are detected.
+
 Database backends
 ~~~~~~~~~~~~~~~~~
 

--- a/tests/view_tests/tests/test_csrf.py
+++ b/tests/view_tests/tests/test_csrf.py
@@ -130,7 +130,7 @@ class CsrfViewTests(SimpleTestCase):
         from django.views.csrf import Path
 
         with mock.patch.object(Path, "open") as m:
-            csrf_failure(mock.MagicMock(), mock.Mock())
+            csrf_failure(mock.MagicMock(), "Example reason")
             m.assert_called_once_with(encoding="utf-8")
 
     @override_settings(DEBUG=True)


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35328

# Branch description
When in debug mode, we can  make some better error messaging when the `Origin` header checking fails. In common scenarios, we can notice that they are likely missing headers from proxies. In any case, we can remove the verbose messaging around CSRF Tokens, which are *not* the way they have failed and are unhelpful to solving the error they are viewing.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
<!-- - [ ] For UI changes, I have attached **screenshots** in both light and dark modes. -->
