### PR TITLE
Fixed #33548 Use ->> operator to implement KeyTransform on SQLite 3.38+

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -387,7 +387,7 @@ class KeyTransform(Transform):
         )
         return (
             "(CASE WHEN JSON_TYPE(%s, %%s) IN (%s) "
-            "THEN JSON_TYPE(%s, %%s) ELSE JSON_EXTRACT(%s, %%s) END)"
+            "THEN JSON_TYPE(%s, %%s) ELSE %s ->> %%s END)"
         ) % (lhs, datatype_values, lhs, lhs), (tuple(params) + (json_path,)) * 3
 
 


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-33548

# Branch description
Use the ->> operator to implement KeyTransform for JSON fields on SQLite.

I didn't add the version check because Python 3.10 upgraded SQLite to 3.39 in the 3.10.9 release https://docs.python.org/3.10/whatsnew/changelog.html#id26

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
