### PR TITLE
Fixed #35033 -- Fixed repeated headers in EmailMessage.

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -286,7 +286,8 @@ class EmailMessage:
             # Use cached DNS_NAME for performance
             msg["Message-ID"] = make_msgid(domain=DNS_NAME)
         for name, value in self.extra_headers.items():
-            if name.lower() != "from":  # From is already handled
+            # Avoid headers handled above.
+            if name.lower() not in {"from", "to", "cc", "reply-to"}:
                 msg[name] = value
         return msg
 
@@ -427,14 +428,13 @@ class EmailMessage:
     def _set_list_header_if_not_empty(self, msg, header, values):
         """
         Set msg's header, either from self.extra_headers, if present, or from
-        the values argument.
+        the values argument if not empty.
         """
-        if values:
-            try:
-                value = self.extra_headers[header]
-            except KeyError:
-                value = ", ".join(str(v) for v in values)
-            msg[header] = value
+        try:
+            msg[header] = self.extra_headers[header]
+        except KeyError:
+            if values:
+                msg[header] = ", ".join(str(v) for v in values)
 
 
 class EmailMultiAlternatives(EmailMessage):

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -223,7 +223,7 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             cc=["foo@example.com"],
             headers={"Cc": "override@example.com"},
         ).message()
-        self.assertEqual(message["Cc"], "override@example.com")
+        self.assertEqual(message.get_all("Cc"), ["override@example.com"])
 
     def test_cc_in_headers_only(self):
         message = EmailMessage(
@@ -233,7 +233,7 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             ["to@example.com"],
             headers={"Cc": "foo@example.com"},
         ).message()
-        self.assertEqual(message["Cc"], "foo@example.com")
+        self.assertEqual(message.get_all("Cc"), ["foo@example.com"])
 
     def test_reply_to(self):
         email = EmailMessage(
@@ -379,7 +379,7 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             headers={"From": "from@example.com"},
         )
         message = email.message()
-        self.assertEqual(message["From"], "from@example.com")
+        self.assertEqual(message.get_all("From"), ["from@example.com"])
 
     def test_to_header(self):
         """
@@ -393,7 +393,7 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             headers={"To": "mailing-list@example.com"},
         )
         message = email.message()
-        self.assertEqual(message["To"], "mailing-list@example.com")
+        self.assertEqual(message.get_all("To"), ["mailing-list@example.com"])
         self.assertEqual(
             email.to, ["list-subscriber@example.com", "list-subscriber2@example.com"]
         )
@@ -408,7 +408,8 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
         )
         message = email.message()
         self.assertEqual(
-            message["To"], "list-subscriber@example.com, list-subscriber2@example.com"
+            message.get_all("To"),
+            ["list-subscriber@example.com, list-subscriber2@example.com"],
         )
         self.assertEqual(
             email.to, ["list-subscriber@example.com", "list-subscriber2@example.com"]
@@ -421,7 +422,7 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             "bounce@example.com",
             headers={"To": "to@example.com"},
         ).message()
-        self.assertEqual(message["To"], "to@example.com")
+        self.assertEqual(message.get_all("To"), ["to@example.com"])
 
     def test_reply_to_header(self):
         """
@@ -436,7 +437,7 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             headers={"Reply-To": "override@example.com"},
         )
         message = email.message()
-        self.assertEqual(message["Reply-To"], "override@example.com")
+        self.assertEqual(message.get_all("Reply-To"), ["override@example.com"])
 
     def test_reply_to_in_headers_only(self):
         message = EmailMessage(
@@ -446,7 +447,7 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             ["to@example.com"],
             headers={"Reply-To": "reply_to@example.com"},
         ).message()
-        self.assertEqual(message["Reply-To"], "reply_to@example.com")
+        self.assertEqual(message.get_all("Reply-To"), ["reply_to@example.com"])
 
     def test_multiple_message_call(self):
         """
@@ -461,9 +462,9 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             headers={"From": "from@example.com"},
         )
         message = email.message()
-        self.assertEqual(message["From"], "from@example.com")
+        self.assertEqual(message.get_all("From"), ["from@example.com"])
         message = email.message()
-        self.assertEqual(message["From"], "from@example.com")
+        self.assertEqual(message.get_all("From"), ["from@example.com"])
 
     def test_unicode_address_header(self):
         """


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35033

# Branch description

ticket-35033 as originally reported was caused by a regression introduced in ticket-28912 (PR #9454).

This PR fixes that specific regression, and updates the tests to avoid it in the future.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [n/a] I have added or updated relevant docs, including release notes if applicable.
- [n/a] I have attached screenshots in both light and dark modes for any UI changes.
