### PR TITLE
Fixed #35742 -- Removed hardcoded "username" references in admin templates.

### DIFF
--- a/django/contrib/admin/templates/admin/auth/user/add_form.html
+++ b/django/contrib/admin/templates/admin/auth/user/add_form.html
@@ -3,9 +3,7 @@
 
 {% block form_top %}
   {% if not is_popup %}
-    <p>{% translate 'First, enter a username and password. Then, you’ll be able to edit more user options.' %}</p>
-  {% else %}
-    <p>{% translate "Enter a username and password." %}</p>
+    <p>{% translate "After you've created a user, you’ll be able to edit more user options." %}</p>
   {% endif %}
 {% endblock %}
 {% block extrahead %}

--- a/django/contrib/admin/templates/admin/login.html
+++ b/django/contrib/admin/templates/admin/login.html
@@ -57,7 +57,7 @@
   {% url 'admin_password_reset' as password_reset_url %}
   {% if password_reset_url %}
   <div class="password-reset-link">
-    <a href="{{ password_reset_url }}">{% translate 'Forgotten your password or username?' %}</a>
+    <a href="{{ password_reset_url }}">{% translate 'Forgotten your login credentials?' %}</a>
   </div>
   {% endif %}
   <div class="submit-row">

--- a/django/contrib/admin/templates/registration/password_reset_email.html
+++ b/django/contrib/admin/templates/registration/password_reset_email.html
@@ -5,7 +5,7 @@
 {% block reset_link %}
 {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
 {% endblock %}
-{% translate 'Your username, in case you’ve forgotten:' %} {{ user.get_username }}
+{% translate 'In case you’ve forgotten, you are:' %} {{ user.get_username }}
 
 {% translate "Thanks for using our site!" %}
 


### PR DESCRIPTION
#### Trac ticket number

[ticket-35742](https://code.djangoproject.com/ticket/35742#ticket)

#### Branch description
Improve UserAdmin by replacing the static "username" with the dynamic USERNAME_FIELD value.
```
# admin.py
class CustomUserAdmin(UserAdmin):
  add_fieldsets = (
    (
      None,
      {
        "classes": ("wide",),
        "fields": (User.USERNAME_FIELD, "usable_password", "password1", "password2"),
      },
    ),
  )

# add_form.html
{% block form_top %}
  {% if not is_popup %}
    <p>{% blocktranslate %}First, enter a {{ username }} and password. Then, you’ll be able to edit more user options.{% endblocktranslate %}</p>
  {% else %}
    <p>{% blcoktranslate %}Enter a {{ username }} and password.{% endblocktranslate %}</p>
  {% endif %}
{% endblock %}
```


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
