### PR TITLE
Fixed #35350 -- Fixed save() with pk set on models with GeneratedFields.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1063,12 +1063,16 @@ class Model(AltersData, metaclass=ModelBase):
         for a single table.
         """
         meta = cls._meta
-        non_pks = [f for f in meta.local_concrete_fields if not f.primary_key]
+        non_pks_non_generated = [
+            f
+            for f in meta.local_concrete_fields
+            if not f.primary_key and not f.generated
+        ]
 
         if update_fields:
-            non_pks = [
+            non_pks_non_generated = [
                 f
-                for f in non_pks
+                for f in non_pks_non_generated
                 if f.name in update_fields or f.attname in update_fields
             ]
 
@@ -1100,7 +1104,7 @@ class Model(AltersData, metaclass=ModelBase):
                     None,
                     (getattr(self, f.attname) if raw else f.pre_save(self, False)),
                 )
-                for f in non_pks
+                for f in non_pks_non_generated
             ]
             forced_update = update_fields or force_update
             updated = self._do_update(

--- a/docs/releases/5.0.5.txt
+++ b/docs/releases/5.0.5.txt
@@ -9,4 +9,6 @@ Django 5.0.5 fixes several bugs in 5.0.4.
 Bugfixes
 ========
 
-* ...
+* Fixed a bug in Django 5.0 that caused a crash of ``Model.save()`` when
+  creating an instance of a model with a ``GeneratedField`` and providing a
+  primary key (:ticket:`35350`).

--- a/tests/model_fields/test_generatedfield.py
+++ b/tests/model_fields/test_generatedfield.py
@@ -207,6 +207,12 @@ class GeneratedFieldTestMixin:
         m.refresh_from_db()
         self.assertEqual(m.field, 8)
 
+    def test_save_model_with_pk(self):
+        m = self.base_model(pk=1, a=1, b=2)
+        m.save()
+        m = self._refresh_if_needed(m)
+        self.assertEqual(m.field, 3)
+
     def test_save_model_with_foreign_key(self):
         fk_object = Foo.objects.create(a="abc", d=Decimal("12.34"))
         m = self.base_model(a=1, b=2, fk=fk_object)


### PR DESCRIPTION
Thanks Matt Hegarty for the report.

Regression in f333e35.

# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35350

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [X] I have added or updated relevant **tests**.
- [X] I have added or updated relevant **docs**, including release notes if applicable.
