### PR TITLE
Added tests for urlize handling of trailing semicolons.

### DIFF
--- a/tests/template_tests/filter_tests/test_urlize.py
+++ b/tests/template_tests/filter_tests/test_urlize.py
@@ -305,6 +305,23 @@ class FunctionTests(SimpleTestCase):
             "http://testing.com/example</a>.,:;)&quot;!",
         )
 
+    def test_trailing_semicolon(self):
+        self.assertEqual(
+            urlize("http://example.com?x=&amp;", autoescape=False),
+            '<a href="http://example.com?x=" rel="nofollow">'
+            "http://example.com?x=&amp;</a>",
+        )
+        self.assertEqual(
+            urlize("http://example.com?x=&amp;;", autoescape=False),
+            '<a href="http://example.com?x=" rel="nofollow">'
+            "http://example.com?x=&amp;</a>;",
+        )
+        self.assertEqual(
+            urlize("http://example.com?x=&amp;;;", autoescape=False),
+            '<a href="http://example.com?x=" rel="nofollow">'
+            "http://example.com?x=&amp;</a>;;",
+        )
+
     def test_brackets(self):
         """
         #19070 - Check urlize handles brackets properly


### PR DESCRIPTION
# Branch description
Following from d6664574539c1531612dea833d264ed5c2b04e1e, the following adds to the test coverage of trailing punctuation for semicolons