### PR TITLE
Clarified docs for default email value in UserManager.create_user().

### DIFF
--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -322,6 +322,9 @@ Manager methods
         :meth:`~django.contrib.auth.models.User.set_unusable_password()` will
         be called.
 
+        If no email is provided, :attr:`~django.contrib.auth.models.User.email`
+        will be set to an empty string.
+
         The ``extra_fields`` keyword arguments are passed through to the
         :class:`~django.contrib.auth.models.User`’s ``__init__`` method to
         allow setting arbitrary fields on a :ref:`custom user model


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

#### Branch description
if email is set to `unique=True` and `null=True`, if we create users with `create_user`  but don't specify an email, create_user will turn both into an emty string and thus cause an error, so i think it should be documented.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
