### PR TITLE
Refs #35167 -- Fixed test test_bulk_update_custom_get_prep_value on Oracle < 23c.

### DIFF
--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -305,14 +305,12 @@ class TestSaveLoad(TestCase):
         self.assertEqual(obj.value, value)
 
     def test_bulk_update_custom_get_prep_value(self):
-        objs = CustomSerializationJSONModel.objects.bulk_create(
-            [CustomSerializationJSONModel(pk=1, json_field={"version": "1"})]
-        )
-        objs[0].json_field["version"] = "1-alpha"
-        CustomSerializationJSONModel.objects.bulk_update(objs, ["json_field"])
+        obj = CustomSerializationJSONModel.objects.create(json_field={"version": "1"})
+        obj.json_field = {"version": "2"}
+        CustomSerializationJSONModel.objects.bulk_update([obj], ["json_field"])
         self.assertSequenceEqual(
             CustomSerializationJSONModel.objects.values("json_field"),
-            [{"json_field": '{"version": "1-alpha"}'}],
+            [{"json_field": '{"version": "2"}'}],
         )
 
 


### PR DESCRIPTION
https://djangoci.com/job/django-oracle-5.2/database=oracle19,label=oracle,python=python3.13/lastCompletedBuild/testReport/model_fields.test_jsonfield/TestSaveLoad/test_bulk_update_custom_get_prep_value/

