### PR TITLE
Added atomic note for `bulk_create`, `bulk_update`.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2418,7 +2418,7 @@ are), and returns created objects as a list, in the same order as provided:
     ...     ]
     ... )
 
-This has a number of caveats though:
+This method is atomic, i.e., all batches of creation succeed or none. This has a number of caveats though:
 
 * The model's ``save()`` method will not be called, and the ``pre_save`` and
   ``post_save`` signals will not be sent.
@@ -2495,6 +2495,7 @@ updated:
     >>> Entry.objects.bulk_update(objs, ["headline"])
     2
 
+This method is atomic, i.e., all batches of creation succeed or none.
 :meth:`.QuerySet.update` is used to save the changes, so this is more efficient
 than iterating through the list of models and calling ``save()`` on each of
 them, but it has a few caveats:


### PR DESCRIPTION
#### Branch description
As of Django 5, all bulk operations are and should be atomic. It’s better to be explicit in the docs so that the user does not have to worry.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period. (**Will be when squash & merge**)
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant docs, including release notes if applicable.