### PR TITLE
Cleaned up temporary test directories.

### DIFF
--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -259,6 +259,7 @@ class FormsModelTestCase(TestCase):
             m.file.name,
             "tests/\u6211\u96bb\u6c23\u588a\u8239\u88dd\u6eff\u6652\u9c54.txt",
         )
+        m.file.delete()
         m.delete()
 
     def test_boundary_conditions(self):

--- a/tests/model_forms/models.py
+++ b/tests/model_forms/models.py
@@ -135,7 +135,7 @@ class WriterProfile(models.Model):
 
 
 class Document(models.Model):
-    myfile = models.FileField(upload_to="unused", blank=True)
+    myfile = models.FileField(storage=temp_storage, upload_to="unused", blank=True)
 
 
 class TextFile(models.Model):

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import shutil
 from decimal import Decimal
 from unittest import mock, skipUnless
 
@@ -72,6 +73,7 @@ from .models import (
     Triple,
     Writer,
     WriterProfile,
+    temp_storage_dir,
     test_images,
 )
 
@@ -2482,6 +2484,12 @@ class ModelOneToOneFieldTests(TestCase):
 
 
 class FileAndImageFieldTests(TestCase):
+    def setUp(self):
+        if os.path.exists(temp_storage_dir):
+            shutil.rmtree(temp_storage_dir)
+        os.mkdir(temp_storage_dir)
+        self.addCleanup(shutil.rmtree, temp_storage_dir)
+
     def test_clean_false(self):
         """
         If the ``clean`` method on a non-required FileField receives False as


### PR DESCRIPTION
I noticed the following leftovers in Jenkins nodes:
```
- tmpyp83y_wr/
  - test4.png
  - foo/
  - tests/
    - no_extension
    - test4.png
- unused/
  - something.txt
- tmp_jecbuyi/
  - tests/
    - 我隻氣墊船裝滿晒鱔.txt
```