### PR TITLE
Refs #373 -- Errored when providing db_column to CompositePrimaryKey.

### DIFF
--- a/django/db/models/fields/composite.py
+++ b/django/db/models/fields/composite.py
@@ -56,6 +56,8 @@ class CompositePrimaryKey(Field):
             raise ValueError("CompositePrimaryKey cannot have a default.")
         if kwargs.get("db_default", NOT_PROVIDED) is not NOT_PROVIDED:
             raise ValueError("CompositePrimaryKey cannot have a database default.")
+        if kwargs.get("db_column", None) is not None:
+            raise ValueError("CompositePrimaryKey cannot have a db_column.")
         if kwargs.setdefault("editable", False):
             raise ValueError("CompositePrimaryKey cannot be editable.")
         if not kwargs.setdefault("primary_key", True):

--- a/tests/composite_pk/test_checks.py
+++ b/tests/composite_pk/test_checks.py
@@ -43,6 +43,11 @@ class CompositePKChecksTests(TestCase):
         with self.assertRaisesMessage(ValueError, expected_message):
             models.CompositePrimaryKey("tenant_id", "id", db_default=models.F("id"))
 
+    def test_composite_pk_cannot_have_a_db_column(self):
+        expected_message = "CompositePrimaryKey cannot have a db_column."
+        with self.assertRaisesMessage(ValueError, expected_message):
+            models.CompositePrimaryKey("tenant_id", "id", db_column="tenant_pk")
+
     def test_composite_pk_cannot_be_editable(self):
         expected_message = "CompositePrimaryKey cannot be editable."
         with self.assertRaisesMessage(ValueError, expected_message):


### PR DESCRIPTION
#### Branch description
`db_column` is silently ignored when creating CompositePrimaryKey, so add it to the list of forbidden options.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
