### PR TITLE
Refs #35361 -- Added test for Email line length checks when dealing with surrogate pairs.

### DIFF
--- a/docs/releases/4.2.12.txt
+++ b/docs/releases/4.2.12.txt
@@ -1,0 +1,14 @@
+===========================
+Django 4.2.12 release notes
+===========================
+
+*Expected May 6, 2024*
+
+Django 4.2.12 fixes a bug in 4.2.11.
+
+Bugfixes
+========
+
+* Fixed a crash in Django 4.2 when validating email max line lengths with
+  content decoded using the ``surrogateescape`` error handling scheme,
+  particularly in Python versions 3.11.9+ and 3.12.3+ (:ticket:`35361`).

--- a/docs/releases/5.0.5.txt
+++ b/docs/releases/5.0.5.txt
@@ -12,3 +12,7 @@ Bugfixes
 * Fixed a bug in Django 5.0 that caused a crash of ``Model.save()`` when
   creating an instance of a model with a ``GeneratedField`` and providing a
   primary key (:ticket:`35350`).
+
+* Fixed a crash in Django 5.0 when validating email max line lengths with
+  content decoded using the ``surrogateescape`` error handling scheme,
+  particularly in Python versions 3.11.9+ and 3.12.3+ (:ticket:`35361`).

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -45,6 +45,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   4.2.12
    4.2.11
    4.2.10
    4.2.9

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -92,6 +92,37 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
         self.assertEqual(message["From"], "from@example.com")
         self.assertEqual(message["To"], "to@example.com")
 
+    @mock.patch("django.core.mail.message.MIMEText.set_payload")
+    def test_nonascii_as_string_with_ascii_charset(self, mock_set_payload):
+        """Line length check should encode the payload supporting `surrogateescape`.
+
+        Following https://github.com/python/cpython/issues/76511, newer
+        versions of Python (3.11.9, 3.12.3 and 3.13) ensure that a message's
+        payload is encoded with the provided charset and `surrogateescape` is
+        used as the error handling strategy.
+
+        This test is heavily based on the test from the fix for the bug above.
+        Line length checks in SafeMIMEText's set_payload should also use the
+        same error handling strategy to avoid errors such as:
+
+        UnicodeEncodeError: 'utf-8' codec can't encode <...>: surrogates not allowed
+
+        """
+
+        def simplified_set_payload(instance, payload, charset):
+            instance._payload = payload
+
+        mock_set_payload.side_effect = simplified_set_payload
+
+        text = (
+            "Text heavily based in Python's text for non-ascii messages: Föö bär"
+        ).encode("iso-8859-1")
+        body = text.decode("ascii", errors="surrogateescape")
+        email = EmailMessage("Subject", body, "from@example.com", ["to@example.com"])
+        message = email.message()
+        mock_set_payload.assert_called_once()
+        self.assertEqual(message.get_payload(decode=True), text)
+
     def test_multiple_recipients(self):
         email = EmailMessage(
             "Subject",


### PR DESCRIPTION
# Trac ticket number
ticket-35361

# Branch description
This branch provides a test to cover for the fix added in b231bcd19e57267ce1fc21d42d46f0b65fdcfcf8 which needs backporting to 4.2 and 5.0 versions due to Python backporting the fix for [this issue](https://github.com/python/cpython/issues/76511) to 3.11 and 3.12:

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" **ticket flag** in the Trac system.
- [X] I have added or updated relevant **tests**.
- [X] I have added or updated relevant **docs**, including release notes if applicable.
- [X] For UI changes, I have attached **screenshots** in both light and dark modes.