### PR TITLE
Fixed #36207 -- Cleared cached ForeignObject relations via refresh_from_db().

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -756,11 +756,12 @@ class Model(AltersData, metaclass=ModelBase):
 
         db_instance = db_instance_qs.get()
         non_loaded_fields = db_instance.get_deferred_fields()
-        for field in self._meta.concrete_fields:
+        for field in self._meta.fields:
             if field.attname in non_loaded_fields:
                 # This field wasn't refreshed - skip ahead.
                 continue
-            setattr(self, field.attname, getattr(db_instance, field.attname))
+            if field.concrete:
+                setattr(self, field.attname, getattr(db_instance, field.attname))
             # Clear or copy cached foreign keys.
             if field.is_relation:
                 if field.is_cached(db_instance):

--- a/tests/foreign_object/tests.py
+++ b/tests/foreign_object/tests.py
@@ -450,6 +450,15 @@ class MultiColumnFKTests(TestCase):
         normal_groups_lists = [list(p.groups.all()) for p in Person.objects.all()]
         self.assertEqual(groups_lists, normal_groups_lists)
 
+    def test_refresh_foreign_object(self):
+        member = Membership.objects.create(
+            membership_country=self.usa, person=self.bob, group=self.cia
+        )
+        member.person = self.jim
+        with self.assertNumQueries(1):
+            member.refresh_from_db()
+        self.assertEqual(member.person, self.bob)
+
     @translation.override("fi")
     def test_translations(self):
         a1 = Article.objects.create(pub_date=datetime.date.today())


### PR DESCRIPTION
#### Trac ticket number
ticket-36207

#### Branch description
Before, model fields using the private API `models.ForeignObject` to relate foreign objects without enforcing a foreign key (as [modeled](https://docs.djangoproject.com/en/5.2/topics/composite-primary-key/#composite-primary-keys-and-relations) in the composite pk docs) didn't have their relations cleared via `refresh_from_db()`.

Alternative to #19207

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [n/a] I have added or updated relevant docs, including release notes if applicable.
- [n/a] I have attached screenshots in both light and dark modes for any UI changes.
