### PR TITLE
Refs #373 -- Fixed false failure of test_error_on_comment_pk_conflict.

### DIFF
--- a/tests/composite_pk/tests.py
+++ b/tests/composite_pk/tests.py
@@ -128,7 +128,7 @@ class CompositePKTests(TestCase):
 
     def test_error_on_comment_pk_conflict(self):
         with self.assertRaises(IntegrityError):
-            Comment.objects.create(tenant=self.tenant, id=self.comment.id)
+            Comment.objects.create(tenant=self.tenant, id=self.comment.id, user_id=1)
 
     def test_get_primary_key_columns(self):
         self.assertEqual(


### PR DESCRIPTION
The test failed with "NOT NULL constraint failed" rather than "UNIQUE constraint failed: tenant_id, comment_id".