### PR TITLE
Fixed #35402 -- Fixed crash in django_test_skips for unimported submodules.

### DIFF
--- a/tests/backends/base/test_creation.py
+++ b/tests/backends/base/test_creation.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import os
+import sys
 from unittest import mock
 
 from django.db import DEFAULT_DB_ALIAS, connection, connections
@@ -296,6 +297,9 @@ class TestMarkTests(SimpleTestCase):
                 "backends.base.test_creation.skip_test_function",
             },
         }
+        popped_module = sys.modules.pop("backends.base")
+        self.addCleanup(sys.modules.__setitem__, "backends.base", popped_module)
+
         creation.mark_expected_failures_and_skips()
         self.assertIs(
             expected_failure_test_function.__unittest_expecting_failure__,


### PR DESCRIPTION
# Trac ticket number
ticket-35402

# Branch description
The logic in `django_test_skips()` was relying on undocumented behavior of `import_string()` to mostly succeed when given a module. (It is doc'd to accept classes/attributes.)

Failures could happen if given a module that hasn't yet been imported.

Alternative to adjusting import_string() to reliably accept modules, as #18103 does, which isn't its documented behavior.


# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
