### PR TITLE
Fixed #35666 -- Documented stacklevel testing and adjusted test suite accordingly.

### DIFF
--- a/django/contrib/staticfiles/finders.py
+++ b/django/contrib/staticfiles/finders.py
@@ -18,7 +18,7 @@ searched_locations = []
 
 
 # RemovedInDjango61Warning: When the deprecation ends, remove completely.
-def _check_deprecated_find_param(class_name="", find_all=False, **kwargs):
+def _check_deprecated_find_param(class_name="", find_all=False, stacklevel=3, **kwargs):
     method_name = "find" if not class_name else f"{class_name}.find"
     if "all" in kwargs:
         legacy_all = kwargs.pop("all")
@@ -26,7 +26,7 @@ def _check_deprecated_find_param(class_name="", find_all=False, **kwargs):
             "Passing the `all` argument to find() is deprecated. Use `find_all` "
             "instead."
         )
-        warnings.warn(msg, RemovedInDjango61Warning, stacklevel=2)
+        warnings.warn(msg, RemovedInDjango61Warning, stacklevel=stacklevel)
 
         # If both `find_all` and `all` were given, raise TypeError.
         if find_all is not False:
@@ -57,7 +57,7 @@ class BaseFinder:
     # RemovedInDjango61Warning: When the deprecation ends, remove completely.
     def _check_deprecated_find_param(self, **kwargs):
         return _check_deprecated_find_param(
-            class_name=self.__class__.__qualname__, **kwargs
+            class_name=self.__class__.__qualname__, stacklevel=4, **kwargs
         )
 
     # RemovedInDjango61Warning: When the deprecation ends, replace with:

--- a/django/core/files/storage/filesystem.py
+++ b/django/core/files/storage/filesystem.py
@@ -48,6 +48,7 @@ class FileSystemStorage(Storage, StorageSettingsMixin):
                 "Overriding OS_OPEN_FLAGS is deprecated. Use "
                 "the allow_overwrite parameter instead.",
                 RemovedInDjango60Warning,
+                stacklevel=2,
             )
 
     @cached_property

--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -175,7 +175,8 @@ class BaseDatabaseWrapper:
         if len(self.queries_log) == self.queries_log.maxlen:
             warnings.warn(
                 "Limit for query logging exceeded, only the last {} queries "
-                "will be returned.".format(self.queries_log.maxlen)
+                "will be returned.".format(self.queries_log.maxlen),
+                stacklevel=2,
             )
         return list(self.queries_log)
 

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -228,6 +228,7 @@ class BaseDatabaseOperations:
                 "DatabaseOperations.lookup_cast() instead."
             ),
             RemovedInDjango60Warning,
+            stacklevel=2,
         )
         return "%s"
 

--- a/django/db/models/fields/mixins.py
+++ b/django/db/models/fields/mixins.py
@@ -28,6 +28,7 @@ class FieldCacheMixin:
             f"Override {self.__class__.__qualname__}.cache_name instead of "
             "get_cache_name().",
             RemovedInDjango60Warning,
+            stacklevel=3,
         )
         return cache_name
 

--- a/django/forms/renderers.py
+++ b/django/forms/renderers.py
@@ -80,6 +80,7 @@ class DjangoDivFormRenderer(DjangoTemplates):
             "The DjangoDivFormRenderer transitional form renderer is deprecated. Use "
             "DjangoTemplates instead.",
             RemovedInDjango60Warning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)
 
@@ -96,6 +97,7 @@ class Jinja2DivFormRenderer(Jinja2):
             "The Jinja2DivFormRenderer transitional form renderer is deprecated. Use "
             "Jinja2 instead.",
             RemovedInDjango60Warning,
+            stacklevel=2,
         )
         super().__init__(*args, **kwargs)
 

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -498,6 +498,7 @@ class StreamingHttpResponse(HttpResponseBase):
                 "StreamingHttpResponse must consume asynchronous iterators in order to "
                 "serve them synchronously. Use a synchronous iterator instead.",
                 Warning,
+                stacklevel=2,
             )
 
             # async iterator. Consume in async_to_sync and map back.
@@ -518,6 +519,7 @@ class StreamingHttpResponse(HttpResponseBase):
                 "StreamingHttpResponse must consume synchronous iterators in order to "
                 "serve them asynchronously. Use an asynchronous iterator instead.",
                 Warning,
+                stacklevel=2,
             )
             # sync iterator. Consume via sync_to_async and yield via async
             # generator.

--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -114,7 +114,7 @@ requirements:
   feature, the change should also contain documentation.
 
 When you think your work is ready to be reviewed, send :doc:`a GitHub pull
-request <working-with-git>`. 
+request <working-with-git>`.
 If you can't send a pull request for some reason, you can also use patches in
 Trac. When using this style, follow these guidelines.
 
@@ -209,9 +209,10 @@ You should also add a test for the deprecation warning::
 
     def test_foo_deprecation_warning(self):
         msg = "Expected deprecation message"
-        with self.assertWarnsMessage(RemovedInDjangoXXWarning, msg):
+        with self.assertWarnsMessage(RemovedInDjangoXXWarning, msg) as ctx:
             # invoke deprecated behavior
             ...
+        self.assertEqual(ctx.filename, __file__)
 
 It's important to include a ``RemovedInDjangoXXWarning`` comment above code
 which has no warning reference, but will need to be changed or removed when the
@@ -233,6 +234,7 @@ deprecation ends. For example::
         warnings.warn(
             "foo() is deprecated.",
             category=RemovedInDjangoXXWarning,
+            stacklevel=2,
         )
         old_private_helper()
         ...

--- a/tests/backends/base/test_operations.py
+++ b/tests/backends/base/test_operations.py
@@ -239,8 +239,9 @@ class DeprecationTests(TestCase):
             "DatabaseOperations.field_cast_sql() is deprecated use "
             "DatabaseOperations.lookup_cast() instead."
         )
-        with self.assertRaisesMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             base_ops.field_cast_sql("integer", "IntegerField")
+        self.assertEqual(ctx.filename, __file__)
 
     def test_field_cast_sql_usage_warning(self):
         compiler = Author.objects.all().query.get_compiler(connection.alias)

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -557,8 +557,9 @@ class BackendTestCase(TransactionTestCase):
                 "Limit for query logging exceeded, only the last 3 queries will be "
                 "returned."
             )
-            with self.assertWarnsMessage(UserWarning, msg):
+            with self.assertWarnsMessage(UserWarning, msg) as ctx:
                 self.assertEqual(3, len(new_connection.queries))
+            self.assertEqual(ctx.filename, __file__)
 
         finally:
             BaseDatabaseWrapper.queries_limit = old_queries_limit

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -206,9 +206,10 @@ class ModelInstanceCreationTests(TestCase):
     def test_save_deprecation(self):
         a = Article(headline="original", pub_date=datetime(2014, 5, 16))
         msg = "Passing positional arguments to save() is deprecated"
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             a.save(False, False, None, None)
             self.assertEqual(Article.objects.count(), 1)
+        self.assertEqual(ctx.filename, __file__)
 
     def test_save_deprecation_positional_arguments_used(self):
         a = Article()
@@ -259,9 +260,10 @@ class ModelInstanceCreationTests(TestCase):
     async def test_asave_deprecation(self):
         a = Article(headline="original", pub_date=datetime(2014, 5, 16))
         msg = "Passing positional arguments to asave() is deprecated"
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             await a.asave(False, False, None, None)
             self.assertEqual(await Article.objects.acount(), 1)
+        self.assertEqual(ctx.filename, __file__)
 
     async def test_asave_deprecation_positional_arguments_used(self):
         a = Article()

--- a/tests/cache/tests_async.py
+++ b/tests/cache/tests_async.py
@@ -38,8 +38,9 @@ class AsyncDummyCacheTests(SimpleTestCase):
 
     async def test_aget_many_invalid_key(self):
         msg = KEY_ERRORS_WITH_MEMCACHED_MSG % ":1:key with spaces"
-        with self.assertWarnsMessage(CacheKeyWarning, msg):
+        with self.assertWarnsMessage(CacheKeyWarning, msg) as ctx:
             await cache.aget_many(["key with spaces"])
+        self.assertEqual(ctx.filename, __file__)
 
     async def test_adelete(self):
         """
@@ -138,8 +139,9 @@ class AsyncDummyCacheTests(SimpleTestCase):
 
     async def test_aset_many_invalid_key(self):
         msg = KEY_ERRORS_WITH_MEMCACHED_MSG % ":1:key with spaces"
-        with self.assertWarnsMessage(CacheKeyWarning, msg):
+        with self.assertWarnsMessage(CacheKeyWarning, msg) as ctx:
             await cache.aset_many({"key with spaces": "foo"})
+        self.assertEqual(ctx.filename, __file__)
 
     async def test_adelete_many(self):
         """adelete_many() does nothing for the dummy cache backend."""
@@ -147,8 +149,9 @@ class AsyncDummyCacheTests(SimpleTestCase):
 
     async def test_adelete_many_invalid_key(self):
         msg = KEY_ERRORS_WITH_MEMCACHED_MSG % ":1:key with spaces"
-        with self.assertWarnsMessage(CacheKeyWarning, msg):
+        with self.assertWarnsMessage(CacheKeyWarning, msg) as ctx:
             await cache.adelete_many({"key with spaces": "foo"})
+        self.assertEqual(ctx.filename, __file__)
 
     async def test_aclear(self):
         """aclear() does nothing for the dummy cache backend."""

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -387,15 +387,19 @@ class CheckConstraintTests(TestCase):
     def test_check_deprecation(self):
         msg = "CheckConstraint.check is deprecated in favor of `.condition`."
         condition = models.Q(foo="bar")
-        with self.assertWarnsRegex(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             constraint = models.CheckConstraint(name="constraint", check=condition)
-        with self.assertWarnsRegex(RemovedInDjango60Warning, msg):
+        self.assertEqual(ctx.filename, __file__)
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             self.assertIs(constraint.check, condition)
+        self.assertEqual(ctx.filename, __file__)
         other_condition = models.Q(something="else")
-        with self.assertWarnsRegex(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             constraint.check = other_condition
-        with self.assertWarnsRegex(RemovedInDjango60Warning, msg):
+        self.assertEqual(ctx.filename, __file__)
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             self.assertIs(constraint.check, other_condition)
+        self.assertEqual(ctx.filename, __file__)
 
     def test_database_default(self):
         models.CheckConstraint(

--- a/tests/contenttypes_tests/test_fields.py
+++ b/tests/contenttypes_tests/test_fields.py
@@ -98,8 +98,9 @@ class GetPrefetchQuerySetDeprecation(TestCase):
             "get_prefetch_queryset() is deprecated. Use get_prefetch_querysets() "
             "instead."
         )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             questions[0].answer_set.get_prefetch_queryset(questions)
+        self.assertEqual(ctx.filename, __file__)
 
     def test_generic_foreign_key_warning(self):
         answers = Answer.objects.all()
@@ -107,8 +108,9 @@ class GetPrefetchQuerySetDeprecation(TestCase):
             "get_prefetch_queryset() is deprecated. Use get_prefetch_querysets() "
             "instead."
         )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             Answer.question.get_prefetch_queryset(answers)
+        self.assertEqual(ctx.filename, __file__)
 
 
 class GetPrefetchQuerySetsTests(TestCase):

--- a/tests/deprecation/tests.py
+++ b/tests/deprecation/tests.py
@@ -20,11 +20,13 @@ class RenameMethodsTests(SimpleTestCase):
         the faulty method.
         """
         msg = "`Manager.old` method should be renamed `new`."
-        with self.assertWarnsMessage(DeprecationWarning, msg):
+        with self.assertWarnsMessage(DeprecationWarning, msg) as ctx:
 
             class Manager(metaclass=RenameManagerMethods):
                 def old(self):
                     pass
+
+        self.assertEqual(ctx.filename, __file__)
 
     def test_get_new_defined(self):
         """
@@ -43,19 +45,22 @@ class RenameMethodsTests(SimpleTestCase):
         self.assertEqual(len(recorded), 0)
 
         msg = "`Manager.old` is deprecated, use `new` instead."
-        with self.assertWarnsMessage(DeprecationWarning, msg):
+        with self.assertWarnsMessage(DeprecationWarning, msg) as ctx:
             manager.old()
+        self.assertEqual(ctx.filename, __file__)
 
     def test_get_old_defined(self):
         """
         Ensure `old` complains when only `old` is defined.
         """
         msg = "`Manager.old` method should be renamed `new`."
-        with self.assertWarnsMessage(DeprecationWarning, msg):
+        with self.assertWarnsMessage(DeprecationWarning, msg) as ctx:
 
             class Manager(metaclass=RenameManagerMethods):
                 def old(self):
                     pass
+
+        self.assertEqual(ctx.filename, __file__)
 
         manager = Manager()
 
@@ -65,8 +70,9 @@ class RenameMethodsTests(SimpleTestCase):
         self.assertEqual(len(recorded), 0)
 
         msg = "`Manager.old` is deprecated, use `new` instead."
-        with self.assertWarnsMessage(DeprecationWarning, msg):
+        with self.assertWarnsMessage(DeprecationWarning, msg) as ctx:
             manager.old()
+        self.assertEqual(ctx.filename, __file__)
 
     def test_deprecated_subclass_renamed(self):
         """
@@ -79,21 +85,25 @@ class RenameMethodsTests(SimpleTestCase):
                 pass
 
         msg = "`Deprecated.old` method should be renamed `new`."
-        with self.assertWarnsMessage(DeprecationWarning, msg):
+        with self.assertWarnsMessage(DeprecationWarning, msg) as ctx:
 
             class Deprecated(Renamed):
                 def old(self):
                     super().old()
 
+        self.assertEqual(ctx.filename, __file__)
+
         deprecated = Deprecated()
 
         msg = "`Renamed.old` is deprecated, use `new` instead."
-        with self.assertWarnsMessage(DeprecationWarning, msg):
+        with self.assertWarnsMessage(DeprecationWarning, msg) as ctx:
             deprecated.new()
+        self.assertEqual(ctx.filename, __file__)
 
         msg = "`Deprecated.old` is deprecated, use `new` instead."
-        with self.assertWarnsMessage(DeprecationWarning, msg):
+        with self.assertWarnsMessage(DeprecationWarning, msg) as ctx:
             deprecated.old()
+        self.assertEqual(ctx.filename, __file__)
 
     def test_renamed_subclass_deprecated(self):
         """
@@ -101,11 +111,13 @@ class RenameMethodsTests(SimpleTestCase):
         `old` subclass one that didn't.
         """
         msg = "`Deprecated.old` method should be renamed `new`."
-        with self.assertWarnsMessage(DeprecationWarning, msg):
+        with self.assertWarnsMessage(DeprecationWarning, msg) as ctx:
 
             class Deprecated(metaclass=RenameManagerMethods):
                 def old(self):
                     pass
+
+        self.assertEqual(ctx.filename, __file__)
 
         class Renamed(Deprecated):
             def new(self):
@@ -119,8 +131,9 @@ class RenameMethodsTests(SimpleTestCase):
         self.assertEqual(len(recorded), 0)
 
         msg = "`Renamed.old` is deprecated, use `new` instead."
-        with self.assertWarnsMessage(DeprecationWarning, msg):
+        with self.assertWarnsMessage(DeprecationWarning, msg) as ctx:
             renamed.old()
+        self.assertEqual(ctx.filename, __file__)
 
     def test_deprecated_subclass_renamed_and_mixins(self):
         """
@@ -142,20 +155,24 @@ class RenameMethodsTests(SimpleTestCase):
                 super().old()
 
         msg = "`DeprecatedMixin.old` method should be renamed `new`."
-        with self.assertWarnsMessage(DeprecationWarning, msg):
+        with self.assertWarnsMessage(DeprecationWarning, msg) as ctx:
 
             class Deprecated(DeprecatedMixin, RenamedMixin, Renamed):
                 pass
 
+        self.assertEqual(ctx.filename, __file__)
+
         deprecated = Deprecated()
 
         msg = "`RenamedMixin.old` is deprecated, use `new` instead."
-        with self.assertWarnsMessage(DeprecationWarning, msg):
+        with self.assertWarnsMessage(DeprecationWarning, msg) as ctx:
             deprecated.new()
+        self.assertEqual(ctx.filename, __file__)
 
         msg = "`DeprecatedMixin.old` is deprecated, use `new` instead."
-        with self.assertWarnsMessage(DeprecationWarning, msg):
+        with self.assertWarnsMessage(DeprecationWarning, msg) as ctx:
             deprecated.old()
+        self.assertEqual(ctx.filename, __file__)
 
     def test_removedafternextversionwarning_pending(self):
         self.assertTrue(

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -635,10 +635,11 @@ class OverwritingStorageOSOpenFlagsWarningTests(SimpleTestCase):
     def test_os_open_flags_deprecation_warning(self):
         msg = "Overriding OS_OPEN_FLAGS is deprecated. Use the allow_overwrite "
         msg += "parameter instead."
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             self.storage = self.storage_class(
                 location=self.temp_dir, base_url="/test_media_url/"
             )
+        self.assertEqual(ctx.filename, __file__)
 
 
 # RemovedInDjango60Warning: Remove this test class.

--- a/tests/foreign_object/tests.py
+++ b/tests/foreign_object/tests.py
@@ -703,24 +703,27 @@ class GetJoiningDeprecationTests(TestCase):
             "ForeignObject.get_joining_columns() is deprecated. Use "
             "get_joining_fields() instead."
         )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             Membership.person.field.get_joining_columns()
+        self.assertEqual(ctx.filename, __file__)
 
     def test_foreign_object_get_reverse_joining_columns_warning(self):
         msg = (
             "ForeignObject.get_reverse_joining_columns() is deprecated. Use "
             "get_reverse_joining_fields() instead."
         )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             Membership.person.field.get_reverse_joining_columns()
+        self.assertEqual(ctx.filename, __file__)
 
     def test_foreign_object_rel_get_joining_columns_warning(self):
         msg = (
             "ForeignObjectRel.get_joining_columns() is deprecated. Use "
             "get_joining_fields() instead."
         )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             Membership.person.field.remote_field.get_joining_columns()
+        self.assertEqual(ctx.filename, __file__)
 
     def test_join_get_joining_columns_warning(self):
         class CustomForeignKey(models.ForeignKey):

--- a/tests/forms_tests/field_tests/test_urlfield.py
+++ b/tests/forms_tests/field_tests/test_urlfield.py
@@ -163,9 +163,10 @@ class URLFieldAssumeSchemeDeprecationTest(FormFieldAssertionsMixin, SimpleTestCa
             "or set the FORMS_URLFIELD_ASSUME_HTTPS transitional setting to True to "
             "opt into using 'https' as the new default scheme."
         )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             f = URLField()
             self.assertEqual(f.clean("example.com"), "http://example.com")
+        self.assertEqual(ctx.filename, __file__)
 
     @ignore_warnings(category=RemovedInDjango60Warning)
     def test_urlfield_forms_urlfield_assume_https(self):

--- a/tests/forms_tests/tests/test_renderers.py
+++ b/tests/forms_tests/tests/test_renderers.py
@@ -64,16 +64,18 @@ class DeprecationTests(SimpleTestCase):
             "The DjangoDivFormRenderer transitional form renderer is deprecated. Use "
             "DjangoTemplates instead."
         )
-        with self.assertRaisesMessage(RemovedInDjango60Warning, msg):
+        with self.assertRaisesMessage(RemovedInDjango60Warning, msg) as ctx:
             DjangoDivFormRenderer()
+        self.assertEqual(ctx.filename, __file__)
 
     def test_jinja2_div_renderer_warning(self):
         msg = (
             "The Jinja2DivFormRenderer transitional form renderer is deprecated. Use "
             "Jinja2 instead."
         )
-        with self.assertRaisesMessage(RemovedInDjango60Warning, msg):
+        with self.assertRaisesMessage(RemovedInDjango60Warning, msg) as ctx:
             Jinja2DivFormRenderer()
+        self.assertEqual(ctx.filename, __file__)
 
     @ignore_warnings(category=RemovedInDjango60Warning)
     def test_deprecation_renderers_can_be_instantiated(self):

--- a/tests/gis_tests/gdal_tests/test_geom.py
+++ b/tests/gis_tests/gdal_tests/test_geom.py
@@ -972,6 +972,7 @@ class DeprecationTests(SimpleTestCase):
     def test_coord_setter_deprecation(self):
         geom = OGRGeometry("POINT (1 2)")
         msg = "coord_dim setter is deprecated. Use set_3d() instead."
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             geom.coord_dim = 3
         self.assertEqual(geom.coord_dim, 3)
+        self.assertEqual(ctx.filename, __file__)

--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -207,16 +207,18 @@ class GeoLite2Test(SimpleTestCase):
     def test_coords_deprecation_warning(self):
         g = GeoIP2()
         msg = "GeoIP2.coords() is deprecated. Use GeoIP2.lon_lat() instead."
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             e1, e2 = g.coords(self.ipv4_str)
         self.assertIsInstance(e1, float)
         self.assertIsInstance(e2, float)
+        self.assertEqual(ctx.filename, __file__)
 
     def test_open_deprecation_warning(self):
         msg = "GeoIP2.open() is deprecated. Use GeoIP2() instead."
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             g = GeoIP2.open(settings.GEOIP_PATH, GeoIP2.MODE_AUTO)
         self.assertTrue(g._reader)
+        self.assertEqual(ctx.filename, __file__)
 
 
 @skipUnless(HAS_GEOIP2, "GeoIP2 is required.")

--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -258,8 +258,9 @@ class HandlerRequestTests(SimpleTestCase):
             "StreamingHttpResponse must consume asynchronous iterators in order to "
             "serve them synchronously. Use a synchronous iterator instead."
         )
-        with self.assertWarnsMessage(Warning, msg):
+        with self.assertWarnsMessage(Warning, msg) as ctx:
             self.assertEqual(b"".join(list(response)), b"streaming content")
+        self.assertEqual(ctx.filename, __file__)
 
 
 class ScriptNameTests(SimpleTestCase):
@@ -350,10 +351,11 @@ class AsyncHandlerRequestTests(SimpleTestCase):
             "StreamingHttpResponse must consume synchronous iterators in order to "
             "serve them asynchronously. Use an asynchronous iterator instead."
         )
-        with self.assertWarnsMessage(Warning, msg):
+        with self.assertWarnsMessage(Warning, msg) as ctx:
             self.assertEqual(
                 b"".join([chunk async for chunk in response]), b"streaming content"
             )
+        self.assertEqual(ctx.filename, __file__)
 
     async def test_async_streaming(self):
         response = await self.async_client.get("/async_streaming/")

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -583,8 +583,9 @@ class ManyToManyTests(TestCase):
             "get_prefetch_queryset() is deprecated. Use get_prefetch_querysets() "
             "instead."
         )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             self.a1.publications.get_prefetch_queryset(articles)
+        self.assertEqual(ctx.filename, __file__)
 
     def test_get_prefetch_querysets_invalid_querysets_length(self):
         articles = Article.objects.all()

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -894,8 +894,9 @@ class ManyToOneTests(TestCase):
             "get_prefetch_queryset() is deprecated. Use get_prefetch_querysets() "
             "instead."
         )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             City.country.get_prefetch_queryset(cities)
+        self.assertEqual(ctx.filename, __file__)
 
     def test_get_prefetch_queryset_reverse_warning(self):
         usa = Country.objects.create(name="United States")
@@ -905,8 +906,9 @@ class ManyToOneTests(TestCase):
             "get_prefetch_queryset() is deprecated. Use get_prefetch_querysets() "
             "instead."
         )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             usa.cities.get_prefetch_queryset(countries)
+        self.assertEqual(ctx.filename, __file__)
 
     def test_get_prefetch_querysets_invalid_querysets_length(self):
         City.objects.create(name="Chicago")

--- a/tests/model_enums/tests.py
+++ b/tests/model_enums/tests.py
@@ -328,5 +328,6 @@ class ChoicesMetaDeprecationTests(SimpleTestCase):
         from django.db.models import enums
 
         msg = "ChoicesMeta is deprecated in favor of ChoicesType."
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             enums.ChoicesMeta
+        self.assertEqual(ctx.filename, __file__)

--- a/tests/model_fields/test_mixins.py
+++ b/tests/model_fields/test_mixins.py
@@ -34,9 +34,10 @@ class FieldCacheMixinTests(SimpleTestCase):
     # RemovedInDjango60Warning.
     def test_get_cache_name_deprecated(self):
         msg = "Override ExampleOld.cache_name instead of get_cache_name()."
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             result = ExampleOld().cache_name
         self.assertEqual(result, "example")
+        self.assertEqual(ctx.filename, __file__)
 
     def test_cache_name(self):
         result = Example().cache_name

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -2007,13 +2007,15 @@ class DeprecationTests(TestCase):
             "get_current_querysets() instead."
         )
         authors = Author.objects.all()
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             self.assertEqual(
                 Prefetch("authors", authors).get_current_queryset(1),
                 authors,
             )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        self.assertEqual(ctx.filename, __file__)
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             self.assertIsNone(Prefetch("authors").get_current_queryset(1))
+        self.assertEqual(ctx.filename, __file__)
 
     @ignore_warnings(category=RemovedInDjango60Warning)
     def test_prefetch_one_level_fallback(self):

--- a/tests/staticfiles_tests/test_finders.py
+++ b/tests/staticfiles_tests/test_finders.py
@@ -37,11 +37,12 @@ class TestFinders:
 
     def test_find_all_deprecated_param(self):
         src, dst = self.find_all
-        with self.assertWarnsMessage(RemovedInDjango61Warning, DEPRECATION_MSG):
+        with self.assertWarnsMessage(RemovedInDjango61Warning, DEPRECATION_MSG) as ctx:
             found = self.finder.find(src, all=True)
             found = [os.path.normcase(f) for f in found]
             dst = [os.path.normcase(d) for d in dst]
             self.assertEqual(found, dst)
+        self.assertEqual(ctx.filename, __file__)
 
     def test_find_all_conflicting_params(self):
         src, dst = self.find_all
@@ -50,10 +51,11 @@ class TestFinders:
             "argument 'find_all'"
         )
         with (
-            self.assertWarnsMessage(RemovedInDjango61Warning, DEPRECATION_MSG),
+            self.assertWarnsMessage(RemovedInDjango61Warning, DEPRECATION_MSG) as ctx,
             self.assertRaisesMessage(TypeError, msg),
         ):
             self.finder.find(src, find_all=True, all=True)
+        self.assertEqual(ctx.filename, __file__)
 
     def test_find_all_unexpected_params(self):
         src, dst = self.find_all
@@ -62,10 +64,11 @@ class TestFinders:
             "argument 'wrong'"
         )
         with (
-            self.assertWarnsMessage(RemovedInDjango61Warning, DEPRECATION_MSG),
+            self.assertWarnsMessage(RemovedInDjango61Warning, DEPRECATION_MSG) as ctx,
             self.assertRaisesMessage(TypeError, msg),
         ):
             self.finder.find(src, all=True, wrong=1)
+        self.assertEqual(ctx.filename, __file__)
 
         with self.assertRaisesMessage(TypeError, msg):
             self.finder.find(src, find_all=True, wrong=1)
@@ -165,28 +168,31 @@ class TestMiscFinder(SimpleTestCase):
         )
 
     def test_searched_locations_deprecated_all(self):
-        with self.assertWarnsMessage(RemovedInDjango61Warning, DEPRECATION_MSG):
+        with self.assertWarnsMessage(RemovedInDjango61Warning, DEPRECATION_MSG) as ctx:
             finders.find("spam", all=True)
             self.assertEqual(
                 finders.searched_locations,
                 [os.path.join(TEST_ROOT, "project", "documents")],
             )
+        self.assertEqual(ctx.filename, __file__)
 
     def test_searched_locations_conflicting_params(self):
         msg = "find() got multiple values for argument 'find_all'"
         with (
-            self.assertWarnsMessage(RemovedInDjango61Warning, DEPRECATION_MSG),
+            self.assertWarnsMessage(RemovedInDjango61Warning, DEPRECATION_MSG) as ctx,
             self.assertRaisesMessage(TypeError, msg),
         ):
             finders.find("spam", find_all=True, all=True)
+        self.assertEqual(ctx.filename, __file__)
 
     def test_searched_locations_unexpected_params(self):
         msg = "find() got an unexpected keyword argument 'wrong'"
         with (
-            self.assertWarnsMessage(RemovedInDjango61Warning, DEPRECATION_MSG),
+            self.assertWarnsMessage(RemovedInDjango61Warning, DEPRECATION_MSG) as ctx,
             self.assertRaisesMessage(TypeError, msg),
         ):
             finders.find("spam", all=True, wrong=1)
+        self.assertEqual(ctx.filename, __file__)
 
         with self.assertRaisesMessage(TypeError, msg):
             finders.find("spam", find_all=True, wrong=1)

--- a/tests/update_only_fields/tests.py
+++ b/tests/update_only_fields/tests.py
@@ -264,8 +264,9 @@ class UpdateOnlyFieldsTests(TestCase):
         with (
             self.assertWarnsMessage(RemovedInDjango60Warning, msg),
             self.assertNumQueries(0),
-        ):
+        ) as ctx:
             s.save(False, False, None, [])
+        self.assertEqual(ctx.filename, __file__)
 
     async def test_empty_update_fields_positional_asave(self):
         s = await Person.objects.acreate(name="Sara", gender="F")
@@ -273,8 +274,9 @@ class UpdateOnlyFieldsTests(TestCase):
         s.name = "Other"
 
         msg = "Passing positional arguments to asave() is deprecated"
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             await s.asave(False, False, None, [])
+        self.assertEqual(ctx.filename, __file__)
 
         # No save occurred for an empty update_fields.
         await s.arefresh_from_db()

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -226,11 +226,12 @@ class SimplifiedURLTests(SimpleTestCase):
             "registered converters is deprecated and will be removed in Django 6.0."
         )
         try:
-            with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+            with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
                 register_converter(Base64Converter, "base64")
                 register_converter(Base64Converter, "base64")
         finally:
             REGISTERED_CONVERTERS.pop("base64", None)
+        self.assertEqual(ctx.filename, __file__)
 
     def test_invalid_view(self):
         msg = "view must be a callable or a list/tuple in the case of include()."

--- a/tests/utils_tests/test_itercompat.py
+++ b/tests/utils_tests/test_itercompat.py
@@ -11,5 +11,6 @@ class TestIterCompat(SimpleTestCase):
             "django.utils.itercompat.is_iterable() is deprecated. "
             "Use isinstance(..., collections.abc.Iterable) instead."
         )
-        with self.assertWarnsMessage(RemovedInDjango60Warning, msg):
+        with self.assertWarnsMessage(RemovedInDjango60Warning, msg) as ctx:
             is_iterable([])
+        self.assertEqual(ctx.filename, __file__)


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35666

# Branch description

Per a discussion #18463 I figured I'd spend some time auditing all our usage of `warnings.warn` to see if we had more violations. I addressed them and adjusting the documentation about deprecating a feature to mention that `filename` should be compared to `__file__`.
