### PR TITLE
Bumped isort version to 6.0.0.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         files: 'docs/.*\.txt$'
         args: ["--rst-literal-block"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/flake8

--- a/django/db/backends/postgresql/compiler.py
+++ b/django/db/backends/postgresql/compiler.py
@@ -4,7 +4,9 @@ from django.db.models.sql.compiler import (
     SQLDeleteCompiler,
 )
 from django.db.models.sql.compiler import SQLInsertCompiler as BaseSQLInsertCompiler
-from django.db.models.sql.compiler import SQLUpdateCompiler
+from django.db.models.sql.compiler import (
+    SQLUpdateCompiler,
+)
 
 __all__ = [
     "SQLAggregateCompiler",


### PR DESCRIPTION
Yesterday 6.0.0 was released for `isort`: https://pypi.org/project/isort/#history