### PR TITLE
Simplified OperationTestCase.alter_gis_model() test hook a bit.

### DIFF
--- a/tests/gis_tests/gis_migrations/test_operations.py
+++ b/tests/gis_tests/gis_migrations/test_operations.py
@@ -97,13 +97,12 @@ class OperationTestCase(TransactionTestCase):
         migration_class,
         model_name,
         field_name,
-        blank=False,
         field_class=None,
         field_class_kwargs=None,
     ):
         args = [model_name, field_name]
         if field_class:
-            field_class_kwargs = field_class_kwargs or {"srid": 4326, "blank": blank}
+            field_class_kwargs = field_class_kwargs or {}
             args.append(field_class(**field_class_kwargs))
         operation = migration_class(*args)
         old_state = self.current_state.clone()
@@ -122,7 +121,7 @@ class OperationTests(OperationTestCase):
         Test the AddField operation with a geometry-enabled column.
         """
         self.alter_gis_model(
-            migrations.AddField, "Neighborhood", "path", False, fields.LineStringField
+            migrations.AddField, "Neighborhood", "path", fields.LineStringField
         )
         self.assertColumnExists("gis_neighborhood", "path")
 
@@ -147,7 +146,7 @@ class OperationTests(OperationTestCase):
         Test the AddField operation with a raster-enabled column.
         """
         self.alter_gis_model(
-            migrations.AddField, "Neighborhood", "heatmap", False, fields.RasterField
+            migrations.AddField, "Neighborhood", "heatmap", fields.RasterField
         )
         self.assertColumnExists("gis_neighborhood", "heatmap")
 
@@ -160,7 +159,11 @@ class OperationTests(OperationTestCase):
         Should be able to add a GeometryField with blank=True.
         """
         self.alter_gis_model(
-            migrations.AddField, "Neighborhood", "path", True, fields.LineStringField
+            migrations.AddField,
+            "Neighborhood",
+            "path",
+            fields.LineStringField,
+            field_class_kwargs={"blank": True},
         )
         self.assertColumnExists("gis_neighborhood", "path")
 
@@ -178,7 +181,11 @@ class OperationTests(OperationTestCase):
         Should be able to add a RasterField with blank=True.
         """
         self.alter_gis_model(
-            migrations.AddField, "Neighborhood", "heatmap", True, fields.RasterField
+            migrations.AddField,
+            "Neighborhood",
+            "heatmap",
+            fields.RasterField,
+            field_class_kwargs={"blank": True},
         )
         self.assertColumnExists("gis_neighborhood", "heatmap")
 
@@ -247,9 +254,8 @@ class OperationTests(OperationTestCase):
             migrations.AlterField,
             "Neighborhood",
             "geom",
-            False,
             fields.MultiPolygonField,
-            field_class_kwargs={"srid": 4326, "dim": 3},
+            field_class_kwargs={"dim": 3},
         )
         self.assertTrue(Neighborhood.objects.first().geom.hasz)
         # Rewind to 2 dimensions.
@@ -257,9 +263,8 @@ class OperationTests(OperationTestCase):
             migrations.AlterField,
             "Neighborhood",
             "geom",
-            False,
             fields.MultiPolygonField,
-            field_class_kwargs={"srid": 4326, "dim": 2},
+            field_class_kwargs={"dim": 2},
         )
         self.assertFalse(Neighborhood.objects.first().geom.hasz)
 
@@ -296,9 +301,5 @@ class NoRasterSupportTests(OperationTestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             self.set_up_test_model()
             self.alter_gis_model(
-                migrations.AddField,
-                "Neighborhood",
-                "heatmap",
-                False,
-                fields.RasterField,
+                migrations.AddField, "Neighborhood", "heatmap", fields.RasterField
             )


### PR DESCRIPTION
This avoids passing `blank=False` and `srid=4326` to field classes, which are the default values, and removes special treatment for the `blank` parameter.

I'd like to add tests for `null=True` for ticket-35074 so this cleanup sounds reasonable. I also didn't want to push to many changes to the #18175.