### PR TITLE
Fixed #35354 -- Simplified ASGIRequest path handling.

### DIFF
--- a/django/core/handlers/asgi.py
+++ b/django/core/handlers/asgi.py
@@ -50,21 +50,13 @@ class ASGIRequest(HttpRequest):
         self._post_parse_error = False
         self._read_started = False
         self.resolver_match = None
+        self.path = scope["path"]
         self.script_name = get_script_prefix(scope)
         if self.script_name:
             # TODO: Better is-prefix checking, slash handling?
             self.path_info = scope["path"].removeprefix(self.script_name)
         else:
             self.path_info = scope["path"]
-        # The Django path is different from ASGI scope path args, it should
-        # combine with script name.
-        if self.script_name:
-            self.path = "%s/%s" % (
-                self.script_name.rstrip("/"),
-                self.path_info.replace("/", "", 1),
-            )
-        else:
-            self.path = scope["path"]
         # HTTP basics.
         self.method = self.scope["method"].upper()
         # Ensure query string is encoded correctly.

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1667,7 +1667,7 @@ the server-provided value of ``SCRIPT_NAME``, which may be a rewritten version
 of the preferred value or not supplied at all. It is also used by
 :func:`django.setup()` to set the URL resolver script prefix outside of the
 request/response cycle (e.g. in management commands and standalone scripts) to
-generate correct URLs when ``SCRIPT_NAME`` is not ``/``.
+generate correct URLs when ``FORCE_SCRIPT_NAME`` is provided.
 
 .. setting:: FORM_RENDERER
 

--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -335,11 +335,13 @@ class AsyncHandlerRequestTests(SimpleTestCase):
         self.assertEqual(request.script_name, "/root")
         self.assertEqual(request.path_info, "/somepath/")
 
-    @override_settings(FORCE_SCRIPT_NAME="/FORCED_PREFIX/")
+    @override_settings(FORCE_SCRIPT_NAME="/FORCED_PREFIX")
     def test_force_script_name(self):
         async_request_factory = AsyncRequestFactory()
-        request = async_request_factory.request(**{"path": "/somepath/"})
+        request = async_request_factory.request(**{"path": "/FORCED_PREFIX/somepath/"})
         self.assertEqual(request.path, "/FORCED_PREFIX/somepath/")
+        self.assertEqual(request.script_name, "/FORCED_PREFIX")
+        self.assertEqual(request.path_info, "/somepath/")
 
     async def test_sync_streaming(self):
         response = await self.async_client.get("/streaming/")


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35354

# Branch description

Following the ASGI HTTP Connection Scope docs[0], the provided `path` is already the correct value that Django requires.

In combination with `root_path`, from which `script_name` is derived, the `path_info` variable is set. It's then redundant to re-calculate `path` from `script_name` and `path_info`.

See also, a clarifying discussion on the ASGIref repo[1].

[0]: https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope
[1]: https://github.com/django/asgiref/issues/424

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
