### PR TITLE
Refs #34007 -- Added Q.referenced_based_fields property

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -175,6 +175,19 @@ class Q(tree.Node):
     def __hash__(self):
         return hash(self.identity)
 
+    @cached_property
+    def referenced_base_fields(self):
+        """
+        Retrieve all base fields referenced directly or through F expressions
+        excluding any fields referenced through joins.
+        """
+        # Avoid circular imports.
+        from django.db.models.sql import query
+
+        return {
+            child.split(LOOKUP_SEP, 1)[0] for child in query.get_children_from_q(self)
+        }
+
 
 class DeferredAttribute:
     """

--- a/tests/queries/test_q.py
+++ b/tests/queries/test_q.py
@@ -10,6 +10,7 @@ from django.db.models import (
 )
 from django.db.models.expressions import NegatedExpression, RawSQL
 from django.db.models.functions import Lower
+from django.db.models.lookups import Exact, IsNull
 from django.db.models.sql.where import NothingNode
 from django.test import SimpleTestCase, TestCase
 
@@ -261,6 +262,33 @@ class QTests(SimpleTestCase):
                 self.assertEqual(
                     Q.create(items, connector=connector),
                     Q(*items, _connector=connector),
+                )
+
+    def test_referenced_base_fields(self):
+        # Make sure Q.referenced_base_fields retrieves all base fields from
+        # both filters and F expressions.
+        tests = [
+            (Q(field_1=1) & Q(field_2=1), {"field_1", "field_2"}),
+            (
+                Q(Exact(F("field_3"), IsNull(F("field_4"), True))),
+                {"field_3", "field_4"},
+            ),
+            (Q(Exact(Q(field_5=F("field_6")), True)), {"field_5", "field_6"}),
+            (Q(field_2=1), {"field_2"}),
+            (Q(field_7__lookup=True), {"field_7"}),
+            (Q(field_7__joined_field__lookup=True), {"field_7"}),
+        ]
+        combined_q = Q(1)
+        combined_q_base_fields = set()
+        for q, expected_base_fields in tests:
+            combined_q &= q
+            combined_q_base_fields |= expected_base_fields
+        tests.append((combined_q, combined_q_base_fields))
+        for q, expected_base_fields in tests:
+            with self.subTest(q=q):
+                self.assertEqual(
+                    q.referenced_base_fields,
+                    expected_base_fields,
                 )
 
 


### PR DESCRIPTION
Refs [ticket-34007](https://code.djangoproject.com/ticket/34007) & [ticket-35359](https://code.djangoproject.com/ticket/35359)
Cherry picked from #16054 to be used in #18068

**Notes:**
 - I changed `@property` into `@cached_property`, this wasn't reviewed so will need to be confirmed whether this is acceptable
 - Test was updated with felix's suggestion to mix combining all params & subtest