### PR TITLE
Fixed #35899 -- Allowed multiline template tags.

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -224,6 +224,9 @@ INSTALLED_APPS = []
 
 TEMPLATES = []
 
+# RemovedInDjango71Warning: When the deprecation ends, remove this setting.
+TEMPLATE_TAGS_MULTILINE = True
+
 # Default form rendering class.
 FORM_RENDERER = "django.forms.renderers.DjangoTemplates"
 # RemovedInDjango70Warning: This setting allows to revert back to the old

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -56,8 +56,12 @@ import re
 import warnings
 from enum import Enum
 
+from django.conf import settings
 from django.template.context import BaseContext
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.utils.deprecation import (
+    RemovedInDjango70Warning,
+    RemovedInDjango71Warning,
+)
 from django.utils.formats import localize
 from django.utils.html import conditional_escape
 from django.utils.inspect import getfullargspec, signature
@@ -90,7 +94,10 @@ UNKNOWN_SOURCE = "<unknown source>"
 # Match BLOCK_TAG_*, VARIABLE_TAG_*, and COMMENT_TAG_* tags and capture the
 # entire tag, including start/end delimiters. Using re.compile() is faster
 # than instantiating SimpleLazyObject with _lazy_re_compile().
-tag_re = re.compile(r"({%.*?%}|{{.*?}}|{#.*?#})")
+tag_re = re.compile(r"({%.*?%}|{{.*?}}|{#.*?#})", re.DOTALL)
+
+# RemovedInDjango71Warning: When the deprecation ends, remove.
+tag_re_legacy = re.compile(r"({%.*?%}|{{.*?}}|{#.*?#})")
 
 logger = logging.getLogger("django.template")
 
@@ -416,6 +423,21 @@ class Lexer:
             self.verbatim,
         )
 
+    # RemovedInDjango71Warning: When the deprecation ends, remove this
+    # property.
+    @property
+    def tag_re(self):
+        if settings.TEMPLATE_TAGS_MULTILINE:
+            return tag_re
+        warnings.warn(
+            "Setting TEMPLATE_TAGS_MULTILINE to False is deprecated. The "
+            "setting will be removed in Django 7.1, and template tags will "
+            "always allow multiple lines.",
+            RemovedInDjango71Warning,
+            skip_file_prefixes=django_file_prefixes(),
+        )
+        return tag_re_legacy
+
     def tokenize(self):
         """
         Return a list of tokens from a given template_string.
@@ -423,7 +445,9 @@ class Lexer:
         in_tag = False
         lineno = 1
         result = []
-        for token_string in tag_re.split(self.template_string):
+        # RemovedInDjango71Warning: When the deprecation ends, replace
+        # all usages of self.tag_re with just tag_re
+        for token_string in self.tag_re.split(self.template_string):
             if token_string:
                 result.append(self.create_token(token_string, None, lineno, in_tag))
                 lineno += token_string.count("\n")
@@ -468,7 +492,9 @@ class Lexer:
 class DebugLexer(Lexer):
     def _tag_re_split_positions(self):
         last = 0
-        for match in tag_re.finditer(self.template_string):
+        # RemovedInDjango71Warning: When the deprecation ends, replace
+        # all usages of self.tag_re with just tag_re
+        for match in self.tag_re.finditer(self.template_string):
             start, end = match.span()
             yield last, start
             yield start, end

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -23,6 +23,9 @@ details on these changes.
 * Calling ``QuerySet.aiterator()`` after ``prefetch_related()`` without
   providing a ``chunk_size`` will raise :exc:`ValueError`.
 
+* The ``TEMPLATE_TAGS_MULTILINE`` transitional setting will be removed, making
+  multiline template tags mandatory.
+
 .. _deprecation-removed-in-7.0:
 
 7.0

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -3010,6 +3010,22 @@ Default: ``{}``
 Extra parameters to pass to the Task backend. Available parameters vary
 depending on the Task backend.
 
+.. setting:: TEMPLATE_TAGS_MULTILINE
+
+``TEMPLATE_TAGS_MULTILINE``
+---------------------------
+
+.. versionadded:: 6.2
+
+.. deprecated:: 6.2
+
+Default: ``True``
+
+Set this transitional setting to ``False`` to restore the old behavior where
+template tags, variables, and comments could not span multiple lines. Setting
+it to ``False`` emits a deprecation warning each time a template is compiled.
+This setting will be removed in Django 7.1.
+
 .. setting:: TEMPLATES
 
 ``TEMPLATES``

--- a/docs/ref/templates/language.txt
+++ b/docs/ref/templates/language.txt
@@ -289,9 +289,11 @@ A comment can contain any template code, invalid or not. For example:
 
     {# {% if foo %}bar{% else %} #}
 
-This syntax can only be used for single-line comments (no newlines are
-permitted between the ``{#`` and ``#}`` delimiters). If you need to comment out
-a multiline portion of the template, see the :ttag:`comment` tag.
+.. versionchanged:: 6.2
+
+    Support for comments spanning multiple lines was added. In older
+    versions, no newlines were permitted between the ``{#`` and ``#}``
+    delimiters.
 
 .. _template-inheritance:
 

--- a/docs/releases/6.2.txt
+++ b/docs/releases/6.2.txt
@@ -31,6 +31,36 @@ only officially support the latest release of each series.
 What's new in Django 6.2
 ========================
 
+Multi-line template tags, variables, and comments
+-------------------------------------------------
+
+Template tags, variables, and comments may now span multiple lines:
+
+.. code-block:: html+django
+
+    {%
+        load
+            static
+            i18n
+    %}
+
+    {{
+        some_variable
+        | filter1
+        | filter2
+    }}
+
+    {#
+        comment
+    #}
+
+As a consequence, templates that relied on unmatched tag delimiters (such as
+``{%``, ``{{``, or ``{#``) being treated as literal text when the closing
+delimiter appeared on a later line may now render differently or raise
+``TemplateSyntaxError``. The transitional
+:setting:`TEMPLATE_TAGS_MULTILINE` setting allows restoring the old behavior
+during the deprecation period. This setting will be removed in Django 7.1.
+
 Minor features
 --------------
 
@@ -330,3 +360,8 @@ Miscellaneous
   providing a ``chunk_size`` is deprecated. It currently falls back to a
   ``chunk_size`` of 2000, but a ``ValueError`` will be raised in
   Django 7.1.
+
+* The transitional :setting:`TEMPLATE_TAGS_MULTILINE` setting is deprecated.
+  Setting it to ``False`` restores the old behavior where template tags,
+  variables, and comments could not span multiple lines. The setting will be
+  removed in Django 7.1.

--- a/tests/template_tests/syntax_tests/test_basic.py
+++ b/tests/template_tests/syntax_tests/test_basic.py
@@ -3,7 +3,11 @@ from django.template.base import Origin, Template, TemplateSyntaxError
 from django.template.context import Context
 from django.template.loader_tags import BlockContext, BlockNode
 from django.test import SimpleTestCase, ignore_warnings
-from django.utils.deprecation import RemovedInDjango70Warning
+from django.test.utils import override_settings
+from django.utils.deprecation import (
+    RemovedInDjango70Warning,
+    RemovedInDjango71Warning,
+)
 from django.views.debug import ExceptionReporter
 
 from ..utils import SilentAttrClass, SilentGetItemClass, SomeClass, setup
@@ -210,13 +214,31 @@ class BasicSyntaxTests(SimpleTestCase):
         with self.assertRaises(TemplateSyntaxError):
             self.engine.get_template("basic-syntax23")
 
-    @setup({"basic-syntax24": "{{ moo\n }}"})
+    # RemovedInDjango71Warning: When the deprecation ends, remove.
+    @override_settings(TEMPLATE_TAGS_MULTILINE=False)
+    @setup({"basic-syntax24": "{{ moo\n }}"}, test_once=True)
     def test_basic_syntax24(self):
         """
-        Embedded newlines make it not-a-tag.
+        Embedded newlines make it not-a-tag if not in multiline mode.
         """
-        output = self.engine.render_to_string("basic-syntax24")
+        msg = (
+            "Setting TEMPLATE_TAGS_MULTILINE to False is deprecated. The "
+            "setting will be removed in Django 7.1, and template tags will "
+            "always allow multiple lines."
+        )
+        with self.assertWarnsMessage(RemovedInDjango71Warning, msg):
+            output = self.engine.render_to_string("basic-syntax24")
         self.assertEqual(output, "{{ moo\n }}")
+
+    @setup({"basic-syntax24-multiline": "{{ \nfoo\n }}"})
+    def test_basic_syntax24_multiline(self):
+        """
+        Embedded newlines are ok in multiline mode.
+        """
+        output = self.engine.render_to_string(
+            "basic-syntax24-multiline", {"foo": "bar"}
+        )
+        self.assertEqual(output, "bar")
 
     # Literal strings are permitted inside variables, mostly for i18n
     # purposes.
@@ -327,6 +349,67 @@ class BasicSyntaxTests(SimpleTestCase):
             "basic-syntax38", {"var": {"callable": lambda: "foo bar"}}
         )
         self.assertEqual(output, "foo bar")
+
+    @setup({"basic-syntax39-multiline": """
+                {% if
+                    foo
+                %}
+                    a
+                {%
+                    else
+                %}
+                    b
+                {%
+                    endif
+                %}
+                {#
+                    comment
+                #}
+                """})
+    def test_basic_syntax39_multiline(self):
+        """
+        Embedded newlines are ok in multiline mode.
+        """
+        output = self.engine.render_to_string(
+            "basic-syntax39-multiline", {"foo": True}
+        ).strip()
+        self.assertEqual(output, "a")
+        output = self.engine.render_to_string(
+            "basic-syntax39-multiline", {"foo": False}
+        ).strip()
+        self.assertEqual(output, "b")
+
+    @setup({"basic-syntax39-multiline": """
+                {{
+                    foo
+                        | upper
+                }}
+                """})
+    def test_basic_syntax39_multiline_variable(self):
+        """
+        Embedded newlines are ok in multiline mode.
+        """
+        output = self.engine.render_to_string(
+            "basic-syntax39-multiline", {"foo": "foo"}
+        ).strip()
+        self.assertEqual(output, "FOO")
+
+    @setup({"basic-syntax39-multiline": """
+                {% with a=3
+                     b='bar'|upper
+                     c=foo|upper
+                %}
+                    {{ a }} {{ b }} {{ c }}
+                {% endwith %}
+                """})
+    def test_basic_syntax39_multiline_complex_with(self):
+        """
+        Embedded newlines are ok in multiline mode.
+        """
+        output = self.engine.render_to_string(
+            "basic-syntax39-multiline", {"foo": "foo"}
+        ).strip()
+        self.assertEqual(output, "3 BAR FOO")
 
     @setup({"template": "{% block content %}"})
     def test_unclosed_block(self):

--- a/tests/template_tests/syntax_tests/test_partials.py
+++ b/tests/template_tests/syntax_tests/test_partials.py
@@ -5,7 +5,8 @@ from django.template import (
     VariableDoesNotExist,
 )
 from django.template.base import Token, TokenType
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, ignore_warnings, override_settings
+from django.utils.deprecation import RemovedInDjango71Warning
 from django.views.debug import ExceptionReporter
 
 from ..utils import setup
@@ -287,7 +288,6 @@ class PartialTagTests(SimpleTestCase):
             "partialdef_opening_closing_name_mismatch": (
                 "{% partialdef testing-name %}TEST{% endpartialdef invalid %}"
             ),
-            "partialdef_invalid_name": gen_partial_template("with\nnewline"),
             "partialdef_extra_params": (
                 "{% partialdef testing-name inline extra %}TEST{% endpartialdef %}"
             ),
@@ -306,6 +306,72 @@ class PartialTagTests(SimpleTestCase):
         },
     )
     def test_basic_parse_errors(self):
+        for template_name, error_msg in (
+            (
+                "partial_undefined_name",
+                "Partial 'undefined' is not defined in the current template.",
+            ),
+            ("partial_missing_name", "'partial' tag requires a single argument"),
+            ("partial_closing_tag", "Invalid block tag on line 1: 'endpartial'"),
+            ("partialdef_missing_name", "'partialdef' tag requires a name"),
+            ("partialdef_missing_close_tag", "Unclosed tag on line 1: 'partialdef'"),
+            (
+                "partialdef_opening_closing_name_mismatch",
+                "expected 'endpartialdef' or 'endpartialdef testing-name'.",
+            ),
+            ("partialdef_extra_params", "'partialdef' tag takes at most 2 arguments"),
+            (
+                "partialdef_duplicated_names",
+                "Partial 'testing-name' is already defined in the "
+                "'partialdef_duplicated_names' template.",
+            ),
+            (
+                "partialdef_duplicated_nested_names",
+                "Partial 'testing-name' is already defined in the "
+                "'partialdef_duplicated_nested_names' template.",
+            ),
+        ):
+            with (
+                self.subTest(template_name=template_name),
+                self.assertRaisesMessage(TemplateSyntaxError, error_msg),
+            ):
+                self.engine.render_to_string(template_name)
+
+    # RemovedInDjango71Warning: When the deprecation ends, remove this test.
+    @ignore_warnings(category=RemovedInDjango71Warning)
+    @override_settings(TEMPLATE_TAGS_MULTILINE=False)
+    @setup(
+        {
+            "partial_undefined_name": "{% partial undefined %}",
+            "partial_missing_name": "{% partial %}",
+            "partial_closing_tag": (
+                "{% partialdef testing-name %}TEST{% endpartialdef %}"
+                "{% partial testing-name %}{% endpartial %}"
+            ),
+            "partialdef_missing_name": "{% partialdef %}{% endpartialdef %}",
+            "partialdef_missing_close_tag": "{% partialdef name %}TEST",
+            "partialdef_opening_closing_name_mismatch": (
+                "{% partialdef testing-name %}TEST{% endpartialdef invalid %}"
+            ),
+            "partialdef_invalid_name": gen_partial_template("with\nnewline"),
+            "partialdef_extra_params": (
+                "{% partialdef testing-name inline extra %}TEST{% endpartialdef %}"
+            ),
+            "partialdef_duplicated_names": (
+                "{% partialdef testing-name %}TEST{% endpartialdef %}"
+                "{% partialdef testing-name %}TEST{% endpartialdef %}"
+                "{% partial testing-name %}"
+            ),
+            "partialdef_duplicated_nested_names": (
+                "{% partialdef testing-name %}"
+                "TEST"
+                "{% partialdef testing-name %}TEST{% endpartialdef %}"
+                "{% endpartialdef %}"
+                "{% partial testing-name %}"
+            ),
+        },
+    )
+    def test_basic_parse_errors_multiline_off(self):
         for template_name, error_msg in (
             (
                 "partial_undefined_name",
@@ -495,6 +561,36 @@ class PartialTagTests(SimpleTestCase):
         }
     )
     def test_partial_with_syntax_error_exception_info(self):
+        with self.assertRaises(TemplateSyntaxError) as cm:
+            self.engine.get_template("partial_with_syntax_error")
+
+        self.assertIn("endif", str(cm.exception).lower())
+
+        if self.engine.debug:
+            exc_debug = cm.exception.template_debug
+
+            self.assertEqual(exc_debug["during"], "{% if user %}")
+            self.assertEqual(exc_debug["name"], "partial_with_syntax_error")
+            self.assertIn("endif", exc_debug["message"].lower())
+
+    # RemovedInDjango71Warning: When the deprecation ends, remove this test.
+    @ignore_warnings(category=RemovedInDjango71Warning)
+    @override_settings(TEMPLATE_TAGS_MULTILINE=False)
+    @setup(
+        {
+            "partial_with_syntax_error": (
+                "<h1>Title</h1>\n"
+                "{% partialdef syntax_error_partial %}\n"
+                "    {% if user %}\n"
+                "        <p>User: {{ user.name }}</p>\n"
+                "    {% endif\n"
+                "    <p>Missing closing tag above</p>\n"
+                "{% endpartialdef %}\n"
+                "{% partial syntax_error_partial %}\n"
+            ),
+        }
+    )
+    def test_partial_with_syntax_error_exception_info_multiline_off(self):
         with self.assertRaises(TemplateSyntaxError) as cm:
             self.engine.get_template("partial_with_syntax_error")
 

--- a/tests/template_tests/test_parser.py
+++ b/tests/template_tests/test_parser.py
@@ -49,6 +49,13 @@ class ParserTests(SimpleTestCase):
             '<Lexer template_string="{% for i in 1 %}{{ a...", verbatim=False>',
         )
 
+    def test_repr_multiline(self):
+        lexer = Lexer("{% \nfor i in 1\n %}{{ a }}\n{% \nendfor \n%}")
+        self.assertEqual(
+            repr(lexer),
+            '<Lexer template_string="{% for i in 1 %}{{...", verbatim=False>',
+        )
+
     def test_filter_parsing(self):
         c = {"article": {"section": "News"}}
         p = Parser("", builtins=[filter_library])


### PR DESCRIPTION
#### Trac ticket number

ticket-35899

#### Branch description
Option to support newlines inside `{% %}` in templates. As discussed https://forum.djangoproject.com/t/allow-newlines-inside-tags/36040/23 

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs
- [x] I have written release notes if applicable.
