### PR TITLE
Fixed #36078 -- Doc'd that Postgres normalizes a range field with no points to empty.

### DIFF
--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -517,6 +517,15 @@ excluded, that is ``[)`` (see the PostgreSQL documentation for details about
 fields (:class:`.DateTimeRangeField` and :class:`.DecimalRangeField`) by using
 the ``default_bounds`` argument.
 
+.. admonition:: PostgreSQL normalizes a range with no points to the empty range
+
+    A range with equal values specified for an included lower bound and an
+    excluded upper bound, such as ``Range(datetime.date(2005, 6, 21),
+    datetime.date(2005, 6, 21))`` or ``[4, 4)``, has no points. PostgreSQL will
+    normalize the value to empty when saving to the database, and the original
+    bound values will be lost. See the `PostgreSQL documentation for details
+    <https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-IO>`_.
+
 ``IntegerRangeField``
 ---------------------
 


### PR DESCRIPTION


#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36078

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
