### PR TITLE
Disambiguated url in flatpages URLconf example.

### DIFF
--- a/docs/ref/contrib/flatpages.txt
+++ b/docs/ref/contrib/flatpages.txt
@@ -89,15 +89,20 @@ to place the pattern at the end of the other urlpatterns::
     matched.
 
 Another common setup is to use flat pages for a limited set of known pages and
-to hard code the urls, so you can reference them with the :ttag:`url` template
-tag::
+to hard code their URLs in the :doc:`URLconf </topics/http/urls>`::
 
     from django.contrib.flatpages import views
 
     urlpatterns += [
-        path("about-us/", views.flatpage, {"url": "/about-us/"}, name="about"),
-        path("license/", views.flatpage, {"url": "/license/"}, name="license"),
+        path("about-us/", views.flatpage, kwargs={"url": "/about-us/"}, name="about"),
+        path("license/", views.flatpage, kwargs={"url": "/license/"}, name="license"),
     ]
+
+The ``kwargs`` argument sets the ``url`` value used for the ``FlatPage`` model
+lookup in the flatpage view.
+
+The ``name`` argument allows the URL to be reversed in templates, for example
+using the :ttag:`url` template tag.
 
 Using the middleware
 --------------------

--- a/docs/ref/contrib/flatpages.txt
+++ b/docs/ref/contrib/flatpages.txt
@@ -31,7 +31,7 @@ To install the flatpages app, follow these steps:
 
    Also make sure you've correctly set :setting:`SITE_ID` to the ID of the
    site the settings file represents. This will usually be ``1`` (i.e.
-   ``SITE_ID = 1``, but if you're using the sites framework to manage
+   ``SITE_ID = 1``), but if you're using the sites framework to manage
    multiple sites, it could be the ID of a different site.
 
 2. Add ``'django.contrib.flatpages'`` to your :setting:`INSTALLED_APPS`


### PR DESCRIPTION
The mention of the `url` template tag followed by the appearance of `"url"` in the `kwargs` argument of `path()` made it seem like they were related. This was especially confusing since `kwargs` is not commonly used in URL patterns.

This change clarifies that the `name` argument is what allows referencing the URLs with `{% url %}` and explicitly states that `kwargs` is simply passing a static argument to `views.flatpage` to retrieve the correct flat page.

Also adds the missing `# Your other patterns here.` comment to make the use of the addition assignment operator (`+=`) for `urlpatterns` clearer.
