### PR TITLE
Update validators.py to allow for (more) correct URL Validation

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -137,8 +137,9 @@ class URLValidator(RegexValidator):
     hostname_re = DomainNameValidator.hostname_re
     domain_re = DomainNameValidator.domain_re
     tld_re = DomainNameValidator.tld_re
+    local_re = DomainNameValidator.hostname_re
 
-    host_re = "(" + hostname_re + domain_re + tld_re + "|localhost)"
+    host_re = "(" + hostname_re + domain_re + tld_re + "|" + local_re + ")"
 
     regex = _lazy_re_compile(
         r"^(?:[a-z0-9.+-]*)://"  # scheme is validated separately


### PR DESCRIPTION
fully allowing for URLs as per rfc3986#section-3.2.2 - with a regex solution for localhost (and whatever else is possible) instead of a hardcoded < "magicnumber"-80%-"solution" >

what is not said in rfc3986, dealing with URI/URLs:
- that a hostname requires multiple labels
- thus - no "." is required to seperate them
- actually, length limit of 63 is also not a given if we're not in a DNS context. but for simplistical reasons, i chose to keep it aligned to DNS-Labels, as provided via DomainNameValidator.hostname_re

Why this is necessary & usefull:
Single-label URLs might be used
- in intranet situations
- for URLs that represent services / schemes that do not comply to DNS naming conventions
- for local testing (local DNS resolution that is not based on FQDN)
- mDNS [RFC 6762] solutions, operating under .local TLD (which as of that RFC can be ommitted in a local context)
- the validator is name URLValidator, not DNSURLValidator

#### Trac ticket number

ticket-36131

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
