### PR TITLE
Fixed #35778 -- Used JSON_OBJECT database function on PostgreSQL 16+ with server-side bindings.

### DIFF
--- a/django/db/models/functions/comparison.py
+++ b/django/db/models/functions/comparison.py
@@ -162,7 +162,8 @@ class JSONObject(Func):
 
     def join(self, args):
         pairs = zip(args[::2], args[1::2], strict=True)
-        return ", ".join([" VALUE ".join(pair) for pair in pairs])
+        # Wrap 'key' in parentheses in case of postgres cast :: syntax.
+        return ", ".join([f"({key}) VALUE {value}" for key, value in pairs])
 
     def as_native(self, compiler, connection, *, returning, **extra_context):
         return self.as_sql(
@@ -174,24 +175,28 @@ class JSONObject(Func):
         )
 
     def as_postgresql(self, compiler, connection, **extra_context):
-        if (
-            not connection.features.is_postgresql_16
-            or connection.features.uses_server_side_binding
-        ):
-            copy = self.copy()
-            copy.set_source_expressions(
-                [
-                    Cast(expression, TextField()) if index % 2 == 0 else expression
-                    for index, expression in enumerate(copy.get_source_expressions())
-                ]
+        # Casting keys to text is only required when using JSONB_BUILD_OBJECT
+        # or when using JSON_OBJECT on PostgreSQL 16+ with server-side bindings.
+        # This is done in all cases for consistency.
+        copy = self.copy()
+        copy.set_source_expressions(
+            [
+                Cast(expression, TextField()) if index % 2 == 0 else expression
+                for index, expression in enumerate(copy.get_source_expressions())
+            ]
+        )
+
+        if connection.features.is_postgresql_16:
+            return copy.as_native(
+                compiler, connection, returning="JSONB", **extra_context
             )
-            return super(JSONObject, copy).as_sql(
-                compiler,
-                connection,
-                function="JSONB_BUILD_OBJECT",
-                **extra_context,
-            )
-        return self.as_native(compiler, connection, returning="JSONB", **extra_context)
+
+        return super(JSONObject, copy).as_sql(
+            compiler,
+            connection,
+            function="JSONB_BUILD_OBJECT",
+            **extra_context,
+        )
 
     def as_oracle(self, compiler, connection, **extra_context):
         return self.as_native(compiler, connection, returning="CLOB", **extra_context)


### PR DESCRIPTION
Fixed #35778 -- Use native JSON_OBJECT on postgres 16+ with server-side binding.

#### Trac ticket number
https://code.djangoproject.com/ticket/35778#ticket

#### Branch description
In a prior version of Django, there was an attempt to use the `JSON_OBJECT` function on postgres 16+ with server side bindings, but it didn't work because keys must be cast to text. This change makes it so that keys are always cast to text when using postgres. It also wraps the keys in parenthesis on all backends to remove a parsing error while using `::` to cast within the context of the json_object function which uses `:` to separate keys.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
