### PR TITLE
Fixed #36234 -- Restored single_object argument to LogEntry.objects.log_actions().

### DIFF
--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -24,7 +24,9 @@ ACTION_FLAG_CHOICES = [
 class LogEntryManager(models.Manager):
     use_in_migrations = True
 
-    def log_actions(self, user_id, queryset, action_flag, change_message=""):
+    def log_actions(
+        self, user_id, queryset, action_flag, change_message="", *, single_object=False
+    ):
         if isinstance(change_message, list):
             change_message = json.dumps(change_message)
 
@@ -45,7 +47,9 @@ class LogEntryManager(models.Manager):
         if len(log_entry_list) == 1:
             instance = log_entry_list[0]
             instance.save()
-            return instance
+            if single_object:
+                return instance
+            return [instance]
 
         return self.model.objects.bulk_create(log_entry_list)
 

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -946,6 +946,7 @@ class ModelAdmin(BaseModelAdmin):
             queryset=[obj],
             action_flag=ADDITION,
             change_message=message,
+            single_object=True,
         )
 
     def log_change(self, request, obj, message):
@@ -961,6 +962,7 @@ class ModelAdmin(BaseModelAdmin):
             queryset=[obj],
             action_flag=CHANGE,
             change_message=message,
+            single_object=True,
         )
 
     def log_deletions(self, request, queryset):

--- a/docs/releases/5.1.8.txt
+++ b/docs/releases/5.1.8.txt
@@ -9,4 +9,6 @@ Django 5.1.8 fixes several bugs in 5.1.7.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 5.1.7 where the removal of the ``single_object``
+  parameter unintentionally altered the signature and return type of
+  ``LogEntryManager.log_actions()`` (:ticket:`36234`).


### PR DESCRIPTION
#### Trac ticket number

ticket-36234

#### Branch description

Restore the argument. This commit is for backporting to 5.1, and maybe 5.2. The argument can be immediately deprecated for the next version (5.2 / 6.0), in a follow-up PR.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
