### PR TITLE
Fixed #35678 -- unusable_password moved to AdminUserCreationForm

### DIFF
--- a/django/contrib/auth/admin.py
+++ b/django/contrib/auth/admin.py
@@ -5,8 +5,8 @@ from django.contrib.admin.utils import unquote
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.forms import (
     AdminPasswordChangeForm,
+    AdminUserCreationForm,
     UserChangeForm,
-    UserCreationForm,
 )
 from django.contrib.auth.models import Group, User
 from django.core.exceptions import PermissionDenied
@@ -71,7 +71,7 @@ class UserAdmin(admin.ModelAdmin):
         ),
     )
     form = UserChangeForm
-    add_form = UserCreationForm
+    add_form = AdminUserCreationForm
     change_password_form = AdminPasswordChangeForm
     list_display = ("username", "email", "first_name", "last_name", "is_staff")
     list_filter = ("is_staff", "is_superuser", "is_active", "groups")

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -200,7 +200,6 @@ class BaseUserCreationForm(SetPasswordMixin, forms.ModelForm):
     """
 
     password1, password2 = SetPasswordMixin.create_password_fields()
-    usable_password = SetPasswordMixin.create_usable_password_field()
 
     class Meta:
         model = User
@@ -518,6 +517,15 @@ class PasswordChangeForm(SetPasswordForm):
                 code="password_incorrect",
             )
         return old_password
+
+
+class AdminUserCreationForm(UserCreationForm):
+    """
+    A form used in the admin to create a user. It adds the usable password field
+    which the user facing UserCreationForm does not have,
+    """
+
+    usable_password = SetPasswordMixin.create_usable_password_field()
 
 
 class AdminPasswordChangeForm(SetPasswordMixin, forms.Form):


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35678

# Branch description
This PR moves the `unusable_password` field from `UserCreationForm` to a new form called `AdminUserCreationForm` to allow the re-use of `UserCreationForm` on user-side where unusable passwords are not desirable. 

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
