### PR TITLE
Fixed typos in test docstrings.

### DIFF
--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2652,7 +2652,7 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
             urls.urlpatterns = old_urlpatterns
 
     def test_project_template_tarball_url(self):
-        """ "
+        """
         Startproject management command handles project template tar/zip balls
         from non-canonical urls.
         """

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -3927,7 +3927,7 @@ class AdminViewStringPrimaryKeyTest(TestCase):
                 )
 
     def test_deleteconfirmation_link(self):
-        """ "
+        """
         The link from the delete confirmation page referring back to the
         changeform of the object should be quoted.
         """


### PR DESCRIPTION
Before:

```
./runtests.py admin_views.tests.AdminViewStringPrimaryKeyTest.test_deleteconfirmation_link -v2
...
System check identified no issues (1 silenced).
test_deleteconfirmation_link (admin_views.tests.AdminViewStringPrimaryKeyTest)
" ... ok

----------------------------------------------------------------------
Ran 1 test in 0.359s

OK
```

After:

```
./runtests.py admin_views.tests.AdminViewStringPrimaryKeyTest.test_deleteconfirmation_link -v2
...
System check identified no issues (1 silenced).
test_deleteconfirmation_link (admin_views.tests.AdminViewStringPrimaryKeyTest)
The link from the delete confirmation page referring back to the ... ok

----------------------------------------------------------------------
Ran 1 test in 0.542s

OK
```