### PR TITLE
Fixed #36095 -- Introduced lazy references before they are used in docs.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -2025,6 +2025,10 @@ that control how the relationship functions.
     the Django model that represents the intermediate table that you want to
     use.
 
+    The ``through`` model can be specified using either the model class
+    directly or a :ref:`lazy reference <lazy-relationships>` to the model
+    class.
+
     The most common use for this option is when you want to associate
     :ref:`extra data with a many-to-many relationship
     <intermediary-manytomany>`.

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -720,6 +720,24 @@ refer to the other model class wherever needed. For example::
             null=True,
         )
 
+Alternatively, you can use a lazy reference to the related model, specified as
+a string in the format ``"app_label.ModelName"``. This does not require the
+related model to be imported. For example::
+
+    from django.db import models
+
+
+    class Restaurant(models.Model):
+        # ...
+        zip_code = models.ForeignKey(
+            "geography.ZipCode",
+            on_delete=models.SET_NULL,
+            blank=True,
+            null=True,
+        )
+
+See :ref:`lazy relationships <lazy-relationships>` for more details.
+
 Field name restrictions
 -----------------------
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36095

#### Branch description
1. Explicitly introduces lazy relationships in the "Models across files" section of topics/db/models before lazy references are used in the docs below that (under https://docs.djangoproject.com/en/dev/topics/db/models/#extra-fields-on-many-to-many-relationships)
2. Doc's that M2M.through supports lazy relationships (as seen in the under https://docs.djangoproject.com/en/dev/topics/db/models/#extra-fields-on-many-to-many-relationships and m2m refs but without explicit documentation).

 

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
