### PR TITLE
Fixed #36012 -- Fixed broken mailto punctuation encoding in Urlizer.

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -357,6 +357,8 @@ class Urlizer:
                     domain = punycode(domain)
                 except UnicodeError:
                     return word
+                local = quote(local, safe="")
+                domain = quote(domain, safe="")
                 url = self.mailto_template.format(local=local, domain=domain)
                 nofollow_attr = ""
             # Make link.

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -376,6 +376,19 @@ class TestUtilsHtml(SimpleTestCase):
                 + "한.글." * 15
                 + "aaa</a>",
             ),
+            (
+                # RFC 6068 requires a mailto URI to percent-encode a number of
+                # characters that can appear in <addr-spec>.
+                "yes;this=is&a%valid!email@example.com",
+                '<a href="mailto:yes%3Bthis%3Dis%26a%25valid%21email@example.com"'
+                ">yes;this=is&a%valid!email@example.com</a>",
+            ),
+            (
+                # Urlizer shouldn't urlize the "?org" part of this. But since
+                # it does, RFC 6068 requires percent encoding the "?".
+                "test@example.com?org",
+                '<a href="mailto:test@example.com%3Forg">test@example.com?org</a>',
+            ),
         )
         for value, output in tests:
             with self.subTest(value=value):


### PR DESCRIPTION
#### Trac ticket number

ticket-36012

#### Branch description
Urlizer was not properly encoding email addresses containing punctuation in generated mailto links. Per RFC 6068, fixed by percent encoding (urllib.parse.quote) the local and domain address parts.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- n/a I have added or updated relevant docs, including release notes if applicable.
- n/a I have attached screenshots in both light and dark modes for any UI changes.
