### PR TITLE
Fixed #35503 -- Removed PHP references in tutorial 1.

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -64,18 +64,6 @@ work, see :ref:`troubleshooting-django-admin`.
     ``django`` (which will conflict with Django itself) or ``test`` (which
     conflicts with a built-in Python package).
 
-.. admonition:: Where should this code live?
-
-    If your background is in plain old PHP (with no use of modern frameworks),
-    you're probably used to putting code under the web server's document root
-    (in a place such as ``/var/www``). With Django, you don't do that. It's
-    not a good idea to put any of this Python code within your web server's
-    document root, because it risks the possibility that people may be able
-    to view your code over the web. That's not good for security.
-
-    Put your code in some directory **outside** of the document root, such as
-    :file:`/home/mycode`.
-
 Let's look at what :djadmin:`startproject` created:
 
 .. code-block:: text


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35503

# Branch description
Reference to PHP may not be the best to include in beginners documentation at the time this ticket is being open. It may have made sense in 2007, but must seem perplexing to readers in 2024.

​https://docs.djangoproject.com/en/dev/intro/tutorial01/#creating-a-project

This ticket has been issued at [DjangoCon](https://code.djangoproject.com/wiki/DjangoCon) 2024 - Vigo, at the Sprints Days.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.