### PR TITLE
Fixed #35670 -- Clarified get_login_url() in LoginRequiredMiddleware docs.

### DIFF
--- a/docs/ref/middleware.txt
+++ b/docs/ref/middleware.txt
@@ -563,19 +563,19 @@ unauthenticated requests.
 
 .. method:: get_login_url()
 
-    Returns the URL that unauthenticated requests will be redirected to. If
-    defined, this returns the ``login_url`` set on the
-    :func:`~.django.contrib.auth.decorators.login_required` decorator. Defaults
-    to :setting:`settings.LOGIN_URL <LOGIN_URL>`.
+    Returns the URL that unauthenticated requests will be redirected to. This
+    result is either the ``login_url`` set on the
+    :func:`~django.contrib.auth.decorators.login_required` decorator (if not
+    ``None``), or :setting:`settings.LOGIN_URL <LOGIN_URL>`.
 
 .. method:: get_redirect_field_name()
 
     Returns the name of the query parameter that contains the URL the user
-    should be redirected to after a successful login. If defined, this returns
+    should be redirected to after a successful login. This result is either
     the ``redirect_field_name`` set on the
-    :func:`~.django.contrib.auth.decorators.login_required` decorator. Defaults
-    to :attr:`redirect_field_name`. If ``None`` is returned, a query parameter
-    won't be added.
+    :func:`~.django.contrib.auth.decorators.login_required` decorator (if not
+    ``None``), or :attr:`redirect_field_name`. If ``None`` is returned, a query
+    parameter won't be added.
 
 .. class:: RemoteUserMiddleware
 


### PR DESCRIPTION
Summary: 
This PR updates the documentation for the get_login_url() method in LoginRequiredMiddleware. The previous wording was unclear, particularly in the explanation of the behavior when login_url is defined by the login_required() decorator. This revision improves clarity and consistency in line with Django’s documentation standards.

Changes:
Reworded the explanation to clarify the behavior when login_url is set via the login_required() decorator.
Updated formatting to correctly reference the login_required() decorator and settings.LOGIN_URL.


ticket-[35670](https://code.djangoproject.com/ticket/35670)

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
