### PR TITLE
Add NO_LOG_EXCEPTION_IN_RESPONSE for disabling exc_info when logging responses

### DIFF
--- a/django/core/handlers/exception.py
+++ b/django/core/handlers/exception.py
@@ -61,6 +61,10 @@ def convert_exception_to_response(get_response):
 
 
 def response_for_exception(request, exc):
+    if getattr(settings, "NO_LOG_EXCEPTION_IN_RESPONSE", False):
+        exception = None
+    else:
+        exception = exc
     if isinstance(exc, Http404):
         if settings.DEBUG:
             response = debug.technical_404_response(request, exc)
@@ -78,7 +82,7 @@ def response_for_exception(request, exc):
             request.path,
             response=response,
             request=request,
-            exception=exc,
+            exception=exception,
         )
 
     elif isinstance(exc, MultiPartParserError):
@@ -90,7 +94,7 @@ def response_for_exception(request, exc):
             request.path,
             response=response,
             request=request,
-            exception=exc,
+            exception=exception,
         )
 
     elif isinstance(exc, BadRequest):
@@ -108,7 +112,7 @@ def response_for_exception(request, exc):
             request.path,
             response=response,
             request=request,
-            exception=exc,
+            exception=exception,
         )
     elif isinstance(exc, SuspiciousOperation):
         if isinstance(exc, (RequestDataTooBig, TooManyFieldsSent, TooManyFilesSent)):


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description
Raising `Http404` logs the response as if `HttpResponseNotFound` was returned, but raising `BadRequest` includes `exc_info` and that differs from a response of `HttpResponseBadRequest` and looks like something exceptional went wrong in the logs, so being able to disable this behavior using `NO_LOG_EXCEPTION_IN_RESPONSE` allows the `raise` handling to be a first class citizen like `return` handling

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
