### PR TITLE
Added Django Commons as maintainers of debug toolbar.

### DIFF
--- a/docs/intro/tutorial08.txt
+++ b/docs/intro/tutorial08.txt
@@ -22,10 +22,11 @@ Installing Django Debug Toolbar
 ===============================
 
 Django Debug Toolbar is a useful tool for debugging Django web applications.
-It's a third-party package maintained by the `Jazzband
-<https://jazzband.co>`_ organization. The toolbar helps you understand how your
-application functions and to identify problems. It does so by providing panels
-that provide debug information about the current request and response.
+It's a third-party package that is maintained by the community organization
+`Django Commons <https://github.com/django-commons>`_. The toolbar helps you
+understand how your application functions and to identify problems. It does so
+by providing panels that provide debug information about the current request
+and response.
 
 To install a third-party application like the toolbar, you need to install
 the package by running the below command within an activated virtual
@@ -67,7 +68,7 @@ resolve the issue yourself, there are options available to you.
    <https://django-debug-toolbar.readthedocs.io/en/latest/tips.html>`_ that
    outlines troubleshooting options.
 #. Search for similar issues on the package's issue tracker. Django Debug
-   Toolbar’s is `on GitHub <https://github.com/jazzband/django-debug-toolbar/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc>`_.
+   Toolbar’s is `on GitHub <https://github.com/django-commons/django-debug-toolbar/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc>`_.
 #. Consult the `Django Forum <https://forum.djangoproject.com/>`_.
 #. Join the `Django Discord server <https://discord.gg/xcRH6mN4fa>`_.
 #. Join the #Django IRC channel on `Libera.chat <https://libera.chat/>`_.


### PR DESCRIPTION
The Django Commons organization is now maintaining the Django Debug Toolbar. Jazzband is still included as the organization maintains several Django packages.

#### Trac ticket number

N/A

#### Branch description

The Django Debug Toolbar is now maintained by the Django Commons organization. The documentation was modified to continue to mention Jazzband as it maintains several Django packages.


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
