### PR TITLE
Fixed #36056 -- Made OutputWrapper a virtual TextIOBase subclass only.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -142,7 +142,7 @@ class DjangoHelpFormatter(HelpFormatter):
         super().add_arguments(self._reordered_actions(actions))
 
 
-class OutputWrapper(TextIOBase):
+class OutputWrapper:
     """
     Wrapper around stdout/stderr
     """
@@ -179,6 +179,9 @@ class OutputWrapper(TextIOBase):
             msg += ending
         style_func = style_func or self.style_func
         self._out.write(style_func(msg))
+
+
+TextIOBase.register(OutputWrapper)
 
 
 class BaseCommand:


### PR DESCRIPTION
#### Trac ticket number

ticket-36056

#### Branch description

See ticket for explanation.

Initially, I just removed inheritance from `TextIOBase`. But then I found a few test failures like:

```
======================================================================
ERROR: test_serialization (m2m_through_regress.tests.M2MThroughSerializationTestCase.test_serialization)
m2m-through models aren't serialized as m2m fields. Refs #8134
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/.../django/core/management/commands/dumpdata.py", line 269, in handle
    serializers.serialize(
    ~~~~~~~~~~~~~~~~~~~~~^
        format,
        ^^^^^^^
    ...<6 lines>...
        object_count=object_count,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/.../django/core/serializers/__init__.py", line 134, in serialize
    s.serialize(queryset, **options)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/.../django/core/serializers/base.py", line 107, in serialize
    self.start_serialization()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/.../django/core/serializers/xml_serializer.py", line 34, in start_serialization
    self.xml.startDocument()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/.../lib/python3.13/xml/sax/saxutils.py", line 151, in startDocument
    self._write('<?xml version="1.0" encoding="%s"?>\n' %
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                    self._encoding)
                    ^^^^^^^^^^^^^^^
  File "/.../django/core/management/base.py", line 180, in write
    self._out.write(style_func(msg))
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
TypeError: string argument expected, got 'bytes'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/.../tests/m2m_through_regress/tests.py", line 96, in test_serialization
    management.call_command(
    ~~~~~~~~~~~~~~~~~~~~~~~^
        "dumpdata", "m2m_through_regress", format="xml", indent=2, stdout=out
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/.../django/core/management/__init__.py", line 194, in call_command
    return command.execute(*args, **defaults)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/.../django/core/management/base.py", line 456, in execute
    output = self.handle(*args, **options)
  File "/.../django/core/management/commands/dumpdata.py", line 285, in handle
    raise CommandError("Unable to serialize database: %s" % e)
django.core.management.base.CommandError: Unable to serialize database: string argument expected, got 'bytes'
```

I think this is probably why the inheritance was added in the first place.

I fixed it by using [`ABCMeta.register()`](https://docs.python.org/3.13/library/abc.html#abc.ABCMeta.register) to make `OutputWrapper` pass [this check](https://github.com/python/cpython/blob/e1baa778f602ede66831eb34b9ef17f21e4d4347/Lib/xml/sax/saxutils.py#L76-L78) inside Python’s XML module. This makes it treat the `OutputWrapper` as text, rather than binary. Registering as virtual subclass of `TextIOBase` is already used in Python, for example [for `StringIO`](https://github.com/python/cpython/blob/e1baa778f602ede66831eb34b9ef17f21e4d4347/Lib/io.py#L90-L91).

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
