### PR TITLE
Fixed #35449 -- Fixed validation issue with SplitArrayField when remove_trailing_nulls=True

### DIFF
--- a/django/contrib/postgres/forms/array.py
+++ b/django/contrib/postgres/forms/array.py
@@ -228,13 +228,10 @@ class SplitArrayField(forms.Field):
                         params={"nth": index + 1},
                     )
                 )
-                cleaned_data.append(None)
-            else:
-                errors.append(None)
+                cleaned_data.append(item)
         cleaned_data, null_index = self._remove_trailing_nulls(cleaned_data)
         if null_index is not None:
             errors = errors[:null_index]
-        errors = list(filter(None, errors))
         if errors:
             raise ValidationError(list(chain.from_iterable(errors)))
         return cleaned_data

--- a/docs/releases/5.0.7.txt
+++ b/docs/releases/5.0.7.txt
@@ -9,4 +9,5 @@ Django 5.0.7 fixes several bugs in 5.0.6.
 Bugfixes
 ========
 
-* ...
+* Fixed a bug in ``SplitArrayField`` where validation did not work properly 
+  when ``remove_trailing_nulls=True`` (:ticket:`35449`).

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -1339,6 +1339,22 @@ class TestSplitFormField(PostgreSQLSimpleTestCase):
             ],
         )
 
+    def test_invalid_char_length_with_remove_trailing_nulls(self):
+        field = SplitArrayField(
+            forms.CharField(max_length=2),
+            size=3,
+            remove_trailing_nulls=True,
+        )
+        with self.assertRaises(exceptions.ValidationError) as cm:
+            field.clean(["abc", "", ""])
+        self.assertEqual(
+            cm.exception.messages,
+            [
+                "Item 1 in the array did not validate: Ensure this value has at most 2 "
+                "characters (it has 3).",
+            ],
+        )
+
     def test_splitarraywidget_value_omitted_from_data(self):
         class Form(forms.ModelForm):
             field = SplitArrayField(forms.IntegerField(), required=False, size=2)


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-35449](https://code.djangoproject.com/ticket/35449)

# Branch description
The proposed changes ensure that trailing null values are correctly removed before validation occurs, and that errors are appropriately handled.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
