### PR TITLE
Fixed #35464 -- Updated docs to note fieldsets do not impact TabularI…

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -437,15 +437,24 @@ subclass::
 
     * ``description``
         A string of optional extra text to be displayed at the top of each
-        fieldset, under the heading of the fieldset. This string is not
-        rendered for :class:`~django.contrib.admin.TabularInline` due to its
-        layout.
+        fieldset, under the heading of the fieldset.
 
         Note that this value is *not* HTML-escaped when it's displayed in
         the admin interface. This lets you include HTML if you so desire.
         Alternatively you can use plain text and
         :func:`django.utils.html.escape` to escape any HTML special
         characters.
+
+    .. admonition:: :class:`~django.contrib.admin.TabularInline` has limited
+        support for ``fieldsets``
+
+        Using ``fieldsets`` with :class:`~django.contrib.admin.TabularInline`
+        has limited functionality. You can specify which fields will be
+        displayed and their order within the ``TabularInline`` layout by
+        defining ``fields`` in the ``field_options`` dictionary.
+
+        All other features are not supported. This includes the use of ``name``
+        to define a title for a group of fields.
 
 .. attribute:: ModelAdmin.filter_horizontal
 

--- a/tests/admin_inlines/admin.py
+++ b/tests/admin_inlines/admin.py
@@ -106,14 +106,18 @@ class PhotoInlineMixin:
     model = Photo
     extra = 2
     fieldsets = [
-        (None, {"fields": ["image", "title"]}),
+        (None, {"fields": ["image", "title"], "description": "First group"}),
         (
             "Details",
-            {"fields": ["description", "creation_date"], "classes": ["collapse"]},
+            {
+                "fields": ["description", "creation_date"],
+                "classes": ["collapse"],
+                "description": "Second group",
+            },
         ),
         (
             "Details",  # Fieldset name intentionally duplicated
-            {"fields": ["update_date", "updated_by"]},
+            {"fields": ["update_date", "updated_by"], "description": "Third group"},
         ),
     ]
 

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -2422,3 +2422,39 @@ class SeleniumTests(AdminSeleniumTestCase):
                 )
                 self.assertEqual(available.text, "AVAILABLE ATTENDANT")
                 self.assertEqual(chosen.text, "CHOSEN ATTENDANT")
+
+    def test_tabular_inline_layout(self):
+        from selenium.webdriver.common.by import By
+
+        self.admin_login(username="super", password="secret")
+        self.selenium.get(
+            self.live_server_url + reverse("admin:admin_inlines_photographer_add")
+        )
+        tabular_inline = self.selenium.find_element(
+            By.CSS_SELECTOR, "[data-inline-type='tabular']"
+        )
+        headers = tabular_inline.find_elements(By.TAG_NAME, "th")
+        self.assertEqual(
+            [h.get_attribute("innerText") for h in headers],
+            [
+                "",
+                "IMAGE",
+                "TITLE",
+                "DESCRIPTION",
+                "CREATION DATE",
+                "UPDATE DATE",
+                "UPDATED BY",
+                "DELETE?",
+            ],
+        )
+        # There are no fieldset section names rendered.
+        self.assertNotIn("Details", tabular_inline.text)
+        # There are no fieldset section descriptions rendered.
+        self.assertNotIn("First group", tabular_inline.text)
+        self.assertNotIn("Second group", tabular_inline.text)
+        self.assertNotIn("Third group", tabular_inline.text)
+        # There are no fieldset classes applied.
+        self.assertEqual(
+            tabular_inline.find_elements(By.CSS_SELECTOR, ".collapse"),
+            [],
+        )


### PR DESCRIPTION
# Trac ticket number
ticket-35464

# Branch description
From the Trac ticket, we decided to go with option 2: Explicitly document that fieldsets make no sense for TabularInline, as the current documentation implies that this setup is valid.

Since the ticket also mentioned that the HTML collapsible details element is not allowed within a table and didn't work in a previous proof of concept, adding this note to the documentation seems to be the best approach.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
