### PR TITLE
Refs #35542 -- Made BoundField's label, help_text and renderer properties instead of class members

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -20,12 +20,30 @@ class BoundField(RenderableFieldMixin):
         self.html_name = form.add_prefix(name)
         self.html_initial_name = form.add_initial_prefix(name)
         self.html_initial_id = form.add_initial_prefix(self.auto_id)
-        if self.field.label is None:
-            self.label = pretty_name(name)
-        else:
-            self.label = self.field.label
-        self.help_text = field.help_text or ""
-        self.renderer = form.renderer
+
+    @property
+    def label(self):
+        return pretty_name(self.name) if self.field.label is None else self.field.label
+
+    @label.setter
+    def label(self, value):
+        self.field.label = value
+
+    @property
+    def help_text(self):
+        return self.field.help_text or ""
+
+    @help_text.setter
+    def help_text(self, value):
+        self.field.help_text = value
+
+    @property
+    def renderer(self):
+        return self.form.renderer
+
+    @renderer.setter
+    def renderer(self, value):
+        self.form.renderer = value
 
     @cached_property
     def subwidgets(self):


### PR DESCRIPTION
# Trac ticket number

ticket-35542

# Branch description

Made `BoundField'`s label, help_text and renderer properties instead of class members to avoid diverging data between `BoundField` and underlying `Field`

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
