### PR TITLE
Removed obsolete tuple() in SQLCompiler.get_from_clause().

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1134,7 +1134,7 @@ class SQLCompiler:
         """
         result = []
         params = []
-        for alias in tuple(self.query.alias_map):
+        for alias in self.query.alias_map:
             if not self.query.alias_refcount[alias]:
                 continue
             try:


### PR DESCRIPTION
This was added in 01d440fa1e6b5c62acfa8b3fde43dfa1505f93c6 to prevent "RuntimeError: OrderedDict mutated during iteration", however, usage of OrdereDict was removed in 24b82cd201e21060fbc02117dc16d1702877a1f3.