### PR TITLE
Fixed #35395 -- slice filter crashes on an empty dict with Python 3.12

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -644,7 +644,7 @@ def slice_filter(value, arg):
                 bits.append(int(x))
         return value[slice(*bits)]
 
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, KeyError):
         return value  # Fail silently.
 
 

--- a/tests/template_tests/filter_tests/test_slice.py
+++ b/tests/template_tests/filter_tests/test_slice.py
@@ -53,3 +53,6 @@ class FunctionTests(SimpleTestCase):
     def test_fail_silently(self):
         obj = object()
         self.assertEqual(slice_filter(obj, "0::2"), obj)
+
+    def test_empty_dict(self):
+        self.assertEqual(slice_filter({}, "1"), {})


### PR DESCRIPTION
Keep consistent behaviour of slice() filter between python 3.12 and prior versions in the case of a dict passed to the filter (catch the new to python 3.12 KeyError exception).

# Trac ticket number


ticket-35395

# Branch description
In python 3.12 the behaviour of built in function slice() has changed; it now returns a hashable value, and if it is applied to a dictionary, it will raise a KeyError exception in the likely case that such a key does not exist. In prior python versions, this caused a different exception.

KeyError is not captured by the slice template function, so it raises a runtime error and the template does not render.
It is not expected to request a slice of a dictionary, none the less with python 3.11 and earlier, this silently returned an empty dict, and now it causes a runtime exception when rendering the same template. The slice filter already includes "silent failure" handling of some exceptions.

In my opinion, this means that Python 4.2 LTS is not fully python 3.12 compatible since a previously working template now raises an exception. 

This patch adds KeyError to the set of exceptions which cause "silent failure"


# Checklist
- [ X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ X] I have checked the "Has patch" **ticket flag** in the Trac system.
- [X ] I have added or updated relevant **tests**.
- [ ] I have added or updated relevant **docs**, including release notes if applicable.
- [ ] For UI changes, I have attached **screenshots** in both light and dark modes.
