### PR TITLE
Fixed #36092 -- Disallowed non-local fields in composite primary keys.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1804,6 +1804,8 @@ class Model(AltersData, metaclass=ModelBase):
                 hint = f"{field_name!r} field may not set 'null=True'."
             elif field.generated:
                 hint = f"{field_name!r} field is a generated field."
+            elif field not in meta.local_fields:
+                hint = f"{field_name!r} field is not a local field."
             else:
                 seen_columns[field.column].append(field_name)
 

--- a/tests/composite_pk/test_checks.py
+++ b/tests/composite_pk/test_checks.py
@@ -247,3 +247,24 @@ class CompositePKChecksTests(TestCase):
                 ),
             ],
         )
+
+    def test_composite_pk_cannot_include_non_local_field(self):
+        class Foo(models.Model):
+            a = models.SmallIntegerField()
+
+        class Bar(Foo):
+            pk = models.CompositePrimaryKey("a", "b")
+            b = models.SmallIntegerField()
+
+        self.assertEqual(Foo.check(databases=self.databases), [])
+        self.assertEqual(
+            Bar.check(databases=self.databases),
+            [
+                checks.Error(
+                    "'a' cannot be included in the composite primary key.",
+                    hint="'a' field is not a local field.",
+                    obj=Bar,
+                    id="models.E042",
+                ),
+            ],
+        )


### PR DESCRIPTION
#### Trac ticket number
ticket-36092

#### Branch description
Add a check so non-local fields are not allowed in composite pks

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [X] I have attached screenshots in both light and dark modes for any UI changes.
