### PR TITLE
Updated parameter order for password1 and password2 in SetPasswordMixin.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -117,8 +117,8 @@ class SetPasswordMixin:
         password2 = forms.CharField(
             label=label2,
             required=False,
-            widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
             strip=False,
+            widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
             help_text=_("Enter the same password as before, for verification."),
         )
         return password1, password2


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-XXXXX

#### Branch description
The argument order for password1 and password2 is not critical to functionality, but I think it would be better to make the argument order consistent.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
