### PR TITLE
Fixed #35781 -- Modified DateField presave to hanlde timezones.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1502,7 +1502,7 @@ class DateField(DateTimeCheckMixin, Field):
 
     def pre_save(self, model_instance, add):
         if self.auto_now or (self.auto_now_add and add):
-            value = datetime.date.today()
+            value = timezone.now().date()
             setattr(model_instance, self.attname, value)
             return value
         else:

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -172,6 +172,10 @@ class DateTimeModel(models.Model):
     t = models.TimeField()
 
 
+class AutoNowDateModel(models.Model):
+    d = models.DateField(auto_now=True)
+
+
 class DurationModel(models.Model):
     field = models.DurationField()
 

--- a/tests/model_fields/test_datetimefield.py
+++ b/tests/model_fields/test_datetimefield.py
@@ -1,12 +1,12 @@
 import datetime
+from unittest import mock
 
 from django.db import models
 from django.test import SimpleTestCase, TestCase, override_settings, skipUnlessDBFeature
 from django.test.utils import requires_tz_support
 from django.utils import timezone
-from unittest import mock
 
-from .models import DateTimeModel, AutoNowDateModel
+from .models import AutoNowDateModel, DateTimeModel
 
 
 class DateTimeFieldTests(TestCase):
@@ -89,11 +89,10 @@ class DateFieldAutoNowTests(TestCase):
         obj.refresh_from_db()
         self.assertEqual(obj.d, current_time.date())
 
-    @mock.patch('django.utils.timezone.now')
+    @mock.patch("django.utils.timezone.now")
     def test_auto_now_near_midnight(self, mock_timezone_now):
         mock_time = timezone.make_aware(datetime.datetime(2024, 9, 22, 23, 59, 59))
         mock_timezone_now.return_value = mock_time
-        
         obj = AutoNowDateModel.objects.create()
         obj.refresh_from_db()
         self.assertEqual(obj.d, mock_time.date())


### PR DESCRIPTION
#### Trac ticket number

ticket-35781

#### Branch description
When using DateField with auto_now=True or auto_now_add=True, the field uses datetime.date.today() to set the date, which is based on the system’s local time and not the configured time zone. This can result in inconsistent data, especially when the difference between the local time and the time zone is sufficient to cause a date mismatch (e.g., when crossing midnight in the configured time zone).
For example, if the local time is just past midnight but the time zone is still on the previous day, DateField will save the current local date instead of the correct date in the configured time zone. This behavior is particularly problematic in applications where time zone accuracy is critical for date-related records (e.g., in reports or logs).
The expected behavior is for DateField to respect the Django TIME_ZONE setting when auto_now or auto_now_add is used, ensuring that the saved date is consistent with the configured time zone, not just the local system time.
Your ticket description looks good, but I suggest making a few adjustments for clarity and specificity. Here's a refined version:
Title: DateField with auto_now or auto_now_add ignores time zone, leading to inconsistent dates
Description:
When using DateField with auto_now=True or auto_now_add=True, the field uses datetime.date.today() to set the date, which is based on the system’s local time and not the configured time zone. This can result in inconsistent data, especially when the difference between the local time and the time zone is sufficient to cause a date mismatch (e.g., when crossing midnight in the configured time zone).
For example, if the local time is just past midnight but the time zone is still on the previous day, DateField will save the current local date instead of the correct date in the configured time zone. This behavior is particularly problematic in applications where time zone accuracy is critical for date-related records (e.g., in reports or logs).
The expected behavior is for DateField to respect the Django TIME_ZONE setting when auto_now or auto_now_add is used, ensuring that the saved date is consistent with the configured time zone, not just the local system time.
Steps to Reproduce:
Set Django’s TIME_ZONE to a time zone different from the system's local time (e.g., America/New_York).
Create a model with a DateField using auto_now_add=True or auto_now=True.
Save a new instance of the model or update an existing instance.
Observe the saved date in the database. It will reflect the local system date, ignoring the configured time zone
Expected Behavior:
The DateField should set the date according to the configured TIME_ZONE setting, ensuring consistent date records, regardless of the local system time.

Changes:
In the presave of DateField the value set  if auto_now or auto_now_add  equal True is set to timezone.now.date instead of using datetime date


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
