### PR TITLE
Fixed #35921 -- Fixed failure when running tests in parallel on postgres.

### DIFF
--- a/tests/migration_test_data_persistence/tests.py
+++ b/tests/migration_test_data_persistence/tests.py
@@ -32,7 +32,7 @@ class MigrationDataPersistenceClassSetup(TransactionTestCase):
     @classmethod
     def setUpClass(cls):
         # Simulate another TransactionTestCase having just torn down.
-        call_command("flush", verbosity=0, interactive=False)
+        call_command("flush", verbosity=0, interactive=False, allow_cascade=True)
         super().setUpClass()
         cls.book = Book.objects.first()
 


### PR DESCRIPTION
Follow-up to a060a22ee2dde7aa29a5a29120087c4864887325.

#### Trac ticket number
ticket-35921

#### Branch description
Fixes failure to truncate related tables referenced here:
```py
django.db.utils.NotSupportedError: cannot truncate a table referenced in a foreign key constraint
DETAIL:  Table "model_package_advertisement_publications" references "model_package_publication".
HINT:  Truncate table "model_package_advertisement_publications" at the same time, or use TRUNCATE ... CASCADE.
```

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
