### PR TITLE
Fixed #35436 -- Fixed displaying Unicode chars in `postgres.forms.HStoreField`

### DIFF
--- a/django/contrib/postgres/forms/hstore.py
+++ b/django/contrib/postgres/forms/hstore.py
@@ -20,7 +20,7 @@ class HStoreField(forms.CharField):
 
     def prepare_value(self, value):
         if isinstance(value, dict):
-            return json.dumps(value)
+            return json.dumps(value, ensure_ascii=False)
         return value
 
     def to_python(self, value):

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -410,6 +410,13 @@ class TestFormField(PostgreSQLSimpleTestCase):
         form_w_hstore = HStoreFormTest({"f1": '{"a": 2}'}, initial={"f1": {"a": 1}})
         self.assertTrue(form_w_hstore.has_changed())
 
+    def test_prepare_value(self):
+        field = forms.HStoreField()
+        self.assertEqual(
+            field.prepare_value({"aira_maplayer": "Αρδευτικό δίκτυο"}),
+            '{"aira_maplayer": "Αρδευτικό δίκτυο"}',
+        )
+
 
 class TestValidator(PostgreSQLSimpleTestCase):
     def test_simple_valid(self):


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-35436](https://code.djangoproject.com/ticket/35436)

# Branch description

I applied [ticket-32080](https://code.djangoproject.com/ticket/32080) to HStoreField because it does not apply to `contrib.postgres.forms.HStoreField.prepare_value` when resolved as stated in the ticket.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
