### PR TITLE
Fixed #35344 -- Corrected output_field of resolved columns of table alias for GeneratedFields.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -508,6 +508,7 @@ answer newbie questions, and generally made Django that much better:
     Joe Topjian <http://joe.terrarum.net/geek/code/python/django/>
     Johan C. Stöver <johan@nilling.nl>
     Johann Queuniet <johann.queuniet@adh.naellia.eu>
+    Johannes Westphal <jojo@w-hat.de>
     john@calixto.net
     John D'Agostino <john.dagostino@gmail.com>
     John D'Ambrosio <dambrosioj@gmail.com>

--- a/django/db/models/fields/generated.py
+++ b/django/db/models/fields/generated.py
@@ -39,7 +39,7 @@ class GeneratedField(Field):
         return Col(self.model._meta.db_table, self, self.output_field)
 
     def get_col(self, alias, output_field=None):
-        if alias != self.model._meta.db_table and output_field is None:
+        if alias != self.model._meta.db_table and output_field in (None, self):
             output_field = self.output_field
         return super().get_col(alias, output_field)
 

--- a/docs/releases/5.0.4.txt
+++ b/docs/releases/5.0.4.txt
@@ -21,3 +21,6 @@ Bugfixes
 * Fixed a bug in Django 5.0 that caused a migration crash on PostgreSQL 15+
   when adding a partial ``UniqueConstraint`` with ``nulls_distinct``
   (:ticket:`35329`).
+
+* Fixed a crash in Django 5.0 when performing queries involving table aliases
+  and lookups on a ``GeneratedField`` of the aliased table (:ticket:`35344`).

--- a/tests/model_fields/test_generatedfield.py
+++ b/tests/model_fields/test_generatedfield.py
@@ -123,7 +123,12 @@ class BaseGeneratedFieldTests(SimpleTestCase):
                 db_persist=True,
             )
 
-        col = Square._meta.get_field("area").get_col("alias")
+        field = Square._meta.get_field("area")
+
+        col = field.get_col("alias")
+        self.assertIsInstance(col.output_field, IntegerField)
+
+        col = field.get_col("alias", field)
         self.assertIsInstance(col.output_field, IntegerField)
 
         class FloatSquare(Model):
@@ -134,7 +139,12 @@ class BaseGeneratedFieldTests(SimpleTestCase):
                 output_field=FloatField(),
             )
 
-        col = FloatSquare._meta.get_field("area").get_col("alias")
+        field = FloatSquare._meta.get_field("area")
+
+        col = field.get_col("alias")
+        self.assertIsInstance(col.output_field, FloatField)
+
+        col = field.get_col("alias", field)
         self.assertIsInstance(col.output_field, FloatField)
 
     @isolate_apps("model_fields")


### PR DESCRIPTION
# Trac ticket number
[ticket-35344](https://code.djangoproject.com/ticket/35344)

# Branch description
For generated fields, `get_col` gets called with `output_field=<instance of the generated field>`. Consequently, if an `alias` is specified, the `output_field` of the generated `Col` is of type `GeneratedField` instead of the actual `output_field` of the `GeneratedField`, since the previous code only handled the case where `get_col`'s `output_field` parameter is `None`, but not when it is `self`.

# Checklist
* [x]  This PR targets the `main` branch.
* [x]  The commit message is written in past tense, mentions the ticket number, and ends with a period.
* [x]  I have checked the "Has patch" **ticket flag** in the Trac system.
* [x]  I have added or updated relevant **tests**.
* [x]  I have added or updated relevant **docs**, including release notes if applicable.
* [x]  For UI changes, I have attached **screenshots** in both light and dark modes.

