### PR TITLE
Refs #35402 -- Add coverage for invalid usage of submodules in some settings.

### DIFF
--- a/tests/auth_tests/test_models.py
+++ b/tests/auth_tests/test_models.py
@@ -433,6 +433,14 @@ class UserWithPermTestCase(TestCase):
                 backend="invalid.backend.CustomModelBackend",
             )
 
+    def test_invalid_backend_submodule(self):
+        """A submodule not imported when its parent is imported is invalid."""
+        with self.assertRaises(ImportError):
+            User.objects.with_perm(
+                "auth.test",
+                backend="json.tool",
+            )
+
     @override_settings(
         AUTHENTICATION_BACKENDS=["auth_tests.test_models.CustomModelBackend"]
     )

--- a/tests/auth_tests/test_validators.py
+++ b/tests/auth_tests/test_validators.py
@@ -14,7 +14,7 @@ from django.contrib.auth.password_validation import (
     password_validators_help_texts,
     validate_password,
 )
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.test.utils import isolate_apps
@@ -49,6 +49,16 @@ class PasswordValidationTest(SimpleTestCase):
         self.assertEqual(validators[0].__class__.__name__, "CommonPasswordValidator")
 
         self.assertEqual(get_password_validators([]), [])
+
+    def test_get_password_validators_custom_invalid(self):
+        """A submodule not imported when its parent is imported is invalid."""
+        validator_config = [{"NAME": "json.tool"}]
+        msg = (
+            "The module in NAME could not be imported: json.tool. "
+            "Check your AUTH_PASSWORD_VALIDATORS setting."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            get_password_validators(validator_config)
 
     def test_validate_password(self):
         self.assertIsNone(validate_password("sufficiently-long"))


### PR DESCRIPTION

# Trac ticket number
ticket-35402

# Branch description
Adds tests that fail with the current state of the proposal to fix ticket-35402 (d21dc2ed7eeb70645175ee066077e0a0b2627a3f).

Also covers [uncovered lines](https://djangoci.com/view/%C2%ADCoverage/job/django-coverage/HTML_20Coverage_20Report/z_faff9d89c0269099_password_validation_py.html#t30) in password_validation.py.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
