### PR TITLE
Fixed #36052 -- Supported CompositePrimaryKey in inspectdb.

### DIFF
--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -655,11 +655,10 @@ class InspectDBTransactionalTests(TransactionTestCase):
             call_command("inspectdb", table_name, stdout=out)
             output = out.getvalue()
             self.assertIn(
-                f"column_1 = models.{field_type}(primary_key=True)  # The composite "
-                f"primary key (column_1, column_2) found, that is not supported. The "
-                f"first column is selected.",
+                "pk = models.CompositePrimaryKey('column_1', 'column_2')",
                 output,
             )
+            self.assertIn(f"column_1 = models.{field_type}()", output)
             self.assertIn(
                 "column_2 = models.%s()"
                 % connection.features.introspected_field_types["IntegerField"],


### PR DESCRIPTION
#### Trac ticket number
ticket-36052

#### Branch description
Add inspectdb support for composite primary keys.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
