### PR TITLE
Updated asgiref dependency for 5.1 release series.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -313,7 +313,7 @@ dependencies:
 
 * :pypi:`aiosmtpd`
 * :pypi:`argon2-cffi` 19.2.0+
-* :pypi:`asgiref` 3.7.0+ (required)
+* :pypi:`asgiref` 3.8.1+ (required)
 * :pypi:`bcrypt`
 * :pypi:`colorama` 0.4.6+
 * :pypi:`docutils` 0.19+

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -394,6 +394,9 @@ Miscellaneous
   ``width_field`` and ``height_field`` will not match the width and height of
   the image.
 
+* The minimum supported version of ``asgiref`` is increased from 3.7.0 to
+  3.8.1.
+
 .. _deprecated-features-5.1:
 
 Features deprecated in 5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "Django"
 dynamic = ["version"]
 requires-python = ">= 3.10"
 dependencies = [
-    "asgiref>=3.7.0",
+    "asgiref>=3.8.1",
     "sqlparse>=0.3.1",
     "tzdata; sys_platform == 'win32'",
 ]

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,5 +1,5 @@
 aiosmtpd
-asgiref >= 3.7.0
+asgiref >= 3.8.1
 argon2-cffi >= 19.2.0; sys_platform != 'win32' or python_version < '3.13'
 bcrypt
 black


### PR DESCRIPTION
We always bump `asgiref` version before a feature release, e.g.  2a2bde52f31e09e95ce616e8e6bc0ffeb68f76c9, 513441240f874dd0b6187c0c6aaa3e8eccd8ddbe.