### PR TITLE
Fixed #36120 -- Raised FieldError when targeting a composite primary key field with QuerySet.update().

### DIFF
--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -90,6 +90,10 @@ class UpdateQuery(Query):
                 not (field.auto_created and not field.concrete) or not field.concrete
             )
             model = field.model._meta.concrete_model
+            if field.name == "pk" and model._meta.is_composite_pk:
+                raise FieldError(
+                    "Composite primary key fields must be updated individually."
+                )
             if not direct or (field.is_relation and field.many_to_many):
                 raise FieldError(
                     "Cannot update model field %r (only non-relations and "

--- a/tests/composite_pk/test_update.py
+++ b/tests/composite_pk/test_update.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import FieldError
 from django.db import connection
 from django.test import TestCase
 
@@ -175,3 +176,9 @@ class CompositePKUpdateTests(TestCase):
 
         with self.assertRaisesMessage(ValueError, msg):
             Comment.objects.update(user=User())
+
+    def test_cant_update_pk_field(self):
+        qs = Comment.objects.filter(user__email=self.user_1.email)
+        msg = "Composite primary key fields must be updated individually."
+        with self.assertRaisesMessage(FieldError, msg):
+            qs.update(pk=(1, 10))


### PR DESCRIPTION
#### Trac ticket number
ticket-36120

#### Branch description
Before, attempting to call `.update(pk=...` on a model with a composite primary key would fail with AttributeError.

Thanks Simon Charette for the implementation hint.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
