### PR TITLE
Fixed #35740 -- Fixed FileFieldStorageTests.test_extended_length_storage when using bcachefs.

### DIFF
--- a/tests/file_storage/models.py
+++ b/tests/file_storage/models.py
@@ -80,5 +80,5 @@ class Storage(models.Model):
         storage=temp_storage, upload_to="tests", max_length=20
     )
     extended_length = models.FileField(
-        storage=temp_storage, upload_to="tests", max_length=300
+        storage=temp_storage, upload_to="tests", max_length=1024
     )


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35740

#### Branch description
filesystem (like bcachefs) allows file names longer than 300 characters, the file name will get truncated by Django's FileField (due to its max_length=300 setting). So i made the changes accordingly mentioned in the discussions.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
