### PR TITLE
The patch for XSS vulnerabilty in BaseModelAdmin.get_empty_value_display()

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -57,7 +57,7 @@ from django.template.response import SimpleTemplateResponse, TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.deprecation import RemovedInDjango60Warning
-from django.utils.html import format_html
+from django.utils.html import format_html, escape
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.text import (
@@ -378,9 +378,9 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         Return the empty_value_display set on ModelAdmin or AdminSite.
         """
         try:
-            return mark_safe(self.empty_value_display)
+            return escape(self.empty_value_display)
         except AttributeError:
-            return mark_safe(self.admin_site.empty_value_display)
+            return escape(self.admin_site.empty_value_display)
 
     def get_exclude(self, request, obj=None):
         """


### PR DESCRIPTION
## Description

The get_empty_value_display() function renders the value `self.empty_value_display` without sanitization, leading to potential XSS exploitation. I made this pull request to sanitize the string before rendering on the admin dashboard.

## Tested environment
- Platform: Windows 11
- Django: version 5.1.3

## Vulnerable code

```py
class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
...
     def get_empty_value_display(self):
        """
        Return the empty_value_display set on ModelAdmin or AdminSite.
        """
        try:
            return mark_safe(self.empty_value_display)
        except AttributeError:
            return mark_safe(self.admin_site.empty_value_display)
```

## PoC

```py
# models.py
class Author(models.Model):
    name = models.CharField(max_length=100)
    birth_date = models.DateField(null=True, blank=True)

class AuthorAdmin(admin.ModelAdmin):
    list_display = ('name', 'birth_date')
    empty_value_display = "\"><script>alert(document.domain)</script>"

admin.site.register(Author, AuthorAdmin)


```