### PR TITLE
Fixed docstring for django.core.exceptions module

### DIFF
--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -1,5 +1,5 @@
 """
-Global Django exception and warning classes.
+Global Django exception classes.
 """
 
 import operator


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A (trivial change)

#### Branch description
I noticed that the docstring was a bit inacurrate: there are no warning classes in the module.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] **N/A** I have checked the "Has patch" ticket flag in the Trac system.
- [ ] **N/A** I have added or updated relevant tests.
- [ ] **N/A** I have added or updated relevant docs, including release notes if applicable.
- [ ] **N/A** I have attached screenshots in both light and dark modes for any UI changes.
