### PR TITLE
Fixed #35734 -- Used JSONB_BUILD_OBJECT database function on PostgreSQL when using server-side bindings.

### DIFF
--- a/django/db/models/functions/comparison.py
+++ b/django/db/models/functions/comparison.py
@@ -175,7 +175,10 @@ class JSONObject(Func):
         )
 
     def as_postgresql(self, compiler, connection, **extra_context):
-        if not connection.features.is_postgresql_16:
+        if (
+            not connection.features.is_postgresql_16
+            or connection.features.uses_server_side_binding
+        ):
             copy = self.copy()
             copy.set_source_expressions(
                 [

--- a/docs/releases/5.1.2.txt
+++ b/docs/releases/5.1.2.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Fixed a regression in Django 5.1 that caused a crash when using the
   PostgreSQL lookup :lookup:`trigram_similar` on output fields from ``Concat``
   (:ticket:`35732`).
+
+* Fixed a regression in Django 5.1 that caused a crash of ``JSONObject()``
+  when using server-side binding with PostgreSQL 16+ (:ticket:`35734`).


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->
https://code.djangoproject.com/ticket/35734

#### Branch description
An earlier update switched the JSONObject class to use the new standard `json_object` function when using postgres 16, which worked fine so long as you weren't using server side binding. The solution is to cast the keys to text, just as with the prior jsonb_build_object implementation, but you can't just wrap it in a `Cast`, because the actual SQL that gets built out will use the double colon operator to cast. This is a problem because you can also use a single colon to separate keys/values using the `json_object` function. I resolved this by just wrapping the cast'd key in a set of parentheses. An alternative would be to switch to using `CAST(value AS target_type )`, but I thought such a change would probably be invasive, result in some sort of broken abstraction, or just generally be a bad idea.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
