### PR TITLE
Fixed #36032 -- Add a link to the URLField value on the app index page.

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -454,6 +454,8 @@ def display_for_field(value, field, empty_value_display, avoid_link=False):
         return formats.number_format(value)
     elif isinstance(field, models.FileField) and value and not avoid_link:
         return format_html('<a href="{}">{}</a>', value.url, value)
+    elif isinstance(field, models.URLField) and value and not avoid_link:
+        return format_html('<a href="{}">{}</a>', value, value)
     elif isinstance(field, models.JSONField) and value:
         try:
             return json.dumps(value, ensure_ascii=False, cls=field.encoder)

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -60,6 +60,8 @@ Minor features
   :ref:`extrabody <extrabody>` for adding custom code before the closing
   ``</body>`` tag.
 
+* The value of a :class:`~django.db.models.URLField` now renders as a link.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -158,8 +158,8 @@ site.register(Parent, NoListDisplayLinksParentAdmin)
 
 
 class ListDisplayLinksGenreAdmin(admin.ModelAdmin):
-    list_display = ["name", "file"]
-    list_display_links = ["file"]
+    list_display = ["name", "file", "url"]
+    list_display_links = ["file", "url"]
 
 
 site.register(Genre, ListDisplayLinksGenreAdmin)

--- a/tests/admin_changelist/models.py
+++ b/tests/admin_changelist/models.py
@@ -33,6 +33,7 @@ class GrandChild(models.Model):
 class Genre(models.Model):
     name = models.CharField(max_length=20)
     file = models.FileField(upload_to="documents/", blank=True, null=True)
+    url = models.URLField(blank=True, null=True)
 
 
 class Band(models.Model):

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1059,12 +1059,21 @@ class ChangeListTests(TestCase):
 
     def test_link_field_display_links(self):
         self.client.force_login(self.superuser)
-        g = Genre.objects.create(name="Blues", file="documents/blues_history.txt")
+        g = Genre.objects.create(
+            name="Blues",
+            file="documents/blues_history.txt",
+            url="http://blues_history.com",
+        )
         response = self.client.get(reverse("admin:admin_changelist_genre_changelist"))
         self.assertContains(
             response,
             '<a href="/admin/admin_changelist/genre/%s/change/">'
             "documents/blues_history.txt</a>" % g.pk,
+        )
+        self.assertContains(
+            response,
+            '<a href="/admin/admin_changelist/genre/%s/change/">'
+            "http://blues_history.com</a>" % g.pk,
         )
 
     def test_clear_all_filters_link(self):

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -157,6 +157,7 @@ class UtilsTests(SimpleTestCase):
             models.DateField(),
             models.DecimalField(),
             models.FloatField(),
+            models.URLField(),
             models.JSONField(),
             models.TimeField(),
         ]
@@ -195,6 +196,14 @@ class UtilsTests(SimpleTestCase):
                     display_for_field(value, models.JSONField(), self.empty_value),
                     display_value,
                 )
+
+    def test_url_display_for_field(self):
+        model_field = models.URLField()
+        display_value = display_for_field(
+            "http://example.com", model_field, self.empty_value
+        )
+        expected = '<a href="http://example.com">http://example.com</a>'
+        self.assertHTMLEqual(display_value, expected)
 
     def test_number_formats_display_for_field(self):
         display_value = display_for_field(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36032

#### Branch description
I modified the URLField value on the Django Admin app index page to provide a link.

<img width="684" alt="Screenshot 2024-12-25 at 8 29 43 PM" src="https://github.com/user-attachments/assets/b58bf236-59dc-48d5-98d6-d48959516a96" />


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
