### PR TITLE
Fixed #35604, Refs #35326 -- Made FileSystemStorage.exists() behaviour independent from allow_overwrite.

### DIFF
--- a/django/core/files/storage/base.py
+++ b/django/core/files/storage/base.py
@@ -51,6 +51,10 @@ class Storage:
         validate_file_name(name, allow_relative_path=True)
         return name
 
+    def is_name_available(self, name, max_length=None):
+        exceeds_max_length = max_length and len(name) > max_length
+        return not self.exists(name) and not exceeds_max_length
+
     # These methods are part of the public API, with default implementations.
 
     def get_valid_name(self, name):
@@ -82,11 +86,11 @@ class Storage:
         validate_file_name(file_name)
         file_ext = "".join(pathlib.PurePath(file_name).suffixes)
         file_root = file_name.removesuffix(file_ext)
-        # If the filename already exists, generate an alternative filename
-        # until it doesn't exist.
+        # If the filename is not available, generate an alternative
+        # filename until one is available.
         # Truncate original name if required, so the new filename does not
         # exceed the max_length.
-        while self.exists(name) or (max_length and len(name) > max_length):
+        while not self.is_name_available(name, max_length=max_length):
             # file_ext includes the dot.
             name = os.path.join(
                 dir_name, self.get_alternative_name(file_root, file_ext)

--- a/docs/ref/files/storage.txt
+++ b/docs/ref/files/storage.txt
@@ -129,8 +129,7 @@ The ``Storage`` class
     .. method:: exists(name)
 
         Returns ``True`` if a file referenced by the given name already exists
-        in the storage system, or ``False`` if the name is available for a new
-        file.
+        in the storage system.
 
     .. method:: get_accessed_time(name)
 

--- a/tests/file_storage/test_generate_filename.py
+++ b/tests/file_storage/test_generate_filename.py
@@ -80,11 +80,14 @@ class GenerateFilenameStorageTests(SimpleTestCase):
             ("", ""),
         ]
         s = FileSystemStorage()
+        s_overwrite = FileSystemStorage(allow_overwrite=True)
         msg = "Could not derive file name from '%s'"
         for file_name, base_name in candidates:
             with self.subTest(file_name=file_name):
                 with self.assertRaisesMessage(SuspiciousFileOperation, msg % base_name):
                     s.get_available_name(file_name)
+                with self.assertRaisesMessage(SuspiciousFileOperation, msg % base_name):
+                    s_overwrite.get_available_name(file_name)
                 with self.assertRaisesMessage(SuspiciousFileOperation, msg % base_name):
                     s.generate_filename(file_name)
 
@@ -98,11 +101,14 @@ class GenerateFilenameStorageTests(SimpleTestCase):
             ("\\tmp\\..\\path", "/tmp/.."),
         ]
         s = FileSystemStorage()
+        s_overwrite = FileSystemStorage(allow_overwrite=True)
         for file_name, path in candidates:
             msg = "Detected path traversal attempt in '%s'" % path
             with self.subTest(file_name=file_name):
                 with self.assertRaisesMessage(SuspiciousFileOperation, msg):
                     s.get_available_name(file_name)
+                with self.assertRaisesMessage(SuspiciousFileOperation, msg):
+                    s_overwrite.get_available_name(file_name)
                 with self.assertRaisesMessage(SuspiciousFileOperation, msg):
                     s.generate_filename(file_name)
 


### PR DESCRIPTION
# Trac ticket number

ticket-35604

# Branch description

Partially reverts 0b33a3abc2ca7d68a24f6d0772bc2b9fa603744e.

`Storage.exists(name)` was documented to "return False if the name is available for a new file." but return True if the file exists. This is ambiguous in the overwrite file case.

Overwriting `get_available_name()` should still ensure all file name validation is applied, ref CVE-2024-39330.

This is motivated from this discussion on django-storages: https://github.com/jschneier/django-storages/issues/1430

Note: this concern was already raised by @bcail [here](https://github.com/django/django/pull/18020#issuecomment-2107536342) (thank you). At the time, I believed the impact to be limited and the implementation to still be within the definition of `Storages.exists(name)`.

This is to be backported to 5.1

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
