### PR TITLE
Fixed #35414 -- Used default headers in AsyncRequestFactory.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -752,6 +752,8 @@ class AsyncRequestFactory(RequestFactory):
             "scheme": "https" if secure else "http",
             "headers": [(b"host", b"testserver")],
         }
+        if self.defaults:
+            extra = {**self.defaults, **extra}
         if data:
             s["headers"].extend(
                 [

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -1327,6 +1327,19 @@ class AsyncRequestFactoryTest(SimpleTestCase):
         self.assertEqual(request.headers["x-another-header"], "some other value")
         self.assertIn("HTTP_X_ANOTHER_HEADER", request.META)
 
+    def test_async_request_factory_default_headers(self):
+        request_factory_with_headers = AsyncRequestFactory(
+            **{
+                "Authorization": "Bearer faketoken",
+                "X-Another-Header": "some other value",
+            }
+        )
+        request = request_factory_with_headers.get("/somewhere/")
+        self.assertEqual(request.headers["authorization"], "Bearer faketoken")
+        self.assertIn("HTTP_AUTHORIZATION", request.META)
+        self.assertEqual(request.headers["x-another-header"], "some other value")
+        self.assertIn("HTTP_X_ANOTHER_HEADER", request.META)
+
     def test_request_factory_query_string(self):
         request = self.request_factory.get("/somewhere/", {"example": "data"})
         self.assertNotIn("Query-String", request.headers)


### PR DESCRIPTION
Issue with AsyncClient ignoring default headers compared to synchronous Client.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35414

#### Branch description
So this ticket mentioned that " there is any inconsistency between Django's asynchronous AsyncClient and its synchronous counterpart Client regarding the handling of default headers. While the synchronous Client correctly includes default headers, the asynchronous AsyncClient ignores them. This behavior leads to discrepancies when utilizing fixtures with default headers, causing tests to fail unexpectedly. " So i have opened a PR for that, and i agree with the solution that the ticket owner proposed. So i made the changes accordingly so that the defaults value are now not ignored.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
