### PR TITLE
Ticket 36089

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -11,6 +11,7 @@ from argparse import (
 from collections import defaultdict
 from difflib import get_close_matches
 from importlib import import_module
+from typing import Dict
 
 import django
 from django.apps import apps
@@ -209,7 +210,7 @@ class ManagementUtility:
     def main_help_text(self, commands_only=False):
         """Return the script's main help text, as a string."""
         if commands_only:
-            usage = sorted(get_commands())
+            usage = sorted(self.get_management_commands())
         else:
             usage = [
                 "",
@@ -219,7 +220,7 @@ class ManagementUtility:
                 "Available subcommands:",
             ]
             commands_dict = defaultdict(lambda: [])
-            for name, app in get_commands().items():
+            for name, app in self.get_management_commands().items():
                 if app == "django.core":
                     app = "django"
                 else:
@@ -243,6 +244,12 @@ class ManagementUtility:
 
         return "\n".join(usage)
 
+    def get_management_commands(self) -> Dict[str, str]:
+        """
+        Return a dictionary mapping command names to their callback applications.
+        """
+        return get_commands()
+
     def fetch_command(self, subcommand):
         """
         Try to fetch the given subcommand, printing a message with the
@@ -250,7 +257,7 @@ class ManagementUtility:
         "django-admin" or "manage.py") if it can't be found.
         """
         # Get commands outside of try block to prevent swallowing exceptions
-        commands = get_commands()
+        commands = self.get_management_commands()
         try:
             app_name = commands[subcommand]
         except KeyError:
@@ -308,7 +315,7 @@ class ManagementUtility:
         except IndexError:
             curr = ""
 
-        subcommands = [*get_commands(), "help"]
+        subcommands = [*self.get_management_commands(), "help"]
         options = [("--help", False)]
 
         # subcommand

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -319,6 +319,9 @@ Management Commands
   custom commands to control the running of system checks, e.g. to opt into
   database-dependent checks.
 
+* The new :meth:`.ManagementUtility.get_management_commands` method can be overridden in
+  custom ManagementUtility to exclude some unwanted command from the command line utility.
+
 Migrations
 ~~~~~~~~~~
 

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -319,7 +319,7 @@ Management Commands
   custom commands to control the running of system checks, e.g. to opt into
   database-dependent checks.
 
-* The new :meth:`.ManagementUtility.get_management_commands` method can be overridden in
+* The new :meth:`~django.core.management.ManagementUtility.get_management_commands` method can be overridden in
   custom ManagementUtility to exclude some unwanted command from the command line utility.
 
 Migrations

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -109,6 +109,7 @@ class CommandTests(SimpleTestCase):
         """
         commands = management.ManagementUtility(["manage.py"]).get_management_commands()
         self.assertIn("shell", commands)
+
         class FilteredCommands(management.ManagementUtility):
             def get_management_commands(self) -> Dict[str, str]:
                 commands_ = super().get_management_commands()

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -3,6 +3,7 @@ import sys
 from argparse import ArgumentDefaultsHelpFormatter
 from io import BytesIO, StringIO, TextIOWrapper
 from pathlib import Path
+from typing import Dict
 from unittest import mock
 
 from admin_scripts.tests import AdminScriptTestCase
@@ -101,6 +102,21 @@ class CommandTests(SimpleTestCase):
         finally:
             dance.Command.requires_system_checks = "__all__"
         self.assertIn("CommandError", stderr.getvalue())
+
+    def test_get_management_commands(self):
+        """
+        Ensure that the get_management_commands is working and can be overridden.
+        """
+        commands = management.ManagementUtility(["manage.py"]).get_management_commands()
+        self.assertIn("shell", commands)
+        class FilteredCommands(management.ManagementUtility):
+            def get_management_commands(self) -> Dict[str, str]:
+                commands_ = super().get_management_commands()
+                del commands_["shell"]
+                return commands_
+
+        commands = FilteredCommands(["manage.py"]).get_management_commands()
+        self.assertNotIn("shell", commands)
 
     def test_no_translations_deactivate_translations(self):
         """


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36089

#### Branch description
The ManagementUtility directly uses the get_commands function instead of encapsulating it in a method that could be overridden, for example to exclude some unwanted Django commands.

To ensure compatibility, the simplest way is to add a get_management_commands method to ManagementUtility that only calls the original get_commands function.


#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
