### PR TITLE
Fixed #35336 -- Addressed crash when adding a GeneratedField with % literals.

### DIFF
--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -198,9 +198,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         return self.normalize_name(for_name + "_" + suffix)
 
     def prepare_default(self, value):
-        # Replace % with %% as %-formatting is applied in
-        # FormatStylePlaceholderCursor._fix_for_params().
-        return self.quote_value(value).replace("%", "%%")
+        return self.quote_value(value)
 
     def _field_should_be_indexed(self, model, field):
         create_index = super()._field_should_be_indexed(model, field)

--- a/docs/releases/5.0.4.txt
+++ b/docs/releases/5.0.4.txt
@@ -24,3 +24,7 @@ Bugfixes
 
 * Fixed a crash in Django 5.0 when performing queries involving table aliases
   and lookups on a ``GeneratedField`` of the aliased table (:ticket:`35344`).
+
+* Fixed a bug in Django 5.0 that caused a migration crash when adding a
+  ``GeneratedField`` relying on the ``__contains`` or ``__icontains``
+  lookups or using a ``Value`` containing a ``"%"`` (:ticket:`35336`).

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -54,7 +54,16 @@ from django.db.models import (
     Value,
 )
 from django.db.models.fields.json import KT, KeyTextTransform
-from django.db.models.functions import Abs, Cast, Collate, Lower, Random, Round, Upper
+from django.db.models.functions import (
+    Abs,
+    Cast,
+    Collate,
+    Concat,
+    Lower,
+    Random,
+    Round,
+    Upper,
+)
 from django.db.models.indexes import IndexExpression
 from django.db.transaction import TransactionManagementError, atomic
 from django.test import TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature
@@ -885,6 +894,39 @@ class SchemaTests(TransactionTestCase):
 
         with connection.schema_editor() as editor:
             editor.create_model(GeneratedFieldOutputFieldModel)
+
+    @isolate_apps("schema")
+    @skipUnlessDBFeature("supports_stored_generated_columns")
+    def test_add_generated_field_contains(self):
+        class GeneratedFieldContainsModel(Model):
+            text = TextField(default="foo")
+            generated = GeneratedField(
+                expression=Concat("text", Value("%")),
+                db_persist=True,
+                output_field=TextField(),
+            )
+
+            class Meta:
+                app_label = "schema"
+
+        with connection.schema_editor() as editor:
+            editor.create_model(GeneratedFieldContainsModel)
+
+        field = GeneratedField(
+            expression=Q(text__icontains="FOO"),
+            db_persist=True,
+            output_field=BooleanField(),
+        )
+        field.contribute_to_class(GeneratedFieldContainsModel, "contains_foo")
+
+        with connection.schema_editor() as editor:
+            editor.add_field(GeneratedFieldContainsModel, field)
+
+        obj = GeneratedFieldContainsModel.objects.create()
+        obj.refresh_from_db()
+        self.assertEqual(obj.text, "foo")
+        self.assertEqual(obj.generated, "foo%")
+        self.assertIs(obj.contains_foo, True)
 
     @isolate_apps("schema")
     def test_add_auto_field(self):


### PR DESCRIPTION
ticket-35336

--- 

A longer term solution is likely to have a better separation of parametrized DDL altogether to handle checks, constraints, defaults, and generated fields but such a change would require a significant refactor that isn't suitable for a backport.

Thanks Adrian Garcia for the report.
