### PR TITLE
Fixed #35440 -- Simplified parse_header_parameters by leveraging stdlid's Message.

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -3,8 +3,9 @@ import re
 import unicodedata
 from binascii import Error as BinasciiError
 from datetime import UTC, datetime
-from email.utils import formatdate
-from urllib.parse import quote, unquote
+from email.message import Message
+from email.utils import collapse_rfc2231_value, formatdate
+from urllib.parse import quote
 from urllib.parse import urlencode as original_urlencode
 from urllib.parse import urlsplit
 
@@ -24,6 +25,7 @@ ETAG_MATCH = _lazy_re_compile(
     re.X,
 )
 
+MAX_HEADER_LENGTH = 10_000
 MONTHS = "jan feb mar apr may jun jul aug sep oct nov dec".split()
 __D = r"(?P<day>[0-9]{2})"
 __D2 = r"(?P<day>[ 0-9][0-9])"
@@ -310,46 +312,28 @@ def escape_leading_slashes(url):
     return url
 
 
-def _parseparam(s):
-    while s[:1] == ";":
-        s = s[1:]
-        end = s.find(";")
-        while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
-            end = s.find(";", end + 1)
-        if end < 0:
-            end = len(s)
-        f = s[:end]
-        yield f.strip()
-        s = s[end:]
-
-
-def parse_header_parameters(line):
+def parse_header_parameters(line, max_length=MAX_HEADER_LENGTH):
     """
     Parse a Content-type like header.
     Return the main content-type and a dictionary of options.
+
+    If `line` is longer than `max_length`, `ValueError` is raised.
     """
-    parts = _parseparam(";" + line)
-    key = parts.__next__().lower()
+    if max_length is not None and line and len(line) > max_length:
+        raise ValueError("Unable to parse header parameters (value too long).")
+
+    m = Message()
+    m["content-type"] = line
+    params = m.get_params()
+
     pdict = {}
-    for p in parts:
-        i = p.find("=")
-        if i >= 0:
-            has_encoding = False
-            name = p[:i].strip().lower()
-            if name.endswith("*"):
-                # Lang/encoding embedded in the value (like "filename*=UTF-8''file.ext")
-                # https://tools.ietf.org/html/rfc2231#section-4
-                name = name[:-1]
-                if p.count("'") == 2:
-                    has_encoding = True
-            value = p[i + 1 :].strip()
-            if len(value) >= 2 and value[0] == value[-1] == '"':
-                value = value[1:-1]
-                value = value.replace("\\\\", "\\").replace('\\"', '"')
-            if has_encoding:
-                encoding, lang, value = value.split("'")
-                value = unquote(value, encoding=encoding)
-            pdict[name] = value
+    key = params.pop(0)[0].lower()
+    for name, value in params:
+        if not name:
+            continue
+        if isinstance(value, tuple):
+            value = collapse_rfc2231_value(value)
+        pdict[name] = value
     return key, pdict
 
 

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -311,6 +311,10 @@ Miscellaneous
 * The :ref:`JSON <serialization-formats-json>` serializer now writes a newline
   at the end of the output, even without the ``indent`` option set.
 
+* The undocumented ``django.utils.http.parse_header_parameters()`` function is
+  refactored to use Python's :py:class:`email.message.Message` for parsing.
+  Input headers exceeding 10000 characters will now raise :exc:`ValueError`.
+
 .. _deprecated-features-6.0:
 
 Features deprecated in 6.0


### PR DESCRIPTION
Updated parse_header_parameters to leverage the parsing logic from (stdlib) email Message implementation. Limited the number of parameters that parsed by default to two.

# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35440

# Branch description
### Logic leveraging
> The goal of this ticket is to track the improvement of the current parse_header_parameters implementation by leveraging the logic from email.message.Message.

In this branch I've changed code of the `parse_header_parameters` function with logic elements from python `email.utils` module implementation. This is mainly done through the use of the `decode_params` function from email.utils, and then converted to the old format.

:exclamation:  There is one difference from the current implementation: logic of `decode_params` functions [always](https://github.com/python/cpython/blob/main/Lib/email/utils.py#L432) unquote  in encoding in params values, even if it doesn't correct due to "wrongly formatted RFC 2231 headers" (shown in tests):

```python
#cgi and old implementations
>>> from django.utils.http import parse_header_parameters
>>> parse_header_parameters("Content-Type: application/x-stuff; title*='This%20is%20%2A%2A%2Afun%2A%2A%2A")
('content-type: application/x-stuff', {'title': "'This%20is%20%2A%2A%2Afun%2A%2A%2A"})
>>> from cgi import parse_header
parse_header("Content-Type: application/x-stuff; title*='This%20is%20%2A%2A%2Afun%2A%2A%2A")

#email and new implementations
>>> from email.message import Message
>>> m = Message()
>>> m["Content-Type"] = "application/x-stuff; title*='This%20is%20%2A%2A%2Afun%2A%2A%2A"
>>> m.get_params()
[('application/x-stuff', ''), ('title', (None, None, "'This is ***fun***"))]
>>> from django.utils.http import parse_header_parameters
>>> parse_header_parameters("Content-Type: application/x-stuff; title*='This%20is%20%2A%2A%2Afun%2A%2A%2A")
('content-type: application/x-stuff', {'title': "'This is ***fun***"})
```

And I do not see it possible to revert such a conversion of the param value to the initial state when using the `decode_params` function. 

```python
>>> s = "'This%20is%20%2A%2A%2Afun%2A%2A%2A"
>>> s1 = urllib.parse.quote(urllib.parse.unquote(s, encoding="latin-1") , encoding="latin-1")
>>> s1
'%27This%20is%20%2A%2A%2Afun%2A%2A%2A'
>>> s1 == s
False
```

So this can be fixed by copying functionality of decode_params into the django code base, with change of the unqote part, to lead current logic to the old implementation, but I'm not sure this is necessary.


### Parameters limitations

> The Security Team also agreed that it's worth adding some early checks in the `parse_header_parameters` function to limit the amount of provided semicolons. This would require some investigation as to what would be a good threshold, considering that it's likely that more than one semicolon may not be necessary in valid HTTP headers.

In this branch I've added an optional parameter `limit` to the function `parse_header_parameters` with default value=`2`. That means that current usages of this function in django project will return only first `limit` parameters for the value, for example: 

```python
>>> s = 'attachment; one=one; two=two; three=three'
>>> from cgi import parse_header
>>> parse_header(s)
('attachment', {'one': 'one', 'two': 'two', 'three': 'three'})

>>> from django.utils.http import parse_header_parameters
>>> parse_header_parameters(s)
('attachment', {'one': 'one', 'two': 'two'})
>>> parse_header_parameters(s, limit=3)
('attachment', {'one': 'one', 'two': 'two', 'three': 'three'})
>>> parse_header_parameters(s, 0)
('attachment', {})
```
The choice of the value 2 was justified by existing examples of using several parameters, like in [Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header. Despite the  [resolution](https://datatracker.ietf.org/doc/html/rfc7231) that allows Content-Type header has multiple parameters without limitations `media-type = type "/" subtype *( OWS ";" OWS parameter )`, it's really hard to find any real usage examples.

It is also worth noting that the task description talks about pre-counting semicolons. But since there may be semicolons inside the parameters, it is not possible to determine in advance which of them are inside the parameters. Therefore, the checks are based on the number of parsed parameters.

p.s. This is my first pull request, so any comments or suggestions are greatly welcomed.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
