### PR TITLE
Fixed #35693 -- Made password validators callable.

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -213,6 +213,9 @@ class UserAttributeSimilarityValidator:
             "Your password can’t be too similar to your other personal information."
         )
 
+    def __call__(self, *args, **kwargs):
+        return self.validate(*args, **kwargs)
+
 
 class CommonPasswordValidator:
     """
@@ -249,6 +252,9 @@ class CommonPasswordValidator:
     def get_help_text(self):
         return _("Your password can’t be a commonly used password.")
 
+    def __call__(self, *args, **kwargs):
+        return self.validate(*args, **kwargs)
+
 
 class NumericPasswordValidator:
     """
@@ -264,3 +270,6 @@ class NumericPasswordValidator:
 
     def get_help_text(self):
         return _("Your password can’t be entirely numeric.")
+
+    def __call__(self, *args, **kwargs):
+        return self.validate(*args, **kwargs)


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[#35693](https://code.djangoproject.com/ticket/35693)

# Branch description
By default validating fields use this syntax `validator(value)` but password validators don't implement `.__call__()`. Therefore making them unusable outside of `validate_password()`.
This is small change doesn't change any behavior but add support for intuitive approach to password validators.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.