### PR TITLE
Tweaked docs to avoid reformatting given new black version.

### DIFF
--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -51,11 +51,10 @@ General-purpose aggregation functions
 
         Examples::
 
-            "some_field"
-            "-some_field"
             from django.db.models import F
 
-            F("some_field").desc()
+            ArrayAgg("a_field", order_by="-some_field")
+            ArrayAgg("a_field", order_by=F("some_field").desc())
 
     .. deprecated:: 5.2
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -687,13 +687,13 @@ If you have an old Django project with MD5 or SHA1 (even salted) encoded
 passwords, be aware that these can be cracked fairly easily with today's
 hardware. To make Django users acknowledge continued use of weak hashers, the
 following hashers are removed from the default :setting:`PASSWORD_HASHERS`
-setting::
+setting:
 
-    "django.contrib.auth.hashers.SHA1PasswordHasher"
-    "django.contrib.auth.hashers.MD5PasswordHasher"
-    "django.contrib.auth.hashers.UnsaltedSHA1PasswordHasher"
-    "django.contrib.auth.hashers.UnsaltedMD5PasswordHasher"
-    "django.contrib.auth.hashers.CryptPasswordHasher"
+* ``"django.contrib.auth.hashers.SHA1PasswordHasher"``
+* ``"django.contrib.auth.hashers.MD5PasswordHasher"``
+* ``"django.contrib.auth.hashers.UnsaltedSHA1PasswordHasher"``
+* ``"django.contrib.auth.hashers.UnsaltedMD5PasswordHasher"``
+* ``"django.contrib.auth.hashers.CryptPasswordHasher"``
 
 Consider using a :ref:`wrapped password hasher <wrapping-password-hashers>` to
 strengthen the hashes in your database. If that's not feasible, add the


### PR DESCRIPTION
Blacken-docs lint has been failing since black released `25.1.0`. Output was:
```
Build finished. The HTML pages are in _build/html.
find -name "*.txt" -not -path "./_build/*" -not -path "./_theme/*" \
        | xargs blacken-docs --rst-literal-block; echo $? > "_build/black/output.txt"
./ref/contrib/postgres/aggregates.txt: Rewriting...
./releases/1.10.txt: Rewriting...

Code blocks reformatted
```
The reformatted files showed this diff:
```diff

diff --git a/docs/ref/contrib/postgres/aggregates.txt b/docs/ref/contrib/postgres/aggregates.txt
index e9d6de5d74..a08fdc29bf 100644
--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -52,6 +52,7 @@ General-purpose aggregation functions
         Examples::
 
             "some_field"
+
             "-some_field"
             from django.db.models import F
 
diff --git a/docs/releases/1.10.txt b/docs/releases/1.10.txt
index d98fad2c66..50f9e543e5 100644
--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -690,6 +690,7 @@ following hashers are removed from the default :setting:`PASSWORD_HASHERS`
 setting::
 
     "django.contrib.auth.hashers.SHA1PasswordHasher"
+
     "django.contrib.auth.hashers.MD5PasswordHasher"
     "django.contrib.auth.hashers.UnsaltedSHA1PasswordHasher"
     "django.contrib.auth.hashers.UnsaltedMD5PasswordHasher"
```
This PR slightly changes the reformatted docs to not have unexpected whitelines added to them. New proposals:
* `./ref/contrib/postgres/aggregates.txt`
![image](https://github.com/user-attachments/assets/b0bfaa82-2ac5-41e8-82df-aadaba62ed82)
* `./releases/1.10.txt`
![image](https://github.com/user-attachments/assets/ba26b114-4000-4025-9e92-7f61ff181ecd)
