### PR TITLE
Fixed #36022 -- Added django alternative spelling of django-admin.

### DIFF
--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -473,7 +473,7 @@ Miscellaneous
 * The minimum supported version of ``oracledb`` is increased from 1.3.2 to
   2.3.0.
 
-* The ``django`` command is added as an alterative spelling for ``django-admin``.
+* The ``django`` command is added as an alternative spelling for ``django-admin``.
 
 .. _deprecated-features-5.2:
 

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -473,6 +473,8 @@ Miscellaneous
 * The minimum supported version of ``oracledb`` is increased from 1.3.2 to
   2.3.0.
 
+* The ``django`` command is added as an alterative spelling for ``django-admin``.
+
 .. _deprecated-features-5.2:
 
 Features deprecated in 5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ argon2 = ["argon2-cffi>=19.1.0"]
 bcrypt = ["bcrypt"]
 
 [project.scripts]
+django = "django.core.management:execute_from_command_line"
 django-admin = "django.core.management:execute_from_command_line"
 
 [project.urls]

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2517,6 +2517,12 @@ class ExecuteFromCommandLine(SimpleTestCase):
         self.assertIn("usage: django-admin shell", out.getvalue())
         self.assertEqual(err.getvalue(), "")
 
+        with captured_stdout() as out, captured_stderr() as err:
+            with mock.patch("sys.argv", [None] + args):
+                execute_from_command_line(["django"] + args)
+        self.assertIn("usage: django shell", out.getvalue())
+        self.assertEqual(err.getvalue(), "")
+
 
 @override_settings(ROOT_URLCONF="admin_scripts.urls")
 class StartProject(LiveServerTestCase, AdminScriptTestCase):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36022

#### Branch description
As discussed on [the forum](https://forum.djangoproject.com/t/name-the-main-command-django/37230), this adds `django` as an alternative way to spell `django-admin`. While we have the eye to move toward replacing existing usages of `django-admin` in the documentation, I'd like to get this merged sooner so that I can take a little more time going through the documentation, without missing the Django 5.2 code freeze.

I looked through the `tests/admin_scripts` test file. The only place that I can see `django-admin` being used in code is in a mocked-out sys.argv to test that the `django-admin` name is passed through. I updated it to also check the same thing for `django`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
