### PR TITLE
Fixed #36106 - Added exclude option for django-admin flush command.

### DIFF
--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -4,13 +4,14 @@ from django.apps import apps
 from django.db import models
 
 
-def sql_flush(style, connection, reset_sequences=True, allow_cascade=False):
+def sql_flush(style, connection, reset_sequences=True, allow_cascade=False, exclude=[]):
     """
     Return a list of the SQL statements used to flush the database.
     """
     tables = connection.introspection.django_table_names(
         only_existing=True, include_views=False
     )
+    tables = [table for table in tables if table not in exclude]
     return connection.ops.sql_flush(
         style,
         tables,

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -411,6 +411,12 @@ Suppresses all user prompts.
 
 Specifies the database to flush. Defaults to ``default``.
 
+.. django-admin-option:: --exclude EXCLUDE
+.. versionadded:: A.B
+
+Specifies a list of table names to exclude from flushing.
+Tables can be separated by commas, spaces, or both.
+
 ``inspectdb``
 -------------
 

--- a/tests/flush/models.py
+++ b/tests/flush/models.py
@@ -1,0 +1,7 @@
+from django.db import models
+
+class Restaurant(models.Model):
+    name = models.CharField(max_length=50)
+
+class Address(models.Model):
+    street = models.CharField(max_length=50)

--- a/tests/flush/models.py
+++ b/tests/flush/models.py
@@ -1,7 +1,9 @@
 from django.db import models
 
+
 class Restaurant(models.Model):
     name = models.CharField(max_length=50)
+
 
 class Address(models.Model):
     street = models.CharField(max_length=50)

--- a/tests/flush/tests.py
+++ b/tests/flush/tests.py
@@ -5,7 +5,8 @@ from .models import Address, Restaurant
 
 
 class FlushCommandTest(TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         Restaurant.objects.create(name="Jeff's Place")
         Restaurant.objects.create(name="Dotino's")
         Address.objects.create(street="Cool avenue")

--- a/tests/flush/tests.py
+++ b/tests/flush/tests.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from django.core.management import call_command
 from .models import Restaurant, Address
 
+
 class FlushCommandTest(TestCase):
     def setUp(self):
         Restaurant.objects.create(name="Jeff's Place")

--- a/tests/flush/tests.py
+++ b/tests/flush/tests.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from django.core.management import call_command
+from .models import Restaurant, Address
+
+class FlushCommandTest(TestCase):
+    def setUp(self):
+        Restaurant.objects.create(name="Jeff's Place")
+        Restaurant.objects.create(name="Dotino's")
+        Address.objects.create(street="Cool avenue")
+        Address.objects.create(street="Cooler avenue")
+
+    def test_flush_clears_all_data(self):
+        self.assertEqual(Restaurant.objects.count(), 2)
+        call_command("flush", interactive=False)
+        self.assertEqual(Restaurant.objects.count(), 0)
+        self.assertEqual(Address.objects.count(), 0)
+
+    def test_flush_with_exclude_option(self):
+        self.assertEqual(Restaurant.objects.count(), 2)
+        self.assertEqual(Address.objects.count(), 2)
+        call_command("flush", interactive=False, exclude=["flush_restaurant"])
+        self.assertEqual(Restaurant.objects.count(), 2)
+        self.assertEqual(Address.objects.count(), 0)

--- a/tests/flush/tests.py
+++ b/tests/flush/tests.py
@@ -1,6 +1,7 @@
-from django.test import TestCase
 from django.core.management import call_command
-from .models import Restaurant, Address
+from django.test import TestCase
+
+from .models import Address, Restaurant
 
 
 class FlushCommandTest(TestCase):


### PR DESCRIPTION
ticket-36106

Added exclude option for django-admin flush command.
Also wrote a test for the flush command along with a test for the newly added exclude flag.