### PR TITLE
Refs #36084 -- Added role_required decorator for role-based access control

### DIFF
--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -139,7 +139,7 @@ def role_required(
     roles: list[str],
     test_all=False,
     redirect_field_name=REDIRECT_FIELD_NAME,
-    login_url=None
+    login_url=None,
 ):
     """
     Decorator for views that checks that the user has a specific role,

--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -133,3 +133,32 @@ def permission_required(perm, login_url=None, raise_exception=False):
         return user_passes_test(check_perms, login_url=login_url)(view_func)
 
     return decorator
+
+
+def role_required(
+    roles: list[str],
+    test_all=False,
+    redirect_field_name=REDIRECT_FIELD_NAME,
+    login_url=None
+):
+    """
+    Decorator for views that checks that the user has a specific role,
+    redirecting to the log-in page if necessary.
+    role: must be a list of valid string user attributes as they ware
+    declared in their models
+    test_all: bool value that determines if all roles are required or just one.
+    """
+    def _test_role(user):
+        if test_all:
+            return user.is_authenticated and all(
+                getattr(user, role, False) for role in roles
+            )
+        return user.is_authenticated and any(
+            getattr(user, role, False) for role in roles
+        )
+    actual_decorator = user_passes_test(
+        lambda u: _test_role(u),
+        login_url,
+        redirect_field_name,
+    )
+    return actual_decorator

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -605,6 +605,54 @@ The ``login_required`` decorator
 
     Support for wrapping asynchronous view functions was added.
 
+The ``role_required`` decorator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. function:: role_required(roles, test_all=False, redirect_field_name='next', login_url=None)
+
+    The ``role_required`` decorator restricts access to views based on user roles. 
+    It checks if the user has one or all of the specified roles (depending on the 
+    ``test_all`` parameter) and redirects unauthorized users to the login page.
+
+    ``role_required`` has these 2 specific params (alongside with the ``redirect_field_name`` 
+    and the ``login_url``)
+
+    * ``roles`` (list[str]):
+       A list of role attributes to check on the user model. Each role must be a valid 
+       attribute of the user model.
+       Example: ``['is_seller', 'is_admin']``.
+
+    * ``test_all`` (bool, optional):
+       If ``True``, the user must have **all** the specified roles to access the view.
+       If ``False``, the user needs **any one** of the specified roles.
+       Default: ``False``.
+
+    The :func:`~django.contrib.auth.decorators.role_required` returns a decorator that 
+    can be applied to view functions.
+
+    *Examples*
+    The usage of this decorator is as follows::
+
+        from django.contrib.auth.decorators import login_required, role_required
+
+
+        @login_required
+        @role_required(["is_seller"], login_url="/create-store/")
+        def my_view(request): ...
+
+
+        @login_required
+        @role_required(["is_admin", "is_moderator"], test_all=True, login_url="/create-store/")
+        def admin_dashboard(request): ...
+
+
+.. note::
+
+    The ``role_required`` decorator does NOT check the ``is_active`` flag on a
+    user, but the default :setting:`AUTHENTICATION_BACKENDS` reject inactive
+    users.
+
+
 .. currentmodule:: django.contrib.auth.mixins
 
 The ``LoginRequiredMixin`` mixin

--- a/tests/auth_tests/test_decorators.py
+++ b/tests/auth_tests/test_decorators.py
@@ -6,6 +6,7 @@ from django.contrib.auth.decorators import (
     login_not_required,
     login_required,
     permission_required,
+    role_required,
     user_passes_test,
 )
 from django.core.exceptions import PermissionDenied
@@ -422,3 +423,98 @@ class UserPassesTestDecoratorTest(TestCase):
         request.auser = self.auser_deny
         response = await async_view(request)
         self.assertEqual(response.status_code, 302)
+
+
+class RoleRequiredDecoratorTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = models.User.objects.create_user(
+            username='testuser', password='testpass'
+        )
+        self.user.is_seller = True
+        self.user.is_admin = True
+        self.user.is_moderator = False
+        self.user.save()
+
+    def test_single_role_required_success(self):
+        @role_required(['is_seller'])
+        def dummy_view(request):
+            return HttpResponse("Success")
+
+        request = self.factory.get('/')
+        request.user = self.user
+        response = dummy_view(request)
+        self.assertEqual(response.content.decode(), "Success")
+
+    def test_single_role_required_failure(self):
+        @role_required(['is_moderator'])
+        def dummy_view(request):
+            return HttpResponse("Success")
+
+        request = self.factory.get('/')
+        request.user = self.user
+        response = dummy_view(request)
+        self.assertEqual(response.status_code, 302)  # Redirect to login
+
+    def test_multiple_roles_any_success(self):
+        @role_required(['is_admin', 'is_moderator'], test_all=False)
+        def dummy_view(request):
+            return HttpResponse("Success")
+
+        request = self.factory.get('/')
+        request.user = self.user
+        response = dummy_view(request)
+        self.assertEqual(response.content.decode(), "Success")
+
+    def test_multiple_roles_any_failure(self):
+        @role_required(['is_moderator', 'is_editor'], test_all=False)
+        def dummy_view(request):
+            return HttpResponse("Success")
+
+        request = self.factory.get('/')
+        request.user = self.user
+        response = dummy_view(request)
+        self.assertEqual(response.status_code, 302)  # Redirect to login
+
+    def test_multiple_roles_all_success(self):
+        self.user.is_moderator = True
+        self.user.save()
+
+        @role_required(['is_admin', 'is_moderator'], test_all=True)
+        def dummy_view(request):
+            return HttpResponse("Success")
+
+        request = self.factory.get('/')
+        request.user = self.user
+        response = dummy_view(request)
+        self.assertEqual(response.content.decode(), "Success")
+
+    def test_multiple_roles_all_failure(self):
+        @role_required(['is_admin', 'is_moderator'], test_all=True)
+        def dummy_view(request):
+            return HttpResponse("Success")
+
+        request = self.factory.get('/')
+        request.user = self.user
+        response = dummy_view(request)
+        self.assertEqual(response.status_code, 302)  # Redirect to login
+
+    def test_custom_login_url(self):
+        @role_required(['is_moderator'], login_url='/custom-login/')
+        def dummy_view(request):
+            return HttpResponse("Success")
+
+        request = self.factory.get('/')
+        request.user = self.user
+        response = dummy_view(request)
+        self.assertEqual(response.url, '/custom-login/?next=/')
+
+    def test_unauthenticated_user(self):
+        @role_required(['is_seller'])
+        def dummy_view(request):
+            return HttpResponse("Success")
+
+        request = self.factory.get('/')
+        request.user = models.AnonymousUser()  # Anonymous user
+        response = dummy_view(request)
+        self.assertEqual(response.status_code, 302)  # Redirect to login

--- a/tests/auth_tests/test_decorators.py
+++ b/tests/auth_tests/test_decorators.py
@@ -429,7 +429,8 @@ class RoleRequiredDecoratorTests(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.user = models.User.objects.create_user(
-            username='testuser', password='testpass'
+            username="testuser",
+            password="testpass",
         )
         self.user.is_seller = True
         self.user.is_admin = True
@@ -437,41 +438,41 @@ class RoleRequiredDecoratorTests(TestCase):
         self.user.save()
 
     def test_single_role_required_success(self):
-        @role_required(['is_seller'])
+        @role_required(["is_seller"])
         def dummy_view(request):
             return HttpResponse("Success")
 
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         request.user = self.user
         response = dummy_view(request)
         self.assertEqual(response.content.decode(), "Success")
 
     def test_single_role_required_failure(self):
-        @role_required(['is_moderator'])
+        @role_required(["is_moderator"])
         def dummy_view(request):
             return HttpResponse("Success")
 
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         request.user = self.user
         response = dummy_view(request)
         self.assertEqual(response.status_code, 302)  # Redirect to login
 
     def test_multiple_roles_any_success(self):
-        @role_required(['is_admin', 'is_moderator'], test_all=False)
+        @role_required(["is_admin", "is_moderator"], test_all=False)
         def dummy_view(request):
             return HttpResponse("Success")
 
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         request.user = self.user
         response = dummy_view(request)
         self.assertEqual(response.content.decode(), "Success")
 
     def test_multiple_roles_any_failure(self):
-        @role_required(['is_moderator', 'is_editor'], test_all=False)
+        @role_required(["is_moderator", "is_editor"], test_all=False)
         def dummy_view(request):
             return HttpResponse("Success")
 
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         request.user = self.user
         response = dummy_view(request)
         self.assertEqual(response.status_code, 302)  # Redirect to login
@@ -480,41 +481,41 @@ class RoleRequiredDecoratorTests(TestCase):
         self.user.is_moderator = True
         self.user.save()
 
-        @role_required(['is_admin', 'is_moderator'], test_all=True)
+        @role_required(["is_admin", "is_moderator"], test_all=True)
         def dummy_view(request):
             return HttpResponse("Success")
 
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         request.user = self.user
         response = dummy_view(request)
         self.assertEqual(response.content.decode(), "Success")
 
     def test_multiple_roles_all_failure(self):
-        @role_required(['is_admin', 'is_moderator'], test_all=True)
+        @role_required(["is_admin", "is_moderator"], test_all=True)
         def dummy_view(request):
             return HttpResponse("Success")
 
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         request.user = self.user
         response = dummy_view(request)
         self.assertEqual(response.status_code, 302)  # Redirect to login
 
     def test_custom_login_url(self):
-        @role_required(['is_moderator'], login_url='/custom-login/')
+        @role_required(["is_moderator"], login_url="/custom-login/")
         def dummy_view(request):
             return HttpResponse("Success")
 
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         request.user = self.user
         response = dummy_view(request)
-        self.assertEqual(response.url, '/custom-login/?next=/')
+        self.assertEqual(response.url, "/custom-login/?next=/")
 
     def test_unauthenticated_user(self):
-        @role_required(['is_seller'])
+        @role_required(["is_seller"])
         def dummy_view(request):
             return HttpResponse("Success")
 
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         request.user = models.AnonymousUser()  # Anonymous user
         response = dummy_view(request)
         self.assertEqual(response.status_code, 302)  # Redirect to login


### PR DESCRIPTION
#### Trac ticket number
ticket-[36084](https://code.djangoproject.com/ticket/36084)

#### Branch description
This PR introduces a new `role_required` decorator for Django's authentication system. The decorator allows developers to restrict access to views based on user roles, providing a flexible way to implement role-based access control.

Key features:
- Supports checking for one or multiple roles.
- Allows developers to specify whether all roles are required (`test_all=True`) or any one role suffices (`test_all=False`).
- Integrates seamlessly with Django's existing authentication decorators like `@login_required`.

This decorator is particularly useful for applications that require fine-grained access control based on user roles (e.g., `is_seller`, `is_admin`).

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. <!-- Not applicable for this PR. -->