### PR TITLE
Documented that SessionMiddleware is required for admin.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -41,7 +41,8 @@ If you're not using the default project template, here are the requirements:
    <TEMPLATES-OPTIONS>`.
 
 #. If you've customized the :setting:`MIDDLEWARE` setting,
-   :class:`django.contrib.auth.middleware.AuthenticationMiddleware` and
+   :class:`django.contrib.sessions.middleware.SessionMiddleware`,
+   :class:`django.contrib.auth.middleware.AuthenticationMiddleware`, and
    :class:`django.contrib.messages.middleware.MessageMiddleware` must be
    included.
 


### PR DESCRIPTION
# Trac ticket number
N/A - Doc PR

# Branch description
Trying to use `django.contrib.admin` without SessionMiddleware leads to error:

```
?: (admin.E410) 'django.contrib.sessions.middleware.SessionMiddleware' must be in MIDDLEWARE in order to use the admin application.
	HINT: Insert 'django.contrib.sessions.middleware.SessionMiddleware' before 'django.contrib.auth.middleware.AuthenticationMiddleware'.
```

Update documentation to be in sync with the actual system requirements.

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [N/A] I have checked the "Has patch" ticket flag in the Trac system.
- [N/A] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [N/A] I have attached screenshots in both light and dark modes for any UI changes.
