### PR TITLE
Corrected syntax of CSS file in staticfiles_tests.

### DIFF
--- a/tests/staticfiles_tests/project/documents/cached/css/fragments.css
+++ b/tests/staticfiles_tests/project/documents/cached/css/fragments.css
@@ -1,7 +1,8 @@
 @font-face {
+    font-family: "test";
     src: url('fonts/font.eot?#iefix') format('embedded-opentype'),
-         url('fonts/font.svg#webfontIyfZbseF') format('svg');
-         url('fonts/font.svg#path/to/../../fonts/font.svg') format('svg');
+         url('fonts/font.svg#webfontIyfZbseF') format('svg'),
+         url('fonts/font.svg#path/to/../../fonts/font.svg') format('svg'),
          url('data:font/woff;charset=utf-8;base64,d09GRgABAAAAADJoAA0AAAAAR2QAAQAAAAAAAAAAAAA');
 }
 div {

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -101,7 +101,7 @@ class TestHashedFiles:
 
     def test_path_with_querystring_and_fragment(self):
         relpath = self.hashed_file_path("cached/css/fragments.css")
-        self.assertEqual(relpath, "cached/css/fragments.a60c0e74834f.css")
+        self.assertEqual(relpath, "cached/css/fragments.7fe344dee895.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertIn(b"fonts/font.b9b105392eb8.eot?#iefix", content)


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description
This fixes an issue I noticed when working on Prettier formatting for CSS. The syntax in the file is invalid. Firstly, semi-colons are used where commas should be, and the `font-face` at-rule requires `font-family` to be present.

I also had to update the test with the new hash (which will likely change again in the formatting PR).