### PR TITLE
Fixed #36107 -- Adjusted UNNEST bulk_create strategy to opt-out sized arrays.

### DIFF
--- a/django/db/backends/postgresql/compiler.py
+++ b/django/db/backends/postgresql/compiler.py
@@ -43,7 +43,7 @@ class SQLInsertCompiler(BaseSQLInsertCompiler):
         db_types = [field.db_type(self.connection) for field in fields]
         # Abort if any of the fields are arrays as UNNEST indiscriminately
         # flatten them instead of reducing their nesting by one.
-        if any(db_type.endswith("[]") for db_type in db_types):
+        if any(db_type.endswith("]") for db_type in db_types):
             return super().assemble_as_sql(fields, value_rows)
         return InsertUnnest(["(%%s)::%s[]" % db_type for db_type in db_types]), [
             list(map(list, zip(*value_rows)))

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -168,6 +168,28 @@ class Migration(migrations.Migration):
             bases=(models.Model,),
         ),
         migrations.CreateModel(
+            name="WithSizeArrayModel",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    "field",
+                    ArrayField(models.FloatField(), size=2, null=True, blank=True),
+                ),
+            ],
+            options={
+                "required_db_vendor": "postgresql",
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
             name="NullableIntegerArrayModel",
             fields=[
                 (

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -64,6 +64,10 @@ class DateTimeArrayModel(PostgreSQLModel):
     times = ArrayField(models.TimeField())
 
 
+class WithSizeArrayModel(PostgreSQLModel):
+    field = ArrayField(models.FloatField(), size=3)
+
+
 class NestedIntegerArrayModel(PostgreSQLModel):
     field = ArrayField(ArrayField(models.IntegerField()))
 

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -28,6 +28,7 @@ from .models import (
     OtherTypesArrayModel,
     PostgreSQLModel,
     Tag,
+    WithSizeArrayModel,
 )
 
 try:
@@ -215,6 +216,16 @@ class TestQuerying(PostgreSQLTestCase):
                 NullableIntegerArrayModel(order=5, field=None),
             ]
         )
+
+    def test_bulk_create_with_sized_arrayfield(self):
+        objs = WithSizeArrayModel.objects.bulk_create(
+            [
+                WithSizeArrayModel(field=[1, 2]),
+                WithSizeArrayModel(field=[3, 4]),
+            ]
+        )
+        self.assertEqual(objs[0].field, [1, 2])
+        self.assertEqual(objs[1].field, [3, 4])
 
     def test_empty_list(self):
         NullableIntegerArrayModel.objects.create(field=[])


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36107

#### Branch description

The array fields opt-out heuristic failed to account for sized arrays.

Note that we keep relying on db_type as opposed to performing an ArrayField instance check against the column's field as there could be other implementations of model fields that use Postgres arrays to persist data and the optimization must be disabled for all of them.

Refs ticket-36107

Thanks @claudep for the report and test.