### PR TITLE
Fixed 35561 -- Made *args and **kwargs parsing more strict in Model.save()/asave().

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -799,17 +799,17 @@ class Model(AltersData, metaclass=ModelBase):
                 f"arguments but {total_len_args} were given"
             )
 
-        def get_param(arg_name, arg_value, arg_index):
+        def get_param(param_name, param_value, arg_index):
             if arg_index < len(args):
-                if arg_value is not defaults[arg_name]:
+                if param_value is not defaults[param_name]:
                     # Recreate the proper TypeError message from Python.
                     raise TypeError(
                         f"Model.{method_name}() got multiple values for argument "
-                        f"'{arg_name}'"
+                        f"'{param_name}'"
                     )
                 return args[arg_index]
 
-            return arg_value
+            return param_value
 
         return [get_param(k, v, i) for i, (k, v) in enumerate(kwargs.items())]
 

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -239,6 +239,23 @@ class ModelInstanceCreationTests(TestCase):
         ):
             a.save(False, False, None, None, None)
 
+    def test_save_conflicting_positional_and_named_arguments(self):
+        a = Article()
+        cases = [
+            ("force_insert", True, [42]),
+            ("force_update", None, [42, 41]),
+            ("using", "some-db", [42, 41, 40]),
+            ("update_fields", ["foo"], [42, 41, 40, 39]),
+        ]
+        for param_name, param_value, args in cases:
+            with self.subTest(param_name=param_name):
+                msg = f"Model.save() got multiple values for argument '{param_name}'"
+                with (
+                    self.assertWarns(RemovedInDjango60Warning),
+                    self.assertRaisesMessage(TypeError, msg),
+                ):
+                    a.save(*args, **{param_name: param_value})
+
     async def test_asave_deprecation(self):
         a = Article(headline="original", pub_date=datetime(2014, 5, 16))
         msg = "Passing positional arguments to asave() is deprecated"
@@ -274,6 +291,23 @@ class ModelInstanceCreationTests(TestCase):
             self.assertRaisesMessage(TypeError, msg),
         ):
             await a.asave(False, False, None, None, None)
+
+    async def test_asave_conflicting_positional_and_named_arguments(self):
+        a = Article()
+        cases = [
+            ("force_insert", True, [42]),
+            ("force_update", None, [42, 41]),
+            ("using", "some-db", [42, 41, 40]),
+            ("update_fields", ["foo"], [42, 41, 40, 39]),
+        ]
+        for param_name, param_value, args in cases:
+            with self.subTest(param_name=param_name):
+                msg = f"Model.asave() got multiple values for argument '{param_name}'"
+                with (
+                    self.assertWarns(RemovedInDjango60Warning),
+                    self.assertRaisesMessage(TypeError, msg),
+                ):
+                    await a.asave(*args, **{param_name: param_value})
 
     @ignore_warnings(category=RemovedInDjango60Warning)
     def test_save_positional_arguments(self):


### PR DESCRIPTION
# Trac ticket number

ticket-35561

# Branch description
Fixing a 5.1 release blocker to ensure that arguments passed to `Model.save()` and `Model.asave()` do not allow for unsupported or duplicated parameters.

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
