### PR TITLE
Fixed #35762 -- Avoided unneeded quote_name() calls in SQLite introspection.

### DIFF
--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -316,8 +316,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Find inline check constraints.
         try:
             table_schema = cursor.execute(
-                "SELECT sql FROM sqlite_master WHERE type='table' and name=%s"
-                % (self.connection.ops.quote_name(table_name),)
+                "SELECT sql FROM sqlite_master WHERE type='table' and name=%s",
+                (table_name,),
             ).fetchone()[0]
         except TypeError:
             # table_name is a view.
@@ -337,8 +337,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             # columns. Discard last 2 columns if there.
             number, index, unique = row[:3]
             cursor.execute(
-                "SELECT sql FROM sqlite_master "
-                "WHERE type='index' AND name=%s" % self.connection.ops.quote_name(index)
+                "SELECT sql FROM sqlite_master WHERE type='index' AND name=%s",
+                (index,),
             )
             # There's at most one row.
             (sql,) = cursor.fetchone() or (None,)

--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -317,7 +317,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         try:
             table_schema = cursor.execute(
                 "SELECT sql FROM sqlite_master WHERE type='table' and name=%s",
-                (table_name,),
+                [table_name],
             ).fetchone()[0]
         except TypeError:
             # table_name is a view.
@@ -338,7 +338,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             number, index, unique = row[:3]
             cursor.execute(
                 "SELECT sql FROM sqlite_master WHERE type='index' AND name=%s",
-                (index,),
+                [index],
             )
             # There's at most one row.
             (sql,) = cursor.fetchone() or (None,)


### PR DESCRIPTION
Double-quoting string literals is deprecated in recent SQLite versions.