### PR TITLE
Fixed Number.__str__() crash when float/decimal_value is None.

### DIFF
--- a/tests/expressions/models.py
+++ b/tests/expressions/models.py
@@ -56,7 +56,11 @@ class Number(models.Model):
     decimal_value = models.DecimalField(max_digits=20, decimal_places=17, null=True)
 
     def __str__(self):
-        return "%i, %.3f, %.17f" % (self.integer, self.float, self.decimal_value)
+        return "%i, %s, %s" % (
+            self.integer,
+            "%.3f" % self.float if self.float is not None else None,
+            "%.17f" % self.decimal_value if self.decimal_value is not None else None,
+        )
 
 
 class Experiment(models.Model):


### PR DESCRIPTION
I encountered this crash while debugging test failures.