### PR TITLE
Fixed #35614 -- Prevented SQLCompiler.as_subquery_condition() from mutating a query.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1616,14 +1616,15 @@ class SQLCompiler:
     def as_subquery_condition(self, alias, columns, compiler):
         qn = compiler.quote_name_unless_alias
         qn2 = self.connection.ops.quote_name
+        query = self.query.clone()
 
-        for index, select_col in enumerate(self.query.select):
+        for index, select_col in enumerate(query.select):
             lhs_sql, lhs_params = self.compile(select_col)
             rhs = "%s.%s" % (qn(alias), qn2(columns[index]))
-            self.query.where.add(RawSQL("%s = %s" % (lhs_sql, rhs), lhs_params), AND)
+            query.where.add(RawSQL("%s = %s" % (lhs_sql, rhs), lhs_params), AND)
 
-        sql, params = self.as_sql()
-        return "EXISTS (%s)" % sql, params
+        sql, params = query.as_sql(compiler, self.connection)
+        return "EXISTS %s" % sql, params
 
     def explain_query(self):
         result = list(self.execute_sql())

--- a/tests/foreign_object/tests.py
+++ b/tests/foreign_object/tests.py
@@ -223,6 +223,13 @@ class MultiColumnFKTests(TestCase):
             [m2],
         )
 
+    def test_query_does_not_mutate(self):
+        """
+        Recompiling the same subquery doesn't mutate it.
+        """
+        queryset = Friendship.objects.filter(to_friend__in=Person.objects.all())
+        self.assertEqual(str(queryset.query), str(queryset.query))
+
     def test_select_related_foreignkey_forward_works(self):
         Membership.objects.create(
             membership_country=self.usa, person=self.bob, group=self.cia


### PR DESCRIPTION
# Trac ticket number
ticket-35614

# Branch description
Fixed the bug that adds a new `where` condition to the query whenever it's re-compiled.

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
