### PR TITLE
Small fix: fix the result of `TruncHour` example

### DIFF
--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -791,7 +791,7 @@ Usage example:
     ... ).values("date", "day", "hour", "minute", "second").get()
     {'date': datetime.date(2014, 6, 15),
      'day': datetime.datetime(2014, 6, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo('Australia/Melbourne')),
-     'hour': datetime.datetime(2014, 6, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo('Australia/Melbourne')),
+     'hour': datetime.datetime(2014, 6, 16, 14, 0, tzinfo=zoneinfo.ZoneInfo('Australia/Melbourne')),
      'minute': 'minute': datetime.datetime(2014, 6, 15, 14, 30, tzinfo=timezone.utc),
      'second': datetime.datetime(2014, 6, 15, 14, 30, 50, tzinfo=timezone.utc)
     }


### PR DESCRIPTION
# Trac ticket number

N/A

# Branch description
The result of `TruncHour` in the example should be `'hour': datetime.datetime(2014, 6, 16, 14, 0`, not `'hour': datetime.datetime(2014, 6, 16, 0, 0`