### PR TITLE
Updated GitHub PR template headings to level 4.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
-# Trac ticket number
+#### Trac ticket number
 <!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->
 
 ticket-XXXXX
 
-# Branch description
+#### Branch description
 Provide a concise overview of the issue or rationale behind the proposed changes.
 
-# Checklist
+#### Checklist
 - [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
 - [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
 - [ ] I have checked the "Has patch" ticket flag in the Trac system.


### PR DESCRIPTION
# Trac ticket number
N/A

# Branch description
This is a document flow and accessibility improvement: The GitHub PR description lives in an element with an H3 heading, so any headings inside cannot be H1–H3.

# Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
