### PR TITLE
suggestionfix 29446

### DIFF
--- a/django/views/context.py
+++ b/django/views/context.py
@@ -1,0 +1,9 @@
+def get_context():
+
+    return {
+        "message": "Hell this is Bhupesh Panwar",
+        "message1": "this is Bhupesh Panwar"
+    }
+
+# for example this is an context( this is an suggestion fix). if somehow we import context/dictionary from the user view to debug.py file. we are able to show the context
+#in error page

--- a/django/views/context.py
+++ b/django/views/context.py
@@ -2,8 +2,8 @@ def get_context():
 
     return {
         "message": "Hell this is Bhupesh Panwar",
-        "message1": "this is Bhupesh Panwar"
+        "message1": "this is Bhupesh Panwar",
     }
 
-# for example this is an context( this is an suggestion fix). if somehow we import context/dictionary from the user view to debug.py file. we are able to show the context
-#in error page
+
+# for example this is an context( this is an suggestion fix).

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -18,6 +18,7 @@ from django.utils.encoding import force_str
 from django.utils.module_loading import import_string
 from django.utils.regex_helper import _lazy_re_compile
 from django.utils.version import get_docs_version
+from django.views.context import get_context  # importing context
 from django.views.decorators.debug import coroutine_functions_to_sensitive_variables
 
 # Minimal Django templates engine to render the error templates
@@ -391,6 +392,7 @@ class ExceptionReporter:
             "request_meta": self.filter.get_safe_request_meta(self.request),
             "request_COOKIES_items": self.filter.get_safe_cookies(self.request).items(),
             "user_str": user_str,
+            "context": get_context(),  # storing the dictionary with name context
             "filtered_POST_items": list(
                 self.filter.get_post_parameters(self.request).items()
             ),
@@ -425,7 +427,9 @@ class ExceptionReporter:
         """Return HTML version of debug 500 HTTP error page."""
         with self.html_template_path.open(encoding="utf-8") as fh:
             t = DEBUG_ENGINE.from_string(fh.read())
-        c = Context(self.get_traceback_data(), use_l10n=False)
+        c = Context(
+            self.get_traceback_data(), use_l10n=False
+        )  # these stored context  will be used through this
         return t.render(c)
 
     def get_traceback_text(self):

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -217,6 +217,9 @@
   </h2>
   <div id="browserTraceback">
     <ul class="traceback">
+      {% for key,value in context.items%}
+      {{ key }}:{{ value }} <!-- using for loop for each entries in context-->
+      {%  endfor %}
       {% for frame in frames %}
         {% ifchanged frame.exc_cause %}{% if frame.exc_cause %}
           <li class="cause"><h3>


### PR DESCRIPTION
####  Issue 29446


ticket-29446

template context issue

I have implemented a  fix by creating a context file. I then imported this context into debug.py and stored it in a dictionary (c). After that, I made some modifications to the 500.html error page.
I understand that the changes should allow us to retrieve the context from the user view, but I found multiple approaches online and am unsure which one is best.
Previously, I had  closed my pr  due to ESLint errors(during precommit). I have now created a new branch and submitted a fresh pull request.
