### PR TITLE
Fixed #36070 -- Doc'd model validation behavior for composite pks.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -722,8 +722,8 @@ isn't defined.
 
 A virtual field used for defining a composite primary key.
 
-This field must be defined as the model's ``pk`` field. If present, Django will
-create the underlying model table with a composite primary key.
+This field must be defined as the model's ``pk`` attribute. If present, Django
+will create the underlying model table with a composite primary key.
 
 The ``*field_names`` argument is a list of positional field names that compose
 the primary key.

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -468,9 +468,14 @@ The ``pk`` property
 Regardless of whether you define a primary key field yourself, or let Django
 supply one for you, each model will have a property called ``pk``. It behaves
 like a normal attribute on the model, but is actually an alias for whichever
-attribute is the primary key field for the model. You can read and set this
-value, just as you would for any other attribute, and it will update the
-correct field in the model.
+field or fields compose the primary key for the model. You can read and set
+this value, just as you would for any other attribute, and it will update the
+correct fields in the model.
+
+.. versionchanged:: 5.2
+
+    Support for the primary key to be composed of multiple fields was added via
+    ``CompositePrimaryKey``.
 
 Explicitly specifying auto-primary-key values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -57,8 +57,8 @@ Composite Primary Keys
 The new :class:`django.db.models.CompositePrimaryKey` allows tables to be
 created with a primary key consisting of multiple fields.
 
-To use a composite primary key, when creating a model set the ``pk`` field to
-be a ``CompositePrimaryKey``::
+To use a composite primary key, when defining a model set the ``pk`` attribute
+to be a ``CompositePrimaryKey``::
 
     from django.db import models
 

--- a/docs/topics/composite-primary-key.txt
+++ b/docs/topics/composite-primary-key.txt
@@ -11,8 +11,8 @@ In most cases, a single primary key should suffice. In database design,
 however, defining a primary key consisting of multiple fields is sometimes
 necessary.
 
-To use a composite primary key, when creating a model set the ``pk`` field to
-be a :class:`.CompositePrimaryKey`::
+To use a composite primary key, when defining a model set the ``pk`` attribute
+to be a :class:`.CompositePrimaryKey`::
 
     class Product(models.Model):
         name = models.CharField(max_length=100)
@@ -41,8 +41,8 @@ A composite primary key is represented by a ``tuple``:
     >>> item.pk
     (1, "A755H")
 
-You can assign a ``tuple`` to a composite primary key. This sets the associated
-field values.
+You can assign a ``tuple`` to the :attr:`~django.db.models.Model.pk` attribute.
+This sets the associated field values:
 
 .. code-block:: pycon
 

--- a/docs/topics/composite-primary-key.txt
+++ b/docs/topics/composite-primary-key.txt
@@ -186,6 +186,16 @@ field :exc:`.FieldError`.
     :attr:`.Field.editable` to ``False`` on all primary key fields to exclude
     them from ModelForms.
 
+Composite primary keys in model validation
+==========================================
+
+Since ``pk`` is only a virtual field, including ``pk`` as a field name in the
+``exclude`` argument of :meth:`.Model.clean_fields` has no effect. To exclude
+the composite primary key fields from
+:ref:`model validation <validating-objects>`, specify each field individually.
+:meth:`.Model.validate_unique` can still be called with ``exclude={"pk"}`` to
+skip uniqueness checks.
+
 Building composite primary key ready applications
 =================================================
 


### PR DESCRIPTION
#### Trac ticket number
ticket-36070

#### Branch description
Clarify what happens if passing `exclude={"pk"}` to model validation methods when `pk` is a `CompositePrimaryKey`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
