### PR TITLE
Add "return self" for HttpResponseBase.set_cookie()

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -274,7 +274,8 @@ class HttpResponseBase:
             if samesite.lower() not in ("lax", "none", "strict"):
                 raise ValueError('samesite must be "lax", "none", or "strict".')
             self.cookies[key]["samesite"] = samesite
-
+        return self
+    
     def setdefault(self, key, value):
         """Set a header unless it has already been set."""
         self.headers.setdefault(key, value)


### PR DESCRIPTION
Add "return self" for HttpResponseBase.set_cookie()

#### Trac ticket number
N/A

#### Branch description
Add "return self" to allow chained code. Ex:

```python
# Before
def my_redirect(url, cookie_to_delete) -> HttpResponseRedirect:
    redirect = redirect(url)
    redirect.delete_cookie(cookie_to_delete)
    return resposta

# After
def my_redirect(url, cookie_to_delete) -> HttpResponseRedirect:
    return redirect(url).delete_cookie(cookie_to_delete)
```

