### PR TITLE
Fixed #27880 -- Replaced usages of `contribute_to_class()` with `__set_name__()`.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -440,7 +440,7 @@ class ModelBase(type):
                 )
             manager = Manager()
             manager.auto_created = True
-            cls.add_to_class("objects", manager)
+            manager.__set_name__(cls, "objects")
 
         # Set the name of _meta.indexes. This can't be done in
         # Options.__set_name__() because fields haven't been added to

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -89,6 +89,25 @@ def _has_contribute_to_class(value):
     return not inspect.isclass(value) and hasattr(value, "contribute_to_class")
 
 
+def get_base_metas(bases):
+    """
+    Given a list of bases, return a tuple with (base_meta, ab_meta).
+
+    ``base_meta`` is from the first base with ``_meta``, and ``ab_meta`` is
+    from the first abstract model base.
+    """
+    base_meta = None
+    ab_meta = None
+    for base in bases:
+        if hasattr(base, "_meta") and base_meta is None:
+            base_meta = base._meta
+        if hasattr(base, "Meta") and ab_meta is None:
+            ab_meta = base.Meta
+        if base_meta and ab_meta:
+            break
+    return base_meta, ab_meta
+
+
 class ModelBase(type):
     """Metaclass for all models."""
 
@@ -107,27 +126,17 @@ class ModelBase(type):
         classcell = attrs.pop("__classcell__", None)
         if classcell is not None:
             new_attrs["__classcell__"] = classcell
+
+        # Prepare the model options.
         attr_meta = attrs.pop("Meta", None)
-        # Pass all attrs without a (Django-specific) contribute_to_class()
-        # method to type.__new__() so that they're properly initialized
-        # (i.e. __set_name__()).
-        contributable_attrs = {}
-        for obj_name, obj in attrs.items():
-            if _has_contribute_to_class(obj):
-                contributable_attrs[obj_name] = obj
-            else:
-                new_attrs[obj_name] = obj
-        new_class = super_new(cls, name, bases, new_attrs, **kwargs)
+        base_meta, ab_meta = get_base_metas(bases)
+        meta = attr_meta or ab_meta
 
         abstract = getattr(attr_meta, "abstract", False)
-        meta = attr_meta or getattr(new_class, "Meta", None)
-        base_meta = getattr(new_class, "_meta", None)
-
-        app_label = None
 
         # Look for an application configuration to attach the model to.
+        app_label = None
         app_config = apps.get_containing_app_config(module)
-
         if getattr(meta, "app_label", None) is None:
             if app_config is None:
                 if not abstract:
@@ -136,11 +145,35 @@ class ModelBase(type):
                         "app_label and isn't in an application in "
                         "INSTALLED_APPS." % (module, name)
                     )
-
             else:
                 app_label = app_config.label
 
-        new_class.add_to_class("_meta", Options(meta, app_label))
+        # Assign model options (_meta) to the new class.
+        new_attrs["_meta"] = Options(meta, app_label)
+
+        is_proxy = getattr(meta, "proxy", False) if meta else False
+        # If the model is a proxy, ensure that the base class
+        # hasn't been swapped out.
+        if is_proxy and base_meta and base_meta.swapped:
+            raise TypeError(
+                "%s cannot proxy the swapped model '%s'." % (name, base_meta.swapped)
+            )
+
+        # Pass all attributes without a (Django-specific) contribute_to_class()
+        # method to type.__new__() so that they're properly initialized
+        # (i.e. __set_name__()).
+        contributable_attrs = {}
+        for obj_name, obj in attrs.items():
+            if _has_contribute_to_class(obj):
+                contributable_attrs[obj_name] = obj
+            else:
+                new_attrs[obj_name] = obj
+
+        # Create the class -- super_new ensures special attributes, those with
+        # __set_name__(), are properly handled.
+        new_class = super_new(cls, name, bases, new_attrs, **kwargs)
+
+        # Add model-specific exceptions if the model isn't abstract.
         if not abstract:
             new_class.add_to_class(
                 "DoesNotExist",
@@ -178,15 +211,6 @@ class ModelBase(type):
                     new_class._meta.ordering = base_meta.ordering
                 if not hasattr(meta, "get_latest_by"):
                     new_class._meta.get_latest_by = base_meta.get_latest_by
-
-        is_proxy = new_class._meta.proxy
-
-        # If the model is a proxy, ensure that the base class
-        # hasn't been swapped out.
-        if is_proxy and base_meta and base_meta.swapped:
-            raise TypeError(
-                "%s cannot proxy the swapped model '%s'." % (name, base_meta.swapped)
-            )
 
         # Add remaining attributes (those with a contribute_to_class() method)
         # to the class.
@@ -419,7 +443,7 @@ class ModelBase(type):
             cls.add_to_class("objects", manager)
 
         # Set the name of _meta.indexes. This can't be done in
-        # Options.contribute_to_class() because fields haven't been added to
+        # Options.__set_name__() because fields haven't been added to
         # the model at that point.
         for index in cls._meta.indexes:
             if not index.name:

--- a/django/db/models/fields/generated.py
+++ b/django/db/models/fields/generated.py
@@ -43,13 +43,18 @@ class GeneratedField(Field):
             output_field = self.output_field
         return super().get_col(alias, output_field)
 
-    def contribute_to_class(self, *args, **kwargs):
-        super().contribute_to_class(*args, **kwargs)
+    def __set_name__(self, cls, name):
+        super().__set_name__(cls, name)
 
         self._query = Query(model=self.model, alias_cols=False)
         # Register lookups from the output_field class.
         for lookup_name, lookup in self.output_field.get_class_lookups().items():
             self.register_lookup(lookup, lookup_name=lookup_name)
+
+    # RemovedInDjango61Warning
+    def contribute_to_class(self, cls, name, private_only=False):
+        self._private_only = private_only
+        self.__set_name__(cls, name)
 
     def generated_sql(self, connection):
         compiler = connection.ops.compiler("SQLCompiler")(

--- a/django/db/models/fields/reverse_related.py
+++ b/django/db/models/fields/reverse_related.py
@@ -62,7 +62,7 @@ class ForeignObjectRel(FieldCacheMixin):
 
     # Some of the following cached_properties can't be initialized in
     # __init__ as the field doesn't have its model yet. Calling these methods
-    # before field.contribute_to_class() has been called will result in
+    # before field.__set_name__() has been called will result in
     # AttributeError
     @cached_property
     def hidden(self):
@@ -94,7 +94,7 @@ class ForeignObjectRel(FieldCacheMixin):
     def related_model(self):
         if not self.field.model:
             raise AttributeError(
-                "This property can't be accessed before self.field.contribute_to_class "
+                "This property can't be accessed before self.field.__set_name__ "
                 "has been called."
             )
         return self.field.model

--- a/django/db/models/manager.py
+++ b/django/db/models/manager.py
@@ -32,6 +32,14 @@ class BaseManager:
         self._db = None
         self._hints = {}
 
+    def __set_name__(self, cls, name):
+        if not hasattr(cls, "_meta"):
+            return
+        self.name = self.name or name
+        self.model = cls
+        setattr(cls, name, ManagerDescriptor(self))
+        cls._meta.add_manager(self)
+
     def __str__(self):
         """Return "app_label.model_label.manager_name"."""
         return "%s.%s" % (self.model._meta.label, self.name)
@@ -116,14 +124,6 @@ class BaseManager:
                 **cls._get_queryset_methods(queryset_class),
             },
         )
-
-    def contribute_to_class(self, cls, name):
-        self.name = self.name or name
-        self.model = cls
-
-        setattr(cls, name, ManagerDescriptor(self))
-
-        cls._meta.add_manager(self)
 
     def _set_creation_counter(self):
         """

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -168,7 +168,7 @@ class Options:
         # Don't go through get_app_config to avoid triggering imports.
         return self.apps.app_configs.get(self.app_label)
 
-    def contribute_to_class(self, cls, name):
+    def __set_name__(self, cls, name):
         from django.db import connection
         from django.db.backends.utils import truncate_name
 

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -295,7 +295,7 @@ class Options:
             if not any(
                 isinstance(field, OrderWrt) for field in model._meta.local_fields
             ):
-                model.add_to_class("_order", OrderWrt())
+                OrderWrt().contribute_to_class(model, "_order")
         else:
             self.order_with_respect_to = None
 
@@ -317,7 +317,7 @@ class Options:
             else:
                 pk_class = self._get_default_pk_class()
                 auto = pk_class(verbose_name="ID", primary_key=True, auto_created=True)
-                model.add_to_class("id", auto)
+                auto.contribute_to_class(model, "id")
 
     def add_manager(self, manager):
         self.local_managers.append(manager)

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -295,7 +295,7 @@ class Options:
             if not any(
                 isinstance(field, OrderWrt) for field in model._meta.local_fields
             ):
-                OrderWrt().contribute_to_class(model, "_order")
+                OrderWrt().__set_name__(model, "_order")
         else:
             self.order_with_respect_to = None
 
@@ -317,7 +317,7 @@ class Options:
             else:
                 pk_class = self._get_default_pk_class()
                 auto = pk_class(verbose_name="ID", primary_key=True, auto_created=True)
-                auto.contribute_to_class(model, "id")
+                auto.__set_name__(model, "id")
 
     def add_manager(self, manager):
         self.local_managers.append(manager)

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -950,7 +950,7 @@ duplicated. That also means you cannot use those methods on unsaved objects.
     ``get_next_by_FOO()``, and ``get_previous_by_FOO()`` should work as
     expected. Since they are added by the metaclass however, it is not
     practical to account for all possible inheritance structures. In more
-    complex cases you should override ``Field.contribute_to_class()`` to set
+    complex cases you should override ``Field.__set_name__()`` to set
     the methods you need.
 
 Other attributes

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -344,3 +344,6 @@ Miscellaneous
 
 * The ``all`` argument for the ``django.contrib.staticfiles.finders.find()``
   function is deprecated in favor of the ``find_all`` argument.
+
+* ``Field.contribute_to_class()`` is deprecated in favor of
+  ``Field.__set_name__().``

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -227,6 +227,8 @@ Models
   longer required to be set on SQLite, which supports unlimited ``VARCHAR``
   columns.
 
+* ``Options.contribute_to_class()`` is replaced with ``Options.__set_name__().``
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -229,6 +229,8 @@ Models
 
 * ``Options.contribute_to_class()`` is replaced with ``Options.__set_name__().``
 
+* ``Manager.contribute_to_class()`` is replaced with ``Manager.__set_name__().``
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -231,6 +231,8 @@ Models
 
 * ``Manager.contribute_to_class()`` is replaced with ``Manager.__set_name__().``
 
+* ``Model.add_to_class()`` is removed.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/auth_tests/models/custom_user.py
+++ b/tests/auth_tests/models/custom_user.py
@@ -86,9 +86,9 @@ class RemoveGroupsAndPermissions:
         self._old_au_local_m2m = AbstractUser._meta.local_many_to_many
         self._old_pm_local_m2m = PermissionsMixin._meta.local_many_to_many
         groups = models.ManyToManyField(Group, blank=True)
-        groups.contribute_to_class(PermissionsMixin, "groups")
+        groups.__set_name__(PermissionsMixin, "groups")
         user_permissions = models.ManyToManyField(Permission, blank=True)
-        user_permissions.contribute_to_class(PermissionsMixin, "user_permissions")
+        user_permissions.__set_name__(PermissionsMixin, "user_permissions")
         PermissionsMixin._meta.local_many_to_many = [groups, user_permissions]
         AbstractUser._meta.local_many_to_many = [groups, user_permissions]
 

--- a/tests/field_subclassing/fields.py
+++ b/tests/field_subclassing/fields.py
@@ -24,3 +24,33 @@ class CustomDeferredAttribute(DeferredAttribute):
 
 class CustomDescriptorField(models.CharField):
     descriptor_class = CustomDeferredAttribute
+
+
+class NotOKCustomField(models.CharField):
+    def contribute_to_class(self, cls, name, private_only=False):
+        super().contribute_to_class(cls, name, private_only=private_only)
+
+        def get_uppercase_value(instance):
+            value = getattr(instance, name)
+            return value.upper() if value else value
+
+        setattr(cls, f"get_{name}_uppercase", get_uppercase_value)
+
+
+class OKCustomField(models.CharField):
+    def __set_name__(self, owner, name):
+        super().__set_name__(owner, name)
+
+        def get_uppercase_value(instance):
+            value = getattr(instance, name)
+            return value.upper() if value else value
+
+        setattr(owner, f"get_{name}_uppercase", get_uppercase_value)
+
+
+class ChildNotOKField(NotOKCustomField):
+    pass
+
+
+class ChildOKField(OKCustomField):
+    pass

--- a/tests/field_subclassing/tests.py
+++ b/tests/field_subclassing/tests.py
@@ -1,7 +1,16 @@
+from django.core.checks import Warning, model_checks
 from django.db import connection, models
 from django.test import SimpleTestCase
+from django.test.utils import isolate_apps
 
-from .fields import CustomDescriptorField, CustomTypedField
+from .fields import (
+    ChildNotOKField,
+    ChildOKField,
+    CustomDescriptorField,
+    CustomTypedField,
+    NotOKCustomField,
+    OKCustomField,
+)
 
 
 class TestDbType(SimpleTestCase):
@@ -31,3 +40,50 @@ class DescriptorClassTest(SimpleTestCase):
         self.assertEqual(m.name, "bar")
         self.assertEqual(m._name_get_count, 2)
         self.assertEqual(m._name_set_count, 3)
+
+
+# RemovedInDjango61Warning
+@isolate_apps("field_subclassing", attr_name="apps")
+class TestFieldTransitionFromContributeToClass(SimpleTestCase):
+    def setUp(self):
+        class MyModel(models.Model):
+            not_ok = NotOKCustomField()
+            ok = OKCustomField()
+            child_not_ok = ChildNotOKField()
+            child_ok = ChildOKField()
+
+        self.model = MyModel
+        self.warnings = model_checks.check_deprecated_field_contribute_to_class(
+            app_configs=self.apps.get_app_configs()
+        )
+
+    def test_warning_field_overrides_contribute_to_class_and_not_set_name(self):
+        expected_warnings = [
+            Warning(
+                "%s.contribute_to_class() is deprecated for field '%s' in "
+                "model '%s'." % ("NotOKCustomField", "not_ok", "MyModel"),
+                hint="Implement __set_name__() instead.",
+                obj=self.model,
+                id="models.W048",
+            ),
+            Warning(
+                "%s.contribute_to_class() is deprecated for field '%s' in "
+                "model '%s'." % ("ChildNotOKField", "child_not_ok", "MyModel"),
+                hint="Implement __set_name__() instead.",
+                obj=self.model,
+                id="models.W048",
+            ),
+        ]
+
+        self.assertEqual(len(self.warnings), len(expected_warnings))
+        for warning, expected in zip(self.warnings, expected_warnings):
+            self.assertEqual(warning.msg, expected.msg)
+            self.assertEqual(warning.hint, expected.hint)
+            self.assertEqual(warning.id, expected.id)
+
+    def test_override_effects_for_both_set_name_and_contribute_to_cls(self):
+        # Check if methods are added correctly.
+        self.assertTrue(hasattr(self.model, "get_ok_uppercase"))
+        self.assertTrue(hasattr(self.model, "get_not_ok_uppercase"))
+        self.assertTrue(hasattr(self.model, "get_child_not_ok_uppercase"))
+        self.assertTrue(hasattr(self.model, "get_child_ok_uppercase"))

--- a/tests/foreign_object/models/article.py
+++ b/tests/foreign_object/models/article.py
@@ -40,8 +40,8 @@ class ActiveTranslationField(models.ForeignObject):
     def get_extra_descriptor_filter(self, instance):
         return {"lang": get_language()}
 
-    def contribute_to_class(self, cls, name):
-        super().contribute_to_class(cls, name)
+    def __set_name__(self, cls, name):
+        super().__set_name__(cls, name)
         setattr(cls, self.name, ArticleTranslationDescriptor(self))
 
 

--- a/tests/foreign_object/models/empty_join.py
+++ b/tests/foreign_object/models/empty_join.py
@@ -83,8 +83,8 @@ class StartsWithRelation(models.ForeignObject):
             )
         ]
 
-    def contribute_to_class(self, cls, name, private_only=False):
-        super().contribute_to_class(cls, name, private_only)
+    def __set_name__(self, cls, name):
+        super().__set_name__(cls, name)
         setattr(cls, self.name, ReverseManyToOneDescriptor(self))
 
 

--- a/tests/model_fields/test_generatedfield.py
+++ b/tests/model_fields/test_generatedfield.py
@@ -45,7 +45,7 @@ class BaseGeneratedFieldTests(SimpleTestCase):
             )
 
     @isolate_apps("model_fields")
-    def test_contribute_to_class(self):
+    def test_set_name(self):
         class BareModel(Model):
             pass
 
@@ -58,7 +58,7 @@ class BaseGeneratedFieldTests(SimpleTestCase):
         try:
             # GeneratedField can be added to the model even when apps are not
             # fully loaded.
-            new_field.contribute_to_class(BareModel, "name")
+            new_field.__set_name__(BareModel, "name")
             self.assertEqual(BareModel._meta.get_field("name"), new_field)
         finally:
             apps.models_ready = True

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -710,8 +710,8 @@ class ListDisplayTests(CheckTestCase):
         class PositionField(Field):
             """Custom field accessible only via instance."""
 
-            def contribute_to_class(self, cls, name):
-                super().contribute_to_class(cls, name)
+            def __set_name__(self, cls, name):
+                super().__set_name__(cls, name)
                 setattr(cls, self.name, self)
 
             def __get__(self, instance, owner):

--- a/tests/schema/fields.py
+++ b/tests/schema/fields.py
@@ -63,13 +63,13 @@ class CustomManyToManyField(RelatedField):
             **kwargs,
         )
 
-    def contribute_to_class(self, cls, name, **kwargs):
+    def __set_name__(self, cls, name):
         if self.remote_field.symmetrical and (
             self.remote_field.model == "self"
             or self.remote_field.model == cls._meta.object_name
         ):
             self.remote_field.related_name = "%s_rel_+" % name
-        super().contribute_to_class(cls, name, **kwargs)
+        super().__set_name__(cls, name)
         if (
             not self.remote_field.through
             and not cls._meta.abstract

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -617,7 +617,7 @@ class SchemaTests(TransactionTestCase):
         list(Tag.objects.all())
         # Make a db_constraint=False FK
         new_field = M2MFieldClass(Tag, related_name="authors", db_constraint=False)
-        new_field.contribute_to_class(LocalAuthorWithM2M, "tags")
+        new_field.__set_name__(LocalAuthorWithM2M, "tags")
         # Add the field
         with connection.schema_editor() as editor:
             editor.add_field(LocalAuthorWithM2M, new_field)
@@ -917,7 +917,7 @@ class SchemaTests(TransactionTestCase):
             db_persist=True,
             output_field=BooleanField(),
         )
-        field.contribute_to_class(GeneratedFieldContainsModel, "contains_foo")
+        field.__set_name__(GeneratedFieldContainsModel, "contains_foo")
 
         with connection.schema_editor() as editor:
             editor.add_field(GeneratedFieldContainsModel, field)
@@ -952,7 +952,7 @@ class SchemaTests(TransactionTestCase):
             db_index=True,
             output_field=IntegerField(),
         )
-        new_field.contribute_to_class(GeneratedFieldIndexedModel, "generated")
+        new_field.__set_name__(GeneratedFieldIndexedModel, "generated")
 
         with connection.schema_editor() as editor:
             editor.alter_field(GeneratedFieldIndexedModel, old_field, new_field)
@@ -2618,7 +2618,7 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(TagM2MTest)
         # Create an M2M field
         new_field = M2MFieldClass("schema.TagM2MTest", related_name="authors")
-        new_field.contribute_to_class(LocalAuthorWithM2M, "tags")
+        new_field.__set_name__(LocalAuthorWithM2M, "tags")
         # Ensure there's no m2m table there
         with self.assertRaises(DatabaseError):
             self.column_classes(new_field.remote_field.through)
@@ -2716,7 +2716,7 @@ class SchemaTests(TransactionTestCase):
         new_field = M2MFieldClass(
             "schema.TagM2MTest", related_name="authors", through=LocalAuthorTag
         )
-        new_field.contribute_to_class(LocalAuthorWithM2MThrough, "tags")
+        new_field.__set_name__(LocalAuthorWithM2MThrough, "tags")
         with connection.schema_editor() as editor:
             editor.alter_field(
                 LocalAuthorWithM2MThrough, old_field, new_field, strict=True
@@ -2765,7 +2765,7 @@ class SchemaTests(TransactionTestCase):
         # Repoint the M2M
         old_field = LocalBookWithM2M._meta.get_field("tags")
         new_field = M2MFieldClass(UniqueTest)
-        new_field.contribute_to_class(LocalBookWithM2M, "uniques")
+        new_field.__set_name__(LocalBookWithM2M, "uniques")
         with connection.schema_editor() as editor:
             editor.alter_field(LocalBookWithM2M, old_field, new_field, strict=True)
         # Ensure old M2M is gone
@@ -2816,7 +2816,7 @@ class SchemaTests(TransactionTestCase):
         # Alter a field in LocalTagM2MTest.
         old_field = LocalTagM2MTest._meta.get_field("title")
         new_field = CharField(max_length=254)
-        new_field.contribute_to_class(LocalTagM2MTest, "title1")
+        new_field.__set_name__(LocalTagM2MTest, "title1")
         # @isolate_apps() and inner models are needed to have the model
         # relations populated, otherwise this doesn't act as a regression test.
         self.assertEqual(len(new_field.model._meta.related_objects), 1)


### PR DESCRIPTION
#### Trac ticket number

ticket-27880

#### Branch description
Replaced usages of `contribute_to_class` with `__set_name__` for `models.Field`, `Manager`, and `Options`, simplifying model class attribute assignment in `ModelBase`. Implemented transition logic to ensure compatibility with existing custom `Field`s, whose API privacy status was semi-private ([#35772](https://code.djangoproject.com/ticket/35772)).

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.

#### Tasks
- [ ] Improve tests. (Needs help and reviews.)
- [ ] Document instantiation of Fields in non-model classes? (Needs forum discussion.)
- [x] Release notes. 

