### PR TITLE
Fixed #35989 -- Removed crs from GeoJSON serializer.

### DIFF
--- a/django/contrib/gis/serializers/geojson.py
+++ b/django/contrib/gis/serializers/geojson.py
@@ -25,11 +25,7 @@ class Serializer(JSONSerializer):
     def start_serialization(self):
         self._init_options()
         self._cts = {}  # cache of CoordTransform's
-        self.stream.write(
-            '{"type": "FeatureCollection", '
-            '"crs": {"type": "name", "properties": {"name": "EPSG:%d"}},'
-            ' "features": [' % self.srid
-        )
+        self.stream.write('{"type": "FeatureCollection", "features": [')
 
     def end_serialization(self):
         self.stream.write("]}")

--- a/docs/releases/5.1.5.txt
+++ b/docs/releases/5.1.5.txt
@@ -9,4 +9,4 @@ Django 5.1.5 fixes several bugs in 5.1.4.
 Bugfixes
 ========
 
-* ...
+* Removed the invalid "crs" attribute from the GeoJSON serializer output.


### PR DESCRIPTION
Specification of coordinate reference systems (crs) was removed from the GeoJSON spec in 2016.

https://datatracker.ietf.org/doc/html/rfc7946#appendix-B.1

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35989

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
