### PR TITLE
Refs #35448 -- Fixed BackendTestCase.test_queries_logger() on Oracle < 23c

### DIFF
--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -575,6 +575,7 @@ class BackendTestCase(TransactionTestCase):
     @override_settings(DEBUG=True)
     def test_queries_logger(self, mocked_logger):
         sql = "SELECT 1" + connection.features.bare_select_suffix
+        sql = connection.ops.format_debug_sql(sql)
         with connection.cursor() as cursor:
             cursor.execute(sql)
         params, kwargs = mocked_logger.debug.call_args


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.13/unittest/mock.py", line 1423, in patched
    return func(*newargs, **newkeywargs)
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/django/test/utils.py", line 446, in inner
    return func(*args, **kwargs)
  File "/home/jenkins/workspace/django-oracle/database/oracle19/label/oracle/python/python3.13/tests/backends/tests.py", line 582, in test_queries_logger
    self.assertEqual(params[2], sql)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
AssertionError: 'SELECT 1\nFROM DUAL' != 'SELECT 1 FROM DUAL'
+ SELECT 1 FROM DUAL
- SELECT 1
- FROM DUAL
```