### PR TITLE
Fixed #35952 -- Used class property for available apps check on `TransactionTestCase`

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -32,8 +32,10 @@ else:
         RemovedInDjango60Warning,
         RemovedInDjango61Warning,
     )
+    from django.utils.functional import classproperty
     from django.utils.log import DEFAULT_LOGGING
     from django.utils.version import PY312, PYPY
+
 
 try:
     import MySQLdb
@@ -307,12 +309,12 @@ def setup_run_tests(verbosity, start_at, start_after, test_labels=None):
     apps.set_installed_apps(settings.INSTALLED_APPS)
 
     # Force declaring available_apps in TransactionTestCase for faster tests.
-    def no_available_apps(self):
+    def no_available_apps(cls):
         raise Exception(
             "Please define available_apps in TransactionTestCase and its subclasses."
         )
 
-    TransactionTestCase.available_apps = property(no_available_apps)
+    TransactionTestCase.available_apps = classproperty(no_available_apps)
     TestCase.available_apps = None
 
     # Set an environment variable that other code may consult to see if


### PR DESCRIPTION
#### Trac ticket number

ticket-35952

#### Branch description

The previous check to ensure `available_apps` is explicitly set on `TransactionTestCase` uses a `property` as a class variable, which isn't valid. This PR changes it to use `classproperty`.

This can be validated by defining a `TransactionTestCase` without setting `available_apps`, and seeing the strange error during `setUpClass`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
