### PR TITLE
Fixed #34846 -- Added copy button to code snippets on the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,11 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.linkcode",
+    "sphinx_copybutton",
 ]
+
+copybutton_prompt_text = r"\.\.\.\\\> |\$ "
+copybutton_prompt_is_regexp = True
 
 # AutosectionLabel settings.
 # Uses a <page>:<label> schema which doesn't work for duplicate sub-section

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ pyenchant
 Sphinx>=4.5.0
 sphinxcontrib-spelling
 blacken-docs
+sphinx-copybutton


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

Done during Django Conference Europe 2024 sprint 🎉

ticket-34846

# Branch description
This solution will use the sphinx framework provided copy-button to copy the whole code. On the original PR(https://github.com/django/django/pull/16342) I found this comment https://github.com/django/django/pull/16342#issuecomment-1728734503 which I struggle to understand why this solution would conflict. When checking https://github.com/django/djangoproject.com/blob/main/djangoproject/static/js/mod/clippify.js I found them to be different projects using different frameworks, could some extra context be provided on the possible conflict?

Light:
<img width="668" alt="image" src="https://github.com/django/django/assets/1286768/d6b9cba4-fcd6-4cbf-b61d-2bad8150e244">
Dark:
I couldn't find how to switch to dark mode.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
