### PR TITLE
Refs #373 - Added composite primary key support to admin URLs.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1808,7 +1808,7 @@ class ModelAdmin(BaseModelAdmin):
         """
         msg = _("%(name)s with ID “%(key)s” doesn’t exist. Perhaps it was deleted?") % {
             "name": opts.verbose_name,
-            "key": unquote(object_id),
+            "key": self.unquote(object_id),
         }
         self.message_user(request, msg, messages.WARNING)
         url = reverse("admin:index", current_app=self.admin_site.name)
@@ -1840,7 +1840,7 @@ class ModelAdmin(BaseModelAdmin):
             obj = None
 
         else:
-            obj = self.get_object(request, unquote(object_id), to_field)
+            obj = self.get_object(request, self.unquote(object_id), to_field)
 
             if request.method == "POST":
                 if not self.has_change_permission(request, obj):
@@ -2196,7 +2196,7 @@ class ModelAdmin(BaseModelAdmin):
                 "The field %s cannot be referenced." % to_field
             )
 
-        obj = self.get_object(request, unquote(object_id), to_field)
+        obj = self.get_object(request, self.unquote(object_id), to_field)
 
         if not self.has_delete_permission(request, obj):
             raise PermissionDenied
@@ -2258,7 +2258,7 @@ class ModelAdmin(BaseModelAdmin):
 
         # First check if the user can see this history.
         model = self.model
-        obj = self.get_object(request, unquote(object_id))
+        obj = self.get_object(request, self.unquote(object_id))
         if obj is None:
             return self._get_obj_does_not_exist_redirect(
                 request, model._meta, object_id
@@ -2271,7 +2271,7 @@ class ModelAdmin(BaseModelAdmin):
         app_label = self.opts.app_label
         action_list = (
             LogEntry.objects.filter(
-                object_id=unquote(object_id),
+                object_id=self.unquote(object_id),
                 content_type=get_content_type_for_model(model),
             )
             .select_related()
@@ -2361,6 +2361,9 @@ class ModelAdmin(BaseModelAdmin):
             formsets.append(formset)
             inline_instances.append(inline)
         return formsets, inline_instances
+
+    def unquote(self, pk):
+        return unquote(pk, is_composite=self.opts.is_composite_pk())
 
 
 class InlineModelAdmin(BaseModelAdmin):

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -23,6 +23,7 @@ from django.utils.translation import override as translation_override
 QUOTE_MAP = {i: "_%02X" % i for i in b'":/_#?;@&=+$,"[]<>%\n\\'}
 UNQUOTE_MAP = {v: chr(k) for k, v in QUOTE_MAP.items()}
 UNQUOTE_RE = _lazy_re_compile("_(?:%s)" % "|".join([x[1:] for x in UNQUOTE_MAP]))
+PK_SEP = ","
 
 
 class FieldIsAForeignKeyColumnName(Exception):
@@ -91,12 +92,20 @@ def quote(s):
     Similar to urllib.parse.quote(), except that the quoting is slightly
     different so that it doesn't get automatically unquoted by the web browser.
     """
-    return s.translate(QUOTE_MAP) if isinstance(s, str) else s
+    if isinstance(s, str):
+        return s.translate(QUOTE_MAP)
+    elif isinstance(s, tuple):
+        return PK_SEP.join(str(quote(f)) for f in s)
+    else:
+        return s
 
 
-def unquote(s):
+def unquote(s, is_composite=False):
     """Undo the effects of quote()."""
-    return UNQUOTE_RE.sub(lambda m: UNQUOTE_MAP[m[0]], s)
+    if is_composite:
+        return tuple(unquote(f) for f in s.split(PK_SEP))
+    else:
+        return UNQUOTE_RE.sub(lambda m: UNQUOTE_MAP[m[0]], s)
 
 
 def flatten(fields):

--- a/django/contrib/auth/admin.py
+++ b/django/contrib/auth/admin.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.admin.options import IS_POPUP_VAR
-from django.contrib.admin.utils import unquote
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.forms import (
     AdminPasswordChangeForm,
@@ -153,7 +152,7 @@ class UserAdmin(admin.ModelAdmin):
 
     @sensitive_post_parameters_m
     def user_change_password(self, request, id, form_url=""):
-        user = self.get_object(request, unquote(id))
+        user = self.get_object(request, self.unquote(id))
         if not self.has_change_permission(request, user):
             raise PermissionDenied
         if user is None:

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -973,6 +973,9 @@ class Options:
             )
         ]
 
+    def is_composite_pk(self):
+        return False
+
     @cached_property
     def _property_names(self):
         """Return a set of the names of the properties defined on the model."""

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -16,6 +16,7 @@ from django.contrib.admin.utils import (
     label_for_field,
     lookup_field,
     quote,
+    unquote,
 )
 from django.core.validators import EMPTY_VALUES
 from django.db import DEFAULT_DB_ALIAS, models
@@ -436,7 +437,38 @@ class UtilsTests(SimpleTestCase):
         )
 
     def test_quote(self):
-        self.assertEqual(quote("something\nor\nother"), "something_0Aor_0Aother")
+        test_cases = (
+            ("something\nor\nother", "something_0Aor_0Aother"),
+            ("f,o,o", "f_2Co_2Co"),
+            ("b-a-r", "b-a-r"),
+            ((), ""),
+            ((1, 2), "1,2"),
+            ((3, "f,o,o"), "3,f_2Co_2Co"),
+            ((4, "b-a-r"), "4,b-a-r"),
+        )
+
+        for s, expected in test_cases:
+            with self.subTest(s=s, expected=expected):
+                self.assertEqual(quote(s), expected)
+
+    def test_unquote(self):
+        test_cases = (
+            ("something_0Aor_0Aother", False, "something\nor\nother"),
+            ("f_2Co_2Co", False, "f,o,o"),
+            ("b-a-r", False, "b-a-r"),
+            ("", False, ""),
+            ("", True, ("",)),
+            ("1,2,3", False, "1,2,3"),
+            ("1,2,3", True, ("1", "2", "3")),
+            ("3,f_2Co_2Co", False, "3,f,o,o"),
+            ("3,f_2Co_2Co", True, ("3", "f,o,o")),
+            ("4,b-a-r", False, "4,b-a-r"),
+            ("4,b-a-r", True, ("4", "b-a-r")),
+        )
+
+        for s, is_composite, expected in test_cases:
+            with self.subTest(s=s, is_composite=is_composite, expected=expected):
+                self.assertEqual(unquote(s, is_composite=is_composite), expected)
 
     def test_build_q_object_from_lookup_parameters(self):
         parameters = {


### PR DESCRIPTION
# Trac ticket number

ticket-373

# Branch description

This branch adds composite primary key support to admin URLs.

This code has been separated from the [Composite PK](https://github.com/django/django/pull/18056) branch for easier review.

# Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
