### PR TITLE
Fixed #36222 -- Fixed ExclusionConstraint validation crash on excluded fields in condition.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -455,6 +455,7 @@ answer newbie questions, and generally made Django that much better:
     Jacob Kaplan-Moss <jacob@jacobian.org>
     Jacob Rief <jacob.rief@gmail.com>
     Jacob Walls <http://www.jacobtylerwalls.com/>
+    JaeHyuck Sa <wogur981208@gmail.com>
     Jakub Bagiński <https://github.com/Jacob1507>
     Jakub Paczkowski <jakub@paczkowski.eu>
     Jakub Wilk <jwilk@jwilk.net>

--- a/django/contrib/postgres/constraints.py
+++ b/django/contrib/postgres/constraints.py
@@ -206,6 +206,11 @@ class ExclusionConstraint(BaseConstraint):
                     self.get_violation_error_message(), code=self.violation_error_code
                 )
         else:
+            # Ignore constraints with excluded fields in condition.
+            if exclude and self._expression_refs_exclude(
+                model, self.condition, exclude
+            ):
+                return
             if (self.condition & Exists(queryset.filter(self.condition))).check(
                 replacement_map, using=using
             ):

--- a/tests/postgres_tests/test_constraints.py
+++ b/tests/postgres_tests/test_constraints.py
@@ -797,6 +797,17 @@ class ExclusionConstraintTests(PostgreSQLTestCase):
             ),
             exclude={"datespan", "start", "end", "room"},
         )
+        # Constraints with excluded fields in condition are ignored.
+        constraint.validate(
+            HotelReservation,
+            HotelReservation(
+                datespan=(datetimes[1].date(), datetimes[2].date()),
+                start=datetimes[1],
+                end=datetimes[2],
+                room=room102,
+            ),
+            exclude={"cancelled"},
+        )
 
     def test_range_overlaps_custom(self):
         class TsTzRange(Func):


### PR DESCRIPTION
#### Trac ticket number
ticket-36222

#### Branch description
This PR fixes a crash in `ExclusionConstraint.validate()` that occurs when the `condition` references a field that is included in the `exclude` list. 

@cliff688  Thank you for providing the test code for this ticket.

#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
