### PR TITLE
Fixed #35752 -- Fixed crash when using In() lookup in filters.

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -300,7 +300,11 @@ class FieldGetDbPrepValueIterableMixin(FieldGetDbPrepValueMixin):
                 # An expression will be handled by the database but can coexist
                 # alongside real values.
                 pass
-            elif self.prepare_rhs and hasattr(self.lhs.output_field, "get_prep_value"):
+            elif (
+                self.prepare_rhs
+                and hasattr(self.lhs, "output_field")
+                and hasattr(self.lhs.output_field, "get_prep_value")
+            ):
                 rhs_value = self.lhs.output_field.get_prep_value(rhs_value)
             prepared_values.append(rhs_value)
         return prepared_values


### PR DESCRIPTION
#### Trac ticket number
ticket-35752

#### Branch description
At the moment, the `In` lookup cannot be used in `.filter()`.

The following raises an error:
```
.filter(In(F("field"), [1, 2, 3]))
```

I believe this is a bug, `In` should work in `.filter()` similar to the other lookups.

This doesn't really relate to ticket-373, I just noticed the bug while investigating using `TupleIn` in `.filter()`.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
