### PR TITLE
Made postgresql.tests.Tests.test_connect_pool less flakey by increasing timeout value.

### DIFF
--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -241,7 +241,7 @@ class Tests(TestCase):
         new_connection.settings_dict["OPTIONS"]["pool"] = {
             "min_size": 0,
             "max_size": 2,
-            "timeout": 0.1,
+            "timeout": 5,
         }
         self.assertIsNotNone(new_connection.pool)
 


### PR DESCRIPTION
# Trac ticket number

N/A

# Branch description
Aims to address [this flakey ci failure](https://djangoci.com/job/pull-requests-pg-server-side-binding/database=postgres,label=focal-pr,python=python3.12/6005/testReport/backends.postgresql.tests/Tests/test_connect_pool/) for `postgresql.tests.Tests.test_connect_pool`

```
psycopg_pool.PoolTimeout: couldn't get a connection after 0.10 sec
```

When not set, the [default timeout value is 30 seconds](https://www.psycopg.org/psycopg3/docs/api/pool.html). 
During the development of the connection pool feature, testing locally 30 seconds was very slow and so I updated to 0.1 seconds to get quick feedback on failures. This value might be too quick for the ci on occasions and hoping 5 seconds is a good compromise.

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
