### PR TITLE
Refs #373 -- Added Model._is_pk_set().

### DIFF
--- a/django/contrib/contenttypes/forms.py
+++ b/django/contrib/contenttypes/forms.py
@@ -31,7 +31,7 @@ class BaseGenericInlineFormSet(BaseModelFormSet):
             + self.ct_fk_field.name
         )
         self.save_as_new = save_as_new
-        if self.instance is None or self.instance.pk is None:
+        if self.instance is None or not self.instance._is_pk_set():
             qs = self.model._default_manager.none()
         else:
             if queryset is None:

--- a/django/contrib/postgres/constraints.py
+++ b/django/contrib/postgres/constraints.py
@@ -198,7 +198,7 @@ class ExclusionConstraint(BaseConstraint):
             lookups.append(lookup)
         queryset = queryset.filter(*lookups)
         model_class_pk = instance._get_pk_val(model._meta)
-        if not instance._state.adding and model_class_pk is not None:
+        if not instance._state.adding and instance._is_pk_set(model._meta):
             queryset = queryset.exclude(pk=model_class_pk)
         if not self.condition:
             if queryset.exists():

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -686,7 +686,7 @@ class UniqueConstraint(BaseConstraint):
                 filters.append(condition)
             queryset = queryset.filter(*filters)
         model_class_pk = instance._get_pk_val(model._meta)
-        if not instance._state.adding and model_class_pk is not None:
+        if not instance._state.adding and instance._is_pk_set(model._meta):
             queryset = queryset.exclude(pk=model_class_pk)
         if not self.condition:
             if queryset.exists():

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1969,7 +1969,7 @@ class ManyToManyField(RelatedField):
         pass
 
     def value_from_object(self, obj):
-        return [] if obj.pk is None else list(getattr(obj, self.attname).all())
+        return list(getattr(obj, self.attname).all()) if obj._is_pk_set() else []
 
     def save_form_data(self, instance, data):
         getattr(instance, self.attname).set(data)

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -511,8 +511,7 @@ class ReverseOneToOneDescriptor:
         try:
             rel_obj = self.related.get_cached_value(instance)
         except KeyError:
-            related_pk = instance.pk
-            if related_pk is None:
+            if not instance._is_pk_set():
                 rel_obj = None
             else:
                 filter_args = self.related.field.get_forward_related_filter(instance)
@@ -753,7 +752,7 @@ def create_reverse_many_to_one_manager(superclass, rel):
             # Even if this relation is not to pk, we require still pk value.
             # The wish is that the instance has been already saved to DB,
             # although having a pk value isn't a guarantee of that.
-            if self.instance.pk is None:
+            if not self.instance._is_pk_set():
                 raise ValueError(
                     f"{self.instance.__class__.__name__!r} instance needs to have a "
                     f"primary key value before this relationship can be used."
@@ -1081,7 +1080,7 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
             # Even if this relation is not to pk, we require still pk value.
             # The wish is that the instance has been already saved to DB,
             # although having a pk value isn't a guarantee of that.
-            if instance.pk is None:
+            if not instance._is_pk_set():
                 raise ValueError(
                     "%r instance needs to have a primary key value before "
                     "a many-to-many relationship can be used."

--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -16,7 +16,7 @@ def get_normalized_value(value, lhs):
     from django.db.models import Model
 
     if isinstance(value, Model):
-        if value.pk is None:
+        if not value._is_pk_set():
             raise ValueError("Model instances passed to related filters must be saved.")
         value_list = []
         sources = lhs.output_field.path_infos[-1].target_fields

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -220,7 +220,7 @@ class DeferredAttribute:
             # might be able to reuse the already loaded value. Refs #18343.
             val = self._check_parent_chain(instance)
             if val is None:
-                if instance.pk is None and self.field.generated:
+                if not instance._is_pk_set() and self.field.generated:
                     raise AttributeError(
                         "Cannot read a generated field from an unsaved model."
                     )

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -935,7 +935,7 @@ class BaseModelFormSet(BaseFormSet, AltersData):
             # 1. The object is an unexpected empty model, created by invalid
             #    POST data such as an object outside the formset's queryset.
             # 2. The object was already deleted from the database.
-            if obj.pk is None:
+            if not obj._is_pk_set():
                 continue
             if form in forms_to_delete:
                 self.deleted_objects.append(obj)
@@ -1103,7 +1103,7 @@ class BaseInlineFormSet(BaseModelFormSet):
         self.save_as_new = save_as_new
         if queryset is None:
             queryset = self.model._default_manager
-        if self.instance.pk is not None:
+        if self.instance._is_pk_set():
             qs = queryset.filter(**{self.fk.name: self.instance})
         else:
             qs = queryset.none()

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -973,3 +973,14 @@ Other attributes
     since they are yet to be saved. Instances fetched from a ``QuerySet``
     will have ``adding=False`` and ``db`` set to the alias of the associated
     database.
+
+``_is_pk_set()``
+----------------
+
+.. method:: Model._is_pk_set()
+
+.. versionadded:: 5.2
+
+The ``_is_pk_set()`` method returns whether the model instance's ``pk`` is set.
+It abstracts the model's primary key definition, ensuring consistent behavior
+regardless of the specific ``pk`` configuration.

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -289,7 +289,9 @@ Database backend API
 This section describes changes that may be needed in third-party database
 backends.
 
-* ...
+* The new :meth:`Model._is_pk_set() <django.db.models.Model._is_pk_set>` method
+  allows checking if a Model instance's primary key is defined.
+
 
 :mod:`django.contrib.gis`
 -------------------------

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -661,6 +661,31 @@ class ModelTest(TestCase):
             headline__startswith="Area",
         )
 
+    def test_is_pk_unset(self):
+        cases = [
+            Article(),
+            Article(id=None),
+        ]
+        for case in cases:
+            with self.subTest(case=case):
+                self.assertIs(case._is_pk_set(), False)
+
+    def test_is_pk_set(self):
+        def new_instance():
+            a = Article(pub_date=datetime.today())
+            a.save()
+            return a
+
+        cases = [
+            Article(id=1),
+            Article(id=0),
+            Article.objects.create(pub_date=datetime.today()),
+            new_instance(),
+        ]
+        for case in cases:
+            with self.subTest(case=case):
+                self.assertIs(case._is_pk_set(), True)
+
 
 class ModelLookupTest(TestCase):
     @classmethod


### PR DESCRIPTION
**[GSoC-2024]**

# Trac ticket number
ticket-373

# Branch description
Added the `Model._is_pk_set()` function as suggested by @charettes and @LilyFoote (https://github.com/django/django/pull/18056#discussion_r1604282430).

It's a simple utility function for checking if the primary key has been set on an object.

It's a pre-requisite for composite primary keys (https://github.com/django/django/pull/18056).

This function will get modified by the [composite primary keys patch](https://github.com/django/django/pull/18056/files#diff-1c8b882c73bfda668d5451d4578c97191b0ebc0f088d0c0ba2296ab89b428c44R672).

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
