### PR TITLE
Fixed #32519 -- Added support for using key and path transforms in update() for JSONFields.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -342,6 +342,10 @@ class BaseDatabaseFeatures:
     json_key_contains_list_matching_requires_list = False
     # Does the backend support JSONObject() database function?
     has_json_object_function = True
+    # Does the backend support partial updates to JSONField?
+    supports_partial_json_update = True
+    # Does JSONSet only append to an array if the index equals to the array length?
+    json_set_array_append_requires_length_as_index = False
 
     # Does the backend support column collations?
     supports_collation_on_charfield = True

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -208,3 +208,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def bare_select_suffix(self):
         return "" if self.connection.oracle_version >= (23,) else " FROM DUAL"
+
+    @cached_property
+    def supports_partial_json_update(self):
+        return self.connection.oracle_version >= (21,)

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -61,6 +61,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     insert_test_table_with_defaults = 'INSERT INTO {} ("null") VALUES (1)'
     supports_default_keyword_in_insert = False
     supports_unlimited_charfield = True
+    json_set_array_append_requires_length_as_index = True
 
     @cached_property
     def django_test_skips(self):

--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -340,12 +340,16 @@ class KeyTransform(Transform):
         super().__init__(*args, **kwargs)
         self.key_name = str(key_name)
 
-    def preprocess_lhs(self, compiler, connection):
+    def unwrap_transforms(self):
         key_transforms = [self.key_name]
         previous = self.lhs
         while isinstance(previous, KeyTransform):
             key_transforms.insert(0, previous.key_name)
             previous = previous.lhs
+        return previous, key_transforms
+
+    def preprocess_lhs(self, compiler, connection):
+        previous, key_transforms = self.unwrap_transforms()
         lhs, params = compiler.compile(previous)
         if connection.vendor == "oracle":
             # Escape string-formatting.

--- a/django/db/models/functions/__init__.py
+++ b/django/db/models/functions/__init__.py
@@ -25,7 +25,7 @@ from .datetime import (
     TruncWeek,
     TruncYear,
 )
-from .json import JSONSet
+from .json import JSONRemove, JSONSet
 from .math import (
     Abs,
     ACos,
@@ -189,5 +189,6 @@ __all__ = [
     "Rank",
     "RowNumber",
     # JSON-related functions
+    "JSONRemove",
     "JSONSet",
 ]

--- a/django/db/models/functions/__init__.py
+++ b/django/db/models/functions/__init__.py
@@ -25,6 +25,7 @@ from .datetime import (
     TruncWeek,
     TruncYear,
 )
+from .json import JSONSet
 from .math import (
     Abs,
     ACos,
@@ -187,4 +188,6 @@ __all__ = [
     "PercentRank",
     "Rank",
     "RowNumber",
+    # JSON-related functions
+    "JSONSet",
 ]

--- a/django/db/models/functions/comparison.py
+++ b/django/db/models/functions/comparison.py
@@ -22,6 +22,7 @@ class Cast(Func):
 
     def as_sqlite(self, compiler, connection, **extra_context):
         db_type = self.output_field.db_type(connection)
+        output_type = self.output_field.get_internal_type()
         if db_type in {"datetime", "time"}:
             # Use strftime as datetime/time don't keep fractional seconds.
             template = "strftime(%%s, %(expressions)s)"
@@ -33,6 +34,11 @@ class Cast(Func):
             return sql, params
         elif db_type == "date":
             template = "date(%(expressions)s)"
+            return super().as_sql(
+                compiler, connection, template=template, **extra_context
+            )
+        elif output_type == "JSONField":
+            template = "JSON(%(expressions)s)"
             return super().as_sql(
                 compiler, connection, template=template, **extra_context
             )

--- a/django/db/models/functions/json.py
+++ b/django/db/models/functions/json.py
@@ -1,0 +1,149 @@
+from django.db import NotSupportedError
+from django.db.models.constants import LOOKUP_SEP
+from django.db.models.expressions import Func, Value
+from django.db.models.fields.json import compile_json_path
+from django.db.models.functions import Cast
+
+
+class JSONSet(Func):
+    def __init__(self, expression, output_field=None, **fields):
+        if not fields:
+            raise TypeError("JSONSet requires at least one key-value pair to be set.")
+        self.fields = fields
+        super().__init__(expression, output_field=output_field)
+
+    def resolve_expression(
+        self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False
+    ):
+        c = super().resolve_expression(query, allow_joins, reuse, summarize, for_save)
+        # Resolve expressions in the JSON update values.
+        c.fields = {
+            key: (
+                value.resolve_expression(query, allow_joins, reuse, summarize, for_save)
+                if hasattr(value, "resolve_expression")
+                else value
+            )
+            for key, value in self.fields.items()
+        }
+        return c
+
+    def as_sql(
+        self,
+        compiler,
+        connection,
+        function=None,
+        template=None,
+        arg_joiner=None,
+        **extra_context,
+    ):
+        if not connection.features.supports_partial_json_update:
+            raise NotSupportedError(
+                "JSONSet() is not supported on this database backend."
+            )
+        copy = self.copy()
+        new_source_expressions = copy.get_source_expressions()
+
+        for key, value in self.fields.items():
+            key_paths = key.split(LOOKUP_SEP)
+            key_paths_join = compile_json_path(key_paths)
+
+            if not hasattr(value, "resolve_expression"):
+                # Use Value to serialize the data to string,
+                # then use Cast to ensure the string is treated as JSON.
+                value = Cast(
+                    Value(value, output_field=self.output_field),
+                    output_field=self.output_field,
+                )
+
+            new_source_expressions.extend((Value(key_paths_join), value))
+
+        copy.set_source_expressions(new_source_expressions)
+
+        return super(JSONSet, copy).as_sql(
+            compiler,
+            connection,
+            function="JSON_SET",
+            **extra_context,
+        )
+
+    def as_postgresql(self, compiler, connection, **extra_context):
+        copy = self.copy()
+
+        all_items = list(self.fields.items())
+        key, value = all_items[0]
+        rest = all_items[1:]
+
+        # JSONB_SET does not support arbitrary number of arguments,
+        # so convert multiple updates into recursive calls.
+        if rest:
+            copy.fields = {key: value}
+            return JSONSet(copy, **dict(rest)).as_postgresql(
+                compiler, connection, **extra_context
+            )
+
+        new_source_expressions = copy.get_source_expressions()
+        key_paths = key.split(LOOKUP_SEP)
+        key_paths_join = ",".join(key_paths)
+
+        new_source_expressions.append(Value(f"{{{key_paths_join}}}"))
+
+        if not hasattr(value, "resolve_expression"):
+            new_source_expressions.append(Value(value, output_field=self.output_field))
+        else:
+
+            class ToJSONB(Func):
+                function = "TO_JSONB"
+
+            new_source_expressions.append(
+                ToJSONB(value, output_field=self.output_field),
+            )
+
+        copy.set_source_expressions(new_source_expressions)
+        return super(JSONSet, copy).as_sql(
+            compiler, connection, function="JSONB_SET", **extra_context
+        )
+
+    def as_oracle(self, compiler, connection, **extra_context):
+        if not connection.features.supports_partial_json_update:
+            raise NotSupportedError(
+                "JSONSet() is not supported on this database backend."
+            )
+        copy = self.copy()
+
+        all_items = list(self.fields.items())
+        key, value = all_items[0]
+        rest = all_items[1:]
+
+        # JSON_TRANSFORM does not support arbitrary number of arguments,
+        # so convert multiple updates into recursive calls.
+        if rest:
+            copy.fields = {key: value}
+            return JSONSet(copy, **dict(rest)).as_oracle(
+                compiler, connection, **extra_context
+            )
+
+        new_source_expressions = copy.get_source_expressions()
+        key_paths = key.split(LOOKUP_SEP)
+        key_paths_join = compile_json_path(key_paths)
+        if not hasattr(value, "resolve_expression"):
+            new_source_expressions.append(Value(value, output_field=self.output_field))
+        else:
+            new_source_expressions.append(value)
+        copy.set_source_expressions(new_source_expressions)
+
+        class ArgJoiner:
+            def join(self, args):
+                if not hasattr(value, "resolve_expression"):
+                    # Interpolate the JSON path directly to the query string, because
+                    # Oracle does not support passing the JSON path using parameter
+                    # binding.
+                    return f"{args[0]}, SET '{key_paths_join}' = {args[-1]} FORMAT JSON"
+                return f"{args[0]}, SET '{key_paths_join}' = {args[-1]}"
+
+        return super(JSONSet, copy).as_sql(
+            compiler,
+            connection,
+            function="JSON_TRANSFORM",
+            arg_joiner=ArgJoiner(),
+            **extra_context,
+        )

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -215,6 +215,17 @@ class Transform(RegisterLookupMixin, Func):
             bilateral_transforms.append(self.__class__)
         return bilateral_transforms
 
+    def get_update_expression(self, value, lhs=None):
+        """
+        Compose an update expression for this transform with a given value,
+        to be used in QuerySet.update(). Multiple transforms may be used for the same
+        field in a single update() call, in which case, the previous expression is
+        provided by the lhs parameter.
+        """
+        raise NotImplementedError(
+            f"Using {self.__class__.__name__} is not supported in QuerySet.update()."
+        )
+
 
 class BuiltinLookup(Lookup):
     def process_lhs(self, compiler, connection, lhs=None):

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -1982,3 +1982,36 @@ gaps.
 Computes the row number according to the ordering of either the frame clause
 or the ordering of the whole query if there is no partitioning of the
 :ref:`window frame <window-frames>`.
+
+.. json-related-functions:
+
+JSON-related functions
+======================
+
+We'll be using the following model in examples of each function::
+
+    class UserPreferences(models.Model):
+        settings = models.JSONField(encoder=DjangoJSONEncoder)
+
+``JSONSet``
+-----------
+
+.. class:: JSONSet(expression, **fields)
+
+Updates specific fields within a JSON field in the database. Takes an
+expression which will be updated and key-value pairs that specify which fields
+within the JSON structure should be updated.
+
+Usage example:
+
+.. code-block:: pycon
+
+    >>> from django.db.models.functions import JSONSet
+    >>> user_preferences = UserPreferences.objects.create(
+    ...     settings={"theme": "dark", "notifications": True}
+    ... )
+    >>> UserPreferences.objects.update(settings=JSONSet("settings", theme="light"))
+    1
+    >>> user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+    >>> print(user_preferences.settings)
+    {'theme': 'light', 'notifications': True}

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -2015,3 +2015,27 @@ Usage example:
     >>> user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
     >>> print(user_preferences.settings)
     {'theme': 'light', 'notifications': True}
+
+
+``JSONRemove``
+--------------
+
+.. class:: JSONRemove(expression, *paths)
+
+Removes specific paths from a JSON field in the database. Accepts an expression
+from which paths will be removed and variable number of paths indicating
+the keys within the JSON structure that should be removed
+
+Usage example:
+
+.. code-block:: pycon
+
+    >>> from django.db.models.functions import JSONRemove
+    >>> user_preferences = UserPreferences.objects.create(
+    ...     settings={"theme": "dark", "notifications": True}
+    ... )
+    >>> UserPreferences.objects.update(settings=JSONRemove("settings", "theme"))
+    1
+    >>> user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+    >>> print(user_preferences.settings)
+    {'notifications': True}

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -2039,3 +2039,6 @@ Usage example:
     >>> user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
     >>> print(user_preferences.settings)
     {'notifications': True}
+
+For more information on how to use the JSONSet and JSONRemove functions, see
+:ref:`updating-jsonfield`.

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1421,7 +1421,8 @@ Python native format: dictionaries, lists, strings, numbers, booleans and
 
     Defaults to ``json.JSONDecoder``.
 
-To query ``JSONField`` in the database, see :ref:`querying-jsonfield`.
+To query and update ``JSONField`` in the database, see :ref:`querying-jsonfield`
+and :ref:`updating-jsonfield`.
 
 .. admonition:: Default value
 

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -31,6 +31,50 @@ and only officially support the latest release of each series.
 What's new in Django 5.2
 ========================
 
+Support for ``JSONField`` key transforms in ``update()``
+--------------------------------------------------------
+
+Django 5.2 introduces support for ``JSONField`` key transforms in ``update`` so
+you can do partial update ``JSONField`` more efficiently. Consider following
+example to update a ``JSONField``.
+
+.. code-block:: pycon
+
+    >>> user_preferences = UserPreferences.objects.create(
+    ...     settings={
+    ...         "theme": "dark",
+    ...         "notifications": True,
+    ...         "font": {"size": 10, "name": "Arial"},
+    ...     }
+    ... )
+    >>> UserPreferences.objects.update(
+    ...     settings__theme="light",
+    ...     settings__font__size=20,
+    ... )
+    >>> user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+    >>> print(user_preferences.settings)
+    {'theme': 'light', 'notifications': True, 'font': {'size': 20, 'name': 'Arial'}}
+
+You can also remove a key by providing ``NOT_PROVIDED`` to parameter value.
+
+.. code-block:: pycon
+
+    >>> from django.db.models import NOT_PROVIDED
+    >>> user_preferences = UserPreferences.objects.create(
+    ...     settings={
+    ...         "theme": "dark",
+    ...         "notifications": True,
+    ...         "font": {"size": 10, "name": "Arial"},
+    ...     }
+    ... )
+    >>> UserPreferences.objects.update(
+    ...     settings__theme=NOT_PROVIDED,
+    ...     settings__font__size=20,
+    ... )
+    >>> user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+    >>> print(user_preferences.settings)
+    {'notifications': True, 'font': {'size': 20, 'name': 'Arial'}}
+
 Minor features
 --------------
 

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -1332,6 +1332,199 @@ For example:
     >>> Dog.objects.filter(data__has_any_keys=["owner", "breed"])
     <QuerySet [<Dog: Rufus>, <Dog: Meg>]>
 
+.. _updating-jsonfield:
+
+Updating ``JSONField``
+======================
+
+Updating ``JSONField`` can be achieved through various steps: basic updates
+by treating it like dictionary, making use ``JSONSet`` and ``JSONRemove``
+functions and saving them through model instance, utilizing ``JSONSet`` and
+``JSONRemove`` inside ``update()``, and using key transforms in ``update()``
+as a shorthand for ``JSONSet`` and ``JSONRemove``.
+
+To demonstrate, we will use the following example model::
+
+    from django.core.serializers.json import DjangoJSONEncoder
+    from django.db import models
+
+
+    class UserPreferences(models.Model):
+        settings = models.JSONField(encoder=DjangoJSONEncoder)
+
+A simple way to update a ``JSONField`` is by treating it like a dictionary.
+To update a specific key within the ``JSONField``, you can modify it just as
+you would a key in a regular dictionary. After making the necessary changes,
+you can save the updated data using the model instance.
+
+Consider the following example:
+
+.. code-block:: pycon
+
+    >>> user_preferences = UserPreferences.objects.create(
+    ...     settings={"theme": "dark", "notifications": True}
+    ... )
+    >>> user_preferences.settings["theme"] = "light"
+    >>> user_preferences.save()
+    >>> print(user_preferences.settings)
+    {'theme': 'light', 'notifications': True}
+
+Django provides ``JSONSet`` function to insert or update data in ``JSONField``.
+Take a look at following example where we use ``JSONSet`` to update data and
+saving it using the model instance.
+
+.. code-block:: pycon
+
+    >>> from django.db.models.functions import JSONSet
+    >>> user_preferences = UserPreferences.objects.create(
+    ...     settings={"theme": "dark", "notifications": True}
+    ... )
+    >>> user_preferences.settings = JSONSet("settings", theme="light")
+    >>> user_preferences.save()
+    >>> UserPreferences.objects.filter(settings__theme="light")
+    <QuerySet [<UserPreferences: UserPreferences object (1)>]>
+
+We can also update multiple keys at a same time.
+
+.. code-block:: pycon
+
+    >>> user_preferences.settings = JSONSet("settings", theme="dark", notifications=False)
+    >>> user_preferences.save()
+    >>> UserPreferences.objects.filter(
+    ...     settings__theme="dark",
+    ...     settings__notifications=False,
+    ... )
+    <QuerySet [<UserPreferences: UserPreferences object (1)>]>
+
+To insert or update nested keys, we can use key transforms inside ``JSONSet``.
+
+.. code-block:: pycon
+
+    >>> user_preferences.settings = JSONSet(
+    ...     "settings",
+    ...     font__name="Arial",
+    ...     font__size=10,
+    ... )  # {'theme': 'dark', 'notifications': True, 'font': {'name': 'Arial', 'size': 10}}
+    >>> user_preferences.save()
+    >>> UserPreferences.objects.filter(
+    ...     settings__font__name="Arial",
+    ...     settings__font__size=10,
+    ... )
+    <QuerySet [<UserPreferences: UserPreferences object (1)>]>
+
+You can pass ``None`` value inside ``JSONSet`` key to make JSON ``null``.
+
+.. code-block:: pycon
+
+    >>> user_preferences.settings = JSONSet(
+    ...     "settings",
+    ...     font__name="Arial",
+    ...     font__size=None,
+    ... )  # {'theme': 'dark', 'notifications': True, 'font': {'name': 'Arial', 'size': null}}
+    >>> user_preferences.save()
+    >>> UserPreferences.objects.filter(
+    ...     settings__font__name="Arial",
+    ...     settings__font__size=None,
+    ... )
+    <QuerySet [<UserPreferences: UserPreferences object (1)>]>
+
+Django provides ``JSONRemove`` to remove specific key from a ``JSONField``.
+Here is an example where we use ``JSONRemove`` to remove data and saving it using the
+model instance.
+
+.. code-block:: pycon
+
+    >>> from django.db.models.functions import JSONRemove
+    >>> user_preferences = UserPreferences.objects.create(
+    ...     settings={
+    ...         "theme": "dark",
+    ...         "notifications": True,
+    ...         "font": {"size": 10, "name": "Arial"},
+    ...     }
+    ... )
+    >>> user_preferences.settings = JSONRemove("settings", "theme")
+    >>> user_preferences.save()
+    >>> UserPreferences.objects.filter(settings__theme__isnull=True)
+    <QuerySet [<UserPreferences: UserPreferences object (1)>]>
+
+We can also remove multiple keys at once.
+
+.. code-block:: pycon
+
+    >>> user_preferences.settings = JSONRemove("settings", "notifications", "font__size")
+    >>> user_preferences.save()
+    >>> UserPreferences.objects.filter(
+    ...     settings__notifications__isnull=True,
+    ...     settings__font__size__isnull=True,
+    ... )
+    <QuerySet [<UserPreferences: UserPreferences object (1)>]>
+
+We can use ``JSONSet`` and ``JSONRemove`` inside ``update()`` to update ``JSONField``.
+To demonstrate using ``JSONSet`` inside ``update()``, take a look at this example.
+
+.. code-block:: pycon
+
+    >>> from django.db.models.functions import JSONSet
+    >>> user_preferences = UserPreferences.objects.create(
+    ...     settings={"theme": "dark", "notifications": True}
+    ... )
+    >>> UserPreferences.objects.update(settings=JSONSet("settings", theme="light"))
+    >>> user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+    >>> print(user_preferences.settings)
+    {'theme': 'light', 'notifications': True}
+
+We can also use ``JSONRemove`` inside ``update()``.
+
+.. code-block:: pycon
+
+    >>> from django.db.models.functions import JSONRemove
+    >>> UserPreferences.objects.update(settings=JSONRemove("settings", "theme"))
+    >>> user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+    >>> print(user_preferences.settings)
+    {'notifications': True}
+
+A more convenient method for updating a ``JSONField`` is to use key transforms
+within the ``update()`` method. Consider following example to update ``JSONField``
+using key transforms.
+
+.. code-block:: pycon
+
+    >>> user_preferences = UserPreferences.objects.create(
+    ...     settings={
+    ...         "theme": "dark",
+    ...         "notifications": True,
+    ...         "font": {"size": 10, "name": "Arial"},
+    ...     }
+    ... )
+    >>> UserPreferences.objects.update(
+    ...     settings__theme="light",
+    ...     settings__font__size=20,
+    ... )
+    >>> user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+    >>> print(user_preferences.settings)
+    {'theme': 'light', 'notifications': True, 'font': {'size': 20, 'name': 'Arial'}}
+
+To remove a key, you need to pass ``NOT_PROVIDED`` to parameter value. For
+example:
+
+.. code-block:: pycon
+
+    >>> from django.db.models import NOT_PROVIDED
+    >>> user_preferences = UserPreferences.objects.create(
+    ...     settings={
+    ...         "theme": "dark",
+    ...         "notifications": True,
+    ...         "font": {"size": 10, "name": "Arial"},
+    ...     }
+    ... )
+    >>> UserPreferences.objects.update(
+    ...     settings__theme=NOT_PROVIDED,
+    ...     settings__font__size=20,
+    ... )
+    >>> user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+    >>> print(user_preferences.settings)
+    {'notifications': True, 'font': {'size': 20, 'name': 'Arial'}}
+
 .. _complex-lookups-with-q:
 
 Complex lookups with ``Q`` objects

--- a/tests/db_functions/comparison/test_cast.py
+++ b/tests/db_functions/comparison/test_cast.py
@@ -186,3 +186,13 @@ class CastTests(TestCase):
             ).get(),
             "1",
         )
+
+    def test_cast_to_json_field(self):
+        """
+        Some database backends (e.g. MariaDB, Oracle, and SQLite) do not support
+        explicit cast to JSON. Ensure that our workarounds work on those databases.
+        """
+        json_value = Author.objects.annotate(
+            cast_json=Cast(models.Value('{"age": 20}'), models.JSONField())
+        )
+        self.assertEqual(json_value.get().cast_json, {"age": 20})

--- a/tests/db_functions/json/test_json_remove.py
+++ b/tests/db_functions/json/test_json_remove.py
@@ -1,0 +1,79 @@
+from django.db import NotSupportedError
+from django.db.models.functions.json import JSONRemove
+from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
+
+from ..models import UserPreferences
+
+
+@skipUnlessDBFeature("supports_partial_json_update")
+class JSONRemoveTests(TestCase):
+    def test_remove_single_key(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"theme": "dark", "font": "Arial"}
+        )
+        UserPreferences.objects.update(settings=JSONRemove("settings", "theme"))
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(user_preferences.settings, {"font": "Arial"})
+
+    def test_remove_nonexistent_key(self):
+        user_preferences = UserPreferences.objects.create(settings={"theme": "dark"})
+        UserPreferences.objects.update(settings=JSONRemove("settings", "font"))
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(user_preferences.settings, {"theme": "dark"})
+
+    def test_remove_nested_key(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"font": {"size": 20, "color": "red"}}
+        )
+        UserPreferences.objects.update(settings=JSONRemove("settings", "font__color"))
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(user_preferences.settings, {"font": {"size": 20}})
+
+    def test_remove_multiple_keys(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"font": {"size": 20, "color": "red"}, "theme": "dark"}
+        )
+        UserPreferences.objects.update(
+            settings=JSONRemove("settings", "font__color", "theme")
+        )
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(user_preferences.settings, {"font": {"size": 20}})
+
+    def test_remove_keys_with_recursive_call(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"font": {"size": 20, "color": "red"}, "theme": "dark"}
+        )
+        UserPreferences.objects.update(
+            settings=JSONRemove(JSONRemove("settings", "font__color"), "theme")
+        )
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(user_preferences.settings, {"font": {"size": 20}})
+
+    def test_remove_using_instance(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"theme": "dark", "font": "Arial"}
+        )
+        user_preferences.settings = JSONRemove("settings", "theme")
+        user_preferences.save()
+
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(user_preferences.settings, {"font": "Arial"})
+
+
+class InvalidJSONRemoveTests(TestCase):
+    @skipIfDBFeature("supports_partial_json_update")
+    def test_remove_not_supported(self):
+        with self.assertRaisesMessage(
+            NotSupportedError, "JSONRemove() is not supported on this database backend."
+        ):
+            UserPreferences.objects.create(settings={"theme": "dark", "font": "Arial"})
+            UserPreferences.objects.update(settings=JSONRemove("settings", "theme"))
+
+    def test_remove_missing_path_to_be_removed_error(self):
+        with self.assertRaisesMessage(
+            TypeError, "JSONRemove requires at least one path to remove"
+        ):
+            UserPreferences.objects.create(
+                settings={"theme": "dark", "notifications": True}
+            )
+            UserPreferences.objects.update(settings=JSONRemove("settings"))

--- a/tests/db_functions/json/test_json_set.py
+++ b/tests/db_functions/json/test_json_set.py
@@ -1,0 +1,403 @@
+import decimal
+import json
+
+from django.db import NotSupportedError, connection
+from django.db.models import F, JSONField, Value
+from django.db.models.functions import JSONObject
+from django.db.models.functions.json import JSONSet
+from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
+
+from ..models import UserPreferences
+
+
+@skipUnlessDBFeature("supports_partial_json_update")
+class JSONSetTests(TestCase):
+    def test_set_single_key(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"theme": "dark", "notifications": True}
+        )
+        UserPreferences.objects.update(settings=JSONSet("settings", theme="light"))
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings, {"theme": "light", "notifications": True}
+        )
+
+    def test_set_multiple_keys(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={
+                "theme": "dark",
+                "font": "Arial",
+                "notifications": True,
+                "cookies": False,
+            }
+        )
+        UserPreferences.objects.update(
+            settings=JSONSet(
+                "settings", theme="light", font="Comic Sans", notifications=False
+            )
+        )
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {
+                "theme": "light",
+                "font": "Comic Sans",
+                "notifications": False,
+                "cookies": False,
+            },
+        )
+
+    def test_set_single_new_key(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"theme": "dark", "notifications": True}
+        )
+        UserPreferences.objects.update(
+            settings=JSONSet("settings", font={"name": "Arial", "size": 20})
+        )
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {
+                "theme": "dark",
+                "notifications": True,
+                "font": {"name": "Arial", "size": 20},
+            },
+        )
+
+    def test_set_single_key_in_nested_json_object(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"font": {"size": 20, "name": "Arial"}, "theme": "dark"}
+        )
+        UserPreferences.objects.update(settings=JSONSet("settings", font__size=10))
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {"font": {"size": 10, "name": "Arial"}, "theme": "dark"},
+        )
+
+    def test_set_key_with_dot_character(self):
+        """
+        Most databases use a dot-notation for the JSON path.
+        Ensure that using a key that contains a dot is escaped properly.
+        """
+        user_preferences = UserPreferences.objects.create(
+            settings={"font.size": 20, "notifications": True, "font": {"size": 30}}
+        )
+        # Update the key that contains a dot character.
+        UserPreferences.objects.update(
+            settings=JSONSet("settings", **{"font.size": 10})
+        )
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {"font.size": 10, "notifications": True, "font": {"size": 30}},
+        )
+
+        # Update the nested key.
+        UserPreferences.objects.update(settings=JSONSet("settings", font__size=20))
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {"font.size": 10, "notifications": True, "font": {"size": 20}},
+        )
+
+    def test_set_multiple_keys_in_nested_json_object_with_nested_calls(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={
+                "font": {"size": 20, "name": "Arial", "bold": False},
+                "notifications": True,
+            }
+        )
+        UserPreferences.objects.update(
+            settings=JSONSet(
+                JSONSet("settings", font__size=10), font__name="Comic Sans"
+            )
+        )
+
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {
+                "font": {"size": 10, "name": "Comic Sans", "bold": False},
+                "notifications": True,
+            },
+        )
+
+    def test_set_single_key_with_json_object(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"theme": "dark", "notifications": True}
+        )
+        UserPreferences.objects.update(
+            settings=JSONSet(
+                "settings", theme={"type": "dark", "background_color": "black"}
+            )
+        )
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {
+                "theme": {"type": "dark", "background_color": "black"},
+                "notifications": True,
+            },
+        )
+
+    def test_with_annotated_expression(self):
+        UserPreferences.objects.create(settings={"theme": "dark", "font_size": 20})
+        obj = (
+            UserPreferences.objects.annotate(
+                settings_updated=JSONSet(
+                    "settings", theme={"type": "dark", "background_color": "black"}
+                )
+            )
+            .annotate(
+                settings_updated_again=JSONSet(
+                    "settings_updated",
+                    theme={"type": "dark", "background_color": "red"},
+                )
+            )
+            .first()
+        )
+        self.assertEqual(
+            obj.settings_updated,
+            {"theme": {"type": "dark", "background_color": "black"}, "font_size": 20},
+        )
+        self.assertEqual(
+            obj.settings_updated_again,
+            {"theme": {"type": "dark", "background_color": "red"}, "font_size": 20},
+        )
+
+    def test_set_single_key_with_nested_json(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={
+                "theme": {"type": "dark", "background_color": "red"},
+                "notifications": False,
+            }
+        )
+        # Updating the theme key with a JSON object will replace the entire object for
+        # that key instead of merging them.
+        UserPreferences.objects.update(
+            settings=JSONSet(
+                "settings",
+                theme={
+                    "type": "dark",
+                    "background": {
+                        "color": {"gradient-1": "black", "gradient-2": "grey"},
+                        "opacity": 0.5,
+                    },
+                },
+            )
+        )
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {
+                "theme": {
+                    "type": "dark",
+                    "background": {
+                        "color": {"gradient-1": "black", "gradient-2": "grey"},
+                        "opacity": 0.5,
+                    },
+                },
+                "notifications": False,
+            },
+        )
+
+    def test_set_single_key_with_list(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"colors": ["black", "blue", "red"], "notifications": True}
+        )
+        UserPreferences.objects.update(
+            settings=JSONSet("settings", colors=["yellow", "green"])
+        )
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {"colors": ["yellow", "green"], "notifications": True},
+        )
+
+    def test_set_single_key_with_list_using_index(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"colors": ["black", "blue", "red"], "notifications": True}
+        )
+        # Update using an existing index.
+        UserPreferences.objects.update(settings=JSONSet("settings", colors__1="yellow"))
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {"colors": ["black", "yellow", "red"], "notifications": True},
+        )
+
+        # Update using an index that is equal to the array length. It should append the
+        # value to the array.
+        UserPreferences.objects.update(settings=JSONSet("settings", colors__3="green"))
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {"colors": ["black", "yellow", "red", "green"], "notifications": True},
+        )
+
+        # Update using a nonexistent index that is greater than the array length.
+        UserPreferences.objects.update(settings=JSONSet("settings", colors__10="white"))
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+
+        # It should append the value to the array if the database supports it.
+        if not connection.features.json_set_array_append_requires_length_as_index:
+            if connection.vendor == "oracle":
+                self.assertEqual(
+                    user_preferences.settings,
+                    {
+                        "colors": [
+                            "black",
+                            "yellow",
+                            "red",
+                            "green",
+                            *(6 * [None]),
+                            "white",
+                        ],
+                        "notifications": True,
+                    },
+                )
+            else:
+                self.assertEqual(
+                    user_preferences.settings,
+                    {
+                        "colors": ["black", "yellow", "red", "green", "white"],
+                        "notifications": True,
+                    },
+                )
+        else:
+            self.assertEqual(
+                user_preferences.settings,
+                {
+                    "colors": ["black", "yellow", "red", "green"],
+                    "notifications": True,
+                },
+            )
+
+    def test_set_single_key_with_json_null(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"theme": "dark", "notifications": True}
+        )
+        # Set the value to JSON null.
+        UserPreferences.objects.update(settings=JSONSet("settings", theme=None))
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {"theme": None, "notifications": True},
+        )
+
+    def test_save_on_model_field(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"font": {"size": 20}, "notifications": True}
+        )
+        # Use JSONSet as an expression directly on the field of the model instance.
+        user_preferences.settings = JSONSet("settings", font__size=30)
+        user_preferences.save()
+
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {"font": {"size": 30}, "notifications": True},
+        )
+
+    def test_using_custom_encoder_on_model_field(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={
+                "theme": {"type": "dark", "opacity": decimal.Decimal(100.0)},
+                "notifications": True,
+            }
+        )
+        # The settings field uses DjangoJSONEncoder and JSONSet should pick it up.
+        UserPreferences.objects.update(
+            settings=JSONSet(
+                "settings",
+                theme__opacity=decimal.Decimal(50.0),
+            )
+        )
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {"theme": {"type": "dark", "opacity": "50"}, "notifications": True},
+        )
+
+    def test_using_explicit_custom_encoder(self):
+        class CustomJSONEncoder(json.JSONEncoder):
+            def default(self, o):
+                if isinstance(o, decimal.Decimal):
+                    return str(o.quantize(decimal.Decimal("0.01")))
+                return super().default(o)
+
+        user_preferences = UserPreferences.objects.create(
+            settings={
+                "theme": {"type": "dark", "opacity": decimal.Decimal(100.0)},
+                "notifications": True,
+            }
+        )
+        # We pass a JSONField with a custom encoder as the output field of JSONSet.
+        UserPreferences.objects.update(
+            settings=JSONSet(
+                "settings",
+                output_field=JSONField(encoder=CustomJSONEncoder),
+                theme__opacity=decimal.Decimal(50.0),
+            )
+        )
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {"theme": {"type": "dark", "opacity": "50.00"}, "notifications": True},
+        )
+
+    @skipIfDBFeature("supports_partial_json_update")
+    def test_not_supported(self):
+        with self.assertRaisesMessage(
+            NotSupportedError, "JSONSet() is not supported on this database backend."
+        ):
+            UserPreferences.objects.create(
+                settings={"theme": "dark", "notifications": True}
+            )
+            UserPreferences.objects.update(settings=JSONSet("settings", theme="light"))
+
+    def test_set_single_key_using_jsonobject(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"theme": "dark", "notifications": True}
+        )
+        UserPreferences.objects.update(
+            settings=JSONSet("settings", theme=JSONObject(color=Value("black")))
+        )
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {"theme": {"color": "black"}, "notifications": True},
+        )
+
+    def test_set_single_key_using_expressions(self):
+        user_preferences = UserPreferences.objects.create(
+            settings={"theme": "dark", "notifications": True}
+        )
+        UserPreferences.objects.update(settings=JSONSet("settings", id=F("id")))
+        user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
+        self.assertEqual(
+            user_preferences.settings,
+            {"theme": "dark", "notifications": True, "id": user_preferences.pk},
+        )
+
+
+class InvalidJSONSetTests(TestCase):
+    @skipIfDBFeature("supports_partial_json_update")
+    def test_not_supported(self):
+        with self.assertRaisesMessage(
+            NotSupportedError, "JSONSet() is not supported on this database backend."
+        ):
+            UserPreferences.objects.create(
+                settings={"theme": "dark", "notifications": True}
+            )
+            UserPreferences.objects.update(settings=JSONSet("settings", theme="light"))
+
+    def test_missing_key_value_raises_error(self):
+        with self.assertRaisesMessage(
+            TypeError, "JSONSet requires at least one key-value pair to be set."
+        ):
+            UserPreferences.objects.create(
+                settings={"theme": "dark", "notifications": True}
+            )
+            UserPreferences.objects.update(settings=JSONSet("settings"))

--- a/tests/db_functions/migrations/0002_create_test_models.py
+++ b/tests/db_functions/migrations/0002_create_test_models.py
@@ -88,4 +88,10 @@ class Migration(migrations.Migration):
                 ("f2", models.FloatField(null=True, blank=True)),
             ],
         ),
+        migrations.CreateModel(
+            name="UserPreferences",
+            fields=[
+                ("settings", models.JSONField()),
+            ],
+        ),
     ]

--- a/tests/db_functions/models.py
+++ b/tests/db_functions/models.py
@@ -2,6 +2,7 @@
 Tests for built in Function expressions.
 """
 
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 
 
@@ -55,3 +56,7 @@ class IntegerModel(models.Model):
 class FloatModel(models.Model):
     f1 = models.FloatField(null=True, blank=True)
     f2 = models.FloatField(null=True, blank=True)
+
+
+class UserPreferences(models.Model):
+    settings = models.JSONField(encoder=DjangoJSONEncoder)

--- a/tests/update/models.py
+++ b/tests/update/models.py
@@ -3,6 +3,7 @@ Tests for the update() queryset method that allows in-place, multi-object
 updates.
 """
 
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 
 
@@ -54,4 +55,5 @@ class UniqueNumberChild(UniqueNumber):
 
 
 class UserPreferences(models.Model):
+    settings = models.JSONField(encoder=DjangoJSONEncoder, default=dict)
     date_created = models.DateTimeField(null=True)

--- a/tests/update/models.py
+++ b/tests/update/models.py
@@ -51,3 +51,7 @@ class UniqueNumber(models.Model):
 
 class UniqueNumberChild(UniqueNumber):
     pass
+
+
+class UserPreferences(models.Model):
+    date_created = models.DateTimeField(null=True)


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-32519

# Branch description

This PR introduces support for ``JSONField`` key transforms in ``update`` so we can do partial update ``JSONField`` more efficiently. Consider following example to update a ``JSONField``.

```pycon
>>> user_preferences = UserPreferences.objects.create(
...     settings={
...         "theme": "dark",
...         "notifications": True,
...         "font": {"size": 10, "name": "Arial"},
...     }
... )
>>> UserPreferences.objects.update(
...     settings__theme="light",
...     settings__font__size=20,
... )
>>> user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
>>> print(user_preferences.settings)
{'theme': 'light', 'notifications': True, 'font': {'size': 20, 'name': 'Arial'}}
```

You can also remove a key by providing ``NOT_PROVIDED`` to parameter value.

```pycon
>>> from django.db.models import NOT_PROVIDED
>>> user_preferences = UserPreferences.objects.create(
...     settings={
...         "theme": "dark",
...         "notifications": True,
...         "font": {"size": 10, "name": "Arial"},
...     }
... )
>>> UserPreferences.objects.update(
...     settings__theme=NOT_PROVIDED,
...     settings__font__size=20,
... )
>>> user_preferences = UserPreferences.objects.get(pk=user_preferences.pk)
>>> print(user_preferences.settings)
{'notifications': True, 'font': {'size': 20, 'name': 'Arial'}}
```

This feature is implemented using the newly added databases functions `JSONSet` and `JSONRemove` which serves as abstraction on top of the suitable functions on each database backend.

This PR is a part of the [Google Summer of Code](https://summerofcode.withgoogle.com/programs/2024/projects/dav6kK0h) program.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
