### PR TITLE
Removed PY36 and PY37 version constants.

### DIFF
--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -13,8 +13,6 @@ PYPY = sys.implementation.name == "pypy"
 # or later". So that third-party apps can use these values, each constant
 # should remain as long as the oldest supported Django version supports that
 # Python version.
-PY36 = sys.version_info >= (3, 6)
-PY37 = sys.version_info >= (3, 7)
 PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
 PY310 = sys.version_info >= (3, 10)


### PR DESCRIPTION
~We could also remove PY310 as we are not using it but it _could_ be used in future.~