### PR TITLE
Used docs_url variable in docs link

### DIFF
--- a/django/views/templates/csrf_403.html
+++ b/django/views/templates/csrf_403.html
@@ -53,7 +53,7 @@
     <li>Your browser is accepting cookies.</li>
 
     <li>The view function passes a <code>request</code> to the template’s <a
-    href="https://docs.djangoproject.com/en/dev/topics/templates/#django.template.backends.base.Template.render"><code>render</code></a>
+    href="https://docs.djangoproject.com/en/{{ docs_version }}/topics/templates/#django.template.backends.base.Template.render"><code>render</code></a>
     method.</li>
 
     <li>In the template, there is a <code>{% templatetag openblock %} csrf_token

--- a/tests/view_tests/tests/test_csrf.py
+++ b/tests/view_tests/tests/test_csrf.py
@@ -132,3 +132,15 @@ class CsrfViewTests(SimpleTestCase):
         with mock.patch.object(Path, "open") as m:
             csrf_failure(mock.MagicMock(), mock.Mock())
             m.assert_called_once_with(encoding="utf-8")
+
+    @override_settings(DEBUG=True)
+    @mock.patch("django.views.csrf.get_docs_version", return_value="4.2")
+    def test_doc_links(self, mocked_get_complete_version):
+        response = self.client.post("/")
+        self.assertContains(response, "Forbidden", status_code=403)
+        self.assertNotContains(
+            response, "https://docs.djangoproject.com/en/dev/", status_code=403
+        )
+        self.assertContains(
+            response, "https://docs.djangoproject.com/en/4.2/", status_code=403
+        )


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description
Use the `{{ docs_version }}` template variable instead of hardcoding a link to the dev version.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
