### PR TITLE
[5.1.x] Corrected ArrayAgg example for ordering usage.

### DIFF
--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -51,8 +51,8 @@ General-purpose aggregation functions
 
             from django.db.models import F
 
-            ArrayAgg("a_field", order_by="-some_field")
-            ArrayAgg("a_field", order_by=F("some_field").desc())
+            ArrayAgg("a_field", ordering="-some_field")
+            ArrayAgg("a_field", ordering=F("some_field").desc())
 
     .. versionchanged:: 5.0
 


### PR DESCRIPTION
When backporting, replacement `s/order_by/ordering/` should have been applied since `order_by` was added in 5.2 :see_no_evil: 