### PR TITLE
Fixed #35502: Clarified tutorial instructions

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -48,13 +48,13 @@ including database configuration, Django-specific options and
 application-specific settings.
 
 From the command line, ``cd`` into a directory where you'd like to store your
-code, then run the following command:
+code and create a new directory called ``djangotutorial``, then run the following command:
 
 .. console::
 
-   $ django-admin startproject mysite
+   $ django-admin startproject mysite djangotutorial
 
-This will create a ``mysite`` directory in your current directory. If it didn't
+This will create a project named ``mysite`` inside ``djangotutorial`` directory. If it didn't
 work, see :ref:`troubleshooting-django-admin`.
 
 .. note::
@@ -68,7 +68,7 @@ Let's look at what :djadmin:`startproject` created:
 
 .. code-block:: text
 
-    mysite/
+    djangotutorial/
         manage.py
         mysite/
             __init__.py
@@ -79,14 +79,14 @@ Let's look at what :djadmin:`startproject` created:
 
 These files are:
 
-* The outer :file:`mysite/` root directory is a container for your project. Its
+* The :file:`djangotutorial/` root directory is a container for your project. Its
   name doesn't matter to Django; you can rename it to anything you like.
 
 * :file:`manage.py`: A command-line utility that lets you interact with this
   Django project in various ways. You can read all the details about
   :file:`manage.py` in :doc:`/ref/django-admin`.
 
-* The inner :file:`mysite/` directory is the actual Python package for your
+* The :file:`mysite/` directory is the actual Python package for your
   project. Its name is the Python package name you'll need to use to import
   anything inside it (e.g. ``mysite.urls``).
 
@@ -111,7 +111,7 @@ These files are:
 The development server
 ======================
 
-Let's verify your Django project works. Change into the outer :file:`mysite` directory, if
+Let's verify your Django project works. Change into the :file:`djangotutorial` directory, if
 you haven't already, and run the following commands:
 
 .. console::


### PR DESCRIPTION
Updated startproject command in tutorial to 'django-admin startproject mysite djangotutorial' for clearer directory structure explanation.

# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35502

# Branch description
The tutorial previously instructed users to create a 'mysite' directory and another directory with the same name inside it. This update resolves the confusion by changing the start project command to: `django-admin startproject mysite djangotutorial.`, and updating references to the new folder. This makes it clear to which directory the tutorial is referring.


# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. 
