### PR TITLE
Fixed #36155 -- Improved error handling when annotate arguments require an alias.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1053,6 +1053,7 @@ answer newbie questions, and generally made Django that much better:
     Vinay Karanam <https://github.com/vinayinvicible>
     Vinay Sajip <vinay_sajip@yahoo.co.uk>
     Vincent Foley <vfoleybourgon@yahoo.ca>
+    Vinko Mlačić <vinkomlacic@outlook.com>
     Vinny Do <vdo.code@gmail.com>
     Vitaly Babiy <vbabiy86@gmail.com>
     Vitaliy Yelnik <velnik@gmail.com>

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1646,14 +1646,16 @@ class QuerySet(AltersData):
         )
         annotations = {}
         for arg in args:
-            # The default_alias property may raise a TypeError.
+            # The default_alias property raises TypeError if default_alias
+            # can't be set automatically or AttributeError if it isn't an
+            # attribute.
             try:
                 if arg.default_alias in kwargs:
                     raise ValueError(
                         "The named annotation '%s' conflicts with the "
                         "default name for another annotation." % arg.default_alias
                     )
-            except TypeError:
+            except (TypeError, AttributeError):
                 raise TypeError("Complex annotations require an alias")
             annotations[arg.default_alias] = arg
         annotations.update(kwargs)

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -969,6 +969,24 @@ class NonAggregateAnnotationTestCase(TestCase):
         ):
             Book.objects.annotate(BooleanField(), Value(False), is_book=True)
 
+    def test_complex_annotations_must_have_an_alias(self):
+        complex_annotations = [
+            F("rating") * F("price"),
+            Value("title"),
+            Case(When(pages__gte=400, then=Value("Long")), default=Value("Short")),
+            Subquery(
+                Book.objects.filter(publisher_id=OuterRef("pk"))
+                .order_by("-pubdate")
+                .values("name")[:1]
+            ),
+            Exists(Book.objects.filter(publisher_id=OuterRef("pk"))),
+        ]
+        msg = "Complex annotations require an alias"
+        for annotation in complex_annotations:
+            with self.subTest(annotation=annotation):
+                with self.assertRaisesMessage(TypeError, msg):
+                    Book.objects.annotate(annotation)
+
     def test_chaining_annotation_filter_with_m2m(self):
         qs = (
             Author.objects.filter(


### PR DESCRIPTION
#### Trac ticket number
N/A

ticket-36155

#### Branch description
Before, using complex annotations (except subclasses of `Aggregate`) without an alias would raise an `AttributeError` about a missing `default_alias` attribute. This is does not clearly point to the problem.

Now, the `AttributeError` is handled and a more informative message is shown when the user forgets to add an alias.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
