### PR TITLE
Fixed #35375 -- Fixed tabular inline admin original line position to use `inset-inline-start`. (solution 2)

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -455,7 +455,7 @@ body.popup .submit-row {
 
 .inline-group .tabular td.original p {
     position: absolute;
-    left: 0;
+    inset-inline-start: 0;
     height: 1.1em;
     padding: 2px 9px;
     overflow: hidden;


### PR DESCRIPTION
# Trac ticket number

ticket-35375

# Branch description

As mentioned in the issue, this changes the way the original line of tabular inlines is positioned so that it's correctly positioned on the right in RTL languages _without_ any special/additional styles specific for RTL.

Please see #18076 as this solution is an alternative.

# Checklist

- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [ ] I have added or updated relevant **tests**.
- [ ] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
