### PR TITLE
Add a `seprarate_dirname_filename` method

### DIFF
--- a/django/core/files/storage/base.py
+++ b/django/core/files/storage/base.py
@@ -57,7 +57,7 @@ class Storage:
         """
         return "%s_%s%s" % (file_root, get_random_string(7), file_ext)
     
-    def seprarate_dirname_filename(self, filename): 
+    def seprarate_dirname_filename(self, filename):
         """
         Return a tuple of dirname and filename.
         This method can be overridden to customize how the filename is split.

--- a/django/core/files/storage/base.py
+++ b/django/core/files/storage/base.py
@@ -56,7 +56,7 @@ class Storage:
         exists) to the filename.
         """
         return "%s_%s%s" % (file_root, get_random_string(7), file_ext)
-    
+
     def seprarate_dirname_filename(self, filename):
         """
         Return a tuple of dirname and filename.

--- a/django/core/files/storage/base.py
+++ b/django/core/files/storage/base.py
@@ -56,6 +56,13 @@ class Storage:
         exists) to the filename.
         """
         return "%s_%s%s" % (file_root, get_random_string(7), file_ext)
+    
+    def seprarate_dirname_filename(self, filename): 
+        """
+        Return a tuple of dirname and filename.
+        This method can be overridden to customize how the filename is split.
+        """
+        return os.path.split(filename)
 
     def get_available_name(self, name, max_length=None):
         """
@@ -106,7 +113,7 @@ class Storage:
         """
         filename = str(filename).replace("\\", "/")
         # `filename` may include a path as returned by FileField.upload_to.
-        dirname, filename = os.path.split(filename)
+        dirname, filename = self.seprarate_dirname_filename(filename)
         if ".." in pathlib.PurePath(dirname).parts:
             raise SuspiciousFileOperation(
                 "Detected path traversal attempt in '%s'" % dirname


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description
Adding the `separate_dirname_filename` method allows us to modify how Django separates the filename from the dirname without fully rewriting any method that needs to perform this separation. This can be useful when a file has a double extension, such as `.json.sbom` or anything similar.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.