### PR TITLE
Fixed #35747 -- Used default ordering in the admin changelist when the ORDER_VAR param is blank.

### DIFF
--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -395,7 +395,7 @@ class ChangeList:
         ordering = list(
             self.model_admin.get_ordering(request) or self._get_default_ordering()
         )
-        if ORDER_VAR in params:
+        if params.get(ORDER_VAR):
             # Clear ordering and used params
             ordering = []
             order_params = params[ORDER_VAR].split(".")

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1328,6 +1328,20 @@ class ChangeListTests(TestCase):
         UnorderedObjectAdmin.ordering = ["id", "bool"]
         check_results_order(ascending=True)
 
+    def test_ordering_from_model_meta(self):
+        Swallow.objects.create(origin="Swallow A", load=4, speed=2)
+        Swallow.objects.create(origin="Swallow B", load=2, speed=1)
+        Swallow.objects.create(origin="Swallow C", load=5, speed=1)
+        m = SwallowAdmin(Swallow, custom_site)
+        request = self._mocked_authenticated_request("/swallow/?o=", self.superuser)
+        changelist = m.get_changelist_instance(request)
+        queryset = changelist.get_queryset(request)
+        self.assertQuerySetEqual(
+            queryset,
+            [(1.0, 2.0), (1.0, 5.0), (2.0, 4.0)],
+            lambda s: (s.speed, s.load),
+        )
+
     def test_deterministic_order_for_model_ordered_by_its_manager(self):
         """
         The primary key is used in the ordering of the changelist's results to


### PR DESCRIPTION
From #18558
