### PR TITLE
Bugfix #35884 and support Pillow v11 in get_image_dimensions() and TIFFs

### DIFF
--- a/django/core/files/images.py
+++ b/django/core/files/images.py
@@ -78,6 +78,10 @@ def get_image_dimensions(file_or_path, close=False):
                 # e.g. "RuntimeError: could not create decoder object" for
                 # WebP files. A different chunk_size may work.
                 pass
+            except ValueError:
+                # e.g.: ValueError('Invalid dimensions') because PIL
+                # needs more data from a TIFF file.
+                pass
             if p.image:
                 return p.image.size
             chunk_size *= 2


### PR DESCRIPTION
Django's django.core.files.images.get_image_dimensions() feeds PIL with chunks to get the image size. Pillow v11 adds "raise ValueError" in v11 with ​https://github.com/python-pillow/Pillow/commit/e6e5ef5c5fbd83ac5dd63301e4d7d6860a7b2d09#diff-6ad43f85f1a075181d4d8cfcd97ae27bba1eccf5c3db5a3457160f98218eba6eR1404 that Django doesn't catch in the feed loop, here: ​https://github.com/django/django/blob/968397228fe03968bb855856532569586c8a8a1c/django/core/files/images.py#L35-L89

#### Trac ticket number

ticket-35884

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
