### PR TITLE
Updated BRIN index links in contrib.postgres indexes docs.

### DIFF
--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -34,14 +34,14 @@ available from the ``django.contrib.postgres.indexes`` module.
 .. class:: BrinIndex(*expressions, autosummarize=None, pages_per_range=None, **options)
 
     Creates a `BRIN index
-    <https://www.postgresql.org/docs/current/brin-intro.html>`_.
+    <https://www.postgresql.org/docs/current/brin.html>`_.
 
     Set the ``autosummarize`` parameter to ``True`` to enable `automatic
     summarization`_ to be performed by autovacuum.
 
     The ``pages_per_range`` argument takes a positive integer.
 
-    .. _automatic summarization: https://www.postgresql.org/docs/current/brin-intro.html#BRIN-OPERATION
+    .. _automatic summarization: https://www.postgresql.org/docs/current/brin.html#BRIN-OPERATION
 
 ``BTreeIndex``
 ==============


### PR DESCRIPTION
#### Trac ticket number

N/A

#### Branch description

The www.postgresql.org links for BRIN indexes are incorrect in the `contrib.postgres` docs. This branch fixes them.

#### Checklist

- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
