### PR TITLE
Refs #35844 -- Expanded compatibility for expected error messages in command tests on Python 3.12 and 3.13.

### DIFF
--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -34,7 +34,7 @@ from django.db.migrations.recorder import MigrationRecorder
 from django.test import LiveServerTestCase, SimpleTestCase, TestCase, override_settings
 from django.test.utils import captured_stderr, captured_stdout
 from django.urls import path
-from django.utils.version import PY313, PY314, get_docs_version
+from django.utils.version import PY313, get_docs_version
 from django.views.static import serve
 
 from . import urls
@@ -2355,16 +2355,10 @@ class Discovery(SimpleTestCase):
 
 class CommandDBOptionChoiceTests(SimpleTestCase):
     def test_invalid_choice_db_option(self):
-        if PY314:
-            expected_error = (
-                "Error: argument --database: invalid choice: 'deflaut' "
-                "(choose from default, other)"
-            )
-        else:
-            expected_error = (
-                "Error: argument --database: invalid choice: 'deflaut' "
-                "(choose from 'default', 'other')"
-            )
+        expected_error = (
+            r"Error: argument --database: invalid choice: 'deflaut' "
+            r"\(choose from '?default'?, '?other'?\)"
+        )
         args = [
             "changepassword",
             "createsuperuser",
@@ -2384,7 +2378,7 @@ class CommandDBOptionChoiceTests(SimpleTestCase):
         ]
 
         for arg in args:
-            with self.assertRaisesMessage(CommandError, expected_error):
+            with self.assertRaisesRegex(CommandError, expected_error):
                 call_command(arg, "--database", "deflaut", verbosity=0)
 
 

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -20,7 +20,6 @@ from django.db import connection
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import captured_stderr, extend_sys_path
 from django.utils import translation
-from django.utils.version import PY314
 
 from .management.commands import dance
 
@@ -401,11 +400,8 @@ class CommandTests(SimpleTestCase):
         self.assertIn("bar", out.getvalue())
 
     def test_subparser_invalid_option(self):
-        if PY314:
-            msg = "invalid choice: 'test' (choose from foo)"
-        else:
-            msg = "invalid choice: 'test' (choose from 'foo')"
-        with self.assertRaisesMessage(CommandError, msg):
+        msg = r"invalid choice: 'test' \(choose from '?foo'?\)"
+        with self.assertRaisesRegex(CommandError, msg):
             management.call_command("subparser", "test", 12)
         msg = "Error: the following arguments are required: subcommand"
         with self.assertRaisesMessage(CommandError, msg):


### PR DESCRIPTION
Refs #35844 -- Expanded compatibility for expected error messages in command tests on Python 3.12 and 3.13.

#### Trac ticket number
[ticket-35844](https://code.djangoproject.com/ticket/35844#ticket)

#### Branch description
Updated CommandTests.test_subparser_invalid_option and CommandDBOptionChoiceTests.test_invalid_choice_db_option to use assertRaisesRegex() for compatibility with modified error messages in Python 3.12, 3.13, and 3.14+.

https://github.com/python/cpython/commit/66b3922b97388c328c9bd8df050eef11c0261fae

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
