### PR TITLE
Added link to the csrf template tag in the csrf documentation page

### DIFF
--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -43,7 +43,7 @@ The CSRF protection is based on the following things:
    a mask. The mask is generated randomly on every call to ``get_token()``, so
    the form field value is different each time.
 
-   This part is done by the template tag.
+   This part is done by the :ttag:`csrf_token` template tag.
 
 #. For all incoming requests that are not using HTTP GET, HEAD, OPTIONS or
    TRACE, a CSRF cookie must be present, and the 'csrfmiddlewaretoken' field


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

# Branch description
The CSRF docs, in the 2nd point of how it works mention the csrf template tag but do not link to is.

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
