### PR TITLE
Fixed #36065 -- Fixed ordering by expression referencing composite primary key.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1861,6 +1861,16 @@ class OrderBy(Expression):
         return [self.expression]
 
     def as_sql(self, compiler, connection, template=None, **extra_context):
+        if isinstance(self.expression, ColPairs):
+            sql_parts = []
+            params = []
+            for col in self.expression.get_cols():
+                copy = self.copy()
+                copy.set_source_expressions([col])
+                sql, col_params = compiler.compile(copy)
+                sql_parts.append(sql)
+                params.extend(col_params)
+            return ", ".join(sql_parts), params
         template = template or self.template
         if connection.features.supports_order_by_nulls_modifier:
             if self.nulls_last:

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1117,10 +1117,9 @@ class SQLCompiler:
                 )
             return results
         targets, alias, _ = self.query.trim_joins(targets, joins, path)
-        target_fields = composite.unnest(targets)
         return [
             (OrderBy(transform_function(t, alias), descending=descending), False)
-            for t in target_fields
+            for t in targets
         ]
 
     def _setup_joins(self, pieces, opts, alias):

--- a/tests/composite_pk/test_filter.py
+++ b/tests/composite_pk/test_filter.py
@@ -70,30 +70,6 @@ class CompositePKFilterTests(TestCase):
             ):
                 Comment.objects.filter(text__gt=expr).count()
 
-    def test_order_comments_by_pk_asc(self):
-        self.assertSequenceEqual(
-            Comment.objects.order_by("pk"),
-            (
-                self.comment_1,  # (1, 1)
-                self.comment_2,  # (1, 2)
-                self.comment_3,  # (1, 3)
-                self.comment_5,  # (1, 5)
-                self.comment_4,  # (2, 4)
-            ),
-        )
-
-    def test_order_comments_by_pk_desc(self):
-        self.assertSequenceEqual(
-            Comment.objects.order_by("-pk"),
-            (
-                self.comment_4,  # (2, 4)
-                self.comment_5,  # (1, 5)
-                self.comment_3,  # (1, 3)
-                self.comment_2,  # (1, 2)
-                self.comment_1,  # (1, 1)
-            ),
-        )
-
     def test_filter_comments_by_pk_gt(self):
         c11, c12, c13, c24, c15 = (
             self.comment_1,

--- a/tests/composite_pk/test_order_by.py
+++ b/tests/composite_pk/test_order_by.py
@@ -1,3 +1,4 @@
+from django.db.models import F
 from django.test import TestCase
 
 from .models import Comment, Tenant, User
@@ -54,4 +55,18 @@ class CompositePKOrderByTests(TestCase):
                 self.comment_2,  # (1, 2)
                 self.comment_1,  # (1, 1)
             ),
+        )
+
+    def test_order_comments_by_pk_expr(self):
+        self.assertQuerySetEqual(
+            Comment.objects.order_by("pk"),
+            Comment.objects.order_by(F("pk")),
+        )
+        self.assertQuerySetEqual(
+            Comment.objects.order_by("-pk"),
+            Comment.objects.order_by(F("pk").desc()),
+        )
+        self.assertQuerySetEqual(
+            Comment.objects.order_by("-pk"),
+            Comment.objects.order_by(F("pk").desc(nulls_last=True)),
         )

--- a/tests/composite_pk/test_order_by.py
+++ b/tests/composite_pk/test_order_by.py
@@ -1,0 +1,57 @@
+from django.test import TestCase
+
+from .models import Comment, Tenant, User
+
+
+class CompositePKOrderByTests(TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant_1 = Tenant.objects.create()
+        cls.tenant_2 = Tenant.objects.create()
+        cls.tenant_3 = Tenant.objects.create()
+        cls.user_1 = User.objects.create(
+            tenant=cls.tenant_1,
+            id=1,
+            email="user0001@example.com",
+        )
+        cls.user_2 = User.objects.create(
+            tenant=cls.tenant_1,
+            id=2,
+            email="user0002@example.com",
+        )
+        cls.user_3 = User.objects.create(
+            tenant=cls.tenant_2,
+            id=3,
+            email="user0003@example.com",
+        )
+        cls.comment_1 = Comment.objects.create(id=1, user=cls.user_1)
+        cls.comment_2 = Comment.objects.create(id=2, user=cls.user_1)
+        cls.comment_3 = Comment.objects.create(id=3, user=cls.user_2)
+        cls.comment_4 = Comment.objects.create(id=4, user=cls.user_3)
+        cls.comment_5 = Comment.objects.create(id=5, user=cls.user_1)
+
+    def test_order_comments_by_pk_asc(self):
+        self.assertSequenceEqual(
+            Comment.objects.order_by("pk"),
+            (
+                self.comment_1,  # (1, 1)
+                self.comment_2,  # (1, 2)
+                self.comment_3,  # (1, 3)
+                self.comment_5,  # (1, 5)
+                self.comment_4,  # (2, 4)
+            ),
+        )
+
+    def test_order_comments_by_pk_desc(self):
+        self.assertSequenceEqual(
+            Comment.objects.order_by("-pk"),
+            (
+                self.comment_4,  # (2, 4)
+                self.comment_5,  # (1, 5)
+                self.comment_3,  # (1, 3)
+                self.comment_2,  # (1, 2)
+                self.comment_1,  # (1, 1)
+            ),
+        )


### PR DESCRIPTION
Thanks @jacobtylerwalls for the report and test.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36065

#### Branch description

 For `CompositePrimaryKey`, `order_by("pk")` and `order_by(F("pk"))` produce different results [as the initial composite primary key support for ordering was only implemented for ordering by string references](https://github.com/django/django/commit/978aae4334fa71ba78a3e94408f0f3aebde8d07c#diff-f58de2deaccecd2d53199c5ca29e3e1050ec2adb80fb057cdfc0b4e6accdf14fR1119).

cc @csirmazbendeguz as that might of interest to you.

