### PR TITLE
Fixed #34819 -- Allowed GenericForeignKey to prefetch using prepped primary keys.

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -205,14 +205,11 @@ class GenericForeignKey(FieldCacheMixin, Field):
                 model = self.get_content_type(
                     id=ct_id, using=obj._state.db
                 ).model_class()
-                return (
-                    model._meta.pk.get_prep_value(getattr(obj, self.fk_field)),
-                    model,
-                )
+                return str(getattr(obj, self.fk_field)), model
 
         return (
             ret_val,
-            lambda obj: (obj.pk, obj.__class__),
+            lambda obj: (obj._meta.pk.value_to_string(obj), obj.__class__),
             gfk_key,
             True,
             self.name,

--- a/tests/prefetch_related/models.py
+++ b/tests/prefetch_related/models.py
@@ -216,6 +216,15 @@ class Comment(models.Model):
         ordering = ["id"]
 
 
+class ArticleCustomUUID(models.Model):
+    class CustomUUIDField(models.UUIDField):
+        def get_prep_value(self, value):
+            return str(value)
+
+    id = CustomUUIDField(primary_key=True, default=uuid.uuid4)
+    name = models.CharField(max_length=30)
+
+
 # Models for lookup ordering tests
 
 

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -16,6 +16,7 @@ from django.test.utils import CaptureQueriesContext
 
 from .models import (
     Article,
+    ArticleCustomUUID,
     Author,
     Author2,
     AuthorAddress,
@@ -1178,6 +1179,14 @@ class GenericRelationTests(TestCase):
         Comment.objects.create(comment="awesome", content_object_uuid=article)
         qs = Comment.objects.prefetch_related("content_object_uuid")
         self.assertEqual([c.content_object_uuid for c in qs], [article])
+
+    def test_prefetch_GFK_uses_prepped_primary_key(self):
+        article = ArticleCustomUUID.objects.create(name="Blanche")
+        Comment.objects.create(comment="Enchantment", content_object_uuid=article)
+        obj = Comment.objects.prefetch_related("content_object_uuid").get(
+            comment="Enchantment"
+        )
+        self.assertEqual(obj.content_object_uuid, article)
 
     def test_prefetch_GFK_fk_pk(self):
         book = Book.objects.create(title="Poems")


### PR DESCRIPTION


#### Trac ticket number
<!-- Replace  with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-34819

#### Branch description
In `GenericForeignKey.get_prefetch_query()`, the `rel_obj_attr` (`gfk_key`) returned a `get_prep_value()`d primary key, but the `instance_attr` lambda returned `obj.pk` directly. This mismatch caused prefetching failures when the database representation differed from the Python object, resulting in prefetched instances being set to None.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
