### PR TITLE
Upgraded actions/cache to v4.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Requirements
         run: pip install -r requirements.txt
       - name: Cache Django
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: Django/*
           key: Django


### PR DESCRIPTION
The benchmark workflow has started to fail. This appears to be because it is only receiving a partial cache, upgrading `actions/cache`.