### PR TITLE
Fixed #35748 -- Documented that Field.formfield() may return None.

### DIFF
--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -645,6 +645,9 @@ delegate further handling to the parent class. This might require you to write
 a custom form field (and even a form widget). See the :doc:`forms documentation
 </topics/forms/index>` for information about this.
 
+If you wish to exclude the field from the :class:`~django.forms.ModelForm`, you
+can override the :meth:`~Field.formfield` method to return ``None``.
+
 Continuing our ongoing example, we can write the :meth:`~Field.formfield` method
 as::
 
@@ -652,8 +655,12 @@ as::
         # ...
 
         def formfield(self, **kwargs):
-            # This is a fairly standard way to set up some defaults
-            # while letting the caller override them.
+            # Exclude the field from the ModelForm when some condition is met.
+            some_condition = kwargs.get("some_condition", False)
+            if some_condition:
+                return None
+
+            # Set up some defaults while letting the caller override them.
             defaults = {"form_class": MyFormField}
             defaults.update(kwargs)
             return super().formfield(**defaults)

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -2441,6 +2441,9 @@ Field API reference
         Returns the default :class:`django.forms.Field` of this field for
         :class:`~django.forms.ModelForm`.
 
+        If :meth:`~Field.formfield` is overridden to return ``None``, this field
+        is excluded from the :class:`~django.forms.ModelForm`.
+
         By default, if both ``form_class`` and ``choices_form_class`` are
         ``None``, it uses :class:`~django.forms.CharField`. If the field has
         :attr:`~django.db.models.Field.choices` and ``choices_form_class``


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35748

#### Branch description
This branch adds documentation to ``models.Fields.formfield()`` specifying that the method may return ``None``,
and extends the usage example in [specifying form fields for model field](https://docs.djangoproject.com/en/dev/howto/custom-model-fields/#specifying-form-field-for-model-field) to demonstrate how to do this to ignore a ``Field`` from ``ModelForm``

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
