### PR TITLE
Fixed #35667 -- Improved deprecation warning handling by replacing `stacklevel` with `skip_file_prefixes`.

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -6,6 +6,7 @@ from collections import Counter, defaultdict
 from functools import partial
 
 from django.core.exceptions import AppRegistryNotReady, ImproperlyConfigured
+from django.utils.deprecation import adjust_stacklevel_for_warning
 
 from .config import AppConfig
 
@@ -228,7 +229,7 @@ class Apps:
                     "advised as it can lead to inconsistencies, most notably with "
                     "related models." % (app_label, model_name),
                     RuntimeWarning,
-                    stacklevel=2,
+                    **adjust_stacklevel_for_warning(__file__),
                 )
             else:
                 raise RuntimeError(

--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -7,7 +7,10 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.text import get_text_list
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
@@ -38,7 +41,7 @@ class LogEntryManager(models.Manager):
         warnings.warn(
             "LogEntryManager.log_action() is deprecated. Use log_actions() instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         if isinstance(change_message, list):
             change_message = json.dumps(change_message)
@@ -60,7 +63,7 @@ class LogEntryManager(models.Manager):
                 "The usage of log_action() is deprecated. Implement log_actions() "
                 "instead.",
                 RemovedInDjango60Warning,
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
             return [
                 self.log_action(

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -55,7 +55,10 @@ from django.http.response import HttpResponseBase
 from django.template.response import SimpleTemplateResponse, TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.html import format_html
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
@@ -983,7 +986,7 @@ class ModelAdmin(BaseModelAdmin):
         warnings.warn(
             "ModelAdmin.log_deletion() is deprecated. Use log_deletions() instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         from django.contrib.admin.models import DELETION, LogEntry
 
@@ -1010,7 +1013,7 @@ class ModelAdmin(BaseModelAdmin):
                 "The usage of log_deletion() is deprecated. Implement log_deletions() "
                 "instead.",
                 RemovedInDjango60Warning,
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
             return [self.log_deletion(request, obj, str(obj)) for obj in queryset]
 

--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -21,7 +21,10 @@ from django.db.models.query_utils import PathInfo
 from django.db.models.sql import AND
 from django.db.models.sql.where import WhereNode
 from django.db.models.utils import AltersData
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.functional import cached_property
 
 
@@ -164,7 +167,7 @@ class GenericForeignKey(FieldCacheMixin, Field):
             "get_prefetch_queryset() is deprecated. Use get_prefetch_querysets() "
             "instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         if queryset is None:
             return self.get_prefetch_querysets(instances)
@@ -631,7 +634,7 @@ def create_generic_related_manager(superclass, rel):
                 "get_prefetch_queryset() is deprecated. Use get_prefetch_querysets() "
                 "instead.",
                 RemovedInDjango60Warning,
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
             if queryset is None:
                 return self.get_prefetch_querysets(instances)

--- a/django/contrib/gis/gdal/geometries.py
+++ b/django/contrib/gis/gdal/geometries.py
@@ -52,7 +52,10 @@ from django.contrib.gis.gdal.prototypes import geom as capi
 from django.contrib.gis.gdal.prototypes import srs as srs_api
 from django.contrib.gis.gdal.srs import CoordTransform, SpatialReference
 from django.contrib.gis.geometry import hex_regex, json_regex, wkt_regex
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.encoding import force_bytes
 
 
@@ -219,7 +222,9 @@ class OGRGeometry(GDALBase):
     def coord_dim(self, dim):
         "Set the coordinate dimension of this Geometry."
         msg = "coord_dim setter is deprecated. Use set_3d() instead."
-        warnings.warn(msg, RemovedInDjango60Warning, stacklevel=2)
+        warnings.warn(
+            msg, RemovedInDjango60Warning, **adjust_stacklevel_for_warning(__file__)
+        )
         if dim not in (2, 3):
             raise ValueError("Geometry dimension must be either 2 or 3")
         capi.set_coord_dim(self.ptr, dim)

--- a/django/contrib/gis/geoip2.py
+++ b/django/contrib/gis/geoip2.py
@@ -20,7 +20,10 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_ipv46_address
 from django.utils._os import to_path
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.functional import cached_property
 
 __all__ = ["HAS_GEOIP2"]
@@ -199,7 +202,7 @@ class GeoIP2:
         warnings.warn(
             "GeoIP2.coords() is deprecated. Use GeoIP2.lon_lat() instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         data = self.city(query)
         return tuple(data[o] for o in ordering)
@@ -226,6 +229,6 @@ class GeoIP2:
         warnings.warn(
             "GeoIP2.open() is deprecated. Use GeoIP2() instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         return GeoIP2(full_path, cache)

--- a/django/contrib/staticfiles/finders.py
+++ b/django/contrib/staticfiles/finders.py
@@ -9,7 +9,10 @@ from django.core.checks import Error, Warning
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import FileSystemStorage, Storage, default_storage
 from django.utils._os import safe_join
-from django.utils.deprecation import RemovedInDjango61Warning
+from django.utils.deprecation import (
+    RemovedInDjango61Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.functional import LazyObject, empty
 from django.utils.module_loading import import_string
 
@@ -18,7 +21,7 @@ searched_locations = []
 
 
 # RemovedInDjango61Warning: When the deprecation ends, remove completely.
-def _check_deprecated_find_param(class_name="", find_all=False, stacklevel=3, **kwargs):
+def _check_deprecated_find_param(class_name="", find_all=False, **kwargs):
     method_name = "find" if not class_name else f"{class_name}.find"
     if "all" in kwargs:
         legacy_all = kwargs.pop("all")
@@ -26,7 +29,9 @@ def _check_deprecated_find_param(class_name="", find_all=False, stacklevel=3, **
             "Passing the `all` argument to find() is deprecated. Use `find_all` "
             "instead."
         )
-        warnings.warn(msg, RemovedInDjango61Warning, stacklevel=stacklevel)
+        warnings.warn(
+            msg, RemovedInDjango61Warning, **adjust_stacklevel_for_warning(__file__)
+        )
 
         # If both `find_all` and `all` were given, raise TypeError.
         if find_all is not False:
@@ -57,7 +62,7 @@ class BaseFinder:
     # RemovedInDjango61Warning: When the deprecation ends, remove completely.
     def _check_deprecated_find_param(self, **kwargs):
         return _check_deprecated_find_param(
-            class_name=self.__class__.__qualname__, stacklevel=4, **kwargs
+            class_name=self.__class__.__qualname__, **kwargs
         )
 
     # RemovedInDjango61Warning: When the deprecation ends, replace with:

--- a/django/core/files/storage/filesystem.py
+++ b/django/core/files/storage/filesystem.py
@@ -9,7 +9,10 @@ from django.core.files.move import file_move_safe
 from django.core.signals import setting_changed
 from django.utils._os import safe_join
 from django.utils.deconstruct import deconstructible
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.encoding import filepath_to_uri
 from django.utils.functional import cached_property
 
@@ -48,7 +51,7 @@ class FileSystemStorage(Storage, StorageSettingsMixin):
                 "Overriding OS_OPEN_FLAGS is deprecated. Use "
                 "the allow_overwrite parameter instead.",
                 RemovedInDjango60Warning,
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
 
     @cached_property

--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -3,6 +3,7 @@ import inspect
 import warnings
 from math import ceil
 
+from django.utils.deprecation import adjust_stacklevel_for_warning
 from django.utils.functional import cached_property
 from django.utils.inspect import method_has_no_args
 from django.utils.translation import gettext_lazy as _
@@ -143,7 +144,7 @@ class Paginator:
                 "Pagination may yield inconsistent results with an unordered "
                 "object_list: {}.".format(obj_list_repr),
                 UnorderedObjectListWarning,
-                stacklevel=3,
+                **adjust_stacklevel_for_warning(__file__),
             )
 
     def get_elided_page_range(self, number=1, *, on_each_side=3, on_ends=2):

--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -19,6 +19,7 @@ from django.db.backends.utils import debug_transaction
 from django.db.transaction import TransactionManagementError
 from django.db.utils import DatabaseErrorWrapper, ProgrammingError
 from django.utils.asyncio import async_unsafe
+from django.utils.deprecation import adjust_stacklevel_for_warning
 from django.utils.functional import cached_property
 
 NO_DB_ALIAS = "__no_db__"
@@ -176,7 +177,7 @@ class BaseDatabaseWrapper:
             warnings.warn(
                 "Limit for query logging exceeded, only the last {} queries "
                 "will be returned.".format(self.queries_log.maxlen),
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
         return list(self.queries_log)
 

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -11,7 +11,10 @@ from django.db import NotSupportedError, transaction
 from django.db.backends import utils
 from django.db.models.expressions import Col
 from django.utils import timezone
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.encoding import force_str
 
 
@@ -228,7 +231,7 @@ class BaseDatabaseOperations:
                 "DatabaseOperations.lookup_cast() instead."
             ),
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         return "%s"
 

--- a/django/db/backends/oracle/oracledb_any.py
+++ b/django/db/backends/oracle/oracledb_any.py
@@ -1,6 +1,9 @@
 import warnings
 
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 
 try:
     import oracledb
@@ -13,7 +16,7 @@ except ImportError as e:
         warnings.warn(
             "cx_Oracle is deprecated. Use oracledb instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         is_oracledb = False
     except ImportError:

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -48,7 +48,10 @@ from django.db.models.signals import (
     pre_save,
 )
 from django.db.models.utils import AltersData, make_model_tuple
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.encoding import force_str
 from django.utils.hashable import make_hashable
 from django.utils.text import capfirst, get_text_list
@@ -637,13 +640,13 @@ class Model(AltersData, metaclass=ModelBase):
                     "match the current version %s."
                     % (pickled_version, django.__version__),
                     RuntimeWarning,
-                    stacklevel=2,
+                    **adjust_stacklevel_for_warning(__file__),
                 )
         else:
             warnings.warn(
                 "Pickled model instance's Django version is not specified.",
                 RuntimeWarning,
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
         if "_memoryview_attrs" in state:
             for attr, value in state.pop("_memoryview_attrs"):
@@ -791,7 +794,7 @@ class Model(AltersData, metaclass=ModelBase):
         warnings.warn(
             f"Passing positional arguments to {method_name}() is deprecated",
             RemovedInDjango60Warning,
-            stacklevel=3,
+            **adjust_stacklevel_for_warning(__file__),
         )
         total_len_args = len(args) + 1  # include self
         max_len_args = len(defaults) + 1

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -12,7 +12,10 @@ from django.db.models.lookups import Exact, IsNull
 from django.db.models.query_utils import Q
 from django.db.models.sql.query import Query
 from django.db.utils import DEFAULT_DB_ALIAS
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.translation import gettext_lazy as _
 
 __all__ = ["BaseConstraint", "CheckConstraint", "Deferrable", "UniqueConstraint"]
@@ -49,7 +52,7 @@ class BaseConstraint:
                 f"Passing positional arguments to {self.__class__.__name__} is "
                 f"deprecated.",
                 RemovedInDjango60Warning,
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
             for arg, attr in zip(args, ["name", "violation_error_message"]):
                 if arg:
@@ -164,7 +167,7 @@ class CheckConstraint(BaseConstraint):
             warnings.warn(
                 "CheckConstraint.check is deprecated in favor of `.condition`.",
                 RemovedInDjango60Warning,
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
             condition = check
         self.condition = condition
@@ -182,7 +185,7 @@ class CheckConstraint(BaseConstraint):
         warnings.warn(
             "CheckConstraint.check is deprecated in favor of `.condition`.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         return self.condition
 
@@ -190,7 +193,7 @@ class CheckConstraint(BaseConstraint):
         warnings.warn(
             "CheckConstraint.check is deprecated in favor of `.condition`.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         self.condition = value
 

--- a/django/db/models/enums.py
+++ b/django/db/models/enums.py
@@ -1,7 +1,10 @@
 import enum
 import warnings
 
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.functional import Promise
 from django.utils.version import PY311, PY312
 
@@ -117,7 +120,7 @@ def __getattr__(name):
         warnings.warn(
             "ChoicesMeta is deprecated in favor of ChoicesType.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         return ChoicesType
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/django/db/models/fields/mixins.py
+++ b/django/db/models/fields/mixins.py
@@ -1,7 +1,11 @@
 import warnings
 
+import django
 from django.core import checks
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.functional import cached_property
 
 NOT_PROVIDED = object()
@@ -28,7 +32,7 @@ class FieldCacheMixin:
             f"Override {self.__class__.__qualname__}.cache_name instead of "
             "get_cache_name().",
             RemovedInDjango60Warning,
-            stacklevel=3,
+            **adjust_stacklevel_for_warning(django.utils.functional.__file__),
         )
         return cache_name
 

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -14,7 +14,10 @@ from django.db.models.constants import LOOKUP_SEP
 from django.db.models.deletion import CASCADE, SET_DEFAULT, SET_NULL
 from django.db.models.query_utils import PathInfo
 from django.db.models.utils import make_model_tuple
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
@@ -781,7 +784,7 @@ class ForeignObject(RelatedField):
             "ForeignObject.get_joining_columns() is deprecated. Use "
             "get_joining_fields() instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         source = self.reverse_related_fields if reverse_join else self.related_fields
         return tuple(
@@ -793,7 +796,7 @@ class ForeignObject(RelatedField):
             "ForeignObject.get_reverse_joining_columns() is deprecated. Use "
             "get_reverse_joining_fields() instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         return self.get_joining_columns(reverse_join=True)
 

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -81,7 +81,10 @@ from django.db.models.lookups import GreaterThan, LessThanOrEqual
 from django.db.models.query import QuerySet
 from django.db.models.query_utils import DeferredAttribute
 from django.db.models.utils import AltersData, resolve_callables
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.functional import cached_property
 
 
@@ -160,7 +163,7 @@ class ForwardManyToOneDescriptor:
             "get_prefetch_queryset() is deprecated. Use get_prefetch_querysets() "
             "instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         if queryset is None:
             return self.get_prefetch_querysets(instances)
@@ -452,7 +455,7 @@ class ReverseOneToOneDescriptor:
             "get_prefetch_queryset() is deprecated. Use get_prefetch_querysets() "
             "instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         if queryset is None:
             return self.get_prefetch_querysets(instances)
@@ -770,7 +773,7 @@ def create_reverse_many_to_one_manager(superclass, rel):
                 "get_prefetch_queryset() is deprecated. Use get_prefetch_querysets() "
                 "instead.",
                 RemovedInDjango60Warning,
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
             if queryset is None:
                 return self.get_prefetch_querysets(instances)
@@ -1150,7 +1153,7 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
                 "get_prefetch_queryset() is deprecated. Use get_prefetch_querysets() "
                 "instead.",
                 RemovedInDjango60Warning,
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
             if queryset is None:
                 return self.get_prefetch_querysets(instances)

--- a/django/db/models/fields/reverse_related.py
+++ b/django/db/models/fields/reverse_related.py
@@ -12,7 +12,10 @@ they're the closest concept currently available.
 import warnings
 
 from django.core import exceptions
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.functional import cached_property
 from django.utils.hashable import make_hashable
 
@@ -197,7 +200,7 @@ class ForeignObjectRel(FieldCacheMixin):
             "ForeignObjectRel.get_joining_columns() is deprecated. Use "
             "get_joining_fields() instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         return self.field.get_reverse_joining_columns()
 

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -33,7 +33,10 @@ from django.db.models.utils import (
     resolve_callables,
 )
 from django.utils import timezone
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.functional import cached_property, partition
 
 # The maximum number of results to fetch in a get() query.
@@ -343,13 +346,13 @@ class QuerySet(AltersData):
                     "match the current version %s."
                     % (pickled_version, django.__version__),
                     RuntimeWarning,
-                    stacklevel=2,
+                    **adjust_stacklevel_for_warning(__file__),
                 )
         else:
             warnings.warn(
                 "Pickled queryset instance's Django version is not specified.",
                 RuntimeWarning,
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
         self.__dict__.update(state)
 
@@ -2225,7 +2228,7 @@ class Prefetch:
             "Prefetch.get_current_queryset() is deprecated. Use "
             "get_current_querysets() instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         querysets = self.get_current_querysets(level)
         return querysets[0] if querysets is not None else None
@@ -2532,7 +2535,7 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
             "The usage of get_prefetch_queryset() in prefetch_related_objects() is "
             "deprecated. Implement get_prefetch_querysets() instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         queryset = None
         if querysets := lookup.get_current_querysets(level):

--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -44,7 +44,10 @@ from django.forms.widgets import (
 from django.utils import formats
 from django.utils.choices import normalize_choices
 from django.utils.dateparse import parse_datetime, parse_duration
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.duration import duration_string
 from django.utils.ipv6 import clean_ipv6_address
 from django.utils.regex_helper import _lazy_re_compile
@@ -781,7 +784,7 @@ class URLField(CharField):
                     "transitional setting to True to opt into using 'https' as the new "
                     "default scheme.",
                     RemovedInDjango60Warning,
-                    stacklevel=2,
+                    **adjust_stacklevel_for_warning(__file__),
                 )
                 assume_scheme = "http"
         # RemovedInDjango60Warning: When the deprecation ends, replace with:

--- a/django/forms/renderers.py
+++ b/django/forms/renderers.py
@@ -5,7 +5,10 @@ from pathlib import Path
 from django.conf import settings
 from django.template.backends.django import DjangoTemplates
 from django.template.loader import get_template
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 
@@ -80,7 +83,7 @@ class DjangoDivFormRenderer(DjangoTemplates):
             "The DjangoDivFormRenderer transitional form renderer is deprecated. Use "
             "DjangoTemplates instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         super().__init__(*args, **kwargs)
 
@@ -97,7 +100,7 @@ class Jinja2DivFormRenderer(Jinja2):
             "The Jinja2DivFormRenderer transitional form renderer is deprecated. Use "
             "Jinja2 instead.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         super().__init__(*args, **kwargs)
 

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -20,6 +20,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.http.cookie import SimpleCookie
 from django.utils import timezone
 from django.utils.datastructures import CaseInsensitiveMapping
+from django.utils.deprecation import adjust_stacklevel_for_warning
 from django.utils.encoding import iri_to_uri
 from django.utils.http import content_disposition_header, http_date
 from django.utils.regex_helper import _lazy_re_compile
@@ -498,7 +499,7 @@ class StreamingHttpResponse(HttpResponseBase):
                 "StreamingHttpResponse must consume asynchronous iterators in order to "
                 "serve them synchronously. Use a synchronous iterator instead.",
                 Warning,
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
 
             # async iterator. Consume in async_to_sync and map back.
@@ -519,7 +520,7 @@ class StreamingHttpResponse(HttpResponseBase):
                 "StreamingHttpResponse must consume synchronous iterators in order to "
                 "serve them asynchronously. Use an asynchronous iterator instead.",
                 Warning,
-                stacklevel=2,
+                **adjust_stacklevel_for_warning(__file__),
             )
             # sync iterator. Consume via sync_to_async and yield via async
             # generator.

--- a/django/urls/converters.py
+++ b/django/urls/converters.py
@@ -2,7 +2,10 @@ import functools
 import uuid
 import warnings
 
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 
 
 class IntConverter:
@@ -63,7 +66,7 @@ def register_converter(converter, type_name):
             f"Converter {type_name!r} is already registered. Support for overriding "
             "registered converters is deprecated and will be removed in Django 6.0.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
     REGISTERED_CONVERTERS[type_name] = converter()
     get_converters.cache_clear()

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -8,7 +8,10 @@ from collections.abc import Mapping
 from html.parser import HTMLParser
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit, urlunsplit
 
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 from django.utils.encoding import punycode
 from django.utils.functional import Promise, cached_property, keep_lazy, keep_lazy_text
 from django.utils.http import RFC3986_GENDELIMS, RFC3986_SUBDELIMS
@@ -134,7 +137,7 @@ def format_html(format_string, *args, **kwargs):
         warnings.warn(
             "Calling format_html() without passing args or kwargs is deprecated.",
             RemovedInDjango60Warning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
     args_safe = map(conditional_escape, args)
     kwargs_safe = {k: conditional_escape(v) for (k, v) in kwargs.items()}

--- a/django/utils/itercompat.py
+++ b/django/utils/itercompat.py
@@ -2,7 +2,10 @@
 
 import warnings
 
-from django.utils.deprecation import RemovedInDjango60Warning
+from django.utils.deprecation import (
+    RemovedInDjango60Warning,
+    adjust_stacklevel_for_warning,
+)
 
 
 def is_iterable(x):
@@ -11,7 +14,7 @@ def is_iterable(x):
         "django.utils.itercompat.is_iterable() is deprecated. "
         "Use isinstance(..., collections.abc.Iterable) instead.",
         RemovedInDjango60Warning,
-        stacklevel=2,
+        **adjust_stacklevel_for_warning(__file__),
     )
     try:
         iter(x)

--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -114,7 +114,7 @@ requirements:
   feature, the change should also contain documentation.
 
 When you think your work is ready to be reviewed, send :doc:`a GitHub pull
-request <working-with-git>`. 
+request <working-with-git>`.
 If you can't send a pull request for some reason, you can also use patches in
 Trac. When using this style, follow these guidelines.
 
@@ -221,7 +221,10 @@ previous behavior, or standalone items that are unnecessary or unused when the
 deprecation ends. For example::
 
     import warnings
-    from django.utils.deprecation import RemovedInDjangoXXWarning
+    from django.utils.deprecation import (
+        RemovedInDjangoXXWarning,
+        adjust_stacklevel_for_warning,
+    )
 
 
     # RemovedInDjangoXXWarning.
@@ -234,7 +237,7 @@ deprecation ends. For example::
         warnings.warn(
             "foo() is deprecated.",
             category=RemovedInDjangoXXWarning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         old_private_helper()
         ...


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-35667](https://code.djangoproject.com/ticket/35667)

#### Branch description
Improved the handling of deprecation warnings by replacing the use of `stacklevel` with `skip_file_prefixes`. This change ensures that deprecation warnings accurately reference the offending call site, enhancing clarity and maintainability. The update leverages the new `warnings.warn(skip_file_prefixes: tuple[str] | None)` feature introduced in Python 3.12, and includes a fallback mechanism for compatibility with Python 3.11.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
