### PR TITLE
Switched to pull_request_target event trigger in the Labels Github action.

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,7 +1,7 @@
 name: Labels
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ edited, opened, reopened, ready_for_review ]
 
 concurrency:


### PR DESCRIPTION
The `pull_request` trigger runs in the context of the PR, and has limited access to information stored in the base repo django/django. As access is needed to the label "no ticket" in django/django, use the `pull_request_target` trigger.

----

Previously we tested the workflow on our own forks and so the PR repo and base repo were the same.

This aims to resolve the error: `Unhandled error: HttpError: Resource not accessible by integration`
See https://github.com/django/django/actions/runs/12892302365/job/35946226436?pr=19083