### PR TITLE
Fixed #35571 -- Store template_names as string

### DIFF
--- a/django/template/engine.py
+++ b/django/template/engine.py
@@ -156,11 +156,11 @@ class Engine:
         tried = []
         for loader in self.template_loaders:
             try:
-                template = loader.get_template(name, skip=skip)
+                template = loader.get_template(str(name), skip=skip)
                 return template, template.origin
             except TemplateDoesNotExist as e:
                 tried.extend(e.tried)
-        raise TemplateDoesNotExist(name, tried=tried)
+        raise TemplateDoesNotExist(str(name), tried=tried)
 
     def from_string(self, template_code):
         """
@@ -174,10 +174,10 @@ class Engine:
         Return a compiled Template object for the given template name,
         handling template inheritance recursively.
         """
-        template, origin = self.find_template(template_name)
+        template, origin = self.find_template(str(template_name))
         if not hasattr(template, "render"):
             # template needs to be compiled
-            template = Template(template, origin, template_name, engine=self)
+            template = Template(template, origin, str(template_name), engine=self)
         return template
 
     def render_to_string(self, template_name, context=None):


### PR DESCRIPTION


# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35571

# Branch description
When passing pathlib.Path or pathlib.PosixPath as template names (because templates are in subdirectories, so pathlib seems reasonable to use) the assertTemplateUsed breaks as it performs a str.join on all template names without sanitizing them.

```
File "<stuff>/.local/lib/python3.12/site-packages/django/test/testcases.py", line 681, in _assert_template_used                                                                                                                      
    % (template_name, ", ".join(template_names)),                                                                                                                                                                                              
                      ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                
TypeError: sequence item 0: expected str instance, PosixPath found
```

This causes a lot of confusion as it is quite hard to track down the Template that introduced the PosixPath.

This is one proposed solution for fixing this. I.e. trying to sanitize all template names when they are passed into the template engine, as this seems easier then trying to find all cases where the stringiness of the template name is assumed. Another approach would be to have an assert that the template name is a string, but this could possible break code that doesn't utilize the test framework.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
