### PR TITLE
Added the missing definition for 'john' to ensure the example of adding members to 'beatles' works correctly.

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -525,6 +525,7 @@ the intermediate model:
 
     >>> ringo = Person.objects.create(name="Ringo Starr")
     >>> paul = Person.objects.create(name="Paul McCartney")
+    >>> john = Person.objects.create(name="John Wick")
     >>> beatles = Group.objects.create(name="The Beatles")
     >>> m1 = Membership(
     ...     person=ringo,


### PR DESCRIPTION
The existing example in `5.0/topics/db/models/` documentation for adding members to the 'beatles' band using 'beatles.members.add(john, through_defaults={"date_joined": date(1960, 8, 1)})' caused an error because 'john' was not defined. This commit adds the missing definition for 'john' before using it in the add() method, ensuring the example works without errors.



