### PR TITLE
Fixed broken link in django.core.files.temp docstring.

### DIFF
--- a/django/core/files/temp.py
+++ b/django/core/files/temp.py
@@ -12,7 +12,7 @@ processes in a manner that works across platforms.
 The custom version of NamedTemporaryFile doesn't support the same keyword
 arguments available in tempfile.NamedTemporaryFile.
 
-1: https://mail.python.org/pipermail/python-list/2005-December/336957.html
+1: https://mail.python.org/pipermail/python-list/2005-December/336955.html
 2: https://bugs.python.org/issue14243
 """
 


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

# Branch description
The original link returns Not Found.

The post was at some point available at that URL and was archived. The new link [0] has the same text as the archived old link [1]. The only difference is the timestamps, which is due to timezone localisation.

[0] https://mail.python.org/pipermail/python-list/2005-December/336955.html
[1] http://web.archive.org/web/20180714184848/https://mail.python.org/pipermail/python-list/2005-December/336957.html

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
