### PR TITLE
Fixed #35434 -- Advised validating unfetched instances before testing result cache.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -4158,6 +4158,9 @@ lookups or :class:`Prefetch` objects you want to prefetch for. For example:
     >>> restaurants = fetch_top_restaurants_from_cache()  # A list of Restaurants
     >>> prefetch_related_objects(restaurants, "pizzas__toppings")
 
+Validating primary keys may be necessary on
+:ref:`unfetched model instances <caching-and-querysets>`.
+
 When using multiple databases with ``prefetch_related_objects``, the prefetch
 query will use the database associated with the model instance. This can be
 overridden by using a custom queryset in a related lookup.

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -896,6 +896,40 @@ reuse it:
     >>> print([p.headline for p in queryset])  # Evaluate the query set.
     >>> print([p.pub_date for p in queryset])  # Reuse the cache from the evaluation.
 
+.. admonition:: Validate unfetched instances before comparing to the cache
+
+    Because the result cache consists of Python objects, you need may need to
+    validate unfetched instances to obtain the correct Python type for the
+    primary key.
+
+    .. code-block:: pycon
+
+        from django.db import models
+
+        class DailyEntry(models.Model):
+            day = models.DateField(primary_key=True)
+            headline = models.CharField(max_length=255)
+
+            def __str__(self):
+                return f"{self.headline} ({self.day})"
+
+        >>> from datetime import date
+        >>> entry1 = DailyEntry.objects.create(
+                day=date(2020, 1, 1),
+                headline="Happy New Year!",
+            )
+        >>> entry2 = DailyEntry(day="2020-01-01", headline="Happy New Year!")
+        >>> all_entries = DailyEntry.objects.all()
+        >>> all_entries.contains(entry2)
+        True
+        >>> list(all_entries)  # Populate cache.
+        [<DailyEntry: Happy New Year! (2020-01-01)>]
+        >>> all_entries.contains(entry2)
+        False
+        >>> entry2.full_clean(validate_unique=False)
+        >>> all_entries.contains(entry2)
+        True
+
 When ``QuerySet``\s are not cached
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Trac ticket number

ticket-35434

# Branch description
Clarify in the discussion of queryset caching that validating the primary key field on unfetched instances may be necessary when testing against the result cache.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
