### PR TITLE
Fixed #35804 -- Removed unused rules for ul.tools from admin CSS.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -445,17 +445,6 @@ body.popup .submit-row {
     _width: 700px;
 }
 
-.inline-group ul.tools {
-    padding: 0;
-    margin: 0;
-    list-style: none;
-}
-
-.inline-group ul.tools li {
-    display: inline;
-    padding: 0 5px;
-}
-
 .inline-group div.add-row,
 .inline-group .tabular tr.add-row td {
     color: var(--body-quiet-color);
@@ -469,7 +458,6 @@ body.popup .submit-row {
     border-bottom: 1px solid var(--hairline-color);
 }
 
-.inline-group ul.tools a.add,
 .inline-group div.add-row a,
 .inline-group .tabular tr.add-row td a {
     background: url(../img/icon-addlink.svg) 0 1px no-repeat;

--- a/django/contrib/admin/static/admin/css/responsive_rtl.css
+++ b/django/contrib/admin/static/admin/css/responsive_rtl.css
@@ -28,7 +28,6 @@
         margin-left: 0;
     }
 
-    [dir="rtl"] .inline-group ul.tools a.add,
     [dir="rtl"] .inline-group div.add-row a,
     [dir="rtl"] .inline-group .tabular tr.add-row td a {
         padding: 8px 26px 8px 10px;


### PR DESCRIPTION
ticket-35804

#### Branch description
This branch removes obsolete CSS rules targeting the `ul.tools` element in the `.inline-group` class. The `ul.tools` element and its associated styles were present in the codebase since 2008 but have been commented out and subsequently removed from the HTML. Cleaning up these styles helps improve code maintainability and reduce unnecessary bloat.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
