### PR TITLE
Fixed #27452 -- Added serial fields to contrib.postgres.

### DIFF
--- a/django/contrib/postgres/fields/__init__.py
+++ b/django/contrib/postgres/fields/__init__.py
@@ -3,3 +3,4 @@ from .citext import *  # NOQA
 from .hstore import *  # NOQA
 from .jsonb import *  # NOQA
 from .ranges import *  # NOQA
+from .serial import *  # NOQA

--- a/django/contrib/postgres/fields/serial.py
+++ b/django/contrib/postgres/fields/serial.py
@@ -1,0 +1,67 @@
+from django.db import models
+from django.db.models import NOT_PROVIDED
+from django.db.models.expressions import DatabaseDefault
+from django.utils.translation import gettext_lazy as _
+
+__all__ = ("BigSerialField", "SmallSerialField", "SerialField")
+
+
+class SerialFieldMixin:
+    db_returning = True
+
+    def __init__(self, *args, **kwargs):
+        default = DatabaseDefault()
+
+        if not kwargs.setdefault("blank", True):
+            raise ValueError(f"{self.__class__.__name__} must be blank.")
+        if kwargs.setdefault("null", False):
+            raise ValueError(f"{self.__class__.__name__} must not be null.")
+        if kwargs.setdefault("default", default) is not default:
+            raise ValueError(f"{self.__class__.__name__} cannot have a default.")
+        if kwargs.get("db_default", NOT_PROVIDED) is not NOT_PROVIDED:
+            raise ValueError(
+                f"{self.__class__.__name__} cannot have a database default."
+            )
+
+        super().__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        del kwargs["default"]
+        return name, path, args, kwargs
+
+    def get_prep_value(self, value):
+        value = super().get_prep_value(value)
+        if value is None:
+            value = self.get_default()
+        return value
+
+
+class BigSerialField(SerialFieldMixin, models.BigIntegerField):
+    description = _("Big serial")
+
+    def get_internal_type(self):
+        return "BigSerialField"
+
+    def db_type(self, connection):
+        return "bigserial"
+
+
+class SmallSerialField(SerialFieldMixin, models.SmallIntegerField):
+    description = _("Small serial")
+
+    def get_internal_type(self):
+        return "SmallSerialField"
+
+    def db_type(self, connection):
+        return "smallserial"
+
+
+class SerialField(SerialFieldMixin, models.IntegerField):
+    description = _("Serial")
+
+    def get_internal_type(self):
+        return "SerialField"
+
+    def db_type(self, connection):
+        return "serial"

--- a/django/contrib/postgres/fields/serial.py
+++ b/django/contrib/postgres/fields/serial.py
@@ -46,6 +46,9 @@ class BigSerialField(SerialFieldMixin, models.BigIntegerField):
     def db_type(self, connection):
         return "bigserial"
 
+    def rel_db_type(self, connection):
+        return "bigint"
+
 
 class SmallSerialField(SerialFieldMixin, models.SmallIntegerField):
     description = _("Small serial")
@@ -56,6 +59,9 @@ class SmallSerialField(SerialFieldMixin, models.SmallIntegerField):
     def db_type(self, connection):
         return "smallserial"
 
+    def rel_db_type(self, connection):
+        return "smallint"
+
 
 class SerialField(SerialFieldMixin, models.IntegerField):
     description = _("Serial")
@@ -65,3 +71,6 @@ class SerialField(SerialFieldMixin, models.IntegerField):
 
     def db_type(self, connection):
         return "serial"
+
+    def rel_db_type(self, connection):
+        return "integer"

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -298,7 +298,7 @@ class BaseDatabaseSchemaEditor:
         # Work out nullability.
         null = field.null
         # Add database default.
-        if field.db_default is not NOT_PROVIDED:
+        if field.db_default is not NOT_PROVIDED and not self.skip_default(field):
             default_sql, default_params = self.db_default_sql(field)
             yield f"DEFAULT {default_sql}"
             params.extend(default_params)

--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -40,17 +40,22 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
     def get_field_type(self, data_type, description):
         field_type = super().get_field_type(data_type, description)
-        if description.is_autofield or (
-            # Required for pre-Django 4.1 serial columns.
-            description.default
-            and "nextval" in description.default
-        ):
+
+        if description.is_autofield:
             if field_type == "IntegerField":
                 return "AutoField"
             elif field_type == "BigIntegerField":
                 return "BigAutoField"
             elif field_type == "SmallIntegerField":
                 return "SmallAutoField"
+        elif description.default and "nextval" in description.default:
+            if field_type == "IntegerField":
+                return "postgres.fields.SerialField"
+            elif field_type == "BigIntegerField":
+                return "postgres.fields.BigSerialField"
+            elif field_type == "SmallIntegerField":
+                return "postgres.fields.SmallSerialField"
+
         return field_type
 
     def get_table_list(self, cursor):

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -2,6 +2,7 @@ import json
 from functools import lru_cache, partial
 
 from django.conf import settings
+from django.contrib.postgres.fields.serial import SerialFieldMixin
 from django.db.backends.base.operations import BaseDatabaseOperations
 from django.db.backends.postgresql.psycopg_any import (
     Inet,
@@ -43,6 +44,15 @@ class DatabaseOperations(BaseDatabaseOperations):
         "AutoField": "integer",
         "BigAutoField": "bigint",
         "SmallAutoField": "smallint",
+        "SerialField": "integer",
+        "BigSerialField": "bigint",
+        "SmallSerialField": "smallint",
+    }
+    integer_field_ranges = {
+        **BaseDatabaseOperations.integer_field_ranges,
+        "SmallSerialField": (-32768, 32767),
+        "SerialField": (-2147483648, 2147483647),
+        "BigSerialField": (-9223372036854775808, 9223372036854775807),
     }
 
     if is_psycopg3:
@@ -55,6 +65,9 @@ class DatabaseOperations(BaseDatabaseOperations):
             "PositiveSmallIntegerField": numeric.Int2,
             "PositiveIntegerField": numeric.Int4,
             "PositiveBigIntegerField": numeric.Int8,
+            "SmallSerialField": numeric.Int2,
+            "SerialField": numeric.Int4,
+            "BigSerialField": numeric.Int8,
         }
 
     def unification_cast_sql(self, output_field):
@@ -250,7 +263,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             # underlying sequence name from the table name and column name.
 
             for f in model._meta.local_fields:
-                if isinstance(f, models.AutoField):
+                if isinstance(f, (models.AutoField, SerialFieldMixin)):
                     output.append(
                         "%s setval(pg_get_serial_sequence('%s','%s'), "
                         "coalesce(max(%s), 1), max(%s) %s null) %s %s;"
@@ -265,9 +278,7 @@ class DatabaseOperations(BaseDatabaseOperations):
                             style.SQL_TABLE(qn(model._meta.db_table)),
                         )
                     )
-                    # Only one AutoField is allowed per model, so don't bother
-                    # continuing.
-                    break
+
         return output
 
     def prep_for_iexact_query(self, x):

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -367,3 +367,17 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             )
             row = cursor.fetchone()
             return row[0] if row else None
+
+    def skip_default(self, field):
+        return field.get_internal_type() in {
+            "SerialField",
+            "BigSerialField",
+            "SmallSerialField",
+        }
+
+    def skip_default_on_alter(self, field):
+        return field.get_internal_type() in {
+            "SerialField",
+            "BigSerialField",
+            "SmallSerialField",
+        }

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -13,6 +13,16 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     )
     sql_alter_sequence_type = "ALTER SEQUENCE IF EXISTS %(sequence)s AS %(type)s"
     sql_delete_sequence = "DROP SEQUENCE IF EXISTS %(sequence)s CASCADE"
+    sql_create_sequence = (
+        "CREATE SEQUENCE IF NOT EXISTS %(sequence)s "
+        "AS %(data_type)s "
+        "OWNED BY %(table)s.%(column)s"
+    )
+    sql_reset_sequence = (
+        "SELECT setval(pg_get_serial_sequence(%s, %s), "
+        "coalesce(max(%s), 1), max(%s) IS NOT NULL) FROM %s;"
+    )
+    sql_rename_sequence = "ALTER SEQUENCE %s RENAME TO %s;"
 
     sql_create_index = (
         "CREATE INDEX %(name)s ON %(table)s%(using)s "
@@ -38,6 +48,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         "ALTER TABLE %(table)s DROP CONSTRAINT %(name)s"
     )
     sql_delete_procedure = "DROP FUNCTION %(procedure)s(%(param_types)s)"
+    serial_field_types = {
+        "SerialField": "integer",
+        "BigSerialField": "bigint",
+        "SmallSerialField": "smallint",
+    }
 
     def execute(self, sql, params=()):
         # Merge the query client-side, as PostgreSQL won't do it server-side.
@@ -167,15 +182,51 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         old_internal_type = old_field.get_internal_type()
         # Make ALTER TYPE with IDENTITY make sense.
         table = strip_quotes(model._meta.db_table)
+
         auto_field_types = {
-            "AutoField",
-            "BigAutoField",
-            "SmallAutoField",
+            "AutoField": "integer",
+            "BigAutoField": "bigint",
+            "SmallAutoField": "smallint",
         }
         old_is_auto = old_internal_type in auto_field_types
         new_is_auto = new_internal_type in auto_field_types
-        if new_is_auto and not old_is_auto:
-            column = strip_quotes(new_field.column)
+
+        old_is_serial = old_internal_type in self.serial_field_types
+        new_is_serial = new_internal_type in self.serial_field_types
+        column = strip_quotes(new_field.column)
+
+        if old_is_auto and new_is_serial:
+            data_type = self.serial_field_types[new_internal_type]
+            self.execute(self._drop_identity_sql(table, column))
+            self.execute(self._create_sequence_sql(table, column, data_type))
+            fragment, other_actions = super()._alter_column_type_sql(
+                model, old_field, new_field, data_type, old_collation, new_collation
+            )
+
+            return (
+                fragment,
+                other_actions
+                + [
+                    (self._reset_sequence_sql(table, column), []),
+                ],
+            )
+        elif old_is_serial and new_is_auto:
+            sequence_name = self._get_sequence_name(table, column)
+            self.execute(self._delete_sequence_sql(sequence_name))
+            data_type = auto_field_types[new_internal_type]
+            fragment, other_actions = super()._alter_column_type_sql(
+                model, old_field, new_field, data_type, old_collation, new_collation
+            )
+
+            return (
+                fragment,
+                other_actions
+                + [
+                    (self._add_identity_sql(table, column), []),
+                    (self._reset_sequence_sql(table, column), []),
+                ],
+            )
+        elif new_is_auto and not old_is_auto:
             return (
                 (
                     self.sql_alter_column_type
@@ -187,27 +238,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     [],
                 ),
                 [
-                    (
-                        self.sql_add_identity
-                        % {
-                            "table": self.quote_name(table),
-                            "column": self.quote_name(column),
-                        },
-                        [],
-                    ),
+                    (self._add_identity_sql(table, column), []),
                 ],
             )
         elif old_is_auto and not new_is_auto:
             # Drop IDENTITY if exists (pre-Django 4.1 serial columns don't have
             # it).
-            self.execute(
-                self.sql_drop_indentity
-                % {
-                    "table": self.quote_name(table),
-                    "column": self.quote_name(strip_quotes(new_field.column)),
-                }
-            )
-            column = strip_quotes(new_field.column)
+            self.execute(self._drop_identity_sql(table, column))
             fragment, _ = super()._alter_column_type_sql(
                 model, old_field, new_field, new_type, old_collation, new_collation
             )
@@ -215,41 +252,56 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # have it).
             other_actions = []
             if sequence_name := self._get_sequence_name(table, column):
-                other_actions = [
-                    (
-                        self.sql_delete_sequence
-                        % {
-                            "sequence": self.quote_name(sequence_name),
-                        },
-                        [],
-                    )
-                ]
+                other_actions = [(self._delete_sequence_sql(sequence_name), [])]
             return fragment, other_actions
         elif new_is_auto and old_is_auto and old_internal_type != new_internal_type:
             fragment, _ = super()._alter_column_type_sql(
                 model, old_field, new_field, new_type, old_collation, new_collation
             )
-            column = strip_quotes(new_field.column)
-            db_types = {
-                "AutoField": "integer",
-                "BigAutoField": "bigint",
-                "SmallAutoField": "smallint",
-            }
             # Alter the sequence type if exists (Django 4.1+ identity columns
             # don't have it).
             other_actions = []
             if sequence_name := self._get_sequence_name(table, column):
+                data_type = auto_field_types[new_internal_type]
                 other_actions = [
-                    (
-                        self.sql_alter_sequence_type
-                        % {
-                            "sequence": self.quote_name(sequence_name),
-                            "type": db_types[new_internal_type],
-                        },
-                        [],
-                    ),
+                    (self._alter_sequence_type_sql(sequence_name, data_type), []),
                 ]
             return fragment, other_actions
+        elif new_is_serial and not old_is_serial:
+            data_type = self.serial_field_types[new_internal_type]
+            self.execute(self._create_sequence_sql(table, column, data_type))
+            self.execute(self._reset_sequence_sql(table, column))
+
+            return super()._alter_column_type_sql(
+                model, old_field, new_field, data_type, old_collation, new_collation
+            )
+        elif old_is_serial and not new_is_serial:
+            sequence_name = self._get_sequence_name(table, column)
+            fragment, other_actions = super()._alter_column_type_sql(
+                model, old_field, new_field, new_type, old_collation, new_collation
+            )
+
+            return (
+                fragment,
+                other_actions
+                + [
+                    (self._delete_sequence_sql(sequence_name), []),
+                ],
+            )
+        elif old_is_serial and new_is_serial and old_internal_type != new_internal_type:
+            data_type = self.serial_field_types[new_internal_type]
+            sequence_name = self._get_sequence_name(table, column)
+            fragment, other_actions = super()._alter_column_type_sql(
+                model, old_field, new_field, data_type, old_collation, new_collation
+            )
+
+            return (
+                fragment,
+                other_actions
+                + [
+                    (self._alter_sequence_type_sql(sequence_name, data_type), []),
+                ],
+            )
         else:
             return super()._alter_column_type_sql(
                 model, old_field, new_field, new_type, old_collation, new_collation
@@ -368,16 +420,66 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             row = cursor.fetchone()
             return row[0] if row else None
 
-    def skip_default(self, field):
-        return field.get_internal_type() in {
-            "SerialField",
-            "BigSerialField",
-            "SmallSerialField",
+    def _add_identity_sql(self, table, column):
+        return self.sql_add_identity % {
+            "table": self.quote_name(table),
+            "column": self.quote_name(column),
         }
 
-    def skip_default_on_alter(self, field):
-        return field.get_internal_type() in {
-            "SerialField",
-            "BigSerialField",
-            "SmallSerialField",
+    def _drop_identity_sql(self, table, column):
+        return self.sql_drop_indentity % {
+            "table": self.quote_name(table),
+            "column": self.quote_name(column),
         }
+
+    def _create_sequence_sql(self, table, column, data_type):
+        return self.sql_create_sequence % {
+            "sequence": self.quote_name(self._sequence_name(table, column)),
+            "data_type": data_type,
+            "table": self.quote_name(table),
+            "column": self.quote_name(column),
+        }
+
+    def _reset_sequence_sql(self, table, column):
+        return self.sql_reset_sequence % (
+            self.quote_value(table),
+            self.quote_value(column),
+            self.quote_name(column),
+            self.quote_name(column),
+            self.quote_name(table),
+        )
+
+    def _alter_sequence_type_sql(self, sequence, data_type):
+        return self.sql_alter_sequence_type % {
+            "sequence": self.quote_name(sequence),
+            "type": data_type,
+        }
+
+    def _delete_sequence_sql(self, sequence):
+        return self.sql_delete_sequence % {
+            "sequence": self.quote_name(sequence),
+        }
+
+    def _rename_sequence_sql(self, table, old_column, new_column):
+        return self.sql_rename_sequence % (
+            self._sequence_name(table, strip_quotes(old_column)),
+            self._sequence_name(table, strip_quotes(new_column)),
+        )
+
+    def _sequence_name(self, table, column):
+        return f"{table}_{column}_seq"
+
+    def _rename_field_sql(self, table, old_field, new_field, new_type):
+        # Renamed a serial field? Rename the sequence.
+        if (
+            old_field.get_internal_type() in self.serial_field_types
+            and new_field.get_internal_type() in self.serial_field_types
+        ):
+            self.execute(
+                self._rename_sequence_sql(table, old_field.column, new_field.column)
+            )
+
+        return super()._rename_field_sql(table, old_field, new_field, new_type)
+
+    def skip_default(self, field):
+        return field.get_internal_type() in self.serial_field_types

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -932,6 +932,10 @@ docs/current/rangetypes.html#RANGETYPES-INCLUSIVITY>`_.
     much like :class:`~django.db.models.AutoField` except that it does not have
     to be a primary key, and is not limited to a single instance per model.
 
+    It's backed by PostgreSQL's ``serial`` type. See `the PostgreSQL
+    documentation for the full details <https://www.postgresql.org/
+    docs/current/datatype-numeric.html#DATATYPE-SERIAL>`_.
+
 .. class:: BigSerialField(**options)
 
     A 64-bit integer, much like a :class:`SerialField` except that it is

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -920,3 +920,24 @@ define :class:`~django.contrib.postgres.constraints.ExclusionConstraint`. See
 docs/current/rangetypes.html#RANGETYPES-INCLUSIVITY>`_.
 
 .. _different bounds: https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-IO
+
+``Serial`` fields
+=================
+
+.. versionadded:: 5.2
+
+.. class:: SerialField(**options)
+
+    An automatically incrementing :class:`~django.db.models.IntegerField`,
+    much like :class:`~django.db.models.AutoField` except that it does not have
+    to be a primary key, and is not limited to a single instance per model.
+
+.. class:: BigSerialField(**options)
+
+    A 64-bit integer, much like a :class:`SerialField` except that it is
+    guaranteed to fit numbers from ``1`` to ``9223372036854775807``.
+
+.. class:: SmallSerialField(**options)
+
+    A 16-bit integer, much like a :class:`SerialField` except that it is
+    guaranteed to fit numbers from ``1`` to ``32767``.

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -933,8 +933,9 @@ docs/current/rangetypes.html#RANGETYPES-INCLUSIVITY>`_.
     to be a primary key, and is not limited to a single instance per model.
 
     It's backed by PostgreSQL's ``serial`` type. See `the PostgreSQL
-    documentation for the full details <https://www.postgresql.org/
-    docs/current/datatype-numeric.html#DATATYPE-SERIAL>`_.
+    documentation for the full details`_.
+
+.. _`the PostgreSQL documentation for the full details`: https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL
 
 .. class:: BigSerialField(**options)
 

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -933,9 +933,8 @@ docs/current/rangetypes.html#RANGETYPES-INCLUSIVITY>`_.
     to be a primary key, and is not limited to a single instance per model.
 
     It's backed by PostgreSQL's ``serial`` type. See `the PostgreSQL
-    documentation for the full details`_.
-
-.. _`the PostgreSQL documentation for the full details`: https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL
+    documentation for the full details <https://www.postgresql.org/
+    docs/current/datatype-numeric.html#DATATYPE-SERIAL>`__.
 
 .. class:: BigSerialField(**options)
 

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -70,7 +70,10 @@ Minor features
 :mod:`django.contrib.postgres`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* :class:`~django.contrib.postgres.fields.SerialField`,
+  :class:`~django.contrib.postgres.fields.BigSerialField` and
+  :class:`~django.contrib.postgres.fields.SmallSerialField` have been added
+  corresponding to their respective PostgreSQL database types.
 
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -6161,56 +6161,84 @@ class OperationTests(OperationTestBase):
 
         app_label = "test_3650d5bb"
         project_state = self.set_up_test_model(app_label)
-        operation_1 = migrations.AddField("Pony", "foo", SerialField())
-        operation_2 = migrations.RenameField("Pony", "foo", "bar")
-        operation_3 = migrations.RemoveField("Pony", "bar")
+        operation_1 = migrations.AddField("Pony", "serial", SerialField())
+        operation_2 = migrations.RemoveField("Pony", "serial")
+        operation_3 = migrations.AlterField("Pony", "green", SerialField())
+        operation_4 = migrations.AlterField("Pony", "pink", SerialField())
+        operation_5 = migrations.AddField("Pony", "serial_2", SerialField())
         table_name = f"{app_label}_pony"
-
-        # 1. Add field (foo).
-        self.assertColumnNotExists(table_name, "foo")
+        # Add field (serial).
+        self.assertColumnNotExists(table_name, "serial")
         new_state = project_state.clone()
         operation_1.state_forwards(app_label, new_state)
         with connection.schema_editor() as editor:
             operation_1.database_forwards(app_label, editor, project_state, new_state)
-        self.assertColumnExists(table_name, "foo")
-        with connection.cursor() as cursor:
-            seqs = connection.introspection.get_sequences(cursor, table_name)
-        self.assertEqual(["id", "foo"], [seq["column"] for seq in seqs])
-        self.assertEqual(f"{table_name}_foo_seq", seqs[1]["name"])
+        self.assertColumnExists(table_name, "serial")
         Pony = new_state.apps.get_model(app_label, "pony")
         obj_1 = Pony.objects.create(weight=1, green=1)
-        self.assertEqual(obj_1.foo, 1)
+        self.assertEqual(obj_1.serial, 1)
+        self.assertEqual(obj_1.green, 1)
+        self.assertEqual(obj_1.pink, 3)
         obj_2 = Pony.objects.create(weight=1)
-        self.assertEqual(obj_2.foo, 2)
-
-        # 2. Rename field (foo -> bar).
+        self.assertEqual(obj_2.serial, 2)
+        self.assertIsNone(obj_2.green)
+        self.assertEqual(obj_2.pink, 3)
+        # Remove field (serial).
         project_state, new_state = new_state, new_state.clone()
         operation_2.state_forwards(app_label, new_state)
         with connection.schema_editor() as editor:
             operation_2.database_forwards(app_label, editor, project_state, new_state)
-        self.assertColumnNotExists(table_name, "foo")
-        self.assertColumnExists(table_name, "bar")
-        with connection.cursor() as cursor:
-            seqs = connection.introspection.get_sequences(cursor, table_name)
-        self.assertEqual(["id", "bar"], [seq["column"] for seq in seqs])
-        # PostgreSQL doesn't rename the sequence.
-        self.assertEqual(f"{table_name}_foo_seq", seqs[1]["name"])
-        Pony = new_state.apps.get_model(app_label, "pony")
-        obj_1 = Pony.objects.get(id=obj_1.id)
-        self.assertEqual(obj_1.bar, 1)
-        obj_2 = Pony.objects.get(id=obj_2.id)
-        self.assertEqual(obj_2.bar, 2)
-
-        # 3. Remove field (bar).
+        self.assertColumnNotExists(table_name, "serial")
+        # Alter field (green -> SerialField()).
         project_state, new_state = new_state, new_state.clone()
         operation_3.state_forwards(app_label, new_state)
         with connection.schema_editor() as editor:
             operation_3.database_forwards(app_label, editor, project_state, new_state)
-        self.assertColumnNotExists(table_name, "foo")
-        self.assertColumnNotExists(table_name, "bar")
-        with connection.cursor() as cursor:
-            seqs = connection.introspection.get_sequences(cursor, table_name)
-        self.assertEqual(["id"], [seq["column"] for seq in seqs])
+        Pony = new_state.apps.get_model(app_label, "pony")
+        obj_1 = Pony.objects.get(id=obj_1.id)
+        self.assertEqual(obj_1.green, 1)
+        self.assertEqual(obj_1.pink, 3)
+        obj_2 = Pony.objects.get(id=obj_2.id)
+        self.assertEqual(obj_2.green, 2)
+        self.assertEqual(obj_2.pink, 3)
+        # Alter field (pink -> SerialField()).
+        project_state, new_state = new_state, new_state.clone()
+        operation_4.state_forwards(app_label, new_state)
+        with connection.schema_editor() as editor:
+            operation_4.database_forwards(app_label, editor, project_state, new_state)
+        Pony = new_state.apps.get_model(app_label, "pony")
+        obj_1 = Pony.objects.get(id=obj_1.id)
+        self.assertEqual(obj_1.green, 1)
+        self.assertEqual(obj_1.pink, 3)
+        obj_2 = Pony.objects.get(id=obj_2.id)
+        self.assertEqual(obj_2.green, 2)
+        self.assertEqual(obj_2.pink, 3)
+        obj_3 = Pony.objects.create(weight=1)
+        self.assertEqual(obj_3.green, 3)
+        self.assertEqual(obj_3.pink, 4)
+        # Add field (serial_2).
+        self.assertColumnNotExists(table_name, "serial_2")
+        project_state, new_state = new_state, new_state.clone()
+        operation_5.state_forwards(app_label, new_state)
+        with connection.schema_editor() as editor:
+            operation_5.database_forwards(app_label, editor, project_state, new_state)
+        Pony = new_state.apps.get_model(app_label, "pony")
+        obj_1 = Pony.objects.get(id=obj_1.id)
+        self.assertEqual(obj_1.green, 1)
+        self.assertEqual(obj_1.pink, 3)
+        self.assertEqual(obj_1.serial_2, 1)
+        obj_2 = Pony.objects.get(id=obj_2.id)
+        self.assertEqual(obj_2.green, 2)
+        self.assertEqual(obj_2.pink, 3)
+        self.assertEqual(obj_2.serial_2, 2)
+        obj_3 = Pony.objects.get(id=obj_3.id)
+        self.assertEqual(obj_3.green, 3)
+        self.assertEqual(obj_3.pink, 4)
+        self.assertEqual(obj_3.serial_2, 3)
+        obj_4 = Pony.objects.create(weight=1)
+        self.assertEqual(obj_4.green, 4)
+        self.assertEqual(obj_4.pink, 5)
+        self.assertEqual(obj_4.serial_2, 4)
 
 
 class SwappableOperationTests(OperationTestBase):

--- a/tests/postgres_tests/fields.py
+++ b/tests/postgres_tests/fields.py
@@ -11,11 +11,14 @@ try:
     from django.contrib.postgres.fields import (
         ArrayField,
         BigIntegerRangeField,
+        BigSerialField,
         DateRangeField,
         DateTimeRangeField,
         DecimalRangeField,
         HStoreField,
         IntegerRangeField,
+        SerialField,
+        SmallSerialField,
     )
     from django.contrib.postgres.search import SearchVector, SearchVectorField
 except ImportError:
@@ -45,6 +48,7 @@ except ImportError:
 
     ArrayField = DummyArrayField
     BigIntegerRangeField = models.Field
+    BigSerialField = models.Field
     DateRangeField = models.Field
     DateTimeRangeField = DummyContinuousRangeField
     DecimalRangeField = DummyContinuousRangeField
@@ -52,6 +56,8 @@ except ImportError:
     IntegerRangeField = models.Field
     SearchVector = models.Expression
     SearchVectorField = models.Field
+    SerialField = models.Field
+    SmallSerialField = models.Field
 
 
 class EnumField(models.CharField):

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -3,6 +3,7 @@ from django.db import migrations, models
 from ..fields import (
     ArrayField,
     BigIntegerRangeField,
+    BigSerialField,
     DateRangeField,
     DateTimeRangeField,
     DecimalRangeField,
@@ -10,6 +11,8 @@ from ..fields import (
     HStoreField,
     IntegerRangeField,
     SearchVectorField,
+    SerialField,
+    SmallSerialField,
 )
 from ..models import TagField
 
@@ -547,5 +550,26 @@ class Migration(migrations.Migration):
             options={
                 "required_db_vendor": "postgresql",
             },
+        ),
+        migrations.CreateModel(
+            name="SerialModel",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                ("small_serial", SmallSerialField()),
+                ("serial", SerialField()),
+                ("big_serial", BigSerialField()),
+            ],
+            options={
+                "required_db_vendor": "postgresql",
+            },
+            bases=(models.Model,),
         ),
     ]

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -572,4 +572,36 @@ class Migration(migrations.Migration):
             },
             bases=(models.Model,),
         ),
+        migrations.CreateModel(
+            name="SerialPKModel",
+            fields=[
+                ("id", SerialField(primary_key=True)),
+            ],
+            options={
+                "required_db_vendor": "postgresql",
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name="SerialFKModel",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    "fk",
+                    models.ForeignKey("postgres_tests.SerialPKModel", models.CASCADE),
+                ),
+            ],
+            options={
+                "required_db_vendor": "postgresql",
+            },
+            bases=(models.Model,),
+        ),
     ]

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from .fields import (
     ArrayField,
     BigIntegerRangeField,
+    BigSerialField,
     DateRangeField,
     DateTimeRangeField,
     DecimalRangeField,
@@ -10,6 +11,8 @@ from .fields import (
     HStoreField,
     IntegerRangeField,
     SearchVectorField,
+    SerialField,
+    SmallSerialField,
 )
 
 
@@ -203,3 +206,9 @@ class HotelReservation(PostgreSQLModel):
     end = models.DateTimeField()
     cancelled = models.BooleanField(default=False)
     requirements = models.JSONField(blank=True, null=True)
+
+
+class SerialModel(PostgreSQLModel):
+    small_serial = SmallSerialField()
+    serial = SerialField()
+    big_serial = BigSerialField()

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -212,3 +212,11 @@ class SerialModel(PostgreSQLModel):
     small_serial = SmallSerialField()
     serial = SerialField()
     big_serial = BigSerialField()
+
+
+class SerialPKModel(PostgreSQLModel):
+    id = SerialField(primary_key=True)
+
+
+class SerialFKModel(PostgreSQLModel):
+    fk = models.ForeignKey(SerialPKModel, on_delete=models.CASCADE)

--- a/tests/postgres_tests/test_introspection.py
+++ b/tests/postgres_tests/test_introspection.py
@@ -33,3 +33,22 @@ class InspectDBTests(PostgreSQLTestCase):
                 "null=True)",
             ],
         )
+
+    def test_postgres_import(self):
+        out = StringIO()
+        call_command(
+            "inspectdb",
+            "postgres_tests_hotelreservation",
+            "postgres_tests_serialmodel",
+            "postgres_tests_room",
+            stdout=out,
+        )
+        output = out.getvalue()
+        postgres_import = "from django.contrib import postgres"
+        self.assertEqual(output.count(postgres_import), 1, output)
+        self.assertLess(output.find(postgres_import), output.find("class "))
+        self.assertIn(
+            "serial = postgres.fields.SerialField()  "
+            "# You may want to consider using AutoField instead.",
+            output,
+        )

--- a/tests/postgres_tests/test_serial.py
+++ b/tests/postgres_tests/test_serial.py
@@ -1,0 +1,275 @@
+from django.core.exceptions import ValidationError
+from django.core.management.color import no_style
+from django.db import connection, models
+from django.test.utils import isolate_apps
+
+from . import PostgreSQLTestCase
+from .fields import BigSerialField, SerialField, SmallSerialField
+from .models import SerialModel
+
+
+@isolate_apps("postgres_tests")
+class SerialFieldTests(PostgreSQLTestCase):
+    def test_blank_unsupported(self):
+        with self.assertRaisesMessage(ValueError, "SerialField must be blank."):
+            SerialField(blank=False)
+
+    def test_null_unsupported(self):
+        with self.assertRaisesMessage(ValueError, "SerialField must not be null."):
+            SerialField(null=True)
+
+    def test_default_unsupported(self):
+        with self.assertRaisesMessage(ValueError, "SerialField cannot have a default."):
+            SerialField(default=1)
+
+    def test_db_default_unsupported(self):
+        with self.assertRaisesMessage(
+            ValueError, "SerialField cannot have a database default."
+        ):
+            SerialField(db_default=1)
+
+    def test_db_types(self):
+        class Foo(models.Model):
+            small_serial = SmallSerialField()
+            serial = SerialField()
+            big_serial = BigSerialField()
+
+        small_serial = Foo._meta.get_field("small_serial")
+        serial = Foo._meta.get_field("serial")
+        big_serial = Foo._meta.get_field("big_serial")
+
+        self.assertEqual(small_serial.db_type(connection), "smallserial")
+        self.assertEqual(serial.db_type(connection), "serial")
+        self.assertEqual(big_serial.db_type(connection), "bigserial")
+
+        self.assertEqual(small_serial.cast_db_type(connection), "smallint")
+        self.assertEqual(serial.cast_db_type(connection), "integer")
+        self.assertEqual(big_serial.cast_db_type(connection), "bigint")
+
+
+class SerialModelTests(PostgreSQLTestCase):
+    @classmethod
+    def reset_sequences_to_1(cls):
+        with connection.cursor() as cursor:
+            for statement in cls.get_sequence_reset_by_name_sql():
+                cursor.execute(statement)
+
+    @classmethod
+    def get_sequence_reset_by_name_sql(cls):
+        return connection.ops.sequence_reset_by_name_sql(
+            no_style(), cls.get_sequences()
+        )
+
+    @classmethod
+    def get_sequences(cls):
+        with connection.cursor() as cursor:
+            return connection.introspection.get_sequences(
+                cursor, SerialModel._meta.db_table
+            )
+
+    @classmethod
+    def reset_sequences_to_max(cls):
+        with connection.cursor() as cursor:
+            for statement in cls.get_sequence_reset_sql():
+                cursor.execute(statement)
+
+    @classmethod
+    def get_sequence_reset_sql(cls):
+        return connection.ops.sequence_reset_sql(no_style(), [SerialModel])
+
+    def test_create(self):
+        self.reset_sequences_to_1()
+
+        obj_1 = SerialModel.objects.create()
+        self.assertEqual(obj_1.small_serial, 1)
+        self.assertEqual(obj_1.serial, 1)
+        self.assertEqual(obj_1.big_serial, 1)
+
+        obj_2 = SerialModel.objects.create()
+        self.assertEqual(obj_2.small_serial, 2)
+        self.assertEqual(obj_2.serial, 2)
+        self.assertEqual(obj_2.big_serial, 2)
+
+        obj_3 = SerialModel.objects.create(
+            small_serial=None,
+            serial=None,
+            big_serial=None,
+        )
+        self.assertEqual(obj_3.small_serial, 3)
+        self.assertEqual(obj_3.serial, 3)
+        self.assertEqual(obj_3.big_serial, 3)
+
+        obj_4 = SerialModel.objects.create(
+            small_serial=111,
+            serial=222,
+            big_serial=333,
+        )
+        self.assertEqual(obj_4.small_serial, 111)
+        self.assertEqual(obj_4.serial, 222)
+        self.assertEqual(obj_4.big_serial, 333)
+
+        obj_5 = SerialModel.objects.create()
+        self.assertEqual(obj_5.small_serial, 4)
+        self.assertEqual(obj_5.serial, 4)
+        self.assertEqual(obj_5.big_serial, 4)
+
+        obj_6 = SerialModel.objects.create()
+        self.assertEqual(obj_6.small_serial, 5)
+        self.assertEqual(obj_6.serial, 5)
+        self.assertEqual(obj_6.big_serial, 5)
+
+        obj_7 = SerialModel.objects.create()
+        self.assertEqual(obj_7.small_serial, 6)
+        self.assertEqual(obj_7.serial, 6)
+        self.assertEqual(obj_7.big_serial, 6)
+
+        obj_8 = SerialModel.objects.create(
+            small_serial=1,
+            serial=1,
+            big_serial=1,
+        )
+        self.assertEqual(obj_8.small_serial, 1)
+        self.assertEqual(obj_8.serial, 1)
+        self.assertEqual(obj_8.big_serial, 1)
+
+        obj_9 = SerialModel.objects.create()
+        self.assertEqual(obj_9.small_serial, 7)
+        self.assertEqual(obj_9.serial, 7)
+        self.assertEqual(obj_9.big_serial, 7)
+
+    def test_full_clean_success(self):
+        small_lo, small_hi = (-32768, 32767)
+        lo, hi = (-2147483648, 2147483647)
+        big_lo, big_hi = (-9223372036854775808, 9223372036854775807)
+        test_cases = (
+            {},
+            {"small_serial": None},
+            {"serial": None},
+            {"big_serial": None},
+            {"small_serial": small_lo},
+            {"small_serial": small_hi},
+            {"serial": lo},
+            {"serial": hi},
+            {"big_serial": big_lo},
+            {"big_serial": big_hi},
+        )
+
+        for kwargs in test_cases:
+            with self.subTest(kwargs=kwargs):
+                SerialModel(**kwargs).full_clean()
+
+    def test_full_clean_failure(self):
+        small_lo, small_hi = (-32768, 32767)
+        lo, hi = (-2147483648, 2147483647)
+        big_lo, big_hi = (-9223372036854775808, 9223372036854775807)
+        lte = "Ensure this value is less than or equal to %s."
+        gte = "Ensure this value is greater than or equal to %s."
+        test_cases = (
+            ({"small_serial": small_hi + 1}, [lte % small_hi]),
+            ({"serial": hi + 1}, [lte % hi]),
+            ({"big_serial": big_hi + 1}, [lte % big_hi]),
+            ({"small_serial": small_lo - 1}, [gte % small_lo]),
+            ({"serial": lo - 1}, [gte % lo]),
+            ({"big_serial": big_lo - 1}, [gte % big_lo]),
+        )
+
+        for kwargs, messages in test_cases:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(ValidationError) as ctx:
+                    SerialModel(**kwargs).full_clean()
+
+                self.assertSequenceEqual(ctx.exception.messages, messages)
+
+    def test_get_sequences(self):
+        sequences = self.get_sequences()
+
+        table = SerialModel._meta.db_table
+        self.assertEqual(len(sequences), 4)
+        self.assertEqual(sequences[0]["column"], "id")
+        self.assertEqual(sequences[0]["name"], f"{table}_id_seq")
+        self.assertEqual(sequences[0]["table"], table)
+        self.assertEqual(sequences[1]["column"], "small_serial")
+        self.assertEqual(sequences[1]["name"], f"{table}_small_serial_seq")
+        self.assertEqual(sequences[1]["table"], table)
+        self.assertEqual(sequences[2]["column"], "serial")
+        self.assertEqual(sequences[2]["name"], f"{table}_serial_seq")
+        self.assertEqual(sequences[2]["table"], table)
+        self.assertEqual(sequences[3]["column"], "big_serial")
+        self.assertEqual(sequences[3]["name"], f"{table}_big_serial_seq")
+        self.assertEqual(sequences[3]["table"], table)
+
+    def test_get_sequence_reset_sql(self):
+        def get_statement(field):
+            db_table = SerialModel._meta.db_table
+            return (
+                f"SELECT setval("
+                f"pg_get_serial_sequence('\"{db_table}\"','{field}'), "
+                f'coalesce(max("{field}"), 1), '
+                f'max("{field}") IS NOT null'
+                f') FROM "{db_table}";'
+            )
+
+        statements = self.get_sequence_reset_sql()
+        self.assertEqual(len(statements), 4)
+        self.assertEqual(statements[0], get_statement("id"))
+        self.assertEqual(statements[1], get_statement("small_serial"))
+        self.assertEqual(statements[2], get_statement("serial"))
+        self.assertEqual(statements[3], get_statement("big_serial"))
+
+    def test_reset_sequences_to_max_if_record_exists(self):
+        obj_1 = SerialModel.objects.create(small_serial=1, serial=2, big_serial=3)
+        self.assertEqual(obj_1.small_serial, 1)
+        self.assertEqual(obj_1.serial, 2)
+        self.assertEqual(obj_1.big_serial, 3)
+
+        self.reset_sequences_to_max()
+
+        obj_2 = SerialModel.objects.create()
+        self.assertEqual(obj_2.small_serial, 2)
+        self.assertEqual(obj_2.serial, 3)
+        self.assertEqual(obj_2.big_serial, 4)
+
+        obj_3 = SerialModel.objects.create()
+        self.assertEqual(obj_3.small_serial, 3)
+        self.assertEqual(obj_3.serial, 4)
+        self.assertEqual(obj_3.big_serial, 5)
+
+    def test_reset_sequences_to_max_if_record_doesnt_exist(self):
+        self.reset_sequences_to_max()
+
+        obj_1 = SerialModel.objects.create()
+        self.assertEqual(obj_1.small_serial, 1)
+        self.assertEqual(obj_1.serial, 1)
+        self.assertEqual(obj_1.big_serial, 1)
+
+        obj_2 = SerialModel.objects.create()
+        self.assertEqual(obj_2.small_serial, 2)
+        self.assertEqual(obj_2.serial, 2)
+        self.assertEqual(obj_2.big_serial, 2)
+
+    def test_bulk_create(self):
+        self.reset_sequences_to_1()
+        objs = [
+            SerialModel(),
+            SerialModel(small_serial=1, serial=1, big_serial=1),
+            SerialModel(serial=5),
+            SerialModel(),
+        ]
+
+        obj_1, obj_2, obj_3, obj_4 = SerialModel.objects.bulk_create(objs)
+        self.assertEqual(
+            (obj_1.small_serial, obj_1.serial, obj_1.big_serial),
+            (1, 1, 1),
+        )
+        self.assertEqual(
+            (obj_2.small_serial, obj_2.serial, obj_2.big_serial),
+            (1, 1, 1),
+        )
+        self.assertEqual(
+            (obj_3.small_serial, obj_3.serial, obj_3.big_serial),
+            (2, 5, 2),
+        )
+        self.assertEqual(
+            (obj_4.small_serial, obj_4.serial, obj_4.big_serial),
+            (3, 2, 3),
+        )


### PR DESCRIPTION
# Trac ticket number
ticket-27452

# Branch description
Added `SmallSerialField`, `SerialField`, `BigSerialField` to `contrib.postgres`.

[Previous PR](https://github.com/django/django/pull/12989)
[Composite PK](https://github.com/django/django/pull/18056)

!!! A more basic implementation can be found in [this PR](https://github.com/django/django/pull/18280). !!!

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
