### PR TITLE
Refs #36084 -- Added role_required decorator for role-based access control

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -605,6 +605,54 @@ The ``login_required`` decorator
 
     Support for wrapping asynchronous view functions was added.
 
+The ``role_required`` decorator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. function:: role_required(roles, test_all=False, redirect_field_name='next', login_url=None)
+
+    The ``role_required`` decorator restricts access to views based on user roles. 
+    It checks if the user has one or all of the specified roles (depending on the 
+    ``test_all`` parameter) and redirects unauthorized users to the login page.
+
+    ``role_required`` has these 2 specific params (alongside with the ``redirect_field_name`` 
+    and the ``login_url``)
+
+    * ``roles`` (list[str]):
+       A list of role attributes to check on the user model. Each role must be a valid 
+       attribute of the user model.
+       Example: ``['is_seller', 'is_admin']``.
+
+    * ``test_all`` (bool, optional):
+       If ``True``, the user must have **all** the specified roles to access the view.
+       If ``False``, the user needs **any one** of the specified roles.
+       Default: ``False``.
+
+    The :func:`~django.contrib.auth.decorators.role_required` returns a decorator that 
+    can be applied to view functions.
+
+    *Examples*
+    The usage of this decorator is as follows::
+
+        from django.contrib.auth.decorators import login_required, role_required
+
+
+        @login_required
+        @role_required(["is_seller"], login_url="/create-store/")
+        def my_view(request): ...
+
+
+        @login_required
+        @role_required(["is_admin", "is_moderator"], test_all=True, login_url="/create-store/")
+        def admin_dashboard(request): ...
+
+
+.. note::
+
+    The ``role_required`` decorator does NOT check the ``is_active`` flag on a
+    user, but the default :setting:`AUTHENTICATION_BACKENDS` reject inactive
+    users.
+
+
 .. currentmodule:: django.contrib.auth.mixins
 
 The ``LoginRequiredMixin`` mixin


### PR DESCRIPTION
#### Trac ticket number
ticket-[36084](https://code.djangoproject.com/ticket/36084)

#### Branch description
This PR introduces a new `role_required` decorator for Django's authentication system. The decorator allows developers to restrict access to views based on user roles, providing a flexible way to implement role-based access control.

Key features:
- Supports checking for one or multiple roles.
- Allows developers to specify whether all roles are required (`test_all=True`) or any one role suffices (`test_all=False`).
- Integrates seamlessly with Django's existing authentication decorators like `@login_required`.

This decorator is particularly useful for applications that require fine-grained access control based on user roles (e.g., `is_seller`, `is_admin`).

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes. <!-- Not applicable for this PR. -->