### PR TITLE
Fixed #36100 -- Checked if composite pk is set in get_next/get_previous.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1299,7 +1299,7 @@ class Model(AltersData, metaclass=ModelBase):
         )
 
     def _get_next_or_previous_by_FIELD(self, field, is_next, **kwargs):
-        if not self.pk:
+        if not self._is_pk_set():
             raise ValueError("get_next/get_previous cannot be used on unsaved objects.")
         op = "gt" if is_next else "lt"
         order = "" if is_next else "-"

--- a/tests/composite_pk/test_get.py
+++ b/tests/composite_pk/test_get.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from .models import Comment, Tenant, User
+from .models import Comment, Tenant, TimeStamped, User
 
 
 class CompositePKGetTests(TestCase):
@@ -124,3 +124,12 @@ class CompositePKGetTests(TestCase):
 
     def test_get_user_by_comments(self):
         self.assertEqual(User.objects.get(comments=self.comment_1), self.user_1)
+
+    def test_get_previous_by_field(self):
+        stamp_1 = TimeStamped.objects.create(id=1)
+        stamp_2 = TimeStamped(id=2)
+        msg = "get_next/get_previous cannot be used on unsaved objects."
+        with self.assertRaisesMessage(ValueError, msg):
+            stamp_2.get_previous_by_created()
+        stamp_2.save()
+        self.assertEqual(stamp_2.get_previous_by_created(), stamp_1)


### PR DESCRIPTION
#### Trac ticket number
ticket-36100

#### Branch description
Use `_is_pk_set()` in the check for unsaved objects in get_next/get_previous to avoid checking `(None, None)` and finding it truthy.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
