### PR TITLE
Updated docs/topics/i18n/translation.txt - It's installed in the "built-in" namespace.

### DIFF
--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -48,12 +48,12 @@ as a shorter alias, ``_``, to save typing.
 
 .. note::
     Python's standard library ``gettext`` module installs ``_()`` into the
-    global namespace, as an alias for ``gettext()``. In Django, we have chosen
+    built-in namespace, as an alias for ``gettext()``. In Django, we have chosen
     not to follow this practice, for a couple of reasons:
 
     #. Sometimes, you should use :func:`~django.utils.translation.gettext_lazy`
        as the default translation method for a particular file. Without ``_()``
-       in the global namespace, the developer has to think about which is the
+       in the built-in namespace, the developer has to think about which is the
        most appropriate translation function.
 
     #. The underscore character (``_``) is used to represent "the previous


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

"N/A"

#### Branch description
It's a simple change to the `docs/topics/i18n/translation.txt` file.

As stated in the [`gettext` module](https://docs.python.org/3/library/gettext.html#gettext.install):

> This installs the function `_()` in Python’s ***"builtins namespace"***, ...

Not the global namespace.

It was in one paragraph only. I changed it in two places. Also I deliberately leaved the last "global" name in that paragraph intact as I guessed the "global" word there is just the literal global word in English and doesn't point to the Python's global namespace. If you think otherwise, I can change that too.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
