### PR TITLE
Fixed #35897 -- Removed unnecessary escaping in template's get_exception_info().

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -57,7 +57,7 @@ from enum import Enum
 
 from django.template.context import BaseContext
 from django.utils.formats import localize
-from django.utils.html import conditional_escape, escape
+from django.utils.html import conditional_escape
 from django.utils.regex_helper import _lazy_re_compile
 from django.utils.safestring import SafeData, SafeString, mark_safe
 from django.utils.text import get_text_list, smart_split, unescape_string_literal
@@ -247,10 +247,10 @@ class Template:
         for num, next in enumerate(linebreak_iter(self.source)):
             if start >= upto and end <= next:
                 line = num
-                before = escape(self.source[upto:start])
-                during = escape(self.source[start:end])
-                after = escape(self.source[end:next])
-            source_lines.append((num, escape(self.source[upto:next])))
+                before = self.source[upto:start]
+                during = self.source[start:end]
+                after = self.source[end:next]
+            source_lines.append((num, self.source[upto:next]))
             upto = next
         total = len(source_lines)
 

--- a/tests/template_tests/templates/test_extends_block_error.html
+++ b/tests/template_tests/templates/test_extends_block_error.html
@@ -1,2 +1,2 @@
 {% extends "test_extends_block_error_parent.html" %}
-{% block content %}{% include "missing.html" %}{% endblock %}
+{% block content %}{% include "index.html" %}{% include "missing.html" %}{% include "index.html" %}{% endblock %}


### PR DESCRIPTION
ticket-35897

#### Branch description

"Philosophically" / architecturally these calls shouldn't be here: escaping happens at the edges. The practical implication is the risk of double-escaping; this risk materializes at least for the Sentry-SDK (I ran into this while developing [Bugsink](https://www.bugsink.com), but I've double-checked other Sentry-SDK-compatible servers, and they all suffer from it).

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests. IMHO, "if the tests don't fail" this doesn't require a new test; but others may think differently.
- [ ] I have added or updated relevant docs, including release notes if applicable. N/A
- [ ] I have attached screenshots in both light and dark modes for any UI changes.  N/A
