### PR TITLE
 Improved accessibility of docs text link from generic 'here' to a descriptive name.

### DIFF
--- a/docs/glossary.txt
+++ b/docs/glossary.txt
@@ -18,7 +18,7 @@ Glossary
         A higher-order :term:`view` function that provides an abstract/generic
         implementation of a common idiom or pattern found in view development.
 
-        See :doc:`/topics/class-based-views/index`.
+        See :ref:`class-based-views-explanation`.
 
     model
         Models store your application's data.

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -1230,7 +1230,7 @@ details on these changes.
   instead use ``django.contrib.formtools.utils.form_hmac``
 
 * The function-based generic view modules will be removed in favor of their
-  class-based equivalents, outlined :doc:`here
+  class-based equivalents, outlined in :doc:`class-based views
   </topics/class-based-views/index>`.
 
 * The ``django.core.servers.basehttp.AdminMediaHandler`` will be

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -1230,8 +1230,7 @@ details on these changes.
   instead use ``django.contrib.formtools.utils.form_hmac``
 
 * The function-based generic view modules will be removed in favor of their
-  class-based equivalents, outlined in :doc:`class-based views
-  </topics/class-based-views/index>`.
+  class-based equivalents, outlined in :ref:`class-based-views-explanation`.
 
 * The ``django.core.servers.basehttp.AdminMediaHandler`` will be
   removed.  In its place use

--- a/docs/intro/tutorial04.txt
+++ b/docs/intro/tutorial04.txt
@@ -340,8 +340,7 @@ use the variable you want.
 
 Run the server, and use your new polling app based on generic views.
 
-For full details on generic views, see the :doc:`generic views documentation
-</topics/class-based-views/index>`.
+For full details on generic views, see the generic views documentation under :ref:`class-based-views-explanation`.
 
 When you're comfortable with forms and generic views, read :doc:`part 5 of this
 tutorial</intro/tutorial05>` to learn about testing our polls app.

--- a/docs/ref/class-based-views/index.txt
+++ b/docs/ref/class-based-views/index.txt
@@ -3,7 +3,7 @@ Built-in class-based views API
 ==============================
 
 Class-based views API reference. For introductory material, see the
-:doc:`/topics/class-based-views/index` topic guide.
+:ref:`class-based-views-explanation` topic guide.
 
 .. toctree::
    :maxdepth: 3

--- a/docs/releases/1.3.txt
+++ b/docs/releases/1.3.txt
@@ -69,9 +69,7 @@ provided, along with a completely generic view base class that can be
 used as the basis for reusable applications that can be easily
 extended.
 
-See :doc:`the documentation on class-based generic views</topics/class-based-views/index>`
-for more details. There is also a document to help you `convert
-your function-based generic views to class-based
+See the documentation on :ref:`class-based-views-explanation` for more details. There is also a document to help you `convert your function-based generic views to class-based
 views <https://raw.githubusercontent.com/django/django/ea9dc9f4b03ae034c1dc080730422dda7a9c2e47/docs/topics/generic-views-migration.txt>`_.
 
 Logging

--- a/docs/releases/1.5.txt
+++ b/docs/releases/1.5.txt
@@ -210,7 +210,7 @@ associated with proxy models.
 New ``view`` variable in class-based views context
 --------------------------------------------------
 
-In all :doc:`generic class-based views </topics/class-based-views/index>`
+In all generic :ref:`class-based-views-explanation`
 (or any class-based view inheriting from ``ContextMixin``), the context dictionary
 contains a ``view`` variable that points to the ``View`` instance.
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -728,7 +728,7 @@ email in the desired domain and if not, redirects to the login page::
 
 .. class:: UserPassesTestMixin
 
-    When using :ref:`classed-based views class-based-views-explanation`, you
+    When using :ref:`class-based-views-explanation`, you
     can use the ``UserPassesTestMixin`` to do this.
 
     .. method:: test_func()

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -610,7 +610,7 @@ The ``login_required`` decorator
 The ``LoginRequiredMixin`` mixin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When using :doc:`class-based views </topics/class-based-views/index>`, you can
+When using :ref:`class-based-views-explanation`, you can
 achieve the same behavior as with ``login_required`` by using the
 ``LoginRequiredMixin``. This mixin should be at the leftmost position in the
 inheritance list.
@@ -728,7 +728,7 @@ email in the desired domain and if not, redirects to the login page::
 
 .. class:: UserPassesTestMixin
 
-    When using :doc:`class-based views </topics/class-based-views/index>`, you
+    When using :ref:`classed-based views class-based-views-explanation`, you
     can use the ``UserPassesTestMixin`` to do this.
 
     .. method:: test_func()
@@ -1057,8 +1057,7 @@ arguments in the URLconf, these will be passed on to the view. For example::
         ),
     ]
 
-All views are :doc:`class-based </topics/class-based-views/index>`, which allows
-you to easily customize them by subclassing.
+All views are :ref:`class-based-views-explanation`, which allows you to easily customize them by subclassing.
 
 .. _all-authentication-views:
 

--- a/docs/topics/class-based-views/index.txt
+++ b/docs/topics/class-based-views/index.txt
@@ -1,3 +1,5 @@
+.. _class-based-views-explanation:
+
 =================
 Class-based views
 =================

--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -49,8 +49,7 @@ algorithm the system follows to determine which Python code to execute:
    :attr:`~django.http.HttpRequest.path_info`.
 
 #. Once one of the URL patterns matches, Django imports and calls the given
-   view, which is a Python function (or a :doc:`class-based view
-   </topics/class-based-views/index>`). The view gets passed the following
+   view, which is a Python function (or a :ref:`class-based-views-explanation`). The view gets passed the following
    arguments:
 
    * An instance of :class:`~django.http.HttpRequest`.


### PR DESCRIPTION
#### Trac ticket number
N/A

#### Branch description
Improved docs text link (under deprecation) from a generic "here" to the name of the linked page, "class-based views."

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
