### PR TITLE
Fixed #33579 -- Specialized exception raised on forced update failures.

### DIFF
--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -25,6 +25,10 @@ class ObjectDoesNotExist(Exception):
     silent_variable_failure = True
 
 
+class ObjectNotUpdated(Exception):
+    """The updated object no longer exists."""
+
+
 class MultipleObjectsReturned(Exception):
     """The query returned multiple objects when only one was expected."""
 

--- a/docs/ref/exceptions.txt
+++ b/docs/ref/exceptions.txt
@@ -33,6 +33,20 @@ Django core exception classes are defined in ``django.core.exceptions``.
 
     See :meth:`~django.db.models.query.QuerySet.get()`.
 
+``ObjectNotUpdated``
+--------------------
+
+.. versionadded:: 6.0
+
+.. exception:: ObjectNotUpdated
+
+    The base class for :exc:`Model.NotUpdated
+    <django.db.models.Model.NotUpdated>` exceptions. A ``try/except`` for
+    ``ObjectNotUpdated`` will catch
+    :exc:`~django.db.models.Model.NotUpdated` exceptions for all models.
+
+    See :meth:`~django.db.models.Model.save()`.
+
 ``EmptyResultSet``
 ------------------
 

--- a/docs/ref/models/class.txt
+++ b/docs/ref/models/class.txt
@@ -39,6 +39,23 @@ Attributes
     The exception is a subclass of
     :exc:`django.core.exceptions.MultipleObjectsReturned`.
 
+``NotUpdated``
+--------------
+
+.. versionadded:: 6.0
+
+.. exception:: Model.NotUpdated
+
+    This exception is raised when :ref:`a forced update
+    <ref-models-force-insert>` of a :class:`~django.db.models.Model` instance
+    does not affect any rows.
+
+    Django provides a ``NotUpdated`` exception as an attribute of each model
+    class to identify the class of object that could not be updated, allowing
+    you to catch exceptions for a particular model class. The exception is a
+    subclass of :exc:`django.core.exceptions.ObjectNotUpdated` and inherits
+    from :exc:`django.db.DatabaseError` for backward compatibility reasons.
+
 ``objects``
 -----------
 

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -601,6 +601,12 @@ You can pass ``force_insert=(models.Model,)`` to force an ``INSERT`` statement
 for all parents. By default, ``force_insert=True`` only forces the insertion of
 a new row for the current model.
 
+.. versionchanged:: 6.0
+
+    When a forced update does not affect any rows a
+    :exc:`~django.db.models.Model.NotUpdated` exception is raised. On previous
+    versions a generic :exc:`django.db.DatabaseError` was raised.
+
 It should be very rare that you'll need to use these parameters. Django will
 almost always do the right thing and trying to override that will lead to
 errors that are difficult to track down. This feature is for advanced use

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -194,6 +194,11 @@ Models
   values concatenated into a string, separated by the ``delimiter`` string.
   This aggregate was previously supported only for PostgreSQL.
 
+* The :meth:`~django.db.models.Model.save` method now raises a specialized
+  :exc:`Model.NotUpdated <django.db.models.Model.NotUpdated>` exception, when
+  :ref:`a forced update <ref-models-force-insert>` results in no affected rows,
+  instead of a generic :exc:`django.db.DatabaseError`.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-33579

#### Branch description

Raising `DatabaseError` directly made it harder than it should to differentiate between `IntegrityError` and when a forced update resulted in no affected rows.

Introducing a specialized exception allows for callers to more easily silence, log, or turn them update failures into user facing exceptions (e.g. 404s).
