### PR TITLE
Ticket #34417 - Remove unnecessary recreation of foreign key constrains while dropping index.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -99,6 +99,10 @@ class BaseDatabaseFeatures:
     # Does the database have a copy of the zoneinfo database?
     has_zoneinfo_database = True
 
+    # Does the backend require the foreign key constraints to be recreated
+    # when dropping an index?
+    requires_fk_constraints_to_be_recreated = False
+
     # When performing a GROUP BY, is an ORDER BY NULL required
     # to remove any ordering?
     requires_explicit_null_ordering_when_grouping = False

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -919,6 +919,7 @@ class BaseDatabaseSchemaEditor:
         fks_dropped = set()
         if (
             self.connection.features.supports_foreign_keys
+            and self.connection.features.requires_fk_constraints_to_be_recreated
             and old_field.remote_field
             and old_field.db_constraint
             and self._field_should_be_altered(

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -15,6 +15,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_regex_backreferencing = False
     supports_date_lookup_using_string = False
     supports_timezones = False
+    requires_fk_constraints_to_be_recreated = True
     requires_explicit_null_ordering_when_grouping = True
     atomic_transactions = False
     can_clone_databases = True

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1745,6 +1745,47 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(LocalBook, old_field, new_field, strict=True)
         self.assertForeignKeyExists(LocalBook, "author_id", "schema_author")
 
+    @skipUnlessDBFeature("supports_foreign_keys")
+    def test_fk_constraint_index_drop(self):
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+            editor.create_model(Book)
+
+        author = Author.objects.create(name="Alice")
+        Book.objects.create(
+            author=author,
+            title="Much Ado About Foreign Keys",
+            pub_date=datetime.datetime.now(),
+        )
+
+        old_field = Book._meta.get_field("author")
+        new_field = ForeignKey(Author, CASCADE, db_index=False)
+        new_field.set_attributes_from_name("author")
+        with (
+            CaptureQueriesContext(connection) as ctx,
+            connection.schema_editor() as editor,
+        ):
+            editor.alter_field(Book, old_field, new_field, strict=True)
+
+        if connection.features.requires_fk_constraints_to_be_recreated:
+            self.assertIs(
+                any(
+                    "DROP FOREIGN KEY" in query["sql"] for query in ctx.captured_queries
+                ),
+                True,
+            )
+            self.assertIs(
+                any("ADD CONSTRAINT" in query["sql"] for query in ctx.captured_queries),
+                True,
+            )
+        else:
+            self.assertIs(
+                any(
+                    "DROP CONSTRAINT" in query["sql"] for query in ctx.captured_queries
+                ),
+                False,
+            )
+
     @skipUnlessDBFeature("supports_foreign_keys", "can_introspect_foreign_keys")
     def test_alter_o2o_to_fk(self):
         """


### PR DESCRIPTION

# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->
[Ticket #34417](https://code.djangoproject.com/ticket/34417)
Follow up to : https://github.com/django/django/pull/16922

# Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
