### PR TITLE
Fixed #35638 -- Updated validate_constraints to consider db_default.

### DIFF
--- a/django/contrib/postgres/constraints.py
+++ b/django/contrib/postgres/constraints.py
@@ -178,7 +178,7 @@ class ExclusionConstraint(BaseConstraint):
 
     def validate(self, model, instance, exclude=None, using=DEFAULT_DB_ALIAS):
         queryset = model._default_manager.using(using)
-        replacement_map = instance._get_field_value_map(
+        replacement_map = instance._get_field_expression_map(
             meta=model._meta, exclude=exclude
         )
         replacements = {F(field): value for field, value in replacement_map.items()}

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1333,12 +1333,17 @@ class Model(AltersData, metaclass=ModelBase):
             setattr(self, cachename, obj)
         return getattr(self, cachename)
 
-    def _get_field_value_map(self, meta, exclude=None):
+    def _get_field_expression_map(self, meta, exclude=None):
         if exclude is None:
             exclude = set()
         meta = meta or self._meta
         field_map = {
-            field.name: Value(getattr(self, field.attname), field)
+            field.name: (
+                value
+                if (value := getattr(self, field.attname))
+                and hasattr(value, "resolve_expression")
+                else Value(value, field)
+            )
             for field in meta.local_concrete_fields
             if field.name not in exclude and not field.generated
         }

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -241,7 +241,7 @@ class CheckConstraint(BaseConstraint):
         return schema_editor._delete_check_sql(model, self.name)
 
     def validate(self, model, instance, exclude=None, using=DEFAULT_DB_ALIAS):
-        against = instance._get_field_value_map(meta=model._meta, exclude=exclude)
+        against = instance._get_field_expression_map(meta=model._meta, exclude=exclude)
         try:
             if not Q(self.condition).check(against, using=using):
                 raise ValidationError(
@@ -638,7 +638,7 @@ class UniqueConstraint(BaseConstraint):
                         return
             replacements = {
                 F(field): value
-                for field, value in instance._get_field_value_map(
+                for field, value in instance._get_field_expression_map(
                     meta=model._meta, exclude=exclude
                 ).items()
             }
@@ -668,7 +668,9 @@ class UniqueConstraint(BaseConstraint):
                     code=self.violation_error_code,
                 )
         else:
-            against = instance._get_field_value_map(meta=model._meta, exclude=exclude)
+            against = instance._get_field_expression_map(
+                meta=model._meta, exclude=exclude
+            )
             try:
                 if (self.condition & Exists(queryset.filter(self.condition))).check(
                     against, using=using

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1250,9 +1250,41 @@ class Star(Expression):
 
 
 class DatabaseDefault(Expression):
-    """Placeholder expression for the database default in an insert query."""
+    """
+    Expression to use DEFAULT keyword during insert otherwise the underlying expression.
+    """
+
+    def __init__(self, expression, output_field=None):
+        super().__init__(output_field)
+        self.expression = expression
+
+    def get_source_expressions(self):
+        return [self.expression]
+
+    def set_source_expressions(self, exprs):
+        (self.expression,) = exprs
+
+    def resolve_expression(
+        self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False
+    ):
+        resolved_expression = self.expression.resolve_expression(
+            query=query,
+            allow_joins=allow_joins,
+            reuse=reuse,
+            summarize=summarize,
+            for_save=for_save,
+        )
+        # Defaults used outside an INSERT context should resolve to their
+        # underlying expression.
+        if not for_save:
+            return resolved_expression
+        return DatabaseDefault(
+            resolved_expression, output_field=self._output_field_or_none
+        )
 
     def as_sql(self, compiler, connection):
+        if not connection.features.supports_default_keyword_in_insert:
+            return compiler.compile(self.expression)
         return "DEFAULT", []
 
 

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -983,13 +983,7 @@ class Field(RegisterLookupMixin):
 
     def pre_save(self, model_instance, add):
         """Return field's value just before saving."""
-        value = getattr(model_instance, self.attname)
-        if not connection.features.supports_default_keyword_in_insert:
-            from django.db.models.expressions import DatabaseDefault
-
-            if isinstance(value, DatabaseDefault):
-                return self._db_default_expression
-        return value
+        return getattr(model_instance, self.attname)
 
     def get_prep_value(self, value):
         """Perform preliminary non-db specific value checks and conversions."""
@@ -1031,7 +1025,9 @@ class Field(RegisterLookupMixin):
         if self.db_default is not NOT_PROVIDED:
             from django.db.models.expressions import DatabaseDefault
 
-            return DatabaseDefault
+            return lambda: DatabaseDefault(
+                self._db_default_expression, output_field=self
+            )
 
         if (
             not self.empty_strings_allowed

--- a/docs/releases/5.0.8.txt
+++ b/docs/releases/5.0.8.txt
@@ -28,3 +28,7 @@ Bugfixes
 * Fixed a bug in Django 5.0 that caused a system check crash when
   ``ModelAdmin.date_hierarchy`` was a ``GeneratedField`` with an
   ``output_field`` of ``DateField`` or ``DateTimeField`` (:ticket:`35628`).
+
+* Fixed a bug in Django 5.0 which caused constraint validation to either crash
+  or incorrectly raise validation errors for constraints referring to fields
+  using ``Field.db_default`` (:ticket:`35638`).

--- a/tests/constraints/models.py
+++ b/tests/constraints/models.py
@@ -128,3 +128,10 @@ class JSONFieldModel(models.Model):
 
     class Meta:
         required_db_features = {"supports_json_field"}
+
+
+class ModelWithDatabaseDefault(models.Model):
+    field = models.CharField(max_length=255)
+    field_with_db_default = models.CharField(
+        max_length=255, db_default=models.Value("field_with_db_default")
+    )

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -434,7 +434,7 @@ class Migration(migrations.Migration):
                         primary_key=True,
                     ),
                 ),
-                ("ints", IntegerRangeField(null=True, blank=True)),
+                ("ints", IntegerRangeField(null=True, blank=True, db_default=(5, 10))),
                 ("bigints", BigIntegerRangeField(null=True, blank=True)),
                 ("decimals", DecimalRangeField(null=True, blank=True)),
                 ("timestamps", DateTimeRangeField(null=True, blank=True)),

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -130,7 +130,7 @@ class LineSavedSearch(PostgreSQLModel):
 
 
 class RangesModel(PostgreSQLModel):
-    ints = IntegerRangeField(blank=True, null=True)
+    ints = IntegerRangeField(blank=True, null=True, db_default=(5, 10))
     bigints = BigIntegerRangeField(blank=True, null=True)
     decimals = DecimalRangeField(blank=True, null=True)
     timestamps = DateTimeRangeField(blank=True, null=True)

--- a/tests/postgres_tests/test_constraints.py
+++ b/tests/postgres_tests/test_constraints.py
@@ -1213,3 +1213,12 @@ class ExclusionConstraintTests(PostgreSQLTestCase):
             constraint_name,
             self.get_constraints(ModelWithExclusionConstraint._meta.db_table),
         )
+
+    def test_database_default(self):
+        constraint = ExclusionConstraint(
+            name="ints_equal", expressions=[("ints", RangeOperators.EQUAL)]
+        )
+        RangesModel.objects.create()
+        msg = "Constraint “ints_equal” is violated."
+        with self.assertRaisesMessage(ValidationError, msg):
+            constraint.validate(RangesModel, RangesModel())

--- a/tests/validation/models.py
+++ b/tests/validation/models.py
@@ -48,7 +48,7 @@ class ModelToValidate(models.Model):
 
 class UniqueFieldsModel(models.Model):
     unique_charfield = models.CharField(max_length=100, unique=True)
-    unique_integerfield = models.IntegerField(unique=True)
+    unique_integerfield = models.IntegerField(unique=True, db_default=42)
     non_unique_field = models.IntegerField()
 
 

--- a/tests/validation/test_unique.py
+++ b/tests/validation/test_unique.py
@@ -146,6 +146,20 @@ class PerformUniqueChecksTest(TestCase):
             mtv = ModelToValidate(number=10, name="Some Name")
             mtv.full_clean()
 
+    def test_unique_db_default(self):
+        UniqueFieldsModel.objects.create(unique_charfield="foo", non_unique_field=42)
+        um = UniqueFieldsModel(unique_charfield="bar", non_unique_field=42)
+        with self.assertRaises(ValidationError) as cm:
+            um.full_clean()
+        self.assertEqual(
+            cm.exception.message_dict,
+            {
+                "unique_integerfield": [
+                    "Unique fields model with this Unique integerfield already exists."
+                ]
+            },
+        )
+
     def test_unique_for_date(self):
         Post.objects.create(
             title="Django 1.0 is released",


### PR DESCRIPTION
ticket-35638

 - Rename & update `_get_field_value_map() -> _get_field_expression_map()` to avoid wrapping expressions in `Value`
 - ~Update constraint validation to make consideration for expressions like `DatabaseDefault`~
   - Prefer using Simon's suggestion of updating `DatabaseDefault` to selectively use either the keyword `DEFAULT` or the underlying default expression depending on whether it's an insert or otherwise
 - Add tests for:
   - check constraints
   - unique with fields defined 
   - unique with expression defined
   - exclusion constraints

checklist
 - [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
 - [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
 - [x] I have checked the "Has patch" ticket flag in the Trac system.
 - [x] I have added or updated relevant tests.
 - [x] I have added or updated relevant docs, including release notes if applicable.
 - [ ] I have attached screenshots in both light and dark modes for any UI changes.
