### PR TITLE
Fixed #36250 – Ensured `RelatedFieldWidgetWrapper` uses correct renderer

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -4,12 +4,14 @@ Form Widget classes specific to the Django admin site.
 
 import copy
 import json
+from typing import Any, Dict, Optional
 
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.db.models import CASCADE, UUIDField
+from django.forms.renderers import BaseRenderer
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.html import smart_urlquote
@@ -312,12 +314,40 @@ class RelatedFieldWidgetWrapper(forms.Widget):
             args=args,
         )
 
-    def get_context(self, name, value, attrs):
+    def get_context(
+        self,
+        name: str,
+        value: Any,
+        attrs: Optional[Dict[str, Any]] = None,
+        renderer: Optional[BaseRenderer] = None,
+    ) -> Dict[str, Any]:
+        """
+        Generate context for the widget, supporting optional custom renderer.
+
+        This method ensures that the underlying widget respects the provided
+        renderer, improving flexibility in widget rendering.
+
+        Args:
+            name: Field name
+            value: Current field value
+            attrs: HTML attributes
+            renderer: Optional custom renderer
+
+        Returns:
+            Context dictionary for template rendering
+        """
+        # Ensure attrs is a dictionary to prevent potential None-related errors
+        attrs = attrs or {}
+
+        # IMPORTANT: Lazy import to avoid circular dependencies
         from django.contrib.admin.views.main import IS_POPUP_VAR, TO_FIELD_VAR
 
+        # Retrieve model and related field metadata
         rel_opts = self.rel.model._meta
         info = (rel_opts.app_label, rel_opts.model_name)
         related_field_name = self.rel.get_related_field().name
+
+        # Construct URL parameters for popup and related field
         url_params = "&".join(
             "%s=%s" % param
             for param in [
@@ -325,8 +355,13 @@ class RelatedFieldWidgetWrapper(forms.Widget):
                 (IS_POPUP_VAR, 1),
             ]
         )
+
+        # Render widget with optional renderer
+        rendered_widget = self.widget.render(name, value, attrs, renderer=renderer)
+
+        # Construct context dictionary
         context = {
-            "rendered_widget": self.widget.render(name, value, attrs),
+            "rendered_widget": rendered_widget,
             "is_hidden": self.is_hidden,
             "name": name,
             "url_params": url_params,

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -22,6 +22,7 @@ from django.db.models import (
     ManyToManyField,
     UUIDField,
 )
+from django.forms.renderers import BaseRenderer
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.test.selenium import screenshot_cases
 from django.test.utils import requires_tz_support
@@ -963,6 +964,78 @@ class RelatedFieldWidgetWrapperTests(SimpleTestCase):
         </div>
         """
         self.assertHTMLEqual(output, expected)
+
+    def test_get_context_with_default_renderer(self):
+        """Test get_context() works with default (None) renderer"""
+        rel = Album._meta.get_field("band").remote_field
+        widget = forms.Select()
+        wrapper = widgets.RelatedFieldWidgetWrapper(widget, rel, widget_admin_site)
+        context = wrapper.get_context("field_name", "value")
+        self.assertIn("rendered_widget", context)
+        self.assertIsNotNone(context["rendered_widget"])
+
+    def test_get_context_with_custom_renderer(self):
+        """Test get_context() works with a custom renderer"""
+
+        class MockRenderer(BaseRenderer):
+            """Mock renderer for testing renderer-related functionality"""
+
+            def render(self, template_name, context, request=None):
+                return f"Rendered by MockRenderer: {template_name}"
+
+        rel = Album._meta.get_field("band").remote_field
+        widget = forms.Select()
+        wrapper = widgets.RelatedFieldWidgetWrapper(widget, rel, widget_admin_site)
+
+        mock_renderer = MockRenderer()
+        context = wrapper.get_context("field_name", "value", renderer=mock_renderer)
+
+        self.assertIn("rendered_widget", context)
+        self.assertIsNotNone(context["rendered_widget"])
+
+    def test_renderer_with_different_widget_types(self):
+        """Test renderer works with various widget types"""
+        test_widgets = [forms.Select(), forms.TextInput(), forms.HiddenInput()]
+
+        rel = Album._meta.get_field("band").remote_field
+
+        for test_widget in test_widgets:
+            with self.subTest(widget_type=type(test_widget).__name__):
+
+                class MockRenderer(BaseRenderer):
+                    """Mock renderer for testing renderer-related functionality"""
+
+                    def __init__(self):
+                        self.used = False
+
+                    def render(self, template_name, context, request=None):
+                        self.used = True
+                        return f"Rendered by MockRenderer: {template_name}"
+
+                wrapper = widgets.RelatedFieldWidgetWrapper(
+                    test_widget, rel, widget_admin_site
+                )
+
+                mock_renderer = MockRenderer()
+                context = wrapper.get_context(
+                    "field_name", "value", renderer=mock_renderer
+                )
+
+                self.assertIn("rendered_widget", context)
+                self.assertIsNotNone(context["rendered_widget"])
+                # Verify that the renderer was actually used
+                self.assertTrue(mock_renderer.used)
+
+    def test_renderer_backward_compatibility(self):
+        """Ensure existing code continues to work without renderer"""
+        rel = Album._meta.get_field("band").remote_field
+        widget = forms.Select()
+        wrapper = widgets.RelatedFieldWidgetWrapper(widget, rel, widget_admin_site)
+
+        # Should not raise any TypeError
+        context = wrapper.get_context("field_name", "value")
+        self.assertIn("rendered_widget", context)
+        self.assertIsNotNone(context["rendered_widget"])
 
 
 @override_settings(ROOT_URLCONF="admin_widgets.urls")


### PR DESCRIPTION

📌 **Summary**  
This PR updates `RelatedFieldWidgetWrapper.get_context()` to properly respect the renderer passed to it, ensuring consistency in widget rendering.

🔑 **Key Changes**  
- **Added** an optional `renderer` parameter to `get_context()`.  
- **Updated** the internal widget rendering call to use the provided `renderer`.  
- **Ensured backward compatibility** by maintaining the previous behavior if no renderer is passed.  
- **Refactored** the function with improved type hinting and docstrings.

🎫 **Trac Ticket**  
ticket-36250

🔀 **Branch Description**  
This change ensures that `RelatedFieldWidgetWrapper` does not override custom renderers, preventing inconsistencies in Django’s admin UI.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.

🧪 **Testing & Validation**  
- **Added test case** in `tests/admin_widgets/tests.py` to verify correct behavior.  
- **Ran Django's test suite** to confirm no regressions.  

🛡 **Security & Compatibility**  
- **No breaking changes** – maintains existing functionality.  
- **Improved maintainability** – cleaner, more modular implementation.  

📖 **Documentation**  
- **Inline docstrings** added for clarity.  
- **No additional docs required** as this fixes existing behavior.  

This PR ensures consistency in Django’s admin widget rendering while preserving flexibility for custom renderers.
