### PR TITLE
Fixed #35924 - Removed choose/remove all controls used in FilteredSelectMultiple widget

### DIFF
--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -237,16 +237,8 @@ fieldset .fieldBox {
     background-position: 0 -168px;
 }
 
-.selector-chooseall {
-    background: url(../img/selector-icons.svg) right -128px no-repeat;
-}
-
 .active.selector-chooseall:focus, .active.selector-chooseall:hover {
     background-position: 100% -144px;
-}
-
-.selector-clearall {
-    background: url(../img/selector-icons.svg) 0 -160px no-repeat;
 }
 
 .active.selector-clearall:focus, .active.selector-clearall:hover {

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -182,20 +182,8 @@
     cursor: pointer;
 }
 
-.selector-chooseall {
-    padding: 0 18px 0 0;
-    background: url(../img/selector-icons.svg) right -160px no-repeat;
-    cursor: default;
-}
-
 .active.selector-chooseall:focus, .active.selector-chooseall:hover {
     background-position: 100% -176px;
-}
-
-.selector-clearall {
-    padding: 0 0 0 18px;
-    background: url(../img/selector-icons.svg) 0 -128px no-repeat;
-    cursor: default;
 }
 
 .active.selector-clearall:focus, .active.selector-clearall:hover {


### PR DESCRIPTION
#### Trac ticket number

ticket-35924

#### Branch description
Rremoved CSS class references for choose/remove all controls used in FilteredSelectMultiple widget

![Screenshot 2024-12-13 at 03 31 54](https://github.com/user-attachments/assets/b1155bd8-4a5f-4342-911a-d21f75634f40)
![Screenshot 2024-12-13 at 03 32 06](https://github.com/user-attachments/assets/b7732ff5-9c5d-4f57-b109-c19b5a47ab4c)
![Screenshot 2024-12-13 at 03 32 23](https://github.com/user-attachments/assets/a881cd9c-e710-4d69-945c-f7421bfca21c)
![Screenshot 2024-12-13 at 03 32 30](https://github.com/user-attachments/assets/fe7960e9-17f0-4efe-8098-504a439a4869)


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
