### PR TITLE
Fixed #35925 -- FilteredSelectMultiple filter icon missing padding in RTL

### DIFF
--- a/django/contrib/admin/static/admin/css/responsive.css
+++ b/django/contrib/admin/static/admin/css/responsive.css
@@ -254,10 +254,6 @@ input[type="submit"], button {
         align-items: center;
     }
 
-    .selector .selector-filter label {
-        margin: 0 8px 0 0;
-    }
-
     .selector .selector-filter input {
         width: 100%;
         min-height: 0;

--- a/django/contrib/admin/static/admin/css/responsive_rtl.css
+++ b/django/contrib/admin/static/admin/css/responsive_rtl.css
@@ -34,11 +34,6 @@
         background-position: calc(100% - 8px) 9px;
     }
 
-    [dir="rtl"] .selector .selector-filter label {
-        margin-right: 0;
-        margin-left: 8px;
-    }
-
     [dir="rtl"] .object-tools li {
         float: right;
     }

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -68,6 +68,7 @@
     margin: 0;
     text-align: left;
     display: flex;
+    gap: 8px;
 }
 
 .selector .selector-filter label,
@@ -84,11 +85,6 @@
 
 .selector-filter input {
     flex-grow: 1;
-}
-
-.selector .selector-available input,
-.selector .selector-chosen input {
-    margin-left: 8px;
 }
 
 .selector ul.selector-chooser {


### PR DESCRIPTION
Fixed #35925 -- FilteredSelectMultiple filter icon missing padding in RTL.

#### Trac ticket number
ticket-35925

#### Branch description
Fixed missing padding for the filter icon in the `FilteredSelectMultiple` widget in RTL (Right to Left) layout mode.

#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
