### PR TITLE
POC v2 – Fixed #1688 -- Output translatable labels when displaying permissions

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -77,7 +77,7 @@ class Permission(models.Model):
         ordering = ["content_type__app_label", "content_type__model", "codename"]
 
     def __str__(self):
-        return "%s | %s" % (self.content_type, self.name)
+        return "%s | %s" % (self.content_type, _(self.name))
 
     def natural_key(self):
         return (self.codename,) + self.content_type.natural_key()

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -77,6 +77,19 @@ class Permission(models.Model):
         ordering = ["content_type__app_label", "content_type__model", "codename"]
 
     def __str__(self):
+        names = {"content_type": self.content_type}
+
+        if self.name.startswith("Can add "):
+            # Example: "Demo | Artist | Can add"
+            return _("%(content_type)s | Can add") % names
+        if self.name.startswith("Can change "):
+            return _("%(content_type)s | Can change") % names
+        if self.name.startswith("Can delete "):
+            return _("%(content_type)s | Can delete") % names
+        if self.name.startswith("Can view "):
+            return _("%(content_type)s | Can view") % names
+
+        # Example: "Demo | Artist | Can deliver pizza"
         return "%s | %s" % (self.content_type, _(self.name))
 
     def natural_key(self):


### PR DESCRIPTION
Take two on fixing [ticket-1688](). See take one: #1.

This makes it possible to translate permission names, both for built-in and custom permissions, while still storing the names in the database.

## Custom permissions

Two steps to achieving support for translations:

1. Mark [`Options.permissions`](https://docs.djangoproject.com/en/5.1/ref/models/options/#django.db.models.Options.permissions) strings as translate-able.
2. Use gettext on the DB-stored permission `name` to retrieve the translated label

In the database, permission names are still stored as english only. But when displayed, they show in the appropriate language.

## Built-in permissions

For built-in add/change/delete/view permissions, we change the label so we can create translate-able labels for all model names. The model name is contained in the permission’s `content_type` string representation anyway.