### PR TITLE
Removed definition of JSONObject ArgJoiner class in as_native() function.

### DIFF
--- a/django/db/models/functions/comparison.py
+++ b/django/db/models/functions/comparison.py
@@ -160,16 +160,15 @@ class JSONObject(Func):
             )
         return super().as_sql(compiler, connection, **extra_context)
 
-    def as_native(self, compiler, connection, *, returning, **extra_context):
-        class ArgJoiner:
-            def join(self, args):
-                pairs = zip(args[::2], args[1::2], strict=True)
-                return ", ".join([" VALUE ".join(pair) for pair in pairs])
+    def join(self, args):
+        pairs = zip(args[::2], args[1::2], strict=True)
+        return ", ".join([" VALUE ".join(pair) for pair in pairs])
 
+    def as_native(self, compiler, connection, *, returning, **extra_context):
         return self.as_sql(
             compiler,
             connection,
-            arg_joiner=ArgJoiner(),
+            arg_joiner=self,
             template=f"%(function)s(%(expressions)s RETURNING {returning})",
             **extra_context,
         )


### PR DESCRIPTION
To address [this comment](https://github.com/django/django/pull/18622#discussion_r1805643631) in https://github.com/django/django/pull/18622