### PR TITLE
Removed outdated note about limitations in Clickjacking protection.

### DIFF
--- a/docs/ref/clickjacking.txt
+++ b/docs/ref/clickjacking.txt
@@ -116,24 +116,7 @@ a decorator overrides the middleware.
 Limitations
 ===========
 
-The ``X-Frame-Options`` header will only protect against clickjacking in a
-modern browser. Older browsers will quietly ignore the header and need `other
-clickjacking prevention techniques`_.
+The ``X-Frame-Options`` header will only protect against clickjacking in
+`modern browsers`_.
 
-Browsers that support ``X-Frame-Options``
------------------------------------------
-
-* Internet Explorer 8+
-* Edge
-* Firefox 3.6.9+
-* Opera 10.5+
-* Safari 4+
-* Chrome 4.1+
-
-See also
---------
-
-A `complete list`_ of browsers supporting ``X-Frame-Options``.
-
-.. _complete list: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#browser_compatibility
-.. _other clickjacking prevention techniques: https://en.wikipedia.org/wiki/Clickjacking#Prevention
+.. _modern browsers: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#browser_compatibility


### PR DESCRIPTION
There is no need to list old browser versions or point users to workaround for them.