### PR TITLE
Added dedicated test for invalid inputs in floatformat template filter tests.

### DIFF
--- a/tests/template_tests/filter_tests/test_floatformat.py
+++ b/tests/template_tests/filter_tests/test_floatformat.py
@@ -60,12 +60,8 @@ class FunctionTests(SimpleTestCase):
             floatformat(Decimal("123456.123456789012345678901"), 21),
             "123456.123456789012345678901",
         )
-        self.assertEqual(floatformat("foo"), "")
         self.assertEqual(floatformat(13.1031, "bar"), "13.1031")
         self.assertEqual(floatformat(18.125, 2), "18.13")
-        self.assertEqual(floatformat("foo", "bar"), "")
-        self.assertEqual(floatformat("¿Cómo esta usted?"), "")
-        self.assertEqual(floatformat(None), "")
         self.assertEqual(
             floatformat(-1.323297138040798e35, 2),
             "-132329713804079800000000000000000000.00",
@@ -77,6 +73,45 @@ class FunctionTests(SimpleTestCase):
         self.assertEqual(floatformat(1.5e-15, 20), "0.00000000000000150000")
         self.assertEqual(floatformat(1.5e-15, -20), "0.00000000000000150000")
         self.assertEqual(floatformat(1.00000000000000015, 16), "1.0000000000000002")
+
+    def test_invalid_inputs(self):
+        cases = [
+            # Non-numeric strings.
+            None,
+            [],
+            {},
+            object(),
+            "abc123",
+            "123abc",
+            "foo",
+            "error",
+            "¿Cómo esta usted?",
+            # Scientific notation - missing exponent value.
+            "1e",
+            "1e+",
+            "1e-",
+            # Scientific notation - missing base number.
+            "e400",
+            "e+400",
+            "e-400",
+            # Scientific notation - invalid exponent value.
+            "1e^2",
+            "1e2e3",
+            "1e2a",
+            "1e2.0",
+            "1e2,0",
+            # Scientific notation - misplaced decimal point.
+            "1e.2",
+            "1e2.",
+            # Scientific notation - misplaced '+' sign.
+            "1+e2",
+            "1e2+",
+        ]
+        for value in cases:
+            with self.subTest(value=value):
+                self.assertEqual(floatformat(value), "")
+            with self.subTest(value=value, arg="bar"):
+                self.assertEqual(floatformat(value, "bar"), "")
 
     def test_force_grouping(self):
         with translation.override("en"):


### PR DESCRIPTION
# Branch description
Following the review of some private patches, I realized the `floatformat` tests could benefit from a dedicated test for invalid inputs.

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have added or updated relevant tests.
