### PR TITLE
Refs #35706 -- Prefixed 'Error:' to titles of admin pages with form errors.

### DIFF
--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -2,6 +2,7 @@
 {% load i18n static %}
 {% load admin_urls %}
 
+{% block title %}{% if form.errors %}{{ _('Error:') }} {% endif %}{{ block.super }}{% endblock %}
 {% block extrastyle %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -1,6 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_urls static admin_modify %}
 
+{% block title %}{% if errors %}{{ _('Error:') }} {% endif %}{{ block.super }}{% endblock %}
 {% block extrahead %}{{ block.super }}
 <script src="{% url 'admin:jsi18n' %}"></script>
 {{ media }}

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -1,6 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_urls static admin_list %}
 
+{% block title %}{% if cl.formset and cl.formset.errors %}{{ _('Error:') }} {% endif %}{{ block.super }}{% endblock %}
 {% block extrastyle %}
   {{ block.super }}
   <link rel="stylesheet" href="{% static "admin/css/changelists.css" %}">

--- a/django/contrib/admin/templates/admin/login.html
+++ b/django/contrib/admin/templates/admin/login.html
@@ -1,6 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
+{% block title %}{% if form.errors %}{{ _('Error:') }} {% endif %}{{ block.super }}{% endblock %}
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/login.css" %}">
 {{ form.media }}
 {% endblock %}

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -1,5 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
+
+{% block title %}{% if form.errors %}{{ _('Error:') }} {% endif %}{{ block.super }}{% endblock %}
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
 {% block userlinks %}
   {% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% translate 'Documentation' %}</a> / {% endif %} {% translate 'Change password' %} /

--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -1,6 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
+{% block title %}{% if form.new_password1.errors or form.new_password2.errors %}{{ _('Error:') }} {% endif %}{{ block.super }}{% endblock %}
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">

--- a/django/contrib/admin/templates/registration/password_reset_form.html
+++ b/django/contrib/admin/templates/registration/password_reset_form.html
@@ -1,6 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
+{% block title %}{% if form.email.errors %}{{ _('Error:') }} {% endif %}{{ block.super }}{% endblock %}
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1264,6 +1264,24 @@ class ChangeListTests(TestCase):
             # Check only the first few characters since the UUID may have dashes.
             self.assertIn(str(a.pk)[:8], context.captured_queries[4]["sql"])
 
+    def test_list_editable_error_title(self):
+        a = Swallow.objects.create(origin="Swallow A", load=4, speed=1)
+        Swallow.objects.create(origin="Swallow B", load=2, speed=2)
+        data = {
+            "form-TOTAL_FORMS": "2",
+            "form-INITIAL_FORMS": "2",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-uuid": str(a.pk),
+            "form-0-load": "invalid",
+            "_save": "Save",
+        }
+        superuser = self._create_superuser("superuser")
+        self.client.force_login(superuser)
+        changelist_url = reverse("admin:admin_changelist_swallow_changelist")
+        response = self.client.post(changelist_url, data=data)
+        self.assertContains(response, "Error: Select swallow to change")
+
     def test_deterministic_order_for_unordered_model(self):
         """
         The primary key is used in the ordering of the changelist's results to

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1508,6 +1508,24 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         self.assertContains(response, "<h1>Change article</h1>")
         self.assertContains(response, "<h2>Article 2</h2>")
 
+    def test_error_in_titles(self):
+        for url, subtitle in [
+            (
+                reverse("admin:admin_views_article_change", args=(self.a1.pk,)),
+                "Article 1 | Change article",
+            ),
+            (reverse("admin:admin_views_article_add"), "Add article"),
+            (reverse("admin:login"), "Log in"),
+            (reverse("admin:password_change"), "Password change"),
+            (
+                reverse("admin:auth_user_password_change", args=(self.superuser.id,)),
+                "Change password: super",
+            ),
+        ]:
+            with self.subTest(url=url, subtitle=subtitle):
+                response = self.client.post(url, {})
+                self.assertContains(response, f"<title>Error: {subtitle}")
+
     def test_view_subtitle_per_object(self):
         viewuser = User.objects.create_user(
             username="viewuser",

--- a/tests/auth_tests/test_templates.py
+++ b/tests/auth_tests/test_templates.py
@@ -37,6 +37,12 @@ class AuthTemplateTests(TestCase):
         )
         self.assertContains(response, "<h1>Password reset</h1>")
 
+    def test_password_reset_view_error_title(self):
+        response = self.client.post(reverse("password_reset"), {})
+        self.assertContains(
+            response, "<title>Error: Password reset | Django site admin</title>"
+        )
+
     def test_password_reset_done_view(self):
         response = PasswordResetDoneView.as_view()(self.request)
         self.assertContains(
@@ -75,6 +81,19 @@ class AuthTemplateTests(TestCase):
         self.assertContains(
             response,
             '<input class="hidden" autocomplete="username" value="jsmith">',
+        )
+
+    def test_password_reset_confirm_view_error_title(self):
+        client = PasswordResetConfirmClient()
+        default_token_generator = PasswordResetTokenGenerator()
+        token = default_token_generator.make_token(self.user)
+        uidb64 = urlsafe_base64_encode(str(self.user.pk).encode())
+        url = reverse(
+            "password_reset_confirm", kwargs={"uidb64": uidb64, "token": token}
+        )
+        response = client.post(url, {})
+        self.assertContains(
+            response, "<title>Error: Enter new password | Django site admin</title>"
         )
 
     @override_settings(AUTH_USER_MODEL="auth_tests.CustomUser")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35706

#### Branch description
This Pull Request addresses part of ticket #35706. The change ensures that if there are any errors in the Add or Update forms within the Django admin interface, the title of the document will be prefixed with "Error:".

A test has also been added for this.

### Screenshot
![image](https://github.com/user-attachments/assets/850850ee-e042-41c0-8407-dc5a2e992312)

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
