### PR TITLE
Fixed #35551 - Fixed PK updates in admin.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1289,7 +1289,18 @@ class ModelAdmin(BaseModelAdmin):
         """
         Given a model instance save it to the database.
         """
+        self.update_pk_if_changed(obj, form)
         obj.save()
+
+    def update_pk_if_changed(self, obj, form):
+        old_pk = form.old_pk
+        new_pk = obj.pk
+        empty_vals = (None, "")
+
+        if old_pk not in empty_vals and new_pk not in empty_vals and old_pk != new_pk:
+            meta = obj._meta
+            update_kwargs = {meta.pk.name: new_pk}
+            meta.model.objects.filter(pk=old_pk).update(**update_kwargs)
 
     def delete_model(self, request, obj):
         """

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -367,6 +367,7 @@ class BaseModelForm(BaseForm, AltersData):
         else:
             self.instance = instance
             object_data = model_to_dict(instance, opts.fields, opts.exclude)
+        self.old_pk = self.instance.pk
         # if initial was provided, it should override the values from instance
         if initial is not None:
             object_data.update(initial)

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -18,6 +18,7 @@ from .models import (
     Answer,
     Book,
     ExternalSubscriber,
+    ModelWithStringPrimaryKey,
     Question,
     Subscriber,
     UnchangeableObject,
@@ -489,6 +490,20 @@ action)</option>
         self.assertIn(r"&quot;value\\&quot;", output)
         self.assertIn(r"&quot;new_value\\&quot;", output)
         self.assertIn(r"&quot;obj\\&quot;", output)
+
+    def test_pk_change(self):
+        instance = ModelWithStringPrimaryKey.objects.create(string_pk="a")
+        url = reverse(
+            "admin:admin_views_modelwithstringprimarykey_change", args=(instance.pk,)
+        )
+
+        response = self.client.post(url, {"string_pk": "b"})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(ModelWithStringPrimaryKey.objects.count(), 1)
+        self.assertTrue(
+            ModelWithStringPrimaryKey.objects.filter(string_pk="b").exists()
+        )
 
 
 @override_settings(ROOT_URLCONF="admin_views.urls")


### PR DESCRIPTION
# Trac ticket number

ticket-35551

# Branch description

Fix the issue of duplicates being created when updating an object's primary key in admin.

https://github.com/django/django/pull/18305

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
