### PR TITLE
Fixed #35475 -- Added hiding of empty app headers in admin sidebar.

### DIFF
--- a/django/contrib/admin/static/admin/js/nav_sidebar.js
+++ b/django/contrib/admin/static/admin/js/nav_sidebar.js
@@ -54,6 +54,14 @@
                 }
                 // show/hide parent <TR>
                 o.node.parentNode.parentNode.style.display = displayValue;
+                // hide the parent app module if it has no visible rows
+                const parent_module = o.node.closest('div.module');
+                if (parent_module.querySelectorAll('tr:not([style*="display: none"])').length === 0) {
+                    parent_module.style.display = 'none';
+                }
+                else {
+                    parent_module.style.display = '';
+                }
             }
             if (!filterValue || matches) {
                 event.target.classList.remove('no-results');

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -112,7 +112,7 @@ Minor features
 * The default iteration count for the PBKDF2 password hasher is increased from
   720,000 to 870,000.
 
-* The default ``parallelism`` of the ``ScryptPasswordHasher`` is 
+* The default ``parallelism`` of the ``ScryptPasswordHasher`` is
   increased from 1 to 5, to follow OWASP recommendations.
 
 * :class:`~django.contrib.auth.forms.BaseUserCreationForm` and
@@ -370,6 +370,9 @@ Miscellaneous
 
 * The JavaScript file ``collapse.js`` is removed since it is no longer needed
   in the Django admin site.
+
+* When a filter is used in the admin's sidebar, headers of empty apps
+  (apps without any visible models) are hidden to reduce clutter.
 
 * :meth:`.SimpleTestCase.assertURLEqual` and
   :meth:`~django.test.SimpleTestCase.assertInHTML` now add ``": "`` to the


### PR DESCRIPTION
# Trac ticket number

ticket-35475

# Branch description
When filtering in the admin sidebar, hide empty app headers to avoid clutter.

Before:
<img width="290" alt="image" src="https://github.com/django/django/assets/105996/2226d7dc-a867-4f5a-b495-3de3d4bc008f">


After:
<img width="290" alt="image" src="https://github.com/django/django/assets/105996/17b88e92-0d77-4e73-acd8-14b456907734">
<img width="290" alt="image" src="https://github.com/django/django/assets/105996/570a6cca-0889-43cf-b79f-35d0899507ad">


# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
