### PR TITLE
Fixed typo in docs/intro/reusable-apps.txt.

### DIFF
--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -6,7 +6,7 @@ This advanced tutorial begins where :doc:`Tutorial 8 </intro/tutorial08>`
 left off. We'll be turning our web-poll into a standalone Python package
 you can reuse in new projects and share with other people.
 
-If you haven't recently completed Tutorials 1–7, we encourage you to review
+If you haven't recently completed Tutorials 1–8, we encourage you to review
 these so that your example project matches the one described below.
 
 Reusability matters


### PR DESCRIPTION
This is outdated since we added 8th tutorial in 7715c9fef55c8775608cdb64d5666c7f90ada937.