### PR TITLE
Refs #21286 -- Enabled TextField primary key serializer test data.

### DIFF
--- a/tests/serializers/models/data.py
+++ b/tests/serializers/models/data.py
@@ -242,8 +242,11 @@ class SmallPKData(models.Model):
     data = models.SmallIntegerField(primary_key=True)
 
 
-# class TextPKData(models.Model):
-#     data = models.TextField(primary_key=True)
+class TextPKData(models.Model):
+    data = models.TextField(primary_key=True)
+
+    class Meta:
+        required_db_features = ["supports_index_on_text_field"]
 
 
 class TimePKData(models.Model):

--- a/tests/serializers/test_data.py
+++ b/tests/serializers/test_data.py
@@ -68,6 +68,7 @@ from .models import (
     SmallPKData,
     Tag,
     TextData,
+    TextPKData,
     TimeData,
     TimePKData,
     UniqueAnchor,
@@ -387,10 +388,15 @@ The end.""",
     (pk_obj, 750, SmallPKData, 12),
     (pk_obj, 751, SmallPKData, -12),
     (pk_obj, 752, SmallPKData, 0),
-    # (pk_obj, 760, TextPKData, """This is a long piece of text.
-    # It contains line breaks.
-    # Several of them.
-    # The end."""),
+    (
+        pk_obj,
+        760,
+        TextPKData,
+        """This is a long piece of text.
+    It contains line breaks.
+    Several of them.
+    The end.""",
+    ),
     (pk_obj, 770, TimePKData, datetime.time(10, 42, 37)),
     (pk_obj, 791, UUIDData, uuid_obj),
     (fk_obj, 792, FKToUUID, uuid_obj),
@@ -427,6 +433,10 @@ if connection.features.interprets_empty_strings_as_nulls:
             and data[3] is None
         )
     ]
+
+
+if not connection.features.supports_index_on_text_field:
+    test_data = [data for data in test_data if data[2] != TextPKData]
 
 
 class SerializerDataTests(TestCase):


### PR DESCRIPTION
#### Trac ticket number

ticket-21286

#### Branch description

The `TextPKData` serializer test data was failing on some database backends. This is because a primary key requires an index, and not all backends support indexes on `TextField`.

This patch ensures that the `TextPKData` model and the related test are only included with database backends that have the `supports_index_on_text_field` feature.

#### Checklist

- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x]  I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
