### PR TITLE
Fixed #35551 - Added PK conflict check to forms.

### DIFF
--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1461,6 +1461,27 @@ class UniqueTest(TestCase):
             form.errors["title"], ["Post's Title not unique for Posted date."]
         )
 
+    def test_pk_conflict(self):
+        ExplicitPK.objects.create(key="key1", desc="desc1")
+        instance = ExplicitPK.objects.create(key="key2", desc="desc2")
+
+        with self.subTest("key2 -> key1"):
+            form = ExplicitPKForm({"key": "key1"}, instance=instance)
+            self.assertEqual(len(form.errors), 1, form.errors)
+            self.assertEqual(
+                form.errors["key"], ["Explicit pk with this Key already exists."]
+            )
+
+        with self.subTest("key2 -> key2"):
+            instance = ExplicitPK.objects.get(key="key2")
+            form = ExplicitPKForm({"key": "key2"}, instance=instance)
+            self.assertEqual(len(form.errors), 0, form.errors)
+
+        with self.subTest("key2 -> key3"):
+            instance = ExplicitPK.objects.get(key="key2")
+            form = ExplicitPKForm({"key": "key3"}, instance=instance)
+            self.assertEqual(len(form.errors), 0, form.errors)
+
 
 class ModelFormBasicTests(TestCase):
     def create_basic_data(self):


### PR DESCRIPTION
# Trac ticket number
ticket-35551

# Branch description
If an object's primary key is changed and there's a primary key conflict, an error should be raised.

https://github.com/django/django/pull/18311

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.

# Screenshot

A screenshot of changing an object's id from 2 -> 1 (when object 1 already exists).
As you can see on the screenshot, the subtitle changes as well - it displays **Tenant object (1)** instead of **Tenant object (2)**.
Is this something we should address?

![admin](https://github.com/django/django/assets/19559023/aae0db13-cef3-4834-aaaa-c4920106db4d)