### PR TITLE
Startproject tutorial : Removed files explained after django-admin startproject mysite.

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -89,37 +89,6 @@ Let's look at what :djadmin:`startproject` created:
             asgi.py
             wsgi.py
 
-These files are:
-
-* The outer :file:`mysite/` root directory is a container for your project. Its
-  name doesn't matter to Django; you can rename it to anything you like.
-
-* :file:`manage.py`: A command-line utility that lets you interact with this
-  Django project in various ways. You can read all the details about
-  :file:`manage.py` in :doc:`/ref/django-admin`.
-
-* The inner :file:`mysite/` directory is the actual Python package for your
-  project. Its name is the Python package name you'll need to use to import
-  anything inside it (e.g. ``mysite.urls``).
-
-* :file:`mysite/__init__.py`: An empty file that tells Python that this
-  directory should be considered a Python package. If you're a Python beginner,
-  read :ref:`more about packages <tut-packages>` in the official Python docs.
-
-* :file:`mysite/settings.py`: Settings/configuration for this Django
-  project.  :doc:`/topics/settings` will tell you all about how settings
-  work.
-
-* :file:`mysite/urls.py`: The URL declarations for this Django project; a
-  "table of contents" of your Django-powered site. You can read more about
-  URLs in :doc:`/topics/http/urls`.
-
-* :file:`mysite/asgi.py`: An entry-point for ASGI-compatible web servers to
-  serve your project. See :doc:`/howto/deployment/asgi/index` for more details.
-
-* :file:`mysite/wsgi.py`: An entry-point for WSGI-compatible web servers to
-  serve your project. See :doc:`/howto/deployment/wsgi/index` for more details.
-
 The development server
 ======================
 


### PR DESCRIPTION
# Trac ticket number
No ticket number. Tutorial docs improvement as mentioned in [Djangocon Europe 2024 docs improvement](https://docs.google.com/spreadsheets/d/16UTGwtAoOwznc46cszbwAHU9xbukXnnpwG-faE94Rw8/edit?gid=0#gid=0)

# Branch description
The explanation of different files created after `django-admin startproject mysite` is here redundant, as they will be explained later when the user needs to configure/ interact with each of them.

Before:
![image](https://github.com/django/django/assets/59538059/030ff5d1-c582-4b30-87df-e0827d2caf84)

After removing the explanations:
![image](https://github.com/django/django/assets/59538059/fb171a4a-fed3-4ff6-ba8c-e91f7f952d5c)


# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
~~[] I have checked the "Has patch" ticket flag in the Trac system.~~ **Does not apply here**
~~[] I have added or updated relevant tests.~~ **Does not apply here**
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
