### PR TITLE
Fixed #35564 -- Improved readability of subclass identification in admin and auth checks

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -1,4 +1,5 @@
 import collections
+import contextlib
 from itertools import chain
 
 from django.apps import apps
@@ -21,10 +22,9 @@ def _issubclass(cls, classinfo):
     issubclass() variant that doesn't raise an exception if cls isn't a
     class.
     """
-    try:
+    with contextlib.suppress(TypeError):
         return issubclass(cls, classinfo)
-    except TypeError:
-        return False
+    return False
 
 
 def _contains_subclass(class_path, candidate_paths):
@@ -34,13 +34,9 @@ def _contains_subclass(class_path, candidate_paths):
     """
     cls = import_string(class_path)
     for path in candidate_paths:
-        try:
-            candidate_cls = import_string(path)
-        except ImportError:
-            # ImportErrors are raised elsewhere.
-            continue
-        if _issubclass(candidate_cls, cls):
-            return True
+        with contextlib.suppress(ImportError, TypeError):
+            if issubclass(import_string(path), cls):
+                return True
     return False
 
 

--- a/django/contrib/auth/checks.py
+++ b/django/contrib/auth/checks.py
@@ -1,3 +1,4 @@
+import contextlib
 from itertools import chain
 from types import MethodType
 
@@ -15,13 +16,10 @@ def _subclass_index(class_path, candidate_paths):
     list of candidate paths. If it does not exist, return -1.
     """
     cls = import_string(class_path)
-    for index, path in enumerate(candidate_paths):
-        try:
-            candidate_cls = import_string(path)
-            if issubclass(candidate_cls, cls):
-                return index
-        except (ImportError, TypeError):
-            continue
+    for i, path in enumerate(candidate_paths):
+        with contextlib.suppress(ImportError, TypeError):
+            if issubclass(import_string(path), cls):
+                return i
     return -1
 
 


### PR DESCRIPTION
# Trac ticket number

ticket-35564

# Branch description

`_subclass_index` and `_contains_subclass` behave the same, apart from the return value. However, because of the error handling, and the delegation thereof in `_contains_subclass` it's somewhat hard to confirm at first glance.

This rewrite utilises [`contextlib.supress`](https://docs.python.org/3/library/contextlib.html#contextlib.suppress) to make the flow of the code easier to understand.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
