### PR TITLE
Doc'd that PostgreSQL specifies CASCADE when dropping columns.

### DIFF
--- a/docs/ref/migration-operations.txt
+++ b/docs/ref/migration-operations.txt
@@ -195,6 +195,16 @@ if the field is nullable or if it has a default value that can be used to
 populate the recreated column. If the field is not nullable and does not have a
 default value, the operation is irreversible.
 
+.. admonition:: PostgreSQL
+
+    ``RemoveField`` will also delete any additional database objects that are
+    related to the removed field (like views, for example). This is because the
+    resulting ``DROP COLUMN`` statement will include the ``CASCADE`` clause to
+    ensure `dependent objects outside the table are also dropped`_.
+
+.. _dependent objects outside the table are also dropped: https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-PARMS-CASCADE
+
+
 ``AlterField``
 --------------
 


### PR DESCRIPTION
Submitting an admonition for a gotcha that a colleague spent some time on – they had some views go missing and were wondering what caused it.

I understand that CASCADE may be based on the fact that PG will abort any ALTER TABLE … DROP COLUMN statement if there are any objects dependent on that column 👍  Though probably not a bad idea to just clarify that here.  (We could also adjust the wording to say this?)