### PR TITLE
Corrected Slovak local name.

### DIFF
--- a/django/conf/locale/__init__.py
+++ b/django/conf/locale/__init__.py
@@ -480,7 +480,7 @@ LANG_INFO = {
         "bidi": False,
         "code": "sk",
         "name": "Slovak",
-        "name_local": "Slovensky",
+        "name_local": "slovensky",
     },
     "sl": {
         "bidi": False,


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

# Branch description

When talking about the Slovak language in the form "slovensky", it is correct to use lower case letters.

The same can be found (but already correct) in django/conf/locale/sk/LC_MESSAGES/django.po, line 260.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" **ticket flag** in the Trac system.
- [ ] I have added or updated relevant **tests**.
- [ ] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
