### PR TITLE
Fixed #35622 -- Made unittest ignore Django asserts in tracebacks.

### DIFF
--- a/django/contrib/admin/tests.py
+++ b/django/contrib/admin/tests.py
@@ -6,6 +6,9 @@ from django.test.selenium import SeleniumTestCase
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import gettext as _
 
+# Make unittest ignore frames in this module when reporting failures.
+__unittest = True
+
 
 class CSPMiddleware(MiddlewareMixin):
     """The admin's JavaScript should be compatible with CSP."""

--- a/django/contrib/messages/test.py
+++ b/django/contrib/messages/test.py
@@ -1,5 +1,8 @@
 from .api import get_messages
 
+# Make unittest ignore frames in this module when reporting failures.
+__unittest = True
+
 
 class MessagesTestMixin:
     def assertMessages(self, response, expected_messages, *, ordered=True):

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -67,6 +67,9 @@ __all__ = (
     "skipUnlessDBFeature",
 )
 
+# Make unittest ignore frames in this module when reporting failures.
+__unittest = True
+
 
 if not PY311:
     # Backport of unittest.case._enter_context() from Python 3.11.

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -240,7 +240,9 @@ Templates
 Tests
 ~~~~~
 
-* ...
+* Stack frames from Django's custom assertions are now hidden. This makes test
+  failures easier to read and enables :option:`test --pdb` to directly enter
+  into the failing test method.
 
 URLs
 ~~~~

--- a/tests/messages_tests/tests.py
+++ b/tests/messages_tests/tests.py
@@ -1,5 +1,7 @@
 import importlib
 import sys
+import traceback
+import unittest
 from unittest import mock
 
 from django.conf import settings
@@ -185,3 +187,17 @@ class AssertMessagesTest(MessagesTestMixin, SimpleTestCase):
         )
         with self.assertRaisesMessage(AssertionError, msg):
             self.assertMessages(response, [])
+
+    def test_method_frames_ignored_by_unittest(self):
+        response = FakeResponse()
+        try:
+            self.assertMessages(response, [object()])
+        except AssertionError:
+            exc_type, exc, tb = sys.exc_info()
+
+        result = unittest.TestResult()
+        result.addFailure(self, (exc_type, exc, tb))
+        stack = traceback.extract_tb(exc.__traceback__)
+        self.assertEqual(len(stack), 1)
+        # Top element in the stack is this method, not assertMessages.
+        self.assertEqual(stack[-1].name, "test_method_frames_ignored_by_unittest")

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import threading
+import traceback
 import unittest
 import warnings
 from io import StringIO
@@ -1112,6 +1113,19 @@ class JSONEqualTests(SimpleTestCase):
             self.assertJSONNotEqual(invalid_json, valid_json)
         with self.assertRaises(AssertionError):
             self.assertJSONNotEqual(valid_json, invalid_json)
+
+    def test_method_frames_ignored_by_unittest(self):
+        try:
+            self.assertJSONEqual("1", "2")
+        except AssertionError:
+            exc_type, exc, tb = sys.exc_info()
+
+        result = unittest.TestResult()
+        result.addFailure(self, (exc_type, exc, tb))
+        stack = traceback.extract_tb(exc.__traceback__)
+        self.assertEqual(len(stack), 1)
+        # Top element in the stack is this method, not assertJSONEqual.
+        self.assertEqual(stack[-1].name, "test_method_frames_ignored_by_unittest")
 
 
 class XMLEqualTests(SimpleTestCase):


### PR DESCRIPTION
# Trac ticket number

ticket-35622

# Branch description
Fixes the issue reported on the ticket, as tested on my example project: the `assertJSONEqual` frame no longer appears in the failure report and the debugger opens within the test. I added a unit test.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
