### PR TITLE
refs #33537: Added ability to exit if mysqldump fails.

### DIFF
--- a/django/db/backends/mysql/creation.py
+++ b/django/db/backends/mysql/creation.py
@@ -74,14 +74,35 @@ class DatabaseCreation(BaseDatabaseCreation):
         load_cmd = cmd_args
         load_cmd[-1] = target_database_name
 
-        with subprocess.Popen(
-            dump_cmd, stdout=subprocess.PIPE, env=dump_env
-        ) as dump_proc:
+        try:
             with subprocess.Popen(
-                load_cmd,
-                stdin=dump_proc.stdout,
-                stdout=subprocess.DEVNULL,
-                env=load_env,
-            ):
-                # Allow dump_proc to receive a SIGPIPE if the load process exits.
-                dump_proc.stdout.close()
+                dump_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=dump_env
+            ) as dump_proc:
+                with subprocess.Popen(
+                    load_cmd,
+                    stdin=dump_proc.stdout,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    env=load_env,
+                ) as load_proc:
+                    dump_proc.stdout.close()
+                    load_out, load_err = load_proc.communicate()
+                    dump_err = dump_proc.stderr.read().decode()
+
+            if dump_proc.returncode != 0:
+                self.log(
+                    "Got a fatal error cloning the test database (dump): %s" % dump_err
+                )
+                sys.exit(2)
+
+            if load_proc.returncode != 0:
+                self.log(
+                    "Got a fatal error cloning the test database (load): %s" % load_err
+                )
+                sys.exit(2)
+
+        except Exception as e:
+            self.log("An exception occurred while cloning the database: %s" % e)
+            raise
+
+        self.log("Database cloning process finished.")


### PR DESCRIPTION
ticket-33537

Follow up from PR #16170 , some test were failing back then, created this PR is for rerunning vai jenkins to debug and solve.

 To set up parallel test databases, we initialise the schema of a test database and then copy this to additional databases. In the MySQL case, this is done by dumping the schema of the first database using 'mysqldump' and then loading this into the clones using 'mysql'. However, we do not currently check the output of the 'mysqldump' command, meaning if it fails, Django will happily carry on and tests will fail with errors about missing tables.

Instead of silently continuing, check the return code of the command and quickly fail if it's non-zero.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
