### PR TITLE
Exclude pylibmc on MacOS and Windows

### DIFF
--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -8,8 +8,8 @@ geoip2; python_version < '3.13'
 jinja2 >= 2.11.0
 numpy; sys_platform != 'win32' or python_version < '3.13'
 Pillow >= 6.2.1; sys_platform != 'win32' or python_version < '3.13'
-# pylibmc/libmemcached can't be built on Windows.
-pylibmc; sys_platform != 'win32'
+# pylibmc/libmemcached can't be built on Windows and MacOS.
+pylibmc; sys_platform != 'win32' and sys_platform != 'darwin'
 pymemcache >= 3.4.0
 pywatchman; sys_platform != 'win32'
 PyYAML


### PR DESCRIPTION
# Trac ticket number

N/A

# Branch description

Following the [quickstart](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/unit-tests/#quickstart) I ran into the following issue:

```
$ python -m pip install -r requirements/py3.txt
...
Building wheels for collected packages: pylibmc
  Building wheel for pylibmc (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for pylibmc (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      In file included from src/_pylibmcmodule.c:34:
      src/_pylibmcmodule.h:42:10: fatal error: 'libmemcached/memcached.h' file not found
      #include <libmemcached/memcached.h>
               ^~~~~~~~~~~~~~~~~~~~~~~~~~
      1 error generated.
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pylibmc
Failed to build pylibmc
```

I'm on MacOS, libmemcached is not available and I'm not sure how to get it.

Seeing as Windows is already exempt from this requirement, I've added MacOS to be excluded as well.

Not sure if this requires a track ticket?

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, ~~mentions the ticket number~~, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
