### PR TITLE
Fixed #36125 -- Switched docs to use chat.djangoproject.com when referencing the Discord server.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ To get more help:
 * Join the django-users mailing list, or read the archives, at
   https://groups.google.com/group/django-users.
 
-* Join the `Django Discord community <https://discord.gg/xcRH6mN4fa>`_.
+* Join the `Django Discord community <https://chat.djangoproject.com>`_.
 
 * Join the community on the `Django Forum <https://forum.djangoproject.com/>`_.
 

--- a/docs/faq/contributing.txt
+++ b/docs/faq/contributing.txt
@@ -68,7 +68,7 @@ issue over and over again. This sort of behavior will not gain you any
 additional attention -- certainly not the attention that you need in order to
 get your issue addressed.
 
-.. _`Django Discord server`: https://discord.gg/xcRH6mN4fa
+.. _`Django Discord server`: https://chat.djangoproject.com
 
 But I've reminded you several times and you keep ignoring my contribution!
 ==========================================================================

--- a/docs/faq/help.txt
+++ b/docs/faq/help.txt
@@ -25,7 +25,7 @@ Then, please post it in one of the following channels:
 * The `Django Discord server`_ for chat-based discussions.
 
 .. _`"Using Django"`: https://forum.djangoproject.com/c/users/6
-.. _`Django Discord server`: https://discord.gg/xcRH6mN4fa
+.. _`Django Discord server`: https://chat.djangoproject.com
 
 In all these channels please abide by the `Django Code of Conduct`_. In
 summary, being friendly and patient, considerate, respectful, and careful in

--- a/docs/internals/contributing/bugs-and-features.txt
+++ b/docs/internals/contributing/bugs-and-features.txt
@@ -167,4 +167,4 @@ Votes on technical matters should be announced and held in public on the
 .. _searching: https://code.djangoproject.com/search
 .. _custom queries: https://code.djangoproject.com/query
 .. _Django Forum: https://forum.djangoproject.com/
-.. _Django Discord server: https://discord.gg/xcRH6mN4fa
+.. _Django Discord server: https://chat.djangoproject.com

--- a/docs/internals/contributing/index.txt
+++ b/docs/internals/contributing/index.txt
@@ -46,7 +46,7 @@ a great ecosystem to work in:
 
 .. _posting guidelines: https://code.djangoproject.com/wiki/UsingTheMailingList
 .. _community page: https://www.djangoproject.com/community/
-.. _Django Discord server: https://discord.gg/xcRH6mN4fa
+.. _Django Discord server: https://chat.djangoproject.com
 .. _Django forum: https://forum.djangoproject.com/
 .. _register it here: https://www.djangoproject.com/community/add/blogs/
 

--- a/docs/internals/contributing/new-contributors.txt
+++ b/docs/internals/contributing/new-contributors.txt
@@ -132,7 +132,7 @@ but not completely certain, you might also try asking on the
 ``#contributing-getting-started`` channel in the `Django Discord server`_ to
 see if someone else can confirm your suspicions.
 
-.. _`Django Discord server`: https://discord.gg/xcRH6mN4fa
+.. _`Django Discord server`: https://chat.djangoproject.com
 
 Wait for feedback, and respond to feedback that you receive
 -----------------------------------------------------------

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -47,7 +47,7 @@ so that it can be of use to the widest audience.
 
 .. _Dive Into Python: https://diveintopython3.net/
 .. _Django Forum: https://forum.djangoproject.com/
-.. _Django Discord server: https://discord.gg/xcRH6mN4fa
+.. _Django Discord server: https://chat.djangoproject.com
 
 What does this tutorial cover?
 ------------------------------

--- a/docs/intro/tutorial08.txt
+++ b/docs/intro/tutorial08.txt
@@ -70,7 +70,7 @@ resolve the issue yourself, there are options available to you.
 #. Search for similar issues on the package's issue tracker. Django Debug
    Toolbar’s is `on GitHub <https://github.com/django-commons/django-debug-toolbar/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc>`_.
 #. Consult the `Django Forum <https://forum.djangoproject.com/>`_.
-#. Join the `Django Discord server <https://discord.gg/xcRH6mN4fa>`_.
+#. Join the `Django Discord server <https://chat.djangoproject.com>`_.
 
 Installing other third-party packages
 =====================================

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -127,7 +127,7 @@ particular Django setup, try the |django-users| mailing list or the
 `Django Discord server`_ instead.
 
 .. _ticket system: https://code.djangoproject.com/
-.. _Django Discord server: https://discord.gg/xcRH6mN4fa
+.. _Django Discord server: https://chat.djangoproject.com
 
 In plain text
 -------------


### PR DESCRIPTION
#### Trac ticket number

ticket-36125

#### Branch description
I used `git grep -F discord.gg` to find all instances of the URL and replaced them with the new https://chat.djangoproject.com redirection.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
