### PR TITLE
Fixed #31170 -- Added change event trigger to dismissRelatedLookupPopup.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -57,6 +57,7 @@
         } else {
             elem.value = chosenId;
         }
+        $(elem).trigger('change');
         const index = window.relatedWindows.indexOf(win);
         if (index > -1) {
             window.relatedWindows.splice(index, 1);

--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -55,11 +55,11 @@
         if (elem.classList.contains('vManyToManyRawIdAdminField') && elem.value) {
             elem.value += ',' + chosenId;
         } else {
-            document.getElementById(name).value = chosenId;
+            elem.value = chosenId;
         }
-        const index = relatedWindows.indexOf(win);
+        const index = window.relatedWindows.indexOf(win);
         if (index > -1) {
-            relatedWindows.splice(index, 1);
+            window.relatedWindows.splice(index, 1);
         }
         win.close();
     }

--- a/js_tests/admin/RelatedObjectLookups.test.js
+++ b/js_tests/admin/RelatedObjectLookups.test.js
@@ -36,3 +36,43 @@ QUnit.test('dismissRelatedLookupPopup removes window from relatedWindows array',
     window.dismissRelatedLookupPopup(mockWin, '123');
     assert.equal(window.relatedWindows.indexOf(mockWin), -1, 'Window should be removed from relatedWindows array');
 });
+
+QUnit.test('dismissRelatedLookupPopup triggers change event for single value field', function(assert) {
+    assert.timeout(1000);
+    const done = assert.async();
+    const $ = django.jQuery;
+    const testId = 'test_id';
+    const newValue = '123';
+    const mockWin = {
+        name: testId,
+        close: function() {}
+    };
+    let changeTriggered = false;
+    $('#test_id').on('change', function() {
+        changeTriggered = true;
+        assert.equal(this.value, newValue, 'Value should be updated');
+        done();
+    });
+    window.dismissRelatedLookupPopup(mockWin, newValue);
+    assert.true(changeTriggered, 'Change event should be triggered');
+});
+
+QUnit.test('dismissRelatedLookupPopup triggers change event for many-to-many field', function(assert) {
+    assert.timeout(1000);
+    const $ = django.jQuery;
+    const testId = 'many_test_id';
+    const existingValue = '1,2';
+    const newValue = '3';
+    $('#many_test_id').val(existingValue);
+    const mockWin = {
+        name: testId,
+        close: function() {}
+    };
+    let changeTriggered = false;
+    $('#many_test_id').on('change', function() {
+        changeTriggered = true;
+        assert.equal(this.value, existingValue + ',' + newValue, 'Value should be appended for many-to-many fields');
+    });
+    window.dismissRelatedLookupPopup(mockWin, newValue);
+    assert.true(changeTriggered, 'Change event should be triggered');
+});

--- a/js_tests/admin/RelatedObjectLookups.test.js
+++ b/js_tests/admin/RelatedObjectLookups.test.js
@@ -1,0 +1,38 @@
+/* global QUnit, RelatedObjectLookups */
+'use strict';
+
+QUnit.module('admin.RelatedObjectLookups', {
+    beforeEach: function() {
+        const $ = django.jQuery;
+        $('#qunit-fixture').append(`
+            <input type="text" id="test_id" name="test" />
+            <input type="text" id="many_test_id" name="many_test" class="vManyToManyRawIdAdminField" />
+        `);
+        window.relatedWindows = window.relatedWindows || [];
+    }
+});
+
+QUnit.test('dismissRelatedLookupPopup closes popup window', function(assert) {
+    const testId = 'test_id';
+    let windowClosed = false;
+    const mockWin = {
+        name: testId,
+        close: function() {
+            windowClosed = true;
+        }
+    };
+    window.dismissRelatedLookupPopup(mockWin, '123');
+    assert.true(windowClosed, 'Popup window should be closed');
+});
+
+QUnit.test('dismissRelatedLookupPopup removes window from relatedWindows array', function(assert) {
+    const testId = 'test_id';
+    const mockWin = {
+        name: testId,
+        close: function() {}
+    };
+    window.relatedWindows.push(mockWin);
+    assert.equal(window.relatedWindows.indexOf(mockWin), 0, 'Window should be in relatedWindows array');
+    window.dismissRelatedLookupPopup(mockWin, '123');
+    assert.equal(window.relatedWindows.indexOf(mockWin), -1, 'Window should be removed from relatedWindows array');
+});

--- a/js_tests/tests.html
+++ b/js_tests/tests.html
@@ -125,6 +125,7 @@
     <script src='./admin/navigation.test.js'></script>
 
     <script src='../django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js' data-cover></script>
+    <script src='./admin/RelatedObjectLookups.test.js'></script>
 
     <script src='./admin/DateTimeShortcuts.test.js'></script>
     <script src='../django/contrib/admin/static/admin/js/calendar.js' data-cover></script>


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[ticket-31170](https://code.djangoproject.com/ticket/31170)

#### Branch description
The dismissRelatedLookupPopup function now triggers a change event after
setting the value, matching the behavior of dismissAddRelatedObjectPopup.
This ensures that dependent fields are properly updated when a value is
selected via the popup.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
