### PR TITLE
Fixed #36207 -- Fixed refresh_from_db ForeignObject relations

### DIFF
--- a/tests/composite_pk/test_models.py
+++ b/tests/composite_pk/test_models.py
@@ -155,3 +155,9 @@ class CompositePKModelsTests(TestCase):
         self.assertEqual(4, token.permission_set.count())
         self.assertEqual(4, user.permission_set.count())
         self.assertEqual(4, comment.permission_set.count())
+
+    def test_refresh_foreign_object(self):
+        comment = Comment.objects.get(pk=self.comment_1.pk)
+        comment.user = None
+        comment.refresh_from_db()
+        self.assertEqual(comment.user, self.user_1)


### PR DESCRIPTION
36207 Trac ticket number
ticket-36207

#### Branch description
Fixes refresh_from_db() for models with ForeignObject and composite primary keys by handling PK preservation and accurate data refresh.

## Changes
Added _refresh_from_db_with_foreign_object():
A private method to:
    - Collect ForeignObject and composite PK values.
    - Query the database using these values.
    - Update the instance fields and sync the internal state.

Updated refresh_from_db():
Delegates to the private method only when a ForeignObject is present.

## Result
Ensures accurate data refresh for models with ForeignObject and composite PKs and delegate the responsability  to a specifc function

#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
