### PR TITLE
Fixed #36085 -- Fix sqlite jsonfield negative index

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -790,7 +790,6 @@ class BaseDatabaseOperations:
         # Hook for backends (e.g. NoSQL) to customize formatting.
         return sqlparse.format(sql, reindent=True, keyword_case="upper")
     
-
     def compile_json_path(self, key_transforms, include_root=True):
         """Default JSON path constructor (used for non-SQLite databases)."""
         path = ["$"] if include_root else []

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -789,3 +789,17 @@ class BaseDatabaseOperations:
     def format_debug_sql(self, sql):
         # Hook for backends (e.g. NoSQL) to customize formatting.
         return sqlparse.format(sql, reindent=True, keyword_case="upper")
+    
+
+    def compile_json_path(self, key_transforms, include_root=True):
+        """Default JSON path constructor (used for non-SQLite databases)."""
+        path = ["$"] if include_root else []
+        for key_transform in key_transforms:
+            try:
+                num = int(key_transform)
+            except ValueError:
+                path.append(".")
+                path.append(json.dumps(key_transform))
+            else:
+                path.append("[%s]" % num)  # Standard JSON path syntax
+        return "".join(path)

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -800,5 +800,5 @@ class BaseDatabaseOperations:
                 path.append(".")
                 path.append(json.dumps(key_transform))
             else:
-                path.append("[%s]" % num)  # Standard JSON path syntax
+                path.append("[%s]" % num)
         return "".join(path)

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -802,4 +802,3 @@ class BaseDatabaseOperations:
             else:
                 path.append("[%s]" % num)  # Standard JSON path syntax
         return "".join(path)
-        

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -789,7 +789,7 @@ class BaseDatabaseOperations:
     def format_debug_sql(self, sql):
         # Hook for backends (e.g. NoSQL) to customize formatting.
         return sqlparse.format(sql, reindent=True, keyword_case="upper")
-    
+
     def compile_json_path(self, key_transforms, include_root=True):
         """Default JSON path constructor (used for non-SQLite databases)."""
         path = ["$"] if include_root else []
@@ -802,3 +802,4 @@ class BaseDatabaseOperations:
             else:
                 path.append("[%s]" % num)  # Standard JSON path syntax
         return "".join(path)
+        

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -1,7 +1,7 @@
 import datetime
 import decimal
-import uuid
 import json
+import uuid
 from functools import lru_cache
 from itertools import chain
 
@@ -442,7 +442,7 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def force_group_by(self):
         return ["GROUP BY TRUE"] if Database.sqlite_version_info < (3, 39) else []
-    
+
     def compile_json_path(self, key_transforms, include_root=True):
         """Constructs a JSON path, handling SQLite-specific negative index syntax."""
         path = ["$"] if include_root else []
@@ -454,7 +454,7 @@ class DatabaseOperations(BaseDatabaseOperations):
                 path.append(json.dumps(key_transform))
             else:
                 if num < 0:
-                    path.append("[#%s]" % num)
+                    path.append("[#%s]" % num)  
                 else:
                     path.append("[%s]" % num)
         return "".join(path)

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 import uuid
+import json
 from functools import lru_cache
 from itertools import chain
 
@@ -453,7 +454,7 @@ class DatabaseOperations(BaseDatabaseOperations):
                 path.append(json.dumps(key_transform))
             else:
                 if num < 0:
-                    path.append("[#%s]" % num)  # SQLite requires `#` for negative indices
+                    path.append("[#%s]" % num)
                 else:
                     path.append("[%s]" % num)
         return "".join(path)

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -454,7 +454,7 @@ class DatabaseOperations(BaseDatabaseOperations):
                 path.append(json.dumps(key_transform))
             else:
                 if num < 0:
-                    path.append("[#%s]" % num)  
+                    path.append("[#%s]" % num)
                 else:
                     path.append("[%s]" % num)
         return "".join(path)

--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -373,12 +373,12 @@ class KeyTransform(Transform):
 
     def as_mysql(self, compiler, connection):
         lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-        json_path = compile_json_path(key_transforms)
+        json_path = connection.ops.compile_json_path(key_transforms)
         return "JSON_EXTRACT(%s, %%s)" % lhs, tuple(params) + (json_path,)
 
     def as_oracle(self, compiler, connection):
         lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-        json_path = compile_json_path(key_transforms)
+        json_path = connection.ops.compile_json_path(key_transforms)
         if connection.features.supports_primitives_in_json_field:
             sql = (
                 "COALESCE("
@@ -414,7 +414,7 @@ class KeyTransform(Transform):
 
     def as_sqlite(self, compiler, connection):
         lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-        json_path = compile_json_path(key_transforms)
+        json_path = connection.ops.compile_json_path(key_transforms)
         datatype_values = ",".join(
             [repr(datatype) for datatype in connection.ops.jsonfield_datatype_values]
         )
@@ -436,7 +436,7 @@ class KeyTextTransform(KeyTransform):
             return "JSON_UNQUOTE(%s)" % sql, params
         else:
             lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-            json_path = compile_json_path(key_transforms)
+            json_path = connection.ops.compile_json_path(key_transforms)
             return "(%s ->> %%s)" % lhs, tuple(params) + (json_path,)
 
     @classmethod


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

[#36085](https://code.djangoproject.com/ticket/36085)

#### Branch description
Django's `JSONField` queries for **negative array indices** are not handled correctly in **SQLite**.  

When filtering JSON arrays with negative indices, Django constructs the JSON path as `$[-2]`, but SQLite requires the special syntax `$[#-2]`.  

This causes queries like:  
`Model.objects.filter(jsonfield__-2=1)`

to raise an error:
`django.db.utils.OperationalError: bad JSON path: '$[-2]'`

**Proposed Solution**
- Move compile_json_path() to DatabaseOperations, so backends can override it.
- Implement a SQLite-specific fix that correctly formats negative indices as [#-index].
- Update references to compile_json_path() to use connection.ops.compile_json_path(), ensuring backend-specific behavior

#### Checklist
- [x] This PR targets the main branch
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period
- [x] I have checked the "Has patch" ticket flag in the Trac system
- [ ] I have added or updated relevant tests
- [ ] I have added or updated relevant docs, including release notes if applicable
- [ ] I have attached screenshots in both light and dark modes for any UI changes
