### PR TITLE
Made selenium tests less flaky by waiting until popups are closed and page is loaded.

### DIFF
--- a/django/contrib/admin/tests.py
+++ b/django/contrib/admin/tests.py
@@ -123,13 +123,21 @@ class AdminSeleniumTestCase(SeleniumTestCase, StaticLiveServerTestCase):
         """
         Block until a new page has loaded and is ready.
         """
+        from selenium.common.exceptions import WebDriverException
         from selenium.webdriver.common.by import By
         from selenium.webdriver.support import expected_conditions as ec
 
         old_page = self.selenium.find_element(By.TAG_NAME, "html")
         yield
         # Wait for the next page to be loaded
-        self.wait_until(ec.staleness_of(old_page), timeout=timeout)
+        try:
+            self.wait_until(ec.staleness_of(old_page), timeout=timeout)
+        except WebDriverException:
+            # Issue in version 113+ of Chrome driver where a WebDriverException
+            # error is raised rather than a StaleElementReferenceException, see:
+            # https://issues.chromium.org/issues/42323468
+            pass
+
         self.wait_page_ready(timeout=timeout)
 
     def admin_login(self, username, password, login_url="/admin/"):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -6448,6 +6448,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         ActionChains(self.selenium).move_to_element(delete_parent).click().perform()
         self.wait_for_and_switch_to_popup()
         self.selenium.find_element(By.XPATH, '//input[@value="Yes, I’m sure"]').click()
+        self.wait_until(lambda d: len(d.window_handles) == 1, 1)
         self.selenium.switch_to.window(self.selenium.window_handles[0])
         select = Select(self.selenium.find_element(By.ID, "id_parent"))
         self.assertEqual(ParentWithUUIDPK.objects.count(), 0)
@@ -6582,6 +6583,7 @@ class SeleniumTests(AdminSeleniumTestCase):
 
         self.selenium.find_element(By.ID, "id_title").send_keys("test3")
         self.selenium.find_element(By.XPATH, '//input[@value="Save"]').click()
+        self.wait_until(lambda d: len(d.window_handles) == 3, 1)
         self.selenium.switch_to.window(popup_window_test2)
         select = Select(self.selenium.find_element(By.ID, "id_next_box"))
         next_box_id = str(Box.objects.get(title="test3").id)
@@ -6590,6 +6592,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         )
 
         self.selenium.find_element(By.XPATH, '//input[@value="Save"]').click()
+        self.wait_until(lambda d: len(d.window_handles) == 2, 1)
         self.selenium.switch_to.window(popup_window_test)
         select = Select(self.selenium.find_element(By.ID, "id_next_box"))
         next_box_id = str(Box.objects.get(title="test2").id)
@@ -6598,6 +6601,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         )
 
         self.selenium.find_element(By.XPATH, '//input[@value="Save"]').click()
+        self.wait_until(lambda d: len(d.window_handles) == 1, 1)
         self.selenium.switch_to.window(base_window)
         select = Select(self.selenium.find_element(By.ID, "id_next_box"))
         next_box_id = str(Box.objects.get(title="test").id)
@@ -6833,15 +6837,17 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.selenium.get(self.live_server_url + add_url)
         name_input = self.selenium.find_element(By.ID, "id_name")
         name_input.send_keys("Test section 1")
-        self.selenium.find_element(
-            By.XPATH, '//input[@value="Save and add another"]'
-        ).click()
+        with self.wait_page_loaded():
+            self.selenium.find_element(
+                By.XPATH, '//input[@value="Save and add another"]'
+            ).click()
         self.assertEqual(Section.objects.count(), 1)
         name_input = self.selenium.find_element(By.ID, "id_name")
         name_input.send_keys("Test section 2")
-        self.selenium.find_element(
-            By.XPATH, '//input[@value="Save and add another"]'
-        ).click()
+        with self.wait_page_loaded():
+            self.selenium.find_element(
+                By.XPATH, '//input[@value="Save and add another"]'
+            ).click()
         self.assertEqual(Section.objects.count(), 2)
 
     def test_redirect_on_add_view_continue_button(self):
@@ -6854,9 +6860,10 @@ class SeleniumTests(AdminSeleniumTestCase):
         self.selenium.get(self.live_server_url + add_url)
         name_input = self.selenium.find_element(By.ID, "id_name")
         name_input.send_keys("Test section 1")
-        self.selenium.find_element(
-            By.XPATH, '//input[@value="Save and continue editing"]'
-        ).click()
+        with self.wait_page_loaded():
+            self.selenium.find_element(
+                By.XPATH, '//input[@value="Save and continue editing"]'
+            ).click()
         self.assertEqual(Section.objects.count(), 1)
         name_input = self.selenium.find_element(By.ID, "id_name")
         name_input_value = name_input.get_attribute("value")

--- a/tests/forms_tests/tests/test_widgets.py
+++ b/tests/forms_tests/tests/test_widgets.py
@@ -19,6 +19,7 @@ class LiveWidgetTests(AdminSeleniumTestCase):
         self.selenium.get(
             self.live_server_url + reverse("article_form", args=[article.pk])
         )
-        self.selenium.find_element(By.ID, "submit").click()
+        with self.wait_page_loaded():
+            self.selenium.find_element(By.ID, "submit").click()
         article = Article.objects.get(pk=article.pk)
         self.assertEqual(article.content, "\r\nTst\r\n")


### PR DESCRIPTION
My theory is that since 0ebea6e5c07485a36862e9b6e2be18d1694ad2c5, the saving of objects has become slightly slower
This caused some failures in the selenium test suite: https://github.com/django/django/actions/runs/13826117388/job/38698352291
