### PR TITLE
Use more clear prefixes for bytes

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -919,15 +919,15 @@ def filesizeformat(bytes_):
     if bytes_ < KB:
         value = ngettext("%(size)d byte", "%(size)d bytes", bytes_) % {"size": bytes_}
     elif bytes_ < MB:
-        value = gettext("%s KB") % filesize_number_format(bytes_ / KB)
+        value = gettext("%s KiB") % filesize_number_format(bytes_ / KB)
     elif bytes_ < GB:
-        value = gettext("%s MB") % filesize_number_format(bytes_ / MB)
+        value = gettext("%s MiB") % filesize_number_format(bytes_ / MB)
     elif bytes_ < TB:
-        value = gettext("%s GB") % filesize_number_format(bytes_ / GB)
+        value = gettext("%s GiB") % filesize_number_format(bytes_ / GB)
     elif bytes_ < PB:
-        value = gettext("%s TB") % filesize_number_format(bytes_ / TB)
+        value = gettext("%s TiB") % filesize_number_format(bytes_ / TB)
     else:
-        value = gettext("%s PB") % filesize_number_format(bytes_ / PB)
+        value = gettext("%s PiB") % filesize_number_format(bytes_ / PB)
 
     if negative:
         value = "-%s" % value


### PR DESCRIPTION
KB may lead some to believe the math is base 10 instead of base 2.

I wasn't sure which was being used before checking the source code.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

#### Branch description
I wasn't sure which base was being used for GB, so this change uses GiB to make it clear that base-2 math is being used.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
