### PR TITLE
Fixed #36109 -- Fixed RecursionError when stacking FilteredRelation joins.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -822,6 +822,7 @@ answer newbie questions, and generally made Django that much better:
     Petar Marić <http://www.petarmaric.com/>
     Pete Crosier <pete.crosier@gmail.com>
     peter@mymart.com
+    Peter DeVita <pmdevita2643@gmail.com>
     Peter Sheats <sheats@gmail.com>
     Peter van Kampen
     Peter Zsoldos <http://zsoldosp.eu>

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1946,6 +1946,8 @@ class Query(BaseExpression):
             reuse = can_reuse if join.m2m else None
             alias = self.join(connection, reuse=reuse)
             joins.append(alias)
+            if join.filtered_relation and can_reuse is not None:
+                can_reuse.add(alias)
         return JoinInfo(final_field, targets, opts, joins, path, final_transformer)
 
     def trim_joins(self, targets, joins, path):

--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -582,6 +582,28 @@ class FilteredRelationTests(TestCase):
             lambda x: (x.author, x.book_title, x.preferred_by_author_pk),
         )
 
+    def test_three_level_nested_chained_relations(self):
+        borrower = Borrower.objects.create(name="Jenny")
+        Reservation.objects.create(
+            borrower=borrower,
+            book=self.book1,
+            state=Reservation.STOPPED,
+        )
+        qs = Author.objects.annotate(
+            my_books=FilteredRelation("book"),
+            my_reserved_books=FilteredRelation(
+                "my_books__reservation",
+                condition=Q(my_books__reservation__state=Reservation.STOPPED),
+            ),
+            my_readers=FilteredRelation(
+                "my_reserved_books__borrower",
+                condition=Q(my_reserved_books__borrower=borrower),
+            ),
+        )
+        self.assertSequenceEqual(
+            qs.filter(my_readers=borrower).values_list("name", flat=True), ["Alice"]
+        )
+
     def test_deep_nested_foreign_key(self):
         qs = (
             Book.objects.annotate(


### PR DESCRIPTION
#### Trac ticket number

ticket-36109

#### Branch description
When chaining three or more FilteredRelations, `Query` can get into a recursive loop. The joins it creates as it tries to the get to the last FilteredRelation are not marked as reusable, so it attempts to regenerate them over and over again. This change always marks joins with FilteredRelations as reusable, which should be the desired behavior.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
