### PR TITLE
Fixed #35993 -- Replaced outdated information on gettext f-string support.

### DIFF
--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -130,7 +130,8 @@ translations wouldn't be able to reorder placeholder text.
 
 Since string extraction is done by the ``xgettext`` command, only syntaxes
 supported by ``gettext`` are supported by Django. In particular, Python
-:py:ref:`f-strings <f-strings>` are not yet supported by ``xgettext``, and
+:py:ref:`f-strings <f-strings>` need ``xgettext`` 0.23+ and do not support
+expressions in embedded variables, such as accessing a slice of a list.
 JavaScript template strings need ``gettext`` 0.21+.
 
 .. _translator-comments:


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35993

#### Branch description
gettext 0.23+ supports the f-string syntax according to their [​bugtracker](https://savannah.gnu.org/bugs/?61596). Testing in practice confirms this. The current version of the documentation says that the syntax is not supported. This Pull Request changes this to inform the reader that they can use f-string syntax with  gettext 0.23+.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
