### PR TITLE
Fixed #35518 -- Used simpler string operations for converter-less routes

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -322,17 +322,25 @@ class RoutePattern(CheckURLMixin):
         self.name = name
 
     def match(self, path):
-        match = self.regex.search(path)
-        if match:
-            # RoutePattern doesn't allow non-named groups so args are ignored.
-            kwargs = match.groupdict()
-            for key, value in kwargs.items():
-                converter = self.converters[key]
-                try:
-                    kwargs[key] = converter.to_python(value)
-                except ValueError:
-                    return None
-            return path[match.end() :], (), kwargs
+        # Only use regex overhead if there are converters.
+        if self.converters:
+            if match := self.regex.search(path):
+                # RoutePattern doesn't allow non-named groups so args are ignored.
+                kwargs = match.groupdict()
+                for key, value in kwargs.items():
+                    converter = self.converters[key]
+                    try:
+                        kwargs[key] = converter.to_python(value)
+                    except ValueError:
+                        return None
+                return path[match.end() :], (), kwargs
+        # If this is an endpoint, the path should be exactly the same as the route.
+        elif self._is_endpoint:
+            if self._route == path:
+                return "", (), {}
+        # If this isn't an endpoint, the path should start with the route.
+        elif path.startswith(self._route):
+            return path.removeprefix(self._route), (), {}
         return None
 
     def check(self):

--- a/tests/urlpatterns/test_resolvers.py
+++ b/tests/urlpatterns/test_resolvers.py
@@ -13,6 +13,12 @@ class RoutePatternTests(SimpleTestCase):
     def test_str(self):
         self.assertEqual(str(RoutePattern(_("translated/"))), "translated/")
 
+    def test_has_converters(self):
+        self.assertEqual(len(RoutePattern("translated/").converters), 0)
+        self.assertEqual(len(RoutePattern(_("translated/")).converters), 0)
+        self.assertEqual(len(RoutePattern("translated/<int:foo>").converters), 1)
+        self.assertEqual(len(RoutePattern(_("translated/<int:foo>")).converters), 1)
+
 
 class ResolverCacheTests(SimpleTestCase):
     @override_settings(ROOT_URLCONF="urlpatterns.path_urls")


### PR DESCRIPTION
# Trac ticket number

ticket-35518

# Branch description

The `RoutePattern` assumes all routes provided include some form of converter, and so needs to change it into a regex for matching. However, if no converters are included in the string, the additional overhead of using a regex vs simpler string operations is unnecessary.

Replacing this with a simpler string comparison results in between a 50 and 75% reduction in match time, which stacks up quickly as an application generally has numerous URLs, because `RoutePattern.match` is called once per defined route per request.

**Before**

```python
In [2]: endpoint_pattern = RoutePattern("foo/", "name", is_endpoint=True)

In [3]: pattern = RoutePattern("foo/", "name", is_endpoint=False)

In [4]: %timeit pattern.match("foo/")
441 ns ± 2.68 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [5]: %timeit endpoint_pattern.match("foo/")
435 ns ± 0.974 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

**After**

```python
In [4]: %timeit pattern.match("foo/")
187 ns ± 1.84 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [5]: %timeit endpoint_pattern.match("foo/")
103 ns ± 0.192 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

(Benchmarked on Python 3.12, running `main`)

Theoretically, these improvements get better based on the length of the route pattern (although at this scale, not notably).

This optimisation could be done by adding a different kind of pattern (eg `LiteralPattern`), but the added complexity to a project probably isn't necessary, not to mention the migration effort to take advantage of this.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
