### PR TITLE
Improved reproducibility on staticfiles manifests

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -504,7 +504,7 @@ class ManifestFilesMixin(HashedFilesMixin):
         }
         if self.manifest_storage.exists(self.manifest_name):
             self.manifest_storage.delete(self.manifest_name)
-        contents = json.dumps(payload).encode()
+        contents = json.dumps(payload, sort_keys=True).encode()
         self.manifest_storage._save(self.manifest_name, ContentFile(contents))
 
     def stored_name(self, name):


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[#35846](https://code.djangoproject.com/ticket/35846)

#### Branch description
Previously, the paths would appear in a nondeterministic order in the resulting JSON file. I assume this would often reflect the order in which files are listed by the operating system, given dict's insertion order preservation, but there are probably many more factors affecting this.

Sorting them results in more comparable results, smaller diffs and (depending on the environment) more efficient deployments.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
