### PR TITLE
Optimized template.utils.get_app_template_dirs() a bit.

### DIFF
--- a/django/template/utils.py
+++ b/django/template/utils.py
@@ -102,10 +102,9 @@ def get_app_template_dirs(dirname):
     dirname is the name of the subdirectory containing templates inside
     installed applications.
     """
-    template_dirs = [
-        Path(app_config.path) / dirname
-        for app_config in apps.get_app_configs()
-        if app_config.path and (Path(app_config.path) / dirname).is_dir()
-    ]
     # Immutable return value because it will be cached and shared by callers.
-    return tuple(template_dirs)
+    return tuple(
+        path
+        for app_config in apps.get_app_configs()
+        if app_config.path and (path := Path(app_config.path) / dirname).is_dir()
+    )


### PR DESCRIPTION
There are two small optimizations that I applied:
1. No intermediate list is created. Why? We can simply create a tuple right away
2. Sub `Path` object (`Path(app_config.path) / dirname`) does get created twice for each iteration. It is now only created once per iteration

# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

This is a trivial change.
Found during https://github.com/typeddjango/django-stubs/pull/2266 review.

# Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
