### PR TITLE
Refs #31710 -- Fixed multiple file upload documentation.

### DIFF
--- a/docs/topics/http/file-uploads.txt
+++ b/docs/topics/http/file-uploads.txt
@@ -154,7 +154,7 @@ Uploading multiple files
     should be updated after any changes in the following snippets.
 
 If you want to upload multiple files using one form field, create a subclass
-of the field's widget and set the ``allow_multiple_selected`` attribute on it
+of the field's widget and set its ``allow_multiple_selected`` class attribute
 to ``True``.
 
 In order for such files to be all validated by your form (and have the value of
@@ -186,14 +186,14 @@ below for an example.
             if isinstance(data, (list, tuple)):
                 result = [single_file_clean(d, initial) for d in data]
             else:
-                result = single_file_clean(data, initial)
+                result = [single_file_clean(data, initial)]
             return result
 
 
     class FileFieldForm(forms.Form):
         file_field = MultipleFileField()
 
-Then override the ``post`` method of your
+Then override the ``form_valid()`` method of your
 :class:`~django.views.generic.edit.FormView` subclass to handle multiple file
 uploads:
 
@@ -209,19 +209,11 @@ uploads:
         template_name = "upload.html"  # Replace with your template.
         success_url = "..."  # Replace with your URL or reverse().
 
-        def post(self, request, *args, **kwargs):
-            form_class = self.get_form_class()
-            form = self.get_form(form_class)
-            if form.is_valid():
-                return self.form_valid(form)
-            else:
-                return self.form_invalid(form)
-
         def form_valid(self, form):
             files = form.cleaned_data["file_field"]
             for f in files:
                 ...  # Do something with each file.
-            return super().form_valid()
+            return super().form_valid(form)
 
 .. warning::
 


### PR DESCRIPTION
# Trac ticket number

ticket-31710

# Branch description

Fix two issues in this documentation added in fb4c55d9ec4bb812a7fb91fa20510d91645e411b.

**First**, a small tweak to make the widget consistently return a list of files. Without this, it would break the sample view code’s iteration (`for f in files`) when the form’s `files` is not a `MultiValueDict`, which is typically used in testing.

Before:

```
In [1]: from django.core.files.uploadedfile import SimpleUploadedFile

In [2]: from example.forms import FileFieldForm

In [3]: form = FileFieldForm({}, {"file_field": SimpleUploadedFile("bunny.jpeg", b"bunny")})

In [4]: form.is_valid()
Out[4]: True

In [5]: form.cleaned_data
Out[5]: {'file_field': <SimpleUploadedFile: bunny.jpeg (text/plain)>}
```

After:

```
In [1]: from django.core.files.uploadedfile import SimpleUploadedFile

In [2]: from example.forms import FileFieldForm

In [3]: form = FileFieldForm({}, {"file_field": SimpleUploadedFile("bunny.jpeg", b"bunny")})

In [4]: form.is_valid()
Out[4]: True

In [5]: form.cleaned_data
Out[5]: {'file_field': [<SimpleUploadedFile: bunny.jpeg (text/plain)>]}
```

**Second**, remove the redundant `post()` from the view, and fix the call to `super().form_valid()` to pass `form`. The `post()` method only duplicated `ProcessFormView` with nothing extra added for multiple file handling. The `super()` call crashed with `TypeError` due to the missing argument.

Before:

```
In [1]: from django.core.files.uploadedfile import SimpleUploadedFile

In [2]: from django.test import RequestFactory

In [3]: from example.views import FileFieldFormView

In [4]: rf = RequestFactory()

In [5]: request = rf.post("/", files={"file_field": SimpleUploadedFile("bunny.jpeg", b"bunny")})

In [6]: FileFieldFormView.as_view()(request)
...
File ~/tmp/multiple-test/example/views.py:22, in FileFieldFormView.form_valid(self, form)
     20 for f in files:
     21     ...  # Do something with each file.
---> 22 return super().form_valid()

TypeError: FormMixin.form_valid() missing 1 required positional argument: 'form'
```

After:

```
In [1]: from django.core.files.uploadedfile import SimpleUploadedFile

In [2]: from django.test import RequestFactory

In [3]: from example.views import FileFieldFormView

In [4]: rf = RequestFactory()

In [5]: request = rf.post("/", files={"file_field": SimpleUploadedFile("bunny.jpeg", b"bunny")})

In [6]: FileFieldFormView.as_view()(request)
Out[6]: <HttpResponseRedirect status_code=302, "text/html; charset=utf-8", url="...">
```

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
