### PR TITLE
Fixed #36191 -- Added O_TRUNC flag when overwriting files in FileSystemStorage.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -369,6 +369,7 @@ answer newbie questions, and generally made Django that much better:
     Fraser Nevett <mail@nevett.org>
     Gabriel Grant <g@briel.ca>
     Gabriel Hurley <gabriel@strikeawe.com>
+    Gaël Utard
     gandalf@owca.info
     Garry Lawrence
     Garry Polley <garrympolley@gmail.com>

--- a/django/core/files/storage/filesystem.py
+++ b/django/core/files/storage/filesystem.py
@@ -113,7 +113,7 @@ class FileSystemStorage(Storage, StorageSettingsMixin):
                         | getattr(os, "O_BINARY", 0)
                     )
                     if self._allow_overwrite:
-                        open_flags = open_flags & ~os.O_EXCL
+                        open_flags = open_flags & ~os.O_EXCL | os.O_TRUNC
                     fd = os.open(full_path, open_flags, 0o666)
                     _file = None
                     try:

--- a/docs/releases/5.1.7.txt
+++ b/docs/releases/5.1.7.txt
@@ -12,3 +12,5 @@ Bugfixes
 * Fixed a bug in Django 5.1 where the ``{% querystring %}`` template tag
   returned an empty string rather than ``"?"`` when all parameters had been
   removed from the query string (:ticket:`36182`).
+* Fixed a bug in Django 5.1 where the ``FileSystemStorage`` does not truncate
+  old file when overwriting (:ticket:`36191`).

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -616,8 +616,9 @@ class OverwritingStorageTests(FileStorageTests):
         """Saving to same file name twice overwrites the first file."""
         name = "test.file"
         self.assertFalse(self.storage.exists(name))
-        content_1 = b"content one"
-        content_2 = b"second content"
+        content_1 = b"big first content"
+        content_2 = b"smaller content"
+        assert len(content_1) > len(content_2), "Ensure truncation is tested."
         f_1 = ContentFile(content_1)
         f_2 = ContentFile(content_2)
         stored_name_1 = self.storage.save(name, f_1)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36191

#### Branch description
The new allow_overwrite parameter of FileSystemStorage class allows to overwrite an existing file. However, the previous file is not truncated. So, if the previous file was bigger than the new, the file gets corrupted.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
