### PR TITLE
Fixes [#25656] Stop displaying links in recent changes when user does not have view permission

### DIFF
--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -162,6 +162,16 @@ class LogEntry(models.Model):
     def is_deletion(self):
         return self.action_flag == DELETION
 
+    def get_url_for_user(self):
+        if not self.content_type:
+            return self.get_admin_url()
+
+        view_permission_name = f"{self.content_type.app_label}.view_{self.content_type.model}"
+        if self.user.has_perm(view_permission_name):
+            return self.get_admin_url()
+
+        return None
+
     def get_change_message(self):
         """
         If self.change_message is a JSON structure, interpret it as a change

--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -166,7 +166,9 @@ class LogEntry(models.Model):
         if not self.content_type:
             return self.get_admin_url()
 
-        view_permission_name = f"{self.content_type.app_label}.view_{self.content_type.model}"
+        view_permission_name = (
+            f"{self.content_type.app_label}.view_{self.content_type.model}"
+        )
         if self.user.has_perm(view_permission_name):
             return self.get_admin_url()
 

--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -31,10 +31,10 @@
             {% for entry in admin_log %}
             <li class="{% if entry.is_addition %}addlink{% endif %}{% if entry.is_change %}changelink{% endif %}{% if entry.is_deletion %}deletelink{% endif %}">
                 <span class="visually-hidden">{% if entry.is_addition %}{% translate 'Added:' %}{% elif entry.is_change %}{% translate 'Changed:' %}{% elif entry.is_deletion %}{% translate 'Deleted:' %}{% endif %}</span>
-                {% if entry.is_deletion or not entry.get_admin_url %}
+                {% if entry.is_deletion or not entry.url %}
                     {{ entry.object_repr }}
                 {% else %}
-                    <a href="{{ entry.get_admin_url }}">{{ entry.object_repr }}</a>
+                    <a href="{{ entry.url }}">{{ entry.object_repr }}</a>
                 {% endif %}
                 <br>
                 {% if entry.content_type %}

--- a/django/contrib/admin/templatetags/log.py
+++ b/django/contrib/admin/templatetags/log.py
@@ -20,8 +20,8 @@ class AdminLogNode(template.Node):
                 user_id = context[self.user].pk
             entries = entries.filter(user__pk=user_id)
         filtered_context = entries.select_related("content_type", "user")[
-                           : int(self.limit)
-                           ]
+            : int(self.limit)
+        ]
         for entry in filtered_context:
             content_type = entry.content_type
             if not content_type:

--- a/django/contrib/admin/templatetags/log.py
+++ b/django/contrib/admin/templatetags/log.py
@@ -19,22 +19,9 @@ class AdminLogNode(template.Node):
             if not user_id.isdigit():
                 user_id = context[self.user].pk
             entries = entries.filter(user__pk=user_id)
-        filtered_context = entries.select_related("content_type", "user")[
-            : int(self.limit)
-        ]
-        for entry in filtered_context:
-            content_type = entry.content_type
-            if not content_type:
-                entry.url = entry.get_admin_url()
-                continue
-            user = entry.user
-            view_permission_name = f"{content_type.app_label}.view_{content_type.model}"
-            user_has_permission = user.has_perm(view_permission_name)
-            if user_has_permission:
-                entry.url = entry.get_admin_url()
-            else:
-                entry.url = None
-        context[self.varname] = filtered_context
+        for entry in entries:
+            entry.url = entry.get_url_for_user()
+        context[self.varname] = entries[: int(self.limit)]
         return ""
 
 

--- a/tests/admin_utils/test_logentry.py
+++ b/tests/admin_utils/test_logentry.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from django.contrib.admin.models import ADDITION, CHANGE, DELETION, LogEntry
 from django.contrib.admin.utils import quote
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -350,6 +350,32 @@ class LogEntryTests(TestCase):
         response = self.client.get(reverse("admin:index"))
         counted_presence_after = response.content.count(should_contain)
         self.assertEqual(counted_presence_before - 1, counted_presence_after)
+
+    def test_recent_actions_user_lacks_view_permission(self):
+        # No permission to view articles. Log is a span with no link.
+        response = self.client.get(reverse("admin:index"))
+        should_contain = """<span class="mini quiet">Article</span>"""
+        self.assertContains(response, should_contain)
+
+        # Add permission to view articles. Log is a link.
+        logentry = LogEntry.objects.get(content_type__model__iexact="article")
+        view_permission_name = f"{logentry.content_type.app_label}.view_{logentry.content_type.model}"
+        view_article_permission = Permission.objects.create(
+            name=f"Can view {logentry.content_type.model}",
+            content_type=logentry.content_type,
+            codename=view_permission_name,
+        )
+        self.user.user_permissions.add(view_article_permission)
+
+        response = self.client.get(reverse("admin:index"))
+        expected_log_entry_link = reverse(
+            "admin:admin_utils_article_change", args=(quote(self.a1.pk),)
+        )
+        should_contain = """<a href="%s">%s</a>""" % (
+            escape(expected_log_entry_link),
+            escape(repr(self.a1)),
+        )
+        self.assertContains(response, should_contain)
 
     def test_proxy_model_content_type_is_used_for_log_entries(self):
         """

--- a/tests/admin_utils/test_logentry.py
+++ b/tests/admin_utils/test_logentry.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from django.contrib.admin.models import ADDITION, CHANGE, DELETION, LogEntry
 from django.contrib.admin.utils import quote
-from django.contrib.auth.models import User, Permission
+from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -359,7 +359,9 @@ class LogEntryTests(TestCase):
 
         # Add permission to view articles. Log is a link.
         logentry = LogEntry.objects.get(content_type__model__iexact="article")
-        view_permission_name = f"{logentry.content_type.app_label}.view_{logentry.content_type.model}"
+        view_permission_name = (
+            f"{logentry.content_type.app_label}.view_{logentry.content_type.model}"
+        )
         view_article_permission = Permission.objects.create(
             name=f"Can view {logentry.content_type.model}",
             content_type=logentry.content_type,


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

Ticket: https://code.djangoproject.com/ticket/25656.

#### Branch description
Currently if a user in the admin portal has a add permission on a model, and they add it. They will see a clickable link in the log entries sidebar, which results in a 403 when clicked as the user does not have view permission on said object.  

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
