### PR TITLE
Fixed #36162 -- Made `make black` in docs work on macOS.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -170,7 +170,7 @@ spelling:
 
 black:
 	@mkdir -p $(BUILDDIR)/black
-	find -name "*.txt" -not -path "./_build/*" -not -path "./_theme/*" \
+	find . -name "*.txt" -not -path "./_build/*" -not -path "./_theme/*" \
 		| xargs blacken-docs --rst-literal-block; echo $$? > "$(BUILDDIR)/black/output.txt"
 	@echo
 	@echo "Code blocks reformatted"


### PR DESCRIPTION
#### Trac ticket number

ticket-36162

#### Branch description
The `make black` target in the docs directory used Linux-specific syntax for its `find` command. Changed to syntax that also works on macOS and other BSD Unix variants.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- n/a I have added or updated relevant tests.
- n/a I have added or updated relevant docs, including release notes if applicable.
- n/a I have attached screenshots in both light and dark modes for any UI changes.
