### PR TITLE
Fixed #35973 -- Improved makemessages locale validation to handle num…

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -40,7 +40,7 @@ def check_programs(*programs):
 
 
 def is_valid_locale(locale):
-    return re.match(r"^[a-z]+$", locale) or re.match(r"^[a-z]+_[A-Z].*$", locale)
+    return re.match(r"^[a-z]+$", locale) or re.match(r"^[a-z]+_[A-Z0-9].*$", locale)
 
 
 @total_ordering

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -179,6 +179,15 @@ class BasicExtractorTests(ExtractorTests):
         self.assertIn("processing locale en_GB", out.getvalue())
         self.assertIs(Path("locale/en_GB/LC_MESSAGES/django.po").exists(), True)
 
+    def test_valid_locale_with_numeric_region_code(self):
+        out = StringIO()
+        management.call_command(
+            "makemessages", locale=["ar_002"], stdout=out, verbosity=1
+        )
+        self.assertNotIn("invalid locale ar_002", out.getvalue())
+        self.assertIn("processing locale ar_002", out.getvalue())
+        self.assertIs(Path("locale/ar_002/LC_MESSAGES/django.po").exists(), True)
+
     def test_valid_locale_tachelhit_latin_morocco(self):
         out = StringIO()
         management.call_command(


### PR DESCRIPTION
Expand `is_valid_locale` regex to include numeric region codes in `makemessages`

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35973

#### Branch description
Improve `makemessages` locale handling to correctly process locales like `es_419` to ensure comprehensive localization support. It's essential to accommodate various locale formats, including those with numeric region codes. The UN M49 standard provides a standardized numerical coding system for geographic regions, which is often used in language codes. By extending the `makemessages` command to recognize these codes, we can enhance its ability to generate accurate translation files for a wider range of locales.

Reference: https://unstats.un.org/unsd/methodology/m49/

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
