### PR TITLE
Fixed #36247 Changed the log severity to warning

### DIFF
--- a/django/contrib/gis/forms/widgets.py
+++ b/django/contrib/gis/forms/widgets.py
@@ -37,7 +37,7 @@ class BaseGeometryWidget(Widget):
         try:
             return GEOSGeometry(value)
         except (GEOSException, ValueError, TypeError) as err:
-            logger.error("Error creating geometry from value '%s' (%s)", value, err)
+            logger.warning("Error creating geometry from value '%s' (%s)", value, err)
         return None
 
     def get_context(self, name, value, attrs):

--- a/docs/ref/logging.txt
+++ b/docs/ref/logging.txt
@@ -226,7 +226,7 @@ a mail sending exception.
 
 Log messages related to :doc:`contrib/gis/index` at various points: during the
 loading of external GeoSpatial libraries (GEOS, GDAL, etc.) and when reporting
-errors. Each ``ERROR`` log record includes the caught exception and relevant
+errors. Each ``WARNING`` log record includes the caught exception and relevant
 contextual data.
 
 .. _django-dispatch-logger:

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -72,6 +72,9 @@ Minor features
   function rotates a geometry by a specified angle around the origin or a
   specified point.
 
+* changed log level from ERROR to WARNING in BaseGeometryWidget.deserialize()
+  to reduce noise in error logs when deserializing malformed geometry.
+
 :mod:`django.contrib.messages`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/gis_tests/geoadmin/tests.py
+++ b/tests/gis_tests/geoadmin/tests.py
@@ -12,7 +12,7 @@ class GeoAdminTest(SimpleTestCase):
         geoadmin = self.admin_site.get_model_admin(City)
         form = geoadmin.get_changelist_form(None)({"point": ""})
         with self.assertRaisesMessage(AssertionError, "no logs"):
-            with self.assertLogs("django.contrib.gis", "ERROR"):
+            with self.assertLogs("django.contrib.gis", "WARNING"):
                 output = str(form["point"])
         self.assertInHTML(
             '<textarea id="id_point" class="vSerializedField required" cols="150"'
@@ -23,7 +23,7 @@ class GeoAdminTest(SimpleTestCase):
     def test_widget_invalid_string(self):
         geoadmin = self.admin_site.get_model_admin(City)
         form = geoadmin.get_changelist_form(None)({"point": "INVALID()"})
-        with self.assertLogs("django.contrib.gis", "ERROR") as cm:
+        with self.assertLogs("django.contrib.gis", "WARNING") as cm:
             output = str(form["point"])
         self.assertInHTML(
             '<textarea id="id_point" class="vSerializedField required" cols="150"'

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -154,7 +154,7 @@ class GeometryFieldTest(SimpleTestCase):
             }
         )
 
-        with self.assertLogs("django.contrib.gis", "ERROR") as logger_calls:
+        with self.assertLogs("django.contrib.gis", "WARNING") as logger_calls:
             output = str(form)
 
         # The first point can't use assertInHTML() due to non-deterministic


### PR DESCRIPTION
#### Trac ticket number
ticket-36247

#### Branch description
Changed log level from error to warning in BaseGeometryWidget.deserialize to reduce noise in error logs. The error was being logged when deserializing malformed geometry, but this results in a validation error rather than a failed request, so a warning level is more appropriate.

#### Checklist
- [ ] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.