### PR TITLE
Fixed #32935 -- Call InitSpatialMetaData(1) on spatialite 5.0.1.

### DIFF
--- a/django/contrib/gis/db/backends/spatialite/base.py
+++ b/django/contrib/gis/db/backends/spatialite/base.py
@@ -73,7 +73,11 @@ class DatabaseWrapper(SQLiteDatabaseWrapper):
         with self.cursor() as cursor:
             cursor.execute("PRAGMA table_info(geometry_columns);")
             if cursor.fetchall() == []:
-                if self.ops.spatial_version < (5,):
+                if self.ops.spatial_version < (5,) or self.ops.spatial_version == (
+                    5,
+                    0,
+                    1,
+                ):
                     cursor.execute("SELECT InitSpatialMetaData(1)")
                 else:
                     cursor.execute("SELECT InitSpatialMetaDataFull(1)")


### PR DESCRIPTION
# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-32935

# Branch description
Spatialite 5.0.1 seems to fail with InitSpatialMetaDataFull(). This change fixes an error I'm running into here:
* https://forum.djangoproject.com/t/no-such-column-rowid-error-with-django-4-2-and-spatialite-5-0-1/30277

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [ ] I have added or updated relevant **tests**.
- [ ] I have added or updated relevant **docs**, including release notes if applicable.
