### PR TITLE
Fixed #35732 -- Wrapped Postgresql Concat args in parenthesis to fix operator precedence bug.

### DIFF
--- a/django/db/models/functions/text.py
+++ b/django/db/models/functions/text.py
@@ -78,7 +78,7 @@ class ConcatPair(Func):
         return super(ConcatPair, coalesced).as_sql(
             compiler,
             connection,
-            template="%(expressions)s",
+            template="(%(expressions)s)",
             arg_joiner=" || ",
             **extra_context,
         )

--- a/docs/releases/5.1.2.txt
+++ b/docs/releases/5.1.2.txt
@@ -9,4 +9,6 @@ Django 5.1.2 fixes several bugs in 5.1.1.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 5.1 that caused a crash when using the
+  PostgreSQL lookup :lookup:`trigram_similar` on output fields from ``Concat``
+  (:ticket:`35732`).


### PR DESCRIPTION
#### Trac ticket number

ticket-35732

#### Branch description
A change from 5.0.8 to 5.1 raised a test failure in one of our queries that combines `Concat` with `TrigramSimilarity`. @emicuencac tracked this down to a recently deployed simplification on how Concat is rendered to sql here https://github.com/django/django/pull/17471 which leads to the pipe operator not being wrapped in parenthesis which were implicit when using `CONCAT(...)`.

Sorry for the draftiness of this PR, we will amend any mistakes you point out. We wrote a proposal to fix it and a test to back it up which fails without the fix.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
