### PR TITLE
Fixed #36213 -- Added warning about MySQL’s handling of self-select updates in QuerySet.update() documentation

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2519,6 +2519,15 @@ The ``batch_size`` parameter controls how many objects are saved in a single
 query. The default is to update all objects in one batch, except for SQLite
 and Oracle which have restrictions on the number of variables used in a query.
 
+.. warning::  
+   When using MySQL, ``QuerySet.update()`` may execute two separate SQL queries  
+   (a ``SELECT`` followed by an ``UPDATE``) instead of a single ``UPDATE`` when  
+   filtering on related tables. This behavior occurs because MySQL does not support  
+   self-select updates.As a result, this can introduce **race conditions** if 
+   concurrent changes occur between the ``SELECT`` and ``UPDATE`` queries. 
+   To ensure atomicity, consider **using transactions** or **avoiding such filter conditions**.
+
+
 ``count()``
 ~~~~~~~~~~~
 


### PR DESCRIPTION


#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-[36213](https://code.djangoproject.com/ticket/36213)

#### Branch description
Added a warning in the documentation for QuerySet.update() regarding MySQL's handling of self-select updates, which may result in two separate SQL queries (SELECT followed by UPDATE). Explained how this can lead to race conditions and suggested using transactions or avoiding specific filter conditions to ensure atomicity.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
