### PR TITLE
Fixed #35375 -- Fixed tabular inline admin original line to be on the right in RTL. (solution 1)

### DIFF
--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -282,6 +282,10 @@ form .form-row p.datetime {
     margin-right: 2px;
 }
 
+.inline-group .tabular td.original p {
+    right: 0;
+}
+
 .selector .selector-chooser {
     margin: 0;
 }


### PR DESCRIPTION
# Trac ticket number

ticket-35375

# Branch description

As mentioned in the issue, these changes will make it so the original line of tabular inlines will be on the right in case of RTL languages.

# Checklist

- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [ ] I have added or updated relevant **tests**.
- [ ] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
