### PR TITLE
Fixed #35180 -- Recreated PostgreSQL _like indexes when changing between TextField and CharField field types.

### DIFF
--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -5223,6 +5223,51 @@ class SchemaTests(TransactionTestCase):
             ["schema_tag_slug_2c418ba3_like", "schema_tag_slug_key"],
         )
 
+    @isolate_apps("schema")
+    @unittest.skipUnless(connection.vendor == "postgresql", "PostgreSQL specific")
+    def test_indexed_charfield_to_textfield(self):
+        class SimpleModel(Model):
+            field1 = CharField(max_length=10, db_index=True)
+
+            class Meta:
+                app_label = "schema"
+
+        with connection.schema_editor() as editor:
+            editor.create_model(SimpleModel)
+        self.assertEqual(
+            self.get_constraints_for_column(SimpleModel, "field1"),
+            [
+                "schema_simplemodel_field1_f07a3d6a",
+                "schema_simplemodel_field1_f07a3d6a_like",
+            ],
+        )
+        # Change to TextField.
+        old_field1 = SimpleModel._meta.get_field("field1")
+        new_field1 = TextField(db_index=True)
+        new_field1.set_attributes_from_name("field1")
+        with connection.schema_editor() as editor:
+            editor.alter_field(SimpleModel, old_field1, new_field1, strict=True)
+        self.assertEqual(
+            self.get_constraints_for_column(SimpleModel, "field1"),
+            [
+                "schema_simplemodel_field1_f07a3d6a",
+                "schema_simplemodel_field1_f07a3d6a_like",
+            ],
+        )
+        # Change back to CharField.
+        old_field1 = SimpleModel._meta.get_field("field1")
+        new_field1 = CharField(max_length=10, db_index=True)
+        new_field1.set_attributes_from_name("field1")
+        with connection.schema_editor() as editor:
+            editor.alter_field(SimpleModel, old_field1, new_field1, strict=True)
+        self.assertEqual(
+            self.get_constraints_for_column(SimpleModel, "field1"),
+            [
+                "schema_simplemodel_field1_f07a3d6a",
+                "schema_simplemodel_field1_f07a3d6a_like",
+            ],
+        )
+
     def test_alter_field_add_index_to_integerfield(self):
         # Create the table and verify no initial indexes.
         with connection.schema_editor() as editor:


### PR DESCRIPTION
#### Trac ticket number
ticket-35180

#### Branch description
This branch fixes the issue where an indexed character field (eg. TextField, CharField) is altered and the _like index wasn't being re-created.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
