### PR TITLE
Fixed #36037 -- Fixed default primary key type in docs.

### DIFF
--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -261,7 +261,7 @@ For example, it could be used for a tagging system like so::
     class TaggedItem(models.Model):
         tag = models.SlugField()
         content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
-        object_id = models.PositiveIntegerField()
+        object_id = models.PositiveBigIntegerField()
         content_object = GenericForeignKey("content_type", "object_id")
 
         def __str__(self):
@@ -291,7 +291,7 @@ model:
 
     2. Give your model a field that can store primary key values from the
        models you'll be relating to. For most models, this means a
-       :class:`~django.db.models.PositiveIntegerField`. The usual name
+       :class:`~django.db.models.PositiveBigIntegerField`. The usual name
        for this field is "object_id".
 
     3. Give your model a

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -241,8 +241,8 @@ ones:
     If ``True``, this field is the primary key for the model.
 
     If you don't specify :attr:`primary_key=True <Field.primary_key>` for
-    any fields in your model, Django will automatically add an
-    :class:`IntegerField` to hold the primary key, so you don't need to set
+    any fields in your model, Django will automatically add a field to hold
+    the primary key, so you don't need to set
     :attr:`primary_key=True <Field.primary_key>` on any of your fields
     unless you want to override the default primary-key behavior. For more,
     see :ref:`automatic-primary-key-fields`.


### PR DESCRIPTION
#### Trac ticket number

ticket-36037

#### Branch description
* Currently, Django's default primary key type is a BigAutoField. However, a couple of pages still talk about it being an IntegerField.
* BigAutoField is the default type of primary key now, and in Postgres, regular IntegerField only goes up to around 2 billion.
* In models.txt, the linked anchor shows that the default primary key is a BigAutoField, so it now defers to that section instead of duplicating an (incorrect) type.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
