### PR TITLE
Fixed ambiguous pronoun reference in docs/ref/models/fields.txt.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -497,7 +497,7 @@ The default value can also be set at the database level with
 .. attribute:: Field.editable
 
 If ``False``, the field will not be displayed in the admin or any other
-:class:`~django.forms.ModelForm`. They are also skipped during :ref:`model
+:class:`~django.forms.ModelForm`. It will also be skipped during :ref:`model
 validation <validating-objects>`. Default is ``True``.
 
 ``error_messages``


### PR DESCRIPTION
Fixes a small grammatical inaccuracy:

"They" is used as pronoun for "the field". Corrected to "Such fields"