### PR TITLE
Tutorial 02 Database Setup Documentation update

### DIFF
--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -17,48 +17,15 @@ Database setup
 Now, open up :file:`mysite/settings.py`. It's a normal Python module with
 module-level variables representing Django settings.
 
-By default, the configuration uses SQLite. If you're new to databases, or
-you're just interested in trying Django, this is the easiest choice. SQLite is
-included in Python, so you won't need to install anything else to support your
-database. When starting your first real project, however, you may want to use a
-more scalable database like PostgreSQL, to avoid database-switching headaches
-down the road.
+By default, the :setting:`DATABASES` configuration uses SQLite. If you're new
+to databases, or you're just interested in trying Django, this is the easiest
+choice. SQLite is included in Python, so you won't need to install anything
+else to support your database. When starting your first real project, however,
+you may want to use a more scalable database like PostgreSQL, to avoid
+database-switching headaches down the road.
 
-If you wish to use another database, install the appropriate :ref:`database
-bindings <database-installation>` and change the following keys in the
-:setting:`DATABASES` ``'default'`` item to match your database connection
-settings:
-
-* :setting:`ENGINE <DATABASE-ENGINE>` -- Either
-  ``'django.db.backends.sqlite3'``,
-  ``'django.db.backends.postgresql'``,
-  ``'django.db.backends.mysql'``, or
-  ``'django.db.backends.oracle'``. Other backends are :ref:`also available
-  <third-party-notes>`.
-
-* :setting:`NAME` -- The name of your database. If you're using SQLite, the
-  database will be a file on your computer; in that case, :setting:`NAME`
-  should be the full absolute path, including filename, of that file. The
-  default value, ``BASE_DIR / 'db.sqlite3'``, will store the file in your
-  project directory.
-
-If you are not using SQLite as your database, additional settings such as
-:setting:`USER`, :setting:`PASSWORD`, and :setting:`HOST` must be added.
-For more details, see the reference documentation for :setting:`DATABASES`.
-
-.. admonition:: For databases other than SQLite
-
-    If you're using a database besides SQLite, make sure you've created a
-    database by this point. Do that with "``CREATE DATABASE database_name;``"
-    within your database's interactive prompt.
-
-    Also make sure that the database user provided in :file:`mysite/settings.py`
-    has "create database" privileges. This allows automatic creation of a
-    :ref:`test database <the-test-database>` which will be needed in a later
-    tutorial.
-
-    If you're using SQLite, you don't need to create anything beforehand - the
-    database file will be created automatically when it is needed.
+If you wish to use another database, see :ref:`details to customize and get
+your database running <database-installation>`.
 
 While you're editing :file:`mysite/settings.py`, set :setting:`TIME_ZONE` to
 your time zone.

--- a/docs/topics/install.txt
+++ b/docs/topics/install.txt
@@ -76,8 +76,8 @@ In addition to the officially supported databases, there are :ref:`backends
 provided by 3rd parties <third-party-notes>` that allow you to use other
 databases with Django.
 
-In addition to a database backend, you'll need to make sure your Python
-database bindings are installed.
+To use another database other than SQLite, you'll need to make sure that the
+appropriate Python database bindings are installed:
 
 * If you're using PostgreSQL, you'll need the `psycopg`_ or `psycopg2`_
   package. Refer to the :ref:`PostgreSQL notes <postgresql-notes>` for further
@@ -96,6 +96,33 @@ database bindings are installed.
 
 * If you're using an unofficial 3rd party backend, please consult the
   documentation provided for any additional requirements.
+
+And ensure that the following keys in the ``'default'`` item of the
+:setting:`DATABASES` dictionary match your database connection settings:
+
+* :setting:`ENGINE <DATABASE-ENGINE>` -- Either
+  ``'django.db.backends.sqlite3'``,
+  ``'django.db.backends.postgresql'``,
+  ``'django.db.backends.mysql'``, or
+  ``'django.db.backends.oracle'``. Other backends are :ref:`also available
+  <third-party-notes>`.
+
+* :setting:`NAME` -- The name of your database. If you’re using SQLite, the
+  database will be a file on your computer. In that case, ``NAME`` should be
+  the full absolute path, including the filename of that file. You don’t need
+  to create anything beforehand; the database file will be created
+  automatically when needed. The default value, ``BASE_DIR / 'db.sqlite3'``,
+  will store the file in your project directory.
+
+.. admonition:: For databases other than SQLite
+
+    If you are not using SQLite as your database, additional settings such as
+    :setting:`USER`, :setting:`PASSWORD`, and :setting:`HOST` must be added.
+    For more details, see the reference documentation for :setting:`DATABASES`.
+
+    Also, make sure that you've created the database by this point. Do that
+    with "``CREATE DATABASE database_name;``" within your database's
+    interactive prompt.
 
 If you plan to use Django's ``manage.py migrate`` command to automatically
 create database tables for your models (after first installing Django and


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description
I removed some unnecessary text about setting up a different database than the default SQLite to prevent overwhelming new Django users. This information can be found in more relevant parts of the documentation when the user is ready to experiment with different databases.
