### PR TITLE
Refs #35090 -- Fixed urlpatterns.tests.SimplifiedURLTests when run in reverse.

### DIFF
--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -13,7 +13,7 @@ from django.urls import (
     resolve,
     reverse,
 )
-from django.urls.converters import IntConverter
+from django.urls.converters import REGISTERED_CONVERTERS, IntConverter
 from django.views import View
 
 from .converters import Base64Converter, DynamicConverter
@@ -209,8 +209,12 @@ class SimplifiedURLTests(SimpleTestCase):
 
     def test_warning_override_converter(self):
         msg = "Converter 'base64' is already registered."
-        with self.assertRaisesMessage(ValueError, msg):
-            register_converter(Base64Converter, "base64")
+        try:
+            with self.assertRaisesMessage(ValueError, msg):
+                register_converter(Base64Converter, "base64")
+                register_converter(Base64Converter, "base64")
+        finally:
+            REGISTERED_CONVERTERS.pop("base64", None)
 
     def test_invalid_view(self):
         msg = "view must be a callable or a list/tuple in the case of include()."


### PR DESCRIPTION
Regression in 9cb1ffa67bb0d13f86c2d4627428fcaa4513136d.

Check out 0e84e70bc8e0140a1e22f25bc6cb852d95a79949.

[Logs](https://djangoci.com/job/main-reverse/database=spatialite,label=focal,python=python3.13/308/)