### PR TITLE
Fixed #36217 -- Used LogEntry.save() for single object deletion in admin.

### DIFF
--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -24,9 +24,7 @@ ACTION_FLAG_CHOICES = [
 class LogEntryManager(models.Manager):
     use_in_migrations = True
 
-    def log_actions(
-        self, user_id, queryset, action_flag, change_message="", *, single_object=False
-    ):
+    def log_actions(self, user_id, queryset, action_flag, change_message=""):
         if isinstance(change_message, list):
             change_message = json.dumps(change_message)
 
@@ -44,7 +42,7 @@ class LogEntryManager(models.Manager):
             for obj in queryset
         ]
 
-        if single_object and log_entry_list:
+        if len(log_entry_list) == 1:
             instance = log_entry_list[0]
             instance.save()
             return instance

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -946,7 +946,6 @@ class ModelAdmin(BaseModelAdmin):
             queryset=[obj],
             action_flag=ADDITION,
             change_message=message,
-            single_object=True,
         )
 
     def log_change(self, request, obj, message):
@@ -962,7 +961,6 @@ class ModelAdmin(BaseModelAdmin):
             queryset=[obj],
             action_flag=CHANGE,
             change_message=message,
-            single_object=True,
         )
 
     def log_deletions(self, request, queryset):

--- a/docs/releases/5.1.7.txt
+++ b/docs/releases/5.1.7.txt
@@ -22,3 +22,7 @@ Bugfixes
   of ``ManyToManyField`` related managers would always return ``0`` and
   ``False`` when the intermediary model back references used ``to_field``
   (:ticket:`36197`).
+
+* Fixed a regression in Django 5.1 where the ``pre_save`` and ``post_save``
+  signals for ``LogEntry`` were not sent when deleting a single object in the
+  admin (:ticket:`36217`).

--- a/docs/releases/5.1.txt
+++ b/docs/releases/5.1.txt
@@ -401,6 +401,11 @@ Miscellaneous
 * The minimum supported version of ``asgiref`` is increased from 3.7.0 to
   3.8.1.
 
+* To improve performance, the ``delete_selected`` admin action now uses
+  ``QuerySet.bulk_create()`` when creating multiple ``LogEntry`` objects. As a
+  result, ``pre_save`` and ``post_save`` signals for ``LogEntry`` are not sent
+  when multiple objects are deleted via this admin action.
+
 .. _deprecated-features-5.1:
 
 Features deprecated in 5.1

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1845,7 +1845,7 @@ class GetAdminLogTests(TestCase):
         """{% get_admin_log %} works without specifying a user."""
         user = User(username="jondoe", password="secret", email="super@example.com")
         user.save()
-        LogEntry.objects.log_actions(user.pk, [user], 1, single_object=True)
+        LogEntry.objects.log_actions(user.pk, [user], 1)
         context = Context({"log_entries": LogEntry.objects.all()})
         t = Template(
             "{% load log %}"

--- a/tests/admin_views/test_history_view.py
+++ b/tests/admin_views/test_history_view.py
@@ -66,7 +66,6 @@ class SeleniumTests(AdminSeleniumTestCase):
                 [self.superuser],
                 CHANGE,
                 change_message=f"Changed something {i}",
-                single_object=True,
             )
         self.admin_login(
             username="super",

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -3884,21 +3884,18 @@ class AdminViewStringPrimaryKeyTest(TestCase):
             [cls.m1],
             2,
             change_message="Changed something",
-            single_object=True,
         )
         LogEntry.objects.log_actions(
             user_pk,
             [cls.m1],
             1,
             change_message="Added something",
-            single_object=True,
         )
         LogEntry.objects.log_actions(
             user_pk,
             [cls.m1],
             3,
             change_message="Deleted something",
-            single_object=True,
         )
 
     def setUp(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36217

#### Branch description
I fixed the issue where the signals set in `LogEntry` were not being called when an object was deleted in the admin.
Thank you for @sarahboyce for providing the solution this ticket.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
