### PR TITLE
[5.1.x] Refs #36140 -- Added missing import in django/contrib/auth/forms.py.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -15,6 +15,7 @@ from django.utils.http import urlsafe_base64_encode
 from django.utils.text import capfirst
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
+from django.views.decorators.debug import sensitive_variables
 
 UserModel = get_user_model()
 logger = logging.getLogger("django.contrib.auth")


### PR DESCRIPTION
Follow up to 8552eef95e400d5bad3261b28ad2500b57070d57.