### PR TITLE
Fixed #36266 -- Renamed HIDE_PRODUCTION_WARNING environment variable to DJANGO_RUNSERVER_HIDE_WARNING.

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -189,7 +189,7 @@ class Command(BaseCommand):
             file=self.stdout,
         )
         docs_version = get_docs_version()
-        if os.environ.get("HIDE_PRODUCTION_WARNING") != "true":
+        if os.environ.get("DJANGO_RUNSERVER_HIDE_WARNING") != "true":
             self.stdout.write(
                 self.style.WARNING(
                     "WARNING: This is a development server. Do not use it in a "

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -947,7 +947,7 @@ multithreaded by default.
 Uses IPv6 for the development server. This changes the default IP address from
 ``127.0.0.1`` to ``::1``.
 
-.. envvar:: HIDE_PRODUCTION_WARNING
+.. envvar:: DJANGO_RUNSERVER_HIDE_WARNING
 
 .. versionadded:: 5.2
 

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -276,7 +276,8 @@ Management Commands
 
 * A new warning is displayed when running :djadmin:`runserver`, indicating that
   it is unsuitable for production. This warning can be suppressed by setting
-  the :envvar:`HIDE_PRODUCTION_WARNING` environment variable to ``"true"``.
+  the :envvar:`DJANGO_RUNSERVER_HIDE_WARNING` environment variable to
+  ``"true"``.
 
 * The :djadmin:`makemigrations` and :djadmin:`migrate` commands  have a new
   ``Command.autodetector`` attribute for subclasses to override in order to use

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1630,7 +1630,7 @@ class ManageRunserver(SimpleTestCase):
             self.output.getvalue(),
         )
 
-    @mock.patch.dict(os.environ, {"HIDE_PRODUCTION_WARNING": "true"})
+    @mock.patch.dict(os.environ, {"DJANGO_RUNSERVER_HIDE_WARNING": "true"})
     def test_hide_production_warning_with_environment_variable(self):
         self.cmd.addr = "0"
         self.cmd._raw_ipv6 = False


### PR DESCRIPTION
Changed env variable name from HIDE_PRODUCTION_WARNING to DJANGO_RUNSERVER_HIDE_WARNING

#### Trac ticket number

ticket-36266

#### Branch description
This PR updates the environment variable name from HIDE_PRODUCTION_WARNING to DJANGO_HIDE_PRODUCTION_WARNING to align with Django's naming conventions for environment variables.

Using the DJANGO_ prefix ensures consistency with other Django-related environment variables and reduces potential confusion for developers who may come across this setting without prior context. This change improves clarity and makes it easier for unfamiliar engineers to recognize that the variable is specific to Django

#### Checklist
- [ X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X ] I have checked the "Has patch" ticket flag in the Trac system.
- [X ] I have added or updated relevant tests.
- [ X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
