### PR TITLE
Fixed #35693 -- Made password validators callable.

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -104,6 +104,9 @@ class MinimumLengthValidator:
     def __init__(self, min_length=8):
         self.min_length = min_length
 
+    def __call__(self, *args, **kwargs):
+        return self.validate(*args, kwargs)
+
     def validate(self, password, user=None):
         if len(password) < self.min_length:
             raise ValidationError(self.get_error_message(), code="password_too_short")
@@ -175,6 +178,9 @@ class UserAttributeSimilarityValidator:
             raise ValueError("max_similarity must be at least 0.1")
         self.max_similarity = max_similarity
 
+    def __call__(self, *args, **kwargs):
+        return self.validate(*args, **kwargs)
+
     def validate(self, password, user=None):
         if not user:
             return
@@ -241,6 +247,9 @@ class CommonPasswordValidator:
             with open(password_list_path) as f:
                 self.passwords = {x.strip() for x in f}
 
+    def __call__(self, *args, **kwargs):
+        return self.validate(*args, **kwargs)
+
     def validate(self, password, user=None):
         if password.lower().strip() in self.passwords:
             raise ValidationError(
@@ -259,6 +268,9 @@ class NumericPasswordValidator:
     """
     Validate that the password is not entirely numeric.
     """
+
+    def __call__(self, *args, **kwargs):
+        return self.validate(*args, **kwargs)
 
     def validate(self, password, user=None):
         if password.isdigit():

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -91,6 +91,10 @@ Minor features
   now have a new method ``get_error_message()``, which can be overridden in
   subclasses to customize the error messages.
 
+* The :ref:`password validator classes <included-password-validators>`
+  now have a new method ``__call__()``, calling the password validator class
+  object will perform ``validate()`` method.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35693

#### Branch description
[Continue @iamkorniichuk's PR](https://github.com/django/django/pull/18481)
Implemented a `__call__`magic method to enable password validators to perform validate through `__call__`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
