### PR TITLE
Fixed #36042 -- Raised ValueError when using CompositePrimaryKey as rhs.

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -166,6 +166,7 @@ class Count(Aggregate):
     output_field = IntegerField()
     allow_distinct = True
     empty_result_set_value = 0
+    allows_composite_expressions = True
 
     def __init__(self, expression, filter=None, **extra):
         if expression == "*":

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -758,6 +758,8 @@ class CombinedExpression(SQLiteNumericMixin, Expression):
         rhs = self.rhs.resolve_expression(
             query, allow_joins, reuse, summarize, for_save
         )
+        if isinstance(lhs, ColPairs) or isinstance(rhs, ColPairs):
+            raise ValueError("CompositePrimaryKey is not combinable.")
         if not isinstance(self, (DurationExpression, TemporalSubtraction)):
             try:
                 lhs_type = lhs.output_field.get_internal_type()

--- a/django/db/models/fields/tuple_lookups.py
+++ b/django/db/models/fields/tuple_lookups.py
@@ -17,6 +17,7 @@ from django.db.models.sql.where import AND, OR, WhereNode
 
 
 class Tuple(Func):
+    allows_composite_expressions = True
     function = ""
     output_field = Field()
 
@@ -28,6 +29,8 @@ class Tuple(Func):
 
 
 class TupleLookupMixin:
+    allows_composite_expressions = True
+
     def get_prep_lookup(self):
         self.check_rhs_is_tuple_or_list()
         self.check_rhs_length_equals_lhs_length()

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -4,7 +4,7 @@ import warnings
 
 from django.core.exceptions import EmptyResultSet, FullResultSet
 from django.db.backends.base.operations import BaseDatabaseOperations
-from django.db.models.expressions import Case, Expression, Func, Value, When
+from django.db.models.expressions import Case, ColPairs, Expression, Func, Value, When
 from django.db.models.fields import (
     BooleanField,
     CharField,
@@ -119,6 +119,10 @@ class Lookup(Expression):
             value = value.resolve_expression(compiler.query)
         if hasattr(value, "as_sql"):
             sql, params = compiler.compile(value)
+            if isinstance(value, ColPairs):
+                raise ValueError(
+                    "CompositePrimaryKey cannot be used as a lookup value."
+                )
             # Ensure expression is wrapped in parentheses to respect operator
             # precedence but avoid double wrapping as it can be misinterpreted
             # on some backends (e.g. subqueries on SQLite).

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -1105,6 +1105,14 @@ calling the appropriate methods on the wrapped expression.
         ``UNNEST``, etc.) to skip optimization and be properly evaluated when
         annotations spawn rows themselves. Defaults to ``False``.
 
+    .. attribute:: allows_composite_expressions
+
+        .. versionadded:: 5.2
+
+        Tells Django that this expression allows composite expressions, for
+        example, to support :ref:`composite primary keys
+        <cpk-and-database-functions>`. Defaults to ``False``.
+
     .. method:: resolve_expression(query=None, allow_joins=True, reuse=None, summarize=False, for_save=False)
 
         Provides the chance to do any preprocessing or validation of

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -330,6 +330,10 @@ Models
   accepts a list of field names or expressions and returns a JSON array
   containing those values.
 
+* The new :attr:`.Expression.allows_composite_expressions` attribute specifies
+  that the expression allows composite expressions, for example, to support
+  :ref:`composite primary keys <cpk-and-database-functions>`.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/composite-primary-key.txt
+++ b/docs/topics/composite-primary-key.txt
@@ -131,6 +131,8 @@ database.
     ``ForeignObject`` is an internal API. This means it is not covered by our
     :ref:`deprecation policy <internal-release-deprecation-policy>`.
 
+.. _cpk-and-database-functions:
+
 Composite primary keys and database functions
 =============================================
 
@@ -141,13 +143,15 @@ Many database functions only accept a single expression.
     MAX("order_id")  -- OK
     MAX("product_id", "order_id")  -- ERROR
 
-As a consequence, they cannot be used with composite primary key references as
-they are composed of multiple column expressions.
+In these cases, providing a composite primary key reference raises a
+``ValueError``, since it is composed of multiple column expressions. An
+exception is made for ``Count``.
 
 .. code-block:: python
 
     Max("order_id")  # OK
-    Max("pk")  # ERROR
+    Max("pk")  # ValueError
+    Count("pk")  # OK
 
 Composite primary keys in forms
 ===============================

--- a/tests/composite_pk/test_aggregate.py
+++ b/tests/composite_pk/test_aggregate.py
@@ -1,4 +1,4 @@
-from django.db.models import Count, Q
+from django.db.models import Count, Max, Q
 from django.test import TestCase
 
 from .models import Comment, Tenant, User
@@ -136,3 +136,8 @@ class CompositePKAggregateTests(TestCase):
             ),
             (self.user_3, self.user_1, self.user_2),
         )
+
+    def test_max_pk(self):
+        msg = "Max does not support composite primary keys."
+        with self.assertRaisesMessage(ValueError, msg):
+            Comment.objects.aggregate(Max("pk"))

--- a/tests/composite_pk/test_filter.py
+++ b/tests/composite_pk/test_filter.py
@@ -428,6 +428,6 @@ class CompositePKFilterTests(TestCase):
         self.assertSequenceEqual(queryset, (self.user_2,))
 
     def test_cannot_cast_pk(self):
-        msg = "Casting CompositePrimaryKey is not supported."
+        msg = "Cast does not support composite primary keys."
         with self.assertRaisesMessage(ValueError, msg):
             Comment.objects.filter(text__gt=Cast(F("pk"), TextField())).count()


### PR DESCRIPTION
#### Trac ticket number
ticket-36042

#### Branch description
Before, using `CompositePrimaryKey` in a right-hand side (as `F(pk)`) would raise database errors. It would also fail on all but PostgreSQL when attempting to cast to a TextField.

Now, more informative errors are raised at the ORM compilation level instead of at the database level.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
