### PR TITLE
Fixed #35856 -- Added QuerySet.explain() support for MEMORY/SERIALIZE option on PostgreSQL 17+.

### DIFF
--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -160,6 +160,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     def is_postgresql_16(self):
         return self.connection.pg_version >= 160000
 
+    @cached_property
+    def is_postgresql_17(self):
+        return self.connection.pg_version >= 170000
+
     supports_unlimited_charfield = True
     supports_nulls_distinct_unique_constraints = property(
         operator.attrgetter("is_postgresql_15")

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -32,7 +32,9 @@ class DatabaseOperations(BaseDatabaseOperations):
             "BUFFERS",
             "COSTS",
             "GENERIC_PLAN",
+            "MEMORY",
             "SETTINGS",
+            "SERIALIZE",
             "SUMMARY",
             "TIMING",
             "VERBOSE",
@@ -365,6 +367,9 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def explain_query_prefix(self, format=None, **options):
         extra = {}
+        if serialize := options.pop("serialize", None):
+            if serialize.upper() in {"TEXT", "BINARY"}:
+                extra["SERIALIZE"] = serialize.upper()
         # Normalize options.
         if options:
             options = {

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -3110,6 +3110,11 @@ there are triggers or if a function is called, even for a ``SELECT`` query.
 
     Support for the ``generic_plan`` option on PostgreSQL 16+ was added.
 
+.. versionchanged:: 5.2
+
+    Support for the ``memory`` and ``serialize`` options on PostgreSQL 17+ was
+    added.
+
 .. _field-lookups:
 
 ``Field`` lookups

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -269,6 +269,9 @@ Models
   longer required to be set on SQLite, which supports unlimited ``VARCHAR``
   columns.
 
+* :meth:`.QuerySet.explain` now supports the ``memory`` and ``serialize``
+  options on PostgreSQL 17+.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add support for MEMORY/SERIALIZE option to QuerySet.explain() on PostgreSQL 17+.

#### Trac ticket number

ticket-35856

#### Branch description
Add support for MEMORY/SERIALIZE option to QuerySet.explain() on PostgreSQL 17+.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
