### PR TITLE
Fix misleading instruction

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -43,8 +43,10 @@ TIME_ZONE = "America/Chicago"
 # If you set this to True, Django will use timezone-aware datetimes.
 USE_TZ = True
 
-# Language code for this installation. All choices can be found here:
-# http://www.i18nguy.com/unicode/language-identifiers.html
+# Language code for this installation. Valid choices can be found here:
+# https://www.iana.org/assignments/language-subtag-registry/
+# If LANGUAGE_CODE is not listed in LANGUAGES (below), the project must
+# provide the necessary translations and locale definitions.
 LANGUAGE_CODE = "en-us"
 
 # Languages we provide translations for, out of the box.


### PR DESCRIPTION
The linked link does not include a list of supported locales. Some locales listed there are not supported at all.

Even if the user attempts to use them, Django will error. An example is `ku`: It is listed in the link, but not supported at all.

This PR removes the misleading link.
