### PR TITLE
Fixed #35774 -- Dropped support for GEOS 3.8.

### DIFF
--- a/docs/ref/contrib/gis/install/geolibs.txt
+++ b/docs/ref/contrib/gis/install/geolibs.txt
@@ -8,7 +8,7 @@ geospatial libraries:
 ========================  ====================================  ================================  ======================================
 Program                   Description                           Required                          Supported Versions
 ========================  ====================================  ================================  ======================================
-:doc:`GEOS <../geos>`     Geometry Engine Open Source           Yes                               3.12, 3.11, 3.10, 3.9, 3.8
+:doc:`GEOS <../geos>`     Geometry Engine Open Source           Yes                               3.12, 3.11, 3.10, 3.9
 `PROJ`_                   Cartographic Projections library      Yes (PostgreSQL and SQLite only)  9.x, 8.x, 7.x, 6.x
 :doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               3.8, 3.7, 3.6, 3.5, 3.4, 3.3, 3.2, 3.1
 :doc:`GeoIP <../geoip2>`  IP-based geolocation library          No                                2
@@ -21,7 +21,6 @@ totally fine with GeoDjango. Your mileage may vary.
 
 ..
     Libs release dates:
-    GEOS 3.8.0 2019-10-10
     GEOS 3.9.0 2020-12-14
     GEOS 3.10.0 2021-10-20
     GEOS 3.11.0 2022-07-01

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -311,6 +311,8 @@ backends.
 
 * Support for GDAL 3.0 is removed.
 
+* Support for GEOS 3.8 is removed.
+
 Dropped support for PostgreSQL 13
 ---------------------------------
 

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -1188,10 +1188,8 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
 
             # Testing __getitem__ (doesn't work on Point or Polygon)
             if isinstance(g, Point):
-                # IndexError is not raised in GEOS 3.8.0.
-                if geos_version_tuple() != (3, 8, 0):
-                    with self.assertRaises(IndexError):
-                        g.x
+                with self.assertRaises(IndexError):
+                    g.x
             elif isinstance(g, Polygon):
                 lr = g.shell
                 self.assertEqual("LINEARRING EMPTY", lr.wkt)


### PR DESCRIPTION
GEOS 3.8 (released Oct-2019) will be more than 5 years old when Django 5.2 is released (Apr-2025).

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35774

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
