### PR TITLE
Use a per-installation password pepper

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -537,6 +537,7 @@ PASSWORD_RESET_TIMEOUT = 60 * 60 * 24 * 3
 # password using different algorithms will be converted automatically
 # upon login
 PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.PepperedPBKDF2PasswordHasher",
     "django.contrib.auth.hashers.PBKDF2PasswordHasher",
     "django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher",
     "django.contrib.auth.hashers.Argon2PasswordHasher",

--- a/django/conf/project_template/project_name/settings.py-tpl
+++ b/django/conf/project_template/project_name/settings.py-tpl
@@ -22,6 +22,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '{{ secret_key }}'
 
+# SECURITY WARNING: keep the pepper value used in production secret!
+PASSWORD_PEPPERS = [
+    '{{ password_pepper }}',
+]
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 

--- a/django/core/checks/security/base.py
+++ b/django/core/checks/security/base.py
@@ -92,6 +92,11 @@ W009 = Warning(
     id="security.W009",
 )
 
+W010 = Warning(
+    SECRET_KEY_WARNING_MSG % "PASSWORD_PEPPERS",
+    id="security.W010",
+)
+
 W018 = Warning(
     "You should not have DEBUG set to True in deployment.",
     id="security.W018",
@@ -221,6 +226,19 @@ def check_secret_key(app_configs, **kwargs):
     else:
         passed_check = _check_secret_key(secret_key)
     return [] if passed_check else [W009]
+
+
+@register(Tags.security, deploy=True)
+def check_password_pepper(app_configs, **kwargs):
+    try:
+        # This only checks the first pepper to allow upgrading from an insecure
+        # setting without a warning.
+        primary_pepper = settings.PASSWORD_PEPPERS[0]
+    except (ImproperlyConfigured, AttributeError, IndexError):
+        passed_check = False
+    else:
+        passed_check = _check_secret_key(primary_pepper)
+    return [] if passed_check else [W010]
 
 
 @register(Tags.security, deploy=True)

--- a/django/core/management/commands/startproject.py
+++ b/django/core/management/commands/startproject.py
@@ -18,4 +18,9 @@ class Command(TemplateCommand):
         # Create a random SECRET_KEY to put it in the main settings.
         options["secret_key"] = SECRET_KEY_INSECURE_PREFIX + get_random_secret_key()
 
+        # Create a random pepper value to put it in the main settings.
+        options["password_pepper"] = (
+            SECRET_KEY_INSECURE_PREFIX + get_random_secret_key()
+        )
+
         super().handle("project", project_name, target, **options)


### PR DESCRIPTION
NIST Special Publication 800-63B states:

> In addition, verifiers SHOULD perform an additional iteration of a key
derivation function using a salt value that is secret and known only to the verifier.

Adds the PASSWORD_PEPPERS setting and PepperedPBKDF2PasswordHasher.

https://forum.djangoproject.com/t/adding-a-per-installation-salt-to-password-hashing-for-also-known-as-a-pepper-or-password-peppering/38394
