### PR TITLE
Fixed #20744 -- Removed generic kwargs from form Field class docs.

### DIFF
--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -7,7 +7,7 @@ Form fields
 
 .. currentmodule:: django.forms
 
-.. class:: Field(**kwargs)
+.. class:: Field
 
 When you create a ``Form`` class, the most important part is defining the
 fields of the form. Each field has custom validation logic, along with a few


### PR DESCRIPTION
# Trac ticket number

ticket-20744

# Branch description

I changed `.. class:: Field(**kwargs)` to  `.. class:: Field` in the form `Field` docs because the ticket says having `**kwargs` there implies that any keyword arguments can be passed to the class, which is not true.

<img width="662" alt="image" src="https://github.com/django/django/assets/101698/0fcbeb36-4f6b-477f-800a-63f1c8359afd">

This seems to be how similar classes like `Form` are [documented](https://github.com/django/django/blob/53719d6b5b745dd99b1ab9315afb242f706ebbf1/docs/ref/forms/api.txt#L26), so I thought this simple fix would be sufficient.

# Checklist

- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" **ticket flag** in the Trac system.
- [x] I have added or updated relevant **tests**.
- [x] I have added or updated relevant **docs**, including release notes if applicable.
- [x] For UI changes, I have attached **screenshots** in both light and dark modes.
