### PR TITLE
Fixed #35658 -- Initialized InMemoryFileNode instances with a name.

### DIFF
--- a/django/core/files/storage/memory.py
+++ b/django/core/files/storage/memory.py
@@ -45,10 +45,9 @@ class InMemoryFileNode(ContentFile, TimingMixin):
     modification, and access times.
     """
 
-    def __init__(self, content="", name=""):
-        self.file = None
+    def __init__(self, content="", name=None):
+        super().__init__(content, name)
         self._content_type = type(content)
-        self._initialize_stream()
         self._initialize_times()
 
     def open(self, mode):
@@ -142,7 +141,11 @@ class InMemoryDirNode(TimingMixin):
         if create_if_missing:
             self._update_accessed_time()
             self._update_modified_time()
-            return self._children.setdefault(path_segment, child_cls())
+            if child_cls is InMemoryFileNode:
+                child = child_cls(name=path_segment)
+            else:
+                child = child_cls()
+            return self._children.setdefault(path_segment, child)
         return self._children.get(path_segment)
 
     def listdir(self):

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -1024,6 +1024,23 @@ class FileFieldStorageTests(TestCase):
         with temp_storage.open("tests/stringio") as f:
             self.assertEqual(f.read(), b"content")
 
+    @override_settings(
+        STORAGES={
+            DEFAULT_STORAGE_ALIAS: {
+                "BACKEND": "django.core.files.storage.InMemoryStorage"
+            }
+        }
+    )
+    def test_create_file_field_from_another_file_field_in_memory_storage(self):
+        f = ContentFile("content", "file.txt")
+        obj = Storage.objects.create(storage_callable_default=f)
+        new_obj = Storage.objects.create(
+            storage_callable_default=obj.storage_callable_default.file
+        )
+        storage = callable_default_storage()
+        with storage.open(new_obj.storage_callable_default.name) as f:
+            self.assertEqual(f.read(), b"content")
+
 
 class FieldCallableFileStorageTests(SimpleTestCase):
     def setUp(self):


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35658

# Branch description
`File` and its subclasses all have a `name` attribute that stores the name of the file being contained within the object, if it was possible to determine it.

That name is accessed on some places, such as `File.__str__` and `Storage.save`.

However, it was missing for `InMemoryFileNode`, even through it indirectly inherits from `File`, leading to `AttributeError("'InMemoryFileNode' object has no attribute 'name'")` in some situations.

Here is an easy way to replicate it, provided on the ticket report:
```# models.py

class MyModel(models.Model):
    attachment = models.FileField(...)

# script.py

obj = MyModel.objects.create(attachment=ContentFile(b'content', 'myfile.txt') 
repr(obj.attachment)
```

This PR makes `InMemoryFileNode` to behave as other `File` subclasses in that regard, fixing the issue, and adds a test case.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
