### PR TITLE
Fixed #35702 -- Removed connection pooling note for mysql drivers.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -479,8 +479,6 @@ MySQL has a couple drivers that implement the Python Database API described in
 
 .. _MySQL Connector/Python: https://dev.mysql.com/downloads/connector/python/
 
-These drivers are thread-safe and provide connection pooling.
-
 In addition to a DB API driver, Django needs an adapter to access the database
 drivers from its ORM. Django provides an adapter for mysqlclient while MySQL
 Connector/Python includes `its own`_.


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35702

#### Branch description
This branch makes changes to docs to clarify `mysqlclient` does not have built-in connection pooling.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant docs, including release notes if applicable.
