### PR TITLE
Fixed #35688 -- Moved setting timezone and role to DatabaseWrapper class methods.

### DIFF
--- a/docs/releases/5.1.1.txt
+++ b/docs/releases/5.1.1.txt
@@ -31,3 +31,7 @@ Bugfixes
 * Adjusted the deprecation warning ``stacklevel`` in
   ``FieldCacheMixin.get_cache_name()`` to correctly point to the offending call
   site (:ticket:`35405`).
+
+* Restored, following a regression in Django 5.1, the ability to override the
+  timezone and role setting behavior used within the ``init_connection_state``
+  method of the PostgreSQL backend (:ticket:`35688`).

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -567,3 +567,49 @@ class Tests(TestCase):
             )
         finally:
             new_connection.close()
+
+    def test_bypass_timezone_configuration(self):
+        from django.db.backends.postgresql.base import DatabaseWrapper
+
+        class CustomDatabaseWrapper(DatabaseWrapper):
+            def _configure_timezone(self, connection):
+                return False
+
+        for Wrapper, commit in [
+            (DatabaseWrapper, True),
+            (CustomDatabaseWrapper, False),
+        ]:
+            with self.subTest(wrapper=Wrapper, commit=commit):
+                new_connection = no_pool_connection()
+                self.addCleanup(new_connection.close)
+
+                # Set the database default time zone to be different from
+                # the time zone in new_connection.settings_dict.
+                with new_connection.cursor() as cursor:
+                    cursor.execute("RESET TIMEZONE")
+                    cursor.execute("SHOW TIMEZONE")
+                    db_default_tz = cursor.fetchone()[0]
+                new_tz = "Europe/Paris" if db_default_tz == "UTC" else "UTC"
+                new_connection.timezone_name = new_tz
+
+                settings = new_connection.settings_dict.copy()
+                conn = new_connection.connection
+                self.assertIs(Wrapper(settings)._configure_connection(conn), commit)
+
+    def test_bypass_role_configuration(self):
+        from django.db.backends.postgresql.base import DatabaseWrapper
+
+        class CustomDatabaseWrapper(DatabaseWrapper):
+            def _configure_role(self, connection):
+                return False
+
+        new_connection = no_pool_connection()
+        self.addCleanup(new_connection.close)
+        new_connection.connect()
+
+        settings = new_connection.settings_dict.copy()
+        settings["OPTIONS"]["assume_role"] = "django_nonexistent_role"
+        conn = new_connection.connection
+        self.assertIs(
+            CustomDatabaseWrapper(settings)._configure_connection(conn), False
+        )


### PR DESCRIPTION
# Trac ticket number

ticket-35688

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
