### PR TITLE
Fixed #35871 -- Corrected example on altering the base_fields attribute in forms docs.

### DIFF
--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -406,8 +406,8 @@ process:
 .. code-block:: pycon
 
     >>> f.base_fields["subject"].label_suffix = "?"
-    >>> another_f = CommentForm(auto_id=False)
-    >>> f.as_div().split("</div>")[0]
+    >>> another_f = ContactForm(auto_id=False)
+    >>> another_f.as_div().split("</div>")[0]
     '<div><label for="id_subject">Subject?</label><input type="text" name="subject" maxlength="100" required id="id_subject">'
 
 Accessing "clean" data


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35871

#### Branch description
Changed the example for base_fields attribute modification in the Django Forms API document.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
