### PR TITLE
Fixed #33579 -- Added exception to be raised when no rows are affected on Model.save().

### DIFF
--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -31,6 +31,10 @@ class MultipleObjectsReturned(Exception):
     pass
 
 
+class ObjectNotUpdated(Exception):
+    pass
+
+
 class SuspiciousOperation(Exception):
     """The user did something suspicious"""
 

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -20,7 +20,6 @@ from django.core.exceptions import (
 )
 from django.db import (
     DJANGO_VERSION_PICKLE_KEY,
-    DatabaseError,
     connection,
     connections,
     router,
@@ -48,6 +47,7 @@ from django.db.models.signals import (
     pre_save,
 )
 from django.db.models.utils import AltersData, make_model_tuple
+from django.db.utils import NoRowsAffected
 from django.utils.deprecation import RemovedInDjango60Warning
 from django.utils.encoding import force_str
 from django.utils.hashable import make_hashable
@@ -1112,9 +1112,9 @@ class Model(AltersData, metaclass=ModelBase):
                 base_qs, using, pk_val, values, update_fields, forced_update
             )
             if force_update and not updated:
-                raise DatabaseError("Forced update did not affect any rows.")
+                raise NoRowsAffected("Forced update did not affect any rows.")
             if update_fields and not updated:
-                raise DatabaseError("Save with update_fields did not affect any rows.")
+                raise NoRowsAffected("Save with update_fields did not affect any rows.")
         if not updated:
             if meta.order_with_respect_to:
                 # If this is a model with an order_with_respect_to

--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -26,6 +26,10 @@ class DatabaseError(Error):
     pass
 
 
+class NoRowsAffected(DatabaseError):
+    pass
+
+
 class DataError(DatabaseError):
     pass
 


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-33579

# Branch description
Change `DatabaseError` to a more specialized one, that inherits from `DatabaseError`, to make detecting this specific error easily, while mantaining backwards compatibility with old code (by inheriting from old exception)

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
