### PR TITLE
Corrected test case in ExclusionConstraintTests.test_invalid_expressions().

### DIFF
--- a/tests/postgres_tests/test_constraints.py
+++ b/tests/postgres_tests/test_constraints.py
@@ -309,7 +309,7 @@ class ExclusionConstraintTests(PostgreSQLTestCase):
 
     def test_invalid_expressions(self):
         msg = "The expressions must be a list of 2-tuples."
-        for expressions in (["foo"], ["foo"], [("foo_1", "foo_2", "foo_3")]):
+        for expressions in (["foo"], [("foo",)], [("foo_1", "foo_2", "foo_3")]):
             with self.subTest(expressions), self.assertRaisesMessage(ValueError, msg):
                 ExclusionConstraint(
                     index_type="GIST",


### PR DESCRIPTION
Originally this was `[("foo")]` (https://github.com/django/django/commit/a3417282ac0464a9a2d1d7685bcfef10feed2597#diff-9bcfdc1360b06330a51e54b7565748f9ef23685b7ac2983d7b390bd93e7f71e1R113 note that black reformatted this in ff3aaf036f0cb66cd8f404cd51c603e68aaa7676), I think this intended to be a 1-tuple. Currently, the test case is duplicated