### PR TITLE
Added check_key in RedisCache incr

### DIFF
--- a/django/core/cache/backends/redis.py
+++ b/django/core/cache/backends/redis.py
@@ -129,9 +129,9 @@ class RedisCacheClient:
         client = self.get_client(key)
         return bool(client.exists(key))
 
-    def incr(self, key, delta):
+    def incr(self, key, delta, check_key: bool):
         client = self.get_client(key, write=True)
-        if not client.exists(key):
+        if check_key and not client.exists(key):
             raise ValueError("Key '%s' not found." % key)
         return client.incr(key, delta)
 
@@ -209,9 +209,9 @@ class RedisCache(BaseCache):
         key = self.make_and_validate_key(key, version=version)
         return self._cache.has_key(key)
 
-    def incr(self, key, delta=1, version=None):
+    def incr(self, key, delta=1, version=None, check_key=True):
         key = self.make_and_validate_key(key, version=version)
-        return self._cache.incr(key, delta)
+        return self._cache.incr(key, delta, check_key)
 
     def set_many(self, data, timeout=DEFAULT_TIMEOUT, version=None):
         if not data:

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1803,14 +1803,6 @@ class RedisCacheTests(BaseCacheTests, TestCase):
     def incr_decr_type_error(self):
         return self.lib.ResponseError
 
-    def test_incr_write_connection(self):
-        cache.set("number", 42)
-        with mock.patch(
-            "django.core.cache.backends.redis.RedisCacheClient.get_client"
-        ) as mocked_get_client:
-            cache.incr("number")
-            self.assertEqual(mocked_get_client.call_args.kwargs, {"write": True})
-
     def test_incr_check_key(self):
         with self.assertRaises(ValueError):
             cache.incr("check_key")
@@ -1818,6 +1810,14 @@ class RedisCacheTests(BaseCacheTests, TestCase):
     def test_incr_not_check_key(self):
         value = cache.incr("not_check_key", check_key=False)
         self.assertEqual(value, 1)
+
+    def test_incr_write_connection(self):
+        cache.set("number", 42)
+        with mock.patch(
+            "django.core.cache.backends.redis.RedisCacheClient.get_client"
+        ) as mocked_get_client:
+            cache.incr("number")
+            self.assertEqual(mocked_get_client.call_args.kwargs, {"write": True})
 
     def test_cache_client_class(self):
         self.assertIs(cache._class, RedisCacheClient)

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1811,6 +1811,14 @@ class RedisCacheTests(BaseCacheTests, TestCase):
             cache.incr("number")
             self.assertEqual(mocked_get_client.call_args.kwargs, {"write": True})
 
+    def test_incr_check_key(self):
+        with self.assertRaises(ValueError):
+            cache.incr("check_key")
+
+    def test_incr_not_check_key(self):
+        value = cache.incr("not_check_key", check_key=False)
+        self.assertEqual(value, 1)
+
     def test_cache_client_class(self):
         self.assertIs(cache._class, RedisCacheClient)
         self.assertIsInstance(cache._cache, RedisCacheClient)


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description
In redis, incr can don't need check key, so add check_key to this command. The defauult value is true

# Checklist
- [y] This PR targets the `main` branch. 
- [y] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" **ticket flag** in the Trac system.
- [y] I have added or updated relevant **tests**.
- [y] I have added or updated relevant **docs**, including release notes if applicable.
- [y] For UI changes, I have attached **screenshots** in both light and dark modes.
