### PR TITLE
Refs #32365 -- Removed pytz from list of test dependencies in unit test docs.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -322,7 +322,6 @@ dependencies:
 * :pypi:`numpy`
 * :pypi:`Pillow` 6.2.1+
 * :pypi:`PyYAML`
-* :pypi:`pytz` (required)
 * :pypi:`pywatchman`
 * :pypi:`redis` 3.4+
 * :pypi:`setuptools`


### PR DESCRIPTION
Follow up to e6f82438d4e3750e8d299bfd79dac98eebe9f1e0.