### PR TITLE
Added "IF NOT EXISTS" to "CREATE COLLATION".

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -53,6 +53,7 @@ answer newbie questions, and generally made Django that much better:
     Alex Dutton <django@alexdutton.co.uk>
     Alexander Lazarević <laza@e11bits.com>
     Alexander Myodov <alex@myodov.com>
+    Alexander Nestorov <alexandernst@gmail.com>
     Alexandr Tatarinov <tatarinov.dev@gmail.com>
     Alex Aktsipetrov <alex.akts@gmail.com>
     Alex Becker <https://alexcbecker.net/>

--- a/django/contrib/postgres/operations.py
+++ b/django/contrib/postgres/operations.py
@@ -198,7 +198,7 @@ class CollationOperation(Operation):
         if self.deterministic is False:
             args["deterministic"] = "false"
         schema_editor.execute(
-            "CREATE COLLATION %(name)s (%(args)s)"
+            "CREATE COLLATION IF NOT EXISTS %(name)s (%(args)s)"
             % {
                 "name": schema_editor.quote_name(self.name),
                 "args": ", ".join(


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description
Attempting to create a collation that already existe shouldn't trigger an error, instead `IF NOT EXISTS` should be used.
The rationale is that attempting to create an extension that already exists behaves in the same way (code ref: https://github.com/django/django/blob/99f23eaabd8da653f046dc1d19f5008c030a4f79/django/contrib/postgres/operations.py#L29)

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
