### PR TITLE
Fixed #35999 -- Removed #django IRC channel references where appropriate.

### DIFF
--- a/docs/faq/help.txt
+++ b/docs/faq/help.txt
@@ -23,14 +23,9 @@ Then, please post it in one of the following channels:
   discussions.
 * The |django-users| mailing list. This is for email-based discussions.
 * The `Django Discord server`_ for chat-based discussions.
-* The `#django IRC channel`_ on the Libera.Chat IRC network. This is for
-  chat-based discussions. If you're new to IRC, see the `Libera.Chat
-  documentation`_ for different ways to connect.
 
 .. _`"Using Django"`: https://forum.djangoproject.com/c/users/6
 .. _`Django Discord server`: https://discord.gg/xcRH6mN4fa
-.. _#django IRC channel: https://web.libera.chat/#django
-.. _Libera.Chat documentation: https://libera.chat/guides/connect
 
 In all these channels please abide by the `Django Code of Conduct`_. In
 summary, being friendly and patient, considerate, respectful, and careful in

--- a/docs/internals/contributing/bugs-and-features.txt
+++ b/docs/internals/contributing/bugs-and-features.txt
@@ -17,7 +17,7 @@ Otherwise, before reporting a bug or requesting a new feature on the
   `searching`_ or running `custom queries`_ in the ticket tracker.
 
 * Don't use the ticket system to ask support questions. Use the
-  |django-users| list or the `#django`_ IRC channel for that.
+  |django-users| list or the `Django Discord server`_ for that.
 
 * Don't reopen issues that have been marked "wontfix" without finding consensus
   to do so on the `Django Forum`_ or |django-developers| list.
@@ -39,8 +39,8 @@ particular:
 * **Do** read the :doc:`FAQ </faq/index>` to see if your issue might
   be a well-known question.
 
-* **Do** ask on |django-users| or `#django`_ *first* if you're not sure if
-  what you're seeing is a bug.
+* **Do** ask on |django-users| or the `Django Discord server`_ *first* if
+  you're not sure if what you're seeing is a bug.
 
 * **Do** write complete, reproducible, specific bug reports. You must
   include a clear, concise description of the problem, and a set of
@@ -166,5 +166,5 @@ Votes on technical matters should be announced and held in public on the
 
 .. _searching: https://code.djangoproject.com/search
 .. _custom queries: https://code.djangoproject.com/query
-.. _#django: https://web.libera.chat/#django
 .. _Django Forum: https://forum.djangoproject.com/
+.. _Django Discord server: https://discord.gg/xcRH6mN4fa

--- a/docs/internals/contributing/index.txt
+++ b/docs/internals/contributing/index.txt
@@ -31,9 +31,9 @@ a great ecosystem to work in:
   friendly and helpful atmosphere. If you're new to the Django community,
   you should read the `posting guidelines`_.
 
-* Join the `Django Discord server`_ or the `#django IRC channel`_ on
-  Libera.Chat to discuss and answer questions. By explaining Django to other
-  users, you're going to learn a lot about the framework yourself.
+* Join the `Django Discord server`_ to discuss and answer questions. By
+  explaining Django to other users, you're going to learn a lot about the
+  framework yourself.
 
 * Blog about Django. We syndicate all the Django blogs we know about on
   the `community page`_; if you'd like to see your blog on that page you
@@ -45,7 +45,6 @@ a great ecosystem to work in:
   build it!
 
 .. _posting guidelines: https://code.djangoproject.com/wiki/UsingTheMailingList
-.. _#django IRC channel: https://web.libera.chat/#django
 .. _community page: https://www.djangoproject.com/community/
 .. _Django Discord server: https://discord.gg/xcRH6mN4fa
 .. _Django forum: https://forum.djangoproject.com/

--- a/docs/internals/howto-release-django.txt
+++ b/docs/internals/howto-release-django.txt
@@ -561,9 +561,6 @@ Now you're ready to actually put the release out there. To do this:
    message body should include the vulnerability details, for example, the
    announcement blog post text. Include a link to the announcement blog post.
 
-#. Add a link to the blog post in the topic of the ``#django`` IRC channel:
-   ``/msg chanserv TOPIC #django new topic goes here``.
-
 Post-release
 ============
 

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -41,13 +41,13 @@ so that it can be of use to the widest audience.
 .. admonition:: Where to get help:
 
     If you're having trouble going through this tutorial, please post a message
-    on the `Django Forum`_, |django-developers|, or drop by
-    `#django-dev on irc.libera.chat`__ to chat with other Django users who
-    might be able to help.
+    on the `Django Forum`_, |django-developers|, or drop by the
+    `Django Discord server`_ to chat with other Django users who might be able
+    to help.
 
-__ https://web.libera.chat/#django-dev
 .. _Dive Into Python: https://diveintopython3.net/
 .. _Django Forum: https://forum.djangoproject.com/
+.. _Django Discord server: https://discord.gg/xcRH6mN4fa
 
 What does this tutorial cover?
 ------------------------------

--- a/docs/intro/tutorial08.txt
+++ b/docs/intro/tutorial08.txt
@@ -71,7 +71,6 @@ resolve the issue yourself, there are options available to you.
    Toolbar’s is `on GitHub <https://github.com/django-commons/django-debug-toolbar/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc>`_.
 #. Consult the `Django Forum <https://forum.djangoproject.com/>`_.
 #. Join the `Django Discord server <https://discord.gg/xcRH6mN4fa>`_.
-#. Join the #Django IRC channel on `Libera.chat <https://libera.chat/>`_.
 
 Installing other third-party packages
 =====================================

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -123,11 +123,11 @@ ticket system and use your feedback to improve the documentation for everybody.
 
 Note, however, that tickets should explicitly relate to the documentation,
 rather than asking broad tech-support questions. If you need help with your
-particular Django setup, try the |django-users| mailing list or the `#django
-IRC channel`_ instead.
+particular Django setup, try the |django-users| mailing list or the
+`Django Discord server`_ instead.
 
 .. _ticket system: https://code.djangoproject.com/
-.. _#django IRC channel: https://web.libera.chat/#django
+.. _Django Discord server: https://discord.gg/xcRH6mN4fa
 
 In plain text
 -------------


### PR DESCRIPTION
Some references are replaced with links to the Django Discord server.

I have left mailing list references as these will be cleanup in ticket-35908

#### Trac ticket number

ticket-35999