### PR TITLE
Refs #29049 -- Fixed isolation of BasicExpressionsTests._test_slicing_of_f_expressions() subtests.

### DIFF
--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -208,24 +208,28 @@ class BasicExpressionsTests(TestCase):
 
     def _test_slicing_of_f_expressions(self, model):
         tests = [
-            (F("name")[:], "Example Inc.", "Example Inc."),
-            (F("name")[:7], "Example Inc.", "Example"),
-            (F("name")[:6][:5], "Example", "Examp"),  # Nested slicing.
-            (F("name")[0], "Examp", "E"),
-            (F("name")[5], "E", ""),
-            (F("name")[7:], "Foobar Ltd.", "Ltd."),
-            (F("name")[0:10], "Ltd.", "Ltd."),
-            (F("name")[2:7], "Test GmbH", "st Gm"),
-            (F("name")[1:][:3], "st Gm", "t G"),
-            (F("name")[2:2], "t G", ""),
+            (F("name")[:], "Example Inc."),
+            (F("name")[:7], "Example"),
+            (F("name")[:6][:5], "Examp"),  # Nested slicing.
+            (F("name")[0], "E"),
+            (F("name")[13], ""),
+            (F("name")[8:], "Inc."),
+            (F("name")[0:15], "Example Inc."),
+            (F("name")[2:7], "ample"),
+            (F("name")[1:][:3], "xam"),
+            (F("name")[2:2], ""),
         ]
-        for expression, name, expected in tests:
-            with self.subTest(expression=expression, name=name, expected=expected):
-                obj = model.objects.get(name=name)
-                obj.name = expression
-                obj.save()
-                obj.refresh_from_db()
-                self.assertEqual(obj.name, expected)
+        for expression, expected in tests:
+            with self.subTest(expression=expression, expected=expected):
+                obj = model.objects.get(name="Example Inc.")
+                try:
+                    obj.name = expression
+                    obj.save(update_fields=["name"])
+                    obj.refresh_from_db()
+                    self.assertEqual(obj.name, expected)
+                finally:
+                    obj.name = "Example Inc."
+                    obj.save(update_fields=["name"])
 
     def test_slicing_of_f_expressions_charfield(self):
         self._test_slicing_of_f_expressions(Company)


### PR DESCRIPTION
Thanks Tim Graham for the [report](https://github.com/django/django/pull/17596/files#r1679386032).