### PR TITLE
Refs #29942 -- Avoided Python 3.9+ syntax in docs build.

### DIFF
--- a/docs/_ext/github_links.py
+++ b/docs/_ext/github_links.py
@@ -41,10 +41,10 @@ class CodeLocator(ast.NodeVisitor):
                 file = module_name_to_file_path(node.module)
                 file_contents = file.read_text(encoding="utf-8")
                 locator = CodeLocator.from_code(file_contents)
-                self.import_locations |= locator.import_locations
-                self.import_locations |= {
-                    n: node.module for n in locator.node_line_numbers if "." not in n
-                }
+                self.import_locations.update(locator.import_locations)
+                self.import_locations.update(
+                    {n: node.module for n in locator.node_line_numbers if "." not in n}
+                )
             else:
                 self.import_locations[alias.name] = ("." * node.level) + (
                     node.module or ""


### PR DESCRIPTION
Djangoproject.com uses Python 3.8 and therefore the docs build process needs to be compatible with this version.

Dict union operator was added in Python 3.9.

# Trac ticket number

Ticket-29942

# Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
