### PR TITLE
Fixed #26007: Improved the error message for SingleObjectTemplateResponseMixin.get_template_names when the class is not configured correctly

### DIFF
--- a/django/views/generic/detail.py
+++ b/django/views/generic/detail.py
@@ -170,7 +170,11 @@ class SingleObjectTemplateResponseMixin(TemplateResponseMixin):
             # If we still haven't managed to find any template names, we should
             # re-raise the ImproperlyConfigured to alert the user.
             if not names:
-                raise
+                raise ImproperlyConfigured(
+                    "SingleObjectTemplateResponseMixin requires a definition "
+                    "of 'template_name', 'template_name_field', or 'model'; "
+                    "or an implementation of 'get_template_names()'."
+                )
 
         return names
 

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -607,8 +607,9 @@ class SingleObjectTemplateResponseMixinTest(SimpleTestCase):
         """
         view = views.TemplateResponseWithoutTemplate()
         msg = (
-            "TemplateResponseMixin requires either a definition of "
-            "'template_name' or an implementation of 'get_template_names()'"
+            "SingleObjectTemplateResponseMixin requires a definition "
+            "of 'template_name', 'template_name_field', or 'model'; "
+            "or an implementation of 'get_template_names()'."
         )
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             view.get_template_names()


### PR DESCRIPTION

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-26007

#### Branch description

Updated the content of the ImproperlyConfigured error message to be more explicit on what is required for the view to work correctly.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
