### PR TITLE
Fixed #35443 -- Changed ordinal to return negative integers as is.

### DIFF
--- a/django/contrib/humanize/templatetags/humanize.py
+++ b/django/contrib/humanize/templatetags/humanize.py
@@ -24,12 +24,14 @@ register = template.Library()
 def ordinal(value):
     """
     Convert an integer to its ordinal as a string. 1 is '1st', 2 is '2nd',
-    3 is '3rd', etc. Works for any integer.
+    3 is '3rd', etc. Works for any non-negative integer.
     """
     try:
         value = int(value)
     except (TypeError, ValueError):
         return value
+    if value < 0:
+        return str(value)
     if value % 100 in (11, 12, 13):
         # Translators: Ordinal format for 11 (11th), 12 (12th), and 13 (13th).
         value = pgettext("ordinal 11, 12, 13", "{}th").format(value)

--- a/docs/ref/contrib/humanize.txt
+++ b/docs/ref/contrib/humanize.txt
@@ -143,3 +143,4 @@ Examples:
 * ``3`` becomes ``3rd``.
 
 You can pass in either an integer or a string representation of an integer.
+Negative integers are returned unchanged.

--- a/tests/humanize_tests/tests.py
+++ b/tests/humanize_tests/tests.py
@@ -55,6 +55,9 @@ class HumanizeTests(SimpleTestCase):
             "102",
             "103",
             "111",
+            "-0",
+            "-1",
+            "-105",
             "something else",
             None,
         )
@@ -70,6 +73,9 @@ class HumanizeTests(SimpleTestCase):
             "102nd",
             "103rd",
             "111th",
+            "0th",
+            "-1",
+            "-105",
             "something else",
             None,
         )


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35443

# Branch description
"-1st", "-2nd" and so on are incorrect words. Function `ordinal` in module `humanize` has been changed to return negative number "as is", so that for example `-1` is converted to `"-1"`.

The changes corresponds to alternative 1 of the suggested solutions in ticket #35443, which was accepted by Sarah Boyce.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
