### PR TITLE
Made GitHub actions display all warnings in Python tests.

### DIFF
--- a/.github/workflows/python_matrix.yml
+++ b/.github/workflows/python_matrix.yml
@@ -49,4 +49,4 @@ jobs:
         run: python -m pip install --upgrade pip setuptools wheel
       - run: python -m pip install -r tests/requirements/py3.txt -e .
       - name: Run tests
-        run: python tests/runtests.py -v2
+        run: python -Wall tests/runtests.py -v2

--- a/.github/workflows/schedule_tests.yml
+++ b/.github/workflows/schedule_tests.yml
@@ -36,7 +36,7 @@ jobs:
         run: python -m pip install --upgrade pip setuptools wheel
       - run: python -m pip install -r tests/requirements/py3.txt -e .
       - name: Run tests
-        run: python tests/runtests.py -v2
+        run: python -Wall tests/runtests.py -v2
 
   pyc-only:
     runs-on: ubuntu-latest
@@ -62,7 +62,7 @@ jobs:
           find $DJANGO_PACKAGE_ROOT -name '*.py' -print -delete
       - run: python -m pip install -r tests/requirements/py3.txt
       - name: Run tests
-        run: python tests/runtests.py --verbosity=2
+        run: python -Wall tests/runtests.py --verbosity=2
 
   pypy-sqlite:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: python -m pip install --upgrade pip setuptools wheel
       - run: python -m pip install -r tests/requirements/py3.txt -e .
       - name: Run tests
-        run: python tests/runtests.py -v2
+        run: python -Wall tests/runtests.py -v2
 
   javascript-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We should consistently display all warnings when running Python tests. This will help avoid reversing efforts to fix deprecation warnings.