### PR TITLE
Fixed #35809 -- Set background color for selected rows in the admin's form select widget.

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -169,6 +169,10 @@ form .aligned select + div.help {
     padding-left: 10px;
 }
 
+form .aligned select option:checked {
+    background-color: var(--selected-row);
+}
+
 form .aligned ul li {
     list-style: none;
 }

--- a/docs/releases/5.1.2.txt
+++ b/docs/releases/5.1.2.txt
@@ -16,3 +16,7 @@ Bugfixes
 
 * Fixed a regression in Django 5.1 that caused a crash of ``JSONObject()``
   when using server-side binding with PostgreSQL 16+ (:ticket:`35734`).
+
+* Fixed a regression in Django 5.1 that made selected items in multi-select
+  widgets indistinguishable from non-selected items in the admin dark theme
+  (:ticket:`35809`).

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -6176,6 +6176,65 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.take_screenshot("selectbox-non-collapsible")
 
     @screenshot_cases(["desktop_size", "mobile_size", "rtl", "dark", "high_contrast"])
+    def test_selectbox_selected_rows(self):
+        from selenium.webdriver import ActionChains
+        from selenium.webdriver.common.by import By
+        from selenium.webdriver.common.keys import Keys
+
+        self.admin_login(
+            username="super", password="secret", login_url=reverse("admin:index")
+        )
+        # Create a new user to ensure that no extra permissions have been set.
+        user = User.objects.create_user(username="new", password="newuser")
+        url = self.live_server_url + reverse("admin:auth_user_change", args=[user.id])
+        self.selenium.get(url)
+
+        # Scroll to the User permissions section.
+        user_permissions = self.selenium.find_element(
+            By.CSS_SELECTOR, "#id_user_permissions_from"
+        )
+        ActionChains(self.selenium).move_to_element(user_permissions).perform()
+        self.take_screenshot("selectbox-available-perms-none-selected")
+
+        # Select multiple permissions from the "Available" list.
+        ct = ContentType.objects.get_for_model(Permission)
+        perms = list(Permission.objects.filter(content_type=ct))
+        for perm in perms:
+            elem = self.selenium.find_element(
+                By.CSS_SELECTOR, f"#id_user_permissions_from option[value='{perm.id}']"
+            )
+            ActionChains(self.selenium).key_down(Keys.CONTROL).click(elem).key_up(
+                Keys.CONTROL
+            ).perform()
+
+        # Move focus to other element.
+        self.selenium.find_element(
+            By.CSS_SELECTOR, "#id_user_permissions_input"
+        ).click()
+        self.take_screenshot("selectbox-available-perms-some-selected")
+
+        # Move permissions to the "Chosen" list, but none is selected yet.
+        self.selenium.find_element(
+            By.CSS_SELECTOR, "#id_user_permissions_add_link"
+        ).click()
+        self.take_screenshot("selectbox-chosen-perms-none-selected")
+
+        # Select some permissions from the "Chosen" list.
+        for perm in [perms[0], perms[-1]]:
+            elem = self.selenium.find_element(
+                By.CSS_SELECTOR, f"#id_user_permissions_to option[value='{perm.id}']"
+            )
+            ActionChains(self.selenium).key_down(Keys.CONTROL).click(elem).key_up(
+                Keys.CONTROL
+            ).perform()
+
+        # Move focus to other element.
+        self.selenium.find_element(
+            By.CSS_SELECTOR, "#id_user_permissions_selected_input"
+        ).click()
+        self.take_screenshot("selectbox-chosen-perms-some-selected")
+
+    @screenshot_cases(["desktop_size", "mobile_size", "rtl", "dark", "high_contrast"])
     def test_first_field_focus(self):
         """JavaScript-assisted auto-focus on first usable form field."""
         from selenium.webdriver.common.by import By


### PR DESCRIPTION
Regression in b47bdb4cd9149ee2a39bf1cc9996a36a940bd7d9.

Thank you Giannis Terzopoulos for the review.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35809

#### Branch description
This branch provides explicitly in the CSS definitions the color for the form's select selected row. See before (in both screenshots there are selected rows in the multi-select with focus somewhere else):
![image](https://github.com/user-attachments/assets/c355cb5e-d23c-40df-b141-57d1e8d47c4b)
![image](https://github.com/user-attachments/assets/f9f2b1e4-ab9a-4b43-9e4f-3f3808fc9b1c)

And after:
![image](https://github.com/user-attachments/assets/c11c3c55-b02b-46e7-bde7-f492e40e7237)
![image](https://github.com/user-attachments/assets/01f2cc2f-4583-49b2-81b3-a22410ff6ec4)



#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
