### PR TITLE
comment line 226:229 and disable raise TypeError

### DIFF
--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -223,10 +223,10 @@ class Options:
             self._ordering_clash = bool(self.ordering and self.order_with_respect_to)
 
             # Any leftover attributes must be invalid.
-            if meta_attrs != {}:
-                raise TypeError(
-                    "'class Meta' got invalid attribute(s): %s" % ",".join(meta_attrs)
-                )
+            # if meta_attrs != {}:
+            #     raise TypeError(
+            #         "'class Meta' got invalid attribute(s): %s" % ",".join(meta_attrs)
+            #     )
         else:
             self.verbose_name_plural = format_lazy("{}s", self.verbose_name)
         del self.meta


### PR DESCRIPTION
N/A
### branch fixed_bug_django_db_models_options description
While integrating the taggit app into my Django project, I encountered the following error.

_Traceback (most recent call last):
 ...\manage.py", line 22, in <module>
    main()
  ...\manage.py", line 18, in main
    execute_from_command_line(sys.argv)
 ...\venv\lib\python3.11\site-packages\django\core\management\__init__.py", line 442, in execute_from_command_line
    utility.execute()
  ...\venv\lib\python3.11\site-packages\django\core\management\__init__.py", line 416, in execute
    django.setup()
  ...\venv\lib\python3.11\site-packages\django\__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  ...\venv\lib\python3.11\site-packages\django\apps\registry.py", line 116, in populate
    app_config.import_models()
 ...\venv\lib\python3.11\site-packages\django\apps\config.py", line 269, in import_models
    self.models_module = import_module(models_module_name)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\msys64\mingw64\lib\python3.11\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 944, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  ...\models.py", line 5, in <module>
    from taggit.managers import TaggableManager
  ...\venv\lib\python3.11\site-packages\taggit\managers.py", line 22, in <module>
    from taggit.models import (
  ...\venv\lib\python3.11\site-packages\taggit\models.py", line 185, in <module>
    class TaggedItem(GenericTaggedItemBase, TaggedItemBase):
  ...\venv\lib\python3.11\site-packages\django\db\models\base.py", line 143, in __new__
    new_class.add_to_class("_meta", Options(meta, app_label))
  ...\venv\lib\python3.11\site-packages\django\db\models\base.py", line 371, in add_to_class
    value.contribute_to_class(cls, name)
  ...\venv\lib\python3.11\site-packages\django\db\models\options.py", line 221, in contribute_to_class
    raise TypeError(
**TypeError: 'class Meta' got invalid attribute(s): index_together**_

Upon investigating the issue, I discovered that temporarily commenting out the code in lines 226 to 229 of the django/db/models/options.py file resolved the problem with installing the app. However, I am fully aware that this is not a proper or recommended solution to the issue. I simply wanted to share this observation with the Django community for informational purposes.

My Django version: 5.1.4
My django-taggit version: 3.0.0


