### PR TITLE
Imported Coalesce from django.db.models.functions.

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -6,7 +6,7 @@ from django.core.exceptions import FieldError, FullResultSet
 from django.db import NotSupportedError
 from django.db.models.expressions import Case, ColPairs, Func, Star, Value, When
 from django.db.models.fields import IntegerField
-from django.db.models.functions.comparison import Coalesce
+from django.db.models.functions import Coalesce
 from django.db.models.functions.mixins import (
     FixDurationInputMixin,
     NumericOutputFieldMixin,


### PR DESCRIPTION
As discussed in #18939, the documented import for database functions is `django.db.models.functions`. Update this module to avoid what #18939 describes as incorrect.