### PR TITLE
Fixed #36165 -- Made PostgreSQL's SchemaEditor._delete_index_sql() respect the "sql" argument.

### DIFF
--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -322,7 +322,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         self.execute(index.remove_sql(model, self, concurrently=concurrently))
 
     def _delete_index_sql(self, model, name, sql=None, concurrently=False):
-        sql = (
+        sql = sql or (
             self.sql_delete_index_concurrently
             if concurrently
             else self.sql_delete_index

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -665,6 +665,30 @@ class SchemaTests(PostgreSQLTestCase):
                 str(index.create_sql(CharFieldModel, editor)),
             )
 
+    def test_custom_sql(self):
+        class CustomSQLIndex(PostgresIndex):
+            sql_create_index = "SELECT 1"
+            sql_delete_index = "SELECT 2"
+
+            def create_sql(self, model, schema_editor, using="", **kwargs):
+                kwargs.setdefault("sql", self.sql_create_index)
+                return super().create_sql(model, schema_editor, using, **kwargs)
+
+            def remove_sql(self, model, schema_editor, **kwargs):
+                kwargs.setdefault("sql", self.sql_delete_index)
+                return super().remove_sql(model, schema_editor, **kwargs)
+
+        index = CustomSQLIndex(fields=["field"], name="custom_sql_idx")
+
+        operations = [
+            (index.create_sql, CustomSQLIndex.sql_create_index),
+            (index.remove_sql, CustomSQLIndex.sql_delete_index),
+        ]
+        for operation, expected in operations:
+            with self.subTest(operation=operation.__name__):
+                with connection.schema_editor() as editor:
+                    self.assertEqual(expected, str(operation(CharFieldModel, editor)))
+
     def test_op_class(self):
         index_name = "test_op_class"
         index = Index(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36165

#### Branch description
This is a follow up of bd366ca2aeffa869b7dbc0b0aa01caea75e6dc31.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
