### PR TITLE
Fixed #35681 -- fix documentation for geoip2.GeoIP2Exception.

### DIFF
--- a/docs/ref/contrib/gis/geoip2.txt
+++ b/docs/ref/contrib/gis/geoip2.txt
@@ -195,8 +195,9 @@ Exceptions
 
 .. exception:: GeoIP2Exception
 
-    The exception raised when an error occurs in a call to the underlying
-    ``geoip2`` library.
+    The exception raised when an error occurs in the :class:`GeoIP2` wrapper.
+    Exceptions from the underlying ``geoip2`` library are passed through
+    unchanged.
 
 .. rubric:: Footnotes
 .. [#] GeoIP(R) is a registered trademark of MaxMind, Inc.


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35681

#### Branch description
The current documentation for geoip2.GeoIPException is simply false. It does not get raised "raised when an error occurs in a call to the underlying geoip2 library" as the documentation claims. This patch corrects the documentation to match the actual code behaviour.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
