### PR TITLE
Updated instruction sentence on how to claim a ticket.

### DIFF
--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -47,10 +47,14 @@ and time availability), claim it by following these steps:
   any activity, it's probably safe to reassign it to yourself.
 
 * Log into your account, if you haven't already, by clicking "GitHub Login"
-  or "DjangoProject Login" in the upper left of the ticket page.
+  or "DjangoProject Login" in the upper left of the ticket page. Once logged
+  in, you can then click the "Modify Ticket" button near the bottom of the
+  page.
 
-* Claim the ticket by clicking the "assign to myself" radio button under
-  "Action" near the bottom of the page, then click "Submit changes."
+* Claim the ticket by clicking the "assign to" radio button in the "Action"
+  section. Your username will be filled in the text box by default.
+
+* Finally click the "Submit changes" button at the bottom to save.
 
 .. note::
     The Django software foundation requests that anyone contributing more than


### PR DESCRIPTION
#### Trac ticket number
N/A

#### Branch description
The page `contributing/writing-code/submitting-patches.html` has been updated with this change. The issue was that the instructions on how to assign a ticket to yourself was out of date and confusing for a first time user of TRAC. This PR updates the sentence to accurately explain where to click on the page to assign a ticket.

The original instruction which is out of date with the UI:
>![The current instructions which do not mention the 'Modify ticket' button](https://github.com/user-attachments/assets/70790108-e997-4a87-9fd7-4334ca06f07e)

The new instruction which is more accurate:
>![The updated sentence that mentions the 'Modify ticket' button](https://github.com/user-attachments/assets/bb58bf68-36f1-450a-bdae-1fa39bec966d)


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
