### PR TITLE
Fixed #35690 -- Add support for calling QuerySet.in_bulk() after QuerySet.values()

### DIFF
--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -205,6 +205,23 @@ class LookupTests(TestCase):
         with self.assertRaises(TypeError):
             Article.objects.in_bulk(headline__startswith="Blah")
 
+    def test_in_bulk_values(self):
+        bulk = Article.objects.values().in_bulk([self.a1.id])
+        self.assertIsInstance(bulk[self.a1.id], dict)
+
+    def test_in_bulk_values_without_pk(self):
+        bulk = Article.objects.values("headline").in_bulk([self.a1.id])
+        self.assertIn("pk", bulk[self.a1.id])
+
+    def test_in_bulk_values_list(self):
+        with self.assertRaises(TypeError):
+            Article.objects.values_list().in_bulk([self.a1.id])
+
+    def test_in_bulk_values_list_named(self) -> None:
+        # At some point this could return tuples
+        with self.assertRaises(TypeError):
+            Article.objects.values_list(named=True).in_bulk([self.a1.id])
+
     def test_in_bulk_lots_of_ids(self):
         test_range = 2000
         max_query_params = connection.features.max_query_params


### PR DESCRIPTION
# Trac ticket number

https://code.djangoproject.com/ticket/35690

# Branch description

Note: I would recommend you consider merging https://github.com/django/django/pull/18496 immediately, as it solves the immediate bug, but this is a feature expanding on the original issue.

This adds support for calling `QuerySet.in_bulk()` after having called `QuerySet.values()`. It works as you would expect: the resulting dictionary contains lists of dictionaries instead of lists of model instances.

The only caveat is that `field_name` is always included in the dictionary, even if you didn't explicitly request it, to avoid a common foot-gun where `pk` isn't included in the `values()` call.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
