### PR TITLE
Add a new `get_object_or_none` shortcut

### DIFF
--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -188,3 +188,45 @@ def resolve_url(to, *args, **kwargs):
 
     # Finally, fall back and assume it's a URL
     return to
+
+
+def get_object_or_none(klass, *args, **kwargs):
+    """
+    Use get() to return an object, or return None if the object does not exist.
+
+    klass may be a Model, Manager, or QuerySet object. All other passed
+    arguments and keyword arguments are used in the get() query.
+
+    Like with QuerySet.get(), MultipleObjectsReturned is raised if more than
+    one object is found.
+    """
+    queryset = _get_queryset(klass)
+    if not hasattr(queryset, "get"):
+        klass__name = (
+            klass.__name__ if isinstance(klass, type) else klass.__class__.__name__
+        )
+        raise ValueError(
+            "First argument to get_object_or_none() must be a Model, Manager, "
+            "or QuerySet, not '%s'." % klass__name
+        )
+    try:
+        return queryset.get(*args, **kwargs)
+    except queryset.model.DoesNotExist:
+        return None
+
+
+async def aget_object_or_none(klass, *args, **kwargs):
+    """See get_object_or_none()."""
+    queryset = _get_queryset(klass)
+    if not hasattr(queryset, "aget"):
+        klass__name = (
+            klass.__name__ if isinstance(klass, type) else klass.__class__.__name__
+        )
+        raise ValueError(
+            "First argument to aget_object_or_none() must be a Model, Manager, or "
+            f"QuerySet, not '{klass__name}'."
+        )
+    try:
+        return await queryset.aget(*args, **kwargs)
+    except queryset.model.DoesNotExist:
+        return None

--- a/tests/get_object_or_none/models.py
+++ b/tests/get_object_or_none/models.py
@@ -1,0 +1,31 @@
+"""
+DB-API Shortcuts
+
+``get_object_or_none()`` is a shortcut function to be used in view functions for
+performing a ``get()`` lookup and returning ``None`` if a ``DoesNotExist``
+exception was raised during the ``get()`` call.
+"""
+
+from django.db import models
+
+
+class Author(models.Model):
+    name = models.CharField(max_length=50)
+
+
+class ArticleManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().filter(authors__name__icontains="sir")
+
+
+class AttributeErrorManager(models.Manager):
+    def get_queryset(self):
+        raise AttributeError("AttributeErrorManager")
+
+
+class Article(models.Model):
+    authors = models.ManyToManyField(Author)
+    title = models.CharField(max_length=50)
+    objects = models.Manager()
+    by_a_sir = ArticleManager()
+    attribute_error_objects = AttributeErrorManager()

--- a/tests/get_object_or_none/tests.py
+++ b/tests/get_object_or_none/tests.py
@@ -1,0 +1,66 @@
+from django.db.models import Q
+from django.shortcuts import get_object_or_none
+from django.test import TestCase
+
+from .models import Article, Author
+
+
+class GetObjectOrNoneTests(TestCase):
+    def test_get_object_or_none(self):
+        a1 = Author.objects.create(name="Brave Sir Robin")
+        article = Article.objects.create(title="Run away!")
+        article.authors.set([a1])
+
+        # Test successful retrieval with different query methods
+        self.assertEqual(get_object_or_none(Article, title="Run away!"), article)
+        self.assertEqual(
+            get_object_or_none(Article, Q(title__startswith="Run")), article
+        )
+        self.assertEqual(
+            get_object_or_none(Article.objects.all(), title="Run away!"), article
+        )
+        self.assertEqual(
+            get_object_or_none(a1.article_set, title="Run away!"), article
+        )
+
+        # Test non-existent object returns None
+        self.assertIsNone(get_object_or_none(Article, title="Does not exist"))
+        self.assertIsNone(get_object_or_none(a1.article_set, title="Missing"))
+
+        # Custom managers can be used too
+        self.assertEqual(
+            get_object_or_none(Article.by_a_sir, title="Run away!"), article
+        )
+
+        # Multiple objects should still raise MultipleObjectsReturned
+        Author.objects.create(name="Patsy")
+        with self.assertRaises(Author.MultipleObjectsReturned):
+            get_object_or_none(Author.objects.all())
+
+        # Using an empty QuerySet returns None
+        self.assertIsNone(
+            get_object_or_none(Article.objects.none(), title="Run away!")
+        )
+
+    def test_get_object_or_none_bad_class(self):
+        msg = (
+            "First argument to get_object_or_none() must be a Model, Manager, or "
+            "QuerySet, not 'str'."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            get_object_or_none("Article", title="Run away!")
+
+        class CustomClass:
+            pass
+
+        msg = (
+            "First argument to get_object_or_none() must be a Model, Manager, or "
+            "QuerySet, not 'CustomClass'."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            get_object_or_none(CustomClass, title="Run away!")
+
+    def test_get_object_or_none_queryset_attribute_error(self):
+        """AttributeError raised by QuerySet.get() isn't hidden."""
+        with self.assertRaisesMessage(AttributeError, "AttributeErrorManager"):
+            get_object_or_none(Article.attribute_error_objects, id=42)


### PR DESCRIPTION
#### Branch description
Adds a new `get_object_or_none` shortcut function that provides a cleaner alternative to try/except blocks when querying for objects that may not exist.

Similar to `get_object_or_404`, this function attempts to retrieve an object from the database, but instead of raising a 404 error when the object isn't found, it gracefully returns `None`. This makes it particularly useful for:

- Optional relationship lookups
- Checking for existence without exception handling
- Cases where a missing object is an acceptable scenario rather than an error condition

Example usage:
```python
# Instead of:
try:
    user = User.objects.get(id=user_id)
except User.DoesNotExist:
    user = None

# You can now write:
user = get_object_or_none(User, id=user_id)
```

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
