### PR TITLE
Refs #21286 -- Fixed YAML serialization of TimeField primary key.

### DIFF
--- a/django/core/serializers/pyyaml.py
+++ b/django/core/serializers/pyyaml.py
@@ -5,6 +5,7 @@ Requires PyYaml (https://pyyaml.org/), but that's checked for in __init__.
 """
 
 import collections
+import datetime
 import decimal
 
 import yaml
@@ -12,7 +13,6 @@ import yaml
 from django.core.serializers.base import DeserializationError
 from django.core.serializers.python import Deserializer as PythonDeserializer
 from django.core.serializers.python import Serializer as PythonSerializer
-from django.db import models
 
 # Use the C (faster) implementation if possible
 try:
@@ -44,17 +44,17 @@ class Serializer(PythonSerializer):
 
     internal_use_only = False
 
-    def handle_field(self, obj, field):
+    def _value_from_field(self, obj, field):
         # A nasty special case: base YAML doesn't support serialization of time
         # types (as opposed to dates or datetimes, which it does support). Since
         # we want to use the "safe" serializer for better interoperability, we
         # need to do something with those pesky times. Converting 'em to strings
         # isn't perfect, but it's better than a "!!python/time" type which would
         # halt deserialization under any other language.
-        if isinstance(field, models.TimeField) and getattr(obj, field.name) is not None:
-            self._current[field.name] = str(getattr(obj, field.name))
-        else:
-            super().handle_field(obj, field)
+        value = super()._value_from_field(obj, field)
+        if isinstance(value, datetime.time):
+            value = str(value)
+        return value
 
     def end_serialization(self):
         self.options.setdefault("allow_unicode", True)

--- a/tests/serializers/models/data.py
+++ b/tests/serializers/models/data.py
@@ -245,8 +245,9 @@ class SmallPKData(models.Model):
 # class TextPKData(models.Model):
 #     data = models.TextField(primary_key=True)
 
-# class TimePKData(models.Model):
-#    data = models.TimeField(primary_key=True)
+
+class TimePKData(models.Model):
+    data = models.TimeField(primary_key=True)
 
 
 class UUIDData(models.Model):

--- a/tests/serializers/test_data.py
+++ b/tests/serializers/test_data.py
@@ -69,6 +69,7 @@ from .models import (
     Tag,
     TextData,
     TimeData,
+    TimePKData,
     UniqueAnchor,
     UUIDData,
     UUIDDefaultData,
@@ -390,7 +391,7 @@ The end.""",
     # It contains line breaks.
     # Several of them.
     # The end."""),
-    # (pk_obj, 770, TimePKData, datetime.time(10, 42, 37)),
+    (pk_obj, 770, TimePKData, datetime.time(10, 42, 37)),
     (pk_obj, 791, UUIDData, uuid_obj),
     (fk_obj, 792, FKToUUID, uuid_obj),
     (pk_obj, 793, UUIDDefaultData, uuid_obj),


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-21286

#### Branch description

The `TimePKData` model, which contains a `TimeField` that is a primary key, was commented out of the serializer data tests because it would cause the YAML serializer throw an error. However, the `TimeData` model, which contains a `TimeField` that isn't a primary key, works fine with the YAML serializer.

The YAML serializer class inherits from the Python serializer class and overrides `handle_field` to special-case `TimeField` since PyYAML can't serialize `datetime.time` values.

This patch changes which method the YAML serializer overrides from `handle_field` to `_value_from_field` because only non-primary key, non-relation fields are passed into `handle_field`. All fields seem to be passed into `_value_for_field`, which seems like the appropriate override since we would always need to handle `TimeField` as a special case in the YAML serializer.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
