### PR TITLE
Clarified that readonly_fields are also displayed when fields and fieldsets are not set on ModelAdmin.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -337,7 +337,8 @@ subclass::
     If neither ``fields`` nor :attr:`~ModelAdmin.fieldsets` options are present,
     Django will default to displaying each field that isn't an ``AutoField`` and
     has ``editable=True``, in a single fieldset, in the same order as the fields
-    are defined in the model.
+    are defined in the model, followed by any fields defined in
+    :attr:`~ModelAdmin.readonly_fields`.
 
 .. attribute:: ModelAdmin.fieldsets
 


### PR DESCRIPTION
This is a minor change regarding the use of `readonly_fields` to display a non-editable field, such as a `DateTimeField` with `auto_now_add=True`.

It is enough to only add the field to `readonly_fields` of the `ModelAdmin`, setting `fields` is unnecessary.

This is a widely used (for instance, mentioned [here](https://stackoverflow.com/questions/61158984/how-can-i-show-auto-now-add-field-in-django-admin)) and cool feature that needs to be mentioned in the documentation.