### PR TITLE
Added support to add floating point numbers using |add template filter.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -728,7 +728,7 @@ def unordered_list(value, autoescape=True):
 def add(value, arg):
     """Add the arg to the value."""
     try:
-        return int(value) + int(arg)
+        return float(value) + float(arg)
     except (ValueError, TypeError):
         try:
             return value + arg


### PR DESCRIPTION
# Checklist
- [x] This PR targets the `main` branch. 
- [x] I have added support for floating point number addition using the add filter of the template system
- [x] This will be helpful for manipulation of ratings in e-commerce applications


# Why I am doing this PR
- When I was making an ecommerce application.I needed to some floating point number in order to show half and full stars in the product cards.But when I saw my rating was 4.8 and using rating|add:0.5 gave 4 I was very confused then I went to the source code and I thought typecasting value, add to float instead of integers will be helpful.
- If you find this change appropriate then please merge it.
- And if not please let me why we should use integer instead so that I may learn from you and understand your perspective.

