### PR TITLE
Updated validate_slug regular expression in form validation docs.

### DIFF
--- a/docs/ref/forms/validation.txt
+++ b/docs/ref/forms/validation.txt
@@ -254,7 +254,7 @@ Common cases such as validating against an email or a regular expression can be
 handled using existing validator classes available in Django. For example,
 ``validators.validate_slug`` is an instance of
 a :class:`~django.core.validators.RegexValidator` constructed with the first
-argument being the pattern: ``^[-a-zA-Z0-9_]+$``. See the section on
+argument being the pattern: ``^[-a-zA-Z0-9_]+\Z``. See the section on
 :doc:`writing validators </ref/validators>` to see a list of what is already
 available and for an example of how to write a validator.
 


### PR DESCRIPTION
#### Branch description
https://github.com/django/django/commit/014247ad1922931a2f17beaf6249247298e9dc44
The regular expression used by validate_slug has changed.
before: `slug_re = re.compile(r'^[-a-zA-Z0-9_]+$')`
after: `slug_re = re.compile(r'^[-a-zA-Z0-9_]+\Z')`
However, an deprecated regular expression is being used in the [Form and field validation document](https://docs.djangoproject.com/en/5.1/ref/forms/validation/#using-validators), so I modified that.
<img width="881" alt="Screenshot 2024-11-07 at 9 50 48 AM" src="https://github.com/user-attachments/assets/2d2c8827-9086-477f-8079-846f0877014b">


