### PR TITLE
Fixed #35882 -- Made migration questioner loop on all errors.

### DIFF
--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -160,8 +160,8 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
             else:
                 try:
                     return eval(code, {}, {"datetime": datetime, "timezone": timezone})
-                except (SyntaxError, NameError) as e:
-                    self.prompt_output.write("Invalid input: %s" % e)
+                except Exception as e:
+                    self.prompt_output.write(f"{e.__class__.__name__}: {e}")
 
     def ask_not_null_addition(self, field_name, model_name):
         """Adding a NOT NULL field to a model."""

--- a/tests/migrations/test_questioner.py
+++ b/tests/migrations/test_questioner.py
@@ -61,10 +61,27 @@ class QuestionerHelperMethodsTests(SimpleTestCase):
         )
 
     @mock.patch("builtins.input", side_effect=["bad code", "exit"])
-    def test_questioner_no_default_bad_user_entry_code(self, mock_input):
+    def test_questioner_no_default_syntax_error(self, mock_input):
         with self.assertRaises(SystemExit):
             self.questioner._ask_default()
-        self.assertIn("Invalid input: ", self.prompt.getvalue())
+        self.assertIn("SyntaxError: invalid syntax", self.prompt.getvalue())
+
+    @mock.patch("builtins.input", side_effect=["datetim", "exit"])
+    def test_questioner_no_default_name_error(self, mock_input):
+        with self.assertRaises(SystemExit):
+            self.questioner._ask_default()
+        self.assertIn(
+            "NameError: name 'datetim' is not defined", self.prompt.getvalue()
+        )
+
+    @mock.patch("builtins.input", side_effect=["datetime.dat", "exit"])
+    def test_questioner_no_default_attribute_error(self, mock_input):
+        with self.assertRaises(SystemExit):
+            self.questioner._ask_default()
+        self.assertIn(
+            "AttributeError: module 'datetime' has no attribute 'dat'",
+            self.prompt.getvalue(),
+        )
 
     @mock.patch("builtins.input", side_effect=[KeyboardInterrupt()])
     def test_questioner_no_default_keyboard_interrupt(self, mock_input):

--- a/tests/migrations/test_questioner.py
+++ b/tests/migrations/test_questioner.py
@@ -66,6 +66,11 @@ class QuestionerHelperMethodsTests(SimpleTestCase):
             self.questioner._ask_default()
         self.assertIn("Invalid input: ", self.prompt.getvalue())
 
+    @mock.patch("builtins.input", side_effect=[KeyboardInterrupt()])
+    def test_questioner_no_default_keyboard_interrupt(self, mock_input):
+        with self.assertRaises(KeyboardInterrupt):
+            self.questioner._ask_default()
+
     @mock.patch("builtins.input", side_effect=["", "n"])
     def test_questioner_no_default_no_user_entry_boolean(self, mock_input):
         value = self.questioner._boolean_input("Proceed?")


### PR DESCRIPTION
#### Trac ticket number

ticket-35882

#### Branch description

Expand `InteractiveMigrationQuestioner._ask_default()` to loop on all exception types, update its display to show the exception type, and expand tests to existing types plus the `AttributeError` I encountered.

Thanks to @jacobtylerwalls for expanding the test coverage back in #15212, it let me make this change quite easily.

#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
