### PR TITLE
Fixed #35425 -- Avoided INSERT with force_update and explicit pk.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1088,6 +1088,7 @@ class Model(AltersData, metaclass=ModelBase):
         if (
             not raw
             and not force_insert
+            and not force_update
             and self._state.adding
             and (
                 (meta.pk.default and meta.pk.default is not NOT_PROVIDED)

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -186,6 +186,12 @@ class ModelInstanceCreationTests(TestCase):
         with self.assertNumQueries(1):
             PrimaryKeyWithDefault().save()
 
+    def test_save_primary_with_default_force_update(self):
+        # An UPDATE attempt is made if explicitly requested.
+        obj = PrimaryKeyWithDefault.objects.create()
+        with self.assertNumQueries(1):
+            PrimaryKeyWithDefault(uuid=obj.pk).save(force_update=True)
+
     def test_save_primary_with_db_default(self):
         # An UPDATE attempt is skipped when a primary key has db_default.
         with self.assertNumQueries(1):


### PR DESCRIPTION
# Trac ticket number

ticket-35425

# Branch description
Allows `force_update=True` to issue an `UPDATE` when saving instances with explicit pk's (but where the field happened to have a default pk) as envisioned in ticket-29260.

Affected models where the primary key field is defined with a default or db_default, such as UUIDField.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
