### PR TITLE
Fixed #36248 -- Limited delete-time related-model updates to batch size.

### DIFF
--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -1,7 +1,7 @@
 from collections import Counter, defaultdict
-from functools import partial, reduce
+from functools import partial
 from itertools import chain
-from operator import attrgetter, or_
+from operator import attrgetter
 
 from django.db import IntegrityError, connections, models, transaction
 from django.db.models import query_utils, signals, sql
@@ -480,9 +480,8 @@ class Collector:
                         updates.append(instances)
                     else:
                         objs.extend(instances)
-                if updates:
-                    combined_updates = reduce(or_, updates)
-                    combined_updates.update(**{field.name: value})
+                for update in updates:
+                    update.update(**{field.name: value})
                 if objs:
                     model = objs[0].__class__
                     query = sql.UpdateQuery(model)

--- a/tests/delete/models.py
+++ b/tests/delete/models.py
@@ -136,6 +136,29 @@ class Avatar(models.Model):
     desc = models.TextField(null=True)
 
 
+class LargeDeleteReferent(models.Model):
+    pass
+
+
+class LargeDeleteReferrer(models.Model):
+    protect = models.ForeignKey(
+        LargeDeleteReferent,
+        on_delete=models.PROTECT,
+        related_name="protecting",
+    )
+    cascade = models.ForeignKey(
+        LargeDeleteReferent,
+        on_delete=models.CASCADE,
+        related_name="cascading",
+    )
+    set_null = models.ForeignKey(
+        LargeDeleteReferent,
+        null=True,
+        on_delete=models.SET_NULL,
+        related_name="setting_null",
+    )
+
+
 # This model is used to test a duplicate query regression (#25685)
 class AvatarProxy(Avatar):
     class Meta:


### PR DESCRIPTION
#### Trac ticket number

ticket-36248

#### Branch description

During deletion, when there is a relation pointing to the deleted model with an on_delete mode that requires an update operation (such as SET_NULL), ensured we do one update statement for each batch of deletes that get_del_batches has calculated, instead of combining them into one filter. This should prevent us hitting the parameter limit in DBMSs that have one (eg SQLite, MSSQL).

Added a DeletionTest that counts the number of params used in deletion queries, including for related tables with SET_NULL and other on_delete options, to ensure we aren't in danger of hitting a limit.

#### Checklist
- [X] This PR targets the `main` branch.
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
