### PR TITLE
Refs #35844 -- Fixed tests for test --parallel option on Python 3.14+.

### DIFF
--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -45,6 +45,7 @@ def change_loader_patterns(patterns):
 @mock.patch.dict(os.environ, {}, clear=True)
 @mock.patch.object(multiprocessing, "cpu_count", return_value=12)
 # Python 3.8 on macOS defaults to 'spawn' mode.
+# Python 3.14 on POSIX systems defaults to 'forkserver' mode.
 @mock.patch.object(multiprocessing, "get_start_method", return_value="fork")
 class DiscoverRunnerParallelArgumentTests(SimpleTestCase):
     def get_parser(self):

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -506,6 +506,7 @@ class ManageCommandTests(unittest.TestCase):
 @mock.patch.dict(os.environ, {}, clear=True)
 @mock.patch.object(multiprocessing, "cpu_count", return_value=12)
 class ManageCommandParallelTests(SimpleTestCase):
+    @mock.patch.object(multiprocessing, "get_start_method", return_value="fork")
     def test_parallel_default(self, *mocked_objects):
         with captured_stderr() as stderr:
             call_command(
@@ -515,6 +516,7 @@ class ManageCommandParallelTests(SimpleTestCase):
             )
         self.assertIn("parallel=12", stderr.getvalue())
 
+    @mock.patch.object(multiprocessing, "get_start_method", return_value="fork")
     def test_parallel_auto(self, *mocked_objects):
         with captured_stderr() as stderr:
             call_command(
@@ -550,12 +552,14 @@ class ManageCommandParallelTests(SimpleTestCase):
         self.assertEqual(stderr.getvalue(), "")
 
     @mock.patch.dict(os.environ, {"DJANGO_TEST_PROCESSES": "7"})
+    @mock.patch.object(multiprocessing, "get_start_method", return_value="fork")
     def test_no_parallel_django_test_processes_env(self, *mocked_objects):
         with captured_stderr() as stderr:
             call_command("test", testrunner="test_runner.tests.MockTestRunner")
         self.assertEqual(stderr.getvalue(), "")
 
     @mock.patch.dict(os.environ, {"DJANGO_TEST_PROCESSES": "invalid"})
+    @mock.patch.object(multiprocessing, "get_start_method", return_value="fork")
     def test_django_test_processes_env_non_int(self, *mocked_objects):
         with self.assertRaises(ValueError):
             call_command(
@@ -565,6 +569,7 @@ class ManageCommandParallelTests(SimpleTestCase):
             )
 
     @mock.patch.dict(os.environ, {"DJANGO_TEST_PROCESSES": "7"})
+    @mock.patch.object(multiprocessing, "get_start_method", return_value="fork")
     def test_django_test_processes_parallel_default(self, *mocked_objects):
         for parallel in ["--parallel", "--parallel=auto"]:
             with self.subTest(parallel=parallel):


### PR DESCRIPTION
"forkserver" is the new default on POSIX systems, and Django doesn't support parallel tests with "forkserver", so we have to mock `get_start_method()`: https://github.com/python/cpython/commit/b65f2cdfa77d8d12c213aec663ddaaa30d75a4b2

ticket-35844

This PR fixes 5 tests on Python 3.14.0a1.