### PR TITLE
Fixed #36083 -- Ran system checks in ParallelTestSuite workers

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -439,7 +439,7 @@ def _init_worker(
     used_aliases=None,
 ):
     """
-    Switch to databases dedicated to this worker.
+    Switch to databases dedicated to this worker and run system checks.
 
     This helper lives at module-level because of the multiprocessing module's
     requirements.
@@ -463,6 +463,9 @@ def _init_worker(
             process_setup(*process_setup_args)
         django.setup()
         setup_test_environment(debug=debug_mode)
+        call_command(
+            "check", stdout=io.StringIO(), stderr=io.StringIO(), databases=used_aliases
+        )
 
     db_aliases = used_aliases if used_aliases is not None else connections
     for alias in db_aliases:

--- a/tests/test_runner/models.py
+++ b/tests/test_runner/models.py
@@ -6,6 +6,13 @@ class Person(models.Model):
     last_name = models.CharField(max_length=20)
     friends = models.ManyToManyField("self")
 
+    system_check_run_count = 0
+
+    @classmethod
+    def check(cls, *args, **kwargs):
+        cls.system_check_run_count += 1
+        return super().check(**kwargs)
+
 
 # A set of models that use a non-abstract inherited 'through' model.
 class ThroughBase(models.Model):

--- a/tests/test_runner/test_parallel.py
+++ b/tests/test_runner/test_parallel.py
@@ -8,6 +8,8 @@ from unittest.suite import TestSuite, _ErrorHolder
 from django.test import SimpleTestCase
 from django.test.runner import ParallelTestSuite, RemoteTestResult
 
+from . import models
+
 try:
     import tblib.pickling_support
 except ImportError:
@@ -47,6 +49,9 @@ class ParallelTestRunnerTest(SimpleTestCase):
         for i in range(2):
             with self.subTest(index=i):
                 self.assertEqual(i, i)
+
+    def test_system_checks(self):
+        self.assertEqual(models.Person.system_check_run_count, 1)
 
 
 class SampleFailingSubtest(SimpleTestCase):


### PR DESCRIPTION
#### Trac ticket number

ticket-36083

#### Branch description

Workers created by ParallelTestSuite were not running system checks. In general this is fine, but system checks can have side effects that the tests expect.

This patch runs system checks inside of _init_worker, which is only called by ParallelTestSuite.

#### Checklist

- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
