### PR TITLE
Fixed #36029 -- Handled implicit exact lookups in condition depth checks for FilteredRelation.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1704,12 +1704,12 @@ class Query(BaseExpression):
                             "relations outside the %r (got %r)."
                             % (filtered_relation.relation_name, lookup)
                         )
-                else:
-                    raise ValueError(
-                        "FilteredRelation's condition doesn't support nested "
-                        "relations deeper than the relation_name (got %r for "
-                        "%r)." % (lookup, filtered_relation.relation_name)
-                    )
+            if len(lookup_field_parts) > len(relation_field_parts) + 1:
+                raise ValueError(
+                    "FilteredRelation's condition doesn't support nested "
+                    "relations deeper than the relation_name (got %r for "
+                    "%r)." % (lookup, filtered_relation.relation_name)
+                )
         filtered_relation.condition = rename_prefix_from_q(
             filtered_relation.relation_name,
             alias,

--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -668,6 +668,19 @@ class FilteredRelationTests(TestCase):
                 ),
             )
 
+    def test_condition_deeper_relation_name_implicit_exact(self):
+        msg = (
+            "FilteredRelation's condition doesn't support nested relations "
+            "deeper than the relation_name (got 'book__editor__name' for 'book')."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            Author.objects.annotate(
+                book_editor=FilteredRelation(
+                    "book",
+                    condition=Q(book__editor__name="b"),
+                ),
+            )
+
     def test_with_empty_relation_name_error(self):
         with self.assertRaisesMessage(ValueError, "relation_name cannot be empty."):
             FilteredRelation("", condition=Q(blank=""))


### PR DESCRIPTION
#### Trac ticket number
ticket-36029

#### Branch description
Raise ValueError for condition depths in FilteredRelation even when the exact lookup is implicit.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
