### PR TITLE
Fixed #36048 -- Preferred ValueError to NotSupportedError for composite pk lookup checks.

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -3,7 +3,6 @@ Classes to represent the definitions of aggregate functions.
 """
 
 from django.core.exceptions import FieldError, FullResultSet
-from django.db import NotSupportedError
 from django.db.models.expressions import Case, ColPairs, Func, Star, Value, When
 from django.db.models.fields import IntegerField
 from django.db.models.functions import Coalesce
@@ -182,7 +181,7 @@ class Count(Aggregate):
         # In case of composite primary keys, count the first column.
         if isinstance(expr, ColPairs):
             if self.distinct:
-                raise NotSupportedError(
+                raise ValueError(
                     "COUNT(DISTINCT) doesn't support composite primary keys"
                 )
 

--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -1,4 +1,3 @@
-from django.db import NotSupportedError
 from django.db.models.expressions import ColPairs
 from django.db.models.fields import composite
 from django.db.models.fields.tuple_lookups import TupleIn, tuple_lookups
@@ -117,7 +116,7 @@ class RelatedLookupMixin:
     def as_sql(self, compiler, connection):
         if isinstance(self.lhs, ColPairs):
             if not self.rhs_is_direct_value():
-                raise NotSupportedError(
+                raise ValueError(
                     f"'{self.lookup_name}' doesn't support multi-column subqueries."
                 )
             self.rhs = get_normalized_value(self.rhs, self.lhs)

--- a/tests/composite_pk/test_aggregate.py
+++ b/tests/composite_pk/test_aggregate.py
@@ -1,4 +1,3 @@
-from django.db import NotSupportedError
 from django.db.models import Count, Q
 from django.test import TestCase
 
@@ -82,7 +81,7 @@ class CompositePKAggregateTests(TestCase):
 
     def test_count_distinct_not_supported(self):
         with self.assertRaisesMessage(
-            NotSupportedError, "COUNT(DISTINCT) doesn't support composite primary keys"
+            ValueError, "COUNT(DISTINCT) doesn't support composite primary keys"
         ):
             self.assertIsNone(
                 User.objects.annotate(comments__count=Count("comments", distinct=True))

--- a/tests/foreign_object/test_tuple_lookups.py
+++ b/tests/foreign_object/test_tuple_lookups.py
@@ -1,6 +1,5 @@
 import itertools
 
-from django.db import NotSupportedError
 from django.db.models import F
 from django.db.models.fields.tuple_lookups import (
     TupleExact,
@@ -65,7 +64,7 @@ class TupleLookupsTests(TestCase):
 
     def test_exact_subquery(self):
         with self.assertRaisesMessage(
-            NotSupportedError, "'exact' doesn't support multi-column subqueries."
+            ValueError, "'exact' doesn't support multi-column subqueries."
         ):
             subquery = Customer.objects.filter(id=self.customer_1.id)[:1]
             self.assertSequenceEqual(
@@ -239,7 +238,7 @@ class TupleLookupsTests(TestCase):
 
     def test_lt_subquery(self):
         with self.assertRaisesMessage(
-            NotSupportedError, "'lt' doesn't support multi-column subqueries."
+            ValueError, "'lt' doesn't support multi-column subqueries."
         ):
             subquery = Customer.objects.filter(id=self.customer_1.id)[:1]
             self.assertSequenceEqual(
@@ -287,7 +286,7 @@ class TupleLookupsTests(TestCase):
 
     def test_lte_subquery(self):
         with self.assertRaisesMessage(
-            NotSupportedError, "'lte' doesn't support multi-column subqueries."
+            ValueError, "'lte' doesn't support multi-column subqueries."
         ):
             subquery = Customer.objects.filter(id=self.customer_1.id)[:1]
             self.assertSequenceEqual(
@@ -327,7 +326,7 @@ class TupleLookupsTests(TestCase):
 
     def test_gt_subquery(self):
         with self.assertRaisesMessage(
-            NotSupportedError, "'gt' doesn't support multi-column subqueries."
+            ValueError, "'gt' doesn't support multi-column subqueries."
         ):
             subquery = Customer.objects.filter(id=self.customer_1.id)[:1]
             self.assertSequenceEqual(
@@ -375,7 +374,7 @@ class TupleLookupsTests(TestCase):
 
     def test_gte_subquery(self):
         with self.assertRaisesMessage(
-            NotSupportedError, "'gte' doesn't support multi-column subqueries."
+            ValueError, "'gte' doesn't support multi-column subqueries."
         ):
             subquery = Customer.objects.filter(id=self.customer_1.id)[:1]
             self.assertSequenceEqual(
@@ -419,7 +418,7 @@ class TupleLookupsTests(TestCase):
 
     def test_isnull_subquery(self):
         with self.assertRaisesMessage(
-            NotSupportedError, "'isnull' doesn't support multi-column subqueries."
+            ValueError, "'isnull' doesn't support multi-column subqueries."
         ):
             subquery = Customer.objects.filter(id=0)[:1]
             self.assertSequenceEqual(


### PR DESCRIPTION
#### Trac ticket number
ticket-36048

#### Branch description
These checks are not backend-dependent. See ticket: the suggestion is that only backend-dependent checks should raise NotSupportedError. Maybe ValueError to signify user error or NotImplementedError if we just haven't gotten to it yet.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
