### PR TITLE
Fixed #35378 -- Added maximum header length for long addresses.

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -131,7 +131,7 @@ class MIMEMixin:
         lines that begin with 'From '. See bug #13433 for details.
         """
         fp = StringIO()
-        g = generator.Generator(fp, mangle_from_=False)
+        g = generator.Generator(fp, mangle_from_=False, maxheaderlen=0)
         g.flatten(self, unixfrom=unixfrom, linesep=linesep)
         return fp.getvalue()
 
@@ -144,7 +144,7 @@ class MIMEMixin:
         lines that begin with 'From '. See bug #13433 for details.
         """
         fp = BytesIO()
-        g = generator.BytesGenerator(fp, mangle_from_=False)
+        g = generator.BytesGenerator(fp, mangle_from_=False, maxheaderlen=0)
         g.flatten(self, unixfrom=unixfrom, linesep=linesep)
         return fp.getvalue()
 

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -902,7 +902,7 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             "Subject",
             "Long address with special characters",
             "from@example.com",
-            ['"Người nhận a very very long, name" <to@example.com>']
+            ['"Người nhận a very very long, name" <to@example.com>'],
         )
         s = msg.message().as_bytes()
         self.assertIn(b"Content-Transfer-Encoding: 7bit", s)

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -894,6 +894,21 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
         )
         self.assertNotIn(b">From the future", email.message().as_bytes())
 
+    def test_long_address_folding(self):
+        # Ticket #35378
+        # should encode long addresses with special characters using
+        # 7bit Content-Transfer-Encoding
+        msg = EmailMessage(
+            "Subject",
+            "Long address with special characters",
+            "from@example.com",
+            ['"Người nhận a very very long, name" <to@example.com>']
+        )
+        s = msg.message().as_bytes()
+        self.assertIn(b"Content-Transfer-Encoding: 7bit", s)
+        s = msg.message().as_string()
+        self.assertIn("Content-Transfer-Encoding: 7bit", s)
+
     def test_dont_base64_encode(self):
         # Ticket #3472
         # Shouldn't use Base64 encoding at all


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35378 
# Branch description
Incorrect folding of long address headers with special characters when using 7bit Content-Transfer-Encoding in EmailMessage.


# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
