### PR TITLE
Refs #35167 -- Fixed test_bulk_update_custom_get_prep_value() crash on databases that don't support primitives in JSONFields.

### DIFF
--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -438,7 +438,10 @@ class CustomSerializationJSONModel(models.Model):
     json_field = StringifiedJSONField()
 
     class Meta:
-        required_db_features = {"supports_json_field"}
+        required_db_features = {
+            "supports_json_field",
+            "supports_primitives_in_json_field",
+        }
 
 
 class AllFieldsModel(models.Model):

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -304,6 +304,7 @@ class TestSaveLoad(TestCase):
         obj.refresh_from_db()
         self.assertEqual(obj.value, value)
 
+    @skipUnlessDBFeature("supports_primitives_in_json_field")
     def test_bulk_update_custom_get_prep_value(self):
         objs = CustomSerializationJSONModel.objects.bulk_create(
             [CustomSerializationJSONModel(pk=1, json_field={"version": "1"})]


### PR DESCRIPTION
We cannot save strings in `json` columns when primitives are not supported, e.g. on Oracle < 21c.