### PR TITLE
Fixed #35659 -- Documented db_default behaviour before instances are saved.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -702,7 +702,7 @@ isn't defined.
 
 .. note::
 
-   When using the `db_default` attribute, the field value will be an instance of `DatabaseDefault` before the instance is saved to the database. This means that a `bool()` evaluation of the field will not reflect the specified `db_default` value until the instance is saved.
+   When using the ``db_default`` attribute, the field value will be an instance of ``DatabaseDefault`` before the instance is saved to the database. This means that a ``bool()`` evaluation of the field will not reflect the specified ``db_default`` value until the instance is saved.
 
    For example:
 
@@ -721,7 +721,7 @@ isn't defined.
       my_obj.save()
       print(bool(my_obj.my_field))  # False, as expected.
 
-   To ensure the field value reflects the desired default before saving, also set the `default` attribute:
+   To ensure the field value reflects the desired default before saving, also set the ``default`` attribute:
 
    .. code-block:: python
 

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -690,15 +690,38 @@ case it can't be included in a :class:`~django.forms.ModelForm`.
 ``BooleanField``
 ----------------
 
-.. class:: BooleanField(**options)
-
+class BooleanField(**options)
 A true/false field.
 
-The default form widget for this field is :class:`~django.forms.CheckboxInput`,
-or :class:`~django.forms.NullBooleanSelect` if :attr:`null=True <Field.null>`.
+The default form widget for this field is CheckboxInput, or NullBooleanSelect if null=True.
 
-The default value of ``BooleanField`` is ``None`` when :attr:`Field.default`
-isn't defined.
+The default value of BooleanField is None when Field.default isn’t defined.
+
+.. note::
+
+   When using the `db_default` attribute, the field value will be an instance of `DatabaseDefault` before the instance is saved to the database. This means that a `bool()` evaluation of the field will not reflect the specified `db_default` value until the instance is saved.
+
+   For example:
+
+   .. code-block:: python
+
+      from django.db import models
+
+      class MyModel(models.Model):
+          my_field = models.BooleanField(db_default=False)
+
+      my_obj = MyModel()
+      print(bool(my_obj.my_field))  # True, which is unexpected.
+
+      my_obj.save()
+      print(bool(my_obj.my_field))  # False, as expected.
+
+   To ensure the field value reflects the desired default before saving, also set the `default` attribute:
+
+   .. code-block:: python
+
+      class MyModel(models.Model):
+          my_field = models.BooleanField(default=False, db_default=False)
 
 ``CharField``
 -------------

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -690,12 +690,15 @@ case it can't be included in a :class:`~django.forms.ModelForm`.
 ``BooleanField``
 ----------------
 
-class BooleanField(**options)
+.. class:: BooleanField(**options)
+
 A true/false field.
 
-The default form widget for this field is CheckboxInput, or NullBooleanSelect if null=True.
+The default form widget for this field is :class:`~django.forms.CheckboxInput`,
+or :class:`~django.forms.NullBooleanSelect` if :attr:`null=True <Field.null>`.
 
-The default value of BooleanField is None when Field.default isn’t defined.
+The default value of ``BooleanField`` is ``None`` when :attr:`Field.default`
+isn't defined.
 
 .. note::
 
@@ -707,8 +710,10 @@ The default value of BooleanField is None when Field.default isn’t defined.
 
       from django.db import models
 
+
       class MyModel(models.Model):
           my_field = models.BooleanField(db_default=False)
+
 
       my_obj = MyModel()
       print(bool(my_obj.my_field))  # True, which is unexpected.


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35659

# Branch description
Added documentation to explain the db_default behavior in the BooleanField class, ensuring users understand how default values are handled when Field.default isn't specified. 

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
