### PR TITLE
[4.2.x] Fixed auth_tests and file_storage tests on Python 3.8.

### DIFF
--- a/tests/file_storage/test_base.py
+++ b/tests/file_storage/test_base.py
@@ -27,15 +27,15 @@ class StorageValidateFileNameTests(SimpleTestCase):
         s = CustomStorage()
         # The initial name passed to `save` is not valid nor safe, fail early.
         for name in self.invalid_file_names:
-            with (
-                self.subTest(name=name),
-                mock.patch.object(s, "get_available_name") as mock_get_available_name,
-                mock.patch.object(s, "_save") as mock_internal_save,
-            ):
-                with self.assertRaisesMessage(
-                    SuspiciousFileOperation, self.error_msg % name
-                ):
-                    s.save(name, content="irrelevant")
+            with self.subTest(name=name):
+                with mock.patch.object(
+                    s, "get_available_name"
+                ) as mock_get_available_name:
+                    with mock.patch.object(s, "_save") as mock_internal_save:
+                        with self.assertRaisesMessage(
+                            SuspiciousFileOperation, self.error_msg % name
+                        ):
+                            s.save(name, content="irrelevant")
                 self.assertEqual(mock_get_available_name.mock_calls, [])
                 self.assertEqual(mock_internal_save.mock_calls, [])
 
@@ -44,15 +44,13 @@ class StorageValidateFileNameTests(SimpleTestCase):
         # The initial name passed to `save` is valid and safe, but the returned
         # name from `get_available_name` is not.
         for name in self.invalid_file_names:
-            with (
-                self.subTest(name=name),
-                mock.patch.object(s, "get_available_name", return_value=name),
-                mock.patch.object(s, "_save") as mock_internal_save,
-            ):
-                with self.assertRaisesMessage(
-                    SuspiciousFileOperation, self.error_msg % name
-                ):
-                    s.save("valid-file-name.txt", content="irrelevant")
+            with self.subTest(name=name):
+                with mock.patch.object(s, "get_available_name", return_value=name):
+                    with mock.patch.object(s, "_save") as mock_internal_save:
+                        with self.assertRaisesMessage(
+                            SuspiciousFileOperation, self.error_msg % name
+                        ):
+                            s.save("valid-file-name.txt", content="irrelevant")
                 self.assertEqual(mock_internal_save.mock_calls, [])
 
     def test_validate_after_internal_save(self):
@@ -60,11 +58,9 @@ class StorageValidateFileNameTests(SimpleTestCase):
         # The initial name passed to `save` is valid and safe, but the result
         # from `_save` is not (this is achieved by monkeypatching _save).
         for name in self.invalid_file_names:
-            with (
-                self.subTest(name=name),
-                mock.patch.object(s, "_save", return_value=name),
-            ):
-                with self.assertRaisesMessage(
-                    SuspiciousFileOperation, self.error_msg % name
-                ):
-                    s.save("valid-file-name.txt", content="irrelevant")
+            with self.subTest(name=name):
+                with mock.patch.object(s, "_save", return_value=name):
+                    with self.assertRaisesMessage(
+                        SuspiciousFileOperation, self.error_msg % name
+                    ):
+                        s.save("valid-file-name.txt", content="irrelevant")


### PR DESCRIPTION
```
ImportError: Failed to import test module: auth_tests.test_hashers
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.8/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/home/jenkins/workspace/django-4.2/database/sqlite3/label/focal/python/python3.8/tests/auth_tests/test_hashers.py", line 629
    ) as mock_identify_hasher,
      ^
SyntaxError: invalid syntax

ImportError: Failed to import test module: file_storage.test_base
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.8/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/home/jenkins/workspace/django-4.2/database/sqlite3/label/focal/python/python3.8/tests/file_storage/test_base.py", line 32
    mock.patch.object(s, "get_available_name") as mock_get_available_name,
                                               ^
SyntaxError: invalid syntax
```