### PR TITLE
Added GitHub action to label pull requests without a ticket in title.

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,52 @@
+name: Labels
+
+on:
+  pull_request:
+    types: [ edited, opened, reopened, ready_for_review ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  no_ticket:
+    name: "Flag if no Trac ticket is found in the title"
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Check title and manage labels"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const regex = /#[0-9]+[ ,:]?/gm;
+            const label = "no ticket";
+            const hasMatch = regex.test(title);
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr_number = context.payload.pull_request.number;
+            console.log(`=> Pull Request Title: ${title}`);
+            console.log(`=> Labels on PR: [${labels}]`);
+            if (hasMatch && labels.includes(label)) {
+              console.log(`==> Removing label "${label}" from PR #${pr_number}`);
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: pr_number,
+                name: label
+              });
+            } else if (!hasMatch && !labels.includes(label)) {
+              console.log(`==> Adding label "${label}" to PR #${pr_number}`);
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr_number,
+                labels: [label]
+              });
+            } else {
+              console.log(`No action needed for PR #${pr_number}`);
+            }


### PR DESCRIPTION
#### Branch description

This aims to label PRs which have not got a title such that they will be linked to a trac ticket. This logic should align with https://github.com/django/code.djangoproject.com/blob/72f85efc886e5c5ddfceb1b4a3793af247873c02/trac-env/htdocs/tickethacks.js#L39

This should help with the following:
- when a PR has a ticket, but is titled incorrectly, this should be hinted to the PR author as they will get a "no ticket" label
- when a PR does not have a ticket, we have a way to filter for these. This can be like a "minor review" queue. Hoping this might mean less tickets are created for very minor changes just to "encourage" a review.

----

I have created a forum discussion for some wider feedback: https://forum.djangoproject.com/t/github-action-to-label-prs-with-no-ticket/37663
I will only progress this if there are no strong objections and the reception is positive :+1: 
