### PR TITLE
Fixed #36116 -- Optimized multi-column ForwardManyToOne prefetching.

### DIFF
--- a/tests/foreign_object/models/person.py
+++ b/tests/foreign_object/models/person.py
@@ -107,6 +107,6 @@ class Friendship(models.Model):
         Person,
         from_fields=["to_friend_country_id", "to_friend_id"],
         to_fields=["person_country_id", "id"],
-        related_name="to_friend",
+        related_name="to_friend+",
         on_delete=models.CASCADE,
     )


### PR DESCRIPTION


#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36116

#### Branch description

Rely on ColPairs and TupleIn as they allows for a single or multiple fields to be specified which delegates multi-column handling to them.

Thanks @jacobtylerwalls for the report.
