### PR TITLE
Fixed #36074 -- Excluded composite primary key fields on save() updates.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1091,10 +1091,11 @@ class Model(AltersData, metaclass=ModelBase):
         for a single table.
         """
         meta = cls._meta
+        pk_fields = meta.pk_fields
         non_pks_non_generated = [
             f
             for f in meta.local_concrete_fields
-            if not f.primary_key and not f.generated
+            if f not in pk_fields and not f.generated
         ]
 
         if update_fields:

--- a/tests/composite_pk/test_update.py
+++ b/tests/composite_pk/test_update.py
@@ -1,3 +1,4 @@
+from django.db import connection
 from django.test import TestCase
 
 from .models import Comment, Tenant, Token, User
@@ -45,7 +46,11 @@ class CompositePKUpdateTests(TestCase):
         email = "user9314@example.com"
         user = User.objects.get(pk=self.user_1.pk)
         user.email = email
-        user.save()
+        with self.assertNumQueries(1) as ctx:
+            user.save()
+        sql = ctx[0]["sql"]
+        self.assertEqual(sql.count(connection.ops.quote_name("tenant_id")), 1)
+        self.assertEqual(sql.count(connection.ops.quote_name("id")), 1)
         user.refresh_from_db()
         self.assertEqual(user.email, email)
         user = User.objects.get(pk=self.user_1.pk)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36074

#### Branch description

Prior to the changes any update induced by calling the `save()` method on a model with a composite primary would result in a re-assignment of primary key fields.

e.g.

```python
class User(models.Model):
    tenant = models.ForeignKey(Tenant)
    id = models.UUIDField(default=uuid.uuid4)
    username = models.EmailField()

user = User.objects.create(tenant=tenant, id=1, email="foo@bar.org")
user.email = "something@example.com"
user.save()
```


```sql
UPDATE user SET tenant_id = %s, id = %s, email = %s WHERE tenant_id = %s AND id = %s
```

while `tenant_id` and `id` shouldn't be set as they are part of the lookup

```sql
UPDATE user SET email = %s WHERE tenant_id = %s AND id = %s
```