### PR TITLE
Fixed #35690 -- Raise TypeError if QuerySet.in_bulk is called after QuerySet.values or QuerySet.values_list.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1101,6 +1101,8 @@ class QuerySet(AltersData):
         """
         if self.query.is_sliced:
             raise TypeError("Cannot use 'limit' or 'offset' with in_bulk().")
+        if not issubclass(self._iterable_class, ModelIterable):
+            raise TypeError("in_bulk() cannot be used with values() or values_list().")
         opts = self.model._meta
         unique_fields = [
             constraint.fields[0]

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -327,6 +327,13 @@ class LookupTests(TestCase):
         with self.assertRaisesMessage(TypeError, msg):
             Article.objects.all()[0:5].in_bulk([self.a1.id, self.a2.id])
 
+    def test_in_bulk_not_model_iterable(self):
+        msg = "in_bulk() cannot be used with values() or values_list()."
+        with self.assertRaisesMessage(TypeError, msg):
+            Author.objects.values().in_bulk()
+        with self.assertRaisesMessage(TypeError, msg):
+            Author.objects.values_list().in_bulk()
+
     def test_values(self):
         # values() returns a list of dictionaries instead of object instances --
         # and you can specify which fields you want to retrieve.


### PR DESCRIPTION
# Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[35690](https://code.djangoproject.com/ticket/35690)

# Branch description

When calling QuerySet.values() followed by QuerySet.in_bulk(), an `AttributeError` is raised, which doesn't directly give the user feedback on how to resolve the error or what the user even did wrong. This adds an additional check and raises a `TypeError` with the appropriate message.

I can try and define the behavior, but I wanted to submit the simpler pull request for review before working on a more complicated fix.

Let me know if docs are required. A simple short note on the `in_bulk` method might be sufficient.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
