### PR TITLE
Refs #35844 -- Corrected expected error messages in commands tests on Python 3.14+.

### DIFF
--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -19,6 +19,7 @@ PY310 = sys.version_info >= (3, 10)
 PY311 = sys.version_info >= (3, 11)
 PY312 = sys.version_info >= (3, 12)
 PY313 = sys.version_info >= (3, 13)
+PY314 = sys.version_info >= (3, 14)
 
 
 def get_version(version=None):

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -34,7 +34,7 @@ from django.db.migrations.recorder import MigrationRecorder
 from django.test import LiveServerTestCase, SimpleTestCase, TestCase, override_settings
 from django.test.utils import captured_stderr, captured_stdout
 from django.urls import path
-from django.utils.version import PY313, get_docs_version
+from django.utils.version import PY313, PY314, get_docs_version
 from django.views.static import serve
 
 from . import urls
@@ -2355,10 +2355,16 @@ class Discovery(SimpleTestCase):
 
 class CommandDBOptionChoiceTests(SimpleTestCase):
     def test_invalid_choice_db_option(self):
-        expected_error = (
-            "Error: argument --database: invalid choice: "
-            "'deflaut' (choose from 'default', 'other')"
-        )
+        if PY314:
+            expected_error = (
+                "Error: argument --database: invalid choice: 'deflaut' "
+                "(choose from default, other)"
+            )
+        else:
+            expected_error = (
+                "Error: argument --database: invalid choice: 'deflaut' "
+                "(choose from 'default', 'other')"
+            )
         args = [
             "changepassword",
             "createsuperuser",

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -20,6 +20,7 @@ from django.db import connection
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import captured_stderr, extend_sys_path
 from django.utils import translation
+from django.utils.version import PY314
 
 from .management.commands import dance
 
@@ -400,7 +401,10 @@ class CommandTests(SimpleTestCase):
         self.assertIn("bar", out.getvalue())
 
     def test_subparser_invalid_option(self):
-        msg = "invalid choice: 'test' (choose from 'foo')"
+        if PY314:
+            msg = "invalid choice: 'test' (choose from foo)"
+        else:
+            msg = "invalid choice: 'test' (choose from 'foo')"
         with self.assertRaisesMessage(CommandError, msg):
             management.call_command("subparser", "test", 12)
         msg = "Error: the following arguments are required: subcommand"


### PR DESCRIPTION
Refs #35844 -- Corrected expected error messages in commands tests on Python 3.14+.

#### Trac ticket number
[ticket-35844](https://code.djangoproject.com/ticket/35844#ticket)

#### Branch description
Updated CommandTests.test_subparser_invalid_option and CommandDBOptionChoiceTests.test_invalid_choice_db_option to address changes in Python 3.14+ error handling.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
