### PR TITLE
Closed connection pool in clean up of test_allowed_database_copy_queries.

### DIFF
--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -2186,6 +2186,8 @@ class AllowedDatabaseQueriesTests(SimpleTestCase):
         finally:
             new_connection.validate_thread_sharing()
             new_connection._close()
+            if hasattr(new_connection, "close_pool"):
+                new_connection.close_pool()
 
 
 class DatabaseAliasTests(SimpleTestCase):


### PR DESCRIPTION
Pulled from #18568

This can be seen when running postgres tests with a connection pool.

Before:
```
$ docker-compose run --rm postgres test_utils.tests.AllowedDatabaseQueriesTests
Creating django-docker-box_postgres_run ... done
wait-for-it.sh: waiting 20 seconds for postgres-db:5432
wait-for-it.sh: postgres-db:5432 is available after 0 seconds
Testing against Django installed in '/tests/django/django' with up to 12 processes
Found 4 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).

Running tests...
----------------------------------------------------------------------
....
----------------------------------------------------------------------
Ran 4 tests in 0.018s

OK

Generating XML reports...
Destroying test database for alias 'default'...
Traceback (most recent call last):
  File "/tests/django/django/db/backends/utils.py", line 103, in _execute
    return self.cursor.execute(sql)
  File "/usr/local/lib/python3.10/site-packages/psycopg/cursor.py", line 97, in execute
    raise ex.with_traceback(None)
psycopg.errors.ObjectInUse: database "test_django" is being accessed by other users
DETAIL:  There are 4 other sessions using the database.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tests/django/tests/runtests.py", line 788, in <module>
    failures = django_tests(
  File "/tests/django/tests/runtests.py", line 426, in django_tests
    failures = test_runner.run_tests(test_labels)
  File "/tests/django/django/test/runner.py", line 1080, in run_tests
    self.teardown_databases(old_config)
  File "/tests/django/django/test/runner.py", line 1008, in teardown_databases
    _teardown_databases(
  File "/tests/django/django/test/utils.py", line 369, in teardown_databases
    connection.creation.destroy_test_db(old_name, verbosity, keepdb)
  File "/tests/django/django/db/backends/base/creation.py", line 311, in destroy_test_db
    self._destroy_test_db(test_database_name, verbosity)
  File "/tests/django/django/db/backends/postgresql/creation.py", line 91, in _destroy_test_db
    return super()._destroy_test_db(test_database_name, verbosity)
  File "/tests/django/django/db/backends/base/creation.py", line 327, in _destroy_test_db
    cursor.execute(
  File "/tests/django/django/db/backends/utils.py", line 79, in execute
    return self._execute_with_wrappers(
  File "/tests/django/django/db/backends/utils.py", line 92, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/tests/django/django/db/backends/utils.py", line 100, in _execute
    with self.db.wrap_database_errors:
  File "/tests/django/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/tests/django/django/db/backends/utils.py", line 103, in _execute
    return self.cursor.execute(sql)
  File "/usr/local/lib/python3.10/site-packages/psycopg/cursor.py", line 97, in execute
    raise ex.with_traceback(None)
django.db.utils.OperationalError: database "test_django" is being accessed by other users
DETAIL:  There are 4 other sessions using the database.
ERROR: 1

```

After:
```
$ docker-compose run --rm postgres test_utils.tests.AllowedDatabaseQueriesTests
Creating django-docker-box_postgres_run  ... done
wait-for-it.sh: waiting 20 seconds for postgres-db:5432
wait-for-it.sh: postgres-db:5432 is available after 0 seconds
Testing against Django installed in '/tests/django/django' with up to 12 processes
Found 4 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).

Running tests...
----------------------------------------------------------------------
....
----------------------------------------------------------------------
Ran 4 tests in 0.025s

OK

Generating XML reports...
Destroying test database for alias 'default'...
```