### PR TITLE
Fixed #35530 -- Deprecated request.user fallback in auth.login.

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -1,11 +1,13 @@
 import inspect
 import re
+import warnings
 
 from django.apps import apps as django_apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.middleware.csrf import rotate_token
 from django.utils.crypto import constant_time_compare
+from django.utils.deprecation import RemovedInDjango61Warning
 from django.utils.module_loading import import_string
 from django.views.decorators.debug import sensitive_variables
 
@@ -154,9 +156,19 @@ def login(request, user, backend=None):
     have to reauthenticate on every request. Note that data set during
     the anonymous session is retained when the user logs in.
     """
+    # RemovedInDjango61Warning: When the deprecation ends, replace with:
+    # session_auth_hash = user.get_session_auth_hash()
     session_auth_hash = ""
+    # RemovedInDjango61Warning.
     if user is None:
         user = request.user
+        warnings.warn(
+            "Fallback to request.user when user is None will be removed.",
+            RemovedInDjango61Warning,
+            stacklevel=2,
+        )
+
+    # RemovedInDjango61Warning.
     if hasattr(user, "get_session_auth_hash"):
         session_auth_hash = user.get_session_auth_hash()
 
@@ -187,9 +199,18 @@ def login(request, user, backend=None):
 
 async def alogin(request, user, backend=None):
     """See login()."""
+    # RemovedInDjango61Warning: When the deprecation ends, replace with:
+    # session_auth_hash = user.get_session_auth_hash()
     session_auth_hash = ""
+    # RemovedInDjango61Warning.
     if user is None:
+        warnings.warn(
+            "Fallback to request.user when user is None will be removed.",
+            RemovedInDjango61Warning,
+            stacklevel=2,
+        )
         user = await request.auser()
+    # RemovedInDjango61Warning.
     if hasattr(user, "get_session_auth_hash"):
         session_auth_hash = user.get_session_auth_hash()
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -18,6 +18,10 @@ details on these changes.
 * The ``all`` keyword argument of ``django.contrib.staticfiles.finders.find()``
   will be removed.
 
+* The fallback to ``request.user`` when ``user`` is ``None`` in
+  ``django.contrib.auth.login()`` and ``django.contrib.auth.alogin()`` will be
+  removed.
+
 .. _deprecation-removed-in-6.0:
 
 6.0

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -442,3 +442,7 @@ Miscellaneous
 
 * The ``all`` argument for the ``django.contrib.staticfiles.finders.find()``
   function is deprecated in favor of the ``find_all`` argument.
+
+* The fallback to ``request.user`` when ``user`` is ``None`` in
+  ``django.contrib.auth.login()`` and ``django.contrib.auth.alogin()`` will be
+  removed.

--- a/tests/auth_tests/test_login.py
+++ b/tests/auth_tests/test_login.py
@@ -1,0 +1,25 @@
+from django.contrib import auth
+from django.contrib.auth.models import User
+from django.http import HttpRequest
+from django.test import TestCase
+
+
+class TestLogin(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username="testuser", password="password")
+
+    def setUp(self):
+        self.request = HttpRequest()
+        self.request.session = self.client.session
+
+    def test_user_login(self):
+        auth.login(self.request, self.user)
+        self.assertEqual(self.request.session[auth.SESSION_KEY], str(self.user.pk))
+
+    def test_inactive_user(self):
+        self.user.is_active = False
+        self.user.save(update_fields=["is_active"])
+
+        auth.login(self.request, self.user)
+        self.assertEqual(self.request.session[auth.SESSION_KEY], str(self.user.pk))

--- a/tests/auth_tests/test_login.py
+++ b/tests/auth_tests/test_login.py
@@ -1,7 +1,8 @@
 from django.contrib import auth
-from django.contrib.auth.models import User
+from django.contrib.auth.models import AnonymousUser, User
 from django.http import HttpRequest
 from django.test import TestCase
+from django.utils.deprecation import RemovedInDjango61Warning
 
 
 class TestLogin(TestCase):
@@ -22,4 +23,50 @@ class TestLogin(TestCase):
         self.user.save(update_fields=["is_active"])
 
         auth.login(self.request, self.user)
+        self.assertEqual(self.request.session[auth.SESSION_KEY], str(self.user.pk))
+
+    # RemovedInDjango61Warning: When the deprecation ends, replace with:
+    # def test_without_user(self):
+    def test_without_user_no_request_user(self):
+        # RemovedInDjango61Warning: When the deprecation ends, replace with:
+        # with self.assertRaisesMessage(
+        #     AttributeError,
+        #     "'NoneType' object has no attribute 'get_session_auth_hash'",
+        # ):
+        #     auth.login(self.request, None)
+        with (
+            self.assertRaisesMessage(
+                AttributeError,
+                "'HttpRequest' object has no attribute 'user'",
+            ),
+            self.assertWarnsMessage(
+                RemovedInDjango61Warning,
+                "Fallback to request.user when user is None will be removed.",
+            ),
+        ):
+            auth.login(self.request, None)
+
+    # RemovedInDjango61Warning: When the deprecation ends, remove completely.
+    def test_without_user_anonymous_request(self):
+        self.request.user = AnonymousUser()
+        with (
+            self.assertRaisesMessage(
+                AttributeError,
+                "'AnonymousUser' object has no attribute '_meta'",
+            ),
+            self.assertWarnsMessage(
+                RemovedInDjango61Warning,
+                "Fallback to request.user when user is None will be removed.",
+            ),
+        ):
+            auth.login(self.request, None)
+
+    # RemovedInDjango61Warning: When the deprecation ends, remove completely.
+    def test_without_user_authenticated_request(self):
+        self.request.user = self.user
+        self.assertNotIn(auth.SESSION_KEY, self.request.session)
+
+        msg = "Fallback to request.user when user is None will be removed."
+        with self.assertWarnsMessage(RemovedInDjango61Warning, msg):
+            auth.login(self.request, None)
         self.assertEqual(self.request.session[auth.SESSION_KEY], str(self.user.pk))


### PR DESCRIPTION
# Trac ticket number

ticket-35530

# Branch description

Removed `request.user` fallback logic in `auth.login`. There is no clear reason for it to exist, hasn't been tested until recently (through the async wraper) and is confusing at best.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
