### PR TITLE
Fixed typo of check-in in contributing doc

### DIFF
--- a/docs/faq/contributing.txt
+++ b/docs/faq/contributing.txt
@@ -25,7 +25,7 @@ the amount of time that we have to work on the framework is limited and will
 vary from week to week depending on our spare time. If we're busy, we may not
 be able to spend as much time on Django as we might want.
 
-The best way to make sure tickets do not get hung up on the way to checkin is
+The best way to make sure tickets do not get hung up on the way to check-in is
 to make it dead easy, even for someone who may not be intimately familiar with
 that area of the code, to understand the problem and verify the fix:
 


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-N/A

# Branch description
Corrected the term "checkin" to "check-in" for consistency with standard usage.

# Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
