### PR TITLE
Fixed #35849 -- Made ParallelTestSuite report correct error location.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -282,6 +282,7 @@ answer newbie questions, and generally made Django that much better:
     David Sanders <dsanders11@ucsbalum.com>
     David Schein
     David Tulig <david.tulig@gmail.com>
+    David Winiecki <david.winiecki@gmail.com>
     David Winterbottom <david.winterbottom@gmail.com>
     David Wobrock <david.wobrock@gmail.com>
     Davide Ceretti <dav.ceretti@gmail.com>

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -547,17 +547,20 @@ class ParallelTestSuite(unittest.TestSuite):
 
             tests = list(self.subsuites[subsuite_index])
             for event in events:
-                event_name = event[0]
-                handler = getattr(result, event_name, None)
-                if handler is None:
-                    continue
-                test = tests[event[1]]
-                args = event[2:]
-                handler(test, *args)
+                self.handle_event(result, tests, event)
 
         pool.join()
 
         return result
+
+    def handle_event(self, result, tests, event):
+        event_name = event[0]
+        handler = getattr(result, event_name, None)
+        if handler is None:
+            return
+        test = tests[event[1]]
+        args = event[2:]
+        handler(test, *args)
 
     def __iter__(self):
         return iter(self.subsuites)

--- a/tests/test_runner/test_parallel.py
+++ b/tests/test_runner/test_parallel.py
@@ -1,9 +1,12 @@
 import pickle
 import sys
 import unittest
+from unittest.case import TestCase
+from unittest.result import TestResult
+from unittest.suite import TestSuite, _ErrorHolder
 
 from django.test import SimpleTestCase
-from django.test.runner import RemoteTestResult
+from django.test.runner import ParallelTestSuite, RemoteTestResult
 from django.utils.version import PY311, PY312
 
 try:
@@ -59,6 +62,18 @@ class SampleFailingSubtest(SimpleTestCase):
             self.fail("expected failure")
 
 
+class SampleErrorTest(SimpleTestCase):
+    @classmethod
+    def setUpClass(cls):
+        raise ValueError("woops")
+        super().setUpClass()
+
+    # This method name doesn't begin with "test" to prevent test discovery
+    # from seeing it.
+    def dummy_test(self):
+        raise AssertionError("SampleErrorTest.dummy_test() was called")
+
+
 class RemoteTestResultTest(SimpleTestCase):
     def _test_error_exc_info(self):
         try:
@@ -72,29 +87,70 @@ class RemoteTestResultTest(SimpleTestCase):
 
     def test_was_successful_one_success(self):
         result = RemoteTestResult()
-        result.addSuccess(None)
+        test = None
+        result.startTest(test)
+        try:
+            result.addSuccess(test)
+        finally:
+            result.stopTest(test)
         self.assertIs(result.wasSuccessful(), True)
 
     def test_was_successful_one_expected_failure(self):
         result = RemoteTestResult()
-        result.addExpectedFailure(None, self._test_error_exc_info())
+        test = None
+        result.startTest(test)
+        try:
+            result.addExpectedFailure(test, self._test_error_exc_info())
+        finally:
+            result.stopTest(test)
         self.assertIs(result.wasSuccessful(), True)
 
     def test_was_successful_one_skip(self):
         result = RemoteTestResult()
-        result.addSkip(None, "Skipped")
+        test = None
+        result.startTest(test)
+        try:
+            result.addSkip(test, "Skipped")
+        finally:
+            result.stopTest(test)
         self.assertIs(result.wasSuccessful(), True)
 
     @unittest.skipUnless(tblib is not None, "requires tblib to be installed")
     def test_was_successful_one_error(self):
         result = RemoteTestResult()
-        result.addError(None, self._test_error_exc_info())
+        test = None
+        result.startTest(test)
+        try:
+            result.addError(test, self._test_error_exc_info())
+        finally:
+            result.stopTest(test)
         self.assertIs(result.wasSuccessful(), False)
 
     @unittest.skipUnless(tblib is not None, "requires tblib to be installed")
     def test_was_successful_one_failure(self):
         result = RemoteTestResult()
-        result.addFailure(None, self._test_error_exc_info())
+        test = None
+        result.startTest(test)
+        try:
+            result.addFailure(test, self._test_error_exc_info())
+        finally:
+            result.stopTest(test)
+        self.assertIs(result.wasSuccessful(), False)
+
+    @unittest.skipUnless(tblib is not None, "requires tblib to be installed")
+    def test_add_error_before_first_test(self):
+        result = RemoteTestResult()
+        test_id = "test_foo (tests.test_foo.FooTest.test_foo)"
+        test = _ErrorHolder(test_id)
+        # Call addError() without a call to startTest().
+        result.addError(test, self._test_error_exc_info())
+
+        (event,) = result.events
+        self.assertEqual(event[0], "addError")
+        self.assertEqual(event[1], -1)
+        self.assertEqual(event[2], test_id)
+        (error_type, _, _) = event[3]
+        self.assertEqual(error_type, ValueError)
         self.assertIs(result.wasSuccessful(), False)
 
     def test_picklable(self):
@@ -161,3 +217,75 @@ class RemoteTestResultTest(SimpleTestCase):
         result = RemoteTestResult()
         result.addDuration(None, 2.3)
         self.assertEqual(result.collectedDurations, [("None", 2.3)])
+
+
+class ParallelTestSuiteTest(SimpleTestCase):
+    def test_handle_add_error_before_first_test(self):
+        dummy_subsuites = []
+        pts = ParallelTestSuite(dummy_subsuites, processes=2)
+        result = TestResult()
+        remote_result = RemoteTestResult()
+        test = SampleErrorTest(methodName="dummy_test")
+        suite = TestSuite([test])
+        suite.run(remote_result)
+        for event in remote_result.events:
+            pts.handle_event(result, tests=list(suite), event=event)
+
+        self.assertEqual(len(result.errors), 1)
+        actual_test, tb_and_details_str = result.errors[0]
+        self.assertIsInstance(actual_test, _ErrorHolder)
+        self.assertEqual(
+            actual_test.id(), "setUpClass (test_runner.test_parallel.SampleErrorTest)"
+        )
+        self.assertIn("Traceback (most recent call last):", tb_and_details_str)
+        self.assertIn("ValueError: woops", tb_and_details_str)
+
+    def test_handle_add_error_during_test(self):
+        dummy_subsuites = []
+        pts = ParallelTestSuite(dummy_subsuites, processes=2)
+        result = TestResult()
+        test = TestCase()
+        err = _test_error_exc_info()
+        event = ("addError", 0, err)
+        pts.handle_event(result, tests=[test], event=event)
+
+        self.assertEqual(len(result.errors), 1)
+        actual_test, tb_and_details_str = result.errors[0]
+        self.assertIsInstance(actual_test, TestCase)
+        self.assertEqual(actual_test.id(), "unittest.case.TestCase.runTest")
+        self.assertIn("Traceback (most recent call last):", tb_and_details_str)
+        self.assertIn("ValueError: woops", tb_and_details_str)
+
+    def test_handle_add_failure(self):
+        dummy_subsuites = []
+        pts = ParallelTestSuite(dummy_subsuites, processes=2)
+        result = TestResult()
+        test = TestCase()
+        err = _test_error_exc_info()
+        event = ("addFailure", 0, err)
+        pts.handle_event(result, tests=[test], event=event)
+
+        self.assertEqual(len(result.failures), 1)
+        actual_test, tb_and_details_str = result.failures[0]
+        self.assertIsInstance(actual_test, TestCase)
+        self.assertEqual(actual_test.id(), "unittest.case.TestCase.runTest")
+        self.assertIn("Traceback (most recent call last):", tb_and_details_str)
+        self.assertIn("ValueError: woops", tb_and_details_str)
+
+    def test_handle_add_success(self):
+        dummy_subsuites = []
+        pts = ParallelTestSuite(dummy_subsuites, processes=2)
+        result = TestResult()
+        test = TestCase()
+        event = ("addSuccess", 0)
+        pts.handle_event(result, tests=[test], event=event)
+
+        self.assertEqual(len(result.errors), 0)
+        self.assertEqual(len(result.failures), 0)
+
+
+def _test_error_exc_info():
+    try:
+        raise ValueError("woops")
+    except ValueError:
+        return sys.exc_info()


### PR DESCRIPTION
#### Trac ticket number

ticket-35849

#### Branch description

When running tests in parallel, if an error occurs in a test suite (`TestCase`) before the first test method runs, for example in `setUpClass`, then the shell output incorrectly states that the error occurred in an arbitrary test method, rather than, for example, `setUpClass`.

This is a problem because a user reading the test output may not notice the real error location (for example, `setUpClass`) in the traceback and may not run the other tests in the test suite.

This is especially problematic if automation parses the error location to automatically re-run tests (to address flaky, intermittently failing tests), because the other tests in the suite may never be run.

Expected output:

```
...
ERROR: setUpClass (mysite.tests.test_things.AlwaysFailTest)
...
```

Actual output:

```
...
ERROR: test_should_pass_b (mysite.tests.test_things.AlwaysFailTest.test_should_pass_b)
...
```

For more details about the problem, see the [ticket description](https://code.djangoproject.com/ticket/35849).

Part of the problem is that `ParallelTestSuite.run()` always passes one of the test methods in `tests` to `handler`, even though some events, like `"addError"` (only `"addError"`?), may occur before any test method begins to run (for example in `setUpClass`). Instead, when `event_name` is `"addError"` and test index is `-1`, then the `test` object passed to `handler` should represent the actual error location.

Another challenge is that `RemoteTestResult.addError()` sends limited information to `ParallelTestSuite`. The only pieces of information that `RemoteTestResult.addError()` sends that can be used to identify the error location are `self.test_index` and `err`. Neither of these seem ideal in the case where an error occurs before any test method runs (for example in `setUpClass`). In that case, `self.test_index` is `-1` and `err` is [a tuple](https://docs.python.org/3/library/sys.html#sys.exc_info) of `(type(e), e, e.__traceback__)` (where `e` is the error that occurred). In the context of `ParallelTestSuite.run()`, a test index of `-1` and event name `"addError"` implies that an error happened before the first test method, but it doesn't indicate where. `type(e)` and `e` also don't indicate where. `e.__traceback__` **could** be parsed to determine the error location, but I wonder if that would be a reliable solution.

To attempt to address these challenges, this branch makes `RemoteTestResult.addError()` include more information in the event, and makes `ParallelTestSuite.run()` check for that extra information and handle it.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
    - Not applicable
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
    - Not applicable