### PR TITLE
Fixed #36102 -- Moved i18n comments directly above the translatable string.

### DIFF
--- a/django/contrib/humanize/templatetags/humanize.py
+++ b/django/contrib/humanize/templatetags/humanize.py
@@ -223,29 +223,36 @@ class NaturalTimeFormatter:
         # and time unit.
         "past-second": ngettext_lazy("a second ago", "%(count)s seconds ago", "count"),
         "now": gettext_lazy("now"),
-        # Translators: please keep a non-breaking space (U+00A0) between count
-        # and time unit.
+        # fmt: off
+        # fmt turned off to avoid black splitting the ngettext_lazy calls to multiple
+        # lines, as this results in gettext missing the 'Translators:' comments.
         "future-second": ngettext_lazy(
+            # Translators: please keep a non-breaking space (U+00A0) between count
+            # and time unit.
             "a second from now", "%(count)s seconds from now", "count"
         ),
-        # Translators: please keep a non-breaking space (U+00A0) between count
-        # and time unit.
         "future-minute": ngettext_lazy(
-            "a minute from now", "%(count)s minutes from now", "count"
+            # Translators: please keep a non-breaking space (U+00A0) between count
+            # and time unit.
+            "a minute from now", "%(count)s minutes from now", "count",
         ),
-        # Translators: please keep a non-breaking space (U+00A0) between count
-        # and time unit.
         "future-hour": ngettext_lazy(
-            "an hour from now", "%(count)s hours from now", "count"
+            # Translators: please keep a non-breaking space (U+00A0) between count
+            # and time unit.
+            "an hour from now", "%(count)s hours from now", "count",
         ),
+        # fmt: on
         # Translators: delta will contain a string like '2 months' or '1 month, 2 weeks'
         "future-day": gettext_lazy("%(delta)s from now"),
     }
     past_substrings = {
-        # Translators: 'naturaltime-past' strings will be included in '%(delta)s ago'
+        # fmt: off
         "year": npgettext_lazy(
-            "naturaltime-past", "%(num)d year", "%(num)d years", "num"
+            # Translators: 'naturaltime-past' strings will be included in
+            # '%(delta)s ago'
+            "naturaltime-past", "%(num)d year", "%(num)d years", "num",
         ),
+        # fmt:on
         "month": npgettext_lazy(
             "naturaltime-past", "%(num)d month", "%(num)d months", "num"
         ),
@@ -261,11 +268,13 @@ class NaturalTimeFormatter:
         ),
     }
     future_substrings = {
-        # Translators: 'naturaltime-future' strings will be included in
-        # '%(delta)s from now'.
+        # fmt: off
         "year": npgettext_lazy(
-            "naturaltime-future", "%(num)d year", "%(num)d years", "num"
+            # Translators: 'naturaltime-future' strings will be included in
+            # '%(delta)s from now'.
+            "naturaltime-future", "%(num)d year", "%(num)d years", "num",
         ),
+        # fmt: on
         "month": npgettext_lazy(
             "naturaltime-future", "%(num)d month", "%(num)d months", "num"
         ),


### PR DESCRIPTION
According to
https://www.gnu.org/software/gettext/manual/html_node/xgettext-Invocation.html the comments have to be very close to the string to get spotted.

Without this patch, the comments were dissapearing from the po file when scripts/manage_translations.py is ran.

#### Trac ticket number

ticket-36102

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
