### PR TITLE
Refs #35617 -- Removed hardcoded pk in test_bulk_update_custom_get_prep_value().

### DIFF
--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -306,11 +306,9 @@ class TestSaveLoad(TestCase):
 
     @skipUnlessDBFeature("supports_primitives_in_json_field")
     def test_bulk_update_custom_get_prep_value(self):
-        objs = CustomSerializationJSONModel.objects.bulk_create(
-            [CustomSerializationJSONModel(pk=1, json_field={"version": "1"})]
-        )
-        objs[0].json_field["version"] = "1-alpha"
-        CustomSerializationJSONModel.objects.bulk_update(objs, ["json_field"])
+        obj = CustomSerializationJSONModel.objects.create(json_field={"version": "1"})
+        obj.json_field["version"] = "1-alpha"
+        CustomSerializationJSONModel.objects.bulk_update([obj], ["json_field"])
         self.assertSequenceEqual(
             CustomSerializationJSONModel.objects.values("json_field"),
             [{"json_field": '{"version": "1-alpha"}'}],


### PR DESCRIPTION
See https://github.com/django/django/pull/19183#discussion_r1970088173. I take it this will be friendlier for other database backends.

cc/ @timgraham