### PR TITLE
Clarified the Releaser's discretion for determining and postponing the release date.

### DIFF
--- a/docs/internals/howto-release-django.txt
+++ b/docs/internals/howto-release-django.txt
@@ -188,8 +188,12 @@ A week before a security release
 A few days before any release
 -----------------------------
 
-#. As the release approaches, watch Trac to make sure no release blockers
-   are left for the upcoming release.
+#. As the release approaches, watch Trac to make sure no release blockers are
+   left for the upcoming release. Under exceptional circumstances, such as to
+   meet a pre-determined security release date, a release could still go ahead
+   with an open release blocker. The releaser is trusted with the decision to
+   release with an open release blocker or to postpone the release date of a
+   non-security release if required.
 
 #. Check with the other mergers to make sure they don't have any uncommitted
    changes for the release.


### PR DESCRIPTION
For context, there has recently been conversations around perceived pressures of releasing and that release blockers can come just before a release has come up as a topic.

According to our current documentation, there isn't room to decide to release with an open release blocker and a security release (after the pre-notification announcement) is quite rigid with the release date.
This adds a little room to our docs around possible solutions in case we struggle to find the right solution to a release blocker on schedule.

The steering council wanted to make clear that we can use our best judgement in these cases
