### PR TITLE
awaiting auser in middleware level

### DIFF
--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -35,7 +35,10 @@ class AuthenticationMiddleware(MiddlewareMixin):
                 "'django.contrib.auth.middleware.AuthenticationMiddleware'."
             )
         request.user = SimpleLazyObject(lambda: get_user(request))
-        request.auser = partial(auser, request)
+
+    async def aprocess_request(self, request):
+        self.process_request(request)
+        request.auser = await auser(request)
 
 
 class LoginRequiredMiddleware(MiddlewareMixin):

--- a/django/utils/deprecation.py
+++ b/django/utils/deprecation.py
@@ -128,7 +128,9 @@ class MiddlewareMixin:
         is running.
         """
         response = None
-        if hasattr(self, "process_request"):
+        if hasattr(self, "aprocess_request"):
+            response = await self.aprocess_request(request)
+        elif hasattr(self, "process_request"):
             response = await sync_to_async(
                 self.process_request,
                 thread_sensitive=True,

--- a/tests/auth_tests/test_middleware.py
+++ b/tests/auth_tests/test_middleware.py
@@ -52,9 +52,9 @@ class TestAuthenticationMiddleware(TestCase):
 
     async def test_auser(self):
         self.middleware(self.request)
-        auser = await self.request.auser()
+        auser = self.request.auser
         self.assertEqual(auser, self.user)
-        auser_second = await self.request.auser()
+        auser_second = self.request.auser
         self.assertIs(auser, auser_second)
 
 


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35615


# Branch description
#### provide `auser` to templates when an Aync view is being used.
#### this has been done because django's templates can not `await` on coroutines and the current form of `auser` only provides a coroutine object which isn't very useful.
#### more complete description has been provided in the ticket.

# Checklist
- [ x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x ] I have checked the "Has patch" ticket flag in the Trac system.
- [ x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
