### PR TITLE
Fixed #35900 -- `staticfiles`: Made `staticfiles.json` location unguessable for security.

### DIFF
--- a/docs/ref/contrib/staticfiles.txt
+++ b/docs/ref/contrib/staticfiles.txt
@@ -383,7 +383,7 @@ following requirements are met:
 
 Since creating the MD5 hash can be a performance burden to your website
 during runtime, ``staticfiles`` will automatically store the mapping with
-hashed names for all processed files in a file called ``staticfiles.json``.
+hashed names for all processed files in a file called ``staticfiles_[..].json``.
 This happens once when you run the :djadmin:`collectstatic` management
 command.
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35900

#### Branch description
Hi! :wave: 

This is my first pull request to core Django, I'm happy to make adjustments as needed.

One way to start attacking a Django setup is to check URL `/static/staticfiles.json` and use its content to first derive used dependencies (potentially down to a specific version) to then derive attack vectors base on that information.

This change makes `HashedFilesMixin.manifest_name` depend on `settings.SECRET_KEY` and hence unguessable to an attacker by default while remaining robust. The "by default" is key here, because most users do not consider the security implications of serving file `staticfiles.json` to attackers. Yes, security by obscurity is never enough in isolation, but it does make attacking harder in practice.

For a practical example:
```
In [1]: from django.conf import settings

In [2]: settings.configure(SECRET_KEY='xxxxxxxxxxxxxxx')

In [3]: from django.contrib.staticfiles.storage import ManifestFilesMixin

In [4]: ManifestFilesMixin.manifest_name
Out[4]: 'staticfiles_USD7M7XPCLK3CJAEXNMGXN2WLYSHLNE2.json'
```

I can add tests (and extend docs as needed) when there is approval for this general direction from you.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
