### PR TITLE
Removed unneeded hyphens in "counterintuitive".

### DIFF
--- a/django/middleware/cache.py
+++ b/django/middleware/cache.py
@@ -10,7 +10,7 @@ URL. The canonical way to enable cache middleware is to set
         'django.middleware.cache.FetchFromCacheMiddleware'
     ]
 
-This is counter-intuitive, but correct: ``UpdateCacheMiddleware`` needs to run
+This is counterintuitive, but correct: ``UpdateCacheMiddleware`` needs to run
 last during the response phase, which processes middleware bottom-up;
 ``FetchFromCacheMiddleware`` needs to run last during the request phase, which
 processes middleware top-down.

--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -111,7 +111,7 @@ There are many ways to approach writing tests.
 
 Some programmers follow a discipline called "`test-driven development`_"; they
 actually write their tests before they write their code. This might seem
-counter-intuitive, but in fact it's similar to what most people will often do
+counterintuitive, but in fact it's similar to what most people will often do
 anyway: they describe a problem, then create some code to solve it. Test-driven
 development formalizes the problem in a Python test case.
 

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -826,7 +826,7 @@ specific to SQLite that you should be aware of.
 Substring matching and case sensitivity
 ---------------------------------------
 
-For all SQLite versions, there is some slightly counter-intuitive behavior when
+For all SQLite versions, there is some slightly counterintuitive behavior when
 attempting to match some types of strings.  These are triggered when using the
 :lookup:`iexact` or :lookup:`contains` filters in Querysets. The behavior
 splits into two cases:


### PR DESCRIPTION
Follow-up to 65ad4ade74dc9208b9d686a451cd6045df0c9c3a which added counterintuitive to the wordlist. Removes unneeded (antiquated) hyphenated usages.

See e.g. https://www.merriam-webster.com/dictionary/counterintuitive

