### PR TITLE
Refs #32819 -- Avoided adding 'aria-describedby' to hidden inputs.

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -298,6 +298,7 @@ class BoundField(RenderableFieldMixin):
             and self.field.help_text
             and not self.use_fieldset
             and self.auto_id
+            and not self.is_hidden
         ):
             attrs["aria-describedby"] = f"{self.auto_id}_helptext"
         return attrs

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -2136,6 +2136,15 @@ class FormsTestCase(SimpleTestCase):
             p.as_p(), '<input type="hidden" name="foo"><input type="hidden" name="bar">'
         )
 
+    def test_hidden_widget_does_not_have_aria_describedby(self):
+        class TestForm(Form):
+            hidden_text = CharField(widget=HiddenInput, help_text="Help Text")
+
+        f = TestForm()
+        self.assertEqual(
+            str(f), '<input type="hidden" name="hidden_text" id="id_hidden_text">'
+        )
+
     def test_field_order(self):
         # A Form's fields are displayed in the same order in which they were defined.
         class TestForm(Form):


### PR DESCRIPTION
Hidden elements are not visible for both accessibility tools and browsers presentation layer. This change therefore only reduces the size of the generated HTML.

# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-32819

# Branch description
Extract from #17520 -- see comment https://github.com/django/django/pull/17520#discussion_r1445261430

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
