### PR TITLE
Fixed #36061 -- Added missing migration support for through_fields

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -180,6 +180,7 @@ answer newbie questions, and generally made Django that much better:
     Brian Fabian Crain <http://www.bfc.do/>
     Brian Harring <ferringb@gmail.com>
     Brian Helba <brian.helba@kitware.com>
+    Brian Nettleton <bdnettleton@gmail.com>
     Brian Ray <http://brianray.chipy.org/>
     Brian Rosner <brosner@gmail.com>
     Bruce Kroeze <https://coderseye.com/>

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1796,6 +1796,8 @@ class ManyToManyField(RelatedField):
                 kwargs["through"] = self.remote_field.through
             elif not self.remote_field.through._meta.auto_created:
                 kwargs["through"] = self.remote_field.through._meta.label
+        if through_fields := getattr(self.remote_field, "through_fields", None):
+            kwargs["through_fields"] = through_fields
         # If swappable is True, then see if we're actually pointing to the target
         # of a swap.
         swappable_setting = self.swappable_setting

--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -516,6 +516,23 @@ class FieldDeconstructionTests(SimpleTestCase):
         self.assertEqual(path, "django.db.models.ManyToManyField")
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {"to": "auth.permission", "through": "auth.Group"})
+        # Test through_fields
+        field = models.ManyToManyField(
+            "auth.Permission",
+            through="auth.Group",
+            through_fields=("foo", "permissions"),
+        )
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.ManyToManyField")
+        self.assertEqual(args, [])
+        self.assertEqual(
+            kwargs,
+            {
+                "to": "auth.permission",
+                "through": "auth.Group",
+                "through_fields": ("foo", "permissions"),
+            },
+        )
         # Test custom db_table
         field = models.ManyToManyField("auth.Permission", db_table="custom_table")
         name, path, args, kwargs = field.deconstruct()


### PR DESCRIPTION
Fixed #36061.  -- Added missing migration support for through_fields

Added through_fields support to ManyToManyField.deconstruct.  Thanks to 
Simon Charette for pointer on where to add the fix and test case.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36061

#### Branch description
Support for through_fields was never implemented for ManyToManyField which can cause a failure in a data migration on models with through_fields.  Fixed by adding through_fields to the 

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
