### PR TITLE
Fixed #25705 -- Added Queryset.executed_queries.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -35,6 +35,7 @@ from django.db.models.utils import (
     AltersData,
     create_namedtuple_class,
     resolve_callables,
+    set_executed_queries,
 )
 from django.utils import timezone
 from django.utils.deprecation import (
@@ -347,6 +348,7 @@ class QuerySet(AltersData):
         self._defer_next_filter = False
         self._deferred_filter = None
         self._cloning_enabled = True
+        self.executed_queries = None
 
     @property
     def query(self):
@@ -1654,6 +1656,7 @@ class QuerySet(AltersData):
         """Return an empty QuerySet."""
         clone = self._chain()
         clone.query.set_empty()
+        clone.executed_queries = []
         return clone
 
     ##################################################################
@@ -2258,10 +2261,19 @@ class QuerySet(AltersData):
         return c
 
     def _fetch_all(self):
+        executed_queries_length = None
+
         if self._result_cache is None:
+            executed_queries_length = len(connections[self.db].queries)
             self._result_cache = list(self._iterable_class(self))
+
         if self._prefetch_related_lookups and not self._prefetch_done:
             self._prefetch_related_objects()
+
+        if executed_queries_length is not None:
+            self.executed_queries = set_executed_queries(
+                connections[self.db].queries, executed_queries_length
+            )
 
     def _next_is_sticky(self):
         """
@@ -2410,6 +2422,7 @@ class RawQuerySet:
         self._prefetch_related_lookups = ()
         self._prefetch_done = False
         self._fetch_mode = fetch_mode
+        self.executed_queries = None
 
     def resolve_model_init_order(self):
         """Resolve the init field names and value positions."""
@@ -2458,10 +2471,18 @@ class RawQuerySet:
         return c
 
     def _fetch_all(self):
+        executed_queries_length = None
+
         if self._result_cache is None:
+            executed_queries_length = len(connections[self.db].queries)
             self._result_cache = list(self.iterator())
         if self._prefetch_related_lookups and not self._prefetch_done:
             self._prefetch_related_objects()
+
+        if executed_queries_length is not None:
+            self.executed_queries = set_executed_queries(
+                connections[self.db].queries, executed_queries_length
+            )
 
     def __len__(self):
         self._fetch_all()

--- a/django/db/models/utils.py
+++ b/django/db/models/utils.py
@@ -69,6 +69,16 @@ class AltersData:
         super().__init_subclass__(**kwargs)
 
 
+def set_executed_queries(queries, previous_queries_length):
+    executed_queries = []
+
+    if len(queries) > previous_queries_length:
+        for query in queries[previous_queries_length:]:
+            executed_queries.append(query["sql"])
+
+    return executed_queries
+
+
 # RemovedInDjango70Warning: At the end of the deprecation, remove this function
 # and use .fields.BLANK_CHOICE_LABEL directly instead.
 def get_blank_choice_label():

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -186,6 +186,15 @@ Here's the formal declaration of a ``QuerySet``:
 
         The database that will be used if this query is executed now.
 
+    .. attribute:: executed_queries
+
+        .. versionadded:: 6.2
+
+        A list with the executed SQL queries if the ``QuerySet``
+        has been evaluated.
+        Only if :setting:`DEBUG` is ``True``. ``None`` otherwise
+        or if not evaluated.
+
     .. note::
 
         The ``query`` parameter to :class:`QuerySet` exists so that specialized

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -195,7 +195,9 @@ Migrations
 Models
 ~~~~~~
 
-* ...
+* The new :attr:`QuerySet.executed_queries <.QuerySet.executed_queries>`
+  attribute returns the SQL query if the QuerySet
+  has been evaluated and :setting:`DEBUG` is ``True``.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -118,7 +118,7 @@ class QueryTestCase(TestCase):
         )
         with self.settings(DATABASE_ROUTERS=[router]):
             book.refresh_from_db()
-        router.db_for_read.assert_called_once_with(Book, instance=book)
+        router.db_for_read.assert_called_with(Book, instance=book)
 
     def test_basic_queries(self):
         "Queries are constrained to a single database"

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -13,7 +13,12 @@ from django.db.models.functions import ExtractYear, Length, LTrim
 from django.db.models.sql.constants import LOUTER
 from django.db.models.sql.where import AND, OR, NothingNode, WhereNode
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
-from django.test.utils import CaptureQueriesContext, ignore_warnings, register_lookup
+from django.test.utils import (
+    CaptureQueriesContext,
+    ignore_warnings,
+    override_settings,
+    register_lookup,
+)
 from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import (
@@ -4687,3 +4692,81 @@ class QuerySetCloningTests(TestCase):
         # QuerySet. qs3 is now all of the filters applied to qs + an additional
         # filter.
         self.assertIsNot(qs3, qs)
+
+
+class ExecutedQueriesTests(TestCase):
+    @override_settings(DEBUG=False)
+    def test_no_debug_executed_queries(self):
+        School.objects.create()
+        queryset = School.objects.all()
+
+        self.assertEqual(
+            queryset.executed_queries,
+            None,
+        )
+
+        list(queryset)
+        self.assertEqual(
+            queryset.executed_queries,
+            [],
+        )
+
+    @override_settings(DEBUG=True)
+    def test_no_executed_queries(self):
+        School.objects.create()
+        queryset = School.objects.filter(pk__in=[])
+
+        self.assertEqual(
+            queryset.executed_queries,
+            None,
+        )
+
+        list(queryset)
+        self.assertEqual(
+            queryset.executed_queries,
+            [],
+        )
+        queryset = queryset.none()
+        list(queryset)
+        self.assertEqual(
+            queryset.executed_queries,
+            [],
+        )
+
+    @override_settings(DEBUG=True)
+    def test_single_executed_query(self):
+        School.objects.create()
+        queryset = School.objects.all()
+        list(queryset)
+
+        self.assertEqual(len(queryset.executed_queries), 1)
+
+    @override_settings(DEBUG=True)
+    def test_multiple_executed_queries(self):
+        instance = School.objects.create()
+        Student.objects.create(school=instance)
+
+        queryset = School.objects.prefetch_related("student_set__classroom")
+        list(queryset)
+
+        self.assertEqual(len(queryset.executed_queries), 3)
+
+    @override_settings(DEBUG=True)
+    def test_raw_queryset_single_executed_query(self):
+        School.objects.create()
+        queryset = School.objects.raw("SELECT * FROM queries_school")
+        list(queryset)
+
+        self.assertEqual(len(queryset.executed_queries), 1)
+
+    @override_settings(DEBUG=True)
+    def test_raw_queryset_multiple_executed_queries(self):
+        instance = School.objects.create()
+        Student.objects.create(school=instance)
+
+        queryset = School.objects.raw("SELECT * FROM queries_school").prefetch_related(
+            "student_set__classroom"
+        )
+        list(queryset)
+
+        self.assertEqual(len(queryset.executed_queries), 3)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-25705](https://code.djangoproject.com/ticket/25705)

#### Branch description
Based on the discussion with @charettes it was agreed to follow the path of adding `Queryset.executed_queries`. To solve the ticket.

Since the DB connections are per-thread as far as I know, this approach should not have any race condition issues. And since it's done before the prefetch, it should pick the Queryset query. Also, since queries are only logged if DEBUG is enabled, this approach requires that too.


My discarded approach was to to get it somehow in the return of `self._result_cache = list(self._iterable_class(self))`, or stored in the QuerySet.
However, it's much more complicated, because as far as I see the flow is something like
QuerySet when [evaluating](https://github.com/django/django/blob/d5bebc1c26d4c0ec9eaa057aefc5b38649c0ba3b/django/db/models/query.py#L1909) calls the [IterableClass](https://github.com/django/django/blob/d5bebc1c26d4c0ec9eaa057aefc5b38649c0ba3b/django/db/models/query.py#L82) which then  [executes the query](https://github.com/django/django/blob/d5bebc1c26d4c0ec9eaa057aefc5b38649c0ba3b/django/db/models/query.py#L91) which then gets the [connection cursor](https://github.com/django/django/blob/d5bebc1c26d4c0ec9eaa057aefc5b38649c0ba3b/django/db/models/sql/compiler.py#L1585), which is wrapped in the previous mentioned one that can log the query.

So the a way would be to make all 4 `SqlCompiler.execute_sql` return the result *and* the SQL query. Then you have to adapt all 6 `Iterable.__iter__` to also return the query. Then you can store it in the Queryset. Since these methods are part of the public API, this would be a breaking change in both methods. Also I'm not 100% sure how to get the query in the wrapper since the `Cursor.execute` is wrapped in a context manager which is the one logging the query. 

#### AI Assistance Disclosure (REQUIRED)
<!-- Select exactly ONE of the following: -->
- [X] **No AI tools were used** in preparing this PR.
- [ ] **If AI tools were used**, I have disclosed which ones, and fully reviewed and verified their output.
<!-- If AI tools were used, provide which tools were used here. -->

#### Checklist
- [X] This PR follows the [contribution guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/submitting-patches/).
- [X] This PR **does not** disclose a security vulnerability (see [vulnerability reporting](https://docs.djangoproject.com/en/stable/internals/security/)).
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number (if applicable), and ends with a period (see [guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/committing-code/#committing-guidelines)).
- [X] I have not requested, and will not request, an automated AI review for this PR. <!-- You are welcome to do so in your own fork. -->

<!-- Leave the following items unchecked if not applicable. -->
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
