### PR TITLE
Fixed #35703 -- Returned defult url conf when running under prefix.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -620,7 +620,7 @@ def technical_404_response(request, exception):
     else:
         resolved = False
         if not tried or (  # empty URLconf
-            request.path == "/"
+            request.path_info == "/"
             and len(tried) == 1
             and len(tried[0]) == 1  # default URLconf
             and getattr(tried[0][0], "app_name", "")

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -398,6 +398,15 @@ class DebugViewTests(SimpleTestCase):
             response, "<h1>The install worked successfully! Congratulations!</h1>"
         )
 
+    @override_settings(
+        ROOT_URLCONF="view_tests.default_urls", FORCE_SCRIPT_NAME="/FORCED_PREFIX"
+    )
+    def test_default_urlconf_script_name(self):
+        response = self.client.request(**{"path": "/FORCED_PREFIX/"})
+        self.assertContains(
+            response, "<h1>The install worked successfully! Congratulations!</h1>"
+        )
+
     @override_settings(ROOT_URLCONF="view_tests.regression_21530_urls")
     def test_regression_21530(self):
         """


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35703

#### Branch description

When Django runs onder a prefix (often described by SCRIPT_NAME for cgi/wsgi or root_path in asgi land).
The nice default view showing:
"The install worked successfully! Congratulations!
is not shown.

I hit this but when trying out if I could run django on py.cafe (a platform that can run web applications on pyodide)
at https://py.cafe/maartenbreddels/django-start-template (which includes this patch)

For technical reasons, we need to run under a prefix (we configure root_path in the asgi scope), and django was giving me a 404. This gave the (false) impression django did not support running under a prefix (StackOverflow falsely confirmed this suspicion). Luckily it's a small bug in django

Since path_info does not contain the prefix, path_info should be used, and not path
#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
