### PR TITLE
Used "django" repository in twine call in release how-to.

### DIFF
--- a/docs/internals/howto-release-django.txt
+++ b/docs/internals/howto-release-django.txt
@@ -615,7 +615,7 @@ Now you're ready to actually put the release out there. To do this:
 
    .. code-block:: shell
 
-       $ twine upload dist/*
+       $ twine upload --repository django dist/*
 
 #. Go to the `Add release page in the admin`__, enter the new release number
    exactly as it appears in the name of the tarball


### PR DESCRIPTION
It's necessary to specify a repository for `.pypirc` user configurations with multiple per-project PyPI tokens. Otherwise `twine` will always try to use the default token. 

Follow up to 26aedbbc0835df83140c7424df62bda03382f598.