### PR TITLE
Fix #8307 -- Saving a model with an ImageField with width_field or height_field no longer results in an extra read operation

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -88,10 +88,15 @@ class FieldFile(File, AltersData):
     # to further manipulate the underlying file, as well as update the
     # associated model instance.
 
+    def _set_instance_attribute(self, name, content):
+        # Existence of this method is primarily motivated by custom logic
+        # in ImageFieldFile._set_instance_attribute
+        setattr(self.instance, self.field.attname, name)
+
     def save(self, name, content, save=True):
         name = self.field.generate_filename(self.instance, name)
         self.name = self.storage.save(name, content, max_length=self.field.max_length)
-        setattr(self.instance, self.field.attname, self.name)
+        self._set_instance_attribute(self.name, content)
         self._committed = True
 
         # Save the object because it has changed, unless save is False
@@ -380,6 +385,12 @@ class ImageFileDescriptor(FileDescriptor):
 
 
 class ImageFieldFile(ImageFile, FieldFile):
+    def _set_instance_attribute(self, name, content):
+        setattr(self.instance, self.field.attname, content)
+        # Update the name in case generate_filename() or storage.save() changed
+        # it, but bypass the descriptor to avoid re-reading the file.
+        self.instance.__dict__[self.field.attname] = self.name
+
     def delete(self, save=True):
         # Clear the image dimensions cache
         if hasattr(self, "_dimensions_cache"):

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1361,6 +1361,13 @@ can change the maximum length using the :attr:`~CharField.max_length` argument.
 The default form widget for this field is a
 :class:`~django.forms.ClearableFileInput`.
 
+.. versionchanged:: 5.1
+
+    In older versions, auto-populating ``height_field`` and ``width_field`` 
+    would always result in re-reading the file from the storage backend. If 
+    your storage backend resizes images, the actual image's width and height 
+    will not match the auto-populated fields.
+
 ``IntegerField``
 ----------------
 

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -419,6 +419,11 @@ Miscellaneous
 * The undocumented ``django.urls.converters.get_converter()`` function is
   removed.
 
+* :class:`~django.db.models.ImageField` no longer re-reads the file from the
+  storage backend after ``width_field`` and ``height_field`` are set. If
+  your storage backend resizes images, the actual image's width and height will
+  not match the auto-populated fields.
+
 * The minimum supported version of SQLite is increased from 3.27.0 to 3.31.0.
 
 .. _deprecated-features-5.1:

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -13,6 +13,8 @@ from django.db.models.functions import Lower
 from django.utils.functional import SimpleLazyObject
 from django.utils.translation import gettext_lazy as _
 
+from .storage import NoReadFileSystemStorage
+
 try:
     from PIL import Image
 except ImportError:
@@ -372,6 +374,23 @@ if Image:
             height_field="headshot_height",
             width_field="headshot_width",
         )
+
+    class PersonNoReadImage(models.Model):
+        """
+        Model that defines an ImageField with a storage backend that does not
+        support reading.
+
+        This supports a test to avoid a double-read performance problem.
+        """
+
+        mugshot = models.ImageField(
+            upload_to="tests",
+            storage=NoReadFileSystemStorage(),
+            width_field="mugshot_width",
+            height_field="mugshot_height",
+        )
+        mugshot_width = models.IntegerField()
+        mugshot_height = models.IntegerField()
 
 
 class CustomJSONDecoder(json.JSONDecoder):

--- a/tests/model_fields/storage.py
+++ b/tests/model_fields/storage.py
@@ -1,0 +1,6 @@
+from django.core.files.storage.filesystem import FileSystemStorage
+
+
+class NoReadFileSystemStorage(FileSystemStorage):
+    def open(self, *args, **kwargs):
+        raise AssertionError("This storage class does not support reading.")

--- a/tests/model_fields/test_imagefield.py
+++ b/tests/model_fields/test_imagefield.py
@@ -18,6 +18,7 @@ if Image:
     from .models import (
         Person,
         PersonDimensionsFirst,
+        PersonNoReadImage,
         PersonTwoImages,
         PersonWithHeight,
         PersonWithHeightAndWidth,
@@ -30,7 +31,7 @@ else:
         pass
 
     PersonWithHeight = PersonWithHeightAndWidth = PersonDimensionsFirst = Person
-    PersonTwoImages = Person
+    PersonTwoImages = PersonNoReadImage = Person
 
 
 class ImageFieldTestMixin(SerializeMixin):
@@ -469,3 +470,28 @@ class TwoImageFieldTests(ImageFieldTestMixin, TestCase):
         # Dimensions were recalculated, and hence file should have opened.
         self.assertIs(p.mugshot.was_opened, True)
         self.assertIs(p.headshot.was_opened, True)
+
+
+@skipIf(Image is None, "Pillow is required to test ImageField")
+class NoReadTests(ImageFieldTestMixin, TestCase):
+    def test_width_height_correct_name_mangling_correct(self):
+        instance1 = PersonNoReadImage()
+
+        instance1.mugshot.save("mug", self.file1)
+
+        self.assertEqual(instance1.mugshot_width, 4)
+        self.assertEqual(instance1.mugshot_height, 8)
+
+        instance1.save()
+
+        self.assertEqual(instance1.mugshot_width, 4)
+        self.assertEqual(instance1.mugshot_height, 8)
+
+        instance2 = PersonNoReadImage()
+        instance2.mugshot.save("mug", self.file1)
+        instance2.save()
+
+        self.assertNotEqual(instance1.mugshot.name, instance2.mugshot.name)
+
+        self.assertEqual(instance1.mugshot_width, instance2.mugshot_width)
+        self.assertEqual(instance1.mugshot_height, instance2.mugshot_height)


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-8307

# Branch description

This is an alternate approach from https://github.com/django/django/pull/17775 to solving 8307.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [ ] For UI changes, I have attached **screenshots** in both light and dark modes.
