### PR TITLE
[5.0.x] Refs #35560 -- Corrected CheckConstraint argument name in model_fields tests.

### DIFF
--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -626,7 +626,7 @@ class GeneratedModelCheckConstraint(GeneratedModelBase):
         }
         constraints = [
             models.CheckConstraint(
-                condition=models.Q(a__gt=0),
+                check=models.Q(a__gt=0),
                 name="Generated model check constraint a > 0",
             )
         ]
@@ -640,7 +640,7 @@ class GeneratedModelCheckConstraintVirtual(GeneratedModelVirtualBase):
         }
         constraints = [
             models.CheckConstraint(
-                condition=models.Q(a__gt=0),
+                check=models.Q(a__gt=0),
                 name="Generated model check constraint virtual a > 0",
             )
         ]


### PR DESCRIPTION
```
    models.CheckConstraint(
TypeError: CheckConstraint.__init__() got an unexpected keyword argument 'condition'
```