### PR TITLE
Fixed #35727 -- Added HttpResponse.text property.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -21,6 +21,7 @@ from django.http.cookie import SimpleCookie
 from django.utils import timezone
 from django.utils.datastructures import CaseInsensitiveMapping
 from django.utils.encoding import iri_to_uri
+from django.utils.functional import cached_property
 from django.utils.http import content_disposition_header, http_date
 from django.utils.regex_helper import _lazy_re_compile
 
@@ -408,6 +409,11 @@ class HttpResponse(HttpResponseBase):
             content = self.make_bytes(value)
         # Create a list of properly encoded bytestrings to support write().
         self._container = [content]
+        self.__dict__.pop("text", None)
+
+    @cached_property
+    def text(self):
+        return self.content.decode(self.charset or "utf-8")
 
     def __iter__(self):
         return iter(self._container)
@@ -458,6 +464,12 @@ class StreamingHttpResponse(HttpResponseBase):
         raise AttributeError(
             "This %s instance has no `content` attribute. Use "
             "`streaming_content` instead." % self.__class__.__name__
+        )
+
+    @property
+    def text(self):
+        raise AttributeError(
+            "This %s instance has no `text` attribute." % self.__class__.__name__
         )
 
     @property

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -947,9 +947,7 @@ class ClientMixin:
                     'Content-Type header is "%s", not "application/json"'
                     % response.get("Content-Type")
                 )
-            response._json = json.loads(
-                response.content.decode(response.charset), **extra
-            )
+            response._json = json.loads(response.text, **extra)
         return response._json
 
     def _follow_redirect(

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -583,7 +583,11 @@ class SimpleTestCase(unittest.TestCase):
         content_repr = safe_repr(content)
         if not isinstance(text, bytes) or html:
             text = str(text)
-            content = content.decode(response.charset)
+            content = (
+                content.decode(response.charset)
+                if response.streaming
+                else response.text
+            )
             text_repr = "'%s'" % text
         else:
             text_repr = repr(text)

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -833,6 +833,13 @@ Attributes
 
     A bytestring representing the content, encoded from a string if necessary.
 
+.. attribute:: HttpResponse.text
+
+    .. versionadded:: 5.2
+
+    A string representation of :attr:`HttpResponse.content`, decoded using the
+    response's :attr:`HttpResponse.charset` (defaulting to ``UTF-8`` if empty).
+
 .. attribute:: HttpResponse.cookies
 
     A :py:obj:`http.cookies.SimpleCookie` object holding the cookies included
@@ -1271,6 +1278,8 @@ with the following notable differences:
 * It has no ``content`` attribute. Instead, it has a
   :attr:`~StreamingHttpResponse.streaming_content` attribute. This can be used
   in middleware to wrap the response iterable, but should not be consumed.
+
+* It has no ``text`` attribute, as it would require iterating the response object.
 
 * You cannot use the file-like object ``tell()`` or ``write()`` methods.
   Doing so will raise an exception.

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -226,6 +226,9 @@ Models
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
+* The new :attr:`.HttpResponse.text` property provides the string representation
+  of :attr:`.HttpResponse.content`.
+
 * The new :meth:`.HttpRequest.get_preferred_type` method can be used to query
   the preferred media type the client accepts.
 

--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -102,7 +102,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
         request.user = self.superuser
         response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
+        data = json.loads(response.text)
         self.assertEqual(
             data,
             {
@@ -120,7 +120,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
         request.user = self.superuser
         response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
+        data = json.loads(response.text)
         self.assertEqual(
             data,
             {
@@ -150,7 +150,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
         request.user = self.superuser
         response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
+        data = json.loads(response.text)
         self.assertEqual(
             data,
             {
@@ -184,7 +184,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
                 request.user = self.superuser
                 response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
                 self.assertEqual(response.status_code, 200)
-                data = json.loads(response.content.decode("utf-8"))
+                data = json.loads(response.text)
                 self.assertEqual(
                     data,
                     {
@@ -205,7 +205,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
         request.user = self.superuser
         response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
+        data = json.loads(response.text)
         self.assertEqual(
             data,
             {
@@ -250,7 +250,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
         request.user = self.superuser
         response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
+        data = json.loads(response.text)
         self.assertEqual(
             data,
             {
@@ -306,7 +306,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
         with model_admin(Question, DistinctQuestionAdmin):
             response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
+        data = json.loads(response.text)
         self.assertEqual(len(data["results"]), 3)
 
     def test_missing_search_fields(self):
@@ -335,7 +335,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
         with model_admin(Question, PKOrderingQuestionAdmin):
             response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
+        data = json.loads(response.text)
         self.assertEqual(
             data,
             {
@@ -352,7 +352,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
         with model_admin(Question, PKOrderingQuestionAdmin):
             response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
+        data = json.loads(response.text)
         self.assertEqual(
             data,
             {
@@ -380,7 +380,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
             request
         )
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
+        data = json.loads(response.text)
         self.assertEqual(
             data,
             {

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -296,9 +296,7 @@ class AdminViewBasicTestCase(TestCase):
         self.assertLess(
             response.content.index(text1.encode()),
             response.content.index(text2.encode()),
-            (failing_msg or "")
-            + "\nResponse:\n"
-            + response.content.decode(response.charset),
+            (failing_msg or "") + "\nResponse:\n" + response.text,
         )
 
 
@@ -3604,7 +3602,7 @@ class AdminViewDeletedObjectsTest(TestCase):
         response = self.client.get(
             reverse("admin:admin_views_villain_delete", args=(self.v1.pk,))
         )
-        self.assertRegex(response.content.decode(), pattern)
+        self.assertRegex(response.text, pattern)
 
     def test_cyclic(self):
         """
@@ -8209,7 +8207,7 @@ class AdminKeepChangeListFiltersTests(TestCase):
         # Check the `change_view` link has the correct querystring.
         detail_link = re.search(
             '<a href="(.*?)">{}</a>'.format(self.joepublicuser.username),
-            response.content.decode(),
+            response.text,
         )
         self.assertURLEqual(detail_link[1], self.get_change_url())
 
@@ -8221,7 +8219,7 @@ class AdminKeepChangeListFiltersTests(TestCase):
         # Check the form action.
         form_action = re.search(
             '<form action="(.*?)" method="post" id="user_form" novalidate>',
-            response.content.decode(),
+            response.text,
         )
         self.assertURLEqual(
             form_action[1], "?%s" % self.get_preserved_filters_querystring()
@@ -8229,13 +8227,13 @@ class AdminKeepChangeListFiltersTests(TestCase):
 
         # Check the history link.
         history_link = re.search(
-            '<a href="(.*?)" class="historylink">History</a>', response.content.decode()
+            '<a href="(.*?)" class="historylink">History</a>', response.text
         )
         self.assertURLEqual(history_link[1], self.get_history_url())
 
         # Check the delete link.
         delete_link = re.search(
-            '<a href="(.*?)" class="deletelink">Delete</a>', response.content.decode()
+            '<a href="(.*?)" class="deletelink">Delete</a>', response.text
         )
         self.assertURLEqual(delete_link[1], self.get_delete_url())
 
@@ -8275,7 +8273,7 @@ class AdminKeepChangeListFiltersTests(TestCase):
         self.client.force_login(viewuser)
         response = self.client.get(self.get_change_url())
         close_link = re.search(
-            '<a href="(.*?)" class="closelink">Close</a>', response.content.decode()
+            '<a href="(.*?)" class="closelink">Close</a>', response.text
         )
         close_link = close_link[1].replace("&amp;", "&")
         self.assertURLEqual(close_link, self.get_changelist_url())
@@ -8293,7 +8291,7 @@ class AdminKeepChangeListFiltersTests(TestCase):
         # Check the form action.
         form_action = re.search(
             '<form action="(.*?)" method="post" id="user_form" novalidate>',
-            response.content.decode(),
+            response.text,
         )
         self.assertURLEqual(
             form_action[1], "?%s" % self.get_preserved_filters_querystring()

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -1521,7 +1521,7 @@ class ChangelistTests(MessagesTestMixin, AuthViewsTestCase):
         # Test the link inside password field help_text.
         rel_link = re.search(
             r'<a class="button" href="([^"]*)">Reset password</a>',
-            response.content.decode(),
+            response.text,
         )[1]
         self.assertEqual(urljoin(user_change_url, rel_link), password_change_url)
 
@@ -1617,7 +1617,7 @@ class ChangelistTests(MessagesTestMixin, AuthViewsTestCase):
         # Test the link inside password field help_text.
         rel_link = re.search(
             r'<a class="button" href="([^"]*)">Set password</a>',
-            response.content.decode(),
+            response.text,
         )[1]
         self.assertEqual(urljoin(user_change_url, rel_link), password_change_url)
 

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -1481,9 +1481,11 @@ class CsrfInErrorHandlingViewsTests(CsrfFunctionTestMixin, SimpleTestCase):
         response = self.client.get("/does not exist/")
         # The error handler returns status code 599.
         self.assertEqual(response.status_code, 599)
-        token1 = response.content.decode("ascii")
+        response.charset = "ascii"
+        token1 = response.text
         response = self.client.get("/does not exist/")
         self.assertEqual(response.status_code, 599)
-        token2 = response.content.decode("ascii")
+        response.charset = "ascii"
+        token2 = response.text
         secret2 = _unmask_cipher_token(token2)
         self.assertMaskedSecretCorrect(token1, secret2)

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -630,7 +630,7 @@ class JsonResponseTests(SimpleTestCase):
     def test_json_response_non_ascii(self):
         data = {"key": "łóżko"}
         response = JsonResponse(data)
-        self.assertEqual(json.loads(response.content.decode()), data)
+        self.assertEqual(json.loads(response.text), data)
 
     def test_json_response_raises_type_error_with_default_setting(self):
         with self.assertRaisesMessage(
@@ -642,16 +642,16 @@ class JsonResponseTests(SimpleTestCase):
 
     def test_json_response_text(self):
         response = JsonResponse("foobar", safe=False)
-        self.assertEqual(json.loads(response.content.decode()), "foobar")
+        self.assertEqual(json.loads(response.text), "foobar")
 
     def test_json_response_list(self):
         response = JsonResponse(["foo", "bar"], safe=False)
-        self.assertEqual(json.loads(response.content.decode()), ["foo", "bar"])
+        self.assertEqual(json.loads(response.text), ["foo", "bar"])
 
     def test_json_response_uuid(self):
         u = uuid.uuid4()
         response = JsonResponse(u, safe=False)
-        self.assertEqual(json.loads(response.content.decode()), str(u))
+        self.assertEqual(json.loads(response.text), str(u))
 
     def test_json_response_custom_encoder(self):
         class CustomDjangoJSONEncoder(DjangoJSONEncoder):
@@ -659,11 +659,11 @@ class JsonResponseTests(SimpleTestCase):
                 return json.dumps({"foo": "bar"})
 
         response = JsonResponse({}, encoder=CustomDjangoJSONEncoder)
-        self.assertEqual(json.loads(response.content.decode()), {"foo": "bar"})
+        self.assertEqual(json.loads(response.text), {"foo": "bar"})
 
     def test_json_response_passing_arguments_to_json_dumps(self):
         response = JsonResponse({"foo": "bar"}, json_dumps_params={"indent": 2})
-        self.assertEqual(response.content.decode(), '{\n  "foo": "bar"\n}')
+        self.assertEqual(response.text, '{\n  "foo": "bar"\n}')
 
 
 class StreamingHttpResponseTests(SimpleTestCase):

--- a/tests/serializers/tests.py
+++ b/tests/serializers/tests.py
@@ -155,7 +155,7 @@ class SerializersTestBase:
             if isinstance(stream, StringIO):
                 self.assertEqual(string_data, stream.getvalue())
             else:
-                self.assertEqual(string_data, stream.content.decode())
+                self.assertEqual(string_data, stream.text)
 
     def test_serialize_specific_fields(self):
         obj = ComplexModel(field1="first", field2="second", field3="third")

--- a/tests/sitemaps_tests/test_generic.py
+++ b/tests/sitemaps_tests/test_generic.py
@@ -45,7 +45,7 @@ class GenericViewsSitemapTests(SitemapTestsBase):
             "%s\n"
             "</urlset>"
         ) % expected
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     def test_generic_sitemap_lastmod(self):
         test_model = TestModel.objects.first()
@@ -61,7 +61,7 @@ class GenericViewsSitemapTests(SitemapTestsBase):
             self.base_url,
             test_model.pk,
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
         self.assertEqual(
             response.headers["Last-Modified"], "Wed, 13 Mar 2013 10:00:00 GMT"
         )
@@ -89,4 +89,4 @@ class GenericViewsSitemapTests(SitemapTestsBase):
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <sitemap><loc>http://example.com/simple/sitemap-generic.xml</loc><lastmod>2013-03-13T10:00:00</lastmod></sitemap>
 </sitemapindex>"""
-        self.assertXMLEqual(response.content.decode("utf-8"), expected_content)
+        self.assertXMLEqual(response.text, expected_content)

--- a/tests/sitemaps_tests/test_http.py
+++ b/tests/sitemaps_tests/test_http.py
@@ -29,7 +29,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             self.base_url,
             date.today(),
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     def test_sitemap_not_callable(self):
         """A sitemap may not be callable."""
@@ -42,7 +42,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             self.base_url,
             date.today(),
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     def test_paged_sitemap(self):
         """A sitemap may have multiple pages."""
@@ -54,7 +54,7 @@ class HTTPSitemapTests(SitemapTestsBase):
 """.format(
             self.base_url, date.today()
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     @override_settings(
         TEMPLATES=[
@@ -76,7 +76,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             self.base_url,
             date.today(),
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     def test_simple_sitemap_section(self):
         "A simple sitemap section can be rendered"
@@ -92,7 +92,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             self.base_url,
             date.today(),
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     def test_no_section(self):
         response = self.client.get("/simple/sitemap-simple2.xml")
@@ -126,7 +126,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             self.base_url,
             date.today(),
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     @override_settings(
         TEMPLATES=[
@@ -148,7 +148,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             self.base_url,
             date.today(),
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     def test_sitemap_last_modified(self):
         "Last-Modified header is set correctly"
@@ -268,7 +268,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             "<changefreq>never</changefreq><priority>0.5</priority></url>\n"
             "</urlset>"
         ) % date.today()
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     def test_sitemap_get_urls_no_site_1(self):
         """
@@ -316,7 +316,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             self.base_url,
             date.today(),
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     def test_x_robots_sitemap(self):
         response = self.client.get("/simple/index.xml")
@@ -346,7 +346,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             "<changefreq>never</changefreq><priority>0.5</priority></url>\n"
             "</urlset>"
         ).format(self.base_url, self.i18n_model.pk)
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     @override_settings(LANGUAGES=(("en", "English"), ("pt", "Portuguese")))
     def test_alternate_i18n_sitemap_index(self):
@@ -374,7 +374,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             f"{expected_urls}\n"
             f"</urlset>"
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     @override_settings(
         LANGUAGES=(("en", "English"), ("pt", "Portuguese"), ("es", "Spanish"))
@@ -404,7 +404,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             f"{expected_urls}\n"
             f"</urlset>"
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     @override_settings(LANGUAGES=(("en", "English"), ("pt", "Portuguese")))
     def test_alternate_i18n_sitemap_xdefault(self):
@@ -434,7 +434,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             f"{expected_urls}\n"
             f"</urlset>"
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     @override_settings(LANGUAGES=(("en", "English"), ("pt", "Portuguese")))
     def test_language_for_item_i18n_sitemap(self):
@@ -460,7 +460,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             f"{expected_urls}\n"
             f"</urlset>"
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     @override_settings(LANGUAGES=(("en", "English"), ("pt", "Portuguese")))
     def test_alternate_language_for_item_i18n_sitemap(self):
@@ -500,7 +500,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             f"{expected_urls}\n"
             f"</urlset>"
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     def test_sitemap_without_entries(self):
         response = self.client.get("/sitemap-without-entries/sitemap.xml")
@@ -510,7 +510,7 @@ class HTTPSitemapTests(SitemapTestsBase):
             'xmlns:xhtml="http://www.w3.org/1999/xhtml">\n\n'
             "</urlset>"
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     def test_callable_sitemod_partial(self):
         """
@@ -535,8 +535,8 @@ class HTTPSitemapTests(SitemapTestsBase):
             "<loc>http://example.com/location/</loc></url>\n"
             "</urlset>"
         )
-        self.assertXMLEqual(index_response.content.decode(), expected_content_index)
-        self.assertXMLEqual(sitemap_response.content.decode(), expected_content_sitemap)
+        self.assertXMLEqual(index_response.text, expected_content_index)
+        self.assertXMLEqual(sitemap_response.text, expected_content_sitemap)
 
     def test_callable_sitemod_full(self):
         """
@@ -566,8 +566,8 @@ class HTTPSitemapTests(SitemapTestsBase):
             "<lastmod>2014-03-13</lastmod></url>\n"
             "</urlset>"
         )
-        self.assertXMLEqual(index_response.content.decode(), expected_content_index)
-        self.assertXMLEqual(sitemap_response.content.decode(), expected_content_sitemap)
+        self.assertXMLEqual(index_response.text, expected_content_index)
+        self.assertXMLEqual(sitemap_response.text, expected_content_sitemap)
 
     def test_callable_sitemod_no_items(self):
         index_response = self.client.get("/callable-lastmod-no-items/index.xml")
@@ -577,4 +577,4 @@ class HTTPSitemapTests(SitemapTestsBase):
         <sitemap><loc>http://example.com/simple/sitemap-callable-lastmod.xml</loc></sitemap>
         </sitemapindex>
         """
-        self.assertXMLEqual(index_response.content.decode(), expected_content_index)
+        self.assertXMLEqual(index_response.text, expected_content_index)

--- a/tests/sitemaps_tests/test_https.py
+++ b/tests/sitemaps_tests/test_https.py
@@ -20,7 +20,7 @@ class HTTPSSitemapTests(SitemapTestsBase):
             self.base_url,
             date.today(),
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     def test_secure_sitemap_section(self):
         "A secure sitemap section can be rendered"
@@ -36,7 +36,7 @@ class HTTPSSitemapTests(SitemapTestsBase):
             self.base_url,
             date.today(),
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
 
 @override_settings(SECURE_PROXY_SSL_HEADER=False)
@@ -54,7 +54,7 @@ class HTTPSDetectionSitemapTests(SitemapTestsBase):
             self.base_url.replace("http://", "https://"),
             date.today(),
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)
 
     def test_sitemap_section_with_https_request(self):
         "A sitemap section requested in HTTPS is rendered with HTTPS links"
@@ -70,4 +70,4 @@ class HTTPSDetectionSitemapTests(SitemapTestsBase):
             self.base_url.replace("http://", "https://"),
             date.today(),
         )
-        self.assertXMLEqual(response.content.decode(), expected_content)
+        self.assertXMLEqual(response.text, expected_content)

--- a/tests/view_tests/tests/test_i18n.py
+++ b/tests/view_tests/tests/test_i18n.py
@@ -295,7 +295,7 @@ class I18NViewTests(SimpleTestCase):
         """
         with override("de"):
             response = self.client.get("/jsoni18n/")
-            data = json.loads(response.content.decode())
+            data = json.loads(response.text)
             self.assertIn("catalog", data)
             self.assertIn("formats", data)
             self.assertEqual(
@@ -329,7 +329,7 @@ class I18NViewTests(SimpleTestCase):
         """
         with self.settings(LANGUAGE_CODE="es"), override("en-us"):
             response = self.client.get("/jsoni18n/")
-            data = json.loads(response.content.decode())
+            data = json.loads(response.text)
             self.assertIn("catalog", data)
             self.assertIn("formats", data)
             self.assertIn("plural", data)

--- a/tests/view_tests/tests/test_json.py
+++ b/tests/view_tests/tests/test_json.py
@@ -10,7 +10,7 @@ class JsonResponseTests(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers["content-type"], "application/json")
         self.assertEqual(
-            json.loads(response.content.decode()),
+            json.loads(response.text),
             {
                 "a": [1, 2, 3],
                 "foo": {"bar": "baz"},


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-35727](https://code.djangoproject.com/ticket/35727)

#### Branch description
Added a text property to the HttpResponse class to simplify access to the response content as a decoded string.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
