### PR TITLE
Fixed #35428 -- Increased parallelism parameter for the ScryptPasswordHasher.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -570,7 +570,7 @@ class ScryptPasswordHasher(BasePasswordHasher):
     algorithm = "scrypt"
     block_size = 8
     maxmem = 0
-    parallelism = 1
+    parallelism = 5
     work_factor = 2**14
 
     def encode(self, password, salt, n=None, r=None, p=None):

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -46,6 +46,9 @@ Minor features
 * The default iteration count for the PBKDF2 password hasher is increased from
   720,000 to 870,000.
 
+* In order to follow OWASP recommendations, the default ``parallelism`` of the
+  ``ScryptPasswordHasher`` is increased from 1 to 5.
+
 * :class:`~django.contrib.auth.forms.BaseUserCreationForm` and
   :class:`~django.contrib.auth.forms.AdminPasswordChangeForm` now support
   disabling password-based authentication by setting an unusable password on

--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -650,8 +650,8 @@ class TestUtilsHashPassScrypt(SimpleTestCase):
         encoded = make_password("lètmein", "seasalt", "scrypt")
         self.assertEqual(
             encoded,
-            "scrypt$16384$seasalt$8$1$Qj3+9PPyRjSJIebHnG81TMjsqtaIGxNQG/aEB/NY"
-            "afTJ7tibgfYz71m0ldQESkXFRkdVCBhhY8mx7rQwite/Pw==",
+            "scrypt$16384$seasalt$8$5$ECMIUp+LMxMSK8xB/IVyba+KYGTI7FTnet025q/1f"
+            "/vBAVnnP3hdYqJuRi+mJn6ji6ze3Fbb7JEFPKGpuEf5vw==",
         )
         self.assertIs(is_password_usable(encoded), True)
         self.assertIs(check_password("lètmein", encoded), True)


### PR DESCRIPTION
# Trac ticket number

[ticket-35428](https://code.djangoproject.com/ticket/35428)

# Branch description
I modified the `parallelism` value of the `ScriptPasswordHasher` to the value recommended by [OAWSP](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#scrypt:~:text=and%20RAM%20usage.-,scrypt,%C2%B6,-scrypt%20is%20a). For other options, increasing `N=2^x` would exceed the specified limited memory, so I did not want to increase the parameters of `maxmem`, so I only increased the parallelism value.

I think the best value is this option.
`N=2^14 (16 MiB), r=8 (1024 bytes), p=5`

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
