### PR TITLE
Fixed #35424 - Allow _order fields after removed order_with_respect_to

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -761,8 +761,11 @@ class ModelState:
         return self.name.lower()
 
     def get_field(self, field_name):
-        if field_name == "_order":
-            field_name = self.options.get("order_with_respect_to", field_name)
+        if (
+            field_name == "_order"
+            and self.options.get("order_with_respect_to") is not None
+        ):
+            field_name = self.options["order_with_respect_to"]
         return self.fields[field_name]
 
     @classmethod

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -1131,6 +1131,22 @@ class StateTests(SimpleTestCase):
         self.assertIsNone(order_field.related_model)
         self.assertIsInstance(order_field, models.PositiveSmallIntegerField)
 
+    def test_get_order_field_after_removed_order_with_respect_to_field(self):
+        new_apps = Apps()
+
+        class HistoricalRecord(models.Model):
+            _order = models.PositiveSmallIntegerField()
+
+            class Meta:
+                app_label = "migrations"
+                apps = new_apps
+
+        model_state = ModelState.from_model(HistoricalRecord)
+        model_state.options["order_with_respect_to"] = None
+        order_field = model_state.get_field("_order")
+        self.assertIsNone(order_field.related_model)
+        self.assertIsInstance(order_field, models.PositiveSmallIntegerField)
+
     def test_manager_refer_correct_model_version(self):
         """
         #24147 - Managers refer to the correct version of a


### PR DESCRIPTION
# Trac ticket number

[ticket-35424](https://code.djangoproject.com/ticket/35424)

# Branch description

Migrations now work as expected following the removal of an `order_with_respect_to` field from a model and the addition of an `_order` field.

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
