### PR TITLE
Fixed backends.oracle.tests.TransactionalTests.test_hidden_no_data_found_exception() on oracledb >= 2.1.2.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -19,6 +19,7 @@ from django.db.backends.utils import debug_transaction
 from django.utils.asyncio import async_unsafe
 from django.utils.encoding import force_bytes, force_str
 from django.utils.functional import cached_property
+from django.utils.version import get_version_tuple
 
 
 def _setup_environment(environ):
@@ -344,6 +345,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def oracle_version(self):
         with self.temporary_connection():
             return tuple(int(x) for x in self.connection.version.split("."))
+
+    @cached_property
+    def oracledb_version(self):
+        return get_version_tuple(Database.__version__)
 
 
 class OracleParam:

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -1,5 +1,6 @@
 from django.db import DatabaseError, InterfaceError
 from django.db.backends.base.features import BaseDatabaseFeatures
+from django.db.backends.oracle.oracledb_any import is_oracledb
 from django.utils.functional import cached_property
 
 
@@ -136,6 +137,16 @@ class DatabaseFeatures(BaseDatabaseFeatures):
                         "test_usage_in_subquery",
                     },
                 }
+            )
+        if is_oracledb and self.connection.oracledb_version >= (2, 1, 2):
+            skips.update(
+                {
+                    "python-oracledb 2.1.2+ no longer hides 'ORA-1403: no data found' "
+                    "exceptions raised in database triggers.": {
+                        "backends.oracle.tests.TransactionalTests."
+                        "test_hidden_no_data_found_exception"
+                    },
+                },
             )
         return skips
 

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -295,6 +295,8 @@ END;
         columns = []
         for param in returning_params:
             value = param.get_value()
+            # Can be removed when cx_Oracle is no longer supported and
+            # python-oracle 2.1.2 becomes the minimum supported version.
             if value == []:
                 raise DatabaseError(
                     "The database did not return a new row id. Probably "


### PR DESCRIPTION
`python-oracledb` 2.1.2+ no longer hides 'ORA-1403: no data found' exceptions raised in database triggers:

https://github.com/oracle/python-oracledb/issues/321

This is a test update that should be backported to the `stable/5.0.x` branch (no release notes needed)