### PR TITLE
Fixed #36200 -- Clarified MIDDLEWARE setting updates when using a custom RemoteUserMiddleware.

### DIFF
--- a/docs/howto/auth-remote-user.txt
+++ b/docs/howto/auth-remote-user.txt
@@ -76,13 +76,26 @@ regardless of ``AUTHENTICATION_BACKENDS``.
 
 If your authentication mechanism uses a custom HTTP header and not
 ``REMOTE_USER``, you can subclass ``RemoteUserMiddleware`` and set the
-``header`` attribute to the desired ``request.META`` key.  For example::
+``header`` attribute to the desired ``request.META`` key.  For example:
+
+.. code-block:: python
+   :caption: ``mysite/middleware.py``
 
     from django.contrib.auth.middleware import RemoteUserMiddleware
 
 
-    class CustomHeaderMiddleware(RemoteUserMiddleware):
+    class CustomHeaderRemoteUserMiddleware(RemoteUserMiddleware):
         header = "HTTP_AUTHUSER"
+
+This custom middleware is then used in the :setting:`MIDDLEWARE` setting
+instead of :class:`django.contrib.auth.middleware.RemoteUserMiddleware`::
+
+    MIDDLEWARE = [
+        "...",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "mysite.middleware.CustomHeaderRemoteUserMiddleware",
+        "...",
+    ]
 
 .. warning::
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36200

#### Branch description

`REMOTE_USER` authentication docs cover using a custom middleware to read the username from HTTP headers but fail to mention that the custom middleware should replace `RemoteUserMiddleware` rather than be appended to `MIDDLEWARE`.

#### Checklist

- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant docs, including release notes if applicable.
