### PR TITLE
Fixed #35959 -- Checked for change permission to show "password" field.

### DIFF
--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -1692,7 +1692,7 @@ class ChangelistTests(MessagesTestMixin, AuthViewsTestCase):
         (_request, user), _kwargs = has_change_permission.call_args
         self.assertEqual(user.pk, self.admin.pk)
 
-    def test_view_user_password_is_readonly(self):
+    def test_password_not_viewable_for_user_without_change_permission(self):
         u = User.objects.get(username="testclient")
         u.is_superuser = False
         u.save()
@@ -1704,7 +1704,7 @@ class ChangelistTests(MessagesTestMixin, AuthViewsTestCase):
         algo, salt, hash_string = u.password.split("$")
         self.assertContains(response, '<div class="readonly">testclient</div>')
         # ReadOnlyPasswordHashWidget is used to render the field.
-        self.assertContains(
+        self.assertNotContains(
             response,
             "<strong>algorithm</strong>: <bdi>%s</bdi>\n\n"
             "<strong>salt</strong>: <bdi>%s********************</bdi>\n\n"
@@ -1715,6 +1715,9 @@ class ChangelistTests(MessagesTestMixin, AuthViewsTestCase):
                 hash_string[:6],
             ),
             html=True,
+        )
+        self.assertNotContains(
+            response, '<a class="button" href="../password/">Reset password</a>'
         )
         # Value in POST data is ignored.
         data = self.get_user_data(u)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35959

#### Branch description
Removed "password" from UserAdmin fieldset for users without change permission, omitting ReadOnlyPasswordHashField in UserChangeForm.

Thanks to Sarah Boyce for help with implementation!
Co-authored-by: Sarah Boyce <sarahvboyce95@gmail.com>

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
