### PR TITLE
Fixed invalid html templates in tests.

### DIFF
--- a/tests/forms_tests/templates/forms_tests/custom_field.html
+++ b/tests/forms_tests/templates/forms_tests/custom_field.html
@@ -1,3 +1,3 @@
 {{ field.label_tag }}
-<p>Custom Field<p>
+<p>Custom Field</p>
 {{ field }}

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -5354,7 +5354,7 @@ class TemplateTests(SimpleTestCase):
         f = MyForm()
         self.assertHTMLEqual(
             f.render(),
-            '<div><label for="id_first_name">First name:</label><p>Custom Field<p>'
+            '<div><label for="id_first_name">First name:</label><p>Custom Field</p>'
             '<input type="text" name="first_name" required id="id_first_name"></div>',
         )
 
@@ -5365,7 +5365,7 @@ class TemplateTests(SimpleTestCase):
         f = MyForm()
         self.assertHTMLEqual(
             f["first_name"].render(template_name="forms_tests/custom_field.html"),
-            '<label for="id_first_name">First name:</label><p>Custom Field<p>'
+            '<label for="id_first_name">First name:</label><p>Custom Field</p>'
             '<input type="text" name="first_name" required id="id_first_name">',
         )
 
@@ -5393,7 +5393,7 @@ class OverrideTests(SimpleTestCase):
         html = t.render(Context({"form": Person()}))
         expected = """
         <label for="id_first_name">First name:</label>
-        <p>Custom Field<p>
+        <p>Custom Field</p>
         <input type="text" name="first_name" required id="id_first_name">
         """
         self.assertHTMLEqual(html, expected)

--- a/tests/view_tests/templates/jsi18n-multi-catalogs.html
+++ b/tests/view_tests/templates/jsi18n-multi-catalogs.html
@@ -2,6 +2,7 @@
 <head>
   <script src="/jsi18n/app1/"></script>
   <script src="/jsi18n/app2/"></script>
+</head>
 <body>
   <p id="app1string">
     <script>


### PR DESCRIPTION
#### Trac ticket number
N/A
#### Branch description
I'm in the process of writing a django template formatter and was doing some testing on Django, found a few templates in tests folders with invalid html syntax's that this PR fixes.

I've ran `./runtests.py` locally to test this change.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
