### PR TITLE
Fixed #35901 -- `conf`: Protected users from accidental debug mode for security.

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -88,6 +88,16 @@ class LazySettings(LazyObject):
             val = self._add_script_prefix(val)
         elif name == "SECRET_KEY" and not val:
             raise ImproperlyConfigured("The SECRET_KEY setting must not be empty.")
+        elif name == "DEBUG" and not isinstance(val, bool):
+            # This is supposed to protect against accidental debug mode:
+            # String values like "0" or "False" evaluate to True in Python and so guard
+            # "if settings.DEBUG:" would then activate debug mode, which was precisely
+            # not what the user had intended.  Accidental debug mode can have serious
+            # security implications, and that's why Django started being stricter about
+            # it.
+            raise ImproperlyConfigured(
+                "The DEBUG setting must be of type bool (for safety reasons)."
+            )
 
         self.__dict__[name] = val
         return val


### PR DESCRIPTION



#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35901

#### Branch description
We're helping users that enable/disable debug mode based on e.g. environment variables for good, but gone wrong:
- good: `DEBUG = os.environ.get("DEBUG", "False") == "True"`
- (bad: `DEBUG = os.environ.get("DEBUG", "True") != "False"` … but not the point here)
- very bad: `DEBUG = os.environ.get("DEBUG", False)` — will end up `True` for any non-empty string including `"False"` and `"0"`

I have seen this mistake happen in real life at https://github.com/climateconnect/climateconnect/pull/1331 with very unfortunate consequences. Please help me help the next user not end up in the same situation.

I'm happy to extend docs and tests when I have confirmation on the general direction. Thank you!

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
