### PR TITLE
Fixed #35869 -- Added explicit warning when AppConfig.create() can't choose from multiple subclasses of AppConfig.

### DIFF
--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+import warnings
 from importlib import import_module
 
 from django.core.exceptions import ImproperlyConfigured
@@ -134,7 +135,7 @@ class AppConfig:
                 ]
                 if len(app_configs) == 1:
                     app_config_class = app_configs[0][1]
-                else:
+                elif len(app_configs) > 1:
                     # Check if there's exactly one AppConfig subclass,
                     # among those that explicitly define default = True.
                     app_configs = [
@@ -150,6 +151,12 @@ class AppConfig:
                         )
                     elif len(app_configs) == 1:
                         app_config_class = app_configs[0][1]
+                    else:
+                        warnings.warn(
+                            "The base AppConfig class will be used because multiple "
+                            f"subclasses of AppConfig were detected in {mod_path} "
+                            "and none of them specified AppConfig.default as True.",
+                        )
 
             # Use the default app config class if we didn't find anything.
             if app_config_class is None:


### PR DESCRIPTION
#### Trac ticket number
[ticket-35869](https://code.djangoproject.com/ticket/35869)

#### Branch description
Added explicit warning when `AppConfig.create()` use base AppConfig because **multiple subclasses** of AppConfig were detected in `apps.py` and none of them specified `AppConfig.default` as True.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
