### PR TITLE
Added a test for QuerySet.delete() raising EmptyResultSet.

### DIFF
--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -794,6 +794,15 @@ class FastDeleteTests(TestCase):
             )
         self.assertIs(Base.objects.exists(), False)
 
+    def test_fast_delete_empty_result_set(self):
+        user = User.objects.create()
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                User.objects.filter(pk__in=[]).delete(),
+                (0, {}),
+            )
+        self.assertSequenceEqual(User.objects.all(), [user])
+
     def test_fast_delete_full_match(self):
         avatar = Avatar.objects.create(desc="bar")
         User.objects.create(avatar=avatar)


### PR DESCRIPTION
The missing test led to [the case being unhandled in django-mongodb](
https://github.com/mongodb-labs/django-mongodb/pull/201).

I made this temporary modification to confirm that no existing tests fail when the delete condition raises EmptyResultSet:
```diff
diff --git a/django/db/models/sql/compiler.py b/django/db/models/sql/compiler.py
index 49c5d301cc..d9a73882c0 100644
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1967,7 +1967,10 @@ class SQLDeleteCompiler(SQLCompiler):
     def _as_sql(self, query):
         delete = "DELETE FROM %s" % self.quote_name_unless_alias(query.base_table)
         try:
-            where, params = self.compile(query.where)
+            try:
+                where, params = self.compile(query.where)
+            except EmptyResultSet:
+                assert False
         except FullResultSet:
             return delete, ()
         return f"{delete} WHERE {where}", tuple(params)
```
Perhaps the oversight isn't completely surprising since the full match case wasn't tested until 4b702c832cd550fe682ef37a69e93866815b9123.