### PR TITLE
Refs #34619 -- Fixed labels width in FilteredSelectMultiple in the admin.

### DIFF
--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -49,14 +49,19 @@
     padding: 8px;
 }
 
-.selector-chosen-title label {
+.aligned .selector-chosen-title label {
     color: var(--header-link-color);
+    width: 100%;
 }
 
 .selector-available-title {
     background: var(--darkened-bg);
     color: var(--body-quiet-color);
     padding: 8px;
+}
+
+.aligned .selector-available-title label {
+    width: 100%;
 }
 
 .selector .selector-filter {


### PR DESCRIPTION
Visual regression in 857b1048d53ebf5fc5581c110e85c212b81ca83a.

Width of labels in selector is limited to `160px`  (see `Available user permissions`):

![image](https://github.com/user-attachments/assets/6541cbdd-9bd9-4a2e-a267-a09c2c506b40)

with this patch:

![image](https://github.com/user-attachments/assets/78ae4254-9a3a-4a9c-971a-c8abe57906d7)