### PR TITLE
Fixed #35342 -- Increased Integer clean reliability.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2141,6 +2141,9 @@ class IntegerField(Field):
         if value is None:
             return value
         try:
+            if isinstance(value, float):
+                if value%1 != 0:
+                    raise TypeError
             return int(value)
         except (TypeError, ValueError):
             raise exceptions.ValidationError(

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2142,7 +2142,7 @@ class IntegerField(Field):
             return value
         try:
             if isinstance(value, float):
-                if value%1 != 0:
+                if value % 1 != 0:
                     raise TypeError
             return int(value)
         except (TypeError, ValueError):

--- a/tests/model_fields/test_integerfield.py
+++ b/tests/model_fields/test_integerfield.py
@@ -275,6 +275,15 @@ class ValidationTests(SimpleTestCase):
         with self.assertRaises(ValidationError):
             f.clean("a", None)
 
+    def test_integerfield_raises_error_on_inconvertible_float(self):
+        f = models.IntegerField()
+        with self.assertRaises(ValidationError):
+            f.clean(1.2, None)
+
+    def test_integerfield_cleans_convertible_float(self):
+        f = models.IntegerField()
+        self.assertEqual(f.clean(2.0, None), 2)
+
     def test_choices_validation_supports_named_groups(self):
         f = models.IntegerField(choices=(("group", ((10, "A"), (20, "B"))), (30, "C")))
         self.assertEqual(10, f.clean(10, None))


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35342

# Branch description
During the full_clean( ) routine, when an IntegerField is being cleaned and the code calls the field's to_python( ) method, if the value of the field is a float, it will just be converted to an integer using int(value). As it is characteristic of python's native int( ) function, it converts any float to int regardless of decimal places and approximations necessary, allowing for examples like this to happen:
```
exModel = ModelWithIntegerField(value=1.2)
>>   exModel.value     #1.2
exModel.clean_fields() #no validation error raised
>>   exModel.value     #1
```

I don't know if this behaviour is because of ticket [#24229](https://code.djangoproject.com/ticket/24229), but I believe there are better ways than just allowing any number through IntegerField verification as long as it's a number, regardless of how it affects the output.
My suggestions to improve this are:
1# Check first if it's a float type then verify if the numbers after the decimal point are 0 if value%1 == 0, if they are, no problem converting, if not raise a TypeError as it would distort the original value without warning.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [ ] I have added or updated relevant **docs**, including release notes if applicable.
- [ ] For UI changes, I have attached **screenshots** in both light and dark modes.
