### PR TITLE
Fixed #35655 -- Reverted "Fixed #35295 -- Used INSERT with multiple rows on Oracle 23c."

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -205,9 +205,5 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         return self.connection.oracle_version >= (23,)
 
     @cached_property
-    def supports_bulk_insert_with_multiple_rows(self):
-        return self.connection.oracle_version >= (23,)
-
-    @cached_property
     def bare_select_suffix(self):
         return "" if self.connection.oracle_version >= (23,) else " FROM DUAL"

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -678,24 +678,6 @@ END;
             for field in fields
             if field
         ]
-        if (
-            self.connection.features.supports_bulk_insert_with_multiple_rows
-            # A workaround with UNION of SELECTs is required for models without
-            # any fields.
-            and field_placeholders
-        ):
-            placeholder_rows_sql = []
-            for row in placeholder_rows:
-                placeholders_row = (
-                    field_placeholder % placeholder
-                    for field_placeholder, placeholder in zip(
-                        field_placeholders, row, strict=True
-                    )
-                )
-                placeholder_rows_sql.append(placeholders_row)
-            return super().bulk_insert_sql(fields, placeholder_rows_sql)
-        # Oracle < 23c doesn't support inserting multiple rows in a single
-        # statement, use UNION of SELECTs as a workaround.
         query = []
         for row in placeholder_rows:
             select = []


### PR DESCRIPTION
This reverts commit 175b04942afaff978013db61495f3b39ea12989b due to a crash when Oracle > 23.3.

----

@csirmazbendeguz can you confirm this fixes https://github.com/oracle/python-oracledb/issues/356 for you?
