### PR TITLE
Fix broken URL in docs.

### DIFF
--- a/docs/faq/general.txt
+++ b/docs/faq/general.txt
@@ -88,9 +88,10 @@ under a permissive open source license. :source:`A copy of the Python license
 Which sites use Django?
 =======================
 
-`DjangoSites.org`_ features a constantly growing list of Django-powered sites.
+`BuiltWithDjango.com`_ features a constantly growing list of Django-powered
+sites.
 
-.. _DjangoSites.org: https://djangosites.org
+.. _BuiltWithDjango.com: https://builtwithdjango.com/projects/
 
 .. _faq-mtv:
 


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A
# Branch description
In the faq/general at "which websites uses django" the URL will no longer work [see this](https://www.rossp.org/blog/farewell-djangosites/?utm_source=djangosites.org&utm_medium=redirect&utm_campaign=djangosites-farewell). So I replaced it with https://builtwithdjango.com/projects.
# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
