### PR TITLE
Refs #23968 -- Removed unnecessary list comprehension in contrib.admin.helpers.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -121,7 +121,7 @@ class Fieldset:
 
     @cached_property
     def is_collapsible(self):
-        if any([field in self.fields for field in self.form.errors]):
+        if any(field in self.fields for field in self.form.errors):
             return False
         return "collapse" in self.classes
 


### PR DESCRIPTION

#### Trac ticket number
https://code.djangoproject.com/ticket/35893

#### Branch description
Grepping through the code base, I found two instances where `any`/`all` were called with an intermediately generated list-comprehension. This is _usually_ an anti-pattern, because it prevents short-circuiting. One of the instances has a comment explaining why it needs to use list comprehension. I fleshed that out a tiny bit more to make the intent clearer. I removed the other instance of list comprehension

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
