### PR TITLE
Fixed #36068 -- Raised ValueError when providing a composite PK field to bulk_create() update_fields.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -728,7 +728,7 @@ class QuerySet(AltersData):
                     "bulk_create() can only be used with concrete fields in "
                     "update_fields."
                 )
-            if any(f.primary_key for f in update_fields):
+            if any(f in self.model._meta.pk_fields for f in update_fields):
                 raise ValueError(
                     "bulk_create() cannot be used with primary keys in "
                     "update_fields."

--- a/tests/composite_pk/test_create.py
+++ b/tests/composite_pk/test_create.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, skipUnlessDBFeature
 
 from .models import Tenant, User
 
@@ -76,6 +76,21 @@ class CompositePKCreateTests(TestCase):
         self.assertEqual(obj_3.id, 8214)
         self.assertEqual(obj_3.pk, (obj_3.tenant_id, obj_3.id))
         self.assertEqual(obj_3.email, "user8214@example.com")
+
+    @skipUnlessDBFeature(
+        "supports_update_conflicts",
+        "supports_update_conflicts_with_target",
+    )
+    def test_bulk_create_user_with_pk_field_in_update_fields(self):
+        objs = [User(tenant=self.tenant, id=8291, email="user8291@example.com")]
+        msg = "bulk_create() cannot be used with primary keys in update_fields."
+        with self.assertRaisesMessage(ValueError, msg):
+            User.objects.bulk_create(
+                objs,
+                update_conflicts=True,
+                update_fields=["tenant_id"],
+                unique_fields=["id", "tenant_id"],
+            )
 
     def test_get_or_create_user(self):
         test_cases = (


### PR DESCRIPTION
#### Trac ticket number
ticket-36068

#### Branch description
Extend the check against primary keys in `bulk_create()`'s `update_fields` arg to any fields participating in a composite primary key.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
