### PR TITLE
Fixed #35469 -- Removed deferred SQL to create index removed by ALTER FIELD operation.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1582,11 +1582,22 @@ class BaseDatabaseSchemaEditor:
         )
 
     def _delete_index_sql(self, model, name, sql=None):
-        return Statement(
+        statement = Statement(
             sql or self.sql_delete_index,
             table=Table(model._meta.db_table, self.quote_name),
             name=self.quote_name(name),
         )
+
+        # Remove all deferred statements referencing the deleted index.
+        table_name = statement.parts["table"].table
+        index_name = statement.parts["name"]
+        for sql in list(self.deferred_sql):
+            if isinstance(sql, Statement) and sql.references_index(
+                table_name, index_name
+            ):
+                self.deferred_sql.remove(sql)
+
+        return statement
 
     def _rename_index_sql(self, model, old_name, new_name):
         return Statement(

--- a/django/db/backends/ddl_references.py
+++ b/django/db/backends/ddl_references.py
@@ -21,6 +21,12 @@ class Reference:
         """
         return False
 
+    def references_index(self, table, index):
+        """
+        Return whether or not this instance references the specified index.
+        """
+        return False
+
     def rename_table_references(self, old_table, new_table):
         """
         Rename all references to the old_name to the new_table.
@@ -51,6 +57,9 @@ class Table(Reference):
 
     def references_table(self, table):
         return self.table == table
+
+    def references_index(self, table, index):
+        return self.references_table(table) and str(self) == index
 
     def rename_table_references(self, old_table, new_table):
         if self.table == old_table:
@@ -204,6 +213,12 @@ class Statement(Reference):
     def references_column(self, table, column):
         return any(
             hasattr(part, "references_column") and part.references_column(table, column)
+            for part in self.parts.values()
+        )
+
+    def references_index(self, table, index):
+        return any(
+            hasattr(part, "references_index") and part.references_index(table, index)
             for part in self.parts.values()
         )
 

--- a/tests/indexes/tests.py
+++ b/tests/indexes/tests.py
@@ -3,7 +3,7 @@ from unittest import skipUnless
 
 from django.conf import settings
 from django.db import connection
-from django.db.models import CASCADE, ForeignKey, Index, Q
+from django.db.models import CASCADE, CharField, ForeignKey, Index, Q
 from django.db.models.functions import Lower
 from django.test import (
     TestCase,
@@ -86,6 +86,24 @@ class SchemaIndexesTests(TestCase):
             "(%s DESC)" % editor.quote_name("headline"),
             str(index.create_sql(Article, editor)),
         )
+
+    @skipUnlessDBFeature("can_create_inline_fk", "can_rollback_ddl")
+    def test_alter_field_unique_false_removes_deferred_sql(self):
+        field_added = CharField(max_length=127, unique=True)
+        field_added.set_attributes_from_name("charfield_added")
+
+        field_to_alter = CharField(max_length=127, unique=True)
+        field_to_alter.set_attributes_from_name("charfield_altered")
+        altered_field = CharField(max_length=127, unique=False)
+        altered_field.set_attributes_from_name("charfield_altered")
+
+        with connection.schema_editor() as editor:
+            editor.add_field(ArticleTranslation, field_added)
+            editor.add_field(ArticleTranslation, field_to_alter)
+            self.assertEqual(len(editor.deferred_sql), 2)
+            editor.alter_field(ArticleTranslation, field_to_alter, altered_field)
+            self.assertEqual(len(editor.deferred_sql), 1)
+            self.assertIn("charfield_added", str(editor.deferred_sql[0].parts["name"]))
 
 
 class SchemaIndexesNotPostgreSQLTests(TransactionTestCase):


### PR DESCRIPTION
# Trac ticket number
ticket-35469

# Branch description
When a unique CharField is added on Postgres, a CREATE INDEX command is added to `deferred_sql`. If this is later combined with an ALTER FIELD operation to unique=False, and included in the same migration, this index becomes unnecessary, causing problems when attempting to reverse the migration.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
