### PR TITLE
Disambiguated the purpose of refs docs for contributors.

### DIFF
--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -72,9 +72,9 @@ The documentation is organized into several categories:
   Providing background context helps a newcomer connect the topic to things
   that they already know.
 
-* :doc:`Reference guides </ref/index>` contain technical references for APIs.
-  They describe the functioning of Django's internal machinery and instruct in
-  its use.
+* :doc:`Reference guides </ref/index>` contain technical references for APIs
+  and other components of the framework. They detail how these elements
+  function and how to use them effectively.
 
   Keep reference material tightly focused on the subject. Assume that the
   reader already understands the basic concepts involved but needs to know or
@@ -88,8 +88,8 @@ The documentation is organized into several categories:
   steps in key subjects.
 
   What matters most in a how-to guide is what a user wants to achieve.
-  A how-to should always be result-oriented rather than focused on internal
-  details of how Django implements whatever is being discussed.
+  A how-to should always be focused on the desired outcome, rather than on the
+  implementation details of Django.
 
   These guides are more advanced than tutorials and assume some knowledge about
   how Django works. Assume that the reader has followed the tutorials and don't


### PR DESCRIPTION
In [writing documentation](https://docs.djangoproject.com/en/dev/internals/contributing/writing-documentation/#how-the-documentation-is-organized) it's mentioned that:

>[reference guides] describe the functioning of Django’s internal machinery and instruct in its use.
>

This is not quite accurate as the reference docs describe the **public** API and only include descriptions
of internal machinery when necessary. When tickets like [27617](https://code.djangoproject.com/ticket/27617) and [24989](https://code.djangoproject.com/ticket/24989) gets addressed, then
maybe those will describe "the functioning of Django's internal machinery," but presumably their
work will also live somewhere in docs/internals.

I also removed a similar use of "internal" in the "how-to" section below that.