### PR TITLE
Fixed issue with update_fields in save() method on docs example.

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -917,7 +917,7 @@ example::
             if (
                 update_fields := kwargs.get("update_fields")
             ) is not None and "name" in update_fields:
-                update_fields = {"slug"}.union(update_fields)
+                kwargs["update_fields"] = {"slug"}.union(update_fields)
             super().save(**kwargs)
 
 See :ref:`ref-models-update-fields` for more details.


### PR DESCRIPTION
Ensured that update_fields properly updated when calling super().save()
in the documentation example that proposed a way to solve [#34099.](https://code.djangoproject.com/ticket/34099)

The previous code forgot to update kwargs with the updated update_field,
which resulted in the example code having no effect.

