### PR TITLE
Fixed #35628 -- Allowed compatible GeneratedFields for ModelAdmin.date_hierarchy.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -1184,7 +1184,7 @@ class ModelAdminChecks(BaseModelAdminChecks):
                     )
                 ]
             else:
-                if not isinstance(field, (models.DateField, models.DateTimeField)):
+                if field.get_internal_type() not in {"DateField", "DateTimeField"}:
                     return must_be(
                         "a DateField or DateTimeField",
                         option="date_hierarchy",

--- a/docs/releases/5.0.8.txt
+++ b/docs/releases/5.0.8.txt
@@ -24,3 +24,7 @@ Bugfixes
 * Fixed a regression in Django 5.0.7 that caused a crash in
   ``LocaleMiddleware`` when processing a language code over 500 characters
   (:ticket:`35627`).
+
+* Fixed a bug in Django 5.0 that caused a system check crash when
+  ``ModelAdmin.date_hierarchy`` was a ``GeneratedField`` with an
+  ``output_field`` of ``DateField`` or ``DateTimeField`` (:ticket:`35628`).

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -4,16 +4,17 @@ from django.contrib.admin import BooleanFieldListFilter, SimpleListFilter
 from django.contrib.admin.options import VERTICAL, ModelAdmin, TabularInline
 from django.contrib.admin.sites import AdminSite
 from django.core.checks import Error
+from django.db import models
 from django.db.models import CASCADE, F, Field, ForeignKey, ManyToManyField, Model
 from django.db.models.functions import Upper
 from django.forms.models import BaseModelFormSet
-from django.test import SimpleTestCase
+from django.test import TestCase, skipUnlessDBFeature
 from django.test.utils import isolate_apps
 
 from .models import Band, Song, User, ValidationTestInlineModel, ValidationTestModel
 
 
-class CheckTestCase(SimpleTestCase):
+class CheckTestCase(TestCase):
     def assertIsInvalid(
         self,
         model_admin,
@@ -96,6 +97,29 @@ class RawIdCheckTests(CheckTestCase):
             raw_id_fields = ("users",)
 
         self.assertIsValid(TestModelAdmin, ValidationTestModel)
+
+    @isolate_apps("modeladmin")
+    def assertGeneratedDateTimeFieldIsValid(self, *, db_persist):
+        class TestModel(Model):
+            date = models.DateTimeField()
+            date_copy = models.GeneratedField(
+                expression=F("date"),
+                output_field=models.DateTimeField(),
+                db_persist=db_persist,
+            )
+
+        class TestModelAdmin(ModelAdmin):
+            date_hierarchy = "date_copy"
+
+        self.assertIsValid(TestModelAdmin, TestModel)
+
+    @skipUnlessDBFeature("supports_stored_generated_columns")
+    def test_valid_case_stored_generated_field(self):
+        self.assertGeneratedDateTimeFieldIsValid(db_persist=True)
+
+    @skipUnlessDBFeature("supports_virtual_generated_columns")
+    def test_valid_case_virtual_generated_field(self):
+        self.assertGeneratedDateTimeFieldIsValid(db_persist=False)
 
     def test_field_attname(self):
         class TestModelAdmin(ModelAdmin):
@@ -1028,6 +1052,33 @@ class DateHierarchyCheckTests(CheckTestCase):
             "The value of 'date_hierarchy' must be a DateField or DateTimeField.",
             "admin.E128",
         )
+
+    @isolate_apps("modeladmin")
+    def assertGeneratedIntegerFieldIsInvalid(self, *, db_persist):
+        class TestModel(Model):
+            generated = models.GeneratedField(
+                expression=models.Value(1),
+                output_field=models.IntegerField(),
+                db_persist=db_persist,
+            )
+
+        class TestModelAdmin(ModelAdmin):
+            date_hierarchy = "generated"
+
+        self.assertIsInvalid(
+            TestModelAdmin,
+            TestModel,
+            "The value of 'date_hierarchy' must be a DateField or DateTimeField.",
+            "admin.E128",
+        )
+
+    @skipUnlessDBFeature("supports_stored_generated_columns")
+    def test_related_invalid_field_type_stored_generated_field(self):
+        self.assertGeneratedIntegerFieldIsInvalid(db_persist=True)
+
+    @skipUnlessDBFeature("supports_virtual_generated_columns")
+    def test_related_invalid_field_type_virtual_generated_field(self):
+        self.assertGeneratedIntegerFieldIsInvalid(db_persist=False)
 
     def test_valid_case(self):
         class TestModelAdmin(ModelAdmin):


### PR DESCRIPTION
Fixed #35628, allow GeneratedField with appropriate output_field for date_hierarchy.

# Trac ticket number

This is the basic fix for https://code.djangoproject.com/ticket/35628# , but without tests/docs. Will add tests/docs if approach is deemed appropriate.

# Branch description
Essentially, there's a check to make sure that `date_hierarchy` is a `DateField` or `DateTimeField`, but there is no technical reason to prohibit a `GeneratedField` with `output_field` set to `DateField` or `DateTimeField`.

This adjusts the check to allow that specific case through.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
