### PR TITLE
Add an index on the combination of the two ForeignKeys of the ManyToManyField through model.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1303,6 +1303,7 @@ def create_many_to_many_intermediary_model(field, klass):
             "verbose_name_plural": _("%(from)s-%(to)s relationships")
             % {"from": from_, "to": to},
             "apps": field.model._meta.apps,
+            "indexes": [models.Index(fields=(from_, to), name="index_together")],
         },
     )
     # Construct and return the new class.

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1303,7 +1303,9 @@ def create_many_to_many_intermediary_model(field, klass):
             "verbose_name_plural": _("%(from)s-%(to)s relationships")
             % {"from": from_, "to": to},
             "apps": field.model._meta.apps,
-            "indexes": [models.Index(fields=(from_, to), name="index_together")],
+            "indexes": [
+                models.Index(fields=(from_, to), name="index_two_foreignkeys_together")
+            ],
         },
     )
     # Construct and return the new class.

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1304,7 +1304,9 @@ def create_many_to_many_intermediary_model(field, klass):
             % {"from": from_, "to": to},
             "apps": field.model._meta.apps,
             "indexes": [
-                models.Index(fields=(from_, to), name=f"{name}_{from_}_{to}_index_together")
+                models.Index(
+                    fields=(from_, to), name=f"{name}_{from_}_{to}_index_together"
+                )
             ],
         },
     )

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1304,7 +1304,7 @@ def create_many_to_many_intermediary_model(field, klass):
             % {"from": from_, "to": to},
             "apps": field.model._meta.apps,
             "indexes": [
-                models.Index(fields=(from_, to), name="index_two_foreignkeys_together")
+                models.Index(fields=(from_, to), name=f"{name}_{from_}_{to}_index_together")
             ],
         },
     )


### PR DESCRIPTION
# ticket-36046

See the [Django-ticket-#36046](https://code.djangoproject.com/ticket/36046)


#### Branch description

Currently the through table makes indexes on the individual foreign keys (because these are foreign keys, the index is implied), but there is no index on the combination of the foreign keys. This PR automatically adds an index on the combo, which can boost for example checks if two items are linked through a `ManyToManyField.