### PR TITLE
Fixed #35598 -- Added SearchInput widget.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -494,6 +494,7 @@ answer newbie questions, and generally made Django that much better:
     Jeremy Carbaugh <jcarbaugh@gmail.com>
     Jeremy Dunck <jdunck@gmail.com>
     Jeremy Lainé <jeremy.laine@m4x.org>
+    Jeremy Thompson <https://jhthompson.ca>
     Jerin Peter George <jerinpetergeorge@gmail.com>
     Jesse Young <adunar@gmail.com>
     Jezeniel Zapanta <jezeniel.zapanta@gmail.com>

--- a/django/forms/jinja2/django/forms/widgets/search.html
+++ b/django/forms/jinja2/django/forms/widgets/search.html
@@ -1,0 +1,1 @@
+{% include "django/forms/widgets/input.html" %}

--- a/django/forms/templates/django/forms/widgets/search.html
+++ b/django/forms/templates/django/forms/widgets/search.html
@@ -1,0 +1,1 @@
+{% include "django/forms/widgets/input.html" %}

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -30,6 +30,7 @@ __all__ = (
     "NumberInput",
     "EmailInput",
     "URLInput",
+    "SearchInput",
     "PasswordInput",
     "HiddenInput",
     "MultipleHiddenInput",
@@ -351,6 +352,11 @@ class EmailInput(Input):
 class URLInput(Input):
     input_type = "url"
     template_name = "django/forms/widgets/url.html"
+
+
+class SearchInput(Input):
+    input_type = "search"
+    template_name = "django/forms/widgets/search.html"
 
 
 class PasswordInput(Input):

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -558,6 +558,17 @@ These widgets make use of the HTML elements ``input`` and ``textarea``.
     * ``template_name``: ``'django/forms/widgets/url.html'``
     * Renders as: ``<input type="url" ...>``
 
+``SearchInput``
+~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.2
+
+.. class:: SearchInput
+
+    * ``input_type``: ``'search'``
+    * ``template_name``: ``'django/forms/widgets/search.html'``
+    * Renders as: ``<input type="search" ...>``
+
 ``PasswordInput``
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -165,7 +165,8 @@ File Uploads
 Forms
 ~~~~~
 
-* ...
+* The new :class:`~django.forms.SearchInput` form widget is for entering search
+  queries and renders as ``<input type="search" ...>``.
 
 Generic Views
 ~~~~~~~~~~~~~

--- a/tests/forms_tests/widget_tests/test_searchinput.py
+++ b/tests/forms_tests/widget_tests/test_searchinput.py
@@ -1,0 +1,12 @@
+from django.forms import SearchInput
+
+from .base import WidgetTest
+
+
+class SearchInputTest(WidgetTest):
+    widget = SearchInput()
+
+    def test_render(self):
+        self.check_html(
+            self.widget, "search", "", html='<input type="search" name="search">'
+        )


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35598

# Branch description
Adds a `SearchInput` widget that renders as `<input type="search" ... >`

As discussed [in the forum](https://forum.djangoproject.com/t/adding-searchinput-widget/32496), benefits of adding this include:
- Widgets have both the class and a corresponding template, so if Django provides them, they are easier for users to override. -@adamchainz
- For form template packs, such as those used by [django-crispy-forms](https://github.com/django-crispy-forms/django-crispy-forms), if a widget class exists, it has a corresponding template, and a form template pack can override it. Widgets left to the user don’t have predictable template locations, so a template pack can’t override them—except by providing the widget class too. -@adamchainz
- Discoverability of different input types if devs don't know a more appropriate type exists
- Improved accessibility by encouraging more semantic use of form inputs

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
