### PR TITLE
Fixed #34886 -- Modified sample use of lazy in delayed translations.

### DIFF
--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -515,14 +515,18 @@ pass the translatable string as argument to another function, you can wrap
 this function inside a lazy call yourself. For example::
 
     from django.utils.functional import lazy
-    from django.utils.safestring import mark_safe
     from django.utils.translation import gettext_lazy as _
 
-    mark_safe_lazy = lazy(mark_safe, str)
+
+    def to_lower(string):
+        return string.lower()
+
+
+    to_lower_lazy = lazy(to_lower, str)
 
 And then later::
 
-    lazy_string = mark_safe_lazy(_("<p>My <strong>string!</strong></p>"))
+    lazy_string = to_lower_lazy(_("My STRING!"))
 
 Localized names of languages
 ----------------------------


### PR DESCRIPTION
Modified example to use python standard library function to lower the case of the string.

# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-34886

# Branch description
The example to illustrate the use of lazy objects in delayed translations in django versions `4.2` and `4.1` has been updated to use a python standard library function.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
