### PR TITLE
Fixed #35623 -- Documented that a field cannot be named 'check'.

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -720,6 +720,9 @@ Django places some restrictions on model field names:
 
 #. A field name cannot end with an underscore, for similar reasons.
 
+#. A field name cannot be ``check``, as this would override the check
+   framework's ``Model.check()`` method.
+
 These limitations can be worked around, though, because your field name doesn't
 necessarily have to match your database column name. See the
 :attr:`~Field.db_column` option.


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35623

# Branch description
Based on the discussion in #35623, I added a section to the documentation explaining that the word ‍‍‍‍‍‍check is a reserved keyword, and included the suggested solution along with an example.


# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
