### PR TITLE
Adjust docs slightly so that behavior of width/height fields is documented more precisely.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1342,13 +1342,13 @@ following optional arguments:
 
 .. attribute:: ImageField.height_field
 
-    Name of a model field which will be auto-populated with the height of the
-    image each time the model instance is saved.
+    Name of a model field which is auto-populated with the height of the image
+    each time an image object is set.
 
 .. attribute:: ImageField.width_field
 
-    Name of a model field which will be auto-populated with the width of the
-    image each time the model instance is saved.
+    Name of a model field which is auto-populated with the width of the image
+    each time an image object is set.
 
 Requires the `Pillow`_ library.
 


### PR DESCRIPTION
…ented more precisely.

# Trac ticket number
N/A

# Branch description
This is a trivial change which adjust the docs regarding the `width` and `height` fields for `ImageField`. 

If you do the following:

1. Save a model with an image field and width/height fields
2. Modify the underlying file outside of django.
3. Load the instance from the DB and re-save it.

Then the width/height fields will not be updated. This might seem obvious to a more experienced dev, but the current documentation isn't exactly clear on the behavior.

See discussion: https://github.com/django/django/pull/18070

# Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
