### PR TITLE
Updated docs to use py <script.py> for running Python scripts in Windows.

### DIFF
--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -335,11 +335,11 @@ class ConsoleDirective(CodeBlock):
             if line.startswith("$ # "):
                 return "REM " + args_to_win(line[4:])
             if line.startswith("$ ./manage.py"):
-                return "manage.py " + args_to_win(line[13:])
+                return "py manage.py " + args_to_win(line[13:])
             if line.startswith("$ manage.py"):
-                return "manage.py " + args_to_win(line[11:])
+                return "py manage.py " + args_to_win(line[11:])
             if line.startswith("$ ./runtests.py"):
-                return "runtests.py " + args_to_win(line[15:])
+                return "py runtests.py " + args_to_win(line[15:])
             if line.startswith("$ ./"):
                 return args_to_win(line[4:])
             if line.startswith("$ python3"):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

#### Branch Description

In the documentation, the `manage.py` and `runtests.py` scripts are sometimes shown being run as `./manage.py` and `./runtests.py` on Linux, and as `.\manage.py` and `.\runtests.py` on Windows. However, on Windows this method of running scripts depends on whether `*.py` files are associated with the Python executable in File Explorer. If associated with another application like a text editor, running `.\manage.py` or `.\runtests.py` will either open the script in that application or do nothing if no association exists.

This PR updates the documentation to consistently use `py <script.py>` when demonstrating how to run Python scripts on Windows. This method ensures scripts will run correctly regardless of file associations in Windows File Explorer.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
