### PR TITLE
Hide help text on hidden fields

### DIFF
--- a/django/contrib/admin/templates/admin/includes/fieldset.html
+++ b/django/contrib/admin/templates/admin/includes/fieldset.html
@@ -27,7 +27,7 @@
                             {% endif %}
                         </div>
                     {% if field.field.help_text %}
-                        <div class="help"{% if field.field.id_for_label %} id="{{ field.field.id_for_label }}_helptext"{% endif %}>
+                        <div class="help{% if field.field.is_hidden %} hidden{% endif %}"{% if field.field.id_for_label %} id="{{ field.field.id_for_label }}_helptext"{% endif %}>
                             <div>{{ field.field.help_text|safe }}</div>
                         </div>
                     {% endif %}

--- a/tests/admin_inlines/models.py
+++ b/tests/admin_inlines/models.py
@@ -332,7 +332,7 @@ class SomeParentModel(models.Model):
 
 class SomeChildModel(models.Model):
     name = models.CharField(max_length=1)
-    position = models.PositiveIntegerField()
+    position = models.PositiveIntegerField(help_text="Position help_text.")
     parent = models.ForeignKey(SomeParentModel, models.CASCADE)
     readonly_field = models.CharField(max_length=1)
 

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -385,14 +385,14 @@ class TestInline(TestDataMixin, TestCase):
             '<div class="flex-container fieldBox field-position hidden">'
             '<label class="inline">Position:</label>'
             '<div class="readonly">0</div></div>'
-            '<div class="help"><div>Position help_text.</div></div>',
+            '<div class="help hidden"><div>Position help_text.</div></div>',
             response.rendered_content,
         )
         self.assertInHTML(
             '<div class="flex-container fieldBox field-position hidden">'
             '<label class="inline">Position:</label>'
             '<div class="readonly">1</div></div>'
-            '<div class="help"><div>Position help_text.</div></div>',
+            '<div class="help hidden"><div>Position help_text.</div></div>',
             response.rendered_content,
         )
 
@@ -415,7 +415,7 @@ class TestInline(TestDataMixin, TestCase):
             '<div class="form-row hidden field-position">'
             '<div><div class="flex-container"><label>Position:</label>'
             '<div class="readonly">0</div></div>'
-            '<div class="help"><div>Position help_text.</div></div>'
+            '<div class="help hidden"><div>Position help_text.</div></div>'
             '</div></div>',
             response.rendered_content,
         )
@@ -423,7 +423,7 @@ class TestInline(TestDataMixin, TestCase):
             '<div class="form-row hidden field-position">'
             '<div><div class="flex-container"><label>Position:</label>'
             '<div class="readonly">1</div></div>'
-            '<div class="help"><div>Position help_text.</div></div>'
+            '<div class="help hidden"><div>Position help_text.</div></div>'
             '</div></div>',
             response.rendered_content,
         )

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -349,7 +349,12 @@ class TestInline(TestDataMixin, TestCase):
         )
         response = self.client.get(url)
         self.assertInHTML(
-            '<th class="column-position hidden">Position</th>',
+            '<th class="column-position hidden">Position'
+            '<img src="/static/admin/img/icon-unknown.svg" '
+            'class="help help-tooltip" width="10" height="10" '
+            'alt="(Position help_text.)" '
+            'title="Position help_text.">'
+            '</th>',
             response.rendered_content,
         )
         self.assertInHTML(
@@ -379,13 +384,15 @@ class TestInline(TestDataMixin, TestCase):
         self.assertInHTML(
             '<div class="flex-container fieldBox field-position hidden">'
             '<label class="inline">Position:</label>'
-            '<div class="readonly">0</div></div>',
+            '<div class="readonly">0</div></div>'
+            '<div class="help"><div>Position help_text.</div></div>',
             response.rendered_content,
         )
         self.assertInHTML(
             '<div class="flex-container fieldBox field-position hidden">'
             '<label class="inline">Position:</label>'
-            '<div class="readonly">1</div></div>',
+            '<div class="readonly">1</div></div>'
+            '<div class="help"><div>Position help_text.</div></div>',
             response.rendered_content,
         )
 
@@ -407,13 +414,17 @@ class TestInline(TestDataMixin, TestCase):
         self.assertInHTML(
             '<div class="form-row hidden field-position">'
             '<div><div class="flex-container"><label>Position:</label>'
-            '<div class="readonly">0</div></div></div></div>',
+            '<div class="readonly">0</div></div>'
+            '<div class="help"><div>Position help_text.</div></div>'
+            '</div></div>',
             response.rendered_content,
         )
         self.assertInHTML(
             '<div class="form-row hidden field-position">'
             '<div><div class="flex-container"><label>Position:</label>'
-            '<div class="readonly">1</div></div></div></div>',
+            '<div class="readonly">1</div></div>'
+            '<div class="help"><div>Position help_text.</div></div>'
+            '</div></div>',
             response.rendered_content,
         )
 
@@ -448,7 +459,12 @@ class TestInline(TestDataMixin, TestCase):
         self.assertInHTML(
             '<thead><tr><th class="original"></th>'
             '<th class="column-name required">Name</th>'
-            '<th class="column-position required hidden">Position</th>'
+            '<th class="column-position required hidden">Position'
+            '<img src="/static/admin/img/icon-unknown.svg" '
+            'class="help help-tooltip" width="10" height="10" '
+            'alt="(Position help_text.)" '
+            'title="Position help_text.">'
+            '</th>'
             "<th>Delete?</th></tr></thead>",
             response.rendered_content,
         )


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35755

#### Branch description
If a field is hidden, its help_text shows.
This regressed in commit 96a598356a9ea8c2c05b22cadc12e256a3b295fd

from PR #16161:
This happened because the <div class="help"> is now after, as opposed to inside, the <div> that gets class "hidden".

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
