### PR TITLE
Fixed path in Homebrew SpatiaLite docs.

### DIFF
--- a/docs/ref/contrib/gis/install/spatialite.txt
+++ b/docs/ref/contrib/gis/install/spatialite.txt
@@ -111,9 +111,17 @@ including SQLite, SpatiaLite, PROJ, and GEOS. Install them like this:
     $ brew install spatialite-tools
     $ brew install gdal
 
-Finally, for GeoDjango to be able to find the SpatiaLite library, add the
-following to your ``settings.py``::
+Finally, for GeoDjango to be able to find the SpatiaLite library, set
+the ``SPATIALITE_LIBRARY_PATH`` setting to its path. This will be within
+your brew install path, which you can check with:
 
-    SPATIALITE_LIBRARY_PATH = "/usr/local/lib/mod_spatialite.dylib"
+.. code-block:: console
+
+    $ brew --prefix
+    /opt/homebrew
+
+Using this brew install path, the full path can be constructed like this::
+
+    SPATIALITE_LIBRARY_PATH = "/opt/homebrew/lib/mod_spatialite.dylib"
 
 .. _Homebrew: https://brew.sh/


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description

Homebrew hasn’t used `/usr/local` for some time. I couldn’t find exactly which version changed that, but the [3.0.0 release notes (2021)](https://brew.sh/2021/02/05/homebrew-3.0.0/) mention that M1 Macs now support the location, so presumably before that.

This PR changes the recommended path to one that exists (tested on my mac) and covers the case where the install path is non-default.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
