### PR TITLE
Fixed #35643 -- Fixed a crash when ordering a QuerySet by a reference containing "__".

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -403,8 +403,13 @@ class SQLCompiler:
                 )
                 continue
 
-            ref, *transforms = col.split(LOOKUP_SEP)
-            if expr := self.query.annotations.get(ref):
+            if expr := self.query.annotations.get(col):
+                ref = col
+                transforms = []
+            else:
+                ref, *transforms = col.split(LOOKUP_SEP)
+                expr = self.query.annotations.get(ref)
+            if expr:
                 if self.query.combinator and self.select:
                     if transforms:
                         raise NotImplementedError(

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -1750,6 +1750,26 @@ class AggregateTestCase(TestCase):
             ],
         )
 
+    def test_order_by_aggregate_default_alias(self):
+        publisher_books = (
+            Publisher.objects.values("book")
+            .annotate(Count("book"))
+            .order_by("book__count", "book__id")
+            .values_list("book", flat=True)
+        )
+        self.assertQuerySetEqual(
+            publisher_books,
+            [
+                None,
+                self.b1.id,
+                self.b2.id,
+                self.b3.id,
+                self.b4.id,
+                self.b5.id,
+                self.b6.id,
+            ],
+        )
+
     def test_empty_result_optimization(self):
         with self.assertNumQueries(0):
             self.assertEqual(


### PR DESCRIPTION
# Trac ticket number

ticket-35643

# Branch description

Regression in b0ad41198b3e333f57351e3fce5a1fb47f23f376.

Refs ticket-34013.

The initial logic failed to account for the fact that annotation aliases are allowed to contain lookup / transform separators.

Thanks @gvangool for the report.
