### PR TITLE
35737: Clarify where `models` comes from to understand missing import in tutorial

### DIFF
--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -232,7 +232,8 @@ underscores replaced with spaces), and that each line contains the string
 representation of the output.
 
 You can improve that by using the :func:`~django.contrib.admin.display`
-decorator on that method (in :file:`polls/models.py`), as follows:
+decorator on that method (extending the :file:`polls/models.py` file that was
+created in :doc:`Tutorial 2 </intro/tutorial02>`), as follows:
 
 .. code-block:: python
     :caption: ``polls/models.py``


### PR DESCRIPTION
#### Trac ticket number

ticket-35737

#### Branch description
The tutorial was missing an import statement. The last time the import for `django.db.models` was tutorial04.
The tutorial refers to the `models` from both `django.db.models` and `polls.models` so I think it's useful to remind the user about it.



#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
