### PR TITLE
Updated email validator max length.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -252,9 +252,9 @@ class EmailValidator:
             self.domain_allowlist = allowlist
 
     def __call__(self, value):
-        # The maximum length of an email is 320 characters per RFC 3696
-        # section 3.
-        if not value or "@" not in value or len(value) > 320:
+        # The maximum length of an email is 254 characters per RFC 3696
+        # section 3 (erratum 1690).
+        if not value or "@" not in value or len(value) > 254:
             raise ValidationError(self.message, code=self.code, params={"value": value})
 
         user_part, domain_part = value.rsplit("@", 1)


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

# Branch description
This change updates the maximum length that the EmailValidator allows to 254, which is the maximum value per [RFC 3696 (erratum 1690)](https://www.rfc-editor.org/errata/eid1690).

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
