### PR TITLE
Enabled fail_on_warning on RTD builds.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,8 +21,7 @@ permissions:
 
 jobs:
   docs:
-    # OS must be the same as on djangoproject.com.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: docs
     steps:
       - name: Checkout

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,7 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.12"
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
I noticed that RTD builds are successful even when they contain 'errors'. See [logs](https://app.readthedocs.org/projects/django/builds/26274498/).

It seems that setting [`fail_on_warning`](https://docs.readthedocs.io/en/stable/config-file/v2.html#sphinx-fail-on-warning) to `true` will result in the build failing if there are warnings / exit code is 1. 