### PR TITLE
Fixed #36239 -- Fixed ManyToManyField check error which are invalid "to" when passing through/through_fields

### DIFF
--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -341,9 +341,7 @@ END;
 
     def last_insert_id(self, cursor, table_name, pk_name):
         sq_name = self._get_sequence_name(cursor, strip_quotes(table_name), pk_name)
-        template = 'SELECT "%s".currval' + self.connection.features.bare_select_suffix
-
-        cursor.execute(template % sq_name)
+        cursor.execute('"%s".currval' % sq_name)
         return cursor.fetchone()[0]
 
     def lookup_cast(self, lookup_type, internal_type=None):

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -341,7 +341,9 @@ END;
 
     def last_insert_id(self, cursor, table_name, pk_name):
         sq_name = self._get_sequence_name(cursor, strip_quotes(table_name), pk_name)
-        cursor.execute('"%s".currval' % sq_name)
+        template = 'SELECT "%s".currval' + self.connection.features.bare_select_suffix
+
+        cursor.execute(template % sq_name)
         return cursor.fetchone()[0]
 
     def lookup_cast(self, lookup_type, internal_type=None):

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1679,13 +1679,33 @@ class ManyToManyField(RelatedField):
                             possible_field_names.append(f.name)
                     if possible_field_names:
                         hint = (
-                            "Did you mean one of the following foreign keys to '%s': "
-                            "%s?"
+                            "Did you mean one of the following foreign keys to '%s': %s?"
                             % (
-                                related_model._meta.object_name,
+                                related_model if isinstance(related_model, str) else related_model._meta.object_name,
                                 ", ".join(possible_field_names),
                             )
                         )
+
+                        if (
+                            isinstance(field, ForeignKey)
+                            and getattr(field.remote_field, "model", None)
+                            == related_model
+                        ):
+                            related_object_name = (
+                                related_model if isinstance(related_model, str) else related_model._meta.object_name
+                            )
+                            errors.append(
+                                checks.Error(
+                                    "'%s.%s' is not a foreign key to '%s'."
+                                    % (
+                                        through._meta.object_name,
+                                        field_name,
+                                        related_object_name,
+                                    ),
+                                    hint=hint,  
+                                    obj=self,
+                                )
+                            )
                     else:
                         hint = None
 


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36239

#### Branch description
This fix addresses a bug in the ManyToManyField system check when an invalid to argument is passed along with through and through_fields arguments. Previously, this scenario caused an AttributeError: 'str' object has no attribute '_meta', resulting in an unhelpful traceback.

The fix introduces a safer approach by conditionally accessing related_model._meta.object_name only if related_model is not a string. This prevents crashes and provides a clearer error message, improving the developer experience during model validation.
#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
