### PR TITLE
Fixed mismatched blacken-docs behavior between CI and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
         additional_dependencies:
         - black==24.2.0
         files: 'docs/.*\.txt$'
+        args: ["--rst-literal-block"]
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:


### PR DESCRIPTION
Noticed that my PR #18120 was failing on CI but not locally with pre-commit.

I first thought this was due to a `black` version mismatched between the two tools, so I fixed that (first commit on this PR) but that didn't make the problem go away.

In the end I figured out that it was caused by `make black` (what the CI eventually calls) using the `--rst-literal-block` flag for `blacken-docs` which the commit hook didn't use. I fixed that too (2nd commit) and that made the pre-commit hook fail locally on my PR too.