### PR TITLE
Changed [yN] prompt to [y/N] in squashmigrations

### DIFF
--- a/django/core/management/commands/squashmigrations.py
+++ b/django/core/management/commands/squashmigrations.py
@@ -123,7 +123,7 @@ class Command(BaseCommand):
             if self.interactive:
                 answer = None
                 while not answer or answer not in "yn":
-                    answer = input("Do you wish to proceed? [yN] ")
+                    answer = input("Do you wish to proceed? [y/N] ")
                     if not answer:
                         answer = "n"
                         break

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -703,7 +703,7 @@ app label and migration name you want to squash up to, and it'll get to work:
    - 0002_some_change
    - 0003_another_change
    - 0004_undo_something
-  Do you wish to proceed? [yN] y
+  Do you wish to proceed? [y/N] y
   Optimizing...
     Optimized from 12 operations to 7 operations.
   Created new squashed migration /home/andrew/Programs/DjangoTest/test/migrations/0001_squashed_0004_undo_something.py


### PR DESCRIPTION
Added a slash between the yes/no options printed from `squashmigrations` command to make it consistent with other commands that print similar prompts. Updated the corresponding documentation of `squashmigration` to match.
