### PR TITLE
Fixed #35987 -- Made ErrorList.copy() copy the renderer attribute.

### DIFF
--- a/django/forms/utils.py
+++ b/django/forms/utils.py
@@ -163,6 +163,7 @@ class ErrorList(UserList, list, RenderableErrorMixin):
     def copy(self):
         copy = super().copy()
         copy.error_class = self.error_class
+        copy.renderer = self.renderer
         return copy
 
     def get_json_data(self, escape_html=False):

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -4849,6 +4849,12 @@ class RendererTests(SimpleTestCase):
         form = CustomForm(renderer=custom)
         self.assertEqual(form.renderer, custom)
 
+    def test_get_context_errors(self):
+        custom = CustomRenderer()
+        form = Form(renderer=custom)
+        context = form.get_context()
+        self.assertEqual(context["errors"].renderer, custom)
+
 
 class TemplateTests(SimpleTestCase):
     def test_iterate_radios(self):

--- a/tests/forms_tests/tests/test_utils.py
+++ b/tests/forms_tests/tests/test_utils.py
@@ -162,6 +162,24 @@ class FormsUtilsTestCase(SimpleTestCase):
             '<a href="http://www.example.com/">example</a></li></ul>',
         )
 
+    def test_error_list_copy(self):
+        e = ErrorList(
+            [
+                ValidationError(
+                    message="message %(i)s",
+                    params={"i": 1},
+                ),
+                ValidationError(
+                    message="message %(i)s",
+                    params={"i": 2},
+                ),
+            ]
+        )
+
+        e_copy = copy.copy(e)
+        self.assertEqual(e, e_copy)
+        self.assertEqual(e.as_data(), e_copy.as_data())
+
     def test_error_list_copy_attributes(self):
         class CustomRenderer(DjangoTemplates):
             pass
@@ -194,6 +212,16 @@ class FormsUtilsTestCase(SimpleTestCase):
 
         e_deepcopy = copy.deepcopy(e)
         self.assertEqual(e, e_deepcopy)
+
+    def test_error_dict_copy_attributes(self):
+        class CustomRenderer(DjangoTemplates):
+            pass
+
+        renderer = CustomRenderer()
+        e = ErrorDict(renderer=renderer)
+
+        e_copy = copy.copy(e)
+        self.assertEqual(e.renderer, e_copy.renderer)
 
     def test_error_dict_html_safe(self):
         e = ErrorDict()

--- a/tests/forms_tests/tests/test_utils.py
+++ b/tests/forms_tests/tests/test_utils.py
@@ -2,6 +2,7 @@ import copy
 import json
 
 from django.core.exceptions import ValidationError
+from django.forms.renderers import DjangoTemplates
 from django.forms.utils import (
     ErrorDict,
     ErrorList,
@@ -160,6 +161,17 @@ class FormsUtilsTestCase(SimpleTestCase):
             '<ul class="errorlist"><li>nameExample of link: '
             '<a href="http://www.example.com/">example</a></li></ul>',
         )
+
+    def test_error_list_copy_attributes(self):
+        class CustomRenderer(DjangoTemplates):
+            pass
+
+        renderer = CustomRenderer()
+        e = ErrorList(error_class="woopsies", renderer=renderer)
+
+        e_copy = e.copy()
+        self.assertEqual(e.error_class, e_copy.error_class)
+        self.assertEqual(e.renderer, e_copy.renderer)
 
     def test_error_dict_copy(self):
         e = ErrorDict()


### PR DESCRIPTION
#### Trac ticket number

ticket-35987

#### Branch description

Fix the issue by adding an extra attribute copy in `ErrorList.copy()`.

I discovered the issue is due to the underlying `UserList.copy()` method in Python, which makes a copy by reinstantiating the class:

https://github.com/python/cpython/blob/2041a95e68ebf6d13f867e214ada28affa830669/Lib/collections/__init__.py#L1334-L1335

That's why there an explicit copy of `error_class` was already added in 49275c548887769cd70bbd85a3b125491f0c4062.

I added tests, both directly for `ErrorList` and `form.get_context()` where an error list is copied. I also added a defensive test for `ErrorDict` to ensure the same issue doesn't occur there, just in ase.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
