### PR TITLE
Refs #29522 -- Fixed serializers/fixtures test crash if PyYAML isn't installed.

### DIFF
--- a/tests/fixtures_regress/tests.py
+++ b/tests/fixtures_regress/tests.py
@@ -2,6 +2,7 @@
 import json
 import os
 import re
+import unittest
 from io import StringIO
 from pathlib import Path
 
@@ -55,6 +56,13 @@ from .models import (
     Widget,
 )
 
+try:
+    import yaml  # NOQA
+
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+
 _cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -96,11 +104,13 @@ class TestFixtures(TestCase):
         the serialized data for fields that have been removed
         from the database when not ignored.
         """
-        for fixture_file in (
+        test_fixtures = [
             "sequence_extra",
             "sequence_extra_jsonl",
-            "sequence_extra_yaml",
-        ):
+        ]
+        if HAS_YAML:
+            test_fixtures.append("sequence_extra_yaml")
+        for fixture_file in test_fixtures:
             with (
                 self.subTest(fixture_file=fixture_file),
                 self.assertRaises(DeserializationError),
@@ -147,6 +157,7 @@ class TestFixtures(TestCase):
         )
         self.assertEqual(Animal.specimens.all()[0].name, "Eagle")
 
+    @unittest.skipUnless(HAS_YAML, "No yaml library detected")
     def test_loaddata_not_found_fields_ignore_yaml(self):
         management.call_command(
             "loaddata",

--- a/tests/serializers/test_deserialization.py
+++ b/tests/serializers/test_deserialization.py
@@ -1,13 +1,20 @@
 import json
+import unittest
 
 from django.core.serializers.base import DeserializationError, DeserializedObject
 from django.core.serializers.json import Deserializer as JsonDeserializer
 from django.core.serializers.jsonl import Deserializer as JsonlDeserializer
 from django.core.serializers.python import Deserializer
-from django.core.serializers.pyyaml import Deserializer as YamlDeserializer
 from django.test import SimpleTestCase
 
 from .models import Author
+
+try:
+    import yaml  # NOQA
+
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
 
 
 class TestDeserializer(SimpleTestCase):
@@ -94,7 +101,10 @@ class TestDeserializer(SimpleTestCase):
         self.assertEqual(first_item.object, self.jane)
         self.assertEqual(second_item.object, self.joe)
 
+    @unittest.skipUnless(HAS_YAML, "No yaml library detected")
     def test_yaml_bytes_input(self):
+        from django.core.serializers.pyyaml import Deserializer as YamlDeserializer
+
         test_string = """- pk: 1
   model: serializers.author
   fields:


### PR DESCRIPTION
**[Logs](https://djangoci.com/job/main-no-requirements/database=mysql,label=focal,python=python3.12/294/testReport/junit/)**

Test regression in b2501759eb91edddaeb5ddfccb40a44f39da7798 and ee5147cfd7de2add74a285537a8968ec074e70cd.