### PR TITLE
Early adopt UTF-8 Mode on Windows.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ permissions:
 
 jobs:
   windows:
+    env:
+      # Python 3.15 will make UTF-8 Mode the default.
+      PYTHONUTF8: 1
     runs-on: windows-latest
     strategy:
       matrix:


### PR DESCRIPTION
Python 3.15 will enable UTF-8 mode by default

https://peps.python.org/pep-0686/#enable-utf-8-mode-by-default