### PR TITLE
Fixed #35572 - Migrated os.listdir calls to os.scandir.

### DIFF
--- a/django/contrib/sessions/backends/file.py
+++ b/django/contrib/sessions/backends/file.py
@@ -210,16 +210,17 @@ class SessionStore(SessionBase):
         storage_path = cls._get_storage_path()
         file_prefix = settings.SESSION_COOKIE_NAME
 
-        for session_file in os.listdir(storage_path):
-            if not session_file.startswith(file_prefix):
-                continue
-            session_key = session_file.removeprefix(file_prefix)
-            session = cls(session_key)
-            # When an expired session is loaded, its file is removed, and a
-            # new file is immediately created. Prevent this by disabling
-            # the create() method.
-            session.create = lambda: None
-            session.load()
+        with os.scandir(storage_path) as entries:
+            for session_file in entries:
+                if not session_file.name.startswith(file_prefix):
+                    continue
+                session_key = session_file.name.removeprefix(file_prefix)
+                session = cls(session_key)
+                # When an expired session is loaded, its file is removed, and a
+                # new file is immediately created. Prevent this by disabling
+                # the create() method.
+                session.create = lambda: None
+                session.load()
 
     @classmethod
     async def aclear_expired(cls):

--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -47,11 +47,13 @@ class MigrationQuestioner:
             return self.defaults.get("ask_initial", False)
         else:
             if getattr(migrations_module, "__file__", None):
-                filenames = os.listdir(os.path.dirname(migrations_module.__file__))
+                with os.scandir(os.path.dirname(migrations_module.__file__)) as entries:
+                    filenames = [entry.name for entry in entries]
             elif hasattr(migrations_module, "__path__"):
                 if len(migrations_module.__path__) > 1:
                     return False
-                filenames = os.listdir(list(migrations_module.__path__)[0])
+                with os.scandir(list(migrations_module.__path__)[0]) as entries:
+                    filenames = [entry.name for entry in entries]
             return not any(x.endswith(".py") for x in filenames if x != "__init__.py")
 
     def ask_not_null_addition(self, field_name, model_name):

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -42,6 +42,26 @@ from .models import (
 FILE_SUFFIX_REGEX = "[A-Za-z0-9]{7}"
 
 
+class Helper:
+    """
+    A helper class that provides utility methods for file operations.
+    """
+
+    @classmethod
+    def get_sorted_files(cls, directory):
+        """
+        Get a sorted list of file names in the specified directory.
+
+        Args:
+            directory (str): The path to the directory to scan for files.
+
+        Returns:
+            list: A sorted list of file names in the directory.
+        """
+        with os.scandir(directory) as entries:
+            return sorted(entry.name for entry in entries if entry.is_file())
+
+
 class FileSystemStorageTests(unittest.TestCase):
     def test_deconstruction(self):
         path, args, kwargs = temp_storage.deconstruct()
@@ -1064,7 +1084,7 @@ class FileSaveRaceConditionTest(SimpleTestCase):
         self.thread.start()
         self.save_file("conflict")
         self.thread.join()
-        files = sorted(os.listdir(self.storage_dir))
+        files = Helper.get_sorted_files(self.storage_dir)
         self.assertEqual(files[0], "conflict")
         self.assertRegex(files[1], "conflict_%s" % FILE_SUFFIX_REGEX)
 
@@ -1128,7 +1148,7 @@ class FileStoragePathParsing(SimpleTestCase):
         self.storage.save("dotted.path/test", ContentFile("1"))
         self.storage.save("dotted.path/test", ContentFile("2"))
 
-        files = sorted(os.listdir(os.path.join(self.storage_dir, "dotted.path")))
+        files = Helper.get_sorted_files(os.path.join(self.storage_dir, "dotted.path"))
         self.assertFalse(os.path.exists(os.path.join(self.storage_dir, "dotted_.path")))
         self.assertEqual(files[0], "test")
         self.assertRegex(files[1], "test_%s" % FILE_SUFFIX_REGEX)
@@ -1141,7 +1161,7 @@ class FileStoragePathParsing(SimpleTestCase):
         self.storage.save("dotted.path/.test", ContentFile("1"))
         self.storage.save("dotted.path/.test", ContentFile("2"))
 
-        files = sorted(os.listdir(os.path.join(self.storage_dir, "dotted.path")))
+        files = Helper.get_sorted_files(os.path.join(self.storage_dir, "dotted.path"))
         self.assertFalse(os.path.exists(os.path.join(self.storage_dir, "dotted_.path")))
         self.assertEqual(files[0], ".test")
         self.assertRegex(files[1], ".test_%s" % FILE_SUFFIX_REGEX)

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -658,9 +658,10 @@ class PycLoaderTests(MigrationTestBase):
         ) as migration_dir:
             # Compile .py files to .pyc files and delete .py files.
             compileall.compile_dir(migration_dir, force=True, quiet=1, legacy=True)
-            for name in os.listdir(migration_dir):
-                if name.endswith(".py"):
-                    os.remove(os.path.join(migration_dir, name))
+            with os.scandir(migration_dir) as entries:
+                for entry in entries:
+                    if entry.name.endswith(".py"):
+                        os.remove(entry.path)
             loader = MigrationLoader(connection)
             self.assertIn(("migrations", "0001_initial"), loader.disk_migrations)
 

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -918,13 +918,12 @@ class FileSessionTests(SessionTestsMixin, SimpleTestCase):
         file_prefix = settings.SESSION_COOKIE_NAME
 
         def count_sessions():
-            return len(
-                [
-                    session_file
-                    for session_file in os.listdir(storage_path)
-                    if session_file.startswith(file_prefix)
-                ]
-            )
+            with os.scandir(storage_path) as entries:
+                return sum(
+                    1
+                    for session_file in entries
+                    if session_file.name.startswith(file_prefix)
+                )
 
         self.assertEqual(0, count_sessions())
 

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -30,7 +30,8 @@ class TestNoFilesCreated:
         """
         Make sure no files were create in the destination directory.
         """
-        self.assertEqual(os.listdir(settings.STATIC_ROOT), [])
+        with os.scandir(settings.STATIC_ROOT) as entries:
+            self.assertEqual(next(entries, None), None)
 
 
 class TestRunserver(StaticFilesTestCase):

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -525,18 +525,11 @@ class TestCollectionManifestStorage(TestHashedFiles, CollectionTestCase):
         self.hashed_file_path(missing_file_name)
 
     def test_intermediate_files(self):
-        cached_files = os.listdir(os.path.join(settings.STATIC_ROOT, "cached"))
-        # Intermediate files shouldn't be created for reference.
-        self.assertEqual(
-            len(
-                [
-                    cached_file
-                    for cached_file in cached_files
-                    if cached_file.startswith("relative.")
-                ]
-            ),
-            2,
-        )
+        with os.scandir(os.path.join(settings.STATIC_ROOT, "cached")) as entries:
+            self.assertEqual(
+                sum(1 for entry in entries if entry.name.startswith("relative.")),
+                2,
+            )
 
     def test_manifest_hash(self):
         # Collect the additional file.


### PR DESCRIPTION
#### Trac ticket number
ticket-35572

#### Branch description
Changed all `os.listdir` to `os.scandir`, also adjusting the tests.
Added new test scenarios to `test_questioner.py`
Left `scripts/manage_translations.py` untouched as there aren't tests written for it.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
