### PR TITLE
Fixed TypeError comparing datetime.datetime to datetime.date.

### DIFF
--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -463,7 +463,7 @@ Let's also add a custom method to this model:
     class Question(models.Model):
         # ...
         def was_published_recently(self):
-            return self.pub_date >= timezone.now() - datetime.timedelta(days=1)
+            return self.pub_date >= timezone.now().date() - datetime.timedelta(days=1)
 
 Note the addition of ``import datetime`` and ``from django.utils import
 timezone``, to reference Python's standard :mod:`datetime` module and Django's


### PR DESCRIPTION
# Trac ticket number
N/A


# Branch description
On part 2 of the tutorial, it is suggested to add a `was_published_recently` custom method. However, this method throws a type error when called, since it's comparing two different types. By converting the `now()` instance to a Date, it fixes the problem.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
