### PR TITLE
Docs: Consistent alphabetical order for languages examples

### DIFF
--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -749,7 +749,7 @@ variables:
 
 * ``LANGUAGES`` -- The value of the :setting:`LANGUAGES` setting.
 * ``LANGUAGE_BIDI`` -- ``True`` if the current language is a right-to-left
-  language, e.g. Hebrew, Arabic. ``False`` if it's a left-to-right language,
+  language, e.g. Arabic, Hebrew. ``False`` if it's a left-to-right language,
   e.g. English, French, German.
 * ``LANGUAGE_CODE`` -- ``request.LANGUAGE_CODE``, if it exists. Otherwise,
   the value of the :setting:`LANGUAGE_CODE` setting.

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -904,8 +904,8 @@ preferred language as a string. Example: ``en-us``. See
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``{% get_current_language_bidi as LANGUAGE_BIDI %}`` returns the current
-locale's direction. If ``True``, it's a right-to-left language, e.g. Hebrew,
-Arabic. If ``False`` it's a left-to-right language, e.g. English, French,
+locale's direction. If ``True``, it's a right-to-left language, e.g. Arabic,
+Hebrew. If ``False`` it's a left-to-right language, e.g. English, French,
 German, etc.
 
 .. _template-translation-vars:


### PR DESCRIPTION
# Trac ticket number

"N/A"

# Branch description
Consistent alphabetical order for language examples

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [] I have attached screenshots in both light and dark modes for any UI changes.
