### PR TITLE
Fixed #36017 -- Used EmailValidator in urlize to detect emails.

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -7,7 +7,8 @@ from collections.abc import Mapping
 from html.parser import HTMLParser
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit, urlunsplit
 
-from django.core.exceptions import SuspiciousOperation
+from django.core.exceptions import SuspiciousOperation, ValidationError
+from django.core.validators import EmailValidator
 from django.utils.encoding import punycode
 from django.utils.functional import Promise, cached_property, keep_lazy, keep_lazy_text
 from django.utils.http import RFC3986_GENDELIMS, RFC3986_SUBDELIMS
@@ -455,20 +456,9 @@ class Urlizer:
     @staticmethod
     def is_email_simple(value):
         """Return True if value looks like an email address."""
-        # An @ must be in the middle of the value.
-        if "@" not in value or value.startswith("@") or value.endswith("@"):
-            return False
         try:
-            p1, p2 = value.split("@")
-        except ValueError:
-            # value contains more than one @.
-            return False
-        # Max length for domain name labels is 63 characters per RFC 1034.
-        # Helps to avoid ReDoS vectors in the domain part.
-        if len(p2) > 63:
-            return False
-        # Dot must be in p2 (e.g. example.com)
-        if "." not in p2 or p2.startswith("."):
+            EmailValidator(allowlist=[])(value)
+        except ValidationError:
             return False
         return True
 

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -374,15 +374,9 @@ class TestUtilsHtml(SimpleTestCase):
             (
                 # RFC 6068 requires a mailto URI to percent-encode a number of
                 # characters that can appear in <addr-spec>.
-                "yes;this=is&a%valid!email@example.com",
-                '<a href="mailto:yes%3Bthis%3Dis%26a%25valid%21email@example.com"'
-                ">yes;this=is&a%valid!email@example.com</a>",
-            ),
-            (
-                # Urlizer shouldn't urlize the "?org" part of this. But since
-                # it does, RFC 6068 requires percent encoding the "?".
-                "test@example.com?org",
-                '<a href="mailto:test@example.com%3Forg">test@example.com?org</a>',
+                "yes+this=is&a%valid!email@example.com",
+                '<a href="mailto:yes%2Bthis%3Dis%26a%25valid%21email@example.com"'
+                ">yes+this=is&a%valid!email@example.com</a>",
             ),
         )
         for value, output in tests:
@@ -402,6 +396,8 @@ class TestUtilsHtml(SimpleTestCase):
             "foo@.example.com",
             "foo@localhost",
             "foo@localhost.",
+            "test@example?;+!.com",
+            "email me@example.com,then I'll respond",
             # trim_punctuation catastrophic tests
             "(" * 100_000 + ":" + ")" * 100_000,
             "(" * 100_000 + "&:" + ")" * 100_000,


### PR DESCRIPTION
[#36017]
Urlize email address allows punctuation in domains

ticket-36017

#### Branch description
Improve def is_email_simple by adding email validator method

#### Checklist
- ✅ This PR targets the `main` branch.
- ✅ The commit message is written in past tense, mentions the ticket number, and ends with a period.
- ✅ I have checked the "Has patch" ticket flag in the Trac system.
- ✅ I have added or updated relevant tests.
- N/A I have added or updated relevant docs, including release notes if applicable.
- N/A I have attached screenshots in both light and dark modes for any UI changes.
