### PR TITLE
Fixed #34856 -- Fixed references to index_together in historical migrations.

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -95,6 +95,17 @@ class CreateModel(ModelOperation):
         model = to_state.apps.get_model(app_label, self.name)
         if self.allow_migrate_model(schema_editor.connection.alias, model):
             schema_editor.create_model(model)
+            # While the `index_together` option has been deprecated some
+            # historical migrations might still have references to them.
+            # This can be moved to the schema editor once it's adapted to
+            # from model states instead of rendered models (#29898).
+            to_model_state = to_state.models[app_label, self.name_lower]
+            if index_together := to_model_state.options.get("index_together"):
+                schema_editor.alter_index_together(
+                    model,
+                    set(),
+                    index_together,
+                )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         model = from_state.apps.get_model(app_label, self.name)
@@ -700,12 +711,13 @@ class AlterTogetherOptionOperation(ModelOptionOperation):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         new_model = to_state.apps.get_model(app_label, self.name)
         if self.allow_migrate_model(schema_editor.connection.alias, new_model):
-            old_model = from_state.apps.get_model(app_label, self.name)
+            from_model_state = from_state.models[app_label, self.name_lower]
+            to_model_state = to_state.models[app_label, self.name_lower]
             alter_together = getattr(schema_editor, "alter_%s" % self.option_name)
             alter_together(
                 new_model,
-                getattr(old_model._meta, self.option_name, set()),
-                getattr(new_model._meta, self.option_name, set()),
+                from_model_state.options.get(self.option_name) or set(),
+                to_model_state.options.get(self.option_name) or set(),
             )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -827,9 +827,6 @@ class ModelState:
                 if name == "unique_together":
                     ut = model._meta.original_attrs["unique_together"]
                     options[name] = set(normalize_together(ut))
-                elif name == "index_together":
-                    it = model._meta.original_attrs["index_together"]
-                    options[name] = set(normalize_together(it))
                 elif name == "indexes":
                     indexes = [idx.clone() for idx in model._meta.indexes]
                     for index in indexes:
@@ -845,7 +842,7 @@ class ModelState:
         # If we're ignoring relationships, remove all field-listing model
         # options (that option basically just means "make a stub model")
         if exclude_rels:
-            for key in ["unique_together", "index_together", "order_with_respect_to"]:
+            for key in ["unique_together", "order_with_respect_to"]:
                 if key in options:
                     del options[key]
         # Private fields are ignored, so remove options that refer to them.

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -947,7 +947,11 @@ class ModelState:
     def render(self, apps):
         """Create a Model object from our current state into the given apps."""
         # First, make a Meta object
-        meta_contents = {"app_label": self.app_label, "apps": apps, **self.options}
+        meta_options = {**self.options}
+        # Prune index_together from options as it's no longer an allowed meta
+        # attribute.
+        meta_options.pop("index_together", None)
+        meta_contents = {"app_label": self.app_label, "apps": apps, **meta_options}
         meta = type("Meta", (), meta_contents)
         # Then, work out our bases
         try:

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -4011,6 +4011,38 @@ class OperationTests(OperationTestBase):
         # Ensure the index is still there
         self.assertIndexExists("test_alflin_pony", ["pink"])
 
+    def test_historical_index_together(self):
+        app_label = "test"
+        operations = [
+            migrations.CreateModel(
+                "Author",
+                fields=[
+                    ("id", models.AutoField(primary_key=True)),
+                    ("first_name", models.CharField(max_length=100)),
+                    ("last_name", models.CharField(max_length=100)),
+                ],
+                options={
+                    "index_together": {("first_name", "last_name")},
+                },
+            ),
+        ]
+        state = self.apply_operations(app_label, ProjectState(), operations)
+        self.assertIndexExists("test_author", ("first_name", "last_name"))
+        operations = [
+            migrations.AlterIndexTogether("Author", {("last_name", "first_name")})
+        ]
+        state = self.apply_operations(app_label, state, operations)
+        self.assertIndexExists("test_author", ("last_name", "first_name"))
+        self.assertIndexNotExists("test_author", ("first_name", "last_name"))
+        operations = [
+            migrations.AlterIndexTogether(
+                "Author",
+                None,
+            )
+        ]
+        state = self.apply_operations(app_label, state, operations)
+        self.assertIndexNotExists("test_author", ("last_name", "first_name"))
+
     def test_alter_index_together_remove(self):
         operation = migrations.AlterIndexTogether("Pony", None)
         self.assertEqual(


### PR DESCRIPTION
#### Trac ticket number

ticket-34856

Follow up to [this forum discussion](https://forum.djangoproject.com/t/django-5-1-alterindextogether-raising-typeerror-class-meta-got-invalid-attribute-s-index-together/36450) about the broken guarantee that 

> AlterIndexTogether is officially supported only for pre-Django 4.2 migration files. For backward compatibility reasons, it’s still part of the public API, and there’s no plan to deprecate or remove it, but it should not be used for new migrations. Use AddIndex and RemoveIndex operations instead.

Thinking more about it I believe this is a good solution to keeping minimal support for historical `AlterIndexTogether`. I do wonder if we should restore some of the tests removed in 2abf417c815c20f41c0868d6f66520b32347106e to ensure it still works properly though or maybe the one added here is sufficient?