### PR TITLE
Fixed #35667 -- Improved deprecation warning handling by replacing `stacklevel` with `skip_file_prefixes`. 

### DIFF
--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -114,7 +114,7 @@ requirements:
   feature, the change should also contain documentation.
 
 When you think your work is ready to be reviewed, send :doc:`a GitHub pull
-request <working-with-git>`. 
+request <working-with-git>`.
 If you can't send a pull request for some reason, you can also use patches in
 Trac. When using this style, follow these guidelines.
 
@@ -221,7 +221,10 @@ previous behavior, or standalone items that are unnecessary or unused when the
 deprecation ends. For example::
 
     import warnings
-    from django.utils.deprecation import RemovedInDjangoXXWarning
+    from django.utils.deprecation import (
+        RemovedInDjangoXXWarning,
+        adjust_stacklevel_for_warning,
+    )
 
 
     # RemovedInDjangoXXWarning.
@@ -234,7 +237,7 @@ deprecation ends. For example::
         warnings.warn(
             "foo() is deprecated.",
             category=RemovedInDjangoXXWarning,
-            stacklevel=2,
+            **adjust_stacklevel_for_warning(__file__),
         )
         old_private_helper()
         ...


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-35667](https://code.djangoproject.com/ticket/35667)

#### Branch description
Improved the handling of deprecation warnings by replacing the use of `stacklevel` with `skip_file_prefixes`. This change ensures that deprecation warnings accurately reference the offending call site, enhancing clarity and maintainability. The update leverages the new `warnings.warn(skip_file_prefixes: tuple[str] | None)` feature introduced in Python 3.12, and includes a fallback mechanism for compatibility with Python 3.11.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
