### PR TITLE
Fixed #35417 -- RequestContext.new creates a context that cannot be flattened.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -375,6 +375,7 @@ answer newbie questions, and generally made Django that much better:
     George Karpenkov <george@metaworld.ru>
     George Song <george@damacy.net>
     George Vilches <gav@thataddress.com>
+    George Y. Kussumoto <georgeyk.dev@gmail.com>
     Georg "Hugo" Bauer <gb@hugo.westfalen.de>
     Georgi Stanojevski <glisha@gmail.com>
     Gerardo Orozco <gerardo.orozco.mosqueda@gmail.com>

--- a/django/template/context.py
+++ b/django/template/context.py
@@ -31,7 +31,9 @@ class BaseContext:
     def _reset_dicts(self, value=None):
         builtins = {"True": True, "False": False, "None": None}
         self.dicts = [builtins]
-        if value is not None:
+        if isinstance(value, BaseContext):
+            self.dicts += value.dicts[1:]
+        elif value is not None:
             self.dicts.append(value)
 
     def __copy__(self):

--- a/tests/template_tests/test_context.py
+++ b/tests/template_tests/test_context.py
@@ -158,6 +158,17 @@ class ContextTests(SimpleTestCase):
             },
         )
 
+    def test_flatten_context_with_context_copy(self):
+        ctx1 = Context({"a": 2})
+        ctx2 = ctx1.new(Context({"b": 4}))
+        self.assertEqual(
+            ctx2.dicts, [{"True": True, "False": False, "None": None}, {"b": 4}]
+        )
+        self.assertEqual(
+            ctx2.flatten(),
+            {"False": False, "None": None, "True": True, "b": 4},
+        )
+
     def test_context_comparable(self):
         """
         #21765 -- equality comparison should work


### PR DESCRIPTION
Updated `BaseContext.new()` to correctly copy the context properties when the optional parameter `values` is given. When this parameter is an instance of BaseContext, we should copy its underlying properties.

# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35417

# Branch description
Replicate the similar logic that exists in push/update methods to copy context properties. 
`new()` create a copy of the given context, when it happens to be instance of a `BaseContext` instead of dict, the current code will copy the whole "stack", instead of the properties.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
