### PR TITLE
Fixed #35866 -- Clarified the internal Model style guide on the positioning of other Python magic methods.

### DIFF
--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -417,7 +417,7 @@ Model style
   * All database fields
   * Custom manager attributes
   * ``class Meta``
-  * ``def __str__()``
+  * ``def __str__()`` and other Python magic methods
   * ``def save()``
   * ``def get_absolute_url()``
   * Any custom methods


### PR DESCRIPTION
Fixed #35866 -- Django documentaion style guide on models is unclear what to do with any other Python dunder methods that the model class might have

#### Trac ticket number

[ticket-35866](https://code.djangoproject.com/ticket/35866)

#### Branch description
Update Django documentation regarding the clearness of the Model style guide about the order of the model's inner classes

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
