### PR TITLE
Fixed #35473 typo in security advisory

### DIFF
--- a/docs/releases/security.txt
+++ b/docs/releases/security.txt
@@ -1381,7 +1381,7 @@ Versions affected
 
 * Django 1.2 :commit:`(patch) <7f84657b6b2243cc787bdb9f296710c8d13ad0bd>`
 
-October 9, 2009 - :cve:`2009-3965`
+October 9, 2009 - :cve:`2009-3695`
 ----------------------------------
 
 Denial-of-service via pathological regular expression performance. `Full


### PR DESCRIPTION
# Trac ticket number

ticket-35473

# Branch description
Fixed the typo in historic security advisory from 3965 to 3695

# Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
