### PR TITLE
Fixed #35580 -- Allowed related fields referencing auto-created through models.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -187,7 +187,9 @@ class RelatedField(FieldCacheMixin, Field):
         return errors
 
     def _check_relation_model_exists(self):
-        rel_is_missing = self.remote_field.model not in self.opts.apps.get_models()
+        rel_is_missing = self.remote_field.model not in self.opts.apps.get_models(
+            include_auto_created=True
+        )
         rel_is_string = isinstance(self.remote_field.model, str)
         model_name = (
             self.remote_field.model

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -89,6 +89,23 @@ class RelativeFieldTests(SimpleTestCase):
         field = Model._meta.get_field("m2m")
         self.assertEqual(field.check(from_model=Model), [])
 
+    @isolate_apps("invalid_models_tests")
+    def test_auto_created_through_model(self):
+        class OtherModel(models.Model):
+            pass
+
+        class M2MModel(models.Model):
+            many_to_many_rel = models.ManyToManyField(OtherModel)
+
+        class O2OModel(models.Model):
+            one_to_one_rel = models.OneToOneField(
+                "invalid_models_tests.M2MModel_many_to_many_rel",
+                on_delete=models.CASCADE,
+            )
+
+        field = O2OModel._meta.get_field("one_to_one_rel")
+        self.assertEqual(field.check(from_model=O2OModel), [])
+
     def test_many_to_many_with_useless_options(self):
         class Model(models.Model):
             name = models.CharField(max_length=20)


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35580

# Branch description
Fixed ticket-35580. Updated system checks to not raise error fields.E300 when an auto_created through model is the target of a related field.

# Checklist
- [ x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ x] I have checked the "Has patch" ticket flag in the Trac system.
- [ x] I have added or updated relevant tests.
- [ x] I have added or updated relevant docs, including release notes if applicable.
- [ x] I have attached screenshots in both light and dark modes for any UI changes.
