### PR TITLE
Refs #35560 -- Corrected required feature flags in GeneratedModelUniqueConstraint.

### DIFF
--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -667,7 +667,7 @@ class GeneratedModelUniqueConstraint(GeneratedModelBase):
     class Meta:
         required_db_features = {
             "supports_stored_generated_columns",
-            "supports_table_check_constraints",
+            "supports_expression_indexes",
         }
         constraints = [
             models.UniqueConstraint(F("a"), name="Generated model unique constraint a"),


### PR DESCRIPTION
Currently tests crash when `supports_expression_indexes` is `True`, e.g. on MySQL 8.0.13+ when storage engine is not `MyISAM`:

```
ERROR [0.006s]: test_full_clean_with_unique_constraint_expression (model_fields.test_generatedfield.StoredGeneratedFieldTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tests/django/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
  File "/tests/django/django/db/backends/mysql/base.py", line 76, in execute
    return self.cursor.execute(query, args)
  File "/usr/local/lib/python3.10/site-packages/MySQLdb/cursors.py", line 179, in execute
    res = self._query(mogrified_query)
  File "/usr/local/lib/python3.10/site-packages/MySQLdb/cursors.py", line 330, in _query
    db.query(q)
  File "/usr/local/lib/python3.10/site-packages/MySQLdb/connections.py", line 261, in query
    _mysql.connection.query(self, query)
MySQLdb.ProgrammingError: (1146, "Table 'test_django.model_fields_generatedmodeluniqueconstraint' doesn't exist")

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tests/django/django/test/testcases.py", line 1546, in skip_wrapper
    return test_func(*args, **kwargs)
  File "/tests/django/tests/model_fields/test_generatedfield.py", line 217, in test_full_clean_with_unique_constraint_expression
    m.full_clean()
  File "/tests/django/django/db/models/base.py", line 1640, in full_clean
    self.validate_constraints(exclude=exclude)
  File "/tests/django/django/db/models/base.py", line 1588, in validate_constraints
    constraint.validate(model_class, self, exclude=exclude, using=using)
  File "/tests/django/django/db/models/constraints.py", line 655, in validate
    if queryset.exists():
  File "/tests/django/django/db/models/query.py", line 1269, in exists
    return self.query.has_results(using=self.db)
  File "/tests/django/django/db/models/sql/query.py", line 661, in has_results
    return compiler.has_results()
  File "/tests/django/django/db/models/sql/compiler.py", line 1547, in has_results
    return bool(self.execute_sql(SINGLE))
  File "/tests/django/django/db/models/sql/compiler.py", line 1579, in execute_sql
    cursor.execute(sql, params)
  File "/tests/django/django/db/backends/utils.py", line 79, in execute
    return self._execute_with_wrappers(
  File "/tests/django/django/db/backends/utils.py", line 92, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/tests/django/django/db/backends/utils.py", line 100, in _execute
    with self.db.wrap_database_errors:
  File "/tests/django/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/tests/django/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
  File "/tests/django/django/db/backends/mysql/base.py", line 76, in execute
    return self.cursor.execute(query, args)
  File "/usr/local/lib/python3.10/site-packages/MySQLdb/cursors.py", line 179, in execute
    res = self._query(mogrified_query)
  File "/usr/local/lib/python3.10/site-packages/MySQLdb/cursors.py", line 330, in _query
    db.query(q)
  File "/usr/local/lib/python3.10/site-packages/MySQLdb/connections.py", line 261, in query
    _mysql.connection.query(self, query)
django.db.utils.ProgrammingError: (1146, "Table 'test_django.model_fields_generatedmodeluniqueconstraint' doesn't exist")
```

This should be backported to `stable/5.1.x` and `stable/5.0.x`.