### PR TITLE
Removed trailing whitespace in docs.

### DIFF
--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -198,7 +198,7 @@ Output is printed to the terminal, but can also be found in
     The execution of the command requires an internet connection and takes
     several minutes to complete, because the command tests all the links
     that are found in the documentation.
-    
+
 Entries that have a status of "working" are fine, those that are "unchecked" or
 "ignored" have been skipped because they either cannot be checked or have
 matched ignore rules in the configuration.

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -679,7 +679,7 @@ The following backends are available in :mod:`django.contrib.auth.backends`:
         user permissions and group permissions. Returns an empty set if
         :attr:`~django.contrib.auth.models.AbstractBaseUser.is_anonymous` or
         :attr:`~django.contrib.auth.models.CustomUser.is_active` is ``False``.
-    
+
         .. versionchanged:: 5.2
 
             ``aget_all_permissions()`` function was added.

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -1416,7 +1416,7 @@ Methods of ``BoundField``
 
 .. method:: BoundField.render(template_name=None, context=None, renderer=None)
 
-    The render method is called by ``as_field_group``. All arguments are 
+    The render method is called by ``as_field_group``. All arguments are
     optional and default to:
 
     * ``template_name``: :attr:`.BoundField.template_name`

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -392,7 +392,7 @@ be ignored in favor of the value from the form's initial data.
 .. attribute:: Field.template_name
 
 The ``template_name`` argument allows a custom template to be used when the
-field is rendered with :meth:`~django.forms.BoundField.as_field_group`. By 
+field is rendered with :meth:`~django.forms.BoundField.as_field_group`. By
 default this value is set to ``"django/forms/field.html"``. Can be changed per
 field by overriding this attribute or more generally by overriding the default
 template, see also :ref:`overriding-built-in-field-templates`.

--- a/docs/releases/3.1.6.txt
+++ b/docs/releases/3.1.6.txt
@@ -17,5 +17,5 @@ dot segments.
 Bugfixes
 ========
 
-* Fixed an admin layout issue in Django 3.1 where changelist filter controls 
+* Fixed an admin layout issue in Django 3.1 where changelist filter controls
   would become squashed (:ticket:`32391`).

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -116,8 +116,8 @@ Minor features
 * The default iteration count for the PBKDF2 password hasher is increased from
   720,000 to 870,000.
 
-* The default ``parallelism`` of the ``ScryptPasswordHasher`` is 
-  increased from 1 to 5, to follow OWASP recommendations.
+* The default ``parallelism`` of the ``ScryptPasswordHasher`` is increased from
+  1 to 5, to follow OWASP recommendations.
 
 * The new :class:`~django.contrib.auth.forms.AdminUserCreationForm` and
   the existing :class:`~django.contrib.auth.forms.AdminPasswordChangeForm` now


### PR DESCRIPTION
#### Trac ticket number

N/A

#### Branch description

These were found using `sphinx-lint`, which was brought up in the Django Discord.

#### Checklist

- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.