### PR TITLE
Pinned Miniforge in benchmark workflow.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           repository: django/django-asv
           path: "."
+      - name: Setup Miniforge
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: "24.1.2-0"
+          activate-environment: asv-bench
       - name: Install Requirements
         run: pip install -r requirements.txt
       - name: Cache Django


### PR DESCRIPTION
Currently benchmarks quietly fail to run, see logs in "Run benchmarks": https://github.com/django/django/actions/runs/10828135806/job/30042813165?pr=18335

This pins miniforge - which was similar to a fix in django-asv, see: https://github.com/django/django-asv/pull/83

See successful run: https://github.com/django/django/actions/runs/10828437126/