### PR TITLE
Fixed #35528 -- Added helper method EmailMultiAlternatives.body_contains().

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -505,3 +505,16 @@ class EmailMultiAlternatives(EmailMessage):
                     )
                 )
         return msg
+
+    def body_contains(self, text):
+        """
+        Checks that ``text`` occurs in the email body and in all attached MIME
+        type text/* alternatives.
+        """
+        if text not in self.body:
+            return False
+
+        for content, mimetype in self.alternatives:
+            if mimetype.startswith("text/") and text not in content:
+                return False
+        return True

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -143,6 +143,10 @@ Email
   <django.core.mail.EmailMultiAlternatives.alternatives>` is now a list of
   named tuples, as opposed to regular tuples.
 
+* The new :meth:`~django.core.mail.EmailMultiAlternatives.body_contains` method
+  returns a boolean indicating whether a provided text is contained in the
+  email ``body`` and in all attached MIME type ``text/*`` alternatives.
+
 Error Reporting
 ~~~~~~~~~~~~~~~
 

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -436,6 +436,26 @@ Django's email library, you can do this using the
             msg.attach_alternative(html_content, "text/html")
             msg.send()
 
+    .. method:: body_contains(text)
+
+        .. versionadded:: 5.2
+
+        Returns a boolean indicating whether the provided ``text`` is
+        contained in the email ``body`` and in all attached MIME type
+        ``text/*`` alternatives.
+
+        This can be useful when testing emails. For example::
+
+            def test_contains_email_content(self):
+                subject = "Hello World"
+                from_email = "from@example.com"
+                to = "to@example.com"
+                msg = EmailMultiAlternatives(subject, "I am content.", from_email, [to])
+                msg.attach_alternative("<p>I am content.</p>", "text/html")
+
+                self.assertIs(msg.body_contains("I am content"), True)
+                self.assertIs(msg.body_contains("<p>I am content.</p>"), False)
+
 Updating the default content type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -1163,6 +1163,24 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
         with self.assertRaisesMessage(ValueError, msg):
             email_msg.attach_alternative("<p>content</p>", None)
 
+    def test_body_contains(self):
+        email_msg = EmailMultiAlternatives()
+        email_msg.body = "I am content."
+        self.assertIs(email_msg.body_contains("I am"), True)
+        self.assertIs(email_msg.body_contains("I am content."), True)
+
+        email_msg.attach_alternative("<p>I am different content.</p>", "text/html")
+        self.assertIs(email_msg.body_contains("I am"), True)
+        self.assertIs(email_msg.body_contains("I am content."), False)
+        self.assertIs(email_msg.body_contains("<p>I am different content.</p>"), False)
+
+    def test_body_contains_alternative_non_text(self):
+        email_msg = EmailMultiAlternatives()
+        email_msg.body = "I am content."
+        email_msg.attach_alternative("I am content.", "text/html")
+        email_msg.attach_alternative(b"I am a song.", "audio/mpeg")
+        self.assertIs(email_msg.body_contains("I am content"), True)
+
 
 @requires_tz_support
 class MailTimeZoneTests(SimpleTestCase):


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35528

# Branch description

Currently, it's very hard and tedious to assert the content of an email object. Therefore, we want to add a method "body_contains()" to "EmailMultiAlternatives" to check a search string in all available text-based alternatives (content parts, like HTML).

This method can then be easily asserted in any given unit-test.

There's a forum discussion going on about this topic: [​https://forum.djangoproject.com/t/improve-email-unit-testing/32044/1](https://forum.djangoproject.com/t/improve-email-unit-testing/32044/1)

I've already created a PR for a suggetion: [​https://github.com/django/django/pull/18278/files](https://github.com/django/django/pull/18278/files)

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
