### PR TITLE
Fixes #34994 and #35386 -- Applied checkbox-row unconditionally in Admin.

### DIFF
--- a/django/contrib/admin/templates/admin/includes/fieldset.html
+++ b/django/contrib/admin/templates/admin/includes/fieldset.html
@@ -9,7 +9,7 @@
             {% for field in line %}
                 <div>
                     {% if not line.fields|length == 1 and not field.is_readonly %}{{ field.errors }}{% endif %}
-                        <div class="flex-container{% if not line.fields|length == 1 %} fieldBox{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %}{% elif field.is_checkbox %} checkbox-row{% endif %}">
+                        <div class="flex-container{% if not line.fields|length == 1 %} fieldBox{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %}{% endif %}{% if field.is_checkbox %} checkbox-row{% endif %}">
                             {% if field.is_checkbox %}
                                 {{ field.field }}{{ field.label_tag }}
                             {% else %}

--- a/docs/releases/4.2.12.txt
+++ b/docs/releases/4.2.12.txt
@@ -12,3 +12,7 @@ Bugfixes
 * Fixed a crash in Django 4.2 when validating email max line lengths with
   content decoded using the ``surrogateescape`` error handling scheme
   (:ticket:`35361`).
+
+* Fixed a regression in Django 4.2 where multiple checkboxes in the admin would
+  be centered on narrower screen widths (:ticket:`34994`) or have misaligned
+  labels (:ticket:`35386`).

--- a/docs/releases/5.0.5.txt
+++ b/docs/releases/5.0.5.txt
@@ -20,3 +20,7 @@ Bugfixes
 * Fixed a bug in Django 5.0 that caused a crash when applying migrations
   including alterations to ``GeneratedField`` such as setting ``db_index=True``
   on SQLite (:ticket:`35373`).
+
+* Fixed a regression in Django 4.2 where multiple checkboxes in the admin would
+  be centered on narrower screen widths (:ticket:`34994`) or have misaligned
+  labels (:ticket:`35386`).


### PR DESCRIPTION
# Trac ticket number
ticket-34994
ticket-35386

# Branch description

Fix the alignment issues covered in the referenced tickets.

Fixed ticket-34994, centring of checkboxes:

<img width="519" alt="Xnapper-2024-04-18-12 54 51" src="https://github.com/django/django/assets/857609/d716c1e5-4afb-4f05-b9b9-8d278a21f71f">

Fixed ticket-35386, help text misaligned when >1 field on a line:

<img width="562" alt="Xnapper-2024-04-16-10 31 01" src="https://github.com/django/django/assets/857609/3b92fef5-0467-42c0-a8ed-465bcb1a7706">

Test model:

```python
from django.db import models


class Switcher(models.Model):
    up = models.BooleanField(default=True, help_text="Switch up")
    down = models.BooleanField(default=True, help_text="Switch down")
    name = models.CharField(max_length=100, help_text="Naming is hard")
```

Test admin:

```python
from django.contrib import admin
from example.models import Switcher


class SwitcherAdmin(admin.ModelAdmin):
    fieldsets = [
        (
            None,
            {
                "fields": [
                    ("up", "down"),
                ],
            },
        ),
    ]


admin.site.register(Switcher, SwitcherAdmin)
```

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in ~both light and~ dark mode~s~.
