### PR TITLE
Fixed #1509 -- Added clear documentation in tutorial 1 docs to avoid confusion

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -289,8 +289,8 @@ In the ``polls/urls.py`` file include the following code:
         path("", views.index, name="index"),
     ]
 
-The next step is to point the root URLconf at the ``polls.urls`` module. In
-``mysite/urls.py``, add an import for ``django.urls.include`` and insert an
+The next step is to point the root URLconf at the ``polls.urls`` module. Go back into the project root directory ``/mysite/``, and open the file 
+``mysite/urls.py``. Here, add an import for ``django.urls.include`` and insert an
 :func:`~django.urls.include` in the ``urlpatterns`` list, so you have:
 
 .. code-block:: python


### PR DESCRIPTION
Modified the tutorial 1 documentation on the polls app. ([django#1509](https://github.com/django/djangoproject.com/issues/1509))

There was a possibility of confusion to occur that the user might create a new "urls.py" file in the root "mysite" directory instead of adding code into the existing "urls.py" file inside the inner "mysite" directory, in the sentence

`The next step is to point the root URLconf at the polls.urls module. In mysite/urls.py, add an import for django.urls.include and insert an include() in the urlpatterns list, so you have...`
