### PR TITLE
Refs #31224 -- Fixed typo in django/test/client.py.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -688,7 +688,7 @@ class AsyncRequestFactory(RequestFactory):
     Once you have a request object you can pass it to any view function,
     including synchronous ones. The reason we have a separate class here is:
     a) this makes ASGIRequest subclasses, and
-    b) AsyncTestClient can subclass it.
+    b) AsyncClient can subclass it.
     """
 
     def _base_scope(self, **request):


### PR DESCRIPTION
# Trac ticket number
ticket-31224

# Branch description
Apparently when the asynchronous test client was added in ticket-31224 there was a small typo in a docstring which got me confused for a while (there is no `AsyncTestClient` in the source code!).

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.