### PR TITLE
Updated release date for Django 5.0.7.

### DIFF
--- a/docs/releases/5.0.7.txt
+++ b/docs/releases/5.0.7.txt
@@ -2,7 +2,7 @@
 Django 5.0.7 release notes
 ==========================
 
-*Expected June 4, 2024*
+*Expected July 9, 2024*
 
 Django 5.0.7 fixes several bugs in 5.0.6.
 


### PR DESCRIPTION
# Branch description
The release date for 5.0.7 is being moved to July, considering that there are no bugfixes to release as of today. If a release blocker is confirmed between now and next week, I'll make the release adjusting this date accordingly. 