### PR TITLE
Refs #35844 -- Removed unnecessary and deprecated ArgumentParser.add_argument_group()'s prefix_chars argument.

### DIFF
--- a/django/core/management/commands/dbshell.py
+++ b/django/core/management/commands/dbshell.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
                 '"default" database.'
             ),
         )
-        parameters = parser.add_argument_group("parameters", prefix_chars="--")
+        parameters = parser.add_argument_group("parameters")
         parameters.add_argument("parameters", nargs="*")
 
     def handle(self, **options):


### PR DESCRIPTION
https://github.com/python/cpython/commit/7b04496e5c7ed47e9653f4591674fc9ffef34587

As far as I'm aware, it was unnecessary since its introduction in 5b884d45ac5b76234eca614d90c83b347294c332.

ticket-35844

```
\django\django\django\core\management\commands\dbshell.py:25: DeprecationWarning:
The use of the undocumented 'prefix_chars' parameter in ArgumentParser.add_argument_group() is deprecated.
  parameters = parser.add_argument_group("parameters", prefix_chars="--")
```