### PR TITLE
Fixed typo in docs/topics/signals.txt.

### DIFF
--- a/docs/topics/signals.txt
+++ b/docs/topics/signals.txt
@@ -314,7 +314,7 @@ Whether synchronous or asynchronous, receivers will be correctly adapted to
 whether ``send()`` or ``asend()`` is used. Synchronous receivers will be
 called using :func:`~.sync_to_async` when invoked via ``asend()``. Asynchronous
 receivers will be called using :func:`~.async_to_sync` when invoked via
-``sync()``. Similar to the :ref:`case for middleware <async_performance>`,
+``send()``. Similar to the :ref:`case for middleware <async_performance>`,
 there is a small performance cost to adapting receivers in this way. Note that
 in order to reduce the number of sync/async calling-style switches within a
 ``send()`` or ``asend()`` call, the receivers are grouped by whether or not


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

N/A

#### Branch description
Fixed a typo in the Signals documentation: Asynchronous receivers are called using ``async_to_sync`` when invoked via ``send()`` (as opposed to ``asend()``) and not by ``sync()``.
