### PR TITLE
Updated instruction for deploying with Uvicorn and Gunicorn.

### DIFF
--- a/docs/howto/deployment/asgi/uvicorn.txt
+++ b/docs/howto/deployment/asgi/uvicorn.txt
@@ -47,13 +47,13 @@ To install Uvicorn and Gunicorn, use the following:
 
 .. code-block:: shell
 
-    python -m pip install uvicorn gunicorn
+    python -m pip install uvicorn uvicorn-worker gunicorn
 
 Then start Gunicorn using the Uvicorn worker class like this:
 
 .. code-block:: shell
 
-    python -m gunicorn myproject.asgi:application -k uvicorn.workers.UvicornWorker
+    python -m gunicorn myproject.asgi:application -k uvicorn_worker.UvicornWorker
 
 .. _Uvicorn: https://www.uvicorn.org/
 .. _Gunicorn: https://gunicorn.org/


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description
This PR replaces the deprecated uvicorn worker with the package `uvicorn-worker` proposed by [Kludex](https://github.com/Kludex) in encode/uvicorn#2302.
It is also already noted as a warning in the [uvicorn docs](https://www.uvicorn.org/deployment/#gunicorn)
The command `-k uvicorn_worker.UvicornWorker` comes from [here](https://github.com/Kludex/uvicorn-worker?tab=readme-ov-file#deployment)
- `uvicorn-worker` itself installs both uvicorn and gunicorn, so the command could just be `python -m pip install uvicorn-worker`. They are not removed because doing so would confuse the reader in the ambiguity of the command.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
