### PR TITLE
Fixed #34699 -- Added warning about using Trunc functions in filters

### DIFF
--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -307,6 +307,34 @@ Usage example:
     >>> Experiment.objects.filter(start_datetime__year=Extract("end_datetime", "year")).count()
     1
 
+.. admonition:: ``Extract()`` uses the active timezone
+
+    When :setting:`USE_TZ` is ``True``, Django saves values in ``UTC`` (or the
+    connection's configured timezone). Since ``tzinfo`` defaults to
+    :setting:`TIME_ZONE` when not provided, you may need to provide an explicit
+    ``tzinfo`` to compare extracted values. The following example demonstrates
+    what happens when "Europe/Berlin" is active and how to adjust for this:
+
+    .. code-block:: pycon
+
+        >>> from django.utils import timezone
+        >>> from datetime import UTC, datetime
+        >>> from django.db.models.functions import ExtractHour
+        >>> start = datetime(2015, 6, 15, 14, 30, 50, 321)
+        >>> start = timezone.make_aware(start)
+        >>> exp = Experiment.objects.create(start_datetime=start)
+        >>> find_this_exp = Experiment.objects.annotate(
+        ...     extract_hour_start=ExtractHour("start_datetime")
+        ... ).filter(extract_hour_start=start.hour)
+        # Comparing local time to UTC finds no results.
+        >>> find_this_exp.count()
+        0
+        >>> find_this_exp_adjusted = Experiment.objects.annotate(
+        ...     extract_hour_start=ExtractHour("start_datetime", tzinfo=UTC)
+        ... ).filter(extract_hour_start=start.hour)
+        >>> find_this_exp_adjusted.count()
+        1
+
 ``DateField`` extracts
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -584,16 +612,16 @@ The timezone offset for Melbourne in the example date above is +10:00. The
 values returned when this timezone is active will be:
 
 * "year": 2015-01-01 00:00:00+11:00
-* "quarter": 2015-04-01 00:00:00+10:00
+* "quarter": 2015-04-01 00:00:00+11:00
 * "month": 2015-06-01 00:00:00+10:00
-* "week": 2015-06-16 00:00:00+10:00
+* "week": 2015-06-15 00:00:00+10:00
 * "day": 2015-06-16 00:00:00+10:00
 * "hour": 2015-06-16 00:00:00+10:00
 * "minute": 2015-06-16 00:30:00+10:00
 * "second": 2015-06-16 00:30:50+10:00
 
-The year has an offset of +11:00 because the result transitioned into daylight
-saving time.
+The year and quarter have an offset of +11:00 because each result falls before
+the daylight saving time transition.
 
 Each ``kind`` above has a corresponding ``Trunc`` subclass (listed below) that
 should typically be used instead of the more verbose equivalent,
@@ -633,6 +661,34 @@ Usage example:
     ...
     2015-06-15 14:30:50.000321
     2015-06-15 14:40:02.000123
+
+.. admonition:: ``Trunc()`` produces naive datetimes
+
+    When :setting:`USE_TZ` is ``True``, Django saves values in ``UTC`` (or the
+    connection's configured timezone). Since ``tzinfo`` defaults to
+    :setting:`TIME_ZONE` when not provided, you may need to provide an explicit
+    ``tzinfo`` to compare truncated values. The following example demonstrates
+    what happens when "Europe/Berlin" is active and how to adjust for this:
+
+    .. code-block:: pycon
+
+        >>> from django.utils import timezone
+        >>> from datetime import UTC, datetime
+        >>> from django.db.models.functions import TruncSecond
+        >>> start = datetime(2015, 6, 15, 14, 30, 50, 321)
+        >>> start = timezone.make_aware(start)
+        >>> exp = Experiment.objects.create(start_datetime=start)
+        >>> find_this_exp = Experiment.objects.annotate(
+        ...     trunc_start=TruncSecond("start_datetime")
+        ... ).filter(trunc_start__lte=start)
+        # Comparing local time to UTC finds no results.
+        >>> find_this_exp.count()
+        0
+        >>> find_this_exp_adjusted = Experiment.objects.annotate(
+        ...     trunc_start=TruncSecond("start_datetime", tzinfo=UTC)
+        ... ).filter(trunc_start__lte=start)
+        >>> find_this_exp_adjusted.count()
+        1
 
 ``DateField`` truncation
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -1948,3 +1948,29 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
             DTModel.objects.annotate(
                 hour_melb=Trunc("start_time", "hour", tzinfo=melb),
             ).get()
+
+    @override_settings(TIME_ZONE="Australia/Melbourne")
+    def test_trunc_filter_non_utc_active(self):
+        melb = zoneinfo.ZoneInfo("Australia/Melbourne")
+        start_datetime = datetime.datetime(2015, 6, 15, 1, 30, 1, 321, tzinfo=melb)
+        end_datetime = datetime.datetime(2015, 6, 16, 2, 30, 1, 123, tzinfo=melb)
+        self.create_model(start_datetime, end_datetime)
+
+        # Trunc() yields a naive datetime (June 15), but the RHS is aware.
+        self.assertEqual(
+            DTModel.objects.annotate(
+                day_melb=Trunc("start_datetime", "day"),
+            )
+            .filter(day_melb__lt=start_datetime)
+            .count(),
+            0,
+        )
+        # When TIME_ZONE != "UTC", supply tzinfo explicitly.
+        self.assertEqual(
+            DTModel.objects.annotate(
+                day_melb=Trunc("start_datetime", "day", tzinfo=datetime.UTC),
+            )
+            .filter(day_melb__lt=start_datetime)
+            .count(),
+            1,
+        )


### PR DESCRIPTION
#### Trac ticket number
ticket-34699

#### Branch description
A warning about using Trunc functions in filters when the timezone is not UTC was added. Tests that replicate the unexpected behavior and demonstrate one of the possible workarounds was added.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
