### PR TITLE
Fixed #35992, Fixed #35997 -- Added system check for CompositePrimaryKeys in Meta.indexes/constraints/unique_together.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -2288,6 +2288,16 @@ class Model(AltersData, metaclass=ModelBase):
                             id="models.E013",
                         )
                     )
+                elif isinstance(field, models.CompositePrimaryKey):
+                    errors.append(
+                        checks.Error(
+                            f"{option!r} refers to a CompositePrimaryKey "
+                            f"{field_name!r}, but CompositePrimaryKeys are not "
+                            f"permitted in {option!r}.",
+                            obj=cls,
+                            id="models.E048",
+                        )
+                    )
                 elif field not in cls._meta.local_fields:
                     errors.append(
                         checks.Error(

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -93,11 +93,13 @@ class BaseConstraint:
         return []
 
     def _check_references(self, model, references):
+        from django.db.models.fields.composite import CompositePrimaryKey
+
         errors = []
         fields = set()
         for field_name, *lookups in references:
-            # pk is an alias that won't be found by opts.get_field.
-            if field_name != "pk":
+            # pk is an alias that won't be found by opts.get_field().
+            if field_name != "pk" or isinstance(model._meta.pk, CompositePrimaryKey):
                 fields.add(field_name)
             if not lookups:
                 # If it has no lookups it cannot result in a JOIN.

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -431,6 +431,9 @@ Models
   (``db_table_comment``).
 * **models.W047**: ``<database>`` does not support unique constraints with
   nulls distinct.
+* **models.E048**: ``constraints/indexes/unique_together`` refers to a
+  ``CompositePrimaryKey`` ``<field name>``, but ``CompositePrimaryKey``\s are
+  not supported for that option.
 
 Management Commands
 -------------------


### PR DESCRIPTION
`CompositePrimaryKeys` are not supported in any of these options.

ticket-35992
ticket-35997

Alternative approach to the #18915. TBH, I agree with Simon that it's better to prohibit it now while we still have a chance.