### PR TITLE
Fixed #35754 -- Mapped full-width characters in latex to half-width.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -110,6 +110,7 @@ answer newbie questions, and generally made Django that much better:
     Anubhav Joshi <anubhav9042@gmail.com>
     Anvesh Mishra <anveshgreat11@gmail.com>
     Anže Pečar <anze@pecar.me>
+    A. Rafey Khan <khanxbahria@gmail.com>
     Aram Dulyan
     arien <regexbot@gmail.com>
     Arjun Omray <arjunomray@gmail.com>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -292,8 +292,12 @@ latex_elements = {
         \setmainfont{Symbola}
     """,
     "preamble": r"""
-        \usepackage{newunicodechar}
         \usepackage[UTF8]{ctex}
+        \xeCJKDeclareCharClass{HalfLeft}{"2018, "201C}
+        \xeCJKDeclareCharClass{HalfRight}{
+            "00B7, "2019, "201D, "2013, "2014, "2025, "2026, "2E3A
+        }
+        \usepackage{newunicodechar}
         \newunicodechar{π}{\ensuremath{\pi}}
         \newunicodechar{≤}{\ensuremath{\le}}
         \newunicodechar{≥}{\ensuremath{\ge}}


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35754

#### Branch description
Prior to the proposed change, pdf documentation builds rendered curly quotes as full-width due to an issue in `ctex` latex package: https://github.com/CTeX-org/ctex-kit/issues/389. Relevant mappings are added to convert full-width characters to half-width.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
