### PR TITLE
Fixed #35646 -- Extended SafeExceptionReporterFilter.hidden_settings to treat `AUTH` as a sensitive match.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -113,7 +113,7 @@ class SafeExceptionReporterFilter:
 
     cleansed_substitute = "********************"
     hidden_settings = _lazy_re_compile(
-        "API|TOKEN|KEY|SECRET|PASS|SIGNATURE|HTTP_COOKIE", flags=re.I
+        "API|AUTH|TOKEN|KEY|SECRET|PASS|SIGNATURE|HTTP_COOKIE", flags=re.I
     )
 
     def cleanse_setting(self, key, value):

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -282,7 +282,11 @@ following attributes and methods:
 
             import re
 
-            re.compile(r"API|TOKEN|KEY|SECRET|PASS|SIGNATURE|HTTP_COOKIE", flags=re.IGNORECASE)
+            re.compile(r"API|AUTH|TOKEN|KEY|SECRET|PASS|SIGNATURE|HTTP_COOKIE", flags=re.IGNORECASE)
+
+        .. versionchanged:: 5.2
+
+            The term ``AUTH`` was added.
 
     .. method:: is_active(request)
 

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -150,7 +150,8 @@ Email
 Error Reporting
 ~~~~~~~~~~~~~~~
 
-* ...
+* The attribute :attr:`.SafeExceptionReporterFilter.hidden_settings` now
+  treats values as sensitive if their name includes ``AUTH``.
 
 File Storage
 ~~~~~~~~~~~~

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -1557,7 +1557,8 @@ class ExceptionReporterFilterTests(
         "SECRET_KEY_FALLBACKS",
         "PASSWORD",
         "API_KEY",
-        "AUTH_TOKEN",
+        "SOME_TOKEN",
+        "MY_AUTH",
     ]
 
     def test_non_sensitive_request(self):
@@ -1885,6 +1886,7 @@ class ExceptionReporterFilterTests(
             "PASSWORD": "super secret",
             "SECRET_VALUE": "super secret",
             "SOME_TOKEN": "super secret",
+            "THE_AUTH": "super secret",
         }
         request = self.rf.get("/", headers=headers)
         reporter_filter = SafeExceptionReporterFilter()

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -1552,6 +1552,13 @@ class ExceptionReporterFilterTests(
     """
 
     rf = RequestFactory()
+    sensitive_settings = [
+        "SECRET_KEY",
+        "SECRET_KEY_FALLBACKS",
+        "PASSWORD",
+        "API_KEY",
+        "AUTH_TOKEN",
+    ]
 
     def test_non_sensitive_request(self):
         """
@@ -1774,42 +1781,30 @@ class ExceptionReporterFilterTests(
         The debug page should not show some sensitive settings
         (password, secret key, ...).
         """
-        sensitive_settings = [
-            "SECRET_KEY",
-            "SECRET_KEY_FALLBACKS",
-            "PASSWORD",
-            "API_KEY",
-            "AUTH_TOKEN",
-        ]
-        for setting in sensitive_settings:
-            with self.settings(DEBUG=True, **{setting: "should not be displayed"}):
-                response = self.client.get("/raises500/")
-                self.assertNotContains(
-                    response, "should not be displayed", status_code=500
-                )
+        for setting in self.sensitive_settings:
+            with self.subTest(setting=setting):
+                with self.settings(DEBUG=True, **{setting: "should not be displayed"}):
+                    response = self.client.get("/raises500/")
+                    self.assertNotContains(
+                        response, "should not be displayed", status_code=500
+                    )
 
     def test_settings_with_sensitive_keys(self):
         """
         The debug page should filter out some sensitive information found in
         dict settings.
         """
-        sensitive_settings = [
-            "SECRET_KEY",
-            "SECRET_KEY_FALLBACKS",
-            "PASSWORD",
-            "API_KEY",
-            "AUTH_TOKEN",
-        ]
-        for setting in sensitive_settings:
+        for setting in self.sensitive_settings:
             FOOBAR = {
                 setting: "should not be displayed",
                 "recursive": {setting: "should not be displayed"},
             }
-            with self.settings(DEBUG=True, FOOBAR=FOOBAR):
-                response = self.client.get("/raises500/")
-                self.assertNotContains(
-                    response, "should not be displayed", status_code=500
-                )
+            with self.subTest(setting=setting):
+                with self.settings(DEBUG=True, FOOBAR=FOOBAR):
+                    response = self.client.get("/raises500/")
+                    self.assertNotContains(
+                        response, "should not be displayed", status_code=500
+                    )
 
     def test_cleanse_setting_basic(self):
         reporter_filter = SafeExceptionReporterFilter()
@@ -1883,10 +1878,25 @@ class ExceptionReporterFilterTests(
         )
 
     def test_request_meta_filtering(self):
-        request = self.rf.get("/", headers={"secret-header": "super_secret"})
+        headers = {
+            "API_URL": "super secret",
+            "A_SIGNATURE_VALUE": "super secret",
+            "MY_KEY": "super secret",
+            "PASSWORD": "super secret",
+            "SECRET_VALUE": "super secret",
+            "SOME_TOKEN": "super secret",
+        }
+        request = self.rf.get("/", headers=headers)
         reporter_filter = SafeExceptionReporterFilter()
+        cleansed_headers = reporter_filter.get_safe_request_meta(request)
+        for header in headers:
+            with self.subTest(header=header):
+                self.assertEqual(
+                    cleansed_headers[f"HTTP_{header}"],
+                    reporter_filter.cleansed_substitute,
+                )
         self.assertEqual(
-            reporter_filter.get_safe_request_meta(request)["HTTP_SECRET_HEADER"],
+            cleansed_headers["HTTP_COOKIE"],
             reporter_filter.cleansed_substitute,
         )
 
@@ -1910,9 +1920,7 @@ class ExceptionReporterFilterTests(
 
 class CustomExceptionReporterFilter(SafeExceptionReporterFilter):
     cleansed_substitute = "XXXXXXXXXXXXXXXXXXXX"
-    hidden_settings = _lazy_re_compile(
-        "API|TOKEN|KEY|SECRET|PASS|SIGNATURE|DATABASE_URL", flags=re.I
-    )
+    hidden_settings = _lazy_re_compile("PASS|DATABASE", flags=re.I)
 
 
 @override_settings(


### PR DESCRIPTION
# Trac ticket number
ticket-35646

# Branch description
Harden the filtering of settings and meta values during error reporting.

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
