### PR TITLE
Fixed #35876 -- Displayed non-ASCII fieldset names when rendering ModelAdmin.fieldsets.

### DIFF
--- a/django/contrib/admin/templates/admin/includes/fieldset.html
+++ b/django/contrib/admin/templates/admin/includes/fieldset.html
@@ -1,8 +1,7 @@
-{% with name=fieldset.name|default:""|slugify %}
-<fieldset class="module aligned {{ fieldset.classes }}"{% if name %} aria-labelledby="{{ prefix }}-{{ id_prefix}}-{{ name }}-{{ id_suffix }}-heading"{% endif %}>
-    {% if name %}
+<fieldset class="module aligned {{ fieldset.classes }}"{% if fieldset.name %} aria-labelledby="{{ prefix }}-{{ id_prefix}}-{{ id_suffix }}-heading"{% endif %}>
+    {% if fieldset.name %}
         {% if fieldset.is_collapsible %}<details><summary>{% endif %}
-        <h{{ heading_level|default:2 }} id="{{ prefix }}-{{ id_prefix}}-{{ name }}-{{ id_suffix }}-heading" class="fieldset-heading">{{ fieldset.name }}</h{{ heading_level|default:2 }}>
+        <h{{ heading_level|default:2 }} id="{{ prefix }}-{{ id_prefix}}-{{ id_suffix }}-heading" class="fieldset-heading">{{ fieldset.name }}</h{{ heading_level|default:2 }}>
         {% if fieldset.is_collapsible %}</summary>{% endif %}
     {% endif %}
     {% if fieldset.description %}
@@ -36,6 +35,5 @@
             {% if not line.fields|length == 1 %}</div>{% endif %}
         </div>
     {% endfor %}
-    {% if name and fieldset.is_collapsible %}</details>{% endif %}
+    {% if fieldset.name and fieldset.is_collapsible %}</details>{% endif %}
 </fieldset>
-{% endwith %}

--- a/docs/releases/5.1.3.txt
+++ b/docs/releases/5.1.3.txt
@@ -17,3 +17,6 @@ Bugfixes
 
 * Fixed a regression in Django 5.1 that prevented the use of DB-IP databases
   with :class:`~django.contrib.gis.geoip2.GeoIP2` (:ticket:`35841`).
+
+* Fixed a regression in Django 5.1 where non-ASCII fieldset names were not
+  displayed when rendering admin fieldsets (:ticket:`35876`).

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -1801,7 +1801,7 @@ class TestInlineWithFieldsets(TestDataMixin, TestCase):
         # The second and third have the same "Advanced options" name, but the
         # second one has the "collapse" class.
         for x, classes in ((1, ""), (2, "collapse")):
-            heading_id = f"fieldset-0-advanced-options-{x}-heading"
+            heading_id = f"fieldset-0-{x}-heading"
             with self.subTest(heading_id=heading_id):
                 self.assertContains(
                     response,
@@ -1846,7 +1846,7 @@ class TestInlineWithFieldsets(TestDataMixin, TestCase):
                 # Every fieldset defined for an inline's form.
                 for z, fieldset in enumerate(inline_admin_form):
                     if fieldset.name:
-                        heading_id = f"{prefix}-{y}-details-{z}-heading"
+                        heading_id = f"{prefix}-{y}-{z}-heading"
                         self.assertContains(
                             response,
                             f'<fieldset class="module aligned {fieldset.classes}" '

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -237,6 +237,7 @@ class ArticleAdmin(ArticleAdminWithExtraUrl):
             "Some other fields",
             {"classes": ("wide",), "fields": ("date", "section", "sub_section")},
         ),
+        ("이름", {"fields": ("another_section",)}),
     )
 
     # These orderings aren't particularly useful but show that expressions can

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -2533,6 +2533,19 @@ class AdminViewPermissionsTest(TestCase):
         self.assertContains(
             response, '<input type="submit" value="Save and view" name="_continue">'
         )
+        self.assertContains(
+            response,
+            '<h2 id="fieldset-0-0-heading" class="fieldset-heading">Some fields</h2>',
+        )
+        self.assertContains(
+            response,
+            '<h2 id="fieldset-0-1-heading" class="fieldset-heading">'
+            "Some other fields</h2>",
+        )
+        self.assertContains(
+            response,
+            '<h2 id="fieldset-0-2-heading" class="fieldset-heading">이름</h2>',
+        )
         post = self.client.post(
             reverse("admin:admin_views_article_add"), add_dict, follow=False
         )


### PR DESCRIPTION
Regression in 01ed59f753139afb514170ee7f7384c155ecbc2d.

#### Trac ticket number

ticket-35876

#### Branch description

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
