### PR TITLE
Moved permissions setup to toplevel for the Labels Github action.

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -8,12 +8,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: write
+
 jobs:
   no_ticket:
     name: "Flag if no Trac ticket is found in the title"
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This attempts to fix the currently failing "Labels" Github Action.