### PR TITLE
Fixed pre-commit ESLint configuration.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,15 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.2.0
+  - repo: local
     hooks:
-      - id: eslint
+    - id: eslint
+      name: eslint
+      language: node
+      additional_dependencies:
+      - 'eslint@9.2.0'
+      - '@eslint/js@9.2.0'
+      - 'globals@15.2.0'
+      entry: eslint
+      types_or:
+      - javascript


### PR DESCRIPTION
# Trac ticket number

N/A

# Branch description

Broken in https://github.com/django/django/pull/18133 because the mirrors-eslint package does not depend on @eslint/js or globals, leading to the error:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals' imported from /.../django/eslint.config.mjs
```

The simplest solution is to instead use a local hook, as done in this PR. This will require manual updates, but that’s the same as we have for the configuration in `package.json`.

(I put a lot of time into researching options for this upgrade, for my recommendations in Boost Your Django DX. I don’t think the mirrors-eslint repository is going to be usable because there are various packages one wants to pull in for eslint now.)

Tested with:

```console
$ pre-commit run eslint -a
eslint...................................................................Passed
```

Also ensured that failures would work by patching `eslint.config.mjs` to require weird indentation:

```diff
@@ -11,7 +11,7 @@ export default [
             "curly": ["error", "all"],
             "dot-notation": ["error", {"allowKeywords": true}],
             "eqeqeq": ["error"],
-            "indent": ["error", 4],
+            "indent": ["error", 7],
             "key-spacing": ["error", {"beforeColon": false, "afterColon": true}],
             "linebreak-style": ["error", "unix"],
             "new-cap": ["off", {"newIsCap": true, "capIsNew": true}],

```

This made ESLint report many errors:

```console
$ pre-commit run eslint -a
eslint...................................................................Failed
- hook id: eslint
- exit code: 1


/.../django/django/contrib/admin/static/admin/js/inlines.js
   20:1  error  Expected indentation of 7 spaces but found 4    indent
   ...
```

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
