### PR TITLE
Fixed #31354: Properly reconstruct host header in presence of X-Forwarded-* header.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -1,6 +1,7 @@
 import codecs
 import copy
-import operator
+import warnings
+from collections import namedtuple
 from io import BytesIO
 from itertools import chain
 from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlsplit
@@ -31,7 +32,9 @@ from django.utils.http import is_same_domain, parse_header_parameters
 from django.utils.regex_helper import _lazy_re_compile
 
 RAISE_ERROR = object()
-host_validation_re = _lazy_re_compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(?::(\d+))?$")
+host_validation_re = _lazy_re_compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(?::([0-9]+))?$")
+
+ParsedHostHeader = namedtuple('ParsedHostHeader', ['domain', 'port', 'combined'])
 
 
 class UnreadablePostError(OSError):
@@ -143,60 +146,62 @@ class HttpRequest:
             else:
                 self.encoding = self.content_params["charset"]
 
-    @cached_property
-    def _parsed_host_header(self):
-        use_x_fw_host = settings.USE_X_FORWARDED_HOST
-        use_x_fw_port = settings.USE_X_FORWARDED_PORT
+    def _get_parsed_host_header(self, validate=True):
+        if not hasattr(self, '_parsed_host_obj'):
+            use_x_fw_host = settings.USE_X_FORWARDED_HOST
+            use_x_fw_port = settings.USE_X_FORWARDED_PORT
 
-        port_in_x_fw_host = False
-        default_port = ('443' if self.is_secure() else '80')
+            port_in_x_fw_host = False
+            default_port = ('443' if self.is_secure() else '80')
 
-        if use_x_fw_host and 'HTTP_X_FORWARDED_HOST' in self.META:
-            host, port = _parse_host_header(self.META['HTTP_X_FORWARDED_HOST'])
-            port_in_x_fw_host = port != ''
-        elif 'HTTP_HOST' in self.META:
-            host, port = _parse_host_header(self.META['HTTP_HOST'])
+            if use_x_fw_host and 'HTTP_X_FORWARDED_HOST' in self.META:
+                host, port = _parse_host_header(self.META['HTTP_X_FORWARDED_HOST'])
+                port_in_x_fw_host = port != ''
+            elif 'HTTP_HOST' in self.META:
+                host, port = _parse_host_header(self.META['HTTP_HOST'])
+            else:
+                # Reconstruct the host using the algorithm from PEP 333.
+                host, port = self.META['SERVER_NAME'], str(self.META['SERVER_PORT'])
+                if port == default_port:
+                    port = ''
+
+            if use_x_fw_port and 'HTTP_X_FORWARDED_PORT' in self.META:
+                if port_in_x_fw_host:
+                    raise ImproperlyConfigured('HTTP_X_FORWARDED_HOST contains a port number '
+                                               'and USE_X_FORWARDED_PORT is set to True')
+                port = self.META['HTTP_X_FORWARDED_PORT']
+
+            reconstructed = '%s:%s' % (host, port) if port else host
+
+            domain, port = split_domain_port(reconstructed)
+            parsed_host = self._parsed_host_obj = ParsedHostHeader(domain, port or default_port, reconstructed)
         else:
-            # Reconstruct the host using the algorithm from PEP 333.
-            host, port = self.META['SERVER_NAME'], str(self.META['SERVER_PORT'])
-            if port == default_port:
-                port = ''
-
-        if use_x_fw_port and 'HTTP_X_FORWARDED_PORT' in self.META:
-            if port_in_x_fw_host:
-                raise ImproperlyConfigured('HTTP_X_FORWARDED_HOST contains a port number '
-                                           'and USE_X_FORWARDED_PORT is set to True')
-            port = self.META['HTTP_X_FORWARDED_PORT']
-
-        reconstructed = '%s:%s' % (host, port) if port else host
-        return host, port or default_port, reconstructed
-
-    def get_host(self):
-        """Return the HTTP host using the environment or request headers."""
-        _, _, host_header = self._parsed_host_header
+            parsed_host = self._parsed_host_obj
 
         # Allow variants of localhost if ALLOWED_HOSTS is empty and DEBUG=True.
         allowed_hosts = settings.ALLOWED_HOSTS
         if settings.DEBUG and not allowed_hosts:
             allowed_hosts = [".localhost", "127.0.0.1", "[::1]"]
 
-        domain, port = split_domain_port(host_header)
-        if domain and validate_host(domain, allowed_hosts):
-            return host_header
-        else:
-            msg = "Invalid HTTP_HOST header: %r." % host_header
-            if domain:
-                msg += " You may need to add %r to ALLOWED_HOSTS." % domain
+        msg = "Invalid HTTP_HOST header: %r." % parsed_host.combined
+        if validate and not (parsed_host.domain and validate_host(parsed_host.domain, allowed_hosts)):
+            if parsed_host.domain:
+                msg += " You may need to add %r to ALLOWED_HOSTS." % parsed_host.domain
             else:
                 msg += (
                     " The domain name provided is not valid according to RFC 1034/1035."
                 )
             raise DisallowedHost(msg)
 
+        return parsed_host
+
+    def get_host(self):
+        """Return the HTTP host using the environment or request headers."""
+        return self._get_parsed_host_header().combined
+
     def get_port(self):
         """Return the port number for the request as a string."""
-        _, port, _ = self._parsed_host_header
-        return port
+        return self._get_parsed_host_header().port
 
     def get_full_path(self, force_append_slash=False):
         return self._get_full_path(self.path, force_append_slash)
@@ -246,10 +251,9 @@ class HttpRequest:
         Return an absolute URI from variables available in this request. Skip
         allowed hosts protection, so may return insecure URI.
         """
-        _, _, host_header = self._parsed_host_header
         return '{scheme}://{host}{path}'.format(
             scheme=self.scheme,
-            host=host_header,
+            host=self._get_parsed_host_header(validate=False).combined,
             path=self.get_full_path(),
         )
 

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -260,10 +260,10 @@ class HttpRequest:
         Return an absolute URI from variables available in this request. Skip
         allowed hosts protection, so may return insecure URI.
         """
-        return "{scheme}://{host}{path}".format(
-            scheme=self.scheme,
-            host=self._get_parsed_host_header(validate=False).combined,
-            path=self.get_full_path(),
+        return (
+            f"{self.scheme}://"
+            f"{self._get_parsed_host_header(validate=False).combined}"
+            f"{self.get_full_path()}"
         )
 
     def build_absolute_uri(self, location=None):
@@ -307,7 +307,7 @@ class HttpRequest:
 
     @cached_property
     def _current_scheme_host(self):
-        return "{}://{}".format(self.scheme, self.get_host())
+        return f"{self.scheme}://{self.get_host()}"
 
     def _get_scheme(self):
         """

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -1,6 +1,7 @@
 import codecs
 import copy
-import warnings
+import operator
+
 from collections import namedtuple
 from io import BytesIO
 from itertools import chain
@@ -32,9 +33,11 @@ from django.utils.http import is_same_domain, parse_header_parameters
 from django.utils.regex_helper import _lazy_re_compile
 
 RAISE_ERROR = object()
-host_validation_re = _lazy_re_compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(?::([0-9]+))?$")
+host_validation_re = _lazy_re_compile(
+    r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(?::([0-9]+))?$"
+)
 
-ParsedHostHeader = namedtuple('ParsedHostHeader', ['domain', 'port', 'combined'])
+ParsedHostHeader = namedtuple("ParsedHostHeader", ["domain", "port", "combined"])
 
 
 class UnreadablePostError(OSError):
@@ -147,34 +150,38 @@ class HttpRequest:
                 self.encoding = self.content_params["charset"]
 
     def _get_parsed_host_header(self, validate=True):
-        if not hasattr(self, '_parsed_host_obj'):
+        if not hasattr(self, "_parsed_host_obj"):
             use_x_fw_host = settings.USE_X_FORWARDED_HOST
             use_x_fw_port = settings.USE_X_FORWARDED_PORT
 
             port_in_x_fw_host = False
-            default_port = ('443' if self.is_secure() else '80')
+            default_port = "443" if self.is_secure() else "80"
 
-            if use_x_fw_host and 'HTTP_X_FORWARDED_HOST' in self.META:
-                host, port = _parse_host_header(self.META['HTTP_X_FORWARDED_HOST'])
-                port_in_x_fw_host = port != ''
-            elif 'HTTP_HOST' in self.META:
-                host, port = _parse_host_header(self.META['HTTP_HOST'])
+            if use_x_fw_host and "HTTP_X_FORWARDED_HOST" in self.META:
+                host, port = _parse_host_header(self.META["HTTP_X_FORWARDED_HOST"])
+                port_in_x_fw_host = port != ""
+            elif "HTTP_HOST" in self.META:
+                host, port = _parse_host_header(self.META["HTTP_HOST"])
             else:
                 # Reconstruct the host using the algorithm from PEP 333.
-                host, port = self.META['SERVER_NAME'], str(self.META['SERVER_PORT'])
+                host, port = self.META["SERVER_NAME"], str(self.META["SERVER_PORT"])
                 if port == default_port:
-                    port = ''
+                    port = ""
 
-            if use_x_fw_port and 'HTTP_X_FORWARDED_PORT' in self.META:
+            if use_x_fw_port and "HTTP_X_FORWARDED_PORT" in self.META:
                 if port_in_x_fw_host:
-                    raise ImproperlyConfigured('HTTP_X_FORWARDED_HOST contains a port number '
-                                               'and USE_X_FORWARDED_PORT is set to True')
-                port = self.META['HTTP_X_FORWARDED_PORT']
+                    raise ImproperlyConfigured(
+                        "HTTP_X_FORWARDED_HOST contains a port number "
+                        "and USE_X_FORWARDED_PORT is set to True"
+                    )
+                port = self.META["HTTP_X_FORWARDED_PORT"]
 
-            reconstructed = '%s:%s' % (host, port) if port else host
+            reconstructed = "%s:%s" % (host, port) if port else host
 
             domain, port = split_domain_port(reconstructed)
-            parsed_host = self._parsed_host_obj = ParsedHostHeader(domain, port or default_port, reconstructed)
+            parsed_host = self._parsed_host_obj = ParsedHostHeader(
+                domain, port or default_port, reconstructed
+            )
         else:
             parsed_host = self._parsed_host_obj
 
@@ -184,7 +191,9 @@ class HttpRequest:
             allowed_hosts = [".localhost", "127.0.0.1", "[::1]"]
 
         msg = "Invalid HTTP_HOST header: %r." % parsed_host.combined
-        if validate and not (parsed_host.domain and validate_host(parsed_host.domain, allowed_hosts)):
+        if validate and not (
+            parsed_host.domain and validate_host(parsed_host.domain, allowed_hosts)
+        ):
             if parsed_host.domain:
                 msg += " You may need to add %r to ALLOWED_HOSTS." % parsed_host.domain
             else:
@@ -251,7 +260,7 @@ class HttpRequest:
         Return an absolute URI from variables available in this request. Skip
         allowed hosts protection, so may return insecure URI.
         """
-        return '{scheme}://{host}{path}'.format(
+        return "{scheme}://{host}{path}".format(
             scheme=self.scheme,
             host=self._get_parsed_host_header(validate=False).combined,
             path=self.get_full_path(),
@@ -791,11 +800,11 @@ def _parse_host_header(host_header):
     Neither domain name nor port are validated.
     """
 
-    if host_header[-1] == ']':
+    if host_header[-1] == "]":
         # It's an IPv6 address without a port.
-        return host_header, ''
-    bits = host_header.rsplit(':', 1)
-    return tuple(bits) if len(bits) == 2 else (bits[0], '')
+        return host_header, ""
+    bits = host_header.rsplit(":", 1)
+    return tuple(bits) if len(bits) == 2 else (bits[0], "")
 
 
 def split_domain_port(host):
@@ -809,12 +818,12 @@ def split_domain_port(host):
 
     host_match = host_validation_re.match(host)
     if not host_match:
-        return '', ''
+        return "", ""
 
     domain, port = host_match.groups()
-    port = port or ''
+    port = port or ""
     # Remove a trailing dot (if present) from the domain.
-    domain = domain[:-1] if domain.endswith('.') else domain
+    domain = domain[:-1] if domain.endswith(".") else domain
     return domain, port
 
 

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -3,6 +3,7 @@ import copy
 import operator
 
 from collections import namedtuple
+from cgi import parse_header
 from io import BytesIO
 from itertools import chain
 from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlsplit
@@ -20,7 +21,6 @@ from django.core.files import uploadhandler
 from django.http.multipartparser import (
     MultiPartParser,
     MultiPartParserError,
-    TooManyFilesSent,
 )
 from django.utils.datastructures import (
     CaseInsensitiveMapping,
@@ -29,13 +29,11 @@ from django.utils.datastructures import (
 )
 from django.utils.encoding import escape_uri_path, iri_to_uri
 from django.utils.functional import cached_property
-from django.utils.http import is_same_domain, parse_header_parameters
-from django.utils.regex_helper import _lazy_re_compile
+from django.utils.http import is_same_domain
 
 RAISE_ERROR = object()
-host_validation_re = _lazy_re_compile(
-    r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(?::([0-9]+))?$"
-)
+MAX_ALLOWED_FILES = 1000
+host_validation_re = r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(?::([0-9]+))?$"
 
 ParsedHostHeader = namedtuple("ParsedHostHeader", ["domain", "port", "combined"])
 
@@ -138,7 +136,7 @@ class HttpRequest:
 
     def _set_content_type_params(self, meta):
         """Set content_type, content_params, and encoding."""
-        self.content_type, self.content_params = parse_header_parameters(
+        self.content_type, self.content_params = parse_header(
             meta.get("CONTENT_TYPE", "")
         )
         if "charset" in self.content_params:
@@ -437,7 +435,11 @@ class HttpRequest:
                 data = self
             try:
                 self._post, self._files = self.parse_file_upload(self.META, data)
-            except (MultiPartParserError, TooManyFilesSent):
+                if len(self._files) > MAX_ALLOWED_FILES:
+                    raise MultiPartParserError(
+                        f"{len(self._files)} files processed. Maximum {MAX_ALLOWED_FILES} files allowed."
+                    )
+            except MultiPartParserError:
                 # An error occurred while parsing POST data. Since when
                 # formatting the error the request handler might access
                 # self.POST, set self._post and self._file to prevent
@@ -719,7 +721,7 @@ class QueryDict(MultiValueDict):
 
 class MediaType:
     def __init__(self, media_type_raw_line):
-        full_type, self.params = parse_header_parameters(
+        full_type, self.params = parse_header(
             media_type_raw_line if media_type_raw_line else ""
         )
         self.main_type, _, self.sub_type = full_type.partition("/")

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -31,9 +31,7 @@ from django.utils.http import is_same_domain, parse_header_parameters
 from django.utils.regex_helper import _lazy_re_compile
 
 RAISE_ERROR = object()
-host_validation_re = _lazy_re_compile(
-    r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9.:]+\])(?::([0-9]+))?$"
-)
+host_validation_re = _lazy_re_compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(?::(\d+))?$")
 
 
 class UnreadablePostError(OSError):
@@ -145,38 +143,48 @@ class HttpRequest:
             else:
                 self.encoding = self.content_params["charset"]
 
-    def _get_raw_host(self):
-        """
-        Return the HTTP host using the environment or request headers. Skip
-        allowed hosts protection, so may return an insecure host.
-        """
-        # We try three options, in order of decreasing preference.
-        if settings.USE_X_FORWARDED_HOST and ("HTTP_X_FORWARDED_HOST" in self.META):
-            host = self.META["HTTP_X_FORWARDED_HOST"]
-        elif "HTTP_HOST" in self.META:
-            host = self.META["HTTP_HOST"]
+    @cached_property
+    def _parsed_host_header(self):
+        use_x_fw_host = settings.USE_X_FORWARDED_HOST
+        use_x_fw_port = settings.USE_X_FORWARDED_PORT
+
+        port_in_x_fw_host = False
+        default_port = ('443' if self.is_secure() else '80')
+
+        if use_x_fw_host and 'HTTP_X_FORWARDED_HOST' in self.META:
+            host, port = _parse_host_header(self.META['HTTP_X_FORWARDED_HOST'])
+            port_in_x_fw_host = port != ''
+        elif 'HTTP_HOST' in self.META:
+            host, port = _parse_host_header(self.META['HTTP_HOST'])
         else:
             # Reconstruct the host using the algorithm from PEP 333.
-            host = self.META["SERVER_NAME"]
-            server_port = self.get_port()
-            if server_port != ("443" if self.is_secure() else "80"):
-                host = "%s:%s" % (host, server_port)
-        return host
+            host, port = self.META['SERVER_NAME'], str(self.META['SERVER_PORT'])
+            if port == default_port:
+                port = ''
+
+        if use_x_fw_port and 'HTTP_X_FORWARDED_PORT' in self.META:
+            if port_in_x_fw_host:
+                raise ImproperlyConfigured('HTTP_X_FORWARDED_HOST contains a port number '
+                                           'and USE_X_FORWARDED_PORT is set to True')
+            port = self.META['HTTP_X_FORWARDED_PORT']
+
+        reconstructed = '%s:%s' % (host, port) if port else host
+        return host, port or default_port, reconstructed
 
     def get_host(self):
         """Return the HTTP host using the environment or request headers."""
-        host = self._get_raw_host()
+        _, _, host_header = self._parsed_host_header
 
         # Allow variants of localhost if ALLOWED_HOSTS is empty and DEBUG=True.
         allowed_hosts = settings.ALLOWED_HOSTS
         if settings.DEBUG and not allowed_hosts:
             allowed_hosts = [".localhost", "127.0.0.1", "[::1]"]
 
-        domain, port = split_domain_port(host)
+        domain, port = split_domain_port(host_header)
         if domain and validate_host(domain, allowed_hosts):
-            return host
+            return host_header
         else:
-            msg = "Invalid HTTP_HOST header: %r." % host
+            msg = "Invalid HTTP_HOST header: %r." % host_header
             if domain:
                 msg += " You may need to add %r to ALLOWED_HOSTS." % domain
             else:
@@ -187,11 +195,8 @@ class HttpRequest:
 
     def get_port(self):
         """Return the port number for the request as a string."""
-        if settings.USE_X_FORWARDED_PORT and "HTTP_X_FORWARDED_PORT" in self.META:
-            port = self.META["HTTP_X_FORWARDED_PORT"]
-        else:
-            port = self.META["SERVER_PORT"]
-        return str(port)
+        _, port, _ = self._parsed_host_header
+        return port
 
     def get_full_path(self, force_append_slash=False):
         return self._get_full_path(self.path, force_append_slash)
@@ -235,6 +240,18 @@ class HttpRequest:
             else:
                 raise
         return value
+
+    def get_raw_uri(self):
+        """
+        Return an absolute URI from variables available in this request. Skip
+        allowed hosts protection, so may return insecure URI.
+        """
+        _, _, host_header = self._parsed_host_header
+        return '{scheme}://{host}{path}'.format(
+            scheme=self.scheme,
+            host=host_header,
+            path=self.get_full_path(),
+        )
 
     def build_absolute_uri(self, location=None):
         """
@@ -763,6 +780,20 @@ def bytes_to_text(s, encoding):
         return s
 
 
+def _parse_host_header(host_header):
+    """
+    Returns a (domain, port) tuple for a given host.
+
+    Neither domain name nor port are validated.
+    """
+
+    if host_header[-1] == ']':
+        # It's an IPv6 address without a port.
+        return host_header, ''
+    bits = host_header.rsplit(':', 1)
+    return tuple(bits) if len(bits) == 2 else (bits[0], '')
+
+
 def split_domain_port(host):
     """
     Return a (domain, port) tuple from a given host.
@@ -770,11 +801,17 @@ def split_domain_port(host):
     Returned domain is lowercased. If the host is invalid, the domain will be
     empty.
     """
-    if match := host_validation_re.fullmatch(host.lower()):
-        domain, port = match.groups(default="")
-        # Remove a trailing dot (if present) from the domain.
-        return domain.removesuffix("."), port
-    return "", ""
+    host = host.lower()
+
+    host_match = host_validation_re.match(host)
+    if not host_match:
+        return '', ''
+
+    domain, port = host_match.groups()
+    port = port or ''
+    # Remove a trailing dot (if present) from the domain.
+    domain = domain[:-1] if domain.endswith('.') else domain
+    return domain, port
 
 
 def validate_host(host, allowed_hosts):

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -1274,28 +1274,15 @@ class CsrfViewMiddlewareTests(CsrfViewMiddlewareTestMixin, SimpleTestCase):
         self.assertEqual(csrf_cookie, TEST_SECRET)
         self._check_token_present(resp, csrf_cookie)
 
-    def test_bare_secret_accepted_and_not_replaced(self):
-        """
-        The csrf cookie is left unchanged if originally not masked.
-        """
-        req = self._get_POST_request_with_token(cookie=TEST_SECRET)
-        mw = CsrfViewMiddleware(token_view)
-        mw.process_request(req)
-        resp = mw.process_view(req, token_view, (), {})
-        self.assertIsNone(resp)
-        resp = mw(req)
-        csrf_cookie = self._read_csrf_cookie(req, resp)
-        self.assertEqual(csrf_cookie, TEST_SECRET)
-        self._check_token_present(resp, csrf_cookie)
-
     @override_settings(
-        ALLOWED_HOSTS=["www.example.com"],
-        CSRF_COOKIE_DOMAIN=".example.com",
+        ALLOWED_HOSTS=['www.example.com'],
+        CSRF_COOKIE_DOMAIN='.example.com',
         USE_X_FORWARDED_PORT=True,
+        USE_X_FORWARDED_HOST=True
     )
     def test_https_good_referer_behind_proxy(self):
         """
-        A POST HTTPS request is accepted when USE_X_FORWARDED_PORT=True.
+        A POST HTTPS request is accepted when USE_X_FORWARDED_*=True.
         """
         self._test_https_good_referer_behind_proxy()
 
@@ -1428,11 +1415,12 @@ class CsrfViewMiddlewareUseSessionsTests(CsrfViewMiddlewareTestMixin, SimpleTest
         ALLOWED_HOSTS=["www.example.com"],
         SESSION_COOKIE_DOMAIN=".example.com",
         USE_X_FORWARDED_PORT=True,
+        USE_X_FORWARDED_HOST=True,
         DEBUG=True,
     )
     def test_https_good_referer_behind_proxy(self):
         """
-        A POST HTTPS request is accepted when USE_X_FORWARDED_PORT=True.
+        A POST HTTPS request is accepted when USE_X_FORWARDED_*=True.
         """
         self._test_https_good_referer_behind_proxy()
 

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -831,8 +831,8 @@ class CsrfViewMiddlewareTestMixin(CsrfFunctionTestMixin):
     def _test_https_good_referer_matches_cookie_domain(self):
         req = self._get_POST_request_with_token()
         req._is_secure_override = True
-        req.META['HTTP_HOST'] = 'www.example.com'
-        req.META['HTTP_REFERER'] = 'https://foo.example.com/'
+        req.META["HTTP_HOST"] = "www.example.com"
+        req.META["HTTP_REFERER"] = "https://foo.example.com/"
         mw = CsrfViewMiddleware(post_form_view)
         mw.process_request(req)
         response = mw.process_view(req, post_form_view, (), {})
@@ -841,8 +841,8 @@ class CsrfViewMiddlewareTestMixin(CsrfFunctionTestMixin):
     def _test_https_good_referer_matches_cookie_domain_with_different_port(self):
         req = self._get_POST_request_with_token()
         req._is_secure_override = True
-        req.META['HTTP_HOST'] = 'www.example.com:4443'
-        req.META['HTTP_REFERER'] = 'https://foo.example.com:4443/'
+        req.META["HTTP_HOST"] = "www.example.com:4443"
+        req.META["HTTP_REFERER"] = "https://foo.example.com:4443/"
         mw = CsrfViewMiddleware(post_form_view)
         mw.process_request(req)
         response = mw.process_view(req, post_form_view, (), {})
@@ -1275,10 +1275,10 @@ class CsrfViewMiddlewareTests(CsrfViewMiddlewareTestMixin, SimpleTestCase):
         self._check_token_present(resp, csrf_cookie)
 
     @override_settings(
-        ALLOWED_HOSTS=['www.example.com'],
-        CSRF_COOKIE_DOMAIN='.example.com',
+        ALLOWED_HOSTS=["www.example.com"],
+        CSRF_COOKIE_DOMAIN=".example.com",
         USE_X_FORWARDED_PORT=True,
-        USE_X_FORWARDED_HOST=True
+        USE_X_FORWARDED_HOST=True,
     )
     def test_https_good_referer_behind_proxy(self):
         """

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -831,8 +831,8 @@ class CsrfViewMiddlewareTestMixin(CsrfFunctionTestMixin):
     def _test_https_good_referer_matches_cookie_domain(self):
         req = self._get_POST_request_with_token()
         req._is_secure_override = True
-        req.META["HTTP_REFERER"] = "https://foo.example.com/"
-        req.META["SERVER_PORT"] = "443"
+        req.META['HTTP_HOST'] = 'www.example.com'
+        req.META['HTTP_REFERER'] = 'https://foo.example.com/'
         mw = CsrfViewMiddleware(post_form_view)
         mw.process_request(req)
         response = mw.process_view(req, post_form_view, (), {})
@@ -841,9 +841,8 @@ class CsrfViewMiddlewareTestMixin(CsrfFunctionTestMixin):
     def _test_https_good_referer_matches_cookie_domain_with_different_port(self):
         req = self._get_POST_request_with_token()
         req._is_secure_override = True
-        req.META["HTTP_HOST"] = "www.example.com"
-        req.META["HTTP_REFERER"] = "https://foo.example.com:4443/"
-        req.META["SERVER_PORT"] = "4443"
+        req.META['HTTP_HOST'] = 'www.example.com:4443'
+        req.META['HTTP_REFERER'] = 'https://foo.example.com:4443/'
         mw = CsrfViewMiddleware(post_form_view)
         mw.process_request(req)
         response = mw.process_view(req, post_form_view, (), {})

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -20,40 +20,40 @@ class RequestsTests(SimpleTestCase):
         self.assertEqual(list(request.META), [])
 
         # .GET and .POST should be QueryDicts
-        self.assertEqual(request.GET.urlencode(), '')
-        self.assertEqual(request.POST.urlencode(), '')
+        self.assertEqual(request.GET.urlencode(), "")
+        self.assertEqual(request.POST.urlencode(), "")
 
         # and FILES should be MultiValueDict
-        self.assertEqual(request.FILES.getlist('foo'), [])
+        self.assertEqual(request.FILES.getlist("foo"), [])
 
         self.assertIsNone(request.content_type)
         self.assertIsNone(request.content_params)
 
     def test_httprequest_full_path(self):
         request = HttpRequest()
-        request.path = '/;some/?awful/=path/foo:bar/'
-        request.path_info = '/prefix' + request.path
-        request.META['QUERY_STRING'] = ';some=query&+query=string'
-        expected = '/%3Bsome/%3Fawful/%3Dpath/foo:bar/?;some=query&+query=string'
+        request.path = "/;some/?awful/=path/foo:bar/"
+        request.path_info = "/prefix" + request.path
+        request.META["QUERY_STRING"] = ";some=query&+query=string"
+        expected = "/%3Bsome/%3Fawful/%3Dpath/foo:bar/?;some=query&+query=string"
         self.assertEqual(request.get_full_path(), expected)
-        self.assertEqual(request.get_full_path_info(), '/prefix' + expected)
+        self.assertEqual(request.get_full_path_info(), "/prefix" + expected)
 
     def test_httprequest_full_path_with_query_string_and_fragment(self):
         request = HttpRequest()
-        request.path = '/foo#bar'
-        request.path_info = '/prefix' + request.path
-        request.META['QUERY_STRING'] = 'baz#quux'
-        self.assertEqual(request.get_full_path(), '/foo%23bar?baz#quux')
-        self.assertEqual(request.get_full_path_info(), '/prefix/foo%23bar?baz#quux')
+        request.path = "/foo#bar"
+        request.path_info = "/prefix" + request.path
+        request.META["QUERY_STRING"] = "baz#quux"
+        self.assertEqual(request.get_full_path(), "/foo%23bar?baz#quux")
+        self.assertEqual(request.get_full_path_info(), "/prefix/foo%23bar?baz#quux")
 
     def test_httprequest_repr(self):
         request = HttpRequest()
-        request.path = '/somepath/'
-        request.method = 'GET'
-        request.GET = {'get-key': 'get-value'}
-        request.POST = {'post-key': 'post-value'}
-        request.COOKIES = {'post-key': 'post-value'}
-        request.META = {'post-key': 'post-value'}
+        request.path = "/somepath/"
+        request.method = "GET"
+        request.GET = {"get-key": "get-value"}
+        request.POST = {"post-key": "post-value"}
+        request.COOKIES = {"post-key": "post-value"}
+        request.META = {"post-key": "post-value"}
         self.assertEqual(repr(request), "<HttpRequest: GET '/somepath/'>")
 
     def test_httprequest_repr_invalid_method_and_path(self):
@@ -67,24 +67,32 @@ class RequestsTests(SimpleTestCase):
         self.assertEqual(repr(request), "<HttpRequest>")
 
     def test_wsgirequest(self):
-        request = WSGIRequest({
-            'PATH_INFO': 'bogus',
-            'REQUEST_METHOD': 'bogus',
-            'CONTENT_TYPE': 'text/html; charset=utf8',
-            'wsgi.input': BytesIO(b''),
-        })
+        request = WSGIRequest(
+            {
+                "PATH_INFO": "bogus",
+                "REQUEST_METHOD": "bogus",
+                "CONTENT_TYPE": "text/html; charset=utf8",
+                "wsgi.input": BytesIO(b""),
+            }
+        )
         self.assertEqual(list(request.GET), [])
         self.assertEqual(list(request.POST), [])
         self.assertEqual(list(request.COOKIES), [])
         self.assertEqual(
             set(request.META),
-            {'PATH_INFO', 'REQUEST_METHOD', 'SCRIPT_NAME', 'CONTENT_TYPE', 'wsgi.input'}
+            {
+                "PATH_INFO",
+                "REQUEST_METHOD",
+                "SCRIPT_NAME",
+                "CONTENT_TYPE",
+                "wsgi.input",
+            },
         )
-        self.assertEqual(request.META['PATH_INFO'], 'bogus')
-        self.assertEqual(request.META['REQUEST_METHOD'], 'bogus')
-        self.assertEqual(request.META['SCRIPT_NAME'], '')
-        self.assertEqual(request.content_type, 'text/html')
-        self.assertEqual(request.content_params, {'charset': 'utf8'})
+        self.assertEqual(request.META["PATH_INFO"], "bogus")
+        self.assertEqual(request.META["REQUEST_METHOD"], "bogus")
+        self.assertEqual(request.META["SCRIPT_NAME"], "")
+        self.assertEqual(request.content_type, "text/html")
+        self.assertEqual(request.content_params, {"charset": "utf8"})
 
     def test_wsgirequest_with_script_name(self):
         """
@@ -92,21 +100,25 @@ class RequestsTests(SimpleTestCase):
         not the SCRIPT_NAME has a trailing slash (#20169).
         """
         # With trailing slash
-        request = WSGIRequest({
-            'PATH_INFO': '/somepath/',
-            'SCRIPT_NAME': '/PREFIX/',
-            'REQUEST_METHOD': 'get',
-            'wsgi.input': BytesIO(b''),
-        })
-        self.assertEqual(request.path, '/PREFIX/somepath/')
+        request = WSGIRequest(
+            {
+                "PATH_INFO": "/somepath/",
+                "SCRIPT_NAME": "/PREFIX/",
+                "REQUEST_METHOD": "get",
+                "wsgi.input": BytesIO(b""),
+            }
+        )
+        self.assertEqual(request.path, "/PREFIX/somepath/")
         # Without trailing slash
-        request = WSGIRequest({
-            'PATH_INFO': '/somepath/',
-            'SCRIPT_NAME': '/PREFIX',
-            'REQUEST_METHOD': 'get',
-            'wsgi.input': BytesIO(b''),
-        })
-        self.assertEqual(request.path, '/PREFIX/somepath/')
+        request = WSGIRequest(
+            {
+                "PATH_INFO": "/somepath/",
+                "SCRIPT_NAME": "/PREFIX",
+                "REQUEST_METHOD": "get",
+                "wsgi.input": BytesIO(b""),
+            }
+        )
+        self.assertEqual(request.path, "/PREFIX/somepath/")
 
     def test_wsgirequest_script_url_double_slashes(self):
         """
@@ -114,28 +126,32 @@ class RequestsTests(SimpleTestCase):
         should take that into account when populating request.path and
         request.META['SCRIPT_NAME'] (#17133).
         """
-        request = WSGIRequest({
-            'SCRIPT_URL': '/mst/milestones//accounts/login//help',
-            'PATH_INFO': '/milestones/accounts/login/help',
-            'REQUEST_METHOD': 'get',
-            'wsgi.input': BytesIO(b''),
-        })
-        self.assertEqual(request.path, '/mst/milestones/accounts/login/help')
-        self.assertEqual(request.META['SCRIPT_NAME'], '/mst')
+        request = WSGIRequest(
+            {
+                "SCRIPT_URL": "/mst/milestones//accounts/login//help",
+                "PATH_INFO": "/milestones/accounts/login/help",
+                "REQUEST_METHOD": "get",
+                "wsgi.input": BytesIO(b""),
+            }
+        )
+        self.assertEqual(request.path, "/mst/milestones/accounts/login/help")
+        self.assertEqual(request.META["SCRIPT_NAME"], "/mst")
 
     def test_wsgirequest_with_force_script_name(self):
         """
         The FORCE_SCRIPT_NAME setting takes precedence over the request's
         SCRIPT_NAME environment parameter (#20169).
         """
-        with override_settings(FORCE_SCRIPT_NAME='/FORCED_PREFIX/'):
-            request = WSGIRequest({
-                'PATH_INFO': '/somepath/',
-                'SCRIPT_NAME': '/PREFIX/',
-                'REQUEST_METHOD': 'get',
-                'wsgi.input': BytesIO(b''),
-            })
-            self.assertEqual(request.path, '/FORCED_PREFIX/somepath/')
+        with override_settings(FORCE_SCRIPT_NAME="/FORCED_PREFIX/"):
+            request = WSGIRequest(
+                {
+                    "PATH_INFO": "/somepath/",
+                    "SCRIPT_NAME": "/PREFIX/",
+                    "REQUEST_METHOD": "get",
+                    "wsgi.input": BytesIO(b""),
+                }
+            )
+            self.assertEqual(request.path, "/FORCED_PREFIX/somepath/")
 
     def test_wsgirequest_path_with_force_script_name_trailing_slash(self):
         """
@@ -143,165 +159,206 @@ class RequestsTests(SimpleTestCase):
         the FORCE_SCRIPT_NAME setting has a trailing slash (#20169).
         """
         # With trailing slash
-        with override_settings(FORCE_SCRIPT_NAME='/FORCED_PREFIX/'):
-            request = WSGIRequest({'PATH_INFO': '/somepath/', 'REQUEST_METHOD': 'get', 'wsgi.input': BytesIO(b'')})
-            self.assertEqual(request.path, '/FORCED_PREFIX/somepath/')
+        with override_settings(FORCE_SCRIPT_NAME="/FORCED_PREFIX/"):
+            request = WSGIRequest(
+                {
+                    "PATH_INFO": "/somepath/",
+                    "REQUEST_METHOD": "get",
+                    "wsgi.input": BytesIO(b""),
+                }
+            )
+            self.assertEqual(request.path, "/FORCED_PREFIX/somepath/")
         # Without trailing slash
-        with override_settings(FORCE_SCRIPT_NAME='/FORCED_PREFIX'):
-            request = WSGIRequest({'PATH_INFO': '/somepath/', 'REQUEST_METHOD': 'get', 'wsgi.input': BytesIO(b'')})
-            self.assertEqual(request.path, '/FORCED_PREFIX/somepath/')
+        with override_settings(FORCE_SCRIPT_NAME="/FORCED_PREFIX"):
+            request = WSGIRequest(
+                {
+                    "PATH_INFO": "/somepath/",
+                    "REQUEST_METHOD": "get",
+                    "wsgi.input": BytesIO(b""),
+                }
+            )
+            self.assertEqual(request.path, "/FORCED_PREFIX/somepath/")
 
     def test_wsgirequest_repr(self):
-        request = WSGIRequest({'REQUEST_METHOD': 'get', 'wsgi.input': BytesIO(b'')})
+        request = WSGIRequest({"REQUEST_METHOD": "get", "wsgi.input": BytesIO(b"")})
         self.assertEqual(repr(request), "<WSGIRequest: GET '/'>")
-        request = WSGIRequest({'PATH_INFO': '/somepath/', 'REQUEST_METHOD': 'get', 'wsgi.input': BytesIO(b'')})
-        request.GET = {'get-key': 'get-value'}
-        request.POST = {'post-key': 'post-value'}
-        request.COOKIES = {'post-key': 'post-value'}
-        request.META = {'post-key': 'post-value'}
+        request = WSGIRequest(
+            {
+                "PATH_INFO": "/somepath/",
+                "REQUEST_METHOD": "get",
+                "wsgi.input": BytesIO(b""),
+            }
+        )
+        request.GET = {"get-key": "get-value"}
+        request.POST = {"post-key": "post-value"}
+        request.COOKIES = {"post-key": "post-value"}
+        request.META = {"post-key": "post-value"}
         self.assertEqual(repr(request), "<WSGIRequest: GET '/somepath/'>")
 
     def test_wsgirequest_path_info(self):
-        def wsgi_str(path_info, encoding='utf-8'):
-            path_info = path_info.encode(encoding)  # Actual URL sent by the browser (bytestring)
-            path_info = path_info.decode('iso-8859-1')  # Value in the WSGI environ dict (native string)
+        def wsgi_str(path_info, encoding="utf-8"):
+            path_info = path_info.encode(
+                encoding
+            )  # Actual URL sent by the browser (bytestring)
+            path_info = path_info.decode(
+                "iso-8859-1"
+            )  # Value in the WSGI environ dict (native string)
             return path_info
+
         # Regression for #19468
-        request = WSGIRequest({'PATH_INFO': wsgi_str("/سلام/"), 'REQUEST_METHOD': 'get', 'wsgi.input': BytesIO(b'')})
+        request = WSGIRequest(
+            {
+                "PATH_INFO": wsgi_str("/سلام/"),
+                "REQUEST_METHOD": "get",
+                "wsgi.input": BytesIO(b""),
+            }
+        )
         self.assertEqual(request.path, "/سلام/")
 
         # The URL may be incorrectly encoded in a non-UTF-8 encoding (#26971)
-        request = WSGIRequest({
-            'PATH_INFO': wsgi_str("/café/", encoding='iso-8859-1'),
-            'REQUEST_METHOD': 'get',
-            'wsgi.input': BytesIO(b''),
-        })
+        request = WSGIRequest(
+            {
+                "PATH_INFO": wsgi_str("/café/", encoding="iso-8859-1"),
+                "REQUEST_METHOD": "get",
+                "wsgi.input": BytesIO(b""),
+            }
+        )
         # Since it's impossible to decide the (wrong) encoding of the URL, it's
         # left percent-encoded in the path.
         self.assertEqual(request.path, "/caf%E9/")
 
     def test_limited_stream(self):
         # Read all of a limited stream
-        stream = LimitedStream(BytesIO(b'test'), 2)
-        self.assertEqual(stream.read(), b'te')
+        stream = LimitedStream(BytesIO(b"test"), 2)
+        self.assertEqual(stream.read(), b"te")
         # Reading again returns nothing.
-        self.assertEqual(stream.read(), b'')
+        self.assertEqual(stream.read(), b"")
 
         # Read a number of characters greater than the stream has to offer
-        stream = LimitedStream(BytesIO(b'test'), 2)
-        self.assertEqual(stream.read(5), b'te')
+        stream = LimitedStream(BytesIO(b"test"), 2)
+        self.assertEqual(stream.read(5), b"te")
         # Reading again returns nothing.
-        self.assertEqual(stream.readline(5), b'')
+        self.assertEqual(stream.readline(5), b"")
 
         # Read sequentially from a stream
-        stream = LimitedStream(BytesIO(b'12345678'), 8)
-        self.assertEqual(stream.read(5), b'12345')
-        self.assertEqual(stream.read(5), b'678')
+        stream = LimitedStream(BytesIO(b"12345678"), 8)
+        self.assertEqual(stream.read(5), b"12345")
+        self.assertEqual(stream.read(5), b"678")
         # Reading again returns nothing.
-        self.assertEqual(stream.readline(5), b'')
+        self.assertEqual(stream.readline(5), b"")
 
         # Read lines from a stream
-        stream = LimitedStream(BytesIO(b'1234\n5678\nabcd\nefgh\nijkl'), 24)
+        stream = LimitedStream(BytesIO(b"1234\n5678\nabcd\nefgh\nijkl"), 24)
         # Read a full line, unconditionally
-        self.assertEqual(stream.readline(), b'1234\n')
+        self.assertEqual(stream.readline(), b"1234\n")
         # Read a number of characters less than a line
-        self.assertEqual(stream.readline(2), b'56')
+        self.assertEqual(stream.readline(2), b"56")
         # Read the rest of the partial line
-        self.assertEqual(stream.readline(), b'78\n')
+        self.assertEqual(stream.readline(), b"78\n")
         # Read a full line, with a character limit greater than the line length
-        self.assertEqual(stream.readline(6), b'abcd\n')
+        self.assertEqual(stream.readline(6), b"abcd\n")
         # Read the next line, deliberately terminated at the line end
-        self.assertEqual(stream.readline(4), b'efgh')
+        self.assertEqual(stream.readline(4), b"efgh")
         # Read the next line... just the line end
-        self.assertEqual(stream.readline(), b'\n')
+        self.assertEqual(stream.readline(), b"\n")
         # Read everything else.
-        self.assertEqual(stream.readline(), b'ijkl')
+        self.assertEqual(stream.readline(), b"ijkl")
 
         # Regression for #15018
         # If a stream contains a newline, but the provided length
         # is less than the number of provided characters, the newline
         # doesn't reset the available character count
-        stream = LimitedStream(BytesIO(b'1234\nabcdef'), 9)
-        self.assertEqual(stream.readline(10), b'1234\n')
-        self.assertEqual(stream.readline(3), b'abc')
+        stream = LimitedStream(BytesIO(b"1234\nabcdef"), 9)
+        self.assertEqual(stream.readline(10), b"1234\n")
+        self.assertEqual(stream.readline(3), b"abc")
         # Now expire the available characters
-        self.assertEqual(stream.readline(3), b'd')
+        self.assertEqual(stream.readline(3), b"d")
         # Reading again returns nothing.
-        self.assertEqual(stream.readline(2), b'')
+        self.assertEqual(stream.readline(2), b"")
 
         # Same test, but with read, not readline.
-        stream = LimitedStream(BytesIO(b'1234\nabcdef'), 9)
-        self.assertEqual(stream.read(6), b'1234\na')
-        self.assertEqual(stream.read(2), b'bc')
-        self.assertEqual(stream.read(2), b'd')
-        self.assertEqual(stream.read(2), b'')
-        self.assertEqual(stream.read(), b'')
+        stream = LimitedStream(BytesIO(b"1234\nabcdef"), 9)
+        self.assertEqual(stream.read(6), b"1234\na")
+        self.assertEqual(stream.read(2), b"bc")
+        self.assertEqual(stream.read(2), b"d")
+        self.assertEqual(stream.read(2), b"")
+        self.assertEqual(stream.read(), b"")
 
     def test_stream(self):
-        payload = FakePayload('name=value')
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': payload},
+        payload = FakePayload("name=value")
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "application/x-www-form-urlencoded",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": payload,
+            },
         )
-        self.assertEqual(request.read(), b'name=value')
+        self.assertEqual(request.read(), b"name=value")
 
     def test_read_after_value(self):
         """
         Reading from request is allowed after accessing request contents as
         POST or body.
         """
-        payload = FakePayload('name=value')
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': payload,
-        })
-        self.assertEqual(request.POST, {'name': ['value']})
-        self.assertEqual(request.body, b'name=value')
-        self.assertEqual(request.read(), b'name=value')
+        payload = FakePayload("name=value")
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "application/x-www-form-urlencoded",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": payload,
+            }
+        )
+        self.assertEqual(request.POST, {"name": ["value"]})
+        self.assertEqual(request.body, b"name=value")
+        self.assertEqual(request.read(), b"name=value")
 
     def test_value_after_read(self):
         """
         Construction of POST or body is not allowed after reading
         from request.
         """
-        payload = FakePayload('name=value')
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': payload,
-        })
-        self.assertEqual(request.read(2), b'na')
+        payload = FakePayload("name=value")
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "application/x-www-form-urlencoded",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": payload,
+            }
+        )
+        self.assertEqual(request.read(2), b"na")
         with self.assertRaises(RawPostDataException):
             request.body
         self.assertEqual(request.POST, {})
 
     def test_non_ascii_POST(self):
-        payload = FakePayload(urlencode({'key': 'España'}))
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_LENGTH': len(payload),
-            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
-            'wsgi.input': payload,
-        })
-        self.assertEqual(request.POST, {'key': ['España']})
+        payload = FakePayload(urlencode({"key": "España"}))
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_LENGTH": len(payload),
+                "CONTENT_TYPE": "application/x-www-form-urlencoded",
+                "wsgi.input": payload,
+            }
+        )
+        self.assertEqual(request.POST, {"key": ["España"]})
 
     def test_alternate_charset_POST(self):
         """
         Test a POST with non-utf-8 payload encoding.
         """
-        payload = FakePayload(urlencode({'key': 'España'.encode('latin-1')}))
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_LENGTH': len(payload),
-            'CONTENT_TYPE': 'application/x-www-form-urlencoded; charset=iso-8859-1',
-            'wsgi.input': payload,
-        })
-        self.assertEqual(request.POST, {'key': ['España']})
+        payload = FakePayload(urlencode({"key": "España".encode("latin-1")}))
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_LENGTH": len(payload),
+                "CONTENT_TYPE": "application/x-www-form-urlencoded; charset=iso-8859-1",
+                "wsgi.input": payload,
+            }
+        )
+        self.assertEqual(request.POST, {"key": ["España"]})
 
     def test_body_after_POST_multipart_form_data(self):
         """
@@ -310,20 +367,26 @@ class RequestsTests(SimpleTestCase):
         # Because multipart is used for large amounts of data i.e. file uploads,
         # we don't want the data held in memory twice, and we don't want to
         # silence the error by setting body = '' either.
-        payload = FakePayload("\r\n".join([
-            '--boundary',
-            'Content-Disposition: form-data; name="name"',
-            '',
-            'value',
-            '--boundary--'
-            '']))
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': payload,
-        })
-        self.assertEqual(request.POST, {'name': ['value']})
+        payload = FakePayload(
+            "\r\n".join(
+                [
+                    "--boundary",
+                    'Content-Disposition: form-data; name="name"',
+                    "",
+                    "value",
+                    "--boundary--" "",
+                ]
+            )
+        )
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "multipart/form-data; boundary=boundary",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": payload,
+            }
+        )
+        self.assertEqual(request.POST, {"name": ["value"]})
         with self.assertRaises(RawPostDataException):
             request.body
 
@@ -335,20 +398,24 @@ class RequestsTests(SimpleTestCase):
         # There are cases in which the multipart data is related instead of
         # being a binary upload, in which case it should still be accessible
         # via body.
-        payload_data = b"\r\n".join([
-            b'--boundary',
-            b'Content-ID: id; name="name"',
-            b'',
-            b'value',
-            b'--boundary--'
-            b''])
+        payload_data = b"\r\n".join(
+            [
+                b"--boundary",
+                b'Content-ID: id; name="name"',
+                b"",
+                b"value",
+                b"--boundary--" b"",
+            ]
+        )
         payload = FakePayload(payload_data)
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'multipart/related; boundary=boundary',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': payload,
-        })
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "multipart/related; boundary=boundary",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": payload,
+            }
+        )
         self.assertEqual(request.POST, {})
         self.assertEqual(request.body, payload_data)
 
@@ -360,28 +427,34 @@ class RequestsTests(SimpleTestCase):
         # https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
         # Every request.POST with Content-Length >= 0 is a valid request,
         # this test ensures that we handle Content-Length == 0.
-        payload = FakePayload("\r\n".join([
-            '--boundary',
-            'Content-Disposition: form-data; name="name"',
-            '',
-            'value',
-            '--boundary--'
-            '']))
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
-            'CONTENT_LENGTH': 0,
-            'wsgi.input': payload,
-        })
+        payload = FakePayload(
+            "\r\n".join(
+                [
+                    "--boundary",
+                    'Content-Disposition: form-data; name="name"',
+                    "",
+                    "value",
+                    "--boundary--" "",
+                ]
+            )
+        )
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "multipart/form-data; boundary=boundary",
+                "CONTENT_LENGTH": 0,
+                "wsgi.input": payload,
+            }
+        )
         self.assertEqual(request.POST, {})
 
     def test_POST_binary_only(self):
-        payload = b'\r\n\x01\x00\x00\x00ab\x00\x00\xcd\xcc,@'
+        payload = b"\r\n\x01\x00\x00\x00ab\x00\x00\xcd\xcc,@"
         environ = {
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'application/octet-stream',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': BytesIO(payload),
+            "REQUEST_METHOD": "POST",
+            "CONTENT_TYPE": "application/octet-stream",
+            "CONTENT_LENGTH": len(payload),
+            "wsgi.input": BytesIO(payload),
         }
         request = WSGIRequest(environ)
         self.assertEqual(request.POST, {})
@@ -389,112 +462,136 @@ class RequestsTests(SimpleTestCase):
         self.assertEqual(request.body, payload)
 
         # Same test without specifying content-type
-        environ.update({'CONTENT_TYPE': '', 'wsgi.input': BytesIO(payload)})
+        environ.update({"CONTENT_TYPE": "", "wsgi.input": BytesIO(payload)})
         request = WSGIRequest(environ)
         self.assertEqual(request.POST, {})
         self.assertEqual(request.FILES, {})
         self.assertEqual(request.body, payload)
 
     def test_read_by_lines(self):
-        payload = FakePayload('name=value')
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': payload,
-        })
-        self.assertEqual(list(request), [b'name=value'])
+        payload = FakePayload("name=value")
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "application/x-www-form-urlencoded",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": payload,
+            }
+        )
+        self.assertEqual(list(request), [b"name=value"])
 
     def test_POST_after_body_read(self):
         """
         POST should be populated even if body is read first
         """
-        payload = FakePayload('name=value')
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': payload,
-        })
+        payload = FakePayload("name=value")
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "application/x-www-form-urlencoded",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": payload,
+            }
+        )
         request.body  # evaluate
-        self.assertEqual(request.POST, {'name': ['value']})
+        self.assertEqual(request.POST, {"name": ["value"]})
 
     def test_POST_after_body_read_and_stream_read(self):
         """
         POST should be populated even if body is read first, and then
         the stream is read second.
         """
-        payload = FakePayload('name=value')
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': payload,
-        })
+        payload = FakePayload("name=value")
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "application/x-www-form-urlencoded",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": payload,
+            }
+        )
         request.body  # evaluate
-        self.assertEqual(request.read(1), b'n')
-        self.assertEqual(request.POST, {'name': ['value']})
+        self.assertEqual(request.read(1), b"n")
+        self.assertEqual(request.POST, {"name": ["value"]})
 
     def test_POST_after_body_read_and_stream_read_multipart(self):
         """
         POST should be populated even if body is read first, and then
         the stream is read second. Using multipart/form-data instead of urlencoded.
         """
-        payload = FakePayload("\r\n".join([
-            '--boundary',
-            'Content-Disposition: form-data; name="name"',
-            '',
-            'value',
-            '--boundary--'
-            '']))
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': payload,
-        })
+        payload = FakePayload(
+            "\r\n".join(
+                [
+                    "--boundary",
+                    'Content-Disposition: form-data; name="name"',
+                    "",
+                    "value",
+                    "--boundary--" "",
+                ]
+            )
+        )
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "multipart/form-data; boundary=boundary",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": payload,
+            }
+        )
         request.body  # evaluate
         # Consume enough data to mess up the parsing:
-        self.assertEqual(request.read(13), b'--boundary\r\nC')
-        self.assertEqual(request.POST, {'name': ['value']})
+        self.assertEqual(request.read(13), b"--boundary\r\nC")
+        self.assertEqual(request.POST, {"name": ["value"]})
 
     def test_POST_immutable_for_multipart(self):
         """
         MultiPartParser.parse() leaves request.POST immutable.
         """
-        payload = FakePayload("\r\n".join([
-            '--boundary',
-            'Content-Disposition: form-data; name="name"',
-            '',
-            'value',
-            '--boundary--',
-        ]))
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': payload,
-        })
+        payload = FakePayload(
+            "\r\n".join(
+                [
+                    "--boundary",
+                    'Content-Disposition: form-data; name="name"',
+                    "",
+                    "value",
+                    "--boundary--",
+                ]
+            )
+        )
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "multipart/form-data; boundary=boundary",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": payload,
+            }
+        )
         self.assertFalse(request.POST._mutable)
 
     def test_multipart_without_boundary(self):
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'multipart/form-data;',
-            'CONTENT_LENGTH': 0,
-            'wsgi.input': FakePayload(),
-        })
-        with self.assertRaisesMessage(MultiPartParserError, 'Invalid boundary in multipart: None'):
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "multipart/form-data;",
+                "CONTENT_LENGTH": 0,
+                "wsgi.input": FakePayload(),
+            }
+        )
+        with self.assertRaisesMessage(
+            MultiPartParserError, "Invalid boundary in multipart: None"
+        ):
             request.POST
 
     def test_multipart_non_ascii_content_type(self):
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'multipart/form-data; boundary = \xe0',
-            'CONTENT_LENGTH': 0,
-            'wsgi.input': FakePayload(),
-        })
-        msg = 'Invalid non-ASCII Content-Type in multipart: multipart/form-data; boundary = à'
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "multipart/form-data; boundary = \xe0",
+                "CONTENT_LENGTH": 0,
+                "wsgi.input": FakePayload(),
+            }
+        )
+        msg = "Invalid non-ASCII Content-Type in multipart: multipart/form-data; boundary = à"
         with self.assertRaisesMessage(MultiPartParserError, msg):
             request.POST
 
@@ -503,223 +600,240 @@ class RequestsTests(SimpleTestCase):
         If wsgi.input.read() raises an exception while trying to read() the
         POST, the exception is identifiable (not a generic OSError).
         """
+
         class ExplodingBytesIO(BytesIO):
             def read(self, len=0):
-                raise OSError('kaboom!')
+                raise OSError("kaboom!")
 
-        payload = b'name=value'
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': ExplodingBytesIO(payload),
-        })
+        payload = b"name=value"
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "application/x-www-form-urlencoded",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": ExplodingBytesIO(payload),
+            }
+        )
         with self.assertRaises(UnreadablePostError):
             request.body
 
     def test_set_encoding_clears_POST(self):
-        payload = FakePayload('name=Hello Günter')
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': payload,
-        })
-        self.assertEqual(request.POST, {'name': ['Hello Günter']})
-        request.encoding = 'iso-8859-16'
-        self.assertEqual(request.POST, {'name': ['Hello GĂŒnter']})
+        payload = FakePayload("name=Hello Günter")
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "application/x-www-form-urlencoded",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": payload,
+            }
+        )
+        self.assertEqual(request.POST, {"name": ["Hello Günter"]})
+        request.encoding = "iso-8859-16"
+        self.assertEqual(request.POST, {"name": ["Hello GĂŒnter"]})
 
     def test_set_encoding_clears_GET(self):
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'GET',
-            'wsgi.input': '',
-            'QUERY_STRING': 'name=Hello%20G%C3%BCnter',
-        })
-        self.assertEqual(request.GET, {'name': ['Hello Günter']})
-        request.encoding = 'iso-8859-16'
-        self.assertEqual(request.GET, {'name': ['Hello G\u0102\u0152nter']})
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "GET",
+                "wsgi.input": "",
+                "QUERY_STRING": "name=Hello%20G%C3%BCnter",
+            }
+        )
+        self.assertEqual(request.GET, {"name": ["Hello Günter"]})
+        request.encoding = "iso-8859-16"
+        self.assertEqual(request.GET, {"name": ["Hello G\u0102\u0152nter"]})
 
     def test_FILES_connection_error(self):
         """
         If wsgi.input.read() raises an exception while trying to read() the
         FILES, the exception is identifiable (not a generic OSError).
         """
+
         class ExplodingBytesIO(BytesIO):
             def read(self, len=0):
-                raise OSError('kaboom!')
+                raise OSError("kaboom!")
 
-        payload = b'x'
-        request = WSGIRequest({
-            'REQUEST_METHOD': 'POST',
-            'CONTENT_TYPE': 'multipart/form-data; boundary=foo_',
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input': ExplodingBytesIO(payload),
-        })
+        payload = b"x"
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": "multipart/form-data; boundary=foo_",
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": ExplodingBytesIO(payload),
+            }
+        )
         with self.assertRaises(UnreadablePostError):
             request.FILES
 
-    @override_settings(ALLOWED_HOSTS=['example.com'])
+    @override_settings(ALLOWED_HOSTS=["example.com"])
     def test_get_raw_uri(self):
-        factory = RequestFactory(HTTP_HOST='evil.com')
-        request = factory.get('////absolute-uri')
-        self.assertEqual(request.get_raw_uri(), 'http://evil.com//absolute-uri')
+        factory = RequestFactory(HTTP_HOST="evil.com")
+        request = factory.get("////absolute-uri")
+        self.assertEqual(request.get_raw_uri(), "http://evil.com//absolute-uri")
 
-        request = factory.get('/?foo=bar')
-        self.assertEqual(request.get_raw_uri(), 'http://evil.com/?foo=bar')
+        request = factory.get("/?foo=bar")
+        self.assertEqual(request.get_raw_uri(), "http://evil.com/?foo=bar")
 
-        request = factory.get('/path/with:colons')
-        self.assertEqual(request.get_raw_uri(), 'http://evil.com/path/with:colons')
+        request = factory.get("/path/with:colons")
+        self.assertEqual(request.get_raw_uri(), "http://evil.com/path/with:colons")
 
 
 class HostValidationTests(SimpleTestCase):
     poisoned_hosts = [
-        'example.com@evil.tld',
-        'example.com:dr.frankenstein@evil.tld',
-        'example.com:dr.frankenstein@evil.tld:80',
-        'example.com:80/badpath',
-        'example.com: recovermypassword.com',
+        "example.com@evil.tld",
+        "example.com:dr.frankenstein@evil.tld",
+        "example.com:dr.frankenstein@evil.tld:80",
+        "example.com:80/badpath",
+        "example.com: recovermypassword.com",
     ]
 
     @override_settings(
         USE_X_FORWARDED_HOST=False,
         ALLOWED_HOSTS=[
-            'forward.com', 'example.com', 'internal.com', '12.34.56.78',
-            '[2001:19f0:feee::dead:beef:cafe]', 'xn--4ca9at.com',
-            '.multitenant.com', 'INSENSITIVE.com', '[::ffff:169.254.169.254]',
-        ])
+            "forward.com",
+            "example.com",
+            "internal.com",
+            "12.34.56.78",
+            "[2001:19f0:feee::dead:beef:cafe]",
+            "xn--4ca9at.com",
+            ".multitenant.com",
+            "INSENSITIVE.com",
+            "[::ffff:169.254.169.254]",
+        ],
+    )
     def test_http_get_host(self):
         # Check if X_FORWARDED_HOST is provided.
         request = HttpRequest()
         request.META = {
-            'HTTP_X_FORWARDED_HOST': 'forward.com',
-            'HTTP_HOST': 'example.com',
-            'SERVER_NAME': 'internal.com',
-            'SERVER_PORT': 80,
+            "HTTP_X_FORWARDED_HOST": "forward.com",
+            "HTTP_HOST": "example.com",
+            "SERVER_NAME": "internal.com",
+            "SERVER_PORT": 80,
         }
         # X_FORWARDED_HOST is ignored.
-        self.assertEqual(request.get_host(), 'example.com')
+        self.assertEqual(request.get_host(), "example.com")
 
         # Check if X_FORWARDED_HOST isn't provided.
         request = HttpRequest()
         request.META = {
-            'HTTP_HOST': 'example.com',
-            'SERVER_NAME': 'internal.com',
-            'SERVER_PORT': 80,
+            "HTTP_HOST": "example.com",
+            "SERVER_NAME": "internal.com",
+            "SERVER_PORT": 80,
         }
-        self.assertEqual(request.get_host(), 'example.com')
+        self.assertEqual(request.get_host(), "example.com")
 
         # Check if HTTP_HOST isn't provided.
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'internal.com',
-            'SERVER_PORT': 80,
+            "SERVER_NAME": "internal.com",
+            "SERVER_PORT": 80,
         }
-        self.assertEqual(request.get_host(), 'internal.com')
+        self.assertEqual(request.get_host(), "internal.com")
 
         # Check if HTTP_HOST isn't provided, and we're on a nonstandard port
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'internal.com',
-            'SERVER_PORT': 8042,
+            "SERVER_NAME": "internal.com",
+            "SERVER_PORT": 8042,
         }
-        self.assertEqual(request.get_host(), 'internal.com:8042')
+        self.assertEqual(request.get_host(), "internal.com:8042")
 
         legit_hosts = [
-            'example.com',
-            'example.com:80',
-            '12.34.56.78',
-            '12.34.56.78:443',
-            '[2001:19f0:feee::dead:beef:cafe]',
-            '[2001:19f0:feee::dead:beef:cafe]:8080',
-            'xn--4ca9at.com',  # Punycode for öäü.com
-            'anything.multitenant.com',
-            'multitenant.com',
-            'insensitive.com',
-            'example.com.',
-            'example.com.:80',
-            '[::ffff:169.254.169.254]',
+            "example.com",
+            "example.com:80",
+            "12.34.56.78",
+            "12.34.56.78:443",
+            "[2001:19f0:feee::dead:beef:cafe]",
+            "[2001:19f0:feee::dead:beef:cafe]:8080",
+            "xn--4ca9at.com",  # Punycode for öäü.com
+            "anything.multitenant.com",
+            "multitenant.com",
+            "insensitive.com",
+            "example.com.",
+            "example.com.:80",
+            "[::ffff:169.254.169.254]",
         ]
 
         for host in legit_hosts:
             request = HttpRequest()
             request.META = {
-                'HTTP_HOST': host,
+                "HTTP_HOST": host,
             }
             request.get_host()
 
         # Poisoned host headers are rejected as suspicious
-        for host in chain(self.poisoned_hosts, ['other.com', 'example.com..']):
+        for host in chain(self.poisoned_hosts, ["other.com", "example.com.."]):
             with self.assertRaises(DisallowedHost):
                 request = HttpRequest()
                 request.META = {
-                    'HTTP_HOST': host,
+                    "HTTP_HOST": host,
                 }
                 request.get_host()
 
-    @override_settings(USE_X_FORWARDED_HOST=True, ALLOWED_HOSTS=['*'])
+    @override_settings(USE_X_FORWARDED_HOST=True, ALLOWED_HOSTS=["*"])
     def test_http_get_host_with_x_forwarded_host(self):
         # Check if X_FORWARDED_HOST is provided.
         request = HttpRequest()
         request.META = {
-            'HTTP_X_FORWARDED_HOST': 'forward.com',
-            'HTTP_HOST': 'example.com',
-            'SERVER_NAME': 'internal.com',
-            'SERVER_PORT': 80,
+            "HTTP_X_FORWARDED_HOST": "forward.com",
+            "HTTP_HOST": "example.com",
+            "SERVER_NAME": "internal.com",
+            "SERVER_PORT": 80,
         }
         # X_FORWARDED_HOST is obeyed.
-        self.assertEqual(request.get_host(), 'forward.com')
+        self.assertEqual(request.get_host(), "forward.com")
 
         # Check if X_FORWARDED_HOST is provided with a port.
         request = HttpRequest()
         request.META = {
-            'HTTP_X_FORWARDED_HOST': 'forward.com:8080',
-            'HTTP_HOST': 'example.com',
-            'SERVER_NAME': 'internal.com',
-            'SERVER_PORT': 80,
+            "HTTP_X_FORWARDED_HOST": "forward.com:8080",
+            "HTTP_HOST": "example.com",
+            "SERVER_NAME": "internal.com",
+            "SERVER_PORT": 80,
         }
         # X_FORWARDED_HOST is obeyed.
-        self.assertEqual(request.get_host(), 'forward.com:8080')
+        self.assertEqual(request.get_host(), "forward.com:8080")
 
         # Check if X_FORWARDED_HOST isn't provided.
         request = HttpRequest()
         request.META = {
-            'HTTP_HOST': 'example.com',
-            'SERVER_NAME': 'internal.com',
-            'SERVER_PORT': 80,
+            "HTTP_HOST": "example.com",
+            "SERVER_NAME": "internal.com",
+            "SERVER_PORT": 80,
         }
-        self.assertEqual(request.get_host(), 'example.com')
+        self.assertEqual(request.get_host(), "example.com")
 
         # Check if HTTP_HOST isn't provided.
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'internal.com',
-            'SERVER_PORT': 80,
+            "SERVER_NAME": "internal.com",
+            "SERVER_PORT": 80,
         }
-        self.assertEqual(request.get_host(), 'internal.com')
+        self.assertEqual(request.get_host(), "internal.com")
 
         # Check if HTTP_HOST isn't provided, and we're on a nonstandard port
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'internal.com',
-            'SERVER_PORT': 8042,
+            "SERVER_NAME": "internal.com",
+            "SERVER_PORT": 8042,
         }
-        self.assertEqual(request.get_host(), 'internal.com:8042')
+        self.assertEqual(request.get_host(), "internal.com:8042")
 
         # Poisoned host headers are rejected as suspicious
         legit_hosts = [
-            'example.com',
-            'example.com:80',
-            '12.34.56.78',
-            '12.34.56.78:443',
-            '[2001:19f0:feee::dead:beef:cafe]',
-            '[2001:19f0:feee::dead:beef:cafe]:8080',
-            'xn--4ca9at.com',  # Punycode for öäü.com
+            "example.com",
+            "example.com:80",
+            "12.34.56.78",
+            "12.34.56.78:443",
+            "[2001:19f0:feee::dead:beef:cafe]",
+            "[2001:19f0:feee::dead:beef:cafe]:8080",
+            "xn--4ca9at.com",  # Punycode for öäü.com
         ]
 
         for host in legit_hosts:
             request = HttpRequest()
             request.META = {
-                'HTTP_HOST': host,
+                "HTTP_HOST": host,
             }
             request.get_host()
 
@@ -727,145 +841,141 @@ class HostValidationTests(SimpleTestCase):
             with self.assertRaises(DisallowedHost):
                 request = HttpRequest()
                 request.META = {
-                    'HTTP_HOST': host,
+                    "HTTP_HOST": host,
                 }
                 request.get_host()
 
     @override_settings(
-        USE_X_FORWARDED_PORT=True,
-        USE_X_FORWARDED_HOST=False,
-        ALLOWED_HOSTS=['*'])
+        USE_X_FORWARDED_PORT=True, USE_X_FORWARDED_HOST=False, ALLOWED_HOSTS=["*"]
+    )
     def test_get_host_with_use_x_forwarded_port_and_http_host(self):
         request = HttpRequest()
         request.META = {
-            'HTTP_HOST': 'original.com',
-            'SERVER_PORT': '8000',
-            'HTTP_X_FORWARDED_HOST': 'example.com',
-            'HTTP_X_FORWARDED_PORT': '8080',
+            "HTTP_HOST": "original.com",
+            "SERVER_PORT": "8000",
+            "HTTP_X_FORWARDED_HOST": "example.com",
+            "HTTP_X_FORWARDED_PORT": "8080",
         }
         # Should NOT use the X-Forwarded-Port header
-        self.assertEqual(request.get_host(), 'original.com:8080')
-        self.assertEqual(request.get_port(), '8080')
+        self.assertEqual(request.get_host(), "original.com:8080")
+        self.assertEqual(request.get_port(), "8080")
 
     @override_settings(USE_X_FORWARDED_PORT=False)
     def test_get_port(self):
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '8080',
-            'HTTP_X_FORWARDED_PORT': '80',
+            "SERVER_NAME": "testserver",
+            "SERVER_PORT": "8080",
+            "HTTP_X_FORWARDED_PORT": "80",
         }
         # Shouldn't use the X-Forwarded-Port header
-        self.assertEqual(request.get_port(), '8080')
+        self.assertEqual(request.get_port(), "8080")
 
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '8080',
+            "SERVER_NAME": "testserver",
+            "SERVER_PORT": "8080",
         }
-        self.assertEqual(request.get_port(), '8080')
+        self.assertEqual(request.get_port(), "8080")
 
     @override_settings(USE_X_FORWARDED_PORT=True)
     def test_get_port_with_x_forwarded_port(self):
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '8080',
-            'HTTP_X_FORWARDED_PORT': '80',
+            "SERVER_NAME": "testserver",
+            "SERVER_PORT": "8080",
+            "HTTP_X_FORWARDED_PORT": "80",
         }
         # Should use the X-Forwarded-Port header
-        self.assertEqual(request.get_port(), '80')
+        self.assertEqual(request.get_port(), "80")
 
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '8080',
+            "SERVER_NAME": "testserver",
+            "SERVER_PORT": "8080",
         }
-        self.assertEqual(request.get_port(), '8080')
+        self.assertEqual(request.get_port(), "8080")
 
     @override_settings(USE_X_FORWARDED_HOST=True)
     def test_get_port_with_x_forwarded_host(self):
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '8080',
-            'HTTP_X_FORWARDED_HOST': 'example.com:8000',
+            "SERVER_NAME": "testserver",
+            "SERVER_PORT": "8080",
+            "HTTP_X_FORWARDED_HOST": "example.com:8000",
         }
         # Should use the X-Forwarded-Host header
-        with override_settings(ALLOWED_HOSTS=['example.com']):
-            self.assertEqual(request.get_port(), '8000')
+        with override_settings(ALLOWED_HOSTS=["example.com"]):
+            self.assertEqual(request.get_port(), "8000")
 
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '8080',
+            "SERVER_NAME": "testserver",
+            "SERVER_PORT": "8080",
         }
-        self.assertEqual(request.get_port(), '8080')
+        self.assertEqual(request.get_port(), "8080")
 
     @override_settings(USE_X_FORWARDED_HOST=True)
     def test_get_port_with_x_forwarded_host_ipv6(self):
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '8080',
-            'HTTP_X_FORWARDED_HOST': '[2001:19f0:feee::dead:beef:cafe]:8000',
+            "SERVER_NAME": "testserver",
+            "SERVER_PORT": "8080",
+            "HTTP_X_FORWARDED_HOST": "[2001:19f0:feee::dead:beef:cafe]:8000",
         }
         # Should use the X-Forwarded-Host header
-        with override_settings(ALLOWED_HOSTS=['[2001:19f0:feee::dead:beef:cafe]']):
-            self.assertEqual(request.get_port(), '8000')
+        with override_settings(ALLOWED_HOSTS=["[2001:19f0:feee::dead:beef:cafe]"]):
+            self.assertEqual(request.get_port(), "8000")
 
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '8080',
+            "SERVER_NAME": "testserver",
+            "SERVER_PORT": "8080",
         }
-        self.assertEqual(request.get_port(), '8080')
+        self.assertEqual(request.get_port(), "8080")
 
-    @override_settings(USE_X_FORWARDED_HOST=True,
-                       USE_X_FORWARDED_PORT=True)
+    @override_settings(USE_X_FORWARDED_HOST=True, USE_X_FORWARDED_PORT=True)
     def test_get_port_with_x_forwarded_host_and_port(self):
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '8080',
-            'HTTP_X_FORWARDED_HOST': 'example.com',
-            'HTTP_X_FORWARDED_PORT': '8010',
+            "SERVER_NAME": "testserver",
+            "SERVER_PORT": "8080",
+            "HTTP_X_FORWARDED_HOST": "example.com",
+            "HTTP_X_FORWARDED_PORT": "8010",
         }
-        with override_settings(ALLOWED_HOSTS=['example.com']):
+        with override_settings(ALLOWED_HOSTS=["example.com"]):
             # Should use the X-Forwarded-Port header
-            self.assertEqual(request.get_port(), '8010')
+            self.assertEqual(request.get_port(), "8010")
 
         request = HttpRequest()
         request.META = {
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '8080',
+            "SERVER_NAME": "testserver",
+            "SERVER_PORT": "8080",
         }
-        self.assertEqual(request.get_port(), '8080')
+        self.assertEqual(request.get_port(), "8080")
 
     @override_settings(
-        USE_X_FORWARDED_PORT=True,
-        USE_X_FORWARDED_HOST=True,
-        ALLOWED_HOSTS=['*'])
+        USE_X_FORWARDED_PORT=True, USE_X_FORWARDED_HOST=True, ALLOWED_HOSTS=["*"]
+    )
     def test_get_host_with_x_forwarded_port(self):
         request = HttpRequest()
         request.META = {
-            'SERVER_PORT': '80',
-            'HTTP_X_FORWARDED_HOST': 'example.com',
-            'HTTP_X_FORWARDED_PORT': '8080',
+            "SERVER_PORT": "80",
+            "HTTP_X_FORWARDED_HOST": "example.com",
+            "HTTP_X_FORWARDED_PORT": "8080",
         }
         # Should use the X-Forwarded-Port header
-        self.assertEqual(request.get_host(), 'example.com:8080')
+        self.assertEqual(request.get_host(), "example.com:8080")
 
     @override_settings(
-        USE_X_FORWARDED_PORT=True,
-        USE_X_FORWARDED_HOST=True,
-        ALLOWED_HOSTS=['*'])
+        USE_X_FORWARDED_PORT=True, USE_X_FORWARDED_HOST=True, ALLOWED_HOSTS=["*"]
+    )
     def test_get_host_with_use_x_forwarded_port_and_port_in_host(self):
         request = HttpRequest()
         request.META = {
-            'SERVER_PORT': '80',
-            'HTTP_X_FORWARDED_HOST': 'example.com:8081',
-            'HTTP_X_FORWARDED_PORT': '8080',
+            "SERVER_PORT": "80",
+            "HTTP_X_FORWARDED_HOST": "example.com:8081",
+            "HTTP_X_FORWARDED_PORT": "8080",
         }
         # Should use the X-Forwarded-Port header
         with self.assertRaises(ImproperlyConfigured):
@@ -877,16 +987,16 @@ class HostValidationTests(SimpleTestCase):
         If ALLOWED_HOSTS is empty and DEBUG is True, variants of localhost are
         allowed.
         """
-        valid_hosts = ['localhost', 'subdomain.localhost', '127.0.0.1', '[::1]']
+        valid_hosts = ["localhost", "subdomain.localhost", "127.0.0.1", "[::1]"]
         for host in valid_hosts:
             request = HttpRequest()
-            request.META = {'HTTP_HOST': host}
+            request.META = {"HTTP_HOST": host}
             self.assertEqual(request.get_host(), host)
 
         # Other hostnames raise a DisallowedHost.
         with self.assertRaises(DisallowedHost):
             request = HttpRequest()
-            request.META = {'HTTP_HOST': 'example.com'}
+            request.META = {"HTTP_HOST": "example.com"}
             request.get_host()
 
     @override_settings(ALLOWED_HOSTS=[])
@@ -894,45 +1004,54 @@ class HostValidationTests(SimpleTestCase):
         """get_host() makes helpful suggestions if a valid-looking host is not in ALLOWED_HOSTS."""
         msg_invalid_host = "Invalid HTTP_HOST header: %r."
         msg_suggestion = msg_invalid_host + " You may need to add %r to ALLOWED_HOSTS."
-        msg_suggestion2 = msg_invalid_host + " The domain name provided is not valid according to RFC 1034/1035"
+        msg_suggestion2 = (
+            msg_invalid_host
+            + " The domain name provided is not valid according to RFC 1034/1035"
+        )
 
         for host in [  # Valid-looking hosts
-            'example.com',
-            '12.34.56.78',
-            '[2001:19f0:feee::dead:beef:cafe]',
-            'xn--4ca9at.com',  # Punycode for öäü.com
+            "example.com",
+            "12.34.56.78",
+            "[2001:19f0:feee::dead:beef:cafe]",
+            "xn--4ca9at.com",  # Punycode for öäü.com
         ]:
             request = HttpRequest()
-            request.META = {'HTTP_HOST': host}
-            with self.assertRaisesMessage(DisallowedHost, msg_suggestion % (host, host)):
+            request.META = {"HTTP_HOST": host}
+            with self.assertRaisesMessage(
+                DisallowedHost, msg_suggestion % (host, host)
+            ):
                 request.get_host()
 
         for domain, port in [  # Valid-looking hosts with a port number
-            ('example.com', 80),
-            ('12.34.56.78', 443),
-            ('[2001:19f0:feee::dead:beef:cafe]', 8080),
+            ("example.com", 80),
+            ("12.34.56.78", 443),
+            ("[2001:19f0:feee::dead:beef:cafe]", 8080),
         ]:
-            host = '%s:%s' % (domain, port)
+            host = "%s:%s" % (domain, port)
             request = HttpRequest()
-            request.META = {'HTTP_HOST': host}
-            with self.assertRaisesMessage(DisallowedHost, msg_suggestion % (host, domain)):
+            request.META = {"HTTP_HOST": host}
+            with self.assertRaisesMessage(
+                DisallowedHost, msg_suggestion % (host, domain)
+            ):
                 request.get_host()
 
         for host in self.poisoned_hosts:
             request = HttpRequest()
-            request.META = {'HTTP_HOST': host}
+            request.META = {"HTTP_HOST": host}
             with self.assertRaisesMessage(DisallowedHost, msg_invalid_host % host):
                 request.get_host()
 
         request = HttpRequest()
-        request.META = {'HTTP_HOST': "invalid_hostname.com"}
-        with self.assertRaisesMessage(DisallowedHost, msg_suggestion2 % "invalid_hostname.com"):
+        request.META = {"HTTP_HOST": "invalid_hostname.com"}
+        with self.assertRaisesMessage(
+            DisallowedHost, msg_suggestion2 % "invalid_hostname.com"
+        ):
             request.get_host()
 
     def test_split_domain_port_removes_trailing_dot(self):
-        domain, port = split_domain_port('example.com.:8080')
-        self.assertEqual(domain, 'example.com')
-        self.assertEqual(port, '8080')
+        domain, port = split_domain_port("example.com.:8080")
+        self.assertEqual(domain, "example.com")
+        self.assertEqual(port, "8080")
 
 
 class BuildAbsoluteURITests(SimpleTestCase):
@@ -940,116 +1059,127 @@ class BuildAbsoluteURITests(SimpleTestCase):
 
     def test_absolute_url(self):
         request = HttpRequest()
-        url = 'https://www.example.com/asdf'
+        url = "https://www.example.com/asdf"
         self.assertEqual(request.build_absolute_uri(location=url), url)
 
     def test_host_retrieval(self):
         request = HttpRequest()
-        request.get_host = lambda: 'www.example.com'
-        request.path = ''
+        request.get_host = lambda: "www.example.com"
+        request.path = ""
         self.assertEqual(
-            request.build_absolute_uri(location='/path/with:colons'),
-            'http://www.example.com/path/with:colons'
+            request.build_absolute_uri(location="/path/with:colons"),
+            "http://www.example.com/path/with:colons",
         )
 
     def test_request_path_begins_with_two_slashes(self):
         # //// creates a request with a path beginning with //
-        request = self.factory.get('////absolute-uri')
+        request = self.factory.get("////absolute-uri")
         tests = (
             # location isn't provided
-            (None, 'http://testserver//absolute-uri'),
+            (None, "http://testserver//absolute-uri"),
             # An absolute URL
-            ('http://example.com/?foo=bar', 'http://example.com/?foo=bar'),
+            ("http://example.com/?foo=bar", "http://example.com/?foo=bar"),
             # A schema-relative URL
-            ('//example.com/?foo=bar', 'http://example.com/?foo=bar'),
+            ("//example.com/?foo=bar", "http://example.com/?foo=bar"),
             # Relative URLs
-            ('/foo/bar/', 'http://testserver/foo/bar/'),
-            ('/foo/./bar/', 'http://testserver/foo/bar/'),
-            ('/foo/../bar/', 'http://testserver/bar/'),
-            ('///foo/bar/', 'http://testserver/foo/bar/'),
+            ("/foo/bar/", "http://testserver/foo/bar/"),
+            ("/foo/./bar/", "http://testserver/foo/bar/"),
+            ("/foo/../bar/", "http://testserver/bar/"),
+            ("///foo/bar/", "http://testserver/foo/bar/"),
         )
         for location, expected_url in tests:
             with self.subTest(location=location):
-                self.assertEqual(request.build_absolute_uri(location=location), expected_url)
+                self.assertEqual(
+                    request.build_absolute_uri(location=location), expected_url
+                )
 
 
 class RequestHeadersTests(SimpleTestCase):
     ENVIRON = {
         # Non-headers are ignored.
-        'PATH_INFO': '/somepath/',
-        'REQUEST_METHOD': 'get',
-        'wsgi.input': BytesIO(b''),
-        'SERVER_NAME': 'internal.com',
-        'SERVER_PORT': 80,
+        "PATH_INFO": "/somepath/",
+        "REQUEST_METHOD": "get",
+        "wsgi.input": BytesIO(b""),
+        "SERVER_NAME": "internal.com",
+        "SERVER_PORT": 80,
         # These non-HTTP prefixed headers are included.
-        'CONTENT_TYPE': 'text/html',
-        'CONTENT_LENGTH': '100',
+        "CONTENT_TYPE": "text/html",
+        "CONTENT_LENGTH": "100",
         # All HTTP-prefixed headers are included.
-        'HTTP_ACCEPT': '*',
-        'HTTP_HOST': 'example.com',
-        'HTTP_USER_AGENT': 'python-requests/1.2.0',
+        "HTTP_ACCEPT": "*",
+        "HTTP_HOST": "example.com",
+        "HTTP_USER_AGENT": "python-requests/1.2.0",
     }
 
     def test_base_request_headers(self):
         request = HttpRequest()
         request.META = self.ENVIRON
-        self.assertEqual(dict(request.headers), {
-            'Content-Type': 'text/html',
-            'Content-Length': '100',
-            'Accept': '*',
-            'Host': 'example.com',
-            'User-Agent': 'python-requests/1.2.0',
-        })
+        self.assertEqual(
+            dict(request.headers),
+            {
+                "Content-Type": "text/html",
+                "Content-Length": "100",
+                "Accept": "*",
+                "Host": "example.com",
+                "User-Agent": "python-requests/1.2.0",
+            },
+        )
 
     def test_wsgi_request_headers(self):
         request = WSGIRequest(self.ENVIRON)
-        self.assertEqual(dict(request.headers), {
-            'Content-Type': 'text/html',
-            'Content-Length': '100',
-            'Accept': '*',
-            'Host': 'example.com',
-            'User-Agent': 'python-requests/1.2.0',
-        })
+        self.assertEqual(
+            dict(request.headers),
+            {
+                "Content-Type": "text/html",
+                "Content-Length": "100",
+                "Accept": "*",
+                "Host": "example.com",
+                "User-Agent": "python-requests/1.2.0",
+            },
+        )
 
     def test_wsgi_request_headers_getitem(self):
         request = WSGIRequest(self.ENVIRON)
-        self.assertEqual(request.headers['User-Agent'], 'python-requests/1.2.0')
-        self.assertEqual(request.headers['user-agent'], 'python-requests/1.2.0')
-        self.assertEqual(request.headers['user_agent'], 'python-requests/1.2.0')
-        self.assertEqual(request.headers['Content-Type'], 'text/html')
-        self.assertEqual(request.headers['Content-Length'], '100')
+        self.assertEqual(request.headers["User-Agent"], "python-requests/1.2.0")
+        self.assertEqual(request.headers["user-agent"], "python-requests/1.2.0")
+        self.assertEqual(request.headers["user_agent"], "python-requests/1.2.0")
+        self.assertEqual(request.headers["Content-Type"], "text/html")
+        self.assertEqual(request.headers["Content-Length"], "100")
 
     def test_wsgi_request_headers_get(self):
         request = WSGIRequest(self.ENVIRON)
-        self.assertEqual(request.headers.get('User-Agent'), 'python-requests/1.2.0')
-        self.assertEqual(request.headers.get('user-agent'), 'python-requests/1.2.0')
-        self.assertEqual(request.headers.get('Content-Type'), 'text/html')
-        self.assertEqual(request.headers.get('Content-Length'), '100')
+        self.assertEqual(request.headers.get("User-Agent"), "python-requests/1.2.0")
+        self.assertEqual(request.headers.get("user-agent"), "python-requests/1.2.0")
+        self.assertEqual(request.headers.get("Content-Type"), "text/html")
+        self.assertEqual(request.headers.get("Content-Length"), "100")
 
 
 class HttpHeadersTests(SimpleTestCase):
     def test_basic(self):
         environ = {
-            'CONTENT_TYPE': 'text/html',
-            'CONTENT_LENGTH': '100',
-            'HTTP_HOST': 'example.com',
+            "CONTENT_TYPE": "text/html",
+            "CONTENT_LENGTH": "100",
+            "HTTP_HOST": "example.com",
         }
         headers = HttpHeaders(environ)
-        self.assertEqual(sorted(headers), ['Content-Length', 'Content-Type', 'Host'])
-        self.assertEqual(headers, {
-            'Content-Type': 'text/html',
-            'Content-Length': '100',
-            'Host': 'example.com',
-        })
+        self.assertEqual(sorted(headers), ["Content-Length", "Content-Type", "Host"])
+        self.assertEqual(
+            headers,
+            {
+                "Content-Type": "text/html",
+                "Content-Length": "100",
+                "Host": "example.com",
+            },
+        )
 
     def test_parse_header_name(self):
         tests = (
-            ('PATH_INFO', None),
-            ('HTTP_ACCEPT', 'Accept'),
-            ('HTTP_USER_AGENT', 'User-Agent'),
-            ('HTTP_X_FORWARDED_PROTO', 'X-Forwarded-Proto'),
-            ('CONTENT_TYPE', 'Content-Type'),
-            ('CONTENT_LENGTH', 'Content-Length'),
+            ("PATH_INFO", None),
+            ("HTTP_ACCEPT", "Accept"),
+            ("HTTP_USER_AGENT", "User-Agent"),
+            ("HTTP_X_FORWARDED_PROTO", "X-Forwarded-Proto"),
+            ("CONTENT_TYPE", "Content-Type"),
+            ("CONTENT_LENGTH", "Content-Length"),
         )
         for header, expected in tests:
             with self.subTest(header=header):

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -1,0 +1,1053 @@
+from io import BytesIO
+from itertools import chain
+from urllib.parse import urlencode
+
+from django.core.exceptions import DisallowedHost, ImproperlyConfigured
+from django.core.handlers.wsgi import LimitedStream, WSGIRequest
+from django.http import HttpRequest, RawPostDataException, UnreadablePostError
+from django.http.multipartparser import MultiPartParserError
+from django.http.request import HttpHeaders, split_domain_port
+from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.test.client import FakePayload
+
+
+class RequestsTests(SimpleTestCase):
+    def test_httprequest(self):
+        request = HttpRequest()
+        self.assertEqual(list(request.GET), [])
+        self.assertEqual(list(request.POST), [])
+        self.assertEqual(list(request.COOKIES), [])
+        self.assertEqual(list(request.META), [])
+
+        # .GET and .POST should be QueryDicts
+        self.assertEqual(request.GET.urlencode(), '')
+        self.assertEqual(request.POST.urlencode(), '')
+
+        # and FILES should be MultiValueDict
+        self.assertEqual(request.FILES.getlist('foo'), [])
+
+        self.assertIsNone(request.content_type)
+        self.assertIsNone(request.content_params)
+
+    def test_httprequest_full_path(self):
+        request = HttpRequest()
+        request.path = '/;some/?awful/=path/foo:bar/'
+        request.path_info = '/prefix' + request.path
+        request.META['QUERY_STRING'] = ';some=query&+query=string'
+        expected = '/%3Bsome/%3Fawful/%3Dpath/foo:bar/?;some=query&+query=string'
+        self.assertEqual(request.get_full_path(), expected)
+        self.assertEqual(request.get_full_path_info(), '/prefix' + expected)
+
+    def test_httprequest_full_path_with_query_string_and_fragment(self):
+        request = HttpRequest()
+        request.path = '/foo#bar'
+        request.path_info = '/prefix' + request.path
+        request.META['QUERY_STRING'] = 'baz#quux'
+        self.assertEqual(request.get_full_path(), '/foo%23bar?baz#quux')
+        self.assertEqual(request.get_full_path_info(), '/prefix/foo%23bar?baz#quux')
+
+    def test_httprequest_repr(self):
+        request = HttpRequest()
+        request.path = '/somepath/'
+        request.method = 'GET'
+        request.GET = {'get-key': 'get-value'}
+        request.POST = {'post-key': 'post-value'}
+        request.COOKIES = {'post-key': 'post-value'}
+        request.META = {'post-key': 'post-value'}
+        self.assertEqual(repr(request), "<HttpRequest: GET '/somepath/'>")
+
+    def test_httprequest_repr_invalid_method_and_path(self):
+        request = HttpRequest()
+        self.assertEqual(repr(request), "<HttpRequest>")
+        request = HttpRequest()
+        request.method = "GET"
+        self.assertEqual(repr(request), "<HttpRequest>")
+        request = HttpRequest()
+        request.path = ""
+        self.assertEqual(repr(request), "<HttpRequest>")
+
+    def test_wsgirequest(self):
+        request = WSGIRequest({
+            'PATH_INFO': 'bogus',
+            'REQUEST_METHOD': 'bogus',
+            'CONTENT_TYPE': 'text/html; charset=utf8',
+            'wsgi.input': BytesIO(b''),
+        })
+        self.assertEqual(list(request.GET), [])
+        self.assertEqual(list(request.POST), [])
+        self.assertEqual(list(request.COOKIES), [])
+        self.assertEqual(
+            set(request.META),
+            {'PATH_INFO', 'REQUEST_METHOD', 'SCRIPT_NAME', 'CONTENT_TYPE', 'wsgi.input'}
+        )
+        self.assertEqual(request.META['PATH_INFO'], 'bogus')
+        self.assertEqual(request.META['REQUEST_METHOD'], 'bogus')
+        self.assertEqual(request.META['SCRIPT_NAME'], '')
+        self.assertEqual(request.content_type, 'text/html')
+        self.assertEqual(request.content_params, {'charset': 'utf8'})
+
+    def test_wsgirequest_with_script_name(self):
+        """
+        The request's path is correctly assembled, regardless of whether or
+        not the SCRIPT_NAME has a trailing slash (#20169).
+        """
+        # With trailing slash
+        request = WSGIRequest({
+            'PATH_INFO': '/somepath/',
+            'SCRIPT_NAME': '/PREFIX/',
+            'REQUEST_METHOD': 'get',
+            'wsgi.input': BytesIO(b''),
+        })
+        self.assertEqual(request.path, '/PREFIX/somepath/')
+        # Without trailing slash
+        request = WSGIRequest({
+            'PATH_INFO': '/somepath/',
+            'SCRIPT_NAME': '/PREFIX',
+            'REQUEST_METHOD': 'get',
+            'wsgi.input': BytesIO(b''),
+        })
+        self.assertEqual(request.path, '/PREFIX/somepath/')
+
+    def test_wsgirequest_script_url_double_slashes(self):
+        """
+        WSGI squashes multiple successive slashes in PATH_INFO, WSGIRequest
+        should take that into account when populating request.path and
+        request.META['SCRIPT_NAME'] (#17133).
+        """
+        request = WSGIRequest({
+            'SCRIPT_URL': '/mst/milestones//accounts/login//help',
+            'PATH_INFO': '/milestones/accounts/login/help',
+            'REQUEST_METHOD': 'get',
+            'wsgi.input': BytesIO(b''),
+        })
+        self.assertEqual(request.path, '/mst/milestones/accounts/login/help')
+        self.assertEqual(request.META['SCRIPT_NAME'], '/mst')
+
+    def test_wsgirequest_with_force_script_name(self):
+        """
+        The FORCE_SCRIPT_NAME setting takes precedence over the request's
+        SCRIPT_NAME environment parameter (#20169).
+        """
+        with override_settings(FORCE_SCRIPT_NAME='/FORCED_PREFIX/'):
+            request = WSGIRequest({
+                'PATH_INFO': '/somepath/',
+                'SCRIPT_NAME': '/PREFIX/',
+                'REQUEST_METHOD': 'get',
+                'wsgi.input': BytesIO(b''),
+            })
+            self.assertEqual(request.path, '/FORCED_PREFIX/somepath/')
+
+    def test_wsgirequest_path_with_force_script_name_trailing_slash(self):
+        """
+        The request's path is correctly assembled, regardless of whether or not
+        the FORCE_SCRIPT_NAME setting has a trailing slash (#20169).
+        """
+        # With trailing slash
+        with override_settings(FORCE_SCRIPT_NAME='/FORCED_PREFIX/'):
+            request = WSGIRequest({'PATH_INFO': '/somepath/', 'REQUEST_METHOD': 'get', 'wsgi.input': BytesIO(b'')})
+            self.assertEqual(request.path, '/FORCED_PREFIX/somepath/')
+        # Without trailing slash
+        with override_settings(FORCE_SCRIPT_NAME='/FORCED_PREFIX'):
+            request = WSGIRequest({'PATH_INFO': '/somepath/', 'REQUEST_METHOD': 'get', 'wsgi.input': BytesIO(b'')})
+            self.assertEqual(request.path, '/FORCED_PREFIX/somepath/')
+
+    def test_wsgirequest_repr(self):
+        request = WSGIRequest({'REQUEST_METHOD': 'get', 'wsgi.input': BytesIO(b'')})
+        self.assertEqual(repr(request), "<WSGIRequest: GET '/'>")
+        request = WSGIRequest({'PATH_INFO': '/somepath/', 'REQUEST_METHOD': 'get', 'wsgi.input': BytesIO(b'')})
+        request.GET = {'get-key': 'get-value'}
+        request.POST = {'post-key': 'post-value'}
+        request.COOKIES = {'post-key': 'post-value'}
+        request.META = {'post-key': 'post-value'}
+        self.assertEqual(repr(request), "<WSGIRequest: GET '/somepath/'>")
+
+    def test_wsgirequest_path_info(self):
+        def wsgi_str(path_info, encoding='utf-8'):
+            path_info = path_info.encode(encoding)  # Actual URL sent by the browser (bytestring)
+            path_info = path_info.decode('iso-8859-1')  # Value in the WSGI environ dict (native string)
+            return path_info
+        # Regression for #19468
+        request = WSGIRequest({'PATH_INFO': wsgi_str("/سلام/"), 'REQUEST_METHOD': 'get', 'wsgi.input': BytesIO(b'')})
+        self.assertEqual(request.path, "/سلام/")
+
+        # The URL may be incorrectly encoded in a non-UTF-8 encoding (#26971)
+        request = WSGIRequest({
+            'PATH_INFO': wsgi_str("/café/", encoding='iso-8859-1'),
+            'REQUEST_METHOD': 'get',
+            'wsgi.input': BytesIO(b''),
+        })
+        # Since it's impossible to decide the (wrong) encoding of the URL, it's
+        # left percent-encoded in the path.
+        self.assertEqual(request.path, "/caf%E9/")
+
+    def test_limited_stream(self):
+        # Read all of a limited stream
+        stream = LimitedStream(BytesIO(b'test'), 2)
+        self.assertEqual(stream.read(), b'te')
+        # Reading again returns nothing.
+        self.assertEqual(stream.read(), b'')
+
+        # Read a number of characters greater than the stream has to offer
+        stream = LimitedStream(BytesIO(b'test'), 2)
+        self.assertEqual(stream.read(5), b'te')
+        # Reading again returns nothing.
+        self.assertEqual(stream.readline(5), b'')
+
+        # Read sequentially from a stream
+        stream = LimitedStream(BytesIO(b'12345678'), 8)
+        self.assertEqual(stream.read(5), b'12345')
+        self.assertEqual(stream.read(5), b'678')
+        # Reading again returns nothing.
+        self.assertEqual(stream.readline(5), b'')
+
+        # Read lines from a stream
+        stream = LimitedStream(BytesIO(b'1234\n5678\nabcd\nefgh\nijkl'), 24)
+        # Read a full line, unconditionally
+        self.assertEqual(stream.readline(), b'1234\n')
+        # Read a number of characters less than a line
+        self.assertEqual(stream.readline(2), b'56')
+        # Read the rest of the partial line
+        self.assertEqual(stream.readline(), b'78\n')
+        # Read a full line, with a character limit greater than the line length
+        self.assertEqual(stream.readline(6), b'abcd\n')
+        # Read the next line, deliberately terminated at the line end
+        self.assertEqual(stream.readline(4), b'efgh')
+        # Read the next line... just the line end
+        self.assertEqual(stream.readline(), b'\n')
+        # Read everything else.
+        self.assertEqual(stream.readline(), b'ijkl')
+
+        # Regression for #15018
+        # If a stream contains a newline, but the provided length
+        # is less than the number of provided characters, the newline
+        # doesn't reset the available character count
+        stream = LimitedStream(BytesIO(b'1234\nabcdef'), 9)
+        self.assertEqual(stream.readline(10), b'1234\n')
+        self.assertEqual(stream.readline(3), b'abc')
+        # Now expire the available characters
+        self.assertEqual(stream.readline(3), b'd')
+        # Reading again returns nothing.
+        self.assertEqual(stream.readline(2), b'')
+
+        # Same test, but with read, not readline.
+        stream = LimitedStream(BytesIO(b'1234\nabcdef'), 9)
+        self.assertEqual(stream.read(6), b'1234\na')
+        self.assertEqual(stream.read(2), b'bc')
+        self.assertEqual(stream.read(2), b'd')
+        self.assertEqual(stream.read(2), b'')
+        self.assertEqual(stream.read(), b'')
+
+    def test_stream(self):
+        payload = FakePayload('name=value')
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload},
+        )
+        self.assertEqual(request.read(), b'name=value')
+
+    def test_read_after_value(self):
+        """
+        Reading from request is allowed after accessing request contents as
+        POST or body.
+        """
+        payload = FakePayload('name=value')
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        self.assertEqual(request.POST, {'name': ['value']})
+        self.assertEqual(request.body, b'name=value')
+        self.assertEqual(request.read(), b'name=value')
+
+    def test_value_after_read(self):
+        """
+        Construction of POST or body is not allowed after reading
+        from request.
+        """
+        payload = FakePayload('name=value')
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        self.assertEqual(request.read(2), b'na')
+        with self.assertRaises(RawPostDataException):
+            request.body
+        self.assertEqual(request.POST, {})
+
+    def test_non_ascii_POST(self):
+        payload = FakePayload(urlencode({'key': 'España'}))
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_LENGTH': len(payload),
+            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
+            'wsgi.input': payload,
+        })
+        self.assertEqual(request.POST, {'key': ['España']})
+
+    def test_alternate_charset_POST(self):
+        """
+        Test a POST with non-utf-8 payload encoding.
+        """
+        payload = FakePayload(urlencode({'key': 'España'.encode('latin-1')}))
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_LENGTH': len(payload),
+            'CONTENT_TYPE': 'application/x-www-form-urlencoded; charset=iso-8859-1',
+            'wsgi.input': payload,
+        })
+        self.assertEqual(request.POST, {'key': ['España']})
+
+    def test_body_after_POST_multipart_form_data(self):
+        """
+        Reading body after parsing multipart/form-data is not allowed
+        """
+        # Because multipart is used for large amounts of data i.e. file uploads,
+        # we don't want the data held in memory twice, and we don't want to
+        # silence the error by setting body = '' either.
+        payload = FakePayload("\r\n".join([
+            '--boundary',
+            'Content-Disposition: form-data; name="name"',
+            '',
+            'value',
+            '--boundary--'
+            '']))
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        self.assertEqual(request.POST, {'name': ['value']})
+        with self.assertRaises(RawPostDataException):
+            request.body
+
+    def test_body_after_POST_multipart_related(self):
+        """
+        Reading body after parsing multipart that isn't form-data is allowed
+        """
+        # Ticket #9054
+        # There are cases in which the multipart data is related instead of
+        # being a binary upload, in which case it should still be accessible
+        # via body.
+        payload_data = b"\r\n".join([
+            b'--boundary',
+            b'Content-ID: id; name="name"',
+            b'',
+            b'value',
+            b'--boundary--'
+            b''])
+        payload = FakePayload(payload_data)
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'multipart/related; boundary=boundary',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        self.assertEqual(request.POST, {})
+        self.assertEqual(request.body, payload_data)
+
+    def test_POST_multipart_with_content_length_zero(self):
+        """
+        Multipart POST requests with Content-Length >= 0 are valid and need to be handled.
+        """
+        # According to:
+        # https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
+        # Every request.POST with Content-Length >= 0 is a valid request,
+        # this test ensures that we handle Content-Length == 0.
+        payload = FakePayload("\r\n".join([
+            '--boundary',
+            'Content-Disposition: form-data; name="name"',
+            '',
+            'value',
+            '--boundary--'
+            '']))
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
+            'CONTENT_LENGTH': 0,
+            'wsgi.input': payload,
+        })
+        self.assertEqual(request.POST, {})
+
+    def test_POST_binary_only(self):
+        payload = b'\r\n\x01\x00\x00\x00ab\x00\x00\xcd\xcc,@'
+        environ = {
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'application/octet-stream',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': BytesIO(payload),
+        }
+        request = WSGIRequest(environ)
+        self.assertEqual(request.POST, {})
+        self.assertEqual(request.FILES, {})
+        self.assertEqual(request.body, payload)
+
+        # Same test without specifying content-type
+        environ.update({'CONTENT_TYPE': '', 'wsgi.input': BytesIO(payload)})
+        request = WSGIRequest(environ)
+        self.assertEqual(request.POST, {})
+        self.assertEqual(request.FILES, {})
+        self.assertEqual(request.body, payload)
+
+    def test_read_by_lines(self):
+        payload = FakePayload('name=value')
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        self.assertEqual(list(request), [b'name=value'])
+
+    def test_POST_after_body_read(self):
+        """
+        POST should be populated even if body is read first
+        """
+        payload = FakePayload('name=value')
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        request.body  # evaluate
+        self.assertEqual(request.POST, {'name': ['value']})
+
+    def test_POST_after_body_read_and_stream_read(self):
+        """
+        POST should be populated even if body is read first, and then
+        the stream is read second.
+        """
+        payload = FakePayload('name=value')
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        request.body  # evaluate
+        self.assertEqual(request.read(1), b'n')
+        self.assertEqual(request.POST, {'name': ['value']})
+
+    def test_POST_after_body_read_and_stream_read_multipart(self):
+        """
+        POST should be populated even if body is read first, and then
+        the stream is read second. Using multipart/form-data instead of urlencoded.
+        """
+        payload = FakePayload("\r\n".join([
+            '--boundary',
+            'Content-Disposition: form-data; name="name"',
+            '',
+            'value',
+            '--boundary--'
+            '']))
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        request.body  # evaluate
+        # Consume enough data to mess up the parsing:
+        self.assertEqual(request.read(13), b'--boundary\r\nC')
+        self.assertEqual(request.POST, {'name': ['value']})
+
+    def test_POST_immutable_for_multipart(self):
+        """
+        MultiPartParser.parse() leaves request.POST immutable.
+        """
+        payload = FakePayload("\r\n".join([
+            '--boundary',
+            'Content-Disposition: form-data; name="name"',
+            '',
+            'value',
+            '--boundary--',
+        ]))
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        self.assertFalse(request.POST._mutable)
+
+    def test_multipart_without_boundary(self):
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'multipart/form-data;',
+            'CONTENT_LENGTH': 0,
+            'wsgi.input': FakePayload(),
+        })
+        with self.assertRaisesMessage(MultiPartParserError, 'Invalid boundary in multipart: None'):
+            request.POST
+
+    def test_multipart_non_ascii_content_type(self):
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'multipart/form-data; boundary = \xe0',
+            'CONTENT_LENGTH': 0,
+            'wsgi.input': FakePayload(),
+        })
+        msg = 'Invalid non-ASCII Content-Type in multipart: multipart/form-data; boundary = à'
+        with self.assertRaisesMessage(MultiPartParserError, msg):
+            request.POST
+
+    def test_POST_connection_error(self):
+        """
+        If wsgi.input.read() raises an exception while trying to read() the
+        POST, the exception is identifiable (not a generic OSError).
+        """
+        class ExplodingBytesIO(BytesIO):
+            def read(self, len=0):
+                raise OSError('kaboom!')
+
+        payload = b'name=value'
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': ExplodingBytesIO(payload),
+        })
+        with self.assertRaises(UnreadablePostError):
+            request.body
+
+    def test_set_encoding_clears_POST(self):
+        payload = FakePayload('name=Hello Günter')
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'application/x-www-form-urlencoded',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        self.assertEqual(request.POST, {'name': ['Hello Günter']})
+        request.encoding = 'iso-8859-16'
+        self.assertEqual(request.POST, {'name': ['Hello GĂŒnter']})
+
+    def test_set_encoding_clears_GET(self):
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'GET',
+            'wsgi.input': '',
+            'QUERY_STRING': 'name=Hello%20G%C3%BCnter',
+        })
+        self.assertEqual(request.GET, {'name': ['Hello Günter']})
+        request.encoding = 'iso-8859-16'
+        self.assertEqual(request.GET, {'name': ['Hello G\u0102\u0152nter']})
+
+    def test_FILES_connection_error(self):
+        """
+        If wsgi.input.read() raises an exception while trying to read() the
+        FILES, the exception is identifiable (not a generic OSError).
+        """
+        class ExplodingBytesIO(BytesIO):
+            def read(self, len=0):
+                raise OSError('kaboom!')
+
+        payload = b'x'
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'multipart/form-data; boundary=foo_',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': ExplodingBytesIO(payload),
+        })
+        with self.assertRaises(UnreadablePostError):
+            request.FILES
+
+    @override_settings(ALLOWED_HOSTS=['example.com'])
+    def test_get_raw_uri(self):
+        factory = RequestFactory(HTTP_HOST='evil.com')
+        request = factory.get('////absolute-uri')
+        self.assertEqual(request.get_raw_uri(), 'http://evil.com//absolute-uri')
+
+        request = factory.get('/?foo=bar')
+        self.assertEqual(request.get_raw_uri(), 'http://evil.com/?foo=bar')
+
+        request = factory.get('/path/with:colons')
+        self.assertEqual(request.get_raw_uri(), 'http://evil.com/path/with:colons')
+
+
+class HostValidationTests(SimpleTestCase):
+    poisoned_hosts = [
+        'example.com@evil.tld',
+        'example.com:dr.frankenstein@evil.tld',
+        'example.com:dr.frankenstein@evil.tld:80',
+        'example.com:80/badpath',
+        'example.com: recovermypassword.com',
+    ]
+
+    @override_settings(
+        USE_X_FORWARDED_HOST=False,
+        ALLOWED_HOSTS=[
+            'forward.com', 'example.com', 'internal.com', '12.34.56.78',
+            '[2001:19f0:feee::dead:beef:cafe]', 'xn--4ca9at.com',
+            '.multitenant.com', 'INSENSITIVE.com', '[::ffff:169.254.169.254]',
+        ])
+    def test_http_get_host(self):
+        # Check if X_FORWARDED_HOST is provided.
+        request = HttpRequest()
+        request.META = {
+            'HTTP_X_FORWARDED_HOST': 'forward.com',
+            'HTTP_HOST': 'example.com',
+            'SERVER_NAME': 'internal.com',
+            'SERVER_PORT': 80,
+        }
+        # X_FORWARDED_HOST is ignored.
+        self.assertEqual(request.get_host(), 'example.com')
+
+        # Check if X_FORWARDED_HOST isn't provided.
+        request = HttpRequest()
+        request.META = {
+            'HTTP_HOST': 'example.com',
+            'SERVER_NAME': 'internal.com',
+            'SERVER_PORT': 80,
+        }
+        self.assertEqual(request.get_host(), 'example.com')
+
+        # Check if HTTP_HOST isn't provided.
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'internal.com',
+            'SERVER_PORT': 80,
+        }
+        self.assertEqual(request.get_host(), 'internal.com')
+
+        # Check if HTTP_HOST isn't provided, and we're on a nonstandard port
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'internal.com',
+            'SERVER_PORT': 8042,
+        }
+        self.assertEqual(request.get_host(), 'internal.com:8042')
+
+        legit_hosts = [
+            'example.com',
+            'example.com:80',
+            '12.34.56.78',
+            '12.34.56.78:443',
+            '[2001:19f0:feee::dead:beef:cafe]',
+            '[2001:19f0:feee::dead:beef:cafe]:8080',
+            'xn--4ca9at.com',  # Punycode for öäü.com
+            'anything.multitenant.com',
+            'multitenant.com',
+            'insensitive.com',
+            'example.com.',
+            'example.com.:80',
+            '[::ffff:169.254.169.254]',
+        ]
+
+        for host in legit_hosts:
+            request = HttpRequest()
+            request.META = {
+                'HTTP_HOST': host,
+            }
+            request.get_host()
+
+        # Poisoned host headers are rejected as suspicious
+        for host in chain(self.poisoned_hosts, ['other.com', 'example.com..']):
+            with self.assertRaises(DisallowedHost):
+                request = HttpRequest()
+                request.META = {
+                    'HTTP_HOST': host,
+                }
+                request.get_host()
+
+    @override_settings(USE_X_FORWARDED_HOST=True, ALLOWED_HOSTS=['*'])
+    def test_http_get_host_with_x_forwarded_host(self):
+        # Check if X_FORWARDED_HOST is provided.
+        request = HttpRequest()
+        request.META = {
+            'HTTP_X_FORWARDED_HOST': 'forward.com',
+            'HTTP_HOST': 'example.com',
+            'SERVER_NAME': 'internal.com',
+            'SERVER_PORT': 80,
+        }
+        # X_FORWARDED_HOST is obeyed.
+        self.assertEqual(request.get_host(), 'forward.com')
+
+        # Check if X_FORWARDED_HOST is provided with a port.
+        request = HttpRequest()
+        request.META = {
+            'HTTP_X_FORWARDED_HOST': 'forward.com:8080',
+            'HTTP_HOST': 'example.com',
+            'SERVER_NAME': 'internal.com',
+            'SERVER_PORT': 80,
+        }
+        # X_FORWARDED_HOST is obeyed.
+        self.assertEqual(request.get_host(), 'forward.com:8080')
+
+        # Check if X_FORWARDED_HOST isn't provided.
+        request = HttpRequest()
+        request.META = {
+            'HTTP_HOST': 'example.com',
+            'SERVER_NAME': 'internal.com',
+            'SERVER_PORT': 80,
+        }
+        self.assertEqual(request.get_host(), 'example.com')
+
+        # Check if HTTP_HOST isn't provided.
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'internal.com',
+            'SERVER_PORT': 80,
+        }
+        self.assertEqual(request.get_host(), 'internal.com')
+
+        # Check if HTTP_HOST isn't provided, and we're on a nonstandard port
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'internal.com',
+            'SERVER_PORT': 8042,
+        }
+        self.assertEqual(request.get_host(), 'internal.com:8042')
+
+        # Poisoned host headers are rejected as suspicious
+        legit_hosts = [
+            'example.com',
+            'example.com:80',
+            '12.34.56.78',
+            '12.34.56.78:443',
+            '[2001:19f0:feee::dead:beef:cafe]',
+            '[2001:19f0:feee::dead:beef:cafe]:8080',
+            'xn--4ca9at.com',  # Punycode for öäü.com
+        ]
+
+        for host in legit_hosts:
+            request = HttpRequest()
+            request.META = {
+                'HTTP_HOST': host,
+            }
+            request.get_host()
+
+        for host in self.poisoned_hosts:
+            with self.assertRaises(DisallowedHost):
+                request = HttpRequest()
+                request.META = {
+                    'HTTP_HOST': host,
+                }
+                request.get_host()
+
+    @override_settings(
+        USE_X_FORWARDED_PORT=True,
+        USE_X_FORWARDED_HOST=False,
+        ALLOWED_HOSTS=['*'])
+    def test_get_host_with_use_x_forwarded_port_and_http_host(self):
+        request = HttpRequest()
+        request.META = {
+            'HTTP_HOST': 'original.com',
+            'SERVER_PORT': '8000',
+            'HTTP_X_FORWARDED_HOST': 'example.com',
+            'HTTP_X_FORWARDED_PORT': '8080',
+        }
+        # Should NOT use the X-Forwarded-Port header
+        self.assertEqual(request.get_host(), 'original.com:8080')
+        self.assertEqual(request.get_port(), '8080')
+
+    @override_settings(USE_X_FORWARDED_PORT=False)
+    def test_get_port(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+            'HTTP_X_FORWARDED_PORT': '80',
+        }
+        # Shouldn't use the X-Forwarded-Port header
+        self.assertEqual(request.get_port(), '8080')
+
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+        }
+        self.assertEqual(request.get_port(), '8080')
+
+    @override_settings(USE_X_FORWARDED_PORT=True)
+    def test_get_port_with_x_forwarded_port(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+            'HTTP_X_FORWARDED_PORT': '80',
+        }
+        # Should use the X-Forwarded-Port header
+        self.assertEqual(request.get_port(), '80')
+
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+        }
+        self.assertEqual(request.get_port(), '8080')
+
+    @override_settings(USE_X_FORWARDED_HOST=True)
+    def test_get_port_with_x_forwarded_host(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+            'HTTP_X_FORWARDED_HOST': 'example.com:8000',
+        }
+        # Should use the X-Forwarded-Host header
+        self.assertEqual(request.get_port(), '8000')
+
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+        }
+        self.assertEqual(request.get_port(), '8080')
+
+    @override_settings(USE_X_FORWARDED_HOST=True)
+    def test_get_port_with_x_forwarded_host_ipv6(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+            'HTTP_X_FORWARDED_HOST': '[2001:19f0:feee::dead:beef:cafe]:8000',
+        }
+        # Should use the X-Forwarded-Host header
+        self.assertEqual(request.get_port(), '8000')
+
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+        }
+        self.assertEqual(request.get_port(), '8080')
+
+    @override_settings(USE_X_FORWARDED_HOST=True,
+                       USE_X_FORWARDED_PORT=True)
+    def test_get_port_with_x_forwarded_host_and_port(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+            'HTTP_X_FORWARDED_HOST': 'example.com',
+            'HTTP_X_FORWARDED_PORT': '8010',
+        }
+        # Should use the X-Forwarded-Port header
+        self.assertEqual(request.get_port(), '8010')
+
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '8080',
+        }
+        self.assertEqual(request.get_port(), '8080')
+
+    @override_settings(
+        USE_X_FORWARDED_PORT=True,
+        USE_X_FORWARDED_HOST=True,
+        ALLOWED_HOSTS=['*'])
+    def test_get_host_with_x_forwarded_port(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_PORT': '80',
+            'HTTP_X_FORWARDED_HOST': 'example.com',
+            'HTTP_X_FORWARDED_PORT': '8080',
+        }
+        # Should use the X-Forwarded-Port header
+        self.assertEqual(request.get_host(), 'example.com:8080')
+
+    @override_settings(
+        USE_X_FORWARDED_PORT=True,
+        USE_X_FORWARDED_HOST=True,
+        ALLOWED_HOSTS=['*'])
+    def test_get_host_with_use_x_forwarded_port_and_port_in_host(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_PORT': '80',
+            'HTTP_X_FORWARDED_HOST': 'example.com:8081',
+            'HTTP_X_FORWARDED_PORT': '8080',
+        }
+        # Should use the X-Forwarded-Port header
+        with self.assertRaises(ImproperlyConfigured):
+            request.get_host()
+
+    @override_settings(DEBUG=True, ALLOWED_HOSTS=[])
+    def test_host_validation_in_debug_mode(self):
+        """
+        If ALLOWED_HOSTS is empty and DEBUG is True, variants of localhost are
+        allowed.
+        """
+        valid_hosts = ['localhost', 'subdomain.localhost', '127.0.0.1', '[::1]']
+        for host in valid_hosts:
+            request = HttpRequest()
+            request.META = {'HTTP_HOST': host}
+            self.assertEqual(request.get_host(), host)
+
+        # Other hostnames raise a DisallowedHost.
+        with self.assertRaises(DisallowedHost):
+            request = HttpRequest()
+            request.META = {'HTTP_HOST': 'example.com'}
+            request.get_host()
+
+    @override_settings(ALLOWED_HOSTS=[])
+    def test_get_host_suggestion_of_allowed_host(self):
+        """get_host() makes helpful suggestions if a valid-looking host is not in ALLOWED_HOSTS."""
+        msg_invalid_host = "Invalid HTTP_HOST header: %r."
+        msg_suggestion = msg_invalid_host + " You may need to add %r to ALLOWED_HOSTS."
+        msg_suggestion2 = msg_invalid_host + " The domain name provided is not valid according to RFC 1034/1035"
+
+        for host in [  # Valid-looking hosts
+            'example.com',
+            '12.34.56.78',
+            '[2001:19f0:feee::dead:beef:cafe]',
+            'xn--4ca9at.com',  # Punycode for öäü.com
+        ]:
+            request = HttpRequest()
+            request.META = {'HTTP_HOST': host}
+            with self.assertRaisesMessage(DisallowedHost, msg_suggestion % (host, host)):
+                request.get_host()
+
+        for domain, port in [  # Valid-looking hosts with a port number
+            ('example.com', 80),
+            ('12.34.56.78', 443),
+            ('[2001:19f0:feee::dead:beef:cafe]', 8080),
+        ]:
+            host = '%s:%s' % (domain, port)
+            request = HttpRequest()
+            request.META = {'HTTP_HOST': host}
+            with self.assertRaisesMessage(DisallowedHost, msg_suggestion % (host, domain)):
+                request.get_host()
+
+        for host in self.poisoned_hosts:
+            request = HttpRequest()
+            request.META = {'HTTP_HOST': host}
+            with self.assertRaisesMessage(DisallowedHost, msg_invalid_host % host):
+                request.get_host()
+
+        request = HttpRequest()
+        request.META = {'HTTP_HOST': "invalid_hostname.com"}
+        with self.assertRaisesMessage(DisallowedHost, msg_suggestion2 % "invalid_hostname.com"):
+            request.get_host()
+
+    def test_split_domain_port_removes_trailing_dot(self):
+        domain, port = split_domain_port('example.com.:8080')
+        self.assertEqual(domain, 'example.com')
+        self.assertEqual(port, '8080')
+
+
+class BuildAbsoluteURITests(SimpleTestCase):
+    factory = RequestFactory()
+
+    def test_absolute_url(self):
+        request = HttpRequest()
+        url = 'https://www.example.com/asdf'
+        self.assertEqual(request.build_absolute_uri(location=url), url)
+
+    def test_host_retrieval(self):
+        request = HttpRequest()
+        request.get_host = lambda: 'www.example.com'
+        request.path = ''
+        self.assertEqual(
+            request.build_absolute_uri(location='/path/with:colons'),
+            'http://www.example.com/path/with:colons'
+        )
+
+    def test_request_path_begins_with_two_slashes(self):
+        # //// creates a request with a path beginning with //
+        request = self.factory.get('////absolute-uri')
+        tests = (
+            # location isn't provided
+            (None, 'http://testserver//absolute-uri'),
+            # An absolute URL
+            ('http://example.com/?foo=bar', 'http://example.com/?foo=bar'),
+            # A schema-relative URL
+            ('//example.com/?foo=bar', 'http://example.com/?foo=bar'),
+            # Relative URLs
+            ('/foo/bar/', 'http://testserver/foo/bar/'),
+            ('/foo/./bar/', 'http://testserver/foo/bar/'),
+            ('/foo/../bar/', 'http://testserver/bar/'),
+            ('///foo/bar/', 'http://testserver/foo/bar/'),
+        )
+        for location, expected_url in tests:
+            with self.subTest(location=location):
+                self.assertEqual(request.build_absolute_uri(location=location), expected_url)
+
+
+class RequestHeadersTests(SimpleTestCase):
+    ENVIRON = {
+        # Non-headers are ignored.
+        'PATH_INFO': '/somepath/',
+        'REQUEST_METHOD': 'get',
+        'wsgi.input': BytesIO(b''),
+        'SERVER_NAME': 'internal.com',
+        'SERVER_PORT': 80,
+        # These non-HTTP prefixed headers are included.
+        'CONTENT_TYPE': 'text/html',
+        'CONTENT_LENGTH': '100',
+        # All HTTP-prefixed headers are included.
+        'HTTP_ACCEPT': '*',
+        'HTTP_HOST': 'example.com',
+        'HTTP_USER_AGENT': 'python-requests/1.2.0',
+    }
+
+    def test_base_request_headers(self):
+        request = HttpRequest()
+        request.META = self.ENVIRON
+        self.assertEqual(dict(request.headers), {
+            'Content-Type': 'text/html',
+            'Content-Length': '100',
+            'Accept': '*',
+            'Host': 'example.com',
+            'User-Agent': 'python-requests/1.2.0',
+        })
+
+    def test_wsgi_request_headers(self):
+        request = WSGIRequest(self.ENVIRON)
+        self.assertEqual(dict(request.headers), {
+            'Content-Type': 'text/html',
+            'Content-Length': '100',
+            'Accept': '*',
+            'Host': 'example.com',
+            'User-Agent': 'python-requests/1.2.0',
+        })
+
+    def test_wsgi_request_headers_getitem(self):
+        request = WSGIRequest(self.ENVIRON)
+        self.assertEqual(request.headers['User-Agent'], 'python-requests/1.2.0')
+        self.assertEqual(request.headers['user-agent'], 'python-requests/1.2.0')
+        self.assertEqual(request.headers['user_agent'], 'python-requests/1.2.0')
+        self.assertEqual(request.headers['Content-Type'], 'text/html')
+        self.assertEqual(request.headers['Content-Length'], '100')
+
+    def test_wsgi_request_headers_get(self):
+        request = WSGIRequest(self.ENVIRON)
+        self.assertEqual(request.headers.get('User-Agent'), 'python-requests/1.2.0')
+        self.assertEqual(request.headers.get('user-agent'), 'python-requests/1.2.0')
+        self.assertEqual(request.headers.get('Content-Type'), 'text/html')
+        self.assertEqual(request.headers.get('Content-Length'), '100')
+
+
+class HttpHeadersTests(SimpleTestCase):
+    def test_basic(self):
+        environ = {
+            'CONTENT_TYPE': 'text/html',
+            'CONTENT_LENGTH': '100',
+            'HTTP_HOST': 'example.com',
+        }
+        headers = HttpHeaders(environ)
+        self.assertEqual(sorted(headers), ['Content-Length', 'Content-Type', 'Host'])
+        self.assertEqual(headers, {
+            'Content-Type': 'text/html',
+            'Content-Length': '100',
+            'Host': 'example.com',
+        })
+
+    def test_parse_header_name(self):
+        tests = (
+            ('PATH_INFO', None),
+            ('HTTP_ACCEPT', 'Accept'),
+            ('HTTP_USER_AGENT', 'User-Agent'),
+            ('HTTP_X_FORWARDED_PROTO', 'X-Forwarded-Proto'),
+            ('CONTENT_TYPE', 'Content-Type'),
+            ('CONTENT_LENGTH', 'Content-Length'),
+        )
+        for header, expected in tests:
+            with self.subTest(header=header):
+                self.assertEqual(HttpHeaders.parse_header_name(header), expected)

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -792,7 +792,8 @@ class HostValidationTests(SimpleTestCase):
             'HTTP_X_FORWARDED_HOST': 'example.com:8000',
         }
         # Should use the X-Forwarded-Host header
-        self.assertEqual(request.get_port(), '8000')
+        with override_settings(ALLOWED_HOSTS=['example.com']):
+            self.assertEqual(request.get_port(), '8000')
 
         request = HttpRequest()
         request.META = {
@@ -810,7 +811,8 @@ class HostValidationTests(SimpleTestCase):
             'HTTP_X_FORWARDED_HOST': '[2001:19f0:feee::dead:beef:cafe]:8000',
         }
         # Should use the X-Forwarded-Host header
-        self.assertEqual(request.get_port(), '8000')
+        with override_settings(ALLOWED_HOSTS=['[2001:19f0:feee::dead:beef:cafe]']):
+            self.assertEqual(request.get_port(), '8000')
 
         request = HttpRequest()
         request.META = {
@@ -829,8 +831,9 @@ class HostValidationTests(SimpleTestCase):
             'HTTP_X_FORWARDED_HOST': 'example.com',
             'HTTP_X_FORWARDED_PORT': '8010',
         }
-        # Should use the X-Forwarded-Port header
-        self.assertEqual(request.get_port(), '8010')
+        with override_settings(ALLOWED_HOSTS=['example.com']):
+            # Should use the X-Forwarded-Port header
+            self.assertEqual(request.get_port(), '8010')
 
         request = HttpRequest()
         request.META = {

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -106,37 +106,42 @@ class SitesFrameworkTests(TestCase):
 
     @override_settings(SITE_ID=None, ALLOWED_HOSTS=["example.com", "example.net"])
     def test_get_current_site_no_site_id_and_handle_port_fallback(self):
-        request = HttpRequest()
         s1 = self.site
         s2 = Site.objects.create(domain="example.com:80", name="example.com:80")
 
         # Host header without port
-        request.META = {"HTTP_HOST": "example.com"}
+        request = HttpRequest()
+        request.META = {'HTTP_HOST': 'example.com'}
         site = get_current_site(request)
         self.assertEqual(site, s1)
 
         # Host header with port - match, no fallback without port
-        request.META = {"HTTP_HOST": "example.com:80"}
+        request = HttpRequest()
+        request.META = {'HTTP_HOST': 'example.com:80'}
         site = get_current_site(request)
         self.assertEqual(site, s2)
 
         # Host header with port - no match, fallback without port
-        request.META = {"HTTP_HOST": "example.com:81"}
+        request = HttpRequest()
+        request.META = {'HTTP_HOST': 'example.com:81'}
         site = get_current_site(request)
         self.assertEqual(site, s1)
 
         # Host header with non-matching domain
-        request.META = {"HTTP_HOST": "example.net"}
+        request = HttpRequest()
+        request.META = {'HTTP_HOST': 'example.net'}
         with self.assertRaises(ObjectDoesNotExist):
             get_current_site(request)
 
         # Ensure domain for RequestSite always matches host header
-        with self.modify_settings(INSTALLED_APPS={"remove": "django.contrib.sites"}):
-            request.META = {"HTTP_HOST": "example.com"}
+        with self.modify_settings(INSTALLED_APPS={'remove': 'django.contrib.sites'}):
+            request = HttpRequest()
+            request.META = {'HTTP_HOST': 'example.com'}
             site = get_current_site(request)
             self.assertEqual(site.name, "example.com")
 
-            request.META = {"HTTP_HOST": "example.com:80"}
+            request = HttpRequest()
+            request.META = {'HTTP_HOST': 'example.com:80'}
             site = get_current_site(request)
             self.assertEqual(site.name, "example.com:80")
 

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -111,37 +111,37 @@ class SitesFrameworkTests(TestCase):
 
         # Host header without port
         request = HttpRequest()
-        request.META = {'HTTP_HOST': 'example.com'}
+        request.META = {"HTTP_HOST": "example.com"}
         site = get_current_site(request)
         self.assertEqual(site, s1)
 
         # Host header with port - match, no fallback without port
         request = HttpRequest()
-        request.META = {'HTTP_HOST': 'example.com:80'}
+        request.META = {"HTTP_HOST": "example.com:80"}
         site = get_current_site(request)
         self.assertEqual(site, s2)
 
         # Host header with port - no match, fallback without port
         request = HttpRequest()
-        request.META = {'HTTP_HOST': 'example.com:81'}
+        request.META = {"HTTP_HOST": "example.com:81"}
         site = get_current_site(request)
         self.assertEqual(site, s1)
 
         # Host header with non-matching domain
         request = HttpRequest()
-        request.META = {'HTTP_HOST': 'example.net'}
+        request.META = {"HTTP_HOST": "example.net"}
         with self.assertRaises(ObjectDoesNotExist):
             get_current_site(request)
 
         # Ensure domain for RequestSite always matches host header
-        with self.modify_settings(INSTALLED_APPS={'remove': 'django.contrib.sites'}):
+        with self.modify_settings(INSTALLED_APPS={"remove": "django.contrib.sites"}):
             request = HttpRequest()
-            request.META = {'HTTP_HOST': 'example.com'}
+            request.META = {"HTTP_HOST": "example.com"}
             site = get_current_site(request)
             self.assertEqual(site.name, "example.com")
 
             request = HttpRequest()
-            request.META = {'HTTP_HOST': 'example.com:80'}
+            request.META = {"HTTP_HOST": "example.com:80"}
             site = get_current_site(request)
             self.assertEqual(site.name, "example.com:80")
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-31354

#### Branch description
Continued [#12844](https://github.com/django/django/pull/12844)
I've rebased it, replaced deprecated functions, removed unnecessary regex compilations, and replaced .format() statements with f-strings

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
