### PR TITLE
Refs #29850 -- Removed obsolete test_window_frame_raise_not_supported_error.

### DIFF
--- a/tests/backends/base/test_operations.py
+++ b/tests/backends/base/test_operations.py
@@ -174,12 +174,6 @@ class DatabaseOperationTests(TestCase):
     def setUp(self):
         self.ops = BaseDatabaseOperations(connection=connection)
 
-    @skipIfDBFeature("supports_over_clause")
-    def test_window_frame_raise_not_supported_error(self):
-        msg = "This backend does not support window expressions."
-        with self.assertRaisesMessage(NotSupportedError, msg):
-            self.ops.window_frame_rows_start_end()
-
     @skipIfDBFeature("can_distinct_on_fields")
     def test_distinct_on_fields(self):
         msg = "DISTINCT ON fields is not supported by this database backend"


### PR DESCRIPTION
This NotSupportedError was removed in 6375cee490725969b4f67b3c988ef01350c1ad6d because it will never be reached due to the same exception in [Window.as_sql()](https://github.com/django/django/blob/54059125956789ad4c19b77eb7f5cde76eec0643/django/db/models/expressions.py#L1973-L1974).

Please backport to stable/5.1.x.