### PR TITLE
Remove unintended blockquotes from documentation

### DIFF
--- a/docs/topics/forms/index.txt
+++ b/docs/topics/forms/index.txt
@@ -781,12 +781,10 @@ Useful attributes on ``{{ field }}`` include:
         <label for="id_email">Email address:</label>
 
 ``{{ field.legend_tag }}``
-
     Similar to ``field.label_tag`` but uses a ``<legend>`` tag in place of
     ``<label>``, for widgets with multiple inputs wrapped in a ``<fieldset>``.
 
 ``{{ field.use_fieldset }}``
-
     This attribute is ``True`` if the form field's widget contains multiple
     inputs that should be semantically grouped in a ``<fieldset>`` with a
     ``<legend>`` to improve accessibility. An example use in a template:


### PR DESCRIPTION
The "Looping over the form’s fields" section has 2 unintended blockquotes
(https://docs.djangoproject.com/en/dev/topics/forms/#looping-over-the-form-s-fields).
This change converts them to regular paragraphs.

# Trac ticket number
<!-- Replace [number] with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

# Branch description
Convert these blockquotes to normal paragraphs.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" **ticket flag** in the Trac system.
- [ ] I have added or updated relevant **tests**.
- [ ] I have added or updated relevant **docs**, including release notes if applicable.
- [ ] For UI changes, I have attached **screenshots** in both light and dark modes.
