### PR TITLE
Fixed #35359 -- Made autodetector add fields referenced by GeneratedField.expression before it.

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1126,6 +1126,8 @@ class MigrationAutodetector:
                     self.to_state,
                 )
             )
+        if field.generated:
+            dependencies.extend(self._get_dependencies_for_generated_field(field))
         # You can't just add NOT NULL fields with no default or fields
         # which don't allow empty strings as default.
         time_fields = (models.DateField, models.DateTimeField, models.TimeField)
@@ -1545,6 +1547,27 @@ class MigrationAutodetector:
                     OperationDependency.Type.CREATE,
                 )
             )
+        return dependencies
+
+    def _get_dependencies_for_generated_field(self, field):
+        dependencies = []
+        referenced_base_fields = models.Q(field.expression).referenced_base_fields
+        newly_added_fields = sorted(self.new_field_keys - self.old_field_keys)
+        for app_label, model_name, added_field_name in newly_added_fields:
+            added_field = self.to_state.models[app_label, model_name].get_field(
+                added_field_name
+            )
+            if (
+                added_field.remote_field and added_field.remote_field.model
+            ) or added_field.name in referenced_base_fields:
+                dependencies.append(
+                    OperationDependency(
+                        app_label,
+                        model_name,
+                        added_field.name,
+                        OperationDependency.Type.CREATE,
+                    )
+                )
         return dependencies
 
     def _get_dependencies_for_model(self, app_label, model_name):

--- a/docs/releases/5.0.5.txt
+++ b/docs/releases/5.0.5.txt
@@ -23,3 +23,7 @@ Bugfixes
 
 * Allowed importing ``aprefetch_related_objects`` from ``django.db.models``
   (:ticket:`35392`).
+
+* Fixed a bug in Django 5.0 that caused a migration crash when a
+  ``GeneratedField`` was added before any of the referenced fields from its
+  ``expression`` definition (:ticket:`35359`).

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -9,7 +9,7 @@ from django.db.migrations.operations.fields import FieldOperation
 from django.db.migrations.state import ModelState, ProjectState
 from django.db.models import F
 from django.db.models.expressions import Value
-from django.db.models.functions import Abs, Pi
+from django.db.models.functions import Abs, Concat, Pi
 from django.db.transaction import atomic
 from django.test import (
     SimpleTestCase,
@@ -1378,6 +1378,54 @@ class OperationTests(OperationTestBase):
         self.assertEqual(definition[0], "AddField")
         self.assertEqual(definition[1], [])
         self.assertEqual(sorted(definition[2]), ["field", "model_name", "name"])
+
+    @skipUnlessDBFeature("supports_stored_generated_columns")
+    def test_add_generate_field(self):
+        app_label = "test_add_generate_field"
+        project_state = self.apply_operations(
+            app_label,
+            ProjectState(),
+            operations=[
+                migrations.CreateModel(
+                    "Rider",
+                    fields=[
+                        ("id", models.AutoField(primary_key=True)),
+                    ],
+                ),
+                migrations.CreateModel(
+                    "Pony",
+                    fields=[
+                        ("id", models.AutoField(primary_key=True)),
+                        ("name", models.CharField(max_length=20)),
+                        (
+                            "rider",
+                            models.ForeignKey(
+                                f"{app_label}.Rider", on_delete=models.CASCADE
+                            ),
+                        ),
+                        (
+                            "name_and_id",
+                            models.GeneratedField(
+                                expression=Concat(("name"), ("rider_id")),
+                                output_field=models.TextField(),
+                                db_persist=True,
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+        )
+        Pony = project_state.apps.get_model(app_label, "Pony")
+        Rider = project_state.apps.get_model(app_label, "Rider")
+        rider = Rider.objects.create()
+        pony = Pony.objects.create(name="pony", rider=rider)
+        self.assertEqual(pony.name_and_id, str(pony.name) + str(rider.id))
+
+        new_rider = Rider.objects.create()
+        pony.rider = new_rider
+        pony.save()
+        pony.refresh_from_db()
+        self.assertEqual(pony.name_and_id, str(pony.name) + str(new_rider.id))
 
     def test_add_charfield(self):
         """


### PR DESCRIPTION

# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->
[Ticket #35359](https://code.djangoproject.com/ticket/35359)

# Branch description
While adding a `GeneratedField` field along with a new field, the `AddField` operations were being generated in the wrong order due to which it was breaking the migrations. The `AddField` operation for fields referenced by `GeneratedField.expression` should be added before the `GeneratedField` itself.

My solution modifies the `_generate_added_field` method in the autodetector to check if a field is a `GeneratedField`, then extract the referenced fields from `.expression` and recursively call `_generate_added_field` to add `AddField` operation for the fields referenced by `.expression` before `GeneratedField`.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
