### PR TITLE
Fixed #35373 -- Fixed a crash when indexing a generated field on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -150,6 +150,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             body.pop(old_field.name, None)
             mapping.pop(old_field.column, None)
             body[new_field.name] = new_field
+            rename_mapping[old_field.name] = new_field.name
+            if new_field.generated:
+                continue
             if old_field.null and not new_field.null:
                 if new_field.db_default is NOT_PROVIDED:
                     default = self.prepare_default(self.effective_default(new_field))
@@ -162,7 +165,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 mapping[new_field.column] = case_sql
             else:
                 mapping[new_field.column] = self.quote_name(old_field.column)
-            rename_mapping[old_field.name] = new_field.name
         # Remove any deleted fields
         if delete_field:
             del body[delete_field.name]

--- a/docs/releases/5.0.5.txt
+++ b/docs/releases/5.0.5.txt
@@ -16,3 +16,7 @@ Bugfixes
 * Fixed a compatibility issue encountered in Python 3.11.9+ and 3.12.3+ when
   validating email max line lengths with content decoded using the
   ``surrogateescape`` error handling scheme (:ticket:`35361`).
+
+* Fixed a bug in Django 5.0 that caused a crash when applying migrations
+  including alterations to ``GeneratedField`` such as setting ``db_index=True``
+  on SQLite (:ticket:`35373`).


### PR DESCRIPTION
# Trac ticket number
ticket-35373

# Branch description

Generated fields have to be excluded from the INSERT query against the remade table including the index.

Thanks Moshe Dicker for the report.
