### PR TITLE
[4.2.x] Refs #34060 -- Adjusted CVE-2024-53908 regression test for psycopg2.

### DIFF
--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -611,7 +611,7 @@ class TestQuerying(TestCase):
     def test_has_key_literal_lookup(self):
         self.assertSequenceEqual(
             NullableJSONModel.objects.filter(
-                HasKey(Value({"foo": "bar"}, JSONField()), "foo")
+                HasKey(Cast(Value({"foo": "bar"}, JSONField()), JSONField()), "foo")
             ).order_by("id"),
             self.objs,
         )


### PR DESCRIPTION
#### Trac ticket number

ticket-34060

#### Branch description

The lack of explicit cast for JSON literals on psycopg2 is fixed on 5.1+ by 0d8fbe2ade29f1b7bd9e6ba7a0281f5478603a43 but didn't qualify for a backport to stable/4.2.x at the time.
