### PR TITLE
Removed fictional class 'extrapretty' from admin docs.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -413,18 +413,20 @@ subclass::
 
     * ``classes``
         A list or tuple containing extra CSS classes to apply to the fieldset.
+        This can include any custom CSS class defined in the project, as well
+        as any of the CSS classes provided by Django. Within the default admin
+        site CSS stylesheet, two particularly useful classes are defined:
+        ``collapse`` and ``wide``.
 
         Example::
 
             {
-                "classes": ["wide", "extrapretty"],
+                "classes": ["wide", "collapse"],
             }
 
-        Two useful classes defined by the default admin site stylesheet are
-        ``collapse`` and ``wide``. Fieldsets with the ``collapse`` style
-        will be initially collapsed in the admin and replaced with a small
-        "click to expand" link. Fieldsets with the ``wide`` style will be
-        given extra horizontal space.
+        Fieldsets with the ``collapse`` style will be initially collapsed in
+        the admin and replaced with a small "click to expand" link. Fieldsets
+        with the ``wide`` style will be given extra horizontal space.
 
     * ``description``
         A string of optional extra text to be displayed at the top of each


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

# Branch description

The class `extrapretty` is a fictional example, whilst the class `wide` is not. Its existence in the documentation dates back to when classes were specified in a string, from a19ed8aea395e8e07164ff7d85bd7dff2f24edca, and it has been untouched since.

I just found a project where the example `classes` had been copy-pasted around the place, applying this fictional class in many admins. To avoid this kind of confusion recurring, I think we should remove it from the docs, covering only the concrete classes defined by Django.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.


<!-- bot: {"reminders":[{"id":1,"who":"nessita","what":"about this PR","when":"2024-06-14T09:00:00.000Z"},{"id":2,"who":"nessita","what":"about this PR","when":"2024-06-14T09:00:00.000Z"}]} -->