### PR TITLE
Fixed #35493 -- Allowed template self-inclusion with ./ and ../.

### DIFF
--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -242,7 +242,11 @@ def do_block(parser, token):
     return BlockNode(block_name, nodelist)
 
 
-def construct_relative_path(current_template_name, relative_name):
+def construct_relative_path(
+    current_template_name,
+    relative_name,
+    allow_recursion=True,
+):
     """
     Convert a relative path (starting with './' or '../') to the full template
     name based on the current_template_name.
@@ -264,7 +268,7 @@ def construct_relative_path(current_template_name, relative_name):
             "The relative path '%s' points outside the file hierarchy that "
             "template '%s' is in." % (relative_name, current_template_name)
         )
-    if current_template_name.lstrip("/") == new_name:
+    if not allow_recursion and current_template_name.lstrip("/") == new_name:
         raise TemplateSyntaxError(
             "The relative path '%s' was translated to template name '%s', the "
             "same template in which the tag appears."
@@ -290,7 +294,11 @@ def do_extends(parser, token):
     bits = token.split_contents()
     if len(bits) != 2:
         raise TemplateSyntaxError("'%s' takes one argument" % bits[0])
-    bits[1] = construct_relative_path(parser.origin.template_name, bits[1])
+    bits[1] = construct_relative_path(
+        parser.origin.template_name,
+        bits[1],
+        False,
+    )
     parent_name = parser.compile_filter(bits[1])
     nodelist = parser.parse()
     if nodelist.get_nodes_by_type(ExtendsNode):

--- a/tests/template_tests/templates/recursion/include0.html
+++ b/tests/template_tests/templates/recursion/include0.html
@@ -1,0 +1,1 @@
+{% for item in items %}({{ item.name }}{% if item.items %}{% include "recursion/include0.html" with items=item.items %}{% endif %}){% endfor %}

--- a/tests/template_tests/templates/recursion/include1.html
+++ b/tests/template_tests/templates/recursion/include1.html
@@ -1,0 +1,1 @@
+{% for item in items %}({{ item.name }}{% if item.items %}{% include "./include1.html" with items=item.items %}{% endif %}){% endfor %}

--- a/tests/template_tests/templates/recursion/include2.html
+++ b/tests/template_tests/templates/recursion/include2.html
@@ -1,0 +1,1 @@
+{% for item in items %}({{ item.name }}{% if item.items %}{% include "../recursion/include2.html" with items=item.items %}{% endif %}){% endfor %}

--- a/tests/template_tests/test_recursion.py
+++ b/tests/template_tests/test_recursion.py
@@ -1,0 +1,30 @@
+from django.template import loader
+from django.test import SimpleTestCase
+
+context = {
+    "items": [
+        {
+            "name": "foo",
+            "items": [],
+        },
+        {
+            "name": "bar",
+            "items": [
+                {
+                    "name": "baz",
+                    "items": [],
+                },
+            ],
+        },
+    ],
+}
+
+expected_result = "(foo)(bar(baz))"
+
+
+class RecursionTests(SimpleTestCase):
+    def test_recursion(self):
+        for i in range(3):
+            template = loader.get_template(f"recursion/include{i}.html")
+            actual_result = "".join(template.render(context).split())
+            self.assertEqual(actual_result, expected_result)


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35493

# Branch description
Previously, Django raised a `TemplateSyntaxError` when trying to recursively include a template from within itself via the `includes` tag using a path that contains `./` and `../`. The Django debug toolbar described the error like this: `The relative path ‘“./ul.html”’ was translated to template name ‘app/ul.html’, the same template in which the tag appears.` This error was not raised with paths containing neither `./` nor `../`. This happened because the same error-handling logic was used as the logic for recursively extending a template. The code was modified so that that particular error can only be raised when extending a template, not when including one.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable. (No new docs; the code was updated to be consistent with the documentation)
- [x] I have attached screenshots in both light and dark modes for any UI changes. (No new UI changes)