### PR TITLE
Referenced joining the triage and review team as motivation to do PR reviews.

### DIFF
--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -288,8 +288,11 @@ appropriate flags on the Trac ticket based on the results of your review:
 "Patch needs improvement", "Needs documentation", and/or "Needs tests". As time
 and interest permits, mergers do final reviews of "Ready for checkin" tickets
 and will either commit the changes or bump it back to "Accepted" if further
-work needs to be done. If you're looking to become a merger, doing thorough
-reviews of contributions is a great way to earn trust.
+work needs to be done.
+
+If you're looking to become a member of the `triage & review team
+<https://www.djangoproject.com/foundation/teams/#triage-review-team>`_, doing
+thorough reviews of contributions is a great way to earn trust.
 
 Looking for a patch to review? Check out the "Patches needing review" section
 of the `Django Development Dashboard <https://dashboard.djangoproject.com/>`_.


### PR DESCRIPTION
Thank you @mharyam for this (pulled from #18341) - this was a proposed update after reviewing the contributing docs

The role of "merger" is not often awarded to volunteers, this was suggested to be updated to "Review and Triage team" member.

We could also say something very generic like "If you're looking to be awarded a role of responsibility". This would still include the original role of merger but also things like the "Accessibility Team" - as I think PR reviews would also be a good way to be noticed by the accessibility team also.

I wouldn't want to delete the sentence as it is the only place I think we encourage PR reviews.

What do you think? Are you in favor of updating this or shall we leave it?
