### PR TITLE
Fixed #36117 -- Raised ValueError when providing composite expressions to case / when.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1577,20 +1577,6 @@ class When(Expression):
         # We're only interested in the fields of the result expressions.
         return [self.result._output_field_or_none]
 
-    def resolve_expression(
-        self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False
-    ):
-        c = self.copy()
-        c.is_summary = summarize
-        if hasattr(c.condition, "resolve_expression"):
-            c.condition = c.condition.resolve_expression(
-                query, allow_joins, reuse, summarize, False
-            )
-        c.result = c.result.resolve_expression(
-            query, allow_joins, reuse, summarize, for_save
-        )
-        return c
-
     def as_sql(self, compiler, connection, template=None, **extra_context):
         connection.ops.check_expression_support(self)
         template_params = extra_context
@@ -1657,20 +1643,6 @@ class Case(SQLiteNumericMixin, Expression):
 
     def set_source_expressions(self, exprs):
         *self.cases, self.default = exprs
-
-    def resolve_expression(
-        self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False
-    ):
-        c = self.copy()
-        c.is_summary = summarize
-        for pos, case in enumerate(c.cases):
-            c.cases[pos] = case.resolve_expression(
-                query, allow_joins, reuse, summarize, for_save
-            )
-        c.default = c.default.resolve_expression(
-            query, allow_joins, reuse, summarize, for_save
-        )
-        return c
 
     def copy(self):
         c = super().copy()

--- a/tests/composite_pk/test_aggregate.py
+++ b/tests/composite_pk/test_aggregate.py
@@ -138,6 +138,6 @@ class CompositePKAggregateTests(TestCase):
         )
 
     def test_max_pk(self):
-        msg = "Max does not support composite primary keys."
+        msg = "Max expression does not support composite primary keys."
         with self.assertRaisesMessage(ValueError, msg):
             Comment.objects.aggregate(Max("pk"))

--- a/tests/composite_pk/test_filter.py
+++ b/tests/composite_pk/test_filter.py
@@ -63,7 +63,7 @@ class CompositePKFilterTests(TestCase):
             Comment.objects.filter(text__gt=F("pk")).count()
 
     def test_rhs_combinable(self):
-        msg = "CompositePrimaryKey is not combinable."
+        msg = "CombinedExpression expression does not support composite primary keys."
         for expr in [F("pk") + (1, 1), (1, 1) + F("pk")]:
             with (
                 self.subTest(expression=expr),
@@ -405,7 +405,7 @@ class CompositePKFilterTests(TestCase):
         self.assertSequenceEqual(queryset, (self.user_2,))
 
     def test_cannot_cast_pk(self):
-        msg = "Cast does not support composite primary keys."
+        msg = "Cast expression does not support composite primary keys."
         with self.assertRaisesMessage(ValueError, msg):
             Comment.objects.filter(text__gt=Cast(F("pk"), TextField())).count()
 

--- a/tests/composite_pk/test_filter.py
+++ b/tests/composite_pk/test_filter.py
@@ -1,4 +1,13 @@
-from django.db.models import F, FilteredRelation, OuterRef, Q, Subquery, TextField
+from django.db.models import (
+    Case,
+    F,
+    FilteredRelation,
+    OuterRef,
+    Q,
+    Subquery,
+    TextField,
+    When,
+)
 from django.db.models.functions import Cast
 from django.db.models.lookups import Exact
 from django.test import TestCase
@@ -408,6 +417,14 @@ class CompositePKFilterTests(TestCase):
         msg = "Cast expression does not support composite primary keys."
         with self.assertRaisesMessage(ValueError, msg):
             Comment.objects.filter(text__gt=Cast(F("pk"), TextField())).count()
+
+    def test_filter_case_when(self):
+        msg = "When expression does not support composite primary keys."
+        with self.assertRaisesMessage(ValueError, msg):
+            Comment.objects.filter(text=Case(When(text="", then="pk")))
+        msg = "Case expression does not support composite primary keys."
+        with self.assertRaisesMessage(ValueError, msg):
+            Comment.objects.filter(text=Case(When(text="", then="text"), default="pk"))
 
     def test_outer_ref_pk(self):
         subquery = Subquery(Comment.objects.filter(pk=OuterRef("pk")).values("id"))


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36117

#### Branch description

As discussed on https://github.com/django/django/pull/18979/files#r1904377673 we have many redundant `resolve_expression` implementation that avoid delegating to `BaseExpression` when they should. This makes implementing composite pk support checks harder than they should so this explores removing all the redundant code.
