### PR TITLE
Updated docs to prefer QuerySet.none() as a default for dynamic queryset form field kwargs

### DIFF
--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -1345,12 +1345,13 @@ model object (in the case of ``ModelChoiceField``) or multiple model
 objects (in the case of ``ModelMultipleChoiceField``) into the
 ``cleaned_data`` dictionary of the form.
 
-For more complex uses, you can specify ``queryset=None`` when declaring the
-form field and then populate the ``queryset`` in the form's ``__init__()``
+For more complex uses, you can specify ``queryset=Foo.objects.none()`` when
+declaring the form field and then populate the ``queryset`` in the form's
+``__init__()``
 method::
 
     class FooMultipleChoiceForm(forms.Form):
-        foo_select = forms.ModelMultipleChoiceField(queryset=None)
+        foo_select = forms.ModelMultipleChoiceField(queryset=Foo.objects.none())
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)


### PR DESCRIPTION
Hey folks,

Just noticed that https://docs.djangoproject.com/en/5.0/ref/forms/fields/#fields-which-handle-relationships recommends `queryset=None` as the default. Looks like this has been in the docs since 2014.

I've personally found setting `queryset=None` may occasionally lead to exceptions in certain cases as downstream code assumes it's not `None` and I usually recommend folks use `QuerySet.none()` instead as a safeguard.

Eg I just today ran into this issue where a condition  in `__init__()` was causing `queryset` to not be initialised and causing 500 when rendering the form.

Thoughts?  Tim Graham authored the original doc update so he may have a good opinion?