### PR TITLE
Fixed #35566 -- Added get_FOO_display() support for GeneratedFields.

### DIFF
--- a/django/db/models/fields/generated.py
+++ b/django/db/models/fields/generated.py
@@ -30,6 +30,9 @@ class GeneratedField(Field):
         self.expression = expression
         self.output_field = output_field
         self.db_persist = db_persist
+
+        if kwargs.get("choices", None) is None and output_field.choices is not None:
+            kwargs["choices"] = output_field.choices
         super().__init__(**kwargs)
 
     @cached_property

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -924,6 +924,14 @@ For example::
     >>> p.get_shirt_size_display()
     'Large'
 
+A :class:`~django.db.models.GeneratedField` with ``choices`` set on
+:attr:`.GeneratedField.output_field` also has a ``get_FOO_display()`` method.
+
+.. versionchanged:: 5.2
+
+     Support for ``choices`` defined on :attr:`.GeneratedField.output_field`
+     was added.
+
 .. method:: Model.get_next_by_FOO(**kwargs)
 .. method:: Model.get_previous_by_FOO(**kwargs)
 

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -223,6 +223,9 @@ Models
   expression contains a set-returning function, enforcing subquery evaluation.
   This is necessary for many Postgres set-returning functions.
 
+* :meth:`~django.db.models.Model.get_FOO_display` now supports when ``choices``
+  is defined on :attr:`.GeneratedField.output_field`.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -687,3 +687,27 @@ class GeneratedModelUniqueConstraintVirtual(GeneratedModelVirtualBase):
                 F("a"), name="Generated model unique constraint virtual a"
             ),
         ]
+
+
+class GeneratedModelChoices(models.Model):
+    c = models.IntegerField(choices=Whiz.CHOICES, null=True)
+    c_squared = models.GeneratedField(
+        expression=F("c") * F("c"),
+        output_field=models.IntegerField(choices=Whiz.CHOICES, null=True),
+        db_persist=True,
+    )
+
+    class Meta:
+        required_db_features = {"supports_stored_generated_columns"}
+
+
+class GeneratedModelChoicesVirtual(models.Model):
+    c = models.IntegerField(choices=Whiz.CHOICES, null=True)
+    c_squared = models.GeneratedField(
+        expression=F("c") * F("c"),
+        output_field=models.IntegerField(choices=Whiz.CHOICES, null=True),
+        db_persist=True,
+    )
+
+    class Meta:
+        required_db_features = {"supports_virtual_generated_columns"}

--- a/tests/model_fields/test_generatedfield.py
+++ b/tests/model_fields/test_generatedfield.py
@@ -21,6 +21,8 @@ from .models import (
     GeneratedModel,
     GeneratedModelCheckConstraint,
     GeneratedModelCheckConstraintVirtual,
+    GeneratedModelChoices,
+    GeneratedModelChoicesVirtual,
     GeneratedModelFieldWithConverters,
     GeneratedModelNull,
     GeneratedModelNullVirtual,
@@ -341,6 +343,20 @@ class GeneratedFieldTestMixin:
         m2 = self._refresh_if_needed(m2)
         self.assertEqual(m2.lower_name, "name")
 
+    def test_choices_and_field_display(self):
+        wg_0 = self.choices_model.objects.create(c=0)
+        wg_1 = self.choices_model.objects.create(c=1)
+        wg_none = self.choices_model.objects.create(c=None)
+        self.assertEqual(wg_0.get_c_squared_display(), "Other")
+        self.assertEqual(wg_1.get_c_squared_display(), "First")
+        self.assertIsNone(wg_none.get_c_squared_display())
+        wg_3 = self.choices_model(c=3)
+        wg_3.full_clean()
+        wg_3.save()
+        wg_3.refresh_from_db()
+        self.assertEqual(wg_3.c_squared, 9)
+        self.assertEqual(wg_3.get_c_squared_display(), 9)
+
 
 @skipUnlessDBFeature("supports_stored_generated_columns")
 class StoredGeneratedFieldTests(GeneratedFieldTestMixin, TestCase):
@@ -350,6 +366,7 @@ class StoredGeneratedFieldTests(GeneratedFieldTestMixin, TestCase):
     unique_constraint_model = GeneratedModelUniqueConstraint
     output_field_db_collation_model = GeneratedModelOutputFieldDbCollation
     params_model = GeneratedModelParams
+    choices_model = GeneratedModelChoices
 
     def test_create_field_with_db_converters(self):
         obj = GeneratedModelFieldWithConverters.objects.create(field=uuid.uuid4())
@@ -365,3 +382,4 @@ class VirtualGeneratedFieldTests(GeneratedFieldTestMixin, TestCase):
     unique_constraint_model = GeneratedModelUniqueConstraintVirtual
     output_field_db_collation_model = GeneratedModelOutputFieldDbCollationVirtual
     params_model = GeneratedModelParamsVirtual
+    choices_model = GeneratedModelChoicesVirtual


### PR DESCRIPTION
_get_FIELD_display() did not handle when Field.choices was defined on output_field. Thank you to Ronie Martinez for the report.

# Trac ticket number

ticket-35566

# Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
