### PR TITLE
Removed superfluous request.user assignment in RemoteUserMiddleware.

### DIFF
--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -142,9 +142,8 @@ class RemoteUserMiddleware(MiddlewareMixin):
         # to authenticate the user.
         user = auth.authenticate(request, remote_user=username)
         if user:
-            # User is valid.  Set request.user and persist user in the session
+            # User is valid. Set request.user and persist user in the session
             # by logging the user in.
-            request.user = user
             auth.login(request, user)
 
     def clean_username(self, username, request):


### PR DESCRIPTION
# Trac ticket number

N/A

# Branch description

[`auth.login` sets `request.user`](https://github.com/django/django/blob/bcc327aa326093a39f01a9bc98198807444900f3/django/contrib/auth/__init__.py#L149-L150), there is no need to assign `request.user` before calling `auth.login`.

The conditional in `auth.login` before it sets `request.user` will always succeed. `RemoteUserMiddleware` raises `ImproperlyConfigured` if it doesn't and will never reach this code in that situation.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, ~~mentions the ticket number~~, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
