### PR TITLE
Replaced message suggestions from IRC to Discord in contributing docs.

### DIFF
--- a/docs/faq/contributing.txt
+++ b/docs/faq/contributing.txt
@@ -53,8 +53,8 @@ To determine the right time, you need to keep an eye on the schedule. If you
 post your message right before a release deadline, you're not likely to get the
 sort of attention you require.
 
-Gentle IRC reminders can also work -- again, strategically timed if possible.
-During a bug sprint would be a very good time, for example.
+Gentle reminders in the ``#contributing-getting-started`` channel in the
+`Django Discord server`_ can work.
 
 Another way to get traction is to pull several related tickets together. When
 someone sits down to review a bug in an area they haven't touched for
@@ -67,6 +67,8 @@ Please refrain from emailing anyone personally or repeatedly raising the same
 issue over and over again. This sort of behavior will not gain you any
 additional attention -- certainly not the attention that you need in order to
 get your issue addressed.
+
+.. _`Django Discord server`: https://discord.gg/xcRH6mN4fa
 
 But I've reminded you several times and you keep ignoring my contribution!
 ==========================================================================

--- a/docs/internals/contributing/index.txt
+++ b/docs/internals/contributing/index.txt
@@ -46,7 +46,6 @@ a great ecosystem to work in:
 
 .. _posting guidelines: https://code.djangoproject.com/wiki/UsingTheMailingList
 .. _#django IRC channel: https://web.libera.chat/#django
-.. _#django-dev IRC channel: https://web.libera.chat/#django-dev
 .. _community page: https://www.djangoproject.com/community/
 .. _Django Discord server: https://discord.gg/xcRH6mN4fa
 .. _Django forum: https://forum.djangoproject.com/

--- a/docs/internals/contributing/new-contributors.txt
+++ b/docs/internals/contributing/new-contributors.txt
@@ -128,8 +128,11 @@ Be cautious when marking things "Ready For Check-in"
 
 If you're really not certain if a ticket is ready, don't mark it as such. Leave
 a comment instead, letting others know your thoughts. If you're mostly certain,
-but not completely certain, you might also try asking on IRC to see if someone
-else can confirm your suspicions.
+but not completely certain, you might also try asking on the
+``#contributing-getting-started`` channel in the `Django Discord server`_ to
+see if someone else can confirm your suspicions.
+
+.. _`Django Discord server`: https://discord.gg/xcRH6mN4fa
 
 Wait for feedback, and respond to feedback that you receive
 -----------------------------------------------------------


### PR DESCRIPTION
#### Trac ticket number
<!-- N/A -->

ticket-XXXXX

#### Branch description
There are references to the IRC chat, and it would be better if Discord were also mentioned.
The changes made are in the files:

- docs/faq/contributing.txt
- docs/internals/contributing/new-contributors.txt

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
