### PR TITLE
Fix None response serialisation in make_bytes used by response.content

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -311,6 +311,8 @@ class HttpResponseBase:
         # Handle string types -- we can't rely on force_bytes here because:
         # - Python attempts str conversion first
         # - when self._charset != 'utf-8' it re-encodes the content
+        if value is None:
+            return b""
         if isinstance(value, (bytes, memoryview)):
             return bytes(value)
         if isinstance(value, str):


### PR DESCRIPTION
#### Trac ticket number
N/A

#### Branch description
Currently if response.content is set to None it gets converted to b'None', more correct way would be b''

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
