### PR TITLE
Fixed #35095 -- Formatted the documentation for fixing the monetary values of Swiss (German)

### DIFF
--- a/docs/topics/i18n/formatting.txt
+++ b/docs/topics/i18n/formatting.txt
@@ -192,8 +192,8 @@ Switzerland (German)
 --------------------
 
 The Swiss number formatting depends on the type of number that is being
-formatted. For monetary values, a comma is used as the thousand separator and
-a decimal point for the decimal separator. For all other numbers, a comma is
-used as decimal separator and a space as thousand separator. The locale format
-provided by Django uses the generic separators, a comma for decimal and a space
-for thousand separators.
+formatted. For monetary values, an apostrophe as a thousands separator
+along with a dot as the decimal separator. For all other numbers, a comma is
+used as decimal separator and a space as thousand separator. The locale
+format provided by Django uses the generic separators, a comma for decimal and
+a space for thousand separators.


### PR DESCRIPTION
…s discrepancy

Fixed #35095

Refactored Django’s documentation to correct the Swiss (German) monetary value formatting. Updated the formatting guidelines to reflect the use of a comma as the thousand separator and a period as the decimal separator for monetary values. Additionally, ensured consistency by clarifying the distinction between monetary and other numeric formatting conventions used in the de_CH locale.

<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-[35095](https://code.djangoproject.com/ticket/35095)

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
