### PR TITLE
Fixed #35939 -- Simplified and linked documentation for the Permission.content_type attribute.

### DIFF
--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -419,8 +419,8 @@ fields:
 
     .. attribute:: content_type
 
-        Required. A reference to the ``django_content_type`` database table,
-        which contains a record for each installed model.
+        Required. A foreign key to the
+        :class:`~django.contrib.contenttypes.models.ContentType` model.
 
     .. attribute:: codename
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35939

#### Branch description
The description for `content_type` now clearly states that it is a foreign key to the ContentType model and contains a link to the proper documentation.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
