### PR TITLE
Fixed #35671 -- Clarified string-based fields behavior when null=False.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -43,13 +43,15 @@ If ``True``, Django will store empty values as ``NULL`` in the database. Default
 is ``False``.
 
 Avoid using :attr:`~Field.null` on string-based fields such as
-:class:`CharField` and :class:`TextField`. If a string-based field has
-``null=True``, that means it has two possible values for "no data": ``NULL``,
-and the empty string. In most cases, it's redundant to have two possible values
-for "no data;" the Django convention is to use the empty string, not
-``NULL``. One exception is when a :class:`CharField` has both ``unique=True``
-and ``blank=True`` set. In this situation, ``null=True`` is required to avoid
-unique constraint violations when saving multiple objects with blank values.
+:class:`CharField` and :class:`TextField`. The Django convention is to use an
+empty string, not ``NULL``, as the "no data" state for string-based fields. If a
+string-based field has ``null=False``, empty strings can still be saved for "no
+data". If a string-based field has ``null=True``, that means it has two possible
+values for "no data": ``NULL``, and the empty string. In most cases, it's
+redundant to have two possible values for "no data". One exception is when a
+:class:`CharField` has both ``unique=True`` and ``blank=True`` set. In this
+situation, ``null=True`` is required to avoid unique constraint violations when
+saving multiple objects with blank values.
 
 For both string-based and non-string-based fields, you will also need to
 set ``blank=True`` if you wish to permit empty values in forms, as the


### PR DESCRIPTION
# Trac ticket number
<!-- Replace 35671 with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35671

# Branch description
This branch makes improvements to the documentation of ``Field.null`` and ``Field.default``
clarifying the behaviour of these model options on string-based fields, particularly
what happens when ``null=False`` and ``default`` is left unspecified for these fields.

The current docs do not mention these cases. The case is significant because
unlike other types of fields, ``null=False`` does not have the effect of disallowing empty
values for string-based fields. Empty strings can still be saved. This happens when
a default is unspecified and Django uses an empty string. This is also not clearly
documented.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
