### PR TITLE
Removed advice to propose a new contrib app.

### DIFF
--- a/docs/ref/contrib/index.txt
+++ b/docs/ref/contrib/index.txt
@@ -133,9 +133,3 @@ See the :doc:`sitemaps documentation </ref/contrib/sitemaps>`.
 A framework for generating syndication feeds, in RSS and Atom, quite easily.
 
 See the :doc:`syndication documentation </ref/contrib/syndication>`.
-
-Other add-ons
-=============
-
-If you have an idea for functionality to include in ``contrib``, let us know!
-Code it up, and post it to the |django-users| mailing list.


### PR DESCRIPTION
This advice has existed in the Django docs since 2005.

I think it makes sense to remove it because:
- this advice (code it up and propose it on the mailing list/forum) is true for every new feature 
- calling it out specifically here implies this is particularly welcome. I actually think (speaking from Django 2025 rather than 2005) Django is not keen on adding new contrib apps.

Note this section was found when removing the mailing list references: https://github.com/django/django/pull/19141