### PR TITLE
Removed unneeded sentence on contributing page.

### DIFF
--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -217,8 +217,7 @@ a dependency for one or more of the Python packages. Consult the failing
 package's documentation or search the web with the error message that you
 encounter.
 
-Now we are ready to run the test suite. If you're using GNU/Linux, macOS, or
-some other flavor of Unix, run:
+Now we are ready to run the test suite:
 
 .. console::
 


### PR DESCRIPTION
#### Trac ticket number
N/A

#### Branch description
The users of the django documentation can choose to view certain commands in two different flavours. It is because of this, that the highlighted sentence is not needed on this page https://docs.djangoproject.com/en/dev/intro/contributing/:
>![The original docs with "If you're using GNU/Linux, macOS, or some other flavor of Unix, run" hgihlighted](https://github.com/user-attachments/assets/fb42600f-079b-47f8-aa70-bd88645b0ea1)

This PR removes the highlighted line. Here is the revised section from my local doc build after making this change:
>![The docs after the update with the line removed](https://github.com/user-attachments/assets/b15a88dd-ad40-41fc-b9bc-9b8bfba7124e)


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
