### PR TITLE
Use contextlib.suppress over try: except pass

### DIFF
--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -1,3 +1,4 @@
+import contextlib
 import inspect
 import os
 from importlib import import_module
@@ -158,10 +159,8 @@ class AppConfig:
 
         # If import_string succeeds, entry is an app config class.
         if app_config_class is None:
-            try:
+            with contextlib.suppress(Exception):
                 app_config_class = import_string(entry)
-            except Exception:
-                pass
         # If both import_module and import_string failed, it means that entry
         # doesn't have a valid value.
         if app_module is None and app_config_class is None:

--- a/django/core/files/temp.py
+++ b/django/core/files/temp.py
@@ -16,6 +16,7 @@ arguments available in tempfile.NamedTemporaryFile.
 2: https://bugs.python.org/issue14243
 """
 
+import contextlib
 import os
 import tempfile
 
@@ -53,14 +54,10 @@ if os.name == "nt":
         def close(self):
             if not self.close_called:
                 self.close_called = True
-                try:
+                with contextlib.suppress(OSError):
                     self.file.close()
-                except OSError:
-                    pass
-                try:
+                with contextlib.suppress(OSError):
                     self.unlink(self.name)
-                except OSError:
-                    pass
 
         def __del__(self):
             self.close()

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -1,3 +1,4 @@
+import contextlib
 import functools
 import os
 import pkgutil
@@ -372,11 +373,11 @@ class ManagementUtility:
         parser.add_argument("--settings")
         parser.add_argument("--pythonpath")
         parser.add_argument("args", nargs="*")  # catch-all
-        try:
+
+        # Ignore any option errors at this point.
+        with contextlib.suppress(CommandError):
             options, args = parser.parse_known_args(self.argv[2:])
             handle_default_options(options)
-        except CommandError:
-            pass  # Ignore any option errors at this point.
 
         try:
             settings.INSTALLED_APPS

--- a/django/core/management/commands/flush.py
+++ b/django/core/management/commands/flush.py
@@ -1,3 +1,4 @@
+import contextlib
 from importlib import import_module
 
 from django.apps import apps
@@ -44,10 +45,8 @@ class Command(BaseCommand):
         # Import the 'management' module within each installed app, to register
         # dispatcher events.
         for app_config in apps.get_app_configs():
-            try:
+            with contextlib.suppress(ImportError):
                 import_module(".management", app_config.name)
-            except ImportError:
-                pass
 
         sql_list = sql_flush(
             self.style,

--- a/django/core/serializers/base.py
+++ b/django/core/serializers/base.py
@@ -2,6 +2,7 @@
 Module for abstract serializer/unserializer base classes.
 """
 
+import contextlib
 from io import StringIO
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -316,12 +317,10 @@ def build_instance(Model, data, db):
         obj = Model(**data)
         obj._state.db = db
         natural_key = obj.natural_key()
-        try:
+        with contextlib.suppress(Model.DoesNotExist):
             data[Model._meta.pk.attname] = Model._meta.pk.to_python(
                 default_manager.db_manager(db).get_by_natural_key(*natural_key).pk
             )
-        except Model.DoesNotExist:
-            pass
     return Model(**data)
 
 

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import time
 import warnings
@@ -71,14 +72,10 @@ def update_connections_time_zone(*, setting, **kwargs):
     # Reset the database connections' time zone
     if setting in {"TIME_ZONE", "USE_TZ"}:
         for conn in connections.all(initialized_only=True):
-            try:
+            with contextlib.suppress(AttributeError):
                 del conn.timezone
-            except AttributeError:
-                pass
-            try:
+            with contextlib.suppress(AttributeError):
                 del conn.timezone_name
-            except AttributeError:
-                pass
             conn.ensure_timezone()
 
 

--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -2,6 +2,7 @@
 Sphinx plugins for Django documentation.
 """
 
+import contextlib
 import json
 import os
 import re
@@ -266,10 +267,8 @@ checked>
 <section class="c-content-unix" id="c-content-%(id)s-unix">\n"""
             % {"id": uid}
         )
-        try:
+        with contextlib.suppress(nodes.SkipNode):
             self.visit_literal_block(node)
-        except nodes.SkipNode:
-            pass
         self.body.append("</section>\n")
 
         self.body.append(

--- a/tests/select_for_update/tests.py
+++ b/tests/select_for_update/tests.py
@@ -1,3 +1,4 @@
+import contextlib
 import threading
 import time
 from unittest import mock
@@ -52,10 +53,8 @@ class SelectForUpdateTests(TransactionTestCase):
         self.new_connection = connection.copy()
 
     def tearDown(self):
-        try:
+        with contextlib.suppress(DatabaseError, AttributeError):
             self.end_blocking_transaction()
-        except (DatabaseError, AttributeError):
-            pass
         self.new_connection.close()
 
     def start_blocking_transaction(self):


### PR DESCRIPTION
Replaces usage of
```py
try:
    something()
except SomeException:
    pass
```
with the briefer and easier to read
```py
with contextlib.suppress(SomeException):
    something()
```