### PR TITLE
Docs: Add CSP to Security topic

### DIFF
--- a/docs/topics/security.txt
+++ b/docs/topics/security.txt
@@ -55,19 +55,19 @@ Content Security Policy (CSP)
 =============================
 
 It's widely recommended to add a Content Security Policy (CSP) to your website
-in order to protect the website and its users from XSS attacks as mentioned in
-the previous chapter. CSP defines which source servers that are allowed to embed
-content such as scripts, stylesheets, images and fonts into your web pages.
+in order to protect from for instance XSS attacks. CSP defines which source
+domains that are allowed to embed content such as scripts, stylesheets, images
+and fonts into your web pages.
 
-CSP is defined by one or more HTTP headers sent from the web server. The headers
+CSP consists of one or more HTTP headers sent from the web server. The headers
 follow a special format, informing the browser about which sources it is allowed
-to fetch content from for this particular domain.
+to fetch content from for this particular domain. This allows you to mitigate a
+wide range of attacks.
 
-This allows you to mitigate a wide range of attacks. For instance, an attacker
-could try to sneak in code for an XSS attack that would embed a malicious
-JavaScript to spy on the user. By adding CSP headers, your web server will
-inform the user's browser that such a script is never acceptable in the first
-place.
+For instance, an attacker could try to sneak in code for an XSS attack that 
+would embed a malicious JavaScript, image or font into your web page. By adding
+CSP headers, your web server will inform the user's browser that such a content
+file is never acceptable in the first place.
 
 CSP can be enabled by adding an external Django package, providing a middleware
 and an easy configuration layer **or** by configuring your HTTP server to add
@@ -111,8 +111,6 @@ HSTS for supported browsers.
 
 Be very careful with marking views with the ``csrf_exempt`` decorator unless
 it is absolutely necessary.
-
-
 
 .. _sql-injection-protection:
 

--- a/docs/topics/security.txt
+++ b/docs/topics/security.txt
@@ -57,7 +57,7 @@ Content Security Policy (CSP)
 It's widely recommended to add a Content Security Policy (CSP) to your website
 in order to protect the website and its users from XSS attacks as mentioned in
 the previous chapter. CSP defines which source servers that are allowed to embed
-content such as scripts, stylesheets, images and fonts into your webpages.
+content such as scripts, stylesheets, images and fonts into your web pages.
 
 CSP is defined by one or more HTTP headers sent from the web server. The headers
 follow a special format, informing the browser about which sources it is allowed

--- a/docs/topics/security.txt
+++ b/docs/topics/security.txt
@@ -18,7 +18,7 @@ by the user's browser. However, XSS attacks can originate from any untrusted
 source of data, such as cookies or web services, whenever the data is not
 sufficiently sanitized before including in a page.
 
-Using Django templates protects you against the majority of XSS attacks.
+Using Django templates protects you against many types of XSS attacks.
 However, it is important to understand what protections it provides
 and its limitations.
 
@@ -47,6 +47,39 @@ escaping.
 
 You should also be very careful when storing HTML in the database, especially
 when that HTML is retrieved and displayed.
+
+
+.. _csp:
+
+Content Security Policy (CSP)
+=============================
+
+It's widely recommended to add a Content Security Policy (CSP) to your website
+in order to protect the website and its users from XSS attacks as mentioned in
+the previous chapter. CSP defines which source servers that are allowed to embed
+content such as scripts, stylesheets, images and fonts into your webpages.
+
+CSP is defined by one or more HTTP headers sent from the web server. The headers
+follow a special format, informing the browser about which sources it is allowed
+to fetch content from for this particular domain.
+
+This allows you to mitigate a wide range of attacks. For instance, an attacker
+could try to sneak in code for an XSS attack that would embed a malicious
+JavaScript to spy on the user. By adding CSP headers, your web server will
+inform the user's browser that such a script is never acceptable in the first
+place.
+
+CSP can be enabled by adding an external Django package, providing a middleware
+and an easy configuration layer **or** by configuring your HTTP server to add
+these headers.
+
+.. tip::
+
+   Content Security Policy is quite advanced, and it's recommended to read more
+   on Wikipedia or OWASP. For instance, it's possible to define a reporting URL
+   that the browser will contact through a POST request in case of violations of
+   your policy. In that way, you may softly implement CSP without blocking 
+   requests and only enforce the policy once you know more from reports.
 
 
 Cross site request forgery (CSRF) protection
@@ -78,6 +111,8 @@ HSTS for supported browsers.
 
 Be very careful with marking views with the ``csrf_exempt`` decorator unless
 it is absolutely necessary.
+
+
 
 .. _sql-injection-protection:
 


### PR DESCRIPTION
# Trac ticket number

This references ticket-15727 - but doesn't fix it. This is simply a documentation-based attempt to heighten the awareness of CSP.

# Branch description

The idea here is that while CSP discussions are happening for a long long time (13 years), it would be great to mention CSP in the Security topic.

I would think that this section can reflect the intention and recognition of CSP, and then it can be updated if finally a CSP middleware lands.

I've observed that external URLs and project references aren't widely used in the docs, probably because they tend to break or become inaccurate. That's why I didn't mention django-csp by name... but it's the first result on a simple web search :)

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
