### PR TITLE
Fixed rendering XOR section in docs.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2114,7 +2114,7 @@ SQL equivalent:
             2
         )
 
-   .. versionchanged:: 5.0
+    .. versionchanged:: 5.0
 
         In older versions, on databases without native support for the SQL
         ``XOR`` operator, ``XOR`` returned rows that were matched by exactly


### PR DESCRIPTION
The current [docs](https://docs.djangoproject.com/en/dev/ref/models/querysets/#xor):

![image](https://github.com/django/django/assets/2865885/ec22b356-2861-4826-b87a-e7d5922c40d4)

with this patch:

![image](https://github.com/django/django/assets/2865885/3c51b08f-0b43-4700-b806-5b827b50df2d)
