### PR TITLE
Fixed #35648 -- Extended SafeString to support __radd__.

### DIFF
--- a/django/utils/safestring.py
+++ b/django/utils/safestring.py
@@ -35,10 +35,16 @@ class SafeString(str, SafeData):
         Concatenating a safe string with another safe bytestring or
         safe string is safe. Otherwise, the result is no longer safe.
         """
-        t = super().__add__(rhs)
-        if isinstance(rhs, SafeData):
-            return SafeString(t)
-        return t
+        if isinstance(rhs, str):
+            t = super().__add__(rhs)
+            if isinstance(rhs, SafeData):
+                t = SafeString(t)
+            return t
+
+        # Give the rhs object a chance to handle the addition, for example if
+        # the rhs object's class implements `__radd__`. More details:
+        # https://docs.python.org/3/reference/datamodel.html#object.__radd__
+        return NotImplemented
 
     def __str__(self):
         return self

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -262,7 +262,10 @@ URLs
 Utilities
 ~~~~~~~~~
 
-* ...
+* :class:`~django.utils.safestring.SafeString` now raises
+  :exc:`NotImplementedError` in ``__add__`` for non-string right-hand side
+  values. This aligns with the :py:class:`str` addition behavior and allows
+  ``__radd__`` to be used if available.
 
 Validators
 ~~~~~~~~~~

--- a/tests/utils_tests/test_safestring.py
+++ b/tests/utils_tests/test_safestring.py
@@ -132,3 +132,54 @@ class SafeStringTest(SimpleTestCase):
         for case, expected in cases:
             with self.subTest(case=case):
                 self.assertRenderEqual("{{ s }}", expected, s=s + case)
+
+    def test_add_obj(self):
+
+        base_str = "<strong>strange</strong>"
+        add_str = "hello</br>"
+
+        class Add:
+            def __add__(self, other):
+                return base_str + other
+
+        class AddSafe:
+            def __add__(self, other):
+                return mark_safe(base_str) + other
+
+        class Radd:
+            def __radd__(self, other):
+                return other + base_str
+
+        class RaddSafe:
+            def __radd__(self, other):
+                return other + mark_safe(base_str)
+
+        left_add_expected = f"{base_str}{add_str}"
+        right_add_expected = f"{add_str}{base_str}"
+        cases = [
+            # Left-add test cases.
+            (Add(), add_str, left_add_expected, str),
+            (Add(), mark_safe(add_str), left_add_expected, str),
+            (AddSafe(), add_str, left_add_expected, str),
+            (AddSafe(), mark_safe(add_str), left_add_expected, SafeString),
+            # Right-add test cases.
+            (add_str, Radd(), right_add_expected, str),
+            (mark_safe(add_str), Radd(), right_add_expected, str),
+            (add_str, Radd(), right_add_expected, str),
+            (mark_safe(add_str), RaddSafe(), right_add_expected, SafeString),
+        ]
+        for lhs, rhs, expected, expected_type in cases:
+            with self.subTest(lhs=lhs, rhs=rhs):
+                result = lhs + rhs
+                self.assertEqual(result, expected)
+                self.assertEqual(type(result), expected_type)
+
+        cases = [
+            ("hello", Add()),
+            ("hello", AddSafe()),
+            (Radd(), "hello"),
+            (RaddSafe(), "hello"),
+        ]
+        for lhs, rhs in cases:
+            with self.subTest(lhs=lhs, rhs=rhs), self.assertRaises(TypeError):
+                lhs + rhs

--- a/tests/utils_tests/test_safestring.py
+++ b/tests/utils_tests/test_safestring.py
@@ -121,3 +121,14 @@ class SafeStringTest(SimpleTestCase):
         msg = "object has no attribute 'dynamic_attr'"
         with self.assertRaisesMessage(AttributeError, msg):
             s.dynamic_attr = True
+
+    def test_add_str(self):
+        s = SafeString("a&b")
+        cases = [
+            ("test", "a&amp;btest"),
+            ("<p>unsafe</p>", "a&amp;b&lt;p&gt;unsafe&lt;/p&gt;"),
+            (SafeString("<p>safe</p>"), SafeString("a&b<p>safe</p>")),
+        ]
+        for case, expected in cases:
+            with self.subTest(case=case):
+                self.assertRenderEqual("{{ s }}", expected, s=s + case)


### PR DESCRIPTION
# Trac ticket number

ticket-35648

# Branch description

`SafeString.__add__` should return `NotImplemented` if it isn't sure it can handle the RHS so that the RHS gets a chance at running its `__radd__` method.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
