### PR TITLE
Updated sign() outputs in Cryptographic signing docs.

### DIFF
--- a/docs/topics/signing.txt
+++ b/docs/topics/signing.txt
@@ -50,7 +50,7 @@ To sign a value, first instantiate a ``Signer`` instance:
     >>> signer = Signer()
     >>> value = signer.sign("My string")
     >>> value
-    'My string:GdMGD6HNQ_qdgxYP8yBZAdAIV1w'
+    'My string:v9G-nxfz3iQGTXrePqYPlGvH79WTcIgj1QIQSUODTW0'
 
 The signature is appended to the end of the string, following the colon.
 You can retrieve the original value using the ``unsign`` method:
@@ -79,7 +79,7 @@ If you wish to protect a list, tuple, or dictionary you can do so using the
 
     >>> signed_obj = signer.sign_object({"message": "Hello!"})
     >>> signed_obj
-    'eyJtZXNzYWdlIjoiSGVsbG8hIn0:Xdc-mOFDjs22KsQAqfVfi8PQSPdo3ckWJxPWwQOFhR4'
+    'eyJtZXNzYWdlIjoiSGVsbG8hIn0:bzb48DBkB-bwLaCnUVB75r5VAPUEpzWJPrTb80JMIXM'
     >>> obj = signer.unsign_object(signed_obj)
     >>> obj
     {'message': 'Hello!'}
@@ -108,7 +108,7 @@ generate signatures. You can use a different secret by passing it to the
     >>> signer = Signer(key="my-other-secret")
     >>> value = signer.sign("My string")
     >>> value
-    'My string:EkfQJafvGyiofrdGnuthdxImIJw'
+    'My string:o3DrrsT6JRB73t-HDymfDNbTSxfMlom2d8TiUlb1hWY'
 
 .. class:: Signer(*, key=None, sep=':', salt=None, algorithm=None, fallback_keys=None)
 
@@ -132,13 +132,13 @@ your :setting:`SECRET_KEY`:
 
     >>> signer = Signer()
     >>> signer.sign("My string")
-    'My string:GdMGD6HNQ_qdgxYP8yBZAdAIV1w'
+    'My string:v9G-nxfz3iQGTXrePqYPlGvH79WTcIgj1QIQSUODTW0'
     >>> signer.sign_object({"message": "Hello!"})
-    'eyJtZXNzYWdlIjoiSGVsbG8hIn0:Xdc-mOFDjs22KsQAqfVfi8PQSPdo3ckWJxPWwQOFhR4'
+    'eyJtZXNzYWdlIjoiSGVsbG8hIn0:bzb48DBkB-bwLaCnUVB75r5VAPUEpzWJPrTb80JMIXM'
     >>> signer = Signer(salt="extra")
     >>> signer.sign("My string")
-    'My string:Ee7vGi-ING6n02gkcJ-QLHg6vFw'
-    >>> signer.unsign("My string:Ee7vGi-ING6n02gkcJ-QLHg6vFw")
+    'My string:YMD-FR6rof3heDkFRffdmG4pXbAZSOtb-aQxg3vmmfc'
+    >>> signer.unsign("My string:YMD-FR6rof3heDkFRffdmG4pXbAZSOtb-aQxg3vmmfc")
     'My string'
     >>> signer.sign_object({"message": "Hello!"})
     'eyJtZXNzYWdlIjoiSGVsbG8hIn0:-UWSLCE-oUAHzhkHviYz3SOZYBjFKllEOyVZNuUtM-I'
@@ -172,7 +172,7 @@ created within a specified period of time:
     >>> signer = TimestampSigner()
     >>> value = signer.sign("hello")
     >>> value
-    'hello:1NMg5H:oPVuCqlJWmChm1rA2lyTUtelC-c'
+    'hello:1stLqR:_rvr4oXCgT4HyfwjXaU39QvTnuNuUthFRCzNOy4Hqt0'
     >>> signer.unsign(value)
     'hello'
     >>> signer.unsign(value, max_age=10)
@@ -224,12 +224,12 @@ arbitrary commands by exploiting the pickle format:
     >>> signer = signing.TimestampSigner()
     >>> value = signer.sign_object({"foo": "bar"})
     >>> value
-    'eyJmb28iOiJiYXIifQ:1kx6R3:D4qGKiptAqo5QW9iv4eNLc6xl4RwiFfes6oOcYhkYnc'
+    'eyJmb28iOiJiYXIifQ:1stLrZ:_QiOBHafwucBF9FyAr54qEs84ZO1UdsO1XiTJCvvdno'
     >>> signer.unsign_object(value)
     {'foo': 'bar'}
     >>> value = signing.dumps({"foo": "bar"})
     >>> value
-    'eyJmb28iOiJiYXIifQ:1kx6Rf:LBB39RQmME-SRvilheUe5EmPYRbuDBgQp2tCAi7KGLk'
+    'eyJmb28iOiJiYXIifQ:1stLsC:JItq2ZVjmAK6ivrWI-v1Gk1QVf2hOF52oaEqhZHca7I'
     >>> signing.loads(value)
     {'foo': 'bar'}
 


### PR DESCRIPTION
`Signer`/`TimestampSigner` uses SHA-256 by default.

Follow up to 71c4fb7beb8e3293243140e4bd74e53989196440.
