### PR TITLE
Fixed typo in docs/ref/models/expressions.txt.

### DIFF
--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -975,9 +975,9 @@ frame includes all rows from the partition to the last row in the set.
 The accepted values for the ``start`` and ``end`` arguments are ``None``, an
 integer, or zero. A negative integer for ``start`` results in ``N PRECEDING``,
 while ``None`` yields ``UNBOUNDED PRECEDING``. In ``ROWS`` mode, a positive
-integer can be used for ```start`` resulting in ``N FOLLOWING``. Positive
+integer can be used for ``start`` resulting in ``N FOLLOWING``. Positive
 integers are accepted for ``end`` and results in ``N FOLLOWING``. In ``ROWS``
-mode, a negative integer can be used for ```end`` resulting in ``N PRECEDING``.
+mode, a negative integer can be used for ``end`` resulting in ``N PRECEDING``.
 For both ``start`` and ``end``, zero will return ``CURRENT ROW``.
 
 There's a difference in what ``CURRENT ROW`` includes. When specified in

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -1097,7 +1097,7 @@ calling the appropriate methods on the wrapped expression.
 
     .. attribute:: set_returning
 
-    .. versionadded:: 5.2
+        .. versionadded:: 5.2
 
         Tells Django that this expression contains a set-returning function,
         enforcing subquery evaluation. It's used, for example, to allow some


### PR DESCRIPTION
Current docs:

![image](https://github.com/user-attachments/assets/1c5601ff-9546-4254-9bfd-7fa360bbce16)

----

![image](https://github.com/user-attachments/assets/ba1b8423-6fea-4aaf-887d-19fb721bfee3)
