### PR TITLE
Removed setting the release schedule from Steering Council prerogatives as per DEP 44.

### DIFF
--- a/docs/internals/organization.txt
+++ b/docs/internals/organization.txt
@@ -186,7 +186,6 @@ The steering council holds the following prerogatives:
   the reversion of any particular merge or commit.
 - Announcing calls for proposals and ideas for the future technical direction
   of Django.
-- Setting and adjusting the schedule of releases of Django.
 - Selecting and removing mergers and releasers.
 - Participating in the removal of members of the steering council, when deemed
   appropriate.


### PR DESCRIPTION
The release schedule is defined by [DEP 44](https://github.com/django/deps/blob/main/final/0044-clarify-release-process.rst) and is not set by the Steering Council. Updating our docs accordingly
