### PR TITLE
Removed ordering variable in url_remove if o_list_remove is empty, fixing #35747.

### DIFF
--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -170,7 +170,7 @@ def result_headers(cl):
             "ascending": order_type == "asc",
             "sort_priority": sort_priority,
             "url_primary": cl.get_query_string({ORDER_VAR: ".".join(o_list_primary)}),
-            "url_remove": cl.get_query_string({ORDER_VAR: ".".join(o_list_remove)}),
+            "url_remove": cl.get_query_string({ORDER_VAR: ".".join(o_list_remove) if o_list_remove else None}),
             "url_toggle": cl.get_query_string({ORDER_VAR: ".".join(o_list_toggle)}),
             "class_attrib": (
                 format_html(' class="{}"', " ".join(th_classes)) if th_classes else ""

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -170,7 +170,9 @@ def result_headers(cl):
             "ascending": order_type == "asc",
             "sort_priority": sort_priority,
             "url_primary": cl.get_query_string({ORDER_VAR: ".".join(o_list_primary)}),
-            "url_remove": cl.get_query_string({ORDER_VAR: ".".join(o_list_remove) if o_list_remove else None}),
+            "url_remove": cl.get_query_string(
++                {ORDER_VAR: ".".join(o_list_remove) if o_list_remove else None}
++            ),
             "url_toggle": cl.get_query_string({ORDER_VAR: ".".join(o_list_toggle)}),
             "class_attrib": (
                 format_html(' class="{}"', " ".join(th_classes)) if th_classes else ""

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -171,8 +171,8 @@ def result_headers(cl):
             "sort_priority": sort_priority,
             "url_primary": cl.get_query_string({ORDER_VAR: ".".join(o_list_primary)}),
             "url_remove": cl.get_query_string(
-+                {ORDER_VAR: ".".join(o_list_remove) if o_list_remove else None}
-+            ),
+                {ORDER_VAR: ".".join(o_list_remove) if o_list_remove else None}
+            ),
             "url_toggle": cl.get_query_string({ORDER_VAR: ".".join(o_list_toggle)}),
             "class_attrib": (
                 format_html(' class="{}"', " ".join(th_classes)) if th_classes else ""

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -170,9 +170,7 @@ def result_headers(cl):
             "ascending": order_type == "asc",
             "sort_priority": sort_priority,
             "url_primary": cl.get_query_string({ORDER_VAR: ".".join(o_list_primary)}),
-            "url_remove": cl.get_query_string(
-                {ORDER_VAR: ".".join(o_list_remove) if o_list_remove else None}
-            ),
+            "url_remove": cl.get_query_string({ORDER_VAR: ".".join(o_list_remove)}),
             "url_toggle": cl.get_query_string({ORDER_VAR: ".".join(o_list_toggle)}),
             "class_attrib": (
                 format_html(' class="{}"', " ".join(th_classes)) if th_classes else ""

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -395,7 +395,7 @@ class ChangeList:
         ordering = list(
             self.model_admin.get_ordering(request) or self._get_default_ordering()
         )
-        if ORDER_VAR in params:
+        if ORDER_VAR in params and params[ORDER_VAR]:
             # Clear ordering and used params
             ordering = []
             order_params = params[ORDER_VAR].split(".")

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1375,6 +1375,20 @@ class ChangeListTests(TestCase):
         OrderedObjectAdmin.ordering = ["id", "bool"]
         check_results_order(ascending=True)
 
+    def test_ordering_from_model_meta(self):
+        Swallow.objects.create(origin="Swallow A", load=4, speed=2)
+        Swallow.objects.create(origin="Swallow B", load=2, speed=1)
+        Swallow.objects.create(origin="Swallow C", load=5, speed=1)
+        m = SwallowAdmin(Swallow, custom_site)
+        request = self._mocked_authenticated_request("/swallow/?o=", self.superuser)
+        changelist = m.get_changelist_instance(request)
+        queryset = changelist.get_queryset(request)
+        self.assertQuerySetEqual(
+            queryset,
+            [(1.0, 2.0), (1.0, 5.0), (2.0, 4.0)],
+            lambda s: (s.speed, s.load),
+        )
+
     @isolate_apps("admin_changelist")
     def test_total_ordering_optimization(self):
         class Related(models.Model):


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35747

#### Branch description

I'm adding a conditional expression that avoids inserting the ordering variable query parameter in the sortremove admin change list url link to fix the ticket above.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
