### PR TITLE
Removed changing the port in the first part of the tutorial.

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -163,30 +163,8 @@ Now that the server's running, visit http://127.0.0.1:8000/ with your web
 browser. You'll see a "Congratulations!" page, with a rocket taking off.
 It worked!
 
-.. admonition:: Changing the port
-
-    By default, the :djadmin:`runserver` command starts the development server
-    on the internal IP at port 8000.
-
-    If you want to change the server's port, pass
-    it as a command-line argument. For instance, this command starts the server
-    on port 8080:
-
-    .. console::
-
-        $ python manage.py runserver 8080
-
-    If you want to change the server's IP, pass it along with the port. For
-    example, to listen on all available public IPs (which is useful if you are
-    running Vagrant or want to show off your work on other computers on the
-    network), use:
-
-    .. console::
-
-        $ python manage.py runserver 0.0.0.0:8000
-
-    Full docs for the development server can be found in the
-    :djadmin:`runserver` reference.
+If you need to change the port, you can find how to do it in the :djadmin:`runserver`
+reference.
 
 .. admonition:: Automatic reloading of :djadmin:`runserver`
 

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -163,8 +163,7 @@ Now that the server's running, visit http://127.0.0.1:8000/ with your web
 browser. You'll see a "Congratulations!" page, with a rocket taking off.
 It worked!
 
-If you need to change the port, you can find how to do it in the :djadmin:`runserver`
-reference.
+(To serve the site on a different port, see the :djadmin:`runserver` reference.)
 
 .. admonition:: Automatic reloading of :djadmin:`runserver`
 


### PR DESCRIPTION
Removing the "Changing port section on the first part of the turorial".
This work is part of effort done in the Sprints in DjangoCon Europe in Vigo with Daniele Procida @evildmp

Task picked from the task list in https://docs.google.com/spreadsheets/d/16UTGwtAoOwznc46cszbwAHU9xbukXnnpwG-faE94Rw8/edit?gid=0#gid=0 


