### PR TITLE
Fixed #35868 -- Removed unneeded AttributeError catching in collectstatic's delete_file().

### DIFF
--- a/django/contrib/staticfiles/management/commands/collectstatic.py
+++ b/django/contrib/staticfiles/management/commands/collectstatic.py
@@ -279,14 +279,14 @@ class Command(BaseCommand):
             try:
                 # When was the target file modified last time?
                 target_last_modified = self.storage.get_modified_time(prefixed_path)
-            except (OSError, NotImplementedError, AttributeError):
+            except (OSError, NotImplementedError):
                 # The storage doesn't support get_modified_time() or failed
                 pass
             else:
                 try:
                     # When was the source file modified last time?
                     source_last_modified = source_storage.get_modified_time(path)
-                except (OSError, NotImplementedError, AttributeError):
+                except (OSError, NotImplementedError):
                     pass
                 else:
                     # The full path of the target file


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35868

#### Branch description
The `collectstatic` management command will no longer catch `AttributeError` exceptions.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
