### PR TITLE
Fixed #35308 -- Caught and logged OSError when launching formatters.

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -392,7 +392,7 @@ class Command(BaseCommand):
                         )
                     )
                     self.log(writer.as_string())
-        run_formatters(self.written_files)
+        run_formatters(self.written_files, stderr=self.stderr)
 
     @staticmethod
     def get_relative_path(path):
@@ -499,7 +499,7 @@ class Command(BaseCommand):
                     # Write the merge migrations file to the disk
                     with open(writer.path, "w", encoding="utf-8") as fh:
                         fh.write(writer.as_string())
-                    run_formatters([writer.path])
+                    run_formatters([writer.path], stderr=self.stderr)
                     if self.verbosity > 0:
                         self.log("\nCreated new merge migration %s" % writer.path)
                         if self.scriptable:

--- a/django/core/management/commands/optimizemigration.py
+++ b/django/core/management/commands/optimizemigration.py
@@ -121,7 +121,7 @@ class Command(BaseCommand):
                     )
         with open(writer.path, "w", encoding="utf-8") as fh:
             fh.write(migration_file_string)
-        run_formatters([writer.path])
+        run_formatters([writer.path], stderr=self.stderr)
 
         if verbosity > 0:
             self.stdout.write(

--- a/django/core/management/commands/squashmigrations.py
+++ b/django/core/management/commands/squashmigrations.py
@@ -221,7 +221,7 @@ class Command(BaseCommand):
             )
         with open(writer.path, "w", encoding="utf-8") as fh:
             fh.write(writer.as_string())
-        run_formatters([writer.path])
+        run_formatters([writer.path], stderr=self.stderr)
 
         if self.verbosity > 0:
             self.stdout.write(

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -229,7 +229,7 @@ class TemplateCommand(BaseCommand):
                 else:
                     shutil.rmtree(path_to_remove)
 
-        run_formatters([top_dir], **formatter_paths)
+        run_formatters([top_dir], **formatter_paths, stderr=self.stderr)
 
     def handle_template(self, template, subdir):
         """

--- a/django/core/management/utils.py
+++ b/django/core/management/utils.py
@@ -2,6 +2,8 @@ import fnmatch
 import os
 import shutil
 import subprocess
+import sys
+import traceback
 from pathlib import Path
 from subprocess import run
 
@@ -161,7 +163,7 @@ def find_formatters():
     return {"black_path": shutil.which("black")}
 
 
-def run_formatters(written_files, black_path=(sentinel := object())):
+def run_formatters(written_files, black_path=(sentinel := object()), stderr=sys.stderr):
     """
     Run the black formatter on the specified files.
     """
@@ -169,7 +171,11 @@ def run_formatters(written_files, black_path=(sentinel := object())):
     if black_path is sentinel:
         black_path = shutil.which("black")
     if black_path:
-        subprocess.run(
-            [black_path, "--fast", "--", *written_files],
-            capture_output=True,
-        )
+        try:
+            subprocess.run(
+                [black_path, "--fast", "--", *written_files],
+                capture_output=True,
+            )
+        except OSError:
+            stderr.write("Formatters failed to launch:")
+            traceback.print_exc(file=stderr)

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -16,6 +16,8 @@ import unittest
 from io import StringIO
 from unittest import mock
 
+from user_commands.utils import AssertFormatterFailureCaughtContext
+
 from django import conf, get_version
 from django.conf import settings
 from django.core.management import (
@@ -2942,6 +2944,16 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
                     stat.S_IMODE(os.stat(file_path).st_mode),
                     expected_mode,
                 )
+
+    def test_failure_to_format_code(self):
+        with AssertFormatterFailureCaughtContext(self) as ctx:
+            call_command(
+                "startapp",
+                "mynewapp",
+                directory=self.test_dir,
+                stdout=ctx.stdout,
+                stderr=ctx.stderr,
+            )
 
 
 class StartApp(AdminScriptTestCase):

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -2265,6 +2265,19 @@ class MakeMigrationsTests(MigrationTestBase):
         self.assertEqual(out.getvalue(), f"{merge_file}\n")
         self.assertIn(f"Created new merge migration {merge_file}", err.getvalue())
 
+    def test_makemigrations_failure_to_format_code(self):
+        self.assertFormatterFailureCaught("makemigrations", "migrations")
+
+    def test_merge_makemigrations_failure_to_format_code(self):
+        self.assertFormatterFailureCaught("makemigrations", "migrations", empty=True)
+        self.assertFormatterFailureCaught(
+            "makemigrations",
+            "migrations",
+            merge=True,
+            interactive=False,
+            module="migrations.test_migrations_conflict",
+        )
+
     def test_makemigrations_migrations_modules_path_not_exist(self):
         """
         makemigrations creates migrations when specifying a custom location
@@ -3069,6 +3082,11 @@ class SquashMigrationsTests(MigrationTestBase):
             + black_warning,
         )
 
+    def test_failure_to_format_code(self):
+        self.assertFormatterFailureCaught(
+            "squashmigrations", "migrations", "0002", interactive=False
+        )
+
 
 class AppLabelErrorTests(TestCase):
     """
@@ -3301,6 +3319,9 @@ class OptimizeMigrationTests(MigrationTestBase):
         msg = "Cannot find a migration matching 'nonexistent' from app 'migrations'."
         with self.assertRaisesMessage(CommandError, msg):
             call_command("optimizemigration", "migrations", "nonexistent")
+
+    def test_failure_to_format_code(self):
+        self.assertFormatterFailureCaught("optimizemigration", "migrations", "0001")
 
 
 class CustomMigrationCommandTests(MigrationTestBase):

--- a/tests/user_commands/test_files/black
+++ b/tests/user_commands/test_files/black
@@ -1,0 +1,1 @@
+# This file is not executable, to simulate a broken `black` install.

--- a/tests/user_commands/utils.py
+++ b/tests/user_commands/utils.py
@@ -1,0 +1,23 @@
+from io import StringIO
+from unittest import mock
+
+
+class AssertFormatterFailureCaughtContext:
+
+    def __init__(self, test, shutil_which_result="nonexistent"):
+        self.stdout = StringIO()
+        self.stderr = StringIO()
+        self.test = test
+        self.shutil_which_result = shutil_which_result
+
+    def __enter__(self):
+        self.mocker = mock.patch(
+            "django.core.management.utils.shutil.which",
+            return_value=self.shutil_which_result,
+        )
+        self.mocker.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.mocker.stop()
+        self.test.assertIn("Formatters failed to launch", self.stderr.getvalue())


### PR DESCRIPTION
#### Trac ticket number
ticket-35308

#### Branch description
Catch and log out OSError when black cannot be launched.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
