### PR TITLE
Fixed #35461 -- Added detail in django tutorial step 8 so that django…

### DIFF
--- a/docs/intro/tutorial08.txt
+++ b/docs/intro/tutorial08.txt
@@ -48,11 +48,11 @@ The steps are not duplicated in this tutorial, because as a third-party
 package, it may change separately to Django's schedule.
 
 Once installed, you should be able to see the DjDT "handle" on the right side
-of the browser window when you refresh the polls application. Click it to open
-the debug toolbar and use the tools in each panel. See the `panels
-documentation page
-<https://django-debug-toolbar.readthedocs.io/en/latest/panels.html>`__ for more
-information on what the panels show.
+of the browser window when you browse to ``http://localhost:8000/admin/``.
+Click it to open the debug toolbar and use the tools in each panel. See the
+`panels documentation page`__ for more information on what the panels show.
+
+__ https://django-debug-toolbar.readthedocs.io/en/latest/panels.html
 
 Getting help from others
 ========================


### PR DESCRIPTION
One solution for https://code.djangoproject.com/ticket/35461

# Trac ticket number
[ticket-35461](https://code.djangoproject.com/ticket/35461)

# Branch description
- Following the tutorial 'as is' won't lead to the toolbar working in /polls because the tutorial omits usage of complete HTML templates.
- This solution proposal implements an option of the list of options discussed in the thread. Reasoning available [here](https://www.notion.so/Tutorial-instructions-for-adding-django-debug-toolbar-are-misleading-1f1429081df4473cb5bad80790cc4176).


<img width="709" alt="Screenshot 2024-06-19 at 21 16 09" src="https://github.com/django/django/assets/4906291/87ad4f47-cd19-4c6d-bc73-4ab17e717115">



# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
