### PR TITLE
Refs #35766 -- Added a release note for BaseChoiceIterator slicing regression.

### DIFF
--- a/docs/releases/5.1.2.txt
+++ b/docs/releases/5.1.2.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Fixed a regression in Django 5.1 that caused a crash when using the
   PostgreSQL lookup :lookup:`trigram_similar` on output fields from ``Concat``
   (:ticket:`35732`).
+
+* Fixed a regression that caused a crash when slicing :attr:`.Field.choices`
+  that inherit from ``BaseChoiceIterator`` (:ticket:`35766`).


### PR DESCRIPTION
ticket-35766

This is a release note for ae1ee24178ecd53ac5ef3fc2055e4be8b9602ac9 which should be back ported to 5.1 as was a regression in 07fa79ef2bb3e8cace7bd87b292c6c85230eed05.

I am not 100% sure if a release note is required given 07fa79ef2bb3e8cace7bd87b292c6c85230eed05 was back ported to 5.0 without a release note (711c0547224de00aee39b8720c706ac4977e89fd).

I also wasn't sure whether to start the release note with `Fixed a regression in Django 5.1` given this regression also exists in 5.0 (due to the back port)