### PR TITLE
security.py revised code to resolve 3 Bugs in securityMiddleware

### DIFF
--- a/security.py
+++ b/security.py
@@ -1,0 +1,64 @@
+import re
+
+from django.conf import settings
+from django.http import HttpResponsePermanentRedirect
+from django.utils.deprecation import MiddlewareMixin
+
+
+class SecurityMiddleware(MiddlewareMixin):
+    def __init__(self, get_response):
+        super().__init__(get_response)
+        self.sts_seconds = settings.SECURE_HSTS_SECONDS
+        self.sts_include_subdomains = settings.SECURE_HSTS_INCLUDE_SUBDOMAINS
+        self.sts_preload = settings.SECURE_HSTS_PRELOAD
+        self.content_type_nosniff = settings.SECURE_CONTENT_TYPE_NOSNIFF
+        self.redirect = settings.SECURE_SSL_REDIRECT
+        self.redirect_host = settings.SECURE_SSL_HOST
+        self.redirect_exempt = [re.compile(r) for r in settings.SECURE_REDIRECT_EXEMPT]
+        self.referrer_policy = settings.SECURE_REFERRER_POLICY
+        self.cross_origin_opener_policy = settings.SECURE_CROSS_ORIGIN_OPENER_POLICY
+
+    def process_request(self, request):
+        path = request.path.lstrip("/")
+        if (
+            self.redirect
+            and not request.is_secure()
+            and not any(pattern.search(path) for pattern in self.redirect_exempt)
+        ):
+            host = self.redirect_host or request.get_host()
+            return HttpResponsePermanentRedirect(f"https://{host}{request.get_full_path()}")
+
+    def process_response(self, request, response):
+        if (
+            self.sts_seconds
+            and request.is_secure()
+            and "Strict-Transport-Security" not in response.headers
+        ):
+            sts_header = f"max-age={self.sts_seconds}"
+            if self.sts_include_subdomains:
+                sts_header += "; includeSubDomains"
+            if self.sts_preload:
+                sts_header += "; preload"
+            response.headers.setdefault("Strict-Transport-Security", sts_header)
+
+        if self.content_type_nosniff:
+            response.headers.setdefault("X-Content-Type-Options", "nosniff")
+
+        if self.referrer_policy:
+            # Support a comma-separated string or iterable of values to allow fallback.
+            response.headers.setdefault(
+                "Referrer-Policy",
+                ",".join(
+                    [v.strip() for v in self.referrer_policy.split(",")]
+                    if isinstance(self.referrer_policy, str)
+                    else self.referrer_policy
+                ),
+            )
+
+        if self.cross_origin_opener_policy:
+            response.headers.setdefault(
+                "Cross-Origin-Opener-Policy",
+                self.cross_origin_opener_policy,
+            )
+
+        return response


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace #36206 with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-#36206

#### Branch description
1. **Incorrect use of response.setdefault() instead of response.headers.setdefault()**
Issue:
In the original code, the Cross-Origin-Opener-Policy (COOP) header is set using:

response.setdefault("Cross-Origin-Opener-Policy", self.cross_origin_opener_policy)

This is incorrect because:

a. response.setdefault() does not exist in Django’s HttpResponse class.
b. Headers should be set using response.headers.setdefault() to ensure they are only added if they don’t already exist.

Suggested Modification:
Replace:

response.setdefault("Cross-Origin-Opener-Policy", self.cross_origin_opener_policy)

With:

response.headers.setdefault("Cross-Origin-Opener-Policy", self.cross_origin_opener_policy)

**2. Improving String Formatting for Readability & Performance**

Issue:
In the process_request() method, HTTPS redirection is done using:

return HttpResponsePermanentRedirect(
    "https://%s%s" % (host, request.get_full_path())
)

While this works, %-formatting is less readable and slightly less performant than modern alternatives like f-strings.

Suggested Modification:
Change:

return HttpResponsePermanentRedirect(
    "https://%s%s" % (host, request.get_full_path())
)

To:
return HttpResponsePermanentRedirect(f"https://{host}{request.get_full_path()}")


**3. Preventing Overwriting of Existing Headers**

Issue:

The original code unconditionally sets security headers like:

response.headers["Strict-Transport-Security"] = sts_header
response.headers["X-Content-Type-Options"] = "nosniff"


This could Override existing security policies set by other middleware or custom responses &
Prevent flexibility in modifying security headers dynamically.

Suggested Modification:

Use setdefault() instead of direct assignment:

response.headers.setdefault("Strict-Transport-Security", sts_header)
response.headers.setdefault("X-Content-Type-Options", "nosniff")

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
