### PR TITLE
Refs #35842 -- Fixed handling of quotes in JSONField key lookups on Oracle.

### DIFF
--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -50,6 +50,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # The django_format_dtdelta() function doesn't properly handle mixed
         # Date/DateTime fields and timedeltas.
         "expressions.tests.FTimeDeltaTests.test_mixed_comparisons1",
+        # SQLite doesn't parse escaped double quotes in the JSON path notation,
+        # so it cannot match keys that contains double quotes (#35842).
+        "model_fields.test_jsonfield.TestQuerying."
+        "test_lookups_special_chars_double_quotes",
     }
     create_test_table_with_composite_primary_key = """
         CREATE TABLE test_table_composite_pk (


### PR DESCRIPTION
## Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35842

## Branch description

There are two parts here:

### Oracle

The ticket suggests using the `PASSING` clause on Oracle to pass the path expression as a bind variable. Oracle's documentation only shows examples of using the variable in a ["filter expression"](https://docs.oracle.com/en/database/oracle/oracle-database/23/adjsn/sql-json-path-expression-syntax.html#ADJSN-GUID-AEBAD813-99AB-418A-93AB-F96BC1658618) within the path notation, where the variable is compared to the value at a given path.

The given example is:

```sql
SELECT count(*) FROM j_purchaseorder
WHERE json_exists(po_document, '$.PONumber?(@ > $d)'
PASSING to_number(:1) AS "d" TYPE(STRICT));
```

In the query, the SQL bind parameter (`:1`) is bound to the SQL/JSON variable `d`. Then, the `d` variable is used in a "filter expression", which roughly translates to "the value at the key `PONumber` is greater than the value of `d`". It does not give you an example of something like:

```sql
SELECT count(*) FROM j_purchaseorder
WHERE json_exists(po_document, '$d'
PASSING :1 AS "d" TYPE(STRICT));
```

where `d` is used as part of the path itself. I tried implementing it in different ways (e.g. with or without a single quote around `$d`, doing `$.$d`, etc.), but I couldn't get it to work. I'm starting to think that it's just not supported, because their syntax for path expression can be much more complex (i.e. it can include things like the filter expressions), which might be the reason why it needs to be processed as part of the SQL query itself.

So, I opted for the other approach of using [a different quote delimiter](https://docs.oracle.com/cd/B19306_01/server.102/b14200/sql_elements003.htm#i42617). I'm not sure what is the best character to use, but apparently we can use `\uffff` which is a "non-character" code point. See also this StackOverflow question: https://stackoverflow.com/questions/6493956/least-used-unicode-delimiter

I also tried emojis and they do work, but I doubt we want to use that as the actual delimiter. I chose to use `\uffff` instead.

This issue likely also affects other places where we format the path expression directly to the SQL string, such as the `KeyTransform` implementation. I've updated that accordingly. (I have yet to add the tests though, will do that later.)

### SQLite

As mentioned in the ticket, there is no way we can support using double quotes that are properly escaped (for example, with other special characters like `.`).

I think the issue is a limitation on the SQLite itself and there's not much we can do about it. So for now, I just added a new database flag to acknowledge the behavior, and the corresponding tests with various special characters. The tests will fail on SQLite if they ever fix the bug in a new version.

## Livestream

I did a livestream as I worked on this ticket. The recording is up on youtube:  https://www.youtube.com/watch?v=_LlhHJCgPcs

(I set the noise gate for my mic a bit too high though, so my voice cuts in and out a bit unfortunately.)

## Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
