### PR TITLE
Fixed #36098 -- Fixed validate_ipv6_address()/validate_ipv46_address() crash on ipaddress.IPv6Address instances.

### DIFF
--- a/django/contrib/gis/geoip2.py
+++ b/django/contrib/gis/geoip2.py
@@ -153,11 +153,12 @@ class GeoIP2:
         if require_city and not self.is_city:
             raise GeoIP2Exception(f"Invalid GeoIP city data file: {self._path}")
 
-        try:
-            validate_ipv46_address(query)
-        except ValidationError:
-            # GeoIP2 only takes IP addresses, so try to resolve a hostname.
-            query = socket.gethostbyname(query)
+        if isinstance(query, str):
+            try:
+                validate_ipv46_address(query)
+            except ValidationError:
+                # GeoIP2 only takes IP addresses, so try to resolve a hostname.
+                query = socket.gethostbyname(query)
 
         function = self._reader.city if self.is_city else self._reader.country
         return function(query)

--- a/django/utils/ipv6.py
+++ b/django/utils/ipv6.py
@@ -51,12 +51,14 @@ def clean_ipv6_address(
     return str(addr)
 
 
-def is_valid_ipv6_address(ip_str):
+def is_valid_ipv6_address(ip_addr):
     """
-    Return whether or not the `ip_str` string is a valid IPv6 address.
+    Return whether the `ip_addr` object is a valid IPv6 address.
     """
+    if isinstance(ip_addr, ipaddress.IPv6Address):
+        return True
     try:
-        _ipv6_address_from_str(ip_str)
-    except ValueError:
+        _ipv6_address_from_str(ip_addr)
+    except (TypeError, ValueError):
         return False
     return True

--- a/docs/releases/4.2.19.txt
+++ b/docs/releases/4.2.19.txt
@@ -1,0 +1,14 @@
+===========================
+Django 4.2.19 release notes
+===========================
+
+*Expected February 5, 2025*
+
+Django 4.2.19 fixes a regression in 4.2.18.
+
+Bugfixes
+========
+
+* Fixed a regression in Django 4.2.18 that caused ``validate_ipv6_address()``
+  and ``validate_ipv46_address()`` to crash when handling non-string values
+  (:ticket:`36098`).

--- a/docs/releases/5.0.12.txt
+++ b/docs/releases/5.0.12.txt
@@ -1,0 +1,14 @@
+===========================
+Django 5.0.12 release notes
+===========================
+
+*Expected February 5, 2025*
+
+Django 5.0.12 fixes a regression in 5.0.11.
+
+Bugfixes
+========
+
+* Fixed a regression in Django 5.0.11 that caused ``validate_ipv6_address()``
+  and ``validate_ipv46_address()`` to crash when handling non-string values
+  (:ticket:`36098`).

--- a/docs/releases/5.1.6.txt
+++ b/docs/releases/5.1.6.txt
@@ -9,4 +9,6 @@ Django 5.1.6 fixes several bugs in 5.1.5.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 5.1.5 that caused ``validate_ipv6_address()``
+  and ``validate_ipv46_address()`` to crash when handling non-string values
+  (:ticket:`36098`).

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -45,6 +45,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   5.0.12
    5.0.11
    5.0.10
    5.0.9
@@ -64,6 +65,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   4.2.19
    4.2.18
    4.2.17
    4.2.16

--- a/tests/utils_tests/test_ipv6.py
+++ b/tests/utils_tests/test_ipv6.py
@@ -1,5 +1,7 @@
 import traceback
+from decimal import Decimal
 from io import StringIO
+from ipaddress import IPv6Address
 
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase
@@ -23,6 +25,16 @@ class TestUtilsIPv6(SimpleTestCase):
         self.assertTrue(is_valid_ipv6_address("::ffff:254.42.16.14"))
         self.assertTrue(is_valid_ipv6_address("::ffff:0a0a:0a0a"))
 
+    def test_validates_correct_with_ipv6_instance(self):
+        cases = [
+            IPv6Address("::ffff:2.125.160.216"),
+            IPv6Address("fe80::1"),
+            IPv6Address("::"),
+        ]
+        for case in cases:
+            with self.subTest(case=case):
+                self.assertIs(is_valid_ipv6_address(case), True)
+
     def test_validates_incorrect_plain_address(self):
         self.assertFalse(is_valid_ipv6_address("foo"))
         self.assertFalse(is_valid_ipv6_address("127.0.0.1"))
@@ -44,6 +56,12 @@ class TestUtilsIPv6(SimpleTestCase):
         self.assertTrue(is_valid_ipv6_address("::0a0a:0a0a"))
         self.assertFalse(is_valid_ipv6_address("::999.42.16.14"))
         self.assertFalse(is_valid_ipv6_address("::zzzz:0a0a"))
+
+    def test_validates_incorrect_with_non_string(self):
+        cases = [None, [], {}, (), Decimal("2.46"), 192.168, 42]
+        for case in cases:
+            with self.subTest(case=case):
+                self.assertIs(is_valid_ipv6_address(case), False)
 
     def test_cleans_plain_address(self):
         self.assertEqual(clean_ipv6_address("DEAD::0:BEEF"), "dead::beef")

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -1,3 +1,4 @@
+import ipaddress
 import re
 import types
 from datetime import datetime, timedelta
@@ -398,15 +399,25 @@ TEST_DATA = [
     (validate_ipv6_address, "fe80::1", None),
     (validate_ipv6_address, "::1", None),
     (validate_ipv6_address, "1:2:3:4:5:6:7:8", None),
+    (validate_ipv6_address, ipaddress.IPv6Address("::ffff:2.125.160.216"), None),
+    (validate_ipv6_address, ipaddress.IPv6Address("fe80::1"), None),
+    (validate_ipv6_address, Decimal("33.1"), ValidationError),
+    (validate_ipv6_address, 9.22, ValidationError),
     (validate_ipv6_address, "1:2", ValidationError),
     (validate_ipv6_address, "::zzz", ValidationError),
     (validate_ipv6_address, "12345::", ValidationError),
     (validate_ipv46_address, "1.1.1.1", None),
     (validate_ipv46_address, "255.0.0.0", None),
     (validate_ipv46_address, "0.0.0.0", None),
+    (validate_ipv46_address, ipaddress.IPv4Address("1.1.1.1"), None),
+    (validate_ipv46_address, ipaddress.IPv4Address("255.0.0.0"), None),
     (validate_ipv46_address, "fe80::1", None),
     (validate_ipv46_address, "::1", None),
     (validate_ipv46_address, "1:2:3:4:5:6:7:8", None),
+    (validate_ipv46_address, ipaddress.IPv6Address("::ffff:2.125.160.216"), None),
+    (validate_ipv46_address, ipaddress.IPv6Address("fe80::1"), None),
+    (validate_ipv46_address, Decimal("33.1"), ValidationError),
+    (validate_ipv46_address, 9.22, ValidationError),
     (validate_ipv46_address, "256.1.1.1", ValidationError),
     (validate_ipv46_address, "25.1.1.", ValidationError),
     (validate_ipv46_address, "25,1,1,1", ValidationError),


### PR DESCRIPTION
ticket-36098
