### PR TITLE
Fixed #32831 – marked flaky tests for retry on assertion failure.

### DIFF
--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -11,6 +11,7 @@ import tempfile
 import threading
 import time
 import unittest
+from functools import wraps
 from pathlib import Path
 from unittest import mock, skipIf
 
@@ -87,6 +88,25 @@ def empty_response(request):
 KEY_ERRORS_WITH_MEMCACHED_MSG = (
     "Cache key contains characters that will cause errors if used with memcached: %r"
 )
+
+
+def retry(retries=3, delay=1):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            attempts = 0
+            while attempts < retries:
+                try:
+                    return func(*args, **kwargs)
+                except AssertionError:
+                    attempts += 1
+                    if attempts >= retries:
+                        raise
+                    time.sleep(delay)
+
+        return wrapper
+
+    return decorator
 
 
 @override_settings(
@@ -489,6 +509,7 @@ class BaseCacheTests:
         self.assertEqual(cache.get("expire2"), "newvalue")
         self.assertIs(cache.has_key("expire3"), False)
 
+    @retry()
     def test_touch(self):
         # cache.touch() updates the timeout.
         cache.set("expire1", "very quickly", timeout=1)
@@ -616,6 +637,7 @@ class BaseCacheTests:
         self.assertEqual(cache.get("key3"), "sausage")
         self.assertEqual(cache.get("key4"), "lobster bisque")
 
+    @retry()
     def test_forever_timeout(self):
         """
         Passing in None into timeout results in a value that is cached forever
@@ -1397,6 +1419,7 @@ class LocMemCacheTests(BaseCacheTests, TestCase):
         self.assertEqual(cache.decr(key), 1)
         self.assertEqual(expire, cache._expire_info[_key])
 
+    @retry()
     @limit_locmem_entries
     def test_lru_get(self):
         """get() moves cache keys."""
@@ -1424,6 +1447,7 @@ class LocMemCacheTests(BaseCacheTests, TestCase):
         for key in range(3):
             self.assertIsNone(cache.get(key))
 
+    @retry()
     @limit_locmem_entries
     def test_lru_incr(self):
         """incr() moves cache keys."""
@@ -2674,6 +2698,7 @@ class CacheMiddlewareTest(SimpleTestCase):
         response = other_with_prefix_view(request, "16")
         self.assertEqual(response.content, b"Hello World 16")
 
+    @retry()
     def test_cache_page_timeout(self):
         # Page timeout takes precedence over the "max-age" section of the
         # "Cache-Control".


### PR DESCRIPTION
# Trac ticket number

ticket-32831

# Branch description

so far we don't know which tests exactly are flaky.
mainly the cases mentioned above, and anything that uses a shared medium.

as **Simon Charette** suggested this could be done by figuring out where to set locks, which he also pointed out that it might get tricky depending on how djangoci works (I have no clue)
we might need to handle lock depending on the platform running the test or use something like "portalocker" which covers cross-platform locks but forces the adoption of a new dependency?

expanding on a previous answer by **Chris Jerdonek** on setting assertion retries, why not set it at a unit level instead of individual assertion?

how you'd typically do with some pytest extensions... And we'll be assured the whole test passed without having to reason line-by-line on what went wrong?

only catching/retrying on "AssertionError" so other exceptions are not permitted.
which I'm still not sure about? (maybe a shared medium causes you to pluck a None or something...)


# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
