### PR TITLE
Fixed #15879 -- Assigned default filename for files with empty filenames

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -9,6 +9,7 @@ import base64
 import binascii
 import collections
 import html
+from uuid import uuid4
 
 from django.conf import settings
 from django.core.exceptions import (
@@ -269,7 +270,7 @@ class MultiPartParser:
                         file_name = force_str(file_name, encoding, errors="replace")
                         file_name = self.sanitize_file_name(file_name)
                     if not file_name:
-                        continue
+                        file_name = f"unnamed_file_{uuid4()}"
 
                     content_type, content_type_extra = meta_data.get(
                         "content-type", ("", {})
@@ -731,7 +732,7 @@ def parse_boundary_stream(stream, max_header_size):
 
         if name == "content-disposition":
             TYPE = FIELD
-            if params.get("filename"):
+            if "filename" in params:
                 TYPE = FILE
 
         outdict[name] = value, params

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -338,11 +338,6 @@ class FileUploadTests(TestCase):
         response = self.client.request(**r)
         self.assertEqual(response.status_code, 200)
 
-        # Empty filenames should be ignored
-        received = response.json()
-        for i, name in enumerate(filenames):
-            self.assertIsNone(received.get("file%s" % i))
-
     def test_non_printable_chars_in_file_names(self):
         file_name = "non-\x00printable\x00\n_chars.txt\x00"
         payload = client.FakePayload()

--- a/tests/requests_tests/tests.py
+++ b/tests/requests_tests/tests.py
@@ -737,6 +737,30 @@ class RequestsTests(SimpleTestCase):
         self.assertEqual(len(request.FILES), 1)
         self.assertIsInstance((request.FILES["File"]), InMemoryUploadedFile)
 
+    def test_POST_multipart_with_empty_filename(self):
+        payload = FakePayload(
+            "\r\n".join(
+                [
+                    f"--{BOUNDARY}",
+                    'Content-Disposition: form-data; name="File"; filename=""',
+                    "Content-Type: application/octet-stream",
+                    "",
+                    "DATA",
+                    f"--{BOUNDARY}--",
+                ]
+            )
+        )
+        request = WSGIRequest(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": MULTIPART_CONTENT,
+                "CONTENT_LENGTH": len(payload),
+                "wsgi.input": payload,
+            }
+        )
+        self.assertEqual(len(request.FILES), 1)
+        self.assertIsInstance((request.FILES["File"]), InMemoryUploadedFile)
+
     def test_base64_invalid_encoding(self):
         payload = FakePayload(
             "\r\n".join(


### PR DESCRIPTION
According to [RFC 6266](https://www.rfc-editor.org/rfc/rfc6266#section-4.1), an empty quoted filename (`""`) is valid in multipart requests, see the definition for `value` in [RFC 2616](https://www.rfc-editor.org/rfc/rfc2616#section-3.6) and definition for `quoted-string` in [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-quoted-strings) . 

Previously, Django ignored such file uploads, causing them to be skipped. This fix ensures they are processed by assigning a random default filename.

Thanks to j@… for report and initial patch.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-15879

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
