### PR TITLE
[5.0.x] Refs #35336 -- Fixed SchemaTests.test_add_generated_field_contains() test on PostgreSQL.

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -58,8 +58,8 @@ from django.db.models.functions import (
     Abs,
     Cast,
     Collate,
-    Concat,
     Lower,
+    LPad,
     Random,
     Round,
     Upper,
@@ -907,7 +907,7 @@ class SchemaTests(TransactionTestCase):
         class GeneratedFieldContainsModel(Model):
             text = TextField(default="foo")
             generated = GeneratedField(
-                expression=Concat("text", Value("%")),
+                expression=LPad("text", 5, Value("%")),
                 db_persist=True,
                 output_field=TextField(),
             )
@@ -931,7 +931,7 @@ class SchemaTests(TransactionTestCase):
         obj = GeneratedFieldContainsModel.objects.create()
         obj.refresh_from_db()
         self.assertEqual(obj.text, "foo")
-        self.assertEqual(obj.generated, "foo%")
+        self.assertEqual(obj.generated, "%%foo")
         self.assertIs(obj.contains_foo, True)
 
     @isolate_apps("schema")


### PR DESCRIPTION
`Concat()` in Django 5.0 is not immutable on PostgreSQL and cannot be used in `GeneratedField`, check out
6364b6ee1071381eb3a23ba6b821fc0d6f0fce75.

Regression in fead2dd52303505f30007df5e3c198b48b3ce9ae.