### PR TITLE
Improved test for TokenType.COMMENT by using correct block syntax in template tests.

### DIFF
--- a/tests/template_tests/test_base.py
+++ b/tests/template_tests/test_base.py
@@ -17,7 +17,7 @@ class LexerTestMixin:
         (TokenType.BLOCK, "if test", 2, (5, 18)),
         (TokenType.VAR, "varvalue", 2, (18, 32)),
         (TokenType.BLOCK, "endif", 2, (32, 43)),
-        (TokenType.COMMENT, "comment {{not a var}} %{not a block}%", 2, (43, 85)),
+        (TokenType.COMMENT, "comment {{not a var}} {%not a block%}", 2, (43, 85)),
         (TokenType.TEXT, "end text", 2, (85, 93)),
     ]
 

--- a/tests/template_tests/test_base.py
+++ b/tests/template_tests/test_base.py
@@ -8,7 +8,7 @@ class LexerTestMixin:
     template_string = (
         "text\n"
         "{% if test %}{{ varvalue }}{% endif %}"
-        "{#comment {{not a var}} %{not a block}% #}"
+        "{#comment {{not a var}} {%not a block%} #}"
         "end text"
     )
     expected_token_tuples = [


### PR DESCRIPTION
#### Trac ticket number

N/A

#### Branch description

From the syntax for `{{not a var}}`, it's clear that `%{not a block}%` should actually use real block syntax `{%not a block%}` so we're testing that this is actually handled correctly within a comment.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
