### PR TITLE
Fixed typos in Atomic docstring.

### DIFF
--- a/django/db/transaction.py
+++ b/django/db/transaction.py
@@ -156,7 +156,7 @@ class Atomic(ContextDecorator):
     It's possible to disable the creation of savepoints if the goal is to
     ensure that some code runs within a transaction without creating overhead.
 
-    A stack of savepoints identifiers is maintained as an attribute of the
+    A stack of savepoint identifiers is maintained as an attribute of the
     connection. None denotes the absence of a savepoint.
 
     This allows reentrancy even if the same AtomicWrapper is reused. For
@@ -165,10 +165,10 @@ class Atomic(ContextDecorator):
 
     Since database connections are thread-local, this is thread-safe.
 
-    An atomic block can be tagged as durable. In this case, raise a
-    RuntimeError if it's nested within another atomic block. This guarantees
+    An atomic block can be tagged as durable. In this case, a RuntimeError is
+    raised if it's nested within another atomic block. This guarantees
     that database changes in a durable block are committed to the database when
-    the block exists without error.
+    the block exits without error.
 
     This is a private API.
     """


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

None.

# Branch description
Improved grammar and clarity in the `Atomic` class docstring..

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
