### PR TITLE
Fixed #35682 -- Updated docstrings for base view classes which require a response mixin.

### DIFF
--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -300,7 +300,11 @@ class DateMixin:
 
 
 class BaseDateListView(MultipleObjectMixin, DateMixin, View):
-    """Abstract base class for date-based views displaying a list of objects."""
+    """
+    Base class for date-based views displaying a list of objects.
+
+    This requires subclassing to provide a response mixin.
+    """
 
     allow_empty = False
     date_list_period = "year"
@@ -388,7 +392,9 @@ class BaseDateListView(MultipleObjectMixin, DateMixin, View):
 
 class BaseArchiveIndexView(BaseDateListView):
     """
-    Base class for archives of date-based items. Requires a response mixin.
+    Base view for archives of date-based items.
+
+    This requires subclassing to provide a response mixin.
     """
 
     context_object_name = "latest"
@@ -411,7 +417,11 @@ class ArchiveIndexView(MultipleObjectTemplateResponseMixin, BaseArchiveIndexView
 
 
 class BaseYearArchiveView(YearMixin, BaseDateListView):
-    """List of objects published in a given year."""
+    """
+    Base view for a list of objects published in a given year.
+
+    This requires subclassing to provide a response mixin.
+    """
 
     date_list_period = "month"
     make_object_list = False
@@ -463,7 +473,11 @@ class YearArchiveView(MultipleObjectTemplateResponseMixin, BaseYearArchiveView):
 
 
 class BaseMonthArchiveView(YearMixin, MonthMixin, BaseDateListView):
-    """List of objects published in a given month."""
+    """
+    Base view for a list of objects published in a given month.
+
+    This requires subclassing to provide a response mixin.
+    """
 
     date_list_period = "day"
 
@@ -505,7 +519,11 @@ class MonthArchiveView(MultipleObjectTemplateResponseMixin, BaseMonthArchiveView
 
 
 class BaseWeekArchiveView(YearMixin, WeekMixin, BaseDateListView):
-    """List of objects published in a given week."""
+    """
+    Base view for a list of objects published in a given week.
+
+    This requires subclassing to provide a response mixin.
+    """
 
     def get_dated_items(self):
         """Return (date_list, items, extra_context) for this request."""
@@ -563,7 +581,11 @@ class WeekArchiveView(MultipleObjectTemplateResponseMixin, BaseWeekArchiveView):
 
 
 class BaseDayArchiveView(YearMixin, MonthMixin, DayMixin, BaseDateListView):
-    """List of objects published on a given day."""
+    """
+    Base view for a list of objects published on a given day.
+
+    This requires subclassing to provide a response mixin.
+    """
 
     def get_dated_items(self):
         """Return (date_list, items, extra_context) for this request."""
@@ -610,7 +632,11 @@ class DayArchiveView(MultipleObjectTemplateResponseMixin, BaseDayArchiveView):
 
 
 class BaseTodayArchiveView(BaseDayArchiveView):
-    """List of objects published today."""
+    """
+    Base view for a list of objects published today.
+
+    This requires subclassing to provide a response mixin.
+    """
 
     def get_dated_items(self):
         """Return (date_list, items, extra_context) for this request."""
@@ -625,8 +651,10 @@ class TodayArchiveView(MultipleObjectTemplateResponseMixin, BaseTodayArchiveView
 
 class BaseDateDetailView(YearMixin, MonthMixin, DayMixin, DateMixin, BaseDetailView):
     """
-    Detail view of a single object on a single date; this differs from the
+    Base detail view for a single object on a single date; this differs from the
     standard DetailView by accepting a year/month/day in the URL.
+
+    This requires subclassing to provide a response mixin.
     """
 
     def get_object(self, queryset=None):

--- a/django/views/generic/detail.py
+++ b/django/views/generic/detail.py
@@ -102,7 +102,11 @@ class SingleObjectMixin(ContextMixin):
 
 
 class BaseDetailView(SingleObjectMixin, View):
-    """A base view for displaying a single object."""
+    """
+    Base view for displaying a single object.
+
+    This requires subclassing to provide a response mixin.
+    """
 
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()

--- a/django/views/generic/edit.py
+++ b/django/views/generic/edit.py
@@ -170,7 +170,7 @@ class BaseCreateView(ModelFormMixin, ProcessFormView):
     """
     Base view for creating a new object instance.
 
-    Using this base class requires subclassing to provide a response mixin.
+    This requires subclassing to provide a response mixin.
     """
 
     def get(self, request, *args, **kwargs):
@@ -194,7 +194,7 @@ class BaseUpdateView(ModelFormMixin, ProcessFormView):
     """
     Base view for updating an existing object.
 
-    Using this base class requires subclassing to provide a response mixin.
+    This requires subclassing to provide a response mixin.
     """
 
     def get(self, request, *args, **kwargs):
@@ -242,7 +242,7 @@ class BaseDeleteView(DeletionMixin, FormMixin, BaseDetailView):
     """
     Base view for deleting an object.
 
-    Using this base class requires subclassing to provide a response mixin.
+    This requires subclassing to provide a response mixin.
     """
 
     form_class = Form

--- a/django/views/generic/list.py
+++ b/django/views/generic/list.py
@@ -148,7 +148,11 @@ class MultipleObjectMixin(ContextMixin):
 
 
 class BaseListView(MultipleObjectMixin, View):
-    """A base view for displaying a list of objects."""
+    """
+    Base view for displaying a list of objects.
+
+    This requires subclassing to provide a response mixin.
+    """
 
     def get(self, request, *args, **kwargs):
         self.object_list = self.get_queryset()


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35682

#### Branch description
Majority of the BaseView's has specified in their docstring and their docs that
"Using this base class requires subclassing to provide a response mixin." but in BaseListView(list.py) and BaseDetailView(detail.py) and BaseViews of dates.py  where it is needed to , it is not mentioned inside the docstring but it is mentioned in their docs. So i updated the docstring statements accordingly at the baseviews of list.py, dates.py and details.py.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
