### PR TITLE
Fixed #24638 -- Added support for SQL comments

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1783,6 +1783,17 @@ class QuerySet(AltersData):
         clone._db = alias
         return clone
 
+    def comment(self, message):
+        """Add a comment to the query."""
+        clone = self._clone()
+        if "/*" in message or "*/" in message:
+            raise ValueError(
+                "Cannot pass strings containing /* or */ to comment(). "
+                "Escape or strip these delimiters before calling comment()."
+            )
+        clone.query.comments = (*clone.query.comments, message)
+        return clone
+
     ###################################
     # PUBLIC INTROSPECTION ATTRIBUTES #
     ###################################

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -787,6 +787,9 @@ class SQLCompiler:
                 result = ["SELECT"]
                 params = []
 
+                if self.query.comments:
+                    result += self.comments_sql()
+
                 if self.query.distinct:
                     distinct_result, distinct_params = self.connection.ops.distinct_sql(
                         distinct_fields,
@@ -1627,6 +1630,9 @@ class SQLCompiler:
                 else:
                     yield value
 
+    def comments_sql(self):
+        return [f"/* {comment} */" for comment in self.query.comments]
+
 
 class SQLInsertCompiler(SQLCompiler):
     returning_fields = None
@@ -1976,8 +1982,11 @@ class SQLUpdateCompiler(SQLCompiler):
             else:
                 values.append("%s = NULL" % qn(name))
         table = self.query.base_table
-        result = [
-            "UPDATE %s SET" % qn(table),
+        result = ["UPDATE"]
+        if self.query.comments:
+            result += self.comments_sql()
+        result += [
+            "%s SET" % qn(table),
             ", ".join(values),
         ]
         try:

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -787,8 +787,7 @@ class SQLCompiler:
                 result = ["SELECT"]
                 params = []
 
-                if self.query.comments:
-                    result += self.comments_sql()
+                result += self.query.comments
 
                 if self.query.distinct:
                     distinct_result, distinct_params = self.connection.ops.distinct_sql(
@@ -1630,9 +1629,6 @@ class SQLCompiler:
                 else:
                     yield value
 
-    def comments_sql(self):
-        return [f"/* {comment} */" for comment in self.query.comments]
-
 
 class SQLInsertCompiler(SQLCompiler):
     returning_fields = None
@@ -1751,7 +1747,9 @@ class SQLInsertCompiler(SQLCompiler):
         insert_statement = self.connection.ops.insert_statement(
             on_conflict=self.query.on_conflict,
         )
-        result = ["%s %s" % (insert_statement, qn(opts.db_table))]
+        result = ["%s" % insert_statement]
+        result += self.query.comments
+        result += ["%s" % qn(opts.db_table)]
         fields = self.query.fields or [opts.pk]
         result.append("(%s)" % ", ".join(qn(f.column) for f in fields))
 
@@ -1897,7 +1895,13 @@ class SQLDeleteCompiler(SQLCompiler):
         )
 
     def _as_sql(self, query):
-        delete = "DELETE FROM %s" % self.quote_name_unless_alias(query.base_table)
+        result = [
+            "DELETE",
+            *self.query.comments,
+            "FROM",
+            self.quote_name_unless_alias(query.base_table),
+        ]
+        delete = " ".join(result)
         try:
             where, params = self.compile(query.where)
         except FullResultSet:
@@ -1981,12 +1985,10 @@ class SQLUpdateCompiler(SQLCompiler):
                 update_params.append(val)
             else:
                 values.append("%s = NULL" % qn(name))
-        table = self.query.base_table
-        result = ["UPDATE"]
-        if self.query.comments:
-            result += self.comments_sql()
-        result += [
-            "%s SET" % qn(table),
+        result = [
+            "UPDATE",
+            *self.query.comments,
+            "%s SET" % qn(self.query.base_table),
             ", ".join(values),
         ]
         try:

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -288,6 +288,7 @@ class Query(BaseExpression):
     deferred_loading = (frozenset(), True)
 
     explain_info = None
+    comments = ()
 
     def __init__(self, model, alias_cols=True):
         self.model = model

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2042,7 +2042,8 @@ Adds an SQL comment to be inserted into the resultant SQL statement, after
 
     Entry.objects.comment("blog/views.py:50").all()
 
-… translates (roughly) into the following SQL::
+… translates (roughly) into the following SQL:
+
 .. code-block:: sql
 
     SELECT /* blog/views.py:50 */ blog_entry.* FROM blog_entry
@@ -2058,9 +2059,10 @@ entries, for example::
     )
 
 … translates into
+
 .. code-block:: sql
 
-    UPDATE /* blog/views.py:75 */ /* python=3.12 */ blog_entry SET "headline" = 'This is new'
+    UPDATE /* blog/views.py:50 */ /* python=3.12 */ blog_entry SET "headline" = 'This is new'
 
 Operators that return new ``QuerySet``\s
 ----------------------------------------

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2030,6 +2030,38 @@ See the :doc:`/topics/db/sql` for more information.
   filtering. As such, it should generally be called from the ``Manager`` or
   from a fresh ``QuerySet`` instance.
 
+``comment()``
+~~~~~~~~~~~~~
+
+.. versionadded:: 5.2
+
+.. method:: comment(message)
+
+Adds an SQL comment to be inserted into the resultant SQL statement, after
+``SELECT``/``UPDATE``, and if applicable, ``DISTINCT``.. For example::
+
+    Entry.objects.comment("blog/views.py:50").all()
+
+… translates (roughly) into the following SQL::
+.. code-block:: sql
+
+    SELECT /* blog/views.py:50 */ blog_entry.* FROM blog_entry
+
+This is useful for adding logging information to the generated SQL for
+correlating problematic queries with the responsible Python code.
+
+Comments can be chained and will be added to the SQL statement as separate
+entries, for example::
+
+    Entry.objects.comment("blog/views.py:50").comment("python=3.12").update(
+        headline="This is new"
+    )
+
+… translates into
+.. code-block:: sql
+
+    UPDATE /* blog/views.py:75 */ /* python=3.12 */ blog_entry SET "headline" = 'This is new'
+
 Operators that return new ``QuerySet``\s
 ----------------------------------------
 

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -178,7 +178,9 @@ Migrations
 Models
 ~~~~~~
 
-* ...
+* The new :meth:`.QuerySet.comment` method allows for adding comments into
+  the generated SQL. This can be useful for correlating slow queries with
+  application code.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -768,6 +768,7 @@ class ManagerTest(SimpleTestCase):
         "union",
         "intersection",
         "difference",
+        "comment",
         "aaggregate",
         "abulk_create",
         "abulk_update",


### PR DESCRIPTION
This PR reactivates work done in #4495 and #15711 -  useful addition to Django for adding traceability for queries.

# Trac ticket number

ticket-24638

# Branch description

Add queryset comment() method

- [x] Rebase against 5.x
- [x] Support SELECT statement
- [x] Support UPDATE statement
- [ ] Support INSERT statement
- [ ] Support DELETE statement
- [x] use regex instead if "*/"


# Checklist

- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
