### PR TITLE
Fixed #36267 -- Fixed contenttypes shortcut() view crash with an invalid object_id for a UUIDField pk.

### DIFF
--- a/django/contrib/contenttypes/views.py
+++ b/django/contrib/contenttypes/views.py
@@ -1,7 +1,7 @@
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.http import Http404, HttpResponseRedirect
 from django.utils.translation import gettext as _
 
@@ -19,7 +19,7 @@ def shortcut(request, content_type_id, object_id):
                 % {"ct_id": content_type_id}
             )
         obj = content_type.get_object_for_this_type(pk=object_id)
-    except (ObjectDoesNotExist, ValueError):
+    except (ObjectDoesNotExist, ValueError, ValidationError):
         raise Http404(
             _("Content type %(ct_id)s object %(obj_id)s doesn’t exist")
             % {"ct_id": content_type_id, "obj_id": object_id}

--- a/tests/contenttypes_tests/models.py
+++ b/tests/contenttypes_tests/models.py
@@ -1,3 +1,4 @@
+import uuid
 from urllib.parse import quote
 
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
@@ -112,3 +113,10 @@ class ModelWithM2MToSite(models.Model):
 
     def get_absolute_url(self):
         return "/title/%s/" % quote(self.title)
+
+
+class UUIDModel(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4)
+
+    def get_absolute_url(self):
+        return "/uuid/%s/" % self.pk

--- a/tests/contenttypes_tests/test_views.py
+++ b/tests/contenttypes_tests/test_views.py
@@ -19,6 +19,7 @@ from .models import (
     SchemeIncludedURL,
 )
 from .models import Site as MockSite
+from .models import UUIDModel
 
 
 @override_settings(ROOT_URLCONF="contenttypes_tests.urls")
@@ -263,3 +264,12 @@ class ShortcutViewTests(TestCase):
         obj = FooWithBrokenAbsoluteUrl.objects.create(name="john")
         with self.assertRaises(AttributeError):
             shortcut(self.request, user_ct.id, obj.id)
+
+    def test_invalid_uuid_pk_raises_404(self):
+        content_type = ContentType.objects.get_for_model(UUIDModel)
+        invalid_uuid = "1234-zzzz-5678-0000-invaliduuid"
+        with self.assertRaisesMessage(
+            Http404,
+            f"Content type {content_type.id} object {invalid_uuid} doesn’t exist",
+        ):
+            shortcut(self.request, content_type.id, invalid_uuid)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36267

#### Branch description
Addressed an issue in `content_type.views.shortcut`, where passing an invalid UUID to the view results in an unhandled `ValidationError`. This occurs when attempting to access the "View on Site" button in the Django admin panel with an incorrect UUID format.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
