### PR TITLE
Refs #31026 -- Added an unittest for setting the renderer on model forms.

### DIFF
--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -847,8 +847,15 @@ class ModelFormBaseTest(TestCase):
         self.assertEqual(m1.mode, mode)
 
     def test_renderer_kwarg(self):
-        custom = object()
-        self.assertIs(ProductForm(renderer=custom).renderer, custom)
+        from django.forms.renderers import BaseRenderer
+
+        class CustomRenderer(BaseRenderer):
+            custom_attribute = "test"
+
+        custom = CustomRenderer()
+        form = ProductForm(renderer=custom)
+        self.assertIs(form.renderer, custom)
+        self.assertEqual(form.renderer.custom_attribute, "test")
 
     def test_default_splitdatetime_field(self):
         class PubForm(forms.ModelForm):


### PR DESCRIPTION
#### Trac ticket number

N/A

#### Branch description

This changes the unittest for the `ModelForm` renderer constructor argument to use a real renderer. 

It has been split out from https://github.com/django/django/pull/19043 since it wasn't related to the changes there.

I checked first if the `renderer` argument is already covered by the testsuite and if we could remove this test instead, but it was the only place where a model form was instantiated with a `renderer=`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
