### PR TITLE
Fixed #35569 -- Improved wording of invalid ForeignKey error message.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -929,7 +929,9 @@ class ForeignKey(ForeignObject):
 
     empty_strings_allowed = False
     default_error_messages = {
-        "invalid": _("%(model)s instance with %(field)s %(value)r does not exist.")
+        "invalid": _(
+            "%(model)s instance with %(field)s %(value)r is not a valid choice."
+        )
     }
     description = _("Foreign Key (type determined by related field)")
 

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -523,7 +523,7 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
         self.assertEqual(u.group, group)
 
         non_existent_email = "mymail2@gmail.com"
-        msg = "email instance with email %r does not exist." % non_existent_email
+        msg = "email instance with email %r is not a valid choice." % non_existent_email
         with self.assertRaisesMessage(CommandError, msg):
             call_command(
                 "createsuperuser",
@@ -594,7 +594,7 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
         email = Email.objects.create(email="mymail@gmail.com")
         Group.objects.all().delete()
         nonexistent_group_id = 1
-        msg = f"group instance with id {nonexistent_group_id} does not exist."
+        msg = f"group instance with id {nonexistent_group_id} is not a valid choice."
 
         with self.assertRaisesMessage(CommandError, msg):
             call_command(
@@ -611,7 +611,7 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
         email = Email.objects.create(email="mymail@gmail.com")
         Group.objects.all().delete()
         nonexistent_group_id = 1
-        msg = f"group instance with id {nonexistent_group_id} does not exist."
+        msg = f"group instance with id {nonexistent_group_id} is not a valid choice."
 
         with mock.patch.dict(
             os.environ,
@@ -631,7 +631,7 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
         email = Email.objects.create(email="mymail@gmail.com")
         Group.objects.all().delete()
         nonexistent_group_id = 1
-        msg = f"group instance with id {nonexistent_group_id} does not exist."
+        msg = f"group instance with id {nonexistent_group_id} is not a valid choice."
 
         @mock_inputs(
             {

--- a/tests/validation/tests.py
+++ b/tests/validation/tests.py
@@ -31,15 +31,18 @@ class BaseModelValidationTests(ValidationAssertions, TestCase):
         self.assertFieldFailsValidationWithMessage(
             mtv.full_clean,
             "parent",
-            ["model to validate instance with id %r does not exist." % mtv.parent_id],
+            [
+                "model to validate instance with id %r is not a valid choice."
+                % mtv.parent_id
+            ],
         )
         mtv = ModelToValidate(number=10, name="Some Name", ufm_id="Some Name")
         self.assertFieldFailsValidationWithMessage(
             mtv.full_clean,
             "ufm",
             [
-                "unique fields model instance with unique_charfield %r does not exist."
-                % mtv.name
+                "unique fields model instance with unique_charfield %r is not "
+                "a valid choice." % mtv.name
             ],
         )
 


### PR DESCRIPTION
# Trac ticket number
ticket-35569

# Branch description
Before, when cleaning a ForeignKey field with a `limit_choices_to` attribute, a choice of an existing object that was filtered out by the limit_choices_to condition would be described by the error message as "not exist[ing]".

Now, both nonexistent objects and existing, invalid objects are both described as "not a valid choice".

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
