### PR TITLE
[4.2.x] Refs #36098 -- Fixed validate_ipv4_address() crash for non-string values.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -272,6 +272,8 @@ validate_unicode_slug = RegexValidator(
 
 
 def validate_ipv4_address(value):
+    if isinstance(value, ipaddress.IPv4Address):
+        return
     try:
         ipaddress.IPv4Address(value)
     except ValueError:


### PR DESCRIPTION
Regression in ca2be7724e1244a4cb723de40a070f873c6e94bf.

See logs: https://djangoci.com/job/django-4.2/database=sqlite3,label=focal,python=python3.8/lastCompletedBuild/testReport/
https://djangoci.com/job/django-4.2/
