### PR TITLE
Fixed #34624 -- Removed change, delete, and view buttons for non-Select widgets in RelatedFieldWidgetWrapper.

### DIFF
--- a/django/contrib/redirects/admin.py
+++ b/django/contrib/redirects/admin.py
@@ -7,4 +7,3 @@ class RedirectAdmin(admin.ModelAdmin):
     list_display = ("old_path", "new_path")
     list_filter = ("site",)
     search_fields = ("old_path", "new_path")
-    radio_fields = {"site": admin.VERTICAL}

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -978,6 +978,21 @@ class RelatedFieldWidgetWrapperTests(SimpleTestCase):
         """
         self.assertHTMLEqual(output, expected)
 
+    def test_non_select_widget_cant_change_delete_related(self):
+        main_band = Event._meta.get_field("main_band")
+        widget = widgets.AdminRadioSelect()
+        wrapper = widgets.RelatedFieldWidgetWrapper(
+            widget,
+            main_band,
+            widget_admin_site,
+            can_add_related=True,
+            can_change_related=True,
+            can_delete_related=True,
+        )
+        self.assertTrue(wrapper.can_add_related)
+        self.assertFalse(wrapper.can_change_related)
+        self.assertFalse(wrapper.can_delete_related)
+
 
 @override_settings(ROOT_URLCONF="admin_widgets.urls")
 class AdminWidgetSeleniumTestCase(AdminSeleniumTestCase):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-34624](https://code.djangoproject.com/ticket/34624)

#### Branch description
I continued working on the [PR](https://github.com/django/django/pull/17158) for @allcaps.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
