### PR TITLE
Corrected aggregation example in docs/ref/models/querysets.txt.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2800,16 +2800,16 @@ number of authors that have contributed blog entries:
 .. code-block:: pycon
 
     >>> from django.db.models import Count
-    >>> Blog.objects.aggregate(Count("entry"))
-    {'entry__count': 16}
+    >>> Blog.objects.aggregate(Count("entry__authors"))
+    {'entry__authors__count': 16}
 
 By using a keyword argument to specify the aggregate function, you can
 control the name of the aggregation value that is returned:
 
 .. code-block:: pycon
 
-    >>> Blog.objects.aggregate(number_of_entries=Count("entry"))
-    {'number_of_entries': 16}
+    >>> Blog.objects.aggregate(number_of_authors=Count("entry__authors"))
+    {'number_of_authors': 16}
 
 For an in-depth discussion of aggregation, see :doc:`the topic guide on
 Aggregation </topics/db/aggregation>`.

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2333,9 +2333,9 @@ whenever a request to a page has a side effect on your data. For more, see
       # Raises IntegrityError
 
   This is happening because it's trying to get or create "Chapter 1" through the
-  book "Ulysses", but it can't do any of them: the relation can't fetch that
-  chapter because it isn't related to that book, but it can't create it either
-  because ``title`` field should be unique.
+  book "Ulysses", but it can't do either: the relation can't fetch that chapter
+  because it isn't related to that book, but it can't create it either because
+  ``title`` field should be unique.
 
 ``update_or_create()``
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
1st commit:

The note introducing the example says:
> For example, when you are working with blog entries, you may want to know the
number of authors that have contributed blog entries:

but the example finds the number of entries instead.

2nd commit:
"it can't do any of them" is used for two mutually exclusive singular options.