### PR TITLE
Fixed mail.tests.MailTests.test_backend_arg() test on Python 3.13+.

### DIFF
--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -29,7 +29,6 @@ from django.core.mail.message import BadHeaderError, sanitize_address
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import requires_tz_support
 from django.utils.translation import gettext_lazy
-from django.utils.version import PY311
 
 try:
     from aiosmtpd.controller import Controller
@@ -822,13 +821,7 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
                 filebased.EmailBackend,
             )
 
-        if sys.platform == "win32" and not PY311:
-            msg = (
-                "_getfullpathname: path should be string, bytes or os.PathLike, not "
-                "object"
-            )
-        else:
-            msg = "expected str, bytes or os.PathLike object, not object"
+        msg = " not object"
         with self.assertRaisesMessage(TypeError, msg):
             mail.get_connection(
                 "django.core.mail.backends.filebased.EmailBackend", file_path=object()


### PR DESCRIPTION
There is no point in asserting Python error messages.

https://github.com/python/cpython/commit/93a970ffbce58657cc99305be69e460a11371730
https://github.com/django/django/actions/runs/9509853466/job/26213438376