### PR TITLE
Fixed #35935 -- Colorized system checks when running sqlmigrate.

### DIFF
--- a/django/core/management/commands/sqlmigrate.py
+++ b/django/core/management/commands/sqlmigrate.py
@@ -32,10 +32,9 @@ class Command(BaseCommand):
         )
 
     def execute(self, *args, **options):
-        # sqlmigrate doesn't support coloring its output but we need to force
-        # no_color=True so that the BEGIN/COMMIT statements added by
-        # output_transaction don't get colored either.
-        options["no_color"] = True
+        # sqlmigrate doesn't support coloring its output, so make the
+        # BEGIN/COMMIT statements added by output_transaction colorless also.
+        self.style.SQL_KEYWORD = lambda noop: noop
         return super().execute(*args, **options)
 
     def handle(self, *args, **options):


### PR DESCRIPTION
#### Trac ticket number
ticket-35935

#### Branch description
Before, `sqlmigrate` forced `--no-color=True`, which prevented system check output from being colorized. Now, this limitation is removed.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
