### PR TITLE
Fixed #35606 -- Admin changelist broken for model instances with __html__ method.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -416,6 +416,7 @@ answer newbie questions, and generally made Django that much better:
     Himanshu Chauhan <hchauhan1404@outlook.com>
     hipertracker@gmail.com
     Hiroki Kiyohara <hirokiky@gmail.com>
+    Hisham Mahmood <hishammahmood41@gmail.com>
     Honza Král <honza.kral@gmail.com>
     Horst Gutmann <zerok@zerokspot.com>
     Hugo Osvaldo Barrera <hugo@barrera.io>

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1026,7 +1026,9 @@ class ModelAdmin(BaseModelAdmin):
         """
         attrs = {
             "class": "action-select",
-            "aria-label": format_html(_("Select this object for an action - {}"), obj),
+            "aria-label": format_html(
+                _("Select this object for an action - {}"), str(obj)
+            ),
         }
         checkbox = forms.CheckboxInput(attrs, lambda value: False)
         return checkbox.render(helpers.ACTION_CHECKBOX_NAME, str(obj.pk))

--- a/docs/releases/5.0.8.txt
+++ b/docs/releases/5.0.8.txt
@@ -11,3 +11,7 @@ Bugfixes
 
 * Added missing validation for ``UniqueConstraint(nulls_distinct=False)`` when
   using ``*expressions`` (:ticket:`35594`).
+
+* Fixed a regression in Django 5.0 where ``ModelAdmin.action_checkbox`` could
+  break the admin changelist HTML page when rendering a model instance with a
+  ``__html__`` method (:ticket:`35606`).

--- a/tests/admin_changelist/models.py
+++ b/tests/admin_changelist/models.py
@@ -23,6 +23,12 @@ class GrandChild(models.Model):
     parent = models.ForeignKey(Child, models.SET_NULL, editable=False, null=True)
     name = models.CharField(max_length=30, blank=True)
 
+    def __str__(self):
+        return self.name
+
+    def __html__(self):
+        return f'<h2 class="main">{self.name}</h2>'
+
 
 class Genre(models.Model):
     name = models.CharField(max_length=20)

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -364,6 +364,33 @@ class ChangeListTests(TestCase):
             table_output,
         )
 
+    def test_action_checkbox_for_model_with_dunder_html(self):
+        grandchild = GrandChild.objects.create(name="name")
+        request = self._mocked_authenticated_request("/grandchild/", self.superuser)
+        m = GrandChildAdmin(GrandChild, custom_site)
+        cl = m.get_changelist_instance(request)
+        cl.formset = None
+        template = Template(
+            "{% load admin_list %}{% spaceless %}{% result_list cl %}{% endspaceless %}"
+        )
+        context = Context({"cl": cl, "opts": GrandChild._meta})
+        table_output = template.render(context)
+        link = reverse(
+            "admin:admin_changelist_grandchild_change", args=(grandchild.id,)
+        )
+        row_html = build_tbody_html(
+            grandchild,
+            link,
+            "name",
+            '<td class="field-parent__name">-</td>'
+            '<td class="field-parent__parent__name">-</td>',
+        )
+        self.assertNotEqual(
+            table_output.find(row_html),
+            -1,
+            "Failed to find expected row element: %s" % table_output,
+        )
+
     def test_result_list_editable_html(self):
         """
         Regression tests for #11791: Inclusion tag result_list generates a


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35606

# Branch description
Fixed a regression in 5.0, where if `__html__()` in model's instance contains unsafe characters, admin changelist might break.

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
