### PR TITLE
Fixed #34856 -- Fixed references to index_together in historical migrations.

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -95,6 +95,17 @@ class CreateModel(ModelOperation):
         model = to_state.apps.get_model(app_label, self.name)
         if self.allow_migrate_model(schema_editor.connection.alias, model):
             schema_editor.create_model(model)
+            # While the `index_together` option has been deprecated some
+            # historical migrations might still have references to them.
+            # This can be moved to the schema editor once it's adapted to
+            # from model states instead of rendered models (#29898).
+            to_model_state = to_state.models[app_label, self.name_lower]
+            if index_together := to_model_state.options.get("index_together"):
+                schema_editor.alter_index_together(
+                    model,
+                    set(),
+                    index_together,
+                )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         model = from_state.apps.get_model(app_label, self.name)
@@ -700,12 +711,13 @@ class AlterTogetherOptionOperation(ModelOptionOperation):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         new_model = to_state.apps.get_model(app_label, self.name)
         if self.allow_migrate_model(schema_editor.connection.alias, new_model):
-            old_model = from_state.apps.get_model(app_label, self.name)
+            from_model_state = from_state.models[app_label, self.name_lower]
+            to_model_state = to_state.models[app_label, self.name_lower]
             alter_together = getattr(schema_editor, "alter_%s" % self.option_name)
             alter_together(
                 new_model,
-                getattr(old_model._meta, self.option_name, set()),
-                getattr(new_model._meta, self.option_name, set()),
+                from_model_state.options.get(self.option_name) or set(),
+                to_model_state.options.get(self.option_name) or set(),
             )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -827,9 +827,6 @@ class ModelState:
                 if name == "unique_together":
                     ut = model._meta.original_attrs["unique_together"]
                     options[name] = set(normalize_together(ut))
-                elif name == "index_together":
-                    it = model._meta.original_attrs["index_together"]
-                    options[name] = set(normalize_together(it))
                 elif name == "indexes":
                     indexes = [idx.clone() for idx in model._meta.indexes]
                     for index in indexes:
@@ -845,7 +842,7 @@ class ModelState:
         # If we're ignoring relationships, remove all field-listing model
         # options (that option basically just means "make a stub model")
         if exclude_rels:
-            for key in ["unique_together", "index_together", "order_with_respect_to"]:
+            for key in ["unique_together", "order_with_respect_to"]:
                 if key in options:
                     del options[key]
         # Private fields are ignored, so remove options that refer to them.

--- a/docs/releases/5.1.5.txt
+++ b/docs/releases/5.1.5.txt
@@ -9,4 +9,5 @@ Django 5.1.5 fixes several bugs in 5.1.4.
 Bugfixes
 ========
 
-* ...
+* Fixed a crash when applying migrations with references to the removed
+  ``Meta.index_together`` option (:ticket:`34856`).


### PR DESCRIPTION
#### Trac ticket number
[ticket-34856](https://code.djangoproject.com/ticket/34856)

#### Branch description
This PR builds on top of https://github.com/django/django/pull/18818, including back and adapting some of the tests removed in https://github.com/django/django/commit/2abf417c815c20f41c0868d6f66520b32347106e.

Adding back `test_rename_field_index_together` required reverting [these changes](https://github.com/django/django/commit/2abf417c815c20f41c0868d6f66520b32347106e#diff-5dd147e9e978e645313dd99eab3a7bab1f1cb0a53e256843adb68aeed71e61dc) to `django.db.migrations.state.rename_field`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
