### PR TITLE
Fixed #35502 -- Changed directory name of `mysite` in tutorial.

### DIFF
--- a/docs/intro/overview.txt
+++ b/docs/intro/overview.txt
@@ -26,7 +26,7 @@ representing your models -- so far, it's been solving many years' worth of
 database-schema problems. Here's a quick example:
 
 .. code-block:: python
-    :caption: ``mysite/news/models.py``
+    :caption: ``news/models.py``
 
     from django.db import models
 
@@ -151,7 +151,7 @@ a website that lets authenticated users add, change and delete objects. The
 only step required is to register your model in the admin site:
 
 .. code-block:: python
-    :caption: ``mysite/news/models.py``
+    :caption: ``news/models.py``
 
     from django.db import models
 
@@ -163,7 +163,7 @@ only step required is to register your model in the admin site:
         reporter = models.ForeignKey(Reporter, on_delete=models.CASCADE)
 
 .. code-block:: python
-    :caption: ``mysite/news/admin.py``
+    :caption: ``news/admin.py``
 
     from django.contrib import admin
 
@@ -195,7 +195,7 @@ Here's what a URLconf might look like for the ``Reporter``/``Article``
 example above:
 
 .. code-block:: python
-    :caption: ``mysite/news/urls.py``
+    :caption: ``news/urls.py``
 
     from django.urls import path
 
@@ -235,7 +235,7 @@ and renders the template with the retrieved data. Here's an example view for
 ``year_archive`` from above:
 
 .. code-block:: python
-    :caption: ``mysite/news/views.py``
+    :caption: ``news/views.py``
 
     from django.shortcuts import render
 
@@ -265,7 +265,7 @@ Let's say the ``news/year_archive.html`` template was found. Here's what that
 might look like:
 
 .. code-block:: html+django
-    :caption: ``mysite/news/templates/news/year_archive.html``
+    :caption: ``news/templates/news/year_archive.html``
 
     {% extends "base.html" %}
 
@@ -306,7 +306,7 @@ Here's what the "base.html" template, including the use of :doc:`static files
 </howto/static-files/index>`, might look like:
 
 .. code-block:: html+django
-    :caption: ``mysite/templates/base.html``
+    :caption: ``templates/base.html``
 
     {% load static %}
     <html>

--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -57,7 +57,7 @@ After the previous tutorials, our project should look like this:
 
 .. code-block:: text
 
-    mysite/
+    djangotutorial/
         manage.py
         mysite/
             __init__.py
@@ -90,12 +90,12 @@ After the previous tutorials, our project should look like this:
             admin/
                 base_site.html
 
-You created ``mysite/templates`` in :doc:`Tutorial 7 </intro/tutorial07>`,
-and ``polls/templates`` in :doc:`Tutorial 3 </intro/tutorial03>`. Now perhaps
-it is clearer why we chose to have separate template directories for the
-project and application: everything that is part of the polls application is in
-``polls``. It makes the application self-contained and easier to drop into a
-new project.
+You created ``djangotutorial/templates`` in :doc:`Tutorial 7
+</intro/tutorial07>`, and ``polls/templates`` in
+:doc:`Tutorial 3 </intro/tutorial03>`. Now perhaps it is clearer why we chose
+to have separate template directories for the project and application:
+everything that is part of the polls application is in ``polls``. It makes the
+application self-contained and easier to drop into a new project.
 
 The ``polls`` directory could now be copied into a new Django project and
 immediately reused. It's not quite ready to be published though. For that, we

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -48,14 +48,21 @@ including database configuration, Django-specific options and
 application-specific settings.
 
 From the command line, ``cd`` into a directory where you'd like to store your
-code, then run the following command:
+code and create a new directory named ``djangotutorial``. (This directory name
+doesn't matter to Django; you can rename it to anything you like.)
 
 .. console::
 
-   $ django-admin startproject mysite
+   $ mkdir djangotutorial
 
-This will create a ``mysite`` directory in your current directory. If it didn't
-work, see :ref:`troubleshooting-django-admin`.
+Then, run the following command to bootstrap a new Django project:
+
+.. console::
+
+   $ django-admin startproject mysite djangotutorial
+
+This will create a project called ``mysite`` inside the ``djangotutorial``
+directory. If it didn't work, see :ref:`troubleshooting-django-admin`.
 
 .. note::
 
@@ -68,7 +75,7 @@ Let's look at what :djadmin:`startproject` created:
 
 .. code-block:: text
 
-    mysite/
+    djangotutorial/
         manage.py
         mysite/
             __init__.py
@@ -79,14 +86,11 @@ Let's look at what :djadmin:`startproject` created:
 
 These files are:
 
-* The outer :file:`mysite/` root directory is a container for your project. Its
-  name doesn't matter to Django; you can rename it to anything you like.
-
 * :file:`manage.py`: A command-line utility that lets you interact with this
   Django project in various ways. You can read all the details about
   :file:`manage.py` in :doc:`/ref/django-admin`.
 
-* The inner :file:`mysite/` directory is the actual Python package for your
+* :file:`mysite/`: A directory that is the actual Python package for your
   project. Its name is the Python package name you'll need to use to import
   anything inside it (e.g. ``mysite.urls``).
 
@@ -111,8 +115,8 @@ These files are:
 The development server
 ======================
 
-Let's verify your Django project works. Change into the outer :file:`mysite` directory, if
-you haven't already, and run the following commands:
+Let's verify your Django project works. Change into the :file:`djangotutorial`
+directory, if you haven't already, and run the following commands:
 
 .. console::
 
@@ -182,10 +186,8 @@ rather than creating directories.
     configuration and apps for a particular website. A project can contain
     multiple apps. An app can be in multiple projects.
 
-Your apps can live anywhere on your :ref:`Python path <tut-searchpath>`. In
-this tutorial, we'll create our poll app in the same directory as your
-:file:`manage.py` file so that it can be imported as its own top-level module,
-rather than a submodule of ``mysite``.
+Your apps can live anywhere in your :ref:`Python path <tut-searchpath>`. In
+this tutorial, we'll create our poll app inside the ``djangotutorial`` folder.
 
 To create your app, make sure you're in the same directory as :file:`manage.py`
 and type this command:

--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -216,7 +216,7 @@ and you'll see something like:
     FAIL: test_was_published_recently_with_future_question (polls.tests.QuestionModelTests)
     ----------------------------------------------------------------------
     Traceback (most recent call last):
-      File "/path/to/mysite/polls/tests.py", line 16, in test_was_published_recently_with_future_question
+      File "/path/to/djangotutorial/polls/tests.py", line 16, in test_was_published_recently_with_future_question
         self.assertIs(future_question.was_published_recently(), False)
     AssertionError: True is not False
 

--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -306,10 +306,10 @@ powered by Django itself, and its interfaces use Django's own template system.
 Customizing your *project's* templates
 --------------------------------------
 
-Create a ``templates`` directory in your project directory (the one that
-contains ``manage.py``). Templates can live anywhere on your filesystem that
-Django can access. (Django runs as whatever user your server runs.) However,
-keeping your templates within the project is a good convention to follow.
+Create a ``templates`` directory in your ``djangotutorial`` directory.
+Templates can live anywhere on your filesystem that Django can access. (Django
+runs as whatever user your server runs.) However, keeping your templates within
+the project is a good convention to follow.
 
 Open your settings file (:file:`mysite/settings.py`, remember) and add a
 :setting:`DIRS <TEMPLATES-DIRS>` option in the :setting:`TEMPLATES` setting:

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -141,6 +141,7 @@ Disqus
 distro
 django
 djangoproject
+djangotutorial
 dm
 docstring
 docstrings

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -62,7 +62,8 @@ class represents a particular record in the database table.
 To create an object, instantiate it using keyword arguments to the model class,
 then call :meth:`~django.db.models.Model.save` to save it to the database.
 
-Assuming models live in a file ``mysite/blog/models.py``, here's an example:
+Assuming models live in a ``models.py`` file inside a ``blog`` Django app, here
+is an example:
 
 .. code-block:: pycon
 


### PR DESCRIPTION
# 35502
There was a ticket [#22042](https://code.djangoproject.com/ticket/22042) that has already been closed, but maybe this solution will be beneficial.

ticket-35502

# Branch description
We have two `mysite` directories, and we often see users confused by that. If we rename the `mysite` directory, the confusion would be alleviated.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
