### PR TITLE
Fixed #35717 -- Reduced Create/RemoveCollation operations when optimizing migrations.

### DIFF
--- a/django/contrib/postgres/operations.py
+++ b/django/contrib/postgres/operations.py
@@ -237,6 +237,11 @@ class CreateCollation(CollationOperation):
     def migration_name_fragment(self):
         return "create_collation_%s" % self.name.lower()
 
+    def reduce(self, operation, app_label):
+        if isinstance(operation, RemoveCollation) and self.name == operation.name:
+            return []
+        return super().reduce(operation, app_label)
+
 
 class RemoveCollation(CollationOperation):
     """Remove a collation."""

--- a/tests/postgres_tests/test_operations.py
+++ b/tests/postgres_tests/test_operations.py
@@ -318,7 +318,7 @@ class CreateExtensionTests(PostgreSQLTestCase):
 
 
 @unittest.skipUnless(connection.vendor == "postgresql", "PostgreSQL specific tests.")
-class CreateCollationTests(PostgreSQLTestCase):
+class CreateCollationTests(OptimizerTestBase, PostgreSQLTestCase):
     app_label = "test_allow_create_collation"
 
     @override_settings(DATABASE_ROUTERS=[NoMigrationRouter()])
@@ -457,6 +457,24 @@ class CreateCollationTests(PostgreSQLTestCase):
             "    provider='icu',\n"
             "    deterministic=False,\n"
             "),",
+        )
+
+    def test_reduce_create_remove(self):
+        self.assertOptimizesTo(
+            [
+                CreateCollation(
+                    "sample_collation",
+                    "und-u-ks-level2",
+                    provider="icu",
+                    deterministic=False,
+                ),
+                RemoveCollation(
+                    "sample_collation",
+                    # Different locale
+                    "de-u-ks-level1",
+                ),
+            ],
+            [],
         )
 
 


### PR DESCRIPTION
#### Trac ticket number

ticket-35717

#### Branch description

Add `CreateCollation.reduce()` which will optimize away the addition + removal of a collation.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
