### PR TITLE
Refs #35945 -- Fixed test_paginating_unordered_queryset_raises_warning_async() test on byte-compiled Django.

### DIFF
--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -1,5 +1,6 @@
 import collections.abc
 import inspect
+import pathlib
 import unittest.mock
 import warnings
 from datetime import datetime
@@ -888,7 +889,11 @@ class ModelPaginationTests(TestCase):
             AsyncPaginator(Article.objects.all(), 5)
         # The warning points at the BasePaginator caller.
         # The reason is that the UnorderedObjectListWarning occurs in BasePaginator.
-        self.assertEqual(cm.filename, inspect.getfile(BasePaginator))
+        base_paginator_path = pathlib.Path(inspect.getfile(BasePaginator))
+        self.assertIn(
+            cm.filename,
+            [str(base_paginator_path), str(base_paginator_path.with_suffix(".py"))],
+        )
 
     def test_paginating_empty_queryset_does_not_warn(self):
         with warnings.catch_warnings(record=True) as recorded:


### PR DESCRIPTION
[Logs.](https://github.com/django/django/actions/runs/13826117388/job/38681259619)

```
FAIL: test_paginating_unordered_queryset_raises_warning_async (pagination.tests.ModelPaginationTests.test_paginating_unordered_queryset_raises_warning_async)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/unittest/case.py", line 651, in run
    self._callTestMethod(testMethod)
    
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/unittest/case.py", line 606, in _callTestMethod
    if method() is not None:
    ^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/site-packages/asgiref/sync.py", line 254, in __call__
    return call_result.result()
    ^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
    ^^^
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
    ^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/site-packages/asgiref/sync.py", line 331, in main_wrap
    result = await self.awaitable(*args, **kwargs)
    ^^^^^^^
  File "/home/runner/work/django/django/tests/pagination/tests.py", line 891, in test_paginating_unordered_queryset_raises_warning_async
    self.assertEqual(cm.filename, inspect.getfile(BasePaginator))
    ^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/unittest/case.py", line 907, in assertEqual
    assertion_func(first, second, msg=msg)
    ^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/unittest/case.py", line 1273, in assertMultiLineEqual
    self.fail(self._formatMessage(msg, standardMsg))
    ^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/unittest/case.py", line 732, in fail
    raise self.failureException(msg)
    ^^^^^^^^^^^^^^^
AssertionError: '/opt[27 chars]3.2/x64/lib/python3.13/site-packages/django/core/paginator.py' != '/opt[27 chars]3.2/x64/lib/python3.13/site-packages/django/core/paginator.pyc'
- /opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/site-packages/django/core/paginator.py
+ /opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/site-packages/django/core/paginator.pyc
```