### PR TITLE
Refs #21286 -- Enabled ImageField data in serializer data tests.

### DIFF
--- a/tests/serializers/models/data.py
+++ b/tests/serializers/models/data.py
@@ -62,8 +62,8 @@ class BigIntegerData(models.Model):
     data = models.BigIntegerField(null=True)
 
 
-# class ImageData(models.Model):
-#    data = models.ImageField(null=True)
+class ImageData(models.Model):
+    data = models.ImageField(null=True)
 
 
 class GenericIPAddressData(models.Model):

--- a/tests/serializers/test_data.py
+++ b/tests/serializers/test_data.py
@@ -47,6 +47,7 @@ from .models import (
     GenericData,
     GenericIPAddressData,
     GenericIPAddressPKData,
+    ImageData,
     InheritAbstractModel,
     InheritBaseModel,
     IntegerData,
@@ -291,7 +292,9 @@ test_data = [
     (data_obj, 81, IntegerData, -123456789),
     (data_obj, 82, IntegerData, 0),
     (data_obj, 83, IntegerData, None),
-    # (XX, ImageData
+    (data_obj, 86, ImageData, "file:///foo/bar/whiz.png"),
+    # (data_obj, 87, ImageData, None),
+    (data_obj, 88, ImageData, ""),
     (data_obj, 95, GenericIPAddressData, "fe80:1424:2223:6cff:fe8a:2e8a:2151:abcd"),
     (data_obj, 96, GenericIPAddressData, None),
     (data_obj, 110, PositiveBigIntegerData, 9223372036854775807),


### PR DESCRIPTION
This patch tests ImageField in the serializer data tests in the same way that FileField is tested. This includes one commented-out test.

The commented-out test is a good addition because it implies that because ImageField is a subclass of FileField, the tests are commented-out for the same reason. They can both be enabled when ticket 10244 is resolved.

#### Trac ticket number

ticket-21286

#### Branch description

This patch tests ImageField in the serializer data tests in the same way that FileField is tested. This includes one commented-out test.

The commented-out test is a good addition because it implies that because ImageField is a subclass of FileField, the tests are commented-out for the same reason. They can both be enabled when ticket 10244 is resolved.

#### Checklist

- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.