### PR TITLE
Fixed #17430 -- Documented access to the Django admin when using a custom auth backend.

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -127,15 +127,19 @@ wasn't provided to :func:`~django.contrib.auth.authenticate` (which passes it
 on to the backend).
 
 The Django admin is tightly coupled to the Django :ref:`User object
-<user-objects>`. The best way to deal with this is to create a Django ``User``
-object for each user that exists for your backend (e.g., in your LDAP
-directory, your external SQL database, etc.) You can either write a script to
-do this in advance, or your ``authenticate`` method can do it the first time a
-user logs in.
+<user-objects>`. For example, for a user to access the admin,
+:attr:`.User.is_staff` and :attr:`.User.is_active` must be ``True`` (see
+:meth:`.AdminSite.has_permission` for details).
+
+The best way to deal with this is to create a Django ``User`` object for each
+user that exists for your backend (e.g., in your LDAP directory, your external
+SQL database, etc.). You can either write a script to do this in advance, or
+your ``authenticate`` method can do it the first time a user logs in.
 
 Here's an example backend that authenticates against a username and password
 variable defined in your ``settings.py`` file and creates a Django ``User``
-object the first time a user authenticates::
+object the first time a user authenticates. In this example, the created Django
+``User`` object is a superuser who will have full access to the admin::
 
     from django.conf import settings
     from django.contrib.auth.backends import BaseBackend
@@ -162,7 +166,7 @@ object the first time a user authenticates::
                 except User.DoesNotExist:
                     # Create a new user. There's no need to set a password
                     # because only the password from settings.py is checked.
-                    user = User(username=username)
+                    user = User(username=username)  # is_active defaults to True.
                     user.is_staff = True
                     user.is_superuser = True
                     user.save()


### PR DESCRIPTION
#### Trac ticket number
ticket-17430

#### Branch description
When this Trac ticket was created, it referred to the documentation from Django version 1.3. The most suitable section of the docs in which to add this update had not changed significantly since that time, so the update in this PR is still relevant. The issue is that when reading the section about adding users from a custom backend, there is room for the documentation to be clearer on what fields are needed for a given user to be able to access Django Admin. This is a small change that simply adds some clarification on the fields that matter and also gives additional explanation of the code example that follows in the documentation (which is the same example now as it was then in version 1.3).

_This is the section of docs from v1.3_:
>![Section of documentation from version 1.3](https://github.com/user-attachments/assets/72f3ddbb-bf98-448e-982a-bbdeb719289e)
[link to page in v1.3](https://github.com/django/django/blob/stable/1.3.x/docs/topics/auth.txt#L1554)

_This is the same section from current dev docs_:
>![Section of documentation from version dev](https://github.com/user-attachments/assets/66e8aba3-1e6e-4fd9-b3f6-0e757487118c)

_The finalised changes in this PR, seen in screenshot below, include the review comments from @sarahboyce in [this MR](https://github.com/django/django/pull/18797) which was accidently deleted during a rebase_ 🤕:
>![The changes to the section, clarifying required fields for accessing the Django Admin](https://github.com/user-attachments/assets/f1b15505-3aa4-4ad9-97d2-8a4197bc2137)

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
