### PR TITLE
Fixed TextChoices code example in docs missing an added `.choices`.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -261,7 +261,7 @@ choices in a concise way::
 
         year_in_school = models.CharField(
             max_length=2,
-            choices=YearInSchool,
+            choices=YearInSchool.choices,
             default=YearInSchool.FRESHMAN,
         )
 


### PR DESCRIPTION
#### Trac ticket number
N/A

#### Branch description
The code example explaining to use `models.TextChoices` passes `choices=<TextChoices>` directly, failing e.g. on migration as:

```
core.Student.year_in_school: (fields.E005) 'choices' must be an iterable containing (actual value, human readable name) tuples.
```

Adding `.choices` fixes that.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests. -> Haven't found any relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable. -> This is so trivial it doesn't need release notes, imho.
- [x] I have attached screenshots in both light and dark modes for any UI changes. -> No relevant changes
