### PR TITLE
Fixed #36268 -- Added leading `?` in every querystring template tag result.

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -1175,24 +1175,25 @@ def now(parser, token):
 @register.simple_tag(name="querystring", takes_context=True)
 def querystring(context, query_dict=None, **kwargs):
     """
-    Add, remove, and change parameters of a ``QueryDict`` and return the result
-    as a query string. If the ``query_dict`` argument is not provided, default
-    to ``request.GET``.
+    Build a query string using `query_dict` and `kwargs` arguments.
+
+    This tag constructs a new query string by adding, removing, or modifying
+    parameters, starting from the given `query_dict` (defaulting to
+    `request.GET`). Keyword arguments are processed sequentially, with later
+    arguments taking precedence.
 
     For example::
 
+        {# Set a parameter on top of `request.GET` #}
         {% querystring foo=3 %}
 
-    To remove a key::
-
+        {# Remove a key from `request.GET` #}
         {% querystring foo=None %}
 
-    To use with pagination::
-
+        {# Use with pagination #}
         {% querystring page=page_obj.next_page_number %}
 
-    A custom ``QueryDict`` can also be used::
-
+        {# Use a custom ``QueryDict`` #}
         {% querystring my_query_dict foo=3 %}
     """
     if query_dict is None:

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -1182,6 +1182,8 @@ def querystring(context, query_dict=None, **kwargs):
     `request.GET`). Keyword arguments are processed sequentially, with later
     arguments taking precedence.
 
+    A query string prefixed with `?` is returned.
+
     For example::
 
         {# Set a parameter on top of `request.GET` #}
@@ -1207,9 +1209,7 @@ def querystring(context, query_dict=None, **kwargs):
             params.setlist(key, value)
         else:
             params[key] = value
-    if not params and not query_dict:
-        return ""
-    query_string = params.urlencode()
+    query_string = params.urlencode() if params else ""
     return f"?{query_string}"
 
 

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -967,9 +967,8 @@ Outputs a URL-encoded formatted query string based on the provided parameters.
 This tag requires a :class:`~django.http.QueryDict` instance, which defaults to
 :attr:`request.GET <django.http.HttpRequest.GET>` if none is provided.
 
-If the :class:`~django.http.QueryDict` is empty and no additional parameters
-are provided, an empty string is returned. Otherwise, the result includes a
-leading ``"?"``.
+The result always includes a leading ``"?"`` since this tag is mainly used for
+links, and an empty result could prevent the page from reloading as expected.
 
 .. admonition:: Using ``request.GET`` as default
 
@@ -979,6 +978,10 @@ leading ``"?"``.
     ``request`` object into the template context, or provide a ``QueryDict``
     instance to this tag.
 
+.. versionchanged:: 6.0
+
+    A ``?`` was prepended to the query string for empty results.
+
 Basic usage
 ~~~~~~~~~~~
 
@@ -986,8 +989,9 @@ Basic usage
 
     {% querystring %}
 
-Outputs the current query string verbatim. So if the query string is
-``?color=green``, the output would be ``?color=green``.
+Outputs the current query string verbatim. So if the query string in the
+request is ``?color=green``, the output would be ``?color=green``. If the
+current query string is empty, the output will be ``?``.
 
 .. code-block:: html+django
 
@@ -1038,7 +1042,7 @@ Custom QueryDict
 
 You can provide a custom ``QueryDict`` to be used instead of ``request.GET``.
 So if ``my_query_dict`` is ``<QueryDict: {'color': ['blue']}>``, this outputs
-``?color=blue``.
+``?color=blue``. If ``my_query_dict`` is empty, the output will be ``?``.
 
 Dynamic usage
 ~~~~~~~~~~~~~

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -996,17 +996,6 @@ Outputs the current query string verbatim. So if the query string is
 Outputs the current query string with the addition of the ``size`` parameter.
 Following the previous example, the output would be ``?color=green&size=M``.
 
-Custom QueryDict
-~~~~~~~~~~~~~~~~
-
-.. code-block:: html+django
-
-    {% querystring my_query_dict %}
-
-You can provide a custom ``QueryDict`` to be used instead of ``request.GET``.
-So if ``my_query_dict`` is ``<QueryDict: {'color': ['blue']}>``, this outputs
-``?color=blue``.
-
 Setting items
 ~~~~~~~~~~~~~
 
@@ -1039,6 +1028,17 @@ Handling lists
 
 If ``my_list`` is ``["red", "blue"]``, the output will be
 ``?color=red&color=blue``, preserving the list structure in the query string.
+
+Custom QueryDict
+~~~~~~~~~~~~~~~~
+
+.. code-block:: html+django
+
+    {% querystring my_query_dict %}
+
+You can provide a custom ``QueryDict`` to be used instead of ``request.GET``.
+So if ``my_query_dict`` is ``<QueryDict: {'color': ['blue']}>``, this outputs
+``?color=blue``.
 
 Dynamic usage
 ~~~~~~~~~~~~~

--- a/docs/releases/6.0.txt
+++ b/docs/releases/6.0.txt
@@ -233,6 +233,9 @@ Templates
 * The new variable ``forloop.length`` is now available within a :ttag:`for`
   loop.
 
+* The :ttag:`querystring` template tag now consistently prefixes the returned
+  query string with a ``?``, ensuring reliable link generation behavior.
+
 Tests
 ~~~~~
 

--- a/tests/template_tests/syntax_tests/test_querystring.py
+++ b/tests/template_tests/syntax_tests/test_querystring.py
@@ -13,31 +13,27 @@ class QueryStringTagTests(SimpleTestCase):
         output = self.engine.render_to_string(template_name, context)
         self.assertEqual(output, expected)
 
-    @setup({"test_querystring_empty_get_params": "{% querystring %}"})
+    @setup({"querystring_empty_get_params": "{% querystring %}"})
     def test_querystring_empty_get_params(self):
         context = RequestContext(self.request_factory.get("/"))
-        self.assertRenderEqual(
-            "test_querystring_empty_get_params", context, expected=""
-        )
+        self.assertRenderEqual("querystring_empty_get_params", context, expected="")
 
-    @setup({"test_querystring_remove_all_params": "{% querystring a=None %}"})
+    @setup({"querystring_remove_all_params": "{% querystring a=None %}"})
     def test_querystring_remove_all_params(self):
         non_empty_context = RequestContext(self.request_factory.get("/?a=b"))
         empty_context = RequestContext(self.request_factory.get("/"))
         for context, expected in [(non_empty_context, "?"), (empty_context, "")]:
             with self.subTest(expected=expected):
                 self.assertRenderEqual(
-                    "test_querystring_remove_all_params",
-                    context,
-                    expected,
+                    "querystring_remove_all_params", context, expected
                 )
 
-    @setup({"test_querystring_non_empty_get_params": "{% querystring %}"})
+    @setup({"querystring_non_empty_get_params": "{% querystring %}"})
     def test_querystring_non_empty_get_params(self):
         request = self.request_factory.get("/", {"a": "b"})
         context = RequestContext(request)
         self.assertRenderEqual(
-            "test_querystring_non_empty_get_params", context, expected="?a=b"
+            "querystring_non_empty_get_params", context, expected="?a=b"
         )
 
     @setup({"querystring_multiple": "{% querystring %}"})
@@ -46,16 +42,14 @@ class QueryStringTagTests(SimpleTestCase):
         context = RequestContext(request)
         self.assertRenderEqual("querystring_multiple", context, expected="?x=y&amp;a=b")
 
-    @setup({"test_querystring_empty_params": "{% querystring qd %}"})
+    @setup({"querystring_empty_params": "{% querystring qd %}"})
     def test_querystring_empty_params(self):
         cases = [None, {}, QueryDict()]
         request = self.request_factory.get("/")
         for param in cases:
             with self.subTest(param=param):
                 context = RequestContext(request, {"qd": param})
-                self.assertRenderEqual(
-                    "test_querystring_empty_params", context, expected=""
-                )
+                self.assertRenderEqual("querystring_empty_params", context, expected="")
 
     @setup({"querystring_replace": "{% querystring a=1 %}"})
     def test_querystring_replace(self):


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36268

#### Branch description
This work ensures that the `querystring` template tag always returns a result with a leading `?` to ensure proper page reloads.

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [X] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
