### PR TITLE
Refs #36005 -- Used datetime.UTC alias instead of datetime.timezone.utc.

### DIFF
--- a/django/contrib/humanize/templatetags/humanize.py
+++ b/django/contrib/humanize/templatetags/humanize.py
@@ -1,5 +1,5 @@
 import re
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from decimal import Decimal
 
 from django import template
@@ -297,7 +297,7 @@ class NaturalTimeFormatter:
         if not isinstance(value, date):  # datetime is a subclass of date
             return value
 
-        now = datetime.now(timezone.utc if is_aware(value) else None)
+        now = datetime.now(UTC if is_aware(value) else None)
         if value < now:
             delta = now - value
             if delta.days != 0:

--- a/django/contrib/sessions/backends/file.py
+++ b/django/contrib/sessions/backends/file.py
@@ -64,7 +64,7 @@ class SessionStore(SessionBase):
         Return the modification time of the file storing the session's content.
         """
         modification = os.stat(self._key_to_file()).st_mtime
-        tz = datetime.timezone.utc if settings.USE_TZ else None
+        tz = datetime.UTC if settings.USE_TZ else None
         return datetime.datetime.fromtimestamp(modification, tz=tz)
 
     def _expiry_date(self, session_data):

--- a/django/contrib/sitemaps/views.py
+++ b/django/contrib/sitemaps/views.py
@@ -35,7 +35,7 @@ def _get_latest_lastmod(current_lastmod, new_lastmod):
     if not isinstance(new_lastmod, datetime.datetime):
         new_lastmod = datetime.datetime.combine(new_lastmod, datetime.time.min)
     if timezone.is_naive(new_lastmod):
-        new_lastmod = timezone.make_aware(new_lastmod, datetime.timezone.utc)
+        new_lastmod = timezone.make_aware(new_lastmod, datetime.UTC)
     return new_lastmod if current_lastmod is None else max(current_lastmod, new_lastmod)
 
 

--- a/django/core/cache/backends/db.py
+++ b/django/core/cache/backends/db.py
@@ -1,7 +1,7 @@
 "Database cache backend."
 import base64
 import pickle
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from django.conf import settings
 from django.core.cache.backends.base import DEFAULT_TIMEOUT, BaseCache
@@ -124,7 +124,7 @@ class DatabaseCache(BaseDatabaseCache):
             if timeout is None:
                 exp = datetime.max
             else:
-                tz = timezone.utc if settings.USE_TZ else None
+                tz = UTC if settings.USE_TZ else None
                 exp = datetime.fromtimestamp(timeout, tz=tz)
             exp = exp.replace(microsecond=0)
             if num > self._max_entries:

--- a/django/core/files/storage/filesystem.py
+++ b/django/core/files/storage/filesystem.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -215,7 +215,7 @@ class FileSystemStorage(Storage, StorageSettingsMixin):
         If timezone support is enabled, make an aware datetime object in UTC;
         otherwise make a naive one in the local timezone.
         """
-        tz = timezone.utc if settings.USE_TZ else None
+        tz = UTC if settings.USE_TZ else None
         return datetime.fromtimestamp(ts, tz=tz)
 
     def get_accessed_time(self, name):

--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -150,7 +150,7 @@ class BaseDatabaseWrapper:
         if not settings.USE_TZ:
             return None
         elif self.settings_dict["TIME_ZONE"] is None:
-            return datetime.timezone.utc
+            return datetime.UTC
         else:
             return zoneinfo.ZoneInfo(self.settings_dict["TIME_ZONE"])
 

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -81,8 +81,8 @@ class DatetimeDatetimeSerializer(BaseSerializer):
     """For datetime.datetime."""
 
     def serialize(self):
-        if self.value.tzinfo is not None and self.value.tzinfo != datetime.timezone.utc:
-            self.value = self.value.astimezone(datetime.timezone.utc)
+        if self.value.tzinfo is not None and self.value.tzinfo != datetime.UTC:
+            self.value = self.value.astimezone(datetime.UTC)
         imports = ["import datetime"]
         return repr(self.value), set(imports)
 

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1339,7 +1339,7 @@ class CommaSeparatedIntegerField(CharField):
 
 def _to_naive(value):
     if timezone.is_aware(value):
-        value = timezone.make_naive(value, datetime.timezone.utc)
+        value = timezone.make_naive(value, datetime.UTC)
     return value
 
 

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -240,8 +240,8 @@ class HttpResponseBase:
         if expires is not None:
             if isinstance(expires, datetime.datetime):
                 if timezone.is_naive(expires):
-                    expires = timezone.make_aware(expires, datetime.timezone.utc)
-                delta = expires - datetime.datetime.now(tz=datetime.timezone.utc)
+                    expires = timezone.make_aware(expires, datetime.UTC)
+                delta = expires - datetime.datetime.now(tz=datetime.UTC)
                 # Add one second so the date matches exactly (a fraction of
                 # time gets lost between converting to a timedelta and
                 # then the date string).

--- a/django/templatetags/tz.py
+++ b/django/templatetags/tz.py
@@ -1,7 +1,5 @@
 import zoneinfo
-from datetime import datetime
-from datetime import timezone as datetime_timezone
-from datetime import tzinfo
+from datetime import datetime, tzinfo
 
 from django.template import Library, Node, TemplateSyntaxError
 from django.utils import timezone
@@ -33,7 +31,7 @@ def utc(value):
     """
     Convert a datetime to UTC.
     """
-    return do_timezone(value, datetime_timezone.utc)
+    return do_timezone(value, datetime.UTC)
 
 
 @register.filter("timezone")

--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -118,7 +118,7 @@ def parse_datetime(value):
             kw["microsecond"] = kw["microsecond"] and kw["microsecond"].ljust(6, "0")
             tzinfo = kw.pop("tzinfo")
             if tzinfo == "Z":
-                tzinfo = datetime.timezone.utc
+                tzinfo = datetime.UTC
             elif tzinfo is not None:
                 offset_mins = int(tzinfo[-2:]) if len(tzinfo) > 3 else 0
                 offset = 60 * int(tzinfo[1:3]) + offset_mins

--- a/django/utils/feedgenerator.py
+++ b/django/utils/feedgenerator.py
@@ -277,7 +277,7 @@ class SyndicationFeed:
                     if latest_date is None or item_date > latest_date:
                         latest_date = item_date
 
-        return latest_date or datetime.datetime.now(tz=datetime.timezone.utc)
+        return latest_date or datetime.datetime.now(tz=datetime.UTC)
 
 
 class Enclosure:

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -2,7 +2,7 @@ import base64
 import re
 import unicodedata
 from binascii import Error as BinasciiError
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from email.utils import formatdate
 from urllib.parse import quote, unquote
 from urllib.parse import urlencode as original_urlencode
@@ -115,7 +115,7 @@ def parse_http_date(date):
     try:
         year = int(m["year"])
         if year < 100:
-            current_year = datetime.now(tz=timezone.utc).year
+            current_year = datetime.now(tz=UTC).year
             current_century = current_year - (current_year % 100)
             if year - (current_year % 100) > 50:
                 # year that appears to be more than 50 years in the future are
@@ -128,7 +128,7 @@ def parse_http_date(date):
         hour = int(m["hour"])
         min = int(m["min"])
         sec = int(m["sec"])
-        result = datetime(year, month, day, hour, min, sec, tzinfo=timezone.utc)
+        result = datetime(year, month, day, hour, min, sec, tzinfo=UTC)
         return int(result.timestamp())
     except Exception as exc:
         raise ValueError("%r is not a valid date" % date) from exc

--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -5,7 +5,7 @@ Timezone-related classes and functions.
 import functools
 import zoneinfo
 from contextlib import ContextDecorator
-from datetime import datetime, timedelta, timezone, tzinfo
+from datetime import UTC, datetime, timedelta, timezone, tzinfo
 
 from asgiref.local import Local
 
@@ -201,7 +201,7 @@ def now():
     """
     Return an aware or naive datetime.datetime, depending on settings.USE_TZ.
     """
-    return datetime.now(tz=timezone.utc if settings.USE_TZ else None)
+    return datetime.now(tz=UTC if settings.USE_TZ else None)
 
 
 # By design, these four functions don't perform any checks on their arguments.

--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -96,7 +96,7 @@ def get_git_changeset():
         text=True,
     )
     timestamp = git_log.stdout
-    tz = datetime.timezone.utc
+    tz = datetime.UTC
     try:
         timestamp = datetime.datetime.fromtimestamp(int(timestamp), tz=tz)
     except ValueError:

--- a/django/views/decorators/http.py
+++ b/django/views/decorators/http.py
@@ -110,7 +110,7 @@ def condition(etag_func=None, last_modified_func=None):
             if last_modified_func:
                 if dt := last_modified_func(request, *args, **kwargs):
                     if not timezone.is_aware(dt):
-                        dt = timezone.make_aware(dt, datetime.timezone.utc)
+                        dt = timezone.make_aware(dt, datetime.UTC)
                     res_last_modified = int(dt.timestamp())
             # The value from etag_func() could be quoted or unquoted.
             res_etag = etag_func(request, *args, **kwargs) if etag_func else None

--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -376,7 +376,7 @@ Once you're in the shell, explore the :doc:`database API </topics/db/queries>`:
     >>> q.question_text
     "What's new?"
     >>> q.pub_date
-    datetime.datetime(2012, 2, 26, 13, 0, 0, 775217, tzinfo=datetime.timezone.utc)
+    datetime.datetime(2012, 2, 26, 13, 0, 0, 775217, tzinfo=datetime.UTC)
 
     # Change values by changing the attributes, then calling save().
     >>> q.question_text = "What's up?"

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -355,7 +355,7 @@ that deal with date-parts can be used with ``DateField``:
 
 .. code-block:: pycon
 
-    >>> from datetime import datetime, timezone
+    >>> from datetime import UTC, datetime
     >>> from django.db.models.functions import (
     ...     ExtractDay,
     ...     ExtractMonth,
@@ -366,8 +366,8 @@ that deal with date-parts can be used with ``DateField``:
     ...     ExtractIsoYear,
     ...     ExtractYear,
     ... )
-    >>> start_2015 = datetime(2015, 6, 15, 23, 30, 1, tzinfo=timezone.utc)
-    >>> end_2015 = datetime(2015, 6, 16, 13, 11, 27, tzinfo=timezone.utc)
+    >>> start_2015 = datetime(2015, 6, 15, 23, 30, 1, tzinfo=UTC)
+    >>> end_2015 = datetime(2015, 6, 16, 13, 11, 27, tzinfo=UTC)
     >>> Experiment.objects.create(
     ...     start_datetime=start_2015,
     ...     start_date=start_2015.date(),
@@ -424,7 +424,7 @@ Each class is also a ``Transform`` registered on ``DateTimeField`` as
 
 .. code-block:: pycon
 
-    >>> from datetime import datetime, timezone
+    >>> from datetime import UTC, datetime
     >>> from django.db.models.functions import (
     ...     ExtractDay,
     ...     ExtractHour,
@@ -438,8 +438,8 @@ Each class is also a ``Transform`` registered on ``DateTimeField`` as
     ...     ExtractIsoYear,
     ...     ExtractYear,
     ... )
-    >>> start_2015 = datetime(2015, 6, 15, 23, 30, 1, tzinfo=timezone.utc)
-    >>> end_2015 = datetime(2015, 6, 16, 13, 11, 27, tzinfo=timezone.utc)
+    >>> start_2015 = datetime(2015, 6, 15, 23, 30, 1, tzinfo=UTC)
+    >>> end_2015 = datetime(2015, 6, 16, 13, 11, 27, tzinfo=UTC)
     >>> Experiment.objects.create(
     ...     start_datetime=start_2015,
     ...     start_date=start_2015.date(),
@@ -664,12 +664,12 @@ that deal with date-parts can be used with ``DateField``:
 
 .. code-block:: pycon
 
-    >>> from datetime import datetime, timezone
+    >>> from datetime import UTC, datetime
     >>> from django.db.models import Count
     >>> from django.db.models.functions import TruncMonth, TruncYear
-    >>> start1 = datetime(2014, 6, 15, 14, 30, 50, 321, tzinfo=timezone.utc)
-    >>> start2 = datetime(2015, 6, 15, 14, 40, 2, 123, tzinfo=timezone.utc)
-    >>> start3 = datetime(2015, 12, 31, 17, 5, 27, 999, tzinfo=timezone.utc)
+    >>> start1 = datetime(2014, 6, 15, 14, 30, 50, 321, tzinfo=UTC)
+    >>> start2 = datetime(2015, 6, 15, 14, 40, 2, 123, tzinfo=UTC)
+    >>> start3 = datetime(2015, 12, 31, 17, 5, 27, 999, tzinfo=UTC)
     >>> Experiment.objects.create(start_datetime=start1, start_date=start1.date())
     >>> Experiment.objects.create(start_datetime=start2, start_date=start2.date())
     >>> Experiment.objects.create(start_datetime=start3, start_date=start3.date())
@@ -744,7 +744,7 @@ Usage example:
 
 .. code-block:: pycon
 
-    >>> from datetime import date, datetime, timezone
+    >>> from datetime import UTC, date, datetime
     >>> from django.db.models import Count
     >>> from django.db.models.functions import (
     ...     TruncDate,
@@ -754,7 +754,7 @@ Usage example:
     ...     TruncSecond,
     ... )
     >>> import zoneinfo
-    >>> start1 = datetime(2014, 6, 15, 14, 30, 50, 321, tzinfo=timezone.utc)
+    >>> start1 = datetime(2014, 6, 15, 14, 30, 50, 321, tzinfo=UTC)
     >>> Experiment.objects.create(start_datetime=start1, start_date=start1.date())
     >>> melb = zoneinfo.ZoneInfo("Australia/Melbourne")
     >>> Experiment.objects.annotate(
@@ -767,8 +767,8 @@ Usage example:
     {'date': datetime.date(2014, 6, 15),
      'day': datetime.datetime(2014, 6, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo('Australia/Melbourne')),
      'hour': datetime.datetime(2014, 6, 16, 0, 0, tzinfo=zoneinfo.ZoneInfo('Australia/Melbourne')),
-     'minute': 'minute': datetime.datetime(2014, 6, 15, 14, 30, tzinfo=timezone.utc),
-     'second': datetime.datetime(2014, 6, 15, 14, 30, 50, tzinfo=timezone.utc)
+     'minute': 'minute': datetime.datetime(2014, 6, 15, 14, 30, tzinfo=UTC),
+     'second': datetime.datetime(2014, 6, 15, 14, 30, 50, tzinfo=UTC)
     }
 
 ``TimeField`` truncation
@@ -799,12 +799,12 @@ that deal with time-parts can be used with ``TimeField``:
 
 .. code-block:: pycon
 
-    >>> from datetime import datetime, timezone
+    >>> from datetime import UTC, datetime
     >>> from django.db.models import Count, TimeField
     >>> from django.db.models.functions import TruncHour
-    >>> start1 = datetime(2014, 6, 15, 14, 30, 50, 321, tzinfo=timezone.utc)
-    >>> start2 = datetime(2014, 6, 15, 14, 40, 2, 123, tzinfo=timezone.utc)
-    >>> start3 = datetime(2015, 12, 31, 17, 5, 27, 999, tzinfo=timezone.utc)
+    >>> start1 = datetime(2014, 6, 15, 14, 30, 50, 321, tzinfo=UTC)
+    >>> start2 = datetime(2014, 6, 15, 14, 40, 2, 123, tzinfo=UTC)
+    >>> start3 = datetime(2015, 12, 31, 17, 5, 27, 999, tzinfo=UTC)
     >>> Experiment.objects.create(start_datetime=start1, start_time=start1.time())
     >>> Experiment.objects.create(start_datetime=start2, start_time=start2.time())
     >>> Experiment.objects.create(start_datetime=start3, start_time=start3.time())

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -88,7 +88,7 @@ Argument    Value
             arguments passed to ``__init__()``)
 
 ``kwargs``  ``{'question_text': "What's new?",``
-            ``'pub_date': datetime.datetime(2012, 2, 26, 13, 0, 0, 775217, tzinfo=datetime.timezone.utc)}``
+            ``'pub_date': datetime.datetime(2012, 2, 26, 13, 0, 0, 775217, tzinfo=datetime.UTC)}``
 ==========  ===============================================================
 
 ``post_init``

--- a/docs/topics/i18n/timezones.txt
+++ b/docs/topics/i18n/timezones.txt
@@ -137,7 +137,7 @@ used.
     However, :ref:`as explained above <naive-datetime-objects>`, this isn't
     entirely reliable, and you should always work with aware datetimes in UTC
     in your own code. For instance, use :meth:`~datetime.datetime.fromtimestamp`
-    and set the ``tz`` parameter to :attr:`~datetime.timezone.utc`.
+    and set the ``tz`` parameter to :obj:`datetime.UTC`.
 
 Selecting the current time zone
 -------------------------------

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -1932,7 +1932,7 @@ class AggregateTestCase(TestCase):
         )
 
     def test_aggregation_default_using_time_from_database(self):
-        now = timezone.now().astimezone(datetime.timezone.utc)
+        now = timezone.now().astimezone(datetime.UTC)
         expr = Min(
             "store__friday_night_closing",
             filter=~Q(store__name="Amazon.com"),
@@ -1984,7 +1984,7 @@ class AggregateTestCase(TestCase):
         )
 
     def test_aggregation_default_using_date_from_database(self):
-        now = timezone.now().astimezone(datetime.timezone.utc)
+        now = timezone.now().astimezone(datetime.UTC)
         expr = Min("book__pubdate", default=TruncDate(NowUTC()))
         queryset = Publisher.objects.annotate(earliest_pubdate=expr).order_by("name")
         self.assertSequenceEqual(
@@ -2045,7 +2045,7 @@ class AggregateTestCase(TestCase):
         )
 
     def test_aggregation_default_using_datetime_from_database(self):
-        now = timezone.now().astimezone(datetime.timezone.utc)
+        now = timezone.now().astimezone(datetime.UTC)
         expr = Min(
             "store__original_opening",
             filter=~Q(store__name="Amazon.com"),

--- a/tests/auth_tests/test_remote_user.py
+++ b/tests/auth_tests/test_remote_user.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from django.conf import settings
 from django.contrib.auth import aauthenticate, authenticate
@@ -197,7 +197,7 @@ class RemoteUserTest(TestCase):
         # Set last_login to something so we can determine if it changes.
         default_login = datetime(2000, 1, 1)
         if settings.USE_TZ:
-            default_login = default_login.replace(tzinfo=timezone.utc)
+            default_login = default_login.replace(tzinfo=UTC)
         user.last_login = default_login
         user.save()
 
@@ -216,7 +216,7 @@ class RemoteUserTest(TestCase):
         # Set last_login to something so we can determine if it changes.
         default_login = datetime(2000, 1, 1)
         if settings.USE_TZ:
-            default_login = default_login.replace(tzinfo=timezone.utc)
+            default_login = default_login.replace(tzinfo=UTC)
         user.last_login = default_login
         await user.asave()
 

--- a/tests/datatypes/tests.py
+++ b/tests/datatypes/tests.py
@@ -93,7 +93,7 @@ class DataTypesTestCase(TestCase):
     def test_error_on_timezone(self):
         """Regression test for #8354: the MySQL and Oracle backends should raise
         an error if given a timezone-aware datetime object."""
-        dt = datetime.datetime(2008, 8, 31, 16, 20, tzinfo=datetime.timezone.utc)
+        dt = datetime.datetime(2008, 8, 31, 16, 20, tzinfo=datetime.UTC)
         d = Donut(name="Bear claw", consumed_at=dt)
         # MySQL backend does not support timezone-aware datetimes.
         with self.assertRaises(ValueError):

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -1,6 +1,5 @@
+import datetime
 import zoneinfo
-from datetime import datetime, timedelta
-from datetime import timezone as datetime_timezone
 
 from django.conf import settings
 from django.db import DataError, OperationalError
@@ -63,22 +62,22 @@ def truncate_to(value, kind, tzinfo=None):
         if kind == "hour":
             return value.replace(minute=0, second=0, microsecond=0)
         if kind == "day":
-            if isinstance(value, datetime):
+            if isinstance(value, datetime.datetime):
                 return value.replace(hour=0, minute=0, second=0, microsecond=0)
             return value
         if kind == "week":
-            if isinstance(value, datetime):
-                return (value - timedelta(days=value.weekday())).replace(
+            if isinstance(value, datetime.datetime):
+                return (value - datetime.timedelta(days=value.weekday())).replace(
                     hour=0, minute=0, second=0, microsecond=0
                 )
-            return value - timedelta(days=value.weekday())
+            return value - datetime.timedelta(days=value.weekday())
         if kind == "month":
-            if isinstance(value, datetime):
+            if isinstance(value, datetime.datetime):
                 return value.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
             return value.replace(day=1)
         if kind == "quarter":
             month_in_quarter = value.month - (value.month - 1) % 3
-            if isinstance(value, datetime):
+            if isinstance(value, datetime.datetime):
                 return value.replace(
                     month=month_in_quarter,
                     day=1,
@@ -89,7 +88,7 @@ def truncate_to(value, kind, tzinfo=None):
                 )
             return value.replace(month=month_in_quarter, day=1)
         # otherwise, truncate to year
-        if isinstance(value, datetime):
+        if isinstance(value, datetime.datetime):
             return value.replace(
                 month=1, day=1, hour=0, minute=0, second=0, microsecond=0
             )
@@ -125,8 +124,8 @@ class DateFunctionTests(TestCase):
         Extract year uses a BETWEEN filter to compare the year to allow indexes
         to be used.
         """
-        start_datetime = datetime(2015, 6, 15, 14, 10)
-        end_datetime = datetime(2016, 6, 15, 14, 10)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 10)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -164,8 +163,8 @@ class DateFunctionTests(TestCase):
                 self.assertEqual(query_string.count("extract"), 3)
 
     def test_extract_year_greaterthan_lookup(self):
-        start_datetime = datetime(2015, 6, 15, 14, 10)
-        end_datetime = datetime(2016, 6, 15, 14, 10)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 10)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -189,8 +188,8 @@ class DateFunctionTests(TestCase):
                 self.assertGreaterEqual(str(qs.query).lower().count("extract"), 2)
 
     def test_extract_year_lessthan_lookup(self):
-        start_datetime = datetime(2015, 6, 15, 14, 10)
-        end_datetime = datetime(2016, 6, 15, 14, 10)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 10)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -214,8 +213,8 @@ class DateFunctionTests(TestCase):
                 self.assertGreaterEqual(str(qs.query).lower().count("extract"), 2)
 
     def test_extract_lookup_name_sql_injection(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -230,8 +229,8 @@ class DateFunctionTests(TestCase):
             ).exists()
 
     def test_extract_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -387,8 +386,8 @@ class DateFunctionTests(TestCase):
 
     @skipUnlessDBFeature("has_native_duration_field")
     def test_extract_duration(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -435,8 +434,8 @@ class DateFunctionTests(TestCase):
                     DTModel.objects.annotate(extracted=Extract("duration", lookup))
 
     def test_extract_year_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -464,8 +463,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_iso_year_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -494,12 +493,12 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_iso_year_func_boundaries(self):
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             end_datetime = timezone.make_aware(end_datetime)
-        week_52_day_2014 = datetime(2014, 12, 27, 13, 0)  # Sunday
-        week_1_day_2014_2015 = datetime(2014, 12, 31, 13, 0)  # Wednesday
-        week_53_day_2015 = datetime(2015, 12, 31, 13, 0)  # Thursday
+        week_52_day_2014 = datetime.datetime(2014, 12, 27, 13, 0)  # Sunday
+        week_1_day_2014_2015 = datetime.datetime(2014, 12, 31, 13, 0)  # Wednesday
+        week_53_day_2015 = datetime.datetime(2015, 12, 31, 13, 0)  # Thursday
         if settings.USE_TZ:
             week_1_day_2014_2015 = timezone.make_aware(week_1_day_2014_2015)
             week_52_day_2014 = timezone.make_aware(week_52_day_2014)
@@ -539,8 +538,8 @@ class DateFunctionTests(TestCase):
         self.assertSequenceEqual(qs, [obj_1_iso_2014])
 
     def test_extract_month_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -574,8 +573,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_day_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -603,8 +602,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_week_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -633,8 +632,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_quarter_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 8, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 8, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -662,12 +661,12 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_quarter_func_boundaries(self):
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             end_datetime = timezone.make_aware(end_datetime)
 
-        last_quarter_2014 = datetime(2014, 12, 31, 13, 0)
-        first_quarter_2015 = datetime(2015, 1, 1, 13, 0)
+        last_quarter_2014 = datetime.datetime(2014, 12, 31, 13, 0)
+        first_quarter_2015 = datetime.datetime(2015, 1, 1, 13, 0)
         if settings.USE_TZ:
             last_quarter_2014 = timezone.make_aware(last_quarter_2014)
             first_quarter_2015 = timezone.make_aware(first_quarter_2015)
@@ -691,13 +690,13 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_week_func_boundaries(self):
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             end_datetime = timezone.make_aware(end_datetime)
 
-        week_52_day_2014 = datetime(2014, 12, 27, 13, 0)  # Sunday
-        week_1_day_2014_2015 = datetime(2014, 12, 31, 13, 0)  # Wednesday
-        week_53_day_2015 = datetime(2015, 12, 31, 13, 0)  # Thursday
+        week_52_day_2014 = datetime.datetime(2014, 12, 27, 13, 0)  # Sunday
+        week_1_day_2014_2015 = datetime.datetime(2014, 12, 31, 13, 0)  # Wednesday
+        week_53_day_2015 = datetime.datetime(2015, 12, 31, 13, 0)  # Thursday
         if settings.USE_TZ:
             week_1_day_2014_2015 = timezone.make_aware(week_1_day_2014_2015)
             week_52_day_2014 = timezone.make_aware(week_52_day_2014)
@@ -725,8 +724,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_weekday_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -760,8 +759,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_iso_weekday_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -795,8 +794,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_hour_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -824,8 +823,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_minute_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -859,8 +858,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_second_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -894,8 +893,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_extract_second_func_no_fractional(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 30, 50, 783)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 30, 50, 783)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -910,8 +909,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_trunc_lookup_name_sql_injection(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -931,8 +930,8 @@ class DateFunctionTests(TestCase):
             self.assertIs(exists, False)
 
     def test_trunc_func(self):
-        start_datetime = datetime(999, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(999, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -1045,14 +1044,14 @@ class DateFunctionTests(TestCase):
 
     def test_trunc_week(self):
         self._test_trunc_week(
-            start_datetime=datetime(2015, 6, 15, 14, 30, 50, 321),
-            end_datetime=datetime(2016, 6, 15, 14, 10, 50, 123),
+            start_datetime=datetime.datetime(2015, 6, 15, 14, 30, 50, 321),
+            end_datetime=datetime.datetime(2016, 6, 15, 14, 10, 50, 123),
         )
 
     def test_trunc_week_before_1000(self):
         self._test_trunc_week(
-            start_datetime=datetime(999, 6, 15, 14, 30, 50, 321),
-            end_datetime=datetime(2016, 6, 15, 14, 10, 50, 123),
+            start_datetime=datetime.datetime(999, 6, 15, 14, 30, 50, 321),
+            end_datetime=datetime.datetime(2016, 6, 15, 14, 10, 50, 123),
         )
 
     def test_trunc_invalid_arguments(self):
@@ -1108,8 +1107,10 @@ class DateFunctionTests(TestCase):
                 )
 
     def test_trunc_year_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), "year")
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = truncate_to(
+            datetime.datetime(2016, 6, 15, 14, 10, 50, 123), "year"
+        )
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -1155,13 +1156,15 @@ class DateFunctionTests(TestCase):
             )
 
     def test_trunc_quarter_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = truncate_to(datetime(2016, 10, 15, 14, 10, 50, 123), "quarter")
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = truncate_to(
+            datetime.datetime(2016, 10, 15, 14, 10, 50, 123), "quarter"
+        )
         last_quarter_2015 = truncate_to(
-            datetime(2015, 12, 31, 14, 10, 50, 123), "quarter"
+            datetime.datetime(2015, 12, 31, 14, 10, 50, 123), "quarter"
         )
         first_quarter_2016 = truncate_to(
-            datetime(2016, 1, 1, 14, 10, 50, 123), "quarter"
+            datetime.datetime(2016, 1, 1, 14, 10, 50, 123), "quarter"
         )
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
@@ -1212,8 +1215,10 @@ class DateFunctionTests(TestCase):
             )
 
     def test_trunc_month_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), "month")
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = truncate_to(
+            datetime.datetime(2016, 6, 15, 14, 10, 50, 123), "month"
+        )
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -1259,8 +1264,10 @@ class DateFunctionTests(TestCase):
             )
 
     def test_trunc_week_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), "week")
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = truncate_to(
+            datetime.datetime(2016, 6, 15, 14, 10, 50, 123), "week"
+        )
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -1296,8 +1303,8 @@ class DateFunctionTests(TestCase):
             )
 
     def test_trunc_date_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -1343,8 +1350,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_trunc_time_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -1390,8 +1397,8 @@ class DateFunctionTests(TestCase):
         )
 
     def test_trunc_time_comparison(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 26)  # 0 microseconds.
-        end_datetime = datetime(2015, 6, 15, 14, 30, 26, 321)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 26)  # 0 microseconds.
+        end_datetime = datetime.datetime(2015, 6, 15, 14, 30, 26, 321)
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -1417,8 +1424,10 @@ class DateFunctionTests(TestCase):
         )
 
     def test_trunc_day_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), "day")
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = truncate_to(
+            datetime.datetime(2016, 6, 15, 14, 10, 50, 123), "day"
+        )
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -1453,8 +1462,10 @@ class DateFunctionTests(TestCase):
             )
 
     def test_trunc_hour_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), "hour")
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = truncate_to(
+            datetime.datetime(2016, 6, 15, 14, 10, 50, 123), "hour"
+        )
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -1500,8 +1511,10 @@ class DateFunctionTests(TestCase):
             )
 
     def test_trunc_minute_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), "minute")
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = truncate_to(
+            datetime.datetime(2016, 6, 15, 14, 10, 50, 123), "minute"
+        )
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -1549,8 +1562,10 @@ class DateFunctionTests(TestCase):
             )
 
     def test_trunc_second_func(self):
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = truncate_to(datetime(2016, 6, 15, 14, 10, 50, 123), "second")
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = truncate_to(
+            datetime.datetime(2016, 6, 15, 14, 10, 50, 123), "second"
+        )
         if settings.USE_TZ:
             start_datetime = timezone.make_aware(start_datetime)
             end_datetime = timezone.make_aware(end_datetime)
@@ -1600,9 +1615,9 @@ class DateFunctionTests(TestCase):
     def test_trunc_subquery_with_parameters(self):
         author_1 = Author.objects.create(name="J. R. R. Tolkien")
         author_2 = Author.objects.create(name="G. R. R. Martin")
-        fan_since_1 = datetime(2016, 2, 3, 15, 0, 0)
-        fan_since_2 = datetime(2015, 2, 3, 15, 0, 0)
-        fan_since_3 = datetime(2017, 2, 3, 15, 0, 0)
+        fan_since_1 = datetime.datetime(2016, 2, 3, 15, 0, 0)
+        fan_since_2 = datetime.datetime(2015, 2, 3, 15, 0, 0)
+        fan_since_3 = datetime.datetime(2017, 2, 3, 15, 0, 0)
         if settings.USE_TZ:
             fan_since_1 = timezone.make_aware(fan_since_1)
             fan_since_2 = timezone.make_aware(fan_since_2)
@@ -1622,25 +1637,25 @@ class DateFunctionTests(TestCase):
         outer = Author.objects.annotate(
             newest_fan_year=TruncYear(Subquery(inner, output_field=DateTimeField()))
         )
-        tz = datetime_timezone.utc if settings.USE_TZ else None
+        tz = datetime.UTC if settings.USE_TZ else None
         self.assertSequenceEqual(
             outer.order_by("name").values("name", "newest_fan_year"),
             [
                 {
                     "name": "G. R. R. Martin",
-                    "newest_fan_year": datetime(2017, 1, 1, 0, 0, tzinfo=tz),
+                    "newest_fan_year": datetime.datetime(2017, 1, 1, 0, 0, tzinfo=tz),
                 },
                 {
                     "name": "J. R. R. Tolkien",
-                    "newest_fan_year": datetime(2016, 1, 1, 0, 0, tzinfo=tz),
+                    "newest_fan_year": datetime.datetime(2016, 1, 1, 0, 0, tzinfo=tz),
                 },
             ],
         )
 
     def test_extract_outerref(self):
-        datetime_1 = datetime(2000, 1, 1)
-        datetime_2 = datetime(2001, 3, 5)
-        datetime_3 = datetime(2002, 1, 3)
+        datetime_1 = datetime.datetime(2000, 1, 1)
+        datetime_2 = datetime.datetime(2001, 3, 5)
+        datetime_3 = datetime.datetime(2002, 1, 3)
         if settings.USE_TZ:
             datetime_1 = timezone.make_aware(datetime_1)
             datetime_2 = timezone.make_aware(datetime_2)
@@ -1669,13 +1684,13 @@ class DateFunctionTests(TestCase):
 @override_settings(USE_TZ=True, TIME_ZONE="UTC")
 class DateFunctionWithTimeZoneTests(DateFunctionTests):
     def test_extract_func_with_timezone(self):
-        start_datetime = datetime(2015, 6, 15, 23, 30, 1, 321)
-        end_datetime = datetime(2015, 6, 16, 13, 11, 27, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 23, 30, 1, 321)
+        end_datetime = datetime.datetime(2015, 6, 16, 13, 11, 27, 123)
         start_datetime = timezone.make_aware(start_datetime)
         end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
-        delta_tzinfo_pos = datetime_timezone(timedelta(hours=5))
-        delta_tzinfo_neg = datetime_timezone(timedelta(hours=-5, minutes=17))
+        delta_tzinfo_pos = datetime.timezone(datetime.timedelta(hours=5))
+        delta_tzinfo_neg = datetime.timezone(datetime.timedelta(hours=-5, minutes=17))
         melb = zoneinfo.ZoneInfo("Australia/Melbourne")
 
         qs = DTModel.objects.annotate(
@@ -1729,8 +1744,8 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
         self.assertEqual(melb_model.hour_melb, 9)
 
     def test_extract_func_with_timezone_minus_no_offset(self):
-        start_datetime = datetime(2015, 6, 15, 23, 30, 1, 321)
-        end_datetime = datetime(2015, 6, 16, 13, 11, 27, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 23, 30, 1, 321)
+        end_datetime = datetime.datetime(2015, 6, 16, 13, 11, 27, 123)
         start_datetime = timezone.make_aware(start_datetime)
         end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
@@ -1752,8 +1767,8 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
         self.assertEqual(ust_nera_model.hour_tz, 9)
 
     def test_extract_func_explicit_timezone_priority(self):
-        start_datetime = datetime(2015, 6, 15, 23, 30, 1, 321)
-        end_datetime = datetime(2015, 6, 16, 13, 11, 27, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 23, 30, 1, 321)
+        end_datetime = datetime.datetime(2015, 6, 16, 13, 11, 27, 123)
         start_datetime = timezone.make_aware(start_datetime)
         end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
@@ -1762,9 +1777,7 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
             model = (
                 DTModel.objects.annotate(
                     day_melb=Extract("start_datetime", "day"),
-                    day_utc=Extract(
-                        "start_datetime", "day", tzinfo=datetime_timezone.utc
-                    ),
+                    day_utc=Extract("start_datetime", "day", tzinfo=datetime.UTC),
                 )
                 .order_by("start_datetime")
                 .get()
@@ -1785,8 +1798,8 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
             ).get()
 
     def test_trunc_timezone_applied_before_truncation(self):
-        start_datetime = datetime(2016, 1, 1, 1, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2016, 1, 1, 1, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         start_datetime = timezone.make_aware(start_datetime)
         end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)
@@ -1826,8 +1839,8 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
         If the truncated datetime transitions to a different offset (daylight
         saving) then the returned value will have that new timezone/offset.
         """
-        start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)
-        end_datetime = datetime(2016, 6, 15, 14, 10, 50, 123)
+        start_datetime = datetime.datetime(2015, 6, 15, 14, 30, 50, 321)
+        end_datetime = datetime.datetime(2016, 6, 15, 14, 10, 50, 123)
         start_datetime = timezone.make_aware(start_datetime)
         end_datetime = timezone.make_aware(end_datetime)
         self.create_model(start_datetime, end_datetime)

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import shutil
 import sys
@@ -5,8 +6,6 @@ import tempfile
 import threading
 import time
 import unittest
-from datetime import datetime, timedelta
-from datetime import timezone as datetime_timezone
 from io import StringIO
 from pathlib import Path
 from urllib.request import urlopen
@@ -114,7 +113,7 @@ class FileStorageTests(SimpleTestCase):
         # is UTC+1 and has no DST change. We can set the Django TZ to something
         # else so that UTC, Django's TIME_ZONE, and the system timezone are all
         # different.
-        now_in_algiers = timezone.make_aware(datetime.now())
+        now_in_algiers = timezone.make_aware(datetime.datetime.now())
 
         with timezone.override(timezone.get_fixed_timezone(-300)):
             # At this point the system TZ is +1 and the Django TZ
@@ -131,15 +130,15 @@ class FileStorageTests(SimpleTestCase):
             self.assertEqual(now.tzname(), dt.tzname())
 
             # The three timezones are indeed distinct.
-            naive_now = datetime.now()
+            naive_now = datetime.datetime.now()
             algiers_offset = now_in_algiers.tzinfo.utcoffset(naive_now)
             django_offset = timezone.get_current_timezone().utcoffset(naive_now)
-            utc_offset = datetime_timezone.utc.utcoffset(naive_now)
+            utc_offset = datetime.UTC.utcoffset(naive_now)
             self.assertGreater(algiers_offset, utc_offset)
             self.assertLess(django_offset, utc_offset)
 
             # dt and now should be the same effective time.
-            self.assertLess(abs(dt - now), timedelta(seconds=2))
+            self.assertLess(abs(dt - now), datetime.timedelta(seconds=2))
 
     @override_settings(USE_TZ=False, TIME_ZONE="Africa/Algiers")
     def _test_file_time_getter_tz_handling_off(self, getter):
@@ -147,7 +146,7 @@ class FileStorageTests(SimpleTestCase):
         # is UTC+1 and has no DST change. We can set the Django TZ to something
         # else so that UTC, Django's TIME_ZONE, and the system timezone are all
         # different.
-        now_in_algiers = timezone.make_aware(datetime.now())
+        now_in_algiers = timezone.make_aware(datetime.datetime.now())
 
         with timezone.override(timezone.get_fixed_timezone(-300)):
             # At this point the system TZ is +1 and the Django TZ
@@ -162,20 +161,20 @@ class FileStorageTests(SimpleTestCase):
             self.assertTrue(timezone.is_naive(dt))
 
             # The three timezones are indeed distinct.
-            naive_now = datetime.now()
+            naive_now = datetime.datetime.now()
             algiers_offset = now_in_algiers.tzinfo.utcoffset(naive_now)
             django_offset = timezone.get_current_timezone().utcoffset(naive_now)
-            utc_offset = datetime_timezone.utc.utcoffset(naive_now)
+            utc_offset = datetime.UTC.utcoffset(naive_now)
             self.assertGreater(algiers_offset, utc_offset)
             self.assertLess(django_offset, utc_offset)
 
             # dt and naive_now should be the same effective time.
-            self.assertLess(abs(dt - naive_now), timedelta(seconds=2))
+            self.assertLess(abs(dt - naive_now), datetime.timedelta(seconds=2))
             # If we convert dt to an aware object using the Algiers
             # timezone then it should be the same effective time to
             # now_in_algiers.
             _dt = timezone.make_aware(dt, now_in_algiers.tzinfo)
-            self.assertLess(abs(_dt - now_in_algiers), timedelta(seconds=2))
+            self.assertLess(abs(_dt - now_in_algiers), datetime.timedelta(seconds=2))
 
     def test_file_get_accessed_time(self):
         """
@@ -190,11 +189,14 @@ class FileStorageTests(SimpleTestCase):
         atime = self.storage.get_accessed_time(f_name)
 
         self.assertEqual(
-            atime, datetime.fromtimestamp(os.path.getatime(self.storage.path(f_name)))
+            atime,
+            datetime.datetime.fromtimestamp(
+                os.path.getatime(self.storage.path(f_name))
+            ),
         )
         self.assertLess(
             timezone.now() - self.storage.get_accessed_time(f_name),
-            timedelta(seconds=2),
+            datetime.timedelta(seconds=2),
         )
 
     @requires_tz_support
@@ -213,10 +215,14 @@ class FileStorageTests(SimpleTestCase):
         ctime = self.storage.get_created_time(f_name)
 
         self.assertEqual(
-            ctime, datetime.fromtimestamp(os.path.getctime(self.storage.path(f_name)))
+            ctime,
+            datetime.datetime.fromtimestamp(
+                os.path.getctime(self.storage.path(f_name))
+            ),
         )
         self.assertLess(
-            timezone.now() - self.storage.get_created_time(f_name), timedelta(seconds=2)
+            timezone.now() - self.storage.get_created_time(f_name),
+            datetime.timedelta(seconds=2),
         )
 
     @requires_tz_support
@@ -235,11 +241,14 @@ class FileStorageTests(SimpleTestCase):
         mtime = self.storage.get_modified_time(f_name)
 
         self.assertEqual(
-            mtime, datetime.fromtimestamp(os.path.getmtime(self.storage.path(f_name)))
+            mtime,
+            datetime.datetime.fromtimestamp(
+                os.path.getmtime(self.storage.path(f_name))
+            ),
         )
         self.assertLess(
             timezone.now() - self.storage.get_modified_time(f_name),
-            timedelta(seconds=2),
+            datetime.timedelta(seconds=2),
         )
 
     @requires_tz_support

--- a/tests/foreign_object/tests.py
+++ b/tests/foreign_object/tests.py
@@ -119,7 +119,7 @@ class MultiColumnFKTests(TestCase):
         )
 
     def test_reverse_query_filters_correctly(self):
-        timemark = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
+        timemark = datetime.datetime.now(tz=datetime.UTC).replace(tzinfo=None)
         timedelta = datetime.timedelta(days=1)
 
         # Creating a to valid memberships

--- a/tests/forms_tests/field_tests/test_datetimefield.py
+++ b/tests/forms_tests/field_tests/test_datetimefield.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 
 from django.core.exceptions import ValidationError
 from django.forms import DateTimeField
@@ -40,7 +40,7 @@ class DateTimeFieldTest(SimpleTestCase):
             ("2014-09-23T22:34:41", datetime(2014, 9, 23, 22, 34, 41)),
             ("2014-09-23T22:34", datetime(2014, 9, 23, 22, 34)),
             ("2014-09-23", datetime(2014, 9, 23, 0, 0)),
-            ("2014-09-23T22:34Z", datetime(2014, 9, 23, 22, 34, tzinfo=timezone.utc)),
+            ("2014-09-23T22:34Z", datetime(2014, 9, 23, 22, 34, tzinfo=UTC)),
             (
                 "2014-09-23T22:34+07:00",
                 datetime(2014, 9, 23, 22, 34, tzinfo=get_fixed_timezone(420)),
@@ -57,7 +57,7 @@ class DateTimeFieldTest(SimpleTestCase):
                 " 2014-09-23T22:34:41.614804 ",
                 datetime(2014, 9, 23, 22, 34, 41, 614804),
             ),
-            (" 2014-09-23T22:34Z ", datetime(2014, 9, 23, 22, 34, tzinfo=timezone.utc)),
+            (" 2014-09-23T22:34Z ", datetime(2014, 9, 23, 22, 34, tzinfo=UTC)),
         ]
         f = DateTimeField()
         for value, expected_datetime in tests:

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -156,9 +156,7 @@ class ArchiveIndexViewTests(TestDataMixin, TestCase):
     @override_settings(USE_TZ=True, TIME_ZONE="Africa/Nairobi")
     def test_aware_datetime_archive_view(self):
         BookSigning.objects.create(
-            event_date=datetime.datetime(
-                2008, 4, 2, 12, 0, tzinfo=datetime.timezone.utc
-            )
+            event_date=datetime.datetime(2008, 4, 2, 12, 0, tzinfo=datetime.UTC)
         )
         res = self.client.get("/dates/booksignings/")
         self.assertEqual(res.status_code, 200)
@@ -345,9 +343,7 @@ class YearArchiveViewTests(TestDataMixin, TestCase):
     @override_settings(USE_TZ=True, TIME_ZONE="Africa/Nairobi")
     def test_aware_datetime_year_view(self):
         BookSigning.objects.create(
-            event_date=datetime.datetime(
-                2008, 4, 2, 12, 0, tzinfo=datetime.timezone.utc
-            )
+            event_date=datetime.datetime(2008, 4, 2, 12, 0, tzinfo=datetime.UTC)
         )
         res = self.client.get("/dates/booksignings/2008/")
         self.assertEqual(res.status_code, 200)
@@ -520,19 +516,13 @@ class MonthArchiveViewTests(TestDataMixin, TestCase):
     @override_settings(USE_TZ=True, TIME_ZONE="Africa/Nairobi")
     def test_aware_datetime_month_view(self):
         BookSigning.objects.create(
-            event_date=datetime.datetime(
-                2008, 2, 1, 12, 0, tzinfo=datetime.timezone.utc
-            )
+            event_date=datetime.datetime(2008, 2, 1, 12, 0, tzinfo=datetime.UTC)
         )
         BookSigning.objects.create(
-            event_date=datetime.datetime(
-                2008, 4, 2, 12, 0, tzinfo=datetime.timezone.utc
-            )
+            event_date=datetime.datetime(2008, 4, 2, 12, 0, tzinfo=datetime.UTC)
         )
         BookSigning.objects.create(
-            event_date=datetime.datetime(
-                2008, 6, 3, 12, 0, tzinfo=datetime.timezone.utc
-            )
+            event_date=datetime.datetime(2008, 6, 3, 12, 0, tzinfo=datetime.UTC)
         )
         res = self.client.get("/dates/booksignings/2008/apr/")
         self.assertEqual(res.status_code, 200)
@@ -673,9 +663,7 @@ class WeekArchiveViewTests(TestDataMixin, TestCase):
     @override_settings(USE_TZ=True, TIME_ZONE="Africa/Nairobi")
     def test_aware_datetime_week_view(self):
         BookSigning.objects.create(
-            event_date=datetime.datetime(
-                2008, 4, 2, 12, 0, tzinfo=datetime.timezone.utc
-            )
+            event_date=datetime.datetime(2008, 4, 2, 12, 0, tzinfo=datetime.UTC)
         )
         res = self.client.get("/dates/booksignings/2008/week/13/")
         self.assertEqual(res.status_code, 200)
@@ -805,25 +793,19 @@ class DayArchiveViewTests(TestDataMixin, TestCase):
     @override_settings(USE_TZ=True, TIME_ZONE="Africa/Nairobi")
     def test_aware_datetime_day_view(self):
         bs = BookSigning.objects.create(
-            event_date=datetime.datetime(
-                2008, 4, 2, 12, 0, tzinfo=datetime.timezone.utc
-            )
+            event_date=datetime.datetime(2008, 4, 2, 12, 0, tzinfo=datetime.UTC)
         )
         res = self.client.get("/dates/booksignings/2008/apr/2/")
         self.assertEqual(res.status_code, 200)
         # 2008-04-02T00:00:00+03:00 (beginning of day) >
         # 2008-04-01T22:00:00+00:00 (book signing event date).
-        bs.event_date = datetime.datetime(
-            2008, 4, 1, 22, 0, tzinfo=datetime.timezone.utc
-        )
+        bs.event_date = datetime.datetime(2008, 4, 1, 22, 0, tzinfo=datetime.UTC)
         bs.save()
         res = self.client.get("/dates/booksignings/2008/apr/2/")
         self.assertEqual(res.status_code, 200)
         # 2008-04-03T00:00:00+03:00 (end of day) > 2008-04-02T22:00:00+00:00
         # (book signing event date).
-        bs.event_date = datetime.datetime(
-            2008, 4, 2, 22, 0, tzinfo=datetime.timezone.utc
-        )
+        bs.event_date = datetime.datetime(2008, 4, 2, 22, 0, tzinfo=datetime.UTC)
         bs.save()
         res = self.client.get("/dates/booksignings/2008/apr/2/")
         self.assertEqual(res.status_code, 404)
@@ -914,25 +896,19 @@ class DateDetailViewTests(TestDataMixin, TestCase):
     @override_settings(USE_TZ=True, TIME_ZONE="Africa/Nairobi")
     def test_aware_datetime_date_detail(self):
         bs = BookSigning.objects.create(
-            event_date=datetime.datetime(
-                2008, 4, 2, 12, 0, tzinfo=datetime.timezone.utc
-            )
+            event_date=datetime.datetime(2008, 4, 2, 12, 0, tzinfo=datetime.UTC)
         )
         res = self.client.get("/dates/booksignings/2008/apr/2/%d/" % bs.pk)
         self.assertEqual(res.status_code, 200)
         # 2008-04-02T00:00:00+03:00 (beginning of day) >
         # 2008-04-01T22:00:00+00:00 (book signing event date).
-        bs.event_date = datetime.datetime(
-            2008, 4, 1, 22, 0, tzinfo=datetime.timezone.utc
-        )
+        bs.event_date = datetime.datetime(2008, 4, 1, 22, 0, tzinfo=datetime.UTC)
         bs.save()
         res = self.client.get("/dates/booksignings/2008/apr/2/%d/" % bs.pk)
         self.assertEqual(res.status_code, 200)
         # 2008-04-03T00:00:00+03:00 (end of day) > 2008-04-02T22:00:00+00:00
         # (book signing event date).
-        bs.event_date = datetime.datetime(
-            2008, 4, 2, 22, 0, tzinfo=datetime.timezone.utc
-        )
+        bs.event_date = datetime.datetime(2008, 4, 2, 22, 0, tzinfo=datetime.UTC)
         bs.save()
         res = self.client.get("/dates/booksignings/2008/apr/2/%d/" % bs.pk)
         self.assertEqual(res.status_code, 404)

--- a/tests/humanize_tests/tests.py
+++ b/tests/humanize_tests/tests.py
@@ -441,7 +441,7 @@ class HumanizeTests(SimpleTestCase):
     def test_naturalday_uses_localtime(self):
         # Regression for #18504
         # This is 2012-03-08HT19:30:00-06:00 in America/Chicago
-        dt = datetime.datetime(2012, 3, 9, 1, 30, tzinfo=datetime.timezone.utc)
+        dt = datetime.datetime(2012, 3, 9, 1, 30, tzinfo=datetime.UTC)
 
         orig_humanize_datetime, humanize.datetime = humanize.datetime, MockDateTime
         try:
@@ -478,7 +478,7 @@ class HumanizeTests(SimpleTestCase):
             now + datetime.timedelta(days=2, hours=6),
             now + datetime.timedelta(days=500),
             now.replace(tzinfo=naive()),
-            now.replace(tzinfo=datetime.timezone.utc),
+            now.replace(tzinfo=datetime.UTC),
         ]
         result_list = [
             "test",

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -644,6 +644,13 @@ class WriterTests(SimpleTestCase):
             ("datetime.datetime(2014, 1, 1, 1, 1)", {"import datetime"}),
         )
         self.assertSerializedResultEqual(
+            datetime.datetime(2012, 1, 1, 1, 1, tzinfo=datetime.UTC),
+            (
+                "datetime.datetime(2012, 1, 1, 1, 1, tzinfo=datetime.timezone.utc)",
+                {"import datetime"},
+            ),
+        )
+        self.assertSerializedResultEqual(
             datetime.datetime(2012, 1, 1, 1, 1, tzinfo=datetime.timezone.utc),
             (
                 "datetime.datetime(2012, 1, 1, 1, 1, tzinfo=datetime.timezone.utc)",
@@ -1042,7 +1049,7 @@ class WriterTests(SimpleTestCase):
                         "myfield",
                         models.DateTimeField(
                             default=datetime.datetime(
-                                2012, 1, 1, 1, 1, tzinfo=datetime.timezone.utc
+                                2012, 1, 1, 1, 1, tzinfo=datetime.UTC
                             ),
                         ),
                     ),
@@ -1066,7 +1073,7 @@ class WriterTests(SimpleTestCase):
         Test comments at top of file.
         """
         migration = type("Migration", (migrations.Migration,), {"operations": []})
-        dt = datetime.datetime(2015, 7, 31, 4, 40, 0, 0, tzinfo=datetime.timezone.utc)
+        dt = datetime.datetime(2015, 7, 31, 4, 40, 0, 0, tzinfo=datetime.UTC)
         with mock.patch("django.db.migrations.writer.now", lambda: dt):
             for include_header in (True, False):
                 with self.subTest(include_header=include_header):

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -566,8 +566,8 @@ class TestSerialization(PostgreSQLSimpleTestCase):
 
     lower_date = datetime.date(2014, 1, 1)
     upper_date = datetime.date(2014, 2, 2)
-    lower_dt = datetime.datetime(2014, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    upper_dt = datetime.datetime(2014, 2, 2, 12, 12, 12, tzinfo=datetime.timezone.utc)
+    lower_dt = datetime.datetime(2014, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
+    upper_dt = datetime.datetime(2014, 2, 2, 12, 12, 12, tzinfo=datetime.UTC)
 
     def test_dumping(self):
         instance = RangesModel(
@@ -992,7 +992,7 @@ class TestFormField(PostgreSQLSimpleTestCase):
         field = pg_forms.DateTimeRangeField()
         value = field.prepare_value(
             DateTimeTZRange(
-                datetime.datetime(2015, 5, 22, 16, 6, 33, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2015, 5, 22, 16, 6, 33, tzinfo=datetime.UTC),
                 None,
             )
         )

--- a/tests/responses/test_cookie.py
+++ b/tests/responses/test_cookie.py
@@ -1,5 +1,5 @@
 import time
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from email.utils import format_datetime as format_datetime_rfc5322
 from http import cookies
 
@@ -18,9 +18,7 @@ class SetCookieTests(SimpleTestCase):
         # evaluated expiration time and the time evaluated in set_cookie(). If
         # this difference doesn't exist, the cookie time will be 1 second
         # larger. The sleep guarantees that there will be a time difference.
-        expires = datetime.now(tz=timezone.utc).replace(tzinfo=None) + timedelta(
-            seconds=10
-        )
+        expires = datetime.now(tz=UTC).replace(tzinfo=None) + timedelta(seconds=10)
         time.sleep(0.001)
         response.set_cookie("datetime", expires=expires)
         datetime_cookie = response.cookies["datetime"]
@@ -29,7 +27,7 @@ class SetCookieTests(SimpleTestCase):
     def test_aware_expiration(self):
         """set_cookie() accepts an aware datetime as expiration time."""
         response = HttpResponse()
-        expires = datetime.now(tz=timezone.utc) + timedelta(seconds=10)
+        expires = datetime.now(tz=UTC) + timedelta(seconds=10)
         time.sleep(0.001)
         response.set_cookie("datetime", expires=expires)
         datetime_cookie = response.cookies["datetime"]
@@ -50,9 +48,7 @@ class SetCookieTests(SimpleTestCase):
     def test_far_expiration(self):
         """Cookie will expire when a distant expiration time is provided."""
         response = HttpResponse()
-        future_datetime = datetime(
-            date.today().year + 2, 1, 1, 4, 5, 6, tzinfo=timezone.utc
-        )
+        future_datetime = datetime(date.today().year + 2, 1, 1, 4, 5, 6, tzinfo=UTC)
         response.set_cookie("datetime", expires=future_datetime)
         datetime_cookie = response.cookies["datetime"]
         self.assertIn(

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -2428,7 +2428,7 @@ class SchemaTests(TransactionTestCase):
             data = JSONField(
                 encoder=DjangoJSONEncoder,
                 db_default={
-                    "epoch": datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+                    "epoch": datetime.datetime(1970, 1, 1, tzinfo=datetime.UTC)
                 },
             )
 
@@ -5315,7 +5315,7 @@ class SchemaTests(TransactionTestCase):
         """
         now = datetime.datetime(month=1, day=1, year=2000, hour=1, minute=1)
         now_tz = datetime.datetime(
-            month=1, day=1, year=2000, hour=1, minute=1, tzinfo=datetime.timezone.utc
+            month=1, day=1, year=2000, hour=1, minute=1, tzinfo=datetime.UTC
         )
         mocked_datetime.now = mock.MagicMock(return_value=now)
         mocked_tz.now = mock.MagicMock(return_value=now_tz)

--- a/tests/staticfiles_tests/storage.py
+++ b/tests/staticfiles_tests/storage.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
@@ -22,7 +22,7 @@ class DummyStorage(storage.Storage):
         pass
 
     def get_modified_time(self, name):
-        return datetime(1970, 1, 1, tzinfo=timezone.utc)
+        return datetime(1970, 1, 1, tzinfo=UTC)
 
 
 class PathNotImplementedStorage(storage.Storage):

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -568,7 +568,7 @@ class TestCollectionNonLocalStorage(TestNoFilesCreated, CollectionTestCase):
         storage = DummyStorage()
         self.assertEqual(
             storage.get_modified_time("name"),
-            datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc),
+            datetime.datetime(1970, 1, 1, tzinfo=datetime.UTC),
         )
         with self.assertRaisesMessage(
             NotImplementedError, "This backend doesn't support absolute paths."

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -65,7 +65,7 @@ except ImportError:
 # datetime.datetime(2011, 9, 1, 13, 20, 30), which translates to
 # 10:20:30 in UTC and 17:20:30 in ICT.
 
-UTC = datetime.timezone.utc
+UTC = datetime.UTC
 EAT = timezone.get_fixed_timezone(180)  # Africa/Nairobi
 ICT = timezone.get_fixed_timezone(420)  # Asia/Bangkok
 
@@ -618,7 +618,7 @@ class NewDatabaseTests(TestCase):
     @skipIfDBFeature("supports_timezones")
     def test_cursor_execute_accepts_naive_datetime(self):
         dt = datetime.datetime(2011, 9, 1, 13, 20, 30, tzinfo=EAT)
-        utc_naive_dt = timezone.make_naive(dt, datetime.timezone.utc)
+        utc_naive_dt = timezone.make_naive(dt, UTC)
         with connection.cursor() as cursor:
             cursor.execute(
                 "INSERT INTO timezones_event (dt) VALUES (%s)", [utc_naive_dt]
@@ -637,7 +637,7 @@ class NewDatabaseTests(TestCase):
     @skipIfDBFeature("supports_timezones")
     def test_cursor_execute_returns_naive_datetime(self):
         dt = datetime.datetime(2011, 9, 1, 13, 20, 30, tzinfo=EAT)
-        utc_naive_dt = timezone.make_naive(dt, datetime.timezone.utc)
+        utc_naive_dt = timezone.make_naive(dt, UTC)
         Event.objects.create(dt=dt)
         with connection.cursor() as cursor:
             cursor.execute(

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, time, timezone, tzinfo
+from datetime import UTC, date, datetime, time, tzinfo
 
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import TZ_SUPPORT, requires_tz_support
@@ -63,7 +63,7 @@ class DateFormatTests(SimpleTestCase):
         )
 
     def test_epoch(self):
-        udt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        udt = datetime(1970, 1, 1, tzinfo=UTC)
         self.assertEqual(format(udt, "U"), "0")
 
     def test_empty_format(self):
@@ -208,7 +208,7 @@ class DateFormatTests(SimpleTestCase):
 
     @requires_tz_support
     def test_e_format_with_named_time_zone(self):
-        dt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        dt = datetime(1970, 1, 1, tzinfo=UTC)
         self.assertEqual(dateformat.format(dt, "e"), "UTC")
 
     @requires_tz_support

--- a/tests/utils_tests/test_feedgenerator.py
+++ b/tests/utils_tests/test_feedgenerator.py
@@ -148,7 +148,7 @@ class FeedgeneratorTests(SimpleTestCase):
                 rss_feed = feedgenerator.Rss201rev2Feed("title", "link", "description")
                 self.assertEqual(
                     rss_feed.latest_post_date().tzinfo,
-                    datetime.timezone.utc,
+                    datetime.UTC,
                 )
 
     def test_stylesheet_keeps_lazy_urls(self):

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -1,6 +1,6 @@
 import platform
 import unittest
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest import mock
 
 from django.test import SimpleTestCase
@@ -329,61 +329,61 @@ class HttpDateProcessingTests(unittest.TestCase):
     def test_parsing_rfc1123(self):
         parsed = parse_http_date("Sun, 06 Nov 1994 08:49:37 GMT")
         self.assertEqual(
-            datetime.fromtimestamp(parsed, timezone.utc),
-            datetime(1994, 11, 6, 8, 49, 37, tzinfo=timezone.utc),
+            datetime.fromtimestamp(parsed, UTC),
+            datetime(1994, 11, 6, 8, 49, 37, tzinfo=UTC),
         )
 
     @unittest.skipIf(platform.architecture()[0] == "32bit", "The Year 2038 problem.")
     @mock.patch("django.utils.http.datetime")
     def test_parsing_rfc850(self, mocked_datetime):
         mocked_datetime.side_effect = datetime
-        now_1 = datetime(2019, 11, 6, 8, 49, 37, tzinfo=timezone.utc)
-        now_2 = datetime(2020, 11, 6, 8, 49, 37, tzinfo=timezone.utc)
-        now_3 = datetime(2048, 11, 6, 8, 49, 37, tzinfo=timezone.utc)
+        now_1 = datetime(2019, 11, 6, 8, 49, 37, tzinfo=UTC)
+        now_2 = datetime(2020, 11, 6, 8, 49, 37, tzinfo=UTC)
+        now_3 = datetime(2048, 11, 6, 8, 49, 37, tzinfo=UTC)
         tests = (
             (
                 now_1,
                 "Tuesday, 31-Dec-69 08:49:37 GMT",
-                datetime(2069, 12, 31, 8, 49, 37, tzinfo=timezone.utc),
+                datetime(2069, 12, 31, 8, 49, 37, tzinfo=UTC),
             ),
             (
                 now_1,
                 "Tuesday, 10-Nov-70 08:49:37 GMT",
-                datetime(1970, 11, 10, 8, 49, 37, tzinfo=timezone.utc),
+                datetime(1970, 11, 10, 8, 49, 37, tzinfo=UTC),
             ),
             (
                 now_1,
                 "Sunday, 06-Nov-94 08:49:37 GMT",
-                datetime(1994, 11, 6, 8, 49, 37, tzinfo=timezone.utc),
+                datetime(1994, 11, 6, 8, 49, 37, tzinfo=UTC),
             ),
             (
                 now_2,
                 "Wednesday, 31-Dec-70 08:49:37 GMT",
-                datetime(2070, 12, 31, 8, 49, 37, tzinfo=timezone.utc),
+                datetime(2070, 12, 31, 8, 49, 37, tzinfo=UTC),
             ),
             (
                 now_2,
                 "Friday, 31-Dec-71 08:49:37 GMT",
-                datetime(1971, 12, 31, 8, 49, 37, tzinfo=timezone.utc),
+                datetime(1971, 12, 31, 8, 49, 37, tzinfo=UTC),
             ),
             (
                 now_3,
                 "Sunday, 31-Dec-00 08:49:37 GMT",
-                datetime(2000, 12, 31, 8, 49, 37, tzinfo=timezone.utc),
+                datetime(2000, 12, 31, 8, 49, 37, tzinfo=UTC),
             ),
             (
                 now_3,
                 "Friday, 31-Dec-99 08:49:37 GMT",
-                datetime(1999, 12, 31, 8, 49, 37, tzinfo=timezone.utc),
+                datetime(1999, 12, 31, 8, 49, 37, tzinfo=UTC),
             ),
         )
         for now, rfc850str, expected_date in tests:
             with self.subTest(rfc850str=rfc850str):
                 mocked_datetime.now.return_value = now
                 parsed = parse_http_date(rfc850str)
-                mocked_datetime.now.assert_called_once_with(tz=timezone.utc)
+                mocked_datetime.now.assert_called_once_with(tz=UTC)
                 self.assertEqual(
-                    datetime.fromtimestamp(parsed, timezone.utc),
+                    datetime.fromtimestamp(parsed, UTC),
                     expected_date,
                 )
             mocked_datetime.reset_mock()
@@ -391,8 +391,8 @@ class HttpDateProcessingTests(unittest.TestCase):
     def test_parsing_asctime(self):
         parsed = parse_http_date("Sun Nov  6 08:49:37 1994")
         self.assertEqual(
-            datetime.fromtimestamp(parsed, timezone.utc),
-            datetime(1994, 11, 6, 8, 49, 37, tzinfo=timezone.utc),
+            datetime.fromtimestamp(parsed, UTC),
+            datetime(1994, 11, 6, 8, 49, 37, tzinfo=UTC),
         )
 
     def test_parsing_asctime_nonascii_digits(self):
@@ -405,8 +405,8 @@ class HttpDateProcessingTests(unittest.TestCase):
     def test_parsing_year_less_than_70(self):
         parsed = parse_http_date("Sun Nov  6 08:49:37 0037")
         self.assertEqual(
-            datetime.fromtimestamp(parsed, timezone.utc),
-            datetime(2037, 11, 6, 8, 49, 37, tzinfo=timezone.utc),
+            datetime.fromtimestamp(parsed, UTC),
+            datetime(2037, 11, 6, 8, 49, 37, tzinfo=UTC),
         )
 
 

--- a/tests/utils_tests/test_timesince.py
+++ b/tests/utils_tests/test_timesince.py
@@ -264,7 +264,7 @@ class TimesinceTests(TestCase):
             datetime.datetime(2023, 4, 14, 1, 30, 30),
             zoneinfo.ZoneInfo(key="Asia/Kathmandu"),  # UTC+05:45
         )
-        now_utc = now_with_zoneinfo.astimezone(datetime.timezone.utc)
+        now_utc = now_with_zoneinfo.astimezone(datetime.UTC)
         tests = [
             (now_with_zoneinfo, "0\xa0minutes"),
             (now_with_zoneinfo - self.onemicrosecond, "0\xa0minutes"),

--- a/tests/utils_tests/test_timezone.py
+++ b/tests/utils_tests/test_timezone.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 PARIS_ZI = zoneinfo.ZoneInfo("Europe/Paris")
 EAT = timezone.get_fixed_timezone(180)  # Africa/Nairobi
 ICT = timezone.get_fixed_timezone(420)  # Asia/Bangkok
-UTC = datetime.timezone.utc
+UTC = datetime.UTC
 
 
 class TimezoneTests(SimpleTestCase):


### PR DESCRIPTION
[`datetime.UTC`](https://docs.python.org/3.12/library/datetime.html#datetime.UTC) was added in Python 3.11.