### PR TITLE
Fixed example indentation in docs/howto/overriding-templates.txt.

### DIFF
--- a/docs/howto/overriding-templates.txt
+++ b/docs/howto/overriding-templates.txt
@@ -111,15 +111,15 @@ reimplement the entire template.
 For example, you can use this technique to add a custom logo to the
 ``admin/base_site.html`` template:
 
-    .. code-block:: html+django
-       :caption: ``templates/admin/base_site.html``
+.. code-block:: html+django
+   :caption: ``templates/admin/base_site.html``
 
-        {% extends "admin/base_site.html" %}
+    {% extends "admin/base_site.html" %}
 
-        {% block branding %}
-            <img src="link/to/logo.png" alt="logo">
-            {{ block.super }}
-        {% endblock %}
+    {% block branding %}
+      <img src="link/to/logo.png" alt="logo">
+      {{ block.super }}
+    {% endblock %}
 
 Key points to note:
 


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/668bfd52-a88a-49c2-a620-8ce73524d3e6)