### PR TITLE
Fixed #35776 -- Dropped support for GDAL 3.0.

### DIFF
--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -30,7 +30,6 @@ elif os.name == "nt":
         "gdal303",
         "gdal302",
         "gdal301",
-        "gdal300",
     ]
 elif os.name == "posix":
     # *NIX library names.
@@ -45,7 +44,6 @@ elif os.name == "posix":
         "gdal3.3.0",
         "gdal3.2.0",
         "gdal3.1.0",
-        "gdal3.0.0",
     ]
 else:
     raise ImproperlyConfigured('GDAL is unsupported on OS "%s".' % os.name)

--- a/docs/ref/contrib/gis/install/geolibs.txt
+++ b/docs/ref/contrib/gis/install/geolibs.txt
@@ -5,16 +5,16 @@ Installing Geospatial libraries
 GeoDjango uses and/or provides interfaces for the following open source
 geospatial libraries:
 
-========================  ====================================  ================================  ===========================================
+========================  ====================================  ================================  ======================================
 Program                   Description                           Required                          Supported Versions
-========================  ====================================  ================================  ===========================================
+========================  ====================================  ================================  ======================================
 :doc:`GEOS <../geos>`     Geometry Engine Open Source           Yes                               3.12, 3.11, 3.10, 3.9, 3.8
 `PROJ`_                   Cartographic Projections library      Yes (PostgreSQL and SQLite only)  9.x, 8.x, 7.x, 6.x
-:doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               3.8, 3.7, 3.6, 3.5, 3.4, 3.3, 3.2, 3.1, 3.0
+:doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               3.8, 3.7, 3.6, 3.5, 3.4, 3.3, 3.2, 3.1
 :doc:`GeoIP <../geoip2>`  IP-based geolocation library          No                                2
 `PostGIS`__               Spatial extensions for PostgreSQL     Yes (PostgreSQL only)             3.4, 3.3, 3.2, 3.1
 `SpatiaLite`__            Spatial extensions for SQLite         Yes (SQLite only)                 5.1, 5.0, 4.3
-========================  ====================================  ================================  ===========================================
+========================  ====================================  ================================  ======================================
 
 Note that older or more recent versions of these libraries *may* also work
 totally fine with GeoDjango. Your mileage may vary.
@@ -26,7 +26,6 @@ totally fine with GeoDjango. Your mileage may vary.
     GEOS 3.10.0 2021-10-20
     GEOS 3.11.0 2022-07-01
     GEOS 3.12.0 2023-06-27
-    GDAL 3.0.0 2019-05
     GDAL 3.1.0 2020-05-07
     GDAL 3.2.0 2020-11-02
     GDAL 3.3.0 2021-05-03

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -309,6 +309,8 @@ backends.
 
 * Support for PostGIS 3.0 is removed.
 
+* Support for GDAL 3.0 is removed.
+
 Dropped support for PostgreSQL 13
 ---------------------------------
 


### PR DESCRIPTION
#### Trac ticket number

ticket-35776

#### Branch description
GDAL 3.0 is more than 5 years old and support for it can be dropped.
[​https://github.com/OSGeo/gdal/releases/tag/v3.0.0](https://github.com/OSGeo/gdal/releases/tag/v3.0.0)

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
