### PR TITLE
Fixed #36152 -- Deprecated use of "%" in column aliases.

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -28,6 +28,9 @@ details on these changes.
 
 * The ``URLIZE_ASSUME_HTTPS`` transitional setting will be removed.
 
+* Using a percent sign in a column alias or annotation will raise
+  ``ValueError``.
+
 * Support for setting the ``ADMINS`` or ``MANAGERS`` settings to a list of
   (name, address) tuples will be removed.
 

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -375,6 +375,8 @@ Miscellaneous
   ``per_page`` argument of :class:`django.core.paginator.Paginator` and
   :class:`django.core.paginator.AsyncPaginator` is deprecated.
 
+* Using a percent sign in a column alias or annotation is deprecated.
+
 Features removed in 6.0
 =======================
 

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -39,6 +39,7 @@ from django.db.models.functions import (
 from django.db.models.sql.query import get_field_names_from_opts
 from django.test import TestCase, skipUnlessDBFeature
 from django.test.utils import register_lookup
+from django.utils.deprecation import RemovedInDjango70Warning
 
 from .models import (
     Author,
@@ -1157,6 +1158,11 @@ class NonAggregateAnnotationTestCase(TestCase):
 
     def test_alias_sql_injection(self):
         crafted_alias = """injected_name" from "annotations_book"; --"""
+        # RemovedInDjango70Warning: When the deprecation ends, replace with:
+        # msg = (
+        #    "Column aliases cannot contain whitespace characters, quotation marks, "
+        #    "semicolons, percent signs, or SQL comments."
+        # )
         msg = (
             "Column aliases cannot contain whitespace characters, quotation marks, "
             "semicolons, or SQL comments."
@@ -1176,10 +1182,17 @@ class NonAggregateAnnotationTestCase(TestCase):
             "ali/*as",
             "alias*/",
             "alias;",
+            # RemovedInDjango70Warning: When the deprecation ends, add this case.
+            # "alias%",
             # [] are used by MSSQL.
             "alias[",
             "alias]",
         ]
+        # RemovedInDjango70Warning: When the deprecation ends, replace with:
+        # msg = (
+        #    "Column aliases cannot contain whitespace characters, quotation marks, "
+        #    "semicolons, percent signs, or SQL comments."
+        # )
         msg = (
             "Column aliases cannot contain whitespace characters, quotation marks, "
             "semicolons, or SQL comments."
@@ -1188,6 +1201,11 @@ class NonAggregateAnnotationTestCase(TestCase):
             with self.subTest(crafted_alias):
                 with self.assertRaisesMessage(ValueError, msg):
                     Book.objects.annotate(**{crafted_alias: Value(1)})
+
+    def test_alias_containing_percent_sign_deprecation(self):
+        msg = "Using percent signs in a column alias is deprecated."
+        with self.assertRaisesMessage(RemovedInDjango70Warning, msg):
+            Book.objects.annotate(**{"alias%": Value(1)})
 
     @skipUnless(connection.vendor == "postgresql", "PostgreSQL tests")
     @skipUnlessDBFeature("supports_json_field")
@@ -1476,6 +1494,11 @@ class AliasTests(TestCase):
 
     def test_alias_sql_injection(self):
         crafted_alias = """injected_name" from "annotations_book"; --"""
+        # RemovedInDjango70Warning: When the deprecation ends, replace with:
+        # msg = (
+        #    "Column aliases cannot contain whitespace characters, quotation marks, "
+        #    "semicolons, percent signs, or SQL comments."
+        # )
         msg = (
             "Column aliases cannot contain whitespace characters, quotation marks, "
             "semicolons, or SQL comments."


### PR DESCRIPTION
#### Trac ticket number
ticket-36152

#### Branch description
Unintentional support for "%" in an annotation or column alias existed only on SQLite and Oracle.

#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
