### PR TITLE
Removed default for app_configs from system check functions.

### DIFF
--- a/django/contrib/auth/checks.py
+++ b/django/contrib/auth/checks.py
@@ -25,7 +25,7 @@ def _subclass_index(class_path, candidate_paths):
     return -1
 
 
-def check_user_model(app_configs=None, **kwargs):
+def check_user_model(app_configs, **kwargs):
     if app_configs is None:
         cls = apps.get_model(settings.AUTH_USER_MODEL)
     else:
@@ -121,7 +121,7 @@ def check_user_model(app_configs=None, **kwargs):
     return errors
 
 
-def check_models_permissions(app_configs=None, **kwargs):
+def check_models_permissions(app_configs, **kwargs):
     if app_configs is None:
         models = apps.get_models()
     else:

--- a/django/contrib/contenttypes/checks.py
+++ b/django/contrib/contenttypes/checks.py
@@ -4,7 +4,7 @@ from django.apps import apps
 from django.core.checks import Error
 
 
-def check_generic_foreign_keys(app_configs=None, **kwargs):
+def check_generic_foreign_keys(app_configs, **kwargs):
     from .fields import GenericForeignKey
 
     if app_configs is None:
@@ -25,7 +25,7 @@ def check_generic_foreign_keys(app_configs=None, **kwargs):
     return errors
 
 
-def check_model_name_lengths(app_configs=None, **kwargs):
+def check_model_name_lengths(app_configs, **kwargs):
     if app_configs is None:
         models = apps.get_models()
     else:

--- a/django/contrib/staticfiles/checks.py
+++ b/django/contrib/staticfiles/checks.py
@@ -8,7 +8,7 @@ E005 = Error(
 )
 
 
-def check_finders(app_configs=None, **kwargs):
+def check_finders(app_configs, **kwargs):
     """Check all registered staticfiles finders."""
     errors = []
     for finder in get_finders():
@@ -21,7 +21,7 @@ def check_finders(app_configs=None, **kwargs):
     return errors
 
 
-def check_storages(app_configs=None, **kwargs):
+def check_storages(app_configs, **kwargs):
     """Ensure staticfiles is defined in STORAGES setting."""
     errors = []
     if STATICFILES_STORAGE_ALIAS not in settings.STORAGES:

--- a/django/core/checks/model_checks.py
+++ b/django/core/checks/model_checks.py
@@ -9,7 +9,7 @@ from django.core.checks import Error, Tags, Warning, register
 
 
 @register(Tags.models)
-def check_all_models(app_configs=None, **kwargs):
+def check_all_models(app_configs, **kwargs):
     db_table_models = defaultdict(list)
     indexes = defaultdict(list)
     constraints = defaultdict(list)
@@ -223,5 +223,5 @@ def _check_lazy_references(apps, ignore=None):
 
 
 @register(Tags.models)
-def check_lazy_references(app_configs=None, **kwargs):
+def check_lazy_references(app_configs, **kwargs):
     return _check_lazy_references(apps)


### PR DESCRIPTION
#### Trac ticket number

N/A

#### Branch description

Noticed whilst working on django-stubs that some of Django’s internal system check functions declare `app_configs=None`, even though a default isn't needed or used by the majority of functions. This PR removes the unnecessary defaults.

[The documentation](https://docs.djangoproject.com/en/5.1/topics/checks/#django.core.checks.register) encourages users to write functions without a default for `app_configs`, and checks are always passed the argument:

https://github.com/django/django/blob/d752ec8259a3a3123733cacbfb4f207ee61f6242/django/core/checks/registry.py#L87-L88

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [n/a] I have checked the "Has patch" ticket flag in the Trac system.
- [n/a] I have added or updated relevant tests.
- [n/a] I have added or updated relevant docs, including release notes if applicable.
- [n/a] I have attached screenshots in both light and dark modes for any UI changes.
