### PR TITLE
Fixed #36111 -- Fixed test --debug-sql crash on Oracle when no prior query has executed.

### DIFF
--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -319,7 +319,7 @@ END;
         # Unlike Psycopg's `query` and MySQLdb`'s `_executed`, oracledb's
         # `statement` doesn't contain the query parameters. Substitute
         # parameters manually.
-        if params:
+        if statement and params:
             if isinstance(params, (tuple, list)):
                 params = {
                     f":arg{i}": param for i, param in enumerate(dict.fromkeys(params))

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -73,8 +73,14 @@ class LastExecutedQueryTest(TestCase):
         last_executed_query should not raise an exception even if no previous
         query has been run.
         """
+        suffix = connection.features.bare_select_suffix
         with connection.cursor() as cursor:
+            if connection.vendor == "oracle":
+                cursor.statement = None
+            # No previous query has been run.
             connection.ops.last_executed_query(cursor, "", ())
+            # Previous query crashed.
+            connection.ops.last_executed_query(cursor, "SELECT %s" + suffix, (1,))
 
     def test_debug_sql(self):
         qs = Reporter.objects.filter(first_name="test")


### PR DESCRIPTION
#### Trac ticket number
ticket-36111

#### Branch description
Before, `--debug-sql` crashed on Oracle if a query was prepared (with params) but failed at execution, and if no other queries had executed, i.e. if `cursor.statement` (Oracle-only attribute) was `None`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
