### PR TITLE
Fixed #36051 -- Declared arity on aggregate functions.

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -158,6 +158,7 @@ class Avg(FixDurationInputMixin, NumericOutputFieldMixin, Aggregate):
     function = "AVG"
     name = "Avg"
     allow_distinct = True
+    arity = 1
 
 
 class Count(Aggregate):
@@ -166,6 +167,7 @@ class Count(Aggregate):
     output_field = IntegerField()
     allow_distinct = True
     empty_result_set_value = 0
+    arity = 1
     allows_composite_expressions = True
 
     def __init__(self, expression, filter=None, **extra):
@@ -195,15 +197,18 @@ class Count(Aggregate):
 class Max(Aggregate):
     function = "MAX"
     name = "Max"
+    arity = 1
 
 
 class Min(Aggregate):
     function = "MIN"
     name = "Min"
+    arity = 1
 
 
 class StdDev(NumericOutputFieldMixin, Aggregate):
     name = "StdDev"
+    arity = 1
 
     def __init__(self, expression, sample=False, **extra):
         self.function = "STDDEV_SAMP" if sample else "STDDEV_POP"
@@ -217,10 +222,12 @@ class Sum(FixDurationInputMixin, Aggregate):
     function = "SUM"
     name = "Sum"
     allow_distinct = True
+    arity = 1
 
 
 class Variance(NumericOutputFieldMixin, Aggregate):
     name = "Variance"
+    arity = 1
 
     def __init__(self, expression, sample=False, **extra):
         self.function = "VAR_SAMP" if sample else "VAR_POP"

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -516,6 +516,7 @@ generated. Here's a brief example::
         function = "SUM"
         template = "%(function)s(%(all_values)s%(expressions)s)"
         allow_distinct = False
+        arity = 1
 
         def __init__(self, expression, all_values=False, **extra):
             super().__init__(expression, all_values="ALL " if all_values else "", **extra)

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -511,6 +511,10 @@ Miscellaneous
 * The minimum supported version of ``oracledb`` is increased from 1.3.2 to
   2.3.0.
 
+* Built-in aggregate functions accepting only one argument (``Avg``, ``Count``,
+  ``Max``, ``Min``, ``StdDev``, ``Sum``, and ``Variance``) now raise
+  :exc:`TypeError` when called with an incorrect number of arguments.
+
 .. _deprecated-features-5.2:
 
 Features deprecated in 5.2


### PR DESCRIPTION
#### Trac ticket number
ticket-36051

#### Branch description
Now, calling aggregate functions with too many arguments raises `TypeError`.
    
Follow-up to 4a66a69239c493c05b322815b18c605cd4c96e7c.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
