### PR TITLE
Ticket #36158 -- Fix instance misreporting in get_and_report_namespace when verbosity=2

### DIFF
--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -271,6 +271,22 @@ class ShellCommandAutoImportsTestCase(SimpleTestCase):
             "  from shell.models import Phone, Marker",
         )
 
+    def test_message_with_stdout_listing_object_locations(self):
+        class TestCommand(shell.Command):
+            def get_namespace(self):
+                from django.db import connection
+
+                return {"connection": connection}
+
+        with captured_stdout() as stdout:
+            TestCommand().get_and_report_namespace(verbosity=2)
+
+        self.assertEqual(
+            stdout.getvalue().strip(),
+            "1 object imported automatically, including:\n\n"
+            "  connection: instance of django.utils.connection.ConnectionProxy",
+        )
+
     @override_settings(INSTALLED_APPS=["shell", "django.contrib.contenttypes"])
     def test_message_with_stdout_listing_objects_with_isort(self):
         sorted_imports = (


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36158

#### Branch description
When `get_and_report_namespace` is called with `verbosity=2`, it previously attempted to determine the module where an object was defined using the `__module__` attribute. However, for instances, this resulted in misleading information, as it reported the module where the class was defined rather than where the instance was created.

This fix changes the behavior for instances:
- Instead of attempting to determine the module, instances are now reported as:
```
object_name: instance of ClassName
```
- This keeps the output informative while avoiding unnecessary complexity in tracking instance creation locations.
- Other objects (functions, classes) continue to be reported as before.
#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
