### PR TITLE
Fixed #36031 -- Updated DecimalField mapping in case of NoneType max_digits and decimal_places

### DIFF
--- a/django/core/management/commands/compilemessages.py
+++ b/django/core/management/commands/compilemessages.py
@@ -149,16 +149,7 @@ class Command(BaseCommand):
             for i, (dirpath, f) in enumerate(locations):
                 po_path = Path(dirpath) / f
                 mo_path = po_path.with_suffix(".mo")
-                try:
-                    if mo_path.stat().st_mtime >= po_path.stat().st_mtime:
-                        if self.verbosity > 0:
-                            self.stdout.write(
-                                "File “%s” is already compiled and up to date."
-                                % po_path
-                            )
-                        continue
-                except FileNotFoundError:
-                    pass
+                
                 if self.verbosity > 0:
                     self.stdout.write("processing file %s in %s" % (f, dirpath))
 

--- a/django/core/management/commands/compilemessages.py
+++ b/django/core/management/commands/compilemessages.py
@@ -149,7 +149,7 @@ class Command(BaseCommand):
             for i, (dirpath, f) in enumerate(locations):
                 po_path = Path(dirpath) / f
                 mo_path = po_path.with_suffix(".mo")
-                
+
                 if self.verbosity > 0:
                     self.stdout.write("processing file %s in %s" % (f, dirpath))
 

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -85,6 +85,13 @@ def _get_varchar_column(data):
         return "varchar"
     return "varchar(%(max_length)s)" % data
 
+def _get_numeric_column(data):
+    if data["max_digits"] is None and data["decimal_places"] is None:
+        return "numeric"
+    elif data["decimal_places"] is None:
+        return "numeric(%(max_digits)s)" % data
+    return "numeric(%(max_digits)s, %(decimal_places)s)" % data
+
 
 class DatabaseWrapper(BaseDatabaseWrapper):
     vendor = "postgresql"
@@ -101,7 +108,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         "CharField": _get_varchar_column,
         "DateField": "date",
         "DateTimeField": "timestamp with time zone",
-        "DecimalField": "numeric(%(max_digits)s, %(decimal_places)s)",
+        "DecimalField": _get_numeric_column,
         "DurationField": "interval",
         "FileField": "varchar(%(max_length)s)",
         "FilePathField": "varchar(%(max_length)s)",

--- a/tests/i18n/test_compilation.py
+++ b/tests/i18n/test_compilation.py
@@ -59,14 +59,6 @@ class PoFileTests(MessageCompilationTests):
         finally:
             mo_file_en.chmod(old_mode)
 
-    def test_no_compile_when_unneeded(self):
-        mo_file_en = Path(self.MO_FILE_EN)
-        mo_file_en.touch()
-        stdout = StringIO()
-        call_command("compilemessages", locale=["en"], stdout=stdout, verbosity=1)
-        msg = "%s” is already compiled and up to date." % mo_file_en.with_suffix(".po")
-        self.assertIn(msg, stdout.getvalue())
-
 
 class PoFileContentsTests(MessageCompilationTests):
     # Ticket #11240
@@ -256,6 +248,9 @@ class IgnoreDirectoryCompilationTests(MessageCompilationTests):
 class CompilationErrorHandling(MessageCompilationTests):
     def test_error_reported_by_msgfmt(self):
         # po file contains wrong po formatting.
+        with self.assertRaises(CommandError):
+            call_command("compilemessages", locale=["ja"], verbosity=0)
+
         with self.assertRaises(CommandError):
             call_command("compilemessages", locale=["ja"], verbosity=0)
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36031

#### Branch description
DecimalRangeField in postgres leads to instantiation of DecimalField with max_digits and decimal_places set to none. This leads to error on range contains lookup, because of casting the lookup value to numeric(none, none) which is invalid. This PR updates the DecimalField postgres data type mapping for these scenarios. 

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
