### PR TITLE
Removed unused and unnecessary words from docs/spelling_wordlist.

### DIFF
--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -3,14 +3,12 @@ accessor
 accessors
 Aceh
 admindocs
-affine
 affordances
 Ai
 Alchin
 allowlist
 alphanumerics
 amet
-analytics
 arccosine
 architected
 arcsine
@@ -60,7 +58,6 @@ Bokmål
 Bonham
 bookmarklet
 bookmarklets
-boolean
 booleans
 bpython
 Bronn
@@ -114,23 +111,18 @@ Danga
 Darussalam
 databrowse
 datafile
-dataset
-datasets
 datetimes
 declaratively
-decrementing
 deduplicates
 deduplication
 deepcopy
 deferrable
-DEP
 deprecations
 deserialization
 deserialize
 deserialized
 deserializer
 deserializing
-deterministically
 Deutsch
 dev
 dictConfig
@@ -142,7 +134,6 @@ Disqus
 distro
 django
 djangoproject
-djangotutorial
 dm
 docstring
 docstrings
@@ -165,9 +156,7 @@ esque
 Ess
 ETag
 ETags
-exe
 exfiltration
-extensibility
 fallbacks
 favicon
 fieldset
@@ -177,7 +166,6 @@ filesystems
 flatpage
 flatpages
 focusable
-fooapp
 formatter
 formatters
 formfield
@@ -210,7 +198,6 @@ hashable
 hasher
 hashers
 headerlist
-hoc
 Hoerner
 Holovaty
 Homebrew
@@ -223,7 +210,6 @@ Hypercorn
 ies
 iframe
 Igbo
-incrementing
 indexable
 ing
 ini
@@ -240,7 +226,6 @@ iterable
 iterables
 iteratively
 ize
-Jazzband
 Jinja
 jQuery
 Jupyter
@@ -283,7 +268,6 @@ manouche
 Marino
 memcache
 memcached
-mentorship
 metaclass
 metaclasses
 metre
@@ -338,8 +322,6 @@ orm
 Outdim
 outfile
 paginator
-parallelization
-parallelized
 parameterization
 params
 parens
@@ -361,9 +343,7 @@ pluggable
 pluralizations
 pooler
 postfix
-postgis
 postgres
-postgresql
 pragma
 pre
 precisions
@@ -376,7 +356,6 @@ prefetches
 prefetching
 preload
 preloaded
-prepend
 prepended
 prepending
 prepends
@@ -429,7 +408,6 @@ reflow
 registrable
 reimplement
 reindent
-reindex
 releaser
 releasers
 reloader
@@ -439,7 +417,6 @@ repo
 reportable
 reprojection
 reraising
-resampling
 reST
 reStructuredText
 reusability
@@ -447,7 +424,6 @@ reverter
 roadmap
 Roald
 rss
-runtime
 Sandvik
 savepoint
 savepoints
@@ -458,7 +434,6 @@ screencasts
 semimajor
 semiminor
 serializability
-serializable
 serializer
 serializers
 shapefile
@@ -467,7 +442,6 @@ sharding
 sitewide
 sliceable
 SMTP
-solaris
 Sorani
 sortable
 Spectre
@@ -535,7 +509,6 @@ toolkits
 toolset
 trac
 tracebacks
-transactional
 Transifex
 Tredinnick
 triager


### PR DESCRIPTION
This removes unused words and words contained within the Enchant dictionary.