### PR TITLE
 Fixed 35339 - Fixed PostgreSQL aggregate order by and filter params order 

### DIFF
--- a/django/contrib/postgres/aggregates/mixins.py
+++ b/django/contrib/postgres/aggregates/mixins.py
@@ -17,13 +17,10 @@ class OrderableAggMixin:
         return super().resolve_expression(*args, **kwargs)
 
     def get_source_expressions(self):
-        if self.order_by is not None:
-            return super().get_source_expressions() + [self.order_by]
-        return super().get_source_expressions()
+        return super().get_source_expressions() + [self.order_by]
 
     def set_source_expressions(self, exprs):
-        if isinstance(exprs[-1], OrderByList):
-            *exprs, self.order_by = exprs
+        *exprs, self.order_by = exprs
         return super().set_source_expressions(exprs)
 
     def as_sql(self, compiler, connection):

--- a/django/contrib/postgres/aggregates/mixins.py
+++ b/django/contrib/postgres/aggregates/mixins.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import FullResultSet
 from django.db.models.expressions import OrderByList
 
 
@@ -24,9 +25,23 @@ class OrderableAggMixin:
         return super().set_source_expressions(exprs)
 
     def as_sql(self, compiler, connection):
-        if self.order_by is not None:
-            order_by_sql, order_by_params = compiler.compile(self.order_by)
-        else:
-            order_by_sql, order_by_params = "", ()
-        sql, sql_params = super().as_sql(compiler, connection, ordering=order_by_sql)
-        return sql, (*sql_params, *order_by_params)
+        *source_exprs, filtering_expr, ordering_expr = self.get_source_expressions()
+
+        order_by_sql = ""
+        order_by_params = []
+        if ordering_expr is not None:
+            order_by_sql, order_by_params = compiler.compile(ordering_expr)
+
+        filter_params = []
+        if filtering_expr is not None:
+            try:
+                _, filter_params = compiler.compile(filtering_expr)
+            except FullResultSet:
+                pass
+
+        source_params = []
+        for source_expr in source_exprs:
+            source_params += compiler.compile(source_expr)[1]
+
+        sql, _ = super().as_sql(compiler, connection, ordering=order_by_sql)
+        return sql, (*source_params, *order_by_params, *filter_params)

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -50,12 +50,10 @@ class Aggregate(Func):
 
     def get_source_expressions(self):
         source_expressions = super().get_source_expressions()
-        if self.filter:
-            return source_expressions + [self.filter]
-        return source_expressions
+        return source_expressions + [self.filter]
 
     def set_source_expressions(self, exprs):
-        self.filter = self.filter and exprs.pop()
+        *exprs, self.filter = exprs
         return super().set_source_expressions(exprs)
 
     def resolve_expression(
@@ -63,8 +61,10 @@ class Aggregate(Func):
     ):
         # Aggregates are not allowed in UPDATE queries, so ignore for_save
         c = super().resolve_expression(query, allow_joins, reuse, summarize)
-        c.filter = c.filter and c.filter.resolve_expression(
-            query, allow_joins, reuse, summarize
+        c.filter = (
+            c.filter.resolve_expression(query, allow_joins, reuse, summarize)
+            if c.filter
+            else None
         )
         if summarize:
             # Summarized aggregates cannot refer to summarized aggregates.
@@ -104,7 +104,9 @@ class Aggregate(Func):
 
     @property
     def default_alias(self):
-        expressions = self.get_source_expressions()
+        expressions = [
+            expr for expr in self.get_source_expressions() if expr is not None
+        ]
         if len(expressions) == 1 and hasattr(expressions[0], "name"):
             return "%s__%s" % (expressions[0].name, self.name.lower())
         raise TypeError("Complex expressions require an alias")

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -1291,7 +1291,7 @@ class AggregateTestCase(TestCase):
 
             def as_sql(self, compiler, connection):
                 copy = self.copy()
-                copy.set_source_expressions(copy.get_source_expressions()[0:1])
+                copy.set_source_expressions(copy.get_source_expressions()[0:1] + [None])
                 return super(MyMax, copy).as_sql(compiler, connection)
 
         with self.assertRaisesMessage(TypeError, "Complex aggregates require an alias"):

--- a/tests/postgres_tests/test_aggregates.py
+++ b/tests/postgres_tests/test_aggregates.py
@@ -12,7 +12,7 @@ from django.db.models import (
     Window,
 )
 from django.db.models.fields.json import KeyTextTransform, KeyTransform
-from django.db.models.functions import Cast, Concat, Substr
+from django.db.models.functions import Cast, Concat, LPad, Substr
 from django.test import skipUnlessDBFeature
 from django.test.utils import Approximate
 from django.utils import timezone
@@ -237,6 +237,16 @@ class TestGeneralAggregate(PostgreSQLTestCase):
             ),
         )
         self.assertEqual(values, {"arrayagg": ["en", "pl"]})
+
+    def test_array_agg_filter_and_ordering_params(self):
+        values = AggregateTestModel.objects.aggregate(
+            arrayagg=ArrayAgg(
+                "char_field",
+                filter=Q(json_field__has_key="lang"),
+                ordering=LPad(Cast("integer_field", CharField()), 2, Value("0")),
+            )
+        )
+        self.assertEqual(values, {"arrayagg": ["Foo2", "Foo4"]})
 
     def test_array_agg_filter(self):
         values = AggregateTestModel.objects.aggregate(


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35339

# Branch description
This change fixes a bug in the PostgreSQL aggregate SQL generation when both the filter and order by expressions require parameters.

Additional changes are made to the `Aggregate` class to more consistently return the `source_expressions` for use in generating the SQL.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [ ] I have added or updated relevant **docs**, including release notes if applicable.
- [ ] For UI changes, I have attached **screenshots** in both light and dark modes.
