### PR TITLE
Fixed #35908 -- Retired the django-developers and django-users mailing lists.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,6 @@ ticket here: https://code.djangoproject.com/newticket
 
 To get more help:
 
-* Join the django-users mailing list, or read the archives, at
-  https://groups.google.com/group/django-users.
-
 * Join the `Django Discord community <https://chat.djangoproject.com>`_.
 
 * Join the community on the `Django Forum <https://forum.djangoproject.com/>`_.

--- a/docs/faq/help.txt
+++ b/docs/faq/help.txt
@@ -21,7 +21,6 @@ Then, please post it in one of the following channels:
 
 * The Django Forum section `"Using Django"`_. This is for web-based
   discussions.
-* The |django-users| mailing list. This is for email-based discussions.
 * The `Django Discord server`_ for chat-based discussions.
 
 .. _`"Using Django"`: https://forum.djangoproject.com/c/users/6
@@ -32,22 +31,6 @@ summary, being friendly and patient, considerate, respectful, and careful in
 your choice of words.
 
 .. _Django Code of Conduct: https://www.djangoproject.com/conduct/
-
-.. _message-does-not-appear-on-django-users:
-
-Why hasn't my message appeared on *django-users*?
-=================================================
-
-|django-users| has a lot of subscribers. This is good for the community, as
-it means many people are available to contribute answers to questions.
-Unfortunately, it also means that |django-users| is an attractive target for
-spammers.
-
-In order to combat the spam problem, when you join the |django-users| mailing
-list, we manually moderate the first message you send to the list. This means
-that spammers get caught, but it also means that your first question to the
-list might take a little longer to get answered. We apologize for any
-inconvenience that this policy may cause.
 
 Nobody answered my question! What should I do?
 ==============================================
@@ -62,12 +45,6 @@ everybody that can help is busy.
 
 You can also try asking on a different channel. But please don't post your
 question in all three channels in quick succession.
-
-You might notice we have a second mailing list, called |django-developers|.
-This list is for discussion of the development of Django itself. Please don't
-email support questions to this mailing list. Asking a tech support question
-there is considered impolite, and you will likely be directed to ask on
-|django-users|.
 
 I think I've found a bug! What should I do?
 ===========================================

--- a/docs/internals/contributing/bugs-and-features.txt
+++ b/docs/internals/contributing/bugs-and-features.txt
@@ -16,15 +16,15 @@ Otherwise, before reporting a bug or requesting a new feature on the
 * Check that someone hasn't already filed the bug or feature request by
   `searching`_ or running `custom queries`_ in the ticket tracker.
 
-* Don't use the ticket system to ask support questions. Use the
-  |django-users| list or the `Django Discord server`_ for that.
+* Don't use the ticket system to ask support questions. Use the `Django Forum`_
+  or the `Django Discord server`_ for that.
 
 * Don't reopen issues that have been marked "wontfix" without finding consensus
-  to do so on the `Django Forum`_ or |django-developers| list.
+  to do so on the `Django Forum`_.
 
 * Don't use the ticket tracker for lengthy discussions, because they're
   likely to get lost. If a particular ticket is controversial, please move the
-  discussion to the `Django Forum`_ or |django-developers| list.
+  discussion to the `Django Forum`_.
 
 .. _reporting-bugs:
 
@@ -39,7 +39,7 @@ particular:
 * **Do** read the :doc:`FAQ </faq/index>` to see if your issue might
   be a well-known question.
 
-* **Do** ask on |django-users| or the `Django Discord server`_ *first* if
+* **Do** ask on `Django Forum`_ or the `Django Discord server`_ *first* if
   you're not sure if what you're seeing is a bug.
 
 * **Do** write complete, reproducible, specific bug reports. You must
@@ -49,7 +49,7 @@ particular:
   small test case is the best way to report a bug, as it gives us a
   helpful way to confirm the bug quickly.
 
-* **Don't** post to |django-developers| only to announce that you have filed a
+* **Don't** post to `Django Forum`_ only to announce that you have filed a
   bug report. All the tickets are mailed to another list, |django-updates|,
   which is tracked by developers and interested community members; we see them
   as they are filed.
@@ -94,10 +94,10 @@ part of that. Here are some tips on how to make a request most effectively:
   suggest that you develop it independently. Then, if your project gathers
   sufficient community support, we may consider it for inclusion in Django.
 
-* First request the feature on the `Django Forum`_ or |django-developers| list,
-  not in the ticket tracker. It'll get read more closely if it's on the mailing
-  list. This is even more important for large-scale feature requests. We like
-  to discuss any big changes to Django's core before actually working on them.
+* First request the feature on the `Django Forum`_, not in the ticket tracker.
+  It'll get read more closely and reach a larger audience. This is even more
+  important for large-scale feature requests. We like to discuss any big
+  changes to Django's core before actually working on them.
 
 * Describe clearly and concisely what the missing feature is and how you'd
   like to see it implemented. Include example code (non-functional is OK)
@@ -127,9 +127,9 @@ How we make decisions
 =====================
 
 Whenever possible, we strive for a rough consensus. To that end, we'll often
-have informal votes on |django-developers| or the Django Forum about a feature.
-In these votes we follow the voting style invented by Apache and used on Python
-itself, where votes are given as +1, +0, -0, or -1.
+have informal votes on the Django Forum about a feature. In these votes we
+follow the voting style invented by Apache and used on Python itself, where
+votes are given as +1, +0, -0, or -1.
 Roughly translated, these votes mean:
 
 * +1: "I love the idea and I'm strongly committed to it."
@@ -162,7 +162,7 @@ Since this process allows any steering council member to veto a proposal, a
 convert that "-1" into at least a "+0".
 
 Votes on technical matters should be announced and held in public on the
-|django-developers| mailing list or on the `Django Forum`_.
+`Django Forum`_.
 
 .. _searching: https://code.djangoproject.com/search
 .. _custom queries: https://code.djangoproject.com/query

--- a/docs/internals/contributing/committing-code.txt
+++ b/docs/internals/contributing/committing-code.txt
@@ -109,14 +109,14 @@ Django's Git repository:
   discuss the situation with the team.
 
 * For any medium-to-big changes, where "medium-to-big" is according to
-  your judgment, please bring things up on the `Django Forum`_ or
-  |django-developers| mailing list before making the change.
+  your judgment, please bring things up on the `Django Forum`_ before making
+  the change.
 
   If you bring something up and nobody responds, please don't take that
   to mean your idea is great and should be implemented immediately because
   nobody contested it. Everyone doesn't always have a lot of time to read
-  mailing list discussions immediately, so you may have to wait a couple of
-  days before getting a response.
+  discussions immediately, so you may have to wait a couple of days before
+  getting a response.
 
 * Write detailed commit messages in the past tense, not present tense.
 
@@ -228,14 +228,14 @@ When a mistaken commit is discovered, please follow these guidelines:
 * If the original author can't be reached (within a reasonable amount
   of time -- a day or so) and the problem is severe -- crashing bug,
   major test failures, etc. -- then ask for objections on the `Django Forum`_
-  or |django-developers| mailing list then revert if there are none.
+  then revert if there are none.
 
 * If the problem is small (a feature commit after feature freeze,
   say), wait it out.
 
 * If there's a disagreement between the merger and the reverter-to-be then try
-  to work it out on the `Django Forum`_ or |django-developers| mailing list. If
-  an agreement can't be reached then it should be put to a vote.
+  to work it out on the `Django Forum`_ . If an agreement can't be reached then
+  it should be put to a vote.
 
 * If the commit introduced a confirmed, disclosed security
   vulnerability then the commit may be reverted immediately without

--- a/docs/internals/contributing/index.txt
+++ b/docs/internals/contributing/index.txt
@@ -21,15 +21,10 @@ Join the Django community
 There are several ways you can help the Django community and others to maintain
 a great ecosystem to work in:
 
-* Join the `Django forum`_. This forum is a place for discussing the Django
+* Join the `Django Forum`_. This forum is a place for discussing the Django
   framework and applications and projects that use it. This is also a good
   place to ask and answer any questions related to installing, using, or
   contributing to Django.
-
-* Join the |django-users| mailing list and answer questions. This
-  mailing list has a huge audience, and we really want to maintain a
-  friendly and helpful atmosphere. If you're new to the Django community,
-  you should read the `posting guidelines`_.
 
 * Join the `Django Discord server`_ to discuss and answer questions. By
   explaining Django to other users, you're going to learn a lot about the
@@ -44,10 +39,9 @@ a great ecosystem to work in:
   ecosystem of pluggable applications is a big strength of Django, help us
   build it!
 
-.. _posting guidelines: https://code.djangoproject.com/wiki/UsingTheMailingList
 .. _community page: https://www.djangoproject.com/community/
 .. _Django Discord server: https://chat.djangoproject.com
-.. _Django forum: https://forum.djangoproject.com/
+.. _Django Forum: https://forum.djangoproject.com/
 .. _register it here: https://www.djangoproject.com/community/add/blogs/
 
 Getting started

--- a/docs/internals/contributing/triaging-tickets.txt
+++ b/docs/internals/contributing/triaging-tickets.txt
@@ -24,7 +24,7 @@ mistakes. Trac is "mostly accurate", and we give allowances for the fact that
 sometimes it will be wrong. That's okay. We're perfectionists with deadlines.
 
 We rely on the community to keep participating, keep tickets as accurate as
-possible, and raise issues for discussion on our mailing lists when there is
+possible, and raise issues for discussion on the `Django Forum`_ when there is
 confusion or disagreement.
 
 Django is a community project, and every contribution helps. We can't do this
@@ -308,12 +308,11 @@ A ticket can be resolved in a number of ways:
 * wontfix
       Used when someone decides that the request isn't appropriate for
       consideration in Django. Sometimes a ticket is closed as "wontfix" with a
-      request for the reporter to start a discussion on the `Django Forum`_ or
-      |django-developers| mailing list if they feel differently from the
-      rationale provided by the person who closed the ticket. Other times, a
-      discussion precedes the decision to close a ticket. Always use the forum
-      or mailing list to get a consensus before reopening tickets closed as
-      "wontfix".
+      request for the reporter to start a discussion on the `Django Forum`_ if
+      they feel differently from the rationale provided by the person who
+      closed the ticket. Other times, a discussion precedes the decision to
+      close a ticket. Always use the forum to get a consensus before reopening
+      tickets closed as "wontfix".
 
 * duplicate
       Used when another ticket covers the same issue. By closing duplicate
@@ -333,7 +332,7 @@ If you believe that the ticket was closed in error -- because you're
 still having the issue, or it's popped up somewhere else, or the triagers have
 made a mistake -- please reopen the ticket and provide further information.
 Again, please do not reopen tickets that have been marked as "wontfix" and
-bring the issue to the `Django Forum`_ or |django-developers| instead.
+bring the issue to the `Django Forum`_ instead.
 
 .. _how-can-i-help-with-triaging:
 
@@ -354,7 +353,7 @@ Then, you can help out by:
 
 * Closing "Unreviewed" tickets as "needsinfo" when the description is too
   sparse to be actionable, or when they're feature requests requiring a
-  discussion on the `Django Forum`_ or |django-developers|.
+  discussion on the `Django Forum`_.
 
 * Correcting the "Needs tests", "Needs documentation", or "Has patch"
   flags for tickets where they are incorrectly set.
@@ -372,7 +371,7 @@ Then, you can help out by:
   reports about a particular part of Django, it may indicate we should
   consider refactoring that part of the code. If a trend is emerging,
   you should raise it for discussion (referencing the relevant tickets)
-  on the `Django Forum`_ or |django-developers|.
+  on the `Django Forum`_.
 
 * Verify if solutions submitted by others are correct. If they are correct
   and also contain appropriate documentation and tests then move them to the
@@ -399,12 +398,12 @@ the ticket database:
   review a patch that you submit.
 
 * Please **don't** reverse a decision without posting a message to the
-  `Django Forum`_ or |django-developers| to find consensus.
+  `Django Forum`_ to find consensus.
 
 * If you're unsure if you should be making a change, don't make the
   change but instead leave a comment with your concerns on the ticket,
-  or post a message to the `Django Forum`_ or |django-developers|. It's okay to
-  be unsure, but your input is still valuable.
+  or post a message to the `Django Forum`_. It's okay to be unsure, but your
+  input is still valuable.
 
 .. _Trac: https://code.djangoproject.com/
 .. _`easy pickings`: https://code.djangoproject.com/query?status=!closed&easy=1

--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -154,12 +154,11 @@ or introduces breaking changes.
 
 The following are different approaches for gaining feedback from the community.
 
-The Django Forum or django-developers mailing list
---------------------------------------------------
+The Django Forum
+----------------
 
-You can propose a change on the `Django Forum`_ or |django-developers| mailing
-list. You should explain the need for the change, go into details of the
-approach and discuss alternatives.
+You can propose a change on the `Django Forum`_. You should explain the need
+for the change, go into details of the approach and discuss alternatives.
 
 Please include a link to such discussions in your contributions.
 
@@ -175,8 +174,8 @@ third-party package first. You can iterate on the public API much faster, while
 also validating the need for the feature.
 
 Once this package becomes stable and there are clear benefits of incorporating
-aspects into Django core, starting a discussion on the `Django Forum`_ or
-|django-developers| mailing list would be the next step.
+aspects into Django core, starting a discussion on the `Django Forum`_ would be
+the next step.
 
 Django Enhancement Proposal (DEP)
 ---------------------------------
@@ -188,10 +187,9 @@ specifications of features, along with rationales. DEPs are also the primary
 mechanism for proposing and collecting community input on major new features.
 
 Before considering writing a DEP, it is recommended to first open a discussion
-on the `Django Forum`_ or |django-developers| mailing list. This allows the
-community to provide feedback and helps refine the proposal. Once the DEP is
-ready the :ref:`Steering Council <steering-council>` votes on whether to accept
-it.
+on the `Django Forum`_. This allows the community to provide feedback and helps
+refine the proposal. Once the DEP is ready the :ref:`Steering Council
+<steering-council>` votes on whether to accept it.
 
 Some examples of DEPs that have been approved and fully implemented:
 

--- a/docs/internals/howto-release-django.txt
+++ b/docs/internals/howto-release-django.txt
@@ -129,8 +129,6 @@ permissions.
   <https://forum.djangoproject.com/c/announcements/7>`_ and to  send emails to
   the following mailing lists:
 
-  * `django-users <https://groups.google.com/g/django-users/>`_
-  * `django-developers <https://groups.google.com/g/django-developers/>`_
   * `django-announce <https://groups.google.com/g/django-announce/>`_
 
 * Access to the ``django-security`` repo in GitHub. Among other things, this
@@ -648,9 +646,8 @@ Now you're ready to actually put the release out there. To do this:
    __ https://github.com/django/djangoproject.com/blob/main/djangoproject/static/robots.docs.txt
    __ https://github.com/django/django-docs-translations
 
-#. Post the release announcement to the |django-announce|, |django-developers|,
-   |django-users| mailing lists, and the Django Forum. This should include a
-   link to the announcement blog post.
+#. Post the release announcement to the |django-announce| mailing list and the
+   Django Forum. This should include a link to the announcement blog post.
 
 #. If this is a security release, send a separate email to
    oss-security@lists.openwall.com. Provide a descriptive subject, for example,

--- a/docs/internals/mailing-lists.txt
+++ b/docs/internals/mailing-lists.txt
@@ -21,69 +21,18 @@ There are several categories of discussion including:
   debugging of Django.
 * `Internals`_: for discussion of the development of Django itself.
 
+.. note::
+
+    Before asking a question about how to contribute, read
+    :doc:`/internals/contributing/index`. Many frequently asked questions are
+    answered there.
+
 .. _official Forum: https://forum.djangoproject.com
 .. _Internals: https://forum.djangoproject.com/c/internals/5
 .. _Using Django: https://forum.djangoproject.com/c/users/6
 
 In addition, Django has several official mailing lists on Google Groups that
 are open to anyone.
-
-.. _django-users-mailing-list:
-
-``django-users``
-================
-
-.. note::
-
-    The `Using Django`_ category of the `official Forum`_ is now the preferred
-    venue for asking usage questions.
-
-This is the right place if you are looking to ask any question regarding the
-installation, usage, or debugging of Django.
-
-.. note::
-
-    If it's the first time you send an email to this list, your email must be
-    accepted first so don't worry if :ref:`your message does not appear
-    <message-does-not-appear-on-django-users>` instantly.
-
-* `django-users mailing archive`_
-* `django-users subscription email address`_
-* `django-users posting email`_
-
-.. _django-users mailing archive: https://groups.google.com/g/django-users
-.. _django-users subscription email address: mailto:django-users+subscribe@googlegroups.com
-.. _django-users posting email: mailto:django-users@googlegroups.com
-
-.. _django-developers-mailing-list:
-
-``django-developers``
-=====================
-
-.. note::
-
-    The `Internals`_ category of the `official Forum`_ is now the preferred
-    venue for discussing the development of Django.
-
-The discussion about the development of Django itself takes place here.
-
-Before asking a question about how to contribute, read
-:doc:`/internals/contributing/index`. Many frequently asked questions are
-answered there.
-
-.. note::
-
-    Please make use of
-    :ref:`django-users mailing list <django-users-mailing-list>` if you want
-    to ask for tech support, doing so in this list is inappropriate.
-
-* `django-developers mailing archive`_
-* `django-developers subscription email address`_
-* `django-developers posting email`_
-
-.. _django-developers mailing archive: https://groups.google.com/g/django-developers
-.. _django-developers subscription email address: mailto:django-developers+subscribe@googlegroups.com
-.. _django-developers posting email: mailto:django-developers@googlegroups.com
 
 .. _django-announce-mailing-list:
 
@@ -116,3 +65,42 @@ by developers and interested community members.
 .. _django-updates mailing archive: https://groups.google.com/g/django-updates
 .. _django-updates subscription email address: mailto:django-updates+subscribe@googlegroups.com
 .. _django-updates posting email: mailto:django-updates@googlegroups.com
+
+Archived mailing lists
+======================
+
+The following mailing lists are archived and no longer active. These are still
+available as a historical resource.
+
+.. _django-users-mailing-list:
+
+``django-users``
+----------------
+
+.. note::
+
+    The `Using Django`_ category of the `official Forum`_ is now the preferred
+    venue for asking usage questions.
+
+This was used for questions regarding the installation, usage, or debugging of
+Django projects.
+
+* `django-users mailing archive`_
+
+.. _django-users mailing archive: https://groups.google.com/g/django-users
+
+.. _django-developers-mailing-list:
+
+``django-developers``
+---------------------
+
+.. note::
+
+    The `Internals`_ category of the `official Forum`_ is now the preferred
+    venue for discussing the development of Django.
+
+This was used for discussions about the development of Django itself.
+
+* `django-developers mailing archive`_
+
+.. _django-developers mailing archive: https://groups.google.com/g/django-developers

--- a/docs/internals/organization.txt
+++ b/docs/internals/organization.txt
@@ -215,8 +215,7 @@ who demonstrate:
     Django ecosystem
   - Reviewing pull requests and/or triaging Django project tickets
   - Documentation, tutorials or blog posts
-  - Discussions about Django on the django-developers mailing list or the Django
-    Forum
+  - Discussions about Django on the Django Forum
   - Running Django-related events or user groups
 
 - A history of engagement with the direction and future of Django. This does
@@ -230,8 +229,7 @@ works as follows:
 #. The steering council directs one of its members to notify the Secretary of the
    Django Software Foundation, in writing, of the triggering of the election,
    and the condition which triggered it. The Secretary post to the appropriate
-   venue -- the |django-developers| mailing list and the `Django forum`_ to
-   announce the election and its timeline.
+   venue -- the `Django Forum`_ to announce the election and its timeline.
 #. As soon as the election is announced, the `DSF Board`_ begin a period of
    voter registration. All `individual members of the DSF`_ are automatically
    registered and need not explicitly register. All other persons who believe
@@ -250,10 +248,10 @@ works as follows:
    not meet the qualifications of members of the Steering Council, or who it
    believes are registering in bad faith.
 #. Registration of candidates close one week after it has opened. One week
-   after registration of candidates closes, the Secretary of the DSF publish
-   the roster of candidates to the |django-developers| mailing list and the
-   `Django forum`_, and the election begin. The DSF Board provide a voting form
-   accessible to registered voters, and is the custodian of the votes.
+   after registration of candidates closes, the Secretary of the DSF publishes
+   the roster of candidates to the `Django Forum`_, and the election begins.
+   The DSF Board provides a voting form accessible to registered voters, and is
+   the custodian of the votes.
 #. Voting is by secret ballot containing the roster of candidates, and any
    relevant materials regarding the candidates, in a randomized order. Each
    voter may vote for up to five candidates on the ballot.
@@ -261,9 +259,8 @@ works as follows:
    votes and produce a summary, including the total number of votes cast and
    the number received by each candidate. This summary is ratified by a
    majority vote of the DSF Board, then posted by the Secretary of the DSF to
-   the |django-developers| mailing list and the Django Forum. The five
-   candidates with the highest vote totals are immediately become the new
-   steering council.
+   the `Django Forum`_. The five candidates with the highest vote totals
+   immediately become the new steering council.
 
 A member of the steering council may be removed by:
 
@@ -277,7 +274,7 @@ A member of the steering council may be removed by:
   if a DSF Board member, must not vote) vote "yes" on a motion that the person
   in question is ineligible.
 
-.. _`Django forum`: https://forum.djangoproject.com/
+.. _`Django Forum`: https://forum.djangoproject.com/
 .. _`Django Git repository`: https://github.com/django/django/
 .. _`DSF Board`: https://www.djangoproject.com/foundation/#board
 .. _`individual members of the DSF`: https://www.djangoproject.com/foundation/individual-members/

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -41,9 +41,8 @@ so that it can be of use to the widest audience.
 .. admonition:: Where to get help:
 
     If you're having trouble going through this tutorial, please post a message
-    on the `Django Forum`_, |django-developers|, or drop by the
-    `Django Discord server`_ to chat with other Django users who might be able
-    to help.
+    on the `Django Forum`_ or drop by the `Django Discord server`_ to chat with
+    other Django users who might be able to help.
 
 .. _Dive Into Python: https://diveintopython3.net/
 .. _Django Forum: https://forum.djangoproject.com/

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -123,10 +123,11 @@ ticket system and use your feedback to improve the documentation for everybody.
 
 Note, however, that tickets should explicitly relate to the documentation,
 rather than asking broad tech-support questions. If you need help with your
-particular Django setup, try the |django-users| mailing list or the
+particular Django setup, try the `Django Forum`_ or the
 `Django Discord server`_ instead.
 
 .. _ticket system: https://code.djangoproject.com/
+.. _Django Forum: https://forum.djangoproject.com/
 .. _Django Discord server: https://chat.djangoproject.com
 
 In plain text

--- a/docs/misc/distributions.txt
+++ b/docs/misc/distributions.txt
@@ -26,8 +26,10 @@ For distributors
 ================
 
 If you'd like to package Django for distribution, we'd be happy to help out!
-Please join the |django-developers| mailing list and introduce yourself.
+Please introduce yourself on the `Django Forum`_.
 
 We also encourage all distributors to subscribe to the |django-announce| mailing
 list, which is a (very) low-traffic list for announcing new releases of Django
 and important bugfixes.
+
+.. _Django Forum: https://forum.djangoproject.com/


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35908

#### Branch description

I have removed almost all references to the mailing lists django-users and django-developers
The exceptions are:
- In old release notes, these are still referenced occasionally. We tend to leave old release notes alone.
- As these are still a useful resource for searching past discussions, I have kept them in the [Mailing lists and Forum](https://django--19141.org.readthedocs.build/en/19141/internals/mailing-lists.html) page. These are now in a new "archived" section


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
