### PR TITLE
Fixed #36252 -- Fixed Duplicate Display of Imports in Django Shell

### DIFF
--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -173,6 +173,7 @@ class Command(BaseCommand):
 
         auto_imports = defaultdict(list)
         import_errors = []
+        imported_names = defaultdict(set)
         for path in path_imports:
             try:
                 obj = import_dotted_path(path) if "." in path else import_module(path)
@@ -185,7 +186,10 @@ class Command(BaseCommand):
             else:
                 module = None
                 name = path
+            if name in imported_names[module]:
+                continue
 
+            imported_names[module].add(name)
             auto_imports[module].append((name, obj))
 
         namespace = {

--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -382,6 +382,7 @@ class ShellCommandAutoImportsTestCase(SimpleTestCase):
             def get_auto_imports(self):
                 return super().get_auto_imports() + [
                     "django.urls.reverse",
+                    "django.urls.reverse",
                     "django.urls.resolve",
                     "django",
                 ]


### PR DESCRIPTION
#### Trac ticket number
ticket-36252

#### Branch description
Fixed duplicate imports in the shell command output. When the same import path appeared multiple times in the auto-imports list, it would be displayed multiple times in the verbose output. This change ensures each import is only displayed once.

#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.