### PR TITLE
Fixed #35194 -- Fixed case-insensitive operations in GeneratedFields on Postgres 15.6+.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -152,9 +152,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     }
     operators = {
         "exact": "= %s",
-        "iexact": "= UPPER(%s)",
+        "iexact": "ILIKE %s",
         "contains": "LIKE %s",
-        "icontains": "LIKE UPPER(%s)",
+        "icontains": "ILIKE %s",
         "regex": "~ %s",
         "iregex": "~* %s",
         "gt": "> %s",
@@ -163,8 +163,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         "lte": "<= %s",
         "startswith": "LIKE %s",
         "endswith": "LIKE %s",
-        "istartswith": "LIKE UPPER(%s)",
-        "iendswith": "LIKE UPPER(%s)",
+        "istartswith": "ILIKE %s",
+        "iendswith": "ILIKE %s",
     }
 
     # The patterns below are used to generate SQL pattern lookup clauses when
@@ -180,11 +180,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     )
     pattern_ops = {
         "contains": "LIKE '%%' || {} || '%%'",
-        "icontains": "LIKE '%%' || UPPER({}) || '%%'",
+        "icontains": "ILIKE '%%' || {} || '%%'",
         "startswith": "LIKE {} || '%%'",
-        "istartswith": "LIKE UPPER({}) || '%%'",
+        "istartswith": "ILIKE {} || '%%'",
         "endswith": "LIKE '%%' || {}",
-        "iendswith": "LIKE '%%' || UPPER({})",
+        "iendswith": "ILIKE '%%' || {}",
     }
 
     Database = Database

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -172,10 +172,6 @@ class DatabaseOperations(BaseDatabaseOperations):
             else:
                 lookup = "%s::text"
 
-        # Use UPPER(x) for case-insensitive lookups; it's faster.
-        if lookup_type in ("iexact", "icontains", "istartswith", "iendswith"):
-            lookup = "UPPER(%s)" % lookup
-
         return lookup
 
     def no_limit_value(self):

--- a/docs/releases/5.0.5.txt
+++ b/docs/releases/5.0.5.txt
@@ -20,3 +20,7 @@ Bugfixes
 * Fixed a bug in Django 5.0 that caused a crash when applying migrations
   including alterations to ``GeneratedField`` such as setting ``db_index=True``
   on SQLite (:ticket:`35373`).
+
+* Fixed a bug in Django 5.0 that caused a crash when using ``iexact``,
+  ``icontains``, ``istartswith``, or ``iendswith`` in ``GeneratedField``
+  expressions on Postgres >= 12.18, 13.14, 14.11, 15.6, 16.2 (:ticket:`35373`).

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -913,7 +913,7 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(GeneratedFieldContainsModel)
 
         field = GeneratedField(
-            expression=Q(text__contains="foo"),
+            expression=Q(text__icontains="FOO"),
             db_persist=True,
             output_field=BooleanField(),
         )


### PR DESCRIPTION
# Trac ticket number

ticket-35194

# Branch description

Postgres >= 12.18, 13.14, 14.11, 15.6, 16.2 changed the way the immutability of generated and default expressions is detected in postgres/postgres@743ddaf.

This reverts the optimization of using UPPER instead of ILIKE for postgres case-insensitive comparisons as UPPER can return different value depending on the collation and thus is not immutable.

See: https://code.djangoproject.com/ticket/3575

I can see a [StackOverflow discussion](https://stackoverflow.com/questions/20336665/lower-like-vs-ilike) on how using LOWER/UPPER LIKE is faster than using ILIKE by roughly ~17%, however the advice is also "just use an index".

So....
- Do we think this is a viable solution to the problem?
- If yes, should I note/document the potential performance regression to case-insensitive un-index-ed Postgres queries in the release note?

I guess users could chose to use upper/lower themselves to achieve what we were doing in the background if they experience a performance regression and do not want to use an index 🤔 


# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" **ticket flag** in the Trac system.
- [X] I have added or updated relevant **tests**.
- [X] I have added or updated relevant **docs**, including release notes if applicable.
