### PR TITLE
Fixed #25947 -- Query's str() method worked normally when 'default' database is empty

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -607,6 +607,7 @@ answer newbie questions, and generally made Django that much better:
     lerouxb@gmail.com
     Lex Berezhny <lex@damoti.com>
     Liang Feng <hutuworm@gmail.com>
+    Lin Zhiwen <zhiwenlin1116@gmail.com>
     Lily Foote
     limodou
     Lincoln Smith <lincoln.smith@anu.edu.au>

--- a/AUTHORS
+++ b/AUTHORS
@@ -607,9 +607,9 @@ answer newbie questions, and generally made Django that much better:
     lerouxb@gmail.com
     Lex Berezhny <lex@damoti.com>
     Liang Feng <hutuworm@gmail.com>
-    Lin Zhiwen <zhiwenlin1116@gmail.com>
     Lily Foote
     limodou
+    Lin Zhiwen <zhiwenlin1116@gmail.com>
     Lincoln Smith <lincoln.smith@anu.edu.au>
     Liu Yijie <007gzs@gmail.com>
     Loek van Gent <loek@barakken.nl>

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -298,6 +298,7 @@ class QuerySet(AltersData):
         self._db = using
         self._hints = hints or {}
         self._query = query or sql.Query(self.model)
+        self._query.queryset = self
         self._result_cache = None
         self._sticky_filter = False
         self._for_write = False
@@ -1921,6 +1922,7 @@ class QuerySet(AltersData):
         c._known_related_objects = self._known_related_objects
         c._iterable_class = self._iterable_class
         c._fields = self._fields
+        c._query.queryset = c
         return c
 
     def _fetch_all(self):

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1781,7 +1781,7 @@ class QuerySet(AltersData):
         """Select which database this QuerySet should execute against."""
         clone = self._chain()
         clone._db = alias
-        clone._query.using(self.db)
+        clone._query.using(clone.db)
         return clone
 
     ###################################

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -308,6 +308,8 @@ class QuerySet(AltersData):
         self._fields = None
         self._defer_next_filter = False
         self._deferred_filter = None
+        if query is None:
+            self._query.using(self.db)
 
     @property
     def query(self):

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -298,7 +298,6 @@ class QuerySet(AltersData):
         self._db = using
         self._hints = hints or {}
         self._query = query or sql.Query(self.model)
-        self._query.queryset = self
         self._result_cache = None
         self._sticky_filter = False
         self._for_write = False
@@ -1782,6 +1781,7 @@ class QuerySet(AltersData):
         """Select which database this QuerySet should execute against."""
         clone = self._chain()
         clone._db = alias
+        clone._query.using(self.db)
         return clone
 
     ###################################
@@ -1922,7 +1922,6 @@ class QuerySet(AltersData):
         c._known_related_objects = self._known_related_objects
         c._iterable_class = self._iterable_class
         c._fields = self._fields
-        c._query.queryset = c
         return c
 
     def _fetch_all(self):
@@ -1981,6 +1980,7 @@ class QuerySet(AltersData):
         overwrite existing key/values.
         """
         self._hints.update(hints)
+        self._query.using(self.db)
 
     def _has_filters(self):
         """

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -289,8 +289,9 @@ class Query(BaseExpression):
 
     explain_info = None
 
-    def __init__(self, model, alias_cols=True):
+    def __init__(self, model, alias_cols=True, queryset=None):
         self.model = model
+        self.queryset = queryset
         self.alias_refcount = {}
         # alias_map is the most important data structure regarding joins.
         # It's used for recording which joins exist in the query and what
@@ -316,6 +317,20 @@ class Query(BaseExpression):
         self.extra = {}  # Maps col_alias -> (col_sql, params).
 
         self._filtered_relations = {}
+
+    # Remove queryset from pickle result.
+    # Refer https://code.djangoproject.com/ticket/27159
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["queryset"] = None
+        return state
+
+    @property
+    def db(self):
+        # Must not use ``if self.queryset``, that will trigger evaluation of queryset.
+        if self.queryset is not None:
+            return self.queryset.db
+        return DEFAULT_DB_ALIAS
 
     @property
     def output_field(self):
@@ -346,7 +361,7 @@ class Query(BaseExpression):
         Return the query as an SQL string and the parameters that will be
         substituted into the query.
         """
-        return self.get_compiler(DEFAULT_DB_ALIAS).as_sql()
+        return self.get_compiler(self.db).as_sql()
 
     def __deepcopy__(self, memo):
         """Limit the amount of work when a Query is deepcopied."""
@@ -1399,13 +1414,11 @@ class Query(BaseExpression):
             return lhs.get_lookup("isnull")(lhs, True)
 
         # For Oracle '' is equivalent to null. The check must be done at this
-        # stage because join promotion can't be done in the compiler. Using
-        # DEFAULT_DB_ALIAS isn't nice but it's the best that can be done here.
-        # A similar thing is done in is_nullable(), too.
+        # stage because join promotion can't be done in the compiler.
         if (
             lookup_name == "exact"
             and lookup.rhs == ""
-            and connections[DEFAULT_DB_ALIAS].features.interprets_empty_strings_as_nulls
+            and connections[self.db].features.interprets_empty_strings_as_nulls
         ):
             return lhs.get_lookup("isnull")(lhs, True)
 
@@ -2624,14 +2637,9 @@ class Query(BaseExpression):
         nullable for those backends. In such situations field.null can be
         False even if we should treat the field as nullable.
         """
-        # We need to use DEFAULT_DB_ALIAS here, as QuerySet does not have
-        # (nor should it have) knowledge of which connection is going to be
-        # used. The proper fix would be to defer all decisions where
-        # is_nullable() is needed to the compiler stage, but that is not easy
-        # to do currently.
         return field.null or (
             field.empty_strings_allowed
-            and connections[DEFAULT_DB_ALIAS].features.interprets_empty_strings_as_nulls
+            and connections[self.db].features.interprets_empty_strings_as_nulls
         )
 
 

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -1236,10 +1236,9 @@ class QueryTestCase(TestCase):
         self.assertQuerySetEqual(val, [dive.pk], attrgetter("pk"))
 
     def test_query_string(self):
-        with (
-            patch.object(connections["default"].ops, "compiler")
-            as default_db_compiler
-        ):
+        with patch.object(
+            connections["default"].ops, "compiler"
+        ) as default_db_compiler:
             queryset = Person.objects.using("other").all().order_by("id")
 
         self.assertEqual(
@@ -1247,7 +1246,7 @@ class QueryTestCase(TestCase):
             'SELECT "multiple_database_person"."id", '
             '"multiple_database_person"."name" '
             'FROM "multiple_database_person" '
-            'ORDER BY "multiple_database_person"."id" ASC'
+            'ORDER BY "multiple_database_person"."id" ASC',
         )
         default_db_compiler.assert_not_called()
 

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -1240,15 +1240,14 @@ class QueryTestCase(TestCase):
             connections["default"].ops, "compiler"
         ) as default_db_compiler:
             queryset = Person.objects.using("other").all().order_by("id")
-
-        self.assertEqual(
-            str(queryset.query),
-            'SELECT "multiple_database_person"."id", '
-            '"multiple_database_person"."name" '
-            'FROM "multiple_database_person" '
-            'ORDER BY "multiple_database_person"."id" ASC',
-        )
-        default_db_compiler.assert_not_called()
+            self.assertEqual(
+                str(queryset.query),
+                'SELECT "multiple_database_person"."id", '
+                '"multiple_database_person"."name" '
+                'FROM "multiple_database_person" '
+                'ORDER BY "multiple_database_person"."id" ASC',
+            )
+            default_db_compiler.assert_not_called()
 
     def test_select_related(self):
         """

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core import management
-from django.db import DEFAULT_DB_ALIAS, router, transaction, connections
+from django.db import DEFAULT_DB_ALIAS, connections, router, transaction
 from django.db.models import signals
 from django.db.utils import ConnectionRouter
 from django.test import SimpleTestCase, TestCase, override_settings

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -2,12 +2,12 @@ import datetime
 import pickle
 from io import StringIO
 from operator import attrgetter
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core import management
-from django.db import DEFAULT_DB_ALIAS, router, transaction
+from django.db import DEFAULT_DB_ALIAS, router, transaction, connections
 from django.db.models import signals
 from django.db.utils import ConnectionRouter
 from django.test import SimpleTestCase, TestCase, override_settings

--- a/tests/queries/test_query.py
+++ b/tests/queries/test_query.py
@@ -160,6 +160,11 @@ class TestQuery(SimpleTestCase):
         with self.assertRaisesMessage(TypeError, msg):
             query.build_where(Func(output_field=CharField()))
 
+    def test_use_correct_db(self):
+        qs = Item.objects.using("other")
+        query = Query(Item, queryset=qs)
+        self.assertEqual(query.db, "other")
+
 
 class TestQueryNoModel(TestCase):
     def test_rawsql_annotation(self):

--- a/tests/queries/test_query.py
+++ b/tests/queries/test_query.py
@@ -162,8 +162,7 @@ class TestQuery(SimpleTestCase):
 
     def test_use_correct_db(self):
         qs = Item.objects.using("other")
-        query = Query(Item, queryset=qs)
-        self.assertEqual(query.db, "other")
+        self.assertEqual(qs.query.db, "other")
 
 
 class TestQueryNoModel(TestCase):


### PR DESCRIPTION
`sql_with_params`, `build_lookup` and `is_nullable` in `Query` would use the correct connection and generate more reasonable SQL.

# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-25947

# Branch description
This fix makes output of `print(queryset.query)` more reasonable when the queryset use a different database from `default`.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
