### PR TITLE
Fixed #35816 -- Handled parsing of scientific notation in DTL.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -633,19 +633,18 @@ constant_string = constant_string.replace("\n", "")
 
 filter_raw_string = r"""
 ^(?P<constant>%(constant)s)|
-^(?P<var>[%(var_chars)s]+|%(num)s)|
+^(?P<var>[%(var_chars)s]+)|
  (?:\s*%(filter_sep)s\s*
      (?P<filter_name>\w+)
          (?:%(arg_sep)s
              (?:
               (?P<constant_arg>%(constant)s)|
-              (?P<var_arg>[%(var_chars)s]+|%(num)s)
+              (?P<var_arg>[%(var_chars)s]+)
              )
          )?
  )""" % {
     "constant": constant_string,
-    "num": r"[-+.]?\d[\d.e]*",
-    "var_chars": r"\w\.",
+    "var_chars": r"\w\.\+-",
     "filter_sep": re.escape(FILTER_SEPARATOR),
     "arg_sep": re.escape(FILTER_ARGUMENT_SEPARATOR),
 }

--- a/tests/template_tests/test_parser.py
+++ b/tests/template_tests/test_parser.py
@@ -11,6 +11,7 @@ from django.template.base import (
     Token,
     TokenType,
     Variable,
+    VariableDoesNotExist,
 )
 from django.template.defaultfilters import register as filter_library
 from django.test import SimpleTestCase
@@ -169,3 +170,49 @@ class ParserTests(SimpleTestCase):
             '1|two_one_opt_arg:"1"',
         ):
             FilterExpression(expr, parser)
+
+    def test_filter_numeric_argument_parsing(self):
+        p = Parser("", builtins=[filter_library])
+
+        cases = {
+            "5": 5,
+            "-5": -5,
+            "5.2": 5.2,
+            ".4": 0.4,
+            "5.2e3": 5200.0,  # 5.2 × 10³ = 5200.0.
+            "5.2E3": 5200.0,  # Case-insensitive.
+            "5.2e-3": 0.0052,  # Negative exponent.
+            "-1.5E4": -15000.0,
+            "+3.0e2": 300.0,
+            ".5e2": 50.0,  # 0.5 × 10² = 50.0
+        }
+        for num, expected in cases.items():
+            with self.subTest(num=num):
+                self.assertEqual(FilterExpression(num, p).resolve({}), expected)
+                self.assertEqual(
+                    FilterExpression(f"0|default:{num}", p).resolve({}), expected
+                )
+
+        invalid_numbers = [
+            "abc123",
+            "123abc",
+            "foo",
+            "error",
+            "1e",
+            "e400",
+            "1e.2",
+            "1e2.",
+            "1e2.0",
+            "1e2a",
+            "1e2e3",
+            "1e-",
+            "1e-a",
+        ]
+
+        for num in invalid_numbers:
+            with self.subTest(num=num):
+                self.assertIsNone(
+                    FilterExpression(num, p).resolve({}, ignore_failures=True)
+                )
+                with self.assertRaises(VariableDoesNotExist):
+                    FilterExpression(f"0|default:{num}", p).resolve({})

--- a/tests/template_tests/test_parser.py
+++ b/tests/template_tests/test_parser.py
@@ -72,6 +72,27 @@ class ParserTests(SimpleTestCase):
         with self.assertRaisesMessage(TemplateSyntaxError, msg):
             FilterExpression("article._hidden|upper", p)
 
+    def test_cannot_parse_characters(self):
+        p = Parser("", builtins=[filter_library])
+        for filter_expression, characters in [
+            ('<>|default:"Default"|upper', '|<>||default:"Default"|upper'),
+            ("test|<>|upper", "test||<>||upper"),
+        ]:
+            with self.subTest(filter_expression=filter_expression):
+                with self.assertRaisesMessage(
+                    TemplateSyntaxError,
+                    f"Could not parse some characters: {characters}",
+                ):
+                    FilterExpression(filter_expression, p)
+
+    def test_cannot_find_variable(self):
+        p = Parser("", builtins=[filter_library])
+        with self.assertRaisesMessage(
+            TemplateSyntaxError,
+            'Could not find variable at start of |default:"Default"',
+        ):
+            FilterExpression('|default:"Default"', p)
+
     def test_variable_parsing(self):
         c = {"article": {"section": "News"}}
         self.assertEqual(Variable("article.section").resolve(c), "News")


### PR DESCRIPTION
#### Trac ticket number

ticket-35816

#### Branch description
This PR includes the changes proposed in #19146 to support scientific notation more fully in template parsing and extends the solution to include:

- validates a token as a number before validating it as a list of `var_chars`
- only validates a token as a number if it matches the whole string, otherwise '1.2.3' evaluates as the number '1.2' followed by '.3', which can't be evaluated
- add s'-' to the list of `var_chars` to prevent exception form being thrown on an invalid number such as '1e-': previously the '-' terminated the match and tried to parse '-' as a separate token, producing an error. This is probably the biggest change and we should consider whether '-' is a valid `var_char` (I think it is?)
- implements tests suggested by @sarahboyce in #19146 


#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
