### PR TITLE
Improved ImproperlyConfigured error message in ModelFormMixin.

### DIFF
--- a/django/views/generic/edit.py
+++ b/django/views/generic/edit.py
@@ -101,8 +101,9 @@ class ModelFormMixin(FormMixin, SingleObjectMixin):
 
             if self.fields is None:
                 raise ImproperlyConfigured(
-                    "Using ModelFormMixin (base class of %s) without "
-                    "the 'fields' attribute is prohibited." % self.__class__.__name__
+                    "Using ModelFormMixin (base class of %s) without the 'fields' or "
+                    "the 'form_class' attribute is prohibited."
+                    % self.__class__.__name__
                 )
 
             return model_forms.modelform_factory(model, fields=self.fields)

--- a/tests/generic_views/test_edit.py
+++ b/tests/generic_views/test_edit.py
@@ -218,7 +218,7 @@ class CreateViewTests(TestCase):
 
         message = (
             "Using ModelFormMixin (base class of MyCreateView) without the "
-            "'fields' attribute is prohibited."
+            "'fields' or the 'form_class' attribute is prohibited."
         )
         with self.assertRaisesMessage(ImproperlyConfigured, message):
             MyCreateView().get_form_class()


### PR DESCRIPTION
Clarified that *either* `fields` or `form_class` attribute must be set when using `ModelFormMixin`.

