### PR TITLE
Fixed #35371 -- Ensured that only unhashed file paths were being processed

### DIFF
--- a/tests/staticfiles_tests/project/documents/cached/module.js
+++ b/tests/staticfiles_tests/project/documents/cached/module.js
@@ -1,3 +1,21 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+const moduleConst2 = "module2";
+export default moduleConst2;
+export const moduleConst = "module";
+// export keyword test
+
 // Static imports.
 import rootConst from "/static/absolute_root.js";
 import testConst from "./module_test.js";
@@ -18,9 +36,24 @@ import relativeModule from "../nested/js/nested.js";
 const dynamicModule = import("./module_test.js");
 
 // Modules exports to aggregate modules.
-export * from "./module_test.js";
+export * from "./module_test.js";  // export keyword test
 export { testConst } from "./module_test.js";
 export {
     firstVar as firstVarAlias,
     secondVar as secondVarAlias
 } from "./module_test.js";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/staticfiles_tests/project/documents/cached/module.js
+++ b/tests/staticfiles_tests/project/documents/cached/module.js
@@ -1,16 +1,3 @@
-
-
-
-
-
-
-
-
-
-
-
-
-
 const moduleConst2 = "module2";
 export default moduleConst2;
 export const moduleConst = "module";
@@ -42,18 +29,3 @@ export {
     firstVar as firstVarAlias,
     secondVar as secondVarAlias
 } from "./module_test.js";
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -676,7 +676,7 @@ class TestCollectionJSModuleImportAggregationManifestStorage(CollectionTestCase)
 
     def test_module_import(self):
         relpath = self.hashed_file_path("cached/module.js")
-        self.assertEqual(relpath, "cached/module.4326210cf0bd.js")
+        self.assertEqual(relpath, "cached/module.f0c3a6133ad5.js")
         tests = [
             # Relative imports.
             b'import testConst from "./module_test.477bbebe77f0.js";',
@@ -708,7 +708,7 @@ class TestCollectionJSModuleImportAggregationManifestStorage(CollectionTestCase)
 
     def test_aggregating_modules(self):
         relpath = self.hashed_file_path("cached/module.js")
-        self.assertEqual(relpath, "cached/module.4326210cf0bd.js")
+        self.assertEqual(relpath, "cached/module.f0c3a6133ad5.js")
         tests = [
             b'export * from "./module_test.477bbebe77f0.js";',
             b'export { testConst } from "./module_test.477bbebe77f0.js";',

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -676,7 +676,7 @@ class TestCollectionJSModuleImportAggregationManifestStorage(CollectionTestCase)
 
     def test_module_import(self):
         relpath = self.hashed_file_path("cached/module.js")
-        self.assertEqual(relpath, "cached/module.f0c3a6133ad5.js")
+        self.assertEqual(relpath, "cached/module.6f5edad590fa.js")
         tests = [
             # Relative imports.
             b'import testConst from "./module_test.477bbebe77f0.js";',
@@ -708,7 +708,7 @@ class TestCollectionJSModuleImportAggregationManifestStorage(CollectionTestCase)
 
     def test_aggregating_modules(self):
         relpath = self.hashed_file_path("cached/module.js")
-        self.assertEqual(relpath, "cached/module.f0c3a6133ad5.js")
+        self.assertEqual(relpath, "cached/module.6f5edad590fa.js")
         tests = [
             b'export * from "./module_test.477bbebe77f0.js";',
             b'export { testConst } from "./module_test.477bbebe77f0.js";',


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35371

#### Branch description
Before this change, hashed file paths were searched for in storage containing only unhashed ones. This change ensures that despite the file paths being replaced by their hashed counterparts for each pattern, only the unhashed file paths were searched for in the next patterns.

This works by keeping track of unprocessed content used to process a particular part of the content at a time (e.g., imports and exports) and then merging this part-processed content into a final content containing all the previously processed parts.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
