### PR TITLE
Fixed styles for wrapping form elements

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -540,10 +540,6 @@ input[type="submit"], button {
         max-width: 100vw;
     }
 
-    .aligned .form-row > div {
-        width: calc(100vw - 30px);
-    }
-
     .flex-container {
         flex-flow: column;
     }


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description

I was playing with ModelForm for ModelAdmin:

```python
class PostAdminForm(ModelForm):
  class Meta:
    model = Post
    widgets = {
        'title': TextInput(attrs={'style': 'width: 100%;'}),
    }
    fields = '__all__'
```

And I noticed that I can't properly change the width for my field:

![image](https://github.com/django/django/assets/23037847/68e22c86-7268-4dcb-8d32-05563c5491f9)

It turned out that a strange specific width was set for the .form-row > div style:

```css
.aligned .form-row > div {
    width: calc(100vw - 30px);
}
```

_Now:_ 

![image](https://github.com/django/django/assets/23037847/1c91b4fe-628c-4452-b644-26634d842e5a)

_After:_ 

![image](https://github.com/django/django/assets/23037847/81326dba-3f53-4057-bffa-499fa58f323f)


The 30-pixel offset from 100vw, I suppose, was set to quickly subtract the scrollbar. But by modern standards, this is not the right solution.

I propose to abandon setting the width for this wrapper altogether, so the fields will look nicer on tablet and small desktop screens:


# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
