### PR TITLE
Fixed #35639 -- Improved admin's delete confirmation page title.

### DIFF
--- a/django/contrib/admin/actions.py
+++ b/django/contrib/admin/actions.py
@@ -61,7 +61,7 @@ def delete_selected(modeladmin, request, queryset):
     if perms_needed or protected:
         title = _("Cannot delete %(name)s") % {"name": objects_name}
     else:
-        title = _("Are you sure?")
+        title = _("Delete multiple objects")
 
     context = {
         **modeladmin.admin_site.each_context(request),

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -2229,7 +2229,7 @@ class ModelAdmin(BaseModelAdmin):
         if perms_needed or protected:
             title = _("Cannot delete %(name)s") % {"name": object_name}
         else:
-            title = _("Are you sure?")
+            title = _("Delete")
 
         context = {
             **self.admin_site.each_context(request),

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -72,6 +72,7 @@ class AdminActionsTest(TestCase):
         self.assertContains(
             confirmation, "Are you sure you want to delete the selected subscribers?"
         )
+        self.assertContains(confirmation, "<h1>Delete multiple objects</h1>")
         self.assertContains(confirmation, "<h2>Summary</h2>")
         self.assertContains(confirmation, "<li>Subscribers: 2</li>")
         self.assertContains(confirmation, "<li>External subscribers: 1</li>")

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -3003,6 +3003,7 @@ class AdminViewPermissionsTest(TestCase):
         response = self.client.get(
             reverse("admin:admin_views_section_delete", args=(self.s1.pk,))
         )
+        self.assertContains(response, "<h1>Delete</h1>")
         self.assertContains(response, "<h2>Summary</h2>")
         self.assertContains(response, "<li>Articles: 3</li>")
         # test response contains link to related Article


### PR DESCRIPTION
# Trac ticket number

ticket-35639

# Branch description

Currently, both the delete_selected actions confirmation page and the page for deleting a single object have the title "Are you sure?"

The "Are you sure" is immediately repeated in the sentence below.

I propose replacing the title with the value from the breadcrumb, "Delete multiple objects" and "Delete", to make it clearer to users that they are about to confirm a destructive action.

(This has happened multiple times in the last few years, and has been reported as a problem by a client, it's not just me bikeshedding here.)

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
