### PR TITLE
Fixed #34887 -- Added support for unlimited models.CharField on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -40,6 +40,12 @@ def adapt_datetime(val):
     return val.isoformat(" ")
 
 
+def _get_varchar_column(data):
+    if data["max_length"] is None:
+        return "varchar"
+    return "varchar(%(max_length)s)" % data
+
+
 Database.register_converter("bool", b"1".__eq__)
 Database.register_converter("date", decoder(parse_date))
 Database.register_converter("time", decoder(parse_time))
@@ -62,7 +68,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         "BigAutoField": "integer",
         "BinaryField": "BLOB",
         "BooleanField": "bool",
-        "CharField": "varchar(%(max_length)s)",
+        "CharField": _get_varchar_column,
         "DateField": "date",
         "DateTimeField": "datetime",
         "DecimalField": "decimal",

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -60,6 +60,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     """
     insert_test_table_with_defaults = 'INSERT INTO {} ("null") VALUES (1)'
     supports_default_keyword_in_insert = False
+    supports_unlimited_charfield = True
 
     @cached_property
     def django_test_skips(self):

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -720,8 +720,8 @@ The default form widget for this field is a :class:`~django.forms.TextInput`.
     The maximum length (in characters) of the field. The ``max_length``
     is enforced at the database level and in Django's validation using
     :class:`~django.core.validators.MaxLengthValidator`. It's required for all
-    database backends included with Django except PostgreSQL, which supports
-    unlimited ``VARCHAR`` columns.
+    database backends included with Django except PostgreSQL and SQLite, which
+    supports unlimited ``VARCHAR`` columns.
 
     .. note::
 
@@ -729,6 +729,10 @@ The default form widget for this field is a :class:`~django.forms.TextInput`.
         database backends, you should be aware that there are restrictions on
         ``max_length`` for some backends. Refer to the :doc:`database backend
         notes </ref/databases>` for details.
+
+    .. versionchanged:: 5.2
+
+       Support for unlimited ``VARCHAR`` columns was added on SQLite.
 
 .. attribute:: CharField.db_collation
 

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -223,6 +223,10 @@ Models
   expression contains a set-returning function, enforcing subquery evaluation.
   This is necessary for many Postgres set-returning functions.
 
+* :attr:`CharField.max_length <django.db.models.CharField.max_length>` is no
+  longer required to be set on SQLite, which supports unlimited ``VARCHAR``
+  columns.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-35759](https://code.djangoproject.com/ticket/35759) and ticket-34887

#### Branch description
Allows CharField to have an unlimited length on the SQLite backend. This change simplifies testing and development by removing the need to specify max_length for CharField when using SQLite, similar to PostgreSQL.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
