### PR TITLE
Fixed #35944 -- Serialization of Unicode values

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -169,7 +169,7 @@ class ArrayField(CheckFieldDefaultMixin, Field):
             else:
                 obj = AttributeSetter(base_field.attname, val)
                 values.append(base_field.value_to_string(obj))
-        return json.dumps(values)
+        return json.dumps(values, ensure_ascii=False)
 
     def get_transform(self, name):
         transform = super().get_transform(name)

--- a/django/contrib/postgres/fields/hstore.py
+++ b/django/contrib/postgres/fields/hstore.py
@@ -43,7 +43,7 @@ class HStoreField(CheckFieldDefaultMixin, Field):
         return value
 
     def value_to_string(self, obj):
-        return json.dumps(self.value_from_object(obj))
+        return json.dumps(self.value_from_object(obj), ensure_ascii=False)
 
     def formfield(self, **kwargs):
         return super().formfield(

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -1008,6 +1008,33 @@ class TestSerialization(PostgreSQLSimpleTestCase):
         self.assertEqual(instance.field, [1, 2, None])
 
 
+class TestStringSerialization(PostgreSQLSimpleTestCase):
+    test_data = (
+        '[{"fields": {"field": "[\\"Django\\", \\"Python\\", null]"}, '
+        '"model": "postgres_tests.chararraymodel", "pk": null}]'
+    )
+
+    values = ["Django", "Python", None]
+
+    def test_encode(self):
+        instance = CharArrayModel(field=self.values)
+        data = serializers.serialize("json", [instance])
+        self.assertEqual(json.loads(data), json.loads(self.test_data))
+
+    def test_decode(self):
+        instance = list(serializers.deserialize("json", self.test_data))[0].object
+        self.assertEqual(instance.field, self.values)
+
+
+class TestUnicodeStringSerialization(TestStringSerialization):
+    test_data = (
+        '[{"fields": {"field": "[\\"Джанго\\", \\"פייתון\\", null, \\"król\\"]"}, '
+        '"model": "postgres_tests.chararraymodel", "pk": null}]'
+    )
+
+    values = ["Джанго", "פייתון", None, "król"]
+
+
 class TestValidation(PostgreSQLSimpleTestCase):
     def test_unbounded(self):
         field = ArrayField(models.IntegerField())

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -297,39 +297,53 @@ class TestChecks(PostgreSQLSimpleTestCase):
 
 
 class TestSerialization(PostgreSQLSimpleTestCase):
-    test_data = json.dumps(
-        [
-            {
-                "model": "postgres_tests.hstoremodel",
-                "pk": None,
-                "fields": {
-                    "field": json.dumps({"a": "b"}),
-                    "array_field": json.dumps(
-                        [
-                            json.dumps({"a": "b"}),
-                            json.dumps({"b": "a"}),
-                        ]
-                    ),
-                },
-            }
-        ]
-    )
+    test_field1 = {"a": "b"}
+    array_field1 = {"a": "b"}
+    array_field2 = {"b": "a"}
+    roundtrip_field = {"a": "b", "c": None}
+
+    def setUp(self):
+        self.test_data = json.dumps(
+            [
+                {
+                    "model": "postgres_tests.hstoremodel",
+                    "pk": None,
+                    "fields": {
+                        "field": json.dumps(self.test_field1, ensure_ascii=False),
+                        "array_field": json.dumps(
+                            [
+                                json.dumps(self.array_field1, ensure_ascii=False),
+                                json.dumps(self.array_field2, ensure_ascii=False),
+                            ]
+                        , ensure_ascii=False),
+                    },
+                }
+            ]
+        )
 
     def test_dumping(self):
-        instance = HStoreModel(field={"a": "b"}, array_field=[{"a": "b"}, {"b": "a"}])
+        instance = HStoreModel(field=self.test_field1, array_field=[self.array_field1, self.array_field2])
         data = serializers.serialize("json", [instance])
         self.assertEqual(json.loads(data), json.loads(self.test_data))
 
     def test_loading(self):
         instance = list(serializers.deserialize("json", self.test_data))[0].object
-        self.assertEqual(instance.field, {"a": "b"})
-        self.assertEqual(instance.array_field, [{"a": "b"}, {"b": "a"}])
+        self.assertEqual(instance.field, self.test_field1)
+        self.assertEqual(instance.array_field, [self.array_field1, self.array_field2])
 
     def test_roundtrip_with_null(self):
-        instance = HStoreModel(field={"a": "b", "c": None})
+        instance = HStoreModel(field=self.roundtrip_field)
         data = serializers.serialize("json", [instance])
         new_instance = list(serializers.deserialize("json", data))[0].object
         self.assertEqual(instance.field, new_instance.field)
+
+
+
+class TestUnicodeSerialization(TestSerialization):
+    test_field1 = {"все": "Трурль и Клапауций"}
+    array_field1 = {"Трурль": "Клапауций"}
+    array_field2 = {"Клапауций": "Трурль"}
+    roundtrip_field = {"Енеїда": "Ти знаєш, він який суціга", "Зефір": None}
 
 
 class TestValidation(PostgreSQLSimpleTestCase):


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35944

#### Branch description

- Change serialization method of ArrayField and HStoreField fields to allow Unicode characters to appear in dumpdata.
- Added tests.

Thanks to Simon Charette

#### Checklist
- [V ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ V] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [V ] I have checked the "Has patch" ticket flag in the Trac system.
- [V ] I have added or updated relevant tests.
- [V] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
