### PR TITLE
Fixed #36271 -- Raised TemplateSyntaxError when using a relative template path with an unknown origin.

### DIFF
--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -257,6 +257,13 @@ def construct_relative_path(
         # relative path.
         return relative_name
 
+    if current_template_name is None:
+        # Unknown origin (e.g. Template('...').render(Context({...})).
+        raise TemplateSyntaxError(
+            f"The relative path {relative_name} cannot be evaluated due to "
+            "an unknown template origin."
+        )
+
     new_name = posixpath.normpath(
         posixpath.join(
             posixpath.dirname(current_template_name.lstrip("/")),

--- a/tests/template_tests/syntax_tests/test_exceptions.py
+++ b/tests/template_tests/syntax_tests/test_exceptions.py
@@ -1,4 +1,4 @@
-from django.template import TemplateDoesNotExist, TemplateSyntaxError
+from django.template import Template, TemplateDoesNotExist, TemplateSyntaxError
 from django.test import SimpleTestCase
 
 from ..utils import setup
@@ -64,3 +64,14 @@ class ExceptionsTests(SimpleTestCase):
         """
         with self.assertRaises(TemplateSyntaxError):
             self.engine.render_to_string("exception05")
+
+    def test_unknown_origin_relative_path(self):
+        files = ["./nonexistent.html", "../nonexistent.html"]
+        for template_name in files:
+            with self.subTest(template_name=template_name):
+                msg = (
+                    f"The relative path '{template_name}' cannot be evaluated due to "
+                    "an unknown template origin."
+                )
+                with self.assertRaisesMessage(TemplateSyntaxError, msg):
+                    Template(f"{{% extends '{template_name}' %}}")


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36271

#### Branch description
Added check condition in `loader_tags.py` for template_name being None.
The Attribute Error is raised due to `lstrip()` method called on NoneType, hence a condition check is added before it. Check trac ticket for more details.
Also, three tests which are meant for checking functionality of {% extends %} tag when relative path is being used.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
