### PR TITLE
Fixed #35689 -- Handled custom labels in LabelCommand.missing_args_message.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -672,7 +672,13 @@ class LabelCommand(BaseCommand):
     """
 
     label = "label"
-    missing_args_message = "Enter at least one %s." % label
+    missing_args_message = "Enter at least one %s."
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.missing_args_message == LabelCommand.missing_args_message:
+            self.missing_args_message = self.missing_args_message % self.label
 
     def add_arguments(self, parser):
         parser.add_argument("args", metavar=self.label, nargs="+")

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -25,6 +25,7 @@ from django.core.management import (
     color,
     execute_from_command_line,
 )
+from django.core.management.base import LabelCommand
 from django.core.management.commands.loaddata import Command as LoaddataCommand
 from django.core.management.commands.runserver import Command as RunserverCommand
 from django.core.management.commands.testserver import Command as TestserverCommand
@@ -2279,6 +2280,20 @@ class CommandTypes(AdminScriptTestCase):
             "False), ('no_color', False), ('pythonpath', None), "
             "('settings', None), ('traceback', False), ('verbosity', 1)]",
         )
+
+    def test_custom_label_command_custom_missing_args_message(self):
+        class Command(LabelCommand):
+            missing_args_message = "Missing argument."
+
+        with self.assertRaisesMessage(CommandError, "Error: Missing argument."):
+            call_command(Command())
+
+    def test_custom_label_command_none_missing_args_message(self):
+        class Command(LabelCommand):
+            missing_args_message = None
+
+        with self.assertRaisesMessage(CommandError, ""):
+            call_command(Command())
 
     def test_suppress_base_options_command_help(self):
         args = ["suppress_base_options_command", "--help"]

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -124,6 +124,11 @@ class TestFindStatic(TestDefaults, CollectionTestCase):
             searched_locations,
         )
 
+    def test_missing_args_message(self):
+        msg = "Enter at least one staticfile."
+        with self.assertRaisesMessage(CommandError, msg):
+            call_command("findstatic")
+
 
 class TestConfiguration(StaticFilesTestCase):
     def test_location_empty(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->
[ticket_35689](https://code.djangoproject.com/ticket/35689)

#### Branch description
 The `missing_args_message` attribute of the `django.core.management.base.LabelCommand` is hard-coded using the default value of `label = "label"`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
