### PR TITLE
Fixed #36085 -- Added JSONField support for negative array indexing on SQLite.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -347,6 +347,8 @@ class BaseDatabaseFeatures:
     json_key_contains_list_matching_requires_list = False
     # Does the backend support JSONObject() database function?
     has_json_object_function = True
+    # Does the backend support negative JSON array indexing?
+    supports_json_negative_indexing = True
 
     # Does the backend support column collations?
     supports_collation_on_charfield = True

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -792,3 +792,18 @@ class BaseDatabaseOperations:
     def format_debug_sql(self, sql):
         # Hook for backends (e.g. NoSQL) to customize formatting.
         return sqlparse.format(sql, reindent=True, keyword_case="upper")
+
+    def compile_json_path(self, key_transforms, include_root=True):
+        """
+        Hook for backends to customize all aspects of JSON path construction.
+        """
+        path = ["$"] if include_root else []
+        for key_transform in key_transforms:
+            try:
+                num = int(key_transform)
+            except ValueError:  # Non-integer.
+                path.append(".")
+                path.append(json.dumps(key_transform))
+            else:
+                path.append("[%s]" % num)
+        return "".join(path)

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -793,6 +793,12 @@ class BaseDatabaseOperations:
         # Hook for backends (e.g. NoSQL) to customize formatting.
         return sqlparse.format(sql, reindent=True, keyword_case="upper")
 
+    def format_json_path_numeric_index(self, num):
+        """
+        Hook for backends to customize array indexing in JSON paths.
+        """
+        return "[%s]" % num
+
     def compile_json_path(self, key_transforms, include_root=True):
         """
         Hook for backends to customize all aspects of JSON path construction.
@@ -805,5 +811,13 @@ class BaseDatabaseOperations:
                 path.append(".")
                 path.append(json.dumps(key_transform))
             else:
-                path.append("[%s]" % num)
+                if (
+                    num < 0
+                    and not self.connection.features.supports_json_negative_indexing
+                ):
+                    raise NotSupportedError(
+                        "Using negative JSON array indices is not supported on this "
+                        "database backend."
+                    )
+                path.append(self.format_json_path_numeric_index(num))
         return "".join(path)

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -58,6 +58,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_stored_generated_columns = True
     supports_virtual_generated_columns = True
 
+    supports_json_negative_indexing = False
+
     @cached_property
     def minimum_database_version(self):
         if self.connection.mysql_is_mariadb:

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -73,6 +73,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     requires_compound_order_by_subquery = True
     allows_multiple_constraints_on_same_fields = False
     supports_json_field_contains = False
+    supports_json_negative_indexing = False
     supports_collation_on_textfield = False
     test_now_utc_template = "CURRENT_TIMESTAMP AT TIME ZONE 'UTC'"
     django_test_expected_failures = {

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -441,3 +441,6 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def force_group_by(self):
         return ["GROUP BY TRUE"] if Database.sqlite_version_info < (3, 39) else []
+
+    def format_json_path_numeric_index(self, num):
+        return "[#%s]" % num if num < 0 else super().format_json_path_numeric_index(num)

--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -148,19 +148,6 @@ class JSONField(CheckFieldDefaultMixin, Field):
         )
 
 
-def compile_json_path(key_transforms, include_root=True):
-    path = ["$"] if include_root else []
-    for key_transform in key_transforms:
-        try:
-            num = int(key_transform)
-        except ValueError:  # non-integer
-            path.append(".")
-            path.append(json.dumps(key_transform))
-        else:
-            path.append("[%s]" % num)
-    return "".join(path)
-
-
 class DataContains(FieldGetDbPrepValueMixin, PostgresOperatorLookup):
     lookup_name = "contains"
     postgres_operator = "@>"
@@ -194,7 +181,7 @@ class ContainedBy(FieldGetDbPrepValueMixin, PostgresOperatorLookup):
 class HasKeyLookup(PostgresOperatorLookup):
     logical_operator = None
 
-    def compile_json_path_final_key(self, key_transform):
+    def compile_json_path_final_key(self, connection, key_transform):
         # Compile the final key without interpreting ints as array elements.
         return ".%s" % json.dumps(key_transform)
 
@@ -204,7 +191,7 @@ class HasKeyLookup(PostgresOperatorLookup):
             lhs_sql, lhs_params, lhs_key_transforms = self.lhs.preprocess_lhs(
                 compiler, connection
             )
-            lhs_json_path = compile_json_path(lhs_key_transforms)
+            lhs_json_path = connection.ops.compile_json_path(lhs_key_transforms)
         else:
             lhs_sql, lhs_params = self.process_lhs(compiler, connection)
             lhs_json_path = "$"
@@ -218,8 +205,10 @@ class HasKeyLookup(PostgresOperatorLookup):
             else:
                 rhs_key_transforms = [key]
             *rhs_key_transforms, final_key = rhs_key_transforms
-            rhs_json_path = compile_json_path(rhs_key_transforms, include_root=False)
-            rhs_json_path += self.compile_json_path_final_key(final_key)
+            rhs_json_path = connection.ops.compile_json_path(
+                rhs_key_transforms, include_root=False
+            )
+            rhs_json_path += self.compile_json_path_final_key(connection, final_key)
             yield lhs_sql, lhs_params, lhs_json_path + rhs_json_path
 
     def _combine_sql_parts(self, parts):
@@ -296,8 +285,8 @@ class HasAnyKeys(HasKeys):
 
 
 class HasKeyOrArrayIndex(HasKey):
-    def compile_json_path_final_key(self, key_transform):
-        return compile_json_path([key_transform], include_root=False)
+    def compile_json_path_final_key(self, connection, key_transform):
+        return connection.ops.compile_json_path([key_transform], include_root=False)
 
 
 class CaseInsensitiveMixin:
@@ -378,12 +367,12 @@ class KeyTransform(Transform):
 
     def as_mysql(self, compiler, connection):
         lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-        json_path = compile_json_path(key_transforms)
+        json_path = connection.ops.compile_json_path(key_transforms)
         return "JSON_EXTRACT(%s, %%s)" % lhs, (*params, json_path)
 
     def as_oracle(self, compiler, connection):
         lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-        json_path = compile_json_path(key_transforms)
+        json_path = connection.ops.compile_json_path(key_transforms)
         if connection.features.supports_primitives_in_json_field:
             sql = (
                 "COALESCE("
@@ -419,7 +408,7 @@ class KeyTransform(Transform):
 
     def as_sqlite(self, compiler, connection):
         lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-        json_path = compile_json_path(key_transforms)
+        json_path = connection.ops.compile_json_path(key_transforms)
         datatype_values = ",".join(
             [repr(datatype) for datatype in connection.ops.jsonfield_datatype_values]
         )
@@ -441,7 +430,7 @@ class KeyTextTransform(KeyTransform):
             return "JSON_UNQUOTE(%s)" % sql, params
         else:
             lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-            json_path = compile_json_path(key_transforms)
+            json_path = connection.ops.compile_json_path(key_transforms)
             return "(%s ->> %%s)" % lhs, (*params, json_path)
 
     @classmethod

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -205,6 +205,9 @@ Models
 * :meth:`.QuerySet.raw` now supports models with a
   :class:`~django.db.models.CompositePrimaryKey`.
 
+* :class:`~django.db.models.JSONField` now supports
+  :ref:`negative array indexing <key-index-and-path-transforms>` on SQLite.
+
 Pagination
 ~~~~~~~~~~
 

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -1092,6 +1092,8 @@ Unless you are sure you wish to work with SQL ``NULL`` values, consider setting
 
 .. fieldlookup:: jsonfield.key
 
+.. _key-index-and-path-transforms:
+
 Key, index, and path transforms
 -------------------------------
 
@@ -1133,6 +1135,22 @@ array:
 
     >>> Dog.objects.filter(data__owner__other_pets__0__name="Fishy")
     <QuerySet [<Dog: Rufus>]>
+
+If the key is a negative integer, it cannot be used in a filter keyword
+directly, but you can still use dictionary unpacking to use it in a query:
+
+.. code-block:: pycon
+
+    >>> Dog.objects.filter(**{"data__owner__other_pets__-1__name": "Fishy"})
+    <QuerySet [<Dog: Rufus>]>
+
+.. admonition:: MySQL, MariaDB, and Oracle
+
+    Negative JSON array indices are not supported.
+
+.. versionchanged:: 6.0
+
+    SQLite support for negative JSON array indices was added.
 
 If the key you wish to query by clashes with the name of another lookup, use
 the :lookup:`contains <jsonfield.contains>` lookup instead.

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -785,6 +785,21 @@ class TestQuerying(TestCase):
             [self.objs[5]],
         )
 
+    @skipIfDBFeature("supports_json_negative_indexing")
+    def test_unsupported_negative_lookup(self):
+        msg = (
+            "Using negative JSON array indices is not supported on this database "
+            "backend."
+        )
+        with self.assertRaisesMessage(NotSupportedError, msg):
+            NullableJSONModel.objects.filter(**{"value__-2": 1}).get()
+
+    @skipUnlessDBFeature("supports_json_negative_indexing")
+    def test_shallow_list_negative_lookup(self):
+        self.assertSequenceEqual(
+            NullableJSONModel.objects.filter(**{"value__-2": 1}), [self.objs[5]]
+        )
+
     def test_shallow_obj_lookup(self):
         self.assertCountEqual(
             NullableJSONModel.objects.filter(value__a="b"),
@@ -817,9 +832,23 @@ class TestQuerying(TestCase):
             [self.objs[5]],
         )
 
+    @skipUnlessDBFeature("supports_json_negative_indexing")
+    def test_deep_negative_lookup_array(self):
+        self.assertSequenceEqual(
+            NullableJSONModel.objects.filter(**{"value__-1__0": 2}),
+            [self.objs[5]],
+        )
+
     def test_deep_lookup_mixed(self):
         self.assertSequenceEqual(
             NullableJSONModel.objects.filter(value__d__1__f="g"),
+            [self.objs[4]],
+        )
+
+    @skipUnlessDBFeature("supports_json_negative_indexing")
+    def test_deep_negative_lookup_mixed(self):
+        self.assertSequenceEqual(
+            NullableJSONModel.objects.filter(**{"value__d__-1__f": "g"}),
             [self.objs[4]],
         )
 


### PR DESCRIPTION
#### Trac ticket number
ticket-36085

#### Branch description
The SQLite backend has [special syntax for performing negative-indexing in jsonfields](https://sqlite.org/json1.html#path_arguments) that is different from other backends: negative indices must be prepended by a literal `#` character.

#### Refactor
This change includes a refactor to turn the function `django.db.models.fields.json.compile_json_path` into a method of `[Base]DatabaseOperations`, to allow backend-specific customization. The refactor is cherry-picked from #19182, cleaned up, and modified to reduce duplicated code when customizing backend behavior.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
