### PR TITLE
Fixed #22977 -- Added system check for clashing managers and reverse related fields.

### DIFF
--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -327,6 +327,8 @@ Related fields
 * **fields.E339**: ``<model>.<field name>`` is not a foreign key to ``<model>``.
 * **fields.E340**: The field's intermediary table ``<table name>`` clashes with
   the table name of ``<model>``/``<model>.<field name>``.
+* **fields.E341**: ``<model>``.``related_name`` must be different than the
+  ``<model>``'s manager name.
 * **fields.W340**: ``null`` has no effect on ``ManyToManyField``.
 * **fields.W341**: ``ManyToManyField`` does not support ``validators``.
 * **fields.W342**: Setting ``unique=True`` on a ``ForeignKey`` has the same

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -1408,6 +1408,29 @@ class ExplicitRelatedQueryNameClashTests(SimpleTestCase):
 
 
 @isolate_apps("invalid_models_tests")
+class RelatedQueryNameClashWithManagerTests(SimpleTestCase):
+    def test_clash_between_related_query_name_and_manager(self):
+        class Author(models.Model):
+            authors = models.Manager()
+            mentor = models.ForeignKey(
+                "self", related_name="authors", on_delete=models.CASCADE
+            )
+
+        self.assertEqual(
+            Author.check(),
+            [
+                Error(
+                    "Related name for 'Author.mentor' clashes with manager: "
+                    "'authors' name.",
+                    hint="Rename manager name or related_name in conflicted field",
+                    obj=Author._meta.get_field("mentor"),
+                    id="fields.E341",
+                )
+            ],
+        )
+
+
+@isolate_apps("invalid_models_tests")
 class SelfReferentialM2MClashTests(SimpleTestCase):
     def test_clash_between_accessors(self):
         class Model(models.Model):


### PR DESCRIPTION
Added check for clash between model manager and model field's related_name.

New check added on model related fields to check if the `related_name` conflicts with the respective model's manager name.

With thanks to @kswiat, @loic, @felixxm and @russellm

#### Trac ticket number
<!-- Replace 22977 with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-22977

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
