### PR TITLE
Fixed #36227 -- Updated outdated PostgreSQL documentation links

### DIFF
--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -68,7 +68,7 @@ available from the ``django.contrib.postgres.indexes`` module.
     Creates a `gin index <https://www.postgresql.org/docs/current/gin.html>`_.
 
     To use this index on data types not in the `built-in operator classes
-    <https://www.postgresql.org/docs/current/gin-builtin-opclasses.html>`_,
+    <https://www.postgresql.org/docs/current/gin.html#GIN-BUILTIN-OPCLASSES>`_,
     you need to activate the `btree_gin extension
     <https://www.postgresql.org/docs/current/btree-gin.html>`_ on
     PostgreSQL. You can install it using the
@@ -82,7 +82,7 @@ available from the ``django.contrib.postgres.indexes`` module.
     parameter to tune the maximum size of the GIN pending list which is used
     when ``fastupdate`` is enabled.
 
-    .. _GIN Fast Update Technique: https://www.postgresql.org/docs/current/gin-implementation.html#GIN-FAST-UPDATE
+    .. _GIN Fast Update Technique: https://www.postgresql.org/docs/current/gin.html#GIN-FAST-UPDATE
     .. _gin_pending_list_limit: https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-GIN-PENDING-LIST-LIMIT
 
 ``GistIndex``
@@ -112,7 +112,7 @@ available from the ``django.contrib.postgres.indexes`` module.
     Provide an integer value from 10 to 100 to the fillfactor_ parameter to
     tune how packed the index pages will be. PostgreSQL's default is 90.
 
-    .. _buffering build: https://www.postgresql.org/docs/current/gist-implementation.html#GIST-BUFFERING-BUILD
+    .. _buffering build: https://www.postgresql.org/docs/current/gist.html#GIST-BUFFERING-BUILD
     .. _fillfactor: https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS
 
 ``HashIndex``

--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -99,7 +99,7 @@ available from the ``django.contrib.postgres.indexes`` module.
     fields <range-fields>`.
 
     To use this index on data types not in the built-in `gist operator classes
-    <https://www.postgresql.org/docs/current/gist-builtin-opclasses.html>`_,
+    <https://www.postgresql.org/docs/current/gist.html#GIST-BUILTIN-OPCLASSES>`_,
     you need to activate the `btree_gist extension
     <https://www.postgresql.org/docs/current/btree-gist.html>`_ on PostgreSQL.
     You can install it using the


### PR DESCRIPTION
#### Trac ticket number
Fixed #36227 -- Updated outdated PostgreSQL documentation links

#### Branch description
Fixed outdated links to PostgreSQL documentation in the indexes.txt file. The PostgreSQL documentation has been reorganized, and several URLs referenced in Django's documentation were broken. Updated the links to point to the correct locations in the current PostgreSQL documentation structure.

#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

This is a straightforward documentation fix that updates outdated links to the PostgreSQL documentation. The changes ensure that Django users can access the correct PostgreSQL documentation when following links from the Django documentation.