### PR TITLE
Fixed #35546 -- Updated  contributing pages to align with current requirement of having an accepted ticket

### DIFF
--- a/docs/internals/contributing/bugs-and-features.txt
+++ b/docs/internals/contributing/bugs-and-features.txt
@@ -110,11 +110,6 @@ part of that. Here are some tips on how to make a request most effectively:
 If there's a consensus agreement on the feature, then it's appropriate to
 create a ticket. Include a link to the discussion in the ticket description.
 
-As with most open-source projects, code talks. If you are willing to write the
-code for the feature yourself or, even better, if you've already written it,
-it's much more likely to be accepted. Fork Django on GitHub, create a feature
-branch, and show us your work!
-
 See also: :ref:`documenting-new-features`.
 
 .. _how-we-make-decisions:

--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -6,6 +6,8 @@ We're always grateful for contributions to Django's code. Indeed, bug reports
 with associated contributions will get fixed *far* more quickly than those
 without a solution.
 
+.. _trivial-change:
+
 Typo fixes and trivial documentation changes
 ============================================
 
@@ -52,9 +54,10 @@ and time availability), claim it by following these steps:
 
 .. note::
     The Django software foundation requests that anyone contributing more than
-    a trivial change to Django sign and submit a `Contributor License
-    Agreement`_, this ensures that the Django Software Foundation has clear
-    license to all contributions allowing for a clear license for all users.
+    a :ref:`trivial change <trivial-change>`, to Django sign and submit a
+    `Contributor License Agreement`_, this ensures that the Django Software
+    Foundation has clear license to all contributions allowing for a clear
+    license for all users.
 
 .. _Login using your GitHub account: https://code.djangoproject.com/github/login
 .. _Create an account: https://www.djangoproject.com/accounts/register/
@@ -262,9 +265,12 @@ documentation.
 Contribution checklist
 ======================
 
-Use this checklist to review a pull request. If you are reviewing a pull
-request that is not your own and it passes all the criteria below, please set
-the "Triage Stage" on the corresponding Trac ticket to "Ready for checkin".
+Use this checklist to review a pull request. If this contribution would not be
+:ref:`considered trivial <trivial-change>`, first ensure it has an accepted
+ticket before proceeding with the review.
+
+If the pull request passes all the criteria below and is not your own, please
+set the "Triage Stage" on the corresponding Trac ticket to "Ready for checkin".
 If you've left comments for improvement on the pull request, please tick the
 appropriate flags on the Trac ticket based on the results of your review:
 "Patch needs improvement", "Needs documentation", and/or "Needs tests". As time
@@ -331,5 +337,7 @@ All tickets
   :ref:`commit message format <committing-guidelines>`?
 * Are you the patch author and a new contributor? Please add yourself to the
   :source:`AUTHORS` file and submit a `Contributor License Agreement`_.
+* Does this have an accepted ticket on Trac? All contributions require a ticket
+  unless the :ref:`change is considered trivial <trivial-change>`.
 
 .. _Contributor License Agreement: https://www.djangoproject.com/foundation/cla/


### PR DESCRIPTION
# Trac ticket number
ticket-35546

# Branch description
Following some feedback from PR https://github.com/django/django/pull/17389 mentioned in the TRAC ticket, I have checked and updated the places where we need to be more explicit about the need to have an accepted ticket when working on changes.

Most of the updates involve rewording paragraphs to ensure this requirement is clearly stated.

I am happy to remove any misleading paragraphs if they are unnecessary, as we now explicitly mention the need to add a TRAC ticket for any kind of patches (whether trivial or not) in several places.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
