### PR TITLE
Fixed #35477 -- Fixed field required validation in forms inheriting from SetPassword.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -154,14 +154,14 @@ class SetPasswordMixin:
         if not usable_password:
             return self.cleaned_data
 
-        if not password1:
+        if not password1 and password1_field_name not in self.errors:
             error = ValidationError(
                 self.fields[password1_field_name].error_messages["required"],
                 code="required",
             )
             self.add_error(password1_field_name, error)
 
-        if not password2:
+        if not password2 and password2_field_name not in self.errors:
             error = ValidationError(
                 self.fields[password2_field_name].error_messages["required"],
                 code="required",


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35477

# Branch description

When adding additional validation to the `SetPassword` form in `django.contrib.auth` and they fail, the from's clean method assumed they were empty since it did only check for truthiness of the passwords.

This PR changes the check for empty passwords to them being empty strings.

@sarahboyce Thanks for providing those helpful tests!!

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
