### PR TITLE
#36167 Prevent default_value of None

### DIFF
--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -161,6 +161,8 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
                 self.prompt_output.write(
                     "Please enter some code, or 'exit' (without quotes) to exit."
                 )
+            elif code == "None":
+                self.prompt_output.write("Default value can not be None/NULL.")
             elif code == "exit":
                 sys.exit(1)
             else:

--- a/tests/migrations/test_questioner.py
+++ b/tests/migrations/test_questioner.py
@@ -89,6 +89,14 @@ class QuestionerHelperMethodsTests(SimpleTestCase):
             self.questioner._ask_default()
         self.assertIn("Cancelled.\n", self.prompt.getvalue())
 
+    @mock.patch("builtins.input", side_effect=["None", "exit"])
+    def test_questioner_no_default_user_entered_none(self, mock_input):
+        with self.assertRaises(SystemExit):
+            self.questioner._ask_default()
+        self.assertIn(
+            "Default value can not be None/NULL.", self.prompt.getvalue()
+        )
+
     @mock.patch("builtins.input", side_effect=["", "n"])
     def test_questioner_no_default_no_user_entry_boolean(self, mock_input):
         value = self.questioner._boolean_input("Proceed?")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36167

#### Branch description
Adjusts the prompt for `default_value` option when altering/adding model to have a non-NULL field to disallow supplying a value of `None`. This doesn't really make sense to allow and depending on the current state of the DB can cause runtime constraint errors once the migration is applied.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
