### PR TITLE
Fixed #35581 -- Updated django.core.mail to Python's modern email API.

### DIFF
--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -13,13 +13,10 @@ from django.core.exceptions import ImproperlyConfigured
 # backends and the subsequent reorganization (See #10355)
 from django.core.mail.message import (
     DEFAULT_ATTACHMENT_MIME_TYPE,
-    BadHeaderError,
     EmailAlternative,
     EmailAttachment,
     EmailMessage,
     EmailMultiAlternatives,
-    SafeMIMEMultipart,
-    SafeMIMEText,
     forbid_multi_line_headers,
     make_msgid,
 )
@@ -33,12 +30,8 @@ __all__ = [
     "DNS_NAME",
     "EmailMessage",
     "EmailMultiAlternatives",
-    "SafeMIMEText",
-    "SafeMIMEMultipart",
     "DEFAULT_ATTACHMENT_MIME_TYPE",
     "make_msgid",
-    "BadHeaderError",
-    "forbid_multi_line_headers",
     "get_connection",
     "send_mail",
     "send_mass_mail",
@@ -46,6 +39,12 @@ __all__ = [
     "mail_managers",
     "EmailAlternative",
     "EmailAttachment",
+    # RemovedInDjango70Warning: When the deprecation ends, remove the last
+    # entries.
+    "BadHeaderError",
+    "SafeMIMEText",
+    "SafeMIMEMultipart",
+    "forbid_multi_line_headers",
 ]
 
 
@@ -224,3 +223,31 @@ def mail_managers(
         fail_silently=fail_silently,
         connection=connection,
     )
+
+
+# RemovedInDjango70Warning.
+_deprecate_on_import = {
+    "BadHeaderError": "BadHeaderError is deprecated. Replace with ValueError.",
+    "SafeMIMEText": (
+        "SafeMIMEText is deprecated. The return value"
+        " of EmailMessage.message() is an email.message.EmailMessage."
+    ),
+    "SafeMIMEMultipart": (
+        "SafeMIMEMultipart is deprecated. The return value"
+        " of EmailMessage.message() is an email.message.EmailMessage."
+    ),
+}
+
+
+# RemovedInDjango70Warning.
+def __getattr__(name):
+    try:
+        msg = _deprecate_on_import[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+    else:
+        # Issue deprecation warnings at time of import.
+        from django.core.mail import message
+
+        warnings.warn(msg, category=RemovedInDjango70Warning)
+        return getattr(message, name)

--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -1,13 +1,15 @@
 """SMTP email backend class."""
 
+import email.policy
 import smtplib
 import ssl
 import threading
+from email.headerregistry import Address, AddressHeader
 
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
-from django.core.mail.message import sanitize_address
 from django.core.mail.utils import DNS_NAME
+from django.utils.encoding import force_str, punycode
 from django.utils.functional import cached_property
 
 
@@ -145,18 +147,47 @@ class EmailBackend(BaseEmailBackend):
         """A helper method that does the actual sending."""
         if not email_message.recipients():
             return False
-        encoding = email_message.encoding or settings.DEFAULT_CHARSET
-        from_email = sanitize_address(email_message.from_email, encoding)
-        recipients = [
-            sanitize_address(addr, encoding) for addr in email_message.recipients()
-        ]
-        message = email_message.message()
+        from_email = self.prep_address(email_message.from_email)
+        recipients = [self.prep_address(addr) for addr in email_message.recipients()]
+        message = email_message.message(policy=email.policy.SMTP)
         try:
-            self.connection.sendmail(
-                from_email, recipients, message.as_bytes(linesep="\r\n")
-            )
+            self.connection.sendmail(from_email, recipients, message.as_bytes())
         except smtplib.SMTPException:
             if not self.fail_silently:
                 raise
             return False
         return True
+
+    def prep_address(self, address, force_ascii=True):
+        """
+        Return the addr-spec portion of an email address. Raises ValueError for
+        invalid addresses, including CR/NL injection.
+
+        If force_ascii is True, apply IDNA encoding to non-ASCII domains, and
+        raise ValueError for non-ASCII local-parts (which can't be encoded).
+        Otherwise, leave Unicode characters unencoded (e.g., for sending with
+        SMTPUTF8).
+        """
+        address = force_str(address)
+        parsed = AddressHeader.value_parser(address)
+        defects = set(str(defect) for defect in parsed.all_defects)
+        # Django allows local mailboxes like "From: webmaster" (#15042).
+        defects.discard("addr-spec local part with no domain")
+        if not force_ascii:
+            # Non-ASCII local-part is valid with SMTPUTF8. Remove once
+            # https://github.com/python/cpython/issues/81074 is fixed.
+            defects.discard("local-part contains non-ASCII characters)")
+        if defects:
+            raise ValueError(f"Invalid address {address!r}: {'; '.join(defects)}")
+
+        mailboxes = parsed.all_mailboxes
+        if len(mailboxes) != 1:
+            raise ValueError(f"Invalid address {address!r}: must be a single address")
+
+        mailbox = mailboxes[0]
+        if force_ascii and mailbox.domain and not mailbox.domain.isascii():
+            # Re-compose an addr-spec with the IDNA encoded domain.
+            domain = punycode(mailbox.domain)
+            return str(Address(username=mailbox.local_part, domain=domain))
+        else:
+            return mailbox.addr_spec

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -1,17 +1,19 @@
+import email.message
+import email.policy
 import mimetypes
+import warnings
 from collections import namedtuple
+from datetime import datetime, timezone
 from email import charset as Charset
-from email import encoders as Encoders
-from email import generator, message_from_bytes
+from email import generator
 from email.errors import HeaderParseError
 from email.header import Header
-from email.headerregistry import Address, parser
-from email.message import Message
+from email.headerregistry import Address, AddressHeader, parser
 from email.mime.base import MIMEBase
 from email.mime.message import MIMEMessage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from email.utils import formataddr, formatdate, getaddresses, make_msgid
+from email.utils import formataddr, getaddresses, make_msgid
 from io import BytesIO, StringIO
 from pathlib import Path
 
@@ -19,7 +21,9 @@ from django.conf import settings
 from django.core.mail.utils import DNS_NAME
 from django.utils.deprecation import RemovedInDjango70Warning, deprecate_posargs
 from django.utils.encoding import force_bytes, force_str, punycode
+from django.utils.timezone import get_current_timezone
 
+# RemovedInDjango70Warning.
 # Don't BASE64-encode UTF-8 messages so that we avoid unwanted attention from
 # some spam filters.
 utf8_charset = Charset.Charset("utf-8")
@@ -31,13 +35,17 @@ utf8_charset_qp.body_encoding = Charset.QP
 # and cannot be guessed).
 DEFAULT_ATTACHMENT_MIME_TYPE = "application/octet-stream"
 
+# RemovedInDjango70Warning.
 RFC5322_EMAIL_LINE_LENGTH_LIMIT = 998
 
 
-class BadHeaderError(ValueError):
-    pass
+# RemovedInDjango70Warning.
+# BadHeaderError must be ValueError (not subclass it), so that existing code
+# with `except BadHeaderError` will catch the ValueError that Python's modern
+# email API raises for headers containing CR or NL.
+BadHeaderError = ValueError
 
-
+# RemovedInDjango70Warning.
 # Header names that contain structured address data (RFC 5322).
 ADDRESS_HEADERS = {
     "from",
@@ -54,8 +62,16 @@ ADDRESS_HEADERS = {
 }
 
 
+# RemovedInDjango70Warning.
 def forbid_multi_line_headers(name, val, encoding):
     """Forbid multi-line headers to prevent header injection."""
+    warnings.warn(
+        "The internal API forbid_multi_line_headers() is deprecated."
+        " Python's modern email API (with email.message.EmailMessage or"
+        " email.policy.default) will reject multi-line headers.",
+        RemovedInDjango70Warning,
+    )
+
     encoding = encoding or settings.DEFAULT_CHARSET
     val = str(val)  # val may be lazy
     if "\n" in val or "\r" in val:
@@ -77,10 +93,20 @@ def forbid_multi_line_headers(name, val, encoding):
     return name, val
 
 
+# RemovedInDjango70Warning.
 def sanitize_address(addr, encoding):
     """
     Format a pair of (name, address) or an email address string.
     """
+    warnings.warn(
+        "The internal API sanitize_address() is deprecated."
+        " Python's modern email API (with email.message.EmailMessage or"
+        " email.policy.default) will handle most required validation and"
+        " encoding. Use Python's email.headerregistry.Address to construct"
+        " formatted addresses from component parts.",
+        RemovedInDjango70Warning,
+    )
+
     address = None
     if not isinstance(addr, tuple):
         addr = force_str(addr)
@@ -123,6 +149,7 @@ def sanitize_address(addr, encoding):
     return formataddr((nm, parsed_address.addr_spec))
 
 
+# RemovedInDjango70Warning.
 class MIMEMixin:
     def as_string(self, unixfrom=False, linesep="\n"):
         """Return the entire formatted message as a string.
@@ -151,6 +178,7 @@ class MIMEMixin:
         return fp.getvalue()
 
 
+# RemovedInDjango70Warning.
 class SafeMIMEMessage(MIMEMixin, MIMEMessage):
     def __setitem__(self, name, val):
         # Per RFC 2046 Section 5.2.1, message/rfc822 attachment headers must be
@@ -159,6 +187,7 @@ class SafeMIMEMessage(MIMEMixin, MIMEMessage):
         MIMEMessage.__setitem__(self, name, val)
 
 
+# RemovedInDjango70Warning.
 class SafeMIMEText(MIMEMixin, MIMEText):
     def __init__(self, _text, _subtype="plain", _charset=None):
         self.encoding = _charset
@@ -181,6 +210,7 @@ class SafeMIMEText(MIMEMixin, MIMEText):
         MIMEText.set_payload(self, payload, charset=charset)
 
 
+# RemovedInDjango70Warning.
 class SafeMIMEMultipart(MIMEMixin, MIMEMultipart):
     def __init__(
         self, _subtype="mixed", boundary=None, _subparts=None, encoding=None, **_params
@@ -201,8 +231,10 @@ class EmailMessage:
     """A container for email information."""
 
     content_subtype = "plain"
-    mixed_subtype = "mixed"
-    encoding = None  # None => use settings default
+
+    # Undocumented charset to use for text/* message bodies and attachments.
+    # If None, defaults to settings.DEFAULT_CHARSET.
+    encoding = None
 
     @deprecate_posargs(
         RemovedInDjango70Warning,
@@ -263,7 +295,10 @@ class EmailMessage:
         self.attachments = []
         if attachments:
             for attachment in attachments:
-                if isinstance(attachment, MIMEBase):
+                if isinstance(attachment, email.message.MIMEPart):
+                    self.attach(attachment)
+                elif isinstance(attachment, MIMEBase):
+                    # RemovedInDjango70Warning.
                     self.attach(attachment)
                 else:
                     self.attach(*attachment)
@@ -277,12 +312,13 @@ class EmailMessage:
             self.connection = get_connection(fail_silently=fail_silently)
         return self.connection
 
-    def message(self):
-        encoding = self.encoding or settings.DEFAULT_CHARSET
-        msg = SafeMIMEText(self.body, self.content_subtype, encoding)
-        msg = self._create_message(msg)
-        msg["Subject"] = self.subject
-        msg["From"] = self.extra_headers.get("From", self.from_email)
+    def message(self, *, policy=email.policy.default):
+        msg = email.message.EmailMessage(policy=policy)
+        self._add_bodies(msg)
+        self._add_attachments(msg)
+
+        msg["Subject"] = str(self.subject)
+        msg["From"] = str(self.extra_headers.get("From", self.from_email))
         self._set_list_header_if_not_empty(msg, "To", self.to)
         self._set_list_header_if_not_empty(msg, "Cc", self.cc)
         self._set_list_header_if_not_empty(msg, "Reply-To", self.reply_to)
@@ -291,18 +327,19 @@ class EmailMessage:
         # accommodate that when doing comparisons.
         header_names = [key.lower() for key in self.extra_headers]
         if "date" not in header_names:
-            # formatdate() uses stdlib methods to format the date, which use
-            # the stdlib/OS concept of a timezone, however, Django sets the
-            # TZ environment variable based on the TIME_ZONE setting which
-            # will get picked up by formatdate().
-            msg["Date"] = formatdate(localtime=settings.EMAIL_USE_LOCALTIME)
+            if settings.EMAIL_USE_LOCALTIME:
+                tz = get_current_timezone()
+            else:
+                tz = timezone.utc
+            msg["Date"] = datetime.now(tz)
         if "message-id" not in header_names:
             # Use cached DNS_NAME for performance
             msg["Message-ID"] = make_msgid(domain=DNS_NAME)
         for name, value in self.extra_headers.items():
             # Avoid headers handled above.
             if name.lower() not in {"from", "to", "cc", "reply-to"}:
-                msg[name] = value
+                msg[name] = force_str(value, strings_only=True)
+        self._idna_encode_address_header_domains(msg)
         return msg
 
     def recipients(self):
@@ -332,7 +369,19 @@ class EmailMessage:
         specified as content, decode it as UTF-8. If that fails, set the
         mimetype to DEFAULT_ATTACHMENT_MIME_TYPE and don't decode the content.
         """
-        if isinstance(filename, MIMEBase):
+        if isinstance(filename, email.message.MIMEPart):
+            if content is not None or mimetype is not None:
+                raise ValueError(
+                    "content and mimetype must not be given when a MIMEPart "
+                    "instance is provided."
+                )
+            self.attachments.append(filename)
+        elif isinstance(filename, MIMEBase):
+            warnings.warn(
+                "MIMEBase attachments are deprecated."
+                " Use an email.message.MIMEPart instead.",
+                RemovedInDjango70Warning,
+            )
             if content is not None or mimetype is not None:
                 raise ValueError(
                     "content and mimetype must not be given when a MIMEBase "
@@ -376,77 +425,75 @@ class EmailMessage:
             content = file.read()
             self.attach(path.name, content, mimetype)
 
-    def _create_message(self, msg):
-        return self._create_attachments(msg)
-
-    def _create_attachments(self, msg):
-        if self.attachments:
+    def _add_bodies(self, msg):
+        if self.body or not self.attachments:
             encoding = self.encoding or settings.DEFAULT_CHARSET
-            body_msg = msg
-            msg = SafeMIMEMultipart(_subtype=self.mixed_subtype, encoding=encoding)
-            if self.body or body_msg.is_multipart():
-                msg.attach(body_msg)
+            body = force_str(
+                self.body or "", encoding=encoding, errors="surrogateescape"
+            )
+            msg.set_content(body, subtype=self.content_subtype, charset=encoding)
+
+    def _add_attachments(self, msg):
+        if self.attachments:
+            if hasattr(self, "mixed_subtype"):
+                # RemovedInDjango70Warning.
+                raise AttributeError(
+                    "EmailMessage no longer supports the"
+                    " undocumented `mixed_subtype` attribute"
+                )
+            msg.make_mixed()
             for attachment in self.attachments:
-                if isinstance(attachment, MIMEBase):
+                if isinstance(attachment, email.message.MIMEPart):
+                    msg.attach(attachment)
+                elif isinstance(attachment, MIMEBase):
+                    # RemovedInDjango70Warning.
                     msg.attach(attachment)
                 else:
-                    msg.attach(self._create_attachment(*attachment))
-        return msg
+                    self._add_attachment(msg, *attachment)
 
-    def _create_mime_attachment(self, content, mimetype):
-        """
-        Convert the content, mimetype pair into a MIME attachment object.
+    def _add_attachment(self, msg, filename, content, mimetype):
+        encoding = self.encoding or settings.DEFAULT_CHARSET
+        maintype, subtype = mimetype.split("/", 1)
 
-        If the mimetype is message/rfc822, content may be an
-        email.Message or EmailMessage object, as well as a str.
-        """
-        basetype, subtype = mimetype.split("/", 1)
-        if basetype == "text" and isinstance(content, bytes):
+        if maintype == "text" and isinstance(content, bytes):
             # This duplicates logic from EmailMessage.attach() to properly
             # handle EmailMessage.attachments not created through attach().
             try:
                 content = content.decode()
             except UnicodeDecodeError:
                 mimetype = DEFAULT_ATTACHMENT_MIME_TYPE
-                basetype, subtype = mimetype.split("/", 1)
+                maintype, subtype = mimetype.split("/", 1)
 
-        if basetype == "text":
-            encoding = self.encoding or settings.DEFAULT_CHARSET
-            attachment = SafeMIMEText(content, subtype, encoding)
-        elif basetype == "message" and subtype == "rfc822":
-            # Bug #18967: Per RFC 2046 Section 5.2.1, message/rfc822
-            # attachments must not be base64 encoded.
-            if isinstance(content, EmailMessage):
-                # convert content into an email.Message first
-                content = content.message()
-            elif not isinstance(content, Message):
-                # For compatibility with existing code, parse the message
-                # into an email.Message object if it is not one already.
-                content = message_from_bytes(force_bytes(content))
-
-            attachment = SafeMIMEMessage(content, subtype)
-        else:
-            # Encode non-text attachments with base64.
-            attachment = MIMEBase(basetype, subtype)
-            attachment.set_payload(content)
-            Encoders.encode_base64(attachment)
-        return attachment
-
-    def _create_attachment(self, filename, content, mimetype=None):
-        """
-        Convert the filename, content, mimetype triple into a MIME attachment
-        object.
-        """
-        attachment = self._create_mime_attachment(content, mimetype)
-        if filename:
-            try:
-                filename.encode("ascii")
-            except UnicodeEncodeError:
-                filename = ("utf-8", "", filename)
-            attachment.add_header(
-                "Content-Disposition", "attachment", filename=filename
+        # See email.contentmanager.set_content() docs for the cases here.
+        if maintype == "text":
+            # For text/*, content must be str, and maintype cannot be provided.
+            msg.add_attachment(
+                content, subtype=subtype, filename=filename, charset=encoding
             )
-        return attachment
+        elif maintype == "message":
+            # For message/*, content must be email.message.EmailMessage (or
+            # legacy email.message.Message), and maintype cannot be provided.
+            if isinstance(content, EmailMessage):
+                # Django EmailMessage.
+                content = content.message(policy=msg.policy)
+            elif not isinstance(
+                content, (email.message.EmailMessage, email.message.Message)
+            ):
+                content = email.message_from_bytes(
+                    force_bytes(content), policy=msg.policy
+                )
+            msg.add_attachment(content, subtype=subtype, filename=filename)
+        else:
+            # For all other types, content must be bytes-like, and both
+            # maintype and subtype must be provided.
+            if not isinstance(content, (bytes, bytearray, memoryview)):
+                content = force_bytes(content)
+            msg.add_attachment(
+                content,
+                maintype=maintype,
+                subtype=subtype,
+                filename=filename,
+            )
 
     def _set_list_header_if_not_empty(self, msg, header, values):
         """
@@ -459,6 +506,37 @@ class EmailMessage:
             if values:
                 msg[header] = ", ".join(str(v) for v in values)
 
+    def _idna_encode_address_header_domains(self, msg):
+        """
+        If msg.policy does not permit utf8 in headers, IDNA encode all
+        non-ASCII domains in its address headers.
+        """
+        # Avoids a problem where Python's email incorrectly converts non-ASCII
+        # domains to RFC 2047 encoded-words:
+        # https://github.com/python/cpython/issues/83938.
+        # This applies to the domain only, not to the localpart (username).
+        # There is no RFC that permits any 7-bit encoding for non-ASCII
+        # characters before the '@'.
+        if not getattr(msg.policy, "utf8", False):
+            # Not using SMTPUTF8, so apply IDNA encoding in all address
+            # headers. IDNA encoding does not alter domains that are already
+            # ASCII.
+            for field, value in msg.items():
+                if isinstance(value, AddressHeader) and any(
+                    not addr.domain.isascii() for addr in value.addresses
+                ):
+                    msg.replace_header(
+                        field,
+                        [
+                            Address(
+                                display_name=addr.display_name,
+                                username=addr.username,
+                                domain=punycode(addr.domain),
+                            )
+                            for addr in value.addresses
+                        ],
+                    )
+
 
 class EmailMultiAlternatives(EmailMessage):
     """
@@ -466,8 +544,6 @@ class EmailMultiAlternatives(EmailMessage):
     messages. For example, including text and HTML versions of the text is
     made easier.
     """
-
-    alternative_subtype = "alternative"
 
     @deprecate_posargs(
         RemovedInDjango70Warning,
@@ -522,24 +598,28 @@ class EmailMultiAlternatives(EmailMessage):
             raise ValueError("Both content and mimetype must be provided.")
         self.alternatives.append(EmailAlternative(content, mimetype))
 
-    def _create_message(self, msg):
-        return self._create_attachments(self._create_alternatives(msg))
-
-    def _create_alternatives(self, msg):
-        encoding = self.encoding or settings.DEFAULT_CHARSET
+    def _add_bodies(self, msg):
+        if self.body or not self.alternatives:
+            super()._add_bodies(msg)
         if self.alternatives:
-            body_msg = msg
-            msg = SafeMIMEMultipart(
-                _subtype=self.alternative_subtype, encoding=encoding
-            )
-            if self.body:
-                msg.attach(body_msg)
-            for alternative in self.alternatives:
-                msg.attach(
-                    self._create_mime_attachment(
-                        alternative.content, alternative.mimetype
-                    )
+            if hasattr(self, "alternative_subtype"):
+                # RemovedInDjango70Warning.
+                raise AttributeError(
+                    "EmailMultiAlternatives no longer supports the"
+                    " undocumented `alternative_subtype` attribute"
                 )
+            msg.make_alternative()
+            encoding = self.encoding or settings.DEFAULT_CHARSET
+            for alternative in self.alternatives:
+                maintype, subtype = alternative.mimetype.split("/", 1)
+                content = alternative.content
+                if maintype == "text":
+                    if isinstance(content, bytes):
+                        content = content.decode()
+                    msg.add_alternative(content, subtype=subtype, charset=encoding)
+                else:
+                    content = force_bytes(content, encoding=encoding, strings_only=True)
+                    msg.add_alternative(content, maintype=maintype, subtype=subtype)
         return msg
 
     def body_contains(self, text):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -41,6 +41,18 @@ details on these changes.
 * The :mod:`django.core.mail` APIs will no longer accept certain parameters as
   positional arguments. These must be passed as keyword arguments instead.
 
+* Support for passing Python's legacy email ``email.mime.base.MIMEBase``
+  object to ``EmailMessage.attach()`` (or including one in the message's
+  ``attachments`` list) will be removed.
+
+* The ``django.core.mail.BadHeaderError`` exception will be removed.
+
+* The ``django.core.mail.SafeMIMEText`` and ``SafeMIMEMultipart`` classes will
+  be removed.
+
+* The ``django.core.mail.forbid_multi_line_headers()`` and
+  ``django.core.mail.message.sanitize_address()`` functions will be removed.
+
 .. _deprecation-removed-in-6.1:
 
 6.1

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -74,6 +74,23 @@ To get started, follow the :doc:`CSP how-to guide </howto/csp>`. For in-depth
 guidance, see the :ref:`CSP security overview <security-csp>` and the
 :doc:`reference docs </ref/csp>`.
 
+Adoption of Python's modern email API
+-------------------------------------
+
+Email handling in Django now uses Python's modern email API, introduced in
+Python 3.6. This API, centered around the
+:py:class:`email.message.EmailMessage` class, offers a cleaner and
+Unicode-friendly interface for composing and sending emails. It replaces use of
+Python's older legacy (``Compat32``) API, which relied on lower-level MIME
+classes (from :py:mod:`email.mime`) and required more manual handling of
+message structure and encoding.
+
+Notably, the return type of the :class:`EmailMessage.message()
+<django.core.mail.EmailMessage>` method is now an instance of Python's
+:py:class:`email.message.EmailMessage`. This supports the same API as the
+previous ``SafeMIMEText`` and ``SafeMIMEMultipart`` return types, but is not an
+instance of those now-deprecated classes.
+
 Minor features
 --------------
 
@@ -193,7 +210,13 @@ Decorators
 Email
 ~~~~~
 
-* ...
+* The new ``policy`` argument for :class:`EmailMessage.message()
+  <django.core.mail.EmailMessage>` allows specifying the email policy, the set
+  of rules for updating and serializing the representation of the message.
+  Defaults to :py:data:`email.policy.default`.
+
+* :class:`EmailMessage.attach() <django.core.mail.EmailMessage>` now accepts a
+  :class:`~email.message.MIMEPart` object from Python's modern email API.
 
 Error Reporting
 ~~~~~~~~~~~~~~~
@@ -387,6 +410,22 @@ of each library are the first to add or confirm compatibility with Python 3.12:
 * ``sqlparse`` 0.5.0
 * ``tblib`` 3.0.0
 
+Email
+-----
+
+* The undocumented ``mixed_subtype`` and ``alternative_subtype`` properties
+  of :class:`~django.core.mail.EmailMessage` and
+  :class:`~django.core.mail.EmailMultiAlternatives` are no longer supported.
+
+* The undocumented ``encoding`` property of
+  :class:`~django.core.mail.EmailMessage` no longer supports Python legacy
+  :py:class:`email.charset.Charset` objects.
+
+* As the internal implementations of :class:`~django.core.mail.EmailMessage`
+  and :class:`~django.core.mail.EmailMultiAlternatives` have changed
+  significantly, closely examine any custom subclasses that rely on overriding
+  undocumented, internal underscore methods.
+
 Miscellaneous
 -------------
 
@@ -435,7 +474,9 @@ warning and will raise a :exc:`TypeError` when the deprecation period ends.
   the first four (``subject``, ``body``, ``from_email``, and ``to``), which may
   still be passed either as positional or keyword arguments.
 
-.. currentmodule:: None
+* :mod:`django.core.mail` APIs now require keyword arguments for less commonly
+  used parameters. Using positional arguments for these now emits a deprecation
+  warning and will raise a :exc:`TypeError` when the deprecation period ends:
 
 Miscellaneous
 -------------
@@ -466,6 +507,22 @@ Miscellaneous
   :class:`django.core.paginator.AsyncPaginator` is deprecated.
 
 * Using a percent sign in a column alias or annotation is deprecated.
+
+* Support for passing Python's legacy email :class:`~email.mime.base.MIMEBase`
+  object to :class:`EmailMessage.attach() <django.core.mail.EmailMessage>` (or
+  including one in the message's ``attachments`` list) is deprecated. For
+  complex attachments requiring additional headers or parameters, switch to the
+  modern email API's :class:`~email.message.MIMEPart`.
+
+* The ``django.core.mail.BadHeaderError`` exception is deprecated. Python's
+  modern email raises a :exc:`!ValueError` for email headers containing
+  prohibited characters.
+
+* The ``django.core.mail.SafeMIMEText`` and ``SafeMIMEMultipart`` classes are
+  deprecated.
+
+* The undocumented ``django.core.mail.forbid_multi_line_headers()`` and
+  ``django.core.mail.message.sanitize_address()`` functions are deprecated.
 
 Features removed in 6.0
 =======================

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -249,9 +249,8 @@ The Django email functions outlined above all protect against header injection
 by forbidding newlines in header values. If any ``subject``, ``from_email`` or
 ``recipient_list`` contains a newline (in either Unix, Windows or Mac style),
 the email function (e.g. :meth:`~django.core.mail.send_mail()`) will raise
-``django.core.mail.BadHeaderError`` (a subclass of ``ValueError``) and, hence,
-will not send the email. It's your responsibility to validate all data before
-passing it to the email functions.
+:exc:`ValueError` and, hence, will not send the email. It's your responsibility
+to validate all data before passing it to the email functions.
 
 If a ``message`` contains headers at the start of the string, the headers will
 be printed as the first bit of the email message.
@@ -260,7 +259,7 @@ Here's an example view that takes a ``subject``, ``message`` and ``from_email``
 from the request's POST data, sends that to admin@example.com and redirects to
 "/contact/thanks/" when it's done::
 
-    from django.core.mail import BadHeaderError, send_mail
+    from django.core.mail import send_mail
     from django.http import HttpResponse, HttpResponseRedirect
 
 
@@ -271,13 +270,19 @@ from the request's POST data, sends that to admin@example.com and redirects to
         if subject and message and from_email:
             try:
                 send_mail(subject, message, from_email, ["admin@example.com"])
-            except BadHeaderError:
+            except ValueError:
                 return HttpResponse("Invalid header found.")
             return HttpResponseRedirect("/contact/thanks/")
         else:
             # In reality we'd use a form class
             # to get proper validation errors.
             return HttpResponse("Make sure all fields are entered and valid.")
+
+
+.. versionchanged:: 6.0
+
+    Older versions raised ``django.core.mail.BadHeaderError`` for some
+    invalid headers. This has been replaced with :exc:`!ValueError`.
 
 .. _Header injection: http://www.nyphp.org/phundamentals/8_Preventing-Email-Header-Injection.html
 
@@ -346,8 +351,8 @@ The following parameters must be given as keyword arguments if used:
 * ``reply_to``: A list or tuple of recipient addresses used in the "Reply-To"
   header when sending the email.
 
-* ``attachments``: A list of attachments to put on the message. These can
-  be instances of :class:`~email.mime.base.MIMEBase` or
+* ``attachments``: A list of attachments to put on the message. Each can
+  be an instance of :class:`~email.message.MIMEPart` or
   :class:`~django.core.mail.EmailAttachment`, or a tuple with attributes
   ``(filename, content, mimetype)``.
 
@@ -355,6 +360,17 @@ The following parameters must be given as keyword arguments if used:
 
     Support for :class:`~django.core.mail.EmailAttachment` items of
     ``attachments`` were added.
+
+  .. versionchanged:: 6.0
+
+    Support for :class:`~email.message.MIMEPart` objects in the ``attachments``
+    list was added.
+
+  .. deprecated:: 6.0
+
+    Support for Python's legacy :class:`~email.mime.base.MIMEBase` objects in
+    ``attachments`` is deprecated. Use :class:`~email.message.MIMEPart`
+    instead.
 
 * ``headers``: A dictionary of extra headers to put on the message. The
   keys are the header name, values are the header values. It's up to the
@@ -396,12 +412,27 @@ The class has the following methods:
   recipients will not raise an exception. It will return ``1`` if the message
   was sent successfully, otherwise ``0``.
 
-* ``message()`` constructs a ``django.core.mail.SafeMIMEText`` object (a
-  subclass of Python's :class:`~email.mime.text.MIMEText` class) or a
-  ``django.core.mail.SafeMIMEMultipart`` object holding the message to be
-  sent. If you ever need to extend the
-  :class:`~django.core.mail.EmailMessage` class, you'll probably want to
-  override this method to put the content you want into the MIME object.
+* ``message(policy=email.policy.default)`` constructs and returns a Python
+  :class:`email.message.EmailMessage` object representing the message to be
+  sent.
+
+  The keyword argument ``policy`` allows specifying the set of rules for
+  updating and serializing the representation of the message. It must be an
+  :py:mod:`email.policy.Policy <email.policy>` object. Defaults to
+  :py:data:`email.policy.default`. In certain cases you may want to use
+  :py:data:`~email.policy.SMTP`, :py:data:`~email.policy.SMTPUTF8` or a custom
+  policy. For example, :class:`django.core.mail.backends.smtp.EmailBackend`
+  uses the :py:data:`~email.policy.SMTP` policy to ensure ``\r\n`` line endings
+  as required by the SMTP protocol.
+
+  If you ever need to extend Django's :class:`~django.core.mail.EmailMessage`
+  class, you'll probably want to override this method to put the content you
+  want into the Python EmailMessage object.
+
+  .. versionchanged:: 6.0
+
+      The ``policy`` keyword argument was added and the return type was updated
+      to an instance of :py:class:`~email.message.EmailMessage`.
 
 * ``recipients()`` returns a list of all the recipients of the message,
   whether they're recorded in the ``to``, ``cc`` or ``bcc`` attributes. This
@@ -410,40 +441,57 @@ The class has the following methods:
   is sent. If you add another way to specify recipients in your class, they
   need to be returned from this method as well.
 
-* ``attach()`` creates a new file attachment and adds it to the message.
+* ``attach()`` creates a new attachment and adds it to the message.
   There are two ways to call ``attach()``:
 
-  * You can pass it a single argument that is a
-    :class:`~email.mime.base.MIMEBase` instance. This will be inserted directly
-    into the resulting message.
-
-  * Alternatively, you can pass ``attach()`` three arguments:
-    ``filename``, ``content`` and ``mimetype``. ``filename`` is the name
-    of the file attachment as it will appear in the email, ``content`` is
-    the data that will be contained inside the attachment and
-    ``mimetype`` is the optional MIME type for the attachment. If you
-    omit ``mimetype``, the MIME content type will be guessed from the
-    filename of the attachment.
+  * You can pass it three arguments: ``filename``, ``content`` and
+    ``mimetype``. ``filename`` is the name of the file attachment as it will
+    appear in the email, ``content`` is the data that will be contained inside
+    the attachment and ``mimetype`` is the optional MIME type for the
+    attachment. If you omit ``mimetype``, the MIME content type will be guessed
+    from the filename of the attachment.
 
     For example::
 
        message.attach("design.png", img_data, "image/png")
 
-    If you specify a ``mimetype`` of :mimetype:`message/rfc822`, it will also
-    accept :class:`django.core.mail.EmailMessage` and
-    :py:class:`email.message.Message`.
+    If you specify a ``mimetype`` of :mimetype:`message/rfc822`, ``content``
+    can be a :class:`django.core.mail.EmailMessage` or Python's
+    :class:`email.message.EmailMessage` or :class:`email.message.Message`.
 
     For a ``mimetype`` starting with :mimetype:`text/`, content is expected to
     be a string. Binary data will be decoded using UTF-8, and if that fails,
     the MIME type will be changed to :mimetype:`application/octet-stream` and
     the data will be attached unchanged.
 
-    In addition, :mimetype:`message/rfc822` attachments will no longer be
-    base64-encoded in violation of :rfc:`2046#section-5.2.1`, which can cause
-    issues with displaying the attachments in `Evolution`__ and `Thunderbird`__.
+  * Or for attachments requiring additional headers or parameters, you can pass
+    ``attach()`` a single Python :class:`~email.message.MIMEPart` object.
+    This will be attached directly to the resulting message. For example,
+    to attach an inline image with a :mailheader:`Content-ID`::
 
-    __ https://bugzilla.gnome.org/show_bug.cgi?id=651197
-    __ https://bugzilla.mozilla.org/show_bug.cgi?id=333880
+        cid = email.utils.make_msgid()
+        inline_image = email.message.MIMEPart()
+        inline_image.set_content(
+            image_data_bytes,
+            maintype="image",
+            subtype="png",
+            disposition="inline",
+            cid=f"<{cid}>",
+        )
+        message.attach(inline_image)
+        message.attach_alternative(f'… <img src="cid:${cid}"> …', "text/html")
+
+    Python's :meth:`email.contentmanager.set_content` documentation describes
+    the supported arguments for ``MIMEPart.set_content()``.
+
+    .. versionchanged:: 6.0
+
+        Support for :class:`~email.message.MIMEPart` attachments was added.
+
+    .. deprecated:: 6.0
+
+        Support for :class:`email.mime.base.MIMEBase` attachments is
+        deprecated. Use :class:`~email.message.MIMEPart` instead.
 
 * ``attach_file()`` creates a new attachment using a file from your
   filesystem. Call it with the path of the file to attach and, optionally,

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -1367,13 +1367,13 @@ class PasswordResetFormTest(TestDataMixin, TestCase):
         self.assertTrue(
             re.match(
                 r"^http://example.com/reset/[\w/-]+",
-                message.get_payload(0).get_payload(),
+                message.get_payload(0).get_content(),
             )
         )
         self.assertTrue(
             re.match(
                 r'^<html><a href="http://example.com/reset/[\w/-]+/">Link</a></html>$',
-                message.get_payload(1).get_payload(),
+                message.get_payload(1).get_content(),
             )
         )
 

--- a/tests/mail/test_deprecated.py
+++ b/tests/mail/test_deprecated.py
@@ -1,0 +1,122 @@
+# RemovedInDjango70Warning: This entire file.
+from email.mime.text import MIMEText
+
+from django.core.mail import (
+    EmailAlternative,
+    EmailAttachment,
+    EmailMessage,
+    EmailMultiAlternatives,
+)
+from django.core.mail.message import forbid_multi_line_headers, sanitize_address
+from django.test import SimpleTestCase, ignore_warnings
+from django.utils.deprecation import RemovedInDjango70Warning
+
+from .tests import MailTestsMixin
+
+
+class DeprecationWarningTests(MailTestsMixin, SimpleTestCase):
+    def test_deprecated_on_import(self):
+        """
+        These items are not typically called from user code,
+        so generate deprecation warnings immediately at the time
+        they are imported from django.core.mail.
+        """
+        cases = [
+            # name, msg
+            (
+                "BadHeaderError",
+                "BadHeaderError is deprecated. Replace with ValueError.",
+            ),
+            (
+                "SafeMIMEText",
+                "SafeMIMEText is deprecated. The return value of"
+                " EmailMessage.message() is an email.message.EmailMessage.",
+            ),
+            (
+                "SafeMIMEMultipart",
+                "SafeMIMEMultipart is deprecated. The return value of"
+                " EmailMessage.message() is an email.message.EmailMessage.",
+            ),
+        ]
+        for name, msg in cases:
+            with self.subTest(name=name):
+                with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+                    __import__("django.core.mail", fromlist=[name])
+
+    def test_sanitize_address_deprecated(self):
+        msg = (
+            "The internal API sanitize_address() is deprecated."
+            " Python's modern email API (with email.message.EmailMessage or"
+            " email.policy.default) will handle most required validation and"
+            " encoding. Use Python's email.headerregistry.Address to construct"
+            " formatted addresses from component parts."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            sanitize_address("to@example.com", "ascii")
+
+    def test_forbid_multi_line_headers_deprecated(self):
+        msg = (
+            "The internal API forbid_multi_line_headers() is deprecated."
+            " Python's modern email API (with email.message.EmailMessage or"
+            " email.policy.default) will reject multi-line headers."
+        )
+        with self.assertWarnsMessage(RemovedInDjango70Warning, msg):
+            forbid_multi_line_headers("To", "to@example.com", "ascii")
+
+
+class UndocumentedFeatureErrorTests(SimpleTestCase):
+    """
+    These undocumented features were removed without going through deprecation.
+    In case they were being used, they now raise errors.
+    """
+
+    def test_undocumented_mixed_subtype(self):
+        """
+        Trying to use the previously undocumented, now unsupported
+        EmailMessage.mixed_subtype causes an error.
+        """
+        msg = (
+            "EmailMessage no longer supports"
+            " the undocumented `mixed_subtype` attribute"
+        )
+        email = EmailMessage(
+            attachments=[EmailAttachment(None, b"GIF89a...", "image/gif")]
+        )
+        email.mixed_subtype = "related"
+        with self.assertRaisesMessage(AttributeError, msg):
+            email.message()
+
+    def test_undocumented_alternative_subtype(self):
+        """
+        Trying to use the previously undocumented, now unsupported
+        EmailMultiAlternatives.alternative_subtype causes an error.
+        """
+        msg = (
+            "EmailMultiAlternatives no longer supports"
+            " the undocumented `alternative_subtype` attribute"
+        )
+        email = EmailMultiAlternatives(
+            alternatives=[EmailAlternative("", "text/plain")]
+        )
+        email.alternative_subtype = "multilingual"
+        with self.assertRaisesMessage(AttributeError, msg):
+            email.message()
+
+
+@ignore_warnings(category=RemovedInDjango70Warning)
+class DeprecatedCompatibilityTests(SimpleTestCase):
+    def test_bad_header_error(self):
+        """
+        Existing code that catches deprecated BadHeaderError should be
+        compatible with modern email (which raises ValueError instead).
+        """
+        from django.core.mail import BadHeaderError
+
+        with self.assertRaises(BadHeaderError):
+            EmailMessage(subject="Bad\r\nHeader").message()
+
+    def test_attachments_mimebase_in_constructor(self):
+        txt = MIMEText("content1")
+        msg = EmailMessage(attachments=[txt])
+        payload = msg.message().get_payload()
+        self.assertEqual(payload[0], txt)

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -584,6 +584,14 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         ).message()
         self.assertEqual(message.get_all("Reply-To"), ["reply_to@example.com"])
 
+    def test_lazy_headers(self):
+        message = EmailMessage(
+            subject=gettext_lazy("subject"),
+            headers={"List-Unsubscribe": gettext_lazy("list-unsubscribe")},
+        ).message()
+        self.assertEqual(message.get_all("Subject"), ["subject"])
+        self.assertEqual(message.get_all("List-Unsubscribe"), ["list-unsubscribe"])
+
     def test_multiple_message_call(self):
         """
         Regression for #13259 - Make sure that headers are not changed when


### PR DESCRIPTION
#### Trac ticket number

ticket-35581

#### Branch description

Switch django.core.mail from using Python's "legacy email API" to its newer "modern email API."

~~I believe this PR is ready for review, but I've marked it "draft" for now. It should not be merged until fixes land for two security issues in Python's modern email API: python/cpython#80222 and python/cpython#121284. (I've included tests in this PR that will fail until they've been addressed.)~~ [Edit: The security issues [have been addressed](#issuecomment-2663947020).]

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- n/a I have attached screenshots in both light and dark modes for any UI changes.

#### Notes

This PR includes a few changes not covered in the original django-developers discussion. More details [in the ticket](https://code.djangoproject.com/ticket/35581#comment:19), but briefly:

* Deprecated passing legacy MIMEBase objects to `EmailMessage.attach()`; added support for modern MIMEPart objects instead.
* Dropped support for the undocumented `EmailMessage.mixed_subtype` and `EmailMultiAlternatives.alternative_subtype` properties and for using legacy Charset objects in the undocumented `EmailMessage.encoding` property. (As these are undocumented, dropped without deprecation. But attempting to use any of them will result in an error.)

I've split the changes into separate commits that may be easier to review individually. The first three commits update tests for django.core.mail only, without changing the implementation. These updated tests should pass whether django.core.mail uses Python's legacy or modern email API to generate messages.

The <del>four</del> <ins>five</ins> commits are (more details in the commit messages):

1. Adds trailing newlines to all text content (bodies and attachments) in mail tests. This is because Python's modern API forces trailing newlines in text (python/cpython#121515).

   In the real world, most email text content probably already has a newline at the end, or it won't cause a problem to add one. Unfortunately, a lot of our test cases include variations on `body="Content"` and `assertEqual(generated_body, "Content")` without trailing newlines, which break with the modern APIs. I've updated those tests to use trailing newlines for all text.

2. Prepares the mail tests for switching to the modern API by reducing dependencies on specific implementation details. (E.g., checking that a message sent with non-ASCII content will parse correctly to the original content at the receiving end, rather than checking for specific encodings and byte sequences.)

   This commit also adds comments to describe some tests that will be relocated or removed in the modern email update. (And then commit 4 removes those comments.)

3. Adds tests for the two Python issues python/cpython#80222 and python/cpython#121284.

   These pass with the legacy API, but currently fail with the modern one. <del>I don't believe there's any practical workaround Django could implement, so until they're fixed in Python the next commit must not be merged.</del>

4. Finally switches to the modern email API. (You could review this commit in isolation if you just want to see what is actually changing.)

5. [Edit: added.] Implements a workaround for one of the security issues. (And the other is fixed in Python 3.12.9 and 3.13.2.)
