### PR TITLE
Fixed #36146 -- Updated migration command to record applied/unapplied migration statuses recursively.

### DIFF
--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -254,22 +254,25 @@ class MigrationExecutor:
                 ) as schema_editor:
                     state = migration.apply(state, schema_editor)
                     if not schema_editor.deferred_sql:
-                        self.record_migration(migration)
+                        self.record_migration(migration.app_label, migration.name)
                         migration_recorded = True
         if not migration_recorded:
-            self.record_migration(migration)
+            self.record_migration(migration.app_label, migration.name)
         # Report progress
         if self.progress_callback:
             self.progress_callback("apply_success", migration, fake)
         return state
 
-    def record_migration(self, migration):
+    def record_migration(self, app_label, name, forward=True):
+        migration = self.loader.disk_migrations.get((app_label, name))
         # For replacement migrations, record individual statuses
-        if migration.replaces:
-            for app_label, name in migration.replaces:
-                self.recorder.record_applied(app_label, name)
+        if migration and migration.replaces:
+            for replaced_app_label, replaced_name in migration.replaces:
+                self.record_migration(replaced_app_label, replaced_name, forward)
+        if forward:
+            self.recorder.record_applied(app_label, name)
         else:
-            self.recorder.record_applied(migration.app_label, migration.name)
+            self.recorder.record_unapplied(app_label, name)
 
     def unapply_migration(self, state, migration, fake=False):
         """Run a migration backwards."""
@@ -280,11 +283,7 @@ class MigrationExecutor:
                 atomic=migration.atomic
             ) as schema_editor:
                 state = migration.unapply(state, schema_editor)
-        # For replacement migrations, also record individual statuses.
-        if migration.replaces:
-            for app_label, name in migration.replaces:
-                self.recorder.record_unapplied(app_label, name)
-        self.recorder.record_unapplied(migration.app_label, migration.name)
+        self.record_migration(migration.app_label, migration.name, forward=False)
         # Report progress
         if self.progress_callback:
             self.progress_callback("unapply_success", migration, fake)

--- a/tests/migrations/test_migrations_double_squashed/0001_initial.py
+++ b/tests/migrations/test_migrations_double_squashed/0001_initial.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    operations = [
+        migrations.CreateModel(
+            name="A",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("foo", models.BooleanField()),
+            ],
+        ),
+    ]

--- a/tests/migrations/test_migrations_double_squashed/0002_auto.py
+++ b/tests/migrations/test_migrations_double_squashed/0002_auto.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("migrations", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="a",
+            name="foo",
+            field=models.BooleanField(default=True),
+        ),
+    ]

--- a/tests/migrations/test_migrations_double_squashed/0003_squashed_0001_and_0002.py
+++ b/tests/migrations/test_migrations_double_squashed/0003_squashed_0001_and_0002.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    replaces = [("migrations", "0001_initial"), ("migrations", "0002_auto")]
+
+    operations = [
+        migrations.CreateModel(
+            name="A",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("foo", models.BooleanField(default=True)),
+            ],
+        ),
+    ]

--- a/tests/migrations/test_migrations_double_squashed/0004_auto.py
+++ b/tests/migrations/test_migrations_double_squashed/0004_auto.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("migrations", "0002_auto"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="a",
+            name="foo",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/tests/migrations/test_migrations_double_squashed/0005_squashed_0003_and_0004.py
+++ b/tests/migrations/test_migrations_double_squashed/0005_squashed_0003_and_0004.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    replaces = [
+        ("migrations", "0003_squashed_0001_and_0002"),
+        ("migrations", "0004_auto"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="A",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("foo", models.BooleanField(default=False)),
+            ],
+        ),
+    ]


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36146

#### Branch description
Since #19082, we allow double squashing of db migrations. However when we apply double-replacing migrations, we record as applied/unapplied only the double-replacing migration and the first level replaced migrations. If a migration is double-replaced, then it won't be recorded.
This PR makes sure that applied/unapplied status is recorded recursively.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
