### PR TITLE
Fixed #36173 -- Stabilized identity of Concat with an explicit output_field.

### DIFF
--- a/tests/db_functions/text/test_concat.py
+++ b/tests/db_functions/text/test_concat.py
@@ -107,3 +107,17 @@ class ConcatTests(TestCase):
             ctx.captured_queries[0]["sql"].count("::text"),
             1 if connection.vendor == "postgresql" else 0,
         )
+
+    def test_equal(self):
+        self.assertEqual(
+            Concat("foo", "bar", output_field=TextField()),
+            Concat("foo", "bar", output_field=TextField()),
+        )
+        self.assertNotEqual(
+            Concat("foo", "bar", output_field=TextField()),
+            Concat("foo", "bar", output_field=CharField()),
+        )
+        self.assertNotEqual(
+            Concat("foo", "bar", output_field=TextField()),
+            Concat("bar", "foo", output_field=TextField()),
+        )

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1433,6 +1433,29 @@ class SimpleExpressionTests(SimpleTestCase):
             Expression(TestModel._meta.get_field("other_field")),
         )
 
+        class InitCaptureExpression(Expression):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+        # The identity of expressions that obscure their __init__() signature
+        # with *args and **kwargs cannot be determined when bound with
+        # different combinations or *args and **kwargs.
+        self.assertNotEqual(
+            InitCaptureExpression(IntegerField()),
+            InitCaptureExpression(output_field=IntegerField()),
+        )
+
+        # However, they should be considered equal when their bindings are
+        # equal.
+        self.assertEqual(
+            InitCaptureExpression(IntegerField()),
+            InitCaptureExpression(IntegerField()),
+        )
+        self.assertEqual(
+            InitCaptureExpression(output_field=IntegerField()),
+            InitCaptureExpression(output_field=IntegerField()),
+        )
+
     def test_hash(self):
         self.assertEqual(hash(Expression()), hash(Expression()))
         self.assertEqual(


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36173

#### Branch description

When `Expression.__init__` overrides make use of `*args`, `**kwargs` captures their argument values are respectively bound as a `tuple` and `dict` instances. These composite values might themselves contain values that require special identity treatments such as `Concat(*expressions, output_field)` as it's a `Field` instance.

Refs ticket-30628 which introduced bound `Field` differentiation but lacked argument captures handling.

Thanks @erchenstein for the report.


