### PR TITLE
Fixed #36262 -- Made GeneratedField.db_persist a required key-word argument.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -478,6 +478,7 @@ answer newbie questions, and generally made Django that much better:
     Jarek Głowacki <jarekwg@gmail.com>
     Jarek Zgoda <jarek.zgoda@gmail.com>
     Jarosław Wygoda <jaroslaw@wygoda.me>
+    Jason Cameron <https://jasoncameron.dev>
     Jason Davies (Esaj) <https://www.jasondavies.com/>
     Jason Huggins <http://www.jrandolph.com/blog/>
     Jason McBrayer <http://www.carcosa.net/jason/>

--- a/django/db/models/fields/generated.py
+++ b/django/db/models/fields/generated.py
@@ -15,7 +15,7 @@ class GeneratedField(Field):
     _query = None
     output_field = None
 
-    def __init__(self, *, expression, output_field, db_persist=None, **kwargs):
+    def __init__(self, *, expression, output_field, db_persist, **kwargs):
         if kwargs.setdefault("editable", False):
             raise ValueError("GeneratedField cannot be editable.")
         if not kwargs.setdefault("blank", True):

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1278,7 +1278,7 @@ when :attr:`~django.forms.Field.localize` is ``False`` or
 ``GeneratedField``
 ------------------
 
-.. class:: GeneratedField(expression, output_field, db_persist=None, **kwargs)
+.. class:: GeneratedField(*, expression, output_field, db_persist, **kwargs)
 
 A field that is always computed based on other fields in the model. This field
 is managed and updated by the database itself. Uses the ``GENERATED ALWAYS``

--- a/tests/model_fields/test_generatedfield.py
+++ b/tests/model_fields/test_generatedfield.py
@@ -94,11 +94,11 @@ class BaseGeneratedFieldTests(SimpleTestCase):
             )
 
     def test_db_persist_required(self):
-        msg = "GeneratedField.db_persist must be True or False."
-        with self.assertRaisesMessage(ValueError, msg):
+        with self.assertRaises(TypeError):
             GeneratedField(
                 expression=Lower("name"), output_field=CharField(max_length=255)
             )
+        msg = "GeneratedField.db_persist must be True or False."
         with self.assertRaisesMessage(ValueError, msg):
             GeneratedField(
                 expression=Lower("name"),


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36262

#### Branch description
GeneratedField.db_persist attribute is set to None=True, which implies that the value can be None. However, just 4 lines lower in the code, it is required to be either True or False. This inconsistency leads a developer to believe that it can be left blank but it cannot.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.