### PR TITLE
Refs #36075 -- Used field in pk_fields over field.primary_key.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -891,8 +891,9 @@ class Model(AltersData, metaclass=ModelBase):
             and using == self._state.db
         ):
             field_names = set()
+            pk_fields = self._meta.pk_fields
             for field in self._meta.concrete_fields:
-                if not field.primary_key and not hasattr(field, "through"):
+                if field not in pk_fields and not hasattr(field, "through"):
                     field_names.add(field.attname)
             loaded_fields = field_names.difference(deferred_non_generated_fields)
             if loaded_fields:
@@ -1492,7 +1493,7 @@ class Model(AltersData, metaclass=ModelBase):
                 ):
                     # no value, skip the lookup
                     continue
-                if f.primary_key and not self._state.adding:
+                if f in self._meta.pk_fields and not self._state.adding:
                     # no need to check for unique primary key when editing
                     continue
                 lookup_kwargs[str(field_name)] = lookup_value

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -1009,7 +1009,7 @@ class Options:
         """
         names = []
         for field in self.concrete_fields:
-            if not field.primary_key:
+            if field not in self.pk_fields:
                 names.append(field.name)
                 if field.name != field.attname:
                     names.append(field.attname)

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -878,7 +878,7 @@ class QuerySet(AltersData):
         fields = [self.model._meta.get_field(name) for name in fields]
         if any(not f.concrete or f.many_to_many for f in fields):
             raise ValueError("bulk_update() can only be used with concrete fields.")
-        if any(f.primary_key for f in fields):
+        if any(f in self.model._meta.pk_fields for f in fields):
             raise ValueError("bulk_update() cannot be used with primary key fields.")
         if not objs:
             return 0
@@ -995,9 +995,10 @@ class QuerySet(AltersData):
                 # This is to maintain backward compatibility as these fields
                 # are not updated unless explicitly specified in the
                 # update_fields list.
+                pk_fields = self.model._meta.pk_fields
                 for field in self.model._meta.local_concrete_fields:
                     if not (
-                        field.primary_key or field.__class__.pre_save is Field.pre_save
+                        field in pk_fields or field.__class__.pre_save is Field.pre_save
                     ):
                         update_fields.add(field.name)
                         if field.name != field.attname:

--- a/tests/composite_pk/fixtures/tenant.json
+++ b/tests/composite_pk/fixtures/tenant.json
@@ -77,7 +77,8 @@
         "model": "composite_pk.timestamped",
         "fields": {
             "id": 1,
-            "created": "2022-01-12T05:55:14.956"
+            "created": "2022-01-12T05:55:14.956",
+            "text": ""
         }
     }
 ]

--- a/tests/composite_pk/models/tenant.py
+++ b/tests/composite_pk/models/tenant.py
@@ -54,3 +54,4 @@ class TimeStamped(models.Model):
     pk = models.CompositePrimaryKey("id", "created")
     id = models.SmallIntegerField(unique=True)
     created = models.DateTimeField(auto_now_add=True)
+    text = models.TextField(default="", blank=True)

--- a/tests/composite_pk/test_models.py
+++ b/tests/composite_pk/test_models.py
@@ -118,6 +118,10 @@ class CompositePKModelsTests(TestCase):
 
                 self.assertSequenceEqual(ctx.exception.messages, messages)
 
+    def test_full_clean_update(self):
+        with self.assertNumQueries(1):
+            self.comment_1.full_clean()
+
     def test_field_conflicts(self):
         test_cases = (
             ({"pk": (1, 1), "id": 2}, (1, 1)),

--- a/tests/composite_pk/tests.py
+++ b/tests/composite_pk/tests.py
@@ -340,6 +340,7 @@ class CompositePKFixturesTests(TestCase):
                     "fields": {
                         "id": 1,
                         "created": "2022-01-12T05:55:14.956",
+                        "text": "",
                     },
                 },
             ],


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36075 

#### Branch description

There are still checks against `.primary_key` but some of them I'm not too worried about as they are around the admin, migrations, or related fields (which all are either not supported/have limited supported)
These ones were the most suspicious to me