### PR TITLE
Removed stray comment in ArrayField.check().

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -67,7 +67,6 @@ class ArrayField(CheckFieldDefaultMixin, Field):
                 )
             )
         else:
-            # Remove the field name checks as they are not needed here.
             base_checks = self.base_field.check()
             if base_checks:
                 error_messages = "\n    ".join(


### PR DESCRIPTION
The comment was included in the original work for ArrayField (604162604bf816fa46b0d972621f06de64df6a66) but it looks obsolete even then. 