### PR TITLE
Refs #35359 -- Removed unnecessary use of Concat() in GeneratedField test.

### DIFF
--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -8,7 +8,7 @@ from django.db.migrations.operations.fields import FieldOperation
 from django.db.migrations.state import ModelState, ProjectState
 from django.db.models import F
 from django.db.models.expressions import Value
-from django.db.models.functions import Abs, Concat, Pi
+from django.db.models.functions import Abs, Pi
 from django.db.transaction import atomic
 from django.test import (
     SimpleTestCase,
@@ -1389,7 +1389,7 @@ class OperationTests(OperationTestBase):
                     "Pony",
                     fields=[
                         ("id", models.AutoField(primary_key=True)),
-                        ("name", models.CharField(max_length=20)),
+                        ("pink", models.IntegerField()),
                         (
                             "rider",
                             models.ForeignKey(
@@ -1397,10 +1397,10 @@ class OperationTests(OperationTestBase):
                             ),
                         ),
                         (
-                            "name_and_id",
+                            "pink_plus_rider",
                             models.GeneratedField(
-                                expression=Concat(("name"), ("rider_id")),
-                                output_field=models.TextField(),
+                                expression=F("pink") + F("rider_id"),
+                                output_field=models.IntegerField(),
                                 db_persist=True,
                             ),
                         ),
@@ -1411,14 +1411,8 @@ class OperationTests(OperationTestBase):
         Pony = project_state.apps.get_model(app_label, "Pony")
         Rider = project_state.apps.get_model(app_label, "Rider")
         rider = Rider.objects.create()
-        pony = Pony.objects.create(name="pony", rider=rider)
-        self.assertEqual(pony.name_and_id, str(pony.name) + str(rider.id))
-
-        new_rider = Rider.objects.create()
-        pony.rider = new_rider
-        pony.save()
-        pony.refresh_from_db()
-        self.assertEqual(pony.name_and_id, str(pony.name) + str(new_rider.id))
+        pony = Pony.objects.create(pink=3, rider=rider)
+        self.assertEqual(pony.pink_plus_rider, 3 + rider.id)
 
     def test_add_charfield(self):
         """


### PR DESCRIPTION
OperationTests.test_add_generate_field back ported to 5.0 and used 
Concat(), which in Django 5.0 is not immutable on PostgreSQL and cannot 
be used in GeneratedField, see 6364b6ee1071381eb3a23ba6b821fc0d6f0fce75.

# Trac ticket number

Related to ticket-35359

# Branch description

`OperationTests.test_add_generate_field` fails with `django.db.utils.ProgrammingError: generation expression is not immutable` in the Django 5.0 CI for postgres and postgis: https://djangoci.com/job/django-5.0/

The original test `OperationTests.test_add_generate_field` is "extra" and does not fail when the changes of ticket-35359 are reverted and only confirms that we can add GeneratedFields after FKs. 

Another option is remove the test entirely.


# Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
