### PR TITLE
Fixed #35839 -- Fixed crash when adding GeneratedField with db_comment on MySQL.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -313,8 +313,6 @@ class BaseDatabaseSchemaEditor:
         yield column_db_type
         if collation := field_db_params.get("collation"):
             yield self._collate_sql(collation)
-        if self.connection.features.supports_comments_inline and field.db_comment:
-            yield self._comment_sql(field.db_comment)
         # Work out nullability.
         null = field.null
         # Add database default.
@@ -373,6 +371,8 @@ class BaseDatabaseSchemaEditor:
             and field.unique
         ):
             yield self.connection.ops.tablespace_sql(tablespace, inline=True)
+        if self.connection.features.supports_comments_inline and field.db_comment:
+            yield self._comment_sql(field.db_comment)
 
     def column_sql(self, model, field, include_default=False):
         """

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -4861,6 +4861,24 @@ class SchemaTests(TransactionTestCase):
             comment,
         )
 
+    @skipUnlessDBFeature("supports_comments", "supports_stored_generated_columns")
+    def test_add_db_comment_generated_field(self):
+        comment = "Custom comment"
+        field = GeneratedField(
+            expression=Value(1),
+            db_persist=True,
+            output_field=IntegerField(),
+            db_comment=comment,
+        )
+        field.set_attributes_from_name("volume")
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+            editor.add_field(Author, field)
+        self.assertEqual(
+            self.get_column_comment(Author._meta.db_table, "volume"),
+            comment,
+        )
+
     @skipUnlessDBFeature("supports_comments")
     def test_add_db_comment_and_default_charfield(self):
         comment = "Custom comment with default"


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-35839

#### Branch description
Fixes MySQL syntax error for `GeneratedField` with `db_comment` by ensuring `COMMENT` is placed after GENERATED in `_iter_column_sql`.

Thanks to @charettes for the helpful guidance on this issue!

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
