### PR TITLE
Support conversion of an HttpResponse into a boolean

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -198,6 +198,10 @@ class HttpResponseBase:
     def __getitem__(self, header):
         return self.headers[header]
 
+    def __bool__(self) -> bool:
+        """Returns ``True`` if :attr:`status_code` is less than 400."""
+        return self.status_code < 400
+
     def has_header(self, header):
         """Case-insensitive check for a header."""
         return header in self.headers

--- a/tests/responses/tests.py
+++ b/tests/responses/tests.py
@@ -97,6 +97,12 @@ class HttpResponseTests(SimpleTestCase):
         with self.assertRaisesMessage(ValueError, must_be_integer_in_range):
             HttpResponse(status=600)
 
+    def test_convert_to_bool(self):
+        resp = HttpResponse(status=200)
+        self.assertIs(bool(resp), True)
+        resp = HttpResponse(status=403)
+        self.assertIs(bool(resp), False)
+
     def test_reason_phrase(self):
         reason = "I'm an anarchist coffee pot on crack."
         resp = HttpResponse(status=419, reason=reason)


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

This change allows usage in testing tools such as `pytest`. Here is a (slightly contrived) example - it should be easy to visualize checking the status codes of views from here.
```py
ok_response = HttpResponse("Request successful!", status=200)
assert ok_response
failed_response = HttpResponse(status=403)
assert failed_response  # fails in pytest
```
Based on [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status), any status code < 400 is acceptable to be considered "successful".

I would like to document this somewhere, but I'm not sure where I should document this. Any feedback would be appreciated :)

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
