### PR TITLE
[5.1.x] Pinned black == 24.10.0 in GitHub actions, pre-commit and test requirements.

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -59,4 +59,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: black
-        uses: psf/black@stable
+        uses: psf/black@24.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.2.0
+    rev: 24.10.0
     hooks:
     - id: black
       exclude: \.py-tpl$
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies:
-        - black==24.2.0
+        - black==24.10.0
         files: 'docs/.*\.txt$'
         args: ["--rst-literal-block"]
   - repo: https://github.com/PyCQA/isort

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -2,7 +2,7 @@ aiosmtpd
 asgiref >= 3.8.1
 argon2-cffi >= 19.2.0
 bcrypt
-black
+black == 24.10.0
 docutils >= 0.19
 geoip2
 jinja2 >= 2.11.0

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands =
 [testenv:black]
 basepython = python3
 usedevelop = false
-deps = black
+deps = black == 24.10.0
 changedir = {toxinidir}
 commands = black --check --diff .
 


### PR DESCRIPTION
Similar to https://github.com/django/django/commit/71dd587da9b45f5b4cd4aa93f99a9b14d444801d