### PR TITLE
Doc'd databases connection thread caveat

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -97,7 +97,7 @@ either restore Django's defaults at the end of each request, force an
 appropriate value at the beginning of each request, or disable persistent
 connections.
 
-If a connection is created in a long-running process, outside of Django’s
+If a connection is created in a long-running process or a sub-thread, outside of Django’s
 request-response cycle, the connection will remain open until explicitly
 closed, or timeout occurs. You can use ``django.db.close_old_connections()`` to
 close all old or unusable connections.


### PR DESCRIPTION
# Trac ticket number
N/A

(Related thou: https://code.djangoproject.com/ticket/35672)

# Branch description
Clarify it is not only long-running processes that has this mentioned caveat, also sub-threads. Make the caveat easier detected when one search for `thread` in the document.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
