### PR TITLE
Fixed #36149 -- Allowed subquery values against tuple in and exact lookups.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1367,6 +1367,9 @@ class ColPairs(Expression):
     def resolve_expression(self, *args, **kwargs):
         return self
 
+    def select_format(self, compiler, sql, params):
+        return sql, params
+
 
 class Ref(Expression):
     """

--- a/django/db/models/fields/tuple_lookups.py
+++ b/django/db/models/fields/tuple_lookups.py
@@ -47,7 +47,8 @@ class TupleLookupMixin:
             self.check_rhs_is_tuple_or_list()
             self.check_rhs_length_equals_lhs_length()
         else:
-            self.check_rhs_is_outer_ref()
+            self.check_rhs_is_supported_expression()
+            super().get_prep_lookup()
         return self.rhs
 
     def check_rhs_is_tuple_or_list(self):
@@ -65,13 +66,13 @@ class TupleLookupMixin:
                 f"{self.lookup_name!r} lookup of {lhs_str} must have {len_lhs} elements"
             )
 
-    def check_rhs_is_outer_ref(self):
-        if not isinstance(self.rhs, ResolvedOuterRef):
+    def check_rhs_is_supported_expression(self):
+        if not isinstance(self.rhs, (ResolvedOuterRef, Query)):
             lhs_str = self.get_lhs_str()
             rhs_cls = self.rhs.__class__.__name__
             raise ValueError(
                 f"{self.lookup_name!r} subquery lookup of {lhs_str} "
-                f"only supports OuterRef objects (received {rhs_cls!r})"
+                f"only supports OuterRef and QuerySet objects (received {rhs_cls!r})"
             )
 
     def get_lhs_str(self):
@@ -101,11 +102,14 @@ class TupleLookupMixin:
             return compiler.compile(Tuple(*args))
         else:
             sql, params = compiler.compile(self.rhs)
-            if not isinstance(self.rhs, ColPairs):
+            if isinstance(self.rhs, ColPairs):
+                return "(%s)" % sql, params
+            elif isinstance(self.rhs, Query):
+                return super().process_rhs(compiler, connection)
+            else:
                 raise ValueError(
                     "Composite field lookups only work with composite expressions."
                 )
-            return "(%s)" % sql, params
 
     def get_fallback_sql(self, compiler, connection):
         raise NotImplementedError(
@@ -121,6 +125,8 @@ class TupleLookupMixin:
 
 class TupleExact(TupleLookupMixin, Exact):
     def get_fallback_sql(self, compiler, connection):
+        if isinstance(self.rhs, Query):
+            return super(TupleLookupMixin, self).as_sql(compiler, connection)
         # Process right-hand-side to trigger sanitization.
         self.process_rhs(compiler, connection)
         # e.g.: (a, b, c) == (x, y, z) as SQL:
@@ -273,7 +279,7 @@ class TupleIn(TupleLookupMixin, In):
             self.check_rhs_elements_length_equals_lhs_length()
         else:
             self.check_rhs_is_query()
-            self.check_rhs_select_length_equals_lhs_length()
+            super(TupleLookupMixin, self).get_prep_lookup()
 
         return self.rhs  # skip checks from mixin
 
@@ -303,19 +309,10 @@ class TupleIn(TupleLookupMixin, In):
                 f"must be a Query object (received {rhs_cls!r})"
             )
 
-    def check_rhs_select_length_equals_lhs_length(self):
-        len_rhs = len(self.rhs.select)
-        if len_rhs == 1 and isinstance(self.rhs.select[0], ColPairs):
-            len_rhs = len(self.rhs.select[0])
-        len_lhs = len(self.lhs)
-        if len_rhs != len_lhs:
-            lhs_str = self.get_lhs_str()
-            raise ValueError(
-                f"{self.lookup_name!r} subquery lookup of {lhs_str} "
-                f"must have {len_lhs} fields (received {len_rhs})"
-            )
-
     def process_rhs(self, compiler, connection):
+        if not self.rhs_is_direct_value():
+            return super(TupleLookupMixin, self).process_rhs(compiler, connection)
+
         rhs = self.rhs
         if not rhs:
             raise EmptyResultSet
@@ -337,19 +334,12 @@ class TupleIn(TupleLookupMixin, In):
 
         return compiler.compile(Tuple(*result))
 
-    def as_subquery_sql(self, compiler, connection):
-        lhs = self.lhs
-        rhs = self.rhs
-        if isinstance(lhs, ColPairs):
-            rhs = rhs.clone()
-            rhs.set_values([source.name for source in lhs.sources])
-            lhs = Tuple(lhs)
-        return compiler.compile(In(lhs, rhs))
-
     def get_fallback_sql(self, compiler, connection):
         rhs = self.rhs
         if not rhs:
             raise EmptyResultSet
+        if not self.rhs_is_direct_value():
+            return super(TupleLookupMixin, self).as_sql(compiler, connection)
 
         # e.g.: (a, b, c) in [(x1, y1, z1), (x2, y2, z2)] as SQL:
         # WHERE (a = x1 AND b = y1 AND c = z1) OR (a = x2 AND b = y2 AND c = z2)
@@ -361,11 +351,6 @@ class TupleIn(TupleLookupMixin, In):
             root.children.append(WhereNode(lookups, connector=AND))
 
         return root.as_sql(compiler, connection)
-
-    def as_sql(self, compiler, connection):
-        if not self.rhs_is_direct_value():
-            return self.as_subquery_sql(compiler, connection)
-        return super().as_sql(compiler, connection)
 
 
 tuple_lookups = {

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1958,10 +1958,6 @@ class QuerySet(AltersData):
             self._known_related_objects.setdefault(field, {}).update(objects)
 
     def resolve_expression(self, *args, **kwargs):
-        if self._fields and len(self._fields) > 1:
-            # values() queryset can only be used as nested queries
-            # if they are set up to select only a single field.
-            raise TypeError("Cannot use multi-field values as a filter value.")
         query = self.query.resolve_expression(*args, **kwargs)
         query._db = self._db
         return query

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1224,6 +1224,12 @@ class Query(BaseExpression):
         if self.selected:
             self.selected[alias] = alias
 
+    @property
+    def _subquery_fields_len(self):
+        if self.has_select_fields:
+            return len(self.selected)
+        return len(self.model._meta.pk_fields)
+
     def resolve_expression(self, query, *args, **kwargs):
         clone = self.clone()
         # Subqueries need to use a different set of aliases than the outer query.

--- a/tests/composite_pk/models/tenant.py
+++ b/tests/composite_pk/models/tenant.py
@@ -44,6 +44,7 @@ class Comment(models.Model):
         related_name="comments",
     )
     text = models.TextField(default="", blank=True)
+    integer = models.IntegerField(default=0)
 
 
 class Post(models.Model):

--- a/tests/composite_pk/tests.py
+++ b/tests/composite_pk/tests.py
@@ -109,13 +109,10 @@ class CompositePKTests(TestCase):
 
     def test_composite_pk_in_fields(self):
         user_fields = {f.name for f in User._meta.get_fields()}
-        self.assertEqual(user_fields, {"pk", "tenant", "id", "email", "comments"})
+        self.assertTrue({"pk", "tenant", "id"}.issubset(user_fields))
 
         comment_fields = {f.name for f in Comment._meta.get_fields()}
-        self.assertEqual(
-            comment_fields,
-            {"pk", "tenant", "id", "user_id", "user", "text"},
-        )
+        self.assertTrue({"pk", "tenant", "id"}.issubset(comment_fields))
 
     def test_pk_field(self):
         pk = User._meta.get_field("pk")
@@ -174,7 +171,7 @@ class CompositePKTests(TestCase):
             self.assertEqual(user.email, self.user.email)
 
     def test_model_forms(self):
-        fields = ["tenant", "id", "user_id", "text"]
+        fields = ["tenant", "id", "user_id", "text", "integer"]
         self.assertEqual(list(CommentForm.base_fields), fields)
 
         form = modelform_factory(Comment, fields="__all__")

--- a/tests/foreign_object/test_tuple_lookups.py
+++ b/tests/foreign_object/test_tuple_lookups.py
@@ -63,9 +63,11 @@ class TupleLookupsTests(TestCase):
                 )
 
     def test_exact_subquery(self):
-        with self.assertRaisesMessage(
-            ValueError, "'exact' doesn't support multi-column subqueries."
-        ):
+        msg = (
+            "The QuerySet value for the exact lookup must have 2 selected "
+            "fields (received 1)"
+        )
+        with self.assertRaisesMessage(ValueError, msg):
             subquery = Customer.objects.filter(id=self.customer_1.id)[:1]
             self.assertSequenceEqual(
                 Contact.objects.filter(customer=subquery).order_by("id"), ()
@@ -140,11 +142,11 @@ class TupleLookupsTests(TestCase):
     def test_tuple_in_subquery_must_have_2_fields(self):
         lhs = (F("customer_code"), F("company_code"))
         rhs = Customer.objects.values_list("customer_id").query
-        with self.assertRaisesMessage(
-            ValueError,
-            "'in' subquery lookup of ('customer_code', 'company_code') "
-            "must have 2 fields (received 1)",
-        ):
+        msg = (
+            "The QuerySet value for the 'in' lookup must have 2 selected "
+            "fields (received 1)"
+        )
+        with self.assertRaisesMessage(ValueError, msg):
             TupleIn(lhs, rhs)
 
     def test_tuple_in_subquery(self):

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -789,6 +789,14 @@ class LookupTests(TestCase):
         sql = ctx.captured_queries[0]["sql"]
         self.assertIn("IN (%s)" % self.a1.pk, sql)
 
+    def test_in_select_mismatch(self):
+        msg = (
+            "The QuerySet value for the 'in' lookup must have 1 "
+            "selected fields (received 2)"
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            Article.objects.filter(id__in=Article.objects.values("id", "headline"))
+
     def test_error_messages(self):
         # Programming errors are pointed out with nice error messages
         with self.assertRaisesMessage(
@@ -1363,6 +1371,14 @@ class LookupTests(TestCase):
         )
         authors = Author.objects.filter(id=authors_max_ids[:1])
         self.assertEqual(authors.get(), newest_author)
+
+    def test_exact_query_rhs_with_selected_columns_mismatch(self):
+        msg = (
+            "The QuerySet value for the exact lookup must have 1 "
+            "selected fields (received 2)"
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            Author.objects.filter(id=Author.objects.values("id", "name")[:1])
 
     def test_isnull_non_boolean_value(self):
         msg = "The QuerySet value for an isnull lookup must be True or False."

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -922,20 +922,6 @@ class Queries1Tests(TestCase):
             [self.t2, self.t3],
         )
 
-        # Multi-valued values() and values_list() querysets should raise errors.
-        with self.assertRaisesMessage(
-            TypeError, "Cannot use multi-field values as a filter value."
-        ):
-            Tag.objects.filter(
-                name__in=Tag.objects.filter(parent=self.t1).values("name", "id")
-            )
-        with self.assertRaisesMessage(
-            TypeError, "Cannot use multi-field values as a filter value."
-        ):
-            Tag.objects.filter(
-                name__in=Tag.objects.filter(parent=self.t1).values_list("name", "id")
-            )
-
     def test_ticket9985(self):
         # qs.values_list(...).values(...) combinations should work.
         self.assertSequenceEqual(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36149

#### Branch description

`User.objects.filter(pk=User.objects.values("foo", "bar"))` is implicitly (and wrongly) translated to `User.objects.filter(pk=User.objects.values("pk"))`
