### PR TITLE
Refs #35194 -- Adjusted a generated field test to work on Postgres 15.6+.

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -913,7 +913,7 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(GeneratedFieldContainsModel)
 
         field = GeneratedField(
-            expression=Q(text__icontains="FOO"),
+            expression=Q(text__contains="foo"),
             db_persist=True,
             output_field=BooleanField(),
         )


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35194

# Branch description
Postgres >= 12.18, 13.14, 14.11, 15.6, 16.2 changed the way the immutability of generated and default expressions is detected in postgres/postgres@743ddafc7124604c1f59b5d9f661be47a987a8d0.

The adjusted test intent is preserved by switching from `__icontains` to `__contains` as both make use of a `%` literal which requires proper escaping.

Refs ticket-35336.

Thanks @bcail for the report.