### PR TITLE
Fixed #23790: Added warning to AppConfig.label docs reference.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,6 +87,7 @@ answer newbie questions, and generally made Django that much better:
     Andrew Clark <amclark7@gmail.com>
     Andrew Durdin <adurdin@gmail.com>
     Andrew Godwin <andrew@aeracode.org>
+    Andrew Miller <info+django@akmiller.co.uk>
     Andrew Pinkham <http://AndrewsForge.com>
     Andrews Medina <andrewsmedina@gmail.com>
     Andrew Northall <andrew@northall.me.uk>

--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -186,6 +186,14 @@ Configurable attributes
 
     It must be unique across a Django project.
 
+    .. warning::
+
+        Changing this attribute after migrations have been applied for an
+        application will result in breaking changes to a project or, in the
+        case of a reusable app, any existing installs of that app. This is
+        because ``AppConfig.label`` is used in database tables and migration
+        files when referencing an app in the dependencies list.
+
 .. attribute:: AppConfig.verbose_name
 
     Human-readable name for the application, e.g. "Administration".


### PR DESCRIPTION
# Trac ticket number

ticket-23790

# Branch description
Adds a docs warning to `AppConfig.label` about renaming the label in the middle of a project and how that creates breaking changes to migrations.

![Screenshot 2024-06-28 at 15 16 26](https://github.com/django/django/assets/1997940/68d78763-22e1-44db-a2ba-0c25cc8f3db8)

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
