### PR TITLE
Refs #33735 -- Captured stderr during ASGITest.test_file_response.

### DIFF
--- a/tests/asgi/tests.py
+++ b/tests/asgi/tests.py
@@ -21,6 +21,7 @@ from django.test import (
     modify_settings,
     override_settings,
 )
+from django.test.utils import captured_stderr
 from django.urls import path
 from django.utils.http import http_date
 from django.views.decorators.csrf import csrf_exempt
@@ -95,7 +96,8 @@ class ASGITest(SimpleTestCase):
         with open(test_filename, "rb") as test_file:
             test_file_contents = test_file.read()
         # Read the response.
-        response_start = await communicator.receive_output()
+        with captured_stderr():
+            response_start = await communicator.receive_output()
         self.assertEqual(response_start["type"], "http.response.start")
         self.assertEqual(response_start["status"], 200)
         headers = response_start["headers"]


### PR DESCRIPTION
#### Before

```py
% ./runtests.py asgi.tests.ASGITest.test_file_response 
Testing against Django installed in '/Users/jwalls/django/django' with up to 10 processes
Found 1 test(s).
System check identified no issues (0 silenced).
/Users/jwalls/django/django/core/handlers/asgi.py:332: Warning: StreamingHttpResponse must consume synchronous iterators in order to serve them asynchronously. Use an asynchronous iterator instead.
  async for part in content:
.
----------------------------------------------------------------------
Ran 1 test in 0.005s

OK
```

#### After
```py
% ./runtests.py asgi.tests.ASGITest.test_file_response
Testing against Django installed in '/Users/jwalls/django/django' with up to 10 processes
Found 1 test(s).
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.005s

OK
```