### PR TITLE
Added JS wait in test_inline_add_another_widgets.

### DIFF
--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -576,7 +576,8 @@ class SeleniumTests(AdminSeleniumTestCase):
 
         def assertNoResults(row):
             elem = row.find_element(By.CSS_SELECTOR, ".select2-selection")
-            elem.click()  # Open the autocomplete dropdown.
+            with self.select2_ajax_wait():
+                elem.click()  # Open the autocomplete dropdown.
             results = self.selenium.find_element(By.CSS_SELECTOR, ".select2-results")
             self.assertTrue(results.is_displayed())
             option = self.selenium.find_element(


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description
This Selenium test occasionally fails. We (@sarahboyce and I) suspect it could be due to Selenium being faster than JavaScript while testing.

Sadly, it is hard to test if this fix works due to the random nature of this bug occurring.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.