### PR TITLE
Fixed #36186 -- Added forloop.length variable within a template for loop.

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -206,7 +206,10 @@ class ForNode(Node):
             unpack = num_loopvars > 1
             # Create a forloop value in the context.  We'll update counters on each
             # iteration just below.
-            loop_dict = context["forloop"] = {"parentloop": parentloop}
+            loop_dict = context["forloop"] = {
+                "parentloop": parentloop,
+                "length": len_values,
+            }
             for i, item in enumerate(values):
                 # Shortcuts for current loop iteration number.
                 loop_dict["counter0"] = i

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -423,9 +423,14 @@ Variable                    Description
                             loop (0-indexed)
 ``forloop.first``           True if this is the first time through the loop
 ``forloop.last``            True if this is the last time through the loop
+``forloop.length``          The length of the loop
 ``forloop.parentloop``      For nested loops, this is the loop surrounding
                             the current one
 ==========================  ===============================================
+
+.. versionchanged:: 6.0
+
+    The variable ``forloop.length`` was added.
 
 ``for`` ... ``empty``
 ---------------------

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -203,7 +203,8 @@ Signals
 Templates
 ~~~~~~~~~
 
-* ...
+* The new variable ``forloop.length`` is now available within a :ttag:`for`
+  loop.
 
 Tests
 ~~~~~

--- a/tests/template_tests/syntax_tests/test_for.py
+++ b/tests/template_tests/syntax_tests/test_for.py
@@ -356,6 +356,25 @@ class ForTagTests(SimpleTestCase):
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             self.engine.render_to_string("invalid_for_loop", {"items": (1, 2)})
 
+    @setup(
+        {
+            "forloop-length": "{% for val in values %}{{ forloop.length }}{% endfor %}",
+            "forloop-length-reversed": "{% for val in values reversed %}"
+            "{{ forloop.length }}{% endfor %}",
+        }
+    )
+    def test_forloop_length(self):
+        cases = [
+            ([1, 2, 3], "333"),
+            ([1, 2, 3, 4, 5, 6], "666666"),
+            ([], ""),
+        ]
+        for values, expected_output in cases:
+            for template in ["forloop-length", "forloop-length-reversed"]:
+                with self.subTest(expected_output=expected_output, template=template):
+                    output = self.engine.render_to_string(template, {"values": values})
+                    self.assertEqual(output, expected_output)
+
 
 class ForNodeTests(SimpleTestCase):
     def test_repr(self):


### PR DESCRIPTION
#### Trac ticket number

ticket-36186

#### Branch description
Make the total amount of iterations in a for inside the the template accessible via `forloop.total`.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
