### PR TITLE
Refs #35169 -- Added test for ASGIRequest root_path handling.

### DIFF
--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -326,6 +326,15 @@ class AsyncHandlerRequestTests(SimpleTestCase):
         with self.assertRaisesMessage(ValueError, msg):
             await self.async_client.get("/unawaited/")
 
+    def test_root_path(self):
+        async_request_factory = AsyncRequestFactory()
+        request = async_request_factory.request(
+            **{"path": "/root/somepath/", "root_path": "/root"}
+        )
+        self.assertEqual(request.path, "/root/somepath/")
+        self.assertEqual(request.script_name, "/root")
+        self.assertEqual(request.path_info, "/somepath/")
+
     @override_settings(FORCE_SCRIPT_NAME="/FORCED_PREFIX/")
     def test_force_script_name(self):
         async_request_factory = AsyncRequestFactory()


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35169

# Branch description

I was looking at this again after [ajslater](https://github.com/ajslater)'s https://github.com/django/channels/issues/1973#issuecomment-2037884957. 

Searching the test suite, we didn't have any cases actually passing `root_pass` in scope, so I added one. 

It passes. FWIW I backported it to `stable/4.2.x` and it passes there too. 

Possible change may be in 041b0a3 @sarahboyce: maybe folks have `FORCE_SCRIPT_NAME` set to a non-`None` value. That's the sort of thing one might have done when experimenting with mounting under a `root_path`. 
If it's not that, then I'm out of ideas without a reproduce. 

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
