### PR TITLE
Fixed field_defaults test failures due to year-end boundary conditions.

### DIFF
--- a/tests/field_defaults/tests.py
+++ b/tests/field_defaults/tests.py
@@ -15,7 +15,14 @@ from django.db.models.expressions import (
 )
 from django.db.models.functions import Collate
 from django.db.models.lookups import GreaterThan
-from django.test import SimpleTestCase, TestCase, skipIfDBFeature, skipUnlessDBFeature
+from django.test import (
+    SimpleTestCase,
+    TestCase,
+    override_settings,
+    skipIfDBFeature,
+    skipUnlessDBFeature,
+)
+from django.utils import timezone
 
 from .models import (
     Article,
@@ -69,12 +76,13 @@ class DefaultTests(TestCase):
         self.assertIsNone(obj2.null)
 
     @skipUnlessDBFeature("supports_expression_defaults")
+    @override_settings(USE_TZ=True)
     def test_db_default_function(self):
         m = DBDefaultsFunction.objects.create()
         if not connection.features.can_return_columns_from_insert:
             m.refresh_from_db()
         self.assertAlmostEqual(m.number, pi)
-        self.assertEqual(m.year, datetime.now().year)
+        self.assertEqual(m.year, timezone.now().year)
         self.assertAlmostEqual(m.added, pi + 4.5)
         self.assertEqual(m.multiple_subfunctions, 4.5)
 
@@ -163,12 +171,13 @@ class DefaultTests(TestCase):
         self.assertCountEqual(headlines, ["Default headline", "Something else"])
 
     @skipUnlessDBFeature("supports_expression_defaults")
+    @override_settings(USE_TZ=True)
     def test_bulk_create_mixed_db_defaults_function(self):
         instances = [DBDefaultsFunction(), DBDefaultsFunction(year=2000)]
         DBDefaultsFunction.objects.bulk_create(instances)
 
         years = DBDefaultsFunction.objects.values_list("year", flat=True)
-        self.assertCountEqual(years, [2000, datetime.now().year])
+        self.assertCountEqual(years, [2000, timezone.now().year])
 
     def test_full_clean(self):
         obj = DBArticle()


### PR DESCRIPTION
#### Trac ticket number
n/a

#### Branch description
These two tests failed around New Year's Eve, both locally and on a [pull request](https://djangoci.com/job/pull-requests-focal/database=sqlite3,label=focal-pr,python=python3.10/29048/).

They can be fixed by using an aware datetime comparison. (This is an extremely minor issue, but fixing it has the benefit of modeling good usage in the tests.)

To reproduce the original issue, you can adjust the test to subtract a timedelta from datetime.now() that will result in a time that is still in 2024 in your timezone but at least 01/01/2025 00:00 UTC. Then using that same offset with this branch should pass.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [n/a] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
