### PR TITLE
 Fixed #36274 -- Added support for run_before and atomic in MigrationWriter.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -749,6 +749,7 @@ answer newbie questions, and generally made Django that much better:
     Mikhail Korobov <kmike84@googlemail.com>
     Mikko Hellsing <mikko@sorl.net>
     Mikołaj Siedlarek <mikolaj.siedlarek@gmail.com>
+    Mikuláš Poul <mikulaspoul@gmail.com>
     milkomeda
     Milton Waddams
     mitakummaa@gmail.com

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -131,6 +131,8 @@ class MigrationWriter:
         items = {
             "replaces_str": "",
             "initial_str": "",
+            "run_before_str": "",
+            "atomic_str": "",
         }
 
         imports = set()
@@ -189,10 +191,13 @@ class MigrationWriter:
                 "then update the\n# RunPython operations to refer to the local "
                 "versions:\n# %s"
             ) % "\n# ".join(sorted(migration_imports))
-        # If there's a replaces, make a string for it
         if self.migration.replaces:
             items["replaces_str"] = (
                 "\n    replaces = %s\n" % self.serialize(self.migration.replaces)[0]
+            )
+        if self.migration.run_before:
+            items["run_before_str"] = (
+                "\n    run_before = %s\n" % self.serialize(self.migration.run_before)[0]
             )
         # Hinting that goes into comment
         if self.include_header:
@@ -205,6 +210,8 @@ class MigrationWriter:
 
         if self.migration.initial:
             items["initial_str"] = "\n    initial = True\n"
+        if not self.migration.atomic:
+            items["atomic_str"] = "\n    atomic = False\n"
 
         return MIGRATION_TEMPLATE % items
 
@@ -305,7 +312,7 @@ MIGRATION_TEMPLATE = """\
 %(migration_header)s%(imports)s
 
 class Migration(migrations.Migration):
-%(replaces_str)s%(initial_str)s
+%(replaces_str)s%(initial_str)s%(atomic_str)s%(run_before_str)s
     dependencies = [
 %(dependencies)s\
     ]

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -1164,3 +1164,42 @@ class WriterTests(SimpleTestCase):
         output = writer.as_string()
         self.assertEqual(output.count("import"), 1)
         self.assertIn("from django.db import migrations, models", output)
+
+    def test_run_before(self):
+        for run_before, expected_run_before_str in [
+            ([("foo", "0001_bar")], "    run_before = [('foo', '0001_bar')]\n"),
+            (
+                [("foo", "0001_bar"), ("foo", "0002_baz")],
+                "    run_before = [('foo', '0001_bar'), ('foo', '0002_baz')]\n",
+            ),
+        ]:
+            with self.subTest(run_before=run_before):
+                migration = type(
+                    "Migration",
+                    (migrations.Migration,),
+                    {"operations": [], "run_before": run_before},
+                )
+                writer = MigrationWriter(migration)
+                output = writer.as_string()
+                self.assertIn(expected_run_before_str, output)
+
+    def test_atomic_is_false(self):
+        migration = type(
+            "Migration",
+            (migrations.Migration,),
+            {"operations": [], "atomic": False},
+        )
+        writer = MigrationWriter(migration)
+        output = writer.as_string()
+        self.assertIn("    atomic = False\n", output)
+
+    def test_default_attributes(self):
+        migration = type("Migration", (migrations.Migration,), {})
+        writer = MigrationWriter(migration)
+        output = writer.as_string()
+        self.assertIn("    dependencies = [\n    ]\n", output)
+        self.assertIn("    operations = [\n    ]\n", output)
+        self.assertNotIn("atomic", output)
+        self.assertNotIn("initial", output)
+        self.assertNotIn("run_before", output)
+        self.assertNotIn("replaces", output)


### PR DESCRIPTION
#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-36274

#### Branch description

The `MigrationWriter` class implements writing a instance of `django.db.migrations.migration.Migration`. It supports serializing all the options it could have except for `run_before`. I recently made a PR for a third-party package on remaking migrations (a form of squashing), and had to subclass the writer to be able to include run_before. I think `MigrationWriter` should support all options available on Migration, to make working with migrations easier.

#### Checklist
- [x] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
