### PR TITLE
Fixed #35603 -- Prevented F.__contains__() from hanging.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -884,6 +884,11 @@ class F(Combinable):
     def __getitem__(self, subscript):
         return Sliced(self, subscript)
 
+    def __contains__(self, other):
+        # Disable old-style iteration protocol inherited from implementing
+        # __getitem__() to prevent this method from hanging.
+        raise TypeError(f"argument of type '{self.__class__.__name__}' is not iterable")
+
     def resolve_expression(
         self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False
     ):

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1302,6 +1302,11 @@ class FTests(SimpleTestCase):
         self.assertNotEqual(f, value)
         self.assertNotEqual(value, f)
 
+    def test_contains(self):
+        msg = "argument of type 'F' is not iterable"
+        with self.assertRaisesMessage(TypeError, msg):
+            "" in F("name")
+
 
 class ExpressionsTests(TestCase):
     def test_F_reuse(self):


### PR DESCRIPTION
Regression in 94b6f101f7dc363a8e71593570b17527dbb9f77f.