### PR TITLE
Changed the order to highlight the success of the action after starting the development server

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -138,6 +138,10 @@ You'll see the following output on the command line:
     Ignore the warning about unapplied database migrations for now; we'll deal
     with the database shortly.
 
+Now that the server's running, visit http://127.0.0.1:8000/ with your web
+browser. You'll see a "Congratulations!" page, with a rocket taking off.
+**It worked!**
+
 You've started the Django development server, a lightweight web server written
 purely in Python. We've included this with Django so you can develop things
 rapidly, without having to deal with configuring a production server -- such as

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -140,7 +140,7 @@ You'll see the following output on the command line:
 
 Now that the server's running, visit http://127.0.0.1:8000/ with your web
 browser. You'll see a "Congratulations!" page, with a rocket taking off.
-**It worked!**
+It worked!
 
 You've started the Django development server, a lightweight web server written
 purely in Python. We've included this with Django so you can develop things

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -151,10 +151,6 @@ Now's a good time to note: **don't** use this server in anything resembling a
 production environment. It's intended only for use while developing. (We're in
 the business of making web frameworks, not web servers.)
 
-Now that the server's running, visit http://127.0.0.1:8000/ with your web
-browser. You'll see a "Congratulations!" page, with a rocket taking off.
-It worked!
-
 (To serve the site on a different port, see the :djadmin:`runserver` reference.)
 
 .. admonition:: Automatic reloading of :djadmin:`runserver`


### PR DESCRIPTION
Changed the order to highlight the success of the action after starting the development server

This work is part of effort done in the Sprints in DjangoCon Europe in Vigo with Daniele Procida @evildmp

Task picked from the task list in https://docs.google.com/spreadsheets/d/16UTGwtAoOwznc46cszbwAHU9xbukXnnpwG-faE94Rw8/edit?gid=0#gid=0