### PR TITLE
Removed trailing comma from the first "index" view example from tutorial 03 for consistency

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -234,9 +234,7 @@ Now let's update our ``index`` view in ``polls/views.py`` to use the template:
     def index(request):
         latest_question_list = Question.objects.order_by("-pub_date")[:5]
         template = loader.get_template("polls/index.html")
-        context = {
-            "latest_question_list": latest_question_list,
-        }
+        context = {"latest_question_list": latest_question_list}
         return HttpResponse(template.render(context, request))
 
 That code loads the template called  ``polls/index.html`` and passes it a


### PR DESCRIPTION
#### Branch description

The next version of the same code block doesn't have that comma. Having it inconsistently, makes the difference between two code blocks look bigger than it actually is

The first code block with `latest_question_list`, and the one being changed by this PR, under https://docs.djangoproject.com/en/5.1/intro/tutorial03/#write-views-that-actually-do-something

```python
from django.http import HttpResponse
from django.template import loader

from .models import Question


def index(request):
    latest_question_list = Question.objects.order_by("-pub_date")[:5]
    template = loader.get_template("polls/index.html")
    context = {
        "latest_question_list": latest_question_list,
    }
    return HttpResponse(template.render(context, request))
```

and the second example, the one without the trailing comma, under https://docs.djangoproject.com/en/5.1/intro/tutorial03/#a-shortcut-render

```python
from django.shortcuts import render

from .models import Question


def index(request):
    latest_question_list = Question.objects.order_by("-pub_date")[:5]
    context = {"latest_question_list": latest_question_list}
    return render(request, "polls/index.html", context)
```

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
