### PR TITLE
Refs #36209-- Added HttpResponse subclasses Created and NoContent.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -733,6 +733,7 @@ answer newbie questions, and generally made Django that much better:
     Michal Chruszcz <troll@pld-linux.org>
     michal@plovarna.cz
     Michał Modzelewski <michal.modzelewski@gmail.com>
+    Michiel W. Beijen <mb@x14.nl>
     Mihai Damian <yang_damian@yahoo.com>
     Mihai Preda <mihai_preda@yahoo.com>
     Mikaël Barbero <mikael.barbero nospam at nospam free.fr>

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -652,6 +652,26 @@ class HttpResponseRedirectBase(HttpResponse):
         )
 
 
+class HttpResponseCreated(HttpResponse):
+    status_code = 201
+
+
+class HttpResponseNoContent(HttpResponse):
+    status_code = 204
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        del self["content-type"]
+
+    @HttpResponse.content.setter
+    def content(self, value):
+        if value:
+            raise AttributeError(
+                "You cannot set content to a 204 (No Content) response"
+            )
+        self._container = []
+
+
 class HttpResponseRedirect(HttpResponseRedirectBase):
     status_code = 302
     status_code_preserve_request = 307

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -1072,6 +1072,21 @@ Django includes a number of ``HttpResponse`` subclasses that handle different
 types of HTTP responses. Like ``HttpResponse``, these subclasses live in
 :mod:`django.http`.
 
+.. class:: HttpResponseCreated
+
+    Acts just like :class:`HttpResponse` but uses a 201 status code. Use this to
+    indicate that a resource has been successfully created.
+
+    .. versionadded:: 6.0
+
+.. class:: HttpResponseNoContent
+
+    The constructor doesn't take any arguments and no content should be added
+    to this response. Use this to indicate that a HTTP request has been
+    successfully completed, and there is no message body (status code 204).
+
+    .. versionadded:: 6.0
+
 .. class:: HttpResponseRedirect
 
     The first argument to the constructor is required -- the path to redirect

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -183,7 +183,14 @@ Models
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* Two new subclasses of :class:`response <django.http.HttpResponse>` are added,
+  that can be especially useful when developing RESTful applications:
+
+  * :class:`response <django.http.HttpResponseCreated>` which is exactly the
+    same as a HttpResponse, but returns status code 201 ("Created")
+
+  * :class:`response <django.http.HttpResponseNoContent>` which returns a
+     HTTP 204 response with no content
 
 Security
 ~~~~~~~~

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -12,6 +12,8 @@ from django.db import close_old_connections
 from django.http import (
     BadHeaderError,
     HttpResponse,
+    HttpResponseCreated,
+    HttpResponseNoContent,
     HttpResponseNotAllowed,
     HttpResponseNotModified,
     HttpResponsePermanentRedirect,
@@ -548,6 +550,18 @@ class HttpResponseTests(SimpleTestCase):
 
 
 class HttpResponseSubclassesTests(SimpleTestCase):
+    def test_created(self):
+        response = HttpResponseCreated()
+        self.assertEqual(response.status_code, 201)
+
+    def test_no_content(self):
+        response = HttpResponseNoContent()
+        self.assertEqual(response.status_code, 204)
+        # 204 responses should not have content/content-type
+        with self.assertRaises(AttributeError):
+            response.content = "Hello dear"
+        self.assertNotIn("content-type", response)
+
     def test_redirect(self):
         response = HttpResponseRedirect("/redirected/")
         self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36209

#### Branch description
 Django has `HttpResponse` subclasses for many status codes. Although you can use the generic `HttpResponse` and provide it with a status code, the subclasses provide for more readable code: it's more clear to write `HttpResponseRedirect()` or HttpResponsePermanentRedirect() than to use `HttpResponse()`  with a 301 or 302 status code, because that requires you to 'know' which status code is which.

However for the RESTful HTTP response codes **201 Created** and **204 No Content** there are no HttpResponse subclasses. It would be helpful to people writing RESTful HTTP APIs to have HttpResponse subclasses for these codes.

This patch adds `HttpResponseCreated` and `HttpResponseNoContent` subclasses. I've targeted Django 6 because 5.2 is closed for new features.

#### Checklist
- [ x ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ x  ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ x ] I have checked the "Has patch" ticket flag in the Trac system.
- [ x ] I have added or updated relevant tests.
- [ x ] I have added or updated relevant docs, including release notes if applicable.
