### PR TITLE
Fixed #36064 -- Skipped an UPDATE when adding a model instance with a composite primary key with default values.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1118,7 +1118,7 @@ class Model(AltersData, metaclass=ModelBase):
             and not force_insert
             and not force_update
             and self._state.adding
-            and (meta.pk.has_default() or meta.pk.has_db_default())
+            and all(f.has_default() or f.has_db_default() for f in meta.pk_fields)
         ):
             force_insert = True
         # If possible, try an UPDATE. If that doesn't update anything, do an INSERT.

--- a/tests/basic/models.py
+++ b/tests/basic/models.py
@@ -57,5 +57,13 @@ class PrimaryKeyWithDbDefault(models.Model):
     uuid = models.IntegerField(primary_key=True, db_default=1)
 
 
+class PrimaryKeyWithFalseyDefault(models.Model):
+    uuid = models.IntegerField(primary_key=True, default=0)
+
+
+class PrimaryKeyWithFalseyDbDefault(models.Model):
+    uuid = models.IntegerField(primary_key=True, db_default=0)
+
+
 class ChildPrimaryKeyWithDefault(PrimaryKeyWithDefault):
     pass

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -32,6 +32,8 @@ from .models import (
     FeaturedArticle,
     PrimaryKeyWithDbDefault,
     PrimaryKeyWithDefault,
+    PrimaryKeyWithFalseyDbDefault,
+    PrimaryKeyWithFalseyDefault,
     SelfRef,
 )
 
@@ -202,6 +204,14 @@ class ModelInstanceCreationTests(TestCase):
         # default.
         with self.assertNumQueries(2):
             ChildPrimaryKeyWithDefault().save()
+
+    def test_save_primary_with_falsey_default(self):
+        with self.assertNumQueries(1):
+            PrimaryKeyWithFalseyDefault().save()
+
+    def test_save_primary_with_falsey_db_default(self):
+        with self.assertNumQueries(1):
+            PrimaryKeyWithFalseyDbDefault().save()
 
     def test_save_deprecation(self):
         a = Article(headline="original", pub_date=datetime(2014, 5, 16))

--- a/tests/composite_pk/models/tenant.py
+++ b/tests/composite_pk/models/tenant.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.db import models
 
 
@@ -46,8 +48,8 @@ class Comment(models.Model):
 
 class Post(models.Model):
     pk = models.CompositePrimaryKey("tenant_id", "id")
-    tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE)
-    id = models.UUIDField()
+    tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE, default=1)
+    id = models.UUIDField(default=uuid.uuid4)
 
 
 class TimeStamped(models.Model):

--- a/tests/composite_pk/test_create.py
+++ b/tests/composite_pk/test_create.py
@@ -1,6 +1,7 @@
+from django.db import IntegrityError
 from django.test import TestCase, skipUnlessDBFeature
 
-from .models import Tenant, User
+from .models import Post, Tenant, User
 
 
 class CompositePKCreateTests(TestCase):
@@ -8,7 +9,7 @@ class CompositePKCreateTests(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.tenant = Tenant.objects.create()
+        cls.tenant = Tenant.objects.create(id=1)
         cls.user = User.objects.create(
             tenant=cls.tenant,
             id=1,
@@ -151,3 +152,12 @@ class CompositePKCreateTests(TestCase):
                 self.assertEqual(user.email, fields["defaults"]["email"])
                 self.assertEqual(user.email, f"user{user.id}@example.com")
                 self.assertEqual(count + 1, User.objects.count())
+
+    def test_save_default_pk_not_set(self):
+        with self.assertNumQueries(1):
+            Post().save()
+
+    def test_save_default_pk_set(self):
+        post = Post.objects.create()
+        with self.assertRaises(IntegrityError):
+            Post(tenant_id=post.tenant_id, id=post.id).save()


### PR DESCRIPTION
#### Trac ticket number
ticket-36064

#### Branch description
If all fields of a CompositePrimaryKey has a default or db_default, force insert.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
