### PR TITLE
`prefetch_related_objects` fails to cache UUID FKs when the string representation of a UUID is used

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -766,7 +766,7 @@ class ForeignObject(RelatedField):
                 ):
                     ret.append(instance.pk)
                     continue
-            ret.append(getattr(instance, field.attname))
+            ret.append(field.to_python(getattr(instance, field.attname)))
         return tuple(ret)
 
     def get_attname_column(self):

--- a/tests/prefetch_related/models.py
+++ b/tests/prefetch_related/models.py
@@ -306,6 +306,11 @@ class Pet(models.Model):
     people = models.ManyToManyField(Person, related_name="pets")
 
 
+class Toy(models.Model):
+    pet = models.ForeignKey(Pet, models.CASCADE, related_name="toys")
+    name = models.CharField(max_length=20)
+
+
 class Flea(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     current_room = models.ForeignKey(

--- a/tests/prefetch_related/test_uuid.py
+++ b/tests/prefetch_related/test_uuid.py
@@ -57,9 +57,7 @@ class UUIDPrefetchRelated(TestCase):
         pet = Pet.objects.create(name="Fifi")
         toy_ball = Toy(pet_id=pet.id, name="Ball")
         toy_bone = Toy(pet_id=str(pet.id), name="Bone")
-        prefetch_related_objects(
-            [toy_ball, toy_bone], "pet"
-        )
+        prefetch_related_objects([toy_ball, toy_bone], "pet")
         self.assertEqual(pet, toy_ball.pet)
         self.assertEqual(pet, toy_bone.pet)
 

--- a/tests/prefetch_related/test_uuid.py
+++ b/tests/prefetch_related/test_uuid.py
@@ -1,6 +1,7 @@
+from django.db.models import prefetch_related_objects
 from django.test import TestCase
 
-from .models import Flea, House, Person, Pet, Room
+from .models import Flea, House, Person, Pet, Room, Toy
 
 
 class UUIDPrefetchRelated(TestCase):
@@ -51,6 +52,16 @@ class UUIDPrefetchRelated(TestCase):
             Pet.objects.prefetch_related("fleas_hosted").values_list("id", flat=True),
             [pet.id],
         )
+
+    def test_prefetch_related_objects_str_as_uuid_fk(self):
+        pet = Pet.objects.create(name="Fifi")
+        toy_ball = Toy(pet_id=pet.id, name="Ball")
+        toy_bone = Toy(pet_id=str(pet.id), name="Bone")
+        prefetch_related_objects(
+            [toy_ball, toy_bone], "pet"
+        )
+        self.assertEqual(pet, toy_ball.pet)
+        self.assertEqual(pet, toy_bone.pet)
 
 
 class UUIDPrefetchRelatedLookups(TestCase):

--- a/tests/prefetch_related/test_uuid.py
+++ b/tests/prefetch_related/test_uuid.py
@@ -58,8 +58,9 @@ class UUIDPrefetchRelated(TestCase):
         toy_ball = Toy(pet_id=pet.id, name="Ball")
         toy_bone = Toy(pet_id=str(pet.id), name="Bone")
         prefetch_related_objects([toy_ball, toy_bone], "pet")
-        self.assertEqual(pet, toy_ball.pet)
-        self.assertEqual(pet, toy_bone.pet)
+        with self.assertNumQueries(0):
+            self.assertEqual(pet, toy_ball.pet)
+            self.assertEqual(pet, toy_bone.pet)
 
 
 class UUIDPrefetchRelatedLookups(TestCase):


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35434

# Branch description
Added unit test to reproduce the issue in the title.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
