### PR TITLE
Refactored error messages to use f-strings for improved readerbility

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -29,6 +29,9 @@ from django.test.signals import template_rendered
 from django.urls import get_script_prefix, set_script_prefix
 from django.utils.translation import deactivate
 from django.utils.version import PYPY
+import unittest
+from django.utils.decorators import _dec
+
 
 try:
     import jinja2
@@ -992,3 +995,73 @@ def garbage_collect():
     if PYPY:
         # Collecting weakreferences can take two collections on PyPy.
         gc.collect()
+
+class DummyDecorator:
+    """ Description of DummyDecorator """
+    def __call__(self, f):
+        
+        def wrapped(*args, **kwargs):
+            """
+            Description of wrapped
+
+            Args:
+                *args (undefined):
+                **kwargs (undefined):
+
+            """
+            return f(*args, **kwargs)
+        return wrapped
+
+decorator = DummyDecorator()
+
+def _multi_decorate(decorator, obj):
+    return decorator(obj)
+
+class TestDecFunction(unittest.TestCase):
+    """
+    Description of TestDecFunction
+
+    Inheritance:
+        unittest.TestCase:
+
+    """
+    
+
+    def test_valid_decorate_method(self):
+        """
+        Description of test_valid_decorate_method
+
+        Args:
+            self (undefined):
+
+        """
+        class TestClass:
+            def method(self):
+                return "original"
+
+        name = 'method'
+        result = _dec(TestClass)
+        self.assertTrue(callable(getattr(result, name)))
+        self.assertNotEqual(getattr(result, name)(), "original")
+
+    def test_invalid_decorate_missing_name(self):
+        class TestClass:
+            pass
+
+        name = 'missing_method'
+        with self.assertRaises(ValueError):
+            _dec(TestClass)
+
+    def test_invalid_decorate_non_callable(self):
+        class TestClass:
+            method = "not callable"
+
+        name = 'method'
+        with self.assertRaises(TypeError):
+            _dec(TestClass)
+
+    def test_non_class_object(self):
+        
+        non_class_obj = lambda x: x
+        result = _dec(non_class_obj)
+        self.assertTrue(callable(result))

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -29,9 +29,6 @@ from django.test.signals import template_rendered
 from django.urls import get_script_prefix, set_script_prefix
 from django.utils.translation import deactivate
 from django.utils.version import PYPY
-import unittest
-from django.utils.decorators import _dec
-
 
 try:
     import jinja2
@@ -995,73 +992,3 @@ def garbage_collect():
     if PYPY:
         # Collecting weakreferences can take two collections on PyPy.
         gc.collect()
-
-class DummyDecorator:
-    """ Description of DummyDecorator """
-    def __call__(self, f):
-        
-        def wrapped(*args, **kwargs):
-            """
-            Description of wrapped
-
-            Args:
-                *args (undefined):
-                **kwargs (undefined):
-
-            """
-            return f(*args, **kwargs)
-        return wrapped
-
-decorator = DummyDecorator()
-
-def _multi_decorate(decorator, obj):
-    return decorator(obj)
-
-class TestDecFunction(unittest.TestCase):
-    """
-    Description of TestDecFunction
-
-    Inheritance:
-        unittest.TestCase:
-
-    """
-    
-
-    def test_valid_decorate_method(self):
-        """
-        Description of test_valid_decorate_method
-
-        Args:
-            self (undefined):
-
-        """
-        class TestClass:
-            def method(self):
-                return "original"
-
-        name = 'method'
-        result = _dec(TestClass)
-        self.assertTrue(callable(getattr(result, name)))
-        self.assertNotEqual(getattr(result, name)(), "original")
-
-    def test_invalid_decorate_missing_name(self):
-        class TestClass:
-            pass
-
-        name = 'missing_method'
-        with self.assertRaises(ValueError):
-            _dec(TestClass)
-
-    def test_invalid_decorate_non_callable(self):
-        class TestClass:
-            method = "not callable"
-
-        name = 'method'
-        with self.assertRaises(TypeError):
-            _dec(TestClass)
-
-    def test_non_class_object(self):
-        
-        non_class_obj = lambda x: x
-        result = _dec(non_class_obj)
-        self.assertTrue(callable(result))

--- a/django/utils/decorators.py
+++ b/django/utils/decorators.py
@@ -69,14 +69,14 @@ def method_decorator(decorator, name=""):
             return _multi_decorate(decorator, obj)
         if not (name and hasattr(obj, name)):
             raise ValueError(
-                "The keyword argument `name` must be the name of a method "
-                "of the decorated class: %s. Got '%s' instead." % (obj, name)
+                f"The keyword argument `name` must be the name of a method "
+                f"of the decorated class: {obj}. Got '{name}' instead."
             )
         method = getattr(obj, name)
         if not callable(method):
             raise TypeError(
-                "Cannot decorate '%s' as it isn't a callable attribute of "
-                "%s (%s)." % (name, obj, method)
+                f"Cannot decorate '{name}' as it isn't a callable attribute of "
+                f"{obj} ({method})."
             )
         _wrapper = _multi_decorate(decorator, method)
         setattr(obj, name, _wrapper)


### PR DESCRIPTION
# Trac ticket number
ticket-[#35582](https://code.djangoproject.com/ticket/35582)

### Description

This pull request refactors error messages in the `_dec` method to use f-strings instead of the older `%` formatting method. F-strings are more readable and modern, improving the overall code quality and consistency.

### Changes Made
- Converted string formatting in error messages to use f-strings.
- Enhanced readability of error messages.

### Benefits
- Improved readability and maintainability of the code.
- Consistency with modern Python practices.

### Testing
- Ran existing tests to ensure no functionality is broken.

# Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
