### PR TITLE
Fixed #35462 -- Added support for JSON_ArrayAgg aggregate function.

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -3,8 +3,9 @@ Classes to represent the definitions of aggregate functions.
 """
 
 from django.core.exceptions import FieldError, FullResultSet
-from django.db.models.expressions import Case, Func, Star, Value, When
+from django.db.models.expressions import Case, Func, Star, Value, When, connection
 from django.db.models.fields import IntegerField
+from django.db.models.fields.json import JSONField
 from django.db.models.functions.comparison import Coalesce
 from django.db.models.functions.mixins import (
     FixDurationInputMixin,
@@ -20,6 +21,7 @@ __all__ = [
     "StdDev",
     "Sum",
     "Variance",
+    "JSONArrayAgg",
 ]
 
 
@@ -211,3 +213,12 @@ class Variance(NumericOutputFieldMixin, Aggregate):
 
     def _get_repr_options(self):
         return {**super()._get_repr_options(), "sample": self.function == "VAR_SAMP"}
+
+class JSONArrayAgg(Aggregate):
+    name = "JSONArrayAgg"
+    output_field = JSONField()
+    arity = 1
+
+    def __init__(self, expression, **extra):
+        self.function = "JSON_GROUP_ARRAY" if connection.vendor == "sqlite" else "JSON_ARRAYAGG"
+        super().__init__(expression, **extra)

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -30,6 +30,7 @@ from django.db.models import (
     Variance,
     When,
     Window,
+    JSONArrayAgg,
 )
 from django.db.models.expressions import Func, RawSQL
 from django.db.models.functions import (
@@ -2157,6 +2158,10 @@ class AggregateTestCase(TestCase):
             .values_list("sum", flat=True)
         )
         self.assertEqual(list(author_qs), [337])
+
+    def test_JSONArrayAgg(self):
+        vals = Author.objects.filter(age__gt=29).aggregate(age_array=JSONArrayAgg("age"))
+        self.assertEqual(vals, {'age_array': [34, 35, 45, 37, 57, 46]})
 
 
 class AggregateAnnotationPruningTests(TestCase):


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35462

# Branch description
This tickect adds support for the `JSON_ARRAYAGG` and `JSON_GROUP_ARRAY` for SQLite , these  functions aggregate the contents of a specified column or `SQL` expressions converting each expression into a `JSON` value and returns a single `JSON` array containing those `JSON` values.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
