### PR TITLE
Fixed #36066 -- Documented use of Q objects inside annotations.

### DIFF
--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -1414,7 +1414,7 @@ precede the definition of any keyword arguments. For example::
 
 ... would not be valid.
 
-``Q`` objects can directly be used inside annotations. For example::
+``Q`` objects can directly be used inside annotations. For example ::
 
     queryset = Poll.objects.annotate(
         published_in_2007=Q(pub_date__year='2007')

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -1414,6 +1414,14 @@ precede the definition of any keyword arguments. For example::
 
 ... would not be valid.
 
+``Q`` objects can directly be used inside annotations. For example::
+
+    queryset = Poll.objects.annotate(
+        published_in_2007=Q(pub_date__year='2007')
+    )
+    #Returns True if the publication year is 2007, otherwise returns False.
+    queryset[0].published_in_2007
+
 .. seealso::
 
     The :source:`OR lookups examples <tests/or_lookups/tests.py>` in Django's

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -1416,11 +1416,8 @@ precede the definition of any keyword arguments. For example::
 
 ``Q`` objects can directly be used inside annotations. For example::
 
-    queryset = Poll.objects.annotate(
-        published_in_2007=Q(pub_date__year='2007')
-    )
-
-    #Returns True if the publication year is 2007, otherwise returns False.
+    queryset = Poll.objects.annotate(published_in_2007=Q(pub_date__year="2007"))
+    # Returns True if the publication year is 2007, otherwise returns False.
     queryset[0].published_in_2007
 
 .. seealso::

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -1414,11 +1414,12 @@ precede the definition of any keyword arguments. For example::
 
 ... would not be valid.
 
-``Q`` objects can directly be used inside annotations. For example ::
+``Q`` objects can directly be used inside annotations. For example::
 
     queryset = Poll.objects.annotate(
         published_in_2007=Q(pub_date__year='2007')
     )
+
     #Returns True if the publication year is 2007, otherwise returns False.
     queryset[0].published_in_2007
 


### PR DESCRIPTION
Documented the possible use of Q objects inside annotations.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36066

#### Branch description
Mention the use of Q objects  inside annotations.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
