### PR TITLE
Enable Overriding of MigrationExecutor Class

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -640,6 +640,9 @@ STATICFILES_FINDERS = [
 # MIGRATIONS #
 ##############
 
+# Executor to use for migration.
+MIGRATION_EXECUTOR_BACKEND = 'django.db.migrations.executor.MigrationExecutor'
+
 # Migration module overrides for apps, by app label.
 MIGRATION_MODULES = {}
 

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -15,6 +15,7 @@ from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style, no_style
 from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.migrations.utils import get_migrate_executor
 
 ALL_CHECKS = "__all__"
 
@@ -575,7 +576,7 @@ class BaseCommand:
         Print a warning if the set of migrations on disk don't match the
         migrations in the database.
         """
-        from django.db.migrations.executor import MigrationExecutor
+        MigrationExecutor = get_migrate_executor()
 
         try:
             executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -7,9 +7,9 @@ from django.core.management.base import BaseCommand, CommandError, no_translatio
 from django.core.management.sql import emit_post_migrate_signal, emit_pre_migrate_signal
 from django.db import DEFAULT_DB_ALIAS, connections, router
 from django.db.migrations.autodetector import MigrationAutodetector
-from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.loader import AmbiguityError
 from django.db.migrations.state import ModelState, ProjectState
+from django.db.migrations.utils import get_migrate_executor
 from django.utils.module_loading import module_has_submodule
 from django.utils.text import Truncator
 
@@ -115,6 +115,8 @@ class Command(BaseCommand):
         # Hook for backends needing any database preparation
         connection.prepare_database()
         # Work out which apps have migrations and which do not
+
+        MigrationExecutor = get_migrate_executor()
         executor = MigrationExecutor(connection, self.migration_progress_callback)
 
         # Raise an error if any migrations are applied before their dependencies.

--- a/django/db/migrations/utils.py
+++ b/django/db/migrations/utils.py
@@ -3,6 +3,8 @@ import re
 from collections import namedtuple
 
 from django.db.models.fields.related import RECURSIVE_RELATIONSHIP_CONSTANT
+from django.utils.module_loading import import_string
+from django.conf import settings
 
 FieldReference = namedtuple("FieldReference", "to through")
 
@@ -127,3 +129,8 @@ def get_references(state, model_tuple, field_tuple=()):
 def field_is_referenced(state, model_tuple, field_tuple):
     """Return whether `field_tuple` is referenced by any state models."""
     return next(get_references(state, model_tuple, field_tuple), None) is not None
+
+
+def get_migrate_executor():
+    """Returns the executor to use for migration."""
+    return import_string(settings.MIGRATION_EXECUTOR_BACKEND)


### PR DESCRIPTION

# Trac ticket number
N/A

# Branch description

## Summary:
I am proposing a modification to Django that allows for the overriding of the MigrationExecutor class through a new setting in the Django settings file called MIGRATION_EXECUTOR_BACKEND. This change is crucial for projects utilizing django-tenants, as it enables customization of the migration_plan function to apply only the migrations relevant to a specific tenant.

## Background:
In a multi-tenant architecture, such as the one implemented by django-tenants, it's essential to manage migrations in a way that respects the context of each tenant. The current implementation of the MigrationExecutor class does not provide a straightforward mechanism to override or customize its behavior for tenant-specific migration plans.

## Proposed Change:
This pull request introduces a new setting, MIGRATION_EXECUTOR_BACKEND, which allows developers to specify a custom MigrationExecutor class. By doing so, it becomes possible to tailor the migration_plan function, ensuring that only the migrations pertinent to the active tenant are applied.

## Benefits:

Enhanced Flexibility: Developers can customize the migration process to better suit the needs of multi-tenant applications.
Improved Performance: By applying only the relevant migrations, the migration process can be optimized, reducing unnecessary operations and potential conflicts.
Better Maintainability: This change aligns with the principle of separation of concerns, allowing tenant-specific logic to be encapsulated within a custom MigrationExecutor.
## Implementation Details:

Introduce the MIGRATION_EXECUTOR_BACKEND setting in the Django settings file.
Ensure that the custom MigrationExecutor class specified by this setting is correctly instantiated and used within the migration framework.
Provide documentation and examples to guide developers in implementing and using a custom MigrationExecutor.
## Testing:
Comprehensive tests will be included to ensure that the new functionality works as intended and does not introduce regressions. These tests will cover both the default behavior and scenarios involving a custom MigrationExecutor.

## Conclusion:
Allowing the override of the MigrationExecutor class through the MIGRATION_EXECUTOR_BACKEND setting represents a significant improvement for projects using django-tenants or similar multi-tenant setups. It empowers developers with the flexibility needed to manage tenant-specific migrations efficiently.

Thank you for considering this enhancement. I am looking forward to your feedback and am happy to make any necessary adjustments.
