### PR TITLE
Fixed #26007: Update the doc string on get_template_names of SingleObjectTemplateResponseMixin

### DIFF
--- a/django/views/generic/detail.py
+++ b/django/views/generic/detail.py
@@ -121,9 +121,10 @@ class SingleObjectTemplateResponseMixin(TemplateResponseMixin):
     def get_template_names(self):
         """
         Return a list of template names to be used for the request. May not be
-        called if render_to_response() is overridden. Return the following list:
+        called if render_to_response() is overridden. Return a list containing
+        ``template_name``, if set on the value. Otherwise, return a list
+        containing:
 
-        * the value of ``template_name`` on the view (if provided)
         * the contents of the ``template_name_field`` field on the
           object instance that the view is operating upon (if available)
         * ``<app_label>/<model_name><template_name_suffix>.html``

--- a/django/views/generic/detail.py
+++ b/django/views/generic/detail.py
@@ -171,7 +171,11 @@ class SingleObjectTemplateResponseMixin(TemplateResponseMixin):
             # If we still haven't managed to find any template names, we should
             # re-raise the ImproperlyConfigured to alert the user.
             if not names:
-                raise
+                raise ImproperlyConfigured(
+                    "SingleObjectTemplateResponseMixin requires a definition "
+                    "of 'template_name', 'template_name_field', or 'model'; "
+                    "or an implementation of 'get_template_names()'."
+                )
 
         return names
 

--- a/docs/ref/class-based-views/mixins-single-object.txt
+++ b/docs/ref/class-based-views/mixins-single-object.txt
@@ -164,9 +164,10 @@ Single object mixins
 
     .. method:: get_template_names()
 
-        Returns a list of candidate template names. Returns the following list:
+        Returns a list of candidate template names. Return a list containing
+        ``template_name``, if set on the value. Otherwise, return a list
+        containing:
 
-        * the value of ``template_name`` on the view (if provided)
         * the contents of the ``template_name_field`` field on the
           object instance that the view is operating upon (if available)
         * ``<app_label>/<model_name><template_name_suffix>.html``

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -607,8 +607,9 @@ class SingleObjectTemplateResponseMixinTest(SimpleTestCase):
         """
         view = views.TemplateResponseWithoutTemplate()
         msg = (
-            "TemplateResponseMixin requires either a definition of "
-            "'template_name' or an implementation of 'get_template_names()'"
+            "SingleObjectTemplateResponseMixin requires a definition "
+            "of 'template_name', 'template_name_field', or 'model'; "
+            "or an implementation of 'get_template_names()'."
         )
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             view.get_template_names()


### PR DESCRIPTION
#### Trac ticket number

ticket-26007

#### Branch description

* Updated doc string of get_template_names to clarify how the list gets returned
* Updated the error message to be clearer when the view is incorrectly configured.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
