### PR TITLE
Pinned GitHub Actions for reminders to specific versions.

### DIFF
--- a/.github/workflows/reminders_check.yml
+++ b/.github/workflows/reminders_check.yml
@@ -14,4 +14,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check reminders and notify users
-        uses: agrc/reminder-action@v1
+        uses: agrc/reminder-action@e59091b4e9705a6108120cb50823108df35b5392

--- a/.github/workflows/reminders_create.yml
+++ b/.github/workflows/reminders_create.yml
@@ -14,4 +14,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check comments and create reminders
-        uses: agrc/create-reminder-action@v1
+        uses: agrc/create-reminder-action@922893a5705067719c4c4751843962f56aabf5eb


### PR DESCRIPTION
# Branch description
Following this comment from Mariusz: https://github.com/django/django/pull/17852#pullrequestreview-1895738524, this branch ensured that the reminder actions versions are pinned to a validated release.

See:
https://github.com/agrc/create-reminder-action
https://github.com/agrc/reminder-action

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
