### PR TITLE
Fixed #36151 -- Allowed GenericForeignKey fields to be explicitly included on model forms.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -203,6 +203,7 @@ def fields_for_model(
                 fields is not None
                 and f.name in fields
                 and (exclude is None or f.name not in exclude)
+                and f not in sortable_private_fields
             ):
                 raise FieldError(
                     "'%s' cannot be specified for %s model form as it is a "

--- a/docs/releases/5.1.6.txt
+++ b/docs/releases/5.1.6.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Fixed a regression in Django 5.1.5 that caused ``validate_ipv6_address()``
   and ``validate_ipv46_address()`` to crash when handling non-string values
   (:ticket:`36098`).
+
+* Fixed a regression in Django 5.1 where ``GenericForeignKey`` fields could not
+  be used in a :class:`~django.forms.ModelForm` (:ticket:`36151`).

--- a/tests/contenttypes_tests/test_fields.py
+++ b/tests/contenttypes_tests/test_fields.py
@@ -1,5 +1,6 @@
 import json
 
+from django import forms
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.prefetch import GenericPrefetch
 from django.db import models
@@ -64,6 +65,25 @@ class GenericForeignKeyTests(TestCase):
         # The reverse relation is refreshed even when the text field is deferred.
         answer.refresh_from_db()
         self.assertIsNot(answer.question, old_question_obj)
+
+    def test_form_field(self):
+        class AnswerForm(forms.ModelForm):
+            class Meta:
+                model = Answer
+                fields = "__all__"
+
+        form = AnswerForm()
+        self.assertNotIn("question", form.fields)
+
+        class AnswerWithGFKForm(forms.ModelForm):
+            question = forms.CharField()
+
+            class Meta:
+                model = Answer
+                fields = ["question"]
+
+        form = AnswerWithGFKForm()
+        self.assertIn("question", form.fields)
 
 
 class GenericRelationTests(TestCase):


### PR DESCRIPTION
#### Trac ticket number

ticket-36151

#### Branch description

https://code.djangoproject.com/ticket/35224 made GFK a Field with hard-coded editable=False

This breaks this very nice feature in Django 5.1 [​https://django-autocomplete-light.readthedocs.io/en/master/gfk.html](https://django-autocomplete-light.readthedocs.io/en/master/gfk.html)

With exception: cannot be specified for TModel model form as it is a non-editable field. Check fields/fieldsets/exclude attributes of class TestAdmin

While I understand this is an interesting default protection for users, it would also be nice if Django would keep on allowing users to create their form fields for GFK if they want to, as they could until Django 5.0

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ]I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
