### PR TITLE
Fix typo in Django security policies: 'Long-term support release\s' to 'Long-term support releases

### DIFF
--- a/docs/faq/contributing.txt
+++ b/docs/faq/contributing.txt
@@ -25,7 +25,7 @@ the amount of time that we have to work on the framework is limited and will
 vary from week to week depending on our spare time. If we're busy, we may not
 be able to spend as much time on Django as we might want.
 
-The best way to make sure tickets do not get hung up on the way to checkin is
+The best way to make sure tickets do not get hung up on the way to check-in is
 to make it dead easy, even for someone who may not be intimately familiar with
 that area of the code, to understand the problem and verify the fix:
 

--- a/docs/internals/security.txt
+++ b/docs/internals/security.txt
@@ -58,7 +58,7 @@ for several versions of Django:
   Django 1.3. Upon the release of Django 1.5, Django 1.3's security
   support will end.
 
-* :term:`Long-term support release`\s will receive security updates for a
+* :term:`Long-term support releases` will receive security updates for a
   specified period.
 
 When new releases are issued for security reasons, the accompanying


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-N/A

# Branch description
This PR corrects a typo in the Django security policies documentation. The term "Long-term support release\s" has been updated to "Long-term support releases" to ensure accuracy and clarity in the documentation.

# Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
