### PR TITLE
Refs #25582 -- Doc'd query and fragment arguments for reverse_lazy().

### DIFF
--- a/docs/ref/urlresolvers.txt
+++ b/docs/ref/urlresolvers.txt
@@ -132,7 +132,7 @@ For example:
 
 A lazily evaluated version of `reverse()`_.
 
-.. function:: reverse_lazy(viewname, urlconf=None, args=None, kwargs=None, current_app=None)
+.. function:: reverse_lazy(viewname, urlconf=None, args=None, kwargs=None, current_app=None, *, query=None, fragment=None)
 
 It is useful for when you need to use a URL reversal before your project's
 URLConf is loaded. Some common cases where this function is necessary are:
@@ -146,6 +146,10 @@ URLConf is loaded. Some common cases where this function is necessary are:
 
 * providing a reversed URL as a default value for a parameter in a function's
   signature.
+
+.. versionchanged:: 5.2
+
+    The ``query`` and ``fragment`` arguments were added.
 
 ``resolve()``
 =============

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -371,9 +371,9 @@ Tests
 URLs
 ~~~~
 
-* :func:`~django.urls.reverse` now accepts ``query`` and ``fragment`` keyword
-  arguments, allowing the addition of a query string and/or fragment identifier
-  in the generated URL, respectively.
+* :func:`~django.urls.reverse` and :func:`~django.urls.reverse_lazy` now accept
+  ``query`` and ``fragment`` keyword arguments, allowing the addition of a
+  query string and/or fragment identifier in the generated URL, respectively.
 
 Utilities
 ~~~~~~~~~


### PR DESCRIPTION
#### Trac ticket number

ticket-25582

#### Branch description

The documentation for `reverse_lazy()` was missed in #18848. It gains the new arguments because it's a wrapper around `reverse()`:

https://github.com/django/django/blob/b844f1b9058ef28e4c26804358749a35fce2e874/django/urls/base.py#L111

This PR updates the release note and docs, for backporting to the 5.2 branch.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
