### PR TITLE
#35560: Model.full_clean() errors with GeneratedField and UniqueConstraint or CheckConstraint

### DIFF
--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -609,3 +609,75 @@ class GeneratedModelNullVirtual(models.Model):
 
     class Meta:
         required_db_features = {"supports_virtual_generated_columns"}
+
+
+class GeneratedModelUniqueConstraint(models.Model):
+    name = models.CharField(max_length=10)
+    lower_name = models.GeneratedField(
+        expression=Lower("name"),
+        output_field=models.CharField(max_length=10),
+        db_persist=True,
+    )
+
+    class Meta:
+        required_db_features = {"supports_stored_generated_columns"}
+        constraints = [
+            models.UniqueConstraint(Lower("name"), name="name_uniq_generated")
+        ]
+
+
+class GeneratedModelUniqueConstraintVirtual(models.Model):
+    name = models.CharField(max_length=10)
+    lower_name = models.GeneratedField(
+        expression=Lower("name"),
+        output_field=models.CharField(max_length=10),
+        db_persist=False,
+    )
+
+    class Meta:
+        required_db_features = {"supports_virtual_generated_columns"}
+        constraints = [
+            models.UniqueConstraint(Lower("name"), name="name_uniq_generated_virtual")
+        ]
+
+
+class GeneratedModelCheckConstraint(models.Model):
+    a = models.IntegerField()
+    b = models.IntegerField()
+    field = models.GeneratedField(
+        expression=F("a") + F("b"),
+        output_field=models.IntegerField(),
+        db_persist=True,
+    )
+
+    class Meta:
+        required_db_features = {
+            "supports_stored_generated_columns",
+            "supports_table_check_constraints",
+        }
+        constraints = [
+            models.CheckConstraint(
+                condition=models.Q(a__gt=0), name="check_a_gt_0_generated"
+            )
+        ]
+
+
+class GeneratedModelCheckConstraintVirtual(models.Model):
+    a = models.IntegerField()
+    b = models.IntegerField()
+    field = models.GeneratedField(
+        expression=F("a") + F("b"),
+        output_field=models.IntegerField(),
+        db_persist=False,
+    )
+
+    class Meta:
+        required_db_features = {
+            "supports_stored_generated_columns",
+            "supports_table_check_constraints",
+        }
+        constraints = [
+            models.CheckConstraint(
+                condition=models.Q(a__gt=0), name="check_a_gt_0_generated_virtual"
+            )
+        ]

--- a/tests/model_fields/test_generatedfield.py
+++ b/tests/model_fields/test_generatedfield.py
@@ -18,6 +18,8 @@ from django.test.utils import isolate_apps
 from .models import (
     Foo,
     GeneratedModel,
+    GeneratedModelCheckConstraint,
+    GeneratedModelCheckConstraintVirtual,
     GeneratedModelFieldWithConverters,
     GeneratedModelNull,
     GeneratedModelNullVirtual,
@@ -25,6 +27,8 @@ from .models import (
     GeneratedModelOutputFieldDbCollationVirtual,
     GeneratedModelParams,
     GeneratedModelParamsVirtual,
+    GeneratedModelUniqueConstraint,
+    GeneratedModelUniqueConstraintVirtual,
     GeneratedModelVirtual,
 )
 
@@ -186,6 +190,23 @@ class GeneratedFieldTestMixin:
         m = self._refresh_if_needed(m)
         self.assertEqual(m.field, 3)
 
+    def test_full_clean_with_unique_constraint(self):
+        m = self.unique_constraint_model(name="ABC")
+        # full_clean() ignores GeneratedFields.
+        m.full_clean()
+        m.save()
+        m = self._refresh_if_needed(m)
+        self.assertEqual(m.lower_name, "abc")
+
+    @skipUnlessDBFeature("supports_table_check_constraints")
+    def test_full_clean_with_check_constraint(self):
+        m = self.check_constraint_model(a=1, b=2)
+        # full_clean() ignores GeneratedFields.
+        m.full_clean()
+        m.save()
+        m = self._refresh_if_needed(m)
+        self.assertEqual(m.field, 3)
+
     def test_create(self):
         m = self.base_model.objects.create(a=1, b=2)
         m = self._refresh_if_needed(m)
@@ -305,6 +326,8 @@ class GeneratedFieldTestMixin:
 class StoredGeneratedFieldTests(GeneratedFieldTestMixin, TestCase):
     base_model = GeneratedModel
     nullable_model = GeneratedModelNull
+    unique_constraint_model = GeneratedModelUniqueConstraint
+    check_constraint_model = GeneratedModelCheckConstraint
     output_field_db_collation_model = GeneratedModelOutputFieldDbCollation
     params_model = GeneratedModelParams
 
@@ -318,5 +341,7 @@ class StoredGeneratedFieldTests(GeneratedFieldTestMixin, TestCase):
 class VirtualGeneratedFieldTests(GeneratedFieldTestMixin, TestCase):
     base_model = GeneratedModelVirtual
     nullable_model = GeneratedModelNullVirtual
+    unique_constraint_model = GeneratedModelUniqueConstraintVirtual
+    check_constraint_model = GeneratedModelCheckConstraintVirtual
     output_field_db_collation_model = GeneratedModelOutputFieldDbCollationVirtual
     params_model = GeneratedModelParamsVirtual


### PR DESCRIPTION
ticket-35560

Calling `full_clean()` on an unsaved model instance which has either a `UniqueConstraint` or `CheckConstraint` raises the error:

`AttributeError: Cannot read a generated field from an unsaved model.`

