### PR TITLE
Fixed #35769 -- Fixed multiline fields in phone/tablet sizes.

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -204,7 +204,8 @@ input[type="submit"], button {
         min-height: 0;
     }
 
-    fieldset .fieldBox + .fieldBox {
+    fieldset div:has(> .fieldBox) + div:has(> .fieldBox) {
+        width: 100%;
         margin-top: 10px;
         padding-top: 10px;
         border-top: 1px solid var(--hairline-color);
@@ -560,7 +561,7 @@ input[type="submit"], button {
         width: auto;
     }
 
-    fieldset .fieldBox + .fieldBox {
+    fieldset div:has(> .fieldBox) + div:has(> .fieldBox) {
         margin-top: 15px;
         padding-top: 15px;
     }


### PR DESCRIPTION
Regression in 96a598356a9ea8c2c05b22cadc12e256a3b295fd.

#### Trac ticket number

ticket-35769

#### Branch description
This fixes multiline fields in the tablet and phone screen sizes.

When there are multiple fields in a row, there are issues in both the tablet and mobile screen sizes. First off, there are two instances of a selector that's supposed to match, but doesn't because of the changed structure. If we fix that to match the new structure, then that fixes the phone size class. See phone-before1.png, phone-before2.png, phone-after1.png, and phone-after2.png. The "1" images are manually grabbed/cropped and show a single-line field above it, which is good for comparing to the working single-line example. The "2" images are of that particular DOM node via the Google Chrome Inspector's feature to screenshot just a given node, so those are easier to directly compare.

phone-before1:
![phone-before1](https://github.com/user-attachments/assets/2ee19981-255a-41de-b2fc-42c6b99c4713)

phone-after1:
![phone-after1](https://github.com/user-attachments/assets/e3192e2a-cdb5-4b7e-ab7b-c5edb77c7aae)

phone-before2:
![phone-before2](https://github.com/user-attachments/assets/43899678-b922-4971-8d29-a403ef711c5a)

phone-after2:
![phone-after2](https://github.com/user-attachments/assets/09175b98-4ed0-4a9f-a843-48b62ff12966)

With that first issue fixed, the tablet view still isn't correct. In Django 3.2, moving to the tablet view forced one-field-per-line whether that was necessary (width-wise) or not. If I take the same approach here, by setting `width: 100%` on that `<div>`, then I get the same behavior and it looks good. Compare tablet-mid2.png (which has the fixed selectors, but no `width: 100%`) to tablet-after2.png (which has both).

tablet-mid2:
![tablet-mid2](https://github.com/user-attachments/assets/b11ede96-e741-4dd5-8e71-4017f12b11a5)

tablet-after2:
![tablet-after2](https://github.com/user-attachments/assets/38788dc1-aa92-4687-95c1-4af726d928f3)

#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots ~~in both light and dark modes~~ for any UI changes.