### PR TITLE
Prevented docutils from logging to the console in admindocs test

### DIFF
--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -509,7 +509,8 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
             codename="change_person", content_type=person_content_type
         )
         staff_user.user_permissions.add(view_company, change_person)
-        response_for_person = self.client.get(person_url)
+        with captured_stderr():
+            response_for_person = self.client.get(person_url)
         response_for_company = self.client.get(company_url)
         # View or change permission grants access.
         self.assertEqual(response_for_person.status_code, 200)


### PR DESCRIPTION
#### Trac ticket number

N/A

#### Branch description

The admindocs app doesn't pass a log level to docutils when it parses reStructured Text, so system messages can be logged during parsing.

One test in the admin_docs.test_views.TestModelDetailView logs docutils system messages to the console. This patch captures stderr in that test to hide the irrelevant messages.

See lines 3444 and 3445 of the "Run tests" step of [this](https://github.com/django/django/actions/runs/12905643253/job/35985270689) GitHub Actions run for a live example:

<img width="665" alt="image" src="https://github.com/user-attachments/assets/412b1be2-1948-4246-8da4-dc009748e2f3" />

#### Checklist

- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
