### PR TITLE
Refs #35844 -- Fixed copying BaseContext and its subclasses on Python 3.14+.

### DIFF
--- a/django/template/context.py
+++ b/django/template/context.py
@@ -37,7 +37,9 @@ class BaseContext:
             self.dicts.append(value)
 
     def __copy__(self):
-        duplicate = copy(super())
+        duplicate = BaseContext()
+        duplicate.__class__ = self.__class__
+        duplicate.__dict__ = copy(self.__dict__)
         duplicate.dicts = self.dicts[:]
         return duplicate
 

--- a/tests/template_tests/test_context.py
+++ b/tests/template_tests/test_context.py
@@ -1,3 +1,4 @@
+from copy import copy
 from unittest import mock
 
 from django.http import HttpRequest
@@ -314,3 +315,10 @@ class RequestContextTests(SimpleTestCase):
         with self.assertRaisesMessage(TypeError, msg):
             with request_context.bind_template(Template("")):
                 pass
+
+    def test_context_copyable(self):
+        request_context = RequestContext(HttpRequest())
+        request_context_copy = copy(request_context)
+        self.assertIsInstance(request_context_copy, RequestContext)
+        self.assertEqual(request_context_copy.dicts, request_context.dicts)
+        self.assertIsNot(request_context_copy.dicts, request_context.dicts)


### PR DESCRIPTION
ticket-35844

`super` objects are copyable on Python 3.14+: https://github.com/python/cpython/commit/5ca4e34bc1aab8321911aac6d5b2b9e75ff764d8 and can no longer be used in `BaseContext.__copy__()`. For example:

```
$ ./runtests.py template_tests.test_context
Testing against Django installed in '/django/django'
Found 24 test(s).
System check identified no issues (0 silenced).
..E..E..............E...
======================================================================
ERROR: test_copy_request_context_twice (template_tests.test_context.ContextTests.test_copy_request_context_twice)
#24273 -- Copy twice shouldn't raise an exception
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/tests/template_tests/test_context.py", line 202, in test_copy_request_context_twice
    RequestContext(HttpRequest()).new().new()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/django/django/template/context.py", line 275, in new
    new_context = super().new(values)
  File "/django/django/template/context.py", line 112, in new
    new_context = copy(self)
  File "/cpython/Lib/copy.py", line 80, in copy
    return copier(x)
  File "/django/django/template/context.py", line 160, in __copy__
    duplicate = super().__copy__()
  File "/django/django/template/context.py", line 41, in __copy__
    duplicate.dicts = self.dicts[:]
    ^^^^^^^^^^^^^^^
AttributeError: 'super' object has no attribute 'dicts' and no __dict__ for setting new attributes
    
======================================================================
ERROR: test_flatten_context_with_context_copy (template_tests.test_context.ContextTests.test_flatten_context_with_context_copy)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/tests/template_tests/test_context.py", line 163, in test_flatten_context_with_context_copy
    ctx2 = ctx1.new(Context({"b": 4}))
  File "/django/django/template/context.py", line 112, in new 
    new_context = copy(self)
  File "/cpython/Lib/copy.py", line 80, in copy
    return copier(x)
  File "/django/django/template/context.py", line 160, in __copy__
    duplicate = super().__copy__()
  File "/django/django/template/context.py", line 41, in __copy__
    duplicate.dicts = self.dicts[:]
    ^^^^^^^^^^^^^^^
AttributeError: 'super' object has no attribute 'dicts' and no __dict__ for setting new attributes

======================================================================
ERROR: test_include_only (template_tests.test_context.RequestContextTests.test_include_only)
#15721 -- ``{% include %}`` and ``RequestContext`` should work
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django/tests/template_tests/test_context.py", line 264, in test_include_only
    engine.from_string('{% include "child" only %}').render(ctx), "none"
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/django/django/template/base.py", line 171, in render
    return self._render(context)
           ~~~~~~~~~~~~^^^^^^^^^
  File "/django/django/test/utils.py", line 114, in instrumented_test_render
    return self.nodelist.render(context)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/django/django/template/base.py", line 1016, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/django/django/template/base.py", line 977, in render_annotated
    return self.render(context)
           ~~~~~~~~~~~^^^^^^^^^
  File "/django/django/template/loader_tags.py", line 208, in render
    return template.render(context.new(values))
                           ~~~~~~~~~~~^^^^^^^^
  File "/django/django/template/context.py", line 275, in new
    new_context = super().new(values)
  File "/django/django/template/context.py", line 112, in new
    new_context = copy(self)
  File "/cpython/Lib/copy.py", line 80, in copy
    return copier(x)
  File "/django/django/template/context.py", line 160, in __copy__
    duplicate = super().__copy__()
  File "/django/django/template/context.py", line 41, in __copy__
    duplicate.dicts = self.dicts[:]
    ^^^^^^^^^^^^^^^
AttributeError: 'super' object has no attribute 'dicts' and no __dict__ for setting new attributes

----------------------------------------------------------------------
Ran 24 tests in 0.016s

FAILED (errors=3)
```


Note 1st: _MySQL failures are related with a new configuration of MySQL builds and should be fixed when #18689 is merged._

Note 2nd: _With this patch and https://github.com/python/cpython/commit/dbb6e22cb1f533bba00a61a5b63ec68af9d48836 landed in Python, we only have one test failure left on Python 3.14._ :tada: 