### PR TITLE
Fixed #35529 -- Added support for positional arguments in querystring template tag.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -391,6 +391,7 @@ answer newbie questions, and generally made Django that much better:
     Georg "Hugo" Bauer <gb@hugo.westfalen.de>
     Georgi Stanojevski <glisha@gmail.com>
     Gerardo Orozco <gerardo.orozco.mosqueda@gmail.com>
+    Giannis Terzopoulos <terzo.giannis@gmail.com>
     Gil Gonçalves <lursty@gmail.com>
     Girish Kumar <girishkumarkh@gmail.com>
     Girish Sontakke <girishsontakke7@gmail.com>

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -964,8 +964,14 @@ output (as a string) inside a variable. This is useful if you want to use
 
 Outputs a URL-encoded formatted query string based on the provided parameters.
 
-This tag requires a :class:`~django.http.QueryDict` instance, which defaults to
-:attr:`request.GET <django.http.HttpRequest.GET>` if none is provided.
+This tag accepts positional arguments, which must be mappings (such as
+:class:`~django.http.QueryDict` or :class:`dict`). If no positional arguments
+are provided, :attr:`request.GET <django.http.HttpRequest.GET>` is used as the
+default to construct the query string.
+
+Positional arguments are processed sequentially, while keyword arguments are
+treated as key-value pairs, applied last. Later arguments take precedence over
+earlier ones, ensuring the most recent pairs are reflected in the final result.
 
 The result always includes a leading ``"?"`` since this tag is mainly used for
 links, and an empty result could prevent the page from reloading as expected.
@@ -1033,16 +1039,33 @@ Handling lists
 If ``my_list`` is ``["red", "blue"]``, the output will be
 ``?color=red&color=blue``, preserving the list structure in the query string.
 
-Custom QueryDict
-~~~~~~~~~~~~~~~~
+Customizing the base QueryDict
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can pass custom ``QueryDict`` or ``dict`` instances as positional arguments
+to replace ``request.GET``. When multiple arguments are provided, key-value
+pairs from later arguments take precedence over earlier ones.
+
+For example, if ``my_query_dict`` is ``<QueryDict: {'color': ['blue'], 'size':
+['S']}>`` and ``my_dict`` is ``{'color': 'orange', 'fabric': 'silk', 'type':
+'dress'}``, this outputs ``?color=orange&size=S&fabric=silk``.
 
 .. code-block:: html+django
 
-    {% querystring my_query_dict %}
+    {% querystring my_query_dict my_dict size="S" type=None %}
 
-You can provide a custom ``QueryDict`` to be used instead of ``request.GET``.
-So if ``my_query_dict`` is ``<QueryDict: {'color': ['blue']}>``, this outputs
-``?color=blue``. If ``my_query_dict`` is empty, the output will be ``?``.
+If all keys are removed by setting them to ``None``, this outputs ``?``:
+
+.. code-block:: html+django
+
+    {% querystring my_query_dict my_dict color=None size=None fabric=None type=None %}
+
+Similarly, if all positional arguments are empty and keyword arguments do not
+contribute any new params, the output will also be ``?``.
+
+.. versionchanged:: 6.0
+
+    Support for multiple positional mapping arguments was added.
 
 Dynamic usage
 ~~~~~~~~~~~~~

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -236,6 +236,10 @@ Templates
 * The :ttag:`querystring` template tag now consistently prefixes the returned
   query string with a ``?``, ensuring reliable link generation behavior.
 
+* The :ttag:`querystring` template tag now accepts multiple positional
+  arguments, which must be mappings, such as :class:`~django.http.QueryDict`
+  or :class:`dict`.
+
 Tests
 ~~~~~
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/35529
Forum discussion: https://forum.djangoproject.com/t/adding-a-template-tag-to-generate-query-strings/24521/

I would rather use dictionary merging  `{**d1, **d2}` but this was not enough for `QueryDict`s that may contain list values.