### PR TITLE
Fixed #35364 -- Stopped AdminEmailHandler rendering email unnecessarily.

### DIFF
--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -92,6 +92,13 @@ class AdminEmailHandler(logging.Handler):
         )
 
     def emit(self, record):
+        # Early return when no email will be sent.
+        if (
+            not settings.ADMINS
+            # Method not overridden.
+            and self.send_mail.__func__ is AdminEmailHandler.send_mail
+        ):
+            return
         try:
             request = record.request
             subject = "%s (%s IP): %s" % (

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -470,6 +470,21 @@ class AdminEmailHandlerTest(SimpleTestCase):
         self.assertIn('<div id="traceback">', body_html)
         self.assertNotIn("<form", body_html)
 
+    @override_settings(ADMINS=[])
+    def test_emit_no_admins(self):
+        handler = AdminEmailHandler()
+        record = self.logger.makeRecord(
+            "name",
+            logging.ERROR,
+            "function",
+            "lno",
+            "message",
+            None,
+            None,
+        )
+        handler.emit(record)
+        self.assertEqual(len(mail.outbox), 0)
+
 
 class SettingsConfigTest(AdminScriptTestCase):
     """

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -1,6 +1,7 @@
 import logging
 from contextlib import contextmanager
 from io import StringIO
+from unittest import mock
 
 from admin_scripts.tests import AdminScriptTestCase
 
@@ -482,7 +483,12 @@ class AdminEmailHandlerTest(SimpleTestCase):
             None,
             None,
         )
-        handler.emit(record)
+        with mock.patch.object(
+            handler,
+            "format_subject",
+            side_effect=AssertionError("Should not be called"),
+        ):
+            handler.emit(record)
         self.assertEqual(len(mail.outbox), 0)
 
 

--- a/tests/view_tests/tests/test_defaults.py
+++ b/tests/view_tests/tests/test_defaults.py
@@ -123,7 +123,7 @@ class DefaultsTests(TestCase):
     )
     def test_custom_bad_request_template(self):
         response = self.client.get("/raises400/")
-        self.assertIs(response.wsgi_request, response.context[-1].request)
+        self.assertIs(response.wsgi_request, response.context.request)
 
     @override_settings(
         TEMPLATES=[


### PR DESCRIPTION
# Trac ticket number

ticket-35364

# Branch description

Make `AdminEmailHandler` faster by avoiding message construction work when unnecessary. Two commits: the first adds a test for the empty case, and the second adds the fix and expands the test.

For a quick check, I profiled a call to `logger.error()` on an example project:

* On the main branch: `34137 function calls (32718 primitive calls) in 0.030 seconds`
* On this branch: `79 function calls in 0.000 seconds`

For a larger check, I benchmarked some test modules that use `AdminEmailHandler`. I found them by running the whole test suite with `AdminEmailHandler.emit()` to fail with the line `1/0`, and selecting the test modules that had `ZeroDivisionError` failures.

On the main branch, running that selection of tests with [hyperfine](https://github.com/sharkdp/hyperfine) takes ~5.0s:

```
$ hyperfine './runtests.py --parallel 1 generic_views handlers logging_tests middleware_exceptions test_client view_tests.tests.test_debug.ExceptionReporterFilterTests'
Benchmark 1: ./runtests.py --parallel 1 generic_views handlers logging_tests middleware_exceptions test_client view_tests.tests.test_debug.ExceptionReporterFilterTests
  Time (mean ± σ):      5.037 s ±  0.017 s    [User: 1.843 s, System: 0.147 s]
  Range (min … max):    5.004 s …  5.059 s    10 runs
```

On this branch, it takes ~4.7s:

```
$ hyperfine './runtests.py --parallel 1 generic_views handlers logging_tests middleware_exceptions test_client view_tests.tests.test_debug.ExceptionReporterFilterTests'
Benchmark 1: ./runtests.py --parallel 1 generic_views handlers logging_tests middleware_exceptions test_client view_tests.tests.test_debug.ExceptionReporterFilterTests
  Time (mean ± σ):      4.711 s ±  0.007 s    [User: 1.525 s, System: 0.141 s]
  Range (min … max):    4.701 s …  4.726 s    10 runs
```

A saving of 0.3/5.0 = 6%.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
