### PR TITLE
Refs #34609 -- Fixed stack level of format_html() warning.

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -129,10 +129,11 @@ def format_html(format_string, *args, **kwargs):
     """
     if not (args or kwargs):
         # RemovedInDjango60Warning: when the deprecation ends, replace with:
-        # raise ValueError("args or kwargs must be provided.")
+        # raise TypeError("args or kwargs must be provided.")
         warnings.warn(
             "Calling format_html() without passing args or kwargs is deprecated.",
             RemovedInDjango60Warning,
+            stacklevel=2,
         )
     args_safe = map(conditional_escape, args)
     kwargs_safe = {k: conditional_escape(v) for (k, v) in kwargs.items()}

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -70,10 +70,11 @@ class TestUtilsHtml(SimpleTestCase):
         msg = "Calling format_html() without passing args or kwargs is deprecated."
         # RemovedInDjango60Warning: when the deprecation ends, replace with:
         # msg = "args or kwargs must be provided."
-        # with self.assertRaisesMessage(ValueError, msg):
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        # with self.assertRaisesMessage(TypeError, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             name = "Adam"
             self.assertEqual(format_html(f"<i>{name}</i>"), "<i>Adam</i>")
+        self.assertEqual(ctx.filename, __file__)
 
     def test_linebreaks(self):
         items = (


### PR DESCRIPTION
# Trac ticket number

ticket-34609

# Branch description

The missing `stacklevel` on this warning makes it hard to find out which call sites need updating, as the warning is reported as a problem inside `format_html()`:

```
$ python -X dev -c 'from django.utils.html import format_html; format_html("")'
/.../django/utils/html.py:133: RemovedInDjango60Warning: Calling format_html() without passing args or kwargs is deprecated.
  warnings.warn(
```

Adding `stacklevel=2` shows the warning at the call site instead:

```
$ python -X dev -c 'from django.utils.html import format_html; format_html("")'
<string>:1: RemovedInDjango60Warning: Calling format_html() without passing args or kwargs is deprecated.
```

This issue is a pretty common recurrence and can be checked for with rule B028 of flake8-bugbear: https://pypi.org/project/flake8-bugbear/ .

The [backport policy](https://docs.djangoproject.com/el/5.1/internals/release-process/#supported-versions-policy) doesn’t explicitly allow “fixes to deprecation warnings” to be backported, but maybe we could consider this as a “major functionality bugs in a new feature of the latest stable release.”?? Anyway, I’d hope we can, because the lack of stack level is making it hard for me to upgrade a project to 5.0 right now.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
