### PR TITLE
Fixed #35384 -- Raised FieldError when saving a file without a name to FileField.

### DIFF
--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -421,6 +421,10 @@ Miscellaneous
 
 * The minimum supported version of SQLite is increased from 3.27.0 to 3.31.0.
 
+* :class:`~django.db.models.FileField` now raises a
+  :class:`~django.core.exceptions.FieldError` when saving a file without a
+  ``name``.
+
 .. _deprecated-features-5.1:
 
 Features deprecated in 5.1

--- a/tests/model_fields/test_filefield.py
+++ b/tests/model_fields/test_filefield.py
@@ -5,13 +5,14 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from django.core.exceptions import SuspiciousFileOperation
+from django.core.exceptions import FieldError, SuspiciousFileOperation
 from django.core.files import File, temp
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.db import IntegrityError, models
 from django.test import TestCase, override_settings
 from django.test.utils import isolate_apps
+from django.utils.version import PY311
 
 from .models import Document
 
@@ -71,6 +72,27 @@ class FileFieldTests(TestCase):
             msg = f"Detected path traversal attempt in '{tmp.name}'"
             with self.assertRaisesMessage(SuspiciousFileOperation, msg):
                 document.save()
+
+    def test_save_content_file_without_name(self):
+        d = Document()
+        d.myfile = ContentFile(b"")
+        msg = "File for myfile must have the name attribute specified to be saved."
+        with self.assertRaisesMessage(FieldError, msg) as cm:
+            d.save()
+
+        if PY311:
+            self.assertEqual(
+                cm.exception.__notes__, ["Pass a 'name' argument to ContentFile."]
+            )
+
+    def test_delete_content_file(self):
+        file = ContentFile(b"", name="foo")
+        d = Document.objects.create(myfile=file)
+        d.myfile.delete()
+        self.assertIsNone(d.myfile.name)
+        msg = "The 'myfile' attribute has no file associated with it."
+        with self.assertRaisesMessage(ValueError, msg):
+            getattr(d.myfile, "file")
 
     def test_defer(self):
         Document.objects.create(myfile="something.txt")


### PR DESCRIPTION
…nce to File field

# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35384

# Branch description
Added code for raising `FieldError` when trying to save ContentFile instance to File field.

- The issue originates from `pre_save` of `FileField` class.
    - when `pre_save` get's called to save file-like objects, it checks if file is truthy.
      <img width="615" alt="image" src="https://github.com/django/django/assets/23581144/9eac1e09-b807-4ed4-b4c6-5456ef79434e">
    - File truthy is determined by the following
      <img width="356" alt="image" src="https://github.com/django/django/assets/23581144/50795cae-b918-451d-9a17-454c39574d26">
    - When using regular `File` or `ImageFile` instance, even if they do not have explicit name, name would be retrieved from there actual file. But `ContentFile` instance has nowhere to get its name and its name is set to `None`.
    - Thus, It cannot pass the if statement(`if file and not file._committed:`) which results in `pre_save` method to silently drop it's duty.
- I suppose `pre_save` is adequate location to validate if `ContentFile.name` because looks like it is responsible for letting the file objects to be passed to file storage manager.
- Simply adding `if file.name is None:` would affect many other functioning codes.
   - File fields with `null=True` option will fall into this statement as well
- Besides `None`, it is Needed something to represent a `ContentFile.name` is empty.
- I added `EmptyName` class and made it default if `ContentFile.name` is not passed.
- The following at `pre_save` works fine.
  <img width="628" alt="image" src="https://github.com/django/django/assets/23581144/e1d2f301-d177-4533-a8d0-14e286fe5285">

Thanks to @john-parton for a good description and isolated tests.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
