### PR TITLE
Fixed #35392 -- Allowed importing aprefetch_related_objects from django.db.models.

### DIFF
--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -46,7 +46,12 @@ from django.db.models.indexes import *  # NOQA
 from django.db.models.indexes import __all__ as indexes_all
 from django.db.models.lookups import Lookup, Transform
 from django.db.models.manager import Manager
-from django.db.models.query import Prefetch, QuerySet, prefetch_related_objects
+from django.db.models.query import (
+    Prefetch,
+    QuerySet,
+    aprefetch_related_objects,
+    prefetch_related_objects,
+)
 from django.db.models.query_utils import FilteredRelation, Q
 
 # Imports that would create circular imports if sorted
@@ -104,6 +109,7 @@ __all__ += [
     "Prefetch",
     "Q",
     "QuerySet",
+    "aprefetch_related_objects",
     "prefetch_related_objects",
     "DEFERRED",
     "Model",

--- a/docs/releases/5.0.5.txt
+++ b/docs/releases/5.0.5.txt
@@ -20,3 +20,6 @@ Bugfixes
 * Fixed a bug in Django 5.0 that caused a crash when applying migrations
   including alterations to ``GeneratedField`` such as setting ``db_index=True``
   on SQLite (:ticket:`35373`).
+
+* Allowed importing ``aprefetch_related_objects`` from ``django.db.models``
+  (:ticket:`35392`).


### PR DESCRIPTION
# Trac ticket number
ticket-35392

# Branch description
`aprefetch_related_objects` cannot be imported from `django.db.models` like `prefetch_related_objects` can. Because [the docs](https://docs.djangoproject.com/en/5.0/ref/models/querysets/#prefetch-related-objects) say nothing about importing the async version from a different place, I believe this to be an oversight.

You can work around this by importing from `django.db.models.query` but if that's the intended behavior, the documentation should be updated to reflect that. Let me know and I'll do so happily!

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [ ] I have added or updated relevant **tests**.
- [ ] I have added or updated relevant **docs**, including release notes if applicable.
- [ ] For UI changes, I have attached **screenshots** in both light and dark modes.
