### PR TITLE
Refs #34619 -- Corrected selector description in the admin.

### DIFF
--- a/django/contrib/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/django/contrib/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Django\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-19 11:43-0500\n"
+"POT-Creation-Date: 2025-03-25 15:04-0500\n"
 "PO-Revision-Date: 2010-05-13 15:35+0200\n"
 "Last-Translator: Django team\n"
 "Language-Team: English <en@li.org>\n"
@@ -46,7 +46,7 @@ msgstr ""
 
 #: contrib/admin/static/admin/js/SelectFilter2.js:91
 #, javascript-format
-msgid "Remove selected chosen %s"
+msgid "Remove selected %s"
 msgstr ""
 
 #: contrib/admin/static/admin/js/SelectFilter2.js:102

--- a/django/contrib/admin/static/admin/js/SelectFilter2.js
+++ b/django/contrib/admin/static/admin/js/SelectFilter2.js
@@ -88,7 +88,7 @@ Requires core.js and SelectBox.js.
             const remove_button = quickElement(
                 'button',
                 quickElement('li', selector_chooser),
-                interpolate(gettext('Remove selected chosen %s'), [field_name]),
+                interpolate(gettext('Remove selected %s'), [field_name]),
                 'id', field_id + '_remove',
                 'class', 'selector-remove'
             );

--- a/js_tests/admin/SelectFilter2.test.js
+++ b/js_tests/admin/SelectFilter2.test.js
@@ -19,7 +19,7 @@ QUnit.test('init', function(assert) {
     assert.equal($('.selector-chooseall').prop("tagName"), "BUTTON");
     assert.equal($('.selector-add').text(), "Choose selected things");
     assert.equal($('.selector-add').prop("tagName"), "BUTTON");
-    assert.equal($('.selector-remove').text(), "Remove selected chosen things");
+    assert.equal($('.selector-remove').text(), "Remove selected things");
     assert.equal($('.selector-remove').prop("tagName"), "BUTTON");
     assert.equal($('.selector-clearall').text(), "Remove all things");
     assert.equal($('.selector-clearall').prop("tagName"), "BUTTON");


### PR DESCRIPTION
Follow up to 857b1048d53ebf5fc5581c110e85c212b81ca83a.

Noticed when preparing Polish translations, it doesn't sound good to me. 