### PR TITLE
Refs #35506 -- Reverted "global URLconf" to "root URLconf" in tutorial 1.

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -256,7 +256,7 @@ Your app directory should now look like:
         urls.py
         views.py
 
-The next step is to configure the global URLconf in the ``mysite`` project to
+The next step is to configure the root URLconf in the ``mysite`` project to
 include the URLconf defined in ``polls.urls``. To do this, add an import for
 ``django.urls.include`` in ``mysite/urls.py`` and insert an
 :func:`~django.urls.include` in the ``urlpatterns`` list, so you have:


### PR DESCRIPTION
I believe it was a mistake to substitute a new, unfamiliar term in 2c931fda5b341e0febf68269d2c2447a64875127. The term "root URLconf" is used throughout the documentation and has a setting named after it: `ROOT_URLCONF`.