### PR TITLE
Added release notes for 5.0.6 and 4.2.13.

### DIFF
--- a/docs/releases/4.2.13.txt
+++ b/docs/releases/4.2.13.txt
@@ -1,0 +1,7 @@
+===========================
+Django 4.2.13 release notes
+===========================
+
+*May 7, 2024*
+
+Django 4.2.13 fixes a packaging error in 4.2.12.

--- a/docs/releases/5.0.6.txt
+++ b/docs/releases/5.0.6.txt
@@ -1,0 +1,7 @@
+==========================
+Django 5.0.6 release notes
+==========================
+
+*May 7, 2024*
+
+Django 5.0.6 fixes a packaging error in 5.0.5.

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -32,6 +32,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   5.0.6
    5.0.5
    5.0.4
    5.0.3
@@ -45,6 +46,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   4.2.13
    4.2.12
    4.2.11
    4.2.10


### PR DESCRIPTION
5.0.5 and 4.2.13 were released using windows and this has caused some problems. 
See: https://mastodon.social/@mgorny@treehouse.systems/112399968234268478