### PR TITLE
Fixed #36213 -- Added warning about MySQL’s handling of self-select updates in QuerySet.update() documentation

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2961,6 +2961,14 @@ Using ``update()`` also prevents a race condition wherein something might
 change in your database in the short period of time between loading the object
 and calling ``save()``.
 
+.. admonition:: MySQL does not support self-select updates
+
+    On MySQL, ``QuerySet.update()`` may execute a ``SELECT`` followed by an
+    ``UPDATE`` instead of a single ``UPDATE`` when filtering on related tables,
+    which can introduce a race condition if concurrent changes occur between
+    the queries. To ensure atomicity, consider using transactions or avoiding
+    such filter conditions on MySQL.
+
 Finally, realize that ``update()`` does an update at the SQL level and, thus,
 does not call any ``save()`` methods on your models, nor does it emit the
 :attr:`~django.db.models.signals.pre_save` or


### PR DESCRIPTION
#### Trac ticket number

ticket-36213

#### Branch description

Added a warning in the documentation for `QuerySet.update()` regarding MySQL's handling of self-select updates, which may result in two separate SQL queries (`SELECT` followed by `UPDATE`). Explained how this can lead to race conditions and suggested using transactions or avoiding specific filter conditions to ensure atomicity.

#### Other notes

This is based on PR #19234. Thanks to the original author @edcedcedcedc.

Feedback items from @jacobtylerwalls  applied:
* Moved the warning under `update` (instead of `bulk_update`)
* Convention: Added blank line under `warning::`
* Added space before `As a result`
* Removed emphasis

#### Checklist
- [X] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [X] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [X] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [X] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
