### PR TITLE
Fixed #35789 -- Improve non-first {% extends %} error message.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -535,7 +535,8 @@ class Parser:
         if node.must_be_first and nodelist.contains_nontext:
             raise self.error(
                 token,
-                "%r must be the first tag in the template." % node,
+                "{%% extends %s %%} must be the first tag in the template."
+                % node.parent_name.token,
             )
         if not isinstance(node, TextNode):
             nodelist.contains_nontext = True


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35789

#### Branch description
Improve error message when `{% extends %}` tag doesn't appear first

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
