### PR TITLE
Fixed #35645, Refs #35558 -- Made H1 styling visually stronger than other headings in the admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -149,7 +149,7 @@ h1 {
     margin: 0 0 20px;
     font-weight: 300;
     font-size: 1.25rem;
-    color: var(--body-quiet-color);
+    color: var(--body-loud-color);
 }
 
 h2 {
@@ -340,7 +340,7 @@ tfoot td {
 }
 
 thead th.required {
-    color: var(--body-loud-color);
+    color: var(--body-fg);
 }
 
 tr.alt {


### PR DESCRIPTION
# Trac ticket number
ticket-35645
ticket-35558

# Branch description
Following the review of PR #18308, it was noticed that since the inline H3 header was set to `--body-loud-color`, in the light theme this color (black) is stronger than the page's H1, which is `--body-quiet-color` (`#666`, dark-ish gray).

Once approved I'll update the relevant docs screenshots.

* Before:
![image](https://github.com/user-attachments/assets/5895880a-a6cb-42f3-bd8c-7846db96d860)
![image](https://github.com/user-attachments/assets/45f7916e-6d13-4f1f-a616-47f8e472b23e)

* After:
![image](https://github.com/user-attachments/assets/85e01348-016a-4324-bee8-243325662742)
![image](https://github.com/user-attachments/assets/93df1ae3-1456-415f-b6d0-a94ddd4964d0)

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
