### PR TITLE
Update validators.py

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -401,7 +401,7 @@ class BaseValidator:
 
     def __init__(self, limit_value, message=None):
         self.limit_value = limit_value
-        if message:
+        if message is not None:
             self.message = message
 
     def __call__(self, value):


### PR DESCRIPTION
Fix unnecessary lazy evaluation in BaseValidator

# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-N/A

# Branch description
if you run this:

```python
from django.utils.translation import gettext_lazy
from django.core.validators import MinValidator

MinValidator(0, message=gettext_lazy('hi'))
```

This will raise:

```
django.core.exceptions.AppRegistryNotReady: The translation infrastructure cannot be initialized before the apps registry is ready. Check that you don't make non-lazy gettext calls at import time.
```

And the problem is this line because it tries to evaluate message instead of checking if it is None. This PR will solve this issue

# Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
