### PR TITLE
Fixed #35735 -- Restored access to subscribable class methods and properties in templates.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -880,6 +880,10 @@ class Variable:
         try:  # catch-all for silent variable failures
             for bit in self.lookups:
                 try:  # dictionary lookup
+                    # Only allow if the metaclass implements __getitem__. See
+                    # https://docs.python.org/3/reference/datamodel.html#classgetitem-versus-getitem
+                    if not hasattr(type(current), "__getitem__"):
+                        raise TypeError
                     current = current[bit]
                     # ValueError/IndexError are for numpy.array lookup on
                     # numpy < 1.9 and 1.9+ respectively

--- a/tests/template_tests/syntax_tests/test_basic.py
+++ b/tests/template_tests/syntax_tests/test_basic.py
@@ -346,6 +346,52 @@ class BasicSyntaxTests(SimpleTestCase):
         output = self.engine.render_to_string("tpl-weird-percent")
         self.assertEqual(output, "% %s")
 
+    @setup(
+        {"template": "{{ class_var.class_property }} | {{ class_var.class_method }}"}
+    )
+    def test_subscriptable_class(self):
+        class MyClass(list):
+            # As of Python 3.9 list defines __class_getitem__ which makes it
+            # subscriptable.
+            class_property = "Example property"
+            do_not_call_in_templates = True
+
+            @classmethod
+            def class_method(cls):
+                return "Example method"
+
+        for case in (MyClass, lambda: MyClass):
+            with self.subTest(case=case):
+                output = self.engine.render_to_string("template", {"class_var": case})
+                self.assertEqual(output, "Example property | Example method")
+
+    @setup({"template": "{{ meals.lunch }}"})
+    def test_access_class_property_if_getitem_is_defined_in_metaclass(self):
+        """
+        If the metaclass defines __getitem__, the template system should use
+        it to resolve the dot notation.
+        """
+
+        class MealMeta(type):
+            def __getitem__(cls, name):
+                return getattr(cls, name) + " is yummy."
+
+        class Meals(metaclass=MealMeta):
+            lunch = "soup"
+            do_not_call_in_templates = True
+
+            # Make class type subscriptable.
+            def __class_getitem__(cls, key):
+                from types import GenericAlias
+
+                return GenericAlias(cls, key)
+
+        self.assertEqual(Meals.lunch, "soup")
+        self.assertEqual(Meals["lunch"], "soup is yummy.")
+
+        output = self.engine.render_to_string("template", {"meals": Meals})
+        self.assertEqual(output, "soup is yummy.")
+
 
 class BlockContextTests(SimpleTestCase):
     def test_repr(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35735

#### Branch description
Referencing class properties or methods was not possible for some classes since python 3.9. If a class has a `__class_get_item__` class method, it returned a `types.GenericAlias` object instead of raising a `TypeError`. This leads the Django template engine to finish resolution without accessing the class property or method.

This PR introduces the required `TypeError` if the template system tries to resolve a `__class_get_item__` method.


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
